### PR TITLE
feat(grpc): add typed multi-choice generation

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package sglang.runtime.v1;
 
+import "google/protobuf/struct.proto";
+
 service SglangService {
   // SGLang-native RPCs (typed proto)
   rpc TextGenerate(TextGenerateRequest) returns (stream TextGenerateResponse);
@@ -63,8 +65,26 @@ message SamplingParams {
   repeated int32 stop_token_ids = 11;
   optional bool ignore_eos = 12;
   optional int32 n = 13;
-  optional string json_schema = 14;
-  optional string regex = 15;
+  reserved 14, 15;
+  reserved "json_schema", "regex";
+  optional int64 seed = 16;
+  optional GuidedDecoding guided_decoding = 17;
+  optional bool require_reasoning = 18;
+  optional uint32 max_thinking_tokens = 19;
+}
+
+message GuidedDecoding {
+  oneof constraint {
+    string json_schema = 1;
+    string regex = 2;
+    string ebnf = 3;
+    ChoiceConstraint choice = 4;
+    string structural_tag = 5;
+  }
+}
+
+message ChoiceConstraint {
+  repeated string values = 1;
 }
 
 // ---- Text-based generate (text in, text out) ----
@@ -84,12 +104,22 @@ message TextGenerateRequest {
   map<string, string> trace_headers = 12;
   optional string session_id = 13;
   optional DisaggregatedParams disaggregated_params = 14;
+  optional int32 priority = 15;
 }
 
 message TextGenerateResponse {
-  string text = 1;
-  map<string, string> meta_info = 2;
-  bool finished = 3;
+  string delta_text = 1;
+  reserved 2, 3;
+  reserved "meta_info", "finished";
+  int32 choice_index = 4;
+  optional Logprobs logprobs = 5;
+  optional Usage usage = 6;
+  optional RoutedExpertMetadata routed_experts = 7;
+  google.protobuf.Struct engine_metadata = 8;
+  oneof terminal {
+    GenerationFinish finish = 9;
+    GenerationError error = 10;
+  }
 }
 
 // ---- Tokenized generate (input_ids in, token_ids out) ----
@@ -108,12 +138,88 @@ message GenerateRequest {
   map<string, string> trace_headers = 11;
   optional string session_id = 12;
   optional DisaggregatedParams disaggregated_params = 13;
+  optional int32 priority = 14;
 }
 
 message GenerateResponse {
-  repeated int32 output_ids = 1;
-  map<string, string> meta_info = 2;
-  bool finished = 3;
+  repeated int32 delta_output_ids = 1;
+  reserved 2, 3;
+  reserved "meta_info", "finished";
+  int32 choice_index = 4;
+  optional Logprobs logprobs = 5;
+  optional Usage usage = 6;
+  optional RoutedExpertMetadata routed_experts = 7;
+  google.protobuf.Struct engine_metadata = 8;
+  oneof terminal {
+    GenerationFinish finish = 9;
+    GenerationError error = 10;
+  }
+}
+
+message LogprobAlternative {
+  float logprob = 1;
+  int32 token_id = 2;
+  optional string text = 3;
+  optional int32 rank = 4;
+}
+
+message TokenLogprob {
+  float logprob = 1;
+  int32 token_id = 2;
+  optional string text = 3;
+  repeated LogprobAlternative top_logprobs = 4;
+}
+
+message Logprobs {
+  repeated TokenLogprob output = 1;
+  repeated TokenLogprob prompt = 2;
+}
+
+message Usage {
+  uint64 prompt_tokens = 1;
+  uint64 completion_tokens = 2;
+  uint64 total_tokens = 3;
+  uint64 cached_prompt_tokens = 4;
+}
+
+message RoutedExpertMetadata {
+  bytes packed_expert_ids = 1;
+  repeated int64 shape = 2;
+  int32 start_position = 3;
+}
+
+enum FinishReason {
+  FINISH_REASON_UNSPECIFIED = 0;
+  FINISH_REASON_STOP = 1;
+  FINISH_REASON_LENGTH = 2;
+  FINISH_REASON_CANCELLED = 3;
+}
+
+message StopReason {
+  oneof reason {
+    string matched_string = 1;
+    int32 matched_token_id = 2;
+  }
+}
+
+message GenerationFinish {
+  FinishReason reason = 1;
+  optional StopReason stop_reason = 2;
+}
+
+enum GenerationErrorCode {
+  GENERATION_ERROR_CODE_UNSPECIFIED = 0;
+  GENERATION_ERROR_CODE_INVALID_ARGUMENT = 1;
+  GENERATION_ERROR_CODE_CANCELLED = 2;
+  GENERATION_ERROR_CODE_UNAVAILABLE = 3;
+  GENERATION_ERROR_CODE_INTERNAL = 4;
+  GENERATION_ERROR_CODE_DEADLINE_EXCEEDED = 5;
+}
+
+message GenerationError {
+  GenerationErrorCode code = 1;
+  string message = 2;
+  bool retryable = 3;
 }
 
 // ---- Text-based embed (text in, embedding out) ----

--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -104,22 +104,12 @@ message TextGenerateRequest {
   map<string, string> trace_headers = 12;
   optional string session_id = 13;
   optional DisaggregatedParams disaggregated_params = 14;
-  optional int32 priority = 15;
 }
 
 message TextGenerateResponse {
-  string delta_text = 1;
-  reserved 2, 3;
-  reserved "meta_info", "finished";
-  int32 choice_index = 4;
-  optional Logprobs logprobs = 5;
-  optional Usage usage = 6;
-  optional RoutedExpertMetadata routed_experts = 7;
-  google.protobuf.Struct engine_metadata = 8;
-  oneof terminal {
-    GenerationFinish finish = 9;
-    GenerationError error = 10;
-  }
+  string text = 1;
+  map<string, string> meta_info = 2;
+  bool finished = 3;
 }
 
 // ---- Tokenized generate (input_ids in, token_ids out) ----
@@ -178,8 +168,7 @@ message Logprobs {
 message Usage {
   uint64 prompt_tokens = 1;
   uint64 completion_tokens = 2;
-  uint64 total_tokens = 3;
-  uint64 cached_prompt_tokens = 4;
+  uint64 cached_prompt_tokens = 3;
 }
 
 message RoutedExpertMetadata {

--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -7,7 +7,6 @@ service SglangService {
   // SGLang-native RPCs (typed proto)
   rpc TextGenerate(TextGenerateRequest) returns (stream TextGenerateResponse);
   rpc Generate(GenerateRequest) returns (stream GenerateResponse);
-  rpc TypedGenerate(GenerateRequest) returns (stream TypedGenerateResponse);
   rpc TextEmbed(TextEmbedRequest) returns (TextEmbedResponse);
   rpc Embed(EmbedRequest) returns (EmbedResponse);
   rpc Classify(ClassifyRequest) returns (ClassifyResponse);
@@ -136,18 +135,15 @@ message GenerateResponse {
   repeated int32 output_ids = 1;
   map<string, string> meta_info = 2;
   bool finished = 3;
-}
-
-message TypedGenerateResponse {
-  string request_id = 1;
-  int32 choice_index = 2;
-  repeated int32 delta_output_ids = 3;
-  optional Logprobs logprobs = 4;
-  optional Usage usage = 5;
-  google.protobuf.Struct engine_metadata = 6;
+  string request_id = 4;
+  int32 choice_index = 5;
+  repeated int32 delta_output_ids = 6;
+  optional Logprobs logprobs = 7;
+  optional Usage usage = 8;
+  google.protobuf.Struct engine_metadata = 9;
   oneof terminal {
-    GenerationFinish finish = 7;
-    GenerationError error = 8;
+    GenerationFinish finish = 10;
+    GenerationError error = 11;
   }
 }
 

--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -7,6 +7,7 @@ service SglangService {
   // SGLang-native RPCs (typed proto)
   rpc TextGenerate(TextGenerateRequest) returns (stream TextGenerateResponse);
   rpc Generate(GenerateRequest) returns (stream GenerateResponse);
+  rpc TypedGenerate(GenerateRequest) returns (stream TypedGenerateResponse);
   rpc TextEmbed(TextEmbedRequest) returns (TextEmbedResponse);
   rpc Embed(EmbedRequest) returns (EmbedResponse);
   rpc Classify(ClassifyRequest) returns (ClassifyResponse);
@@ -65,8 +66,8 @@ message SamplingParams {
   repeated int32 stop_token_ids = 11;
   optional bool ignore_eos = 12;
   optional int32 n = 13;
-  reserved 14, 15;
-  reserved "json_schema", "regex";
+  optional string json_schema = 14 [deprecated = true];
+  optional string regex = 15 [deprecated = true];
   optional int64 seed = 16;
   optional GuidedDecoding guided_decoding = 17;
   optional bool require_reasoning = 18;
@@ -132,17 +133,21 @@ message GenerateRequest {
 }
 
 message GenerateResponse {
-  repeated int32 delta_output_ids = 1;
-  reserved 2, 3;
-  reserved "meta_info", "finished";
-  int32 choice_index = 4;
-  optional Logprobs logprobs = 5;
-  optional Usage usage = 6;
-  optional RoutedExpertMetadata routed_experts = 7;
-  google.protobuf.Struct engine_metadata = 8;
+  repeated int32 output_ids = 1;
+  map<string, string> meta_info = 2;
+  bool finished = 3;
+}
+
+message TypedGenerateResponse {
+  string request_id = 1;
+  int32 choice_index = 2;
+  repeated int32 delta_output_ids = 3;
+  optional Logprobs logprobs = 4;
+  optional Usage usage = 5;
+  google.protobuf.Struct engine_metadata = 6;
   oneof terminal {
-    GenerationFinish finish = 9;
-    GenerationError error = 10;
+    GenerationFinish finish = 7;
+    GenerationError error = 8;
   }
 }
 
@@ -169,12 +174,6 @@ message Usage {
   uint64 prompt_tokens = 1;
   uint64 completion_tokens = 2;
   uint64 cached_prompt_tokens = 3;
-}
-
-message RoutedExpertMetadata {
-  bytes packed_expert_ids = 1;
-  repeated int64 shape = 2;
-  int32 start_position = 3;
 }
 
 enum FinishReason {

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -10,6 +10,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+import threading
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
@@ -18,6 +19,81 @@ from pydantic import ValidationError
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 
 logger = logging.getLogger(__name__)
+
+_OUTPUT_LOGPROB_KEYS = (
+    "output_token_logprobs",
+    "output_top_logprobs",
+)
+_OUTPUT_TOKEN_ALIGNED_META_KEYS = (
+    "output_token_ids_logprobs",
+    "output_token_sampling_mask",
+    "output_token_sampling_logprobs",
+)
+_PROMPT_LOGPROB_KEYS = (
+    "input_token_logprobs",
+    "input_top_logprobs",
+    "input_token_ids_logprobs",
+)
+
+
+@dataclasses.dataclass
+class _TypedChoiceOffsets:
+    output_ids: int = 0
+    output_logprobs: int = 0
+    prompt_logprobs_sent: bool = False
+
+
+def _delta_start(previous: int, current: int) -> int:
+    return previous if previous <= current else 0
+
+
+def _normalize_typed_stream_chunk(
+    chunk: dict,
+    offsets: _TypedChoiceOffsets,
+    *,
+    incremental: bool,
+) -> dict:
+    """Copy a typed Generate chunk and keep only metadata not sent previously."""
+    normalized = dict(chunk)
+    meta_info = dict(chunk.get("meta_info") or {})
+    normalized["meta_info"] = meta_info
+
+    output_ids = chunk.get("output_ids")
+    output_start = 0
+    if output_ids is not None:
+        if incremental:
+            normalized["output_ids"] = output_ids
+            offsets.output_ids += len(output_ids)
+        else:
+            output_start = _delta_start(offsets.output_ids, len(output_ids))
+            normalized["output_ids"] = output_ids[output_start:]
+            offsets.output_ids = len(output_ids)
+
+    output_logprobs = meta_info.get("output_token_logprobs")
+    if output_logprobs is not None:
+        if incremental:
+            offsets.output_logprobs += len(output_logprobs)
+        else:
+            logprob_start = _delta_start(offsets.output_logprobs, len(output_logprobs))
+            for key in _OUTPUT_LOGPROB_KEYS:
+                values = meta_info.get(key)
+                if values is not None:
+                    meta_info[key] = values[logprob_start:]
+            offsets.output_logprobs = len(output_logprobs)
+
+    if not incremental:
+        for key in _OUTPUT_TOKEN_ALIGNED_META_KEYS:
+            values = meta_info.get(key)
+            if values is not None:
+                meta_info[key] = values[output_start:]
+
+    if offsets.prompt_logprobs_sent:
+        for key in _PROMPT_LOGPROB_KEYS:
+            meta_info.pop(key, None)
+    elif any(meta_info.get(key) is not None for key in _PROMPT_LOGPROB_KEYS):
+        offsets.prompt_logprobs_sent = True
+
+    return normalized
 
 
 class _BadOpenAIRequest(ValueError):
@@ -74,6 +150,8 @@ class RuntimeHandle:
         self.scheduler_info = scheduler_info or {}
 
         self._openai_serving_classes = None
+        self._active_generation_futures = {}
+        self._generation_futures_lock = threading.Lock()
 
         self.tokenizer_manager.auto_create_handle_loop()
         self._event_loop = self.tokenizer_manager.event_loop
@@ -179,12 +257,36 @@ class RuntimeHandle:
         except Exception as e:
             logger.warning("gRPC clear_on_ready failed: %s", e)
 
-    def _submit_on_tm_loop(self, coro: Awaitable) -> None:
+    def _submit_on_tm_loop(self, coro: Awaitable):
         future = asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
         future.add_done_callback(self._log_unhandled_future_exception)
+        return future
+
+    def _track_generation_future(self, rid: str, future) -> None:
+        with self._generation_futures_lock:
+            self._active_generation_futures[rid] = future
+
+        def _remove_finished(completed) -> None:
+            with self._generation_futures_lock:
+                if self._active_generation_futures.get(rid) is completed:
+                    self._active_generation_futures.pop(rid, None)
+
+        future.add_done_callback(_remove_finished)
+
+    def _cancel_generation_futures(self, rid: str, abort_all: bool) -> None:
+        with self._generation_futures_lock:
+            if abort_all:
+                futures = list(self._active_generation_futures.values())
+            else:
+                future = self._active_generation_futures.get(rid)
+                futures = [] if future is None else [future]
+        for future in futures:
+            future.cancel()
 
     @staticmethod
     def _log_unhandled_future_exception(future) -> None:
+        if future.cancelled():
+            return
         try:
             future.result()
         except Exception as e:
@@ -265,6 +367,7 @@ class RuntimeHandle:
         req_type: str,
         req_dict: dict,
         chunk_callback,
+        typed_generation: bool = False,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         mock_request = (
@@ -277,9 +380,18 @@ class RuntimeHandle:
 
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
-            self._submit_on_tm_loop(
-                self._run_generate(obj, chunk_callback, stream, mock_request)
+            future = self._submit_on_tm_loop(
+                self._run_generate(
+                    obj,
+                    chunk_callback,
+                    stream,
+                    mock_request,
+                    typed_generation=typed_generation,
+                )
             )
+            rid = req_dict.get("rid")
+            if isinstance(rid, str):
+                self._track_generation_future(rid, future)
         elif req_type == "embed":
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
@@ -290,15 +402,73 @@ class RuntimeHandle:
                 f"Unknown req_type: {req_type!r} (expected 'generate' or 'embed')"
             )
 
-    async def _run_generate(self, obj, chunk_callback, stream: bool, request):
+    @staticmethod
+    def _generation_error_meta(error: Exception) -> dict:
+        status_code = getattr(error, "status_code", None)
+        if status_code is None:
+            status_code = (
+                400 if isinstance(error, (ValidationError, ValueError)) else 500
+            )
+        detail = getattr(error, "detail", None)
+        return {
+            "finish_reason": {
+                "type": "error",
+                "status_code": status_code,
+                "message": str(detail if detail is not None else error),
+            }
+        }
+
+    async def _send_typed_generation_errors(
+        self,
+        chunk_callback,
+        ready_event: Optional[asyncio.Event],
+        *,
+        error: Exception,
+        expected_choices: int,
+        terminal_choices: set,
+        timeout_abort_rid,
+    ) -> None:
+        unfinished = [
+            index for index in range(expected_choices) if index not in terminal_choices
+        ]
+        for position, index in enumerate(unfinished):
+            keep_going = await self._send_with_backpressure(
+                chunk_callback,
+                ready_event,
+                {
+                    "index": index,
+                    "output_ids": [],
+                    "meta_info": self._generation_error_meta(error),
+                },
+                finished=position == len(unfinished) - 1,
+                timeout_abort_rid=timeout_abort_rid,
+            )
+            if not keep_going:
+                self._abort_request_id(timeout_abort_rid)
+                return
+
+    async def _run_generate(
+        self,
+        obj,
+        chunk_callback,
+        stream: bool,
+        request,
+        *,
+        typed_generation: bool = False,
+    ):
         ready_event = None
+        sampling_params = getattr(obj, "sampling_params", None) or {}
+        expected_choices = max(1, int(sampling_params.get("n", 1)))
+        terminal_choices = set()
         try:
-            ready_event = self._install_on_ready(chunk_callback) if stream else None
-            gen = self.tokenizer_manager.generate_request(obj, request=request)
-            sampling_params = getattr(obj, "sampling_params", None) or {}
-            expected_choices = max(1, int(sampling_params.get("n", 1)))
+            if stream or typed_generation:
+                ready_event = self._install_on_ready(chunk_callback)
+            gen = self.tokenizer_manager.generate_request(
+                obj,
+                request=request,
+                yield_scheduler_errors=typed_generation,
+            )
             if stream:
-                terminal_choices = set()
                 incremental = bool(
                     getattr(
                         self.tokenizer_manager.server_args,
@@ -306,20 +476,23 @@ class RuntimeHandle:
                         False,
                     )
                 )
+                offsets = {
+                    index: _TypedChoiceOffsets() for index in range(expected_choices)
+                }
                 async for chunk in gen:
+                    choice_index = int(chunk.get("index") or 0)
+                    if not 0 <= choice_index < expected_choices:
+                        self._abort_request_id(obj.rid)
+                        self._send_native_error(
+                            chunk_callback,
+                            f"choice index {choice_index} is outside 0..{expected_choices}",
+                        )
+                        return
                     choice_finished = (
                         chunk.get("meta_info", {}).get("finish_reason") is not None
                     )
                     request_finished = False
                     if choice_finished:
-                        choice_index = int(chunk.get("index") or 0)
-                        if not 0 <= choice_index < expected_choices:
-                            self._abort_request_id(obj.rid)
-                            self._send_native_error(
-                                chunk_callback,
-                                f"choice index {choice_index} is outside 0..{expected_choices}",
-                            )
-                            return
                         if choice_index in terminal_choices:
                             self._abort_request_id(obj.rid)
                             self._send_native_error(
@@ -329,15 +502,26 @@ class RuntimeHandle:
                             return
                         terminal_choices.add(choice_index)
                         request_finished = len(terminal_choices) == expected_choices
+                    callback_chunk = (
+                        _normalize_typed_stream_chunk(
+                            chunk,
+                            offsets[choice_index],
+                            incremental=incremental,
+                        )
+                        if typed_generation
+                        else chunk
+                    )
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,
                         ready_event,
-                        chunk,
+                        callback_chunk,
                         finished=request_finished,
-                        incremental=incremental,
                         timeout_abort_rid=obj.rid,
                     )
-                    if request_finished or not keep_going:
+                    if not keep_going:
+                        self._abort_request_id(obj.rid)
+                        return
+                    if request_finished:
                         return
                 # Defensive: generator exited without a finish_reason chunk.
                 missing = sorted(set(range(expected_choices)) - terminal_choices)
@@ -356,21 +540,44 @@ class RuntimeHandle:
                     return
                 for index, item in enumerate(results):
                     item.setdefault("index", index)
-                    self._safe_callback(
+                    keep_going = await self._send_with_backpressure(
                         chunk_callback,
+                        ready_event,
                         item,
                         finished=index == len(results) - 1,
-                        incremental=False,
+                        timeout_abort_rid=obj.rid,
                     )
+                    if not keep_going:
+                        self._abort_request_id(obj.rid)
+                        return
         except StopAsyncIteration:
-            self._send_native_error(
-                chunk_callback, "SGLang returned no generation result"
-            )
+            error = RuntimeError("SGLang returned no generation result")
+            if typed_generation:
+                await self._send_typed_generation_errors(
+                    chunk_callback,
+                    ready_event,
+                    error=error,
+                    expected_choices=expected_choices,
+                    terminal_choices=terminal_choices,
+                    timeout_abort_rid=obj.rid,
+                )
+            else:
+                self._send_native_error(chunk_callback, str(error))
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
-            self._send_native_error(chunk_callback, str(e))
+            if typed_generation:
+                await self._send_typed_generation_errors(
+                    chunk_callback,
+                    ready_event,
+                    error=e,
+                    expected_choices=expected_choices,
+                    terminal_choices=terminal_choices,
+                    timeout_abort_rid=obj.rid,
+                )
+            else:
+                self._send_native_error(chunk_callback, str(e))
         finally:
-            if stream:
+            if ready_event is not None:
                 self._uninstall_on_ready(chunk_callback)
 
     async def _run_embed(self, obj, chunk_callback, request):
@@ -393,6 +600,7 @@ class RuntimeHandle:
     def abort(self, rid: str = "", abort_all: bool = False):
         """Abort a request by request ID or abort all active requests."""
         loop = self._tm_loop
+        self._cancel_generation_futures(rid, abort_all)
 
         try:
             running_loop = asyncio.get_running_loop()

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -295,27 +295,77 @@ class RuntimeHandle:
         try:
             ready_event = self._install_on_ready(chunk_callback) if stream else None
             gen = self.tokenizer_manager.generate_request(obj, request=request)
+            sampling_params = getattr(obj, "sampling_params", None) or {}
+            expected_choices = max(1, int(sampling_params.get("n", 1)))
             if stream:
+                terminal_choices = set()
+                incremental = bool(
+                    getattr(
+                        self.tokenizer_manager.server_args,
+                        "incremental_streaming_output",
+                        False,
+                    )
+                )
                 async for chunk in gen:
-                    finished = (
+                    choice_finished = (
                         chunk.get("meta_info", {}).get("finish_reason") is not None
                     )
+                    request_finished = False
+                    if choice_finished:
+                        choice_index = int(chunk.get("index") or 0)
+                        if not 0 <= choice_index < expected_choices:
+                            self._abort_request_id(obj.rid)
+                            self._send_native_error(
+                                chunk_callback,
+                                f"choice index {choice_index} is outside 0..{expected_choices}",
+                            )
+                            return
+                        if choice_index in terminal_choices:
+                            self._abort_request_id(obj.rid)
+                            self._send_native_error(
+                                chunk_callback,
+                                f"duplicate terminal for choice {choice_index}",
+                            )
+                            return
+                        terminal_choices.add(choice_index)
+                        request_finished = len(terminal_choices) == expected_choices
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,
                         ready_event,
                         chunk,
-                        finished=finished,
+                        finished=request_finished,
+                        incremental=incremental,
                         timeout_abort_rid=obj.rid,
                     )
-                    if finished or not keep_going:
+                    if request_finished or not keep_going:
                         return
                 # Defensive: generator exited without a finish_reason chunk.
-                self._safe_callback(chunk_callback, {}, finished=True)
+                missing = sorted(set(range(expected_choices)) - terminal_choices)
+                self._send_native_error(
+                    chunk_callback,
+                    f"SGLang stream ended without terminal choices: {missing}",
+                )
             else:
                 result = await gen.__anext__()
-                self._safe_callback(chunk_callback, result, finished=True)
+                results = result if isinstance(result, list) else [result]
+                if len(results) != expected_choices:
+                    self._send_native_error(
+                        chunk_callback,
+                        f"SGLang returned {len(results)} choices; expected {expected_choices}",
+                    )
+                    return
+                for index, item in enumerate(results):
+                    item.setdefault("index", index)
+                    self._safe_callback(
+                        chunk_callback,
+                        item,
+                        finished=index == len(results) - 1,
+                        incremental=False,
+                    )
         except StopAsyncIteration:
-            self._safe_callback(chunk_callback, {}, finished=True)
+            self._send_native_error(
+                chunk_callback, "SGLang returned no generation result"
+            )
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
             self._send_native_error(chunk_callback, str(e))
@@ -505,9 +555,11 @@ class RuntimeHandle:
             obj = UpdateWeightFromDiskReqInput(
                 model_path=model_path, load_format=load_format
             )
-            success, message, num_paused = (
-                await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
-            )
+            (
+                success,
+                message,
+                num_paused,
+            ) = await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
             return {
                 "success": success,
                 "message": message,

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -461,7 +461,7 @@ class RuntimeHandle:
         expected_choices = max(1, int(sampling_params.get("n", 1)))
         terminal_choices = set()
         try:
-            if stream or typed_generation:
+            if stream or typed_generation or expected_choices > 1:
                 ready_event = self._install_on_ready(chunk_callback)
             gen = self.tokenizer_manager.generate_request(
                 obj,
@@ -481,7 +481,7 @@ class RuntimeHandle:
                 }
                 legacy_output_ids = (
                     {index: [] for index in range(expected_choices)}
-                    if incremental and not typed_generation
+                    if incremental
                     else None
                 )
                 async for chunk in gen:
@@ -513,6 +513,19 @@ class RuntimeHandle:
                             offsets[choice_index],
                             incremental=incremental,
                         )
+                        callback_chunk["legacy_meta_info"] = chunk.get("meta_info") or {}
+                        if incremental:
+                            assert legacy_output_ids is not None
+                            legacy_output_ids[choice_index].extend(
+                                chunk.get("output_ids") or []
+                            )
+                            callback_chunk["legacy_output_ids"] = list(
+                                legacy_output_ids[choice_index]
+                            )
+                        else:
+                            callback_chunk["legacy_output_ids"] = list(
+                                chunk.get("output_ids") or []
+                            )
                     elif incremental:
                         assert legacy_output_ids is not None
                         legacy_output_ids[choice_index].extend(
@@ -552,11 +565,20 @@ class RuntimeHandle:
                     )
                     return
                 for index, item in enumerate(results):
-                    item.setdefault("index", index)
+                    callback_item = item
+                    if typed_generation:
+                        callback_item = dict(item)
+                        callback_item["legacy_output_ids"] = list(
+                            item.get("output_ids") or []
+                        )
+                        callback_item["legacy_meta_info"] = (
+                            item.get("meta_info") or {}
+                        )
+                    callback_item.setdefault("index", index)
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,
                         ready_event,
-                        item,
+                        callback_item,
                         finished=index == len(results) - 1,
                         timeout_abort_rid=obj.rid,
                     )

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -479,6 +479,11 @@ class RuntimeHandle:
                 offsets = {
                     index: _TypedChoiceOffsets() for index in range(expected_choices)
                 }
+                legacy_output_ids = (
+                    {index: [] for index in range(expected_choices)}
+                    if incremental and not typed_generation
+                    else None
+                )
                 async for chunk in gen:
                     choice_index = int(chunk.get("index") or 0)
                     if not 0 <= choice_index < expected_choices:
@@ -502,15 +507,23 @@ class RuntimeHandle:
                             return
                         terminal_choices.add(choice_index)
                         request_finished = len(terminal_choices) == expected_choices
-                    callback_chunk = (
-                        _normalize_typed_stream_chunk(
+                    if typed_generation:
+                        callback_chunk = _normalize_typed_stream_chunk(
                             chunk,
                             offsets[choice_index],
                             incremental=incremental,
                         )
-                        if typed_generation
-                        else chunk
-                    )
+                    elif incremental:
+                        assert legacy_output_ids is not None
+                        legacy_output_ids[choice_index].extend(
+                            chunk.get("output_ids") or []
+                        )
+                        callback_chunk = dict(chunk)
+                        callback_chunk["output_ids"] = list(
+                            legacy_output_ids[choice_index]
+                        )
+                    else:
+                        callback_chunk = chunk
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,
                         ready_event,

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -563,6 +563,19 @@ class RuntimeHandle:
                 )
             else:
                 self._send_native_error(chunk_callback, str(error))
+        except asyncio.CancelledError:
+            if not typed_generation:
+                raise
+            error = RuntimeError(f"Request aborted: {obj.rid}")
+            error.status_code = 499
+            await self._send_typed_generation_errors(
+                chunk_callback,
+                ready_event,
+                error=error,
+                expected_choices=expected_choices,
+                terminal_choices=terminal_choices,
+                timeout_abort_rid=obj.rid,
+            )
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
             if typed_generation:

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -513,7 +513,9 @@ class RuntimeHandle:
                             offsets[choice_index],
                             incremental=incremental,
                         )
-                        callback_chunk["legacy_meta_info"] = chunk.get("meta_info") or {}
+                        callback_chunk["legacy_meta_info"] = (
+                            chunk.get("meta_info") or {}
+                        )
                         if incremental:
                             assert legacy_output_ids is not None
                             legacy_output_ids[choice_index].extend(
@@ -571,9 +573,7 @@ class RuntimeHandle:
                         callback_item["legacy_output_ids"] = list(
                             item.get("output_ids") or []
                         )
-                        callback_item["legacy_meta_info"] = (
-                            item.get("meta_info") or {}
-                        )
+                        callback_item["legacy_meta_info"] = item.get("meta_info") or {}
                     callback_item.setdefault("index", index)
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -153,8 +153,9 @@ MultimodalDataInputFormat = Union[
 
 @dataclass
 class GenerateReqInput:
-    # Request ID(s). If omitted, generated during normalization. For batch
-    # requests, a string is expanded to per-item IDs using it as a prefix.
+    # Logical request ID(s). If omitted, generated during normalization. For
+    # batch requests, a string is expanded to one ID per original batch item.
+    # Parallel-sampling child IDs are internal to TokenizerManager.
     rid: Optional[Union[str, List[str]]] = field(default=None, kw_only=True)
     # Stable identity shared by requests in the same session. Unlike
     # session_params, this does not alter or reconstruct the prompt.
@@ -452,7 +453,7 @@ class GenerateReqInput:
 
         # Expand input based on type
         self._expand_inputs(num)
-        self._normalize_rid(num)
+        self._normalize_rid()
         self._normalize_lora_paths(num)
         self._normalize_image_data(num)
         self._normalize_video_data(num)
@@ -561,16 +562,16 @@ class GenerateReqInput:
         else:  # Already a list
             self.sampling_params = self.sampling_params * self.parallel_sample_num
 
-    def _normalize_rid(self, num):
-        """Normalize request IDs for batch processing."""
+    def _normalize_rid(self):
+        """Normalize one logical request ID per original batch item."""
         if self.rid is None:
-            self.rid = [uuid.uuid4().hex for _ in range(num)]
+            self.rid = [uuid.uuid4().hex for _ in range(self.batch_size)]
         elif isinstance(self.rid, str):
-            new_rids = [f"{self.rid}_{i}" for i in range(num)]
-            self.rid = new_rids
+            if self.batch_size == 1:
+                self.rid = [self.rid]
+            else:
+                self.rid = [f"{self.rid}_{i}" for i in range(self.batch_size)]
         elif isinstance(self.rid, list):
-            # Note: the length of rid shall be the same as the batch_size,
-            # as the rid would be expanded for parallel sampling in tokenizer_manager
             if len(self.rid) != self.batch_size:
                 raise ValueError(
                     "The specified rids length mismatch with the batch_size for batch processing."
@@ -706,8 +707,9 @@ class GenerateReqInput:
         cache = self.__dict__.setdefault("_sub_obj_cache", {})
         if i in cache:
             return cache[i]
+        logical_index = i % self.batch_size
         sub = GenerateReqInput(
-            rid=self.rid[i],
+            rid=self.rid[logical_index],
             session_id=self.session_id,
             text=self.text[i] if self.text is not None else None,
             input_ids=self.input_ids[i] if self.input_ids is not None else None,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1817,7 +1817,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         elif rid in self.rid_to_state:
             state = self.rid_to_state[rid]
             state.abort_requested = True
-            if getattr(state.obj, "parallel_sample_num", 1) > 1:
+            parallel_sample_num = getattr(state.obj, "parallel_sample_num", None)
+            if parallel_sample_num is None:
+                sampling_params = getattr(state.obj, "sampling_params", None)
+                parallel_sample_num = (
+                    sampling_params.get("n", 1)
+                    if isinstance(sampling_params, dict)
+                    else 1
+                )
+            if parallel_sample_num > 1:
                 # Snapshot because scheduler abort echoes remove child ownership.
                 target_rids = tuple(sorted(self.logical_rid_to_child_rids.get(rid, ())))
             else:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -168,6 +168,10 @@ _INCREMENTAL_STREAMING_META_INFO_KEYS = (
 )
 
 
+class RequestAbortedError(RuntimeError):
+    status_code = 499
+
+
 @dataclasses.dataclass
 class ReqState:
     """Store the state a request."""
@@ -179,6 +183,7 @@ class ReqState:
 
     # For performance metrics
     time_stats: APIServerReqTimeStats
+    abort_requested: bool = False
     last_completion_tokens: int = 1
     ttft_observed: bool = False
 
@@ -445,6 +450,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     def init_running_status(self):
         # Request states
         self.rid_to_state: Dict[str, ReqState] = {}
+        # Parallel sampling keeps one caller-visible logical RID per original
+        # prompt while the scheduler operates on separate prefix/sample RIDs.
+        self.logical_rid_to_child_rids: Dict[str, set[str]] = {}
+        self.child_rid_to_logical_rid: Dict[str, str] = {}
         self.event_loop = None
         self.asyncio_tasks = set()
 
@@ -625,6 +634,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
+        yield_scheduler_errors: bool = False,
     ):
         self.auto_create_handle_loop()
 
@@ -653,23 +663,34 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
             async with self.is_pause_cond:
                 await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+            self._raise_if_logical_request_aborted(obj)
 
             async with self.model_update_lock.reader_lock:
                 await self._validate_and_resolve_lora(obj)
+                self._raise_if_logical_request_aborted(obj)
 
                 # Tokenize the request and send it to the scheduler
                 if obj.is_single:
                     tokenized_obj = await self._tokenize_one_request(obj)
+                    self._raise_if_logical_rid_aborted(obj.rid)
                     state = self.rid_to_state[obj.rid]
                     if obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_obj.input_ids)
                     self._send_one_request(tokenized_obj)
-                    async for response in self._wait_one_response(obj, request):
+                    async for response in self._wait_one_response(
+                        obj,
+                        request,
+                        yield_scheduler_errors=yield_scheduler_errors,
+                    ):
                         yield response
                 else:
-                    async for response in self._handle_batch_request(obj, request):
+                    async for response in self._handle_batch_request(
+                        obj,
+                        request,
+                        yield_scheduler_errors=yield_scheduler_errors,
+                    ):
                         yield response
-        except Exception:
+        except BaseException:
             # _init_req_state created a rid_to_state entry per (sub-)request up
             # front. The normal remover is the scheduler-response path
             # (_handle_batch_output), so a failure *before* a request reaches the
@@ -677,7 +698,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # request -- would otherwise leak those entries forever. Drop any that
             # are still pending; entries already removed on the normal completion
             # path are left untouched (pop is a no-op).
-            self._discard_pending_req_states(obj)
+            is_parallel = (
+                isinstance(obj, GenerateReqInput)
+                and getattr(obj, "parallel_sample_num", 1) > 1
+            )
+            self._discard_pending_req_states(obj, abort_active_children=is_parallel)
             raise
 
     def _detect_input_format(
@@ -1440,6 +1465,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         out: dict,
         state: ReqState,
         is_stream: bool,
+        yield_scheduler_errors: bool = False,
     ) -> Optional[dict]:
         """Handle abort/error finish reasons from the scheduler.
 
@@ -1447,34 +1473,50 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         for normal flow. Raises ValueError or HTTPException for non-stream aborts.
         """
         finish_reason = out["meta_info"]["finish_reason"]
+        status_code = finish_reason.get("status_code")
 
         if (
             finish_reason.get("type") == "abort"
-            and finish_reason.get("status_code") == HTTPStatus.BAD_REQUEST
+            and status_code == HTTPStatus.BAD_REQUEST
         ):
             if not is_stream:
+                if yield_scheduler_errors:
+                    return out
                 raise ValueError(finish_reason["message"])
             return out
 
-        if finish_reason.get("type") == "abort" and finish_reason.get(
-            "status_code"
-        ) in (
+        if finish_reason.get("type") == "abort" and status_code in (
             HTTPStatus.SERVICE_UNAVAILABLE,
             HTTPStatus.INTERNAL_SERVER_ERROR,
         ):
             # Delete the key to prevent resending abort request to the scheduler and
             # to ensure aborted request state is cleaned up.
             if state.obj.rid in self.rid_to_state:
-                del self.rid_to_state[state.obj.rid]
+                self._remove_req_state(state.obj.rid)
 
             # Mark ongoing LoRA request as finished.
             if self.enable_lora and state.obj.lora_path:
                 await self.lora_registry.release(state.obj.lora_id)
             if not is_stream:
+                if yield_scheduler_errors:
+                    return out
                 raise fastapi.HTTPException(
-                    status_code=finish_reason["status_code"],
+                    status_code=status_code,
                     detail=finish_reason["message"],
                 )
+            return out
+
+        if (
+            yield_scheduler_errors
+            and not is_stream
+            and finish_reason.get("type") == "error"
+            and status_code
+            in (
+                HTTPStatus.BAD_REQUEST,
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                HTTPStatus.SERVICE_UNAVAILABLE,
+            )
+        ):
             return out
 
         return None
@@ -1483,6 +1525,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
+        yield_scheduler_errors: bool = False,
     ):
         """Wait for the response of one request."""
         state = self.rid_to_state[obj.rid]
@@ -1540,9 +1583,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Record response sent time right before we log finished results and metrics.
                 if not state.time_stats.response_sent_to_client_time:
                     state.time_stats.set_response_sent_to_client_time()
-                    out["meta_info"][
-                        "response_sent_to_client_ts"
-                    ] = state.time_stats.get_response_sent_to_client_realtime()
+                    out["meta_info"]["response_sent_to_client_ts"] = (
+                        state.time_stats.get_response_sent_to_client_realtime()
+                    )
                 self.request_logger.log_finished_request(
                     obj,
                     out,
@@ -1557,7 +1600,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Check if this was an abort/error created by scheduler
                 if isinstance(out["meta_info"].get("finish_reason"), dict):
                     abort_out = await self._handle_abort_finish_reason(
-                        out, state, is_stream
+                        out,
+                        state,
+                        is_stream,
+                        yield_scheduler_errors=yield_scheduler_errors,
                     )
                     if abort_out is not None:
                         yield abort_out
@@ -1570,9 +1616,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Record response sent time right before we send response.
                 if not state.time_stats.response_sent_to_client_time:
                     state.time_stats.set_response_sent_to_client_time()
-                    out["meta_info"][
-                        "response_sent_to_client_ts"
-                    ] = state.time_stats.get_response_sent_to_client_realtime()
+                    out["meta_info"]["response_sent_to_client_ts"] = (
+                        state.time_stats.get_response_sent_to_client_realtime()
+                    )
                 yield out
             else:
                 if (
@@ -1591,6 +1637,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
+        yield_scheduler_errors: bool = False,
     ):
         batch_size = obj.batch_size
 
@@ -1599,6 +1646,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if getattr(obj, "parallel_sample_num", 1) == 1:
             if self._should_use_batch_tokenization(batch_size, obj):
                 tokenized_objs = await self._batch_tokenize_and_process(batch_size, obj)
+                self._raise_if_logical_request_aborted(obj)
                 self._send_batch_request(tokenized_objs)
 
                 # Set up generators for each request in the batch
@@ -1607,7 +1655,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     state = self.rid_to_state[tmp_obj.rid]
                     if tmp_obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_objs[i].input_ids)
-                    generators.append(self._wait_one_response(tmp_obj, request))
+                    generators.append(
+                        self._wait_one_response(
+                            tmp_obj,
+                            request,
+                            yield_scheduler_errors=yield_scheduler_errors,
+                        )
+                    )
                     rids.append(tmp_obj.rid)
             else:
                 # Sequential tokenization and processing
@@ -1621,11 +1675,18 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     for i in range(batch_size):
                         tmp_obj = obj[i]
                         tokenized_obj = await self._tokenize_one_request(tmp_obj)
+                        self._raise_if_logical_rid_aborted(tmp_obj.rid)
                         state = self.rid_to_state[tmp_obj.rid]
                         if tmp_obj.return_prompt_token_ids:
                             state.prompt_token_ids = list(tokenized_obj.input_ids)
                         self._send_one_request(tokenized_obj)
-                        generators.append(self._wait_one_response(tmp_obj, request))
+                        generators.append(
+                            self._wait_one_response(
+                                tmp_obj,
+                                request,
+                                yield_scheduler_errors=yield_scheduler_errors,
+                            )
+                        )
                         rids.append(tmp_obj.rid)
         else:
             # FIXME: When using batch and parallel_sample_num together, the perf is not optimal.
@@ -1641,9 +1702,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             tokenized_objs = await asyncio.gather(
                 *(self._tokenize_one_request(obj) for obj in objs)
             )
+            self._raise_if_logical_request_aborted(obj)
 
             # Cache the common prefix for parallel sampling
             for i in range(batch_size):
+                logical_rid = objs[i].rid
+                self._raise_if_logical_rid_aborted(logical_rid)
                 tmp_obj = copy.copy(objs[i])
                 tokenized_obj = copy.copy(tokenized_objs[i])
                 # Ensure independent mm_items so wrap_shm_features won't mutate the original
@@ -1656,13 +1720,18 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 tokenized_obj.sampling_params = copy.copy(tokenized_obj.sampling_params)
                 tokenized_obj.sampling_params.max_new_tokens = 0
                 tokenized_obj.stream = False
-                self._init_req_state(tmp_obj)
+                self._init_child_req_state(logical_rid, tmp_obj)
                 self._send_one_request(tokenized_obj)
+                # This hidden max_new_tokens=0 request is not a caller-visible
+                # choice, so keep legacy exception behavior for its failures.
                 await self._wait_one_response(tmp_obj, request).__anext__()
+                self._raise_if_logical_rid_aborted(logical_rid)
 
             # Expand requests, assign new rids for them, and send them
             for i in range(batch_size):
+                logical_rid = objs[i].rid
                 for _ in range(obj.parallel_sample_num):
+                    self._raise_if_logical_rid_aborted(logical_rid)
                     tmp_obj = copy.copy(objs[i])
                     tokenized_obj = copy.copy(tokenized_objs[i])
                     # Ensure independent mm_items so wrap_shm_features won't mutate the original
@@ -1672,17 +1741,25 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                             copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
                         ]
                     tokenized_obj.rid = tmp_obj.regenerate_rid()
-                    self._init_req_state(tmp_obj)
+                    self._init_child_req_state(logical_rid, tmp_obj)
                     state = self.rid_to_state[tmp_obj.rid]
                     tokenized_obj.time_stats = state.time_stats
                     if tmp_obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_objs[i].input_ids)
                     self._send_one_request(tokenized_obj)
-                    generators.append(self._wait_one_response(tmp_obj, request))
+                    generators.append(
+                        self._wait_one_response(
+                            tmp_obj,
+                            request,
+                            yield_scheduler_errors=yield_scheduler_errors,
+                        )
+                    )
                     rids.append(tmp_obj.rid)
 
-                self.rid_to_state[objs[i].rid].time_stats.set_finished_time()
-                del self.rid_to_state[objs[i].rid]
+                parent_state = self.rid_to_state.get(logical_rid)
+                if parent_state is not None:
+                    parent_state.time_stats.set_finished_time()
+                self._remove_req_state(logical_rid)
 
         # Wait for all requests
         is_stream = hasattr(obj, "stream") and obj.stream
@@ -1690,8 +1767,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             outputs = await asyncio.gather(*(gen.__anext__() for gen in generators))
             yield outputs
         else:
-            rid_to_index = {rid: i for i, rid in enumerate(rids)}
-            task_map = {asyncio.create_task(gen.__anext__()): gen for gen in generators}
+            async for response in self._stream_batch_responses(generators, rids):
+                yield response
+
+    async def _stream_batch_responses(self, generators, rids):
+        rid_to_index = {rid: i for i, rid in enumerate(rids)}
+        task_map = {asyncio.create_task(gen.__anext__()): gen for gen in generators}
+        try:
             while task_map:
                 done, _ = await asyncio.wait(
                     task_map.keys(), return_when=asyncio.FIRST_COMPLETED
@@ -1707,20 +1789,48 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         task_map[new_task] = gen
                     except StopAsyncIteration:
                         pass
+        finally:
+            pending_tasks = list(task_map)
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+            await asyncio.gather(
+                *(gen.aclose() for gen in generators),
+                return_exceptions=True,
+            )
 
     def abort_request(self, rid: str = "", abort_all: bool = False):
         # Empty rid would startswith-match every request on the scheduler.
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
             return
-        if (
-            not abort_all
-            and self.server_args.tokenizer_worker_num == 1
-            and rid not in self.rid_to_state
-        ):
+        self._ensure_rid_lifecycle_state()
+        if abort_all:
+            for state_rid, state in self.rid_to_state.items():
+                if state_rid not in self.child_rid_to_logical_rid:
+                    state.abort_requested = True
+            target_rids = (rid,)
+        elif rid in self.child_rid_to_logical_rid:
+            # Preserve direct child aborts for internal callers.
+            target_rids = (rid,)
+        elif rid in self.rid_to_state:
+            state = self.rid_to_state[rid]
+            state.abort_requested = True
+            if getattr(state.obj, "parallel_sample_num", 1) > 1:
+                # Snapshot because scheduler abort echoes remove child ownership.
+                target_rids = tuple(sorted(self.logical_rid_to_child_rids.get(rid, ())))
+            else:
+                target_rids = (rid,)
+        elif child_rids := self.logical_rid_to_child_rids.get(rid):
+            target_rids = tuple(sorted(child_rids))
+        elif self.server_args.tokenizer_worker_num == 1:
             return
-        req = AbortReq(rid=rid, abort_all=abort_all)
-        self._dispatch_to_scheduler(req)
+        else:
+            target_rids = (rid,)
+
+        for target_rid in target_rids:
+            self._dispatch_to_scheduler(AbortReq(rid=target_rid, abort_all=abort_all))
         if self.enable_metrics:
             # TODO: also use custom_labels from the request
             self.metrics_collector.observe_one_aborted_request(
@@ -1771,9 +1881,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             self.model_update_lock.writer_lock if not is_paused else nullcontext()
         )
         async with lock_context:
-            success, message, num_paused_requests = (
-                await self._wait_for_model_update_from_disk(obj)
-            )
+            (
+                success,
+                message,
+                num_paused_requests,
+            ) = await self._wait_for_model_update_from_disk(obj)
 
         if success and obj.weight_version is not None:
             self._update_weight_version_if_provided(obj.weight_version)
@@ -2162,7 +2274,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         )
                     )
 
-                del self.rid_to_state[rid]
+                self._remove_req_state(rid)
 
                 # Mark ongoing LoRA request as finished.
                 if self.enable_lora and state.obj.lora_path:
@@ -2665,7 +2777,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 filename = os.path.join(
                     self.crash_dump_folder,
                     hostname,
-                    f'crash_dump_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}.pkl',
+                    f"crash_dump_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.pkl",
                 )
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
 
@@ -2824,7 +2936,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "output_ids": output_ids,
             "meta_info": meta_info,
         }
-        del self.rid_to_state[recv_obj.rid]
+        self._remove_req_state(recv_obj.rid)
 
         state.out_list.append(out)
         state.event.set()
@@ -2872,9 +2984,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 scale_phase=self.elastic_scale_phase,
             )
         self.auto_create_handle_loop()
-        responses: List[ScaleElasticEPReqOutput] = (
-            await self.scale_elastic_ep_communicator(obj)
-        )
+        responses: List[
+            ScaleElasticEPReqOutput
+        ] = await self.scale_elastic_ep_communicator(obj)
         for res in responses:
             if not res.success:
                 self.elastic_scale_phase = res.scale_phase
@@ -2980,6 +3092,69 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 obj.lora_id[i] if isinstance(obj.lora_id, list) else obj.lora_id
             )
 
+    def _ensure_rid_lifecycle_state(self) -> None:
+        # Some unit tests construct TokenizerManager with __new__.
+        if not hasattr(self, "logical_rid_to_child_rids"):
+            self.logical_rid_to_child_rids = {}
+        if not hasattr(self, "child_rid_to_logical_rid"):
+            self.child_rid_to_logical_rid = {}
+
+    @staticmethod
+    def _logical_rids(obj) -> List[str]:
+        if not hasattr(obj, "is_single") or obj.is_single:
+            return [obj.rid]
+        return list(obj.rid)
+
+    def _register_child_rid(self, logical_rid: str, child_rid: str) -> None:
+        self._ensure_rid_lifecycle_state()
+        if child_rid == logical_rid:
+            raise ValueError(
+                "Parallel-sampling child RID must differ from its logical RID"
+            )
+        owner = self.child_rid_to_logical_rid.get(child_rid)
+        if owner is not None and owner != logical_rid:
+            raise ValueError(
+                f"Request ID {child_rid} is already owned by logical request {owner}"
+            )
+        self.child_rid_to_logical_rid[child_rid] = logical_rid
+        self.logical_rid_to_child_rids.setdefault(logical_rid, set()).add(child_rid)
+
+    def _init_child_req_state(
+        self,
+        logical_rid: str,
+        obj: Union[GenerateReqInput, EmbeddingReqInput],
+        request: Optional[fastapi.Request] = None,
+    ) -> None:
+        self._raise_if_logical_rid_aborted(logical_rid)
+        self._init_req_state(obj, request)
+        try:
+            self._register_child_rid(logical_rid, obj.rid)
+        except BaseException:
+            self._remove_req_state(obj.rid)
+            raise
+
+    def _remove_req_state(self, rid: str) -> Optional[ReqState]:
+        """Remove a request state and its parallel-sampling ownership."""
+        self._ensure_rid_lifecycle_state()
+        state = self.rid_to_state.pop(rid, None)
+        logical_rid = self.child_rid_to_logical_rid.pop(rid, None)
+        if logical_rid is not None:
+            children = self.logical_rid_to_child_rids.get(logical_rid)
+            if children is not None:
+                children.discard(rid)
+                if not children:
+                    self.logical_rid_to_child_rids.pop(logical_rid, None)
+        return state
+
+    def _raise_if_logical_rid_aborted(self, logical_rid: str) -> None:
+        state = self.rid_to_state.get(logical_rid)
+        if state is not None and state.abort_requested:
+            raise RequestAbortedError(f"Request {logical_rid} was aborted")
+
+    def _raise_if_logical_request_aborted(self, obj) -> None:
+        for logical_rid in self._logical_rids(obj):
+            self._raise_if_logical_rid_aborted(logical_rid)
+
     def _init_req_state(
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
@@ -3015,9 +3190,23 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 for i in range(len(obj.rid))
             ]
 
-        for rid, sub_obj, bootstrap_room in items:
-            if rid in self.rid_to_state:
+        self._ensure_rid_lifecycle_state()
+        rids = [rid for rid, _, _ in items]
+        seen_rids = set()
+        for rid in rids:
+            if rid in seen_rids:
                 raise ValueError(f"Duplicate request ID detected: {rid}")
+            seen_rids.add(rid)
+            if (
+                rid in self.rid_to_state
+                or rid in self.logical_rid_to_child_rids
+                or rid in self.child_rid_to_logical_rid
+            ):
+                raise ValueError(f"Duplicate request ID detected: {rid}")
+
+        # Mutate only after every RID passes duplicate validation so a rejected
+        # batch cannot leave a partial rid_to_state insertion behind.
+        for rid, sub_obj, bootstrap_room in items:
             time_stats = APIServerReqTimeStats(disagg_mode=self.disaggregation_mode)
             state = ReqState([], False, asyncio.Event(), sub_obj, time_stats)
             self.rid_to_state[rid] = state
@@ -3025,19 +3214,31 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 time_stats.init_trace_ctx(rid, bootstrap_room, external_trace_header)
             time_stats.set_created_time(created_time)
 
-    def _discard_pending_req_states(self, obj):
-        """Drop rid_to_state entries created by _init_req_state for *obj*.
+    def _discard_pending_req_states(self, obj, *, abort_active_children=False):
+        """Drop all logical and child state owned by *obj*.
 
         Safe to call after a partial/failed dispatch: only entries still present
         are removed, and the scheduler-response path looks up state with
         ``.get(...)`` so a later output for a discarded rid is ignored, not fatal.
         """
-        if not hasattr(obj, "is_single") or obj.is_single:
-            rids = [obj.rid]
-        else:
-            rids = obj.rid
-        for rid in rids:
-            self.rid_to_state.pop(rid, None)
+        self._ensure_rid_lifecycle_state()
+        for logical_rid in self._logical_rids(obj):
+            child_rids = tuple(self.logical_rid_to_child_rids.get(logical_rid, ()))
+            if abort_active_children:
+                for child_rid in child_rids:
+                    try:
+                        self._dispatch_to_scheduler(
+                            AbortReq(rid=child_rid, abort_all=False)
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to abort parallel-sampling child rid=%s",
+                            child_rid,
+                        )
+            for child_rid in child_rids:
+                self._remove_req_state(child_rid)
+            self._remove_req_state(logical_rid)
+            self.logical_rid_to_child_rids.pop(logical_rid, None)
 
     def _should_dispatch_to_encoder(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1583,9 +1583,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Record response sent time right before we log finished results and metrics.
                 if not state.time_stats.response_sent_to_client_time:
                     state.time_stats.set_response_sent_to_client_time()
-                    out["meta_info"]["response_sent_to_client_ts"] = (
-                        state.time_stats.get_response_sent_to_client_realtime()
-                    )
+                    out["meta_info"][
+                        "response_sent_to_client_ts"
+                    ] = state.time_stats.get_response_sent_to_client_realtime()
                 self.request_logger.log_finished_request(
                     obj,
                     out,
@@ -1616,9 +1616,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Record response sent time right before we send response.
                 if not state.time_stats.response_sent_to_client_time:
                     state.time_stats.set_response_sent_to_client_time()
-                    out["meta_info"]["response_sent_to_client_ts"] = (
-                        state.time_stats.get_response_sent_to_client_realtime()
-                    )
+                    out["meta_info"][
+                        "response_sent_to_client_ts"
+                    ] = state.time_stats.get_response_sent_to_client_realtime()
                 yield out
             else:
                 if (
@@ -2992,9 +2992,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 scale_phase=self.elastic_scale_phase,
             )
         self.auto_create_handle_loop()
-        responses: List[
-            ScaleElasticEPReqOutput
-        ] = await self.scale_elastic_ep_communicator(obj)
+        responses: List[ScaleElasticEPReqOutput] = (
+            await self.scale_elastic_ep_communicator(obj)
+        )
         for res in responses:
             if not res.success:
                 self.elastic_scale_phase = res.scale_phase

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,6 @@ license = "Apache-2.0"
 # where needed).
 [workspace.dependencies]
 async-stream = "0.3"
-base64 = "0.22"
 bytes = "1"
 futures = "0.3"
 prost-types = "0.13"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,8 +16,10 @@ license = "Apache-2.0"
 # where needed).
 [workspace.dependencies]
 async-stream = "0.3"
+base64 = "0.22"
 bytes = "1"
 futures = "0.3"
+prost-types = "0.13"
 pyo3 = { version = "0.29.0", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/sglang-grpc/Cargo.toml
+++ b/rust/sglang-grpc/Cargo.toml
@@ -20,6 +20,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 async-stream = { workspace = true }
+base64 = { workspace = true }
+prost-types = { workspace = true }
 pyo3 = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/rust/sglang-grpc/Cargo.toml
+++ b/rust/sglang-grpc/Cargo.toml
@@ -20,7 +20,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 async-stream = { workspace = true }
-base64 = { workspace = true }
 prost-types = { workspace = true }
 pyo3 = { workspace = true }
 serde_json = { workspace = true }

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -2,13 +2,14 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::tokenizers::RustTokenizer;
-use crate::utils::{json_map_to_pydict, py_value_to_json_value};
+use crate::utils::{json_map_to_pydict, py_value_to_json_string, py_value_to_json_value};
 
 #[derive(Debug, Clone)]
 pub enum ResponseChunk {
@@ -29,9 +30,53 @@ pub struct ResponseData {
     pub output_ids: Option<Vec<i32>>,
     pub embedding: Option<Vec<f32>>,
     pub choice_index: i32,
-    pub incremental: bool,
     pub json_bytes: Option<Vec<u8>>,
-    pub meta_info: serde_json::Map<String, serde_json::Value>,
+    pub meta_info: ResponseMetadata,
+}
+
+#[derive(Debug, Clone)]
+pub enum ResponseMetadata {
+    Legacy(HashMap<String, String>),
+    Typed(serde_json::Map<String, serde_json::Value>),
+}
+
+impl ResponseMetadata {
+    pub fn into_legacy(self) -> Result<HashMap<String, String>, &'static str> {
+        match self {
+            Self::Legacy(meta) => Ok(meta),
+            Self::Typed(_) => Err("expected legacy string metadata"),
+        }
+    }
+
+    pub fn as_typed(&self) -> Result<&serde_json::Map<String, serde_json::Value>, &'static str> {
+        match self {
+            Self::Typed(meta) => Ok(meta),
+            Self::Legacy(_) => Err("expected typed JSON metadata"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResponseMetadataMode {
+    LegacyStringMap,
+    TypedGenerate,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RequestKey {
+    rid: String,
+    incarnation: u64,
+}
+
+impl RequestKey {
+    pub fn rid(&self) -> &str {
+        &self.rid
+    }
+}
+
+pub struct SubmittedRequest {
+    pub key: RequestKey,
+    pub receiver: Receiver<ResponseChunk>,
 }
 
 pub const DEFAULT_RESPONSE_CHANNEL_CAPACITY: usize = 64;
@@ -40,11 +85,17 @@ type BridgeStateRef = Arc<Mutex<BridgeState>>;
 
 #[derive(Default)]
 struct BridgeState {
-    channels: HashMap<String, Sender<ResponseChunk>>,
-    pending_sends: HashSet<String>,
-    ready_callbacks: HashMap<String, Py<PyAny>>,
-    ready_signals: HashSet<String>,
-    terminal_errors: HashMap<String, TerminalError>,
+    channels: HashMap<String, ActiveChannel>,
+    abort_all_in_progress: bool,
+    pending_sends: HashSet<RequestKey>,
+    ready_callbacks: HashMap<RequestKey, Py<PyAny>>,
+    ready_signals: HashSet<RequestKey>,
+    terminal_errors: HashMap<RequestKey, TerminalError>,
+}
+
+struct ActiveChannel {
+    incarnation: u64,
+    sender: Sender<ResponseChunk>,
 }
 
 #[derive(Debug, Clone)]
@@ -94,6 +145,7 @@ pub struct PyBridge {
     context_len: i32,
     response_channel_capacity: usize,
     tokio_handle: Handle,
+    next_incarnation: AtomicU64,
 }
 
 impl PyBridge {
@@ -115,6 +167,7 @@ impl PyBridge {
             context_len,
             response_channel_capacity,
             tokio_handle,
+            next_incarnation: AtomicU64::new(1),
         }
     }
 
@@ -132,26 +185,43 @@ impl PyBridge {
     // Channel + callback helpers
     // ------------------------------------------------------------------
 
-    fn create_channel(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    fn create_channel(&self, rid: &str) -> PyResult<SubmittedRequest> {
         let (sender, receiver) = mpsc::channel(self.response_channel_capacity);
         let mut state = lock_or_recover(self.state.as_ref(), "state");
+        if state.abort_all_in_progress {
+            return Err(PyRuntimeError::new_err(
+                "Cannot submit a gRPC request while abort_all is in progress",
+            ));
+        }
         if state.channels.contains_key(rid) {
             return Err(PyRuntimeError::new_err(format!(
                 "Duplicate active gRPC request id: {}",
                 rid
             )));
         }
-        state.channels.insert(rid.to_string(), sender);
-        state.terminal_errors.remove(rid);
-        state.ready_callbacks.remove(rid);
-        state.ready_signals.remove(rid);
-        state.pending_sends.remove(rid);
-        Ok(receiver)
+        let key = RequestKey {
+            rid: rid.to_string(),
+            incarnation: self.next_incarnation.fetch_add(1, Ordering::Relaxed),
+        };
+        state.channels.insert(
+            rid.to_string(),
+            ActiveChannel {
+                incarnation: key.incarnation,
+                sender,
+            },
+        );
+        Ok(SubmittedRequest { key, receiver })
     }
 
-    fn make_chunk_callback(&self, py: Python<'_>, rid: String) -> PyResult<Py<PyAny>> {
+    fn make_chunk_callback(
+        &self,
+        py: Python<'_>,
+        key: RequestKey,
+        metadata_mode: ResponseMetadataMode,
+    ) -> PyResult<Py<PyAny>> {
         let callback = ChunkCallback {
-            rid,
+            key,
+            metadata_mode,
             state: self.state.clone(),
             runtime_handle: self.runtime_handle.clone_ref(py),
             tokio_handle: self.tokio_handle.clone(),
@@ -160,9 +230,9 @@ impl PyBridge {
         Ok(py_callback.into_any())
     }
 
-    fn make_json_callback(&self, py: Python<'_>, rid: String) -> PyResult<Py<PyAny>> {
+    fn make_json_callback(&self, py: Python<'_>, key: RequestKey) -> PyResult<Py<PyAny>> {
         let callback = JsonChunkCallback {
-            rid,
+            key,
             state: self.state.clone(),
             runtime_handle: self.runtime_handle.clone_ref(py),
             tokio_handle: self.tokio_handle.clone(),
@@ -184,18 +254,22 @@ impl PyBridge {
         rid: &str,
         req_type: &str,
         req_dict: HashMap<String, serde_json::Value>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
-        let receiver = self.create_channel(rid)?;
-        let rid_owned = rid.to_string();
+        metadata_mode: ResponseMetadataMode,
+    ) -> PyResult<SubmittedRequest> {
+        let submitted = self.create_channel(rid)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let py_req_dict = json_map_to_pydict(py, &req_dict)?;
-            let callback = self.make_chunk_callback(py, rid_owned)?;
+            let callback = self.make_chunk_callback(py, submitted.key.clone(), metadata_mode)?;
 
             let kwargs = PyDict::new(py);
             kwargs.set_item("req_type", req_type)?;
             kwargs.set_item("req_dict", py_req_dict)?;
             kwargs.set_item("chunk_callback", callback)?;
+            kwargs.set_item(
+                "typed_generation",
+                metadata_mode == ResponseMetadataMode::TypedGenerate,
+            )?;
 
             self.runtime_handle
                 .call_method(py, "submit_request", (), Some(&kwargs))?;
@@ -203,9 +277,9 @@ impl PyBridge {
         });
 
         match result {
-            Ok(()) => Ok(receiver),
+            Ok(()) => Ok(submitted),
             Err(err) => {
-                self.remove_channel(rid);
+                self.remove_channel(&submitted.key);
                 Err(err)
             }
         }
@@ -222,47 +296,88 @@ impl PyBridge {
             ));
         }
 
-        let should_call_python = if abort_all {
+        let keys = if abort_all {
             let mut state = lock_or_recover(self.state.as_ref(), "state");
-            let rids = state
+            state.abort_all_in_progress = true;
+            state
                 .channels
-                .drain()
-                .map(|(rid, _)| rid)
-                .collect::<Vec<_>>();
-            let affected = rids.len();
-            state.pending_sends.clear();
-            state.ready_callbacks.clear();
-            state.ready_signals.clear();
-            for channel_rid in rids {
-                state.terminal_errors.insert(
-                    channel_rid.clone(),
-                    TerminalError::Aborted { rid: channel_rid },
-                );
-            }
-            tracing::debug!(affected, "gRPC abort_all cleared active response channels");
-            true
+                .iter()
+                .map(|(rid, channel)| RequestKey {
+                    rid: rid.clone(),
+                    incarnation: channel.incarnation,
+                })
+                .collect::<Vec<_>>()
         } else {
-            let mut state = lock_or_recover(self.state.as_ref(), "state");
-            let was_active = remove_channel_refs_locked(&mut state, rid);
-            if was_active {
-                state
-                    .terminal_errors
-                    .insert(rid.to_string(), TerminalError::Aborted { rid: rid.into() });
-            } else {
-                tracing::debug!(rid, "Ignoring abort for inactive gRPC request id");
-            }
-            was_active
+            let state = lock_or_recover(self.state.as_ref(), "state");
+            state.channels.get(rid).map_or_else(Vec::new, |channel| {
+                vec![RequestKey {
+                    rid: rid.to_string(),
+                    incarnation: channel.incarnation,
+                }]
+            })
         };
 
-        if !should_call_python {
+        if !abort_all && keys.is_empty() {
+            tracing::debug!(rid, "Ignoring abort for inactive gRPC request id");
             return Ok(());
         }
 
-        Python::attach(|py| {
+        let call_result = Python::attach(|py| {
             self.runtime_handle
                 .call_method1(py, "abort", (rid, abort_all))?;
             Ok(())
-        })
+        });
+
+        let mut state = lock_or_recover(self.state.as_ref(), "state");
+        for key in &keys {
+            if remove_channel_refs_locked(&mut state, key) {
+                state.terminal_errors.insert(
+                    key.clone(),
+                    TerminalError::Aborted {
+                        rid: key.rid.clone(),
+                    },
+                );
+            }
+        }
+        if abort_all {
+            state.abort_all_in_progress = false;
+            tracing::debug!(
+                affected = keys.len(),
+                "gRPC abort_all cleared active response channels"
+            );
+        }
+        call_result
+    }
+
+    pub fn abort_request(&self, key: &RequestKey) -> PyResult<()> {
+        let is_active = {
+            let state = lock_or_recover(self.state.as_ref(), "state");
+            state
+                .channels
+                .get(key.rid())
+                .is_some_and(|channel| channel.incarnation == key.incarnation)
+        };
+        if !is_active {
+            let mut state = lock_or_recover(self.state.as_ref(), "state");
+            remove_auxiliary_refs_locked(&mut state, key);
+            return Ok(());
+        }
+
+        let call_result = Python::attach(|py| {
+            self.runtime_handle
+                .call_method1(py, "abort", (key.rid(), false))?;
+            Ok(())
+        });
+        let mut state = lock_or_recover(self.state.as_ref(), "state");
+        if remove_channel_refs_locked(&mut state, key) {
+            state.terminal_errors.insert(
+                key.clone(),
+                TerminalError::Aborted {
+                    rid: key.rid.clone(),
+                },
+            );
+        }
+        call_result
     }
 
     // ------------------------------------------------------------------
@@ -317,58 +432,49 @@ impl PyBridge {
         })
     }
 
-    fn submit_json<F>(&self, rid: &str, call: F) -> PyResult<Receiver<ResponseChunk>>
+    fn submit_json<F>(&self, rid: &str, call: F) -> PyResult<SubmittedRequest>
     where
         F: for<'py> FnOnce(Python<'py>, &Py<PyAny>, Py<PyAny>) -> PyResult<()>,
     {
         // Closure args are: current Python token, RuntimeHandle, and the JSON chunk callback.
-        let receiver = self.create_channel(rid)?;
-        let rid_owned = rid.to_string();
+        let submitted = self.create_channel(rid)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
-            let callback = self.make_json_callback(py, rid_owned)?;
+            let callback = self.make_json_callback(py, submitted.key.clone())?;
             call(py, &self.runtime_handle, callback)
         });
 
         match result {
-            Ok(()) => Ok(receiver),
+            Ok(()) => Ok(submitted),
             Err(err) => {
-                self.remove_channel(rid);
+                self.remove_channel(&submitted.key);
                 Err(err)
             }
         }
     }
 
-    pub fn submit_get_load(
-        &self,
-        rid: &str,
-        dp_rank: Option<i32>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_get_load(&self, rid: &str, dp_rank: Option<i32>) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "get_load", (callback, dp_rank))?;
             Ok(())
         })
     }
 
-    pub fn submit_flush_cache(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_flush_cache(&self, rid: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "flush_cache", (callback,))?;
             Ok(())
         })
     }
 
-    pub fn submit_pause_generation(
-        &self,
-        rid: &str,
-        mode: &str,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_pause_generation(&self, rid: &str, mode: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "pause_generation", (mode, callback))?;
             Ok(())
         })
     }
 
-    pub fn submit_continue_generation(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_continue_generation(&self, rid: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "continue_generation", (callback,))?;
             Ok(())
@@ -379,14 +485,14 @@ impl PyBridge {
         &self,
         rid: &str,
         output_dir: Option<&str>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    ) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "start_profile", (output_dir, callback))?;
             Ok(())
         })
     }
 
-    pub fn submit_stop_profile(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_stop_profile(&self, rid: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "stop_profile", (callback,))?;
             Ok(())
@@ -398,7 +504,7 @@ impl PyBridge {
         rid: &str,
         model_path: &str,
         load_format: Option<&str>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    ) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(
                 py,
@@ -419,7 +525,7 @@ impl PyBridge {
         method_name: &str,
         json_body: &[u8],
         trace_headers: &HashMap<String, String>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    ) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             let kwargs = PyDict::new(py);
             let py_bytes = PyBytes::new(py, json_body);
@@ -439,57 +545,78 @@ impl PyBridge {
         })
     }
 
-    pub fn remove_channel(&self, rid: &str) {
+    pub fn remove_channel(&self, key: &RequestKey) {
         let mut state = lock_or_recover(self.state.as_ref(), "state");
-        remove_channel_refs_locked(&mut state, rid);
-        state.terminal_errors.remove(rid);
+        remove_channel_refs_locked(&mut state, key);
+        state.terminal_errors.remove(key);
     }
 
-    pub fn take_terminal_error(&self, rid: &str) -> Option<TerminalError> {
+    pub fn take_terminal_error(&self, key: &RequestKey) -> Option<TerminalError> {
         let mut state = lock_or_recover(self.state.as_ref(), "state");
-        state.terminal_errors.remove(rid)
+        state.terminal_errors.remove(key)
     }
 }
 
 fn close_channel_with_error(
     py: Python<'_>,
-    rid: &str,
+    key: &RequestKey,
     state: &BridgeStateRef,
     runtime_handle: &Py<PyAny>,
     error: TerminalError,
 ) {
+    let is_active = {
+        let state = lock_or_recover(state.as_ref(), "state");
+        state
+            .channels
+            .get(key.rid())
+            .is_some_and(|channel| channel.incarnation == key.incarnation)
+    };
+    if !is_active {
+        return;
+    }
+    let _ = runtime_handle.call_method1(py, "abort", (key.rid(), false));
     let mut state = lock_or_recover(state.as_ref(), "state");
-    remove_channel_refs_locked(&mut state, rid);
-    state.terminal_errors.insert(rid.to_string(), error);
-    drop(state);
-    let _ = runtime_handle.call_method1(py, "abort", (rid, false));
+    if remove_channel_refs_locked(&mut state, key) {
+        state.terminal_errors.insert(key.clone(), error);
+    }
 }
 
-fn remove_channel_refs_locked(state: &mut BridgeState, rid: &str) -> bool {
-    let had_channel = state.channels.remove(rid).is_some();
-    let had_pending = state.pending_sends.remove(rid);
-    let had_callback = state.ready_callbacks.remove(rid).is_some();
-    let had_signal = state.ready_signals.remove(rid);
-    had_channel || had_pending || had_callback || had_signal
+fn remove_auxiliary_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool {
+    let had_pending = state.pending_sends.remove(key);
+    let had_callback = state.ready_callbacks.remove(key).is_some();
+    let had_signal = state.ready_signals.remove(key);
+    had_pending || had_callback || had_signal
 }
 
-fn remove_channel_refs(rid: &str, state: &BridgeStateRef) {
-    let mut state = lock_or_recover(state.as_ref(), "state");
-    remove_channel_refs_locked(&mut state, rid);
+fn remove_channel_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool {
+    let is_active = state
+        .channels
+        .get(key.rid())
+        .is_some_and(|channel| channel.incarnation == key.incarnation);
+    if is_active {
+        state.channels.remove(key.rid());
+    }
+    remove_auxiliary_refs_locked(state, key);
+    is_active
 }
 
-fn register_pending_send(rid: &str, state: &BridgeStateRef) -> bool {
+fn remove_channel_refs(key: &RequestKey, state: &BridgeStateRef) {
     let mut state = lock_or_recover(state.as_ref(), "state");
-    state.pending_sends.insert(rid.to_string())
+    remove_channel_refs_locked(&mut state, key);
 }
 
-fn mark_send_ready(py: Python<'_>, rid: &str, state: &BridgeStateRef) -> Option<Py<PyAny>> {
+fn register_pending_send(key: &RequestKey, state: &BridgeStateRef) -> bool {
     let mut state = lock_or_recover(state.as_ref(), "state");
-    state.pending_sends.remove(rid);
-    if let Some(callback) = state.ready_callbacks.get(rid) {
+    state.pending_sends.insert(key.clone())
+}
+
+fn mark_send_ready(py: Python<'_>, key: &RequestKey, state: &BridgeStateRef) -> Option<Py<PyAny>> {
+    let mut state = lock_or_recover(state.as_ref(), "state");
+    state.pending_sends.remove(key);
+    if let Some(callback) = state.ready_callbacks.get(key) {
         Some(callback.clone_ref(py))
     } else {
-        state.ready_signals.insert(rid.to_string());
+        state.ready_signals.insert(key.clone());
         None
     }
 }
@@ -502,16 +629,23 @@ fn notify_ready(py: Python<'_>, rid: &str, callback: Py<PyAny>) {
 
 fn set_on_ready_for_rid(
     py: Python<'_>,
-    rid: &str,
+    key: &RequestKey,
     state: &BridgeStateRef,
     on_ready: Py<PyAny>,
 ) -> PyResult<()> {
     let should_notify = {
         let mut state = lock_or_recover(state.as_ref(), "state");
+        if !state
+            .channels
+            .get(key.rid())
+            .is_some_and(|channel| channel.incarnation == key.incarnation)
+        {
+            return Ok(());
+        }
         state
             .ready_callbacks
-            .insert(rid.to_string(), on_ready.clone_ref(py));
-        state.ready_signals.remove(rid)
+            .insert(key.clone(), on_ready.clone_ref(py));
+        state.ready_signals.remove(key)
     };
     if should_notify {
         on_ready.call0(py)?;
@@ -519,16 +653,16 @@ fn set_on_ready_for_rid(
     Ok(())
 }
 
-fn clear_on_ready_for_rid(rid: &str, state: &BridgeStateRef) {
+fn clear_on_ready_for_rid(key: &RequestKey, state: &BridgeStateRef) {
     // End notifications for this rid. Do not call set_on_ready again for the same rid.
     let mut state = lock_or_recover(state.as_ref(), "state");
-    state.ready_callbacks.remove(rid);
-    state.ready_signals.remove(rid);
+    state.ready_callbacks.remove(key);
+    state.ready_signals.remove(key);
 }
 
 fn try_send_chunk(
     py: Python<'_>,
-    rid: &str,
+    key: &RequestKey,
     state: &BridgeStateRef,
     runtime_handle: &Py<PyAny>,
     tokio_handle: &Handle,
@@ -539,27 +673,29 @@ fn try_send_chunk(
     match sender.try_send(msg) {
         Ok(()) => {
             if terminal {
-                remove_channel_refs(rid, state);
+                remove_channel_refs(key, state);
             }
             Ok(ChunkSendStatus::Ready)
         }
         Err(TrySendError::Full(msg)) => {
-            if !register_pending_send(rid, state) {
+            if !register_pending_send(key, state) {
                 tracing::warn!(
-                    rid,
+                    rid = key.rid(),
                     "gRPC bridge received another chunk before the parked chunk drained; closing stream"
                 );
                 close_channel_with_error(
                     py,
-                    rid,
+                    key,
                     state,
                     runtime_handle,
-                    TerminalError::ChannelFull { rid: rid.into() },
+                    TerminalError::ChannelFull {
+                        rid: key.rid.clone(),
+                    },
                 );
                 return Ok(ChunkSendStatus::Closed);
             }
 
-            let rid_owned = rid.to_string();
+            let key_owned = key.clone();
             let state = state.clone();
             let runtime_handle = runtime_handle.clone_ref(py);
             let sender = sender.clone();
@@ -570,13 +706,13 @@ fn try_send_chunk(
                         if terminal {
                             // Terminal chunks end the producer contract; no further on_ready
                             // signal is fired after a parked Finished/Error drains.
-                            remove_channel_refs(&rid_owned, &state);
+                            remove_channel_refs(&key_owned, &state);
                             return;
                         }
 
                         Python::attach(|py| {
-                            if let Some(callback) = mark_send_ready(py, &rid_owned, &state) {
-                                notify_ready(py, &rid_owned, callback);
+                            if let Some(callback) = mark_send_ready(py, &key_owned, &state) {
+                                notify_ready(py, key_owned.rid(), callback);
                             }
                         });
                     }
@@ -584,11 +720,11 @@ fn try_send_chunk(
                         Python::attach(|py| {
                             close_channel_with_error(
                                 py,
-                                &rid_owned,
+                                &key_owned,
                                 &state,
                                 &runtime_handle,
                                 TerminalError::ClientDisconnected {
-                                    rid: rid_owned.clone(),
+                                    rid: key_owned.rid.clone(),
                                 },
                             );
                         });
@@ -601,10 +737,12 @@ fn try_send_chunk(
         Err(TrySendError::Closed(_)) => {
             close_channel_with_error(
                 py,
-                rid,
+                key,
                 state,
                 runtime_handle,
-                TerminalError::ClientDisconnected { rid: rid.into() },
+                TerminalError::ClientDisconnected {
+                    rid: key.rid.clone(),
+                },
             );
             Ok(ChunkSendStatus::Closed)
         }
@@ -614,7 +752,8 @@ fn try_send_chunk(
 // Typed chunk callback for SGLang-native RPCs (dict-based chunks).
 #[pyclass]
 struct ChunkCallback {
-    rid: String,
+    key: RequestKey,
+    metadata_mode: ResponseMetadataMode,
     state: BridgeStateRef,
     runtime_handle: Py<PyAny>,
     tokio_handle: Handle,
@@ -625,33 +764,33 @@ impl ChunkCallback {
     /// Register before producing chunks. If a parked chunk drained before registration,
     /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
     fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
-        set_on_ready_for_rid(py, &self.rid, &self.state, on_ready)
+        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
     }
 
     fn clear_on_ready(&self) {
-        clear_on_ready_for_rid(&self.rid, &self.state);
+        clear_on_ready_for_rid(&self.key, &self.state);
     }
 
-    #[pyo3(signature = (chunk, finished=false, error=None, incremental=false))]
+    #[pyo3(signature = (chunk, finished=false, error=None))]
     fn __call__(
         &self,
         chunk: &Bound<'_, PyDict>,
         finished: bool,
         error: Option<String>,
-        incremental: bool,
     ) -> PyResult<ChunkSendStatus> {
         let py = chunk.py();
         let state = lock_or_recover(self.state.as_ref(), "state");
-        let sender = match state.channels.get(&self.rid) {
-            Some(s) => s.clone(),
+        let sender = match state.channels.get(self.key.rid()) {
+            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
             None => return Ok(ChunkSendStatus::Closed),
+            Some(_) => return Ok(ChunkSendStatus::Closed),
         };
         drop(state);
 
         if let Some(err_msg) = error {
             return try_send_chunk(
                 py,
-                &self.rid,
+                &self.key,
                 &self.state,
                 &self.runtime_handle,
                 &self.tokio_handle,
@@ -677,14 +816,20 @@ impl ChunkCallback {
             .and_then(|v| v.extract::<i32>().ok())
             .unwrap_or(0);
 
-        let meta_info = extract_meta_info(chunk);
+        let meta_info = match self.metadata_mode {
+            ResponseMetadataMode::LegacyStringMap => {
+                ResponseMetadata::Legacy(extract_legacy_meta_info(chunk))
+            }
+            ResponseMetadataMode::TypedGenerate => {
+                ResponseMetadata::Typed(extract_typed_meta_info(chunk))
+            }
+        };
 
         let data = ResponseData {
             text,
             output_ids,
             embedding,
             choice_index,
-            incremental,
             json_bytes: None,
             meta_info,
         };
@@ -697,7 +842,7 @@ impl ChunkCallback {
 
         try_send_chunk(
             py,
-            &self.rid,
+            &self.key,
             &self.state,
             &self.runtime_handle,
             &self.tokio_handle,
@@ -710,7 +855,7 @@ impl ChunkCallback {
 // JSON chunk callback for OpenAI pass-through RPCs (raw bytes).
 #[pyclass]
 struct JsonChunkCallback {
-    rid: String,
+    key: RequestKey,
     state: BridgeStateRef,
     runtime_handle: Py<PyAny>,
     tokio_handle: Handle,
@@ -721,11 +866,11 @@ impl JsonChunkCallback {
     /// Register before producing chunks. If a parked chunk drained before registration,
     /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
     fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
-        set_on_ready_for_rid(py, &self.rid, &self.state, on_ready)
+        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
     }
 
     fn clear_on_ready(&self) {
-        clear_on_ready_for_rid(&self.rid, &self.state);
+        clear_on_ready_for_rid(&self.key, &self.state);
     }
 
     #[pyo3(signature = (chunk_bytes, finished=false, error=None, status_code=None))]
@@ -738,16 +883,17 @@ impl JsonChunkCallback {
     ) -> PyResult<ChunkSendStatus> {
         let py = chunk_bytes.py();
         let state = lock_or_recover(self.state.as_ref(), "state");
-        let sender = match state.channels.get(&self.rid) {
-            Some(s) => s.clone(),
+        let sender = match state.channels.get(self.key.rid()) {
+            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
             None => return Ok(ChunkSendStatus::Closed),
+            Some(_) => return Ok(ChunkSendStatus::Closed),
         };
         drop(state);
 
         if let Some(err_msg) = error {
             return try_send_chunk(
                 py,
-                &self.rid,
+                &self.key,
                 &self.state,
                 &self.runtime_handle,
                 &self.tokio_handle,
@@ -764,9 +910,9 @@ impl JsonChunkCallback {
             vec![]
         };
 
-        let mut meta_info = serde_json::Map::new();
+        let mut meta_info = HashMap::new();
         if let Some(code) = status_code {
-            meta_info.insert("status_code".to_string(), serde_json::json!(code));
+            meta_info.insert("status_code".to_string(), code.to_string());
         }
 
         let data = ResponseData {
@@ -774,9 +920,8 @@ impl JsonChunkCallback {
             output_ids: None,
             embedding: None,
             choice_index: 0,
-            incremental: false,
             json_bytes: Some(bytes_data),
-            meta_info,
+            meta_info: ResponseMetadata::Legacy(meta_info),
         };
 
         let msg = if finished {
@@ -787,7 +932,7 @@ impl JsonChunkCallback {
 
         try_send_chunk(
             py,
-            &self.rid,
+            &self.key,
             &self.state,
             &self.runtime_handle,
             &self.tokio_handle,
@@ -797,7 +942,9 @@ impl JsonChunkCallback {
     }
 }
 
-fn extract_meta_info(chunk: &Bound<'_, PyDict>) -> serde_json::Map<String, serde_json::Value> {
+fn extract_typed_meta_info(
+    chunk: &Bound<'_, PyDict>,
+) -> serde_json::Map<String, serde_json::Value> {
     let mut meta = serde_json::Map::new();
     if let Ok(Some(meta_obj)) = chunk.get_item("meta_info")
         && let Ok(meta_dict) = meta_obj.cast::<PyDict>()
@@ -807,6 +954,22 @@ fn extract_meta_info(chunk: &Bound<'_, PyDict>) -> serde_json::Map<String, serde
                 && let Ok(val) = py_value_to_json_value(&v)
             {
                 meta.insert(key, val);
+            }
+        }
+    }
+    meta
+}
+
+fn extract_legacy_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    if let Ok(Some(meta_obj)) = chunk.get_item("meta_info")
+        && let Ok(meta_dict) = meta_obj.cast::<PyDict>()
+    {
+        for (k, v) in meta_dict.iter() {
+            if let Ok(key) = k.extract::<String>() {
+                if let Ok(value) = py_value_to_json_string(&v) {
+                    meta.insert(key, value);
+                }
             }
         }
     }

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -652,10 +652,10 @@ fn set_on_ready_for_rid(
 ) -> PyResult<()> {
     let should_notify = {
         let mut state = lock_or_recover(state.as_ref(), "state");
-        if !state
+        if state
             .channels
             .get(key.rid())
-            .is_some_and(|channel| channel.incarnation == key.incarnation)
+            .is_none_or(|channel| channel.incarnation != key.incarnation)
         {
             return Ok(());
         }
@@ -983,10 +983,10 @@ fn extract_legacy_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String
         && let Ok(meta_dict) = meta_obj.cast::<PyDict>()
     {
         for (k, v) in meta_dict.iter() {
-            if let Ok(key) = k.extract::<String>() {
-                if let Ok(value) = py_value_to_json_string(&v) {
-                    meta.insert(key, value);
-                }
+            if let Ok(key) = k.extract::<String>()
+                && let Ok(value) = py_value_to_json_string(&v)
+            {
+                meta.insert(key, value);
             }
         }
     }

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -28,6 +28,7 @@ impl ResponseChunk {
 pub struct ResponseData {
     pub text: Option<String>,
     pub output_ids: Option<Vec<i32>>,
+    pub legacy_output_ids: Option<Vec<i32>>,
     pub embedding: Option<Vec<f32>>,
     pub choice_index: i32,
     pub json_bytes: Option<Vec<u8>>,
@@ -37,21 +38,39 @@ pub struct ResponseData {
 #[derive(Debug, Clone)]
 pub enum ResponseMetadata {
     Legacy(HashMap<String, String>),
-    Typed(serde_json::Map<String, serde_json::Value>),
+    Generate {
+        legacy: HashMap<String, String>,
+        typed: serde_json::Map<String, serde_json::Value>,
+    },
 }
 
 impl ResponseMetadata {
     pub fn into_legacy(self) -> Result<HashMap<String, String>, &'static str> {
         match self {
             Self::Legacy(meta) => Ok(meta),
-            Self::Typed(_) => Err("expected legacy string metadata"),
+            Self::Generate { legacy, .. } => Ok(legacy),
         }
     }
 
     pub fn as_typed(&self) -> Result<&serde_json::Map<String, serde_json::Value>, &'static str> {
         match self {
-            Self::Typed(meta) => Ok(meta),
+            Self::Generate { typed, .. } => Ok(typed),
             Self::Legacy(_) => Err("expected typed JSON metadata"),
+        }
+    }
+
+    pub fn into_generate(
+        self,
+    ) -> Result<
+        (
+            HashMap<String, String>,
+            serde_json::Map<String, serde_json::Value>,
+        ),
+        &'static str,
+    > {
+        match self {
+            Self::Generate { legacy, typed } => Ok((legacy, typed)),
+            Self::Legacy(_) => Err("expected combined Generate metadata"),
         }
     }
 }
@@ -59,7 +78,7 @@ impl ResponseMetadata {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResponseMetadataMode {
     LegacyStringMap,
-    TypedGenerate,
+    Generate,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -274,7 +293,7 @@ impl PyBridge {
             kwargs.set_item("chunk_callback", callback)?;
             kwargs.set_item(
                 "typed_generation",
-                metadata_mode == ResponseMetadataMode::TypedGenerate,
+                metadata_mode == ResponseMetadataMode::Generate,
             )?;
 
             self.runtime_handle
@@ -602,7 +621,7 @@ fn remove_channel_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool
 fn finalize_explicit_abort_locked(state: &mut BridgeState, key: &RequestKey) {
     let expects_typed_terminals = state.channels.get(key.rid()).is_some_and(|channel| {
         channel.incarnation == key.incarnation
-            && channel.metadata_mode == ResponseMetadataMode::TypedGenerate
+            && channel.metadata_mode == ResponseMetadataMode::Generate
     });
     if expects_typed_terminals {
         return;
@@ -824,6 +843,10 @@ impl ChunkCallback {
             .get_item("output_ids")?
             .and_then(|v| v.extract::<Vec<i32>>().ok());
 
+        let legacy_output_ids: Option<Vec<i32>> = chunk
+            .get_item("legacy_output_ids")?
+            .and_then(|v| v.extract::<Vec<i32>>().ok());
+
         let embedding: Option<Vec<f32>> = chunk
             .get_item("embedding")?
             .and_then(|v| v.extract::<Vec<f32>>().ok());
@@ -837,14 +860,16 @@ impl ChunkCallback {
             ResponseMetadataMode::LegacyStringMap => {
                 ResponseMetadata::Legacy(extract_legacy_meta_info(chunk))
             }
-            ResponseMetadataMode::TypedGenerate => {
-                ResponseMetadata::Typed(extract_typed_meta_info(chunk))
-            }
+            ResponseMetadataMode::Generate => ResponseMetadata::Generate {
+                legacy: extract_legacy_generate_meta_info(chunk),
+                typed: extract_typed_meta_info(chunk),
+            },
         };
 
         let data = ResponseData {
             text,
             output_ids,
+            legacy_output_ids,
             embedding,
             choice_index,
             json_bytes: None,
@@ -935,6 +960,7 @@ impl JsonChunkCallback {
         let data = ResponseData {
             text: None,
             output_ids: None,
+            legacy_output_ids: None,
             embedding: None,
             choice_index: 0,
             json_bytes: Some(bytes_data),
@@ -978,8 +1004,21 @@ fn extract_typed_meta_info(
 }
 
 fn extract_legacy_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String> {
+    extract_meta_info_field(chunk, "meta_info")
+}
+
+fn extract_legacy_generate_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String> {
+    let meta = extract_meta_info_field(chunk, "legacy_meta_info");
+    if meta.is_empty() {
+        extract_legacy_meta_info(chunk)
+    } else {
+        meta
+    }
+}
+
+fn extract_meta_info_field(chunk: &Bound<'_, PyDict>, field: &str) -> HashMap<String, String> {
     let mut meta = HashMap::new();
-    if let Ok(Some(meta_obj)) = chunk.get_item("meta_info")
+    if let Ok(Some(meta_obj)) = chunk.get_item(field)
         && let Ok(meta_dict) = meta_obj.cast::<PyDict>()
     {
         for (k, v) in meta_dict.iter() {

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -96,6 +96,7 @@ struct BridgeState {
 struct ActiveChannel {
     incarnation: u64,
     sender: Sender<ResponseChunk>,
+    metadata_mode: ResponseMetadataMode,
 }
 
 #[derive(Debug, Clone)]
@@ -185,7 +186,11 @@ impl PyBridge {
     // Channel + callback helpers
     // ------------------------------------------------------------------
 
-    fn create_channel(&self, rid: &str) -> PyResult<SubmittedRequest> {
+    fn create_channel(
+        &self,
+        rid: &str,
+        metadata_mode: ResponseMetadataMode,
+    ) -> PyResult<SubmittedRequest> {
         let (sender, receiver) = mpsc::channel(self.response_channel_capacity);
         let mut state = lock_or_recover(self.state.as_ref(), "state");
         if state.abort_all_in_progress {
@@ -208,6 +213,7 @@ impl PyBridge {
             ActiveChannel {
                 incarnation: key.incarnation,
                 sender,
+                metadata_mode,
             },
         );
         Ok(SubmittedRequest { key, receiver })
@@ -256,7 +262,7 @@ impl PyBridge {
         req_dict: HashMap<String, serde_json::Value>,
         metadata_mode: ResponseMetadataMode,
     ) -> PyResult<SubmittedRequest> {
-        let submitted = self.create_channel(rid)?;
+        let submitted = self.create_channel(rid, metadata_mode)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let py_req_dict = json_map_to_pydict(py, &req_dict)?;
@@ -330,14 +336,7 @@ impl PyBridge {
 
         let mut state = lock_or_recover(self.state.as_ref(), "state");
         for key in &keys {
-            if remove_channel_refs_locked(&mut state, key) {
-                state.terminal_errors.insert(
-                    key.clone(),
-                    TerminalError::Aborted {
-                        rid: key.rid.clone(),
-                    },
-                );
-            }
+            finalize_explicit_abort_locked(&mut state, key);
         }
         if abort_all {
             state.abort_all_in_progress = false;
@@ -437,7 +436,7 @@ impl PyBridge {
         F: for<'py> FnOnce(Python<'py>, &Py<PyAny>, Py<PyAny>) -> PyResult<()>,
     {
         // Closure args are: current Python token, RuntimeHandle, and the JSON chunk callback.
-        let submitted = self.create_channel(rid)?;
+        let submitted = self.create_channel(rid, ResponseMetadataMode::LegacyStringMap)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let callback = self.make_json_callback(py, submitted.key.clone())?;
@@ -598,6 +597,24 @@ fn remove_channel_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool
     }
     remove_auxiliary_refs_locked(state, key);
     is_active
+}
+
+fn finalize_explicit_abort_locked(state: &mut BridgeState, key: &RequestKey) {
+    let expects_typed_terminals = state.channels.get(key.rid()).is_some_and(|channel| {
+        channel.incarnation == key.incarnation
+            && channel.metadata_mode == ResponseMetadataMode::TypedGenerate
+    });
+    if expects_typed_terminals {
+        return;
+    }
+    if remove_channel_refs_locked(state, key) {
+        state.terminal_errors.insert(
+            key.clone(),
+            TerminalError::Aborted {
+                rid: key.rid.clone(),
+            },
+        );
+    }
 }
 
 fn remove_channel_refs(key: &RequestKey, state: &BridgeStateRef) {

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::tokenizers::RustTokenizer;
-use crate::utils::{json_map_to_pydict, py_value_to_json_string};
+use crate::utils::{json_map_to_pydict, py_value_to_json_value};
 
 #[derive(Debug, Clone)]
 pub enum ResponseChunk {
@@ -28,8 +28,10 @@ pub struct ResponseData {
     pub text: Option<String>,
     pub output_ids: Option<Vec<i32>>,
     pub embedding: Option<Vec<f32>>,
+    pub choice_index: i32,
+    pub incremental: bool,
     pub json_bytes: Option<Vec<u8>>,
-    pub meta_info: HashMap<String, String>,
+    pub meta_info: serde_json::Map<String, serde_json::Value>,
 }
 
 pub const DEFAULT_RESPONSE_CHANNEL_CAPACITY: usize = 64;
@@ -630,12 +632,13 @@ impl ChunkCallback {
         clear_on_ready_for_rid(&self.rid, &self.state);
     }
 
-    #[pyo3(signature = (chunk, finished=false, error=None))]
+    #[pyo3(signature = (chunk, finished=false, error=None, incremental=false))]
     fn __call__(
         &self,
         chunk: &Bound<'_, PyDict>,
         finished: bool,
         error: Option<String>,
+        incremental: bool,
     ) -> PyResult<ChunkSendStatus> {
         let py = chunk.py();
         let state = lock_or_recover(self.state.as_ref(), "state");
@@ -669,12 +672,19 @@ impl ChunkCallback {
             .get_item("embedding")?
             .and_then(|v| v.extract::<Vec<f32>>().ok());
 
+        let choice_index = chunk
+            .get_item("index")?
+            .and_then(|v| v.extract::<i32>().ok())
+            .unwrap_or(0);
+
         let meta_info = extract_meta_info(chunk);
 
         let data = ResponseData {
             text,
             output_ids,
             embedding,
+            choice_index,
+            incremental,
             json_bytes: None,
             meta_info,
         };
@@ -754,15 +764,17 @@ impl JsonChunkCallback {
             vec![]
         };
 
-        let mut meta_info = HashMap::new();
+        let mut meta_info = serde_json::Map::new();
         if let Some(code) = status_code {
-            meta_info.insert("status_code".to_string(), code.to_string());
+            meta_info.insert("status_code".to_string(), serde_json::json!(code));
         }
 
         let data = ResponseData {
             text: None,
             output_ids: None,
             embedding: None,
+            choice_index: 0,
+            incremental: false,
             json_bytes: Some(bytes_data),
             meta_info,
         };
@@ -785,16 +797,14 @@ impl JsonChunkCallback {
     }
 }
 
-fn extract_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String> {
-    let mut meta = HashMap::new();
+fn extract_meta_info(chunk: &Bound<'_, PyDict>) -> serde_json::Map<String, serde_json::Value> {
+    let mut meta = serde_json::Map::new();
     if let Ok(Some(meta_obj)) = chunk.get_item("meta_info")
         && let Ok(meta_dict) = meta_obj.cast::<PyDict>()
     {
         for (k, v) in meta_dict.iter() {
-            // The proto schema is map<string, string>; encode each Python value as JSON
-            // so clients can recover numbers, booleans, arrays, and objects losslessly.
             if let Ok(key) = k.extract::<String>()
-                && let Ok(val) = py_value_to_json_string(&v)
+                && let Ok(val) = py_value_to_json_value(&v)
             {
                 meta.insert(key, val);
             }

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -44,6 +44,11 @@ pub enum ResponseMetadata {
     },
 }
 
+type GenerateMetadata = (
+    HashMap<String, String>,
+    serde_json::Map<String, serde_json::Value>,
+);
+
 impl ResponseMetadata {
     pub fn into_legacy(self) -> Result<HashMap<String, String>, &'static str> {
         match self {
@@ -59,15 +64,7 @@ impl ResponseMetadata {
         }
     }
 
-    pub fn into_generate(
-        self,
-    ) -> Result<
-        (
-            HashMap<String, String>,
-            serde_json::Map<String, serde_json::Value>,
-        ),
-        &'static str,
-    > {
+    pub fn into_generate(self) -> Result<GenerateMetadata, &'static str> {
         match self {
             Self::Generate { legacy, typed } => Ok((legacy, typed)),
             Self::Legacy(_) => Err("expected combined Generate metadata"),

--- a/rust/sglang-grpc/src/bridge/tests.rs
+++ b/rust/sglang-grpc/src/bridge/tests.rs
@@ -35,6 +35,7 @@ async fn stale_request_key_cannot_abort_reused_request_id() {
             ActiveChannel {
                 incarnation: current_key.incarnation,
                 sender,
+                metadata_mode: ResponseMetadataMode::LegacyStringMap,
             },
         );
         state.pending_sends.insert(old_key.clone());
@@ -50,6 +51,51 @@ async fn stale_request_key_cannot_abort_reused_request_id() {
         current_key.incarnation
     );
     assert!(!state.pending_sends.contains(&old_key));
+}
+
+#[test]
+fn explicit_abort_keeps_typed_channel_until_python_sends_terminals() {
+    let (typed_sender, _typed_receiver) = tokio::sync::mpsc::channel(1);
+    let typed_key = RequestKey {
+        rid: "typed".to_string(),
+        incarnation: 1,
+    };
+    let mut state = BridgeState::default();
+    state.channels.insert(
+        typed_key.rid.clone(),
+        ActiveChannel {
+            incarnation: typed_key.incarnation,
+            sender: typed_sender,
+            metadata_mode: ResponseMetadataMode::TypedGenerate,
+        },
+    );
+
+    finalize_explicit_abort_locked(&mut state, &typed_key);
+
+    assert!(state.channels.contains_key(typed_key.rid()));
+    assert!(!state.terminal_errors.contains_key(&typed_key));
+
+    let (legacy_sender, _legacy_receiver) = tokio::sync::mpsc::channel(1);
+    let legacy_key = RequestKey {
+        rid: "legacy".to_string(),
+        incarnation: 2,
+    };
+    state.channels.insert(
+        legacy_key.rid.clone(),
+        ActiveChannel {
+            incarnation: legacy_key.incarnation,
+            sender: legacy_sender,
+            metadata_mode: ResponseMetadataMode::LegacyStringMap,
+        },
+    );
+
+    finalize_explicit_abort_locked(&mut state, &legacy_key);
+
+    assert!(!state.channels.contains_key(legacy_key.rid()));
+    assert!(matches!(
+        state.terminal_errors.get(&legacy_key),
+        Some(TerminalError::Aborted { .. })
+    ));
 }
 
 #[test]

--- a/rust/sglang-grpc/src/bridge/tests.rs
+++ b/rust/sglang-grpc/src/bridge/tests.rs
@@ -7,3 +7,70 @@ fn terminal_error_messages_include_request_id() {
     };
     assert!(error.message().contains("rid"));
 }
+
+#[tokio::test]
+async fn stale_request_key_cannot_abort_reused_request_id() {
+    Python::initialize();
+    let runtime_handle = Python::attach(|py| PyDict::new(py).clone().unbind().into_any());
+    let bridge = PyBridge::new(
+        runtime_handle,
+        None,
+        1,
+        1,
+        tokio::runtime::Handle::current(),
+    );
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+    let old_key = RequestKey {
+        rid: "reused".to_string(),
+        incarnation: 1,
+    };
+    let current_key = RequestKey {
+        rid: "reused".to_string(),
+        incarnation: 2,
+    };
+    {
+        let mut state = lock_or_recover(bridge.state.as_ref(), "state");
+        state.channels.insert(
+            current_key.rid.clone(),
+            ActiveChannel {
+                incarnation: current_key.incarnation,
+                sender,
+            },
+        );
+        state.pending_sends.insert(old_key.clone());
+    }
+
+    // The dict has no `abort` method, so this also proves the stale path never
+    // invokes the Python abort callback for the new incarnation.
+    bridge.abort_request(&old_key).unwrap();
+
+    let state = lock_or_recover(bridge.state.as_ref(), "state");
+    assert_eq!(
+        state.channels.get(current_key.rid()).unwrap().incarnation,
+        current_key.incarnation
+    );
+    assert!(!state.pending_sends.contains(&old_key));
+}
+
+#[test]
+fn metadata_modes_preserve_legacy_json_and_parse_typed_values() {
+    Python::initialize();
+    Python::attach(|py| {
+        let chunk = PyDict::new(py);
+        let meta = PyDict::new(py);
+        meta.set_item("number", 7).unwrap();
+        meta.set_item("text", "hello").unwrap();
+        meta.set_item("array", vec![1, 2]).unwrap();
+        chunk.set_item("meta_info", meta).unwrap();
+
+        let legacy = extract_legacy_meta_info(&chunk);
+        assert_eq!(legacy["number"], "7");
+        assert_eq!(legacy["text"], "\"hello\"");
+        assert_eq!(legacy["array"], "[1, 2]");
+
+        let typed = extract_typed_meta_info(&chunk);
+        assert_eq!(typed["number"], serde_json::json!(7));
+        assert_eq!(typed["text"], serde_json::json!("hello"));
+        assert_eq!(typed["array"], serde_json::json!([1, 2]));
+    });
+}

--- a/rust/sglang-grpc/src/bridge/tests.rs
+++ b/rust/sglang-grpc/src/bridge/tests.rs
@@ -54,26 +54,26 @@ async fn stale_request_key_cannot_abort_reused_request_id() {
 }
 
 #[test]
-fn explicit_abort_keeps_typed_channel_until_python_sends_terminals() {
-    let (typed_sender, _typed_receiver) = tokio::sync::mpsc::channel(1);
-    let typed_key = RequestKey {
-        rid: "typed".to_string(),
+fn explicit_abort_keeps_generate_channel_until_python_sends_terminals() {
+    let (generate_sender, _generate_receiver) = tokio::sync::mpsc::channel(1);
+    let generate_key = RequestKey {
+        rid: "generate".to_string(),
         incarnation: 1,
     };
     let mut state = BridgeState::default();
     state.channels.insert(
-        typed_key.rid.clone(),
+        generate_key.rid.clone(),
         ActiveChannel {
-            incarnation: typed_key.incarnation,
-            sender: typed_sender,
-            metadata_mode: ResponseMetadataMode::TypedGenerate,
+            incarnation: generate_key.incarnation,
+            sender: generate_sender,
+            metadata_mode: ResponseMetadataMode::Generate,
         },
     );
 
-    finalize_explicit_abort_locked(&mut state, &typed_key);
+    finalize_explicit_abort_locked(&mut state, &generate_key);
 
-    assert!(state.channels.contains_key(typed_key.rid()));
-    assert!(!state.terminal_errors.contains_key(&typed_key));
+    assert!(state.channels.contains_key(generate_key.rid()));
+    assert!(!state.terminal_errors.contains_key(&generate_key));
 
     let (legacy_sender, _legacy_receiver) = tokio::sync::mpsc::channel(1);
     let legacy_key = RequestKey {
@@ -99,7 +99,7 @@ fn explicit_abort_keeps_typed_channel_until_python_sends_terminals() {
 }
 
 #[test]
-fn metadata_modes_preserve_legacy_json_and_parse_typed_values() {
+fn generate_metadata_preserves_legacy_json_and_parses_typed_values() {
     Python::initialize();
     Python::attach(|py| {
         let chunk = PyDict::new(py);
@@ -108,8 +108,13 @@ fn metadata_modes_preserve_legacy_json_and_parse_typed_values() {
         meta.set_item("text", "hello").unwrap();
         meta.set_item("array", vec![1, 2]).unwrap();
         chunk.set_item("meta_info", meta).unwrap();
+        let legacy_meta = PyDict::new(py);
+        legacy_meta.set_item("number", 7).unwrap();
+        legacy_meta.set_item("text", "hello").unwrap();
+        legacy_meta.set_item("array", vec![1, 2]).unwrap();
+        chunk.set_item("legacy_meta_info", legacy_meta).unwrap();
 
-        let legacy = extract_legacy_meta_info(&chunk);
+        let legacy = extract_legacy_generate_meta_info(&chunk);
         assert_eq!(legacy["number"], "7");
         assert_eq!(legacy["text"], "\"hello\"");
         assert_eq!(legacy["array"], "[1, 2]");

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -217,8 +217,10 @@ fn openai_status_code(meta_info: &HashMap<String, String>, default: i32) -> i32 
         .unwrap_or(default)
 }
 
-fn legacy_metadata(meta_info: ResponseMetadata) -> Result<HashMap<String, String>, Status> {
-    meta_info.into_legacy().map_err(Status::internal)
+fn legacy_metadata(meta_info: ResponseMetadata) -> Result<HashMap<String, String>, Box<Status>> {
+    meta_info
+        .into_legacy()
+        .map_err(|error| Box::new(Status::internal(error)))
 }
 
 fn json_to_prost_value(value: serde_json::Value) -> prost_types::Value {
@@ -259,16 +261,16 @@ const TYPED_META_KEYS: &[&str] = &[
 
 const MAX_TYPED_GENERATION_CHOICES: i32 = 1024;
 
-fn expected_generation_choices(request: &proto::GenerateRequest) -> Result<usize, Status> {
+fn expected_generation_choices(request: &proto::GenerateRequest) -> Result<usize, Box<Status>> {
     let choices = request
         .sampling_params
         .as_ref()
         .and_then(|params| params.n)
         .unwrap_or(1);
     if !(1..=MAX_TYPED_GENERATION_CHOICES).contains(&choices) {
-        return Err(Status::invalid_argument(format!(
+        return Err(Box::new(Status::invalid_argument(format!(
             "sampling_params.n must be between 1 and {MAX_TYPED_GENERATION_CHOICES}, got {choices}"
-        )));
+        ))));
     }
     Ok(choices as usize)
 }
@@ -624,7 +626,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                             Ok(meta_info) => meta_info,
                             Err(status) => {
                                 abort_guard.abort_now();
-                                yield Err(status);
+                                yield Err(*status);
                                 break;
                             }
                         };
@@ -639,7 +641,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                         let meta_info = match legacy_metadata(data.meta_info) {
                             Ok(meta_info) => meta_info,
                             Err(status) => {
-                                yield Err(status);
+                                yield Err(*status);
                                 break;
                             }
                         };
@@ -712,7 +714,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                             Ok(meta_info) => meta_info,
                             Err(status) => {
                                 abort_guard.abort_now();
-                                yield Err(status);
+                                yield Err(*status);
                                 break;
                             }
                         };
@@ -727,7 +729,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                         let meta_info = match legacy_metadata(data.meta_info) {
                             Ok(meta_info) => meta_info,
                             Err(status) => {
-                                yield Err(status);
+                                yield Err(*status);
                                 break;
                             }
                         };
@@ -777,7 +779,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
-        let expected_choices = expected_generation_choices(&req)?;
+        let expected_choices = expected_generation_choices(&req).map_err(|status| *status)?;
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
@@ -904,7 +906,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::TextEmbedResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: legacy_metadata(data.meta_info)?,
+                    meta_info: legacy_metadata(data.meta_info).map_err(|status| *status)?,
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -944,7 +946,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::EmbedResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: legacy_metadata(data.meta_info)?,
+                    meta_info: legacy_metadata(data.meta_info).map_err(|status| *status)?,
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -991,7 +993,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::ClassifyResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: legacy_metadata(data.meta_info)?,
+                    meta_info: legacy_metadata(data.meta_info).map_err(|status| *status)?,
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -1455,7 +1457,7 @@ impl SglangServiceImpl {
 
         match chunk {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
-                let meta_info = legacy_metadata(data.meta_info)?;
+                let meta_info = legacy_metadata(data.meta_info).map_err(|status| *status)?;
                 Ok(Response::new(proto::OpenAiResponse {
                     json_body: data.json_bytes.unwrap_or_default(),
                     status_code: openai_status_code(&meta_info, 200),

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -514,7 +514,9 @@ fn generation_terminal(meta: &serde_json::Map<String, serde_json::Value>) -> Typ
     })
 }
 
-struct TypedGenerationChunk {
+struct GenerationChunk {
+    legacy_output_ids: Vec<i32>,
+    legacy_meta_info: HashMap<String, String>,
     choice_index: i32,
     delta_output_ids: Vec<i32>,
     logprobs: Option<proto::Logprobs>,
@@ -523,15 +525,16 @@ struct TypedGenerationChunk {
     terminal: Option<TypedTerminal>,
 }
 
-impl TypedGenerationChunk {
-    fn into_response(self, request_id: String) -> proto::TypedGenerateResponse {
+impl GenerationChunk {
+    fn into_response(self, request_id: String, finished: bool) -> proto::GenerateResponse {
         let terminal = self.terminal.map(|terminal| match terminal {
-            TypedTerminal::Finish(finish) => {
-                proto::typed_generate_response::Terminal::Finish(finish)
-            }
-            TypedTerminal::Error(error) => proto::typed_generate_response::Terminal::Error(error),
+            TypedTerminal::Finish(finish) => proto::generate_response::Terminal::Finish(finish),
+            TypedTerminal::Error(error) => proto::generate_response::Terminal::Error(error),
         });
-        proto::TypedGenerateResponse {
+        proto::GenerateResponse {
+            output_ids: self.legacy_output_ids,
+            meta_info: self.legacy_meta_info,
+            finished,
             request_id,
             delta_output_ids: self.delta_output_ids,
             choice_index: self.choice_index,
@@ -543,19 +546,20 @@ impl TypedGenerationChunk {
     }
 }
 
-fn typed_generation_chunk(
+fn generation_chunk(
     data: crate::bridge::ResponseData,
     choice_terminal: bool,
-) -> Result<TypedGenerationChunk, String> {
+) -> Result<GenerationChunk, String> {
     let crate::bridge::ResponseData {
         output_ids,
+        legacy_output_ids,
         choice_index,
         meta_info,
         ..
     } = data;
-    let meta_info = meta_info.as_typed()?;
+    let (legacy_meta_info, meta_info) = meta_info.into_generate()?;
     let delta_output_ids = output_ids.unwrap_or_default();
-    let logprobs = logprobs_from_meta(meta_info)?;
+    let logprobs = logprobs_from_meta(&meta_info)?;
     let usage_keys = [
         "prompt_tokens",
         "input_tokens",
@@ -566,24 +570,26 @@ fn typed_generation_chunk(
     ];
     let usage = (choice_terminal && usage_keys.iter().any(|key| meta_info.contains_key(*key)))
         .then(|| {
-            let prompt_tokens = meta_u64(meta_info, &["prompt_tokens", "input_tokens"]);
-            let completion_tokens = meta_u64(meta_info, &["completion_tokens", "output_tokens"]);
+            let prompt_tokens = meta_u64(&meta_info, &["prompt_tokens", "input_tokens"]);
+            let completion_tokens = meta_u64(&meta_info, &["completion_tokens", "output_tokens"]);
             proto::Usage {
                 prompt_tokens,
                 completion_tokens,
                 cached_prompt_tokens: meta_u64(
-                    meta_info,
+                    &meta_info,
                     &["cached_tokens", "cached_prompt_tokens"],
                 ),
             }
         });
-    Ok(TypedGenerationChunk {
+    Ok(GenerationChunk {
+        legacy_output_ids: legacy_output_ids.unwrap_or_else(|| delta_output_ids.clone()),
+        legacy_meta_info,
         choice_index,
         delta_output_ids,
         logprobs,
         usage,
-        engine_metadata: engine_metadata(meta_info),
-        terminal: choice_terminal.then(|| generation_terminal(meta_info)),
+        engine_metadata: engine_metadata(&meta_info),
+        terminal: choice_terminal.then(|| generation_terminal(&meta_info)),
     })
 }
 
@@ -691,104 +697,11 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
-
-        let SubmittedRequest { key, mut receiver } = self
-            .bridge
-            .submit_request(
-                &rid,
-                "generate",
-                req_dict,
-                ResponseMetadataMode::LegacyStringMap,
-            )
-            .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
-
-        let bridge = self.bridge.clone();
-        let response_timeout = self.response_timeout;
-
-        let stream = async_stream::stream! {
-            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
-            loop {
-                match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
-                    Ok(Some(ResponseChunk::Data(data))) => {
-                        let meta_info = match legacy_metadata(data.meta_info) {
-                            Ok(meta_info) => meta_info,
-                            Err(status) => {
-                                abort_guard.abort_now();
-                                yield Err(*status);
-                                break;
-                            }
-                        };
-                        yield Ok(proto::GenerateResponse {
-                            output_ids: data.output_ids.unwrap_or_default(),
-                            meta_info,
-                            finished: false,
-                        });
-                    }
-                    Ok(Some(ResponseChunk::Finished(data))) => {
-                        abort_guard.disarm();
-                        let meta_info = match legacy_metadata(data.meta_info) {
-                            Ok(meta_info) => meta_info,
-                            Err(status) => {
-                                yield Err(*status);
-                                break;
-                            }
-                        };
-                        yield Ok(proto::GenerateResponse {
-                            output_ids: data.output_ids.unwrap_or_default(),
-                            meta_info,
-                            finished: true,
-                        });
-                        break;
-                    }
-                    Ok(Some(ResponseChunk::Error(msg))) => {
-                        abort_guard.disarm();
-                        yield Err(Status::internal(msg));
-                        break;
-                    }
-                    Ok(None) => {
-                        let (status, should_abort) = closed_stream_status(&bridge, &key);
-                        if should_abort {
-                            abort_guard.abort_now();
-                        } else {
-                            abort_guard.disarm();
-                        }
-                        yield Err(status);
-                        break;
-                    }
-                    Err(status) => {
-                        abort_guard.abort_now();
-                        yield Err(status);
-                        break;
-                    }
-                }
-            }
-        };
-
-        Ok(Response::new(Box::pin(stream)))
-    }
-
-    type TypedGenerateStream = StreamResult<proto::TypedGenerateResponse>;
-
-    async fn typed_generate(
-        &self,
-        request: Request<proto::GenerateRequest>,
-    ) -> Result<Response<Self::TypedGenerateStream>, Status> {
-        let req = request.into_inner();
-        let rid = req
-            .rid
-            .clone()
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
         let expected_choices = expected_generation_choices(&req).map_err(|status| *status)?;
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(
-                &rid,
-                "generate",
-                req_dict,
-                ResponseMetadataMode::TypedGenerate,
-            )
+            .submit_request(&rid, "generate", req_dict, ResponseMetadataMode::Generate)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
@@ -799,7 +712,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
             let mut choices = ChoiceTracker::new(expected_choices);
             loop {
-                match recv_chunk_with_timeout(&mut receiver, response_timeout, || "TypedGenerate stream chunk timed out".to_string()).await {
+                match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Generate stream chunk timed out".to_string()).await {
                     Ok(Some(chunk @ (ResponseChunk::Data(_) | ResponseChunk::Finished(_)))) => {
                         let request_finished = matches!(&chunk, ResponseChunk::Finished(_));
                         let data = match chunk {
@@ -819,7 +732,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                             choice_index,
                             choice_terminal,
                             request_finished,
-                            "TypedGenerate",
+                            "Generate",
                         ) {
                             Ok(all_terminal) => all_terminal,
                             Err(error) => {
@@ -828,8 +741,8 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                                 break;
                             }
                         };
-                        let mapped = match typed_generation_chunk(data, choice_terminal) {
-                            Ok(mapped) => mapped.into_response(rid_clone.clone()),
+                        let mapped = match generation_chunk(data, choice_terminal) {
+                            Ok(mapped) => mapped.into_response(rid_clone.clone(), request_finished),
                             Err(error) => {
                                 abort_guard.abort_now();
                                 yield Err(Status::internal(error));

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
 
-use base64::Engine as _;
 use pyo3::PyErr;
 use pyo3::Python;
 use pyo3::exceptions::{PyTypeError, PyValueError};
@@ -12,7 +11,10 @@ use tokio_stream::Stream;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
 
-use crate::bridge::{PyBridge, ResponseChunk, TerminalError};
+use crate::bridge::{
+    PyBridge, RequestKey, ResponseChunk, ResponseMetadata, ResponseMetadataMode, SubmittedRequest,
+    TerminalError,
+};
 use crate::proto;
 use crate::utils::{
     build_classify_dict, build_embed_dict, build_generate_dict, build_text_embed_dict,
@@ -88,15 +90,15 @@ async fn recv_chunk_with_timeout(
 
 struct RequestAbortGuard {
     bridge: Arc<PyBridge>,
-    rid: String,
+    key: RequestKey,
     armed: bool,
 }
 
 impl RequestAbortGuard {
-    fn new(bridge: Arc<PyBridge>, rid: impl Into<String>) -> Self {
+    fn new(bridge: Arc<PyBridge>, key: RequestKey) -> Self {
         Self {
             bridge,
-            rid: rid.into(),
+            key,
             armed: true,
         }
     }
@@ -108,7 +110,7 @@ impl RequestAbortGuard {
     fn abort_now(&mut self) {
         if self.armed {
             self.armed = false;
-            spawn_abort(self.bridge.clone(), self.rid.clone());
+            spawn_abort(self.bridge.clone(), self.key.clone());
         }
     }
 }
@@ -118,22 +120,22 @@ impl Drop for RequestAbortGuard {
         if self.armed {
             // Dropping a response stream means the client stopped consuming; propagate
             // cancellation to Python without blocking the Tokio worker.
-            spawn_abort(self.bridge.clone(), self.rid.clone());
+            spawn_abort(self.bridge.clone(), self.key.clone());
         }
     }
 }
 
-fn spawn_abort(bridge: Arc<PyBridge>, rid: String) {
+fn spawn_abort(bridge: Arc<PyBridge>, key: RequestKey) {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => {
             // Fire-and-forget: dropping the JoinHandle detaches the task.
             drop(handle.spawn_blocking(move || {
-                let _ = bridge.abort(&rid, false);
+                let _ = bridge.abort_request(&key);
             }));
         }
         Err(_) => {
             tracing::warn!(
-                rid,
+                rid = key.rid(),
                 "Skipping gRPC request abort because no Tokio runtime is available"
             );
         }
@@ -142,11 +144,11 @@ fn spawn_abort(bridge: Arc<PyBridge>, rid: String) {
 
 async fn recv_terminal_chunk_for_request(
     bridge: &Arc<PyBridge>,
-    rid: &str,
+    key: &RequestKey,
     receiver: &mut Receiver<ResponseChunk>,
     response_timeout: Duration,
 ) -> Result<ResponseChunk, Status> {
-    let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid.to_string());
+    let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
 
     match recv_chunk_with_timeout(receiver, response_timeout, || {
         format!("Request timed out after {}s", response_timeout.as_secs())
@@ -155,7 +157,7 @@ async fn recv_terminal_chunk_for_request(
     {
         Ok(Some(ResponseChunk::Data(_))) => {
             tracing::warn!(
-                rid,
+                rid = key.rid(),
                 "Unary gRPC response received non-terminal Data chunk; expected Finished"
             );
             abort_guard.abort_now();
@@ -168,7 +170,7 @@ async fn recv_terminal_chunk_for_request(
             Ok(chunk)
         }
         Ok(None) => {
-            let (status, should_abort) = closed_stream_status(bridge, rid);
+            let (status, should_abort) = closed_stream_status(bridge, key);
             if should_abort {
                 abort_guard.abort_now();
             } else {
@@ -187,8 +189,8 @@ async fn recv_terminal_chunk_for_request(
     }
 }
 
-fn closed_stream_status(bridge: &Arc<PyBridge>, rid: &str) -> (Status, bool) {
-    if let Some(error) = bridge.take_terminal_error(rid) {
+fn closed_stream_status(bridge: &Arc<PyBridge>, key: &RequestKey) -> (Status, bool) {
+    if let Some(error) = bridge.take_terminal_error(key) {
         (terminal_error_status(error), false)
     } else {
         (
@@ -208,25 +210,15 @@ fn terminal_error_status(error: TerminalError) -> Status {
     }
 }
 
-fn openai_status_code(meta_info: &serde_json::Map<String, serde_json::Value>, default: i32) -> i32 {
+fn openai_status_code(meta_info: &HashMap<String, String>, default: i32) -> i32 {
     meta_info
         .get("status_code")
-        .and_then(|value| {
-            value
-                .as_i64()
-                .and_then(|value| i32::try_from(value).ok())
-                .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
-        })
+        .and_then(|value| value.parse::<i32>().ok())
         .unwrap_or(default)
 }
 
-fn meta_to_string_map(
-    meta_info: serde_json::Map<String, serde_json::Value>,
-) -> HashMap<String, String> {
-    meta_info
-        .into_iter()
-        .map(|(key, value)| (key, value.to_string()))
-        .collect()
+fn legacy_metadata(meta_info: ResponseMetadata) -> Result<HashMap<String, String>, Status> {
+    meta_info.into_legacy().map_err(Status::internal)
 }
 
 fn json_to_prost_value(value: serde_json::Value) -> prost_types::Value {
@@ -263,10 +255,23 @@ const TYPED_META_KEYS: &[&str] = &[
     "input_top_logprobs",
     "output_top_logprobs",
     "output_token_logprobs_length",
-    "routed_experts",
-    "routed_experts_shape",
-    "routed_experts_start_len",
 ];
+
+const MAX_TYPED_GENERATION_CHOICES: i32 = 1024;
+
+fn expected_generation_choices(request: &proto::GenerateRequest) -> Result<usize, Status> {
+    let choices = request
+        .sampling_params
+        .as_ref()
+        .and_then(|params| params.n)
+        .unwrap_or(1);
+    if !(1..=MAX_TYPED_GENERATION_CHOICES).contains(&choices) {
+        return Err(Status::invalid_argument(format!(
+            "sampling_params.n must be between 1 and {MAX_TYPED_GENERATION_CHOICES}, got {choices}"
+        )));
+    }
+    Ok(choices as usize)
+}
 
 fn engine_metadata(
     meta: &serde_json::Map<String, serde_json::Value>,
@@ -352,13 +357,6 @@ fn logprob_entry(
     }))
 }
 
-#[derive(Default)]
-struct GenerationOffsets {
-    token: usize,
-    output_logprob: usize,
-    prompt_logprobs_sent: bool,
-}
-
 struct ChoiceTracker {
     expected: usize,
     terminal: HashSet<i32>,
@@ -368,7 +366,7 @@ impl ChoiceTracker {
     fn new(expected: usize) -> Self {
         Self {
             expected,
-            terminal: HashSet::with_capacity(expected),
+            terminal: HashSet::new(),
         }
     }
 
@@ -406,20 +404,11 @@ impl ChoiceTracker {
 
 fn logprobs_from_meta(
     meta: &serde_json::Map<String, serde_json::Value>,
-    offsets: &mut GenerationOffsets,
-    incremental: bool,
 ) -> Result<Option<proto::Logprobs>, String> {
     let output_values: &[serde_json::Value] = match meta.get("output_token_logprobs") {
         Some(serde_json::Value::Array(values)) => values.as_slice(),
         Some(_) => return Err("SGLang returned non-array output logprobs".into()),
         None => &[],
-    };
-    let output_start = if incremental {
-        0
-    } else if offsets.output_logprob <= output_values.len() {
-        offsets.output_logprob
-    } else {
-        0
     };
     let top_values = match meta.get("output_top_logprobs") {
         Some(serde_json::Value::Array(values)) => Some(values),
@@ -429,7 +418,6 @@ fn logprobs_from_meta(
     let output = output_values
         .iter()
         .enumerate()
-        .skip(output_start)
         .map(|(index, selected)| {
             logprob_entry(selected, top_values.and_then(|values| values.get(index)))
         })
@@ -437,83 +425,27 @@ fn logprobs_from_meta(
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
-    offsets.output_logprob = if incremental {
-        offsets.output_logprob.saturating_add(output_values.len())
-    } else {
-        output_values.len()
+    let prompt_values: &[serde_json::Value] = match meta.get("input_token_logprobs") {
+        Some(serde_json::Value::Array(values)) => values.as_slice(),
+        Some(_) => return Err("SGLang returned non-array prompt logprobs".into()),
+        None => &[],
     };
-
-    let prompt = if offsets.prompt_logprobs_sent {
-        Vec::new()
-    } else {
-        let prompt_values: &[serde_json::Value] = match meta.get("input_token_logprobs") {
-            Some(serde_json::Value::Array(values)) => values.as_slice(),
-            Some(_) => return Err("SGLang returned non-array prompt logprobs".into()),
-            None => &[],
-        };
-        let prompt_top = match meta.get("input_top_logprobs") {
-            Some(serde_json::Value::Array(values)) => Some(values),
-            Some(_) => return Err("SGLang returned non-array prompt top logprobs".into()),
-            None => None,
-        };
-        let mapped = prompt_values
-            .iter()
-            .enumerate()
-            .map(|(index, selected)| {
-                logprob_entry(selected, prompt_top.and_then(|values| values.get(index)))
-            })
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        offsets.prompt_logprobs_sent = !prompt_values.is_empty();
-        mapped
+    let prompt_top = match meta.get("input_top_logprobs") {
+        Some(serde_json::Value::Array(values)) => Some(values),
+        Some(_) => return Err("SGLang returned non-array prompt top logprobs".into()),
+        None => None,
     };
+    let prompt = prompt_values
+        .iter()
+        .enumerate()
+        .map(|(index, selected)| {
+            logprob_entry(selected, prompt_top.and_then(|values| values.get(index)))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
     Ok((!output.is_empty() || !prompt.is_empty()).then_some(proto::Logprobs { output, prompt }))
-}
-
-fn routed_experts(
-    meta: &serde_json::Map<String, serde_json::Value>,
-) -> Result<Option<proto::RoutedExpertMetadata>, String> {
-    let Some(value) = meta.get("routed_experts") else {
-        return Ok(None);
-    };
-    let packed_expert_ids = match value {
-        serde_json::Value::String(encoded) => base64::engine::general_purpose::STANDARD
-            .decode(encoded)
-            .map_err(|error| format!("invalid routed-experts base64: {error}"))?,
-        serde_json::Value::Array(values) => {
-            let mut packed = Vec::with_capacity(values.len() * std::mem::size_of::<i32>());
-            for value in values {
-                let value = value
-                    .as_i64()
-                    .and_then(|value| i32::try_from(value).ok())
-                    .ok_or_else(|| "routed-experts array contains a non-i32 value".to_string())?;
-                packed.extend_from_slice(&value.to_le_bytes());
-            }
-            packed
-        }
-        _ => return Err("SGLang returned unsupported routed-experts metadata".into()),
-    };
-    let shape = match meta.get("routed_experts_shape") {
-        Some(serde_json::Value::Array(values)) => values
-            .iter()
-            .map(|value| {
-                value
-                    .as_i64()
-                    .ok_or_else(|| "routed-experts shape contains a non-integer".to_string())
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-        Some(_) => return Err("SGLang returned a non-array routed-experts shape".into()),
-        None => Vec::new(),
-    };
-    Ok(Some(proto::RoutedExpertMetadata {
-        packed_expert_ids,
-        shape,
-        start_position: meta_u64(meta, &["routed_experts_start_len"])
-            .try_into()
-            .unwrap_or_default(),
-    }))
 }
 
 enum TypedTerminal {
@@ -541,6 +473,7 @@ fn generation_terminal(meta: &serde_json::Map<String, serde_json::Value>) -> Typ
             Some(499) => (proto::GenerationErrorCode::Cancelled, false),
             Some(400..=499) => (proto::GenerationErrorCode::InvalidArgument, false),
             Some(503) => (proto::GenerationErrorCode::Unavailable, true),
+            None if finish_type == "abort" => (proto::GenerationErrorCode::Cancelled, false),
             _ => (proto::GenerationErrorCode::Internal, false),
         };
         return TypedTerminal::Error(proto::GenerationError {
@@ -584,23 +517,24 @@ struct TypedGenerationChunk {
     delta_output_ids: Vec<i32>,
     logprobs: Option<proto::Logprobs>,
     usage: Option<proto::Usage>,
-    routed_experts: Option<proto::RoutedExpertMetadata>,
     engine_metadata: Option<prost_types::Struct>,
     terminal: Option<TypedTerminal>,
 }
 
 impl TypedGenerationChunk {
-    fn into_generate_response(self) -> proto::GenerateResponse {
+    fn into_response(self, request_id: String) -> proto::TypedGenerateResponse {
         let terminal = self.terminal.map(|terminal| match terminal {
-            TypedTerminal::Finish(finish) => proto::generate_response::Terminal::Finish(finish),
-            TypedTerminal::Error(error) => proto::generate_response::Terminal::Error(error),
+            TypedTerminal::Finish(finish) => {
+                proto::typed_generate_response::Terminal::Finish(finish)
+            }
+            TypedTerminal::Error(error) => proto::typed_generate_response::Terminal::Error(error),
         });
-        proto::GenerateResponse {
+        proto::TypedGenerateResponse {
+            request_id,
             delta_output_ids: self.delta_output_ids,
             choice_index: self.choice_index,
             logprobs: self.logprobs,
             usage: self.usage,
-            routed_experts: self.routed_experts,
             engine_metadata: self.engine_metadata,
             terminal,
         }
@@ -610,42 +544,44 @@ impl TypedGenerationChunk {
 fn typed_generation_chunk(
     data: crate::bridge::ResponseData,
     choice_terminal: bool,
-    offsets: &mut GenerationOffsets,
 ) -> Result<TypedGenerationChunk, String> {
-    let output_ids = data.output_ids.unwrap_or_default();
-    let delta_output_ids = if data.incremental {
-        offsets.token = offsets.token.saturating_add(output_ids.len());
-        output_ids
-    } else {
-        let start = if offsets.token <= output_ids.len() {
-            offsets.token
-        } else {
-            0
-        };
-        offsets.token = output_ids.len();
-        output_ids[start..].to_vec()
-    };
-    let logprobs = logprobs_from_meta(&data.meta_info, offsets, data.incremental)?;
-    let usage = choice_terminal.then(|| {
-        let prompt_tokens = meta_u64(&data.meta_info, &["prompt_tokens", "input_tokens"]);
-        let completion_tokens = meta_u64(&data.meta_info, &["completion_tokens", "output_tokens"]);
-        proto::Usage {
-            prompt_tokens,
-            completion_tokens,
-            cached_prompt_tokens: meta_u64(
-                &data.meta_info,
-                &["cached_tokens", "cached_prompt_tokens"],
-            ),
-        }
-    });
+    let crate::bridge::ResponseData {
+        output_ids,
+        choice_index,
+        meta_info,
+        ..
+    } = data;
+    let meta_info = meta_info.as_typed()?;
+    let delta_output_ids = output_ids.unwrap_or_default();
+    let logprobs = logprobs_from_meta(meta_info)?;
+    let usage_keys = [
+        "prompt_tokens",
+        "input_tokens",
+        "completion_tokens",
+        "output_tokens",
+        "cached_tokens",
+        "cached_prompt_tokens",
+    ];
+    let usage = (choice_terminal && usage_keys.iter().any(|key| meta_info.contains_key(*key)))
+        .then(|| {
+            let prompt_tokens = meta_u64(meta_info, &["prompt_tokens", "input_tokens"]);
+            let completion_tokens = meta_u64(meta_info, &["completion_tokens", "output_tokens"]);
+            proto::Usage {
+                prompt_tokens,
+                completion_tokens,
+                cached_prompt_tokens: meta_u64(
+                    meta_info,
+                    &["cached_tokens", "cached_prompt_tokens"],
+                ),
+            }
+        });
     Ok(TypedGenerationChunk {
-        choice_index: data.choice_index,
+        choice_index,
         delta_output_ids,
         logprobs,
         usage,
-        routed_experts: routed_experts(&data.meta_info)?,
-        engine_metadata: engine_metadata(&data.meta_info),
-        terminal: choice_terminal.then(|| generation_terminal(&data.meta_info)),
+        engine_metadata: engine_metadata(meta_info),
+        terminal: choice_terminal.then(|| generation_terminal(meta_info)),
     })
 }
 
@@ -666,31 +602,50 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_text_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "generate", req_dict)
+            .submit_request(
+                &rid,
+                "generate",
+                req_dict,
+                ResponseMetadataMode::LegacyStringMap,
+            )
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
-        let rid_clone = rid.clone();
         let response_timeout = self.response_timeout;
 
         let stream = async_stream::stream! {
-            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
+            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
                     Ok(Some(ResponseChunk::Data(data))) => {
+                        let meta_info = match legacy_metadata(data.meta_info) {
+                            Ok(meta_info) => meta_info,
+                            Err(status) => {
+                                abort_guard.abort_now();
+                                yield Err(status);
+                                break;
+                            }
+                        };
                         yield Ok(proto::TextGenerateResponse {
                             text: data.text.unwrap_or_default(),
-                            meta_info: meta_to_string_map(data.meta_info),
+                            meta_info,
                             finished: false,
                         });
                     }
                     Ok(Some(ResponseChunk::Finished(data))) => {
                         abort_guard.disarm();
+                        let meta_info = match legacy_metadata(data.meta_info) {
+                            Ok(meta_info) => meta_info,
+                            Err(status) => {
+                                yield Err(status);
+                                break;
+                            }
+                        };
                         yield Ok(proto::TextGenerateResponse {
                             text: data.text.unwrap_or_default(),
-                            meta_info: meta_to_string_map(data.meta_info),
+                            meta_info,
                             finished: true,
                         });
                         break;
@@ -701,7 +656,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                         break;
                     }
                     Ok(None) => {
-                        let (status, should_abort) = closed_stream_status(&bridge, &rid_clone);
+                        let (status, should_abort) = closed_stream_status(&bridge, &key);
                         if should_abort {
                             abort_guard.abort_now();
                         } else {
@@ -734,16 +689,104 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
-        let expected_choices = req
-            .sampling_params
-            .as_ref()
-            .and_then(|params| params.n)
-            .unwrap_or(1)
-            .max(1) as usize;
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "generate", req_dict)
+            .submit_request(
+                &rid,
+                "generate",
+                req_dict,
+                ResponseMetadataMode::LegacyStringMap,
+            )
+            .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
+
+        let bridge = self.bridge.clone();
+        let response_timeout = self.response_timeout;
+
+        let stream = async_stream::stream! {
+            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
+            loop {
+                match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
+                    Ok(Some(ResponseChunk::Data(data))) => {
+                        let meta_info = match legacy_metadata(data.meta_info) {
+                            Ok(meta_info) => meta_info,
+                            Err(status) => {
+                                abort_guard.abort_now();
+                                yield Err(status);
+                                break;
+                            }
+                        };
+                        yield Ok(proto::GenerateResponse {
+                            output_ids: data.output_ids.unwrap_or_default(),
+                            meta_info,
+                            finished: false,
+                        });
+                    }
+                    Ok(Some(ResponseChunk::Finished(data))) => {
+                        abort_guard.disarm();
+                        let meta_info = match legacy_metadata(data.meta_info) {
+                            Ok(meta_info) => meta_info,
+                            Err(status) => {
+                                yield Err(status);
+                                break;
+                            }
+                        };
+                        yield Ok(proto::GenerateResponse {
+                            output_ids: data.output_ids.unwrap_or_default(),
+                            meta_info,
+                            finished: true,
+                        });
+                        break;
+                    }
+                    Ok(Some(ResponseChunk::Error(msg))) => {
+                        abort_guard.disarm();
+                        yield Err(Status::internal(msg));
+                        break;
+                    }
+                    Ok(None) => {
+                        let (status, should_abort) = closed_stream_status(&bridge, &key);
+                        if should_abort {
+                            abort_guard.abort_now();
+                        } else {
+                            abort_guard.disarm();
+                        }
+                        yield Err(status);
+                        break;
+                    }
+                    Err(status) => {
+                        abort_guard.abort_now();
+                        yield Err(status);
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    type TypedGenerateStream = StreamResult<proto::TypedGenerateResponse>;
+
+    async fn typed_generate(
+        &self,
+        request: Request<proto::GenerateRequest>,
+    ) -> Result<Response<Self::TypedGenerateStream>, Status> {
+        let req = request.into_inner();
+        let rid = req
+            .rid
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
+        let expected_choices = expected_generation_choices(&req)?;
+
+        let SubmittedRequest { key, mut receiver } = self
+            .bridge
+            .submit_request(
+                &rid,
+                "generate",
+                req_dict,
+                ResponseMetadataMode::TypedGenerate,
+            )
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
@@ -751,11 +794,10 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         let response_timeout = self.response_timeout;
 
         let stream = async_stream::stream! {
-            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
-            let mut offsets = HashMap::<i32, GenerationOffsets>::new();
+            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
             let mut choices = ChoiceTracker::new(expected_choices);
             loop {
-                match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
+                match recv_chunk_with_timeout(&mut receiver, response_timeout, || "TypedGenerate stream chunk timed out".to_string()).await {
                     Ok(Some(chunk @ (ResponseChunk::Data(_) | ResponseChunk::Finished(_)))) => {
                         let request_finished = matches!(&chunk, ResponseChunk::Finished(_));
                         let data = match chunk {
@@ -763,12 +805,19 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                             ResponseChunk::Error(_) => unreachable!(),
                         };
                         let choice_index = data.choice_index;
-                        let choice_terminal = request_finished || has_finish_reason(&data.meta_info);
+                        let choice_terminal = match data.meta_info.as_typed() {
+                            Ok(meta_info) => request_finished || has_finish_reason(meta_info),
+                            Err(error) => {
+                                abort_guard.abort_now();
+                                yield Err(Status::internal(error));
+                                break;
+                            }
+                        };
                         let all_terminal = match choices.observe(
                             choice_index,
                             choice_terminal,
                             request_finished,
-                            "Generate",
+                            "TypedGenerate",
                         ) {
                             Ok(all_terminal) => all_terminal,
                             Err(error) => {
@@ -777,21 +826,19 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                                 break;
                             }
                         };
-                        let mapped = match typed_generation_chunk(
-                            data,
-                            choice_terminal,
-                            offsets.entry(choice_index).or_default(),
-                        ) {
-                            Ok(mapped) => mapped.into_generate_response(),
+                        let mapped = match typed_generation_chunk(data, choice_terminal) {
+                            Ok(mapped) => mapped.into_response(rid_clone.clone()),
                             Err(error) => {
                                 abort_guard.abort_now();
                                 yield Err(Status::internal(error));
                                 break;
                             }
                         };
-                        yield Ok(mapped);
                         if all_terminal {
                             abort_guard.disarm();
+                        }
+                        yield Ok(mapped);
+                        if all_terminal {
                             break;
                         }
                     }
@@ -801,7 +848,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                         break;
                     }
                     Ok(None) => {
-                        let (status, should_abort) = closed_stream_status(&bridge, &rid_clone);
+                        let (status, should_abort) = closed_stream_status(&bridge, &key);
                         if should_abort {
                             abort_guard.abort_now();
                         } else {
@@ -835,14 +882,19 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_text_embed_dict(&rid, &req);
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "embed", req_dict)
+            .submit_request(
+                &rid,
+                "embed",
+                req_dict,
+                ResponseMetadataMode::LegacyStringMap,
+            )
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -852,7 +904,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::TextEmbedResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: meta_to_string_map(data.meta_info),
+                    meta_info: legacy_metadata(data.meta_info)?,
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -870,14 +922,19 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_embed_dict(&rid, &req);
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "embed", req_dict)
+            .submit_request(
+                &rid,
+                "embed",
+                req_dict,
+                ResponseMetadataMode::LegacyStringMap,
+            )
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -887,7 +944,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::EmbedResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: meta_to_string_map(data.meta_info),
+                    meta_info: legacy_metadata(data.meta_info)?,
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -912,14 +969,19 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_classify_dict(&rid, &req);
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "embed", req_dict)
+            .submit_request(
+                &rid,
+                "embed",
+                req_dict,
+                ResponseMetadataMode::LegacyStringMap,
+            )
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -929,7 +991,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::ClassifyResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: meta_to_string_map(data.meta_info),
+                    meta_info: legacy_metadata(data.meta_info)?,
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -1108,13 +1170,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::GetLoadResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_get_load(&rid, req.dp_rank)
             .map_err(|e| pyerr_to_status(e, "Failed to get load"))?;
 
-        let json_info =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_info = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         Ok(Response::new(proto::GetLoadResponse { json_info }))
     }
 
@@ -1145,13 +1206,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         _request: Request<proto::FlushCacheRequest>,
     ) -> Result<Response<proto::FlushCacheResponse>, Status> {
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_flush_cache(&rid)
             .map_err(|e| pyerr_to_status(e, "Failed to flush cache"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::FlushCacheResponse {
@@ -1166,13 +1226,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::PauseGenerationResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_pause_generation(&rid, &req.mode)
             .map_err(|e| pyerr_to_status(e, "Failed to pause generation"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::PauseGenerationResponse {
@@ -1185,13 +1244,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         _request: Request<proto::ContinueGenerationRequest>,
     ) -> Result<Response<proto::ContinueGenerationResponse>, Status> {
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_continue_generation(&rid)
             .map_err(|e| pyerr_to_status(e, "Failed to continue generation"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::ContinueGenerationResponse {
@@ -1258,13 +1316,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::StartProfileResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_start_profile(&rid, req.output_dir.as_deref())
             .map_err(|e| pyerr_to_status(e, "Failed to start profile"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::StartProfileResponse {
@@ -1277,13 +1334,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         _request: Request<proto::StopProfileRequest>,
     ) -> Result<Response<proto::StopProfileResponse>, Status> {
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_stop_profile(&rid)
             .map_err(|e| pyerr_to_status(e, "Failed to stop profile"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::StopProfileResponse {
@@ -1297,13 +1353,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::UpdateWeightsResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_update_weights(&rid, &req.model_path, req.load_format.as_deref())
             .map_err(|e| pyerr_to_status(e, "Failed to update weights"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::UpdateWeightsResponse {
@@ -1323,17 +1378,16 @@ impl SglangServiceImpl {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_openai(&rid, method_name, &req.json_body, &req.trace_headers)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
-        let rid_clone = rid.clone();
         let response_timeout = self.response_timeout;
 
         let stream = async_stream::stream! {
-            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
+            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
                     Ok(Some(ResponseChunk::Data(data))) => {
@@ -1357,7 +1411,7 @@ impl SglangServiceImpl {
                         break;
                     }
                     Ok(None) => {
-                        let (status, should_abort) = closed_stream_status(&bridge, &rid_clone);
+                        let (status, should_abort) = closed_stream_status(&bridge, &key);
                         if should_abort {
                             abort_guard.abort_now();
                         } else {
@@ -1386,14 +1440,14 @@ impl SglangServiceImpl {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_openai(&rid, method_name, &req.json_body, &req.trace_headers)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -1401,9 +1455,10 @@ impl SglangServiceImpl {
 
         match chunk {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
+                let meta_info = legacy_metadata(data.meta_info)?;
                 Ok(Response::new(proto::OpenAiResponse {
                     json_body: data.json_bytes.unwrap_or_default(),
-                    status_code: openai_status_code(&data.meta_info, 200),
+                    status_code: openai_status_code(&meta_info, 200),
                 }))
             }
             ResponseChunk::Error(msg) => {
@@ -1420,12 +1475,12 @@ impl SglangServiceImpl {
 /// Receive a single JSON response from the bridge channel.
 async fn recv_json_response(
     bridge: &Arc<PyBridge>,
-    rid: &str,
-    mut receiver: Receiver<ResponseChunk>,
+    submitted: SubmittedRequest,
     response_timeout: Duration,
 ) -> Result<String, Status> {
+    let SubmittedRequest { key, mut receiver } = submitted;
     let chunk =
-        recv_terminal_chunk_for_request(bridge, rid, &mut receiver, response_timeout).await?;
+        recv_terminal_chunk_for_request(bridge, &key, &mut receiver, response_timeout).await?;
 
     match chunk {
         ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -355,7 +355,6 @@ fn logprob_entry(
 #[derive(Default)]
 struct GenerationOffsets {
     token: usize,
-    text: usize,
     output_logprob: usize,
     prompt_logprobs_sent: bool,
 }
@@ -583,7 +582,6 @@ fn generation_terminal(meta: &serde_json::Map<String, serde_json::Value>) -> Typ
 struct TypedGenerationChunk {
     choice_index: i32,
     delta_output_ids: Vec<i32>,
-    delta_text: String,
     logprobs: Option<proto::Logprobs>,
     usage: Option<proto::Usage>,
     routed_experts: Option<proto::RoutedExpertMetadata>,
@@ -599,24 +597,6 @@ impl TypedGenerationChunk {
         });
         proto::GenerateResponse {
             delta_output_ids: self.delta_output_ids,
-            choice_index: self.choice_index,
-            logprobs: self.logprobs,
-            usage: self.usage,
-            routed_experts: self.routed_experts,
-            engine_metadata: self.engine_metadata,
-            terminal,
-        }
-    }
-
-    fn into_text_generate_response(self) -> proto::TextGenerateResponse {
-        let terminal = self.terminal.map(|terminal| match terminal {
-            TypedTerminal::Finish(finish) => {
-                proto::text_generate_response::Terminal::Finish(finish)
-            }
-            TypedTerminal::Error(error) => proto::text_generate_response::Terminal::Error(error),
-        });
-        proto::TextGenerateResponse {
-            delta_text: self.delta_text,
             choice_index: self.choice_index,
             logprobs: self.logprobs,
             usage: self.usage,
@@ -645,18 +625,6 @@ fn typed_generation_chunk(
         offsets.token = output_ids.len();
         output_ids[start..].to_vec()
     };
-    let text = data.text.unwrap_or_default();
-    let delta_text = if data.incremental {
-        offsets.text = offsets.text.saturating_add(text.len());
-        text
-    } else {
-        let delta = text
-            .get(offsets.text..)
-            .map(str::to_owned)
-            .unwrap_or_else(|| text.clone());
-        offsets.text = text.len();
-        delta
-    };
     let logprobs = logprobs_from_meta(&data.meta_info, offsets, data.incremental)?;
     let usage = choice_terminal.then(|| {
         let prompt_tokens = meta_u64(&data.meta_info, &["prompt_tokens", "input_tokens"]);
@@ -664,7 +632,6 @@ fn typed_generation_chunk(
         proto::Usage {
             prompt_tokens,
             completion_tokens,
-            total_tokens: prompt_tokens.saturating_add(completion_tokens),
             cached_prompt_tokens: meta_u64(
                 &data.meta_info,
                 &["cached_tokens", "cached_prompt_tokens"],
@@ -674,7 +641,6 @@ fn typed_generation_chunk(
     Ok(TypedGenerationChunk {
         choice_index: data.choice_index,
         delta_output_ids,
-        delta_text,
         logprobs,
         usage,
         routed_experts: routed_experts(&data.meta_info)?,
@@ -699,12 +665,6 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_text_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
-        let expected_choices = req
-            .sampling_params
-            .as_ref()
-            .and_then(|params| params.n)
-            .unwrap_or(1)
-            .max(1) as usize;
 
         let mut receiver = self
             .bridge
@@ -717,48 +677,23 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let stream = async_stream::stream! {
             let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
-            let mut offsets = HashMap::<i32, GenerationOffsets>::new();
-            let mut choices = ChoiceTracker::new(expected_choices);
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
-                    Ok(Some(chunk @ (ResponseChunk::Data(_) | ResponseChunk::Finished(_)))) => {
-                        let request_finished = matches!(&chunk, ResponseChunk::Finished(_));
-                        let data = match chunk {
-                            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => data,
-                            ResponseChunk::Error(_) => unreachable!(),
-                        };
-                        let choice_index = data.choice_index;
-                        let choice_terminal = request_finished || has_finish_reason(&data.meta_info);
-                        let all_terminal = match choices.observe(
-                            choice_index,
-                            choice_terminal,
-                            request_finished,
-                            "TextGenerate",
-                        ) {
-                            Ok(all_terminal) => all_terminal,
-                            Err(error) => {
-                                abort_guard.abort_now();
-                                yield Err(Status::internal(error));
-                                break;
-                            }
-                        };
-                        let mapped = match typed_generation_chunk(
-                            data,
-                            choice_terminal,
-                            offsets.entry(choice_index).or_default(),
-                        ) {
-                            Ok(mapped) => mapped.into_text_generate_response(),
-                            Err(error) => {
-                                abort_guard.abort_now();
-                                yield Err(Status::internal(error));
-                                break;
-                            }
-                        };
-                        yield Ok(mapped);
-                        if all_terminal {
-                            abort_guard.disarm();
-                            break;
-                        }
+                    Ok(Some(ResponseChunk::Data(data))) => {
+                        yield Ok(proto::TextGenerateResponse {
+                            text: data.text.unwrap_or_default(),
+                            meta_info: meta_to_string_map(data.meta_info),
+                            finished: false,
+                        });
+                    }
+                    Ok(Some(ResponseChunk::Finished(data))) => {
+                        abort_guard.disarm();
+                        yield Ok(proto::TextGenerateResponse {
+                            text: data.text.unwrap_or_default(),
+                            meta_info: meta_to_string_map(data.meta_info),
+                            finished: true,
+                        });
+                        break;
                     }
                     Ok(Some(ResponseChunk::Error(msg))) => {
                         abort_guard.disarm();

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
 
+use base64::Engine as _;
 use pyo3::PyErr;
 use pyo3::Python;
 use pyo3::exceptions::{PyTypeError, PyValueError};
@@ -207,11 +208,479 @@ fn terminal_error_status(error: TerminalError) -> Status {
     }
 }
 
-fn openai_status_code(meta_info: &HashMap<String, String>, default: i32) -> i32 {
+fn openai_status_code(meta_info: &serde_json::Map<String, serde_json::Value>, default: i32) -> i32 {
     meta_info
         .get("status_code")
-        .and_then(|value| value.parse::<i32>().ok())
+        .and_then(|value| {
+            value
+                .as_i64()
+                .and_then(|value| i32::try_from(value).ok())
+                .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+        })
         .unwrap_or(default)
+}
+
+fn meta_to_string_map(
+    meta_info: serde_json::Map<String, serde_json::Value>,
+) -> HashMap<String, String> {
+    meta_info
+        .into_iter()
+        .map(|(key, value)| (key, value.to_string()))
+        .collect()
+}
+
+fn json_to_prost_value(value: serde_json::Value) -> prost_types::Value {
+    use prost_types::value::Kind;
+    let kind = match value {
+        serde_json::Value::Null => Kind::NullValue(0),
+        serde_json::Value::Bool(value) => Kind::BoolValue(value),
+        serde_json::Value::Number(value) => Kind::NumberValue(value.as_f64().unwrap_or_default()),
+        serde_json::Value::String(value) => Kind::StringValue(value),
+        serde_json::Value::Array(values) => Kind::ListValue(prost_types::ListValue {
+            values: values.into_iter().map(json_to_prost_value).collect(),
+        }),
+        serde_json::Value::Object(fields) => Kind::StructValue(prost_types::Struct {
+            fields: fields
+                .into_iter()
+                .map(|(key, value)| (key, json_to_prost_value(value)))
+                .collect(),
+        }),
+    };
+    prost_types::Value { kind: Some(kind) }
+}
+
+const TYPED_META_KEYS: &[&str] = &[
+    "id",
+    "finish_reason",
+    "prompt_tokens",
+    "input_tokens",
+    "completion_tokens",
+    "output_tokens",
+    "cached_tokens",
+    "cached_prompt_tokens",
+    "input_token_logprobs",
+    "output_token_logprobs",
+    "input_top_logprobs",
+    "output_top_logprobs",
+    "output_token_logprobs_length",
+    "routed_experts",
+    "routed_experts_shape",
+    "routed_experts_start_len",
+];
+
+fn engine_metadata(
+    meta: &serde_json::Map<String, serde_json::Value>,
+) -> Option<prost_types::Struct> {
+    let fields = meta
+        .iter()
+        .filter(|(key, _)| !TYPED_META_KEYS.contains(&key.as_str()))
+        .map(|(key, value)| (key.clone(), json_to_prost_value(value.clone())))
+        .collect::<std::collections::BTreeMap<_, _>>();
+    (!fields.is_empty()).then_some(prost_types::Struct { fields })
+}
+
+fn meta_u64(meta: &serde_json::Map<String, serde_json::Value>, keys: &[&str]) -> u64 {
+    keys.iter()
+        .find_map(|key| meta.get(*key).and_then(serde_json::Value::as_u64))
+        .unwrap_or_default()
+}
+
+fn has_finish_reason(meta: &serde_json::Map<String, serde_json::Value>) -> bool {
+    meta.get("finish_reason")
+        .is_some_and(|value| !value.is_null())
+}
+
+fn logprob_entry(
+    selected: &serde_json::Value,
+    top: Option<&serde_json::Value>,
+) -> Result<Option<proto::TokenLogprob>, String> {
+    let Some(parts) = selected.as_array() else {
+        return Err("SGLang returned a non-array logprob entry".into());
+    };
+    if parts.first().is_none_or(serde_json::Value::is_null) {
+        return Ok(None);
+    }
+    let logprob = parts
+        .first()
+        .and_then(serde_json::Value::as_f64)
+        .ok_or_else(|| "SGLang logprob entry is missing a numeric logprob".to_string())?
+        as f32;
+    let token_id = parts
+        .get(1)
+        .and_then(serde_json::Value::as_i64)
+        .and_then(|value| i32::try_from(value).ok())
+        .ok_or_else(|| "SGLang logprob entry is missing a valid token id".to_string())?;
+    let text = parts
+        .get(2)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
+    let top_logprobs = match top {
+        Some(serde_json::Value::Array(entries)) => entries
+            .iter()
+            .enumerate()
+            .map(|(rank, entry)| {
+                let parts = entry
+                    .as_array()
+                    .ok_or_else(|| "SGLang returned a non-array top-logprob entry".to_string())?;
+                Ok(proto::LogprobAlternative {
+                    logprob: parts
+                        .first()
+                        .and_then(serde_json::Value::as_f64)
+                        .ok_or_else(|| "top-logprob entry is missing a logprob".to_string())?
+                        as f32,
+                    token_id: parts
+                        .get(1)
+                        .and_then(serde_json::Value::as_i64)
+                        .and_then(|value| i32::try_from(value).ok())
+                        .ok_or_else(|| "top-logprob entry is missing a token id".to_string())?,
+                    text: parts
+                        .get(2)
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned),
+                    rank: i32::try_from(rank + 1).ok(),
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?,
+        Some(_) => return Err("SGLang returned non-array top logprobs".into()),
+        None => Vec::new(),
+    };
+    Ok(Some(proto::TokenLogprob {
+        logprob,
+        token_id,
+        text,
+        top_logprobs,
+    }))
+}
+
+#[derive(Default)]
+struct GenerationOffsets {
+    token: usize,
+    text: usize,
+    output_logprob: usize,
+    prompt_logprobs_sent: bool,
+}
+
+struct ChoiceTracker {
+    expected: usize,
+    terminal: HashSet<i32>,
+}
+
+impl ChoiceTracker {
+    fn new(expected: usize) -> Self {
+        Self {
+            expected,
+            terminal: HashSet::with_capacity(expected),
+        }
+    }
+
+    fn observe(
+        &mut self,
+        choice_index: i32,
+        choice_terminal: bool,
+        request_finished: bool,
+        rpc_name: &str,
+    ) -> Result<bool, String> {
+        if choice_index < 0 || choice_index as usize >= self.expected {
+            return Err(format!(
+                "SGLang returned choice index {choice_index} outside 0..{}",
+                self.expected
+            ));
+        }
+        if self.terminal.contains(&choice_index) {
+            return Err(format!(
+                "SGLang returned data after terminal for choice {choice_index}"
+            ));
+        }
+        if choice_terminal {
+            self.terminal.insert(choice_index);
+        }
+        if request_finished && self.terminal.len() != self.expected {
+            return Err(format!(
+                "SGLang closed {rpc_name} after {}/{} terminal choices",
+                self.terminal.len(),
+                self.expected
+            ));
+        }
+        Ok(self.terminal.len() == self.expected)
+    }
+}
+
+fn logprobs_from_meta(
+    meta: &serde_json::Map<String, serde_json::Value>,
+    offsets: &mut GenerationOffsets,
+    incremental: bool,
+) -> Result<Option<proto::Logprobs>, String> {
+    let output_values = match meta.get("output_token_logprobs") {
+        Some(serde_json::Value::Array(values)) => values,
+        Some(_) => return Err("SGLang returned non-array output logprobs".into()),
+        None => return Ok(None),
+    };
+    let output_start = if incremental {
+        0
+    } else if offsets.output_logprob <= output_values.len() {
+        offsets.output_logprob
+    } else {
+        0
+    };
+    let top_values = match meta.get("output_top_logprobs") {
+        Some(serde_json::Value::Array(values)) => Some(values),
+        Some(_) => return Err("SGLang returned non-array output top logprobs".into()),
+        None => None,
+    };
+    let output = output_values
+        .iter()
+        .enumerate()
+        .skip(output_start)
+        .map(|(index, selected)| {
+            logprob_entry(selected, top_values.and_then(|values| values.get(index)))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    offsets.output_logprob = if incremental {
+        offsets.output_logprob.saturating_add(output_values.len())
+    } else {
+        output_values.len()
+    };
+
+    let prompt = if offsets.prompt_logprobs_sent {
+        Vec::new()
+    } else {
+        let prompt_values: &[serde_json::Value] = match meta.get("input_token_logprobs") {
+            Some(serde_json::Value::Array(values)) => values.as_slice(),
+            Some(_) => return Err("SGLang returned non-array prompt logprobs".into()),
+            None => &[],
+        };
+        let prompt_top = match meta.get("input_top_logprobs") {
+            Some(serde_json::Value::Array(values)) => Some(values),
+            Some(_) => return Err("SGLang returned non-array prompt top logprobs".into()),
+            None => None,
+        };
+        let mapped = prompt_values
+            .iter()
+            .enumerate()
+            .map(|(index, selected)| {
+                logprob_entry(selected, prompt_top.and_then(|values| values.get(index)))
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        offsets.prompt_logprobs_sent = !prompt_values.is_empty();
+        mapped
+    };
+    Ok(Some(proto::Logprobs { output, prompt }))
+}
+
+fn routed_experts(
+    meta: &serde_json::Map<String, serde_json::Value>,
+) -> Result<Option<proto::RoutedExpertMetadata>, String> {
+    let Some(value) = meta.get("routed_experts") else {
+        return Ok(None);
+    };
+    let packed_expert_ids = match value {
+        serde_json::Value::String(encoded) => base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|error| format!("invalid routed-experts base64: {error}"))?,
+        serde_json::Value::Array(values) => {
+            let mut packed = Vec::with_capacity(values.len() * std::mem::size_of::<i32>());
+            for value in values {
+                let value = value
+                    .as_i64()
+                    .and_then(|value| i32::try_from(value).ok())
+                    .ok_or_else(|| "routed-experts array contains a non-i32 value".to_string())?;
+                packed.extend_from_slice(&value.to_le_bytes());
+            }
+            packed
+        }
+        _ => return Err("SGLang returned unsupported routed-experts metadata".into()),
+    };
+    let shape = match meta.get("routed_experts_shape") {
+        Some(serde_json::Value::Array(values)) => values
+            .iter()
+            .map(|value| {
+                value
+                    .as_i64()
+                    .ok_or_else(|| "routed-experts shape contains a non-integer".to_string())
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        Some(_) => return Err("SGLang returned a non-array routed-experts shape".into()),
+        None => Vec::new(),
+    };
+    Ok(Some(proto::RoutedExpertMetadata {
+        packed_expert_ids,
+        shape,
+        start_position: meta_u64(meta, &["routed_experts_start_len"])
+            .try_into()
+            .unwrap_or_default(),
+    }))
+}
+
+enum TypedTerminal {
+    Finish(proto::GenerationFinish),
+    Error(proto::GenerationError),
+}
+
+fn generation_terminal(meta: &serde_json::Map<String, serde_json::Value>) -> TypedTerminal {
+    let Some(value) = meta.get("finish_reason").filter(|value| !value.is_null()) else {
+        return TypedTerminal::Error(proto::GenerationError {
+            code: proto::GenerationErrorCode::Internal as i32,
+            message: "SGLang stream ended without finish_reason".into(),
+            retryable: false,
+        });
+    };
+    let finish_type = value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| value.as_str())
+        .unwrap_or("error");
+    if matches!(finish_type, "abort" | "error") {
+        let status_code = value.get("status_code").and_then(serde_json::Value::as_i64);
+        let (code, retryable) = match status_code {
+            Some(408 | 504) => (proto::GenerationErrorCode::DeadlineExceeded, true),
+            Some(499) => (proto::GenerationErrorCode::Cancelled, false),
+            Some(400..=499) => (proto::GenerationErrorCode::InvalidArgument, false),
+            Some(503) => (proto::GenerationErrorCode::Unavailable, true),
+            _ => (proto::GenerationErrorCode::Internal, false),
+        };
+        return TypedTerminal::Error(proto::GenerationError {
+            code: code as i32,
+            message: value
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("SGLang generation failed")
+                .to_string(),
+            retryable,
+        });
+    }
+    let reason = match finish_type {
+        "stop" => proto::FinishReason::Stop,
+        "length" => proto::FinishReason::Length,
+        "cancelled" => proto::FinishReason::Cancelled,
+        _ => proto::FinishReason::Unspecified,
+    };
+    let stop_reason = value.get("matched").and_then(|matched| {
+        use proto::stop_reason::Reason;
+        let reason = if let Some(value) = matched.as_str() {
+            Some(Reason::MatchedString(value.to_string()))
+        } else {
+            matched
+                .as_i64()
+                .and_then(|value| i32::try_from(value).ok())
+                .map(Reason::MatchedTokenId)
+        }?;
+        Some(proto::StopReason {
+            reason: Some(reason),
+        })
+    });
+    TypedTerminal::Finish(proto::GenerationFinish {
+        reason: reason as i32,
+        stop_reason,
+    })
+}
+
+struct TypedGenerationChunk {
+    choice_index: i32,
+    delta_output_ids: Vec<i32>,
+    delta_text: String,
+    logprobs: Option<proto::Logprobs>,
+    usage: Option<proto::Usage>,
+    routed_experts: Option<proto::RoutedExpertMetadata>,
+    engine_metadata: Option<prost_types::Struct>,
+    terminal: Option<TypedTerminal>,
+}
+
+impl TypedGenerationChunk {
+    fn into_generate_response(self) -> proto::GenerateResponse {
+        let terminal = self.terminal.map(|terminal| match terminal {
+            TypedTerminal::Finish(finish) => proto::generate_response::Terminal::Finish(finish),
+            TypedTerminal::Error(error) => proto::generate_response::Terminal::Error(error),
+        });
+        proto::GenerateResponse {
+            delta_output_ids: self.delta_output_ids,
+            choice_index: self.choice_index,
+            logprobs: self.logprobs,
+            usage: self.usage,
+            routed_experts: self.routed_experts,
+            engine_metadata: self.engine_metadata,
+            terminal,
+        }
+    }
+
+    fn into_text_generate_response(self) -> proto::TextGenerateResponse {
+        let terminal = self.terminal.map(|terminal| match terminal {
+            TypedTerminal::Finish(finish) => {
+                proto::text_generate_response::Terminal::Finish(finish)
+            }
+            TypedTerminal::Error(error) => proto::text_generate_response::Terminal::Error(error),
+        });
+        proto::TextGenerateResponse {
+            delta_text: self.delta_text,
+            choice_index: self.choice_index,
+            logprobs: self.logprobs,
+            usage: self.usage,
+            routed_experts: self.routed_experts,
+            engine_metadata: self.engine_metadata,
+            terminal,
+        }
+    }
+}
+
+fn typed_generation_chunk(
+    data: crate::bridge::ResponseData,
+    choice_terminal: bool,
+    offsets: &mut GenerationOffsets,
+) -> Result<TypedGenerationChunk, String> {
+    let output_ids = data.output_ids.unwrap_or_default();
+    let delta_output_ids = if data.incremental {
+        offsets.token = offsets.token.saturating_add(output_ids.len());
+        output_ids
+    } else {
+        let start = if offsets.token <= output_ids.len() {
+            offsets.token
+        } else {
+            0
+        };
+        offsets.token = output_ids.len();
+        output_ids[start..].to_vec()
+    };
+    let text = data.text.unwrap_or_default();
+    let delta_text = if data.incremental {
+        offsets.text = offsets.text.saturating_add(text.len());
+        text
+    } else {
+        let delta = text
+            .get(offsets.text..)
+            .map(str::to_owned)
+            .unwrap_or_else(|| text.clone());
+        offsets.text = text.len();
+        delta
+    };
+    let logprobs = logprobs_from_meta(&data.meta_info, offsets, data.incremental)?;
+    let usage = choice_terminal.then(|| {
+        let prompt_tokens = meta_u64(&data.meta_info, &["prompt_tokens", "input_tokens"]);
+        let completion_tokens = meta_u64(&data.meta_info, &["completion_tokens", "output_tokens"]);
+        proto::Usage {
+            prompt_tokens,
+            completion_tokens,
+            total_tokens: prompt_tokens.saturating_add(completion_tokens),
+            cached_prompt_tokens: meta_u64(
+                &data.meta_info,
+                &["cached_tokens", "cached_prompt_tokens"],
+            ),
+        }
+    });
+    Ok(TypedGenerationChunk {
+        choice_index: data.choice_index,
+        delta_output_ids,
+        delta_text,
+        logprobs,
+        usage,
+        routed_experts: routed_experts(&data.meta_info)?,
+        engine_metadata: engine_metadata(&data.meta_info),
+        terminal: choice_terminal.then(|| generation_terminal(&data.meta_info)),
+    })
 }
 
 #[tonic::async_trait]
@@ -229,7 +698,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .rid
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let req_dict = build_text_generate_dict(&rid, &req);
+        let req_dict = build_text_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
+        let expected_choices = req
+            .sampling_params
+            .as_ref()
+            .and_then(|params| params.n)
+            .unwrap_or(1)
+            .max(1) as usize;
 
         let mut receiver = self
             .bridge
@@ -242,23 +717,48 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let stream = async_stream::stream! {
             let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
+            let mut offsets = HashMap::<i32, GenerationOffsets>::new();
+            let mut choices = ChoiceTracker::new(expected_choices);
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
-                    Ok(Some(ResponseChunk::Data(data))) => {
-                        yield Ok(proto::TextGenerateResponse {
-                            text: data.text.unwrap_or_default(),
-                            meta_info: data.meta_info,
-                            finished: false,
-                        });
-                    }
-                    Ok(Some(ResponseChunk::Finished(data))) => {
-                        abort_guard.disarm();
-                        yield Ok(proto::TextGenerateResponse {
-                            text: data.text.unwrap_or_default(),
-                            meta_info: data.meta_info,
-                            finished: true,
-                        });
-                        break;
+                    Ok(Some(chunk @ (ResponseChunk::Data(_) | ResponseChunk::Finished(_)))) => {
+                        let request_finished = matches!(&chunk, ResponseChunk::Finished(_));
+                        let data = match chunk {
+                            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => data,
+                            ResponseChunk::Error(_) => unreachable!(),
+                        };
+                        let choice_index = data.choice_index;
+                        let choice_terminal = request_finished || has_finish_reason(&data.meta_info);
+                        let all_terminal = match choices.observe(
+                            choice_index,
+                            choice_terminal,
+                            request_finished,
+                            "TextGenerate",
+                        ) {
+                            Ok(all_terminal) => all_terminal,
+                            Err(error) => {
+                                abort_guard.abort_now();
+                                yield Err(Status::internal(error));
+                                break;
+                            }
+                        };
+                        let mapped = match typed_generation_chunk(
+                            data,
+                            choice_terminal,
+                            offsets.entry(choice_index).or_default(),
+                        ) {
+                            Ok(mapped) => mapped.into_text_generate_response(),
+                            Err(error) => {
+                                abort_guard.abort_now();
+                                yield Err(Status::internal(error));
+                                break;
+                            }
+                        };
+                        yield Ok(mapped);
+                        if all_terminal {
+                            abort_guard.disarm();
+                            break;
+                        }
                     }
                     Ok(Some(ResponseChunk::Error(msg))) => {
                         abort_guard.disarm();
@@ -298,7 +798,13 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .rid
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let req_dict = build_generate_dict(&rid, &req);
+        let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
+        let expected_choices = req
+            .sampling_params
+            .as_ref()
+            .and_then(|params| params.n)
+            .unwrap_or(1)
+            .max(1) as usize;
 
         let mut receiver = self
             .bridge
@@ -311,23 +817,48 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let stream = async_stream::stream! {
             let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
+            let mut offsets = HashMap::<i32, GenerationOffsets>::new();
+            let mut choices = ChoiceTracker::new(expected_choices);
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
-                    Ok(Some(ResponseChunk::Data(data))) => {
-                        yield Ok(proto::GenerateResponse {
-                            output_ids: data.output_ids.unwrap_or_default(),
-                            meta_info: data.meta_info,
-                            finished: false,
-                        });
-                    }
-                    Ok(Some(ResponseChunk::Finished(data))) => {
-                        abort_guard.disarm();
-                        yield Ok(proto::GenerateResponse {
-                            output_ids: data.output_ids.unwrap_or_default(),
-                            meta_info: data.meta_info,
-                            finished: true,
-                        });
-                        break;
+                    Ok(Some(chunk @ (ResponseChunk::Data(_) | ResponseChunk::Finished(_)))) => {
+                        let request_finished = matches!(&chunk, ResponseChunk::Finished(_));
+                        let data = match chunk {
+                            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => data,
+                            ResponseChunk::Error(_) => unreachable!(),
+                        };
+                        let choice_index = data.choice_index;
+                        let choice_terminal = request_finished || has_finish_reason(&data.meta_info);
+                        let all_terminal = match choices.observe(
+                            choice_index,
+                            choice_terminal,
+                            request_finished,
+                            "Generate",
+                        ) {
+                            Ok(all_terminal) => all_terminal,
+                            Err(error) => {
+                                abort_guard.abort_now();
+                                yield Err(Status::internal(error));
+                                break;
+                            }
+                        };
+                        let mapped = match typed_generation_chunk(
+                            data,
+                            choice_terminal,
+                            offsets.entry(choice_index).or_default(),
+                        ) {
+                            Ok(mapped) => mapped.into_generate_response(),
+                            Err(error) => {
+                                abort_guard.abort_now();
+                                yield Err(Status::internal(error));
+                                break;
+                            }
+                        };
+                        yield Ok(mapped);
+                        if all_terminal {
+                            abort_guard.disarm();
+                            break;
+                        }
                     }
                     Ok(Some(ResponseChunk::Error(msg))) => {
                         abort_guard.disarm();
@@ -386,7 +917,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::TextEmbedResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: data.meta_info,
+                    meta_info: meta_to_string_map(data.meta_info),
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -421,7 +952,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::EmbedResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: data.meta_info,
+                    meta_info: meta_to_string_map(data.meta_info),
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),
@@ -463,7 +994,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {
                 Ok(Response::new(proto::ClassifyResponse {
                     embedding: data.embedding.unwrap_or_default(),
-                    meta_info: data.meta_info,
+                    meta_info: meta_to_string_map(data.meta_info),
                 }))
             }
             ResponseChunk::Error(msg) => Err(Status::internal(msg)),

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -410,10 +410,10 @@ fn logprobs_from_meta(
     offsets: &mut GenerationOffsets,
     incremental: bool,
 ) -> Result<Option<proto::Logprobs>, String> {
-    let output_values = match meta.get("output_token_logprobs") {
-        Some(serde_json::Value::Array(values)) => values,
+    let output_values: &[serde_json::Value] = match meta.get("output_token_logprobs") {
+        Some(serde_json::Value::Array(values)) => values.as_slice(),
         Some(_) => return Err("SGLang returned non-array output logprobs".into()),
-        None => return Ok(None),
+        None => &[],
     };
     let output_start = if incremental {
         0
@@ -470,7 +470,7 @@ fn logprobs_from_meta(
         offsets.prompt_logprobs_sent = !prompt_values.is_empty();
         mapped
     };
-    Ok(Some(proto::Logprobs { output, prompt }))
+    Ok((!output.is_empty() || !prompt.is_empty()).then_some(proto::Logprobs { output, prompt }))
 }
 
 fn routed_experts(

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     ChoiceTracker, DEFAULT_GRPC_MAX_MESSAGE_SIZE, TypedTerminal, expected_generation_choices,
-    openai_status_code, resolve_max_message_size, terminal_error_status, typed_generation_chunk,
+    generation_chunk, openai_status_code, resolve_max_message_size, terminal_error_status,
 };
 use crate::bridge::{ResponseData, ResponseMetadata, TerminalError};
 use prost::Message;
@@ -48,6 +48,9 @@ fn legacy_generation_wire_fields_remain_compatible() {
     assert_eq!(decoded_response.output_ids, legacy_response.output_ids);
     assert_eq!(decoded_response.meta_info, legacy_response.meta_info);
     assert!(decoded_response.finished);
+    assert!(decoded_response.request_id.is_empty());
+    assert!(decoded_response.delta_output_ids.is_empty());
+    assert!(decoded_response.terminal.is_none());
 }
 
 #[test]
@@ -74,11 +77,15 @@ fn openai_status_code_falls_back_when_missing_or_invalid() {
 fn response_data(output_ids: Vec<i32>, text: &str, meta_info: serde_json::Value) -> ResponseData {
     ResponseData {
         text: Some(text.to_string()),
+        legacy_output_ids: Some(output_ids.clone()),
         output_ids: Some(output_ids),
         embedding: None,
         choice_index: 1,
         json_bytes: None,
-        meta_info: ResponseMetadata::Typed(serde_json::from_value(meta_info).unwrap()),
+        meta_info: ResponseMetadata::Generate {
+            legacy: std::collections::HashMap::new(),
+            typed: serde_json::from_value(meta_info).unwrap(),
+        },
     }
 }
 
@@ -119,7 +126,7 @@ fn typed_logprobs_are_aligned_with_delta_tokens() {
         "output_token_logprobs": [[-0.2, 20, "a"]],
         "output_top_logprobs": [[[-0.2, 20, "a"], [-1.2, 21, "b"]]]
     });
-    let first = typed_generation_chunk(response_data(vec![20], "a", metadata), false).unwrap();
+    let first = generation_chunk(response_data(vec![20], "a", metadata), false).unwrap();
     let logprobs = first.logprobs.unwrap();
     assert_eq!(logprobs.prompt.len(), 1);
     assert_eq!(logprobs.output.len(), first.delta_output_ids.len());
@@ -128,7 +135,7 @@ fn typed_logprobs_are_aligned_with_delta_tokens() {
 
 #[test]
 fn prompt_logprobs_do_not_require_output_logprobs() {
-    let chunk = typed_generation_chunk(
+    let chunk = generation_chunk(
         response_data(
             vec![],
             "",
@@ -146,7 +153,7 @@ fn prompt_logprobs_do_not_require_output_logprobs() {
 
 #[test]
 fn malformed_logprobs_are_rejected() {
-    let error = typed_generation_chunk(
+    let error = generation_chunk(
         response_data(
             vec![1],
             "a",
@@ -165,7 +172,7 @@ fn finish_reasons_preserve_string_and_token_stops() {
         (serde_json::json!("END"), Some("END"), None),
         (serde_json::json!(42), None, Some(42)),
     ] {
-        let chunk = typed_generation_chunk(
+        let chunk = generation_chunk(
             response_data(
                 vec![],
                 "",
@@ -193,7 +200,7 @@ fn finish_reasons_preserve_string_and_token_stops() {
 
 #[test]
 fn terminal_metadata_is_typed_and_not_duplicated_in_extensions() {
-    let chunk = typed_generation_chunk(
+    let chunk = generation_chunk(
         response_data(
             vec![7],
             "done",
@@ -222,8 +229,8 @@ fn terminal_metadata_is_typed_and_not_duplicated_in_extensions() {
 }
 
 #[test]
-fn typed_response_uses_the_rust_owned_public_request_id() {
-    let chunk = typed_generation_chunk(
+fn generate_response_uses_the_rust_owned_public_request_id() {
+    let chunk = generation_chunk(
         response_data(
             vec![7],
             "done",
@@ -236,9 +243,12 @@ fn typed_response_uses_the_rust_owned_public_request_id() {
     )
     .unwrap();
     assert!(chunk.usage.is_none());
-    let response = chunk.into_response("public-parent-rid".into());
+    let response = chunk.into_response("public-parent-rid".into(), true);
 
     assert_eq!(response.request_id, "public-parent-rid");
+    assert_eq!(response.output_ids, vec![7]);
+    assert_eq!(response.delta_output_ids, vec![7]);
+    assert!(response.finished);
     assert!(
         !response
             .engine_metadata
@@ -247,7 +257,7 @@ fn typed_response_uses_the_rust_owned_public_request_id() {
 }
 
 #[test]
-fn typed_generation_rejects_invalid_or_unbounded_choice_counts() {
+fn generation_rejects_invalid_or_unbounded_choice_counts() {
     let request_with_n = |n| crate::proto::GenerateRequest {
         sampling_params: Some(crate::proto::SamplingParams {
             n: Some(n),
@@ -269,7 +279,7 @@ fn typed_generation_rejects_invalid_or_unbounded_choice_counts() {
 
 #[test]
 fn aborts_become_typed_generation_errors() {
-    let chunk = typed_generation_chunk(
+    let chunk = generation_chunk(
         response_data(
             vec![],
             "",

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -1,75 +1,85 @@
 use super::{
-    ChoiceTracker, DEFAULT_GRPC_MAX_MESSAGE_SIZE, GenerationOffsets, TypedTerminal,
+    ChoiceTracker, DEFAULT_GRPC_MAX_MESSAGE_SIZE, TypedTerminal, expected_generation_choices,
     openai_status_code, resolve_max_message_size, terminal_error_status, typed_generation_chunk,
 };
-use crate::bridge::{ResponseData, TerminalError};
+use crate::bridge::{ResponseData, ResponseMetadata, TerminalError};
+use prost::Message;
 use tonic::Code;
+
+#[derive(Clone, PartialEq, Message)]
+struct LegacySamplingParams {
+    #[prost(string, optional, tag = "14")]
+    json_schema: Option<String>,
+    #[prost(string, optional, tag = "15")]
+    regex: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct LegacyGenerateResponse {
+    #[prost(int32, repeated, tag = "1")]
+    output_ids: Vec<i32>,
+    #[prost(map = "string, string", tag = "2")]
+    meta_info: std::collections::HashMap<String, String>,
+    #[prost(bool, tag = "3")]
+    finished: bool,
+}
+
+#[test]
+#[allow(deprecated)]
+fn legacy_generation_wire_fields_remain_compatible() {
+    let legacy_sampling = LegacySamplingParams {
+        json_schema: Some("{\"type\":\"string\"}".into()),
+        regex: Some("[a-z]+".into()),
+    };
+    let decoded_sampling =
+        crate::proto::SamplingParams::decode(legacy_sampling.encode_to_vec().as_slice()).unwrap();
+    assert_eq!(decoded_sampling.json_schema, legacy_sampling.json_schema);
+    assert_eq!(decoded_sampling.regex, legacy_sampling.regex);
+
+    let legacy_response = LegacyGenerateResponse {
+        output_ids: vec![1, 2, 3],
+        meta_info: [("finish_reason".into(), "\"stop\"".into())]
+            .into_iter()
+            .collect(),
+        finished: true,
+    };
+    let decoded_response =
+        crate::proto::GenerateResponse::decode(legacy_response.encode_to_vec().as_slice()).unwrap();
+    assert_eq!(decoded_response.output_ids, legacy_response.output_ids);
+    assert_eq!(decoded_response.meta_info, legacy_response.meta_info);
+    assert!(decoded_response.finished);
+}
 
 #[test]
 fn openai_status_code_uses_forwarded_status_when_present() {
-    let meta_info = serde_json::from_value(serde_json::json!({"status_code": 429})).unwrap();
+    let meta_info = [("status_code".to_string(), "429".to_string())]
+        .into_iter()
+        .collect();
     assert_eq!(openai_status_code(&meta_info, 200), 429);
 }
 
 #[test]
 fn openai_status_code_falls_back_when_missing_or_invalid() {
-    assert_eq!(openai_status_code(&serde_json::Map::new(), 200), 200);
+    assert_eq!(
+        openai_status_code(&std::collections::HashMap::new(), 200),
+        200
+    );
 
-    let meta_info =
-        serde_json::from_value(serde_json::json!({"status_code": "not-an-int"})).unwrap();
+    let meta_info = [("status_code".into(), "not-an-int".into())]
+        .into_iter()
+        .collect();
     assert_eq!(openai_status_code(&meta_info, 200), 200);
 }
 
-fn response_data(
-    output_ids: Vec<i32>,
-    text: &str,
-    incremental: bool,
-    meta_info: serde_json::Value,
-) -> ResponseData {
+fn response_data(output_ids: Vec<i32>, text: &str, meta_info: serde_json::Value) -> ResponseData {
     ResponseData {
         text: Some(text.to_string()),
         output_ids: Some(output_ids),
         embedding: None,
         choice_index: 1,
-        incremental,
         json_bytes: None,
-        meta_info: serde_json::from_value(meta_info).unwrap(),
+        meta_info: ResponseMetadata::Typed(serde_json::from_value(meta_info).unwrap()),
     }
-}
-
-#[test]
-fn cumulative_and_incremental_token_chunks_are_normalized_to_deltas() {
-    let mut cumulative = GenerationOffsets::default();
-    let first = typed_generation_chunk(
-        response_data(vec![1, 2], "hé", false, serde_json::json!({})),
-        false,
-        &mut cumulative,
-    )
-    .unwrap();
-    let second = typed_generation_chunk(
-        response_data(vec![1, 2, 3], "héllo", false, serde_json::json!({})),
-        false,
-        &mut cumulative,
-    )
-    .unwrap();
-    assert_eq!(first.delta_output_ids, vec![1, 2]);
-    assert_eq!(second.delta_output_ids, vec![3]);
-
-    let mut incremental = GenerationOffsets::default();
-    let first = typed_generation_chunk(
-        response_data(vec![1], "hé", true, serde_json::json!({})),
-        false,
-        &mut incremental,
-    )
-    .unwrap();
-    let second = typed_generation_chunk(
-        response_data(vec![2], "llo", true, serde_json::json!({})),
-        false,
-        &mut incremental,
-    )
-    .unwrap();
-    assert_eq!(first.delta_output_ids, vec![1]);
-    assert_eq!(second.delta_output_ids, vec![2]);
 }
 
 #[test]
@@ -102,59 +112,31 @@ fn choice_tracker_requires_one_terminal_per_choice() {
 }
 
 #[test]
-fn logprobs_are_delta_aligned_and_prompt_logprobs_emit_once() {
-    let mut offsets = GenerationOffsets::default();
+fn typed_logprobs_are_aligned_with_delta_tokens() {
     let metadata = serde_json::json!({
         "input_token_logprobs": [[-0.1, 10, "prompt"]],
         "input_top_logprobs": [[[-0.1, 10, "prompt"]]],
         "output_token_logprobs": [[-0.2, 20, "a"]],
         "output_top_logprobs": [[[-0.2, 20, "a"], [-1.2, 21, "b"]]]
     });
-    let first = typed_generation_chunk(
-        response_data(vec![20], "a", false, metadata),
-        false,
-        &mut offsets,
-    )
-    .unwrap();
+    let first = typed_generation_chunk(response_data(vec![20], "a", metadata), false).unwrap();
     let logprobs = first.logprobs.unwrap();
     assert_eq!(logprobs.prompt.len(), 1);
     assert_eq!(logprobs.output.len(), first.delta_output_ids.len());
     assert_eq!(logprobs.output[0].top_logprobs.len(), 2);
-
-    let second = typed_generation_chunk(
-        response_data(
-            vec![20, 22],
-            "ac",
-            false,
-            serde_json::json!({
-                "input_token_logprobs": [[-0.1, 10, "prompt"]],
-                "output_token_logprobs": [[-0.2, 20, "a"], [-0.3, 22, "c"]]
-            }),
-        ),
-        false,
-        &mut offsets,
-    )
-    .unwrap();
-    let logprobs = second.logprobs.unwrap();
-    assert!(logprobs.prompt.is_empty());
-    assert_eq!(logprobs.output.len(), second.delta_output_ids.len());
-    assert_eq!(logprobs.output[0].token_id, 22);
 }
 
 #[test]
 fn prompt_logprobs_do_not_require_output_logprobs() {
-    let mut offsets = GenerationOffsets::default();
     let chunk = typed_generation_chunk(
         response_data(
             vec![],
             "",
-            false,
             serde_json::json!({
                 "input_token_logprobs": [[-0.1, 10, "prompt"]]
             }),
         ),
         true,
-        &mut offsets,
     )
     .unwrap();
     let logprobs = chunk.logprobs.expect("prompt logprobs");
@@ -163,36 +145,18 @@ fn prompt_logprobs_do_not_require_output_logprobs() {
 }
 
 #[test]
-fn malformed_logprobs_and_routed_experts_are_rejected() {
-    let mut offsets = GenerationOffsets::default();
+fn malformed_logprobs_are_rejected() {
     let error = typed_generation_chunk(
         response_data(
             vec![1],
             "a",
-            false,
             serde_json::json!({"output_token_logprobs": "invalid"}),
         ),
         false,
-        &mut offsets,
     )
     .err()
     .expect("malformed output logprobs should fail");
     assert!(error.contains("non-array output logprobs"));
-
-    let mut offsets = GenerationOffsets::default();
-    let error = typed_generation_chunk(
-        response_data(
-            vec![1],
-            "a",
-            false,
-            serde_json::json!({"routed_experts": [1, "invalid"]}),
-        ),
-        false,
-        &mut offsets,
-    )
-    .err()
-    .expect("malformed routed experts should fail");
-    assert!(error.contains("non-i32"));
 }
 
 #[test]
@@ -201,18 +165,15 @@ fn finish_reasons_preserve_string_and_token_stops() {
         (serde_json::json!("END"), Some("END"), None),
         (serde_json::json!(42), None, Some(42)),
     ] {
-        let mut offsets = GenerationOffsets::default();
         let chunk = typed_generation_chunk(
             response_data(
                 vec![],
                 "",
-                false,
                 serde_json::json!({
                     "finish_reason": {"type": "stop", "matched": matched}
                 }),
             ),
             true,
-            &mut offsets,
         )
         .unwrap();
         let TypedTerminal::Finish(finish) = chunk.terminal.unwrap() else {
@@ -232,13 +193,12 @@ fn finish_reasons_preserve_string_and_token_stops() {
 
 #[test]
 fn terminal_metadata_is_typed_and_not_duplicated_in_extensions() {
-    let mut offsets = GenerationOffsets::default();
     let chunk = typed_generation_chunk(
         response_data(
             vec![7],
             "done",
-            false,
             serde_json::json!({
+                "id": "internal-child-rid",
                 "finish_reason": {"type": "stop", "matched": "END"},
                 "prompt_tokens": 8,
                 "completion_tokens": 1,
@@ -247,7 +207,6 @@ fn terminal_metadata_is_typed_and_not_duplicated_in_extensions() {
             }),
         ),
         true,
-        &mut offsets,
     )
     .unwrap();
     let usage = chunk.usage.unwrap();
@@ -257,24 +216,68 @@ fn terminal_metadata_is_typed_and_not_duplicated_in_extensions() {
     assert!(matches!(chunk.terminal, Some(TypedTerminal::Finish(_))));
     let fields = chunk.engine_metadata.unwrap().fields;
     assert!(fields.contains_key("weight_version"));
+    assert!(!fields.contains_key("id"));
     assert!(!fields.contains_key("finish_reason"));
     assert!(!fields.contains_key("prompt_tokens"));
 }
 
 #[test]
+fn typed_response_uses_the_rust_owned_public_request_id() {
+    let chunk = typed_generation_chunk(
+        response_data(
+            vec![7],
+            "done",
+            serde_json::json!({
+                "id": "internal-child-rid",
+                "finish_reason": {"type": "stop"}
+            }),
+        ),
+        true,
+    )
+    .unwrap();
+    assert!(chunk.usage.is_none());
+    let response = chunk.into_response("public-parent-rid".into());
+
+    assert_eq!(response.request_id, "public-parent-rid");
+    assert!(
+        !response
+            .engine_metadata
+            .is_some_and(|metadata| metadata.fields.contains_key("id"))
+    );
+}
+
+#[test]
+fn typed_generation_rejects_invalid_or_unbounded_choice_counts() {
+    let request_with_n = |n| crate::proto::GenerateRequest {
+        sampling_params: Some(crate::proto::SamplingParams {
+            n: Some(n),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(expected_generation_choices(&request_with_n(1)).unwrap(), 1);
+    assert_eq!(
+        expected_generation_choices(&request_with_n(1024)).unwrap(),
+        1024
+    );
+    for invalid in [0, -1, 1025, i32::MAX] {
+        let error = expected_generation_choices(&request_with_n(invalid)).unwrap_err();
+        assert_eq!(error.code(), Code::InvalidArgument);
+    }
+}
+
+#[test]
 fn aborts_become_typed_generation_errors() {
-    let mut offsets = GenerationOffsets::default();
     let chunk = typed_generation_chunk(
         response_data(
             vec![],
             "",
-            false,
             serde_json::json!({
                 "finish_reason": {"type": "abort", "message": "bad request", "status_code": 400}
             }),
         ),
         true,
-        &mut offsets,
     )
     .unwrap();
     match chunk.terminal.unwrap() {

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -38,7 +38,7 @@ fn response_data(
 }
 
 #[test]
-fn cumulative_and_incremental_chunks_are_normalized_to_deltas() {
+fn cumulative_and_incremental_token_chunks_are_normalized_to_deltas() {
     let mut cumulative = GenerationOffsets::default();
     let first = typed_generation_chunk(
         response_data(vec![1, 2], "hé", false, serde_json::json!({})),
@@ -53,9 +53,7 @@ fn cumulative_and_incremental_chunks_are_normalized_to_deltas() {
     )
     .unwrap();
     assert_eq!(first.delta_output_ids, vec![1, 2]);
-    assert_eq!(first.delta_text, "hé");
     assert_eq!(second.delta_output_ids, vec![3]);
-    assert_eq!(second.delta_text, "llo");
 
     let mut incremental = GenerationOffsets::default();
     let first = typed_generation_chunk(
@@ -72,7 +70,6 @@ fn cumulative_and_incremental_chunks_are_normalized_to_deltas() {
     .unwrap();
     assert_eq!(first.delta_output_ids, vec![1]);
     assert_eq!(second.delta_output_ids, vec![2]);
-    assert_eq!(second.delta_text, "llo");
 }
 
 #[test]
@@ -254,7 +251,8 @@ fn terminal_metadata_is_typed_and_not_duplicated_in_extensions() {
     )
     .unwrap();
     let usage = chunk.usage.unwrap();
-    assert_eq!(usage.total_tokens, 9);
+    assert_eq!(usage.prompt_tokens, 8);
+    assert_eq!(usage.completion_tokens, 1);
     assert_eq!(usage.cached_prompt_tokens, 3);
     assert!(matches!(chunk.terminal, Some(TypedTerminal::Finish(_))));
     let fields = chunk.engine_metadata.unwrap().fields;

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -1,23 +1,273 @@
 use super::{
-    DEFAULT_GRPC_MAX_MESSAGE_SIZE, openai_status_code, resolve_max_message_size,
-    terminal_error_status,
+    ChoiceTracker, DEFAULT_GRPC_MAX_MESSAGE_SIZE, GenerationOffsets, TypedTerminal,
+    openai_status_code, resolve_max_message_size, terminal_error_status, typed_generation_chunk,
 };
-use crate::bridge::TerminalError;
-use std::collections::HashMap;
+use crate::bridge::{ResponseData, TerminalError};
 use tonic::Code;
 
 #[test]
 fn openai_status_code_uses_forwarded_status_when_present() {
-    let meta_info = HashMap::from([(String::from("status_code"), String::from("429"))]);
+    let meta_info = serde_json::from_value(serde_json::json!({"status_code": 429})).unwrap();
     assert_eq!(openai_status_code(&meta_info, 200), 429);
 }
 
 #[test]
 fn openai_status_code_falls_back_when_missing_or_invalid() {
-    assert_eq!(openai_status_code(&HashMap::new(), 200), 200);
+    assert_eq!(openai_status_code(&serde_json::Map::new(), 200), 200);
 
-    let meta_info = HashMap::from([(String::from("status_code"), String::from("not-an-int"))]);
+    let meta_info =
+        serde_json::from_value(serde_json::json!({"status_code": "not-an-int"})).unwrap();
     assert_eq!(openai_status_code(&meta_info, 200), 200);
+}
+
+fn response_data(
+    output_ids: Vec<i32>,
+    text: &str,
+    incremental: bool,
+    meta_info: serde_json::Value,
+) -> ResponseData {
+    ResponseData {
+        text: Some(text.to_string()),
+        output_ids: Some(output_ids),
+        embedding: None,
+        choice_index: 1,
+        incremental,
+        json_bytes: None,
+        meta_info: serde_json::from_value(meta_info).unwrap(),
+    }
+}
+
+#[test]
+fn cumulative_and_incremental_chunks_are_normalized_to_deltas() {
+    let mut cumulative = GenerationOffsets::default();
+    let first = typed_generation_chunk(
+        response_data(vec![1, 2], "hé", false, serde_json::json!({})),
+        false,
+        &mut cumulative,
+    )
+    .unwrap();
+    let second = typed_generation_chunk(
+        response_data(vec![1, 2, 3], "héllo", false, serde_json::json!({})),
+        false,
+        &mut cumulative,
+    )
+    .unwrap();
+    assert_eq!(first.delta_output_ids, vec![1, 2]);
+    assert_eq!(first.delta_text, "hé");
+    assert_eq!(second.delta_output_ids, vec![3]);
+    assert_eq!(second.delta_text, "llo");
+
+    let mut incremental = GenerationOffsets::default();
+    let first = typed_generation_chunk(
+        response_data(vec![1], "hé", true, serde_json::json!({})),
+        false,
+        &mut incremental,
+    )
+    .unwrap();
+    let second = typed_generation_chunk(
+        response_data(vec![2], "llo", true, serde_json::json!({})),
+        false,
+        &mut incremental,
+    )
+    .unwrap();
+    assert_eq!(first.delta_output_ids, vec![1]);
+    assert_eq!(second.delta_output_ids, vec![2]);
+    assert_eq!(second.delta_text, "llo");
+}
+
+#[test]
+fn choice_tracker_requires_one_terminal_per_choice() {
+    let mut choices = ChoiceTracker::new(2);
+    assert!(!choices.observe(1, false, false, "Generate").unwrap());
+    assert!(!choices.observe(1, true, false, "Generate").unwrap());
+    assert!(choices.observe(0, true, true, "Generate").unwrap());
+
+    let mut missing = ChoiceTracker::new(2);
+    let error = missing.observe(0, true, true, "Generate").unwrap_err();
+    assert!(error.contains("1/2 terminal choices"));
+
+    let mut duplicate = ChoiceTracker::new(2);
+    duplicate.observe(0, true, false, "Generate").unwrap();
+    assert!(
+        duplicate
+            .observe(0, true, false, "Generate")
+            .unwrap_err()
+            .contains("data after terminal")
+    );
+
+    let mut out_of_range = ChoiceTracker::new(2);
+    assert!(
+        out_of_range
+            .observe(2, false, false, "Generate")
+            .unwrap_err()
+            .contains("outside 0..2")
+    );
+}
+
+#[test]
+fn logprobs_are_delta_aligned_and_prompt_logprobs_emit_once() {
+    let mut offsets = GenerationOffsets::default();
+    let metadata = serde_json::json!({
+        "input_token_logprobs": [[-0.1, 10, "prompt"]],
+        "input_top_logprobs": [[[-0.1, 10, "prompt"]]],
+        "output_token_logprobs": [[-0.2, 20, "a"]],
+        "output_top_logprobs": [[[-0.2, 20, "a"], [-1.2, 21, "b"]]]
+    });
+    let first = typed_generation_chunk(
+        response_data(vec![20], "a", false, metadata),
+        false,
+        &mut offsets,
+    )
+    .unwrap();
+    let logprobs = first.logprobs.unwrap();
+    assert_eq!(logprobs.prompt.len(), 1);
+    assert_eq!(logprobs.output.len(), first.delta_output_ids.len());
+    assert_eq!(logprobs.output[0].top_logprobs.len(), 2);
+
+    let second = typed_generation_chunk(
+        response_data(
+            vec![20, 22],
+            "ac",
+            false,
+            serde_json::json!({
+                "input_token_logprobs": [[-0.1, 10, "prompt"]],
+                "output_token_logprobs": [[-0.2, 20, "a"], [-0.3, 22, "c"]]
+            }),
+        ),
+        false,
+        &mut offsets,
+    )
+    .unwrap();
+    let logprobs = second.logprobs.unwrap();
+    assert!(logprobs.prompt.is_empty());
+    assert_eq!(logprobs.output.len(), second.delta_output_ids.len());
+    assert_eq!(logprobs.output[0].token_id, 22);
+}
+
+#[test]
+fn malformed_logprobs_and_routed_experts_are_rejected() {
+    let mut offsets = GenerationOffsets::default();
+    let error = typed_generation_chunk(
+        response_data(
+            vec![1],
+            "a",
+            false,
+            serde_json::json!({"output_token_logprobs": "invalid"}),
+        ),
+        false,
+        &mut offsets,
+    )
+    .err()
+    .expect("malformed output logprobs should fail");
+    assert!(error.contains("non-array output logprobs"));
+
+    let mut offsets = GenerationOffsets::default();
+    let error = typed_generation_chunk(
+        response_data(
+            vec![1],
+            "a",
+            false,
+            serde_json::json!({"routed_experts": [1, "invalid"]}),
+        ),
+        false,
+        &mut offsets,
+    )
+    .err()
+    .expect("malformed routed experts should fail");
+    assert!(error.contains("non-i32"));
+}
+
+#[test]
+fn finish_reasons_preserve_string_and_token_stops() {
+    for (matched, expected_string, expected_token) in [
+        (serde_json::json!("END"), Some("END"), None),
+        (serde_json::json!(42), None, Some(42)),
+    ] {
+        let mut offsets = GenerationOffsets::default();
+        let chunk = typed_generation_chunk(
+            response_data(
+                vec![],
+                "",
+                false,
+                serde_json::json!({
+                    "finish_reason": {"type": "stop", "matched": matched}
+                }),
+            ),
+            true,
+            &mut offsets,
+        )
+        .unwrap();
+        let TypedTerminal::Finish(finish) = chunk.terminal.unwrap() else {
+            panic!("expected finish terminal");
+        };
+        let reason = finish.stop_reason.unwrap().reason.unwrap();
+        match reason {
+            crate::proto::stop_reason::Reason::MatchedString(value) => {
+                assert_eq!(Some(value.as_str()), expected_string);
+            }
+            crate::proto::stop_reason::Reason::MatchedTokenId(value) => {
+                assert_eq!(Some(value), expected_token);
+            }
+        }
+    }
+}
+
+#[test]
+fn terminal_metadata_is_typed_and_not_duplicated_in_extensions() {
+    let mut offsets = GenerationOffsets::default();
+    let chunk = typed_generation_chunk(
+        response_data(
+            vec![7],
+            "done",
+            false,
+            serde_json::json!({
+                "finish_reason": {"type": "stop", "matched": "END"},
+                "prompt_tokens": 8,
+                "completion_tokens": 1,
+                "cached_tokens": 3,
+                "weight_version": "v2"
+            }),
+        ),
+        true,
+        &mut offsets,
+    )
+    .unwrap();
+    let usage = chunk.usage.unwrap();
+    assert_eq!(usage.total_tokens, 9);
+    assert_eq!(usage.cached_prompt_tokens, 3);
+    assert!(matches!(chunk.terminal, Some(TypedTerminal::Finish(_))));
+    let fields = chunk.engine_metadata.unwrap().fields;
+    assert!(fields.contains_key("weight_version"));
+    assert!(!fields.contains_key("finish_reason"));
+    assert!(!fields.contains_key("prompt_tokens"));
+}
+
+#[test]
+fn aborts_become_typed_generation_errors() {
+    let mut offsets = GenerationOffsets::default();
+    let chunk = typed_generation_chunk(
+        response_data(
+            vec![],
+            "",
+            false,
+            serde_json::json!({
+                "finish_reason": {"type": "abort", "message": "bad request", "status_code": 400}
+            }),
+        ),
+        true,
+        &mut offsets,
+    )
+    .unwrap();
+    match chunk.terminal.unwrap() {
+        TypedTerminal::Error(error) => {
+            assert_eq!(
+                error.code,
+                crate::proto::GenerationErrorCode::InvalidArgument as i32
+            );
+            assert!(!error.retryable);
+        }
+        TypedTerminal::Finish(_) => panic!("expected typed error"),
+    }
 }
 
 #[test]

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -145,6 +145,27 @@ fn logprobs_are_delta_aligned_and_prompt_logprobs_emit_once() {
 }
 
 #[test]
+fn prompt_logprobs_do_not_require_output_logprobs() {
+    let mut offsets = GenerationOffsets::default();
+    let chunk = typed_generation_chunk(
+        response_data(
+            vec![],
+            "",
+            false,
+            serde_json::json!({
+                "input_token_logprobs": [[-0.1, 10, "prompt"]]
+            }),
+        ),
+        true,
+        &mut offsets,
+    )
+    .unwrap();
+    let logprobs = chunk.logprobs.expect("prompt logprobs");
+    assert_eq!(logprobs.prompt.len(), 1);
+    assert!(logprobs.output.is_empty());
+}
+
+#[test]
 fn malformed_logprobs_and_routed_experts_are_rejected() {
     let mut offsets = GenerationOffsets::default();
     let error = typed_generation_chunk(

--- a/rust/sglang-grpc/src/utils/mod.rs
+++ b/rust/sglang-grpc/src/utils/mod.rs
@@ -1,7 +1,7 @@
 mod py_utils;
 mod request_utils;
 
-pub(crate) use py_utils::{json_map_to_pydict, py_value_to_json_string};
+pub(crate) use py_utils::{json_map_to_pydict, py_value_to_json_value};
 pub(crate) use request_utils::{
     build_classify_dict, build_embed_dict, build_generate_dict, build_text_embed_dict,
     build_text_generate_dict, extract_model_path,

--- a/rust/sglang-grpc/src/utils/mod.rs
+++ b/rust/sglang-grpc/src/utils/mod.rs
@@ -1,7 +1,7 @@
 mod py_utils;
 mod request_utils;
 
-pub(crate) use py_utils::{json_map_to_pydict, py_value_to_json_value};
+pub(crate) use py_utils::{json_map_to_pydict, py_value_to_json_string, py_value_to_json_value};
 pub(crate) use request_utils::{
     build_classify_dict, build_embed_dict, build_generate_dict, build_text_embed_dict,
     build_text_generate_dict, extract_model_path,

--- a/rust/sglang-grpc/src/utils/py_utils.rs
+++ b/rust/sglang-grpc/src/utils/py_utils.rs
@@ -69,6 +69,3 @@ pub(crate) fn py_value_to_json_string(value: &Bound<'_, PyAny>) -> PyResult<Stri
         Err(_) => Ok(serde_json::Value::String(value.str()?.to_string()).to_string()),
     }
 }
-
-#[cfg(test)]
-mod tests;

--- a/rust/sglang-grpc/src/utils/py_utils.rs
+++ b/rust/sglang-grpc/src/utils/py_utils.rs
@@ -58,5 +58,17 @@ pub(crate) fn py_value_to_json_value(value: &Bound<'_, PyAny>) -> PyResult<serde
     }
 }
 
+pub(crate) fn py_value_to_json_string(value: &Bound<'_, PyAny>) -> PyResult<String> {
+    match value
+        .py()
+        .import("json")
+        .and_then(|json| json.call_method1("dumps", (value,)))
+        .and_then(|json_str| json_str.extract::<String>())
+    {
+        Ok(serialized) => Ok(serialized),
+        Err(_) => Ok(serde_json::Value::String(value.str()?.to_string()).to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/rust/sglang-grpc/src/utils/py_utils.rs
+++ b/rust/sglang-grpc/src/utils/py_utils.rs
@@ -45,25 +45,17 @@ pub(crate) fn json_map_to_pydict<'py>(
     Ok(py_dict)
 }
 
-pub(crate) fn py_value_to_json_string(value: &Bound<'_, PyAny>) -> PyResult<String> {
-    // gRPC meta_info is a map<string, string>. JSON-encode every value,
-    // including strings, so clients can decode the map uniformly.
+pub(crate) fn py_value_to_json_value(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
     match value
         .py()
         .import("json")
         .and_then(|json| json.call_method1("dumps", (value,)))
         .and_then(|json_str| json_str.extract::<String>())
     {
-        Ok(s) => Ok(s),
-        Err(_) => {
-            let fallback = value.str()?.to_string();
-            Ok(json_encode_string(&fallback))
-        }
+        Ok(serialized) => serde_json::from_str(&serialized)
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string())),
+        Err(_) => Ok(serde_json::Value::String(value.str()?.to_string())),
     }
-}
-
-fn json_encode_string(value: &str) -> String {
-    serde_json::Value::String(value.to_string()).to_string()
 }
 
 #[cfg(test)]

--- a/rust/sglang-grpc/src/utils/py_utils/tests.rs
+++ b/rust/sglang-grpc/src/utils/py_utils/tests.rs
@@ -1,5 +1,0 @@
-#[test]
-fn json_values_are_preserved() {
-    let value = serde_json::json!({"nested": [1, true, "value"]});
-    assert_eq!(value["nested"][2], "value");
-}

--- a/rust/sglang-grpc/src/utils/py_utils/tests.rs
+++ b/rust/sglang-grpc/src/utils/py_utils/tests.rs
@@ -1,8 +1,5 @@
-use super::*;
-
 #[test]
-fn fallback_string_is_json_encoded() {
-    let encoded = json_encode_string("<Foo at 0x123>");
-    let decoded: String = serde_json::from_str(&encoded).unwrap();
-    assert_eq!(decoded, "<Foo at 0x123>");
+fn json_values_are_preserved() {
+    let value = serde_json::json!({"nested": [1, true, "value"]});
+    assert_eq!(value["nested"][2], "value");
 }

--- a/rust/sglang-grpc/src/utils/request_utils.rs
+++ b/rust/sglang-grpc/src/utils/request_utils.rs
@@ -210,9 +210,6 @@ pub(crate) fn build_text_generate_dict(
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
     }
-    if let Some(priority) = req.priority {
-        d.insert("priority".into(), serde_json::json!(priority));
-    }
     if let Some(params) = req.sampling_params.as_ref() {
         d.insert(
             "require_reasoning".into(),

--- a/rust/sglang-grpc/src/utils/request_utils.rs
+++ b/rust/sglang-grpc/src/utils/request_utils.rs
@@ -17,6 +17,7 @@ fn regex_escape_literal(value: &str) -> String {
 }
 
 /// Convert proto SamplingParams to a serde_json map (used as Python dict via PyO3).
+#[allow(deprecated)]
 fn sampling_params_to_map(
     params: &Option<proto::SamplingParams>,
 ) -> Result<serde_json::Value, String> {
@@ -74,6 +75,11 @@ fn sampling_params_to_map(
                     serde_json::json!({"thinking_budget": max_thinking_tokens}),
                 );
             }
+            if p.guided_decoding.is_some() && (p.json_schema.is_some() || p.regex.is_some()) {
+                return Err(
+                    "legacy json_schema/regex cannot be combined with guided_decoding".into(),
+                );
+            }
             if let Some(guided) = p.guided_decoding.as_ref() {
                 use proto::guided_decoding::Constraint;
                 match guided.constraint.as_ref() {
@@ -109,6 +115,13 @@ fn sampling_params_to_map(
                     }
                     Some(_) => return Err("guided decoding constraint must not be empty".into()),
                     None => return Err("guided decoding constraint must be specified".into()),
+                }
+            } else {
+                if let Some(value) = p.json_schema.as_ref() {
+                    map.insert("json_schema".into(), serde_json::json!(value));
+                }
+                if let Some(value) = p.regex.as_ref() {
+                    map.insert("regex".into(), serde_json::json!(value));
                 }
             }
             Ok(serde_json::Value::Object(map))
@@ -341,6 +354,7 @@ pub(crate) fn build_classify_dict(
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
 
@@ -480,6 +494,43 @@ mod tests {
             let mapped = build_generate_dict("request", &request).unwrap();
             assert_eq!(mapped["sampling_params"][key], serde_json::json!(expected));
         }
+    }
+
+    #[test]
+    fn legacy_guided_decoding_fields_are_mapped_and_cannot_mix_with_new_contract() {
+        let legacy = proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                json_schema: Some("{\"type\":\"string\"}".into()),
+                regex: Some("[a-z]+".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mapped = build_generate_dict("request", &legacy).unwrap();
+        assert_eq!(
+            mapped["sampling_params"]["json_schema"],
+            serde_json::json!("{\"type\":\"string\"}")
+        );
+        assert_eq!(
+            mapped["sampling_params"]["regex"],
+            serde_json::json!("[a-z]+")
+        );
+
+        let conflicting = proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                regex: Some("[a-z]+".into()),
+                guided_decoding: Some(proto::GuidedDecoding {
+                    constraint: Some(proto::guided_decoding::Constraint::Regex("[0-9]+".into())),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(
+            build_generate_dict("request", &conflicting)
+                .unwrap_err()
+                .contains("cannot be combined")
+        );
     }
 
     #[test]

--- a/rust/sglang-grpc/src/utils/request_utils.rs
+++ b/rust/sglang-grpc/src/utils/request_utils.rs
@@ -2,10 +2,29 @@ use std::collections::HashMap;
 
 use crate::proto;
 
+fn regex_escape_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if matches!(
+            character,
+            '.' | '+' | '*' | '?' | '^' | '$' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '\\'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
 /// Convert proto SamplingParams to a serde_json map (used as Python dict via PyO3).
-fn sampling_params_to_map(params: &Option<proto::SamplingParams>) -> serde_json::Value {
+fn sampling_params_to_map(
+    params: &Option<proto::SamplingParams>,
+) -> Result<serde_json::Value, String> {
     match params {
         Some(p) => {
+            if p.n.is_some_and(|n| n <= 0) {
+                return Err("n must be greater than zero".into());
+            }
             let mut map = serde_json::Map::new();
             if let Some(v) = p.temperature {
                 map.insert("temperature".into(), serde_json::json!(v));
@@ -46,15 +65,55 @@ fn sampling_params_to_map(params: &Option<proto::SamplingParams>) -> serde_json:
             if let Some(v) = p.n {
                 map.insert("n".into(), serde_json::json!(v));
             }
-            if let Some(ref v) = p.json_schema {
-                map.insert("json_schema".into(), serde_json::json!(v));
+            if let Some(v) = p.seed {
+                map.insert("sampling_seed".into(), serde_json::json!(v));
             }
-            if let Some(ref v) = p.regex {
-                map.insert("regex".into(), serde_json::json!(v));
+            if let Some(max_thinking_tokens) = p.max_thinking_tokens {
+                map.insert(
+                    "custom_params".into(),
+                    serde_json::json!({"thinking_budget": max_thinking_tokens}),
+                );
             }
-            serde_json::Value::Object(map)
+            if let Some(guided) = p.guided_decoding.as_ref() {
+                use proto::guided_decoding::Constraint;
+                match guided.constraint.as_ref() {
+                    Some(Constraint::JsonSchema(value)) if !value.is_empty() => {
+                        map.insert("json_schema".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Regex(value)) if !value.is_empty() => {
+                        map.insert("regex".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Ebnf(value)) if !value.is_empty() => {
+                        map.insert("ebnf".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Choice(choice))
+                        if !choice.values.is_empty()
+                            && choice.values.iter().all(|value| !value.is_empty()) =>
+                    {
+                        let alternatives = choice
+                            .values
+                            .iter()
+                            .map(|value| regex_escape_literal(value))
+                            .collect::<Vec<_>>()
+                            .join("|");
+                        map.insert(
+                            "regex".into(),
+                            serde_json::json!(format!("(?:{alternatives})")),
+                        );
+                    }
+                    Some(Constraint::StructuralTag(value)) if !value.is_empty() => {
+                        map.insert("structural_tag".into(), serde_json::json!(value));
+                    }
+                    Some(Constraint::Choice(_)) => {
+                        return Err("guided choice must contain only non-empty values".into());
+                    }
+                    Some(_) => return Err("guided decoding constraint must not be empty".into()),
+                    None => return Err("guided decoding constraint must be specified".into()),
+                }
+            }
+            Ok(serde_json::Value::Object(map))
         }
-        None => serde_json::Value::Object(serde_json::Map::new()),
+        None => Ok(serde_json::Value::Object(serde_json::Map::new())),
     }
 }
 
@@ -111,13 +170,13 @@ pub(crate) fn extract_model_path(json_info: &str) -> String {
 pub(crate) fn build_text_generate_dict(
     rid: &str,
     req: &proto::TextGenerateRequest,
-) -> HashMap<String, serde_json::Value> {
+) -> Result<HashMap<String, serde_json::Value>, String> {
     let mut d = HashMap::new();
     d.insert("rid".into(), serde_json::json!(rid));
     d.insert("text".into(), serde_json::json!(req.text));
     d.insert(
         "sampling_params".into(),
-        sampling_params_to_map(&req.sampling_params),
+        sampling_params_to_map(&req.sampling_params)?,
     );
     d.insert(
         "stream".into(),
@@ -151,25 +210,34 @@ pub(crate) fn build_text_generate_dict(
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
     }
+    if let Some(priority) = req.priority {
+        d.insert("priority".into(), serde_json::json!(priority));
+    }
+    if let Some(params) = req.sampling_params.as_ref() {
+        d.insert(
+            "require_reasoning".into(),
+            serde_json::json!(params.require_reasoning.unwrap_or(false)),
+        );
+    }
     insert_disaggregated_params(&mut d, &req.disaggregated_params);
     if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
         d.insert("external_trace_header".into(), trace);
     }
     d.insert("received_time".into(), serde_json::json!(now_timestamp()));
-    d
+    Ok(d)
 }
 
 /// Build a request dict for GenerateReqInput from proto GenerateRequest (tokenized).
 pub(crate) fn build_generate_dict(
     rid: &str,
     req: &proto::GenerateRequest,
-) -> HashMap<String, serde_json::Value> {
+) -> Result<HashMap<String, serde_json::Value>, String> {
     let mut d = HashMap::new();
     d.insert("rid".into(), serde_json::json!(rid));
     d.insert("input_ids".into(), serde_json::json!(req.input_ids));
     d.insert(
         "sampling_params".into(),
-        sampling_params_to_map(&req.sampling_params),
+        sampling_params_to_map(&req.sampling_params)?,
     );
     d.insert(
         "stream".into(),
@@ -199,12 +267,21 @@ pub(crate) fn build_generate_dict(
     if let Some(ref session_id) = req.session_id {
         d.insert("session_id".into(), serde_json::json!(session_id));
     }
+    if let Some(priority) = req.priority {
+        d.insert("priority".into(), serde_json::json!(priority));
+    }
+    if let Some(params) = req.sampling_params.as_ref() {
+        d.insert(
+            "require_reasoning".into(),
+            serde_json::json!(params.require_reasoning.unwrap_or(false)),
+        );
+    }
     insert_disaggregated_params(&mut d, &req.disaggregated_params);
     if let Some(trace) = trace_headers_to_json(&req.trace_headers) {
         d.insert("external_trace_header".into(), trace);
     }
     d.insert("received_time".into(), serde_json::json!(now_timestamp()));
-    d
+    Ok(d)
 }
 
 /// Build a request dict for EmbeddingReqInput from proto TextEmbedRequest.
@@ -283,11 +360,15 @@ mod tests {
         };
 
         assert_eq!(
-            build_text_generate_dict("request-1", &text_req).get("session_id"),
+            build_text_generate_dict("request-1", &text_req)
+                .unwrap()
+                .get("session_id"),
             Some(&serde_json::json!("session-1"))
         );
         assert_eq!(
-            build_generate_dict("request-2", &token_req).get("session_id"),
+            build_generate_dict("request-2", &token_req)
+                .unwrap()
+                .get("session_id"),
             Some(&serde_json::json!("session-1"))
         );
     }
@@ -312,6 +393,7 @@ mod tests {
             build_text_generate_dict("request-1", &text_req),
             build_generate_dict("request-2", &token_req),
         ] {
+            let request = request.unwrap();
             assert_eq!(
                 request.get("bootstrap_host"),
                 Some(&serde_json::json!("10.0.0.1"))
@@ -330,13 +412,95 @@ mod tests {
     #[test]
     fn generate_dicts_omit_disaggregated_params_when_absent() {
         let text_request =
-            build_text_generate_dict("request-1", &proto::TextGenerateRequest::default());
-        let token_request = build_generate_dict("request-2", &proto::GenerateRequest::default());
+            build_text_generate_dict("request-1", &proto::TextGenerateRequest::default()).unwrap();
+        let token_request =
+            build_generate_dict("request-2", &proto::GenerateRequest::default()).unwrap();
 
         for request in [text_request, token_request] {
             assert!(!request.contains_key("bootstrap_host"));
             assert!(!request.contains_key("bootstrap_port"));
             assert!(!request.contains_key("bootstrap_room"));
         }
+    }
+
+    #[test]
+    fn generate_maps_seed_priority_reasoning_and_thinking_budget() {
+        let request = proto::GenerateRequest {
+            input_ids: vec![1, 2],
+            priority: Some(7),
+            sampling_params: Some(proto::SamplingParams {
+                seed: Some(42),
+                require_reasoning: Some(true),
+                max_thinking_tokens: Some(128),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mapped = build_generate_dict("request", &request).unwrap();
+        assert_eq!(mapped["priority"], serde_json::json!(7));
+        assert_eq!(mapped["require_reasoning"], serde_json::json!(true));
+        assert_eq!(
+            mapped["sampling_params"]["sampling_seed"],
+            serde_json::json!(42)
+        );
+        assert_eq!(
+            mapped["sampling_params"]["custom_params"]["thinking_budget"],
+            serde_json::json!(128)
+        );
+    }
+
+    #[test]
+    fn generate_maps_all_guided_decoding_constraints() {
+        use proto::guided_decoding::Constraint;
+        let cases = [
+            (
+                Constraint::JsonSchema("{\"type\":\"object\"}".into()),
+                "json_schema",
+                "{\"type\":\"object\"}",
+            ),
+            (Constraint::Regex("[0-9]+".into()), "regex", "[0-9]+"),
+            (
+                Constraint::Ebnf("root ::= 'yes'".into()),
+                "ebnf",
+                "root ::= 'yes'",
+            ),
+            (
+                Constraint::StructuralTag("{\"type\":\"structural_tag\"}".into()),
+                "structural_tag",
+                "{\"type\":\"structural_tag\"}",
+            ),
+        ];
+        for (constraint, key, expected) in cases {
+            let request = proto::GenerateRequest {
+                sampling_params: Some(proto::SamplingParams {
+                    guided_decoding: Some(proto::GuidedDecoding {
+                        constraint: Some(constraint),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            let mapped = build_generate_dict("request", &request).unwrap();
+            assert_eq!(mapped["sampling_params"][key], serde_json::json!(expected));
+        }
+    }
+
+    #[test]
+    fn guided_choices_are_regex_escaped_and_validated() {
+        let request = |values| proto::GenerateRequest {
+            sampling_params: Some(proto::SamplingParams {
+                guided_decoding: Some(proto::GuidedDecoding {
+                    constraint: Some(proto::guided_decoding::Constraint::Choice(
+                        proto::ChoiceConstraint { values },
+                    )),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mapped =
+            build_generate_dict("request", &request(vec!["a+b".into(), "x.y".into()])).unwrap();
+        assert_eq!(mapped["sampling_params"]["regex"], "(?:a\\+b|x\\.y)");
+        assert!(build_generate_dict("request", &request(vec![])).is_err());
     }
 }

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,0 +1,140 @@
+from enum import Enum
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+
+
+class _Status(Enum):
+    Ready = 1
+    Pending = 2
+    Closed = 3
+
+
+class _Callback:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, payload, **kwargs):
+        self.calls.append((payload, kwargs))
+        return _Status.Ready
+
+
+class _TokenizerManager:
+    def __init__(self, outputs, incremental=False):
+        self.outputs = outputs
+        self.server_args = SimpleNamespace(incremental_streaming_output=incremental)
+
+    async def generate_request(self, _obj, request=None):
+        del request
+        for output in self.outputs:
+            yield output
+
+
+def _runtime(outputs, incremental=False):
+    runtime = RuntimeHandle.__new__(RuntimeHandle)
+    runtime.tokenizer_manager = _TokenizerManager(outputs, incremental)
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_streaming_generation_waits_for_every_choice_terminal():
+    runtime = _runtime(
+        [
+            {
+                "index": 0,
+                "output_ids": [1],
+                "meta_info": {"finish_reason": {"type": "stop"}},
+            },
+            {
+                "index": 1,
+                "output_ids": [2],
+                "meta_info": {"finish_reason": {"type": "length"}},
+            },
+        ],
+        incremental=True,
+    )
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+
+    await runtime._run_generate(obj, callback, True, None)
+
+    assert [call[0]["index"] for call in callback.calls] == [0, 1]
+    assert [call[1]["finished"] for call in callback.calls] == [False, True]
+    assert all(call[1]["incremental"] for call in callback.calls)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_generation_assigns_choice_indices():
+    runtime = _runtime(
+        [
+            [
+                {"output_ids": [1], "meta_info": {"finish_reason": {"type": "stop"}}},
+                {"output_ids": [2], "meta_info": {"finish_reason": {"type": "stop"}}},
+            ]
+        ]
+    )
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+
+    await runtime._run_generate(obj, callback, False, None)
+
+    assert [call[0]["index"] for call in callback.calls] == [0, 1]
+    assert [call[1]["finished"] for call in callback.calls] == [False, True]
+    assert not any(call[1]["incremental"] for call in callback.calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outputs", "message"),
+    [
+        (
+            [
+                {
+                    "index": 2,
+                    "meta_info": {"finish_reason": {"type": "stop"}},
+                }
+            ],
+            "choice index 2 is outside 0..2",
+        ),
+        (
+            [
+                {
+                    "index": 0,
+                    "meta_info": {"finish_reason": {"type": "stop"}},
+                },
+                {
+                    "index": 0,
+                    "meta_info": {"finish_reason": {"type": "stop"}},
+                },
+            ],
+            "duplicate terminal for choice 0",
+        ),
+        ([{"index": 0, "meta_info": {}}], "without terminal choices: [0, 1]"),
+    ],
+)
+async def test_streaming_generation_rejects_invalid_choice_lifecycles(outputs, message):
+    runtime = _runtime(outputs)
+    runtime._abort_request_id = lambda _rid: None
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+
+    await runtime._run_generate(obj, callback, True, None)
+
+    assert callback.calls[-1][1]["error"]
+    assert message in callback.calls[-1][1]["error"]
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_generation_rejects_missing_choice():
+    runtime = _runtime(
+        [[{"output_ids": [1], "meta_info": {"finish_reason": {"type": "stop"}}}]]
+    )
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+
+    await runtime._run_generate(obj, callback, False, None)
+
+    assert callback.calls[-1][1]["error"]
+    assert "returned 1 choices; expected 2" in callback.calls[-1][1]["error"]

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -172,6 +172,12 @@ async def test_typed_streaming_normalizes_cumulative_choices_before_callback():
         [11],
         [21],
     ]
+    assert [call[0]["legacy_output_ids"] for call in callback.calls] == [
+        [10],
+        [20],
+        [10, 11],
+        [20, 21],
+    ]
     assert [
         len(call[0]["meta_info"]["output_token_logprobs"]) for call in callback.calls
     ] == [1, 1, 1, 1]
@@ -212,6 +218,10 @@ async def test_typed_incremental_stream_preserves_output_deltas():
     await runtime._run_generate(obj, callback, True, None, typed_generation=True)
 
     assert [call[0]["output_ids"] for call in callback.calls] == [[10], [11]]
+    assert [call[0]["legacy_output_ids"] for call in callback.calls] == [
+        [10],
+        [10, 11],
+    ]
     assert [
         call[0]["meta_info"]["output_token_logprobs"] for call in callback.calls
     ] == [[[-0.2, 10, "10"]], [[-0.3, 11, "11"]]]

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,9 +1,13 @@
+import asyncio
 from enum import Enum
 from types import SimpleNamespace
 
 import pytest
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class _Status(Enum):
@@ -13,11 +17,31 @@ class _Status(Enum):
 
 
 class _Callback:
-    def __init__(self):
+    def __init__(self, statuses=None):
         self.calls = []
+        self.statuses = iter(statuses or [])
 
     def __call__(self, payload, **kwargs):
         self.calls.append((payload, kwargs))
+        return next(self.statuses, _Status.Ready)
+
+
+class _BackpressuredCallback(_Callback):
+    def __init__(self):
+        super().__init__()
+        self.on_ready = None
+
+    def set_on_ready(self, on_ready):
+        self.on_ready = on_ready
+
+    def clear_on_ready(self):
+        self.on_ready = None
+
+    def __call__(self, payload, **kwargs):
+        self.calls.append((payload, kwargs))
+        if not kwargs.get("finished"):
+            asyncio.get_running_loop().call_soon(self.on_ready)
+            return _Status.Pending
         return _Status.Ready
 
 
@@ -25,16 +49,25 @@ class _TokenizerManager:
     def __init__(self, outputs, incremental=False):
         self.outputs = outputs
         self.server_args = SimpleNamespace(incremental_streaming_output=incremental)
+        self.aborted = []
+        self.yield_scheduler_errors = None
 
-    async def generate_request(self, _obj, request=None):
+    async def generate_request(self, _obj, request=None, yield_scheduler_errors=False):
         del request
+        self.yield_scheduler_errors = yield_scheduler_errors
         for output in self.outputs:
+            if isinstance(output, Exception):
+                raise output
             yield output
+
+    def abort_request(self, **kwargs):
+        self.aborted.append(kwargs)
 
 
 def _runtime(outputs, incremental=False):
     runtime = RuntimeHandle.__new__(RuntimeHandle)
     runtime.tokenizer_manager = _TokenizerManager(outputs, incremental)
+    runtime._event_loop = asyncio.get_running_loop()
     return runtime
 
 
@@ -62,11 +95,100 @@ async def test_streaming_generation_waits_for_every_choice_terminal():
 
     assert [call[0]["index"] for call in callback.calls] == [0, 1]
     assert [call[1]["finished"] for call in callback.calls] == [False, True]
-    assert all(call[1]["incremental"] for call in callback.calls)
 
 
 @pytest.mark.asyncio
-async def test_non_streaming_generation_assigns_choice_indices():
+async def test_typed_streaming_normalizes_cumulative_choices_before_callback():
+    def _meta(tokens, *, finished=False):
+        return {
+            "input_token_logprobs": [[-0.1, 100, "prompt"]],
+            "input_top_logprobs": [[[-0.1, 100, "prompt"]]],
+            "output_token_logprobs": [
+                [-0.1 - index, token, str(token)] for index, token in enumerate(tokens)
+            ],
+            "output_top_logprobs": [
+                [[-0.1 - rank, token + rank, str(token + rank)] for rank in range(2)]
+                for token in tokens
+            ],
+            "finish_reason": {"type": "stop"} if finished else None,
+        }
+
+    runtime = _runtime(
+        [
+            {"index": 0, "output_ids": [10], "meta_info": _meta([10])},
+            {"index": 1, "output_ids": [20], "meta_info": _meta([20])},
+            {
+                "index": 0,
+                "output_ids": [10, 11],
+                "meta_info": _meta([10, 11], finished=True),
+            },
+            {
+                "index": 1,
+                "output_ids": [20, 21],
+                "meta_info": _meta([20, 21], finished=True),
+            },
+        ]
+    )
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+
+    await runtime._run_generate(obj, callback, True, None, typed_generation=True)
+
+    assert [call[0]["output_ids"] for call in callback.calls] == [
+        [10],
+        [20],
+        [11],
+        [21],
+    ]
+    assert [
+        len(call[0]["meta_info"]["output_token_logprobs"]) for call in callback.calls
+    ] == [1, 1, 1, 1]
+    assert [
+        len(call[0]["meta_info"]["output_top_logprobs"]) for call in callback.calls
+    ] == [1, 1, 1, 1]
+    assert [
+        "input_token_logprobs" in call[0]["meta_info"] for call in callback.calls
+    ] == [True, True, False, False]
+    assert runtime.tokenizer_manager.yield_scheduler_errors is True
+
+
+@pytest.mark.asyncio
+async def test_typed_incremental_stream_preserves_output_deltas():
+    runtime = _runtime(
+        [
+            {
+                "output_ids": [10],
+                "meta_info": {
+                    "input_token_logprobs": [[-0.1, 1, "prompt"]],
+                    "output_token_logprobs": [[-0.2, 10, "10"]],
+                },
+            },
+            {
+                "output_ids": [11],
+                "meta_info": {
+                    "input_token_logprobs": [[-0.1, 1, "prompt"]],
+                    "output_token_logprobs": [[-0.3, 11, "11"]],
+                    "finish_reason": {"type": "stop"},
+                },
+            },
+        ],
+        incremental=True,
+    )
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 1}, rid="request")
+
+    await runtime._run_generate(obj, callback, True, None, typed_generation=True)
+
+    assert [call[0]["output_ids"] for call in callback.calls] == [[10], [11]]
+    assert [
+        call[0]["meta_info"]["output_token_logprobs"] for call in callback.calls
+    ] == [[[-0.2, 10, "10"]], [[-0.3, 11, "11"]]]
+    assert "input_token_logprobs" in callback.calls[0][0]["meta_info"]
+    assert "input_token_logprobs" not in callback.calls[1][0]["meta_info"]
+
+
+@pytest.mark.asyncio
+async def test_typed_non_streaming_generation_honors_backpressure():
     runtime = _runtime(
         [
             [
@@ -75,14 +197,53 @@ async def test_non_streaming_generation_assigns_choice_indices():
             ]
         ]
     )
-    callback = _Callback()
+    callback = _BackpressuredCallback()
     obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
 
-    await runtime._run_generate(obj, callback, False, None)
+    await runtime._run_generate(obj, callback, False, None, typed_generation=True)
 
     assert [call[0]["index"] for call in callback.calls] == [0, 1]
     assert [call[1]["finished"] for call in callback.calls] == [False, True]
-    assert not any(call[1]["incremental"] for call in callback.calls)
+
+
+@pytest.mark.asyncio
+async def test_typed_non_streaming_generation_stops_on_closed_callback():
+    runtime = _runtime(
+        [
+            [
+                {"output_ids": [1], "meta_info": {"finish_reason": {"type": "stop"}}},
+                {"output_ids": [2], "meta_info": {"finish_reason": {"type": "stop"}}},
+                {"output_ids": [3], "meta_info": {"finish_reason": {"type": "stop"}}},
+            ]
+        ]
+    )
+    callback = _Callback([_Status.Ready, _Status.Closed])
+    obj = SimpleNamespace(sampling_params={"n": 3}, rid="request")
+
+    await runtime._run_generate(obj, callback, False, None, typed_generation=True)
+
+    assert [call[0]["index"] for call in callback.calls] == [0, 1]
+    assert runtime.tokenizer_manager.aborted == [{"rid": "request"}]
+
+
+@pytest.mark.asyncio
+async def test_typed_non_streaming_error_terminates_every_choice():
+    runtime = _runtime([ValueError("invalid sampling parameters")])
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+
+    await runtime._run_generate(obj, callback, False, None, typed_generation=True)
+
+    assert [call[0]["index"] for call in callback.calls] == [0, 1]
+    assert [call[1]["finished"] for call in callback.calls] == [False, True]
+    assert all(
+        call[0]["meta_info"]["finish_reason"]["type"] == "error"
+        for call in callback.calls
+    )
+    assert all(
+        call[0]["meta_info"]["finish_reason"]["status_code"] == 400
+        for call in callback.calls
+    )
 
 
 @pytest.mark.asyncio

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -98,6 +98,38 @@ async def test_streaming_generation_waits_for_every_choice_terminal():
 
 
 @pytest.mark.asyncio
+async def test_legacy_incremental_stream_restores_cumulative_choices():
+    runtime = _runtime(
+        [
+            {"index": 0, "output_ids": [10], "meta_info": {}},
+            {"index": 1, "output_ids": [20], "meta_info": {}},
+            {
+                "index": 0,
+                "output_ids": [11],
+                "meta_info": {"finish_reason": {"type": "stop"}},
+            },
+            {
+                "index": 1,
+                "output_ids": [21],
+                "meta_info": {"finish_reason": {"type": "length"}},
+            },
+        ],
+        incremental=True,
+    )
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+
+    await runtime._run_generate(obj, callback, True, None)
+
+    assert [call[0]["output_ids"] for call in callback.calls] == [
+        [10],
+        [20],
+        [10, 11],
+        [20, 21],
+    ]
+
+
+@pytest.mark.asyncio
 async def test_typed_streaming_normalizes_cumulative_choices_before_callback():
     def _meta(tokens, *, finished=False):
         return {

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -247,6 +247,40 @@ async def test_typed_non_streaming_error_terminates_every_choice():
 
 
 @pytest.mark.asyncio
+async def test_typed_cancellation_terminates_every_unfinished_choice():
+    started = asyncio.Event()
+
+    class _BlockingTokenizerManager(_TokenizerManager):
+        async def generate_request(
+            self, _obj, request=None, yield_scheduler_errors=False
+        ):
+            del request
+            self.yield_scheduler_errors = yield_scheduler_errors
+            started.set()
+            await asyncio.Event().wait()
+            yield
+
+    runtime = _runtime([])
+    runtime.tokenizer_manager = _BlockingTokenizerManager([])
+    callback = _Callback()
+    obj = SimpleNamespace(sampling_params={"n": 2}, rid="request")
+    task = asyncio.create_task(
+        runtime._run_generate(obj, callback, True, None, typed_generation=True)
+    )
+    await started.wait()
+
+    task.cancel()
+    await task
+
+    assert [call[0]["index"] for call in callback.calls] == [0, 1]
+    assert [call[1]["finished"] for call in callback.calls] == [False, True]
+    assert all(
+        call[0]["meta_info"]["finish_reason"]["status_code"] == 499
+        for call in callback.calls
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("outputs", "message"),
     [

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -263,6 +263,30 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         # Modalities should be set for all 3 examples
         self.assertEqual(req.modalities, ["image", "image", "image"])
 
+    def test_parallel_sampling_keeps_one_logical_rid_per_prompt(self):
+        single = GenerateReqInput(
+            text="Hello",
+            rid="single",
+            sampling_params={"n": 3},
+        )
+        single.normalize_batch_and_arguments()
+
+        self.assertEqual(single.rid, ["single"])
+        self.assertEqual([single[i].rid for i in range(3)], ["single"] * 3)
+
+        batch = GenerateReqInput(
+            text=["Hello", "World"],
+            rid="batch",
+            sampling_params={"n": 2},
+        )
+        batch.normalize_batch_and_arguments()
+
+        self.assertEqual(batch.rid, ["batch_0", "batch_1"])
+        self.assertEqual(
+            [batch[i].rid for i in range(4)],
+            ["batch_0", "batch_1", "batch_0", "batch_1"],
+        )
+
     def test_audio_data_handling(self):
         """Test handling of audio_data."""
         req = copy.deepcopy(self.base_req)

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -550,33 +550,6 @@ class TestParallelAbortRouting(CustomTestCase):
         self.assertEqual(request.rid, "")
         self.assertTrue(request.abort_all)
 
-    def test_parent_abort_before_child_registration_blocks_dispatch(self):
-        tm = _make_tokenizer_manager()
-        tm.server_args.tokenizer_worker_num = 1
-        tm._dispatch_to_scheduler = Mock()
-        parent = GenerateReqInput(
-            text="hello",
-            rid="pending-parent",
-            sampling_params={"n": 2},
-        )
-        parent.normalize_batch_and_arguments()
-        tm._init_req_state(parent)
-
-        tm.abort_request("pending-parent")
-
-        self.assertTrue(tm.rid_to_state["pending-parent"].abort_requested)
-        tm._dispatch_to_scheduler.assert_not_called()
-        child = _make_generate_obj("late-child", is_single=True)
-        with self.assertRaisesRegex(RequestAbortedError, "pending-parent"):
-            tm._init_child_req_state("pending-parent", child)
-        self.assertNotIn("late-child", tm.rid_to_state)
-
-        tm._discard_pending_req_states(parent, abort_active_children=True)
-        self.assertFalse(tm.rid_to_state)
-        self.assertFalse(tm.logical_rid_to_child_rids)
-        self.assertFalse(tm.child_rid_to_logical_rid)
-
-
 class TestParallelStreamTaskCleanup(CustomTestCase):
     def test_failing_choice_cancels_and_closes_sibling_waiters(self):
         tm = _make_tokenizer_manager()

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -23,27 +23,21 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import AbortReq, BatchStrOutput, GenerateReqInput
-from sglang.srt.managers.tokenizer_manager import ReqState, TokenizerManager
-from sglang.srt.observability.req_time_stats import APIServerReqTimeStats
+from sglang.srt.managers.io_struct import (  # noqa: E402
+    AbortReq,
+    BatchStrOutput,
+    GenerateReqInput,
+)
+from sglang.srt.managers.tokenizer_manager import (  # noqa: E402
+    ReqState,
+    RequestAbortedError,
+    TokenizerManager,
+)
+from sglang.srt.observability.req_time_stats import (  # noqa: E402
+    APIServerReqTimeStats,
+)
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
-
-
-import pytest as _pytest_defer
-
-_DEFER_REASON = (
-    "Temporarily skipped during the ServerArgs config-namespace migration; "
-    "re-enabled once the runtime-config accessor API stabilizes."
-)
-pytestmark = _pytest_defer.mark.skip(reason=_DEFER_REASON)
-
-
-def setUpModule():
-    import unittest
-
-    raise unittest.SkipTest(_DEFER_REASON)
-
 
 _NOT_FINISHED = object()  # Sentinel: request has not finished yet
 
@@ -125,6 +119,8 @@ def _make_tokenizer_manager() -> TokenizerManager:
     tm.server_args.dp_size = 1
     tm.disaggregation_mode = "none"
     tm.rid_to_state = {}
+    tm.logical_rid_to_child_rids = {}
+    tm.child_rid_to_logical_rid = {}
     tm.enable_metrics = False
     tm.enable_trace = False
     tm.enable_lora = False
@@ -275,11 +271,14 @@ class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
         rid = "batch_finish_rid"
         state = _make_req_state(rid)
         tm.rid_to_state[rid] = state
+        tm._register_child_rid("logical_parent", rid)
 
         batch_output = _make_batch_str_output(rid)
         asyncio.run(tm._handle_batch_output(batch_output))
 
         self.assertNotIn(rid, tm.rid_to_state)
+        self.assertNotIn("logical_parent", tm.logical_rid_to_child_rids)
+        self.assertNotIn(rid, tm.child_rid_to_logical_rid)
 
     def test_batch_output_allows_resubmit_after_finish(self):
         """After a request finishes, the same rid can be resubmitted."""
@@ -351,6 +350,19 @@ class TestInitReqStateDuplicateDetection(CustomTestCase):
 
         tm._init_req_state(obj)
         self.assertIn(rid, tm.rid_to_state)
+
+    def test_batch_duplicate_preflight_does_not_insert_partial_state(self):
+        tm = _make_tokenizer_manager()
+        existing_rid = "existing"
+        existing_state = _make_req_state(existing_rid)
+        tm.rid_to_state[existing_rid] = existing_state
+        obj = _make_generate_obj(["new", existing_rid], is_single=False)
+
+        with self.assertRaisesRegex(ValueError, "Duplicate request ID"):
+            tm._init_req_state(obj)
+
+        self.assertNotIn("new", tm.rid_to_state)
+        self.assertIs(tm.rid_to_state[existing_rid], existing_state)
 
 
 class TestResubmitAfterCompletion(CustomTestCase):
@@ -484,6 +496,226 @@ class TestDiscardPendingReqStates(CustomTestCase):
         tm._discard_pending_req_states(obj)  # must not raise
         self.assertNotIn("p1", tm.rid_to_state)
 
+    def test_parallel_cleanup_aborts_children_and_allows_parent_reuse(self):
+        tm = _make_tokenizer_manager()
+        tm._dispatch_to_scheduler = Mock()
+        parent = _make_generate_obj("parent", is_single=True)
+        tm._init_req_state(parent)
+
+        child_rids = {"prefix", "choice_0", "choice_1"}
+        for child_rid in child_rids:
+            child = _make_generate_obj(child_rid, is_single=True)
+            tm._init_child_req_state("parent", child)
+        tm._remove_req_state("parent")
+
+        tm._discard_pending_req_states(parent, abort_active_children=True)
+
+        aborted_rids = {
+            call.args[0].rid for call in tm._dispatch_to_scheduler.call_args_list
+        }
+        self.assertEqual(aborted_rids, child_rids)
+        self.assertFalse(tm.rid_to_state)
+        self.assertFalse(tm.logical_rid_to_child_rids)
+        self.assertFalse(tm.child_rid_to_logical_rid)
+
+        tm._init_req_state(_make_generate_obj("parent", is_single=True))
+        self.assertIn("parent", tm.rid_to_state)
+
+
+class TestParallelAbortRouting(CustomTestCase):
+    def test_parent_abort_fans_out_without_changing_direct_abort_modes(self):
+        tm = _make_tokenizer_manager()
+        tm.server_args.tokenizer_worker_num = 1
+        tm._dispatch_to_scheduler = Mock()
+        tm._register_child_rid("parent", "choice_0")
+        tm._register_child_rid("parent", "choice_1")
+
+        tm.abort_request("parent")
+
+        requests = [call.args[0] for call in tm._dispatch_to_scheduler.call_args_list]
+        self.assertEqual(
+            {request.rid for request in requests}, {"choice_0", "choice_1"}
+        )
+        self.assertTrue(all(not request.abort_all for request in requests))
+
+        tm._dispatch_to_scheduler.reset_mock()
+        tm.abort_request("choice_0")
+        request = tm._dispatch_to_scheduler.call_args.args[0]
+        self.assertEqual(request.rid, "choice_0")
+        self.assertFalse(request.abort_all)
+
+        tm._dispatch_to_scheduler.reset_mock()
+        tm.abort_request(abort_all=True)
+        request = tm._dispatch_to_scheduler.call_args.args[0]
+        self.assertEqual(request.rid, "")
+        self.assertTrue(request.abort_all)
+
+    def test_parent_abort_before_child_registration_blocks_dispatch(self):
+        tm = _make_tokenizer_manager()
+        tm.server_args.tokenizer_worker_num = 1
+        tm._dispatch_to_scheduler = Mock()
+        parent = GenerateReqInput(
+            text="hello",
+            rid="pending-parent",
+            sampling_params={"n": 2},
+        )
+        parent.normalize_batch_and_arguments()
+        tm._init_req_state(parent)
+
+        tm.abort_request("pending-parent")
+
+        self.assertTrue(tm.rid_to_state["pending-parent"].abort_requested)
+        tm._dispatch_to_scheduler.assert_not_called()
+        child = _make_generate_obj("late-child", is_single=True)
+        with self.assertRaisesRegex(RequestAbortedError, "pending-parent"):
+            tm._init_child_req_state("pending-parent", child)
+        self.assertNotIn("late-child", tm.rid_to_state)
+
+        tm._discard_pending_req_states(parent, abort_active_children=True)
+        self.assertFalse(tm.rid_to_state)
+        self.assertFalse(tm.logical_rid_to_child_rids)
+        self.assertFalse(tm.child_rid_to_logical_rid)
+
+
+class TestParallelStreamTaskCleanup(CustomTestCase):
+    def test_failing_choice_cancels_and_closes_sibling_waiters(self):
+        tm = _make_tokenizer_manager()
+
+        async def drive():
+            sibling_closed = asyncio.Event()
+
+            async def failing_choice():
+                await asyncio.sleep(0)
+                raise RuntimeError("choice failed")
+                yield  # pragma: no cover
+
+            async def blocked_choice():
+                try:
+                    await asyncio.Event().wait()
+                    yield  # pragma: no cover
+                finally:
+                    sibling_closed.set()
+
+            stream = tm._stream_batch_responses(
+                [failing_choice(), blocked_choice()],
+                ["choice-0", "choice-1"],
+            )
+            with self.assertRaisesRegex(RuntimeError, "choice failed"):
+                await stream.__anext__()
+            self.assertTrue(sibling_closed.is_set())
+
+        asyncio.run(drive())
+
+
+class TestParallelRidReuse(CustomTestCase):
+    def test_completed_n2_request_can_repeat_the_same_logical_rid(self):
+        tm = _make_tokenizer_manager()
+
+        async def complete_child(rid):
+            await tm._handle_batch_output(_make_batch_str_output(rid))
+
+        for _ in range(2):
+            logical = GenerateReqInput(
+                text="hello",
+                rid="repeat-n2",
+                sampling_params={"n": 2},
+            )
+            logical.normalize_batch_and_arguments()
+            tm._init_req_state(logical)
+
+            prefix = GenerateReqInput(text="hello", rid="prefix")
+            prefix.normalize_batch_and_arguments()
+            tm._init_child_req_state("repeat-n2", prefix)
+            asyncio.run(complete_child("prefix"))
+
+            for child_rid in ("choice-0", "choice-1"):
+                child = GenerateReqInput(text="hello", rid=child_rid)
+                child.normalize_batch_and_arguments()
+                tm._init_child_req_state("repeat-n2", child)
+            tm._remove_req_state("repeat-n2")
+            asyncio.run(complete_child("choice-0"))
+            asyncio.run(complete_child("choice-1"))
+
+            self.assertFalse(tm.rid_to_state)
+            self.assertFalse(tm.logical_rid_to_child_rids)
+            self.assertFalse(tm.child_rid_to_logical_rid)
+
+
+class TestTypedSchedulerErrors(CustomTestCase):
+    def test_non_stream_scheduler_errors_are_yielded_only_when_opted_in(self):
+        tm = _make_tokenizer_manager()
+        state = _make_req_state("typed_error")
+
+        for status_code in (400, 500, 503):
+            with self.subTest(status_code=status_code):
+                out = {
+                    "meta_info": {
+                        "finish_reason": {
+                            "type": "abort",
+                            "status_code": status_code,
+                            "message": "scheduler rejected request",
+                        }
+                    }
+                }
+                result = asyncio.run(
+                    tm._handle_abort_finish_reason(
+                        out,
+                        state,
+                        is_stream=False,
+                        yield_scheduler_errors=True,
+                    )
+                )
+                self.assertIs(result, out)
+
+        with self.assertRaisesRegex(ValueError, "scheduler rejected request"):
+            asyncio.run(
+                tm._handle_abort_finish_reason(
+                    {
+                        "meta_info": {
+                            "finish_reason": {
+                                "type": "abort",
+                                "status_code": 400,
+                                "message": "scheduler rejected request",
+                            }
+                        }
+                    },
+                    state,
+                    is_stream=False,
+                )
+            )
+
+    def test_opt_in_503_preserves_cleanup_before_yielding(self):
+        tm = _make_tokenizer_manager()
+        tm.enable_lora = True
+        tm.lora_registry = MagicMock()
+        tm.lora_registry.release = AsyncMock()
+        state = _make_req_state("typed_503")
+        state.obj.lora_path = "adapter"
+        state.obj.lora_id = "adapter-id"
+        tm.rid_to_state[state.obj.rid] = state
+        out = {
+            "meta_info": {
+                "finish_reason": {
+                    "type": "abort",
+                    "status_code": 503,
+                    "message": "scheduler unavailable",
+                }
+            }
+        }
+
+        result = asyncio.run(
+            tm._handle_abort_finish_reason(
+                out,
+                state,
+                is_stream=False,
+                yield_scheduler_errors=True,
+            )
+        )
+
+        self.assertIs(result, out)
+        self.assertNotIn(state.obj.rid, tm.rid_to_state)
+        tm.lora_registry.release.assert_awaited_once_with("adapter-id")
+
 
 class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
     """generate_request must not leak rid_to_state when dispatch fails.
@@ -535,6 +767,78 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
         # All sub-request entries created by _init_req_state are cleaned up.
         for r in rids:
             self.assertNotIn(r, tm.rid_to_state)
+
+    def test_parallel_abort_during_tokenization_prevents_child_dispatch(self):
+        tm = _make_tm_for_generate()
+        tm._dispatch_to_scheduler = Mock()
+        tm._send_one_request = Mock()
+        obj = GenerateReqInput(
+            text="hello",
+            rid="abort-during-tokenization",
+            sampling_params={"n": 2},
+        )
+
+        async def drive():
+            tokenization_started = asyncio.Event()
+            allow_tokenization = asyncio.Event()
+
+            async def blocked_tokenization(_obj):
+                tokenization_started.set()
+                await allow_tokenization.wait()
+                return MagicMock()
+
+            tm._tokenize_one_request = blocked_tokenization
+            response = tm.generate_request(obj)
+            task = asyncio.create_task(response.__anext__())
+            await tokenization_started.wait()
+            tm.abort_request("abort-during-tokenization")
+            allow_tokenization.set()
+            with self.assertRaisesRegex(
+                RequestAbortedError, "abort-during-tokenization"
+            ):
+                await task
+
+        asyncio.run(drive())
+
+        tm._send_one_request.assert_not_called()
+        self.assertFalse(tm.rid_to_state)
+        self.assertFalse(tm.logical_rid_to_child_rids)
+        self.assertFalse(tm.child_rid_to_logical_rid)
+
+    def test_single_abort_during_tokenization_prevents_scheduler_dispatch(self):
+        tm = _make_tm_for_generate()
+        tm._dispatch_to_scheduler = Mock()
+        tm._send_one_request = Mock()
+        obj = GenerateReqInput(
+            text="hello",
+            rid="single-abort-during-tokenization",
+            sampling_params={"n": 1},
+        )
+
+        async def drive():
+            tokenization_started = asyncio.Event()
+            allow_tokenization = asyncio.Event()
+
+            async def blocked_tokenization(_obj):
+                tokenization_started.set()
+                await allow_tokenization.wait()
+                return MagicMock()
+
+            tm._tokenize_one_request = blocked_tokenization
+            response = tm.generate_request(obj)
+            task = asyncio.create_task(response.__anext__())
+            await tokenization_started.wait()
+            tm.abort_request("single-abort-during-tokenization")
+            allow_tokenization.set()
+            with self.assertRaisesRegex(
+                RequestAbortedError, "single-abort-during-tokenization"
+            ):
+                await task
+
+        asyncio.run(drive())
+
+        tm._send_one_request.assert_not_called()
+        self.assertFalse(tm.rid_to_state)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -550,6 +550,7 @@ class TestParallelAbortRouting(CustomTestCase):
         self.assertEqual(request.rid, "")
         self.assertTrue(request.abort_all)
 
+
 class TestParallelStreamTaskCleanup(CustomTestCase):
     def test_failing_choice_cancels_and_closes_sibling_waiters(self):
         tm = _make_tokenizer_manager()


### PR DESCRIPTION
## Motivation

The tokenized native gRPC API needs typed generation results and correct multi-choice streaming. This focused draft adds the stack-ranked response, choice-index, and request-control gaps while leaving multimodal transport, LoRA, advanced controls, and response-side handoff to follow-up work.

The paired Dynamo sidecar prototype is https://github.com/connorcarpenter15/dynamo/pull/6.

## Modifications

- Preserve the existing `Generate` RPC and the legacy `GenerateResponse` fields and semantics: cumulative `output_ids = 1`, JSON-string `meta_info = 2`, and request-level `finished = 3`.
- Add typed fields directly to `GenerateResponse`: public request ID, choice index, delta token IDs, aligned prompt/output/top logprobs, usage including cached prompt tokens, structured engine extensions, and exactly one finish or per-choice error terminal.
- Emit both the legacy cumulative representation and the typed delta representation from the same `Generate` stream. No separate `TypedGenerate` RPC remains.
- Preserve deprecated `SamplingParams.json_schema = 14` and `regex = 15`; add the mutually exclusive guided-decoding contract at tag 17 and reject mixed legacy/new constraints.
- Add seed, priority, reasoning-required, and maximum-thinking-token request controls.
- Track one logical parent RID and all active generated RIDs for `n > 1`; make duplicate preflight transactional and centralize cleanup across completion, scheduler failure, cancellation, disconnect, timeout, and partial dispatch.
- Fan parent aborts out to an exact snapshot of active generated RIDs without allowing stale streams to remove or abort a reused RID.
- Normalize cumulative or incremental Python output into per-choice deltas once while reconstructing cumulative legacy output, preserve prompt logprobs on the first applicable chunk, honor bounded-channel backpressure for streaming and non-streaming `n > 1`, and convert attributable scheduler/cancellation failures into typed per-choice errors.
- Keep legacy metadata raw and omit known typed/internal request-ID values from structured engine extensions.
- Remove routed-expert metadata from this focused contract because SGLang does not yet capture the required request controls and output data end to end.

## Accuracy Tests

- Earlier Computelab H100 validation with `Qwen/Qwen3-0.6B` covered legacy streaming, typed streaming and non-streaming `n=2`, deterministic seed, reasoning controls, EBNF, choices, structural tags, aligned logprobs/usage, RID reuse, parent abort, the paired Dynamo sidecar, and a two-H100 1P/1D Mooncake request.
- Contract commit `7b10460ddcb5fe6c8f0f12e5b046c0499a568441` consolidates those already-validated typed fields into the normal `Generate` response while preserving and testing the legacy cumulative fields. Current head `bd4ad898d6eee91927482968d6b41fc8d563b739` adds only Black and Clippy lint fixes.

## Speed Tests and Profiling

- A cumulative 4,096-token stream with top-5 logprobs produced 4,096 delta chunks, emitted prompt logprobs once, and completed in about 69 seconds on H100.
- Deterministic counters verify token and logprob normalization is performed incrementally rather than repeatedly slicing or parsing cumulative history.
- This PR does not change model forward execution.

## Validation

- `python scripts/ci/check_registered_tests.py`
- Python bytecode compilation for the modified bridge and focused tests
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml --workspace -- -D warnings`
- `PYO3_PYTHON=/usr/bin/python3.12 RUSTFLAGS='-C link-arg=-L/usr/lib/x86_64-linux-gnu -C link-arg=-lpython3.12' cargo test --manifest-path rust/Cargo.toml -p sglang-grpc` — 26 passed
- `git diff --check`
- Source and vendored Dynamo proto SHA-256: `73dbab9686eccd5442044eb89b172fca230d12487e4dc85d5668e5bef21c9002`
- Generated descriptor SHA-256: `614d450ac7f7fb4f38b573c104e50ccb97b1d32abf490c1302478ee3188e0451`

The validation image's bundled `nixl_cu13` lacks `nixl_thread_sync_t`, so the two-GPU regression used Mooncake. This is an image dependency limitation; request-side disaggregation itself passed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30122818595](https://github.com/sgl-project/sglang/actions/runs/30122818595)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30122818477](https://github.com/sgl-project/sglang/actions/runs/30122818477)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->