### PR TITLE
Add one-sided RMA support with ncclPutSignal/ncclWaitSignal, registered-window handling, and the required all-rank warm-up protocol

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/pynccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl.py
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/distributed/device_communicators/pynccl.py
 
+import ctypes
 import logging
 from contextlib import contextmanager
-from typing import Optional, Union
+from typing import Optional, Sequence, Tuple, Union
 
 # ===================== import region =====================
 import torch
@@ -12,10 +13,14 @@ import torch.distributed as dist
 from torch.distributed import ProcessGroup, ReduceOp
 
 from sglang.srt.distributed.device_communicators.pynccl_wrapper import (
+    NCCL_API_MAGIC,
+    NCCL_CONFIG_UNDEF_INT,
+    NCCL_WIN_COLL_SYMMETRIC,
     NCCLLibrary,
     buffer_type,
     cudaStream_t,
     ncclComm_t,
+    ncclConfig_t,
     ncclDataTypeEnum,
     ncclRedOpTypeEnum,
     ncclUniqueId,
@@ -24,6 +29,10 @@ from sglang.srt.distributed.utils import StatelessProcessGroup
 from sglang.srt.utils.common import get_current_device_stream_fast
 
 logger = logging.getLogger(__name__)
+
+# ncclPutSignal / one-sided RMA shipped in NCCL 2.30; raw ncclGetVersion() for
+# 2.30.x is MAJOR*10000+MINOR*100+PATCH (e.g. 2.30.7 -> 23007).
+_NCCL_RMA_MIN_VERSION = 23000
 
 
 class PyNcclCommunicator:
@@ -356,11 +365,159 @@ class PyNcclCommunicator:
             cudaStream_t(stream.cuda_stream),
         )
 
-    def register_comm_window_raw(self, ptr: int, size: int):
-        return self.nccl.ncclCommWindowRegister(self.comm, buffer_type(ptr), size, 1)
+    def register_comm_window_raw(
+        self, ptr: int, size: int, win_flags: int = NCCL_WIN_COLL_SYMMETRIC
+    ):
+        """Register ptr..ptr+size as an NCCL symmetric-memory window and return
+        the opaque window handle (ncclWindow_t). On RMA-unavailable HW (no
+        NVLink, vGPU) NCCL returns success but a NULL handle; callers using
+        the handle for one-sided RMA must treat NULL as unavailable."""
+        return self.nccl.ncclCommWindowRegister(
+            self.comm, buffer_type(ptr), size, win_flags
+        )
 
     def deregister_comm_window(self, window):
         return self.nccl.ncclCommWindowDeregister(self.comm, window)
+
+    def supports_rma(self) -> bool:
+        """Whether the loaded NCCL exposes one-sided RMA at a usable version.
+        A capability gate only; does not guarantee the HW can serve RMA."""
+        return getattr(self.nccl, "has_rma", False) and (
+            self.nccl_version >= _NCCL_RMA_MIN_VERSION
+        )
+
+    # ---- one-sided RMA primitives (NCCL 2.29-2.30+) -------------------------
+
+    def put_signal(
+        self,
+        local_ptr: int,
+        count: int,
+        dtype: int,
+        peer: int,
+        peer_win,
+        peer_win_offset: int = 0,
+        sig_idx: int = 0,
+        ctx: int = 0,
+        flags: int = 0,
+        stream: Optional[torch.cuda.Stream] = None,
+    ):
+        """Put count elements of dtype from local_ptr into the peer's window
+        peer_win at peer_win_offset (bytes) and send a signal. peer_win must be
+        the peer's handle, allgathered across ranks."""
+        stream = stream or self._resolve_stream()
+        return self.nccl.ncclPutSignal(
+            buffer_type(local_ptr),
+            count,
+            dtype,
+            peer,
+            peer_win,
+            peer_win_offset,
+            sig_idx,
+            ctx,
+            flags,
+            self.comm,
+            cudaStream_t(stream.cuda_stream),
+        )
+
+    def signal(
+        self,
+        peer: int,
+        sig_idx: int = 0,
+        ctx: int = 0,
+        flags: int = 0,
+        stream: Optional[torch.cuda.Stream] = None,
+    ):
+        stream = stream or self._resolve_stream()
+        return self.nccl.ncclSignal(
+            peer, sig_idx, ctx, flags, self.comm, cudaStream_t(stream.cuda_stream)
+        )
+
+    def wait_signal(
+        self,
+        descs_ptr: int,
+        n_desc: int,
+        stream: Optional[torch.cuda.Stream] = None,
+    ):
+        """Wait for signals described by n_desc contiguous ncclWaitSignalDesc_t
+        at descs_ptr (built via make_wait_descs)."""
+        stream = stream or self._resolve_stream()
+        return self.nccl.ncclWaitSignal(
+            n_desc,
+            ctypes.c_void_p(descs_ptr),
+            self.comm,
+            cudaStream_t(stream.cuda_stream),
+        )
+
+    def win_get_user_ptr(self, window):
+        out = buffer_type()
+        self.nccl.ncclWinGetUserPtr(self.comm, window, ctypes.byref(out))
+        return out.value
+
+    def nccl_mem_alloc(self, size: int) -> int:
+        """Allocate a symmetric-memory buffer (ncclMemAlloc); eligible for
+        window registration. Free with nccl_mem_free."""
+        ptr = buffer_type()
+        self.nccl.ncclMemAlloc(ctypes.byref(ptr), size)
+        return ptr.value
+
+    def nccl_mem_free(self, ptr: int) -> None:
+        if ptr:
+            self.nccl.ncclMemFree(buffer_type(ptr))
+
+    def get_peer_device_pointer(self, window, offset: int, peer: int):
+        out = buffer_type()
+        self.nccl.ncclGetPeerDevicePointer(window, offset, peer, ctypes.byref(out))
+        return out.value
+
+    @staticmethod
+    def make_wait_descs(peers_opcnt: Sequence[Tuple[int, int]]):
+        """Build a contiguous ncclWaitSignalDesc_t[] buffer for wait_signal.
+        peers_opcnt: [(peer_rank, op_cnt), ...]; returns (buffer_ptr, n_desc)."""
+        import numpy as np
+
+        n_desc = len(peers_opcnt)
+        dtype = np.dtype(
+            [("op_cnt", "i4"), ("peer", "i4"), ("sig_idx", "i4"), ("ctx", "i4")]
+        )
+        arr = np.zeros(n_desc, dtype=dtype)
+        for i, (peer, op_cnt) in enumerate(peers_opcnt):
+            arr[i]["peer"] = peer
+            arr[i]["op_cnt"] = op_cnt
+        return np.ascontiguousarray(arr).ctypes.data, n_desc
+
+    def make_nccl_config(
+        self, num_rma_ctx: int = NCCL_CONFIG_UNDEF_INT
+    ) -> "ncclConfig_t":
+        """Build an ncclConfig_t matching NCCL_CONFIG_INITIALIZER for the loaded
+        library. num_rma_ctx defaults to UNDEF (inherit NCCL default); setting
+        it is not required for RMA to work but sizes the RMA contexts."""
+        cfg = ncclConfig_t()
+        cfg.size = ctypes.sizeof(ncclConfig_t)
+        cfg.magic = NCCL_API_MAGIC
+        cfg.version = self.nccl_version
+        for fld in (
+            "blocking",
+            "cgaClusterSize",
+            "minCTAs",
+            "maxCTAs",
+            "splitShare",
+            "trafficClass",
+            "collnetEnable",
+            "CTAPolicy",
+            "shrinkShare",
+            "nvlsCTAs",
+            "nChannelsPerNetPeer",
+            "nvlinkCentricSched",
+            "graphUsageMode",
+            "numRmaCtx",
+            "maxP2pPeers",
+            "graphStreamOrdering",
+        ):
+            setattr(cfg, fld, NCCL_CONFIG_UNDEF_INT)
+        cfg.netName = None
+        cfg.commName = None
+        cfg.numRmaCtx = num_rma_ctx
+        return cfg
 
     def group_start(self):
         self.nccl.ncclGroupStart()

--- a/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_allocator.py
@@ -88,6 +88,13 @@ static std::mutex g_segment_mutex;
 // Key: comm_ptr, Value: the next segment index to register for this comm.
 static std::unordered_map<uintptr_t, size_t> g_comm_registration_index;
 
+// Per-comm registered window handles (ncclWindow_t values), in registration
+// order. Only non-NULL handles are recorded: on RMA-unavailable hardware (no
+// NVLink, vGPU) ncclCommWindowRegister returns success but a NULL handle,
+// which is unusable for one-sided RMA; an empty handle list lets the Python
+// layer detect "RMA unavailable".
+static std::unordered_map<uintptr_t, std::vector<uintptr_t>> g_comm_windows;
+
 // Add a segment to the tracking (appends to end, maintaining FIFO order)
 static void track_segment(void* ptr, size_t size) {
     std::lock_guard<std::mutex> lock(g_segment_mutex);
@@ -136,12 +143,42 @@ int nccl_allocator_register_segments_with_comm(uintptr_t comm_ptr) {
             fprintf(stderr, "ERROR: NCCL symmetric memory registration failed. '%s'\\n", ncclGetErrorString(res));
             return res;
         }
+        // Record non-NULL window handles for one-sided RMA use. NULL handles
+        // (RMA-unavailable HW) are skipped so callers see an empty list.
+        if (win != nullptr) {
+            g_comm_windows[comm_ptr].push_back(reinterpret_cast<uintptr_t>(win));
+        }
     }
 
     // Update the registration index for this communicator
     g_comm_registration_index[comm_ptr] = g_segments.size();
 
     return ncclSuccess;
+}
+
+// Copy the recorded window handles for `comm_ptr` into the caller-provided
+// array `out` (capacity `cap`, in uintptr_t slots). Returns the number of
+// handles written. Callers should size `cap` to the expected segment count;
+// handles beyond `cap` are dropped (use a follow-up call or size generously).
+int nccl_allocator_get_windows_for_comm(uintptr_t comm_ptr, uintptr_t* out, int cap) {
+    std::lock_guard<std::mutex> lock(g_segment_mutex);
+    auto it = g_comm_windows.find(comm_ptr);
+    if (it == g_comm_windows.end() || out == nullptr || cap <= 0) {
+        return 0;
+    }
+    const std::vector<uintptr_t>& wins = it->second;
+    int n = static_cast<int>(wins.size());
+    if (n > cap) n = cap;
+    for (int i = 0; i < n; ++i) out[i] = wins[i];
+    return n;
+}
+
+// Clear the recorded window handles for `comm_ptr` (e.g. after the caller has
+// consumed/deregistered them). Returns 0 on success.
+int nccl_allocator_clear_windows_for_comm(uintptr_t comm_ptr) {
+    std::lock_guard<std::mutex> lock(g_segment_mutex);
+    g_comm_windows.erase(comm_ptr);
+    return 0;
 }
 
 }
@@ -155,6 +192,8 @@ _active_symmetric_memory_context = None
 
 # Reference to the C registration function (with arg types set)
 _register_func = None
+_get_windows_func = None
+_clear_windows_func = None
 
 
 def is_symmetric_memory_enabled():
@@ -228,6 +267,19 @@ def get_nccl_mem_pool() -> torch.cuda.MemPool:
         _register_func.restype = ctypes.c_int
         _register_func.argtypes = [ctypes.c_uint64]
 
+        # Accessors for the per-comm recorded window handles (one-sided RMA).
+        _get_windows_func = nccl_allocator_lib.nccl_allocator_get_windows_for_comm
+        _get_windows_func.restype = ctypes.c_int
+        _get_windows_func.argtypes = [
+            ctypes.c_uint64,
+            ctypes.POINTER(ctypes.c_uint64),
+            ctypes.c_int,
+        ]
+
+        _clear_windows_func = nccl_allocator_lib.nccl_allocator_clear_windows_for_comm
+        _clear_windows_func.restype = ctypes.c_int
+        _clear_windows_func.argtypes = [ctypes.c_uint64]
+
     return _mem_pool
 
 
@@ -261,6 +313,11 @@ class SymmetricMemoryContext:
         # Get comm ptr for tracking registrations
         # Use the comm pointer value as unique identifier
         self._comm_ptr = self.group_coordinator.pynccl_comm.comm.value
+
+        # Registered window handles (ncclWindow_t values), populated at context
+        # exit. Empty means RMA is unavailable on this comm/HW (NCCL returned
+        # NULL handles).
+        self.windows: list = []
 
     def __enter__(self):
         assert (
@@ -321,6 +378,11 @@ class SymmetricMemoryContext:
             result == 0
         ), f"nccl_allocator_register_segments_with_comm failed with return code: {result}"
 
+        # Collect the per-comm window handles for one-sided RMA. The C++ layer
+        # records only non-NULL handles, so an empty result means RMA is
+        # unavailable on this comm/HW.
+        self.windows = _collect_windows_for_comm(self._comm_ptr)
+
 
 def use_symmetric_memory(group_coordinator: GroupCoordinator, disabled: bool = False):
     disabled = (
@@ -329,6 +391,23 @@ def use_symmetric_memory(group_coordinator: GroupCoordinator, disabled: bool = F
         or group_coordinator.world_size == 1
     )
     return SymmetricMemoryContext(group_coordinator) if not disabled else nullcontext()
+
+
+def _collect_windows_for_comm(comm_ptr: int) -> list:
+    """Read the per-comm recorded window handles (ncclWindow_t values) from the
+    C++ layer. Empty when RMA is unavailable (NULL handles) or the accessor is
+    not yet bound."""
+    if _get_windows_func is None or comm_ptr is None:
+        return []
+    cap = 64
+    while True:
+        buf = (ctypes.c_uint64 * cap)()
+        n = _get_windows_func(comm_ptr, buf, cap)
+        if n < cap:
+            return [int(buf[i]) for i in range(n)]
+        cap *= 2
+        if cap > 1 << 20:
+            return [int(buf[i]) for i in range(n)]
 
 
 # --- Debug mode for symmetric memory validation ---

--- a/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl_wrapper.py
@@ -78,6 +78,53 @@ class ncclUniqueId(ctypes.Structure):
     _fields_ = [("internal", ctypes.c_byte * 128)]
 
 
+# NCCL symmetric-memory window registration flags (from nccl.h.in).
+NCCL_WIN_COLL_SYMMETRIC = 0x01
+
+# ncclConfig_t mirrors NCCL_CONFIG_INITIALIZER at v2.30.7-1: 21 fields
+# including the trailing graphStreamOrdering (nccl4py's config_dtype omits
+# the last field; a 20-field binding makes ncclCommInitRankConfig reject the
+# config). magic/version must be set by the caller, tunables left UNDEF.
+NCCL_CONFIG_UNDEF_INT = -2147483648  # INT_MIN
+NCCL_API_MAGIC = 0xCAFEBEEF
+
+
+class ncclConfig_t(ctypes.Structure):
+    _fields_ = [
+        ("size", ctypes.c_size_t),
+        ("magic", ctypes.c_uint),
+        ("version", ctypes.c_uint),
+        ("blocking", ctypes.c_int),
+        ("cgaClusterSize", ctypes.c_int),
+        ("minCTAs", ctypes.c_int),
+        ("maxCTAs", ctypes.c_int),
+        ("netName", ctypes.c_void_p),
+        ("splitShare", ctypes.c_int),
+        ("trafficClass", ctypes.c_int),
+        ("commName", ctypes.c_void_p),
+        ("collnetEnable", ctypes.c_int),
+        ("CTAPolicy", ctypes.c_int),
+        ("shrinkShare", ctypes.c_int),
+        ("nvlsCTAs", ctypes.c_int),
+        ("nChannelsPerNetPeer", ctypes.c_int),
+        ("nvlinkCentricSched", ctypes.c_int),
+        ("graphUsageMode", ctypes.c_int),
+        ("numRmaCtx", ctypes.c_int),
+        ("maxP2pPeers", ctypes.c_int),
+        ("graphStreamOrdering", ctypes.c_int),
+    ]
+
+
+# ncclWaitSignalDesc_t: one descriptor per peer (nccl4py nccl.pyx:781-799).
+class ncclWaitSignalDesc_t(ctypes.Structure):
+    _fields_ = [
+        ("op_cnt", ctypes.c_int32),
+        ("peer", ctypes.c_int32),
+        ("sig_idx", ctypes.c_int32),
+        ("ctx", ctypes.c_int32),
+    ]
+
+
 cudaStream_t = ctypes.c_void_p
 buffer_type = ctypes.c_void_p
 
@@ -325,6 +372,93 @@ class NCCLLibrary:
         Function("ncclCommWindowDeregister", ncclResult_t, [ncclComm_t, ncclWindow_t]),
     ]
 
+    # One-sided RMA primitives (NCCL 2.29-2.30+) plus ncclMemAlloc/Free. Loaded
+    # only when ncclPutSignal is present (see __init__).
+    exported_functions_rma = [
+        # ncclResult_t ncclMemAlloc(void** ptr, size_t size);
+        Function(
+            "ncclMemAlloc",
+            ncclResult_t,
+            [ctypes.POINTER(buffer_type), ctypes.c_size_t],
+        ),
+        # ncclResult_t ncclMemFree(void* ptr);
+        Function("ncclMemFree", ncclResult_t, [buffer_type]),
+        # ncclResult_t ncclPutSignal(const void* localbuff, size_t count,
+        #   ncclDataType_t datatype, int peer, ncclWindow_t peerWin,
+        #   size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags,
+        #   ncclComm_t comm, cudaStream_t stream);
+        Function(
+            "ncclPutSignal",
+            ncclResult_t,
+            [
+                buffer_type,
+                ctypes.c_size_t,
+                ncclDataType_t,
+                ctypes.c_int,
+                ncclWindow_t,
+                ctypes.c_size_t,
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_uint,
+                ncclComm_t,
+                cudaStream_t,
+            ],
+        ),
+        # ncclResult_t ncclSignal(int peer, int sigIdx, int ctx, unsigned int flags,
+        #   ncclComm_t comm, cudaStream_t stream);
+        Function(
+            "ncclSignal",
+            ncclResult_t,
+            [
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_int,
+                ctypes.c_uint,
+                ncclComm_t,
+                cudaStream_t,
+            ],
+        ),
+        # ncclResult_t ncclWaitSignal(int nDesc, ncclWaitSignalDesc_t* descs,
+        #   ncclComm_t comm, cudaStream_t stream);
+        Function(
+            "ncclWaitSignal",
+            ncclResult_t,
+            [ctypes.c_int, ctypes.c_void_p, ncclComm_t, cudaStream_t],
+        ),
+        # ncclResult_t ncclWinGetUserPtr(ncclComm_t comm, ncclWindow_t win,
+        #   void** outPtr);
+        Function(
+            "ncclWinGetUserPtr",
+            ncclResult_t,
+            [ncclComm_t, ncclWindow_t, ctypes.POINTER(buffer_type)],
+        ),
+        # ncclResult_t ncclGetPeerDevicePointer(ncclWindow_t win, size_t offset,
+        #   int peer, void** outPtr);
+        Function(
+            "ncclGetPeerDevicePointer",
+            ncclResult_t,
+            [
+                ncclWindow_t,
+                ctypes.c_size_t,
+                ctypes.c_int,
+                ctypes.POINTER(buffer_type),
+            ],
+        ),
+        # ncclResult_t ncclCommInitRankConfig(ncclComm_t* comm, int nranks,
+        #   ncclUniqueId commId, int rank, ncclConfig_t* config);
+        Function(
+            "ncclCommInitRankConfig",
+            ncclResult_t,
+            [
+                ctypes.POINTER(ncclComm_t),
+                ctypes.c_int,
+                ncclUniqueId,
+                ctypes.c_int,
+                ctypes.POINTER(ncclConfig_t),
+            ],
+        ),
+    ]
+
     # class attribute to store the mapping from the path to the library
     # to avoid loading the same library multiple times
     path_to_library_cache: Dict[str, Any] = {}
@@ -361,13 +495,30 @@ class NCCLLibrary:
             exported_functions = NCCLLibrary.exported_functions
             if hasattr(self.lib, "ncclCommWindowRegister"):
                 exported_functions.extend(NCCLLibrary.exported_functions_symm_mem)
+            # One-sided RMA (NCCL 2.29-2.30+). Bound only when the symbol is
+            # present; callers gate on the has_rma flag.
+            self.has_rma = hasattr(self.lib, "ncclPutSignal")
+            if self.has_rma:
+                exported_functions.extend(NCCLLibrary.exported_functions_rma)
             for func in exported_functions:
                 f = getattr(self.lib, func.name)
                 f.restype = func.restype
                 f.argtypes = func.argtypes
                 _funcs[func.name] = f
             NCCLLibrary.path_to_dict_mapping[so_file] = _funcs
+        else:
+            self.has_rma = hasattr(self.lib, "ncclPutSignal")
         self._funcs = NCCLLibrary.path_to_dict_mapping[so_file]
+
+    def __getattr__(self, name: str):
+        # Resolve RMA primitives (ncclPutSignal/ncclMemAlloc/...) that are bound
+        # in _funcs but not defined as explicit methods.
+        funcs = self.__dict__.get("_funcs")
+        if funcs is not None and name in funcs:
+            return funcs[name]
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
 
     def ncclGetErrorString(self, result: ncclResult_t) -> str:
         return self._funcs["ncclGetErrorString"](result).decode("utf-8")

--- a/python/sglang/srt/distributed/device_communicators/rma_communicator.py
+++ b/python/sglang/srt/distributed/device_communicators/rma_communicator.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""NCCL one-sided RMA communicator (symmetric memory, NCCL 2.29-2.30+).
+
+Wraps ncclPutSignal/ncclWaitSignal on top of a PyNcclCommunicator. __init__
+runs an all-rank warm-up that registers a symmetric window, exchanges
+handles, and verifies a put/wait round-trip; on hardware where NCCL returns
+a NULL window handle (no NVLink, vGPU) it skips and leaves rma_available
+False so callers fall back to collective NCCL.
+"""
+
+import ctypes
+import logging
+from typing import List
+
+import torch
+
+from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+from sglang.srt.distributed.device_communicators.pynccl_wrapper import (
+    NCCL_WIN_COLL_SYMMETRIC,
+)
+
+logger = logging.getLogger(__name__)
+
+# Warm-up window size, in int32 elements. Only needs to carry the ring
+# handshake marker.
+_WARMUP_ELEMS = 4
+_NCCL_INT32 = 2  # ncclDataTypeEnum.ncclInt32
+
+
+class NcclRmaCommunicator:
+    """One-sided RMA communicator over a PyNcclCommunicator."""
+
+    def __init__(self, pynccl_comm: PyNcclCommunicator, cpu_group=None):
+        self.pynccl = pynccl_comm
+        self.cpu_group = cpu_group
+        self.rank = pynccl_comm.rank
+        self.world_size = pynccl_comm.world_size
+
+        # Capability gate: library has RMA symbols at a usable version and the
+        # group has more than one rank. Necessary but not sufficient -- the HW
+        # may still return NULL handles, see rma_available.
+        self.enabled = bool(pynccl_comm.supports_rma()) and self.world_size > 1
+        # True only after warm-up succeeds. Callers must check this before
+        # issuing RMA ops and fall back to collective NCCL otherwise.
+        self.rma_available = False
+
+        if not self.enabled:
+            return
+
+        # Warm-up must never raise out of __init__: any failure is a fallback.
+        try:
+            with pynccl_comm.change_state(enable=True):
+                self._warmup()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "NCCL RMA warm-up failed for rank %d, falling back to "
+                "collective NCCL: %s",
+                self.rank,
+                e,
+            )
+            self.rma_available = False
+
+        if self.rma_available and self.rank == 0:
+            logger.info(
+                "NCCL one-sided RMA warm-up succeeded (world_size=%d).",
+                self.world_size,
+            )
+
+    def _warmup(self) -> None:
+        """Register a temp symmetric window, exchange handles, run a ring
+        put/wait handshake, verify, deregister. Skips (rma_available stays
+        False) if any rank observes a NULL window handle."""
+        nbytes = _WARMUP_ELEMS * 4  # int32
+        buf = self.pynccl.nccl_mem_alloc(nbytes)
+        win = None
+        try:
+            win = self._register_warmup_window(buf, nbytes)
+            my_handle = win.value if win and win.value else 0
+
+            # Each rank writes its own handle into its slot; all_reduce(SUM)
+            # leaves each slot holding the corresponding rank's handle (0 for
+            # NULL handles, since every other slot is zero).
+            handles = self._allgather_handles(my_handle)
+
+            if any(h == 0 for h in handles):
+                if self.rank == 0:
+                    logger.info(
+                        "NCCL RMA unavailable: a rank got a NULL window handle "
+                        "(no NVLink / vGPU?); falling back to collective NCCL."
+                    )
+                return
+
+            self._ring_handshake(buf, handles)
+            self.rma_available = True
+        finally:
+            if win:
+                self.pynccl.deregister_comm_window(win)
+            self.pynccl.nccl_mem_free(buf)
+
+    def _register_warmup_window(self, buf: int, nbytes: int):
+        return self.pynccl.register_comm_window_raw(
+            buf, nbytes, win_flags=NCCL_WIN_COLL_SYMMETRIC
+        )
+
+    def _allgather_handles(self, my_handle: int) -> List[int]:
+        t = torch.zeros(self.world_size, dtype=torch.int64, device=self.pynccl.device)
+        t[self.rank] = my_handle
+        self.pynccl.all_reduce(t, op=torch.distributed.ReduceOp.SUM)
+        return [int(v) for v in t.tolist()]
+
+    def _ring_handshake(self, buf: int, handles: List[int]) -> None:
+        """Rank i puts marker (i+1) to rank (i+1)%n's window, waits for a
+        marker from rank (i-1)%n, and verifies the received value."""
+        next_rank = (self.rank + 1) % self.world_size
+        prev_rank = (self.rank - 1) % self.world_size
+        next_win = handles[next_rank]
+
+        # ncclPutSignal copies from a local buffer; write the marker into our
+        # own warm-up buffer and use it as the source.
+        cudart = self._cudart()
+        host = (ctypes.c_int32 * 1)(self.rank + 1)
+        stream = self.pynccl._resolve_stream()
+        sptr = ctypes.c_void_p(stream.cuda_stream)
+        cudart.cudaMemcpyAsync.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.c_size_t,
+            ctypes.c_int,
+            ctypes.c_void_p,
+        ]
+        cudart.cudaMemcpyAsync.restype = ctypes.c_int
+        cudart.cudaMemcpyAsync(buf, ctypes.cast(host, ctypes.c_void_p), 4, 1, sptr)
+        stream.synchronize()
+
+        self.pynccl.put_signal(
+            buf,
+            1,
+            _NCCL_INT32,
+            peer=next_rank,
+            peer_win=next_win,
+            peer_win_offset=0,
+            stream=stream,
+        )
+
+        descs_ptr, n = PyNcclCommunicator.make_wait_descs([(prev_rank, 1)])
+        self.pynccl.wait_signal(descs_ptr, n, stream=stream)
+        stream.synchronize()
+
+        out = (ctypes.c_int32 * 1)()
+        cudart.cudaMemcpyAsync(ctypes.cast(out, ctypes.c_void_p), buf, 4, 2, sptr)
+        stream.synchronize()
+        got = out[0]
+        expected = prev_rank + 1
+        if got != expected:
+            raise RuntimeError(
+                f"RMA warm-up verify failed on rank {self.rank}: got {got}, "
+                f"expected {expected} (prev_rank={prev_rank})"
+            )
+
+    _cudart_lib = None
+
+    @classmethod
+    def _cudart(cls):
+        if cls._cudart_lib is None:
+            cls._cudart_lib = ctypes.CDLL("libcudart.so")
+        return cls._cudart_lib

--- a/test/registered/unit/distributed/test_pynccl_rma.py
+++ b/test/registered/unit/distributed/test_pynccl_rma.py
@@ -1,0 +1,252 @@
+"""Tests for the NCCL one-sided RMA support.
+
+Tier 1 (no GPU) guards the ctypes binding layer. Tier 2 (2 GPUs + NCCL)
+asserts the warm-up contract on a real communicator: init must not raise
+when NCCL returns a NULL window handle (no NVLink / vGPU), and on NVLink it
+must prove the put/wait round-trip.
+
+Run::
+
+    pytest test/registered/unit/distributed/test_pynccl_rma.py -q
+    python test/registered/unit/distributed/test_pynccl_rma.py --num-gpu 2
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+import pytest
+import torch
+
+from sglang.srt.distributed.device_communicators import pynccl as pynccl_mod
+from sglang.srt.distributed.device_communicators import pynccl_wrapper as W
+from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+from sglang.srt.distributed.device_communicators.pynccl_wrapper import (
+    NCCL_API_MAGIC,
+    NCCL_CONFIG_UNDEF_INT,
+    NCCL_WIN_COLL_SYMMETRIC,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="2-gpu-large")
+
+
+def test_rma_function_table_is_complete():
+    """Guards against dropping a bound RMA symbol (would silently break the
+    warm-up path that needs it)."""
+    names = {f.name for f in W.NCCLLibrary.exported_functions_rma}
+    assert names == {
+        "ncclMemAlloc",
+        "ncclMemFree",
+        "ncclPutSignal",
+        "ncclSignal",
+        "ncclWaitSignal",
+        "ncclWinGetUserPtr",
+        "ncclGetPeerDevicePointer",
+        "ncclCommInitRankConfig",
+    }
+
+
+def test_rma_functions_have_argtypes():
+    """Empty argtypes makes ctypes reject positional calls."""
+    for f in W.NCCLLibrary.exported_functions_rma:
+        assert len(f.argtypes) > 0, f"{f.name} has empty argtypes"
+
+
+def test_window_flag_matches_nccl_source():
+    assert NCCL_WIN_COLL_SYMMETRIC == 0x01
+
+
+def test_config_initializer_constants_match_nccl_source():
+    assert NCCL_API_MAGIC == 0xCAFEBEEF
+    assert NCCL_CONFIG_UNDEF_INT == -2147483648  # INT_MIN
+
+
+def test_rma_min_version_matches_nccl_2_30():
+    """ncclPutSignal shipped in 2.30 (raw 23007); the gate must not drift."""
+    assert pynccl_mod._NCCL_RMA_MIN_VERSION == 23000
+
+
+def test_nccl_config_t_field_count_is_21_with_trailing_graph_stream_ordering():
+    """nccl4py lists 20 fields but NCCL_CONFIG_INITIALIZER at v2.30.7-1 has 21
+    (trailing graphStreamOrdering); a 20-field binding makes init reject the
+    config."""
+    fields = [n for n, _ in W.ncclConfig_t._fields_]
+    assert len(fields) == 21
+    assert fields[-1] == "graphStreamOrdering"
+
+
+def test_wait_signal_desc_layout_matches_nccl():
+    """Field order matters: ncclWaitSignal reads op_cnt from the first int32."""
+    fields = [n for n, _ in W.ncclWaitSignalDesc_t._fields_]
+    assert fields == ["op_cnt", "peer", "sig_idx", "ctx"]
+    assert ctypes.sizeof(W.ncclWaitSignalDesc_t) == 16
+
+
+def test_make_wait_descs_writes_each_peer_into_its_slot():
+    """A peer/op_cnt column swap would wait on the wrong rank."""
+    descs_ptr, n = PyNcclCommunicator.make_wait_descs([(1, 3), (0, 1)])
+    assert n == 2
+    arr = (W.ncclWaitSignalDesc_t * 2).from_address(descs_ptr)
+    assert (arr[0].peer, arr[0].op_cnt) == (1, 3)
+    assert (arr[1].peer, arr[1].op_cnt) == (0, 1)
+
+
+def test_make_nccl_config_header_matches_initializer():
+    """version must be seeded from the library; a wrong value is rejected."""
+
+    class _Standin(PyNcclCommunicator):
+        def __init__(self):
+            self.nccl_version = 23007
+
+    cfg = _Standin().make_nccl_config(num_rma_ctx=2)
+    assert cfg.size == ctypes.sizeof(W.ncclConfig_t)
+    assert cfg.magic == NCCL_API_MAGIC
+    assert cfg.version == 23007
+    assert cfg.numRmaCtx == 2
+
+
+def test_make_nccl_config_fills_every_tunable_with_undef():
+    """A new tunable added to the struct but unset here would hold 0, not the
+    NCCL UNDEF sentinel (INT_MIN)."""
+
+    class _Standin(PyNcclCommunicator):
+        def __init__(self):
+            self.nccl_version = 23007
+
+    cfg = _Standin().make_nccl_config()
+    for fld in (
+        "blocking",
+        "cgaClusterSize",
+        "minCTAs",
+        "maxCTAs",
+        "splitShare",
+        "trafficClass",
+        "collnetEnable",
+        "CTAPolicy",
+        "shrinkShare",
+        "nvlsCTAs",
+        "nChannelsPerNetPeer",
+        "nvlinkCentricSched",
+        "graphUsageMode",
+        "maxP2pPeers",
+        "graphStreamOrdering",
+    ):
+        assert getattr(cfg, fld) == NCCL_CONFIG_UNDEF_INT, f"{fld} not UNDEF"
+
+
+def _supports_rma(has_rma, version):
+    class _Nccl:
+        pass
+
+    class _Probe(PyNcclCommunicator):
+        def __init__(self, h, v):
+            self.nccl = _Nccl()
+            self.nccl.has_rma = h
+            self.nccl_version = v
+
+    return _Probe(has_rma, version).supports_rma()
+
+
+def test_supports_rma_false_when_symbol_missing():
+    """A lib without ncclPutSignal (e.g. torch's bundled 2.27.3) must be gated
+    out, else AttributeError at runtime."""
+    assert _supports_rma(has_rma=False, version=23007) is False
+
+
+def test_supports_rma_false_below_min_version():
+    """An old NCCL that happens to expose the symbol must still be gated out;
+    the ABI stabilized at 2.30."""
+    assert _supports_rma(has_rma=True, version=21903) is False
+
+
+def test_supports_rma_true_at_version_boundary():
+    """Pins the threshold; bumping it to 23001 would turn this red."""
+    assert _supports_rma(has_rma=True, version=23000) is True
+
+
+# --- Tier 2: E2E warm-up on a real 2-rank NCCL communicator ---
+
+_GPU_2 = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.device_count() >= 2),
+    reason="needs >=2 CUDA GPUs",
+)
+
+
+def _group_has_nvlink() -> bool:
+    """True iff the group's GPUs are all NVLink-connected. RMA requires NVLink
+    symmetric memory; PCIe-only groups get a NULL window handle. Requires
+    torch.distributed initialized."""
+    import torch.distributed as dist
+
+    if not dist.is_initialized() or dist.get_world_size() < 2:
+        return False
+    from sglang.srt.distributed.device_communicators.custom_all_reduce_utils import (
+        is_full_nvlink,
+    )
+
+    local_gpu = torch.cuda.current_device()
+    gpu_ids = [None] * dist.get_world_size()
+    dist.all_gather_object(gpu_ids, local_gpu)
+    gpu_ids = [int(x) for x in gpu_ids]
+    return is_full_nvlink(gpu_ids, len(gpu_ids))
+
+
+def _init_gloo_and_build_rma():
+    import torch.distributed as dist
+
+    from sglang.srt.distributed.device_communicators.rma_communicator import (
+        NcclRmaCommunicator,
+    )
+
+    if not dist.is_initialized():
+        dist.init_process_group(backend="gloo")
+    rank = dist.get_rank()
+    if dist.get_world_size() < 2:
+        pytest.skip("needs world_size>=2")
+    device = torch.device("cuda", rank)
+    pynccl_comm = PyNcclCommunicator(group=dist.group.WORLD, device=device)
+    return NcclRmaCommunicator(pynccl_comm)
+
+
+@_GPU_2
+def test_rma_warmup_init_does_not_raise_on_unavailable_hw():
+    """On RMA-unavailable HW NCCL returns success + a NULL window handle; the
+    warm-up must skip without raising (reproduced on 2x RTX 4080 SUPER, no
+    NVLink). Run under torchrun --nproc_per_node=2."""
+    import torch.distributed as dist
+
+    try:
+        rma = _init_gloo_and_build_rma()
+        assert rma.enabled is True
+        dist.barrier()
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@_GPU_2
+def test_rma_warmup_success_path_on_nvlink():
+    """On NVLink the ring put/wait handshake must verify, setting
+    rma_available=True. Guards the success-path logic the graceful-skip test
+    cannot exercise. Skipped on PCIe-only groups."""
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        dist.init_process_group(backend="gloo")
+    torch.cuda.set_device(dist.get_rank())
+    if not _group_has_nvlink():
+        pytest.skip("needs NVLink-connected GPUs for the RMA success path")
+    try:
+        rma = _init_gloo_and_build_rma()
+        assert rma.rma_available is True
+        dist.barrier()
+    finally:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    from sglang.jit_kernel.tests.utils import multigpu_pytest_main
+
+    multigpu_pytest_main(__name__, __file__, num_gpus=(2,))


### PR DESCRIPTION

Closes #32200.

## Motivation

SGLang's SYMM stack wires the window-registration half but not the one-sided RMA primitives, and the allocator discards registered window handles — so no code path can issue an RMA op. This PR adds the RMA primitives, surfaces handles, and runs an all-rank warm-up protocol that proves `put_signal`/`wait_signal` work (or skips when the HW returns a NULL handle).

## Modifications

- `pynccl_wrapper.py`: bind `ncclPutSignal`/`ncclSignal`/`ncclWaitSignal`/`ncclWinGetUserPtr`/`ncclGetPeerDevicePointer`/`ncclCommInitRankConfig`/`ncclMemAlloc`/`ncclMemFree` (loaded only when `ncclPutSignal` is present); add `ncclConfig_t` (21 fields, matching v2.30.7) and `ncclWaitSignalDesc_t`; `has_rma` flag + `__getattr__` to surface bound functions.
- `pynccl.py`: `supports_rma()` (symbol + version ≥ 2.30), RMA thin methods, `make_wait_descs`/`make_nccl_config` helpers; `register_comm_window_raw` takes `win_flags`.
- `pynccl_allocator.py`: record handles per-comm in C++, expose `get_windows_for_comm`/`clear_windows`, populate `SymmetricMemoryContext.windows` at context exit.
- `rma_communicator.py` (new): `NcclRmaCommunicator` — capability gate + all-rank warm-up (register window, allgather handles, ring `put_signal`/`wait_signal` verify). Skips on NULL handle; never raises out of `__init__`.
- `test/registered/unit/distributed/test_pynccl_rma.py` (new): ABI tests + 2-GPU E2E warm-up test (graceful-skip on PCIe-only; success path on NVLink).

Not yet wired into `GroupCoordinator.all_reduce`; the `SGLANG_RMA_DISABLE` kill-switch + cascade integration are the follow-up roadmap item.

## Checklist

- [x] Pre-commit formatting
- [x] Unit tests added
- [ ] Documentation
- [x] Code style guidance

## Test results

```
pytest test/registered/unit/distributed/test_pynccl_rma.py -q
# 13 passed

python -m torch.distributed.run --nproc_per_node=2 -m pytest \
  test/registered/unit/distributed/test_pynccl_rma.py::test_rma_warmup_init_does_not_raise_on_unavailable_hw -q
# 1 passed (graceful-skip, 2x RTX 4080 SUPER, no NVLink)

python -m torch.distributed.run --nproc_per_node=2 -m pytest \
  test/registered/unit/distributed/test_pynccl_rma.py::test_rma_warmup_success_path_on_nvlink -q
# 1 passed (NVLink, rma_available=True)
```

NCCL: `nvidia-nccl-cu12==2.30.7` via `SGLANG_NCCL_SO_PATH` (torch's bundled 2.27.x lacks RMA symbols).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30006332243](https://github.com/sgl-project/sglang/actions/runs/30006332243)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30006331956](https://github.com/sgl-project/sglang/actions/runs/30006331956)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->