### PR TITLE
[docs] Fix inconsistent MOONCAKE_PROTOCOL supported values and default

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -1529,7 +1529,7 @@ SGLang supports various environment variables that can be used to configure its 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>MOONCAKE_PROTOCOL</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Mooncake transport protocol.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Mooncake transport protocol: <code>rdma</code>, <code>tcp</code>, or <code>efa</code>.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>rdma</code></td>
     </tr>
     <tr>

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/README.md
@@ -159,7 +159,7 @@ python -m mooncake.mooncake_store_service --port=8081
 * `local_hostname`, `MOONCAKE_LOCAL_HOSTNAME`: The hostname of the `store service`.
 * `metadata_server`, `MOONCAKE_TE_META_DATA_SERVER` : The network address of the `metadata service`. The default port is 8080. If the `metadata service` is not deployed, set this field to: `"metadata_server": "P2PHANDSHAKE"`.
 * `master_server_address`, `MOONCAKE_MASTER`: The network address of the `master service`. The default port is 50051.
-* `protocol`, `MOONCAKE_PROTOCOL`: The protocol used by Mooncake. Supported values are `"rdma"` or `"tcp"`. For optimal performance, `"rdma"` is recommended.
+* `protocol`, `MOONCAKE_PROTOCOL`: The protocol used by Mooncake. Supported values are `"rdma"`, `"tcp"`, or `"efa"` (AWS EFA). For optimal performance, `"rdma"` is recommended.
 * `device_name`, `MOONCAKE_DEVICE`: The RDMA devices used by Mooncake. This field can usually be left empty, as Mooncake automatically discovers available NICs by default. This parameter is required only when the protocol is set to `"rdma"` **and** a specific set of NICs needs to be used. Example: `"device_name": "mlx5_0,mlx5_1"`. To list available devices, run `ibv_devices`. **Note:** If the environment variable `MC_MS_AUTO_DISC` is set to `1`, any `device_name` or `MOONCAKE_DEVICE` configuration will be overridden, and Mooncake will switch to auto-discovery mode.
   - For tensor parallel deployments where different ranks should use different devices, you can specify device configurations using JSON format:
     ```json
@@ -358,7 +358,7 @@ mooncake_client --global_segment_size=4GB
 
 - **`metadata_server`**: (string, default: "http://localhost:8080/metadata"): The address of the metadata service.
 
-- **`protocol`**: (string, default: "tcp"): The protocol used by the Transfer Engine.
+- **`protocol`**: (string, default: "rdma"): The protocol used by the Transfer Engine.
 
 - **`device_name`**: (string, default: ""): The device name used by the Transfer Engine.
 


### PR DESCRIPTION
## Motivation

`MOONCAKE_PROTOCOL`'s supported values and default are documented inconsistently:
- `mooncake_store/README.md` lists only `"rdma"` or `"tcp"`;
- the Transfer Engine config section of the same README states the default as `"tcp"`;
- `environment_variables.mdx` gives no value list.

In code the default is `"rdma"` (`environ.py`: `EnvStr("rdma")`), and the transport-selection comment in `mooncake_transfer_engine.py` lists `rdma | efa | tcp`.

## Modifications

- `mooncake_store/README.md`: add `"efa"` to the supported values; fix the Transfer Engine config default from `"tcp"` to `"rdma"`.
- `environment_variables.mdx`: list the supported values (`rdma`, `tcp`, `efa`) in the description.

Docs-only; no code changes.

## Checklist
- [x] Documentation updated

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29980937327](https://github.com/sgl-project/sglang/actions/runs/29980937327)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29980937232](https://github.com/sgl-project/sglang/actions/runs/29980937232)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->