### PR TITLE
Fix Triton SWA decode window dropping the oldest in-window key

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -438,6 +438,7 @@ class TritonAttnBackend(AttentionBackend):
                 token_to_kv_pool=self.token_to_kv_pool,
                 window_kv_indices=self.cuda_graph_window_kv_indices,
                 skip_full_to_swa_translation=(self._translate_kv_loc is not None),
+                include_current_token=True,
             )
         return kv_indptr, window_kv_indptr, window_kv_lens, num_kv_splits_lens
 
@@ -737,6 +738,7 @@ class TritonAttnBackend(AttentionBackend):
                             bs,
                             self.device,
                             self.token_to_kv_pool,
+                            include_current_token=True,
                         )
                     )
                     window_num_kv_splits = torch.empty(
@@ -1996,6 +1998,7 @@ def update_sliding_window_buffer(
     token_to_kv_pool=None,
     window_kv_indices=None,
     skip_full_to_swa_translation=False,
+    include_current_token=False,
 ):
     """Fill window KV buffers for sliding-window attention.
 
@@ -2010,10 +2013,25 @@ def update_sliding_window_buffer(
     ``init_forward_metadata_out_graph``, BEFORE ``graph.replay()``), which reads
     the live v2p and rewrites the static window buffer to swa-physical in place;
     baseline SWA leaves it False (eager).
+
+    ``include_current_token=True`` gathers ``sliding_window_size + 1`` tokens
+    instead of ``sliding_window_size``. ``sliding_window_size`` is stored as
+    ``config.sliding_window - 1`` (a radius), and the window is two-side
+    inclusive: a query at position ``p`` attends keys ``[p - sliding_window_size,
+    p]``, i.e. ``sliding_window_size + 1`` of them. The decode path passes this
+    because its kernel consumes the gathered window verbatim with no per-query
+    masking, so the buffer must already hold the exact window (this matches
+    FlashInfer's ``min(seq_lens, sliding_window_size + 1)`` and FlashAttention's
+    two-side-inclusive window). The extend / target-verify paths leave it False:
+    their kernels re-apply the window mask per query, so gathering the radius of
+    prior context tokens is correct there and a wider gather would be wrong.
     """
+    window_cap = (
+        sliding_window_size + 1 if include_current_token else sliding_window_size
+    )
     window_kv_lens = torch.minimum(
         seq_lens,
-        torch.tensor(sliding_window_size),
+        torch.tensor(window_cap),
     )
     window_kv_indptr[1 : bs + 1] = torch.cumsum(window_kv_lens, dim=0)
     window_kv_indptr = window_kv_indptr[: bs + 1]

--- a/test/registered/attention/test_triton_swa_window_len.py
+++ b/test/registered/attention/test_triton_swa_window_len.py
@@ -1,0 +1,114 @@
+"""Unit test: the Triton backend's sliding-window DECODE buffer must be
+two-side inclusive.
+
+``update_sliding_window_buffer`` is passed ``sliding_window_size =
+config.sliding_window - 1`` (a radius). The canonical window for a query at
+position ``p`` is ``[p - radius, p]``, i.e. ``radius + 1`` tokens -- this is what
+FlashInfer (``min(seq_lens, sliding_window_size + 1)``) and FlashAttention
+(two-side-inclusive ``(sliding_window_size, 0)``) produce. The Triton decode
+kernel consumes the gathered window verbatim with no per-query masking, so the
+buffer must already hold the full window.
+
+Regression: the helper capped the decode window at ``radius`` instead of
+``radius + 1``, silently dropping the oldest in-window key on every decode step
+past the window size (e.g. ``seq_len=5000, radius=4095`` kept keys ``[905, 4999]``
+and lost key ``904``). The extend / target-verify paths
+(``include_current_token=False``) re-mask per query and must keep the radius-only
+gather, so this test also pins that path unchanged.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.attention.triton_backend as tb
+from sglang.srt.layers.attention.triton_backend import update_sliding_window_buffer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class _CPUGatherKernel:
+    """CPU stand-in for the ``create_flashinfer_kv_indices_triton`` launch.
+
+    The GPU gather kernel is not launchable on a CPU-only runner; this double
+    performs the identical index copy so the helper's pure-torch window-length /
+    start-index math (the code under test) runs unchanged.
+    """
+
+    def __getitem__(self, grid):
+        def launch(
+            req_to_token,
+            req_pool_indices,
+            kv_lens,
+            kv_indptr,
+            kv_start,
+            kv_indices,
+            stride,
+        ):
+            for b in range(req_pool_indices.shape[0]):
+                s = int(kv_start[b])
+                n = int(kv_lens[b])
+                dst = int(kv_indptr[b])
+                req = int(req_pool_indices[b])
+                kv_indices[dst : dst + n] = req_to_token[req, s : s + n]
+
+        return launch
+
+
+def _run(seq_len, radius, include_current_token):
+    bs = 1
+    max_ctx = seq_len + 8
+    # Identity req_to_token so a gathered kv loc equals its token position.
+    req_to_token = torch.arange(bs * max_ctx, dtype=torch.int32).reshape(bs, max_ctx)
+    req_pool_indices = torch.zeros(bs, dtype=torch.int64)
+    seq_lens = torch.tensor([seq_len], dtype=torch.int64)
+    window_kv_indptr = torch.zeros(bs + 1, dtype=torch.int64)
+    with patch.object(tb, "create_flashinfer_kv_indices_triton", _CPUGatherKernel()):
+        _, indices, lens, start = update_sliding_window_buffer(
+            window_kv_indptr,
+            req_to_token,
+            radius,
+            seq_lens,
+            req_pool_indices,
+            bs,
+            device=torch.device("cpu"),
+            include_current_token=include_current_token,
+        )
+    return int(lens[0]), int(start[0]), indices.tolist()
+
+
+class TestTritonSwaWindowLen(CustomTestCase):
+    RADIUS = 4095  # config.sliding_window = 4096
+
+    def test_decode_window_is_two_side_inclusive(self):
+        # Matches FlashInfer's min(seq_lens, sliding_window_size + 1).
+        for seq_len in (4096, 4097, 5000):
+            length, start, indices = _run(
+                seq_len, self.RADIUS, include_current_token=True
+            )
+            self.assertEqual(length, min(seq_len, self.RADIUS + 1))
+            self.assertEqual(start, seq_len - length)
+            oldest = seq_len - 1 - self.RADIUS
+            self.assertIn(oldest, indices)  # the key the old code dropped
+            self.assertEqual(indices[-1], seq_len - 1)  # current token retained
+
+    def test_decode_window_no_clip_below_window(self):
+        # No change when the sequence is at/under the window size.
+        for seq_len in (1, 100, 4095):
+            length, start, _ = _run(seq_len, self.RADIUS, include_current_token=True)
+            self.assertEqual(length, seq_len)
+            self.assertEqual(start, 0)
+
+    def test_extend_path_keeps_radius_only(self):
+        # include_current_token=False (extend / target-verify) must NOT widen:
+        # those kernels re-mask per query, so the radius-only gather is correct.
+        length, start, _ = _run(5000, self.RADIUS, include_current_token=False)
+        self.assertEqual(length, self.RADIUS)
+        self.assertEqual(start, 5000 - self.RADIUS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem

`update_sliding_window_buffer` (Triton attention backend) caps the sliding-window **decode** buffer at `sliding_window_size` tokens. But `sliding_window_size` is stored as `config.sliding_window - 1` (a radius, e.g. `gemma2.py:52-53`), and the window is two-side inclusive: a query at position `p` attends keys `[p - sliding_window_size, p]`, i.e. `sliding_window_size + 1` of them. The Triton decode kernel (`_fwd_kernel` in `decode_attention.py`) consumes the gathered window verbatim with **no per-query masking**, so the buffer must already hold the full window.

The other two backends agree on `sliding_window_size + 1`:
- FlashInfer decode: `torch.clamp(seq_lens, max=self.sliding_window_size + 1)` (`flashinfer_backend.py`)
- FlashAttention: `(sliding_window_size, 0)`, two-side inclusive (`flashattention_backend.py`)

The Triton path is one token short, so on **every** decode step past the window size it silently drops the oldest in-window key. Example `seq_len=5000`, `config.sliding_window=4096`: it keeps keys `[905, 4999]` and loses key `904`. This degrades attention quality (no crash) for every SWA-layer model on the Triton backend (Gemma2 / Gemma3 / Gemma3n / exaone4 / afmoe, ...), in both the eager and cuda-graph decode paths.

### Fix

Gate the extra token behind `include_current_token` and pass it only from the two decode call sites (eager + cuda-graph). The extend / target-verify paths re-apply the window mask per query in their kernels, so their radius-only gather is correct and stays unchanged.

### Test

Adds a CPU unit test pinning the two-side-inclusive decode window (and the radius-only extend/target-verify gather) against the FlashInfer formula. It drives the real helper (the GPU gather kernel is replaced with an equivalent CPU copy so the pure-torch window math runs on a CPU runner). Reverting the `+ 1` turns it red (`4095 != 4096`).

cc @yizhang2077 @Fridge003 @ispobock

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29931669578](https://github.com/sgl-project/sglang/actions/runs/29931669578)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29931671710](https://github.com/sgl-project/sglang/actions/runs/29931671710)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->