### PR TITLE
[NPU] Support DeepSeek-V4 on A2

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -291,6 +291,13 @@ else:
 
 logger = logging.getLogger(__name__)
 
+
+def _prewarm_hccl_group(device, group, device_module):
+    warmup_tensor = torch.zeros(1, dtype=torch.int32, device=device)
+    torch.distributed.all_reduce(warmup_tensor, group=group)
+    device_module.synchronize()
+
+
 # Test retract decode for debugging purposes
 TEST_RETRACT = envs.SGLANG_TEST_RETRACT.get()
 TEST_RETRACT_INTERVAL = envs.SGLANG_TEST_RETRACT_INTERVAL.get()
@@ -464,6 +471,23 @@ class Scheduler(
         self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
         self.disable_radix_cache = result.disable_radix_cache
         self.tree_cache = result.tree_cache
+
+        if (
+            _is_npu
+            and self.tp_worker.model_runner.model_config.is_deepseek_v4_arch
+        ):
+            rank = (
+                self.ps.dp_rank
+                if self.ps.dp_rank is not None
+                else self.tp_group.rank_in_group
+            )
+            logger.info("HCCL DP prewarm start: rank=%s", rank)
+            _prewarm_hccl_group(
+                device=self.tp_group.device,
+                group=self.tp_group.device_group,
+                device_module=self.tp_group.device_module,
+            )
+            logger.info("HCCL DP prewarm done: rank=%s", rank)
 
         if (c := self.tp_worker.model_runner.canary_manager) is not None:
             c.attach_radix_cache(self.tree_cache)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -472,10 +472,7 @@ class Scheduler(
         self.disable_radix_cache = result.disable_radix_cache
         self.tree_cache = result.tree_cache
 
-        if (
-            _is_npu
-            and self.tp_worker.model_runner.model_config.is_deepseek_v4_arch
-        ):
+        if _is_npu and self.tp_worker.model_runner.model_config.is_deepseek_v4_arch:
             rank = (
                 self.ps.dp_rank
                 if self.ps.dp_rank is not None


### PR DESCRIPTION
## Motivation

DeepSeek-V4 with overlap scheduling fails during the first decode batch on Ascend A2. `SparseAttnSharedkvMetadata` reports AICPU error `507018` (`0x2a`, invalid parameter) when the target HCCL device communicator has not completed lazy initialization before the first Metadata execution.

A one-time blocking HCCL collective before the first DSV4 forward establishes the required device-side communication state and avoids this initialization-order issue. The change is limited to NPU + DeepSeek-V4 and does not affect other devices or model architectures.

## Modifications

- Add a one-time HCCL prewarm helper that runs an int32 `all_reduce` on the TP device group and synchronizes the device.
- Invoke the prewarm after KV-cache initialization and before overlap scheduling starts.
- Log per-rank prewarm start and completion for startup diagnostics.

## Accuracy Tests

Validated DeepSeek-V4-Flash W8A8 ModelSlim on 8 Ascend 910B3 devices with overlap scheduling enabled.

| Benchmark | Configuration | Result |
| --- | --- | ---: |
| GSM8K | 5-shot, 200 questions, concurrency 8, `temperature=0`, `top_p=1`, `max_tokens=2048` | **99.0% (198/200)** |

## Validation

- All 8 ranks completed HCCL prewarm before the first model warmup.
- Server startup and first decode completed without `SparseAttnSharedkvMetadata` error `507018`.
- GSM8K completed with 0 request errors.
- Server health check returned HTTP 200 after evaluation.
- `python3 -m compileall -q python/sglang/srt/managers/scheduler.py`: passed.
- `git diff --check`: passed.
- `pre-commit` was unavailable in the test container.

## Checklist

- [x] The change is scoped to NPU DeepSeek-V4 startup.
- [x] Accuracy and runtime validation results are provided.
- [x] Documentation changes are not required for this startup fix.
- [x] The PR contains only the HCCL prewarm implementation; no unit-test changes are included.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29980416894](https://github.com/sgl-project/sglang/actions/runs/29980416894)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29980416771](https://github.com/sgl-project/sglang/actions/runs/29980416771)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->