### PR TITLE
[DSv4][Bugfix] Fix DSpark verifier state rewrite window

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c_plan.cuh
@@ -448,6 +448,8 @@ using PrefillPlan = tvm::ffi::Tuple<tvm::ffi::Tensor, tvm::ffi::Tensor>;
  * @param compress_plan     `[num_q_tokens, 16]` uint8 (output)
  * @param write_plan        `[num_q_tokens,  8]` uint8 (output)
  * @param compress_ratio 4 for c4, 128 for c128
+ * @param verify_width Number of verifier rows that must be rewritten; 0 keeps
+ *                     the default prefill behavior
  * @param use_cuda_graph Whether the plans will be used with cuda graph (affects padding)
  * @return (compress plan tensor, write plan tensor)
  */
@@ -462,6 +464,7 @@ inline PrefillPlan plan_compress_prefill(
     const int32_t compress_ratio,
     const int32_t swa_page_size,
     const int32_t ring_size,
+    const int32_t verify_width,
     const bool use_cuda_graph) {
   auto B = SymbolicSize{"batch_size"};
   auto N = SymbolicSize{"num_q_tokens"};
@@ -507,12 +510,13 @@ inline PrefillPlan plan_compress_prefill(
   RuntimeCheck(batch_size <= num_q_tokens && num_q_tokens <= kMaxTokens);
   // `swa_page_size` >= `ring_size` >= `compress_ratio`
   RuntimeCheck(swa_page_size % ring_size == 0 && ring_size % compress_ratio == 0);
+  RuntimeCheck(0 <= verify_width && verify_width <= ring_size - compress_ratio);
 
   const auto device = device_.unwrap();
   const auto stream = LaunchKernel::resolve_device(device);
 
   constexpr int32_t kMaxMTPDraftTokens = 4;
-  const auto mtp_pad = std::min(ring_size - compress_ratio, kMaxMTPDraftTokens);
+  const auto mtp_pad = verify_width > 0 ? verify_width : std::min(ring_size - compress_ratio, kMaxMTPDraftTokens);
 
   if (cpu_or_gpu.unwrap().device_type == kDLGPU) {
     // GPU input path: kernel0 builds the (CPU-loop-equivalent) plan metadata directly
@@ -573,7 +577,9 @@ inline PrefillPlan plan_compress_prefill(
     const int32_t extend_len = ext_ptr[i];
     const int32_t prefix_len = seq_len - extend_len;
     const int32_t last_c_pos = seq_len / compress_ratio * compress_ratio;
-    const int32_t first_w_pos = last_c_pos - (is_overlap ? compress_ratio : 0);
+    const int32_t default_first_w_pos = last_c_pos - (is_overlap ? compress_ratio : 0);
+    const int32_t first_w_pos =
+        verify_width > 0 ? std::min(default_first_w_pos, seq_len - verify_width) : default_first_w_pos;
     RuntimeCheck(0 < extend_len && extend_len <= seq_len);
     const auto should_write = [=](int32_t position) {
       if (position >= first_w_pos) return true;

--- a/python/sglang/kernels/ops/attention/dsv4/compress.py
+++ b/python/sglang/kernels/ops/attention/dsv4/compress.py
@@ -237,6 +237,7 @@ class CompressorPrefillPlan(NamedTuple):
         ring_size: int,
         num_q_tokens: int,
         use_cuda_graph: bool = False,
+        verify_width: int = 0,
     ) -> CompressorPrefillPlan:
         is_gpu_input = seq_lens.device.type in ["cuda", "xpu"]
         pin_buffer = torch.empty(
@@ -264,7 +265,7 @@ class CompressorPrefillPlan(NamedTuple):
             module = _jit_compress_plan_module()
             fn = module.plan_prefill
 
-        plan_c, plan_w = fn(
+        plan_args = (
             req_pool_indices,
             req_to_token,
             full_to_state,
@@ -275,8 +276,10 @@ class CompressorPrefillPlan(NamedTuple):
             int(compress_ratio),
             int(swa_page_size),
             int(ring_size),
-            bool(use_cuda_graph),
         )
+        if not _is_xpu:
+            plan_args += (int(verify_width),)
+        plan_c, plan_w = fn(*plan_args, bool(use_cuda_graph))
         return CompressorPrefillPlan(
             compress_ratio,
             torch.from_dlpack(plan_c) if not _is_xpu else plan_c,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -559,13 +559,14 @@ class DeepseekV4AttnBackend(
         self.online_c128_mtp = OnlineC128MTPController(self)
         self.sparse_prefill_workspace = SparsePrefillWorkspace(self.device)
         spec_alg = model_runner.spec_algorithm
-        self.needs_cpu_seq_lens = not spec_alg.is_dspark() and (
+        self.is_dspark = spec_alg.is_dspark()
+        self.needs_cpu_seq_lens = not self.is_dspark and (
             not _is_cuda
             or not envs.SGLANG_PREP_IN_CUDA_GRAPH.get()
             or self.online_c128_mtp.enabled()
         )
 
-        self.is_dspark_draft = model_runner.is_draft_worker and spec_alg.is_dspark()
+        self.is_dspark_draft = model_runner.is_draft_worker and self.is_dspark
         self.is_draft_runner = model_runner.is_draft_worker
         self.cuda_graph_custom_mask = None
 
@@ -713,6 +714,7 @@ class DeepseekV4AttnBackend(
         use_prefill_cuda_graph: bool = False,
         online_c128_state_slot_offset: int = 0,
         dspark_block_size: Optional[int] = None,
+        verify_width: int = 0,
     ) -> DSV4Metadata:
         seq_lens_casual, req_pool_indices_repeated = self.expand_prefill_casually(
             num_tokens=num_tokens,
@@ -766,6 +768,7 @@ class DeepseekV4AttnBackend(
                         extend_lens_cpu=None,
                         use_prefill_cuda_graph=True,
                         num_q_tokens=out_cache_loc.shape[0],
+                        verify_width=verify_width,
                         online_state_slot_offset=online_c128_state_slot_offset,
                     )
                 return create_paged_compressor_data(
@@ -779,6 +782,7 @@ class DeepseekV4AttnBackend(
                     extend_lens=extend_seq_lens,
                     extend_lens_cpu=extend_seq_lens_cpu,
                     use_prefill_cuda_graph=use_graph_plan,
+                    verify_width=verify_width,
                     online_state_slot_offset=online_c128_state_slot_offset,
                 )
 
@@ -904,6 +908,7 @@ class DeepseekV4AttnBackend(
             need_compress=True,
             use_prefill_cuda_graph=use_prefill_cuda_graph,
             online_c128_state_slot_offset=online_c128_state_slot_offset,
+            verify_width=(self.speculative_num_draft_tokens if self.is_dspark else 0),
         )
 
     def init_forward_metadata_dspark_draft_block(
@@ -1000,6 +1005,7 @@ class DeepseekV4AttnBackend(
             extend_lens_cpu=None,
             use_prefill_cuda_graph=True,
             num_q_tokens=num_q_tokens,
+            verify_width=(self.speculative_num_draft_tokens if self.is_dspark else 0),
             online_state_slot_offset=online_c128_state_slot_offset,
         )
         c128_compress_metadata = raw_metadata.c128_compress_metadata

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -413,6 +413,7 @@ def create_paged_compressor_data(
     extend_lens_cpu: Optional[List[int]] = None,
     use_prefill_cuda_graph: bool = False,
     num_q_tokens: Optional[int] = None,
+    verify_width: int = 0,
     online_state_slot_offset: int = 0,
 ) -> CompressMetadata:
     """Build the paged compress metadata (= the plan).
@@ -464,6 +465,7 @@ def create_paged_compressor_data(
             swa_page_size=swa_page_size,
             ring_size=ring_size,
             num_q_tokens=num_q_tokens,
+            verify_width=verify_width,
             use_cuda_graph=use_prefill_cuda_graph,
         )
     else:

--- a/test/registered/kernels/ops/attention/test_c4_v2.py
+++ b/test/registered/kernels/ops/attention/test_c4_v2.py
@@ -125,12 +125,22 @@ def _make_inputs(
 # -----------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "verify_width",
+    [
+        pytest.param(2, id="minimum"),
+        pytest.param(4, id="legacy-limit"),
+        pytest.param(5, id="first-over-limit"),
+        pytest.param(8, id="default"),
+        pytest.param(12, id="ring-capacity"),
+    ],
+)
 @pytest.mark.parametrize("planner_on_device", [False, True], ids=["cpu", "gpu"])
 def test_paged_prefill_dspark_rewrites_full_verify_window(
     planner_on_device: bool,
+    verify_width: int,
 ) -> None:
-    """All gamma+1 verifier rows must be present in the write plan."""
-    verify_width = 5  # DSpark gamma=4 verifies gamma+1 target rows.
+    """Every valid DSpark verify width must be present in the write plan."""
     ctx = make_paged_context(bs=1, compress_ratio=RATIO, ring_size=16)
     seq_lens = torch.tensor([100], dtype=torch.int64)
     extend_lens = torch.tensor([verify_width], dtype=torch.int64)

--- a/test/registered/kernels/ops/attention/test_c4_v2.py
+++ b/test/registered/kernels/ops/attention/test_c4_v2.py
@@ -7,7 +7,10 @@ import pytest
 import torch
 import triton
 
-from sglang.kernels.ops.attention.dsv4 import compress_forward
+from sglang.kernels.ops.attention.dsv4 import (
+    CompressorPrefillPlan,
+    compress_forward,
+)
 from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kernels.deepseek_v4.common import (
@@ -120,6 +123,42 @@ def _make_inputs(
 # -----------------------------------------------------------------------------
 # Tests
 # -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("planner_on_device", [False, True], ids=["cpu", "gpu"])
+def test_paged_prefill_dspark_rewrites_full_verify_window(
+    planner_on_device: bool,
+) -> None:
+    """All gamma+1 verifier rows must be present in the write plan."""
+    verify_width = 5  # DSpark gamma=4 verifies gamma+1 target rows.
+    ctx = make_paged_context(bs=1, compress_ratio=RATIO, ring_size=16)
+    seq_lens = torch.tensor([100], dtype=torch.int64)
+    extend_lens = torch.tensor([verify_width], dtype=torch.int64)
+    if planner_on_device:
+        seq_lens = seq_lens.to(get_device())
+        extend_lens = extend_lens.to(get_device())
+
+    plan = CompressorPrefillPlan.generate(
+        compress_ratio=RATIO,
+        req_pool_indices=ctx.req_pool_indices,
+        seq_lens=seq_lens,
+        extend_lens=extend_lens,
+        req_to_token=ctx.req_to_token,
+        full_to_state=ctx.full_to_swa,
+        swa_page_size=ctx.swa_page_size,
+        ring_size=ctx.ring_size,
+        num_q_tokens=verify_width,
+        verify_width=verify_width,
+    )
+
+    packed_ragged_ids = plan.plan_w.view(torch.int32)[:, 0]
+    ragged_ids = (packed_ragged_ids & 0xFFFF).cpu()
+    torch.testing.assert_close(
+        ragged_ids,
+        torch.arange(verify_width, dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
 
 
 @pytest.mark.parametrize("mode", ["legacy", "paged"])


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
DSpark verifies `gamma + 1` target rows, but the DeepSeek-V4 compressed-state prefill planner protected at most four MTP rows through the hard-coded `kMaxMTPDraftTokens = 4`.

For example, with `gamma = 4`, the target verifies five rows. At certain compression boundaries, the planner omitted the first verifier row from the write plan, so subsequent compressed state was not guaranteed to be reconstructed from the verifier-committed token sequence.

The verifier already knew the correct window through `speculative_num_draft_tokens`; that runtime value was not propagated to the compressed-state planner.

## Modifications
- Propagate the DSpark target-verifier width from `DeepseekV4AttnBackend` through the compressor metadata and Python JIT wrapper to the C++ prefill planner.
- Use the runtime verifier width when calculating the first state row to rewrite in both host-input and device-input planner paths.
- Keep `verify_width = 0` as the default so regular prefill and non-DSpark speculative algorithms preserve their existing behavior.
- Add registered C4 planner regression coverage for:  - verifier widths `2`, `4`, `5`, `8`, and `12`

## Accuracy Tests

Before the fix, the write plan omitted ragged row `0`:

```text
[[1, 0], [2, 1], [3, 2], [4, 3], [-1, -1]]

With the runtime verifier width applied, all five rows are rewritten:

[[0, 15], [1, 0], [2, 1], [3, 2], [4, 3]]
```
Added regression tests assert that every verifier row appears in the write plan for all supported boundary cases.

Local non-GPU validation:

- pre-commit passed for all modified files.
- scripts/ci/check_registered_tests.py passed.
- Python compilation checks passed.
- test_c4_v2.py successfully collected 39 tests, including the 10 new verifier-window cases.

The final branch's GPU unit tests and end-to-end accuracy tests are left to GitHub CI.

## Speed Tests and Profiling

Not benchmarked locally.

The change does not affect regular prefill or non-DSpark speculative algorithms. For DSpark verifier windows larger than four, it
adds the state writes required to reconstruct the full accepted verification path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->