### PR TITLE
feat: native qk_rope_head_dim=0 sparse MLA decode in trtllm-gen DSA backend

### DIFF
--- a/python/sglang/kernels/ops/attention/__init__.py
+++ b/python/sglang/kernels/ops/attention/__init__.py
@@ -94,6 +94,7 @@ for _mod, _fn in [
     ("dsa.triton_sparse_mla", "triton_sparse_mla_fwd"),
     ("dsa.transform_index", "transform_index_page_table_prefill"),
     ("dsa.transform_index", "transform_index_page_table_decode"),
+    ("dsa.transform_index", "prepare_trtllm_nope_sparse_metadata"),
     ("dsa.cp_split", "dsa_cp_round_robin_split_q_seqs_kernel"),
     ("dsv4.fp4_indexer", "quantize_fp4_indexer_tensor"),
     ("dsv4.fp4_indexer", "store_fp4_index_k_cache"),

--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -14,6 +14,51 @@ def transform_index_page_table_decode(**kwargs):
     return transform_index_page_table_decode_fast(**kwargs)
 
 
+@triton.jit
+def prepare_trtllm_nope_sparse_metadata_kernel(
+    page_table_ptr: torch.Tensor,
+    topk_lens_ptr: torch.Tensor,
+    row_stride: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_TOPK)
+    valid = offsets < TOPK
+    indices = tl.load(
+        page_table_ptr + row * row_stride + offsets,
+        mask=valid,
+        other=-1,
+    )
+    topk_len = tl.sum((valid & (indices >= 0)).to(tl.int32), axis=0)
+
+    # TRTLLM-GEN returns NaNs for empty rows. CUDA-graph padding rows are unused,
+    # so they can safely attend to dummy token 0.
+    is_empty = topk_len == 0
+    tl.store(page_table_ptr + row * row_stride, 0, mask=is_empty)
+    tl.store(topk_lens_ptr + row, tl.maximum(topk_len, 1))
+
+
+def prepare_trtllm_nope_sparse_metadata(
+    page_table: torch.Tensor,
+) -> torch.Tensor:
+    assert page_table.ndim == 2
+    assert page_table.dtype == torch.int32
+    assert page_table.is_contiguous()
+    num_rows, topk = page_table.shape
+    topk_lens = torch.empty(num_rows, dtype=torch.int32, device=page_table.device)
+    block_topk = triton.next_power_of_2(topk)
+    prepare_trtllm_nope_sparse_metadata_kernel[(num_rows,)](
+        page_table,
+        topk_lens,
+        page_table.stride(0),
+        TOPK=topk,
+        BLOCK_TOPK=block_topk,
+        num_warps=8,
+    )
+    return topk_lens
+
+
 def _allocate_prefill_result(
     topk_indices: torch.Tensor,
     real_num_tokens: int,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -25,6 +25,7 @@ from sglang.kernels.ops.attention.dsa.dequant_k_cache import (
 )
 from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache
 from sglang.kernels.ops.attention.dsa.transform_index import (
+    prepare_trtllm_nope_sparse_metadata,
     transform_index_page_table_decode,
     transform_index_page_table_prefill,
 )
@@ -3316,6 +3317,9 @@ class DeepseekSparseAttnBackend(
 
         q = q_all.view(batch_size, 1, num_heads, head_dim)
         kv = kv_cache.view(-1, 1, self.real_page_size, self.kv_cache_dim)
+        sparse_mla_top_k_lens = None
+        if self.qk_rope_head_dim == 0:
+            sparse_mla_top_k_lens = prepare_trtllm_nope_sparse_metadata(page_table_1)
         block_tables = page_table_1.unsqueeze(1)
         seq_lens = metadata.cache_seqlens_int32 if seq_lens is None else seq_lens
 
@@ -3343,6 +3347,7 @@ class DeepseekSparseAttnBackend(
             backend="trtllm-gen",
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
             multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
+            sparse_mla_top_k_lens=sparse_mla_top_k_lens,
         )
 
         return out

--- a/test/registered/kernels/ops/attention/test_prepare_trtllm_nope_sparse_metadata.py
+++ b/test/registered/kernels/ops/attention/test_prepare_trtllm_nope_sparse_metadata.py
@@ -1,0 +1,34 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsa.transform_index import (
+    prepare_trtllm_nope_sparse_metadata,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+def test_prepare_trtllm_nope_sparse_metadata() -> None:
+    topk = 2048
+    page_table = torch.full((3, topk), -1, dtype=torch.int32, device="cuda")
+    page_table[0] = torch.arange(topk, dtype=torch.int32, device="cuda")
+    page_table[1, :3] = torch.tensor([11, 17, 23], dtype=torch.int32, device="cuda")
+    expected_page_table = page_table.clone()
+    expected_page_table[2, 0] = 0
+
+    topk_lens = prepare_trtllm_nope_sparse_metadata(page_table)
+
+    torch.testing.assert_close(
+        topk_lens,
+        torch.tensor([topk, 3, 1], dtype=torch.int32, device="cuda"),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(page_table, expected_page_table, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

The trtllm-gen DSA decode backend currently only serves MLA shapes with a rotary tail (`qk_rope_head_dim > 0`). This PR adds the native **no-rotary-tail** sparse MLA shape (`kv_lora_rank=512`, `qk_rope_head_dim=0`), where both KV TMA descriptors address a single 512-wide cache pool. The native H512 TRTLLM-GEN kernel needs the per-query active top-k lengths to bound the sparse gather, which this PR supplies.

[flashinfer-ai/flashinfer#4108](https://github.com/flashinfer-ai/flashinfer/pull/4108) has merged, and `nightly-v0.6.17-20260731` contains its new `sparse_mla_top_k_lens` argument. SGLang still pins `flashinfer_python[cu13]==0.6.15.post1`, so this PR remains a draft until a production FlashInfer release containing #4108 is available and the pin is updated.

## Modifications

- **`python/sglang/kernels/ops/attention/dsa/transform_index.py`** — add `prepare_trtllm_nope_sparse_metadata`, a Triton kernel that derives per-query active top-k lengths from the packed page table. Fully empty CUDA-graph padding rows attend to a valid dummy token because the native H512 kernel returns NaNs for an empty row.
- **`python/sglang/kernels/ops/attention/__init__.py`** — register the new kernel in the inventory.
- **`python/sglang/srt/layers/attention/dsa_backend.py`** — build and pass `sparse_mla_top_k_lens` for the `qk_rope_head_dim == 0` path. The existing rotary-tail path continues to pass `None`.
- **`test/registered/kernels/ops/attention/test_prepare_trtllm_nope_sparse_metadata.py`** — cover full, partial, and empty CUDA-graph padding rows.

## Validation

- `pre-commit run --files ...`: passed.
- Registered CUDA unit test on 1xGB300: `1 passed`.
- FlashInfer `0.6.17.dev20260731` API inspection: `sparse_mla_top_k_lens` is present.
- Exact merged #4108 source, synthetic NoPE sparse MLA integration on GB300: BF16/BF16 and FP8/FP8 paths produced finite outputs for full, partial, and graph-padding rows at max sequence lengths 2K, 4K, and 32K.
- Full GSM8K downstream e2e with merged FlashInfer code: 1319 samples, 95.07% accuracy, 99.17% stop rate, 0% request errors.

The full GSM8K run predates this latest SGLang `main` rebase; the current rebased head has been revalidated with the CUDA and API/metadata tests above.

## Speed Tests and Profiling

N/A. The added Triton kernel performs one per-query reduction over the sparse page table.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Provide accuracy results; speed testing is not applicable to this metadata-only change.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608746906](https://github.com/sgl-project/sglang/actions/runs/30608746906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608746765](https://github.com/sgl-project/sglang/actions/runs/30608746765)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->