### PR TITLE
[attention] Fix broken nsa_backend backward-compat shim (ImportError)

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -3326,9 +3326,12 @@ class DeepseekSparseAttnMultiStepBackend:
             self.attn_backends[i].init_forward_metadata_in_graph(forward_batch)
 
 
-# Backward-compat aliases (deprecated: use DSA class names)
-DeepseekSparseAttnBackend = DeepseekSparseAttnBackend
-DeepseekSparseAttnMultiStepBackend = DeepseekSparseAttnMultiStepBackend
-DSAMetadata = DSAMetadata
-DSAFlashMLAMetadata = DSAFlashMLAMetadata
-DSAIndexerMetadata = DSAIndexerMetadata
+# Backward-compat aliases (deprecated: use DSA class names).
+# NSA (Native Sparse Attention) is the pre-rename public API re-exported by
+# nsa_backend.py; map those names to the current DSA classes so that importing
+# the deprecation shim keeps working.
+NativeSparseAttnBackend = DeepseekSparseAttnBackend
+NativeSparseAttnMultiStepBackend = DeepseekSparseAttnMultiStepBackend
+NSAMetadata = DSAMetadata
+NSAFlashMLAMetadata = DSAFlashMLAMetadata
+NSAIndexerMetadata = DSAIndexerMetadata

--- a/test/registered/unit/layers/attention/test_nsa_backend_compat.py
+++ b/test/registered/unit/layers/attention/test_nsa_backend_compat.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+import unittest
+import warnings
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+_NSA_MODULE = "sglang.srt.layers.attention.nsa_backend"
+
+
+class TestNsaBackendCompatShim(CustomTestCase):
+    """`nsa_backend.py` is a deprecation shim that re-exports the renamed DSA
+    classes under their old NSA (Native Sparse Attention) names. Regression guard
+    for the shim: importing it must succeed and every aliased name must resolve to
+    the current DSA class (previously it raised ImportError because the alias block
+    self-assigned the DSA names instead of defining the NSA names)."""
+
+    def test_shim_imports_and_all_nsa_aliases_resolve(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            nsa = importlib.import_module(_NSA_MODULE)
+        from sglang.srt.layers.attention.dsa_backend import (
+            DeepseekSparseAttnBackend,
+            DeepseekSparseAttnMultiStepBackend,
+            DSAFlashMLAMetadata,
+            DSAIndexerMetadata,
+            DSAMetadata,
+        )
+
+        self.assertIs(nsa.NativeSparseAttnBackend, DeepseekSparseAttnBackend)
+        self.assertIs(
+            nsa.NativeSparseAttnMultiStepBackend, DeepseekSparseAttnMultiStepBackend
+        )
+        self.assertIs(nsa.NSAMetadata, DSAMetadata)
+        self.assertIs(nsa.NSAFlashMLAMetadata, DSAFlashMLAMetadata)
+        self.assertIs(nsa.NSAIndexerMetadata, DSAIndexerMetadata)
+
+    def test_shim_emits_deprecation_warning(self):
+        sys.modules.pop(_NSA_MODULE, None)
+        with self.assertWarns(DeprecationWarning):
+            importlib.import_module(_NSA_MODULE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`sglang.srt.layers.attention.nsa_backend` is a backward-compatibility shim that is meant to re-export the DSA backend under its former "NSA" names. The alias block at the end of `dsa_backend.py` currently assigns the DSA names to themselves (`DSAMetadata = DSAMetadata`, `DSAFlashMLAMetadata = DSAFlashMLAMetadata`, ...) instead of aliasing them to the NSA names the shim expects. As a result `nsa_backend` imports names that do not exist (`NativeSparseAttnBackend`, `NSAMetadata`, `NSAFlashMLAMetadata`, `NSAIndexerMetadata`) and raises `ImportError` on any `import ...nsa_backend` — the deprecation shim is entirely broken.

## Modifications

- `dsa_backend.py`: alias the DSA classes to their NSA-compat names so the shim resolves and emits its intended `DeprecationWarning`. The DSA backend itself is unchanged.
- Add `test/registered/unit/layers/attention/test_nsa_backend_compat.py`: imports the shim, asserts the NSA names resolve to the DSA classes, and checks the deprecation warning fires.

## Accuracy Tests

Import-only / class-identity change; no model outputs affected. `import sglang.srt.layers.attention.nsa_backend` now succeeds (previously `ImportError`); new unit test passes.

## Checklist
- [x] Format with pre-commit
- [x] Add unit tests

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29976913950](https://github.com/sgl-project/sglang/actions/runs/29976913950)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29976913805](https://github.com/sgl-project/sglang/actions/runs/29976913805)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->