### PR TITLE
[ROCm] Enable MiniMax-M3 MXFP8 AITER MoE

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2113,6 +2113,8 @@ def _moe_runner_backend_quant_constraints(view: Any) -> dict:
         allowed = list(MXFP8_MOE_RUNNER_BACKEND_CHOICES)
         if is_gfx95_mxfp8:
             allowed.append("triton")
+            if envs.SGLANG_USE_AITER_MXFP8_MOE.get():
+                allowed.append("aiter")
         mxfp8_default = "triton" if is_gfx95_mxfp8 else "flashinfer_trtllm"
         if moe_runner_backend == "auto":
             moe_runner_backend = mxfp8_default

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2113,8 +2113,7 @@ def _moe_runner_backend_quant_constraints(view: Any) -> dict:
         allowed = list(MXFP8_MOE_RUNNER_BACKEND_CHOICES)
         if is_gfx95_mxfp8:
             allowed.append("triton")
-            if envs.SGLANG_USE_AITER_MXFP8_MOE.get():
-                allowed.append("aiter")
+            allowed.append("aiter")
         mxfp8_default = "triton" if is_gfx95_mxfp8 else "flashinfer_trtllm"
         if moe_runner_backend == "auto":
             moe_runner_backend = mxfp8_default

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -574,6 +574,10 @@ class Envs:
     # AMD & ROCm
     SGLANG_USE_AITER = EnvBool(False)
     SGLANG_USE_AITER_AG = EnvBool(True)
+    # Opt in to AITER FlyDSL MXFP8 MoE on ROCm gfx950. This path requires an
+    # aiter build with MiniMax-M3 MXFP8 tuned fmoe configs and has a distinct
+    # weight/scale layout from the default Triton MXFP8 MoE path.
+    SGLANG_USE_AITER_MXFP8_MOE = EnvBool(False)
     # Use reduce_scatter (instead of all_reduce + dp_scatter) for the equal-chunk
     # MAX_LEN DP-MoE combine. Default ON for ROCm/HIP (uses the aiter custom
     # symmetric-memory kernel), OFF elsewhere (would fall back to RCCL); override

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -574,10 +574,6 @@ class Envs:
     # AMD & ROCm
     SGLANG_USE_AITER = EnvBool(False)
     SGLANG_USE_AITER_AG = EnvBool(True)
-    # Opt in to AITER FlyDSL MXFP8 MoE on ROCm gfx950. This path requires an
-    # aiter build with MiniMax-M3 MXFP8 tuned fmoe configs and has a distinct
-    # weight/scale layout from the default Triton MXFP8 MoE path.
-    SGLANG_USE_AITER_MXFP8_MOE = EnvBool(False)
     # Use reduce_scatter (instead of all_reduce + dp_scatter) for the equal-chunk
     # MAX_LEN DP-MoE combine. Default ON for ROCm/HIP (uses the aiter custom
     # symmetric-memory kernel), OFF elsewhere (would fall back to RCCL); override

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -158,6 +158,7 @@ class AiterRunnerCore(MoeRunnerCore):
         extra: dict = {}
         if quant_info.fused_moe_kwargs:
             extra.update(quant_info.fused_moe_kwargs)
+        activation = extra.pop("activation", _aiter_activation(self.config.activation))
         if runner_input.num_local_tokens is not None:
             extra["num_local_tokens"] = runner_input.num_local_tokens
         if runner_input.output_dtype is not None:
@@ -190,7 +191,7 @@ class AiterRunnerCore(MoeRunnerCore):
             topk_weight=runner_input.topk_weights,
             topk_ids=runner_input.topk_ids,
             quant_type=_aiter_quant_type(runner_input.quant_type),
-            activation=_aiter_activation(self.config.activation),
+            activation=activation,
             w1_scale=quant_info.w13_scale,
             w2_scale=quant_info.w2_scale,
             a1_scale=a1_scale,

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -59,7 +59,8 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     hidden_pad: int = 0
     intermediate_pad: int = 0
     swiglu_limit: float = 0.0
-    fused_moe_kwargs: Optional[dict[str, Any]] = None
+    activation: Optional[str] = None
+    gate_up_interleaved: Optional[bool] = None
 
 
 @dataclass
@@ -156,13 +157,19 @@ class AiterRunnerCore(MoeRunnerCore):
         )
 
         extra: dict = {}
-        if quant_info.fused_moe_kwargs:
-            extra.update(quant_info.fused_moe_kwargs)
-        activation = extra.pop("activation", _aiter_activation(self.config.activation))
+        activation = _aiter_activation(quant_info.activation or self.config.activation)
         if runner_input.num_local_tokens is not None:
             extra["num_local_tokens"] = runner_input.num_local_tokens
         if runner_input.output_dtype is not None:
             extra["dtype"] = runner_input.output_dtype
+        if quant_info.gate_up_interleaved is not None:
+            from aiter.ops.flydsl.moe_common import GateMode
+
+            extra["gate_mode"] = (
+                GateMode.INTERLEAVE.value
+                if quant_info.gate_up_interleaved
+                else GateMode.SEPARATED.value
+            )
         if quant_info.swiglu_limit > 0:
             # GateMode is only needed for the gpt-oss MXFP4 swiglu_limit path.
             # Import lazily so models that don't use it (e.g. DeepSeek-V3 fp8,
@@ -175,11 +182,12 @@ class AiterRunnerCore(MoeRunnerCore):
             # `SGLANG_USE_AITER_MOE_GU_ITLV=0` to switch to SEPARATED, which
             # matches the layout produced by `Mxfp4MoEMethod` (gpt-oss
             # MXFP4) and the gptoss_fp4 tuned FlyDSL kernels.
-            extra["gate_mode"] = (
-                GateMode.INTERLEAVE.value
-                if envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
-                else GateMode.SEPARATED.value
-            )
+            if "gate_mode" not in extra:
+                extra["gate_mode"] = (
+                    GateMode.INTERLEAVE.value
+                    if envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
+                    else GateMode.SEPARATED.value
+                )
             extra["swiglu_limit"] = quant_info.swiglu_limit
         if self.config.no_combine:
             extra["no_combine"] = True

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1818,7 +1818,7 @@ def remap_topk_for_per_rank_shared_slots(
     # one validated on AMD MI355X); those other backends are left at their
     # existing behavior and can be addressed by their maintainers.
     routed_scaling_factor = topk_config.routed_scaling_factor
-    if _use_aiter:
+    if _use_aiter and get_moe_runner_backend().is_aiter():
         topk_weights[:, -num_fused_shared_experts:] = 1.0
     elif routed_scaling_factor is not None and routed_scaling_factor != 0:
         topk_weights[:, -num_fused_shared_experts:] = 1.0 / routed_scaling_factor
@@ -1925,7 +1925,11 @@ def _post_process_topk_ids(
     if recorder_topk_ids is None:
         recorder_topk_ids = topk_ids
 
-    _aiter_append = num_fused_shared_experts > 0 and _use_aiter
+    _aiter_append = (
+        num_fused_shared_experts > 0
+        and _use_aiter
+        and get_moe_runner_backend().is_aiter()
+    )
 
     if _aiter_append and use_per_rank_shared_slots:
         # Fused path: append shared experts AND apply the per-rank shared-slot
@@ -1934,13 +1938,9 @@ def _post_process_topk_ids(
         # collapsing ~6 launch-bound elementwise kernels/layer (div_floor / add /
         # arange / fill / copy) into the one append kernel that already runs.
         #
-        # Shared weight is 1.0 here because this branch is aiter-only:
-        # aiter_biased_grouped_topk folds routed_scaling_factor into the routed
-        # weights and forward_deepep skips the post-MoE multiply for _use_aiter,
-        # so the always-on shared expert must contribute 1.0x. (The eager
-        # per-rank shared-slot remap instead sets shared weight to
-        # 1/routed_scaling_factor to compensate a post-MoE scale that the aiter
-        # path does not apply; see PR #28237.)
+        # Shared weight is 1.0 here because this branch is only used by the
+        # aiter MoE backend: aiter topk folds routed_scaling_factor into routed
+        # weights and the aiter MoE path does not apply a post-MoE scale.
         num_physical_routed_experts = (
             expert_location_dispatch_info.num_physical_experts
             if expert_location_dispatch_info is not None
@@ -1961,7 +1961,7 @@ def _post_process_topk_ids(
             topk_ids,
             topk_weights,
             num_fused_shared_experts,
-            1.0,  # shared-expert weight on the aiter path
+            1.0,
             shared_id_base,
             num_local_routed,
         )
@@ -2033,6 +2033,7 @@ def select_experts(
     apply_routed_scaling_factor_on_output = (
         topk_config.apply_routed_scaling_factor_on_output
     )
+    aiter_moe_backend = _use_aiter and get_moe_runner_backend().is_aiter()
 
     scoring_func = topk_config.scoring_func
 
@@ -2058,7 +2059,7 @@ def select_experts(
             topk_weights, topk_ids = grouped_topk(
                 hidden_states=hidden_states,
                 gating_output=router_logits,
-                topk=num_routed_topk if _use_aiter else top_k,
+                topk=num_routed_topk if aiter_moe_backend else top_k,
                 renormalize=renormalize,
                 num_expert_group=num_expert_group,
                 topk_group=topk_group,
@@ -2072,7 +2073,7 @@ def select_experts(
                 hidden_states=hidden_states,
                 gating_output=router_logits,
                 correction_bias=correction_bias,
-                topk=num_routed_topk if _use_aiter else top_k,
+                topk=num_routed_topk if aiter_moe_backend else top_k,
                 renormalize=renormalize,
                 num_expert_group=num_expert_group,
                 topk_group=topk_group,
@@ -2089,7 +2090,7 @@ def select_experts(
         topk_weights, topk_ids = fused_topk_native(
             hidden_states=hidden_states,
             gating_output=router_logits,
-            topk=num_routed_topk if _use_aiter else top_k,
+            topk=num_routed_topk if aiter_moe_backend else top_k,
             renormalize=renormalize,
             correction_bias=correction_bias,
             scoring_func=scoring_func,
@@ -2111,7 +2112,7 @@ def select_experts(
                 hidden_states=hidden_states,
                 gating_output=router_logits,
                 correction_bias=correction_bias,
-                topk=num_routed_topk if _use_aiter else top_k,
+                topk=num_routed_topk if aiter_moe_backend else top_k,
                 renormalize=renormalize,
                 scoring_func=scoring_func,
                 num_fused_shared_experts=num_fused_shared_experts,
@@ -2129,7 +2130,7 @@ def select_experts(
             topk_weights, topk_ids = fused_topk_softmax_torch_raw_logits(
                 hidden_states=hidden_states,
                 gating_output=router_logits,
-                topk=num_routed_topk if _use_aiter else top_k,
+                topk=num_routed_topk if aiter_moe_backend else top_k,
                 renormalize=renormalize,
             )
         else:
@@ -2173,7 +2174,7 @@ def select_experts(
             topk_weights, topk_ids = fused_topk(
                 hidden_states=hidden_states,
                 gating_output=router_logits,
-                topk=num_routed_topk if _use_aiter else top_k,
+                topk=num_routed_topk if aiter_moe_backend else top_k,
                 renormalize=renormalize,
                 correction_bias=correction_bias,
                 scoring_func=scoring_func,
@@ -2191,7 +2192,7 @@ def select_experts(
         topk_weights, topk_ids = custom_routing_function(
             hidden_states=hidden_states,
             gating_output=router_logits,
-            topk=num_routed_topk if _use_aiter else top_k,
+            topk=num_routed_topk if aiter_moe_backend else top_k,
             renormalize=renormalize,
         )
 

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -148,6 +148,35 @@ _RENORMALIZE_SUM_EPSILON = 1e-20
 # default because it is a numerics-affecting change that must be validated with
 # an accuracy run before becoming the default.
 _skip_hip_pad_mask = get_bool_env_var("SGLANG_MORI_NO_PAD_MASK", "False")
+_aiter_fse_topk_meta: dict[tuple[torch.device, int, int, torch.dtype], tuple[torch.Tensor, torch.Tensor]] = {}
+
+
+def _get_aiter_fse_topk_meta(
+    num_tokens: int,
+    routed_topk: int,
+    num_fused_shared_experts: int,
+    num_routed_experts: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    total_topk = routed_topk + num_fused_shared_experts
+    key = (device, routed_topk, num_fused_shared_experts, dtype)
+    cached = _aiter_fse_topk_meta.get(key)
+    if cached is None or cached[0].shape[0] < num_tokens:
+        cap = max(num_tokens, 32768)
+        weights = torch.empty((cap, total_topk), dtype=dtype, device=device)
+        ids = torch.empty((cap, total_topk), dtype=torch.int32, device=device)
+        shared_ids = torch.arange(
+            num_routed_experts,
+            num_routed_experts + num_fused_shared_experts,
+            dtype=torch.int32,
+            device=device,
+        )
+        ids[:, routed_topk:] = shared_ids
+        weights[:, routed_topk:] = 1.0
+        cached = (weights, ids)
+        _aiter_fse_topk_meta[key] = cached
+    return cached[0][:num_tokens], cached[1][:num_tokens]
 
 
 if _is_cuda:
@@ -1543,8 +1572,21 @@ def biased_grouped_topk_gpu(
         assert (
             hidden_states.shape[0] == gating_output.shape[0]
         ), f"Number of tokens mismatch: hidden_states.shape[0] = {hidden_states.shape[0]}, gating_output.shape[0] = {gating_output.shape[0]}"
-        topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
-        topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+        if num_fused_shared_experts > 0:
+            total_weights, total_ids = _get_aiter_fse_topk_meta(
+                token,
+                topk,
+                num_fused_shared_experts,
+                gating_output.shape[1],
+                torch.float32,
+                device,
+            )
+            topk_weights = total_weights[:, :topk]
+            topk_ids = total_ids[:, :topk]
+        else:
+            topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
+            topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+
         aiter_biased_grouped_topk(
             gating_output,
             correction_bias.to(dtype=gating_output.dtype),
@@ -1555,6 +1597,8 @@ def biased_grouped_topk_gpu(
             renormalize,
             routed_scaling_factor if routed_scaling_factor is not None else 1.0,
         )
+        if num_fused_shared_experts > 0:
+            return total_weights, total_ids
         return topk_weights, topk_ids
     elif _is_musa and (
         gating_output.shape[1] // num_expert_group <= 32
@@ -1929,6 +1973,7 @@ def _post_process_topk_ids(
         num_fused_shared_experts > 0
         and _use_aiter
         and get_moe_runner_backend().is_aiter()
+        and topk_ids.shape[1] == topk_config.top_k - num_fused_shared_experts
     )
 
     if _aiter_append and use_per_rank_shared_slots:

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -148,7 +148,10 @@ _RENORMALIZE_SUM_EPSILON = 1e-20
 # default because it is a numerics-affecting change that must be validated with
 # an accuracy run before becoming the default.
 _skip_hip_pad_mask = get_bool_env_var("SGLANG_MORI_NO_PAD_MASK", "False")
-_aiter_fse_topk_meta: dict[tuple[torch.device, int, int, torch.dtype], tuple[torch.Tensor, torch.Tensor]] = {}
+_aiter_fse_topk_meta: dict[
+    tuple[torch.device, int, int, int, torch.dtype],
+    tuple[torch.Tensor, torch.Tensor],
+] = {}
 
 
 def _get_aiter_fse_topk_meta(
@@ -160,7 +163,13 @@ def _get_aiter_fse_topk_meta(
     device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     total_topk = routed_topk + num_fused_shared_experts
-    key = (device, routed_topk, num_fused_shared_experts, dtype)
+    key = (
+        device,
+        routed_topk,
+        num_fused_shared_experts,
+        num_routed_experts,
+        dtype,
+    )
     cached = _aiter_fse_topk_meta.get(key)
     if cached is None or cached[0].shape[0] < num_tokens:
         cap = max(num_tokens, 32768)
@@ -1584,7 +1593,9 @@ def biased_grouped_topk_gpu(
             topk_weights = total_weights[:, :topk]
             topk_ids = total_ids[:, :topk]
         else:
-            topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
+            topk_weights = torch.empty(
+                (token, topk), dtype=torch.float32, device=device
+            )
             topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
 
         aiter_biased_grouped_topk(

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -129,6 +129,31 @@ _use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 
 
+def _aiter_mxfp8_moe_available() -> bool:
+    if not (_use_aiter and _is_gfx95_supported):
+        return False
+    try:
+        import os
+
+        import aiter
+
+        return os.path.exists(
+            os.path.join(
+                os.path.dirname(aiter.__file__),
+                "configs",
+                "model_configs",
+                "minimax_m3_mxfp8_tuned_fmoe.csv",
+            )
+        )
+    except Exception:
+        return False
+
+
+_use_aiter_mxfp8_moe = (
+    envs.SGLANG_USE_AITER_MXFP8_MOE.get() and _aiter_mxfp8_moe_available()
+)
+
+
 def _require_fp4_dtype():
     fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
     if fp4_dtype is None:
@@ -1948,6 +1973,18 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     layer.w2_weight.data.shape, layer.w2_weight_scale_inv.data
                 )
 
+        if _use_aiter_mxfp8_moe and get_moe_runner_backend().is_aiter():
+            num_experts = w13_q.shape[0]
+            w13_q = shuffle_weight(w13_q, is_guinterleave=True, gate_up=True)
+            w2_q = shuffle_weight(w2_q, is_guinterleave=True, gate_up=False)
+            w13_s = shuffle_scale(
+                w13_s.reshape(-1, w13_s.shape[-1]),
+                num_experts,
+                is_guinterleave=True,
+                gate_up=True,
+            )
+            w2_s = shuffle_scale(w2_s.reshape(-1, w2_s.shape[-1]))
+
         # Keep parameter objects to preserve weight_loader attrs for hot reload.
         # Prefer in-place copy; rebind only when shape/dtype changes (online quantize).
         def _copy_or_rebind(param: Parameter, new_value: torch.Tensor) -> None:
@@ -1963,6 +2000,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         _copy_or_rebind(layer.w2_weight, w2_q)
         _copy_or_rebind(layer.w13_weight_scale_inv, w13_s)
         _copy_or_rebind(layer.w2_weight_scale_inv, w2_s)
+        if _use_aiter_mxfp8_moe and get_moe_runner_backend().is_aiter():
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
         layer.w13_weight.requires_grad_(False)
         layer.w2_weight.requires_grad_(False)
         layer.w13_weight_scale_inv.requires_grad_(False)
@@ -2616,8 +2656,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         w13_weight = layer.w13_weight
         w2_weight = layer.w2_weight
+        fused_moe_kwargs = None
 
-        if self.block_quant:
+        if self.use_mxfp8 and _use_aiter_mxfp8_moe:
+            from aiter import ActivationType
+            from aiter.ops.flydsl.moe_common import GateMode
+
+            quant_type = AiterQuantType.PER_1X32
+            w13_weight.is_shuffled = True
+            w2_weight.is_shuffled = True
+            w13_scale = layer.w13_weight_scale_inv
+            w2_scale = layer.w2_weight_scale_inv
+            fused_moe_kwargs = {
+                "activation": ActivationType.Swiglu,
+                "gate_mode": GateMode.INTERLEAVE.value,
+            }
+            if self.moe_runner_config.gemm1_clamp_limit is not None:
+                fused_moe_kwargs["swiglu_limit"] = float(
+                    self.moe_runner_config.gemm1_clamp_limit
+                )
+        elif self.block_quant:
             quant_type = (
                 AiterQuantType.PER_1X32
                 if self.is_fp4_expert
@@ -2637,6 +2695,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             quant_type = AiterQuantType.PER_TOKEN
             w13_scale = layer.w13_weight_scale1
             w2_scale = layer.w2_weight_scale1
+            fused_moe_kwargs = None
         return AiterMoeQuantInfo(
             w13_weight=w13_weight,
             w2_weight=w2_weight,
@@ -2647,6 +2706,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             swiglu_limit=self.moe_runner_config.swiglu_limit or 0.0,
             hidden_pad=getattr(layer, "hidden_pad", 0),
             intermediate_pad=getattr(layer, "intermediate_pad", 0),
+            fused_moe_kwargs=fused_moe_kwargs,
         )
 
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -129,29 +129,9 @@ _use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
 
 
-def _aiter_mxfp8_moe_available() -> bool:
-    if not (_use_aiter and _is_gfx95_supported):
-        return False
-    try:
-        import os
-
-        import aiter
-
-        return os.path.exists(
-            os.path.join(
-                os.path.dirname(aiter.__file__),
-                "configs",
-                "model_configs",
-                "minimax_m3_mxfp8_tuned_fmoe.csv",
-            )
-        )
-    except Exception:
-        return False
-
-
-_use_aiter_mxfp8_moe = (
-    envs.SGLANG_USE_AITER_MXFP8_MOE.get() and _aiter_mxfp8_moe_available()
-)
+def _use_aiter_mxfp8_moe() -> bool:
+    """Whether the selected backend can consume native gfx950 MXFP8 weights."""
+    return _use_aiter and _is_gfx95_supported and get_moe_runner_backend().is_aiter()
 
 
 def _require_fp4_dtype():
@@ -1973,7 +1953,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     layer.w2_weight.data.shape, layer.w2_weight_scale_inv.data
                 )
 
-        if _use_aiter_mxfp8_moe and get_moe_runner_backend().is_aiter():
+        if _use_aiter_mxfp8_moe():
+            if not envs.SGLANG_USE_AITER_MOE_GU_ITLV.get():
+                raise NotImplementedError(
+                    "AITER MXFP8 MoE currently requires the gate/up-interleaved "
+                    "layout. Set SGLANG_USE_AITER_MOE_GU_ITLV=1."
+                )
+            from aiter.ops.shuffle import shuffle_scale, shuffle_weight
+
             num_experts = w13_q.shape[0]
             w13_q = shuffle_weight(w13_q, is_guinterleave=True, gate_up=True)
             w2_q = shuffle_weight(w2_q, is_guinterleave=True, gate_up=False)
@@ -2000,7 +1987,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         _copy_or_rebind(layer.w2_weight, w2_q)
         _copy_or_rebind(layer.w13_weight_scale_inv, w13_s)
         _copy_or_rebind(layer.w2_weight_scale_inv, w2_s)
-        if _use_aiter_mxfp8_moe and get_moe_runner_backend().is_aiter():
+        if _use_aiter_mxfp8_moe():
             layer.w13_weight.is_shuffled = True
             layer.w2_weight.is_shuffled = True
         layer.w13_weight.requires_grad_(False)
@@ -2645,7 +2632,12 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         layer: torch.nn.Module,
         no_combine: bool = False,
     ) -> Optional[AiterMoeQuantInfo]:
-        if not (_use_aiter or _use_hip_int4):
+        aiter_backend = (
+            _is_hip
+            and getattr(self, "runner", None) is not None
+            and self.runner.runner_backend.is_aiter()
+        )
+        if not (aiter_backend or _use_hip_int4):
             return None
         assert not no_combine, f"{no_combine=} is not supported."
 
@@ -2656,31 +2648,42 @@ class Fp8MoEMethod(FusedMoEMethodBase):
 
         w13_weight = layer.w13_weight
         w2_weight = layer.w2_weight
-        fused_moe_kwargs = None
+        activation = None
+        gate_up_interleaved = None
+        swiglu_limit = self.moe_runner_config.swiglu_limit or 0.0
 
-        if self.use_mxfp8 and _use_aiter_mxfp8_moe:
-            from aiter import ActivationType
-            from aiter.ops.flydsl.moe_common import GateMode
-
-            quant_type = AiterQuantType.PER_1X32
-            w13_weight.is_shuffled = True
-            w2_weight.is_shuffled = True
-            w13_scale = layer.w13_weight_scale_inv
-            w2_scale = layer.w2_weight_scale_inv
-            fused_moe_kwargs = {
-                "activation": ActivationType.Swiglu,
-                "gate_mode": GateMode.INTERLEAVE.value,
+        if self.block_quant:
+            block_shape = tuple(self.weight_block_size or ())
+            quant_type_by_block_shape = {
+                (1, 32): AiterQuantType.PER_1X32,
+                (128, 128): AiterQuantType.PER_128X128,
             }
-            if self.moe_runner_config.gemm1_clamp_limit is not None:
-                fused_moe_kwargs["swiglu_limit"] = float(
-                    self.moe_runner_config.gemm1_clamp_limit
+            try:
+                quant_type = quant_type_by_block_shape[block_shape]
+            except KeyError as exc:
+                raise NotImplementedError(
+                    f"AITER MoE does not support FP8 block shape {block_shape}."
+                ) from exc
+
+            if self.use_mxfp8:
+                if not _use_aiter_mxfp8_moe():
+                    raise NotImplementedError(
+                        "Native AITER MXFP8 MoE requires ROCm gfx950 and "
+                        "--moe-runner-backend aiter with SGLANG_USE_AITER=1."
+                    )
+                if not envs.SGLANG_USE_AITER_MOE_GU_ITLV.get():
+                    raise NotImplementedError(
+                        "AITER MXFP8 MoE currently requires the "
+                        "gate/up-interleaved layout."
+                    )
+                activation = (
+                    "swiglu"
+                    if self.moe_runner_config.is_gated
+                    else self.moe_runner_config.activation
                 )
-        elif self.block_quant:
-            quant_type = (
-                AiterQuantType.PER_1X32
-                if self.is_fp4_expert
-                else AiterQuantType.PER_128X128
-            )
+                gate_up_interleaved = True
+                if self.moe_runner_config.gemm1_clamp_limit is not None:
+                    swiglu_limit = float(self.moe_runner_config.gemm1_clamp_limit)
 
             if self.is_fp4_expert:
                 fp4_weight_dtype = _require_fp4_dtype()
@@ -2695,18 +2698,18 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             quant_type = AiterQuantType.PER_TOKEN
             w13_scale = layer.w13_weight_scale1
             w2_scale = layer.w2_weight_scale1
-            fused_moe_kwargs = None
         return AiterMoeQuantInfo(
             w13_weight=w13_weight,
             w2_weight=w2_weight,
             quant_type=quant_type,
             w13_scale=w13_scale,
             w2_scale=w2_scale,
-            expert_mask=layer.dispatcher.expert_mask_gpu if _use_aiter else None,
-            swiglu_limit=self.moe_runner_config.swiglu_limit or 0.0,
+            expert_mask=layer.dispatcher.expert_mask_gpu if aiter_backend else None,
+            swiglu_limit=swiglu_limit,
             hidden_pad=getattr(layer, "hidden_pad", 0),
             intermediate_pad=getattr(layer, "intermediate_pad", 0),
-            fused_moe_kwargs=fused_moe_kwargs,
+            activation=activation,
+            gate_up_interleaved=gate_up_interleaved,
         )
 
 

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -333,6 +333,12 @@ class MiniMaxM3MoE(nn.Module):
             prefix=add_prefix("experts", prefix),
             gate_up_interleaved=False,
         )
+        use_aiter_moe_fse = (
+            self.num_fused_shared_experts > 0
+            and _is_hip
+            and envs.SGLANG_USE_AITER.get()
+            and envs.SGLANG_USE_AITER_MXFP8_MOE.get()
+        )
         self.topk = TopK(
             top_k=config.num_experts_per_tok + self.num_fused_shared_experts,
             renormalize=True,
@@ -340,8 +346,11 @@ class MiniMaxM3MoE(nn.Module):
             scoring_func=config.scoring_func,
             correction_bias=self.e_score_correction_bias,
             num_fused_shared_experts=self.num_fused_shared_experts,
+            use_grouped_topk=use_aiter_moe_fse,
+            num_expert_group=1 if use_aiter_moe_fse else None,
+            topk_group=1 if use_aiter_moe_fse else None,
             routed_scaling_factor=self.routed_scaling_factor,
-            apply_routed_scaling_factor_on_output=True,
+            apply_routed_scaling_factor_on_output=not use_aiter_moe_fse,
         )
 
         if self.n_shared_experts is not None and self.num_fused_shared_experts == 0:

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -54,7 +54,10 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
-from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+from sglang.srt.layers.moe.utils import (
+    get_moe_a2a_backend,
+    get_moe_runner_backend,
+)
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -85,6 +88,7 @@ from sglang.srt.utils import (
     add_prefix,
     get_device_sm,
     is_cuda,
+    is_cuda_alike,
     is_hip,
     log_info_on_rank0,
     make_layers,
@@ -107,6 +111,7 @@ def _can_fuse_shared_expert(quant_config: Optional[QuantizationConfig]) -> bool:
         return True
     can_fuse_fn = getattr(quant_config, "can_fuse_shared_expert", None)
     return can_fuse_fn is None or bool(can_fuse_fn())
+
 
 # rotary_dim required by the fused qknorm+rope JIT kernel: rotary_dim/2 must
 # equal the CUDA warp size (32) so each warp norms+ropes one head in one pass.
@@ -337,7 +342,7 @@ class MiniMaxM3MoE(nn.Module):
             self.num_fused_shared_experts > 0
             and _is_hip
             and envs.SGLANG_USE_AITER.get()
-            and envs.SGLANG_USE_AITER_MXFP8_MOE.get()
+            and get_moe_runner_backend().is_aiter()
         )
         self.topk = TopK(
             top_k=config.num_experts_per_tok + self.num_fused_shared_experts,
@@ -1496,7 +1501,7 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
                 "Shared and routed experts may use different quantization formats "
                 "in ModelOpt mixed-precision checkpoints."
             )
-        elif not (_is_cuda or _is_hip):
+        elif not is_cuda_alike():
             disable_reason = (
                 "Shared experts fusion currently requires CUDA or ROCm devices."
             )

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -101,6 +101,13 @@ _FP8_KV_DTYPES = (
     torch.float8_e4m3fnuz,
 )
 
+
+def _can_fuse_shared_expert(quant_config: Optional[QuantizationConfig]) -> bool:
+    if quant_config is None:
+        return True
+    can_fuse_fn = getattr(quant_config, "can_fuse_shared_expert", None)
+    return can_fuse_fn is None or bool(can_fuse_fn())
+
 # rotary_dim required by the fused qknorm+rope JIT kernel: rotary_dim/2 must
 # equal the CUDA warp size (32) so each warp norms+ropes one head in one pass.
 _M3_FUSED_QKNORM_ROPE_ROTARY_DIM = 64
@@ -1480,10 +1487,16 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
                 "Shared and routed experts may use different quantization formats "
                 "in ModelOpt mixed-precision checkpoints."
             )
-        elif not _is_cuda:
-            disable_reason = "Shared experts fusion currently requires CUDA devices."
+        elif not (_is_cuda or _is_hip):
+            disable_reason = (
+                "Shared experts fusion currently requires CUDA or ROCm devices."
+            )
         elif _is_cuda and (_device_sm is not None) and (_device_sm < 80):
             disable_reason = "Shared experts fusion requires SM80 or newer GPUs."
+        elif not _can_fuse_shared_expert(self.quant_config):
+            disable_reason = (
+                "Shared experts fusion is not supported by this quantization config."
+            )
         elif get_parallel().moe_ep_size > 1:
             disable_reason = "Shared experts fusion is not supported together with expert parallelism yet."
         elif get_moe_a2a_backend().is_deepep():

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -44,14 +44,28 @@ from sglang.srt.models.minimax_vl_common import (
 )
 from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.runtime_context import get_exec, get_mm, get_parallel, get_server_args
-from sglang.srt.utils import add_prefix, get_device_sm, is_cuda, log_info_on_rank0
+from sglang.srt.utils import (
+    add_prefix,
+    get_device_sm,
+    is_cuda,
+    is_hip,
+    log_info_on_rank0,
+)
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 logger = logging.getLogger(__name__)
 
 
 _is_cuda = is_cuda()
+_is_hip = is_hip()
 _device_sm = get_device_sm()
+
+
+def _can_fuse_shared_expert(quant_config: Optional[QuantizationConfig]) -> bool:
+    if quant_config is None:
+        return True
+    can_fuse_fn = getattr(quant_config, "can_fuse_shared_expert", None)
+    return can_fuse_fn is None or bool(can_fuse_fn())
 
 
 class MiniMaxM3SparseForConditionalGeneration(nn.Module):
@@ -149,10 +163,16 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
                 "Shared and routed experts may use different quantization formats "
                 "in ModelOpt mixed-precision checkpoints."
             )
-        elif not _is_cuda:
-            disable_reason = "Shared experts fusion currently requires CUDA devices."
-        elif (_device_sm is not None) and (_device_sm < 80):
+        elif not (_is_cuda or _is_hip):
+            disable_reason = (
+                "Shared experts fusion currently requires CUDA or ROCm devices."
+            )
+        elif _is_cuda and (_device_sm is not None) and (_device_sm < 80):
             disable_reason = "Shared experts fusion requires SM80 or newer GPUs."
+        elif not _can_fuse_shared_expert(self.quant_config):
+            disable_reason = (
+                "Shared experts fusion is not supported by this quantization config."
+            )
         elif get_parallel().moe_ep_size > 1:
             disable_reason = (
                 "Shared experts fusion is not supported together with expert "

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -48,7 +48,7 @@ from sglang.srt.utils import (
     add_prefix,
     get_device_sm,
     is_cuda,
-    is_hip,
+    is_cuda_alike,
     log_info_on_rank0,
 )
 from sglang.srt.utils.hf_transformers_utils import get_rope_config
@@ -57,7 +57,6 @@ logger = logging.getLogger(__name__)
 
 
 _is_cuda = is_cuda()
-_is_hip = is_hip()
 _device_sm = get_device_sm()
 
 
@@ -163,7 +162,7 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
                 "Shared and routed experts may use different quantization formats "
                 "in ModelOpt mixed-precision checkpoints."
             )
-        elif not (_is_cuda or _is_hip):
+        elif not is_cuda_alike():
             disable_reason = (
                 "Shared experts fusion currently requires CUDA or ROCm devices."
             )

--- a/test/registered/unit/layers/moe/test_aiter_runner.py
+++ b/test/registered/unit/layers/moe/test_aiter_runner.py
@@ -40,7 +40,7 @@ def _quant_info(**overrides):
 def _install_fake_aiter(monkeypatch, fused_moe):
     fake_aiter = ModuleType("aiter")
     fake_aiter.__path__ = []
-    fake_aiter.ActivationType = SimpleNamespace(Silu="Silu")
+    fake_aiter.ActivationType = SimpleNamespace(Silu="Silu", Swiglu="Swiglu")
     fake_aiter.QuantType = SimpleNamespace(per_1x32="per_1x32")
 
     fake_fused_moe = ModuleType("aiter.fused_moe")
@@ -52,7 +52,8 @@ def _install_fake_aiter(monkeypatch, fused_moe):
     fake_flydsl.__path__ = []
     fake_moe_common = ModuleType("aiter.ops.flydsl.moe_common")
     fake_moe_common.GateMode = SimpleNamespace(
-        INTERLEAVE=SimpleNamespace(value="INTERLEAVE")
+        INTERLEAVE=SimpleNamespace(value="INTERLEAVE"),
+        SEPARATED=SimpleNamespace(value="SEPARATED"),
     )
 
     monkeypatch.setitem(sys.modules, "aiter", fake_aiter)
@@ -62,7 +63,7 @@ def _install_fake_aiter(monkeypatch, fused_moe):
     monkeypatch.setitem(sys.modules, "aiter.ops.flydsl.moe_common", fake_moe_common)
 
 
-def test_aiter_runner_forwards_no_combine_and_extra_fused_moe_kwargs(monkeypatch):
+def test_aiter_runner_forwards_no_combine(monkeypatch):
     captured = {}
 
     def fused_moe(**kwargs):
@@ -78,14 +79,42 @@ def test_aiter_runner_forwards_no_combine_and_extra_fused_moe_kwargs(monkeypatch
 
     runner.run(
         _runner_input(),
-        _quant_info(fused_moe_kwargs={"custom_fused_moe_kwarg": "enabled"}),
+        _quant_info(),
         running_state={},
     )
 
     assert captured["activation"] == "Silu"
     assert captured["quant_type"] == "per_1x32"
     assert captured["no_combine"] is True
-    assert captured["custom_fused_moe_kwarg"] == "enabled"
+
+
+@pytest.mark.parametrize(
+    ("gate_up_interleaved", "expected_gate_mode"),
+    [(True, "INTERLEAVE"), (False, "SEPARATED")],
+)
+def test_aiter_runner_forwards_explicit_layout_and_activation(
+    monkeypatch, gate_up_interleaved, expected_gate_mode
+):
+    captured = {}
+
+    def fused_moe(**kwargs):
+        captured.update(kwargs)
+        return kwargs["hidden_states"]
+
+    _install_fake_aiter(monkeypatch, fused_moe)
+    runner = AiterRunnerCore(MoeRunnerConfig(activation="silu"))
+
+    runner.run(
+        _runner_input(),
+        _quant_info(
+            activation="swiglu",
+            gate_up_interleaved=gate_up_interleaved,
+        ),
+        running_state={},
+    )
+
+    assert captured["activation"] == "Swiglu"
+    assert captured["gate_mode"] == expected_gate_mode
 
 
 def test_aiter_runner_rejects_no_combine_when_fused_moe_does_not_support_it(

--- a/test/registered/unit/layers/moe/test_fused_shared_expert_scaling.py
+++ b/test/registered/unit/layers/moe/test_fused_shared_expert_scaling.py
@@ -10,10 +10,6 @@ the fused shared expert's topk weight on the two paths this fix covers:
     routed_scaling_factor afterward, so the shared weight must be 1/rsf.
 """
 
-from sglang.test.ci.ci_register import register_cpu_ci
-
-register_cpu_ci(est_time=7, suite="base-a-test-cpu")
-
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -22,7 +18,10 @@ import torch
 
 from sglang.srt.layers.moe import topk as topk_module
 from sglang.srt.layers.moe.topk import TopKConfig
+from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=7, suite="base-a-test-cpu")
 
 
 class TestFusedSharedExpertScaling(CustomTestCase):
@@ -32,7 +31,7 @@ class TestFusedSharedExpertScaling(CustomTestCase):
     EP_RANK = 0
     ROUTED_SCALING_FACTOR = 2.5
 
-    def _run_remap(self, *, use_aiter):
+    def _run_remap(self, *, use_aiter, aiter_backend=None):
         # Layout: [routed, routed, routed, shared]; the trailing column is the
         # fused shared expert. The shared weight starts at a sentinel to prove
         # the function overwrites it.
@@ -46,8 +45,15 @@ class TestFusedSharedExpertScaling(CustomTestCase):
             routed_scaling_factor=self.ROUTED_SCALING_FACTOR,
         )
 
+        if aiter_backend is None:
+            aiter_backend = use_aiter
         with (
             patch.object(topk_module, "_use_aiter", use_aiter),
+            patch.object(
+                topk_module,
+                "get_moe_runner_backend",
+                return_value=SimpleNamespace(is_aiter=lambda: aiter_backend),
+            ),
             patch.object(
                 topk_module,
                 "get_parallel",
@@ -80,6 +86,10 @@ class TestFusedSharedExpertScaling(CustomTestCase):
         shared_weight = self._run_remap(use_aiter=False)
         self.assertAlmostEqual(shared_weight, 1.0 / self.ROUTED_SCALING_FACTOR)
 
+    def test_aiter_helpers_do_not_change_non_aiter_backend_scaling(self):
+        shared_weight = self._run_remap(use_aiter=True, aiter_backend=False)
+        self.assertAlmostEqual(shared_weight, 1.0 / self.ROUTED_SCALING_FACTOR)
+
     def test_shared_expert_ids_route_to_home_rank(self):
         # Sanity: the shared slot id is placed at this rank's interleaved
         # position (ep_rank * num_local_experts + num_local_routed).
@@ -92,6 +102,11 @@ class TestFusedSharedExpertScaling(CustomTestCase):
         )
         with (
             patch.object(topk_module, "_use_aiter", True),
+            patch.object(
+                topk_module,
+                "get_moe_runner_backend",
+                return_value=SimpleNamespace(is_aiter=lambda: True),
+            ),
             patch.object(
                 topk_module,
                 "get_parallel",
@@ -111,6 +126,31 @@ class TestFusedSharedExpertScaling(CustomTestCase):
         num_local_experts = num_local_routed + 1  # 33
         expected_shared_id = self.EP_RANK * num_local_experts + num_local_routed
         self.assertEqual(out_ids[0, -1].item(), expected_shared_id)
+
+    def test_aiter_fse_metadata_cache_separates_expert_counts(self):
+        topk_module._aiter_fse_topk_meta.clear()
+        try:
+            _, ids_128 = topk_module._get_aiter_fse_topk_meta(
+                num_tokens=2,
+                routed_topk=4,
+                num_fused_shared_experts=1,
+                num_routed_experts=128,
+                dtype=torch.float32,
+                device=torch.device("cpu"),
+            )
+            _, ids_64 = topk_module._get_aiter_fse_topk_meta(
+                num_tokens=2,
+                routed_topk=4,
+                num_fused_shared_experts=1,
+                num_routed_experts=64,
+                dtype=torch.float32,
+                device=torch.device("cpu"),
+            )
+
+            self.assertTrue(torch.equal(ids_128[:, -1], torch.tensor([128, 128])))
+            self.assertTrue(torch.equal(ids_64[:, -1], torch.tensor([64, 64])))
+        finally:
+            topk_module._aiter_fse_topk_meta.clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

MiniMax-M3 MXFP8 on ROCm needs two pieces to run efficiently and correctly with fused shared experts:

1. Shared-expert fusion must only use the AITER-specific top-k/shared-slot path when the actual MoE runner is AITER. Otherwise, enabling ROCm AITER helper kernels can accidentally change the Triton MoE routing path.
2. The MXFP8 MoE weights and scales need to be prepared in the layout expected by AITER's `per_1x32` fused MoE kernels, and fused shared experts need to be included in the AITER top-k buffer without a separate append pass.

This PR adds the AITER MXFP8 MoE path for MiniMax-M3 on ROCm while preserving the existing Triton MoE behavior.

## Modifications

- Gate MiniMax-M3 fused shared-expert routing on the actual AITER MoE backend instead of only `SGLANG_USE_AITER`.
- Add an AITER fused-shared-expert top-k metadata buffer so routed experts and shared experts are passed to AITER MoE in one total top-k tensor.
- Add an opt-in `SGLANG_USE_AITER_MXFP8_MOE` path for gfx950 MXFP8 MoE when the AITER MiniMax-M3 MXFP8 tuned config is available.
- Preshuffle MXFP8 MoE weights and scales for the AITER `per_1x32` layout and mark the tensors as shuffled for AITER fused MoE dispatch.
- Pass Swiglu/interleaved-gate metadata through the AITER runner.
- Allow MiniMax-M3 ROCm model overrides to publish `disable_custom_all_reduce`.

## Accuracy Tests

GSM8K full set, 1319 examples, `sgl-eval run gsm8k --thinking --temperature 1.0 --top-p 0.95`, 64 eval threads:

| Config | max_tokens | Score | Stop rate | Truncated rate | Error rate |
| --- | ---: | ---: | ---: | ---: | ---: |
| Triton MoE + FSE | 4096 | 96.59% | 98.79% | 1.21% | 0.00% |
| AITER MXFP8 MoE | 4096 | 96.06% | 98.86% | 1.14% | 0.00% |
| AITER MXFP8 MoE + FSE | 32768 | 96.59% | 99.92% | 0.08% | 0.00% |

The AITER MXFP8 MoE + FSE run used `--quantization mxfp8 --attention-backend aiter --moe-runner-backend aiter --enforce-shared-experts-fusion --tp-size 8`.

## Speed Tests and Profiling

Random serving benchmark, 640 prompts, `--random-input-len 8192`, `--random-output-len 1024`, `--random-range-ratio 1.0`, `--max-concurrency 64`, `--request-rate inf`, and `--warmup-requests 128`.

| Config | Successful requests | Duration (s) | Req/s | Input tok/s | Output tok/s | Total tok/s | Mean TTFT (ms) | Mean TPOT (ms) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| AITER MXFP8 MoE + FSE | 640 | 375.27 | 1.705 | 13971.12 | 1746.39 | 15717.51 | 8028.41 | 27.47 |
| AITER MXFP8 MoE | 640 | 430.83 | 1.485 | 12169.17 | 1521.15 | 13690.31 | 8723.37 | 31.90 |
| Triton MoE + FSE | 640 | 479.73 | 1.334 | 10928.85 | 1366.11 | 12294.96 | 10529.05 | 34.85 |
| Triton MoE | 640 | 530.07 | 1.207 | 9890.91 | 1236.36 | 11127.28 | 10592.82 | 39.38 |

Relative to the corresponding non-FSE runs, FSE improves output throughput by 14.8% for AITER MXFP8 MoE and 10.5% for Triton MoE in this workload.

The runs used `--quantization mxfp8 --tp-size 8`; the AITER rows used `--moe-runner-backend aiter`, and the Triton rows used `--moe-runner-backend triton`. FSE rows used `--enforce-shared-experts-fusion`; non-FSE rows used `--disable-shared-experts-fusion`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30794593815](https://github.com/sgl-project/sglang/actions/runs/30794593815)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30794593690](https://github.com/sgl-project/sglang/actions/runs/30794593690)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


