### PR TITLE
[PD] Fix PD disaggregation decode warmup crash under DP-attention (#30748)

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2081,22 +2081,31 @@ async def _send_disaggregation_warmup_requests(
     ssl_verify: Union[bool, str],
     timeout: int,
 ) -> List[int]:
+    # Fan out dp_size POSTs; each POST is a dp_size-item batch routed to
+    # one rank so every scheduler sees the pre-#30748 batch shape (fix
+    # for the DP-attention crash). ``routed_dp_rank`` must stay scalar.
     ssl_context = (
         ssl_verify
         if isinstance(ssl_verify, bool)
         else ssl.create_default_context(cafile=ssl_verify)
     )
 
+    dp_size = server_args.dp_size
+    tp_size = server_args.tp_size
+    bootstrap_rooms = [
+        (i + 1) * (2**63 // (max(dp_size, 1) + 1)) + (i % max(tp_size, 1))
+        for i in range(dp_size)
+    ]
+
     async def send_request(session: aiohttp.ClientSession, dp_rank: int) -> int:
         json_data = {
-            "sampling_params": {
-                "temperature": 0.0,
-                "max_new_tokens": 8,
-                "ignore_eos": True,
-            },
-            "bootstrap_host": FAKE_BOOTSTRAP_HOST,
-            "bootstrap_room": dp_rank,
-            "input_ids": [10, 11, 12, 13],
+            "sampling_params": [
+                {"temperature": 0.0, "max_new_tokens": 8, "ignore_eos": True}
+            ]
+            * dp_size,
+            "bootstrap_host": [FAKE_BOOTSTRAP_HOST] * dp_size,
+            "bootstrap_room": bootstrap_rooms,
+            "input_ids": [[10, 11, 12, 13]] * dp_size,
             "routed_dp_rank": dp_rank,
         }
         async with session.post(
@@ -2110,7 +2119,7 @@ async def _send_disaggregation_warmup_requests(
         headers=headers,
     ) as session:
         return await asyncio.gather(
-            *(send_request(session, dp_rank) for dp_rank in range(server_args.dp_size))
+            *(send_request(session, dp_rank) for dp_rank in range(dp_size))
         )
 
 


### PR DESCRIPTION
## motivation

Fix https://github.com/sgl-project/sglang/issues/32182 introduced by PR #30748

PR #30748 changed the PD warmup from a single batched POST to dp_size concurrent single-sequence POSTs (one per DP rank via routed_dp_rank). With enable_dp_attention / enable_dp_lm_head enabled, this leaves every DP rank processing a lone fake req instead of the joint dp_size batch the scheduler used to see, breaking cross-rank batch shape assumptions and crashing on the decode side with:

  /pytorch/aten/src/ATen/native/cuda/IndexKernelUtils.cu:16:
  vectorized_gather_kernel: Assertion `ind >= 0 && ind < ind_dim_size` failed

surfaced at result.copy_done.synchronize() in
scheduler_components/batch_result_processor.process_batch_result_decode.

Keep the fan-out (so every DP rank still reliably receives its fake req), but pad each POST body with dp_size aligned fake sequences by sending arrays for sampling_params / bootstrap_host / bootstrap_room / input_ids / routed_dp_rank. This restores the pre-#30748 batch shape seen by each scheduler and keeps DP-attention shapes consistent across ranks.

Also uses well-separated bootstrap_room ids (spaced with the pre-#30748 formula) so they never collide with the 0 reset marker used by DecodePreallocQueue metadata buffers.

CC  @hnyls2002 @ShangmingCai @hzh0425 

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30071651285](https://github.com/sgl-project/sglang/actions/runs/30071651285)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30071651165](https://github.com/sgl-project/sglang/actions/runs/30071651165)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->