### PR TITLE
[Fix] Guard fused silu_and_mul quant kernels against invalid launch configs

### DIFF
--- a/python/sglang/jit_kernel/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
+++ b/python/sglang/jit_kernel/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
@@ -315,8 +315,12 @@ struct SiluAndMulMaskedPostQuantKernel {
     };
 
     const auto num_threads = hidden_dim / 8;
+    RuntimeCheck(num_threads > 0 && num_threads <= 1024, "hidden_dim/8 exceeds CUDA block limit");
     RuntimeCheck(num_threads % device::kWarpThreads == 0);
     RuntimeCheck(num_threads >= num_experts);
+    if (num_tokens == 0 || topk == 0) {
+      return;
+    }
     const auto kernel = transposed ? kernel_transposed : kernel_normal;
     LaunchKernel(num_tokens * topk, num_threads, device.unwrap())  //
         .enable_pdl(kUsePDL)(kernel, params);
@@ -530,7 +534,11 @@ struct SiluAndMulContigPostQuantKernel {
     };
 
     const auto num_threads = hidden_dim / 8;
+    RuntimeCheck(num_threads > 0 && num_threads <= 1024, "hidden_dim/8 exceeds CUDA block limit");
     RuntimeCheck(num_threads % device::kWarpThreads == 0);
+    if (num_tokens == 0) {
+      return;
+    }
     const auto kernel = transposed ? kernel_transposed : kernel_normal;
     LaunchKernel(num_tokens, num_threads, device.unwrap())  //
         .enable_pdl(kUsePDL)(kernel, params);


### PR DESCRIPTION
# [Fix] Guard fused silu_and_mul quant kernels against invalid launch configs

## Motivation

Fixes #32065.

The masked and contiguous silu_and_mul post-quant launchers
(`SiluAndMulMaskedPostQuantKernel`, `SiluAndMulContigPostQuantKernel`)
build their CUDA launch configuration without two necessary guards:

1. `num_threads = hidden_dim / 8` is never checked against the
   1024-threads-per-block CUDA limit, so any MoE with
   `moe_intermediate_size > 8192` fails at runtime with a raw
   `cudaErrorInvalidConfiguration` instead of a meaningful error.
   (`SiluAndMulClampKernel` in the same file already has this check.)
2. `num_tokens == 0` (masked: also `topk == 0`) still launches a
   zero-block grid, which is an invalid CUDA launch. This happens in
   practice with `--enable-dp-attention` when a DP rank goes idle for a
   step while the JIT EP activation fused quant path is enabled.

## Modifications

For both launchers:

- add `RuntimeCheck(num_threads > 0 && num_threads <= 1024, "hidden_dim/8
  exceeds CUDA block limit")` next to the existing warp-alignment check;
- early-return before the launch when the batch is empty
  (`num_tokens == 0`, masked variant also `topk == 0`). Shape/param
  validation still runs before the early return, so misuse is reported
  even for empty batches.

No behavior change for any currently-working shape: the added checks only
turn previously-invalid launches into a clear error or a no-op.

## Verification

- Verified on 8x H800 under DP attention (DP8) with the fused
  activation-quant path enabled: idle-rank steps previously crashed with
  `cudaErrorInvalidConfiguration`, now proceed as a no-op; non-empty
  batches produce byte-identical outputs to before the change.

## Checklist

- [x] Format your code with pre-commit.
- [x] Verified end-to-end as described above.
- [x] Update documentation as needed. (N/A)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29920726253](https://github.com/sgl-project/sglang/actions/runs/29920726253)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29920725475](https://github.com/sgl-project/sglang/actions/runs/29920725475)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->