### PR TITLE
fix(gateway): use per-DP-rank loads for power-of-two routing

### DIFF
--- a/sgl-model-gateway/src/core/worker_manager.rs
+++ b/sgl-model-gateway/src/core/worker_manager.rs
@@ -26,6 +26,80 @@ use crate::{
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_CONCURRENT: usize = 32;
 
+#[derive(Debug, Default)]
+struct ParsedLoadResponse {
+    aggregate: Option<isize>,
+    aggregate_from_ranks: Option<isize>,
+    by_dp_rank: HashMap<usize, isize>,
+}
+
+type DpHttpGroupKey = (String, Option<String>);
+
+#[derive(Debug)]
+struct DpWorkerLoadTarget {
+    url: String,
+    worker_type: Option<String>,
+    dp_rank: usize,
+}
+
+impl ParsedLoadResponse {
+    fn from_json(json: &Value) -> Self {
+        fn non_negative_isize(value: Option<&Value>) -> Option<isize> {
+            value
+                .and_then(Value::as_u64)
+                .and_then(|value| isize::try_from(value).ok())
+        }
+
+        let aggregate = non_negative_isize(
+            json.get("aggregate")
+                .and_then(|aggregate| aggregate.get("total_tokens")),
+        );
+        let mut by_dp_rank = HashMap::new();
+        let mut aggregate_from_ranks = None;
+
+        if let Some(loads) = json.get("loads").and_then(Value::as_array) {
+            let mut total = Some(0isize);
+            let mut saw_valid_rank = false;
+
+            for load in loads {
+                let parsed = load
+                    .get("dp_rank")
+                    .and_then(Value::as_u64)
+                    .and_then(|rank| usize::try_from(rank).ok())
+                    .zip(non_negative_isize(load.get("num_total_tokens")));
+                let Some((dp_rank, total_tokens)) = parsed else {
+                    // A partial sum would make a malformed response look less
+                    // loaded than it is. Keep valid rank entries for DP-aware
+                    // routing, but do not expose an aggregate for this payload.
+                    total = None;
+                    continue;
+                };
+
+                saw_valid_rank = true;
+                if by_dp_rank.insert(dp_rank, total_tokens).is_some() {
+                    total = None;
+                } else if let Some(current) = total {
+                    total = current.checked_add(total_tokens);
+                }
+            }
+
+            if saw_valid_rank {
+                aggregate_from_ranks = total;
+            }
+        }
+
+        Self {
+            aggregate,
+            aggregate_from_ranks,
+            by_dp_rank,
+        }
+    }
+
+    fn aggregate_load(&self) -> Option<isize> {
+        self.aggregate.or(self.aggregate_from_ranks)
+    }
+}
+
 /// Result of a fan-out request to a single worker
 struct WorkerResponse {
     url: String,
@@ -163,36 +237,88 @@ impl WorkerManager {
     ) -> WorkerLoadsResult {
         let workers = worker_registry.get_all();
         let total_workers = workers.len();
+        let mut loads = Vec::new();
+        let mut direct_http_workers = Vec::new();
+        let mut dp_http_groups: HashMap<DpHttpGroupKey, Vec<DpWorkerLoadTarget>> = HashMap::new();
 
-        let futures: Vec<_> = workers
-            .iter()
-            .map(|worker| {
-                let url = worker.url().to_string();
-                let api_key = worker.api_key().clone();
-                let worker_type = match worker.worker_type() {
-                    WorkerType::Regular => None,
-                    WorkerType::Prefill { .. } => Some("prefill".to_string()),
-                    WorkerType::Decode => Some("decode".to_string()),
-                };
-                let is_http = matches!(worker.connection_mode(), ConnectionMode::Http);
+        for worker in workers {
+            let url = worker.url().to_string();
+            let worker_type = match worker.worker_type() {
+                WorkerType::Regular => None,
+                WorkerType::Prefill { .. } => Some("prefill".to_string()),
+                WorkerType::Decode => Some("decode".to_string()),
+            };
+
+            if !matches!(worker.connection_mode(), ConnectionMode::Http) {
+                loads.push(WorkerLoadInfo {
+                    worker: url,
+                    worker_type,
+                    load: -1,
+                });
+                continue;
+            }
+
+            let api_key = worker.api_key().clone();
+            if let Some(dp_rank) = worker.dp_rank() {
+                let base_url = worker.base_url().trim_end_matches('/').to_string();
+                dp_http_groups
+                    .entry((base_url, api_key))
+                    .or_default()
+                    .push(DpWorkerLoadTarget {
+                        url,
+                        worker_type,
+                        dp_rank,
+                    });
+            } else {
+                direct_http_workers.push((url, worker_type, api_key));
+            }
+        }
+
+        let direct_futures = direct_http_workers
+            .into_iter()
+            .map(|(url, worker_type, api_key)| {
                 let client = client.clone();
-
                 async move {
-                    let load = if is_http {
-                        Self::parse_load_response(&client, &url, api_key.as_deref()).await
-                    } else {
-                        -1
-                    };
+                    let load = Self::fetch_load_response(&client, &url, api_key.as_deref())
+                        .await
+                        .and_then(|response| response.aggregate_load())
+                        .unwrap_or(-1);
                     WorkerLoadInfo {
                         worker: url,
                         worker_type,
                         load,
                     }
                 }
-            })
-            .collect();
+            });
 
-        let loads = future::join_all(futures).await;
+        let dp_futures = dp_http_groups
+            .into_iter()
+            .map(|((base_url, api_key), workers)| {
+                let client = client.clone();
+                async move {
+                    let by_dp_rank =
+                        Self::fetch_load_response(&client, &base_url, api_key.as_deref())
+                            .await
+                            .map(|response| response.by_dp_rank)
+                            .unwrap_or_default();
+                    workers
+                        .into_iter()
+                        .map(|target| WorkerLoadInfo {
+                            worker: target.url,
+                            worker_type: target.worker_type,
+                            load: by_dp_rank.get(&target.dp_rank).copied().unwrap_or(-1),
+                        })
+                        .collect::<Vec<_>>()
+                }
+            });
+
+        let (direct_loads, dp_load_groups) = future::join(
+            future::join_all(direct_futures),
+            future::join_all(dp_futures),
+        )
+        .await;
+        loads.extend(direct_loads);
+        loads.extend(dp_load_groups.into_iter().flatten());
         let successful = loads.iter().filter(|l| l.load >= 0).count();
         let failed = loads.iter().filter(|l| l.load < 0).count();
 
@@ -204,12 +330,12 @@ impl WorkerManager {
         }
     }
 
-    async fn parse_load_response(
+    async fn fetch_load_response(
         client: &reqwest::Client,
         url: &str,
         api_key: Option<&str>,
-    ) -> isize {
-        let load_url = format!("{}/v1/loads?include=core", url);
+    ) -> Option<ParsedLoadResponse> {
+        let load_url = format!("{}/v1/loads?include=core", url.trim_end_matches('/'));
         let mut req = client.get(&load_url).timeout(REQUEST_TIMEOUT);
         if let Some(key) = api_key {
             req = req.bearer_auth(key);
@@ -217,15 +343,10 @@ impl WorkerManager {
 
         match req.send().await {
             Ok(r) if r.status().is_success() => match r.json::<Value>().await {
-                Ok(json) => json
-                    .get("aggregate")
-                    .and_then(|a| a.get("total_tokens"))
-                    .and_then(|v| v.as_i64())
-                    .map(|n| n as isize)
-                    .unwrap_or(-1),
-                _ => -1,
+                Ok(json) => Some(ParsedLoadResponse::from_json(&json)),
+                _ => None,
             },
-            _ => -1,
+            _ => None,
         }
     }
 
@@ -358,7 +479,9 @@ impl LoadMonitor {
 
             let mut loads = HashMap::new();
             for load_info in result.loads {
-                loads.insert(load_info.worker, load_info.load);
+                if load_info.load >= 0 {
+                    loads.insert(load_info.worker, load_info.load);
+                }
             }
 
             if !loads.is_empty() {
@@ -367,13 +490,13 @@ impl LoadMonitor {
                     loads.len(),
                     power_of_two_policies.len()
                 );
-                for policy in &power_of_two_policies {
-                    policy.update_loads(&loads);
-                }
-                let _ = tx.send(loads);
             } else {
-                warn!("No loads fetched from workers");
+                warn!("No valid loads fetched from workers; clearing cached token loads");
             }
+            for policy in &power_of_two_policies {
+                policy.update_loads(&loads);
+            }
+            let _ = tx.send(loads);
         }
     }
 
@@ -390,5 +513,162 @@ impl Drop for LoadMonitor {
                 handle.abort();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use axum::{extract::State, routing::get, Json, Router};
+    use serde_json::json;
+    use tokio::{net::TcpListener, task::JoinHandle};
+
+    use super::*;
+    use crate::core::{BasicWorkerBuilder, DPAwareWorkerBuilder};
+
+    type MockLoadState = (Arc<AtomicUsize>, Arc<Value>);
+
+    async fn mock_loads(State((calls, response)): State<MockLoadState>) -> Json<Value> {
+        calls.fetch_add(1, Ordering::SeqCst);
+        Json((*response).clone())
+    }
+
+    async fn start_load_server(response: Value) -> (String, Arc<AtomicUsize>, JoinHandle<()>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/v1/loads", get(mock_loads))
+            .with_state((Arc::clone(&calls), Arc::new(response)));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}"), calls, server)
+    }
+
+    #[test]
+    fn test_parse_load_response_supports_rank_loads_and_legacy_aggregate() {
+        let parsed = ParsedLoadResponse::from_json(&json!({
+            "aggregate": {"total_tokens": 321},
+            "loads": [
+                {"dp_rank": 0, "num_total_tokens": 100},
+                {"dp_rank": 1, "num_total_tokens": 221},
+                {"dp_rank": 2, "num_total_tokens": -1},
+                {"dp_rank": "bad", "num_total_tokens": 9}
+            ]
+        }));
+
+        assert_eq!(parsed.aggregate_load(), Some(321));
+        assert_eq!(parsed.by_dp_rank.get(&0), Some(&100));
+        assert_eq!(parsed.by_dp_rank.get(&1), Some(&221));
+        assert!(!parsed.by_dp_rank.contains_key(&2));
+        assert_eq!(parsed.by_dp_rank.len(), 2);
+    }
+
+    #[test]
+    fn test_rank_aggregate_requires_a_complete_valid_payload() {
+        let complete = ParsedLoadResponse::from_json(&json!({
+            "loads": [
+                {"dp_rank": 0, "num_total_tokens": 100},
+                {"dp_rank": 1, "num_total_tokens": 221}
+            ]
+        }));
+        assert_eq!(complete.aggregate_load(), Some(321));
+
+        let partial = ParsedLoadResponse::from_json(&json!({
+            "loads": [
+                {"dp_rank": 0, "num_total_tokens": 100},
+                {"dp_rank": 1, "num_total_tokens": -1}
+            ]
+        }));
+        assert_eq!(partial.aggregate_load(), None);
+        assert_eq!(partial.by_dp_rank.get(&0), Some(&100));
+        assert!(!partial.by_dp_rank.contains_key(&1));
+    }
+
+    #[tokio::test]
+    async fn test_dp_workers_fetch_physical_loads_once_and_map_by_rank() {
+        let (base_url, calls, server) = start_load_server(json!({
+            "loads": [
+                {"dp_rank": 0, "num_total_tokens": 900},
+                {"dp_rank": 1, "num_total_tokens": 120}
+            ]
+        }))
+        .await;
+        let registry = WorkerRegistry::new();
+        for rank in 0..3 {
+            let worker = DPAwareWorkerBuilder::new(&base_url, rank, 3)
+                .worker_type(WorkerType::Decode)
+                .build();
+            registry.register(Arc::new(worker));
+        }
+
+        let result = WorkerManager::get_all_worker_loads(&registry, &reqwest::Client::new()).await;
+        let loads: HashMap<_, _> = result
+            .loads
+            .into_iter()
+            .map(|load| (load.worker, load.load))
+            .collect();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(loads.get(&format!("{base_url}@0")), Some(&900));
+        assert_eq!(loads.get(&format!("{base_url}@1")), Some(&120));
+        assert_eq!(loads.get(&format!("{base_url}@2")), Some(&-1));
+        assert_eq!(result.total_workers, 3);
+        assert_eq!(result.successful, 2);
+        assert_eq!(result.failed, 1);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_non_dp_worker_keeps_legacy_aggregate_load() {
+        let (base_url, calls, server) =
+            start_load_server(json!({"aggregate": {"total_tokens": 777}})).await;
+        let registry = WorkerRegistry::new();
+        registry.register(Arc::new(
+            BasicWorkerBuilder::new(&base_url)
+                .worker_type(WorkerType::Decode)
+                .build(),
+        ));
+
+        let result = WorkerManager::get_all_worker_loads(&registry, &reqwest::Client::new()).await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(result.loads.len(), 1);
+        assert_eq!(result.loads[0].worker, base_url);
+        assert_eq!(result.loads[0].load, 777);
+        assert_eq!(result.successful, 1);
+        assert_eq!(result.failed, 0);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn test_non_dp_worker_sums_current_per_rank_loads() {
+        let (base_url, calls, server) = start_load_server(json!({
+            "loads": [
+                {"dp_rank": 0, "num_total_tokens": 300},
+                {"dp_rank": 1, "num_total_tokens": 477}
+            ]
+        }))
+        .await;
+        let registry = WorkerRegistry::new();
+        registry.register(Arc::new(
+            BasicWorkerBuilder::new(&base_url)
+                .worker_type(WorkerType::Decode)
+                .build(),
+        ));
+
+        let result = WorkerManager::get_all_worker_loads(&registry, &reqwest::Client::new()).await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(result.loads.len(), 1);
+        assert_eq!(result.loads[0].load, 777);
+        assert_eq!(result.successful, 1);
+        assert_eq!(result.failed, 0);
+        server.abort();
     }
 }

--- a/sgl-model-gateway/src/policies/power_of_two.rs
+++ b/sgl-model-gateway/src/policies/power_of_two.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use tracing::debug;
 
 use super::{get_healthy_worker_indices, LoadBalancingPolicy, SelectWorkerInfo};
-use crate::core::Worker;
+use crate::core::{ConnectionMode, Worker};
 
 /// Power-of-two choices policy
 ///
@@ -43,6 +43,33 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
             return None;
         }
 
+        // An HTTP DP virtual worker must have a rank-specific token load from
+        // the latest successful monitor poll. Its Router-local request counter
+        // cannot reveal scheduler or KV backlog already present on that rank.
+        // Apply this per worker so mixed DP/non-DP pools remain well-defined.
+        // Non-HTTP DP workers keep the existing request-count fallback because
+        // the load monitor currently polls only HTTP endpoints.
+        let loads_guard = self.cached_loads.read().ok();
+        let healthy_indices = healthy_indices
+            .into_iter()
+            .filter(|idx| {
+                let worker = &workers[*idx];
+                if !worker.is_dp_aware()
+                    || !matches!(worker.connection_mode(), ConnectionMode::Http)
+                {
+                    return true;
+                }
+                loads_guard
+                    .as_ref()
+                    .and_then(|loads| loads.get(worker.url()))
+                    .is_some_and(|load| *load >= 0)
+            })
+            .collect::<Vec<_>>();
+
+        if healthy_indices.is_empty() {
+            return None;
+        }
+
         if healthy_indices.len() == 1 {
             return Some(healthy_indices[0]);
         }
@@ -59,16 +86,15 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
         let worker1 = &workers[worker_idx1];
         let worker2 = &workers[worker_idx2];
 
-        // Access cached loads safely
-        let loads_guard = self.cached_loads.read().ok();
-
         // Try to get high-fidelity token loads for BOTH workers
         let load1_tokens = loads_guard
             .as_ref()
-            .and_then(|m| m.get(worker1.url()).copied());
+            .and_then(|m| m.get(worker1.url()).copied())
+            .filter(|load| *load >= 0);
         let load2_tokens = loads_guard
             .as_ref()
-            .and_then(|m| m.get(worker2.url()).copied());
+            .and_then(|m| m.get(worker2.url()).copied())
+            .filter(|load| *load >= 0);
 
         // If either worker is missing token data (e.g. monitor failure),
         // we must degrade BOTH to request counts to ensure fairness.
@@ -130,7 +156,7 @@ impl Default for PowerOfTwoPolicy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{BasicWorkerBuilder, WorkerType};
+    use crate::core::{BasicWorkerBuilder, ConnectionMode, DPAwareWorkerBuilder, WorkerType};
 
     #[tokio::test]
     async fn test_power_of_two_selection() {
@@ -206,6 +232,140 @@ mod tests {
 
         // Worker2 should be selected significantly more often
         assert!(w2_selected > 35); // Should win most of the time
+    }
+
+    #[tokio::test]
+    async fn test_power_of_two_does_not_treat_unknown_token_load_as_zero() {
+        let policy = PowerOfTwoPolicy::new();
+        let worker1 = BasicWorkerBuilder::new("http://w1:8000")
+            .worker_type(WorkerType::Regular)
+            .build();
+        let worker2 = BasicWorkerBuilder::new("http://w2:8000")
+            .worker_type(WorkerType::Regular)
+            .build();
+
+        for _ in 0..5 {
+            worker1.increment_load();
+        }
+
+        let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(worker1), Arc::new(worker2)];
+        let loads = HashMap::from([
+            ("http://w1:8000".to_string(), -1),
+            ("http://w2:8000".to_string(), 100_000),
+        ]);
+        policy.update_loads(&loads);
+
+        // The unknown token load forces a fair fallback to local request counts,
+        // where worker2 is idle. It must not win by looking like a negative load.
+        assert_eq!(
+            policy
+                .select_worker(&workers, &SelectWorkerInfo::default())
+                .await,
+            Some(1)
+        );
+    }
+
+    fn dp_workers() -> Vec<Arc<dyn Worker>> {
+        vec![
+            Arc::new(
+                DPAwareWorkerBuilder::new("http://dp-worker:8000", 0, 2)
+                    .worker_type(WorkerType::Decode)
+                    .build(),
+            ),
+            Arc::new(
+                DPAwareWorkerBuilder::new("http://dp-worker:8000", 1, 2)
+                    .worker_type(WorkerType::Decode)
+                    .build(),
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_dp_power_of_two_fails_closed_when_rank_loads_are_missing() {
+        let policy = PowerOfTwoPolicy::new();
+
+        assert_eq!(
+            policy
+                .select_worker(&dp_workers(), &SelectWorkerInfo::default())
+                .await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dp_power_of_two_fails_closed_for_negative_rank_loads() {
+        let policy = PowerOfTwoPolicy::new();
+        policy.update_loads(&HashMap::from([
+            ("http://dp-worker:8000@0".to_string(), -1),
+            ("http://dp-worker:8000@1".to_string(), -1),
+        ]));
+
+        assert_eq!(
+            policy
+                .select_worker(&dp_workers(), &SelectWorkerInfo::default())
+                .await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dp_power_of_two_uses_the_only_rank_with_valid_load() {
+        let policy = PowerOfTwoPolicy::new();
+        policy.update_loads(&HashMap::from([(
+            "http://dp-worker:8000@1".to_string(),
+            100_000,
+        )]));
+
+        assert_eq!(
+            policy
+                .select_worker(&dp_workers(), &SelectWorkerInfo::default())
+                .await,
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dp_filter_applies_in_mixed_worker_pool() {
+        let policy = PowerOfTwoPolicy::new();
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                DPAwareWorkerBuilder::new("http://dp-worker:8000", 0, 1)
+                    .worker_type(WorkerType::Decode)
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://regular-worker:8000")
+                    .worker_type(WorkerType::Decode)
+                    .build(),
+            ),
+        ];
+
+        for _ in 0..20 {
+            assert_eq!(
+                policy
+                    .select_worker(&workers, &SelectWorkerInfo::default())
+                    .await,
+                Some(1)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dp_grpc_worker_keeps_existing_request_count_fallback() {
+        let policy = PowerOfTwoPolicy::new();
+        let workers: Vec<Arc<dyn Worker>> = vec![Arc::new(
+            DPAwareWorkerBuilder::new("grpc://dp-worker", 0, 1)
+                .worker_type(WorkerType::Decode)
+                .connection_mode(ConnectionMode::Grpc { port: Some(50051) })
+                .build(),
+        )];
+
+        assert_eq!(
+            policy
+                .select_worker(&workers, &SelectWorkerInfo::default())
+                .await,
+            Some(0)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

The SGLang `/v1/loads` endpoint now returns per-DP-rank load data in `loads[]`, while the Gateway still reads the legacy `aggregate.total_tokens` field. As a result, current responses are parsed as `-1`.

For DP-aware HTTP workers, the registry represents one physical engine as multiple `base_url@rank` virtual workers. The load monitor must query the physical endpoint once and map each `loads[].dp_rank` entry back to its virtual worker. Without that mapping, PowerOfTwo cannot see scheduler/KV backlog for an individual rank and may treat negative cached values as valid token loads.

Related to #28634, which identifies the response-schema mismatch. This PR additionally handles DP-aware virtual workers and rank-specific policy behavior.

## Modifications

- Parse both the current per-rank response and the legacy aggregate response.
- Group HTTP DP virtual workers by physical base URL and API key, fetch `/v1/loads` once per group, and map `num_total_tokens` by `dp_rank`.
- Preserve aggregate behavior for non-DP workers by safely summing complete per-rank payloads.
- Reject missing, negative, duplicate, overflowing, or otherwise malformed aggregate data while retaining valid individual rank entries.
- Cache only valid loads and publish every monitor snapshot, including an empty one, so failed polls clear previous values.
- Exclude HTTP DP ranks without a valid rank-specific load from PowerOfTwo selection. Apply this per worker for mixed pools, while preserving the existing request-count fallback for non-HTTP DP workers.

## Accuracy Tests

This change does not affect model outputs.

Validated with:

- `cargo test --lib worker_manager` — 5 passed
- `cargo test --lib power_of_two` — 14 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`

## Speed Tests and Profiling

No inference benchmark was required. The periodic load monitor now sends one request per physical DP endpoint/API-key pair instead of one request per virtual DP rank.

## Checklist

- [x] Format the code with the repository's nightly rustfmt configuration.
- [x] Add unit tests for parsing, request grouping, rank mapping, invalid loads, mixed pools, and non-HTTP DP behavior.
- [x] Documentation is not required because this changes internal Gateway routing behavior only.
- [x] Accuracy and inference-speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29923942102](https://github.com/sgl-project/sglang/actions/runs/29923942102)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29923941451](https://github.com/sgl-project/sglang/actions/runs/29923941451)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->