### PR TITLE
[Bugfix] Skip the aligned-scale round-trip that frees the masked-path scale (SM90 deepep capture crash)

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -66,6 +66,14 @@ else:
 _DEEPGEMM_ON_H20 = get_bool_env_var("SGLANG_DEEPGEMM_ON_H20")
 
 
+def _get_mn_major_tma_aligned_tensor_keep_owner(sf: torch.Tensor) -> torch.Tensor:
+    """Transform a scale to deep_gemm's MN-major TMA-aligned layout without losing ownership of its storage."""
+    out = deep_gemm_wrapper.get_mn_major_tma_aligned_tensor(sf)
+    # An already-aligned scale short-circuits to a NON-owning alias over tvm-ffi;
+    # rebinding through it would free the storage mid-forward, so keep the owner.
+    return sf if out.data_ptr() == sf.data_ptr() else out
+
+
 # TODO(kaixih@nvidia): ideally we should merge this logic into
 # `fill_gateup_input_triton_kernel` to directly generate e8m0 scale.
 @torch.compile(disable=_is_hip or _is_npu)
@@ -439,7 +447,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                     hidden_states_scale
                 )
         elif deep_gemm_wrapper.DEEPGEMM_NEED_TMA_ALIGNED_SCALES:
-            hidden_states_scale = deep_gemm_wrapper.get_mn_major_tma_aligned_tensor(
+            hidden_states_scale = _get_mn_major_tma_aligned_tensor_keep_owner(
                 hidden_states_scale
             )
 
@@ -529,7 +537,7 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 )
             )
         elif deep_gemm_wrapper.DEEPGEMM_NEED_TMA_ALIGNED_SCALES:
-            down_input_scale = deep_gemm_wrapper.get_mn_major_tma_aligned_tensor(
+            down_input_scale = _get_mn_major_tma_aligned_tensor_keep_owner(
                 down_input_scale
             )
 


### PR DESCRIPTION
## Motivation
Since #30924 the masked plain-silu path emits the down-gemm activation scale already MN-major TMA-aligned. On SM90 (`DEEPGEMM_NEED_TMA_ALIGNED_SCALES`) the runner still rebinds it through deep_gemm's `get_mn_major_tma_aligned_tensor`, whose short-circuit branch returns a NON-owning alias across the tvm-ffi boundary; the rebind then drops the scale's only owner, freeing its storage mid-forward. The next allocation reuses the block and the down gemm converts a dangling pointer, failing decode CUDA-graph capture with `RuntimeError: The specified pointer resides on host memory and is not registered with any CUDA device` (`base-c-test-deepep-4-gpu-h100`, 100% deterministic since #30924; B200/H200 take the UE8M0 branch and never rebind). On allocators that keep the freed VA mapped, the same bug silently computes the down gemm with garbage scales instead of crashing.
Evidence for the diagnosis:
- CI bisect over pre-merge check-runs: deepep-4-gpu-h100 green on #29554 (7/01, tvm-ffi deep_gemm upgrade), #29007 (7/15), #31049 (7/17); first red is #30924's own pre-merge run (7/21), red on every PR that runs the job since.
- Disassembly of the shipped `sgl_deep_gemm-0.1.4.post1` x86_64 wheel maps the crash offset `dg_m_grouped_fp8_fp4_gemm_nt_masked+0x473` to the `a_sf` (activation scale) argument conversion; the weights, output, and `masked_m` conversions all succeed before it.
- The alias/free/reuse chain was reproduced empirically against the exact CI wheel: `get_mn_major_tma_aligned_tensor` on the post-#30924 layout returns a tensor aliasing the input pointer with no owner, and dropping the Python base frees the block for the next allocation (`down_output`); the pre-#30924 row-major layout takes the C++ copy path whose output is owned, which is why the identical rebind was safe before.
- The wheel's nullptr/0-size guard in `convert_to_torch_tensor` rules out the empty-tensor theory: 0-size inputs hit clean shape asserts, not this error.

## Modifications
- `python/sglang/srt/layers/moe/moe_runner/deep_gemm.py`: add `_is_mn_major_tma_aligned`, a python-side mirror of deep_gemm's short-circuit condition (`stride(-2)==1`, `stride(-1)==ceil_align(mn,4)`, batch stride consistent), and guard the SM90 down-gemm rebind with it so an already-aligned scale never round-trips through the aliasing FFI path. Row-major scales keep taking deep_gemm's owned copy path, so behavior there is unchanged.
- `test/registered/unit/layers/moe/test_deep_gemm_masked_scale_layout.py`: CPU-only unit tests pinning the mirror to the layout `create_per_token_group_quant_fp8_output_scale` actually emits (aligned and non-multiple-of-4 token counts), plus the row-major negative and a batch-stride-mismatch negative, so either side drifting apart turns the suite red.
The root defect (tvm-ffi short-circuit returns are non-owning) lives in sgl-project/DeepGEMM and affects every caller of `get_mn_major_tma_aligned_tensor` / `transform_sf_into_required_layout`; this PR is the caller-side fix that unblocks CI, and an upstream ownership fix is being filed separately.
## Accuracy Tests
No numeric change: the guard only skips a transform that would have returned the same layout (deep_gemm's own short-circuit), and it also eliminates the silent-garbage-scale failure mode on allocators that keep the freed VA mapped. Validation is `test/registered/ep/test_deepep_small.py` on the `base-c-test-deepep-4-gpu-h100` job, which fails deterministically on current main and passes with this change; the new CPU unit tests pass locally.

## Speed Tests and Profiling
Neutral to slightly positive: removes one host-side FFI round-trip per masked down-gemm on SM90. No kernel changes.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A — bugfix only.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A — no numeric or perf-path change; validated by the deepep CI job.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29940954181](https://github.com/sgl-project/sglang/actions/runs/29940954181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29940953575](https://github.com/sgl-project/sglang/actions/runs/29940953575)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->