### PR TITLE
[EPLB] Skip expert-distribution pass boundary during CUDA-graph capture

### DIFF
--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -147,6 +147,12 @@ class _ExpertDistributionRecorderReal(ExpertDistributionRecorder):
 
         self._recording = False
         self._disable_all = False
+        # Resolved once: some device modules (e.g. `torch.cpu`) do not expose
+        # `is_current_stream_capturing`; treat "no graph support" as "never
+        # capturing" so the capture guards below work on every backend.
+        self._is_current_stream_capturing = getattr(
+            torch.get_device_module(), "is_current_stream_capturing", lambda: False
+        )
         self._current_forward_pass_id = Withable()
         self._current_layer_idx = Withable()
         self._current_debug_name = Withable()
@@ -193,12 +199,31 @@ class _ExpertDistributionRecorderReal(ExpertDistributionRecorder):
     def _on_forward_pass_start(self, forward_batch: ForwardBatch):
         if not self._recording:
             return
+        if self._is_current_stream_capturing():
+            # Speculative-decoding draft CUDA-graph capture (e.g. EAGLE's
+            # multi-step `draft_forward` with speculative_num_steps >= 2) drives
+            # full `ModelRunner.forward` calls while a stream capture is active,
+            # so this pass boundary can land inside a capture. The pass-boundary
+            # bookkeeping is not capture-safe: with metrics enabled the
+            # accumulator performs a rank-0 GPU->CPU sync
+            # (`utilization_rate_gpu.item()` in `_append_utilization_rate`),
+            # which raises cudaErrorStreamCaptureUnsupported ("operation not
+            # permitted when stream is capturing") and invalidates the capture
+            # (cudaErrorStreamCaptureInvalidated -> startup crash loop); it also
+            # issues a `torch.distributed.reduce` plus buffer writes that would
+            # be baked into the draft graph and replayed on every draft step.
+            # Per-layer hooks intentionally stay active during capture (see
+            # `_on_hook`); only the pass-boundary work must be skipped.
+            return
         for gatherer_key, gatherer in self._single_pass_gatherers.items():
             gatherer.reset()
             gatherer.on_forward_pass_start(forward_batch)
 
     def _on_forward_pass_end(self, forward_pass_id: int, outputs: Dict[str, Any]):
         if not self._recording:
+            return
+        if self._is_current_stream_capturing():
+            # See `_on_forward_pass_start`: not capture-safe.
             return
         for gatherer_key, gatherer in self._single_pass_gatherers.items():
             single_pass_data = gatherer.collect()
@@ -235,9 +260,7 @@ class _ExpertDistributionRecorderReal(ExpertDistributionRecorder):
     def _on_hook(self, hook_name: str, **kwargs):
         if self._disable_all:
             return
-        if not (
-            self._recording or torch.get_device_module().is_current_stream_capturing()
-        ):
+        if not (self._recording or self._is_current_stream_capturing()):
             return
         gatherer = self._single_pass_gatherers[
             self._accumulator.get_single_pass_gatherer_key(

--- a/test/registered/unit/eplb/test_expert_distribution_capture_guard.py
+++ b/test/registered/unit/eplb/test_expert_distribution_capture_guard.py
@@ -1,0 +1,90 @@
+"""Unit tests for the expert-distribution pass-boundary capture guard — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.eplb.expert_distribution import _ExpertDistributionRecorderReal
+from sglang.test.test_utils import CustomTestCase
+
+
+class _StubGatherer:
+    def __init__(self):
+        self.reset_calls = 0
+        self.start_calls = 0
+        self.collect_calls = 0
+
+    def reset(self):
+        self.reset_calls += 1
+
+    def on_forward_pass_start(self, forward_batch):
+        self.start_calls += 1
+
+    def collect(self):
+        self.collect_calls += 1
+        return {}
+
+
+class _StubAccumulator:
+    def __init__(self):
+        self.append_calls = 0
+
+    def append(self, forward_pass_id, gatherer_key, single_pass_data, outputs):
+        self.append_calls += 1
+
+
+def _make_recorder(capturing: bool) -> _ExpertDistributionRecorderReal:
+    """Recorder with stubbed collaborators; __init__ needs a model config so
+    it is bypassed and only the fields the pass boundary touches are set."""
+    recorder = _ExpertDistributionRecorderReal.__new__(_ExpertDistributionRecorderReal)
+    recorder._recording = True
+    recorder._is_current_stream_capturing = lambda: capturing
+    recorder._single_pass_gatherers = {"primary": _StubGatherer()}
+    recorder._accumulator = _StubAccumulator()
+    return recorder
+
+
+class TestExpertDistributionCaptureGuard(CustomTestCase):
+    """The forward-pass boundary must be a no-op while a stream capture is
+    active (e.g. EAGLE multi-step draft CUDA-graph capture drives full
+    `ModelRunner.forward` calls inside the capture): the accumulator's rank-0
+    GPU->CPU sync would otherwise invalidate the capture."""
+
+    def test_pass_boundary_skipped_while_capturing(self):
+        recorder = _make_recorder(capturing=True)
+        recorder._on_forward_pass_start(forward_batch=None)
+        recorder._on_forward_pass_end(forward_pass_id=1, outputs={})
+
+        gatherer = recorder._single_pass_gatherers["primary"]
+        self.assertEqual(gatherer.reset_calls, 0)
+        self.assertEqual(gatherer.start_calls, 0)
+        self.assertEqual(gatherer.collect_calls, 0)
+        self.assertEqual(recorder._accumulator.append_calls, 0)
+
+    def test_pass_boundary_runs_when_not_capturing(self):
+        recorder = _make_recorder(capturing=False)
+        recorder._on_forward_pass_start(forward_batch=None)
+        recorder._on_forward_pass_end(forward_pass_id=1, outputs={})
+
+        gatherer = recorder._single_pass_gatherers["primary"]
+        self.assertEqual(gatherer.reset_calls, 1)
+        self.assertEqual(gatherer.start_calls, 1)
+        self.assertEqual(gatherer.collect_calls, 1)
+        self.assertEqual(recorder._accumulator.append_calls, 1)
+
+    def test_pass_boundary_skipped_when_not_recording(self):
+        recorder = _make_recorder(capturing=False)
+        recorder._recording = False
+        recorder._on_forward_pass_start(forward_batch=None)
+        recorder._on_forward_pass_end(forward_pass_id=1, outputs={})
+
+        gatherer = recorder._single_pass_gatherers["primary"]
+        self.assertEqual(gatherer.reset_calls, 0)
+        self.assertEqual(gatherer.collect_calls, 0)
+        self.assertEqual(recorder._accumulator.append_calls, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #32105.

`--enable-expert-distribution-metrics` combined with EAGLE/MTP speculative decoding and `--speculative-num-steps >= 2` crash-loops server startup: EAGLE's multi-step `draft_forward` drives full `ModelRunner.forward` calls inside the draft CUDA-graph capture, so the expert-distribution recorder's forward-pass boundary runs while the stream is capturing. With metrics enabled the accumulator then performs a rank-0 GPU→CPU sync (`utilization_rate_gpu.item()` in `_append_utilization_rate`), which raises `cudaErrorStreamCaptureUnsupported` ("operation not permitted when stream is capturing") and invalidates the capture (`cudaErrorStreamCaptureInvalidated` → `Exception: Capture cuda graph failed`). Full production traceback and the complete root-cause chain with permalinks are in #32105.

## Modifications

- `_on_forward_pass_start` / `_on_forward_pass_end`: return early while the current stream is capturing. Per-layer hooks intentionally keep firing during capture (`_on_hook` is already capture-aware) so captured graphs keep accumulating into the gatherer buffers at replay; only the pass-boundary bookkeeping (gatherer reset/collect and the accumulator append with its collective + host sync) is skipped. The boundary still runs for the eager wrapper around graph replay, so recorded statistics are unchanged for every configuration that works today — the boundary never previously survived running inside a capture.
- The capture check is resolved once at recorder init via `getattr(torch.get_device_module(), "is_current_stream_capturing", lambda: False)`, because some device modules (e.g. `torch.cpu`) do not expose `is_current_stream_capturing`. `_on_hook` reuses the resolved callable, which also removes a per-MoE-layer attribute-lookup chain from the hook hot path and fixes a latent `AttributeError` on CPU deployments with a recorder mode configured but recording not started.
- New CPU-only unit test `test/registered/unit/eplb/test_expert_distribution_capture_guard.py` covering: boundary skipped while capturing, boundary intact when not capturing, boundary skipped when not recording.

## Accuracy Tests

No kernel or numerics change. The guard adds two host-side boolean checks per forward pass while recording; behavior is byte-identical for all non-capturing passes. The skipped region is frame-for-frame the crash path in the production traceback (#32105).

## Benchmarking and Profiling

Not applicable — two cheap host-side checks per recorded forward pass; `_on_hook` already performs the same check per MoE layer.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-your-code).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests).
- [ ] Update documentation as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29952463701](https://github.com/sgl-project/sglang/actions/runs/29952463701)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29952463304](https://github.com/sgl-project/sglang/actions/runs/29952463304)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->