### PR TITLE
Fix MinimaxM3Detector stripping trailing whitespace from parameter values

### DIFF
--- a/python/sglang/srt/function_call/minimax_m3.py
+++ b/python/sglang/srt/function_call/minimax_m3.py
@@ -498,10 +498,15 @@ class MinimaxM3Detector(BaseFormatDetector):
             {"tag": "", "schema": parameters_schema, "value": root}
         ]
 
-        for chunk in body.split(MINIMAX_NS_TOKEN):
-            chunk = chunk.strip()
+        for raw_chunk in body.split(MINIMAX_NS_TOKEN):
+            chunk = raw_chunk.strip()
             if not chunk:
                 continue
+            # How much leading whitespace strip() removed, so the opening-tag
+            # branch below can recover the parameter value from raw_chunk. The
+            # stripped copy is fine for tag detection, but its trailing end is
+            # the start of the value and must not be trimmed.
+            lead = len(raw_chunk) - len(raw_chunk.lstrip())
 
             if chunk.startswith("</"):
                 gt = chunk.find(">", 2)
@@ -520,7 +525,12 @@ class MinimaxM3Detector(BaseFormatDetector):
             if chunk.startswith("<"):
                 gt = chunk.index(">")
                 tag = chunk[1:gt].strip()
-                text = chunk[gt + 1 :]
+                # Slice the value out of raw_chunk, not chunk: str.strip()
+                # removes all Unicode whitespace, so reading the value off the
+                # stripped copy silently dropped trailing spaces, newlines,
+                # NBSP and ideographic spaces that are part of the argument.
+                # The streaming path never trimmed them, so the two disagreed.
+                text = raw_chunk[lead + gt + 1 :]
                 parent_frame = stack[-1]
                 child_schema = self._get_child_schema(
                     parent_frame["schema"], tag, parent_frame["value"]

--- a/test/registered/unit/function_call/test_minimax_m3_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m3_detector.py
@@ -175,6 +175,35 @@ class TestMinimaxM3DetectAndParse(CustomTestCase):
         self.assertEqual(len(calls), 0)
         self.assertEqual(normal, text)
 
+    def test_trailing_whitespace_in_string_value_is_preserved(self):
+        """Trailing whitespace belongs to the value, not to the markup.
+
+        _parse_parameter read the value off a str.strip()ed copy of the chunk,
+        which removes every kind of Unicode whitespace, so a value ending in a
+        space, newline, NBSP or ideographic space was silently truncated. The
+        streaming path never trimmed it, so the same tool call produced
+        different arguments depending only on `stream`.
+        """
+        for label, value in (
+            ("ascii space", "remember this "),
+            ("newline", "remember this\n"),
+            ("tab", "remember this\t"),
+            ("nbsp", "remember this "),
+            ("ideographic space", "　中　"),
+        ):
+            with self.subTest(label):
+                text = _wire(
+                    "<tool_call>",
+                    '<invoke name="add_note">',
+                    f"<note>{value}",
+                    "</note>",
+                    "</invoke>",
+                    "</tool_call>",
+                )
+                calls, _ = _parse_segments_text(text, self.tools)
+                self.assertEqual(len(calls), 1)
+                self.assertEqual(calls[0]["args"]["note"], value)
+
     def test_single_tool_call(self):
         segments = (
             "<tool_call>",


### PR DESCRIPTION
## Motivation

`MinimaxM3Detector` silently drops trailing whitespace from string tool-call arguments in the non-streaming path. The streaming path keeps it, so **the same tool call yields different arguments depending only on `stream`.**

`_parse_parameter` splits the invoke body on the namespace token and strips each chunk before use:

```python
for chunk in body.split(MINIMAX_NS_TOKEN):
    chunk = chunk.strip()
    ...
    if chunk.startswith("<"):
        gt = chunk.index(">")
        text = chunk[gt + 1 :]      # <- value read off the stripped copy
```

A value chunk is `<tag>value`, so the leading side `strip()` removes is markup — but the trailing side it removes is **the end of the value**. And `str.strip()` with no argument removes every kind of Unicode whitespace, not just ASCII. Leading whitespace survives because the tag protects it, which is why the corruption is one-sided.

Streaming never trims: it accumulates into `_current_param_buffer` and passes that straight to `_convert_leaf_value`.

Measured on `main`, one value per row, sent through both paths:

| value sent | non-streaming (before) | streaming | after this PR |
|---|---|---|---|
| `'remember this '` | `'remember this'` | `'remember this '` | `'remember this '` |
| `'remember this\n'` | `'remember this'` | `'remember this\n'` | `'remember this\n'` |
| `'remember this\t'` | `'remember this'` | `'remember this\t'` | `'remember this\t'` |
| `'remember this\xa0'` (NBSP) | `'remember this'` | `'remember this\xa0'` | `'remember this\xa0'` |
| `'　中　'` (ideographic) | `'　中'` | `'　中　'` | `'　中　'` |
| `'hi'` (control) | `'hi'` | `'hi'` | `'hi'` |

This matters for the same reason as the merged GLM fix #20543 ("do not strip whitespace from GLM tool call values"): agent tools that do exact string matching — file edits, diff application, append-to-buffer — break when a trailing newline or space is eaten, and NBSP/U+3000 loss corrupts CJK text that legitimately ends in a wide space.

## Modifications

- `_parse_parameter` keeps using the stripped chunk for tag detection, but slices the value out of the original chunk, offsetting by the leading whitespace `strip()` removed. Tag parsing, the closing-tag branch, and the empty-chunk skip are all unchanged.
- Added `test_trailing_whitespace_in_string_value_is_preserved` covering ASCII space, newline, tab, NBSP and ideographic space.

## Accuracy Tests

Not applicable — parser-only change, no kernel or model forward code touched.

## Speed Tests and Profiling

Not applicable. The added work is one `lstrip()` length computation per chunk.

## Checklist

- The new test fails on unmodified `main` with all 5 subtests (`'remember this' != 'remember this '`, etc.) and passes with this change.
- `test_minimax_m3_detector.py`: 23 passed before, 24 passed after (23 pre-existing + 1 new); no pre-existing test asserted the stripping behaviour.
- `test_function_call_parser.py` + `test_parallel_tool_calls.py`: 191 passed, no failures.
- `black`, `isort --profile black`, and `ruff --select=F401,F821,UP037` (the repo's pre-commit selection) are clean on both files.
- Verified against `108182cb8`.

Note: as a first-time contributor I can't add the `run-ci` label or trigger CI — a maintainer will need to apply it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29990963858](https://github.com/sgl-project/sglang/actions/runs/29990963858)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29990963729](https://github.com/sgl-project/sglang/actions/runs/29990963729)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->