### PR TITLE
Fix Llama32Detector dropping the first char of trailing text

### DIFF
--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -50,6 +50,23 @@ class Llama32Detector(BaseFormatDetector):
         # prefix the output with the <|python_tag|> token
         return "<|python_tag|>" in text or text.startswith("{")
 
+    def _skip_tool_call_separator(self, text: str, idx: int) -> int:
+        """Advance ``idx`` past a ``tool_call_separator`` if one immediately
+        follows (after optional whitespace); otherwise leave ``idx`` untouched.
+
+        Between two tool calls the model emits ``};{`` and the separator must be
+        consumed. But when plain prose follows the final tool call there is no
+        separator, and unconditionally adding ``len(tool_call_separator)`` would
+        skip into the trailing text and drop its first character
+        (``"{...}Some note"`` -> ``"ome note"``).
+        """
+        rest = text[idx:]
+        stripped = rest.lstrip()
+        if stripped.startswith(self.tool_call_separator):
+            leading_ws = len(rest) - len(stripped)
+            return idx + leading_ws + len(self.tool_call_separator)
+        return idx
+
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         """Parse function calls from text, handling multiple JSON objects."""
         if "<|python_tag|>" not in text and not text.startswith("{"):
@@ -69,7 +86,7 @@ class Llama32Detector(BaseFormatDetector):
             try:
                 obj, end = decoder.raw_decode(action_text[idx:])
                 all_actions.append(obj)
-                idx += end + len(self.tool_call_separator)
+                idx = self._skip_tool_call_separator(action_text, idx + end)
                 safe_idx = idx
             except json.JSONDecodeError:
                 # Try Python dict conversion as fallback
@@ -91,7 +108,7 @@ class Llama32Detector(BaseFormatDetector):
                         if json_version != potential_dict:
                             obj, _ = decoder.raw_decode(json_version)
                             all_actions.append(obj)
-                            idx = dict_end + len(self.tool_call_separator)
+                            idx = self._skip_tool_call_separator(action_text, dict_end)
                             safe_idx = idx
                             continue
                 except:

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -108,6 +108,30 @@ class TestLlama32Detector(CustomTestCase):
         self.assertEqual(args["city"], "London")
         self.assertEqual(args["unit"], "celsius")
 
+    def test_trailing_text_after_tool_call_is_preserved(self):
+        # Prose after the tool call has no ";" separator; the parser used to
+        # unconditionally skip len(tool_call_separator) and drop the first
+        # character ("}}Some note" -> "ome note").
+        text = (
+            '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Beijing"}}'
+            "Some trailing note."
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.normal_text, "Some trailing note.")
+
+    def test_trailing_text_after_multiple_tool_calls_is_preserved(self):
+        text = (
+            '<|python_tag|>{"name": "get_weather", "arguments": {"city": "Beijing"}}'
+            ';{"name": "search", "arguments": {"query": "food"}}'
+            "Done."
+        )
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(result.calls[1].name, "search")
+        self.assertEqual(result.normal_text, "Done.")
+
     # ==================== Python dict conversion Tests ====================
 
     def test_convert_python_dict_to_json(self):


### PR DESCRIPTION
### Problem

`Llama32Detector.detect_and_parse` advances the cursor with `idx += end + len(tool_call_separator)` after each decoded tool call, assuming a `;` separator always follows. When plain prose follows the final tool call there is no separator, so the cursor moves one character into the trailing text and drops its first character:

```
'<|python_tag|>{"name": "get_weather", "arguments": {}}Some note'
```
parses the call but returns `normal_text == 'ome note'`. The Python-dict fallback path (`idx = dict_end + len(tool_call_separator)`) has the same unconditional advance.

### Fix

Consume the separator only when it actually follows (after optional whitespace); otherwise leave the cursor at the end of the tool call so trailing normal text is preserved verbatim. Multi-call parsing is unchanged because the separator is present between calls (`test_multiple_json_objects` still passes).

### Test

Adds regression tests for trailing text after one and after multiple tool calls. Both fail on the pre-fix code (`'ome trailing note.' != 'Some trailing note.'`) and pass with the fix; all 15 existing tests stay green.

Relates to the tool-parser trailing-text data-loss class in #31915. cc @JustinTong0323

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29931692874](https://github.com/sgl-project/sglang/actions/runs/29931692874)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29931691478](https://github.com/sgl-project/sglang/actions/runs/29931691478)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->