### PR TITLE
[DO NOT MERGE] Reproduce #31445

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -663,6 +663,21 @@ class HybridCacheController(BaseHiCacheController):
                 operation.pool_transfers, operation.hash_value, kv_completed_pages
             )
             self._resolve_sidecar_derived_pool_transfers(operation)
+            # Sleep AFTER the is_terminated() guard passes (and after KV/sidecar
+            # results are observable) so the scheduler thread can run
+            # check_prefetch_progress -> _sync_and_check_hybrid_prefetch_result
+            # -> (not all_succeeded) discard -> append_host_mem_release, FREEING
+            # the sidecar host slots while this aux thread still references them.
+            # The access below then touches the freed memory (repros the UAF).
+            logger.warning("!! simulate slow page transfer !!")
+            time.sleep(2)
+            # Validate host_indices slot allocation before batch_get_v2
+            for transfer in operation.pool_transfers:
+                if transfer.host_indices is not None and transfer.host_indices.numel() > 0 and transfer.name == PoolName.SWA:
+                    entry = self.mem_pool_host.entry_map.get(transfer.name)
+                    if entry is not None:
+                        logger.warning("!! check allocated !!")
+                        entry.host_pool.assert_slot_allocated(transfer.host_indices)
             results = self.storage_backend.batch_get_v2(operation.pool_transfers)
             operation.pool_storage_result.update_extra_pool_hit_pages(results)
         operation.pool_transfers_done = True

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -264,6 +264,7 @@ class MambaPoolHost(HostKVCache):
         self.free_slots = torch.arange(self.size, dtype=torch.int64)
         self.release_slots = []
         self.num_release_slots = 0
+        self._init_slot_used()
 
     def available_size(self):
         return len(self.free_slots) + self.num_release_slots
@@ -281,6 +282,7 @@ class MambaPoolHost(HostKVCache):
 
         select_index = self.free_slots[:need_size]
         self.free_slots = self.free_slots[need_size:]
+        self._mark_slot_allocated(select_index)
         return select_index
 
     @synchronized
@@ -291,6 +293,7 @@ class MambaPoolHost(HostKVCache):
 
         self.release_slots.append(indices_cpu)
         self.num_release_slots += len(indices_cpu)
+        self._mark_slot_freed(indices_cpu)
         return len(indices)
 
     def get_size_per_token(self):
@@ -883,6 +886,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         self.free_slots = torch.arange(self.size, dtype=torch.int64)
         self.release_slots = []
         self.num_release_slots = 0
+        self._init_slot_used()
 
     def available_size(self):
         return len(self.free_slots) + self.num_release_slots
@@ -900,6 +904,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
 
         select_index = self.free_slots[:need_size]
         self.free_slots = self.free_slots[need_size:]
+        self._mark_slot_allocated(select_index)
         return select_index
 
     @synchronized
@@ -910,6 +915,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
 
         self.release_slots.append(indices_cpu)
         self.num_release_slots += len(indices_cpu)
+        self._mark_slot_freed(indices)
         return len(indices)
 
     def backup_from_device_all_layer(

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -272,8 +272,7 @@ class HostKVCache(abc.ABC):
         self.release_slots = []
         self.num_release_slots = 0
         # Per-slot flag used to detect double-free.
-        # slot_used[k] is true if slot k is allocated.
-        self.slot_used = torch.zeros(self.size, dtype=torch.bool)
+        self._init_slot_used()
 
     def available_size(self):
         return len(self.free_slots) + self.num_release_slots
@@ -304,12 +303,7 @@ class HostKVCache(abc.ABC):
         select_index = self.free_slots[:need_size]
         self.free_slots = self.free_slots[need_size:]
 
-        assert not self.slot_used[select_index].any(), (
-            f"Double-alloc detected: slots already allocated: "
-            f"{select_index[self.slot_used[select_index]].tolist()}."
-        )
-        self.slot_used[select_index] = True
-
+        self._mark_slot_allocated(select_index)
         return select_index
 
     @synchronized
@@ -318,11 +312,28 @@ class HostKVCache(abc.ABC):
         if indices_cpu.numel() == 0:
             return 0
 
-        assert self.slot_used[indices_cpu].all(), (
-            f"Double-free detected: slots not currently allocated: "
-            f"{indices_cpu[~self.slot_used[indices_cpu]].tolist()}."
-        )
-        self.slot_used[indices_cpu] = False
+        self._mark_slot_freed(indices_cpu)
         self.release_slots.append(indices_cpu)
         self.num_release_slots += len(indices_cpu)
         return len(indices)
+
+    def _init_slot_used(self) -> None:
+        self.slot_used = torch.zeros(self.size, dtype=torch.bool)
+
+    def _mark_slot_allocated(self, indices: torch.Tensor) -> None:
+        assert not self.slot_used[indices].any(), (
+            f"Double-alloc detected: slots already allocated: "
+            f"{indices[self.slot_used[indices]].tolist()}."
+        )
+        self.slot_used[indices] = True
+
+    def _mark_slot_freed(self, indices: torch.Tensor) -> None:
+        self.assert_slot_allocated(indices)
+        self.slot_used[indices] = False
+
+    def assert_slot_allocated(self, indices: torch.Tensor) -> None:
+        """Assert that the given indices are currently allocated."""
+        assert self.slot_used[indices].all(), (
+            f"Expect slot alalocated: "
+            f"{indices[~self.slot_used[indices]].tolist()}."
+        )


### PR DESCRIPTION
This is the reproduce code for #31445.

This PR includes:
- Check for `host_indices` are allocated in pthread aux thread.
- A testing script, which send several requests, flush cache, and then send the same requests, to trigger prefetch.

Reproduce steps:

1. Run sglang.
```sh
nohup sglang serve \
    --model=deepseek-ai/DeepSeek-V4-Flash \
    --tp-size 8 \
    --moe-runner-backend flashinfer_mxfp4 \
    --disable-cuda-graph \
    --max-total-tokens=$((256*1024)) \
    --swa-full-tokens-ratio=1 \
    --mem-fraction-static 0.85 \
    --max-running-requests=4 \
    --host 0.0.0.0 \
    --port 30000 \
    --enable-metrics \
    --enable-hierarchical-cache \
    --hicache-storage-prefetch-policy best_effort \
    --hicache-storage-backend=mooncake \
    --hicache-storage-backend-extra-config '{"master_server_address": "127.0.0.1:50051", "local_hostname": "localhost", "metadata_server": "http://127.0.0.1:8080/metadata", "global_segment_size": "256gb", "protocol": "tcp"}' \
    > sglang.log 2>&1 &
```

2. Run test script.
```
./repro_31445.py -n 16 --length 32768
```


3. Grep for `AssertionError` in `sglang.log`.  The background thread seems catches `AssertionError`, so it will lead to server crash.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30003186605](https://github.com/sgl-project/sglang/actions/runs/30003186605)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30003186432](https://github.com/sgl-project/sglang/actions/runs/30003186432)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->