### PR TITLE
[BugFix][EPD] Fix Mooncake source-MR lifecycle for multi-TP /send

### DIFF
--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -1809,16 +1809,13 @@ class MMEncoder:
                 f"(shape={mm_data.shape}, element_size={self._element_size})"
             )
 
-            # Cache so sibling-TP /send calls reuse the same tensor and MR.
-            mm_data.cached_embedding = embedding
-
             # Request-level shared MR, registered lazily on the first /send;
             # deregistration is deferred to _cleanup_inflight_encode_state.
             fwd_state = self._forward_results.setdefault(req_id, {})
-            mr_shared = fwd_state.get("mr_ptr") == embedding.data_ptr()
-            if not mr_shared:
+            mr_already_registered = fwd_state.get("mr_ptr") == embedding.data_ptr()
+            if not mr_already_registered:
                 self.engine.register(embedding.data_ptr(), embedding.nbytes)
-                fwd_state["mr_ptr"] = embedding.data_ptr()
+                self._forward_results[req_id]["mr_ptr"] = embedding.data_ptr()
             _t_xfer_start = time.monotonic()
             xfer_ret = await asyncio.to_thread(
                 self.engine.transfer_sync,
@@ -1840,10 +1837,10 @@ class MMEncoder:
                 )
             # Only emit at INFO when transfer is slow or the MR was
             # registered lazily by this /send;
-            if xfer_ms > 200.0 or not mr_shared:
+            if xfer_ms > 200.0 or not mr_already_registered:
                 logger.info(
                     f"[{req_id}] mooncake transfer_sync={xfer_ms:.1f}ms "
-                    f"nbytes={embedding.nbytes} shared_mr={mr_shared}"
+                    f"nbytes={embedding.nbytes} shared_mr={mr_already_registered}"
                 )
 
             mm_data.embedding = None

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -1809,16 +1809,18 @@ class MMEncoder:
                 f"(shape={mm_data.shape}, element_size={self._element_size})"
             )
 
-            # MR was registered once in _run_forward and is shared across all
-            # sibling-TP /send calls;
-            mr_already_registered = (
-                self._forward_results.get(req_id, {}).get("mr_ptr")
-                == embedding.data_ptr()
-            )
-            if not mr_already_registered:
+            # Cache so sibling-TP /send calls reuse the same tensor and MR.
+            mm_data.cached_embedding = embedding
+
+            # Request-level shared MR, registered lazily on the first /send;
+            # deregistration is deferred to _cleanup_inflight_encode_state.
+            fwd_state = self._forward_results.setdefault(req_id, {})
+            mr_shared = fwd_state.get("mr_ptr") == embedding.data_ptr()
+            if not mr_shared:
                 self.engine.register(embedding.data_ptr(), embedding.nbytes)
+                fwd_state["mr_ptr"] = embedding.data_ptr()
             _t_xfer_start = time.monotonic()
-            await asyncio.to_thread(
+            xfer_ret = await asyncio.to_thread(
                 self.engine.transfer_sync,
                 session_id,
                 embedding.data_ptr(),
@@ -1830,14 +1832,18 @@ class MMEncoder:
                 encoder_metrics_collector.observe_transfer(
                     xfer_ms / 1000.0, backend="mooncake"
                 )
-            if not mr_already_registered:
-                self.engine.deregister(embedding.data_ptr())
-            # Only emit at INFO when transfer is slow or fell back
-            # to per-/send register;
-            if xfer_ms > 200.0 or not mr_already_registered:
+            if xfer_ret < 0:
+                raise InternalError(
+                    f"Mooncake transfer_sync failed for {req_id} "
+                    f"(session={session_id}, nbytes={embedding.nbytes}, "
+                    f"ret={xfer_ret})"
+                )
+            # Only emit at INFO when transfer is slow or the MR was
+            # registered lazily by this /send;
+            if xfer_ms > 200.0 or not mr_shared:
                 logger.info(
                     f"[{req_id}] mooncake transfer_sync={xfer_ms:.1f}ms "
-                    f"nbytes={embedding.nbytes} shared_mr={mr_already_registered}"
+                    f"nbytes={embedding.nbytes} shared_mr={mr_shared}"
                 )
 
             mm_data.embedding = None

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -1843,8 +1843,6 @@ class MMEncoder:
                     f"nbytes={embedding.nbytes} shared_mr={mr_already_registered}"
                 )
 
-            mm_data.embedding = None
-
         # Send ack/data
         if url is not None:
             endpoint = NetworkAddress.parse(url).to_tcp()
@@ -2009,8 +2007,6 @@ class MMEncoder:
                 task.cancel()
         # Also clean up embedding data and forward state
         mm_data = self.embedding_to_send.pop(req_id, None)
-        if mm_data is not None:
-            mm_data.cached_embedding = None
         # Release the rkey after all /send calls have completed.
         forward_state = self._forward_results.pop(req_id, None)
         if forward_state is not None:
@@ -2022,6 +2018,11 @@ class MMEncoder:
                     logger.warning(
                         f"Shared-MR deregister failed for {req_id}: {dereg_err}"
                     )
+            forward_state.pop("embedding", None)
+        # Release the embedding only after the MR is deregistered.
+        if mm_data is not None:
+            mm_data.embedding = None
+            mm_data.cached_embedding = None
         self._forward_ready_events.pop(req_id, None)
 
     def _schedule_inflight_encode_cleanup(self, req_id: str):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fix Mooncake source-MR / embedding lifecycle race when prefill runs with tp > 1.

Each prefill TP rank POSTs `/encode + /send` for the same req_id. The default batch_encode path never pre-registers a shared MR (unlike encode_with_mooncake), so sibling `/send` calls race on per-call register/deregister and early mm_data.embedding = None. Under concurrency this causes:

```bash
[2026-07-23 11:41:11 encode_server] Dispatching batch of 1 IMAGE requests
E0723 11:41:11.723554 47210 transfer_engine_impl.cpp:516] Transfer Engine does not support overlapped memory region
```

TODO: Currenly this pr is just for hot-fix;  a follow-up refactor need to remove the complex backend × topology branching. cc @ShangmingCai @liusy58 

## Modifications

1. Lazy-register a request-level shared MR on the first `/send`; defer deregister to `_cleanup_inflight_encode_state`. Also surface transfer_sync failures.
2. Keep mm_data.embedding alive across sibling /send; release only after MR deregister in cleanup (send_timeout backstop; early release via #31591 ).

## Accuracy Tests

The issue reproduces when prefill runs with `tp > 1` (concurrent sibling `/send`) under concurrency.

Server command:

```
CUDA_VISIBLE_DEVICES=0,1,2,3 python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
        --host $HOST_IP --port ${PORT} --trust-remote-code --tp-size 4 --mem-fraction-static 0.7 \
        --enable-cache-report --log-level info --max-running-requests 64 --disable-radix-cache --encoder-transfer-backend $ENCODER_TRANSFER_BACKEND \
        --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics --max-prefill-tokens 128000 \
        --encoder-urls http://${HOST_IP}:8091 http://${HOST_IP}:8092 \
        --mm-attention-backend fa3 --language-only &> logs/run_prefill.log &

CUDA_VISIBLE_DEVICES=4 python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
        --host $HOST_IP --port 8091 --trust-remote-code --tp-size 1 --mem-fraction-static 0.7  \
        --enable-cache-report --log-level info --max-running-requests 64 --disable-radix-cache \
        --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics --encoder-transfer-backend $ENCODER_TRANSFER_BACKEND \
        --mm-attention-backend fa3 --encoder-only &> logs/run_encoder_1.log &

CUDA_VISIBLE_DEVICES=5 python3 -m sglang.launch_server --model-path ${MODEL_PATH} \
        --host $HOST_IP --port 8092 --trust-remote-code --tp-size 1 --mem-fraction-static 0.7  \
        --enable-cache-report --log-level info --max-running-requests 64 --disable-radix-cache \
        --chunked-prefill-size 8192 --attention-backend fa3 --enable-metrics --encoder-transfer-backend $ENCODER_TRANSFER_BACKEND \
        --mm-attention-backend fa3 --encoder-only &> logs/run_encoder_2.log &
```

Bench commond:

```bash
set -euo pipefail

URL="http://${HOST:-127.0.0.1}:${PORT:-8090}/v1/chat/completions"
CONCURRENCY="${CONCURRENCY:-64}"

BODY='{
  "model": "auto",
  "messages": [
    {"role": "user", "content": [
      {"type": "image_url", "image_url": {"url": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"}},
      {"type": "text", "text": "Describe the image."}
    ]}
  ],
  "temperature": 0,
  "max_tokens": 128
}'

echo "POST ${URL}  concurrency=${CONCURRENCY}"
for i in $(seq 1 "${CONCURRENCY}"); do
  curl -sS "${URL}" -H 'Content-Type: application/json' -d "${BODY}" \
    | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r["choices"][0]["message"]["content"] if "choices" in r else r)' \
    | sed "s/^/[#${i}] /" &
done
wait
echo "all done"

```


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
4. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
5. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
6. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #29985872575](https://github.com/sgl-project/sglang/actions/runs/29985872575)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29985872225](https://github.com/sgl-project/sglang/actions/runs/29985872225)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->