### PR TITLE
Stop MistralDetector deleting ']' from streamed prose

### DIFF
--- a/python/sglang/srt/function_call/mistral_detector.py
+++ b/python/sglang/srt/function_call/mistral_detector.py
@@ -38,7 +38,10 @@ class MistralDetector(BaseFormatDetector):
         self.bot_token = "[TOOL_CALLS] ["
         # Common marker shared by both JSON-array and compact formats.
         self._tool_calls_marker = "[TOOL_CALLS"
-        self.eot_token = "]"
+        # Intentionally leave eot_token as the base default (""). Mistral's
+        # tool-call array closes with "]", but that is a bare ASCII bracket that
+        # also appears constantly in ordinary prose, so it must never be used as
+        # a token to strip from flushed normal text (see parse_streaming_increment).
         self.tool_call_separator = ", "
 
     def has_tool_call(self, text: str) -> bool:
@@ -130,8 +133,10 @@ class MistralDetector(BaseFormatDetector):
             if not self._ends_with_partial_token(self._buffer, self._tool_calls_marker):
                 normal_text = self._buffer
                 self._buffer = ""
-                if self.eot_token in normal_text:
-                    normal_text = normal_text.replace(self.eot_token, "")
+                # This branch only runs when the buffer has no `[TOOL_CALLS`
+                # marker, so every character is genuine assistant prose. Flush it
+                # verbatim; do not strip "]" (see the eot_token note in __init__).
+                # The non-streaming detect_and_parse path likewise never strips.
                 return StreamingParseResult(normal_text=normal_text)
             return StreamingParseResult()
 

--- a/test/registered/unit/function_call/test_mistral_detector.py
+++ b/test/registered/unit/function_call/test_mistral_detector.py
@@ -217,6 +217,40 @@ class TestMistralDetector(CustomTestCase):
         params = json.loads(full_params)
         self.assertEqual(params["city"], "Tokyo")
 
+    def test_streaming_preserves_brackets_in_plain_prose(self):
+        # A closing bracket in ordinary prose must survive streaming untouched.
+        # Regression: the no-tool-call flush used to run
+        # normal_text.replace(self.eot_token, "") with eot_token == "]", which
+        # deleted every closing bracket ("a[i][j]" -> "a[i[j").
+        for text in (
+            "The list is items[0] and items[1] done.",
+            "See reference [1] and [2] for details.",
+            "Compute a[i][j] = b[k].",
+        ):
+            detector = MistralDetector()
+            streamed = ""
+            for i in range(0, len(text), 4):
+                streamed += detector.parse_streaming_increment(
+                    text[i : i + 4], self.tools
+                ).normal_text
+            self.assertEqual(streamed, text)
+
+    def test_streaming_bracket_prose_then_tool_call(self):
+        # Prose brackets are preserved AND a following real tool call still
+        # parses, with no stray "]" leaking into the normal text.
+        detector = MistralDetector()
+        text = 'Here is data[0]. [TOOL_CALLS]get_weather[ARGS]{"city": "Paris"}'
+        normal = ""
+        calls = []
+        for i in range(0, len(text), 3):
+            result = detector.parse_streaming_increment(text[i : i + 3], self.tools)
+            normal += result.normal_text
+            calls.extend(result.calls)
+        self.assertEqual(normal, "Here is data[0]. ")
+        func_calls = [c for c in calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "get_weather")
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
### Problem

`MistralDetector` sets `self.eot_token = "]"` and its streaming no-tool-call flush runs `normal_text.replace(self.eot_token, "")`. Every other detector's `eot_token` is a multi-character sentinel (`</tool_call>`, `<|call|>`, `<｜tool▁calls▁end｜>`, ...) that never occurs in prose, so that base-class strip is safe for them. With a bare `"]"` it deletes **every** closing bracket in ordinary assistant text, so streamed output is silently corrupted:

- `"a[i][j] = b[k]"` → `"a[i[j = b[k"`
- `"see reference [1] and [2]"` → `"see reference [1 and [2"`

### Root cause

`parse_streaming_increment`'s no-marker branch only runs when the buffer contains no `[TOOL_CALLS` marker, i.e. every character is genuine prose, yet it strips `"]"` from it. The non-streaming `detect_and_parse` path never strips `"]"`, so streaming and non-streaming disagreed.

### Fix

Flush normal text verbatim in that branch and drop the `eot_token = "]"` override (back to the base `""` default). A real tool-call bracket never reaches this branch, so nothing is lost; genuine tool calls still parse (verified).

### Test

Adds streaming regression tests for bracketed prose alone and bracketed prose followed by a real tool call. Both fail on the pre-fix code and pass with the fix.

cc @JustinTong0323

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29931646725](https://github.com/sgl-project/sglang/actions/runs/29931646725)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29931646265](https://github.com/sgl-project/sglang/actions/runs/29931646265)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->