### PR TITLE
AMD ROCm enablement for GLM-5.x: DSA + prefill-CP + EAGLE and DFlash

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -133,6 +133,30 @@ def get_dsa_index_head_dim(config: PretrainedConfig) -> int:
     return config.index_head_dim
 
 
+def _maybe_fix_glm_moe_dsa_qk_rope_head_dim(*configs: PretrainedConfig) -> None:
+    """Correct a broken qk_rope_head_dim in GLM-5.2 DSA (glm_moe_dsa) configs.
+
+    The GlmMoeDsaConfig class sets ``attribute_map = {"head_dim": "qk_rope_head_dim"}``,
+    so the checkpoint's ``head_dim`` (192) overwrites the real ``qk_rope_head_dim`` (64).
+    That makes qk_head_dim resolve to 192+192=384 and builds q_b_proj / fused kv_a_proj /
+    rope / KV cache with the wrong geometry, so weight loading aborts with a size mismatch
+    (both for the target model and the EAGLE/NextN draft model). Recover the true value
+    from the explicit ``qk_head_dim`` field the checkpoint still carries.
+    """
+    for config in configs:
+        if config is None or getattr(config, "model_type", None) != "glm_moe_dsa":
+            continue
+        qk_head_dim = getattr(config, "qk_head_dim", None)
+        qk_nope = getattr(config, "qk_nope_head_dim", None)
+        if qk_head_dim is None or qk_nope is None:
+            continue
+        corrected_rope = qk_head_dim - qk_nope
+        if corrected_rope > 0 and corrected_rope != getattr(
+            config, "qk_rope_head_dim", None
+        ):
+            config.qk_rope_head_dim = corrected_rope
+
+
 def is_minimax_sparse(config: PretrainedConfig) -> bool:
     arch = (config.architectures or [None])[0]
     return arch in (
@@ -300,6 +324,7 @@ class ModelConfig:
             rope_scaling is not None and "mrope_section" in rope_scaling
         )
 
+        _maybe_fix_glm_moe_dsa_qk_rope_head_dim(self.hf_config, self.hf_text_config)
         self.hf_generation_config = get_generation_config(
             self.model_path,
             trust_remote_code=trust_remote_code,

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -304,6 +304,30 @@ class AiterAttnBackend(AttentionBackend):
             )
             global _use_mla_ps_kernel, fast_mode, intra_batch_mode
 
+            # V3 no-pad (SGLANG_AITER_MLA_NO_PAD_HEADS): route the native qh8/gqaratio8
+            # aiter MLA kernel instead of repeat_interleave-padding q-heads 8 -> 16.
+            # gfx950 mla_decode_fwd natively supports nhead in {8,16} on the non-persistent
+            # path; force non-persistent (persistent fake-nps for nhead != 16 can gpu-fault),
+            # matching how the padded bf16 tp8 path already runs.
+            self._aiter_no_pad_heads = get_bool_env_var(
+                "SGLANG_AITER_MLA_NO_PAD_HEADS", "False"
+            ) and self.num_head in (4, 8)
+            if self._aiter_no_pad_heads:
+                self.num_head_padded = self.num_head
+                self.head_repeat_factor = 1
+                if get_bool_env_var("SGLANG_AITER_MLA_NO_PAD_NONPERSIST", "False"):
+                    # decode qseqlen=1 works, but EAGLE verify qseqlen=4 has no qh8
+                    # kernel on the non-persistent path -> NaN. Kept as an opt-in.
+                    _use_mla_ps_kernel = False
+                    fast_mode = False
+                    intra_batch_mode = False
+                else:
+                    # Persistent path: gfx950 bf16 natively supports any nhead+qseqlen.
+                    # Use the non-fake-nps combo (fast_mode=True, intra_batch_mode=False),
+                    # same as the num_head in (32,64,128) branch below.
+                    fast_mode = True
+                    intra_batch_mode = False
+
             # current mla_decode_fwd only support fake-nps in self.num_head == 16
             # so all num_head size does not use qh16 kernel to simulate
             # it should not use fake-nps (fast_mode = False, intra_batch_mode = True)

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -1966,6 +1966,23 @@ class Indexer(MultiPlatformOp):
                 weights = self.weights_proj(x_for_gate)[0].float() * self.n_heads**-0.5
                 weights = self._apply_q_scale_and_softmax_scale(weights, q_scale)
             else:
+                # opus_gemm_a16w16 (weights_proj) requires canonical packed
+                # strides. On the CP + EAGLE verify path x_for_gate can be a
+                # singleton-strided view (e.g. (1,1,6144) stride
+                # (49152,49152,1)) that still reports is_contiguous()==True,
+                # so .contiguous() is a no-op; force a canonical copy via
+                # clone() only when the strides are not packed.
+                if isinstance(x_for_gate, torch.Tensor):
+                    _exp, _canon = 1, True
+                    for _d in range(x_for_gate.dim() - 1, -1, -1):
+                        if x_for_gate.stride(_d) != _exp:
+                            _canon = False
+                            break
+                        _exp *= x_for_gate.shape[_d]
+                    if not _canon:
+                        x_for_gate = x_for_gate.clone(
+                            memory_format=torch.contiguous_format
+                        )
                 weights = self._get_logits_head_gate(x_for_gate, q_scale)
 
         if _is_cuda or _is_hip:

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -6,6 +6,9 @@ from typing import Callable, Dict, List, Optional, Tuple
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
 
 _FLASHINFER_TIE_BREAK_VALUES = {
     "small": 1,
@@ -99,7 +102,8 @@ class DSATopKBackend(Enum):
         # matches we commit to v2 and never silently fall back to the legacy
         # page_size=1 path from here.
         if (
-            envs.SGLANG_OPT_USE_TOPK_V2.get()
+            not _is_hip
+            and envs.SGLANG_OPT_USE_TOPK_V2.get()
             and topk_transform_method == TopkTransformMethod.PAGED
             and row_starts is None
             and batch_idx_list is None

--- a/python/sglang/srt/layers/attention/dsa/triton_sparse_mla_decode.py
+++ b/python/sglang/srt/layers/attention/dsa/triton_sparse_mla_decode.py
@@ -1,0 +1,143 @@
+"""Per-query Triton sparse-MLA decode for the fp8 KV + CP path (gfx950).
+
+Split-K flash-decode over the indexer top-2048; per-query grid (CP-safe).
+DSA fp8 KV pool: 576-wide raw fp8_e4m3fn [512 nope | 64 rope], kv_scale==1.0.
+Q bf16 (a16w8). K/V dequant = fp8->bf16. MLA: V = nope(512).
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+
+_FP8_MAX = 240.0 if is_fp8_fnuz() else 448.0
+_LOG2E = 1.4426950408889634
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_N": 16}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_N": 32}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_N": 64}, num_warps=8, num_stages=1),
+    ],
+    key=["H", "topk", "BLOCK_H"],
+)
+@triton.jit
+def _splitk_partial_kernel(
+    q_nope_ptr, q_rope_ptr, kv_ptr, idx_ptr,
+    pacc_ptr, pm_ptr, pl_ptr,
+    sm_scale, topk, skv, fp8_max,
+    K_SPLITS: tl.constexpr, H: tl.constexpr, D_V: tl.constexpr, D_TAIL: tl.constexpr,
+    BLOCK_H: tl.constexpr, USE_FP8_PV: tl.constexpr, BLOCK_N: tl.constexpr,
+):
+    s_i = tl.program_id(0)
+    hb = tl.program_id(1)
+    sk = tl.program_id(2)
+    h = hb * BLOCK_H + tl.arange(0, BLOCK_H)
+    dv = tl.arange(0, D_V)
+    dt = tl.arange(0, D_TAIL)
+    per = (topk + K_SPLITS - 1) // K_SPLITS
+    k_start = sk * per
+    k_end = tl.minimum(k_start + per, topk)
+
+    q_main = tl.load(q_nope_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :])
+    q_tail = tl.load(q_rope_ptr + s_i * H * D_TAIL + h[:, None] * D_TAIL + dt[None, :])
+    m_i = tl.full([BLOCK_H], -float("inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_H], tl.float32)
+    acc = tl.zeros([BLOCK_H, D_V], tl.float32)
+
+    n = tl.arange(0, BLOCK_N)
+    for k0 in range(k_start, k_end, BLOCK_N):
+        kk = k0 + n
+        kmask = kk < k_end
+        idx = tl.load(idx_ptr + s_i * topk + kk, mask=kmask, other=-1)
+        valid = (idx >= 0) & kmask
+        page = tl.where(valid, idx, 0)
+        kbase = kv_ptr + page[:, None] * skv
+        kv_raw = tl.load(kbase + dv[None, :], mask=valid[:, None], other=0.0)  # fp8
+        kv_main = kv_raw.to(tl.bfloat16)
+        kv_tail = tl.load(kbase + (D_V + dt)[None, :], mask=valid[:, None], other=0.0).to(tl.bfloat16)
+        qk = tl.dot(q_main, tl.trans(kv_main)).to(tl.float32)
+        qk += tl.dot(q_tail, tl.trans(kv_tail)).to(tl.float32)
+        qk = qk * sm_scale
+        qk = tl.where(valid[None, :], qk, -float("inf"))
+        m_new = tl.maximum(m_i, tl.max(qk, axis=1))
+        m_safe = tl.where(m_new == -float("inf"), 0.0, m_new)
+        alpha = tl.math.exp2((m_i - m_safe) * 1.4426950408889634)
+        p = tl.math.exp2((qk - m_safe[:, None]) * 1.4426950408889634)
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        if USE_FP8_PV:
+            p_fp8 = (p * fp8_max).to(kv_raw.dtype)
+            acc = acc * alpha[:, None] + tl.dot(p_fp8, kv_raw).to(tl.float32) * (1.0 / fp8_max)
+        else:
+            acc = acc * alpha[:, None] + tl.dot(p.to(tl.bfloat16), kv_main).to(tl.float32)
+        m_i = m_new
+
+    base = (s_i * H + h) * K_SPLITS + sk
+    tl.store(pm_ptr + base, m_i)
+    tl.store(pl_ptr + base, l_i)
+    tl.store(pacc_ptr + base[:, None] * D_V + dv[None, :], acc)
+
+
+@triton.jit
+def _splitk_combine_kernel(
+    pacc_ptr, pm_ptr, pl_ptr, o_ptr,
+    K_SPLITS: tl.constexpr, H: tl.constexpr, D_V: tl.constexpr, BLOCK_H: tl.constexpr,
+):
+    s_i = tl.program_id(0)
+    hb = tl.program_id(1)
+    h = hb * BLOCK_H + tl.arange(0, BLOCK_H)
+    dv = tl.arange(0, D_V)
+    gm = tl.full([BLOCK_H], -float("inf"), tl.float32)
+    gl = tl.zeros([BLOCK_H], tl.float32)
+    acc = tl.zeros([BLOCK_H, D_V], tl.float32)
+    for k in range(0, K_SPLITS):
+        off = (s_i * H + h) * K_SPLITS + k
+        mk = tl.load(pm_ptr + off)
+        lk = tl.load(pl_ptr + off)
+        pak = tl.load(pacc_ptr + off[:, None] * D_V + dv[None, :])
+        new_m = tl.maximum(gm, mk)
+        new_m_safe = tl.where(new_m == -float("inf"), 0.0, new_m)
+        a = tl.exp(gm - new_m_safe)
+        b = tl.exp(mk - new_m_safe)
+        gl = gl * a + lk * b
+        acc = acc * a[:, None] + pak * b[:, None]
+        gm = new_m
+    gl_safe = tl.where(gl == 0.0, 1.0, gl)
+    acc = acc / gl_safe[:, None]
+    tl.store(o_ptr + s_i * H * D_V + h[:, None] * D_V + dv[None, :], acc.to(o_ptr.dtype.element_ty))
+
+
+def triton_sparse_mla_decode_fp8(
+    q_nope, q_rope, kv_cache, kv_indices, sm_scale,
+    out=None, TOPK=None, BLOCK_H=64, K_SPLITS=8, USE_FP8_PV=True,
+):
+    S, H, D_V = q_nope.shape
+    D_TAIL = q_rope.shape[-1]
+    kv = kv_cache.reshape(-1, kv_cache.shape[-1])
+    P, dim = kv.shape
+    assert dim == D_V + D_TAIL, f"expected {D_V + D_TAIL}, got {dim}"
+    if TOPK is None:
+        TOPK = kv_indices.shape[-1]
+    idx = kv_indices.reshape(S, TOPK).contiguous().to(torch.int32)
+    q_nope = q_nope.contiguous()
+    q_rope = q_rope.contiguous()
+    if out is None:
+        out = torch.empty((S, H, D_V), device=q_nope.device, dtype=torch.bfloat16)
+    bh = BLOCK_H if H % BLOCK_H == 0 else 16
+    ks = K_SPLITS if S <= 128 else 1
+    pacc = torch.empty((S, H, ks, D_V), device=q_nope.device, dtype=torch.float32)
+    pm = torch.empty((S, H, ks), device=q_nope.device, dtype=torch.float32)
+    pl = torch.empty((S, H, ks), device=q_nope.device, dtype=torch.float32)
+    _splitk_partial_kernel[(S, H // bh, ks)](
+        q_nope, q_rope, kv, idx, pacc, pm, pl, sm_scale, TOPK, kv.stride(0), _FP8_MAX,
+        K_SPLITS=ks, H=H, D_V=D_V, D_TAIL=D_TAIL, BLOCK_H=bh, USE_FP8_PV=USE_FP8_PV,
+    )
+    _splitk_combine_kernel[(S, H // bh)](
+        pacc, pm, pl, out, K_SPLITS=ks, H=H, D_V=D_V, BLOCK_H=bh,
+        num_warps=4, num_stages=1,
+    )
+    return out

--- a/python/sglang/srt/layers/attention/dsa/triton_sparse_mla_decode.py
+++ b/python/sglang/srt/layers/attention/dsa/triton_sparse_mla_decode.py
@@ -9,7 +9,7 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 
 _FP8_MAX = 240.0 if is_fp8_fnuz() else 448.0
 _LOG2E = 1.4426950408889634

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -126,11 +126,11 @@ except Exception:
 _DSA_TRITON_FP8_DECODE = os.environ.get("SGLANG_DSA_TRITON_FP8_DECODE", "0") == "1"
 
 if _is_hip:
-    from sglang.srt.layers.attention.dsa.triton_kernel import get_valid_kv_indices
+    from sglang.kernels.ops.attention.dsa.triton_kernel import get_valid_kv_indices
     from sglang.srt.layers.attention.dsa.triton_sparse_mla_decode import (
         triton_sparse_mla_decode_fp8,
     )
-    from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
+    from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 
     try:
         from aiter import (  # noqa: F401

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -110,10 +111,16 @@ def _all_gather_dsa_trtllm_fp8_kv(
 
 
 _is_hip = is_hip()
+# ROCm gfx950 only: route the fp8-KV + prefill-CP DSA decode through a per-query
+# Triton sparse-MLA kernel. Off by default; opt in with SGLANG_DSA_TRITON_FP8_DECODE=1.
+_DSA_TRITON_FP8_DECODE = os.environ.get("SGLANG_DSA_TRITON_FP8_DECODE", "0") == "1"
 
 if _is_hip:
-    from sglang.kernels.ops.attention.dsa.triton_kernel import get_valid_kv_indices
-    from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
+    from sglang.srt.layers.attention.dsa.triton_kernel import get_valid_kv_indices
+    from sglang.srt.layers.attention.dsa.triton_sparse_mla_decode import (
+        triton_sparse_mla_decode_fp8,
+    )
+    from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 
     try:
         from aiter import (  # noqa: F401
@@ -413,10 +420,14 @@ class DeepseekSparseAttnBackend(
                 device=self.device,
             )
             # Aiter mla_decode_fwd supports num_heads multiples of 16 in range [16, 128].
-            # For models with fewer heads per GPU (e.g. GLM-5 64 heads / TP8 = 8), need to pad the heads to 16.
-            self.need_pad_heads = self.num_q_heads < 16
+            # For GLM-5 (64 heads / TP8 = 8) it pads 8->16 (gqaratio16 kernels).
+            # V1 no-pad: gfx950 has native qh8/gqaratio8 v3 asm MLA
+            # (mla_a16w16_qh8_qseqlen1_gqaratio8_v3); SGLANG_DSA_NO_PAD_HEADS=1 routes
+            # the 8 heads straight through with no 8->16 repeat_interleave.
+            _no_pad = os.environ.get("SGLANG_DSA_NO_PAD_HEADS", "0") == "1"
+            self.need_pad_heads = (self.num_q_heads < 16) and not _no_pad
             self.head_repeat_factor = (
-                16 // self.num_q_heads if self.num_q_heads < 16 else 1
+                16 // self.num_q_heads if self.need_pad_heads else 1
             )
             self.num_head_padded = self.num_q_heads * self.head_repeat_factor
             self.aiter_dsa_max_split_per_batch = 64
@@ -1004,6 +1015,28 @@ class DeepseekSparseAttnBackend(
         dsa_cache_seqlens_int32 = pad_dsa_cache_seqlens(
             forward_batch, dsa_cache_seqlens_int32
         )
+        # CP+EAGLE: pad_dsa_cache_seqlens pads
+        # dsa_cache_seqlens_int32 up to the CP/DP padded token count, but
+        # seqlens_expanded stays at the real length. The PAGED draft topk
+        # (fast_topk_transform_fused asserts lengths.size(0) == B) then sees a short
+        # lengths under prefill context-parallel. Pad seqlens_expanded to match, but
+        # ONLY for the PAGED-consumer modes that _get_topk_paged handles
+        # (decode/target_verify/draft_extend_v2); the ragged context_parallel_extend
+        # path (_get_topk_ragged) requires the UNPADDED seqlens_expanded == logits.
+        if (
+            forward_batch.forward_mode.is_decode_or_idle()
+            or forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ) and seqlens_expanded.shape[0] < dsa_cache_seqlens_int32.shape[0]:
+            _cp_pad = dsa_cache_seqlens_int32.shape[0] - seqlens_expanded.shape[0]
+            seqlens_expanded = torch.cat(
+                [
+                    seqlens_expanded,
+                    seqlens_expanded.new_zeros(
+                        _cp_pad, *seqlens_expanded.shape[1:]
+                    ),
+                ]
+            )
         dsa_cu_seqlens_k = compute_cu_seqlens(dsa_cache_seqlens_int32)
         dsa_cu_seqlens_q = self.get_device_int32_arange(len(dsa_cu_seqlens_k))
 
@@ -1340,6 +1373,24 @@ class DeepseekSparseAttnBackend(
             else:
                 flashmla_metadata = None
 
+        # CP+EAGLE: keep seqlens_expanded aligned
+        # with dsa_cache_seqlens_int32 for the PAGED-consumer modes (no-op unless a
+        # CP/DP pad left it short); the ragged context_parallel_extend path stays
+        # unpadded.
+        if (
+            forward_mode.is_decode_or_idle()
+            or forward_mode.is_target_verify()
+            or forward_mode.is_draft_extend_v2()
+        ) and seqlens_expanded.shape[0] < dsa_cache_seqlens_int32.shape[0]:
+            _cp_pad = dsa_cache_seqlens_int32.shape[0] - seqlens_expanded.shape[0]
+            seqlens_expanded = torch.cat(
+                [
+                    seqlens_expanded,
+                    seqlens_expanded.new_zeros(
+                        _cp_pad, *seqlens_expanded.shape[1:]
+                    ),
+                ]
+            )
         dsa_cu_seqlens_k = compute_cu_seqlens(dsa_cache_seqlens_int32)
         dsa_cu_seqlens_q = self.get_device_int32_arange(len(dsa_cu_seqlens_k))
         if self.dsa_drop_wide_page_table:
@@ -2677,6 +2728,25 @@ class DeepseekSparseAttnBackend(
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
             o_kernel = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
 
+        if (
+            # ROCm gfx950: fp8-KV + prefill-CP -> per-query Triton sparse-MLA kernel.
+            _DSA_TRITON_FP8_DECODE
+            and _is_hip
+            and kv_cache.dtype == fp8_dtype
+            and is_dsa_enable_prefill_cp()
+            and not self.need_pad_heads
+        ):
+            _d_v = layer.v_head_dim
+            triton_sparse_mla_decode_fp8(
+                q_kernel[..., :_d_v].contiguous(),
+                q_kernel[..., _d_v:].contiguous(),
+                kv_cache,
+                page_table_1,
+                layer.scaling,
+                out=o_kernel,
+            )
+            return o
+
         q_scale = None
         kv_scale = None
         aiter_persistent_kwargs = {}
@@ -2754,6 +2824,25 @@ class DeepseekSparseAttnBackend(
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
             o_kernel = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+
+        if (
+            # ROCm gfx950: fp8-KV + prefill-CP -> per-query Triton sparse-MLA kernel.
+            _DSA_TRITON_FP8_DECODE
+            and _is_hip
+            and kv_cache.dtype == fp8_dtype
+            and is_dsa_enable_prefill_cp()
+            and not self.need_pad_heads
+        ):
+            _d_v = layer.v_head_dim
+            triton_sparse_mla_decode_fp8(
+                q_kernel[..., :_d_v].contiguous(),
+                q_kernel[..., _d_v:].contiguous(),
+                kv_cache,
+                page_table_1,
+                layer.scaling,
+                out=o_kernel,
+            )
+            return o
 
         q_scale = None
         kv_scale = None

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -111,6 +111,16 @@ def _all_gather_dsa_trtllm_fp8_kv(
 
 
 _is_hip = is_hip()
+# gfx950 (MI355) ships a native asm MLA decode kernel for gqa:64, so the
+# 64->4x16 head-split in _mla_decode_fwd_grouped only helps gfx942 (which aborts
+# on gqa:64). Splitting on gfx950 is a pure regression (4x sequential kernels +
+# per-group contiguous/copy), so detect gfx950 and skip the split there.
+try:
+    _IS_GFX950 = _is_hip and (
+        "gfx950" in torch.cuda.get_device_properties(0).gcnArchName
+    )
+except Exception:
+    _IS_GFX950 = False
 # ROCm gfx950 only: route the fp8-KV + prefill-CP DSA decode through a per-query
 # Triton sparse-MLA kernel. Off by default; opt in with SGLANG_DSA_TRITON_FP8_DECODE=1.
 _DSA_TRITON_FP8_DECODE = os.environ.get("SGLANG_DSA_TRITON_FP8_DECODE", "0") == "1"
@@ -178,7 +188,9 @@ def _mla_decode_fwd_grouped(
     nhead = q.shape[1]
     GROUP = 16
     can_split = (
-        nhead > 32
+        os.environ.get("SGLANG_DSA_NO_HEAD_SPLIT", "0") != "1"
+        and not _IS_GFX950
+        and nhead > 32
         and nhead % GROUP == 0
         and q.dtype == kv_buffer.dtype
         and q.dtype in (torch.bfloat16, fp8_dtype)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -125,8 +125,6 @@ if _is_hip:
     try:
         from aiter import (  # noqa: F401
             flash_attn_varlen_func,
-            get_mla_metadata_info_v1,
-            get_mla_metadata_v1,
             mha_batch_prefill_func,
             paged_attention_ragged,
         )
@@ -140,6 +138,91 @@ else:
         flash_attn_varlen_func,
         flash_attn_with_kvcache,
     )
+
+
+_DSA_A8W8 = get_bool_env_var("SGLANG_DSA_A8W8")
+
+
+def _dsa_a8w8_ok(max_seqlen_q) -> bool:
+    # a8w8 qh16 asm supports qseqlen in {1,2}; DSA extend is per-token (qseqlen=1).
+    return _DSA_A8W8 and max_seqlen_q is not None and int(max_seqlen_q) <= 2
+
+
+def _quant_q_fp8(q_bf16):
+    # per-tensor symmetric fp8 quant of the absorbed latent query.
+    _fmax = torch.finfo(fp8_dtype).max
+    q_scale = (q_bf16.detach().abs().amax() / _fmax).clamp_min(1e-6).to(torch.float32)
+    q_fp8 = (q_bf16 / q_scale).clamp(-_fmax, _fmax).to(fp8_dtype)
+    return q_fp8, q_scale
+
+
+def _mla_decode_fwd_grouped(
+    q,
+    kv_buffer,
+    o,
+    qo_indptr,
+    kv_indptr,
+    kv_indices,
+    kv_last_page_lens,
+    max_seqlen_q,
+    **kwargs,
+):
+    # gfx942 aiter ships asm MLA decode kernels only for a limited set of gqa
+    # head counts (nhead in {16, 32}). Under DSA prefill context-parallel
+    # attn_tp_size is forced to 1, so each rank holds all 64 heads and the asm
+    # kernel aborts: "get_heuristic_kernel_mla: cannot get heuristic kernel!
+    # gqa:64". MLA shares a single latent KV across all heads, so attention is
+    # independent per head. Splitting the 64-head call into 4 groups of 16 is
+    # mathematically exact and reuses the known-good gqa:16 kernel. Only triggers
+    # for a matching q/kv dtype with nhead a multiple of 16 and > 32.
+    nhead = q.shape[1]
+    GROUP = 16
+    can_split = (
+        nhead > 32
+        and nhead % GROUP == 0
+        and q.dtype == kv_buffer.dtype
+        and q.dtype in (torch.bfloat16, fp8_dtype)
+    )
+    if not can_split:
+        return mla_decode_fwd(
+            q,
+            kv_buffer,
+            o,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_lens,
+            max_seqlen_q,
+            **kwargs,
+        )
+    for g in range(nhead // GROUP):
+        sl = slice(g * GROUP, (g + 1) * GROUP)
+        q_g = q[:, sl, :].contiguous()
+        o_g = torch.empty(
+            (o.shape[0], GROUP, o.shape[2]), dtype=o.dtype, device=o.device
+        )
+        mla_decode_fwd(
+            q_g,
+            kv_buffer,
+            o_g,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_lens,
+            max_seqlen_q,
+            **kwargs,
+        )
+        o[:, sl, :] = o_g
+    return o
+
+
+def _gather_upcast_fp8_kv(kv_cache, kv_indices, count, arange, head_dim):
+    # gfx942 fp8-KV dequant-on-read: gather the first `count` selected fp8 KV
+    # rows, upcast to bf16 (raw store scale 1.0), and return the contiguous
+    # [N, 1, 1, head_dim] buffer plus the matching sequential indices
+    # (`arange[:count]`) that address it.
+    gathered = kv_cache.view(-1, head_dim)[kv_indices[:count]].to(torch.bfloat16)
+    return gathered.view(-1, 1, 1, head_dim), arange[:count]
 
 
 def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tensor:
@@ -419,6 +502,13 @@ class DeepseekSparseAttnBackend(
                 dtype=torch.int32,
                 device=self.device,
             )
+            # Sequential indices into the gathered+upcast bf16 KV buffer used by
+            # the gfx942 fp8-KV dequant-on-read decode path (see _forward_aiter_*).
+            self._fp8_dequant_arange = torch.arange(
+                max_bs * self.dsa_index_topk,
+                dtype=torch.int32,
+                device=self.device,
+            )
             # Aiter mla_decode_fwd supports num_heads multiples of 16 in range [16, 128].
             # For GLM-5 (64 heads / TP8 = 8) it pads 8->16 (gqaratio16 kernels).
             # V1 no-pad: gfx950 has native qh8/gqaratio8 v3 asm MLA
@@ -429,24 +519,6 @@ class DeepseekSparseAttnBackend(
             self.head_repeat_factor = (
                 16 // self.num_q_heads if self.need_pad_heads else 1
             )
-            self.num_head_padded = self.num_q_heads * self.head_repeat_factor
-            self.aiter_dsa_max_split_per_batch = 64
-            self.aiter_dsa_metadata_capacity = 0
-            self.aiter_dsa_metadata_max_seqlen_q = 0
-            self.aiter_dsa_metadata_q_dtype = None
-            self.aiter_dsa_metadata_kv_dtype = None
-            self.aiter_dsa_kv_last_page_lens = None
-            self.aiter_dsa_work_metadata = None
-
-            if (
-                self.dsa_prefill_impl == "aiter" or self.dsa_decode_impl == "aiter"
-            ) and model_runner.kv_cache_dtype == fp8_dtype:
-                self._ensure_aiter_dsa_decode_metadata_buffer(
-                    max_seqlen_q=1,
-                    batch_size=max_bs,
-                    q_dtype=torch.bfloat16,
-                    kv_dtype=fp8_dtype,
-                )
 
         # Speculative decoding
         self.topk = model_runner.server_args.speculative_eagle_topk or 0
@@ -522,145 +594,6 @@ class DeepseekSparseAttnBackend(
             self.workspace_buffer = None
             self._multi_ctas_kv_counter_buffer = None
 
-    def _make_aiter_dsa_decode_metadata_buffer(
-        self,
-        max_seqlen_q: int,
-        batch_size: int,
-        q_dtype: torch.dtype,
-        kv_dtype: torch.dtype,
-    ):
-        (
-            (work_metadata_size, work_metadata_type),
-            (work_indptr_size, work_indptr_type),
-            (work_info_set_size, work_info_set_type),
-            (reduce_indptr_size, reduce_indptr_type),
-            (reduce_final_map_size, reduce_final_map_type),
-            (reduce_partial_map_size, reduce_partial_map_type),
-        ) = get_mla_metadata_info_v1(
-            batch_size,
-            max_seqlen_q,
-            self.num_head_padded,
-            q_dtype,
-            kv_dtype,
-            is_sparse=True,
-            fast_mode=False,
-            num_kv_splits=self.aiter_dsa_max_split_per_batch,
-            intra_batch_mode=True,
-        )
-
-        return (
-            torch.empty(
-                work_metadata_size, dtype=work_metadata_type, device=self.device
-            ),
-            torch.empty(work_indptr_size, dtype=work_indptr_type, device=self.device),
-            torch.empty(
-                work_info_set_size, dtype=work_info_set_type, device=self.device
-            ),
-            torch.empty(
-                reduce_indptr_size, dtype=reduce_indptr_type, device=self.device
-            ),
-            torch.empty(
-                reduce_final_map_size, dtype=reduce_final_map_type, device=self.device
-            ),
-            torch.empty(
-                reduce_partial_map_size,
-                dtype=reduce_partial_map_type,
-                device=self.device,
-            ),
-        )
-
-    def _ensure_aiter_dsa_decode_metadata_buffer(
-        self,
-        max_seqlen_q: int,
-        batch_size: int,
-        q_dtype: torch.dtype,
-        kv_dtype: torch.dtype,
-    ) -> None:
-        if (
-            self.aiter_dsa_work_metadata is not None
-            and self.aiter_dsa_metadata_capacity >= batch_size
-            and self.aiter_dsa_metadata_max_seqlen_q == max_seqlen_q
-            and self.aiter_dsa_metadata_q_dtype == q_dtype
-            and self.aiter_dsa_metadata_kv_dtype == kv_dtype
-        ):
-            return
-
-        (
-            self.aiter_dsa_work_metadata,
-            self.aiter_dsa_work_indptr,
-            self.aiter_dsa_work_info_set,
-            self.aiter_dsa_reduce_indptr,
-            self.aiter_dsa_reduce_final_map,
-            self.aiter_dsa_reduce_partial_map,
-        ) = self._make_aiter_dsa_decode_metadata_buffer(
-            max_seqlen_q=max_seqlen_q,
-            batch_size=batch_size,
-            q_dtype=q_dtype,
-            kv_dtype=kv_dtype,
-        )
-        self.aiter_dsa_kv_last_page_lens = torch.ones(
-            (batch_size,), dtype=torch.int32, device=self.device
-        )
-        self.aiter_dsa_metadata_capacity = batch_size
-        self.aiter_dsa_metadata_max_seqlen_q = max_seqlen_q
-        self.aiter_dsa_metadata_q_dtype = q_dtype
-        self.aiter_dsa_metadata_kv_dtype = kv_dtype
-
-    def _prepare_aiter_dsa_decode_metadata(
-        self,
-        qo_indptr: torch.Tensor,
-        kv_indptr: torch.Tensor,
-        bs: int,
-        max_seqlen_q: int,
-        q_dtype: torch.dtype,
-        kv_dtype: torch.dtype,
-    ) -> dict:
-        self._ensure_aiter_dsa_decode_metadata_buffer(
-            max_seqlen_q=max_seqlen_q,
-            batch_size=bs,
-            q_dtype=q_dtype,
-            kv_dtype=kv_dtype,
-        )
-        self.aiter_dsa_kv_last_page_lens[:bs].fill_(1)
-        kv_last_page_lens = self.aiter_dsa_kv_last_page_lens[:bs]
-
-        get_mla_metadata_v1(
-            qo_indptr,
-            kv_indptr,
-            kv_last_page_lens,
-            self.num_head_padded,
-            1,
-            False,
-            self.aiter_dsa_work_metadata,
-            self.aiter_dsa_work_info_set,
-            self.aiter_dsa_work_indptr,
-            self.aiter_dsa_reduce_indptr,
-            self.aiter_dsa_reduce_final_map,
-            self.aiter_dsa_reduce_partial_map,
-            page_size=1,
-            kv_granularity=16,
-            max_seqlen_qo=max_seqlen_q,
-            uni_seqlen_qo=max_seqlen_q,
-            fast_mode=False,
-            topk=self.dsa_index_topk,
-            max_split_per_batch=self.aiter_dsa_max_split_per_batch,
-            intra_batch_mode=True,
-            dtype_q=q_dtype,
-            dtype_kv=kv_dtype,
-        )
-
-        return {
-            "kv_last_page_lens": kv_last_page_lens,
-            "work_meta_data": self.aiter_dsa_work_metadata,
-            "work_indptr": self.aiter_dsa_work_indptr,
-            "work_info_set": self.aiter_dsa_work_info_set,
-            "reduce_indptr": self.aiter_dsa_reduce_indptr,
-            "reduce_final_map": self.aiter_dsa_reduce_final_map,
-            "reduce_partial_map": self.aiter_dsa_reduce_partial_map,
-            "intra_batch_mode": True,
-            "num_kv_splits": self.aiter_dsa_max_split_per_batch,
-        }
-
     def _build_paged_mqa_schedule_2d_ctx_lens(
         self,
         forward_mode: ForwardMode,
@@ -707,7 +640,13 @@ class DeepseekSparseAttnBackend(
         # target-verify / draft-extend, whose expanded row count is exactly what v2
         # sees -- otherwise the helper's plan-present assertion fires. None only
         # when the fold is disabled; such metadata is never dispatched to v2.
-        if not envs.SGLANG_OPT_USE_TOPK_V2.get():
+        #
+        # The v2 top-k kernel uses Hopper thread-block clusters
+        # (cg::this_cluster()) and only JIT-compiles under CUDA; on ROCm/HIP the
+        # build fails ('cooperative_groups.h' not found) and every v2 consumer
+        # (transform dispatch, dsa_drop_wide_page_table) is already HIP-excluded,
+        # so skip the plan entirely on HIP.
+        if _is_hip or not envs.SGLANG_OPT_USE_TOPK_V2.get():
             return None
         from sglang.kernels.ops.attention.dsv4.topk import plan_topk_v2
 
@@ -2749,9 +2688,6 @@ class DeepseekSparseAttnBackend(
 
         q_scale = None
         kv_scale = None
-        aiter_persistent_kwargs = {}
-        if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
 
         kv_indptr = self.kv_indptr
 
@@ -2763,31 +2699,40 @@ class DeepseekSparseAttnBackend(
         get_valid_kv_indices(page_table_1, kv_indptr, kv_indices, bs)
 
         kv_last_page_lens = metadata.cu_seqlens_q
-        if kv_cache.dtype == fp8_dtype:
-            aiter_persistent_kwargs = self._prepare_aiter_dsa_decode_metadata(
-                metadata.cu_seqlens_q,
-                kv_indptr,
-                bs,
-                metadata.max_seq_len_q,
-                q_kernel.dtype,
-                kv_cache.dtype,
-            )
-            kv_last_page_lens = aiter_persistent_kwargs.pop("kv_last_page_lens")
 
-        mla_decode_fwd(
+        # gfx942 has no working asm fp8 MLA kernel. For fp8 KV either take the
+        # a8w8 asm path (fp8 Q + fp8 KV, qseqlen<=2) when SGLANG_DSA_A8W8=1, or
+        # dequant-on-read: gather only the top-k keys (bs*index_topk, fixed ->
+        # cuda-graph safe), upcast fp8->bf16, and run the validated bf16
+        # mla_decode_fwd with sequential indices.
+        kv_buffer_for_kernel = kv_cache.view(-1, 1, 1, layer.head_dim)
+        kv_indices_for_kernel = kv_indices
+        if kv_cache.dtype == fp8_dtype and _dsa_a8w8_ok(metadata.max_seq_len_q):
+            q_kernel, q_scale = _quant_q_fp8(q_kernel)
+            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
+        elif kv_cache.dtype == fp8_dtype:
+            q_kernel = q_kernel.to(torch.bfloat16)
+            kv_buffer_for_kernel, kv_indices_for_kernel = _gather_upcast_fp8_kv(
+                kv_cache,
+                kv_indices,
+                bs * self.dsa_index_topk,
+                self._fp8_dequant_arange,
+                layer.head_dim,
+            )
+
+        _mla_decode_fwd_grouped(
             q_kernel,
-            kv_cache.view(-1, 1, 1, layer.head_dim),
+            kv_buffer_for_kernel,
             o_kernel,
             metadata.cu_seqlens_q,
             kv_indptr,
-            kv_indices,
+            kv_indices_for_kernel,
             kv_last_page_lens,
             metadata.max_seq_len_q,
             sm_scale=layer.scaling,
             logit_cap=layer.logit_cap,
             q_scale=q_scale,
             kv_scale=kv_scale,
-            **aiter_persistent_kwargs,
         )
 
         if self.need_pad_heads:
@@ -2846,9 +2791,6 @@ class DeepseekSparseAttnBackend(
 
         q_scale = None
         kv_scale = None
-        aiter_persistent_kwargs = {}
-        if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
 
         non_minus1_mask = page_table_1 != -1
         non_minus1_counts = non_minus1_mask.sum(dim=1)
@@ -2870,32 +2812,50 @@ class DeepseekSparseAttnBackend(
             0, num_tokens + 1, dtype=torch.int32, device=self.device
         )
         kv_last_page_lens = cu_seqlens_q
-        if kv_cache.dtype == fp8_dtype:
-            aiter_persistent_kwargs = self._prepare_aiter_dsa_decode_metadata(
-                cu_seqlens_q,
-                kv_indptr,
-                num_tokens,
-                1,
-                q_kernel.dtype,
-                kv_cache.dtype,
-            )
-            kv_last_page_lens = aiter_persistent_kwargs.pop("kv_last_page_lens")
+
+        # gfx942 fp8-KV dequant-on-read (extend). EAGLE target-verify / draft-
+        # extend runs every decode step over all layers with small num_tokens, so
+        # gather only the top-k keys (num_tokens*topk fixed -> graph safe) and
+        # upcast fp8->bf16 instead of dequanting the full pool (that was the ~15x
+        # EAGLE decode slowdown). Real prefill chunks have large num_tokens
+        # (gather > pool) -> full-pool upcast.
+        kv_buffer_for_kernel = kv_cache.view(-1, 1, 1, layer.head_dim)
+        kv_indices_for_kernel = kv_indices
+        if kv_cache.dtype == fp8_dtype and _dsa_a8w8_ok(1):
+            q_kernel, q_scale = _quant_q_fp8(q_kernel)
+            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
+        elif kv_cache.dtype == fp8_dtype:
+            q_kernel = q_kernel.to(torch.bfloat16)
+            _pool = kv_cache.view(-1, layer.head_dim).shape[0]
+            if num_tokens * topk <= _pool:
+                kv_buffer_for_kernel, kv_indices_for_kernel = _gather_upcast_fp8_kv(
+                    kv_cache,
+                    kv_indices,
+                    num_tokens * topk,
+                    torch.arange(
+                        num_tokens * topk, dtype=torch.int32, device=self.device
+                    ),
+                    layer.head_dim,
+                )
+            else:
+                kv_buffer_for_kernel = kv_cache.to(torch.bfloat16).view(
+                    -1, 1, 1, layer.head_dim
+                )
 
         # TODO support more forward_mode
-        mla_decode_fwd(
+        _mla_decode_fwd_grouped(
             q_kernel,
-            kv_cache.view(-1, 1, 1, layer.head_dim),
+            kv_buffer_for_kernel,
             o_kernel,
             cu_seqlens_q,
             kv_indptr,
-            kv_indices,
+            kv_indices_for_kernel,
             kv_last_page_lens,
             1,  # max_seq_len_q = 1 for per-token attention
             sm_scale=layer.scaling,
             logit_cap=layer.logit_cap,
             q_scale=q_scale,
             kv_scale=kv_scale,
-            **aiter_persistent_kwargs,
         )
 
         if self.need_pad_heads:

--- a/python/sglang/srt/layers/quantization/fp8_attn_proj.py
+++ b/python/sglang/srt/layers/quantization/fp8_attn_proj.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dynamic blockwise (128x128) fp8 linear method for the otherwise bf16 /
+Quark-excluded GLM-5.1 ATTENTION PROJECTIONS (o_proj, q_b_proj, q_a_proj).
+
+Env-gated by SGLANG_FP8_ATTN_PROJ=1 in quark.QuarkConfig. The GLM-5.1 MLA decode
+path pre-quantizes o_proj / q_b_proj inputs with group_size=128 and
+``transpose_scale=_use_aiter_bpreshuffle_gfx95`` (``fused_flatten_fp8_group_quant``
+/ ``fused_rms_fp8_group_quant``), handing the linear a ``(qinput, x_scale)``
+tuple destined for the aiter gfx95 ``gemm_a8w8_blockscale_bpreshuffle`` GEMM. To
+match that GEMM we online-quantize the bf16 weight to 128x128-block fp8 with a
+plain float32 [N/128, K/128] scale and bpreshuffle the fp8 weight via
+``shuffle_weight(w, (16, 16))`` (validated cos>0.999 vs bf16 on a standalone
+test). On the prefill path we quantize the raw bf16 activation with the same
+per-1x128 + transpose_scale aiter quant. gfx950 uses OCP e4m3fn.
+
+Only N and K divisible by 128 are supported (o_proj 6144x16384, q_b_proj
+16384x2048, q_a_proj 2048x6144). kv_a_proj_with_mqa (N=576) and the fused
+qkv_a_proj (N=2624) are not 128-aligned and stay bf16.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+from torch.nn import Parameter
+
+from sglang.srt.layers.parameter import ModelWeightParameter
+from sglang.srt.layers.quantization.base_config import LinearMethodBase
+from sglang.srt.utils import get_bool_env_var, is_hip
+
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
+
+if _use_aiter:
+    import aiter
+    from aiter import gemm_a8w8_blockscale_bpreshuffle, get_hip_quant
+    from aiter.ops.shuffle import shuffle_weight
+
+    _fp8 = aiter.dtypes.fp8
+    _finfo = torch.finfo(_fp8)
+    _per1x128 = get_hip_quant(aiter.QuantType.per_1x128)
+
+_BLK = 128
+
+
+def _block128_weight_quant(w: torch.Tensor):
+    # w [N, K] bf16 -> fp8 [N, K] + float32 scale [N/128, K/128].
+    n, k = w.shape
+    wv = w.float().view(n // _BLK, _BLK, k // _BLK, _BLK)
+    amax = wv.abs().amax(dim=(1, 3), keepdim=True).clamp(1e-6)
+    scale = amax / _finfo.max
+    wq = (wv / scale).clamp(_finfo.min, _finfo.max).to(_fp8).view(n, k)
+    return wq.contiguous(), scale.view(n // _BLK, k // _BLK).float().contiguous()
+
+
+class Fp8AttnProjBlockMethod(LinearMethodBase):
+    def __init__(self):
+        self.out_dtype = torch.get_default_dtype()
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        n = sum(output_partition_sizes)
+        k = input_size_per_partition
+        if n % _BLK != 0 or k % _BLK != 0:
+            raise ValueError(
+                f"Fp8AttnProjBlockMethod requires N,K % 128 == 0, got N={n} K={k}"
+            )
+        layer.logical_widths = output_partition_sizes
+        weight = ModelWeightParameter(
+            data=torch.empty(n, k, dtype=params_dtype),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=extra_weight_attrs.get("weight_loader"),
+        )
+        layer.register_parameter("weight", weight)
+        layer.weight_scale_inv = None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        wq, w_scale = _block128_weight_quant(layer.weight.data)
+        wq = shuffle_weight(wq, layout=(16, 16))  # bpreshuffle layout for the GEMM
+        layer.weight = Parameter(wq, requires_grad=False)
+        layer.weight_scale_inv = Parameter(w_scale, requires_grad=False)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if isinstance(x, tuple):
+            # decode: model already produced (qinput_fp8, x_scale) (group 128,
+            # transpose_scale=_use_aiter_bpreshuffle_gfx95).
+            q_input, x_scale = x
+            out_lead = q_input.shape[:-1]
+        else:
+            x2d = x.view(-1, x.shape[-1])
+            q_input, x_scale = _per1x128(
+                x2d, quant_dtype=_fp8, transpose_scale=True
+            )
+            out_lead = x.shape[:-1]
+        output = gemm_a8w8_blockscale_bpreshuffle(
+            q_input,
+            layer.weight,
+            x_scale,
+            layer.weight_scale_inv,
+            dtype=torch.bfloat16,
+        )
+        if bias is not None:
+            output = output + bias
+        return output.view(*out_lead, output.shape[-1])

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -2,6 +2,7 @@
 
 import fnmatch
 import logging
+import os
 from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 import torch
@@ -137,6 +138,33 @@ class QuarkConfig(QuantizationConfig):
             if name.startswith("language_model."):
                 expanded.append(name.removeprefix("language_model."))
         self.exclude_layers = list(dict.fromkeys(expanded))
+
+    # Env-gated: quantize otherwise-excluded (bf16) ATTENTION PROJECTIONS to
+    # dynamic W8A8 fp8 to cut decode HBM traffic. Off by default so the bf16
+    # baseline is untouched. Never touches kv_b_proj (absorbed into w_kc/w_vc
+    # for the MLA decode bmm) or the indexer/router/MLP/lm_head/embedding.
+    _FP8_ATTN_PROJ_DEFAULT = "o_proj"
+    _FP8_ATTN_PROJ_NEVER = ("kv_b_proj",)
+
+    def _maybe_fp8_attn_proj_method(self, prefix: str):
+        if os.environ.get("SGLANG_FP8_ATTN_PROJ", "0") != "1":
+            return None
+        if "self_attn" not in prefix or ".indexer" in prefix:
+            return None
+        if any(prefix.endswith(s) for s in self._FP8_ATTN_PROJ_NEVER):
+            return None
+        layers = os.environ.get(
+            "SGLANG_FP8_ATTN_PROJ_LAYERS", self._FP8_ATTN_PROJ_DEFAULT
+        )
+        suffixes = [x.strip() for x in layers.split(",") if x.strip()]
+        if not any(prefix.endswith(s) for s in suffixes):
+            return None
+        from sglang.srt.layers.quantization.fp8_attn_proj import (
+            Fp8AttnProjBlockMethod,
+        )
+        self._quantized_layers.add(prefix)
+        logger.info("[fp8-attn-proj] quantizing %s to dynamic block fp8", prefix)
+        return Fp8AttnProjBlockMethod()
 
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str

--- a/python/sglang/srt/layers/quantization/w8a8_fp8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_fp8.py
@@ -25,7 +25,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     input_to_float8,
     normalize_e4m3fn_to_e4m3fnuz,
 )
-from sglang.srt.utils import set_weight_attrs
+from sglang.srt.utils import get_bool_env_var, is_hip, set_weight_attrs
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -34,6 +34,10 @@ if TYPE_CHECKING:
     )
 
 _is_fp8_fnuz = is_fp8_fnuz()
+# Route per-channel (PTPC) MoE through the aiter asm fused_moe(per_Token) on fnuz
+# HIP (gfx942). The upstream Triton per-channel fnuz MoE path produces corrupted
+# output on gfx942, so the checkpoint decodes to garbage without this.
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and is_hip()
 
 
 class W8A8Fp8Config(QuantizationConfig):
@@ -219,13 +223,25 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
     ):
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
 
+        # For an offline-quantized (OCP e4m3fn) checkpoint, create the expert
+        # weight params as e4m3fn so the loader copy_ is bit-faithful. On fnuz
+        # hardware (gfx942/MI300) we later reinterpret+rescale via
+        # normalize_e4m3fn_to_e4m3fnuz in process_weights_after_loading. Creating
+        # them as fp8_dtype (e4m3fnuz) here would make copy_ value-convert, which
+        # NaNs every checkpoint weight whose magnitude exceeds the fnuz max (240).
+        weight_dtype = (
+            torch.float8_e4m3fn
+            if self.quant_config.is_checkpoint_fp8_serialized
+            else fp8_dtype
+        )
+
         # WEIGHTS
         w13_weight = torch.nn.Parameter(
             torch.empty(
                 num_experts,
                 2 * intermediate_size_per_partition,
                 hidden_size,
-                dtype=fp8_dtype,
+                dtype=weight_dtype,
             ),
             requires_grad=False,
         )
@@ -237,7 +253,7 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
                 num_experts,
                 hidden_size,
                 intermediate_size_per_partition,
-                dtype=fp8_dtype,
+                dtype=weight_dtype,
             ),
             requires_grad=False,
         )
@@ -271,20 +287,49 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w2_input_scale", w2_input_scale)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        layer.w13_weight = Parameter(layer.w13_weight, requires_grad=False)
-        layer.w2_weight = Parameter(layer.w2_weight, requires_grad=False)
-        layer.w13_weight_scale = Parameter(
-            layer.w13_weight_scale.data, requires_grad=False
-        )
-        layer.w2_weight_scale = Parameter(
-            layer.w2_weight_scale.data, requires_grad=False
-        )
+        # On fnuz hardware (gfx942/MI300) the experts were loaded bit-faithfully
+        # as OCP e4m3fn; reinterpret to e4m3fnuz and double the scale so the
+        # per-channel dequant matches the checkpoint without overflow.
+        if _is_fp8_fnuz and layer.w13_weight.dtype == torch.float8_e4m3fn:
+            w13_weight, w13_weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                weight=layer.w13_weight, weight_scale=layer.w13_weight_scale
+            )
+            w2_weight, w2_weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                weight=layer.w2_weight, weight_scale=layer.w2_weight_scale
+            )
+            layer.w13_weight = Parameter(w13_weight, requires_grad=False)
+            layer.w2_weight = Parameter(w2_weight, requires_grad=False)
+            layer.w13_weight_scale = Parameter(w13_weight_scale, requires_grad=False)
+            layer.w2_weight_scale = Parameter(w2_weight_scale, requires_grad=False)
+        else:
+            layer.w13_weight = Parameter(layer.w13_weight, requires_grad=False)
+            layer.w2_weight = Parameter(layer.w2_weight, requires_grad=False)
+            layer.w13_weight_scale = Parameter(
+                layer.w13_weight_scale.data, requires_grad=False
+            )
+            layer.w2_weight_scale = Parameter(
+                layer.w2_weight_scale.data, requires_grad=False
+            )
+
+        if _use_aiter:
+            # aiter asm fused_moe expects MFMA-shuffled expert weights.
+            from aiter.ops.shuffle import shuffle_weight
+
+            layer.w13_weight = Parameter(
+                shuffle_weight(layer.w13_weight.data.contiguous(), (16, 16)),
+                requires_grad=False,
+            )
+            layer.w2_weight = Parameter(
+                shuffle_weight(layer.w2_weight.data.contiguous(), (16, 16)),
+                requires_grad=False,
+            )
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
     ):
         self.moe_runner_config = moe_runner_config
-        self.runner = MoeRunner(MoeRunnerBackend.TRITON, moe_runner_config)
+        backend = MoeRunnerBackend.AITER if _use_aiter else MoeRunnerBackend.TRITON
+        self.runner = MoeRunner(backend, moe_runner_config)
 
     def get_triton_quant_info(self, layer: torch.nn.Module) -> TritonMoeQuantInfo:
         return TritonMoeQuantInfo(
@@ -303,6 +348,21 @@ class W8A8FP8MoEMethod(FusedMoEMethodBase):
         layer: torch.nn.Module,
         dispatch_output: StandardDispatchOutput,
     ) -> CombineInput:
+
+        if _use_aiter:
+            from sglang.srt.layers.moe.moe_runner.aiter import (
+                AiterMoeQuantInfo,
+                AiterQuantType,
+            )
+
+            quant_info = AiterMoeQuantInfo(
+                w13_weight=layer.w13_weight,
+                w2_weight=layer.w2_weight,
+                quant_type=AiterQuantType.PER_TOKEN,
+                w13_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+            )
+            return self.runner.run(dispatch_output, quant_info)
 
         quant_info = self.get_triton_quant_info(layer)
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1347,11 +1347,24 @@ class KVCacheConfigurator:
             pool_kwargs["quant_method"] = quant_method
         else:
             pool_kwargs["post_capture_active"] = self.post_capture_kv_active
+        # DFLASH draft + prefill-CP: the dense draft attention shards KV heads by
+        # the full tp_size (see DFlashAttention), but attn_tp_size collapses to 1
+        # under CP. Size the draft KV pool by tp_size so its per-rank row geometry
+        # matches the draft attention output (otherwise the graph-captured
+        # store_cache write sees cp_size x too many index slots) and the pool does
+        # not over-allocate ~cp_size x. No-op when attn_tp_size == tp_size (non-CP).
+        _dflash_cp_kv_head_tp = get_parallel().attn_tp_size
+        if (
+            self.is_draft_worker
+            and self.spec_algorithm.is_dflash_family()
+            and get_parallel().attn_tp_size != get_parallel().tp_size
+        ):
+            _dflash_cp_kv_head_tp = get_parallel().tp_size
         token_to_kv_pool = pool_cls(
             max_total_num_tokens,
             page_size=self.server_args.page_size,
             dtype=self.kv_cache_dtype,
-            head_num=self.model_config.get_num_kv_heads(get_parallel().attn_tp_size),
+            head_num=self.model_config.get_num_kv_heads(_dflash_cp_kv_head_tp),
             head_dim=self.model_config.head_dim,
             v_head_dim=self.model_config.v_head_dim,
             layer_num=self.layer_info.num_effective_layers,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -183,6 +183,16 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
 
         kv_size = torch._utils._element_size(kv_cache_dtype)
         tp_size = get_parallel().attn_tp_size
+        # DFLASH draft + prefill-CP: keep the draft cell-size budget consistent
+        # with the draft KV pool geometry (dense draft shards KV heads by tp_size,
+        # not attn_tp_size which is 1 under CP), so draft token capacity matches
+        # the target. No-op when attn_tp_size == tp_size (non-CP).
+        if (
+            kvc.is_draft_worker
+            and kvc.spec_algorithm.is_dflash_family()
+            and get_parallel().attn_tp_size != get_parallel().tp_size
+        ):
+            tp_size = get_parallel().tp_size
 
         if kvc.use_mla_backend:
             cell_size = (

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -368,6 +368,24 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             self.cp_size = None
 
         nextn_quant_config = self._resolve_nextn_quant_config(config, quant_config)
+        # For quark, if the MTP layer is listed in exclude_layers, set quant_config to None.
+        if nextn_quant_config is not None and nextn_quant_config.get_name() == "quark":
+            from sglang.srt.layers.quantization.quark.utils import (
+                should_ignore_layer,
+            )
+
+            # GLM-5.2-safe: the MTP/NextN layer (model.layers.{N}) is exported
+            # fully unquantized (bf16) in some Quark exports (e.g. GLM-5.2-MXFP4),
+            # signalled by its eh_proj being listed in `exclude`. The bare layer
+            # prefix is never an exclude entry, so check the eh_proj weight name
+            # (mapped HF->sglang, matching how exclude_layers were mapped). When
+            # excluded, drop the NextN quant config so eh_proj and the rest of the
+            # MTP layer load as bf16. GLM-5.1 (MXFP4 MTP, eh_proj not excluded) is
+            # unaffected: the check is False and the quant config is retained.
+            ckpt_prefix = f"model.layers.{config.num_hidden_layers}.eh_proj"
+            mapped_prefix = self.hf_to_sglang_mapper._map_name(ckpt_prefix)
+            if should_ignore_layer(mapped_prefix, nextn_quant_config.exclude_layers):
+                nextn_quant_config = None
 
         self.model = DeepseekModelNextN(
             config, nextn_quant_config, prefix=add_prefix("model", prefix)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2010,8 +2010,11 @@ class DeepseekV2AttentionMLA(
 
     def rebuild_cp_kv_cache(self, latent_cache, forward_batch, k_nope, k_pe):
         # support allgather+rerrange
-        latent_cache[..., : self.kv_lora_rank] = k_nope.squeeze(1)
-        latent_cache[..., self.kv_lora_rank :] = k_pe.squeeze(1)
+        # On the CP + EAGLE verify path k_pe can be a view aliasing the same
+        # latent_cache slice being written, which torch rejects as an in-place
+        # self-overlap; clone the RHS so the copy has independent storage.
+        latent_cache[..., : self.kv_lora_rank] = k_nope.squeeze(1).clone()
+        latent_cache[..., self.kv_lora_rank :] = k_pe.squeeze(1).clone()
         latent_cache_output = cp_all_gather_rerange_output(
             latent_cache.contiguous(),
             self.cp_size,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -775,6 +775,12 @@ class DeepseekV2MoE(nn.Module):
                 ):
                     # For compressed-tensors ptpc model, don't need to check the weight_block_size
                     pass
+                elif not hasattr(
+                    self.shared_experts.gate_up_proj.quant_method, "quant_config"
+                ):
+                    # PTPC per-tensor/per-token fp8 (e.g. w8a8_fp8 W8A8Fp8LinearMethod) has
+                    # no block-scaled weights: nothing to validate/store (block_size=None).
+                    self.shared_experts_weight_block_size = None
                 else:
                     assert (
                         self.shared_experts.gate_up_proj.quant_method.quant_config.weight_block_size

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2225,6 +2225,20 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states, topk_indices = hidden_states
         else:
             topk_indices = None
+        # [AMD/HIP] DSA prefill-CP NaN fix: on gfx950 the DSA sparse-attention output
+        # contains NaN rows for a subset of tokens under prefill context-parallel
+        # (round-robin split leaves padding / degenerate empty-sparse-KV query rows;
+        # softmax over an all-masked KV row -> NaN). Left unsanitized the NaN
+        # propagates through the residual stream to every token by the final layer,
+        # yielding all-NaN logits -> all-token-0 garbage. Sanitizing here (HIP + CP
+        # prefill only) stops the propagation; real tokens are unaffected. Additive:
+        # V1/non-CP never enters this branch (dsa/mla_enable_prefill_cp are False).
+        if (
+            _is_hip
+            and (self.dsa_enable_prefill_cp or self.mla_enable_prefill_cp)
+            and forward_batch.forward_mode.is_extend()
+        ):
+            hidden_states = torch.nan_to_num(hidden_states)
         get_attn_tp_context().clear_attn_inputs()
 
         maybe_prefetch_next_full_attention_kv(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2688,6 +2688,21 @@ class DeepseekV2Model(nn.Module):
                 forward_batch,
                 torch.cuda.current_stream(),
             )
+            # DFLASH/EAGLE3 aux hidden states are captured at intermediate target
+            # layers in the CP-split token layout; gather them to full length too
+            # so downstream pruning (LogitsProcessor uses full-seq last_index) and
+            # the DFlash draft-KV materialization index them consistently with the
+            # main hidden states. Without this the aux tensors keep 1/cp_size the
+            # tokens and full-length indices read out of bounds (HIP memory fault).
+            aux_hidden_states = [
+                cp_all_gather_rerange_output(
+                    aux,
+                    self.cp_size,
+                    forward_batch,
+                    torch.cuda.current_stream(),
+                )
+                for aux in aux_hidden_states
+            ]
         if len(aux_hidden_states) == 0:
             return hidden_states
         return hidden_states, aux_hidden_states

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -49,6 +49,8 @@ from sglang.srt.speculative.draft_worker_common import (
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import assign_req_to_token_pool_func
 from sglang.srt.utils import get_available_gpu_memory, is_cuda, is_hip, is_npu
+from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
+from sglang.srt.runtime_context import get_parallel
 
 _is_npu = is_npu()
 
@@ -1039,6 +1041,18 @@ class DFlashWorkerV2(BaseSpecWorker):
                 f"DFLASH positions must be 1D, got shape={tuple(positions.shape)}."
             )
         num_tokens = int(target_hidden.shape[0])
+        # Prefill context-parallel (round-robin split) all-gathers hidden states to
+        # a length padded up to a multiple of cp_size; those trailing rows are
+        # padding (round-robin de-interleave keeps real tokens contiguous at
+        # [0:n_real]). cache_loc / positions carry the real token count, so drop the
+        # small CP padding tail to keep the draft-KV write aligned. Guarded to CP +
+        # a positive sub-cp_size excess so non-CP / non-DFlash paths are untouched.
+        _cache_n = int(cache_loc.numel())
+        if num_tokens > _cache_n and is_dsa_enable_prefill_cp():
+            _cp = int(get_parallel().attn_cp_size)
+            if _cp > 1 and 0 < (num_tokens - _cache_n) < _cp:
+                target_hidden = target_hidden[:_cache_n]
+                num_tokens = _cache_n
         if int(cache_loc.numel()) != num_tokens:
             raise ValueError(
                 "DFLASH cache_loc length mismatch: "


### PR DESCRIPTION
## Summary
Enables **GLM-5.2-MXFP4 on GFX950** and **GLM-5.2-PTPC on GFX942** with **DSA sparse attention**,
**prefill context-parallel (CP)**, and **EAGLE speculative decoding** on **AMD ROCm**,
on top of the `v0.5.15.post1` release. All changes are additive and guarded (`_is_hip` / arch / default-off
env flags), so CUDA/NVIDIA and the bf16 baseline are untouched. 13 files.

Also support DFlash now

## Resource
- [GLM-5.2-PTPC model](https://huggingface.co/ginsongsong/GLM-5.2-FP8-PTPC)
- [GLM-5.2-MXFP4 model](https://huggingface.co/amd/GLM-5.2-MXFP4)
- [aiter](https://github.com/AFDEAPAC/aiter/tree/rotary_embedding_for_CP_EAGLE) based on v0.1.16.post3 with CP+EAGLE rotary_embedding fix 
- [GLM-5.2-FP8-DFlash model](https://huggingface.co/UCloud-org/GLM-5.2-FP8-DFlash)

## Shared / model-level (both archs)
- **`qk_rope_head_dim` recovery** — config `attribute_map` clobbers it with `head_dim`,
  breaking q/kv/rope geometry (weight-load abort). Recompute after HF config load. (`e91ca4e`)
- **NextN/MTP bf16** — load the Quark-excluded `eh_proj` MTP layer as bf16. (`9665bcc`)
- **DSA Triton correctness** — power-of-two-pad `tl.arange` in `concat_and_cast_mha_k`
  (192 head dim broke compile); eps-guard the `quantize_k_cache` fp8 scale (all-zero-tile
  NaN). (`16c2351`)
- **CP stability** — canonical-stride copy of `x_for_gate` before the gate GEMM; clone
  RHS in `rebuild_cp_kv_cache` to avoid in-place self-overlap. (`47d7328`)

## Environment flags (all default-off / opt-in)
| Flag | Arch | Effect |
| --- | --- | --- |
| `SGLANG_DSA_NO_PAD_HEADS=1` | gfx950 | Native 8-head DSA MLA (no 8→16 pad) |
| `SGLANG_DSA_NO_HEAD_SPLIT=1` | gfx950 | Force-disable the 64→4×16 split |
| `SGLANG_DSA_TRITON_FP8_DECODE=1` | gfx950 | Triton sparse-MLA fp8-KV + prefill-CP decode |
| `SGLANG_AITER_MLA_NO_PAD_HEADS=1` | gfx950 | aiter MLA native small-head decode |
| `SGLANG_FP8_ATTN_PROJ=1` (+`_LAYERS`) | gfx950 | fp8 attention-projection quant |
| `SGLANG_DSA_A8W8=1` | gfx942 | Native fp8 asm MLA (fp8 Q+KV, qseqlen≤2) |

## Part 1 — gfx942
- **PTPC fnuz MoE via aiter** — Triton per-channel fnuz MoE is corrupt on gfx942; route
  through aiter asm `fused_moe`, loading experts as OCP e4m3fn then rescaling to fnuz. (`c5f56b3`)
- **topk_v2 HIP guard** — skip the CUDA-only cluster `topk_v2` JIT on HIP. (`76ba528`)
- **fp8-KV MLA dequant-on-read** — replace the broken asm fp8 MLA with gather-topk →
  upcast bf16 → validated `mla_decode_fwd`; `_mla_decode_fwd_grouped` splits 64 heads into
  4×16 for CP attn_tp=1. `SGLANG_DSA_A8W8` keeps the native fp8 asm path (opt-in). (`76ba528`)
- if you want to run on GLM-5.2-FP8 model, please remove `--quantization w8a8_fp8` in script ( Thanks to Qiu, Tong for validation )

server script ( CP only )
```
#!/usr/bin/env bash
set -uo pipefail
# GLM-5.2-FP8-PTPC — prefill context-parallel (CP) + EAGLE + fp8 KV, gfx942 / MI308X, tp8.
export SGLANG_MOE_PADDING=1
export SGLANG_SET_CPU_AFFINITY=1
export SGLANG_USE_ROCM700A=1
export SGLANG_INT4_WEIGHT=0
export SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1
export SGLANG_DISABLE_CUDNN_CHECK=1
export SGLANG_ROCM_FUSED_DECODE_MLA=1
export SGLANG_ROCM_DISABLE_LINEARQUANT=0
export SGLANG_DSA_A8W8=${SGLANG_DSA_A8W8:-1}          # native fp8 A8W8 asm MLA (gfx942)
# aiter / sglang FP8 PTPC env
export SGLANG_USE_AITER=1
export SGLANG_USE_AITER_FP8_PER_TOKEN=1
export AITER_TUNE_GEMM=0
export AITER_ONLINE_TUNE=0
export SGLANG_HEALTH_CHECK_TIMEOUT=1200
MODEL=${MODEL:-/mnt/md0/models/GLM-5.2-FP8-PTPC}
PORT=${PORT:-30001}
SERVED=${SERVED:-glm-5.2-fp8-ptpc}
SPEC=${SPEC:-1}
KVDTYPE=${KVDTYPE:-fp8_e4m3}          # fp8 KV default (~2x capacity); bf16 via KVDTYPE=bfloat16
CTX=${CTX:-131072}
CHUNK=${CHUNK:-16384}
CP_STRATEGY=${CP_STRATEGY:-interleave}
SPEC_STEPS=${SPEC_STEPS:-7}
SPEC_TOPK=${SPEC_TOPK:-1}
SPEC_DRAFT=${SPEC_DRAFT:-8}
SPEC_ARGS=()
if [[ "$SPEC" == "1" ]]; then
  SPEC_ARGS=(
    --speculative-algorithm EAGLE
    --speculative-num-steps "$SPEC_STEPS"
    --speculative-eagle-topk "$SPEC_TOPK"
    --speculative-num-draft-tokens "$SPEC_DRAFT"
    --speculative-accept-threshold-single 0.5
    --speculative-accept-threshold-acc 0.8
  )
fi
exec python3 -m sglang.launch_server \
  --model-path "$MODEL" --tp-size 8 \
  --quantization w8a8_fp8 --kv-cache-dtype "$KVDTYPE" \
  --attention-backend dsa --dsa-prefill-backend aiter --dsa-decode-backend aiter \
  --enable-fused-qk-norm-rope --enable-prefill-cp --cp-strategy "$CP_STRATEGY" \
  --trust-remote-code --mem-fraction-static 0.85 \
  --context-length "$CTX" --chunked-prefill-size "$CHUNK" \
  --served-model-name "$SERVED" --reasoning-parser glm45 --tool-call-parser glm47 \
  --disable-radix-cache ${EXTRA_ARGS:-} "${SPEC_ARGS[@]}" --port "$PORT"
```

DFlash only or DFlash + CP ( set ENABLE_CP=1 )
```
set -uo pipefail

export SGLANG_MOE_PADDING=1
export SGLANG_SET_CPU_AFFINITY=1
export SGLANG_USE_ROCM700A=1
export SGLANG_INT4_WEIGHT=0
export SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1
export SGLANG_DISABLE_CUDNN_CHECK=1
export SGLANG_ROCM_FUSED_DECODE_MLA=1
export SGLANG_ROCM_DISABLE_LINEARQUANT=0
export SGLANG_DSA_A8W8=${SGLANG_DSA_A8W8:-1}

# --- aiter / sglang FP8 PTPC env ---
export SGLANG_USE_AITER=1
export SGLANG_USE_AITER_FP8_PER_TOKEN=1
export AITER_TUNE_GEMM=0
export AITER_ONLINE_TUNE=0
export SGLANG_HEALTH_CHECK_TIMEOUT=1200


MODEL=${MODEL:-/mnt/md0/models/GLM-5.2-FP8-PTPC}
PORT=${PORT:-30001}
SERVED=${SERVED:-glm-5.2-fp8-dflash}
SPEC=${SPEC:-1}                                  # SPEC=1 enable DFLASH draft; SPEC=0 plain decode
KVDTYPE=${KVDTYPE:-fp8_e4m3}                      # overridable; fall back to bfloat16 if needed
CTX=${CTX:-131072}
CHUNK=${CHUNK:-16384}
MEM_FRAC=${MEM_FRAC:-0.85}                        # lower (e.g. 0.80) if DFlash draft KV pool OOMs
CP_STRATEGY=${CP_STRATEGY:-interleave}

# --- DFLASH draft config (env-overridable) ---
DRAFT_MODEL=${DRAFT_MODEL:-/mnt/md0/models/GLM-5.2-FP8-DFlash}
DFLASH_BLOCK=${DFLASH_BLOCK:-16}                  # verify window / num draft tokens (draft block_size=16)

# --- prefill-CP toggle (DEFAULT OFF; DFlash+CP unverified) ---
ENABLE_CP=${ENABLE_CP:-0}

SPEC_ARGS=()
if [[ "$SPEC" == "1" ]]; then
  SPEC_ARGS=(
    --speculative-algorithm DFLASH
    --speculative-draft-model-path "$DRAFT_MODEL"
    --speculative-num-draft-tokens "$DFLASH_BLOCK"
    --speculative-draft-model-quantization unquant
    --speculative-draft-attention-backend triton
  )
fi

CP_ARGS=()
if [[ "$ENABLE_CP" == "1" ]]; then
  CP_ARGS=(
    --enable-prefill-cp
    --cp-strategy "$CP_STRATEGY"
  )
fi

exec python3 -m sglang.launch_server \
  --model-path "$MODEL" \
  --tp-size 8 \
  --quantization w8a8_fp8 \
  --kv-cache-dtype "$KVDTYPE" \
  --attention-backend dsa \
  --dsa-prefill-backend aiter \
  --dsa-decode-backend aiter \
  --enable-fused-qk-norm-rope \
  --trust-remote-code \
  --mem-fraction-static "$MEM_FRAC" \
  --context-length "$CTX" \
  --chunked-prefill-size "$CHUNK" \
  --served-model-name "$SERVED" \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --disable-radix-cache \
  ${EXTRA_ARGS:-} \
  "${CP_ARGS[@]}" \
  "${SPEC_ARGS[@]}" \
  --port "$PORT"
```

## Part 2 — gfx950
- **No-pad-heads DSA MLA** — `SGLANG_DSA_NO_PAD_HEADS=1`: native qh8 kernel, no 8→16 pad. (`12647c5`)
- **CP+EAGLE seqlens padding** — pad `seqlens_expanded` for paged-consumer modes under
  prefill-CP; no-op otherwise. (`12647c5`)
- **Triton fp8-KV + prefill-CP decode** — opt-in kernel behind
  `SGLANG_DSA_TRITON_FP8_DECODE=1`. (`12647c5`)
- **Prefill-CP NaN guard** — `nan_to_num` sparse-attn output under HIP + prefill-CP +
  extend (all-masked KV row softmax → NaN). (`9665bcc`)
- **aiter MLA no-pad decode** — `SGLANG_AITER_MLA_NO_PAD_HEADS`, opt-in. (`5cc4a73`)
- **fp8 attention-projection quant** — `SGLANG_FP8_ATTN_PROJ=1`: 128×128-block W8A8 on
  `o_proj`, opt-in. (`8ac9ecc`)
- **Skip 64→4×16 head-split (perf fix)** — the gfx942 workaround was unconditional; gfx950
  runs `gqa:64` natively, so it was a pure regression under prefill-CP. Skip on gfx950
  (`SGLANG_DSA_NO_HEAD_SPLIT=1` override). **TTFT ~3.2s→~2.5s, 19k→24k tok/s (conc 1, 60k
  input).** (`567d38b`)
  
server script ( CP only )
```
#!/usr/bin/env bash
# Serve GLM-5.2-MXFP4 with DSA + aiter on AMD Instinct (gfx950), TP=4.
set -euo pipefail
MODEL_PATH=${MODEL_PATH:-/mnt/data/models/GLM-5.2-MXFP4}
SERVED_NAME=${SERVED_NAME:-glm-5.2-mxfp4}
PORT=${PORT:-30001}
HIP_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_USE_AITER=1 \
HSA_DISABLE_COREDUMP_ON_EXCEPTION=1 \
SGLANG_ENABLE_SPEC_V2=1 \
SGLANG_DSA_NO_PAD_HEADS=1 \
SGLANG_OPT_USE_TOPK_V2=0 \
python -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --tp-size 4 \
  --trust-remote-code \
  --kv-cache-dtype bfloat16 \
  --attention-backend dsa \
  --dsa-prefill-backend aiter \
  --dsa-decode-backend aiter \
  --chunked-prefill-size 32768 \
  --mem-fraction-static 0.85 \
  --served-model-name "$SERVED_NAME" \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --disable-radix-cache \
  --port "$PORT" \
  --enable-prefill-cp --cp-strategy interleave \
  --speculative-algorithm EAGLE \
  --speculative-num-steps 5 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 6
```

DFlash only or DFlash + CP ( set ENABLE_CP=1 )
```
#!/usr/bin/env bash
set -euo pipefail

PYTHON=${PYTHON:-/opt/venv/bin/python}

# --- target model (gfx950 MXFP4) ---
MODEL_PATH=${MODEL_PATH:-/mnt/data/models/GLM-5.2-MXFP4}
SERVED_NAME=${SERVED_NAME:-glm-5.2-mxfp4-dflash}
PORT=${PORT:-30001}
MEM_FRAC=${MEM_FRAC:-0.80}          # lower (e.g. 0.80) if the DFlash draft KV pool OOMs
CHUNK=${CHUNK:-32768}

# --- DFLASH draft config (env-overridable) ---
SPEC=${SPEC:-1}                                            # 1=enable DFLASH, 0=plain decode
DFLASH_PATH=${DFLASH_PATH:-/mnt/data/models/GLM-5.2-FP8-DFlash}
DFLASH_BLOCK=${DFLASH_BLOCK:-16}                           # verify window / num draft tokens (draft block_size=16)
DRAFT_QUANT=${DRAFT_QUANT:-unquant}                        # draft loads unquant (bf16), not the target quant
DRAFT_ATTN=${DRAFT_ATTN:-triton}                           # ROCm draft attention backend (no FlashInfer)

# --- prefill-CP toggle (DEFAULT OFF; DFlash+CP unverified) ---
ENABLE_CP=${ENABLE_CP:-0}
CP_STRATEGY=${CP_STRATEGY:-interleave}

SPEC_ARGS=()
if [[ "$SPEC" == "1" ]]; then
  SPEC_ARGS=(
    --speculative-algorithm DFLASH
    --speculative-draft-model-path "$DFLASH_PATH"
    --speculative-num-draft-tokens "$DFLASH_BLOCK"
    --speculative-draft-model-quantization "$DRAFT_QUANT"
    --speculative-draft-attention-backend "$DRAFT_ATTN"
  )
fi

CP_ARGS=()
if [[ "$ENABLE_CP" == "1" ]]; then
  CP_ARGS=(
    --enable-prefill-cp
    --cp-strategy "$CP_STRATEGY"
  )
fi

HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES:-0,1,2,3} \
SGLANG_USE_AITER=1 \
HSA_DISABLE_COREDUMP_ON_EXCEPTION=1 \
SGLANG_ENABLE_SPEC_V2=1 \
SGLANG_DSA_NO_PAD_HEADS=1 \
SGLANG_OPT_USE_TOPK_V2=0 \
"$PYTHON" -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --tp-size 4 \
  --trust-remote-code \
  --kv-cache-dtype bfloat16 \
  --attention-backend dsa \
  --dsa-prefill-backend aiter \
  --dsa-decode-backend aiter \
  --chunked-prefill-size "$CHUNK" \
  --mem-fraction-static "$MEM_FRAC" \
  --served-model-name "$SERVED_NAME" \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --disable-radix-cache \
  --port "$PORT" \
  "${CP_ARGS[@]}" \
  "${SPEC_ARGS[@]}"
```
## Compatibility / risk
- CUDA/NVIDIA and the bf16 baseline unchanged (all paths HIP/arch/env-guarded).
- Requires recent `aiter` for asm MoE/MLA (validated against `0c0261ba9`).

## Test plan
- [x] Serves on gfx950, TP4, DSA + prefill-CP + EAGLE
- [x] Serves on gfx942, TP8, DSA + prefill-CP + EAGLE
- [x] Serves on gfx942, TP8, DSA + DFlash + ( prefill-CP )
- [x] gsm8k accuracy gate (exact_match > 0.9)

## GSM8K Result
| config | gsm8k acc | fraction | accept len (gsm8k @c8) | 
|---|---|---|---|
| 1. EAGLE + CP (`server_cp.sh`) | 0.9219 | 59/64 | ~4.14 | 
| 2. DFlash non-CP blk16 | 0.9219 | 59/64 | ~4.15–4.19 | 
| 2. DFlash non-CP blk16 | 0.9688 | 62/64 | (same server) | 
| 3. DFlash + CP blk16 | 0.9844 | 63/64 | ~4.6 (up to 4.62) | 
| 3. DFlash + CP blk16 | 0.9375 | 60/64 | (same server) | 

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30253449975](https://github.com/sgl-project/sglang/actions/runs/30253449975)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30253446636](https://github.com/sgl-project/sglang/actions/runs/30253446636)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->