### PR TITLE
Fix ReDoS in PythonicDetector's tool-call locator regex

### DIFF
--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -15,6 +15,13 @@ from sglang.srt.function_call.core_types import (
 
 logger = logging.getLogger(__name__)
 
+# Matches the start of a single pythonic call, e.g. "[get_weather(". Used only
+# to test a candidate '[' position in a single linear pass (see
+# `_find_tool_call_span`) -- it has no nested quantifiers over `.` so it
+# cannot backtrack catastrophically the way the old single-shot locator regex
+# could (see https://github.com/sgl-project/sglang/issues/31912).
+_CALL_START_RE = re.compile(r"\[\s*[a-zA-Z]+\w*\(")
+
 
 class PythonicDetector(BaseFormatDetector):
     """
@@ -31,13 +38,6 @@ class PythonicDetector(BaseFormatDetector):
     Reference: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct?chat_template=default
     """
 
-    def __init__(self):
-        super().__init__()
-        self.tool_call_regex = re.compile(
-            r"\[([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s)?\),\s*)*([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s*)?\)\s*)+\]",
-            re.DOTALL,
-        )
-
     @staticmethod
     def _text_strip(text: str) -> str:
         # Llama 4 model sometime will output <|python_start|> and <|python_end|> tokens
@@ -46,8 +46,32 @@ class PythonicDetector(BaseFormatDetector):
         text = text.replace("<|python_end|>", "")
         return text
 
+    @staticmethod
+    def _find_tool_call_span(text: str) -> tuple[int, int] | None:
+        """
+        Locate the first top-level, call-shaped ``[...]`` span in ``text``,
+        e.g. ``[foo(a=1), bar(b=[1, 2])]``.
+
+        This walks the string once, tracking bracket depth, instead of using
+        a backtracking regex: a bracket-nesting depth counter is inherently
+        linear and can't blow up the way the old regex did on malformed or
+        truncated input (see GH #31912).
+        """
+        depth = 0
+        candidate_start = None
+        for i, ch in enumerate(text):
+            if ch == "[":
+                if depth == 0:
+                    candidate_start = i if _CALL_START_RE.match(text, i) else None
+                depth += 1
+            elif ch == "]" and depth > 0:
+                depth -= 1
+                if depth == 0 and candidate_start is not None:
+                    return candidate_start, i + 1
+        return None
+
     def has_tool_call(self, text: str) -> bool:
-        return bool(self.tool_call_regex.search(self._text_strip(text.strip())))
+        return self._find_tool_call_span(self._text_strip(text.strip())) is not None
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         # Try parsing the text as a Python list of function calls
@@ -56,13 +80,12 @@ class PythonicDetector(BaseFormatDetector):
         # Remove unexpected <|python_start|> and <|python_end|> for llama4
         text = self._text_strip(text)
 
-        match = self.tool_call_regex.search(text)
-        if match is None:
+        span = self._find_tool_call_span(text)
+        if span is None:
             return StreamingParseResult(normal_text=text, calls=[])
 
         # Extract the tool call part and any text before/after it
-        tool_call_start = match.start()
-        tool_call_end = match.end()
+        tool_call_start, tool_call_end = span
 
         normal_text_before = text[:tool_call_start] if tool_call_start > 0 else ""
         tool_call_text = text[tool_call_start:tool_call_end]

--- a/python/sglang/srt/function_call/pythonic_detector.py
+++ b/python/sglang/srt/function_call/pythonic_detector.py
@@ -16,6 +16,13 @@ from sglang.srt.function_call.utils import safe_ast_parse
 
 logger = logging.getLogger(__name__)
 
+# Matches the start of a single pythonic call, e.g. "[get_weather(". Used only
+# to test a candidate '[' position in a single linear pass (see
+# `_find_tool_call_span`) -- it has no nested quantifiers over `.` so it
+# cannot backtrack catastrophically the way the old single-shot locator regex
+# could (see https://github.com/sgl-project/sglang/issues/31912).
+_CALL_START_RE = re.compile(r"\[\s*[a-zA-Z]+\w*\(")
+
 
 class PythonicDetector(BaseFormatDetector):
     """
@@ -32,13 +39,6 @@ class PythonicDetector(BaseFormatDetector):
     Reference: https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct?chat_template=default
     """
 
-    def __init__(self):
-        super().__init__()
-        self.tool_call_regex = re.compile(
-            r"\[([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s)?\),\s*)*([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s*)?\)\s*)+\]",
-            re.DOTALL,
-        )
-
     @staticmethod
     def _text_strip(text: str) -> str:
         # Llama 4 model sometime will output <|python_start|> and <|python_end|> tokens
@@ -47,8 +47,32 @@ class PythonicDetector(BaseFormatDetector):
         text = text.replace("<|python_end|>", "")
         return text
 
+    @staticmethod
+    def _find_tool_call_span(text: str) -> tuple[int, int] | None:
+        """
+        Locate the first top-level, call-shaped ``[...]`` span in ``text``,
+        e.g. ``[foo(a=1), bar(b=[1, 2])]``.
+
+        This walks the string once, tracking bracket depth, instead of using
+        a backtracking regex: a bracket-nesting depth counter is inherently
+        linear and can't blow up the way the old regex did on malformed or
+        truncated input (see GH #31912).
+        """
+        depth = 0
+        candidate_start = None
+        for i, ch in enumerate(text):
+            if ch == "[":
+                if depth == 0:
+                    candidate_start = i if _CALL_START_RE.match(text, i) else None
+                depth += 1
+            elif ch == "]" and depth > 0:
+                depth -= 1
+                if depth == 0 and candidate_start is not None:
+                    return candidate_start, i + 1
+        return None
+
     def has_tool_call(self, text: str) -> bool:
-        return bool(self.tool_call_regex.search(self._text_strip(text.strip())))
+        return self._find_tool_call_span(self._text_strip(text.strip())) is not None
 
     def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         # Try parsing the text as a Python list of function calls
@@ -57,13 +81,12 @@ class PythonicDetector(BaseFormatDetector):
         # Remove unexpected <|python_start|> and <|python_end|> for llama4
         text = self._text_strip(text)
 
-        match = self.tool_call_regex.search(text)
-        if match is None:
+        span = self._find_tool_call_span(text)
+        if span is None:
             return StreamingParseResult(normal_text=text, calls=[])
 
         # Extract the tool call part and any text before/after it
-        tool_call_start = match.start()
-        tool_call_end = match.end()
+        tool_call_start, tool_call_end = span
 
         normal_text_before = text[:tool_call_start] if tool_call_start > 0 else ""
         tool_call_text = text[tool_call_start:tool_call_end]

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1,4 +1,5 @@
 import json
+import time
 import unittest
 
 from sglang.srt.entrypoints.openai.protocol import (
@@ -659,6 +660,40 @@ class TestPythonicDetector(unittest.TestCase):
         params = json.loads(result.calls[0].parameters)
         self.assertEqual(params["location"], "Mars")
         self.assertEqual(params["unit"], "celsius")
+
+    def test_has_tool_call_no_redos_on_truncated_input(self):
+        """Regression test for GH #31912: has_tool_call must not exhibit
+        catastrophic regex backtracking on a truncated/malformed pythonic
+        call. Before the fix, a 22-argument truncated call took ~8s; a
+        24-argument one would take minutes. This must resolve in
+        milliseconds regardless of argument count.
+        """
+        payload = "[search(" + ", ".join(f"a{i}=1" for i in range(40))
+
+        start = time.monotonic()
+        result = self.detector.has_tool_call(payload)
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.5,
+            f"has_tool_call took {elapsed:.3f}s on truncated input; "
+            "looks like catastrophic regex backtracking regressed",
+        )
+        # Truncated call (missing closing bracket) is correctly not a match.
+        self.assertFalse(result)
+
+    def test_detect_and_parse_no_redos_on_truncated_input(self):
+        """Same as above but for detect_and_parse, the other call site that
+        used the vulnerable regex directly (see GH #31912)."""
+        payload = "[search(" + ", ".join(f"a{i}=1" for i in range(40))
+
+        start = time.monotonic()
+        result = self.detector.detect_and_parse(payload, self.tools)
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5)
+        self.assertEqual(result.calls, [])
 
 
 class TestMistralDetector(unittest.TestCase):

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1,4 +1,5 @@
 import json
+import time
 import unittest
 import warnings
 
@@ -789,6 +790,40 @@ class TestPythonicDetector(unittest.TestCase):
 
         self.assertEqual([c.name for c in result.calls], ["get_weather"])
         self.assertEqual(json.loads(result.calls[0].parameters), {"location": "Tokyo"})
+
+    def test_has_tool_call_no_redos_on_truncated_input(self):
+        """Regression test for GH #31912: has_tool_call must not exhibit
+        catastrophic regex backtracking on a truncated/malformed pythonic
+        call. Before the fix, a 22-argument truncated call took ~8s; a
+        24-argument one would take minutes. This must resolve in
+        milliseconds regardless of argument count.
+        """
+        payload = "[search(" + ", ".join(f"a{i}=1" for i in range(40))
+
+        start = time.monotonic()
+        result = self.detector.has_tool_call(payload)
+        elapsed = time.monotonic() - start
+
+        self.assertLess(
+            elapsed,
+            0.5,
+            f"has_tool_call took {elapsed:.3f}s on truncated input; "
+            "looks like catastrophic regex backtracking regressed",
+        )
+        # Truncated call (missing closing bracket) is correctly not a match.
+        self.assertFalse(result)
+
+    def test_detect_and_parse_no_redos_on_truncated_input(self):
+        """Same as above but for detect_and_parse, the other call site that
+        used the vulnerable regex directly (see GH #31912)."""
+        payload = "[search(" + ", ".join(f"a{i}=1" for i in range(40))
+
+        start = time.monotonic()
+        result = self.detector.detect_and_parse(payload, self.tools)
+        elapsed = time.monotonic() - start
+
+        self.assertLess(elapsed, 0.5)
+        self.assertEqual(result.calls, [])
 
 
 class TestMistralDetector(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #31912.

`PythonicDetector.tool_call_regex` (`function_call/pythonic_detector.py`) located the `[func(kw=v), ...]` span using a regex with a `.*` nested inside a `*`-quantified group. On truncated/malformed input (e.g. a response cut off at `max_tokens`) the engine backtracks over every possible comma partition, going exponential:

```
truncated n=12 args: 0.008s
truncated n=16 args: 0.131s
truncated n=20 args: 2.069s
truncated n=22 args: 8.259s
```

`has_tool_call()` runs this regex on every non-streaming request when `tool_call_parser=pythonic` (Llama-4), so a single truncated response can pin a worker CPU for minutes — a low-cost availability DoS. `detect_and_parse()` uses the same regex non-streaming as well.

## Fix

Replaced the regex with `_find_tool_call_span`, a linear single-pass bracket-depth scan that locates the same top-level, call-shaped `[...]` span without backtracking. `parse_streaming_increment` already used an equivalent linear bracket scan (`_find_matching_bracket`) for the streaming path, so this also makes the streaming and non-streaming code paths consistent with each other instead of using two different matching strategies.

I verified the new algorithm is linear (not just fixing the reported payload but also adversarial "many candidates in a row" and "many balanced blocks" inputs) and checked it against every existing `TestPythonicDetector` semantic case (nested list/dict args, multiple calls in one bracket group, multiple separate bracket groups, `<|python_start|>`/`<|python_end|>` stripping, text before/after) before touching the real file.

## Test plan

- [x] Reproduced the original exponential blowup locally, confirmed it matches the issue's numbers exactly
- [x] Added `test_has_tool_call_no_redos_on_truncated_input` / `test_detect_and_parse_no_redos_on_truncated_input` to `TestPythonicDetector` — asserts a 40-argument truncated call resolves in well under the exponential-blowup regime
- [x] `black`, `isort`, `ruff --select=F401,F821,UP037` all pass on both changed files
- [ ] Full `TestPythonicDetector` suite via CI (couldn't install the full CUDA-dependent package stack locally to run it myself — happy to fix anything CI flags)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32702744624](https://github.com/sgl-project/sglang/actions/runs/32702744624)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32702744336](https://github.com/sgl-project/sglang/actions/runs/32702744336)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32702744464](https://github.com/sgl-project/sglang/actions/runs/32702744464)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->