### PR TITLE
[Quant] Support static W4A8 FP8 activation quantization for MoE

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -368,7 +368,12 @@ class CompressedTensorsConfig(QuantizationConfig):
         )
 
     def _is_wint4afp8(self, weight_quant: BaseModel, input_quant: BaseModel) -> bool:
-        """Detect W4AFP8: packed INT4 weights + 8-bit dynamic per-token activations."""
+        """Detect W4AFP8: packed INT4 weights + 8-bit activations (dynamic or static).
+
+        Supports both dynamic per-token and static per-tensor activation quantization.
+        For static W4A8, the CUTLASS kernel will use dynamic quantization as fallback
+        when pre-computed activation scales are not available.
+        """
         if weight_quant is None or input_quant is None:
             return False
         return (
@@ -379,7 +384,6 @@ class CompressedTensorsConfig(QuantizationConfig):
             and not weight_quant.dynamic
             and input_quant.num_bits == 8
             and input_quant.type in [QuantizationType.FLOAT, QuantizationType.INT]
-            and input_quant.dynamic  # currently not support static input scales
         )
 
     def _is_wint4abf16(self, weight_quant: BaseModel, input_quant: BaseModel) -> bool:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
@@ -1,8 +1,9 @@
-"""W4AFP8 MoE scheme: INT4 group-quantized weights + 8-bit dynamic activations.
+"""W4AFP8 MoE scheme: INT4 group-quantized weights + 8-bit FP8 activations
+(dynamic per-token or static per-tensor).
 
 Loads INT4 weights from compressed-tensors pack-quantized format,
 converts to CUTLASS W4A8 layout, and runs CUTLASS grouped GEMM
-with dynamic 8-bit (FP8 or INT8) activation quantization.
+with 8-bit FP8 activation quantization.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from sglang.srt.layers.moe import MoeRunnerConfig
 from sglang.srt.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsMoEScheme,
 )
+from sglang.srt.layers.quantization.utils import all_close_1d
 from sglang.srt.layers.quantization.w4afp8 import interleave_scales
 from sglang.srt.utils import set_weight_attrs
 
@@ -74,7 +76,8 @@ def _unpack_repack_int32_to_cutlass_int8(
 
 
 class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
-    """W4AFP8 MoE: INT4 weights (pack-quantized) + dynamic per-token 8-bit activations,
+    """W4AFP8 MoE: INT4 weights (pack-quantized) + 8-bit activations
+    (dynamic per-token or static per-tensor),
     using CUTLASS W4A8 grouped GEMM kernel."""
 
     def __init__(
@@ -90,6 +93,7 @@ class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
         self.group_size = config.group_size
         self.weight_quant = weight_quant
         self.input_quant = input_quant
+        self.static_input_scales = not self.input_quant.dynamic
 
         assert config.symmetric, "Only symmetric quantization is supported"
         assert (
@@ -182,6 +186,23 @@ class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
             layer.register_parameter(name, p)
             set_weight_attrs(p, extra_weight_attrs)
 
+        # INPUT_SCALES
+        if self.static_input_scales:
+            a13_scale = torch.nn.Parameter(
+                torch.ones(num_experts, dtype=torch.float32), requires_grad=False
+            )
+            layer.register_parameter("a13_scale", a13_scale)
+            set_weight_attrs(a13_scale, extra_weight_attrs)
+
+            a2_scale = torch.nn.Parameter(
+                torch.ones(num_experts, dtype=torch.float32), requires_grad=False
+            )
+            layer.register_parameter("a2_scale", a2_scale)
+            set_weight_attrs(a2_scale, extra_weight_attrs)
+        else:
+            layer.a13_scale = None
+            layer.a2_scale = None
+
         self._init_cutlass_buffers(
             num_experts,
             hidden_size,
@@ -203,9 +224,23 @@ class CompressedTensorsW4AFP8MoE(CompressedTensorsMoEScheme):
         dtype = torch.bfloat16
         device = layer.w2_weight_packed.device
 
-        # TODO: currently only support per tensor quant.
-        layer.a13_scale = None
-        layer.a2_scale = None
+        # Handle static input scales if provided; otherwise kernel falls back
+        # to dynamic per-token quantization.
+        if self.static_input_scales:
+            if not all_close_1d(layer.a13_scale) or not all_close_1d(layer.a2_scale):
+                logger.warning(
+                    "Found input_scales that are not equal for "
+                    "W4AFP8 MoE layer. Using the maximum across experts "
+                    "for each layer."
+                )
+            if layer.a13_scale is not None:
+                layer.a13_scale = torch.nn.Parameter(
+                    layer.a13_scale.max(), requires_grad=False
+                )
+            if layer.a2_scale is not None:
+                layer.a2_scale = torch.nn.Parameter(
+                    layer.a2_scale.max(), requires_grad=False
+                )
 
         w13 = _unpack_repack_int32_to_cutlass_int8(
             layer.w13_weight_packed.data, self.num_bits

--- a/test/manual/quant/test_w4afp8_static_support.py
+++ b/test/manual/quant/test_w4afp8_static_support.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test W4AFP8 static quantization: config detection, MoE routing, and scale lifecycle.
+
+Covers the full static W4AFP8 path end-to-end:
+  test/manual/quant/test_w4afp8_static_support.py
+
+Changes under test:
+  python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+    → _is_wint4afp8(): removed input_quant.dynamic requirement
+  python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8_moe.py
+    → CompressedTensorsW4AFP8MoE: static input scales support
+
+Pure config-parsing and scheme lifecycle — no GPU required.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsW4AFP8MoE,
+    CompressedTensorsWNA16MoE,
+    CompressedTensorsWNA16TritonMoE,
+)
+
+_WNA16_MOE_SCHEMES = (CompressedTensorsWNA16MoE, CompressedTensorsWNA16TritonMoE)
+_NUM_EXPERTS, _HIDDEN, _INTER = 4, 512, 256
+
+
+# ============================================================================
+# config builders
+# ============================================================================
+
+
+def _make_w4afp8_config(dynamic: bool) -> dict:
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 4,
+                    "type": "int",
+                    "symmetric": True,
+                    "strategy": "group",
+                    "group_size": 128,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "strategy": "token" if dynamic else "tensor",
+                    "dynamic": dynamic,
+                },
+            }
+        },
+    }
+
+
+def _make_w4a16_config() -> dict:
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 4,
+                    "type": "int",
+                    "symmetric": True,
+                    "strategy": "group",
+                    "group_size": 128,
+                },
+                "input_activations": None,
+            }
+        },
+    }
+
+
+# ============================================================================
+# 1. _is_wint4afp8 detection
+# ============================================================================
+
+
+class TestDetection:
+    """Verify static configs are recognized by _is_wint4afp8()."""
+
+    def test_static(self):
+        cfg = CompressedTensorsConfig.from_config(_make_w4afp8_config(dynamic=False))
+        d = next(iter(cfg.target_scheme_map.values()))
+        assert cfg._is_wint4afp8(d["weights"], d["input_activations"])
+
+    def test_dynamic(self):
+        cfg = CompressedTensorsConfig.from_config(_make_w4afp8_config(dynamic=True))
+        d = next(iter(cfg.target_scheme_map.values()))
+        assert cfg._is_wint4afp8(d["weights"], d["input_activations"])
+
+    def test_w4a16_not_misdetected(self):
+        cfg = CompressedTensorsConfig.from_config(_make_w4a16_config())
+        d = next(iter(cfg.target_scheme_map.values()))
+        assert not cfg._is_wint4afp8(d["weights"], d["input_activations"])
+
+
+# ============================================================================
+# 2. MoE scheme routing
+# ============================================================================
+
+
+class _FakeLinearModule(nn.Module):
+    pass
+
+
+class TestMoERouting:
+    """Verify static/dynamic W4AFP8 config routes to CompressedTensorsW4AFP8MoE."""
+
+    MOE_LAYER = "model.layers.0.mlp.experts"
+    layer: _FakeLinearModule
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.layer = _FakeLinearModule()
+
+    def test_static_routes_to_moe(self):
+        cfg = CompressedTensorsConfig.from_config(_make_w4afp8_config(dynamic=False))
+        s = cfg.get_moe_scheme(self.layer, layer_name=self.MOE_LAYER)
+        assert isinstance(s, CompressedTensorsW4AFP8MoE)
+
+    def test_dynamic_routes_to_moe(self):
+        cfg = CompressedTensorsConfig.from_config(_make_w4afp8_config(dynamic=True))
+        s = cfg.get_moe_scheme(self.layer, layer_name=self.MOE_LAYER)
+        assert isinstance(s, CompressedTensorsW4AFP8MoE)
+
+    def test_w4a16_not_hijacked(self):
+        cfg = CompressedTensorsConfig.from_config(_make_w4a16_config())
+        s = cfg.get_moe_scheme(self.layer, layer_name=self.MOE_LAYER)
+        assert isinstance(s, _WNA16_MOE_SCHEMES)
+
+
+# ============================================================================
+# 3. static scale lifecycle (create_weights → process_weights_after_loading)
+# ============================================================================
+
+
+def _make_scheme(dynamic: bool) -> CompressedTensorsW4AFP8MoE:
+    cfg = CompressedTensorsConfig.from_config(_make_w4afp8_config(dynamic=dynamic))
+    d = next(iter(cfg.target_scheme_map.values()))
+    return CompressedTensorsW4AFP8MoE(cfg, d["weights"], d["input_activations"])
+
+
+def _create_dummy_layer_and_weights(scheme: CompressedTensorsW4AFP8MoE):
+    """Helper: create a layer with mock weights and run create_weights."""
+    layer = _FakeLinearModule()
+    scheme.create_weights(
+        layer,
+        _NUM_EXPERTS,
+        _HIDDEN,
+        _INTER,
+        params_dtype=torch.float32,
+        input_dim=0,
+        output_dim=0,
+        weight_loader=MagicMock(),
+    )
+    # Fill weights with random data so process_weights_after_loading can run
+    for pname in ("w13_weight_packed", "w2_weight_packed"):
+        p = getattr(layer, pname)
+        p.data = torch.randint(-(2**31), 2**31 - 1, p.shape, dtype=torch.int32)
+        p.data = p.data.to(torch.int32)  # ensure int32 for bit ops
+    for pname in ("w13_weight_scale", "w2_weight_scale"):
+        p = getattr(layer, pname)
+        p.data = torch.randn(p.shape, dtype=torch.float32)
+    return layer
+
+
+def _layer_has_state(layer: nn.Module, static: bool):
+    """Shared assertions for scale parameter state."""
+    has_a13 = hasattr(layer, "a13_scale") and layer.a13_scale is not None
+    has_a2 = hasattr(layer, "a2_scale") and layer.a2_scale is not None
+    if static:
+        assert has_a13 and has_a2, "static mode: scales should be created"
+    else:
+        assert not has_a13 and not has_a2, "dynamic mode: scales should be None"
+
+
+class TestStaticScaleLifecycle:
+    """Verify static scales flow through create_weights → process_weights_after_loading."""
+
+    # ----- static path -----
+
+    def test_static_flag(self):
+        s = _make_scheme(dynamic=False)
+        assert s.static_input_scales is True
+
+    def test_static_create_weights(self):
+        s = _make_scheme(dynamic=False)
+        layer = _FakeLinearModule()
+        s.create_weights(
+            layer,
+            _NUM_EXPERTS,
+            _HIDDEN,
+            _INTER,
+            params_dtype=torch.float32,
+            input_dim=0,
+            output_dim=0,
+            weight_loader=MagicMock(),
+        )
+        _layer_has_state(layer, static=True)
+        assert layer.a13_scale.shape == (_NUM_EXPERTS,)
+        assert layer.a2_scale.shape == (_NUM_EXPERTS,)
+
+    def test_static_process_weights(self):
+        s = _make_scheme(dynamic=False)
+        layer = _create_dummy_layer_and_weights(s)
+        # process_weights_after_loading should collapse per-expert scales to scalar
+        s.process_weights_after_loading(layer)
+        assert (
+            layer.a13_scale.numel() == 1
+        ), f"expected scalar, got {layer.a13_scale.shape}"
+        assert (
+            layer.a2_scale.numel() == 1
+        ), f"expected scalar, got {layer.a2_scale.shape}"
+        assert layer.is_w4afp8_converted is True
+
+    # ----- dynamic path (regression) -----
+
+    def test_dynamic_flag(self):
+        s = _make_scheme(dynamic=True)
+        assert s.static_input_scales is False
+
+    def test_dynamic_create_weights(self):
+        s = _make_scheme(dynamic=True)
+        layer = _FakeLinearModule()
+        s.create_weights(
+            layer,
+            _NUM_EXPERTS,
+            _HIDDEN,
+            _INTER,
+            params_dtype=torch.float32,
+            input_dim=0,
+            output_dim=0,
+            weight_loader=MagicMock(),
+        )
+        _layer_has_state(layer, static=False)
+
+    def test_dynamic_process_weights(self):
+        s = _make_scheme(dynamic=True)
+        layer = _create_dummy_layer_and_weights(s)
+        s.process_weights_after_loading(layer)
+        assert layer.a13_scale is None
+        assert layer.a2_scale is None
+        assert layer.is_w4afp8_converted is True


### PR DESCRIPTION
[Quant] Support static W4A8 FP8 activation quantization for MoE

Remove input_quant.dynamic gate in _is_wint4afp8() to also detect static per-tensor FP8 activations alongside dynamic per-token.

Add static input scales (a13_scale / a2_scale) lifecycle in CompressedTensorsW4AFP8MoE: create per-expert scales, collapse to scalar max during process_weights_after_loading. Fall back to CUTLASS dynamic quantization when static scales absent.

Add unit tests covering config detection, MoE routing, and scale lifecycle for both static and dynamic paths.

## Motivation

Currently W4A8 FP8 MoE only supports dynamic per-token activation quantization. This PR adds support for static per-tensor activation quantization, enabling models quantized with pre-computed per-tensor activation scales to use the W4AFP8 MoE path.

## Modifications

- `compressed_tensors.py`: Remove `input_quant.dynamic` gate in `_is_wint4afp8()` to detect static per-tensor FP8 activations alongside dynamic per-token.
- `compressed_tensors_w4a8_fp8_moe.py`: Add `static_input_scales` flag, create `a13_scale`/`a2_scale` parameters in `create_weights()` for static mode, and collapse per-expert scales to scalar max in `process_weights_after_loading()`. Dynamic path unchanged — falls back to CUTLASS dynamic quantization when static scales are absent.
- `test_w4afp8_static_support.py`: New unit tests covering config detection, MoE scheme routing, and scale lifecycle for both static and dynamic paths.

## Accuracy Tests

No expected change to model outputs. The dynamic path is unchanged, and the static path uses the same CUTLASS W4A8 grouped GEMM kernel with pre-computed scales.

## Speed Tests and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29992916741](https://github.com/sgl-project/sglang/actions/runs/29992916741)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29992916581](https://github.com/sgl-project/sglang/actions/runs/29992916581)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->