### PR TITLE
Fix speculative draft load format resolution (auto)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -808,20 +808,6 @@ class Scheduler(
             target_worker=self.tp_worker,
         )
 
-        if self.server_args.speculative_draft_load_format is not None:
-            # Write the draft load_format onto server_args (not just the bag):
-            # the draft worker is built from a copy of self.server_args and
-            # build_load_config reads server_args.load_format, so a bag-only
-            # override would be ignored and the draft would load in the target's
-            # format.
-            self.server_args.override(
-                "scheduler.draft_load_format",
-                load_format=self.server_args.speculative_draft_load_format,
-            )
-            logger.info(
-                f"Using draft model load_format: '{self.server_args.speculative_draft_load_format}'"
-            )
-
         DraftWorkerClass = self.spec_algorithm.create_worker(self.server_args)
         self.draft_worker = DraftWorkerClass(**draft_worker_kwargs)
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -287,6 +287,8 @@ class TpModelWorker(BaseTpWorker):
         context_length: Optional[int] = None,
     ):
         # Parse args
+        if is_draft_worker:
+            server_args = server_args.copy_for_draft_worker()
         self.server_args = server_args
         self.ps = ps
         self.gpu_id = gpu_id

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7067,9 +7067,7 @@ class ServerArgs:
             if requested_load_format == "auto"
             else requested_load_format
         )
-        draft_server_args.override(
-            "draft_worker.load_format", load_format=resolved_load_format
-        )
+        draft_server_args.load_format = resolved_load_format
         logger.info("Using draft model load_format: %r", resolved_load_format)
         return draft_server_args
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -28,6 +28,7 @@ import random
 import socket
 import tempfile
 import uuid
+from copy import deepcopy
 from functools import cached_property
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
@@ -6971,21 +6972,9 @@ class ServerArgs:
         )
 
         run_post_process_pass(self, _gguf_quantization)
-        if (
-            self.load_format == "auto" or self.load_format == "gguf"
-        ) and check_gguf_file(self.model_path):
-            self.load_format = "gguf"
-
-        if self.load_format == "auto" and self._is_mistral_native_format():
-            self.load_format = "mistral"
-            logger.info(
-                "Detected Mistral native format checkpoint, setting load_format='mistral'"
-            )
-
-        if is_runai_obj_uri(self.model_path):
-            self.load_format = "runai_streamer"
-        elif is_remote_url(self.model_path):
-            self.load_format = "remote"
+        self.load_format = self._resolve_load_format_for_model(
+            self.load_format, self.model_path
+        )
 
         if self.custom_weight_loader is None:
             self.custom_weight_loader = []
@@ -7047,7 +7036,44 @@ class ServerArgs:
                 "(--weight-cache-mode off) for this configuration."
             )
 
-    def _is_mistral_native_format(self) -> bool:
+    def _resolve_load_format_for_model(self, load_format: str, model_path: str) -> str:
+        if is_runai_obj_uri(model_path):
+            return "runai_streamer"
+        if is_remote_url(model_path):
+            return "remote"
+        if load_format in ("auto", "gguf") and check_gguf_file(model_path):
+            return "gguf"
+        if load_format == "auto" and self._is_mistral_native_format(model_path):
+            logger.info(
+                "Detected Mistral native format checkpoint, setting load_format='mistral'"
+            )
+            return "mistral"
+        return load_format
+
+    def copy_for_draft_worker(self) -> ServerArgs:
+        draft_server_args = deepcopy(self)
+        requested_load_format = draft_server_args.speculative_draft_load_format
+        if requested_load_format is None:
+            return draft_server_args
+
+        draft_model_path = (
+            draft_server_args.speculative_draft_model_path
+            or draft_server_args.model_path
+        )
+        resolved_load_format = (
+            draft_server_args._resolve_load_format_for_model(
+                requested_load_format, draft_model_path
+            )
+            if requested_load_format == "auto"
+            else requested_load_format
+        )
+        draft_server_args.override(
+            "draft_worker.load_format", load_format=resolved_load_format
+        )
+        logger.info("Using draft model load_format: %r", resolved_load_format)
+        return draft_server_args
+
+    def _is_mistral_native_format(self, model_path: str) -> bool:
         """True iff the checkpoint requires load_format=mistral.
 
         Looks for consolidated*.safetensors with no competing
@@ -7067,7 +7093,7 @@ class ServerArgs:
             "leanstral",
         )
         name_matches = any(
-            p in str(self.model_path).lower() for p in _MISTRAL_NATIVE_PATTERNS
+            p in str(model_path).lower() for p in _MISTRAL_NATIVE_PATTERNS
         )
 
         def _check_format(has_params, has_consolidated, has_hf_weights) -> bool:
@@ -7075,23 +7101,21 @@ class ServerArgs:
                 return True
             return has_consolidated and not has_hf_weights
 
-        if os.path.isdir(self.model_path):
+        if os.path.isdir(model_path):
             return _check_format(
-                has_params=os.path.exists(os.path.join(self.model_path, "params.json")),
+                has_params=os.path.exists(os.path.join(model_path, "params.json")),
                 has_consolidated=bool(
-                    glob.glob(
-                        os.path.join(self.model_path, "consolidated*.safetensors")
-                    )
+                    glob.glob(os.path.join(model_path, "consolidated*.safetensors"))
                 ),
                 has_hf_weights=bool(
-                    glob.glob(os.path.join(self.model_path, "model-*.safetensors"))
+                    glob.glob(os.path.join(model_path, "model-*.safetensors"))
                 ),
             )
 
         try:
             from huggingface_hub import HfApi
 
-            files = {s.rfilename for s in HfApi().model_info(self.model_path).siblings}
+            files = {s.rfilename for s in HfApi().model_info(model_path).siblings}
             return _check_format(
                 has_params="params.json" in files,
                 has_consolidated=any(

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1564,6 +1564,96 @@ class TestHandleCrashDumpEnv(CustomTestCase):
             )
 
 
+class TestDraftWorkerServerArgs(unittest.TestCase):
+    def _server_args(
+        self,
+        *,
+        target_load_format="runai_streamer",
+        draft_load_format=None,
+        target_model_path="s3://bucket/target",
+        draft_model_path="s3://bucket/draft",
+    ):
+        server_args = ServerArgs.__new__(ServerArgs)
+        server_args.load_format = target_load_format
+        server_args.speculative_draft_load_format = draft_load_format
+        server_args.model_path = target_model_path
+        server_args.speculative_draft_model_path = draft_model_path
+        return server_args
+
+    def test_unspecified_format_inherits_target_without_mutating_it(self):
+        server_args = self._server_args(draft_load_format=None)
+
+        draft_server_args = server_args.copy_for_draft_worker()
+
+        self.assertIsNot(draft_server_args, server_args)
+        self.assertEqual(draft_server_args.load_format, "runai_streamer")
+        self.assertEqual(server_args.load_format, "runai_streamer")
+
+    def test_explicit_format_only_updates_draft_copy(self):
+        server_args = self._server_args(draft_load_format="dummy")
+
+        draft_server_args = server_args.copy_for_draft_worker()
+
+        self.assertEqual(draft_server_args.load_format, "dummy")
+        self.assertEqual(server_args.load_format, "runai_streamer")
+
+    def test_auto_uses_runai_streamer_for_s3_draft(self):
+        server_args = self._server_args(draft_load_format="auto")
+
+        draft_server_args = server_args.copy_for_draft_worker()
+
+        self.assertEqual(draft_server_args.load_format, "runai_streamer")
+        self.assertEqual(server_args.load_format, "runai_streamer")
+
+    def test_auto_uses_remote_loader_for_http_draft(self):
+        server_args = self._server_args(
+            draft_load_format="auto",
+            draft_model_path="https://example.com/draft.safetensors",
+        )
+
+        draft_server_args = server_args.copy_for_draft_worker()
+
+        self.assertEqual(draft_server_args.load_format, "remote")
+
+    @patch("sglang.srt.server_args.check_gguf_file", return_value=True)
+    def test_auto_uses_gguf_loader_for_gguf_draft(self, _mock_check_gguf):
+        server_args = self._server_args(
+            draft_load_format="auto",
+            draft_model_path="/models/draft.gguf",
+        )
+
+        draft_server_args = server_args.copy_for_draft_worker()
+
+        self.assertEqual(draft_server_args.load_format, "gguf")
+
+    @patch.object(ServerArgs, "_is_mistral_native_format", return_value=True)
+    @patch("sglang.srt.server_args.check_gguf_file", return_value=False)
+    def test_auto_uses_mistral_loader_for_native_draft(
+        self, _mock_check_gguf, _mock_is_mistral
+    ):
+        server_args = self._server_args(
+            draft_load_format="auto",
+            draft_model_path="mistralai/native-draft",
+        )
+
+        draft_server_args = server_args.copy_for_draft_worker()
+
+        self.assertEqual(draft_server_args.load_format, "mistral")
+
+    @patch.object(ServerArgs, "_is_mistral_native_format", return_value=False)
+    @patch("sglang.srt.server_args.check_gguf_file", return_value=False)
+    def test_auto_stays_auto_for_local_draft(self, _mock_check_gguf, _mock_is_mistral):
+        server_args = self._server_args(
+            draft_load_format="auto",
+            draft_model_path="/models/draft",
+        )
+
+        draft_server_args = server_args.copy_for_draft_worker()
+
+        self.assertEqual(draft_server_args.load_format, "auto")
+        self.assertEqual(server_args.load_format, "runai_streamer")
+
+
 class TestGrpcServerArgs(CustomTestCase):
     """Native gRPC is enabled by --grpc-port (or SGLANG_GRPC_PORT) and runs
     alongside HTTP; --smg-grpc-mode (and the deprecated --grpc-mode) select the


### PR DESCRIPTION
## Motivation

`--speculative-draft-load-format auto` must be resolved against the draft model path. The target model may already have resolved `--load-format auto` to a target-specific loader such as `runai_streamer`, but that result must not be written into the draft configuration or reused for a different draft path.

Fixes #32202

## Modifications

- Remove the scheduler override that mutated the shared target `ServerArgs` for draft loading.
- Copy `ServerArgs` at the `TpModelWorker(is_draft_worker=True)` boundary.
- Resolve explicit draft `auto` on the draft copy using the draft path, with target-path fallback for bundled drafts.
- Keep unspecified draft format semantics: the draft copy inherits the target resolved format.
- Preserve explicit non-auto formats without URI-based rewriting.
- Add coverage for copy isolation, S3/RunAI, HTTP remote, GGUF, Mistral-native, local auto, and explicit formats.

## Accuracy Tests

Not applicable. This changes checkpoint loader selection only and does not modify model computation.

## Speed Tests and Profiling

Not applicable. The resolution runs once while constructing the draft worker.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Documentation is not required for this bug fix.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

## Testing

Added `TestDraftWorkerServerArgs` in `test/registered/unit/server_args/test_server_args.py` with unit coverage for:

- Inheriting the target load format when no draft format is specified, without mutating the target arguments.
- Preserving an explicit non-auto draft format on the draft copy only.
- Resolving explicit draft `auto` to `runai_streamer` for S3 paths.
- Resolving explicit draft `auto` to `remote`, `gguf`, or `mistral` for the corresponding draft paths.
- Keeping explicit draft `auto` unchanged for ordinary local checkpoints so the default loader can perform its normal auto detection.

Run the focused tests with:

`python3 -m pytest -q test/registered/unit/server_args/test_server_args.py -k TestDraftWorkerServerArgs`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
