### PR TITLE
perf(spec): skip FlashInfer draft verify mask allocation

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -379,6 +379,8 @@ class FlashInferAttnBackend(AttentionBackend):
         self.max_context_len = model_runner.model_config.context_len
         self.page_size = model_runner.page_size
         self.skip_prefill = skip_prefill
+        self.is_draft_runner = model_runner.is_draft_worker
+        self.cuda_graph_custom_mask = None
         self.is_multimodal = model_runner.model_config.is_multimodal
         assert not (
             model_runner.sliding_window_size is not None
@@ -1042,12 +1044,13 @@ class FlashInferAttnBackend(AttentionBackend):
             if len(self.cuda_graph_kv_indices[i]) > 0:
                 self.cuda_graph_kv_indices[i][0] = 0
 
-        if not self.skip_prefill:
+        if not self.skip_prefill and not self.is_draft_runner:
             self.cuda_graph_custom_mask = torch.zeros(
                 (max_num_tokens * self.max_context_len),
                 dtype=torch.uint8,
                 device="cuda",
             )
+        if not self.skip_prefill:
             self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
             self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
 

--- a/test/registered/unit/spec/test_flashinfer_draft_mask_contract.py
+++ b/test/registered/unit/spec/test_flashinfer_draft_mask_contract.py
@@ -10,10 +10,10 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 def _import_flashinfer_backend():
     try:
+        from sglang.srt.layers.attention import flashinfer_backend
         from sglang.srt.layers.attention.flashinfer_backend import (
             FlashInferAttnBackend,
         )
-        from sglang.srt.layers.attention import flashinfer_backend
     except Exception as exc:
         pytest.skip(f"FlashInfer backend is unavailable: {exc}")
     return FlashInferAttnBackend, flashinfer_backend

--- a/test/registered/unit/spec/test_flashinfer_draft_mask_contract.py
+++ b/test/registered/unit/spec/test_flashinfer_draft_mask_contract.py
@@ -1,0 +1,80 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _import_flashinfer_backend():
+    try:
+        from sglang.srt.layers.attention.flashinfer_backend import (
+            FlashInferAttnBackend,
+        )
+        from sglang.srt.layers.attention import flashinfer_backend
+    except Exception as exc:
+        pytest.skip(f"FlashInfer backend is unavailable: {exc}")
+    return FlashInferAttnBackend, flashinfer_backend
+
+
+def _make_backend(*, is_draft_runner: bool):
+    FlashInferAttnBackend, _ = _import_flashinfer_backend()
+    backend = FlashInferAttnBackend.__new__(FlashInferAttnBackend)
+    backend.max_context_len = 128
+    backend.num_wrappers = 1
+    backend.skip_prefill = False
+    backend.is_draft_runner = is_draft_runner
+    backend.cuda_graph_custom_mask = None
+    backend.use_sliding_window_kv_pool = False
+    backend.kv_indptr = [torch.zeros((5,), dtype=torch.int32)]
+    return backend
+
+
+def test_flashinfer_draft_cuda_graph_keeps_indptr_but_skips_custom_mask(
+    monkeypatch,
+):
+    _, flashinfer_backend = _import_flashinfer_backend()
+    real_zeros = torch.zeros
+    allocations = []
+
+    def fake_zeros(*args, **kwargs):
+        allocations.append(
+            {
+                "shape": args[0] if args else kwargs.get("size"),
+                "dtype": kwargs.get("dtype"),
+                "device": kwargs.get("device"),
+            }
+        )
+        kwargs = dict(kwargs)
+        if kwargs.get("device") == "cuda":
+            kwargs["device"] = "cpu"
+        return real_zeros(*args, **kwargs)
+
+    monkeypatch.setattr(flashinfer_backend.torch, "zeros", fake_zeros)
+
+    target = _make_backend(is_draft_runner=False)
+    target.init_cuda_graph_state(max_bs=4, max_num_tokens=2)
+
+    draft = _make_backend(is_draft_runner=True)
+    draft.init_cuda_graph_state(max_bs=4, max_num_tokens=2)
+
+    assert target.cuda_graph_custom_mask is not None
+    assert target.cuda_graph_custom_mask.shape == (256,)
+    assert target.cuda_graph_custom_mask.dtype == torch.uint8
+
+    assert draft.cuda_graph_custom_mask is None
+    assert [x.shape for x in draft.cuda_graph_qk_indptr] == [torch.Size([5])]
+    assert [x.shape for x in draft.cuda_graph_qo_indptr] == [torch.Size([5])]
+
+    mask_allocations = [
+        item
+        for item in allocations
+        if item["dtype"] == torch.uint8 and item["shape"] == 256
+    ]
+    assert len(mask_allocations) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# PR Body: FlashInfer Draft Runner Skip Verify FULL_MASK Allocation

## Title

```text
perf(spec): skip FULL_MASK allocation on FlashInfer draft runner
```

## Summary

This PR skips `cuda_graph_custom_mask` allocation for the FlashInfer draft runner during speculative decoding.

`cuda_graph_custom_mask` is the tree-verify FULL_MASK scratch used by the target-side verify path. The FlashInfer draft runner is currently created with `skip_prefill=False`, so it also allocates this scratch even though the draft path does not consume it. This follow-up applies the same target-only allocation contract to FlashInfer that was added for other backends in #31527.

The change keeps qk/qo indptr allocation under `not self.skip_prefill`, because draft prefill/verify metadata still needs those buffers.

## Why This Is Correct

Draft FlashInfer backend creation:

```text
python/sglang/srt/speculative/draft_utils.py
FlashInferAttnBackend(self.draft_model_runner, skip_prefill=False)
```

Previous behavior:

```python
if not self.skip_prefill:
    self.cuda_graph_custom_mask = torch.zeros(
        (max_num_tokens * self.max_context_len),
        dtype=torch.uint8,
        device="cuda",
    )
    self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
    self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
```

This tied two different buffer classes to the same guard:

- `cuda_graph_custom_mask`: target-side tree verify scratch.
- `cuda_graph_qk_indptr` / `cuda_graph_qo_indptr`: prefill/verify metadata still needed by the draft path.

New behavior:

```python
self.is_draft_runner = model_runner.is_draft_worker
self.cuda_graph_custom_mask = None

if not self.skip_prefill and not self.is_draft_runner:
    self.cuda_graph_custom_mask = torch.zeros(
        (max_num_tokens * self.max_context_len),
        dtype=torch.uint8,
        device="cuda",
    )
if not self.skip_prefill:
    self.cuda_graph_qk_indptr = [x.clone() for x in self.kv_indptr]
    self.cuda_graph_qo_indptr = [x.clone() for x in self.kv_indptr]
```

This makes only the FULL_MASK scratch target-only. The draft runner keeps qk/qo indptr and other metadata. Target runner behavior is unchanged.

## Memory Impact

The skipped allocation size is exact:

```text
bytes = max_num_tokens * max_context_len * sizeof(uint8)
```

For example:

```text
320 * 131072 * 1 = 41,943,040 bytes = 40.0 MiB
```

This is not a global upper bound. It is the per-FlashInfer-draft-backend saving for this example shape. The saving scales linearly with `max_num_tokens`, `max_context_len`, and the number of worker/draft backend instances that would otherwise allocate this scratch buffer.

This is a memory-headroom fix, not a latency claim. It is not expected to change logits, acceptance rate, or attention kernel latency.

## Local Validation

Environment:

```text
GPU: NVIDIA GeForce RTX 5060 Ti 16GB / SM120
Python: 3.12.3
Torch: 2.11.0+cu130
Triton: 3.6.0
flashinfer-python: 0.6.14
flashinfer-cubin: 0.6.14
sglang-kernel: 0.4.5
```

Allocation matrix:

```text
max_num_tokens: 1, 8, 32, 320
max_context_len: 2048, 32768, 131072
cases: 24
target_mask_ok: True
draft_mask_none: True
indptr_ok: True
```

Largest local shape:

```text
target mask bytes: 41,943,040
draft mask bytes: 0
target graph_allocated_delta: 209,716,224
draft graph_allocated_delta: 167,773,184
target/draft delta: 41,943,040
```

The graph allocation delta difference exactly matches the skipped uint8 mask size. A single `graph_allocated_delta` also includes other graph buffers such as KV indices, so the reliable attribution is the target/draft delta plus the mask tensor's own `numel * element_size`.

## Tests

New contract test:

```bash
pytest -q test/registered/unit/spec/test_flashinfer_draft_mask_contract.py
```

Result:

```text
1 passed
```

Existing FlashInfer speculative CUDA graph tests:

```bash
pytest -q \
  test/registered/attention/unittests/dense/test_flashinfer.py::TestFlashInferDenseAttentionBackendCorrectness::test_runner_mode_spec_verify_cuda_graph_cases \
  test/registered/attention/unittests/dense/test_flashinfer.py::TestFlashInferDenseAttentionBackendCorrectness::test_runner_mode_eagle_draft_cuda_graph_runner_cases
```

Result:

```text
2 passed, 23 warnings, 7 subtests passed
```

Repeated graph smoke:

```text
20/20 iterations passed
Per-iteration summary: 2 passed, 23 warnings, 7 subtests passed
```

Repeated eager verify smoke:

```text
20/20 iterations passed
Per-iteration summary: 1 passed, 23 warnings, 5 subtests passed
```

Runner-level case metadata was also recorded for eager/graph coverage:

```text
chain cases: topk=1
tree cases: topk=2
eager/graph max_bs: 2
verify tokens_per_request: [3, 3]
EAGLE draft graph tree tokens_per_request: [4, 4]
```

## Follow-up Context

This is a follow-up to #31527. That PR made tree-mask scratch target-only for other attention backends; this patch applies the same allocation boundary to FlashInfer.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29976037658](https://github.com/sgl-project/sglang/actions/runs/29976037658)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29976037443](https://github.com/sgl-project/sglang/actions/runs/29976037443)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->