### PR TITLE
[Fix] Include disagg prefill waiting queue in FPM

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -304,6 +304,8 @@ class SchedulerMetricsReporter:
         if self.scheduler.disaggregation_mode == DisaggregationMode.PREFILL:
             for req in self.scheduler.disagg_prefill_bootstrap_queue.queue:
                 prefill_q.add(len(req.origin_input_ids))
+            for req in self.scheduler.waiting_queue:
+                prefill_q.add(len(req.origin_input_ids))
         elif self.scheduler.disaggregation_mode == DisaggregationMode.DECODE:
             for req in self.scheduler.disagg_decode_prealloc_queue.queue:
                 decode_q.add(req.seqlen)

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -232,11 +232,12 @@ class TestForwardPassMetrics(unittest.TestCase):
             self.scheduler._fpm_publisher.metrics[0].wall_time, 0.035, places=4
         )
 
-    def test_disagg_prefill_queued_metrics(self):
+    def test_disagg_prefill_queued_metrics_include_compute_waiting_queue(self):
         self.scheduler.disaggregation_mode = DisaggregationMode.PREFILL
         self.scheduler.disagg_prefill_bootstrap_queue = types.SimpleNamespace(
-            queue=[_FakeReq(100), _FakeReq(200), _FakeReq(50)],
+            queue=[_FakeReq(100)],
         )
+        self.scheduler.waiting_queue = [_FakeReq(200), _FakeReq(50)]
         batch = self._make_batch()
 
         with patch(


### PR DESCRIPTION
## Motivation

In disaggregated prefill mode, forward-pass metrics only counted requests in the KV-transfer bootstrap queue. Requests that had completed bootstrap and were waiting for chunked-prefill compute admission in `waiting_queue` were omitted, so downstream autoscalers could observe zero queued prefill tokens under sustained load.

## Modifications

- Include `waiting_queue` requests in disaggregated-prefill queued request metrics.
- Extend the CPU unit test to cover requests in both the bootstrap and compute-admission queues.

## Accuracy Tests

Not applicable. This change only corrects queue telemetry and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. The added queue scan follows the existing aggregated-mode metric collection pattern and only runs when forward-pass metrics are emitted.

## Validation

- `pre-commit run --files python/sglang/srt/managers/scheduler_components/metrics_reporter.py test/registered/unit/observability/test_forward_pass_metrics.py` (all hooks passed)
- A targeted queued-prefill regression smoke test passed for both mixed bootstrap/waiting queues and a waiting-only queue.
- The registered pytest file could not be collected in the local Dynamo virtual environment because the full SGLang runtime dependency `sgl_kernel` is not installed; the updated CPU unit test is included for upstream CI.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required for this internal telemetry correction.
- [x] Accuracy and speed benchmarks are not applicable because model execution is unchanged.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29964572295](https://github.com/sgl-project/sglang/actions/runs/29964572295)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29964572076](https://github.com/sgl-project/sglang/actions/runs/29964572076)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->