### PR TITLE
[AMD] Fix ROCm 7.15 Helios image release

### DIFF
--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -68,11 +68,11 @@ jobs:
           echo "Detected version: ${VERSION}"
           echo "Pretend version for pip: ${PRETEND_VERSION}"
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+      # - name: Login to Docker Hub (AMD)
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
       - name: Build and Push to rocm/sgl-dev
         run: |
@@ -95,7 +95,7 @@ jobs:
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the build runner.
           docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.sha }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg GPU_ARCH_LIST_ARG=gfx1250 --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
-          docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
+          # docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local
       # registry mirror can run even if a later step in this job (lmsys push)

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   publish:
     if: github.repository == 'sgl-project/sglang' && (github.event_name != 'workflow_dispatch' || inputs.job_select == 'all' || inputs.job_select == 'publish')
-    runs-on: amd-docker-scale
+    runs-on: linux-mi300-1gpu-sglang
     environment: 'prod'
     strategy:
       fail-fast: false
@@ -93,7 +93,7 @@ jobs:
 
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
-          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
+          # to Canonical's archive.ubuntu.com mirror IPs from the build runner.
           docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.sha }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg GPU_ARCH_LIST_ARG=gfx1250 --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -97,22 +97,6 @@ jobs:
           docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.sha }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg GPU_ARCH_LIST_ARG=gfx1250 --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           # docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
-      # Persist the tag right after rocm/sgl-dev push succeeds so the local
-      # registry mirror can run even if a later step in this job (lmsys push)
-      # fails. By default this step only runs when the previous step succeeded,
-      # so the artifact only exists when an image actually landed on Docker Hub.
-      - name: Save published image tag
-        run: |
-          mkdir -p image-tag
-          echo "${{ env.IMAGE_TAG }}" > "image-tag/${{ matrix.gpu_arch }}.txt"
-
-      - name: Upload image tag artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: image-tag-${{ matrix.gpu_arch }}
-          path: image-tag/${{ matrix.gpu_arch }}.txt
-          retention-days: 1
-
       - name: Login to Docker Hub (lmsys)
         uses: docker/login-action@v2
         with:
@@ -123,49 +107,3 @@ jobs:
         run: |
           docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
           docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
-
-  # Mirror the freshly published rocm/sgl-dev image to the in-network Docker
-  # registry so AMD CI runners can pull without hitting Docker Hub rate limits.
-  # The tag is read verbatim from the publish job's artifact so this job uses
-  # exactly the same tag that publish pushed (only the registry prefix differs).
-  # `!cancelled()` lets us still mirror successful matrix legs when other legs
-  # of publish failed; legs without an artifact will fail at download and be
-  # the only ones marked red.
-  push_local_registry:
-    if: ${{ !cancelled() && github.repository == 'sgl-project/sglang' && (github.event_name != 'workflow_dispatch' || inputs.job_select == 'all' || inputs.job_select == 'publish') }}
-    runs-on: linux-mi300-1gpu-sglang
-    environment: 'prod'
-    needs: publish
-    strategy:
-      fail-fast: false
-      matrix:
-        gpu_arch: ['gfx1250-rocm7_15']
-    steps:
-      - name: Download image tag artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: image-tag-${{ matrix.gpu_arch }}
-
-      - name: Read image tag
-        run: |
-          image_tag=$(tr -d '[:space:]' < "${{ matrix.gpu_arch }}.txt")
-          if [ -z "${image_tag}" ]; then
-            echo "::error::Image tag artifact is empty"
-            exit 1
-          fi
-          echo "IMAGE_TAG=${image_tag}" >> $GITHUB_ENV
-          echo "Resolved IMAGE_TAG=${image_tag}"
-
-      - name: Login to Docker Hub (AMD)
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
-
-      - name: Mirror rocm/sgl-dev to local registry
-        run: |
-          src="rocm/sgl-dev:${{ env.IMAGE_TAG }}"
-          dst="10.245.143.50:5000/rocm/sgl-dev:${{ env.IMAGE_TAG }}"
-          docker pull "${src}"
-          docker tag "${src}" "${dst}"
-          docker push "${dst}"

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -94,7 +94,7 @@ jobs:
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -19,7 +19,7 @@ concurrency:
   # (postsubmit). The workflow name is prepended to avoid conflicts between
   # different workflows.
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: True
+  cancel-in-progress: false
 
 jobs:
   publish:

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -94,7 +94,7 @@ jobs:
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg GPU_ARCH_LIST_ARG=gfx1250 --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.sha }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg GPU_ARCH_LIST_ARG=gfx1250 --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -94,7 +94,7 @@ jobs:
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.ref_name }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg GPU_ARCH_LIST_ARG=gfx1250 --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
           docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       # Persist the tag right after rocm/sgl-dev push succeeds so the local

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -10,8 +10,8 @@ on:
         options:
           - 'all'
           - publish
-  schedule:
-    - cron: '0 12 * * *'
+  # schedule:
+  #   - cron: '0 12 * * *'
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -82,7 +82,7 @@ jobs:
           echo "Pretend version: ${pretend_version}"
 
           if [ "${{ matrix.gpu_arch }}" = "gfx1250-rocm7_15" ]; then
-            rocm_tag="rocm7_15-gfx1250"
+            rocm_tag="rocm7.15-mi45x"
           else
             echo "Unsupported gfx arch"
             exit 1

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -162,7 +162,7 @@ RUN echo GPU_ARCH="${GPU_ARCH}" \
     && echo "export GPU_ARCH_LIST=${GPU_ARCH_STRIPPED}" >> /etc/bash.bashrc
 ARG GPU_ARCH_LIST_ARG=gfx1250
 ENV GPU_ARCH_LIST=${GPU_ARCH_LIST_ARG}
-ENV PYTORCH_ROCM_ARCH=gfx942;gfx950
+ENV PYTORCH_ROCM_ARCH=${GPU_ARCH_LIST_ARG}
 
 ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
 ARG SGL_DEFAULT="main"

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -169,7 +169,7 @@ ARG SGL_DEFAULT="main"
 ARG SGL_BRANCH=${SGL_DEFAULT}
 
 # Version override for setuptools_scm (used in nightly builds)
-ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
+ARG SGLANG_VERSION=""
 
 ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
 ENV TRITON_COMMIT="${TRITON_COMMIT:-${TRITON_COMMIT_DEFAULT}}"
@@ -326,9 +326,8 @@ RUN if [ "$BUILD_LLVM" = "1" ]; then \
 
 # -----------------------
 # AITER
-# Unset setuptools_scm override so AITER gets its own version (AITER_COMMIT), not SGLang's
-# (SETUPTOOLS_SCM_PRETEND_VERSION is set later for SGLang nightly builds and would otherwise
-# leak into AITER's version when AITER uses setuptools_scm)
+# Clear any inherited setuptools_scm override so AITER gets its own version
+# from AITER_COMMIT rather than SGLang's nightly version.
 
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=
 # Keep the base image's Torch-compatible Triton by default. Override with
@@ -392,7 +391,7 @@ ARG BUILD_TYPE=all
 
 # Set version for setuptools_scm if provided (for nightly builds). Only pass in the SGLang
 # pip install RUN so it does not affect AITER, sgl-model-gateway, TileLang, FHT, MORI, etc.
-ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ARG SGLANG_VERSION
 
 RUN pip install IPython \
     && pip install orjson \
@@ -421,9 +420,9 @@ RUN cd sglang \
     && rm -rf python/pyproject.toml && mv python/pyproject_other.toml python/pyproject.toml \
     && sed -i 's/compressed-tensors[^"]*"/compressed-tensors>=0.9.2"/g' python/pyproject.toml \
     && if [ "$BUILD_TYPE" = "srt" ]; then \
-         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install --no-build-isolation -c /tmp/constraints.txt -e "python[srt_hip,diffusion_hip]"; \
+         SETUPTOOLS_SCM_PRETEND_VERSION="${SGLANG_VERSION}" python -m pip --no-cache-dir install --no-build-isolation -c /tmp/constraints.txt -e "python[srt_hip,diffusion_hip]"; \
        else \
-         export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_PRETEND_VERSION}" && python -m pip --no-cache-dir install --no-build-isolation -c /tmp/constraints.txt -e "python[all_hip]"; \
+         SETUPTOOLS_SCM_PRETEND_VERSION="${SGLANG_VERSION}" python -m pip --no-cache-dir install --no-build-isolation -c /tmp/constraints.txt -e "python[all_hip]"; \
        fi
 
 RUN python -m pip cache purge


### PR DESCRIPTION
## Motivation

Prepare the first ROCm 7.15 / gfx1250 (MI45x) image release from `amd_helios` while keeping the rollout manual and limited to the LMSYS Docker Hub repository.

## Modifications

- keep the workflow manual-only by commenting out the cron trigger
- run the build on `linux-mi300-1gpu-sglang`
- set `cancel-in-progress: false` so a second dispatch does not cancel a long-running build
- publish `v<version>-rocm7.15-mi45x-<date>` only to `lmsysorg/sglang-rocm`
- keep the AMD Docker Hub login and `rocm/sgl-dev` push commented for the initial rollout
- remove the stale local-registry mirror job and its now-unused tag artifacts
- pass the dispatched commit SHA and explicit gfx1250 target into the Docker build
- preserve the requested setuptools-scm nightly version for the installed SGLang package
- compile PyTorch extensions for gfx1250

## Dependency

- Depends on #32054, which replaces the hard-coded personal fork with `SGL_REPO` / `SGL_BRANCH`. This PR passes the exact dispatch SHA through `SGL_BRANCH`, so the image installs that commit after #32054 lands.
- A same-path workflow on `main` is still required to register the manual `workflow_dispatch` entry point. That default-branch change is intentionally outside this `amd_helios` PR.

## Expected image

Example for a build on 2026-07-22:

`lmsysorg/sglang-rocm:v0.5.15.post1-rocm7.15-mi45x-20260722`

`rocm/sgl-dev` is used only as the local build tag and is not pushed.

## Validation

- `pre-commit run --files .github/workflows/release-docker-amd-rocm7_15-nightly.yml docker/rocm.Dockerfile`
- parsed the workflow YAML and checked the trigger, runner, tag, SHA, gfx1250, version, and push-target configuration
- validated Docker ARG/ENV scoping with a minimal Docker build
- `git diff --check`

A full ROCm 7.15 image build has not been run yet.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29918421349](https://github.com/sgl-project/sglang/actions/runs/29918421349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29918421210](https://github.com/sgl-project/sglang/actions/runs/29918421210)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->