### PR TITLE
Support hugepage-backed Mooncake host buffers and fix pinned registration size

### DIFF
--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -61,6 +61,10 @@ class DecodeKVCacheOffloadManager:
                 server_args.hicache_size,
                 self.page_size,
                 server_args.hicache_mem_layout,
+                # Match the prefill-side HiRadixCache: storage backends with a
+                # dedicated host allocator (e.g. mooncake standalone storage)
+                # need decode offload buffers inside their registered segment.
+                allocator_type=server_args.hicache_storage_backend,
             )
         elif isinstance(kv_cache, MLATokenToKVPool):
             self.decode_host_mem_pool = MLATokenToKVPoolHost(
@@ -69,6 +73,7 @@ class DecodeKVCacheOffloadManager:
                 server_args.hicache_size,
                 self.page_size,
                 server_args.hicache_mem_layout,
+                allocator_type=server_args.hicache_storage_backend,
             )
         else:
             raise ValueError("Unsupported KV cache type for decode offload")

--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -24,6 +24,15 @@ class HostTensorAllocator:
         self.dims = dims
         return alloc_mmap(dims, dtype)
 
+    def cuda_registration_nbytes(self, buffer: torch.Tensor) -> int:
+        """Size (bytes) to pass to cudaHostRegister for `buffer`.
+
+        Allocator subclasses whose backing allocation is larger than the
+        tensor's logical size (e.g. hugepage-aligned allocations) must
+        override this so the whole backing region gets pinned.
+        """
+        return buffer.numel() * buffer.element_size()
+
 
 def get_allocator_from_storage(allocator_type):
     if allocator_type == "mooncake":
@@ -58,9 +67,10 @@ def get_allocator_from_storage(allocator_type):
         return HostTensorAllocator()
 
 
-def _cuda_host_register(buffer: torch.Tensor) -> None:
+def _cuda_host_register(buffer: torch.Tensor, n_bytes: int | None = None) -> None:
     cudart = torch.cuda.cudart()
-    n_bytes = buffer.numel() * buffer.element_size()
+    if n_bytes is None:
+        n_bytes = buffer.numel() * buffer.element_size()
     rc = cudart.cudaHostRegister(buffer.data_ptr(), n_bytes, 0)
     if int(rc) != 0:
         raise RuntimeError(
@@ -97,7 +107,7 @@ def alloc_with_host_register(
     """
     buffer = allocator.allocate(dims, dtype=dtype, device=device)
     if pin_memory:
-        _cuda_host_register(buffer)
+        _cuda_host_register(buffer, allocator.cuda_registration_nbytes(buffer))
     return buffer
 
 

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -38,6 +38,8 @@ class MooncakeHostTensorAllocator(HostTensorAllocator):
 
         self.allocator = MooncakeHostMemAllocator()
         self.ptr = None
+        self.logical_size = None
+        self.allocated_size = None
 
     def allocate(
         self, dims: tuple, dtype: torch.dtype, device: str = "cpu"
@@ -51,8 +53,10 @@ class MooncakeHostTensorAllocator(HostTensorAllocator):
         for d in dims:
             size *= d
         size *= torch.tensor([], dtype=self.dtype).element_size()
-        ptr_int = self.allocator.alloc(size)
+        allocated_size = self._allocated_nbytes(size)
+        ptr_int = self.allocator.alloc(allocated_size)
         self.ptr = ptr_int
+        self.logical_size, self.allocated_size = size, allocated_size
         c_type = ctypes.c_byte * size
         c_array = c_type.from_address(ptr_int)
 
@@ -64,6 +68,36 @@ class MooncakeHostTensorAllocator(HostTensorAllocator):
             tensor = tensor.view(dtype)
 
         return tensor.view(dims)
+
+    @staticmethod
+    def _allocated_nbytes(logical_size: int) -> int:
+        if os.getenv("MC_STORE_USE_HUGEPAGE", "0").strip().lower() not in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        ):
+            return logical_size
+        page_size_name = os.getenv("MC_STORE_HUGEPAGE_SIZE", "2MB").strip().upper()
+        page_sizes = {
+            "2MB": 2 * 1024 * 1024,
+            "1GB": 1024 * 1024 * 1024,
+        }
+        if page_size_name not in page_sizes:
+            raise ValueError(
+                f"Unsupported MC_STORE_HUGEPAGE_SIZE={page_size_name!r}; "
+                f"expected one of {sorted(page_sizes)}"
+            )
+        page_size = page_sizes[page_size_name]
+        return (logical_size + page_size - 1) // page_size * page_size
+
+    def cuda_registration_nbytes(self, buffer: torch.Tensor) -> int:
+        # Register the full (hugepage-aligned) backing allocation: pinning
+        # only the logical size would leave the alignment tail unpinned and
+        # break RDMA transfers from within that region.
+        if buffer.data_ptr() != self.ptr or self.allocated_size is None:
+            raise RuntimeError("Mooncake allocator does not own the host buffer")
+        return self.allocated_size
 
 
 def _parse_global_segment_size(value) -> int:


### PR DESCRIPTION
## Motivation

Two related gaps in the mooncake standalone-storage host memory path (HiCache / decode offload):

1. `MooncakeHostTensorAllocator` always allocates exactly the logical tensor size. When the mooncake store is configured with hugepage support, the backing allocation must be hugepage-aligned.
2. `alloc_with_host_register` pins only the tensor's logical size (`numel * element_size`). With an aligned backing allocation this leaves the alignment tail **unpinned**, and RDMA transfers touching that region fail.

Additionally, `DecodeKVCacheOffloadManager` constructs its host pools without any `allocator_type`, so decode-side offload buffers under mooncake standalone storage are plain mmap memory outside the store's registered segment — unlike the prefill-side `HiRadixCache`, which already passes `allocator_type=server_args.hicache_storage_backend`.

## Modifications

`python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py`
- `MooncakeHostTensorAllocator` rounds the backing allocation up to the hugepage size when `MC_STORE_USE_HUGEPAGE` is set (`MC_STORE_HUGEPAGE_SIZE`: `2MB` default, `1GB` supported); the returned tensor keeps the logical shape.
- Override `cuda_registration_nbytes()` to return the full aligned size (with buffer-ownership validation), so the whole backing region gets pinned.

`python/sglang/srt/mem_cache/pool_host/common.py`
- `HostTensorAllocator` gains a `cuda_registration_nbytes()` hook (default: logical size).
- `_cuda_host_register` accepts an explicit byte count; `alloc_with_host_register` passes the allocator-reported size.

`python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py`
- Pass `allocator_type=server_args.hicache_storage_backend` when constructing decode-side host pools, matching the prefill-side `HiRadixCache`.

## Verification

- Hugepage rounding math covered by a standalone test: disabled passthrough, 2MB/1GB rounding (boundary and +1 cases), invalid `MC_STORE_HUGEPAGE_SIZE` rejection.
- Allocator path validated on a production PD deployment with mooncake standalone storage over EFA (DeepSeek-class MLA model, HiCache decode offload enabled).

## Checklist

- [x] py_compile clean on all touched files
- [x] Standalone tests for the alignment logic; production validation for the RDMA path

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29988965918](https://github.com/sgl-project/sglang/actions/runs/29988965918)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29988965800](https://github.com/sgl-project/sglang/actions/runs/29988965800)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->