### PR TITLE
fix(hidden_states): keep prefill offset aligned for non-requesting reqs to stop cross-request leak

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -261,6 +261,17 @@ class SchedulerBatchResultProcessor:
                             logits_output=logits_output,
                             hidden_state_offset=hidden_state_offset,
                         )
+                    elif logits_output.hidden_states is not None:
+                        # FULL hidden-state capture is enabled whenever ANY
+                        # request in the batch asks for hidden states, so the
+                        # buffer holds a row for every request's prefill tokens,
+                        # not just the requesting ones. Advance past this
+                        # (non-requesting) request's rows so that a later
+                        # requesting request slices its own rows rather than this
+                        # request's -> avoids wrong output and a cross-request
+                        # hidden-state leak. Mirrors how logprob_pt advances for
+                        # every contributing request in _apply_prefill_logprobs.
+                        hidden_state_offset += len(req.origin_input_ids)
 
                     if req.grammar is not None:
                         self._apply_prefill_grammar(


### PR DESCRIPTION
### Summary

Fixes #32089. In `process_batch_result_prefill`, `hidden_state_offset` was advanced **only** inside the `req.return_hidden_states` branch. But `logits_output.hidden_states` is captured with `CaptureHiddenMode.FULL` whenever **any** request in the batch requests hidden states (`schedule_batch.py`: `batch.return_hidden_states = any(req.return_hidden_states for req in reqs)`). So the buffer holds a row for **every** request's prefill tokens, not just the requesting ones.

When a prefill batch mixes `return_hidden_states=True` and `return_hidden_states=False` requests, the offset skips the non-requesting requests' rows. A later requesting request then slices from a stale offset and receives **another request's** hidden states — both wrong output and a cross-request information leak.

### Fix

Add an `elif` that advances `hidden_state_offset` past a non-requesting request's rows when the FULL-capture buffer is present, so a later requesting request lands on its own rows. The advance uses the same row count (`len(req.origin_input_ids)`) that `_append_prefill_hidden_states` consumes for a requesting request, keeping skip-length and consume-length in lockstep.

This mirrors the logprob path, where `_apply_prefill_logprobs` advances `logprob_pt` for **every** contributing request and only stores values when `req.return_logprob`.

### Behavior change

- All-requesting or all-non-requesting batches: unchanged.
- Mixed batches: each requesting request now reads its own rows instead of an earlier request's.

The change is a pure insertion; the existing hidden-states branch and `_append_prefill_hidden_states` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29950664247](https://github.com/sgl-project/sglang/actions/runs/29950664247)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29950663725](https://github.com/sgl-project/sglang/actions/runs/29950663725)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->