### PR TITLE
Seed the GDN CuteDSL correctness test inputs to fix flakiness

### DIFF
--- a/test/registered/attention/test_gdn_prefill_cutedsl.py
+++ b/test/registered/attention/test_gdn_prefill_cutedsl.py
@@ -39,6 +39,10 @@ from sglang.kernels.ops.attention.linear.gdn_blackwell import (  # noqa: E402
 @pytest.mark.parametrize("num_seqs", [1, 5, 257])
 @pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float32])
 def test_gdn_chunk_cutedsl_correctness(num_seqs: int, state_dtype: torch.dtype):
+    # Fixed per-case seed: the mean-error assertions sit close to the observed
+    # error distribution (state_error.mean() threshold 6e-4 vs ~6.3e-4 seen on
+    # unlucky draws in CI), so unseeded inputs make the test flaky.
+    torch.manual_seed(num_seqs)
     seq_lens = torch.randint(1, 130, (num_seqs,), dtype=torch.int32)
     cu_seqlens = torch.zeros(num_seqs + 1, device="cuda", dtype=torch.int32)
     cu_seqlens[1:] = seq_lens.to(device="cuda").cumsum(0)


### PR DESCRIPTION
## Motivation

`test_gdn_chunk_cutedsl_correctness` is flaky: it draws every input from unseeded `torch.randn` / `torch.randint`, while asserting `state_error.mean() < 6e-4` — a threshold that sits inside the observed error distribution's tail. With identical kernel code (no GDN change since #30169), the case `[state_dtype0-1]` passed four recent CI executions and failed one at `6.31e-4`:

- failed: [PR #30822 run, jit-kernel-b200](https://github.com/sgl-project/sglang/actions/runs/29954932002/job/89041576855) — `AssertionError: assert 0.0006306682480499148 < 0.0006`
- passed on the same code: main scheduled runs [29916328963](https://github.com/sgl-project/sglang/actions/runs/29916328963) / [29876808251](https://github.com/sgl-project/sglang/actions/runs/29876808251), plus two earlier #30822 rounds.

## Modifications

Seed the generator once per case (`torch.manual_seed(num_seqs)`) at the top of `test_gdn_chunk_cutedsl_correctness`, with a comment explaining why. The sibling `test_gdn_chunk_cutedsl_pool_mode_matches_dense` already seeds (`manual_seed(11)`); this brings the correctness test in line. No kernel or tolerance changes.

## Accuracy Tests

Full file passes deterministically on SM100-class hardware (GB300): 8 passed in 17.7s.

## Speed Tests and Profiling

Not applicable (test-only change).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29969559551](https://github.com/sgl-project/sglang/actions/runs/29969559551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29969559404](https://github.com/sgl-project/sglang/actions/runs/29969559404)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->