### PR TITLE
[DFlash V2] Add configurable target verify budget

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -11,6 +11,47 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_dflash_verify_budget(
+    server_args: ServerArgs, draft_block_size: int
+) -> int:
+    verify_budget = server_args.speculative_dflash_verify_budget
+    if verify_budget is None:
+        return draft_block_size
+
+    verify_budget = int(verify_budget)
+    if verify_budget <= 0 or verify_budget > draft_block_size:
+        raise ValueError(
+            "DFLASH requires --speculative-dflash-verify-budget to be in "
+            f"[1, {draft_block_size}], got {verify_budget}."
+        )
+
+    if verify_budget < draft_block_size:
+        from sglang.srt.arg_groups.overrides import (
+            attention_backends_of,
+            resolved_view,
+        )
+
+        prefill_backend, decode_backend = attention_backends_of(
+            resolved_view(server_args)
+        )
+        speculative_attention_mode = server_args.speculative_attention_mode
+        target_verify_backend = (
+            decode_backend
+            if speculative_attention_mode == "decode"
+            else prefill_backend
+        )
+        if target_verify_backend != "triton":
+            raise ValueError(
+                "DFLASH verify budgets smaller than the draft block currently "
+                "require Triton attention for TARGET_VERIFY; "
+                f"speculative_attention_mode={speculative_attention_mode!r}, "
+                f"selected_backend={target_verify_backend!r}. Set the selected "
+                "target attention backend to triton or use the full draft block."
+            )
+
+    return verify_budget
+
+
 def _disable_overlap_schedule_for_cpu(server_args: ServerArgs) -> None:
     if server_args.device != "cpu" or server_args.disable_overlap_schedule:
         return
@@ -242,6 +283,11 @@ def _handle_dflash(server_args: ServerArgs) -> None:
                 inferred_block_size,
             )
         server_args.speculative_num_draft_tokens = inferred_block_size
+
+    draft_block_size = int(server_args.speculative_num_draft_tokens)
+    server_args.speculative_dflash_verify_budget = _resolve_dflash_verify_budget(
+        server_args, draft_block_size
+    )
 
     if server_args.speculative_draft_window_size is not None:
         draft_tokens = int(server_args.speculative_num_draft_tokens)

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -462,11 +462,12 @@ class TritonAttnBackend(AttentionBackend):
         spec_info,
     ):
         """Fill all cuda-graph buffers for target_verify mode."""
+        verify_width = int(spec_info.draft_token_num)
         qo_indptr = self.qo_indptr[: bs + 1]
         qo_indptr[: bs + 1] = torch.arange(
             0,
-            (1 + bs) * self.num_draft_tokens,
-            step=self.num_draft_tokens,
+            (1 + bs) * verify_width,
+            step=verify_width,
             dtype=torch.int32,
             device=self.device,
         )
@@ -501,8 +502,9 @@ class TritonAttnBackend(AttentionBackend):
             custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
         else:
             custom_mask = None
-        seq_mask_len = self.num_draft_tokens * (seq_lens + self.num_draft_tokens)
+        seq_mask_len = verify_width * (seq_lens + verify_width)
         mask_indptr = self.mask_indptr[: bs + 1]
+        mask_indptr[0] = 0
         mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
         return (
             qo_indptr,
@@ -794,10 +796,11 @@ class TritonAttnBackend(AttentionBackend):
             max_extend_len = None
         elif forward_batch.forward_mode.is_target_verify():
             bs = len(forward_batch.req_pool_indices)
+            verify_width = int(spec_info.draft_token_num)
             qo_indptr = torch.arange(
                 0,
-                (1 + bs) * self.num_draft_tokens,
-                step=self.num_draft_tokens,
+                (1 + bs) * verify_width,
+                step=verify_width,
                 dtype=torch.int32,
                 device=self.device,
             )
@@ -834,13 +837,12 @@ class TritonAttnBackend(AttentionBackend):
                 )
 
             custom_mask = spec_info.custom_mask
-            seq_mask_len = self.num_draft_tokens * (
-                forward_batch.seq_lens + self.num_draft_tokens
-            )
+            seq_mask_len = verify_width * (forward_batch.seq_lens + verify_width)
             mask_indptr = self.mask_indptr
+            mask_indptr[0] = 0
             mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
             mask_indptr = mask_indptr[: bs + 1]
-            max_extend_len = self.num_draft_tokens
+            max_extend_len = verify_width
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
@@ -1075,6 +1077,7 @@ class TritonAttnBackend(AttentionBackend):
                 out_cache_loc_full_physical=out_cache_loc_full_physical,
             )
         elif forward_mode.is_target_verify():
+            verify_width = int(spec_info.draft_token_num)
             custom_mask = (
                 self.cuda_graph_custom_mask
                 if spec_info is not None
@@ -1084,7 +1087,7 @@ class TritonAttnBackend(AttentionBackend):
             return ForwardMetadata(
                 attn_logits=None,
                 attn_lse=None,
-                max_extend_len=self.num_draft_tokens,
+                max_extend_len=verify_width,
                 num_kv_splits=None,
                 kv_indptr=self.kv_indptr[: bs + 1],
                 kv_indices=self.cuda_graph_kv_indices,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2035,7 +2035,15 @@ class ServerArgs:
     ] = None
     speculative_dflash_block_size: A[
         Optional[int],
-        "DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
+        "DFLASH only. Draft block size. Alias of --speculative-num-draft-tokens for DFLASH.",
+        NS("spec"),
+    ] = None
+    speculative_dflash_verify_budget: A[
+        Optional[int],
+        "DFLASH only. Number of draft tokens verified by the target per decode step. "
+        "The draft model still runs with its configured block size. Must be between "
+        "1 and --speculative-num-draft-tokens; defaults to the full draft block. "
+        "A smaller budget currently requires Triton attention for TARGET_VERIFY.",
         NS("spec"),
     ] = None
     speculative_dspark_block_size: A[

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -220,6 +220,9 @@ class DFlashWorkerV2(BaseSpecWorker):
                     model_block_size,
                 )
         self.speculative_num_draft_tokens = int(self.block_size)
+        self.verify_budget = int(
+            server_args.speculative_dflash_verify_budget or self.block_size
+        )
 
         self._mask_token = draft_config.mask_token
         self._mask_token_id_override = draft_config.mask_token_id
@@ -229,10 +232,11 @@ class DFlashWorkerV2(BaseSpecWorker):
         )
         if self.ps.tp_rank == 0:
             logger.info(
-                "Initialized DFLASH draft runner. attention_backend=%s, model=%s, block_size=%s, draft_window_size=%s, compact_cache=%s",
+                "Initialized DFLASH draft runner. attention_backend=%s, model=%s, block_size=%s, verify_budget=%s, draft_window_size=%s, compact_cache=%s",
                 bundle.resolved_attention_backend,
                 self.draft_model.__class__.__name__,
                 self.block_size,
+                self.verify_budget,
                 self.draft_window_size,
                 self.use_compact_draft_cache,
             )
@@ -256,6 +260,9 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_verify_out_cache_loc_buf: Optional[torch.Tensor] = (
             None  # [cap_bs, block_size]
         )
+        self._verify_tokens_buf: Optional[torch.Tensor] = None
+        self._verify_positions_buf: Optional[torch.Tensor] = None
+        self._verify_out_cache_loc_buf: Optional[torch.Tensor] = None
         self._draft_block_end_buf: Optional[torch.Tensor] = None  # [cap_bs]
         self._draft_seq_lens_cpu_buf: Optional[torch.Tensor] = None  # [cap_bs] on CPU
         self._draft_block_spec_info = make_draft_block_spec_info(
@@ -289,6 +296,8 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._commit_lens_bufs: List[torch.Tensor] = []
         self._bonus_id_bufs: List[torch.Tensor] = []
         self._out_tokens_bufs: List[torch.Tensor] = []
+        self._result_tokens_bufs: List[torch.Tensor] = []
+        self._result_tokens_buffer_slot: int = 0
         self._new_seq_lens_bufs: List[torch.Tensor] = []
 
     @property
@@ -523,6 +532,16 @@ class DFlashWorkerV2(BaseSpecWorker):
         )
         self._draft_verify_out_cache_loc_buf = torch.empty(
             (new_cap, block_size), dtype=torch.int64, device=device
+        )
+        verify_budget = int(self.verify_budget)
+        self._verify_tokens_buf = torch.empty(
+            (new_cap, verify_budget), dtype=torch.long, device=device
+        )
+        self._verify_positions_buf = torch.empty(
+            (new_cap, verify_budget), dtype=torch.int64, device=device
+        )
+        self._verify_out_cache_loc_buf = torch.empty(
+            (new_cap, verify_budget), dtype=torch.int64, device=device
         )
         self._draft_block_end_buf = torch.empty(
             (new_cap,), dtype=torch.int32, device=device
@@ -1319,7 +1338,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             ),
         )
         device = self.device
-        block_size = int(self.block_size)
+        block_size = int(self.verify_budget)
         self._accept_len_buf = torch.empty((new_cap,), dtype=torch.int32, device=device)
         self._commit_lens_bufs = [
             torch.empty((new_cap,), dtype=torch.int32, device=device) for _ in range(2)
@@ -1330,6 +1349,12 @@ class DFlashWorkerV2(BaseSpecWorker):
         ]
         self._out_tokens_bufs = [
             torch.empty((new_cap, block_size), dtype=torch.int64, device=device)
+            for _ in range(2)
+        ]
+        self._result_tokens_bufs = [
+            torch.zeros(
+                (new_cap, int(self.block_size)), dtype=torch.int64, device=device
+            )
             for _ in range(2)
         ]
         self._new_seq_lens_bufs = [
@@ -1355,6 +1380,16 @@ class DFlashWorkerV2(BaseSpecWorker):
             self._out_tokens_bufs[slot][:bs],
             self._new_seq_lens_bufs[slot][:bs],
         )
+
+    def _pad_result_tokens(self, out_tokens: torch.Tensor) -> torch.Tensor:
+        if int(self.verify_budget) == int(self.block_size):
+            return out_tokens
+        self._ensure_accept_bonus_buffers(out_tokens.shape[0])
+        slot = self._result_tokens_buffer_slot
+        self._result_tokens_buffer_slot = (slot + 1) % 2
+        result_tokens = self._result_tokens_bufs[slot][: out_tokens.shape[0]]
+        result_tokens[:, : int(self.verify_budget)].copy_(out_tokens)
+        return result_tokens
 
     def _validate_phase1_sampling_support(self, batch: ScheduleBatch) -> None:
         sampling_info = batch.sampling_info
@@ -1659,20 +1694,35 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_tokens[:, 0].copy_(block_ids[:, 0])
         draft_tokens[:, 1:].copy_(draft_next)
 
-        # Must stay ahead of the target verify launch below.
-        grammar_tree = (
-            GrammarTree.from_linear_chain(draft_tokens) if batch.has_grammar else None
-        )
-
         # --- 2) Target verify.
         # TARGET_VERIFY uses standard causal masking; custom masks are unnecessary here.
         custom_mask = None
 
-        verify_input_ids = draft_tokens.reshape(-1)
+        verify_budget = int(self.verify_budget)
+        assert self._verify_tokens_buf is not None
+        assert self._verify_positions_buf is not None
+        assert self._verify_out_cache_loc_buf is not None
+        verify_tokens = self._verify_tokens_buf[:bs]
+        verify_positions_2d = self._verify_positions_buf[:bs]
+        verify_out_cache_loc_2d = self._verify_out_cache_loc_buf[:bs]
+        verify_tokens.copy_(draft_tokens[:, :verify_budget])
+        verify_positions_2d.copy_(positions_2d[:, :verify_budget])
+        verify_out_cache_loc_2d.copy_(
+            self._draft_verify_out_cache_loc_buf[:bs, :verify_budget]
+        )
+        # Start the asynchronous D2H tree copy before launching target verify.
+        # The grammar tree must match the reduced target width, not the full
+        # draft block.
+        grammar_tree = (
+            GrammarTree.from_linear_chain(verify_tokens) if batch.has_grammar else None
+        )
+        verify_input_ids = verify_tokens.reshape(-1)
+        verify_positions = verify_positions_2d.reshape(-1)
+        verify_out_cache_loc = verify_out_cache_loc_2d.reshape(-1)
         verify_input = DFlashVerifyInput(
             draft_token=verify_input_ids,
-            positions=positions,
-            draft_token_num=int(self.block_size),
+            positions=verify_positions,
+            draft_token_num=verify_budget,
             custom_mask=custom_mask,
             capture_hidden_mode=CaptureHiddenMode.FULL,
         )
@@ -1686,8 +1736,8 @@ class DFlashWorkerV2(BaseSpecWorker):
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
         if seq_lens_cpu_backup is not None:
-            # Verify host bound = committed prefix + one verify block (matches draft).
-            verify_host_seq_lens = seq_lens_cpu_backup + block_size
+            # Verify host bound tracks the target prefix, not the full draft block.
+            verify_host_seq_lens = seq_lens_cpu_backup + verify_budget
             batch.seq_lens_cpu = verify_host_seq_lens
             batch.seq_lens_sum = int(verify_host_seq_lens.sum())
         elif draft_input.reserved_seq_lens_cpu is not None:
@@ -1723,14 +1773,14 @@ class DFlashWorkerV2(BaseSpecWorker):
             apply_dflash_verify_logits_adjustments(
                 next_token_logits=logits_output.next_token_logits,
                 sampling_info=sampling_info,
-                draft_token_num=int(self.block_size),
+                draft_token_num=verify_budget,
             )
 
         # Constrain every chain position before accept picks from it.
         if grammar_mask is not None:
             grammar_mask.apply(logits_output.next_token_logits)
 
-        candidates = draft_tokens
+        candidates = verify_tokens
         new_seq_lens = None
         # Only the greedy branch sets target_predict; the simulated-acceptance
         # override below checks for it.
@@ -1749,15 +1799,15 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
             commit_lens = accept_len.to(torch.int32) + 1  # [bs]
             out_tokens = torch.empty(
-                (bs, int(self.block_size)), dtype=torch.int64, device=device
+                (bs, verify_budget), dtype=torch.int64, device=device
             )
-            if int(self.block_size) > 1:
-                out_tokens[:, : int(self.block_size) - 1].copy_(candidates[:, 1:])
-            out_tokens[:, int(self.block_size) - 1].fill_(0)
+            if verify_budget > 1:
+                out_tokens[:, : verify_budget - 1].copy_(candidates[:, 1:])
+            out_tokens[:, verify_budget - 1].fill_(0)
             out_tokens.scatter_(1, accept_len.to(torch.int64)[:, None], bonus[:, None])
         else:
             target_predict = torch.argmax(logits_output.next_token_logits, dim=-1).view(
-                bs, int(self.block_size)
+                bs, verify_budget
             )
             if self._use_triton_accept_bonus:
                 try:
@@ -1790,15 +1840,13 @@ class DFlashWorkerV2(BaseSpecWorker):
                     )
                     commit_lens = accept_len.to(torch.int32) + 1  # [bs]
                     out_tokens = torch.empty(
-                        (bs, int(self.block_size)),
+                        (bs, verify_budget),
                         dtype=torch.int64,
                         device=device,
                     )
-                    if int(self.block_size) > 1:
-                        out_tokens[:, : int(self.block_size) - 1].copy_(
-                            candidates[:, 1:]
-                        )
-                    out_tokens[:, int(self.block_size) - 1].fill_(0)
+                    if verify_budget > 1:
+                        out_tokens[:, : verify_budget - 1].copy_(candidates[:, 1:])
+                    out_tokens[:, verify_budget - 1].fill_(0)
                     out_tokens.scatter_(
                         1, accept_len.to(torch.int64)[:, None], bonus[:, None]
                     )
@@ -1809,11 +1857,11 @@ class DFlashWorkerV2(BaseSpecWorker):
                 )
                 commit_lens = accept_len.to(torch.int32) + 1  # [bs]
                 out_tokens = torch.empty(
-                    (bs, int(self.block_size)), dtype=torch.int64, device=device
+                    (bs, verify_budget), dtype=torch.int64, device=device
                 )
-                if int(self.block_size) > 1:
-                    out_tokens[:, : int(self.block_size) - 1].copy_(candidates[:, 1:])
-                out_tokens[:, int(self.block_size) - 1].fill_(0)
+                if verify_budget > 1:
+                    out_tokens[:, : verify_budget - 1].copy_(candidates[:, 1:])
+                out_tokens[:, verify_budget - 1].fill_(0)
                 out_tokens.scatter_(
                     1, accept_len.to(torch.int64)[:, None], bonus[:, None]
                 )
@@ -1830,7 +1878,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 # The sampling-verify branch does not materialize the target argmax.
                 target_predict = torch.argmax(
                     logits_output.next_token_logits, dim=-1
-                ).view(bs, int(self.block_size))
+                ).view(bs, verify_budget)
             apply_dflash_simulated_acceptance(
                 candidates=candidates,
                 target_predict=target_predict,
@@ -1865,13 +1913,13 @@ class DFlashWorkerV2(BaseSpecWorker):
             raise RuntimeError(
                 "DFLASH verify requires target hidden states, but got None."
             )
-        hidden = hidden.view(bs, int(self.block_size), -1)
+        hidden = hidden.view(bs, verify_budget, -1)
 
         self._append_target_hidden_to_draft_kv_by_loc(
             target_hidden=hidden.reshape(-1, hidden.shape[-1]),
             cache_loc=verify_out_cache_loc,
             cache_loc_2d=verify_out_cache_loc_2d,
-            positions=positions,
+            positions=verify_positions,
             commit_lens=commit_lens,
         )
 
@@ -1882,10 +1930,11 @@ class DFlashWorkerV2(BaseSpecWorker):
             bonus_tokens=bonus,
             new_seq_lens=new_seq_lens,
         )
+        result_tokens = self._pad_result_tokens(out_tokens)
 
         return GenerationBatchResult(
             logits_output=logits_output,
-            next_token_ids=out_tokens.reshape(-1),
+            next_token_ids=result_tokens.reshape(-1),
             accept_lens=commit_lens,
             can_run_cuda_graph=can_run_cuda_graph,
             next_draft_input=next_draft_input,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -109,6 +109,10 @@ def resolve_num_tokens_per_req(
     if phase == "target_verify":
         if num_draft_tokens is None:
             num_draft_tokens = server_args.speculative_num_draft_tokens
+        if spec_algorithm.is_dflash() and not is_draft_worker:
+            num_draft_tokens = (
+                server_args.speculative_dflash_verify_budget or num_draft_tokens
+            )
         return spec_algorithm.get_num_tokens_per_req_for_target_verify(
             num_draft_tokens, is_draft_worker
         )

--- a/test/registered/spec/dflash/test_dflash_verify_budget.py
+++ b/test/registered/spec/dflash/test_dflash_verify_budget.py
@@ -1,0 +1,127 @@
+import os
+import re
+import unittest
+
+import requests
+from transformers import AutoTokenizer
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=180, stage="extra-a", runner_config="1-gpu-large")
+
+TARGET_MODEL = os.environ.get("SGLANG_TEST_QWEN35_MODEL", "Qwen/Qwen3.5-4B")
+DRAFT_MODEL = os.environ.get(
+    "SGLANG_TEST_QWEN35_DFLASH_MODEL", "z-lab/Qwen3.5-4B-DFlash"
+)
+
+
+class TestDFlashVerifyBudget(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.tokenizer = AutoTokenizer.from_pretrained(
+            TARGET_MODEL, trust_remote_code=True
+        )
+        cls.process = popen_launch_server(
+            TARGET_MODEL,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "triton",
+                "--speculative-algorithm",
+                "DFLASH",
+                "--speculative-draft-model-path",
+                DRAFT_MODEL,
+                "--speculative-num-draft-tokens",
+                "16",
+                "--speculative-dflash-verify-budget",
+                "4",
+                "--max-running-requests",
+                "16",
+                "--cuda-graph-max-bs-decode",
+                "16",
+                "--context-length",
+                "8192",
+                "--mem-fraction-static",
+                "0.65",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def _generate_batch(self):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "input_ids": [
+                    self.tokenizer.encode(
+                        f"Request {i}: explain why regression tests are useful.",
+                        add_special_tokens=False,
+                    )
+                    for i in range(16)
+                ],
+                "sampling_params": [
+                    {
+                        "temperature": 0,
+                        "max_new_tokens": 32,
+                        "ignore_eos": True,
+                    }
+                    for _ in range(16)
+                ],
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def test_cuda_graph_batch_completes(self):
+        results = self._generate_batch()
+
+        self.assertEqual(len(results), 16)
+        self.assertTrue(all(len(result["output_ids"]) == 32 for result in results))
+        self.assertTrue(
+            all(result["meta_info"]["spec_verify_ct"] > 0 for result in results)
+        )
+        self.assertIsNone(self.process.poll())
+
+    def test_sampling_and_grammar_complete(self):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "input_ids": [
+                    self.tokenizer.encode(
+                        "Continue this short story:", add_special_tokens=False
+                    ),
+                    self.tokenizer.encode(
+                        "Return a positive integer:", add_special_tokens=False
+                    ),
+                ],
+                "sampling_params": [
+                    {"temperature": 0.7, "top_p": 0.9, "max_new_tokens": 8},
+                    {"temperature": 0, "max_new_tokens": 8, "regex": "[0-9]+"},
+                ],
+            },
+        )
+        response.raise_for_status()
+        results = response.json()
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(
+            all(result["meta_info"]["spec_verify_ct"] > 0 for result in results)
+        )
+        self.assertRegex(results[1]["text"], re.compile(r"[0-9]+"))
+        self.assertIsNone(self.process.poll())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_verify_budget.py
+++ b/test/registered/unit/spec/test_dflash_verify_budget.py
@@ -1,0 +1,143 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.arg_groups.speculative_hook import _resolve_dflash_verify_budget
+from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
+from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDFlashVerifyBudget(unittest.TestCase):
+    def _server_args(
+        self,
+        verify_budget,
+        attention_backend="triton",
+        prefill_attention_backend=None,
+        decode_attention_backend=None,
+        speculative_attention_mode="prefill",
+    ):
+        return SimpleNamespace(
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=16,
+            speculative_dflash_verify_budget=verify_budget,
+            attention_backend=attention_backend,
+            prefill_attention_backend=prefill_attention_backend,
+            decode_attention_backend=decode_attention_backend,
+            speculative_attention_mode=speculative_attention_mode,
+        )
+
+    def test_budget_validation(self):
+        with self.assertRaisesRegex(ValueError, "to be in"):
+            _resolve_dflash_verify_budget(self._server_args(0), 16)
+        with self.assertRaisesRegex(ValueError, "to be in"):
+            _resolve_dflash_verify_budget(self._server_args(17), 16)
+
+    def test_reduced_budget_requires_triton_target_attention(self):
+        with self.assertRaisesRegex(ValueError, "require Triton attention"):
+            _resolve_dflash_verify_budget(
+                self._server_args(4, attention_backend="flashinfer"), 16
+            )
+
+    def test_reduced_budget_checks_selected_hybrid_backend(self):
+        prefill_verify = self._server_args(
+            4,
+            prefill_attention_backend="triton",
+            decode_attention_backend="flashinfer",
+        )
+        self.assertEqual(_resolve_dflash_verify_budget(prefill_verify, 16), 4)
+
+        decode_verify = self._server_args(
+            4,
+            prefill_attention_backend="flashinfer",
+            decode_attention_backend="triton",
+            speculative_attention_mode="decode",
+        )
+        self.assertEqual(_resolve_dflash_verify_budget(decode_verify, 16), 4)
+
+    def test_full_budget_preserves_other_backends(self):
+        self.assertEqual(
+            _resolve_dflash_verify_budget(
+                self._server_args(16, attention_backend="flashinfer"), 16
+            ),
+            16,
+        )
+
+    def test_target_verify_width_uses_independent_budget(self):
+        server_args = self._server_args(4)
+
+        target_width = resolve_num_tokens_per_req(
+            phase="target_verify",
+            server_args=server_args,
+            spec_algorithm=SpeculativeAlgorithm.DFLASH,
+            is_draft_worker=False,
+        )
+        draft_width = resolve_num_tokens_per_req(
+            phase="target_verify",
+            server_args=server_args,
+            spec_algorithm=SpeculativeAlgorithm.DFLASH,
+            is_draft_worker=True,
+        )
+
+        self.assertEqual(target_width, 4)
+        self.assertEqual(draft_width, 16)
+
+    def test_unset_budget_preserves_full_block(self):
+        server_args = self._server_args(None)
+        width = resolve_num_tokens_per_req(
+            phase="target_verify",
+            server_args=server_args,
+            spec_algorithm=SpeculativeAlgorithm.DFLASH,
+            is_draft_worker=False,
+        )
+        self.assertEqual(width, 16)
+
+    def test_triton_verify_metadata_uses_runtime_width(self):
+        backend = object.__new__(TritonAttnBackend)
+        backend.num_draft_tokens = 16
+        backend.device = torch.device("cpu")
+        backend.qo_indptr = torch.empty(3, dtype=torch.int32)
+        backend.cuda_graph_kv_indices = torch.empty(1, dtype=torch.int64)
+        backend.cuda_graph_custom_mask = torch.empty(1, dtype=torch.bool)
+        backend.mask_indptr = torch.empty(3, dtype=torch.int64)
+        backend.sliding_window_size = None
+        backend.window_kv_indptr = None
+        backend._fill_kv_indptr_and_indices = MagicMock(
+            return_value=torch.tensor([0, 10, 30], dtype=torch.int32)
+        )
+
+        metadata = backend._update_target_verify_buffers(
+            bs=2,
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            spec_info=SimpleNamespace(draft_token_num=4, custom_mask=None),
+        )
+
+        qo_indptr, _, _, mask_indptr = metadata[:4]
+        self.assertEqual(qo_indptr.tolist(), [0, 4, 8])
+        self.assertEqual(mask_indptr.tolist(), [0, 56, 152])
+
+    def test_scheduler_result_keeps_native_block_layout(self):
+        worker = object.__new__(DFlashWorkerV2)
+        worker.block_size = 16
+        worker.verify_budget = 4
+        worker.device = torch.device("cpu")
+        worker._accept_bonus_buffer_cap = 0
+        worker._result_tokens_bufs = []
+        worker._result_tokens_buffer_slot = 0
+
+        output = worker._pad_result_tokens(torch.arange(8).view(2, 4))
+
+        self.assertEqual(output.shape, (2, 16))
+        torch.testing.assert_close(output[:, :4], torch.arange(8).view(2, 4))
+        torch.testing.assert_close(output[:, 4:], torch.zeros(2, 12, dtype=torch.long))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This supersedes #31851, refreshed onto current `main` after the original head
branch was removed during additional validation.

A DFlash checkpoint proposes a fixed draft block, but the target need not verify
the entire block when acceptance is much shorter. With Qwen3.5-4B-DFlash, the
native block is 16 tokens while measured mean accepted length was approximately
2.4-3.1 tokens, making target verification the dominant GPU phase.

#24596 adds an adaptive controller to the original DFlash worker. This change is
narrower and targets DFlash V2: it adds the fixed verify-width primitive needed
by target attention, acceptance, hidden-state/KV injection, and CUDA Graph
capture. It does not add an adaptive policy.

## Modifications

- Add `--speculative-dflash-verify-budget` for the target verify prefix.
- Keep draft execution and the scheduler result layout at the checkpoint-native
  block size.
- Use the selected width for target attention, logits, acceptance,
  hidden-state extraction, KV injection, and target CUDA Graph capture.
- Derive Triton target-verify metadata from the runtime width and initialize the
  first mask offset explicitly.
- Require Triton on the backend selected for TARGET_VERIFY when the budget is
  smaller than the draft block; other backends retain the full-width path.
- Zero-initialize scheduler padding only when buffers grow, avoiding a padding
  clear kernel on every speculative step.
- Add CPU contract tests and a registered Qwen3.5 DFlash Batch 16 GPU test.

## Accuracy Tests

- Verify-width and backend-gate tests: 8 passed.
- Existing DFlash overlap/host-sync tests: 7 passed.
- Style checks: Black, isort, ruff, codespell, and `git diff --check` passed.
- Registered Qwen3.5 DFlash GPU test: passed. The server captured
  target verify graphs with K4 through Batch 16 while draft graphs remained K16,
  then completed a real internal Batch 16 request.

## Speed Tests and Profiling

Refreshed same-machine H100 measurements use the refreshed latest-main commit,
fixed prompts, Triton attention, CUDA graphs, and four measured rounds:

| Concurrency | K16 | K4 | Delta |
| ---: | ---: | ---: | ---: |
| 1 | 357.11 tok/s | 373.46 tok/s | +4.58% |
| 8 | 1746.56 tok/s | 2094.03 tok/s | +19.89% |
| 16 | 2474.31 tok/s | 3475.81 tok/s | +40.48% |

Mean accepted length decreased from 2.72/2.75/2.70 to 2.44/2.38/2.38 for
concurrency 1/8/16. The target-compute reduction still improved end-to-end
throughput despite verifying fewer candidates.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit and registered GPU tests.
- [x] Document the new server argument in `ServerArgs` help text.
- [x] Provide real-checkpoint accuracy and speed results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30602639743](https://github.com/sgl-project/sglang/actions/runs/30602639743)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30602639603](https://github.com/sgl-project/sglang/actions/runs/30602639603)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->