### PR TITLE
Fix InklingDetector crashing on a streamed JSON-string tool-call payload

### DIFF
--- a/python/sglang/srt/function_call/inkling_detector.py
+++ b/python/sglang/srt/function_call/inkling_detector.py
@@ -4,7 +4,7 @@ import re
 from collections.abc import Mapping
 from typing import List, Optional
 
-from partial_json_parser.core.exceptions import MalformedJSON
+from partial_json_parser.core.exceptions import MalformedJSON, PartialJSON
 from partial_json_parser.core.options import Allow
 from xgrammar import StructuralTag
 
@@ -173,7 +173,14 @@ class InklingDetector(BaseFormatDetector):
         flags = Allow.ALL if self.current_tool_name_sent else Allow.ALL & ~Allow.STR
         try:
             payload, end_idx = _partial_json_loads(current_text[start_idx:], flags)
-        except (MalformedJSON, json.JSONDecodeError):
+        except (MalformedJSON, PartialJSON, json.JSONDecodeError):
+            # PartialJSON and MalformedJSON are the two subclasses of
+            # partial_json_parser's own JSONDecodeError, which is unrelated to
+            # the stdlib one -- catching json.JSONDecodeError does not cover it.
+            # partial_json_parser raises PartialJSON for an incomplete string
+            # while Allow.STR is masked off (i.e. before the tool name is sent),
+            # which happens whenever a payload begins with a quote instead of an
+            # object. detect_and_parse already rejects those payloads gracefully.
             return StreamingParseResult(), False
         if not isinstance(payload, Mapping):
             return StreamingParseResult(), False

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -49,6 +49,30 @@ class TestInklingDetector(unittest.TestCase):
             )
         ]
 
+    def test_streaming_string_payload_does_not_raise(self):
+        """A JSON-string payload must not escape the streaming entry point.
+
+        partial_json_parser raises PartialJSON for an incomplete string while
+        Allow.STR is masked off. PartialJSON subclasses partial_json_parser's
+        own JSONDecodeError, not the stdlib one, so it slipped past the handler
+        and propagated out of parse_streaming_increment. Non-streaming already
+        rejected these payloads gracefully.
+        """
+        for source in (
+            '<|content_invoke_tool_json|>"hello"<|end_message|>',
+            '<|message_model|>weather<|content_invoke_tool_json|>"hello"<|end_message|>',
+            '<|content_invoke_tool_json|>"unterminated',
+        ):
+            with self.subTest(source=source):
+                detector = InklingDetector()
+                for ch in source:
+                    detector.parse_streaming_increment(ch, self.tools)
+                # And the non-streaming path stays graceful on the same input.
+                self.assertEqual(
+                    len(InklingDetector().detect_and_parse(source, self.tools).calls),
+                    0,
+                )
+
     def test_canonical_header_is_not_visible_content(self):
         detector = InklingDetector()
         source = (


### PR DESCRIPTION
## Motivation

`InklingDetector.parse_streaming_increment` raises an unhandled exception when a tool-call payload arrives as a JSON string instead of an object. Because it escapes the public streaming entry point, it surfaces as a 500 rather than as a rejected tool call.

`partial_json_parser` defines its **own** `JSONDecodeError`, unrelated to the stdlib one, with exactly two subclasses — `MalformedJSON` and `PartialJSON`:

```python
>>> issubclass(PartialJSON, json.JSONDecodeError)   # stdlib
False
>>> issubclass(PartialJSON, MalformedJSON)
False
```

`_parse_buffered_increment` catches `(MalformedJSON, json.JSONDecodeError)`, so `PartialJSON` slips past. It is raised for an incomplete string while `Allow.STR` is masked off — which is exactly the flag state before the tool name has been sent (`inkling_detector.py:173`). So any payload beginning with a quote rather than `{` crashes the streaming path.

The asymmetry is the clearest statement of the bug: **`detect_and_parse` already rejects these payloads gracefully** (logging `Invalid Inkling tool call payload` and returning zero calls). Streaming and non-streaming disagree on identical input.

## Modifications

- Add `PartialJSON` to the caught tuple in `_parse_buffered_increment`, with a comment recording why stdlib `json.JSONDecodeError` does not cover it.
- Add `TestInklingDetector.test_streaming_string_payload_does_not_raise`, covering all three affected shapes and asserting the non-streaming path stays graceful on the same input.

## Repro (before this PR)

```python
from sglang.srt.function_call.inkling_detector import InklingDetector

det = InklingDetector()
for ch in '<|content_invoke_tool_json|>"hello"<|end_message|>':
    det.parse_streaming_increment(ch, tools)   # PartialJSON at char 28
```

I swept nine payload shapes through the public streaming API against `main`:

| payload shape | before | after |
|---|---|---|
| string, no header | **PartialJSON @28** | ok |
| string, with model header | **PartialJSON @56** | ok |
| string, unterminated | **PartialJSON @28** | ok |
| object (well-formed) | ok (1 call) | ok (1 call) |
| number / array / bool / null / empty | ok | ok |

## Accuracy Tests

Not applicable — no kernel or model forward code is touched.

## Speed Tests and Profiling

Not applicable — an exception-handler tuple in a parser error path.

## Checklist

- The new test fails on unmodified `main` (all three subtests raise `PartialJSON`) and passes with this change.
- `test_function_call_parser.py` + `test_parallel_tool_calls.py`: 177 passed, unchanged against a 176-passed baseline apart from the added test. The 15 pre-existing `TestDeepSeekV4Detector` failures are present identically with and without this change and are unrelated.
- `black`, `isort --profile black`, and `ruff --select=F401,F821,UP037` (the repo's pre-commit selection) are clean on both files.
- Verified against `108182cb8`.

Note: as a first-time contributor I can't add the `run-ci` label or trigger CI — a maintainer will need to apply it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29976641022](https://github.com/sgl-project/sglang/actions/runs/29976641022)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29976640893](https://github.com/sgl-project/sglang/actions/runs/29976640893)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->