### PR TITLE
Wire nogds and thread config into the fastsafetensors loader branch

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -608,6 +608,10 @@ class DefaultModelLoader(BaseModelLoader):
             if self.load_config.load_format == LoadFormat.FASTSAFETENSORS:
                 weights_iterator = fastsafetensors_weights_iterator(
                     hf_weights_files,
+                    nogds=server_args.fastsafetensors_nogds,
+                    max_threads=(
+                        prefetch_num_threads if weight_loader_prefetch else None
+                    ),
                 )
             elif use_multithread:
                 weights_iterator = buffered_multi_thread_safetensors_weights_iterator(

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -989,10 +989,22 @@ def safetensors_weights_iterator(
 
 def fastsafetensors_weights_iterator(
     hf_weights_files: List[str],
+    nogds: Optional[bool] = None,
+    max_threads: Optional[int] = None,
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """
     Iterate over the weights in the model safetensor files
     using fastsafetensor library to accelerate loading via GPU Direct Storage (if available).
+
+    nogds: force-disable the GPU Direct Storage path. If None (default), auto-detect:
+        integrated/unified-memory GPUs (props.is_integrated, e.g. DGX Spark/GB10 - see the
+        same check in get_available_gpu_memory) don't have a discrete-VRAM DMA target for GDS
+        to accelerate in the first place, and letting the library attempt it anyway falls back
+        through a non-reclaimable pinned-host-memory staging path that can inflate real memory
+        usage several-fold over the actual checkpoint size. On these devices we default to
+        nogds=True. Discrete GPUs keep the library's own default (attempt GDS).
+    max_threads: forwarded to SafeTensorsFileLoader's max_threads (worker threads per rank).
+        If None, use the fastsafetensors library default.
     """
     if SafeTensorsFileLoader is None:
         raise ImportError(
@@ -1011,6 +1023,16 @@ def fastsafetensors_weights_iterator(
 
     device = torch.device(f"cuda:{rank}")
 
+    if nogds is None:
+        try:
+            nogds = bool(torch.cuda.get_device_properties(device).is_integrated)
+        except Exception:
+            nogds = False
+
+    loader_kwargs = {"nogds": nogds}
+    if max_threads is not None:
+        loader_kwargs["max_threads"] = max_threads
+
     weight_files_sub_lists = [
         hf_weights_files[i : i + pg.size()]
         for i in range(0, len(hf_weights_files), pg.size())
@@ -1026,7 +1048,23 @@ def fastsafetensors_weights_iterator(
         disable=False,
         bar_format=_BAR_FORMAT,
     ):
-        loader = SafeTensorsFileLoader(pg, device)
+        try:
+            loader = SafeTensorsFileLoader(pg, device, **loader_kwargs)
+        except Exception as e:
+            # GDS can fail at construction (e.g. is_gds_supported() raising on a
+            # device/filesystem combination that doesn't back it) rather than
+            # degrading gracefully. Retry once with nogds=True before giving up -
+            # matches vLLM's fastsafetensors integration, which hits the same
+            # library and handles this the same way.
+            if loader_kwargs["nogds"] or "gds" not in str(e).lower():
+                raise
+            logger.warning(
+                "fastsafetensors: GDS construction failed (%s); retrying with "
+                "nogds=True.",
+                e,
+            )
+            loader_kwargs["nogds"] = True
+            loader = SafeTensorsFileLoader(pg, device, **loader_kwargs)
         rank_file_map = {i: [f] for i, f in enumerate(f_list)}
         loader.add_filenames(rank_file_map)
         try:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3017,6 +3017,16 @@ class ServerArgs:
         "Call posix_fadvise(DONTNEED) on each safetensors shard after loading it.",
         NS("model"),
     ] = False
+    fastsafetensors_nogds: A[
+        Optional[bool],
+        "Force GPU Direct Storage on/off for --load-format fastsafetensors. Default "
+        "(unset) auto-detects: disabled on integrated/unified-memory GPUs (e.g. DGX "
+        "Spark/GB10), where GDS has no discrete-VRAM DMA target to accelerate and "
+        "otherwise falls back through a non-reclaimable pinned-host-memory staging "
+        "path that can inflate real memory usage several-fold over the checkpoint "
+        "size; left enabled (library default) on discrete GPUs.",
+        NS("model"),
+    ] = None
     remote_instance_weight_loader_seed_instance_ip: A[
         Optional[str],
         "The ip of the seed instance for loading weights from remote instance.",


### PR DESCRIPTION
## What this fixes

`--load-format fastsafetensors` constructs `SafeTensorsFileLoader` with no kwargs at all:

```python
if self.load_config.load_format == LoadFormat.FASTSAFETENSORS:
    weights_iterator = fastsafetensors_weights_iterator(
        hf_weights_files,
    )
```

The two sibling branches immediately below it both receive the full set of `weight_loader_*` server args (`disable_mmap`, `prefetch`, `prefetch_num_threads`, `drop_cache_after_load`). The fastsafetensors branch silently drops all of them — they're computed, echoed back as set in the `ServerArgs` dump, and never reach the iterator.

This PR:

1. Adds `--fastsafetensors-nogds` (tri-state, default unset/auto). #29272 already identifies that `SafeTensorsFileLoader(pg, device)` never passes `nogds`, and that vLLM's own fastsafetensors integration already handles this. When unset, this auto-detects via `torch.cuda.get_device_properties(device).is_integrated` — the same check `get_available_gpu_memory` already uses elsewhere in this file — and defaults to `nogds=True` on integrated/unified-memory GPUs (DGX Spark/GB10), since GDS has no discrete-VRAM DMA target to accelerate there in the first place. Discrete GPUs keep the library's own default (attempt GDS).
2. Wraps loader construction in a try/except that retries once with `nogds=True` on a GDS-related failure, matching the pattern in vLLM's fastsafetensors integration — per #29272's traceback, construction can raise (`is_gds_supported(...) failed`) rather than degrade gracefully.
3. Forwards `weight_loader_prefetch_num_threads` as `max_threads` when `--weight-loader-prefetch-checkpoints` is set, so that existing flag does something under this loader too instead of only applying to the other two branches.

## What this does *not* fix (important — please read before assuming this closes #29272's memory concerns)

Testing this on a DGX Spark (GB10, unified memory, SM121) confirmed `nogds=True` genuinely takes effect (no GDS warning, confirmed via log) but elevated memory usage under `fastsafetensors` persists unchanged. I isolated this to a separate, deeper issue that lives in the `fastsafetensors` library itself, not in this integration:

```
shard 0: before=95.17GB after_copy=67.15GB after_close+gc=67.15GB (file size=10.01GB)
shard 1: before=67.15GB after_copy=56.87GB after_close+gc=56.87GB (file size=10.00GB)
shard 2: before=56.87GB after_copy=49.29GB after_close+gc=49.29GB (file size=3.41GB)
```

Reproduced by calling `SafeTensorsFileLoader` directly, no SGLang involved: `nogds=True`, every yielded tensor immediately consumed, `loader.close()` + `gc.collect()` + `torch.cuda.empty_cache()` afterward — memory recovered is exactly zero in every shard, and retained is consistently ~2x each shard's file size. Related to `foundation-model-stack/fastsafetensors#26` (closed, different framework, fix not clearly confirmed landed).

So: this PR makes `nogds` and thread count actually configurable (closing the config gap #29272 flagged), but on integrated-memory hardware specifically, `--mem-fraction-static` still needs generous headroom when using `--load-format fastsafetensors` even after this lands — that part needs an upstream fix in `fastsafetensors` itself. Wanted to be upfront about that rather than have this merge read as "problem solved" when only half of it is fixed on SGLang's side.

## Testing

Verified against the exact commit + container this was reported from (`lmsysorg/sglang:latest-cu130`, `sglang==0.5.15.post1`, `nvidia/Qwen3.6-35B-A3B-NVFP4`, single GPU): `nogds` auto-detection correctly triggers (GDS warning no longer appears in the boot log), confirming the wiring itself works as intended.

Related: #29272

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30048866280](https://github.com/sgl-project/sglang/actions/runs/30048866280)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30048866133](https://github.com/sgl-project/sglang/actions/runs/30048866133)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->