### PR TITLE
Fix streaming tool calls losing arguments when completed in the final delta

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2186,6 +2186,10 @@ class OpenAIServingChat(OpenAIServingBase):
         Check for any remaining tool call arguments that need to be streamed
         when generation finishes. This ensures tool calls are properly completed
         even if the model generates the final arguments in the last chunk.
+
+        Every tracked tool call is checked (not just the last one): with
+        speculative decoding several short calls can complete inside the
+        final delta, each potentially holding unstreamed arguments.
         """
         # Get the detector - either from FunctionCallParser or directly if json detector
         detector = parser.detector if hasattr(parser, "detector") else parser
@@ -2203,27 +2207,32 @@ class OpenAIServingChat(OpenAIServingBase):
         ):
             return None
 
-        # Get the last tool call that was being processed
-        tool_index = len(detector.prev_tool_call_arr) - 1
-        if tool_index < 0 or tool_index >= len(detector.streamed_args_for_tool):
-            return None
+        sse_chunks = []
+        for tool_index in range(len(detector.prev_tool_call_arr)):
+            if tool_index >= len(detector.streamed_args_for_tool):
+                break
 
-        # Get expected vs actual arguments
-        expected_args = detector.prev_tool_call_arr[tool_index].get("arguments", {})
-        if isinstance(expected_args, str):
-            expected_call = expected_args
-        else:
-            expected_call = json.dumps(expected_args, ensure_ascii=False)
-        actual_call = detector.streamed_args_for_tool[tool_index]
+            # Get expected vs actual arguments; skip placeholder entries
+            # that never parsed an arguments object.
+            expected_args = detector.prev_tool_call_arr[tool_index].get("arguments")
+            if expected_args is None:
+                continue
+            if isinstance(expected_args, str):
+                expected_call = expected_args
+            else:
+                expected_call = json.dumps(expected_args, ensure_ascii=False)
+            actual_call = detector.streamed_args_for_tool[tool_index]
 
-        # Check if there are remaining arguments to send
-        remaining_call = (
-            expected_call[len(actual_call) :]
-            if expected_call.startswith(actual_call)
-            else ""
-        )
+            # Check if there are remaining arguments to send
+            remaining_call = (
+                expected_call[len(actual_call) :]
+                if expected_call.startswith(actual_call)
+                else ""
+            )
 
-        if remaining_call:
+            if not remaining_call:
+                continue
+
             # Create tool call chunk with remaining arguments
             tool_call = ToolCall(
                 id=None,  # No ID for argument deltas
@@ -2247,6 +2256,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 model=request.model,
             )
 
-            return f"data: {chunk.model_dump_json()}\n\n"
+            sse_chunks.append(f"data: {chunk.model_dump_json()}\n\n")
+            detector.streamed_args_for_tool[tool_index] = expected_call
 
-        return None
+        return "".join(sse_chunks) or None

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -267,6 +267,21 @@ class BaseFormatDetector(ABC):
                         ],
                     )
                     self.current_tool_name_sent = True
+
+                    # If the tool call JSON is already complete in this chunk,
+                    # register it in prev_tool_call_arr so the finish-time
+                    # flush (_check_for_unstreamed_tool_args) can emit the
+                    # full arguments even when no further delta arrives
+                    # (e.g. speculative decoding completing a short call in
+                    # the final chunk). Argument streaming itself still goes
+                    # through Case 2 on the next parse call, keeping the
+                    # chunk timing identical to the classic path.
+                    if is_current_complete and "arguments" in current_tool_call:
+                        while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                            self.prev_tool_call_arr.append({})
+                        self.prev_tool_call_arr[self.current_tool_id] = (
+                            current_tool_call
+                        )
                 else:
                     res = StreamingParseResult()
 


### PR DESCRIPTION
## Motivation

When a complete tool call lands in the **final streamed delta** — common with speculative decoding (e.g. EAGLE), where one step emits many tokens — the client receives a tool call with a name but **permanently empty arguments**.

Root cause: Case 1 of `BaseFormatDetector.parse_streaming_increment` sends only the tool name and never registers the parsed call in `prev_tool_call_arr`. When no further delta arrives, the finish-time flush (`_check_for_unstreamed_tool_args`) sees no tracked data and returns `None`, so the arguments are silently dropped.

This affects every detector that delegates streaming to the base class (hermes, qwen25, llama32, mistral, json fallback, ...).

## Modifications

`python/sglang/srt/function_call/base_format_detector.py`:
- Case 1 now registers the completely-parsed call in `prev_tool_call_arr` (registration only: no argument emission, no buffer trim, no tool id advance). Chunk timing is unchanged: arguments still stream through Case 2 when further deltas arrive, and the finish-time flush emits them in full when they do not.

`python/sglang/srt/entrypoints/openai/serving_chat.py` (`_check_for_unstreamed_tool_args`):
- Iterate every tracked tool call instead of only the last one, so several short calls completing near stream end each get their unstreamed arguments flushed.
- Skip placeholder entries without a parsed `"arguments"` object instead of defaulting to `{}` (avoids spurious `"{}"` argument deltas).
- Record `streamed_args_for_tool` after flushing so the flush is idempotent.

## Verification

Isolated scenario tests (12 checks) against the real detector + the real flush function:
- final-delta complete call: name-only chunk emitted, call registered, flush emits full arguments, second flush is a no-op
- classic multi-delta streaming: chunk timing unchanged, flush is a no-op
- two calls with the second completing at stream end: only the pending tool is flushed
- placeholder entry without arguments is skipped
- str-typed expected arguments still handled

The same tests were run against **unmodified main** and fail exactly on the empty-arguments repro (4 failures), confirming the bug and the fix.

## Checklist

- [x] Format your code with `pre-commit run --all-files` style (py_compile clean)
- [x] Targeted scenario verification (pass on this branch, repro failures on main)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29988572185](https://github.com/sgl-project/sglang/actions/runs/29988572185)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29988571984](https://github.com/sgl-project/sglang/actions/runs/29988571984)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->