### PR TITLE
[AMD][DI][CI] 7/N Add Kimi-K2.6 INT4 wide-EP16 2P1D nightly recipes 

### DIFF
--- a/scripts/ci/slurm/nightly-configs.yaml
+++ b/scripts/ci/slurm/nightly-configs.yaml
@@ -356,3 +356,41 @@ kimik26-fp8-mi355x-mtp-sglang:
       search-space:
         - conc-list: [1, 8, 16, 32, 64, 128, 256]
           config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp.yaml
+
+# Kimi-K2.6 (FP8, int4 wNa16 experts) wide-EP16, 4-node 2P1D (narrow-prefill EP8
+# x2 + wide-decode EP16 across 2 nodes, mori MoE all-to-all + mori KV, runner
+# mi355x). Decode runs EAGER (--disable-cuda-graph): the int4 route-1 dense-
+# compaction builds a data-dependent shape a HIP graph cannot capture. Requires
+# the wide-EP launcher (#31500) and the deepep_normal<->triton MoE permute +
+# _is_hip route-1 guard (#32048) in the running image/source.
+kimik26-fp8-mi355x-ep16-sglang:
+  model: moonshotai/Kimi-K2.6
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--moonshotai--Kimi-K2.6
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16.yaml
+
+kimik26-fp8-mi355x-ep16-mtp-sglang:
+  model: moonshotai/Kimi-K2.6
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--moonshotai--Kimi-K2.6
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16-mtp.yaml

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16-mtp.yaml
@@ -1,0 +1,121 @@
+# MI355X Kimi-K2.6 (FP8) 4-node 2P1D disaggregation recipe (MTP) — narrow-prefill EP8
+# + wide-decode EP16 (mirrors the DSV4-Pro Oren config: wide EP only helps decode).
+#
+# Two prefill engines (EP8, one node each; the router fans requests across both) +
+# one decode engine (EP16) spanning 2 nodes. Still one logical P/D pair per role
+# group, 4 nodes total. nodes-per-engine = ceil(TP/8): prefill 8->1, decode 16->2,
+# so the launcher emits cross-node --nnodes/--node-rank/--dist-init-addr for the
+# decode engine only. Prefill EP8 keeps MoE all-to-all INTRA-node (XGMI); decode
+# gets wide EP16 across nodes. KV (prefill TP8 -> decode TP16) is carried over mori.
+#
+# Kimi-specific bits vs the DSV4-Pro EP16 recipe: split attention backends
+# (aiter prefill / triton decode), the Kimi model env + parsers, and the Kimi
+# model path. Everything else (2P1D topology, mori a2a + KV, dist init) is shared.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 2
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 8
+      data-parallel-size: 8
+    decode:
+      tensor-parallel-size: 16
+      expert-parallel-size: 16
+      data-parallel-size: 16
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260715
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs (8/node) for mori MoE all-to-all AND the P->D KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
+  # Wide-EP MoE all-to-all backend (cross-node expert dispatch/combine).
+  moe_a2a_backend: mori
+  # KV P->D transfer backend (mori for both a2a and KV on this cluster).
+  kv_transfer_backend: mori
+  # Cross-node torch-distributed NIC for the wide decode engine's dist init.
+  dist_socket_ifname: eno0
+  # rocm720 0715 image needs the ROCm-7.0.0-alpha path OFF (validated).
+  rocm700a: 0
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  # Base defaults; the wide_ep block overrides mem-fraction / max-req per role.
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 131072
+  swa_full_tokens_ratio: 0.1
+  # Per-role wide-EP tuning (starting point cloned from the validated DSV4-Pro
+  # EP16 run; may need Kimi-specific retuning). Prefill and decode differ.
+  wide_ep:
+    kv_cache_dtype: fp8_e4m3
+    prefill_mem_fraction_static: 0.8
+    decode_mem_fraction_static: 0.85
+    prefill_chunked_prefill_size: 131072
+    prefill_max_running_requests: 1024
+    decode_max_running_requests: 1024
+    common_extra_flags: "--moe-dense-tp-size 1 --enable-dp-lm-head --decode-log-interval 100 --watchdog-timeout 3600 --load-balance-method round_robin"
+    prefill_extra_flags: "--context-length 9217 --max-total-tokens 262144"
+    decode_extra_flags: "--disable-cuda-graph --prefill-round-robin-balance"
+    prefill_extra_env:
+      MORI_MAX_DISPATCH_TOKENS_PREFILL: 8192
+      MORI_MAX_DISPATCH_TOKENS_DECODE: 256
+      SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK: 16384
+    decode_extra_env:
+      MORI_MAX_DISPATCH_TOKENS_DECODE: 64
+      MORI_MOE_MAX_INPUT_TOKENS_DECODE: 332
+      SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK: 128
+
+
+# EAGLE3 speculative decoding with the external Kimi-K2.6 draft model (same
+# draft + hyperparams as the validated EP8 1p1d-mtp.yaml). Decode stays eager
+# (--disable-cuda-graph) as required by the int4 route-1 path.
+mtp:
+  enabled: true
+  algorithm: EAGLE3
+  num_steps: 3
+  eagle_topk: 1
+  num_draft_tokens: 4
+  draft_model_path: /it-share/model_coverage/models--lightseekorg--kimi-k2.6-eagle3.1-mla
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep (full GSM8K,
+  # 8-shot, accuracy > 0.92). Mirrors the single-node Kimi-K2.6 eval threshold.
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16.yaml
@@ -1,0 +1,109 @@
+# MI355X Kimi-K2.6 (FP8) 4-node 2P1D disaggregation recipe — narrow-prefill EP8
+# + wide-decode EP16 (mirrors the DSV4-Pro Oren config: wide EP only helps decode).
+#
+# Two prefill engines (EP8, one node each; the router fans requests across both) +
+# one decode engine (EP16) spanning 2 nodes. Still one logical P/D pair per role
+# group, 4 nodes total. nodes-per-engine = ceil(TP/8): prefill 8->1, decode 16->2,
+# so the launcher emits cross-node --nnodes/--node-rank/--dist-init-addr for the
+# decode engine only. Prefill EP8 keeps MoE all-to-all INTRA-node (XGMI); decode
+# gets wide EP16 across nodes. KV (prefill TP8 -> decode TP16) is carried over mori.
+#
+# Kimi-specific bits vs the DSV4-Pro EP16 recipe: split attention backends
+# (aiter prefill / triton decode), the Kimi model env + parsers, and the Kimi
+# model path. Everything else (2P1D topology, mori a2a + KV, dist init) is shared.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 2
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 8
+      data-parallel-size: 8
+    decode:
+      tensor-parallel-size: 16
+      expert-parallel-size: 16
+      data-parallel-size: 16
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260715
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs (8/node) for mori MoE all-to-all AND the P->D KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3,rdma4,rdma5,rdma6,rdma7
+  # Wide-EP MoE all-to-all backend (cross-node expert dispatch/combine).
+  moe_a2a_backend: mori
+  # KV P->D transfer backend (mori for both a2a and KV on this cluster).
+  kv_transfer_backend: mori
+  # Cross-node torch-distributed NIC for the wide decode engine's dist init.
+  dist_socket_ifname: eno0
+  # rocm720 0715 image needs the ROCm-7.0.0-alpha path OFF (validated).
+  rocm700a: 0
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  # Base defaults; the wide_ep block overrides mem-fraction / max-req per role.
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 131072
+  swa_full_tokens_ratio: 0.1
+  # Per-role wide-EP tuning (starting point cloned from the validated DSV4-Pro
+  # EP16 run; may need Kimi-specific retuning). Prefill and decode differ.
+  wide_ep:
+    kv_cache_dtype: fp8_e4m3
+    prefill_mem_fraction_static: 0.8
+    decode_mem_fraction_static: 0.85
+    prefill_chunked_prefill_size: 131072
+    prefill_max_running_requests: 1024
+    decode_max_running_requests: 1024
+    common_extra_flags: "--moe-dense-tp-size 1 --enable-dp-lm-head --decode-log-interval 100 --watchdog-timeout 3600 --load-balance-method round_robin"
+    prefill_extra_flags: "--context-length 9217 --max-total-tokens 262144"
+    decode_extra_flags: "--disable-cuda-graph --prefill-round-robin-balance"
+    prefill_extra_env:
+      MORI_MAX_DISPATCH_TOKENS_PREFILL: 8192
+      MORI_MAX_DISPATCH_TOKENS_DECODE: 256
+      SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK: 16384
+    decode_extra_env:
+      MORI_MAX_DISPATCH_TOKENS_DECODE: 64
+      MORI_MOE_MAX_INPUT_TOKENS_DECODE: 332
+      SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK: 128
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep (full GSM8K,
+  # 8-shot, accuracy > 0.92). Mirrors the single-node Kimi-K2.6 eval threshold.
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92


### PR DESCRIPTION
## What this PR does

Add the **Kimi-K2.6 wide-EP16** legs (no-MTP + MTP) to the AMD disaggregation nightly. Same **2P1D EP16 across 4 nodes** topology as the DSV4 EP16 legs (#31500), on the `mi355x` amd-sglang cluster. Kimi-K2.6 uses **int4 wNa16** quantized experts, so it exercises a different MoE code path (triton runner) than the DSV4 EP16 legs.

## Depends on

- **#31500** — the multi-node-per-engine wide-EP launcher support (`moe_a2a_backend`, nodes-per-engine `= ceil(TP/8)`, cross-node `--nnodes/--node-rank/--dist-init-addr`). These recipes reference those launcher fields, so #31500 must land first (or be present in the running source). This PR is diffed against `main` for review clarity and will rebase cleanly once #31500 merges.
- **#32048** — the `deepep_normal<->triton` MoE permute + the `_is_hip` route-1 guard, the actual MoE fix that lets Kimi int4 run wide-EP over mori. Must be present in the running image/source for the nightly to pass.

## Topology (same as the DSV4 EP16 legs)

- **2 prefill engines** — EP8 / TP8 / DP8, one node each; router fans requests across both.
- **1 decode engine** — EP16 / TP16 / DP16, spanning 2 nodes.
- 4 nodes total. `mori` carries both the MoE all-to-all and the P->D KV transfer. Prefill stays narrow EP8 (intra-node XGMI all-to-all); decode gets cross-node EP16.

## Modifications

- **`scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16.yaml`** — base EP16 recipe: prefill TP/EP/DP=8, decode TP/EP/DP=16, split attention backends (`aiter` prefill / `triton` decode), `moe_a2a_backend: mori`, `kv_transfer_backend: mori`, `ib_devices: rdma0..7`, `dist_socket_ifname: eno0`, Kimi model env + parsers. Decode runs **eager (`--disable-cuda-graph`)** — see below.
- **`scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/2p1d-ep16-mtp.yaml`** — same, plus the EAGLE3 external-draft `mtp` block (draft `lightseekorg/kimi-k2.6-eagle3.1-mla`, `num_steps 3`, `eagle_topk 1`, `num_draft_tokens 4`), identical to the validated EP8 `1p1d-mtp.yaml`.
- **`scripts/ci/slurm/nightly-configs.yaml`** — 2 `runner: mi355x` legs: `kimik26-fp8-mi355x-ep16-sglang` + `kimik26-fp8-mi355x-ep16-mtp-sglang`.

## Why decode is eager

The int4 route-1 dense-compaction (`topk_ids[valid_mask].view(-1, 1)`) builds a **data-dependent shape** a HIP graph cannot capture -> capture-time fault (single-node) or silent garbage (multi-node). So decode must run `--disable-cuda-graph`. This is specific to the int4 wNa16 triton MoE path; the DSV4 (aiter MoE) EP16 legs keep cuda graph. Prefill already auto-disables its own graph.

## Validation

Both legs validated on MI355X (gfx950, ROCm 7.2), 2-node standalone EP16 (TP16/EP16/DP16, mori normal, eager), full GSM8K 1319Q 8-shot @ parallel=256, with the #32048 permute + guard present:

| Leg | Accuracy | Invalid |
|---|---|---|
| **base** (`2p1d-ep16.yaml`) | **0.9401** | 0.0000 |
| **MTP** (`2p1d-ep16-mtp.yaml`, EAGLE3) | **0.9447** | 0.0000 |

Base additionally validated on a real 4-node 2P1D wide-EP16 topology (2x prefill EP8 + 1x 2-node decode EP16 over RDMA): GSM8K **0.933**, Invalid 0.0.

## Non-regression

Adds only new files + 2 new nightly legs gated on new `config_file` names. Existing Kimi EP8 recipes (`1p1d.yaml`, `1p1d-mtp.yaml`) and their nightly legs are untouched.
