### PR TITLE
Fix get_server_args import lint error

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -92,6 +92,7 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
     get_parallel,
+    get_server_args,
     get_stream,
 )
 


### PR DESCRIPTION
## Motivation

`qwen3_5.py:181` calls `get_server_args()` without importing it (introduced in https://github.com/sgl-project/sglang/pull/24651), which breaks `ruff` on main (`F821 Undefined name 'get_server_args'`) and would raise `NameError` at runtime on the aiter all-reduce fusion path. Add it to the existing `sglang.srt.runtime_context` import block.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29936091959](https://github.com/sgl-project/sglang/actions/runs/29936091959)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29936089743](https://github.com/sgl-project/sglang/actions/runs/29936089743)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->