### PR TITLE
[Router] Keep cache affinity during cache-aware load rebalancing

### DIFF
--- a/sgl-model-gateway/src/policies/cache_aware.rs
+++ b/sgl-model-gateway/src/policies/cache_aware.rs
@@ -325,11 +325,43 @@ impl CacheAwarePolicy {
             );
         }
 
-        // Use shortest queue when imbalanced
+        // When imbalanced, keep cache locality within the near-min-load window
+        // (load <= min_load + balance_abs_threshold): pick the longest cached
+        // prefix there, falling back to the shortest-queue worker otherwise.
         let min_load_idx = healthy_indices
             .iter()
             .min_by_key(|&&idx| workers[idx].load())
             .copied()?;
+
+        let selected_idx = request_text
+            .and_then(|text| {
+                let tree = self
+                    .trees
+                    .get(tree_key)
+                    .map(|entry| entry.value().clone())?;
+                let max_near_min_load = min_load.saturating_add(self.config.balance_abs_threshold);
+
+                healthy_indices
+                    .iter()
+                    .copied()
+                    .filter(|&idx| workers[idx].load() <= max_near_min_load)
+                    .filter_map(|idx| {
+                        let matched_chars = tree
+                            .prefix_match_tenant(text, workers[idx].url())
+                            .chars()
+                            .count();
+                        (matched_chars > 0).then_some((idx, matched_chars, workers[idx].load()))
+                    })
+                    // Highest cached-prefix match wins; break ties toward the
+                    // lighter-loaded worker so imbalanced routing still sheds load.
+                    .min_by(|a, b| {
+                        b.1.cmp(&a.1)
+                            .then_with(|| a.2.cmp(&b.2))
+                            .then_with(|| a.0.cmp(&b.0))
+                    })
+                    .map(|(idx, _, _)| idx)
+            })
+            .unwrap_or(min_load_idx);
 
         // Even in imbalanced mode, update the tree to maintain cache state
         if let Some(text) = request_text {
@@ -338,7 +370,7 @@ impl CacheAwarePolicy {
             let tree = self.trees.get(tree_key).map(|entry| entry.value().clone());
 
             if let Some(tree) = tree {
-                let worker_url = workers[min_load_idx].url();
+                let worker_url = workers[selected_idx].url();
                 // Now we can work with the tree without holding the HashMap lock
                 tree.insert(text, worker_url);
 
@@ -365,9 +397,9 @@ impl CacheAwarePolicy {
         }
 
         // Increment processed counter
-        workers[min_load_idx].increment_processed();
+        workers[selected_idx].increment_processed();
 
-        Some(min_load_idx)
+        Some(selected_idx)
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Currently the cache-aware policy switches to shortest-queue selection when load is imbalanced. That path picked the minimum-load worker outright and discarded all cache locality, so every request routed during an imbalance paid a full prefill even when a lightly-loaded worker already held the prompt's prefix.

When the current request pressure increases, it frequently leads to SMG ignoring cache-awareness and choosing the worker with the lowest load, resulting in a significant decrease in cache hit rate.

The following figure serves as an example. Through bench_multiturn stress testing, it was found that under high load conditions in the last few rounds of the conversation marked with a red box, the cache hit rate of some nodes decreased significantly.
<img width="600" height="250" alt="Clipboard_Screenshot_1784802140" src="https://github.com/user-attachments/assets/266377fb-4bac-4fce-bc1e-3117c0ca3968" />


<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

When imbalanced, look within the near-min-load window (`load <= min_load + balance_abs_threshold`) for the worker with the longest cached prefix, and route there. Ties break toward the lighter-loaded worker so imbalanced routing still sheds load. Only when no worker in that window holds any cached prefix do we fall back to the plain shortest-queue worker, preserving the original behavior.

The imbalance-detection logic is unchanged; this only refines which worker is chosen once rebalancing kicks in. Applies to both regular and PD pools since both route through the same policy.


```
  select_worker_min_load
          │
          ▼
    is_imbalanced?
     ┌────┴─────┐
    no          yes
     │            │
     ▼            ▼
  cache-aware   ┌─────────────────────────────────────────────┐
   (unchanged)  │ window = workers with                        │
                │   load <= min_load + balance_abs_threshold   │
                └─────────────────────────────────────────────┘
                                │
                       any cached prefix
                         in window?
                      ┌─────────┴──────────┐
                     yes                    no
                      │                      │
                      ▼                      ▼
          longest cached prefix       min-load worker
          (tie → lighter load)        (original behavior)

```

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Does not affect accuracy

## Speed Tests and Profiling
**Setup:** 4× H20, MiniMax-M2.7 with 4 replicas + hierarchical cache (hicache),
served through the PD router.

**Benchmark:**

SMG arguments
```bash
              exec python3 -m sglang_router.launch_router \
                --host 0.0.0.0 \
                --port 8002 \
                --service-discovery \
                --service-discovery-port 30000 \
                --service-discovery-namespace minimax-m27-h20 \
                --selector app=minimax-m27-nonpd role=nonpd \
                --policy cache_aware \
                --cache-threshold 0.5 \
                --balance-abs-threshold 3 \
                --balance-rel-threshold 1.0 \
                --eviction-interval-secs 900 \
                --max-tree-size 671088640 \
                --health-check-interval-secs 30 \
                --health-check-timeout-secs 10 \
                --health-success-threshold 1 \
                --health-failure-threshold 3 \
                --health-check-endpoint /health \
                --log-level debug
```
Bench method
```bash
python3 benchmark/hicache/bench_multiturn.py \
  --api-format openai \
  --model-path /local-models/models/MiniMax-M2.7 \
  --disable-random-sample \
  --disable-auto-run \
  --request-length 10000 \
  --sub-question-input-length 10000 \
  --output-length 1 \
  --num-rounds 10 \
  --num-clients 110 \
  --max-parallel 110 \
  --request-rate 1.5 \
  --ready-queue-policy random \
  --host <router-host> --port 8001
```

Multi-turn workload with 10k-token prompts and 10 rounds per client stresses prefix reuse, so a rebalance that discards cache locality sh
higher TTFT.

**Results (TTFT, seconds):**

| | Mean | P90 | P99 |
|---|---|---|---|
| Before | 6.97 | 22.64 | 47.90 |
| After  | 3.42 | 8.80  | 15.96 |
| **Improvement** | **−51%** | **−61%** | **−67%** |

Keeping cache affinity during rebalancing cuts mean TTFT roughly in half, and the effect grows at the tail (P99 −67%): those are exactly the requests that previously got rerouted to a cold worker and paid a full 10k-token prefill.

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/7d65d62e-0a53-4d87-9aa6-e913de629eb2" />
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/be8bbedc-d99f-4978-83a8-db6db3f5de31" />
<img width="1601" height="636" alt="image" src="https://github.com/user-attachments/assets/134cc5db-cc48-44b2-babb-bebe091de56a" />




<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #29999991769](https://github.com/sgl-project/sglang/actions/runs/29999991769)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #29999991497](https://github.com/sgl-project/sglang/actions/runs/29999991497)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->