### PR TITLE
[MLX] Add Gemma 4 E2B text generation with native caches

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -57,6 +57,7 @@ from sglang.srt.utils.common import (
     is_xpu,
     xpu_has_xmx_support,
 )
+from sglang.srt.utils.tensor_bridge import use_mlx
 
 logger = logging.getLogger(__name__)
 
@@ -707,7 +708,12 @@ def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
 )
 def _gemma4_overrides(server_args: Any, hf_config: Any) -> dict:
     overrides: Dict[str, Any] = {}
-    default_attention_backend = "trtllm_mha" if is_sm100_supported() else "triton"
+    if use_mlx():
+        # The MLX runner owns attention execution; torch_native keeps generic
+        # scheduler allocation on its portable PyTorch path.
+        default_attention_backend = "torch_native"
+    else:
+        default_attention_backend = "trtllm_mha" if is_sm100_supported() else "triton"
     if server_args.is_attention_backend_not_set():
         logger.info(
             f"Use {default_attention_backend} as default attention backend for Gemma4"

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -38,6 +38,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_sparse_attention_config,
 )
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
+from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
@@ -308,6 +309,15 @@ class ModelConfig:
         )
 
         # Set enable_multimodal
+        model_arch = self.hf_config.architectures[0]
+        is_mlx_text_only_model = (
+            use_mlx() and model_arch == "Gemma4ForConditionalGeneration"
+        )
+        if is_mlx_text_only_model and enable_multimodal:
+            raise NotImplementedError(
+                "Gemma 4 multimodal inputs are not supported by the MLX backend yet. "
+                "Remove --enable-multimodal to use the text-only prototype."
+            )
         if enable_multimodal is None:
             mm_disabled_models = [
                 "Gemma3ForConditionalGeneration",
@@ -315,8 +325,15 @@ class ModelConfig:
                 "Step3VLForConditionalGeneration",
                 "InklingForConditionalGeneration",
             ]
-            if (
-                self.hf_config.architectures[0] in mm_disabled_models
+            if is_mlx_text_only_model:
+                enable_multimodal = False
+                logger.info(
+                    "Multimodal is disabled for %s on the MLX backend; "
+                    "the initial Gemma 4 Apple Silicon path is text-only.",
+                    self.hf_config.model_type,
+                )
+            elif (
+                model_arch in mm_disabled_models
                 and self.model_impl != ModelImpl.TRANSFORMERS
             ):
                 enable_multimodal = False

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -111,6 +111,38 @@ _MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
 }
 _MLX_KV_FLOAT_DTYPES = {mx.float16, mx.bfloat16, mx.float32}
 
+# Gemma 4's mlx-lm cache contract cannot yet be represented by SGLang's
+# uniform attention pool.  In particular, it combines per-layer sliding
+# windows, heterogeneous head dimensions, and YOCO layers that reuse K/V from
+# earlier layers (and therefore do not own cache entries).  Keep the initial
+# support narrow and correctness-first: let mlx-lm own those caches until the
+# SGLang pool grows the corresponding per-layer metadata.
+_NATIVE_CACHE_FALLBACK_MODEL_TYPES = frozenset({"gemma4", "gemma4_text"})
+_NATIVE_CACHE_FALLBACK_DEFAULT_POOL_SIZE = 2048
+
+
+def _mlx_model_type(model: Any) -> str | None:
+    """Return the mlx-lm model type from a text or conditional wrapper."""
+    for candidate in (model, getattr(model, "language_model", None)):
+        if candidate is None:
+            continue
+        model_type = getattr(candidate, "model_type", None)
+        if model_type:
+            return str(model_type)
+        args = getattr(candidate, "args", None)
+        model_type = getattr(args, "model_type", None)
+        if model_type:
+            return str(model_type)
+    return None
+
+
+def _mlx_text_model_args(model: Any) -> Any | None:
+    """Return the text-backbone args, unwrapping mlx-lm's Gemma 4 shell."""
+    language_model = getattr(model, "language_model", None)
+    if language_model is not None and getattr(language_model, "args", None) is not None:
+        return language_model.args
+    return getattr(model, "args", None)
+
 
 class MlxModelRunner:
     """MLX model runner with radix-cache prefix sharing."""
@@ -140,6 +172,17 @@ class MlxModelRunner:
 
         self._load_model()
 
+        self._native_cache_fallback = (
+            _mlx_model_type(self.model) in _NATIVE_CACHE_FALLBACK_MODEL_TYPES
+        )
+        if self._native_cache_fallback and not self.disable_radix_cache:
+            raise NotImplementedError(
+                "Gemma 4 on the MLX backend currently requires "
+                "--disable-radix-cache. Its YOCO sharing, mixed head dimensions, "
+                "and sliding-window cache cannot be represented by the uniform "
+                "SGLang MLX radix pool yet."
+            )
+
         # Pin MLX allocations to prevent OS paging
         device_info = mx.device_info()
         max_wired = int(device_info.get("max_recommended_working_set_size", 0))
@@ -147,7 +190,13 @@ class MlxModelRunner:
             mx.set_wired_limit(max_wired)
             logger.info(f"Wired memory limit set to {max_wired / (1024**3):.1f} GB")
 
-        patch_model_attention(self.model)
+        if self._native_cache_fallback:
+            logger.info(
+                "Using mlx-lm native caches for Gemma 4 text generation "
+                "(radix reuse and batched attention are disabled)"
+            )
+        else:
+            patch_model_attention(self.model)
 
         layer_list, attn_attrs = find_attention_layers(self.model)
         self._cache_layout = MlxModelCacheLayout.from_attention_discovery(
@@ -162,7 +211,7 @@ class MlxModelRunner:
             raise RuntimeError(
                 "MLX models with auxiliary cache state require model.make_cache()."
             )
-        if self._cache_layout.has_auxiliary_state:
+        if self._cache_layout.has_auxiliary_state and not self._native_cache_fallback:
             self._model_embed, self._model_norm, self._model_lm_head = (
                 self._extract_model_components()
             )
@@ -189,6 +238,8 @@ class MlxModelRunner:
 
     def _new_cache_skeleton(self) -> list[Any]:
         """Create a model-shaped cache list before attention cache wiring."""
+        if self.native_cache_fallback:
+            return list(self.model.make_cache())
         if self._cache_layout.has_auxiliary_state:
             cache = self.model.make_cache()
             if len(cache) != self._cache_layout.num_layers:
@@ -203,12 +254,16 @@ class MlxModelRunner:
     def _new_native_cache(self) -> list[Any]:
         """Create a model-shaped cache list with attention KV adapters."""
         cache = self._new_cache_skeleton()
+        if self.native_cache_fallback:
+            return cache
         for layer_idx in self._cache_layout.attention_layer_indices:
             cache[layer_idx] = ContiguousAttentionKVCache(max_seq_len=self._max_seq_len)
         return cache
 
     def _acquire_cache(self) -> list[Any]:
         """Get a reusable cache list from the pool, or create a new one."""
+        if self.native_cache_fallback:
+            return self._new_native_cache()
         if not self._cache_layout.has_auxiliary_state and self._cache_pool:
             cache = self._cache_pool.pop()
             for c in cache:
@@ -218,6 +273,8 @@ class MlxModelRunner:
 
     def _release_cache(self, cache: list[Any]) -> None:
         """Return a cache list to the pool for reuse."""
+        if self.native_cache_fallback:
+            return
         if not self._cache_layout.has_auxiliary_state:
             self._cache_pool.append(cache)
 
@@ -550,6 +607,27 @@ class MlxModelRunner:
         """Determine pool slot count (auto-size from available memory if needed)."""
         if explicit_size is not None:
             return explicit_size
+        if self.native_cache_fallback:
+            # Native caches grow per request and do not allocate an SGLang KV
+            # pool.  The scheduler still needs a finite token capacity for its
+            # CPU-side slot allocator. Keep the prototype default conservative:
+            # Gemma 4 advertises a 131k context, which would otherwise combine
+            # with the generic request-count default to allocate a very large
+            # CPU ReqToTokenPool. Production launches can raise this explicitly
+            # with --max-total-tokens.
+            args = _mlx_text_model_args(self.model)
+            context_len = int(getattr(args, "max_position_embeddings", 4096))
+            pool_size = min(
+                context_len,
+                _NATIVE_CACHE_FALLBACK_DEFAULT_POOL_SIZE,
+            )
+            logger.info(
+                "Using conservative native-cache scheduler capacity: %d tokens "
+                "(model context=%d; override with --max-total-tokens)",
+                pool_size,
+                context_len,
+            )
+            return pool_size
         n_kv_heads, head_dim, dtype = self._get_attn_config()
         num_layers = self._cache_layout.num_attention_layers
         sys_available = psutil.virtual_memory().available
@@ -579,8 +657,15 @@ class MlxModelRunner:
     def pool_size(self) -> int:
         return self._pool_size
 
+    @property
+    def native_cache_fallback(self) -> bool:
+        """Whether inference uses model-owned caches instead of SGLang's pool."""
+        return getattr(self, "_native_cache_fallback", False)
+
     def _build_aot_kernels(self) -> MlxAOTKernelSet:
         """Build model-level set of optional registered AOT kernels."""
+        if self.native_cache_fallback:
+            return MlxAOTKernelSet()
         if self._cache_layout.num_attention_layers == 0:
             return MlxAOTKernelSet()
         layer_idx = self._cache_layout.first_attention_layer_index
@@ -1167,7 +1252,12 @@ class MlxModelRunner:
         last_tokens = [self._req_token_ids[rid][-1] for rid in req_ids]
         batched_input = mx.array(last_tokens, dtype=mx.int32)[:, None]
 
-        if self._cache_layout.has_auxiliary_state:
+        if self.native_cache_fallback:
+            lazy_tokens = self._decode_with_native_cache(
+                caches,
+                [batched_input[i : i + 1] for i in range(len(caches))],
+            )
+        elif self._cache_layout.has_auxiliary_state:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, list(req_ids)
             )
@@ -1212,7 +1302,12 @@ class MlxModelRunner:
         # So layer-0 offsets reflect the position the NEW token will
         # be written at in step N+1 (and equivalently the RoPE offset).
         batched_input = prev.lazy_tokens[:, None]
-        if self._cache_layout.has_auxiliary_state:
+        if self.native_cache_fallback:
+            lazy_tokens = self._decode_with_native_cache(
+                caches,
+                [batched_input[i : i + 1] for i in range(len(caches))],
+            )
+        elif self._cache_layout.has_auxiliary_state:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, prev.req_ids
             )

--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -105,8 +105,15 @@ class MlxModelRunnerStub(ModelRunner):
     # that path working instead of raising AttributeError.
     prefill_aware_swa = False
 
-    def __init__(self, *args, mlx_pool_size: int | None = None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        mlx_pool_size: int | None = None,
+        mlx_native_cache_fallback: bool = False,
+        **kwargs,
+    ):
         self._mlx_pool_size = mlx_pool_size
+        self._mlx_native_cache_fallback = mlx_native_cache_fallback
         super().__init__(*args, **kwargs)
 
     def load_model(self):
@@ -167,9 +174,25 @@ class MlxModelRunnerStub(ModelRunner):
         requested = get_schedule().max_running_requests
         if requested is None:
             requested_per_worker = None
-            resolved = min(capacity_cap, 4096)
+            # The initial Gemma 4 path executes each request through its own
+            # model-native cache rather than SGLang's batched attention path.
+            # Default to one live request so a 131k advertised context does not
+            # create a needlessly large CPU ReqToTokenPool. Users can opt into
+            # more independent requests with --max-running-requests.
+            default_max_requests = (
+                1 if getattr(self, "_mlx_native_cache_fallback", False) else 4096
+            )
+            resolved = min(capacity_cap, default_max_requests)
         else:
-            requested_per_worker = requested // self.dp_size
+            # Match the canonical KV-cache resolver: requests are split only
+            # across attention-DP workers. Pure data-parallel replicas each
+            # need the full local limit.
+            attn_dp_size = getattr(
+                getattr(self, "ps", None),
+                "attn_dp_size",
+                1,
+            )
+            requested_per_worker = requested // attn_dp_size
             resolved = min(requested_per_worker, capacity_cap)
 
         aux_state_size = get_schedule().max_mamba_cache_size

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -62,6 +62,24 @@ class MlxTpModelWorker(TpModelWorker):
             init_kwargs["pool_size"] = get_schedule().max_total_tokens
         self._mlx_runner = MlxModelRunner(**init_kwargs)
 
+        if self._mlx_runner.native_cache_fallback:
+            if not get_schedule().disable_overlap_schedule:
+                raise NotImplementedError(
+                    "Gemma 4 on the MLX backend currently requires "
+                    "--disable-overlap-schedule."
+                )
+            if get_schedule().chunked_prefill_size != -1:
+                raise NotImplementedError(
+                    "Gemma 4 on the MLX backend currently requires "
+                    "--chunked-prefill-size -1."
+                )
+            if self.model_config.context_len > self._mlx_runner.pool_size:
+                raise NotImplementedError(
+                    "Gemma 4 on the MLX backend currently requires "
+                    "--context-length to be no larger than --max-total-tokens "
+                    "(2048 is the validated prototype setting)."
+                )
+
         self._model_runner = MlxModelRunnerStub(
             model_config=self.model_config,
             mem_fraction_static=get_schedule().mem_fraction_static,
@@ -74,6 +92,7 @@ class MlxTpModelWorker(TpModelWorker):
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             memory_pool_config=self.memory_pool_config,
             mlx_pool_size=self._mlx_runner.pool_size,
+            mlx_native_cache_fallback=self._mlx_runner.native_cache_fallback,
         )
 
         self._mlx_active_rids: set[str] = set()
@@ -131,6 +150,13 @@ class MlxTpModelWorker(TpModelWorker):
             # Prefer the just-snapshotted live auxiliary state for the final
             # insert. Any older tracked slot is released during component cleanup.
             req.mamba_last_track_seqlen = None
+            if self._mlx_runner.native_cache_fallback:
+                # Native-cache fallback requires overlap scheduling to be off,
+                # so no later in-flight graph can still reference this request.
+                # Release here rather than waiting for a future decode batch:
+                # a request may finish during prefill and the server may go idle.
+                self._mlx_runner.remove_request(req.rid)
+                self._mlx_active_rids.discard(req.rid)
 
     def _route_extend_request(self, rid: str, decoding_rids: set[str]) -> str:
         """Classify a request within an extend / mixed batch.

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5099,12 +5099,21 @@ class ServerArgs:
             # Default attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _gemma4_overrides).
             prefill_backend, decode_backend = self._resolved_attention_backends()
-            accepted_backends = ("trtllm_mha", "triton", "ascend", "intel_xpu")
+            accepted_backends = (
+                "trtllm_mha",
+                "triton",
+                "ascend",
+                "intel_xpu",
+            )
+            if use_mlx():
+                # The MLX runner owns execution; torch_native is a
+                # scheduler-facing placeholder accepted on Apple Silicon.
+                accepted_backends += ("torch_native",)
             assert (
                 prefill_backend in accepted_backends
                 and decode_backend in accepted_backends
             ), (
-                "Gemma4 only supports trtllm_mha, triton, or intel_xpu attention backend, "
+                f"Gemma4 only supports {accepted_backends} attention backends, "
                 f"got prefill={prefill_backend}, decode={decode_backend}"
             )
 

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_native_cache.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_native_cache.py
@@ -1,0 +1,226 @@
+"""Correctness-first Gemma 4 coverage for the MLX native-cache fallback.
+
+The initial Apple Silicon path intentionally delegates cache semantics to
+``mlx-lm``.  Gemma 4 combines YOCO K/V sharing, sliding attention, K=V full
+attention, and heterogeneous head dimensions; the uniform SGLang MLX radix
+pool cannot represent that layout yet.  These tests use a tiny randomly
+initialised Gemma 4 model, so they exercise the real architecture without a
+checkpoint download.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from dataclasses import asdict
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+_HAS_GEMMA4_MLX = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_lm.models.gemma4_text") is not None
+)
+_SKIP_REASON = "requires mlx-lm with Gemma 4 support"
+
+if _HAS_GEMMA4_MLX:
+    import mlx.core as mx
+    from mlx_lm.models import gemma4, gemma4_text
+
+    from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+    from sglang.srt.hardware_backend.mlx.model_runner_stub import MlxModelRunnerStub
+    from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+
+
+def _tiny_gemma4(*, wrapped: bool = False):
+    """Build a four-layer model containing every target cache quirk."""
+    args = gemma4_text.ModelArgs(
+        hidden_size=16,
+        num_hidden_layers=4,
+        intermediate_size=32,
+        num_attention_heads=2,
+        head_dim=4,
+        global_head_dim=8,
+        vocab_size=32,
+        vocab_size_per_layer_input=32,
+        num_key_value_heads=1,
+        num_global_key_value_heads=1,
+        num_kv_shared_layers=2,
+        hidden_size_per_layer_input=0,
+        sliding_window=8,
+        sliding_window_pattern=2,
+        max_position_embeddings=4096,
+        attention_k_eq_v=True,
+        use_double_wide_mlp=False,
+        layer_types=[
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+    )
+    model = (
+        gemma4.Model(
+            gemma4.ModelArgs(
+                text_config=asdict(args),
+                vocab_size=args.vocab_size,
+            )
+        )
+        if wrapped
+        else gemma4_text.Model(args)
+    )
+    mx.eval(model.parameters())
+    return model
+
+
+def _build_runner(model, **kwargs):
+    options = {
+        "model_path": "tiny-gemma4",
+        "disable_radix_cache": True,
+        "pool_size": 64,
+    }
+    options.update(kwargs)
+    with mock.patch.object(
+        MlxModelRunner,
+        "_load_model",
+        new=lambda runner: setattr(runner, "model", model),
+    ):
+        return MlxModelRunner(**options)
+
+
+def _reference_tokens(model, prompt: list[int], steps: int) -> list[int]:
+    cache = model.make_cache()
+    input_ids = mx.array([prompt], dtype=mx.int32)
+    output = []
+    for _ in range(steps):
+        logits = model(input_ids, cache=cache)
+        token = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(token, *[value for entry in cache for value in entry.state])
+        output.append(int(token.item()))
+        input_ids = token[:, None]
+    return output
+
+
+@unittest.skipUnless(_HAS_GEMMA4_MLX, _SKIP_REASON)
+class TestGemma4NativeCacheFallback(unittest.TestCase):
+    def test_wrapped_model_cross_window_matches_raw_mlx_lm(self):
+        # Exercise mlx-lm's conditional-generation shell as loaded from the
+        # public checkpoints, and cross the synthetic sliding window boundary.
+        model = _tiny_gemma4(wrapped=True)
+        prompt = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        expected = _reference_tokens(model, prompt, steps=3)
+        runner = _build_runner(model)
+
+        first = runner.prefill(
+            req_id="request",
+            new_token_ids=prompt,
+            full_token_ids=prompt,
+            prefix_slot_ids=[],
+            new_slot_ids=[],
+            req_pool_idx=0,
+        )
+        actual = [first]
+        for _ in range(2):
+            actual.append(runner.decode_batch(["request"])[0])
+
+        self.assertTrue(runner.native_cache_fallback)
+        self.assertEqual(actual, expected)
+        # Four transformer layers own only two caches; the remaining YOCO
+        # layers reuse the most recent sliding/full cache respectively.
+        self.assertEqual(len(runner._req_caches["request"]), 2)
+
+    def test_multi_request_decode_preserves_cache_isolation(self):
+        model = _tiny_gemma4()
+        expected_a = _reference_tokens(model, [1, 2], steps=2)
+        expected_b = _reference_tokens(model, [3, 4, 5], steps=2)
+        runner = _build_runner(model)
+
+        first_a = runner.prefill("a", [1, 2], [1, 2], [], [], 0)
+        first_b = runner.prefill("b", [3, 4, 5], [3, 4, 5], [], [], 1)
+        second_a, second_b = runner.decode_batch(["a", "b"])
+
+        self.assertEqual([first_a, second_a], expected_a)
+        self.assertEqual([first_b, second_b], expected_b)
+
+    def test_radix_cache_fails_with_actionable_message(self):
+        model = _tiny_gemma4()
+        with self.assertRaisesRegex(NotImplementedError, "disable-radix-cache"):
+            _build_runner(
+                model,
+                disable_radix_cache=False,
+            )
+
+    def test_default_scheduler_capacity_is_conservative(self):
+        model = _tiny_gemma4()
+        runner = _build_runner(model, pool_size=None)
+
+        self.assertEqual(runner.pool_size, 2048)
+
+    def test_native_cache_defaults_to_one_live_request(self):
+        stub = MlxModelRunnerStub.__new__(MlxModelRunnerStub)
+        stub._mlx_native_cache_fallback = True
+        stub.max_total_num_tokens = 2048
+        stub.model_config = SimpleNamespace()
+        schedule = SimpleNamespace(
+            max_running_requests=None,
+            max_mamba_cache_size=None,
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.get_schedule",
+                return_value=schedule,
+            ),
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.mambaish_config",
+                return_value=None,
+            ),
+        ):
+            self.assertEqual(stub._resolve_max_running_requests(), 1)
+
+    def test_explicit_concurrency_uses_attention_dp_width(self):
+        stub = MlxModelRunnerStub.__new__(MlxModelRunnerStub)
+        stub._mlx_native_cache_fallback = True
+        stub.max_total_num_tokens = 2048
+        stub.model_config = SimpleNamespace()
+        stub.ps = SimpleNamespace(attn_dp_size=2)
+        schedule = SimpleNamespace(
+            max_running_requests=8,
+            max_mamba_cache_size=None,
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.get_schedule",
+                return_value=schedule,
+            ),
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.mambaish_config",
+                return_value=None,
+            ),
+        ):
+            self.assertEqual(stub._resolve_max_running_requests(), 4)
+
+    def test_finished_native_request_is_released_immediately(self):
+        worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
+        worker._mlx_runner = mock.Mock(native_cache_fallback=True)
+        worker._mlx_runner.has_request.return_value = True
+        worker._mlx_active_rids = {"done"}
+        req = SimpleNamespace(rid="done", mamba_last_track_seqlen=128)
+
+        worker.prepare_for_kv_cache_release(req)
+
+        worker._mlx_runner.store_auxiliary_state_for_request.assert_called_once_with(
+            "done"
+        )
+        worker._mlx_runner.remove_request.assert_called_once_with("done")
+        self.assertNotIn("done", worker._mlx_active_rids)
+        self.assertIsNone(req.mamba_last_track_seqlen)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1708,9 +1708,11 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             self.assertEqual(
                 _llama4_overrides(_args(attention_backend="fa3"), None), {}
             )
-            self.assertEqual(
-                _gemma4_overrides(_args(), None), {"attention_backend": "trtllm_mha"}
-            )
+            with patch.object(overrides_module, "use_mlx", return_value=False):
+                self.assertEqual(
+                    _gemma4_overrides(_args(), None),
+                    {"attention_backend": "trtllm_mha"},
+                )
             self.assertEqual(
                 _minicpm_v4_6_overrides(_args(), None),
                 {"attention_backend": "triton"},
@@ -1740,9 +1742,11 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 self.assertEqual(
                     _llama4_overrides(_args(), None), {"attention_backend": "fa3"}
                 )
-            self.assertEqual(
-                _gemma4_overrides(_args(), None), {"attention_backend": "triton"}
-            )
+            with patch.object(overrides_module, "use_mlx", return_value=False):
+                self.assertEqual(
+                    _gemma4_overrides(_args(), None),
+                    {"attention_backend": "triton"},
+                )
         # Glm4Moe: unconditional tf32 declaration + (sm100) quant/moe absorption
         with patch.object(overrides_module, "is_sm100_supported", return_value=False):
             self.assertEqual(
@@ -1767,6 +1771,42 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     "enable_tf32_matmul": True,
                 },
             )
+
+    def test_gemma4_mlx_uses_torch_native_attention(self):
+        from sglang.srt.arg_groups.overrides import _gemma4_overrides
+
+        def _args(*, device="cuda", attention_backend=None, backend_not_set=True):
+            return SimpleNamespace(
+                device=device,
+                attention_backend=attention_backend,
+                is_attention_backend_not_set=lambda: backend_not_set,
+                moe_runner_backend="triton",
+                quantization=None,
+            )
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            with patch.object(overrides_module, "use_mlx", return_value=False):
+                self.assertEqual(
+                    _gemma4_overrides(_args(device="mps"), None),
+                    {"attention_backend": "trtllm_mha"},
+                )
+                self.assertEqual(
+                    _gemma4_overrides(
+                        _args(
+                            device="mps",
+                            attention_backend="torch_native",
+                            backend_not_set=False,
+                        ),
+                        None,
+                    ),
+                    {},
+                )
+
+            with patch.object(overrides_module, "use_mlx", return_value=True):
+                self.assertEqual(
+                    _gemma4_overrides(_args(), None),
+                    {"attention_backend": "torch_native"},
+                )
 
     def test_deepseek_moe_quant_slot_pass(self):
         from sglang.srt.arg_groups.overrides import (


### PR DESCRIPTION
## Motivation

Part of #32101 and #19137; cross-links the Gemma 4 roadmap in #26596.

SGLang supports Gemma 4 in the standard GPU model path, while the Apple Silicon backend loads and executes `mlx-lm` models directly. Gemma 4 combines heterogeneous full/sliding attention with YOCO shared KV, K=V layers, and model-specific cache return contracts. Those semantics cannot currently be represented by SGLang's uniform MLX radix pool.

This PR adds a correctness-first E2B text-generation bridge that keeps Gemma 4's cache ownership inside `mlx-lm` while retaining SGLang's scheduler and HTTP APIs.

## Modifications

For `gemma4` and `gemma4_text`, the MLX runner now:

- requires `--disable-radix-cache` and fails early with an actionable error otherwise;
- skips SGLang attention patching and optional AOT attention kernels;
- preserves `model.make_cache()` and allocates an independent native cache per request;
- decodes requests independently, preserving cache isolation without claiming fused batching;
- releases native cache state as soon as a non-overlapped request finishes;
- uses a conservative default capacity of 2,048 tokens and one live request;
- resolves explicit request concurrency with `ps.attn_dp_size`, matching the canonical KV-cache resolver;
- requires overlap scheduling and chunked prefill to be disabled for this initial path; and
- forces the conditional-generation checkpoint through SGLang's text-only configuration.

The `torch_native` attention-backend value is scheduler allocation/validation plumbing only. Model execution and attention still run through MLX/`mlx-lm`; users do not need to select this backend manually.

## Accuracy Tests

Test machine:

- MacBook Pro, Apple M4 Max, 64 GB
- macOS 26.5.2
- `mlx==0.32.0`
- `mlx-lm==0.31.3`
- `transformers==5.12.1`

Synthetic coverage uses a tiny real `mlx_lm.models.gemma4` architecture and verifies:

- the public `gemma4.Model` wrapper;
- prefill/decode parity with raw `mlx-lm` beyond the synthetic sliding-window boundary;
- YOCO ownership (four layers, two owned caches);
- two-request cache isolation;
- actionable radix-cache rejection;
- conservative capacity and concurrency resolution; and
- immediate finished-request cleanup.

Real checkpoint evidence with `mlx-community/gemma-4-e2b-it-4bit`:

- loaded 35 transformer layers with 15 model-owned YOCO caches;
- matched 8/8 greedy tokens against an unmodified raw `mlx-lm` run;
- `/v1/chat/completions` returned `Paris` for the France-capital prompt and `4` for a second request.

Focused regression run after rebasing on current `main`:

```text
125 passed, 18 skipped, 6 subtests passed
```

The skips are pre-existing migration-gated MLX tests. Ruff, Black, isort, `py_compile`, and `git diff --check` pass for the changed files.

## Speed Tests and Profiling

Not included. This is intentionally a correctness fallback: native requests are forwarded independently and there is no radix reuse or fused batched attention. Performance work follows after the first-class per-layer KV design.

## Reproduction

```bash
SGLANG_USE_MLX=1 python -m sglang.launch_server \
  --model-path mlx-community/gemma-4-e2b-it-4bit \
  --disable-radix-cache \
  --disable-overlap-schedule \
  --chunked-prefill-size -1 \
  --max-running-requests 1 \
  --max-total-tokens 2048 \
  --context-length 2048 \
  --cuda-graph-backend-decode disabled \
  --cuda-graph-backend-prefill disabled \
  --tp-size 1
```

## Limitations and follow-ups

This PR validates text-only E2B with greedy decoding and a 2,048-token configuration. It does not claim radix/prefix reuse, fused batched attention, long context, Gemma 4 Unified, E4B, 31B, 26B MoE, multimodal inputs, or MTP.

Follow-up work in #32101 will validate scheduler overlap/chunking and then add model-neutral heterogeneous KV metadata, YOCO owner mappings, per-layer SWA, and exact radix behavior. That work should coordinate with #30050, #30091, and #30156.

## Checklist

- [x] Format code according to the pre-commit configuration.
- [x] Add focused unit tests.
- [x] Provide real-checkpoint accuracy evidence on Apple Silicon.
- [ ] Add performance benchmarks; deferred because this PR is an explicitly non-optimized correctness path.
- [ ] Add user documentation; proposed after the experimental interface is accepted in review.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29946019066](https://github.com/sgl-project/sglang/actions/runs/29946019066)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29946018700](https://github.com/sgl-project/sglang/actions/runs/29946018700)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->