### PR TITLE
[Bugfix] [NPU] Fix w4a8 MoE performance degradation

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
@@ -435,7 +435,8 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
 
         # Process weight
         weight = getattr(layer, f"{weight_prefix}_weight")
-        weight.data = npu_format_cast(weight.data.transpose(1, 2))
+        weight.data = weight.data.transpose(1, 2).contiguous()
+        weight.data = npu_format_cast(weight.data)
         weight.data = self._pack_to_int32(weight.data)
 
         # Set dispatcher output dtype
@@ -491,7 +492,7 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
             f"Last dimension of weight must be divisible by 4 for int8→int32 packing, "
             f"got shape {weight.shape}"
         )
-        return weight.contiguous().view(torch.int32)
+        return weight.view(torch.int32).contiguous()
 
     def apply(
         self,

--- a/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/moe_methods.py
@@ -428,7 +428,7 @@ class NPUW4A8Int8MoEMethod(_NPUMoEMethodBase):
                     layer,
                     f"{weight_prefix}_scale_bias",
                     torch.nn.Parameter(
-                        bias.data.transpose(1, 2).sum(dim=1).contiguous(),
+                        bias.data.contiguous(),
                         requires_grad=False,
                     ),
                 )


### PR DESCRIPTION
## Motivation

The NPU MoE refactor https://github.com/sgl-project/sglang/pull/25663 changed the W4A8 weight-layout conversion order. The transposed weight was passed to `npu_format_cast` without first materializing a contiguous tensor, and packing made the tensor contiguous before reinterpreting it as `int32`.

For Qwen3.5-397B-A17B W4A8 with DeepEP, this increased mean TPOT from 52.53 ms on the known-good commit (`c9b17403e7c2409ac9603a582685b098a399926d`) to 63.64 ms on `main`.

## Modifications

- Materialize the transposed W4A8 expert weight as contiguous before `npu_format_cast`.
- Reinterpret the formatted weight as `int32` before the final contiguous materialization, restoring the known-good packing order.
- The conversion is shared by clipped and non-clipped ModelSlim W4A8 paths.
- Preserve the already-2D bias in activation-clip mode; only the non-clip 3D scale bias is transposed and reduced.

## Speed Tests and Profiling

Model: `Qwen3.5-397B-A17B-w4a8-mtp`  
Device: Ascend NPU, TP16  
MoE communication: DeepEP, `--deepep-mode auto`

### Random 2K input / 2K output, concurrency 64

| Metric | Known-good `c9b17403` | `main` before fix | This PR | This PR vs before | This PR vs known-good |
|---|---:|---:|---:|---:|---:|
| Benchmark duration (s) | 115.22 | 138.11 | 114.31 | **-17.23%** | **-0.79%** |
| Output throughput (tok/s) | 1137.53 | 949.01 | 1146.64 | **+20.82%** | **+0.80%** |
| Total throughput (tok/s) | 2275.07 | 1898.02 | 2293.27 | **+20.82%** | **+0.80%** |
| Mean E2E latency (ms) | 115186.41 | 138072.32 | 114270.85 | **-17.24%** | **-0.79%** |
| Mean TTFT (ms) | 7664.41 | 7796.40 | 7354.59 | **-5.67%** | **-4.04%** |
| Mean TPOT (ms) | 52.53 | 63.64 | 52.23 | **-17.93%** | **-0.57%** |
| P99 TPOT (ms) | 55.34 | 66.53 | 54.94 | **-17.42%** | **-0.72%** |

The PR restores performance to the known-good level: output throughput is 0.80% higher and mean TPOT is 0.57% lower than `c9b17403` in this run.

<details>
<summary>Random benchmark commands</summary>

```bash
ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 \
STREAMS_PER_DEVICE=32 \
HCCL_OP_EXPANSION_MODE=AIV \
AUTO_USE_UC_MEMORY=0 \
P2P_HCCL_BUFFSIZE=20 \
python -m sglang.launch_server \
  --cuda-graph-bs 64 \
  --device npu \
  --attention-backend ascend \
  --trust-remote-code \
  --tp-size 16 \
  --model-path /home/weights/Qwen/Qwen3.5-397B-A17B-w4a8-mtp/ \
  --port 30088 \
  --moe-a2a-backend deepep \
  --deepep-mode auto

python -m sglang.bench_serving \
  --backend sglang \
  --random-range-ratio 1.0 \
  --dataset-path /home/datasets/ShareGPT_V3_unfiltered_cleaned_split.json \
  --dataset-name random \
  --num-prompts 64 \
  --max-concurrency 64 \
  --random-input-len 2048 \
  --random-output-len 2048 \
  --host 127.0.0.1 \
  --port 30088 \
  --flush-cache
```

</details>

### 90% shared-prefix 64K input / 1K output, concurrency 112

| Metric | Known-good `c9b17403` | `main` before fix | This PR | This PR vs before | This PR vs known-good |
|---|---:|---:|---:|---:|---:|
| Benchmark duration (s) | 156.47 | 172.69 | 158.24 | **-8.37%** | **+1.13%** |
| Output throughput (tok/s) | 732.99 | 664.14 | 724.78 | **+9.13%** | **-1.12%** |
| Total throughput (tok/s) | 50917.29 | 46134.60 | 50346.63 | **+9.13%** | **-1.12%** |
| Mean E2E latency (ms) | 148730.36 | 158290.95 | 147535.71 | **-6.79%** | **-0.80%** |
| Mean TTFT (ms) | 86408.05 | 90496.28 | 83559.50 | **-7.67%** | **-3.30%** |
| Mean TPOT (ms) | 60.92 | 66.27 | 62.54 | **-5.63%** | **+2.66%** |
| P99 TPOT (ms) | 117.93 | 127.55 | 106.47 | **-16.53%** | **-9.72%** |
| Speculative accept length | 3.12 | 3.08 | 3.09 | +0.01 | -0.03 |

<details>
<summary>Shared-prefix benchmark command</summary>

```bash
python -m sglang.bench_serving \
  --dataset-name generated-shared-prefix \
  --backend sglang \
  --host 127.0.0.1 \
  --port 6688 \
  --gsp-num-groups 1 \
  --gsp-prompts-per-group 112 \
  --gsp-system-prompt-len 58982 \
  --gsp-question-len 6553 \
  --gsp-output-len 1024 \
  --max-concurrency 112 \
  --num-prompts 112 \
  --request-rate inf
```

</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://github.com/sgl-project/sglang/blob/main/docs/developer_guide/contribution_guide.md#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.




<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #29960834753](https://github.com/sgl-project/sglang/actions/runs/29960834753)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29960834469](https://github.com/sgl-project/sglang/actions/runs/29960834469)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


