### PR TITLE
[DFlash] Avoid D2H sync for sliding-window lengths

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1900,7 +1900,18 @@ class FlashInferIndicesUpdaterPrefill:
                         seq_lens,
                         sliding_window_size + seq_lens - prefix_lens,
                     )
-                    paged_kernel_lens_sum = paged_kernel_lens.sum().item()
+                    if seq_lens_cpu is not None and torch.equal(
+                        prefix_lens, seq_lens
+                    ):
+                        # The lengths reduce to min(seq_lens, window). Use the
+                        # host mirror instead of reading back the CUDA sum.
+                        paged_kernel_lens_sum = int(
+                            torch.clamp(
+                                seq_lens_cpu, max=sliding_window_size
+                            ).sum()
+                        )
+                    else:
+                        paged_kernel_lens_sum = paged_kernel_lens.sum().item()
                     kv_start_idx = seq_lens - paged_kernel_lens
             else:
                 # full attention


### PR DESCRIPTION
## Motivation

When serving Qwen3.5-122B-A10B with DFlash and the FlashInfer draft attention backend, profiling showed a long `aten::item` on the target verification path. The call to `paged_kernel_lens.sum().item()` reads a CUDA scalar back to the host and introduces a stream synchronization in this latency-sensitive path.

## Modifications

For the sliding-window attention case where `prefix_lens` equals `seq_lens`, compute the total paged-kernel length from the existing CPU-side sequence-length mirror:

```python
torch.clamp(seq_lens_cpu, max=sliding_window_size).sum().item()
```

This is equivalent to `min(seq_lens, sliding_window_size)` for each request and avoids reading the CUDA reduction result back to the host. Other cases retain the existing CUDA calculation.

## Accuracy Tests

This change does not modify model computation or attention indices. It only changes how the host-side total buffer length is calculated for the equivalent DFlash sliding-window case.

The change was validated with Qwen3.5-122B-A10B and its DFlash draft model using TP8 and EP8.

## Speed Tests and Profiling

Test configuration:

- Hardware: 8x NVIDIA A800
- Model: Qwen3.5-122B-A10B
- Speculative algorithm: DFLASH
- Draft attention backend: FlashInfer
- Tensor parallelism: 8
- Expert parallelism: 8
- Speculative draft tokens: 4
- DFlash block size: 4
- Concurrency: 1
- `SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1`

Results:

- TPOT decreased from 5.4 ms to 5.1 ms.
- Before the change, the profiler showed a long `aten::item` / `aten::_local_scalar_dense` / `cudaStreamSynchronize` section in target verification.
- After the change, the `aten::item` section was no longer present in the profile.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30013675750](https://github.com/sgl-project/sglang/actions/runs/30013675750)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30013675552](https://github.com/sgl-project/sglang/actions/runs/30013675552)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->