### PR TITLE
[AMD] Fix gfx950 DSA prefill context-parallel RoPE ordering (corrupted KV, garbled output)

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -537,6 +537,18 @@ class DeepseekMLAForwardMixin:
 
         dsa_prefill_cp = dsa_use_prefill_cp(forward_batch)
         mla_prefill_cp = mla_use_prefill_cp(forward_batch)
+        if (
+            dsa_prefill_cp
+            and skip_rope_for_dsa_tilelang_fused
+            and self.rotary_emb is not None
+        ):
+            # gfx950 DSA-CP: the fused rope+cache kernel ropes q and the
+            # (gathered) full K with one positions array, but under CP q is the
+            # local round-robin shard while K is gathered to the full sequence,
+            # so the local positions cannot rope the full K. Rope q/k here with
+            # the local positions (each token by its own global position) before
+            # the gather, then take the non-fused attention branch in core.
+            q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
         defer_kv_gather_until_after_rope = _should_defer_dsa_cp_kv_gather(
             dsa_prefill_cp=dsa_prefill_cp,
             fuse_rope_for_trtllm_mla=fuse_rope_for_trtllm_mla,
@@ -607,7 +619,11 @@ class DeepseekMLAForwardMixin:
         save_kv_cache = True
 
         if self.current_attention_backend in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS:
-            if self._skip_rope_for_dsa_tilelang_fused() and self.rotary_emb is not None:
+            if (
+                self._skip_rope_for_dsa_tilelang_fused()
+                and self.rotary_emb is not None
+                and not dsa_use_prefill_cp(forward_batch)
+            ):
                 cos = self.rotary_emb.cos_cache
                 sin = self.rotary_emb.sin_cache
                 kv_cache_dtype = (


### PR DESCRIPTION
On gfx950 (MI355X), DSA prefill with context parallelism produces degenerate output while the non-CP path is coherent for the same prompt. I traced it to the order of RoPE vs the CP KV gather on the tilelang fused MLA path.

Under CP the latent KV is gathered from each rank's local round-robin shard into the full sequence (`rebuild_cp_kv_cache`) and only then is RoPE applied. On gfx950 the MLA core takes the fused `fused_qk_rope_cat_and_cache_mla` branch, which ropes q and the already-gathered full K with one `positions` array. The problem: q is still the local shard (seq/cp tokens) while K is the full sequence, and `positions` only covers the local tokens, so every gathered K row past the local shard gets the wrong rotary phase. That corrupted K is written to the cache and read back at decode, which is the repetition collapse.

The existing deferral logic doesn't catch this. `_should_defer_dsa_cp_kv_gather` only returns true for the Hopper/trtllm path (`fuse_rope_for_trtllm_mla`), never for the gfx950 tilelang fused path, so on gfx950 the CP gather always happens before RoPE.

The fix is in two places, both gated on `dsa_prefill_cp` and the gfx950 tilelang fused path so nothing else changes:

- In `forward_absorb_prepare`, rope the local q/k with the local positions before `rebuild_cp_kv_cache`. The local round-robin positions are each rank's true global positions, so every local token gets the right phase before the gather, and the reconstructed full K comes out correctly roped.
- In `forward_absorb_core`, keep CP out of the fused rope+cache branch and use the existing non-fused `attn_mqa(..., q_rope=q_pe, k_rope=k_pe)` path, which writes the already-roped full K and runs sparse attention with the local roped q.

Non-CP execution and the Hopper/trtllm deferred path are untouched.

Validation on MI355X (gfx950), GLM-5.2-FP8, `--enable-prefill-cp --cp-strategy interleave --disable-radix-cache`, from a clean source build (sglang cb324cc, aiter 155fb21) with the patched files confirmed as the ones loaded:

- Before: CP is degenerate where non-CP is coherent. "In 1969, the first humans landed on the Moon" collapses into " 2010, the 2010, the ...". After: coherent and on-topic, tracking the non-CP baseline.
- Deterministic input: CP first-8 output ids are byte-identical to non-CP at 131072 / 262144 / 524288 (cp8), and at 128k / 256k (cp4). Exact, not just within bf16 noise.
- With CP correct, the long-context TTFT win shows up. cp8 vs non-CP TP8: 1.20x at 128k, 1.48x at 256k, 2.23x at 512k (warmed, radix off). Decode TPOT is ~1.4-1.7x higher under CP since decode isn't context-parallel, so this helps long-context prefill, not decode.
- 1M doesn't fit on this from-source build: holding a 1M KV pool leaves too little for the DSA indexer's ~O(N^2) prefill working set and OOMs, and lowering mem-fraction drops the pool below 1M. Largest sustained cp8 context is 512k, token-exact. (An earlier run on the smaller-footprint v0.5.15 image measured 1M cp8 TTFT 95.33s, but that no longer fits on the newer build.)
- Regression: the branch is gated on `dsa_prefill_cp`, so the non-CP path is unchanged. Non-CP decode TPOT and prefill throughput match an unpatched build within noise, 128k output ids match, and decode CUDA graph capture completes on both.