### PR TITLE
[CI] Fix n-gram tensor equality test

### DIFF
--- a/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
@@ -110,9 +110,9 @@ class TestNgramTokenTableUpdate(CustomTestCase):
                 kwargs["tokens"], torch.tensor([101, 202, 303], dtype=torch.int32)
             )
         )
-        self.assertIs(kwargs["row_indices"], req_pool_indices)
-        self.assertIs(kwargs["column_starts"], info.out_column_starts)
-        self.assertIs(kwargs["req_lens"], info.out_req_lens)
+        self.assertTrue(torch.equal(kwargs["row_indices"], req_pool_indices))
+        self.assertTrue(torch.equal(kwargs["column_starts"], info.out_column_starts))
+        self.assertTrue(torch.equal(kwargs["req_lens"], info.out_req_lens))
         self.assertTrue(
             torch.equal(
                 info.out_column_starts, torch.tensor([11, 22, 33], dtype=torch.int32)


### PR DESCRIPTION
## Summary

- replace tensor object-identity assertions with tensor value-equality assertions in the LongCat n-gram token-table unit test
- align the existing test with the intentional `batch_size` slicing introduced by #31312

## Root cause

Slicing a PyTorch tensor returns a distinct tensor object even when the slice covers the entire tensor. The production code correctly passes `req_pool_indices[:batch_size]` and sliced output buffers, but the test used `assertIs`, causing equal-valued tensors to fail an object-identity check.

## Validation

- reproduced the original failure locally: `AssertionError: tensor([3, 4, 5]) is not tensor([3, 4, 5])`
- ran the complete `test_ngram_embedding_manager.py` file: 3 tests passed
- isort, ruff, black-jupyter, and commit hooks passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29930822826](https://github.com/sgl-project/sglang/actions/runs/29930822826)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29930819351](https://github.com/sgl-project/sglang/actions/runs/29930819351)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->