### PR TITLE
Fix decode-side release crashes and allow decode radix cache with speculative decoding

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -39,10 +39,12 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
                     "with --disaggregation-transfer-backend fake"
                 )
             if server_args.speculative_algorithm is not None:
-                raise ValueError(
-                    "--disaggregation-decode-enable-radix-cache is incompatible "
-                    "with speculative decoding "
-                    f"(--speculative-algorithm {server_args.speculative_algorithm})"
+                logger.warning(
+                    "EXPERIMENTAL: Decode radix cache together with speculative "
+                    f"decoding (--speculative-algorithm {server_args.speculative_algorithm}). "
+                    "The radix tree uses bigram (EAGLE) keys; prealloc prefix "
+                    "matching, prebuilt caching and finish/retract release all "
+                    "route through the eagle-aware radix paths."
                 )
             from sglang.srt.arg_groups.overrides import resolved_view
 

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -253,9 +253,23 @@ class DecodeKVCacheOffloadManager:
     def _release_finished_req(self, req: Req, start_offset: int):
         # Defensive guard: ReqToTokenPool.free sets req_pool_idx to None,
         # so a previously-released request must be skipped here to avoid
-        # non-idempotent side effects (e.g. tree_cache.protected_size_
-        # double-decrement, host pool double-free).
+        # non-idempotent side effects (e.g. host pool double-free).
         if req.req_pool_idx is None or req.req_pool_idx == -1:
+            return
+
+        if not self.tree_cache.disable:
+            # Decode radix cache is enabled: the raw frees below would
+            # double-free tree-owned prefix slots (rows [0, cache_protected_len)
+            # hold canonical tree indices) and would leak the prefix lock taken
+            # at prealloc (protected_size_ would drift negative while lock_ref
+            # stays >0). Route through the radix-aware release instead: it
+            # inserts the committed KV into the tree, frees only duplicates,
+            # the unaligned tail and spec-overallocated slots, releases the
+            # req slot, and balances the lock via dec_lock_ref.
+            from sglang.srt.mem_cache.common import release_kv_cache
+
+            release_kv_cache(req, self.tree_cache, is_insert=True)
+            self.offloaded_state.pop(req.rid, None)
             return
 
         kv_committed_len = req.effective_kv_committed_len()
@@ -290,7 +304,10 @@ class DecodeKVCacheOffloadManager:
 
         self.req_to_token_pool.free(req)
         req.kv = None
-        self.tree_cache.protected_size_ -= len(req.prefix_indices)
+        # NOTE: no raw tree_cache.protected_size_ manipulation here. ChunkCache
+        # reports protected_size() == 0 unconditionally, and for radix caches
+        # the balanced inc/dec_lock_ref pair owns that counter (see the
+        # release_kv_cache routing above).
         if req.rid in self.offloaded_state:
             del self.offloaded_state[req.rid]
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2899,7 +2899,7 @@ class ServerArgs:
     ] = None
     disaggregation_decode_enable_radix_cache: A[
         bool,
-        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Incompatible with --enable-hisparse, speculative decoding, and --disaggregation-transfer-backend fake.",
+        "Enable radix cache on decode server (PD mode). Caches KV prefixes to avoid redundant transfers. Incompatible with --enable-hisparse and --disaggregation-transfer-backend fake. Combining with speculative decoding is experimental.",
         NS("disagg"),
     ] = False
     disaggregation_decode_enable_offload_kvcache: A[


### PR DESCRIPTION
## Motivation

`--disaggregation-decode-enable-radix-cache` is currently hard-blocked together with `--speculative-algorithm`. The radix tree itself is already EAGLE-aware (`match_prefix` uses bigram keys; `cache_finished_req` / `cache_unfinished_req` handle the speculative tail), so the mutual exclusion is a conservative gate rather than a structural limitation.

The real hazard is the raw release path in `DecodeKVCacheOffloadManager._release_finished_req`, which causes two crashes when the decode radix cache is enabled:

1. **`tree_cache.protected_size_` drifts negative**: the raw `protected_size_ -= len(req.prefix_indices)` is never paired with the `inc_lock_ref` taken at prealloc, tripping the protected-size assert.
2. **Token pool usage goes negative**: the raw `token_to_kv_pool_allocator.free` releases rows `[0, cache_protected_len)` that hold canonical tree-owned prefix slots — a double free that violates the pool usage assert.

## Modifications

`python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py`
- When the decode radix cache is enabled (`tree_cache.disable` is False), `_release_finished_req` routes through `mem_cache.common.release_kv_cache` → `tree_cache.cache_finished_req`: committed KV is inserted into the tree, only duplicated slots / the unaligned tail / spec-overallocated slots are freed, the req slot is released, and the prealloc prefix lock is balanced via `dec_lock_ref`.
- Remove the raw `protected_size_` manipulation entirely: `ChunkCache.protected_size()` is unconditionally 0, and for radix caches the balanced `inc/dec_lock_ref` pair owns that counter.

`python/sglang/srt/arg_groups/pd_disaggregation_hook.py`
- Replace the spec-algorithm `ValueError` with an EXPERIMENTAL warning. Hard incompatibilities with `--enable-hisparse` and the fake transfer backend are kept.

`python/sglang/srt/server_args.py`
- Sync the help text.

## Verification

Validated on a production PD deployment (v0.5.15 base, EAGLE + decode radix cache): prealloc prefix matching/locking, prebuilt batch caching, finish release and retract all route through the eagle-aware radix paths; the protected-size and pool-usage asserts no longer trip under sustained load.

## Checklist

- [x] py_compile clean on all touched files
- [x] Production validation as described above

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29991731371](https://github.com/sgl-project/sglang/actions/runs/29991731371)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29991731243](https://github.com/sgl-project/sglang/actions/runs/29991731243)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->