### PR TITLE
Resolve per-GPU IB device for remote-instance P2P weight loading

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -33,6 +33,24 @@ class RemoteInstanceWeightTransporter:
         return self.get_model()
 
     def init_engine(self):
+        """Initialize the Mooncake ``TransferEngine`` for remote-instance P2P
+        weight loading.
+
+        ``MOONCAKE_DEVICE`` selects the RDMA NIC(s) for the transfer and accepts
+        either:
+
+        * a shared spec applied to every rank, e.g. ``"mlx5_0"`` or
+          ``"mlx5_0,mlx5_1"``; or
+        * a per-GPU mapping so each TP rank binds to its NUMA-local NIC, given
+          as inline JSON ``{"0": "mlx5_0", "1": "mlx5_1"}`` or a path to a
+          ``.json`` file with the same mapping.
+
+        The per-GPU device is resolved here and passed to
+        ``TransferEngine.initialize()``. Under the TENT runtime it reaches
+        ``topology/rdma_whitelist`` (deterministic per-rank NIC binding); with
+        the classic engine the device filter is honored directly. When
+        ``MOONCAKE_DEVICE`` is unset, the engine auto-selects NICs.
+        """
         try:
             from mooncake.engine import TransferEngine
         except ImportError:
@@ -42,11 +60,19 @@ class RemoteInstanceWeightTransporter:
             return
         self.engine = TransferEngine()
         local_ip = get_local_ip_auto()
+        from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import (
+            get_ib_devices_for_gpu,
+        )
+
+        ib_device = (
+            get_ib_devices_for_gpu(envs.MOONCAKE_DEVICE.get(), self.gpu_id)
+            or envs.MOONCAKE_DEVICE.get()
+        )
         self.engine.initialize(
             local_ip,
             "P2PHANDSHAKE",
             envs.MOONCAKE_PROTOCOL.get(),
-            envs.MOONCAKE_DEVICE.get(),
+            ib_device,
         )
         self.session_id = NetworkAddress(
             local_ip, self.engine.get_rpc_port()

--- a/test/registered/unit/model_loader/test_remote_instance_per_gpu_nic.py
+++ b/test/registered/unit/model_loader/test_remote_instance_per_gpu_nic.py
@@ -1,0 +1,64 @@
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sglang.srt.model_executor.model_runner_components.remote_instance_weight_transporter as transporter_mod
+from sglang.srt.environ import envs
+from sglang.srt.model_executor.model_runner_components.remote_instance_weight_transporter import (
+    RemoteInstanceWeightTransporter,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestRemoteInstancePerGpuNic(CustomTestCase):
+    """`init_engine()` should resolve the per-GPU NIC from MOONCAKE_DEVICE and
+    pass it to `TransferEngine.initialize()` so each rank binds to its own NIC.
+    """
+
+    def _make_transporter(self, gpu_id: int) -> RemoteInstanceWeightTransporter:
+        return RemoteInstanceWeightTransporter(
+            server_args=object(),
+            get_model=lambda: None,
+            tp_rank=gpu_id,
+            gpu_id=gpu_id,
+        )
+
+    def _run_init_engine(self, transporter: RemoteInstanceWeightTransporter):
+        fake_engine = MagicMock()
+        fake_engine.get_rpc_port.return_value = 12345
+        fake_engine_cls = MagicMock(return_value=fake_engine)
+
+        fake_mooncake = types.ModuleType("mooncake")
+        fake_mooncake_engine = types.ModuleType("mooncake.engine")
+        fake_mooncake_engine.TransferEngine = fake_engine_cls
+        fake_mooncake.engine = fake_mooncake_engine
+
+        with patch.dict(
+            sys.modules,
+            {"mooncake": fake_mooncake, "mooncake.engine": fake_mooncake_engine},
+        ), patch.object(transporter_mod, "get_local_ip_auto", return_value="10.0.0.1"):
+            transporter.init_engine()
+
+        fake_engine.initialize.assert_called_once()
+        # initialize(local_ip, "P2PHANDSHAKE", protocol, ib_device)
+        return fake_engine.initialize.call_args.args[3]
+
+    def test_per_gpu_mapping_resolves_rank_device(self):
+        transporter = self._make_transporter(gpu_id=1)
+        with envs.MOONCAKE_DEVICE.override('{"0": "mlx5_0", "1": "mlx5_1"}'):
+            passed_device = self._run_init_engine(transporter)
+        self.assertEqual(passed_device, "mlx5_1")
+
+    def test_shared_device_passed_through(self):
+        transporter = self._make_transporter(gpu_id=3)
+        with envs.MOONCAKE_DEVICE.override("mlx5_0"):
+            passed_device = self._run_init_engine(transporter)
+        self.assertEqual(passed_device, "mlx5_0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang already lets users pin the RDMA NIC for Mooncake-based P2P weight
loading through `MOONCAKE_DEVICE`, including a **per-GPU** mapping
(`{gpu_id: "nic"}` or a JSON file) so each TP rank can use its NUMA-local NIC —
the `get_ib_devices_for_gpu()` helper exists for exactly this purpose.

However, the remote-instance weight loading path never applies it: it forwards
the raw `MOONCAKE_DEVICE` string to `TransferEngine.initialize()` unchanged. On
multi-NIC RDMA nodes this means remote-instance P2P weight loading cannot bind
each rank to its local NIC, leaving large load-time speedups unused and risking
imbalanced / cross-NUMA NIC usage.

## Modifications

The remote instance weight transporter passed the raw `MOONCAKE_DEVICE` value
directly to `TransferEngine.initialize()`, without resolving per-GPU device
selection. When `MOONCAKE_DEVICE` is a per-GPU mapping/JSON this meant no rank
actually bound to a specific NIC.

Resolve the per-GPU device via `get_ib_devices_for_gpu()` and pass it to
`initialize()`. It falls back to the raw `MOONCAKE_DEVICE` when no per-GPU
mapping is given, so existing setups are unaffected. This needs no extra
environment variable — it relies solely on the device argument that
`initialize()` already accepts.

Under the Mooncake TENT runtime the resolved device reaches
`topology/rdma_whitelist` (requires kvcache-ai/Mooncake#2994); with the classic
TransferEngine the device filter is already honored, so this works today.

## Accuracy Tests

N/A — this does not change model outputs; it only selects which NIC carries the
P2P weight transfer.

## Speed Tests and Profiling

Measured on a 2-node RoCE cluster (5×200G RDMA NICs across 2 NUMA domains),
DeepSeek-V3.1 (~685GB, TP=8) remote-instance P2P weight loading, 10 runs each
(bottleneck-rank load time):

| NIC selection                   | Load time | vs auto      |
|---------------------------------|-----------|--------------|
| auto (baseline)                 | 16.8s     | 1.0×         |
| per-rank NUMA-local (this PR)   | 7.7s      | ~2.2× faster |
| per-rank cross-NUMA (misconfig) | 77.5s     | 4.6× slower  |

Per-rank transferred bytes are unchanged (85.1 GB/rank); only the NIC path
changes.

## Checklist

- [x] Format your code according to the Format code with pre-commit guide
- [ ] Add unit tests (the path needs multi-NIC RDMA hardware; happy to add a
      targeted test if maintainers suggest a suitable harness)
- [ ] Update documentation (N/A — no user-facing API change)
- [x] Provide speed benchmark results (above)
- [x] Follow the SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29977355273](https://github.com/sgl-project/sglang/actions/runs/29977355273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29977355237](https://github.com/sgl-project/sglang/actions/runs/29977355237)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->