### PR TITLE
[CI] Fix failures on main

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -92,6 +92,7 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
     get_parallel,
+    get_server_args,
     get_stream,
 )
 

--- a/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py
@@ -110,9 +110,9 @@ class TestNgramTokenTableUpdate(CustomTestCase):
                 kwargs["tokens"], torch.tensor([101, 202, 303], dtype=torch.int32)
             )
         )
-        self.assertIs(kwargs["row_indices"], req_pool_indices)
-        self.assertIs(kwargs["column_starts"], info.out_column_starts)
-        self.assertIs(kwargs["req_lens"], info.out_req_lens)
+        self.assertTrue(torch.equal(kwargs["row_indices"], req_pool_indices))
+        self.assertTrue(torch.equal(kwargs["column_starts"], info.out_column_starts))
+        self.assertTrue(torch.equal(kwargs["req_lens"], info.out_req_lens))
         self.assertTrue(
             torch.equal(
                 info.out_column_starts, torch.tensor([11, 22, 33], dtype=torch.int32)


### PR DESCRIPTION
## Summary

- import `get_server_args` in the Qwen3.5 model to resolve the Ruff `F821` failure on `main`
- replace tensor object-identity assertions with value-equality assertions in the LongCat n-gram token-table unit test
- carry the test correction from the closed PR [#32083](https://github.com/sgl-project/sglang/pull/32083) into this PR

## Root causes

The fused all-reduce quantization gate added in [#24651](https://github.com/sgl-project/sglang/pull/24651) referenced `get_server_args` without importing it from `sglang.srt.runtime_context`.

Separately, the intentional `batch_size` slicing added in [#31312](https://github.com/sgl-project/sglang/pull/31312) returns distinct PyTorch tensor objects even when the slice covers the entire tensor. The n-gram unit test still used `assertIs`, so equal-valued tensors failed its object-identity checks.

## Impact

This restores a clean pre-commit lint run and fixes the failing n-gram unit test without changing production behavior.

## Validation

- `python3 registered/unit/model_executor/model_runner_components/test_ngram_embedding_manager.py` from `test/`: 3 tests passed
- `pre-commit run --all-files`: all hooks passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29932605687](https://github.com/sgl-project/sglang/actions/runs/29932605687)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29932605809](https://github.com/sgl-project/sglang/actions/runs/29932605809)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
