### PR TITLE
[Fix] Reserve the mamba pool's +1 padding slot in the memory budget solve

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1717,7 +1717,8 @@ class KVCacheConfigurator:
                 max_mamba_cache_size=server_args.max_mamba_cache_size
                 // self.ps.attn_dp_size,
             )
-            # Reserve intermediate memory based on capped max_num_reqs
+            # Reserve intermediate memory based on capped max_num_reqs (+1:
+            # the pool's padding slot, see memory_pool.py)
             if has_spec_dec:
                 ratio = self._calculate_mamba_ratio()
                 capped_reqs = min(
@@ -1726,7 +1727,7 @@ class KVCacheConfigurator:
                 )
                 intermediate_size = (
                     config.mamba2_cache_params.mamba_cache_per_req
-                    * capped_reqs
+                    * (capped_reqs + 1)
                     * server_args.speculative_num_draft_tokens
                 )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
@@ -1740,11 +1741,12 @@ class KVCacheConfigurator:
                 max_mamba_cache_size=server_args.max_running_requests
                 // self.ps.attn_dp_size,
             )
-            # Reserve intermediate memory based on capped max_num_reqs
+            # Reserve intermediate memory based on capped max_num_reqs (+1:
+            # the pool's padding slot)
             if has_spec_dec:
                 intermediate_size = (
                     config.mamba2_cache_params.mamba_cache_per_req
-                    * server_args.max_mamba_cache_size
+                    * (server_args.max_mamba_cache_size + 1)
                     * server_args.speculative_num_draft_tokens
                 )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
@@ -1753,11 +1755,14 @@ class KVCacheConfigurator:
             assert config.mamba2_cache_params.mamba_cache_per_req > 0
             per_req = config.mamba2_cache_params.mamba_cache_per_req
 
-            # Solve jointly for max_mamba_cache_size accounting for intermediate memory.
-            # The mamba budget (from the ratio split) must cover both:
-            #   1. main mamba state: max_mamba_cache_size * per_req
-            #   2. intermediate states: (max_mamba_cache_size / ratio) * D * per_req
-            # So: max_mamba_cache_size * per_req * (1 + D/ratio) = mamba_budget_bytes
+            # Solve jointly for max_mamba_cache_size accounting for intermediate
+            # memory. Every per-slot pool buffer carries a +1 padding slot
+            # (index 0, the sink for cuda-graph padded batches; see
+            # memory_pool.py), so the mamba budget must cover:
+            #   1. main mamba state: (max_mamba_cache_size + 1) * per_req
+            #   2. intermediate states: (max_mamba_cache_size / ratio + 1) * D * per_req
+            # So: max_mamba_cache_size * per_req * (1 + D/ratio) + (1 + D) * per_req
+            #     = mamba_budget_bytes
             mamba_budget = (
                 total_rest_memory
                 * server_args.mamba_full_memory_ratio
@@ -1772,7 +1777,8 @@ class KVCacheConfigurator:
                 server_args.override(
                     "mamba_pool.memory_budget_spec",
                     max_mamba_cache_size=int(
-                        mamba_budget_bytes // (per_req * (1 + D / ratio))
+                        (mamba_budget_bytes - per_req * (1 + D))
+                        // (per_req * (1 + D / ratio))
                     ),
                 )
                 # Intermediate memory is included in mamba_budget, subtract it
@@ -1781,12 +1787,12 @@ class KVCacheConfigurator:
                     server_args.max_running_requests // self.ps.attn_dp_size,
                     server_args.max_mamba_cache_size // ratio,
                 )
-                intermediate_size = per_req * capped_reqs * D
+                intermediate_size = per_req * (capped_reqs + 1) * D
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
             else:
                 server_args.override(
                     "mamba_pool.memory_budget",
-                    max_mamba_cache_size=int(mamba_budget_bytes // per_req),
+                    max_mamba_cache_size=int((mamba_budget_bytes - per_req) // per_req),
                 )
 
         # Validate: max_mamba_cache_size must be positive after memory allocation.
@@ -1805,8 +1811,9 @@ class KVCacheConfigurator:
                 f"(4) use GPUs with more memory."
             )
 
+        # +1: the pool's padding slot is allocated alongside the request slots
         mamba_state_memory = (
-            server_args.max_mamba_cache_size
+            (server_args.max_mamba_cache_size + 1)
             * config.mamba2_cache_params.mamba_cache_per_req
             / (1 << 30)
         )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1717,8 +1717,7 @@ class KVCacheConfigurator:
                 max_mamba_cache_size=server_args.max_mamba_cache_size
                 // self.ps.attn_dp_size,
             )
-            # Reserve intermediate memory based on capped max_num_reqs (+1:
-            # the pool's padding slot, see memory_pool.py)
+            # Reserve intermediate memory based on capped max_num_reqs (+1 padding slot)
             if has_spec_dec:
                 ratio = self._calculate_mamba_ratio()
                 capped_reqs = min(
@@ -1741,8 +1740,7 @@ class KVCacheConfigurator:
                 max_mamba_cache_size=server_args.max_running_requests
                 // self.ps.attn_dp_size,
             )
-            # Reserve intermediate memory based on capped max_num_reqs (+1:
-            # the pool's padding slot)
+            # Reserve intermediate memory based on capped max_num_reqs (+1 padding slot)
             if has_spec_dec:
                 intermediate_size = (
                     config.mamba2_cache_params.mamba_cache_per_req
@@ -1755,14 +1753,9 @@ class KVCacheConfigurator:
             assert config.mamba2_cache_params.mamba_cache_per_req > 0
             per_req = config.mamba2_cache_params.mamba_cache_per_req
 
-            # Solve jointly for max_mamba_cache_size accounting for intermediate
-            # memory. Every per-slot pool buffer carries a +1 padding slot
-            # (index 0, the sink for cuda-graph padded batches; see
-            # memory_pool.py), so the mamba budget must cover:
-            #   1. main mamba state: (max_mamba_cache_size + 1) * per_req
-            #   2. intermediate states: (max_mamba_cache_size / ratio + 1) * D * per_req
-            # So: max_mamba_cache_size * per_req * (1 + D/ratio) + (1 + D) * per_req
-            #     = mamba_budget_bytes
+            # Solve jointly for max_mamba_cache_size (K), including the pool's
+            # +1 padding slot on both buffers (see memory_pool.py):
+            #   (K + 1) * per_req + (K / ratio + 1) * D * per_req = mamba_budget_bytes
             mamba_budget = (
                 total_rest_memory
                 * server_args.mamba_full_memory_ratio
@@ -1811,7 +1804,7 @@ class KVCacheConfigurator:
                 f"(4) use GPUs with more memory."
             )
 
-        # +1: the pool's padding slot is allocated alongside the request slots
+        # +1: the pool's padding slot
         mamba_state_memory = (
             (server_args.max_mamba_cache_size + 1)
             * config.mamba2_cache_params.mamba_cache_per_req


### PR DESCRIPTION
## Summary

- The mamba/hybrid budget solve in `_handle_max_mamba_cache` reserves only the per-request state slots, but the pool physically allocates every per-slot buffer with **one extra padding slot** (index 0, the sink for cuda-graph padded batches — the `ReqToTokenPool` base convention in `memory_pool.py`): main conv/ssm allocate `K + 1` slots, and the spec intermediate buffers allocate `(spec_state_size + 1) x D` rows
- The unreserved padding slots (`(1 + D) * per_req`, ~0.5 GB at fp32 ssm with D=8) silently came out of the profiled slack; reserve them exactly in all three arms

## The calculation, before vs after

What the pool actually allocates per GPU: main state `(K + 1) * per_req`; with spec, intermediates `(max_running + 1) * D * per_req`, where `K = max_mamba_cache_size`, `max_running = K // S`, and `S` = state slots per running request from `_calculate_mamba_ratio()`.

Before (ratio-based auto arm, spec):

```
K        = budget // (per_req * (1 + D/S))
reserved = K*per_req + (K//S)*D*per_req          # both +1 paddings unaccounted
```

After:

```
K        = (budget - (1 + D)*per_req) // (per_req * (1 + D/S))
reserved = (K+1)*per_req + (K//S + 1)*D*per_req  # == allocated
```

Non-spec auto arm: `K = budget // per_req` -> `K = (budget - per_req) // per_req`. The explicit `--max-mamba-cache-size` and `--disable-radix-cache` arms now reserve intermediates for `capped_reqs + 1` instead of `capped_reqs`, and the final main-state subtraction uses `K + 1`.

## Effect

- Reserved == allocated exactly. Reconciled against a real boot log (tp8, fp32 ssm, D=8): the old solve under-reserved by exactly one padding slot's worth (0.42 GiB); the new reservation matches the pool allocation (main `K+1` slots + intermediate `(max_running+1) x D` rows) to the GiB
- On the same budget K lands slightly lower (measured basis: 134 -> 131 with spec, 363 -> 362 without) and the derived concurrency clamp is unchanged (26 / 72) — no user-visible behavior change
- The paged KV pool's analogue (a padding page, `size + page_size`) was already accounted via `final_span_bytes`; this brings the mamba pool accounting in line

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29992957265](https://github.com/sgl-project/sglang/actions/runs/29992957265)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29992956559](https://github.com/sgl-project/sglang/actions/runs/29992956559)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->