### PR TITLE
Reduce DSpark import side effects

### DIFF
--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_triton
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -15,6 +14,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 
 if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
     from sglang.srt.managers.tp_worker import TpModelWorker
     from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 

--- a/python/sglang/srt/speculative/dflash_info_v2.py
+++ b/python/sglang/srt/speculative/dflash_info_v2.py
@@ -1,17 +1,21 @@
 """DFLASH spec-v2 overlap scheduling data structures."""
 
+from __future__ import annotations
+
 import contextlib
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.mem_cache.allocation import alloc_for_spec_decode
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.utils.common import is_pin_memory_available
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
 
 _OVERLAP_PLAN_STREAMS: dict[str, torch.cuda.Stream] = {}
 

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -1,13 +1,17 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
 from sglang.kernels.ops.speculative.cache_locs import assign_extend_cache_locs_func
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.speculative.dspark_components.kernels.dspark_verify_window import (
     BuildCommitInjectLayout,
 )
-from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 
 class TargetHiddenKvInjector:

--- a/python/sglang/srt/speculative/dspark_components/dspark_observability.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_observability.py
@@ -16,7 +16,6 @@ from sglang.srt.environ import envs
 from sglang.srt.kv_canary.runner.future_tensor import FutureTensors
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
-from sglang.srt.speculative.dflash_utils import compute_dflash_correct_drafts_and_bonus
 from sglang.srt.speculative.dspark_components.dspark_block_accept_estimator import (
     create_block_accept_estimate_recorder,
 )
@@ -28,6 +27,17 @@ from sglang.srt.speculative.dspark_components.dspark_verify import (
 logger = logging.getLogger(__name__)
 
 _NULL_SEGMENT = nullcontext()
+
+
+def _compute_correct_drafts_and_bonus(
+    *, candidates: torch.Tensor, target_predict: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    matches = candidates[:, 1:] == target_predict[:, :-1]
+    correct_len = matches.to(torch.int32).cumprod(dim=1).sum(dim=1)
+    bonus = target_predict[
+        torch.arange(candidates.shape[0], device=candidates.device), correct_len
+    ]
+    return correct_len, bonus.to(torch.int64)
 
 ALL_COMPONENTS_TOKEN = "all"
 
@@ -703,7 +713,7 @@ class ConfidenceMetricsProbe:
         target_predict = torch.argmax(target_logits, dim=-1).view(
             bs, self.verify_num_draft_tokens
         )
-        num_correct_drafts, _ = compute_dflash_correct_drafts_and_bonus(
+        num_correct_drafts, _ = _compute_correct_drafts_and_bonus(
             candidates=verify_ids_2d,
             target_predict=target_predict,
         )
@@ -951,7 +961,7 @@ class DsparkStepObservers:
         target_predict = torch.argmax(target_logits, dim=-1).view(
             bs, self._verify_num_draft_tokens
         )
-        num_correct_drafts, _ = compute_dflash_correct_drafts_and_bonus(
+        num_correct_drafts, _ = _compute_correct_drafts_and_bonus(
             candidates=verify_ids_2d,
             target_predict=target_predict,
         )

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import msgspec
 import torch
@@ -15,11 +15,7 @@ from sglang.srt.managers.overlap_utils import (
     FutureMap,
     ResolvedConfidence,
 )
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.runtime_context import get_parallel
-from sglang.srt.server_args import ServerArgs
-from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
-from sglang.srt.speculative.dflash_utils import apply_dflash_verify_logits_adjustments
 from sglang.srt.speculative.dspark_components.dspark_sps import (
     SpsAdditiveCostTable,
     SpsCostTable,
@@ -46,6 +42,11 @@ from sglang.srt.utils.async_probe import (
     maybe_detect_in_closed_range,
 )
 from sglang.srt.utils.common import require_mlp_tp_gather
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.server_args import ServerArgs
+    from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 
 logger = logging.getLogger(__name__)
 
@@ -866,6 +867,10 @@ def apply_logits_adjustments_strided(
 ) -> None:
     if sampling_info is None:
         return
+    from sglang.srt.speculative.dflash_utils import (
+        apply_dflash_verify_logits_adjustments,
+    )
+
     apply_dflash_verify_logits_adjustments(
         next_token_logits=next_token_logits,
         sampling_info=sampling_info,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import msgspec
 import torch
 
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
-from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
-from sglang.srt.speculative.dflash_utils import apply_dflash_verify_logits_adjustments
-from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockResult
 from sglang.srt.speculative.dspark_components.dspark_kv_inject import (
     TargetHiddenKvInjector,
 )
@@ -37,6 +32,12 @@ from sglang.srt.speculative.dspark_components.kernels.dspark_verify_window impor
     scatter_compact_to_strided_into,
 )
 from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+    from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockResult
 
 
 def verify_logits_adjustments_are_noop(sampling_info) -> bool:
@@ -246,6 +247,10 @@ class TargetVerifyExecutor:
         )
 
         if sampling_info is not None:
+            from sglang.srt.speculative.dflash_utils import (
+                apply_dflash_verify_logits_adjustments,
+            )
+
             apply_dflash_verify_logits_adjustments(
                 next_token_logits=result.logits_output.next_token_logits,
                 sampling_info=sampling_info,
@@ -488,6 +493,8 @@ class DsparkVerifyEpilogue:
     def capture_hook(self, runner, out, forward_batch, num_tokens) -> None:
         if runner.model_runner.is_draft_worker or not runner.ragged_verify_mode:
             return
+        from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+
         if (
             not isinstance(out, LogitsProcessorOutput)
             or out.next_token_logits is None

--- a/python/sglang/srt/speculative/dspark_components/kernels/dspark_accept.py
+++ b/python/sglang/srt/speculative/dspark_components/kernels/dspark_accept.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import msgspec
 import torch
 import triton
 import triton.language as tl
 
-from sglang.kernels.ops.speculative.reject_sampling import (
-    chain_speculative_sampling_triton,
-)
-from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
-from sglang.srt.speculative.dflash_utils import (
-    _get_or_create_chain_verify_buffers,
-    build_dflash_verify_target_probs,
-    compute_dflash_correct_drafts_and_bonus,
-)
 from sglang.srt.speculative.dspark_components.kernels.dispatch import inputs_on_cuda
+
+if TYPE_CHECKING:
+    from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+
+
+def _compute_correct_drafts_and_bonus(
+    *, candidates: torch.Tensor, target_predict: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    matches = candidates[:, 1:] == target_predict[:, :-1]
+    correct_len = matches.to(torch.int32).cumprod(dim=1).sum(dim=1)
+    bonus = target_predict[
+        torch.arange(candidates.shape[0], device=candidates.device), correct_len
+    ]
+    return correct_len, bonus.to(torch.int64)
 
 
 class AcceptSampling:
@@ -88,6 +93,14 @@ def _accept_sampling_core(
     verify_num_draft_tokens: int,
     cutoff_verify_lens: Optional[torch.Tensor],
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    from sglang.kernels.ops.speculative.reject_sampling import (
+        chain_speculative_sampling_triton,
+    )
+    from sglang.srt.speculative.dflash_utils import (
+        _get_or_create_chain_verify_buffers,
+        build_dflash_verify_target_probs,
+    )
+
     bs = candidates.shape[0]
     device = candidates.device
     if not sampling_info.need_top_k_sampling and not sampling_info.need_top_p_sampling:
@@ -608,7 +621,7 @@ def accept_greedy(
     target_predict = torch.argmax(target_logits, dim=-1).view(
         bs, verify_num_draft_tokens
     )
-    correct_len, bonus = compute_dflash_correct_drafts_and_bonus(
+    correct_len, bonus = _compute_correct_drafts_and_bonus(
         candidates=candidates,
         target_predict=target_predict,
     )
@@ -660,7 +673,7 @@ def accept_greedy_triton(
     target_predict = torch.argmax(target_logits, dim=-1).view(
         bs, verify_num_draft_tokens
     )
-    correct_len, bonus = compute_dflash_correct_drafts_and_bonus(
+    correct_len, bonus = _compute_correct_drafts_and_bonus(
         candidates=candidates,
         target_predict=target_predict,
     )

--- a/python/sglang/srt/speculative/dspark_components/kernels/dspark_verify_window.py
+++ b/python/sglang/srt/speculative/dspark_components/kernels/dspark_verify_window.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import msgspec
 import torch
 import triton
 import triton.language as tl
 
 from sglang.kernels.ops.speculative.cache_locs import assign_extend_cache_locs_func
-from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.speculative.dspark_components.kernels.dispatch import inputs_on_cuda
 from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
 
 
 class RaggedVerifyWindow(msgspec.Struct, frozen=True):

--- a/test/registered/spec/dspark/test_dspark_info_dumper.py
+++ b/test/registered/spec/dspark/test_dspark_info_dumper.py
@@ -20,7 +20,6 @@ from sglang.srt.speculative.dspark_components.dspark_observability import (
 )
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 from sglang.test.ci.ci_register import register_cpu_ci
-from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
@@ -84,7 +83,7 @@ def make_obs(
     )
 
 
-class TestResolveComponents(CustomTestCase):
+class TestResolveComponents(unittest.TestCase):
     def test_empty_disables(self):
         self.assertEqual(resolve_components(()), set())
 
@@ -123,7 +122,7 @@ class TestResolveComponents(CustomTestCase):
                 )
 
 
-class TestCoreAndCpuTiming(CustomTestCase):
+class TestCoreAndCpuTiming(unittest.TestCase):
     def test_disabled_dumper_records_nothing(self):
         dumper, clock = make_dumper(set())
         dumper.begin_step()
@@ -231,7 +230,7 @@ class TestCoreAndCpuTiming(CustomTestCase):
         self.assertEqual([r["forward_ct"] for r in dumper.dump()["records"]], [9, 10])
 
 
-class TestPredictedStepFields(CustomTestCase):
+class TestPredictedStepFields(unittest.TestCase):
     def test_predicted_fields_recorded_under_core(self):
         dumper, clock = make_dumper({"core"})
         dumper.observe_decode_step(
@@ -273,7 +272,7 @@ def _pending(*, bs, budget, num_verify_tokens, predicted_step_ms):
     )
 
 
-class TestOnlineSpsReporter(CustomTestCase):
+class TestOnlineSpsReporter(unittest.TestCase):
     def test_report_interval_enables_dumper_and_gpu_timing(self):
         dumper, _ = make_dumper(set(), sps_report_interval=2)
         self.assertTrue(dumper.enabled)
@@ -332,7 +331,7 @@ class TestOnlineSpsReporter(CustomTestCase):
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA for d2h staging")
-class TestReqsAndGpuTiming(CustomTestCase):
+class TestReqsAndGpuTiming(unittest.TestCase):
     def _cuda_obs(self, *, forward_ct, bs=4):
         obs = make_obs(forward_ct=forward_ct, bs=bs)
         return DecodeStepObservation(


### PR DESCRIPTION
Summary:
- move DSpark/DFLASH runtime-only imports behind TYPE_CHECKING or local lazy imports
- keep origin/main behavior unchanged; this is an import-hygiene slice split out from the GLM5.2 DSpark stack
- avoid CustomTestCase in the DSpark info dumper unit so the test has fewer import side effects

Validation:
- git diff origin/main..HEAD --check
- PYTHONPYCACHEPREFIX=/tmp/sglang-import-hygiene-main-pycache python3 -m py_compile on touched files
- Docker CPU pytest was attempted without GPU devices, but current ROCm image collection enters quantization/quark AITER imports and requires GPU/Triton/JAX driver state before reaching this test.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #29992496590](https://github.com/sgl-project/sglang/actions/runs/29992496590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29992493983](https://github.com/sgl-project/sglang/actions/runs/29992493983)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->