### PR TITLE
Add cache-agnostic in-batch prefix defer baseline

### DIFF
--- a/docker/intra-turn-prefix-cache.Dockerfile
+++ b/docker/intra-turn-prefix-cache.Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+ARG BASE_IMAGE=lmsysorg/sglang:deepseek-v4-hopper
+FROM ${BASE_IMAGE}
+
+COPY python/sglang/srt/managers/schedule_policy.py \
+    /sgl-workspace/sglang/python/sglang/srt/managers/schedule_policy.py
+COPY python/sglang/srt/managers/schedule_batch.py \
+    /sgl-workspace/sglang/python/sglang/srt/managers/schedule_batch.py
+COPY python/sglang/srt/managers/scheduler.py \
+    /sgl-workspace/sglang/python/sglang/srt/managers/scheduler.py
+
+ENV SGLANG_ENABLE_CACHE_AGNOSTIC_IN_BATCH_PREFIX_CACHING=true \
+    IN_BATCH_PREFIX_CACHING_CACHE_AGNOSTIC_MAX_QUEUE_SCAN=128

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -910,6 +910,10 @@ class Req(ReqDllmMixin):
         self.swa_prefix_lock_released: bool = False
         # The prefix length that is inserted into the tree cache
         self.cache_protected_len: int = 0
+        # Experimental intra-turn prefix-cache staging. The scheduler can defer
+        # this request for one prefill pass while an earlier request materializes
+        # a shared uncached prefix.
+        self.defer_for_in_batch_prefix_cache: bool = False
 
         # Whether or not if it is chunked. It increments whenever
         # it is chunked, and decrement whenever chunked request is

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -85,6 +85,15 @@ IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD = int(
     os.environ.get("IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD", "32")
 )
 
+# Opt-in experiment: run the waiting-queue radix pass even when the primary
+# scheduler policy is cache-agnostic, such as fcfs.
+ENABLE_CACHE_AGNOSTIC_IN_BATCH_PREFIX_CACHING = get_bool_env_var(
+    "SGLANG_ENABLE_CACHE_AGNOSTIC_IN_BATCH_PREFIX_CACHING"
+)
+IN_BATCH_PREFIX_CACHING_CACHE_AGNOSTIC_MAX_QUEUE_SCAN = int(
+    os.environ.get("IN_BATCH_PREFIX_CACHING_CACHE_AGNOSTIC_MAX_QUEUE_SCAN", "128")
+)
+
 
 IGNORE_EOS_RESERVE_TOKENS = 1
 
@@ -203,6 +212,7 @@ class SchedulePolicy:
                 SchedulePolicy._sort_by_priority_and_fcfs(
                     waiting_queue, self.priority_sign
                 )
+            self._maybe_apply_cache_agnostic_in_batch_prefix_caching(waiting_queue)
             return
 
         if isinstance(policy, CacheAwarePolicy):
@@ -233,6 +243,7 @@ class SchedulePolicy:
                     SchedulePolicy._sort_by_routing_key(waiting_queue, running_batch)
             else:
                 raise ValueError(f"Unknown CacheAgnostic Policy: {policy=}")
+            self._maybe_apply_cache_agnostic_in_batch_prefix_caching(waiting_queue)
 
     def _determine_active_policy(self, waiting_queue: List[Req]) -> Policy:
         if self.policy == CacheAwarePolicy.LPM and len(waiting_queue) > 128:
@@ -265,48 +276,92 @@ class SchedulePolicy:
         Computes and caches the matching prefixes for requests in the waiting queue,
             and handles in-batch prefix caching logic.
         """
-        temporary_deprioritized: Set[int] = set()
-        self.waiting_queue_radix_tree.reset()
-
         for r in waiting_queue:
             prefix_ids = r.origin_input_ids + r.output_ids
-            extra_key = r.extra_key
-            match_result = match_prefix_for_req(
-                self.tree_cache, r, prefix_ids, include_req=True
-            )
+            match_prefix_for_req(self.tree_cache, r, prefix_ids, include_req=True)
 
-            # NOTE(sang): This logic is for in-batch prefix caching;
-            # If there are more than 1 request that have small matching prefix from
-            # existing cache, but all those requests share the same prefix, we prefer
-            # to schedule only one of them so that we can increase the cache hit rate.
-            # We prefer to set IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD > 0 because too small
-            # threshold means we cannot use in-batch prefix caching for short prefixes.
-            # It is kind of common when the engine is long running (e.g., imagine the prefix "the").
-            if len(r.prefix_indices) <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD:
-                match_result = self.waiting_queue_radix_tree.match_prefix(
-                    MatchPrefixParams(
-                        key=RadixKey(token_ids=prefix_ids, extra_key=extra_key)
+        return self._compute_in_batch_prefix_matches(waiting_queue)
+
+    def _compute_in_batch_prefix_matches(
+        self, waiting_queue: List[Req], max_queue_scan: Optional[int] = None
+    ) -> Set[int]:
+        # NOTE(sang): This logic is for in-batch prefix caching;
+        # If there are more than 1 request that have small matching prefix from
+        # existing cache, but all those requests share the same prefix, we prefer
+        # to schedule only one of them so that we can increase the cache hit rate.
+        # We prefer to set IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD > 0 because too small
+        # threshold means we cannot use in-batch prefix caching for short prefixes.
+        # It is kind of common when the engine is long running (e.g., imagine the prefix "the").
+        if IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD < 0:
+            return set()
+
+        temporary_deprioritized: Set[int] = set()
+        self.waiting_queue_radix_tree.reset()
+        scanned_queue = waiting_queue
+        if max_queue_scan is not None and max_queue_scan > 0:
+            scanned_queue = waiting_queue[:max_queue_scan]
+
+        for r in scanned_queue:
+            if len(r.prefix_indices) > IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD:
+                continue
+
+            prefix_ids = r.origin_input_ids + r.output_ids
+            extra_key = r.extra_key
+            match_result = self.waiting_queue_radix_tree.match_prefix(
+                MatchPrefixParams(
+                    key=RadixKey(token_ids=prefix_ids, extra_key=extra_key)
+                )
+            )
+            if envs.SGLANG_RADIX_FORCE_MISS.get():
+                match_result = zero_match_result(
+                    self.waiting_queue_radix_tree, match_result
+                )
+            in_batch_matching_prefixes = match_result.device_indices
+            if (
+                len(in_batch_matching_prefixes)
+                >= IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD
+            ):
+                temporary_deprioritized.add(r.rid)
+            else:
+                self.waiting_queue_radix_tree.insert(
+                    InsertParams(
+                        key=RadixKey(token_ids=prefix_ids, extra_key=extra_key),
+                        value=torch.empty(len(prefix_ids), dtype=torch.bool),
                     )
                 )
-                if envs.SGLANG_RADIX_FORCE_MISS.get():
-                    match_result = zero_match_result(
-                        self.waiting_queue_radix_tree, match_result
-                    )
-                in_batch_matching_prefixes = match_result.device_indices
-                if (
-                    len(in_batch_matching_prefixes)
-                    >= IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD
-                ):
-                    temporary_deprioritized.add(r.rid)
-                else:
-                    # Insert with a dummy key
-                    self.waiting_queue_radix_tree.insert(
-                        InsertParams(
-                            key=RadixKey(token_ids=prefix_ids, extra_key=extra_key),
-                            value=torch.empty(len(prefix_ids), dtype=torch.bool),
-                        )
-                    )
+
         return temporary_deprioritized
+
+    def _maybe_apply_cache_agnostic_in_batch_prefix_caching(
+        self, waiting_queue: List[Req]
+    ) -> None:
+        for req in waiting_queue:
+            req.defer_for_in_batch_prefix_cache = False
+
+        if (
+            not ENABLE_CACHE_AGNOSTIC_IN_BATCH_PREFIX_CACHING
+            or getattr(self.tree_cache, "disable", True)
+            or not self.tree_cache.supports_fast_match_prefix()
+            or get_server_args().disaggregation_mode == "decode"
+        ):
+            return
+
+        temporary_deprioritized = self._compute_in_batch_prefix_matches(
+            waiting_queue,
+            max_queue_scan=IN_BATCH_PREFIX_CACHING_CACHE_AGNOSTIC_MAX_QUEUE_SCAN,
+        )
+        if temporary_deprioritized:
+            for req in waiting_queue:
+                req.defer_for_in_batch_prefix_cache = (
+                    req.rid in temporary_deprioritized
+                )
+            SchedulePolicy._stable_deprioritize(waiting_queue, temporary_deprioritized)
+
+    @staticmethod
+    def _stable_deprioritize(
+        waiting_queue: List[Req], temporary_deprioritized: Set[int]
+    ) -> None:
+        waiting_queue.sort(key=lambda r: r.rid in temporary_deprioritized)
 
     @staticmethod
     def _sort_by_longest_prefix(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -98,6 +98,13 @@ IN_BATCH_PREFIX_CACHING_CACHE_AGNOSTIC_MAX_QUEUE_SCAN = int(
 IGNORE_EOS_RESERVE_TOKENS = 1
 
 
+def _is_disaggregation_decode() -> bool:
+    try:
+        return get_server_args().disaggregation_mode == "decode"
+    except ValueError:
+        return False
+
+
 def match_prefix_for_req(
     tree_cache: BasePrefixCache,
     req: Req,
@@ -202,7 +209,7 @@ class SchedulePolicy:
         if (
             not isinstance(policy, CacheAwarePolicy)
             and self.tree_cache.supports_fast_match_prefix()
-            and get_server_args().disaggregation_mode != "decode"
+            and not _is_disaggregation_decode()
         ):
             for r in waiting_queue:
                 match_prefix_for_req(self.tree_cache, r, include_req=True)
@@ -342,7 +349,7 @@ class SchedulePolicy:
             not ENABLE_CACHE_AGNOSTIC_IN_BATCH_PREFIX_CACHING
             or getattr(self.tree_cache, "disable", True)
             or not self.tree_cache.supports_fast_match_prefix()
-            or get_server_args().disaggregation_mode == "decode"
+            or _is_disaggregation_decode()
         ):
             return
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2934,6 +2934,9 @@ class Scheduler(
             mamba_allocator.alloc_group_begin(len(self.waiting_queue))
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
+            if req.defer_for_in_batch_prefix_cache:
+                continue
+
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
                 continue
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -352,6 +352,9 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
         )
         self._record_all_cleared_event()
 
+    def supports_fast_match_prefix(self) -> bool:
+        return not self.disable
+
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         """Find the longest cached prefix of ``key`` in the radix tree.
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -569,6 +569,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
     def register_sidecar_pool(self, spec: SidecarPoolSpec) -> None:
         self.sidecar_pool_specs.append(spec)
 
+    def supports_fast_match_prefix(self) -> bool:
+        return not self.disable
+
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         result = self.session.try_match_prefix(params)
         if result is not None:

--- a/test/manual/test_schedule_policy.py
+++ b/test/manual/test_schedule_policy.py
@@ -1,5 +1,6 @@
 import unittest
 from array import array
+from unittest.mock import patch
 
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.schedule_policy import (
@@ -90,6 +91,36 @@ class TestSchedulePolicy(CustomTestCase):
         self.assertEqual(waiting_queue[0].rid, 1)
         self.assertEqual(waiting_queue[1].rid, 3)
         self.assertEqual(waiting_queue[2].rid, 2)
+
+    def test_calc_priority_fcfs_cache_agnostic_in_batch_prefix_caching(self):
+        tree_cache = RadixCache.create_simulated()
+        shared_prefix = list(range(64))
+        waiting_queue = [
+            _make_req(1, "shared seed", shared_prefix + [1]),
+            _make_req(2, "shared duplicate", shared_prefix + [2]),
+            _make_req(3, "unrelated", [1000, 1001]),
+            _make_req(4, "shared duplicate 2", shared_prefix + [3]),
+        ]
+
+        policy = SchedulePolicy(
+            policy="fcfs",
+            tree_cache=tree_cache,
+            enable_hierarchical_cache=True,
+            enable_priority_scheduling=False,
+            schedule_low_priority_values_first=False,
+        )
+        with patch(
+            "sglang.srt.managers.schedule_policy."
+            "ENABLE_CACHE_AGNOSTIC_IN_BATCH_PREFIX_CACHING",
+            True,
+        ):
+            policy.calc_priority(waiting_queue)
+
+        self.assertEqual([req.rid for req in waiting_queue], [1, 3, 2, 4])
+        self.assertEqual(
+            [req.defer_for_in_batch_prefix_cache for req in waiting_queue],
+            [False, False, True, True],
+        )
 
     def test_calc_priority_priority_enabled_fcfs_scheduling(self):
         tree_cache = RadixCache.create_simulated()


### PR DESCRIPTION


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->