### PR TITLE
[BugFix] Fix /v1/loads running request when PP enabled

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1868,7 +1868,8 @@ class Scheduler(
         """Return this DP rank's decode requests across all PP slots."""
         if self.ps.pp_size == 1:
             return len(self.running_batch.reqs)
-        return self._pp_get_num_running_reqs()
+        else:
+            return self._pp_get_num_running_reqs()
 
     def init_output_streamer(self) -> None:
         self.output_streamer = SchedulerOutputStreamer(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1852,7 +1852,7 @@ class Scheduler(
             tp_worker=self.tp_worker,
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             spec_algorithm=self.spec_algorithm,
-            get_running_batch=lambda: self.running_batch,
+            get_num_running_reqs=self.get_num_running_reqs,
             get_waiting_queue=lambda: self.waiting_queue,
             get_stats=lambda: self.metrics_reporter.stats,
             get_chunked_req=lambda: self.chunked_req,
@@ -1863,6 +1863,12 @@ class Scheduler(
             get_spec_total_num_accept_tokens=lambda: self.metrics_reporter.spec_total_num_accept_tokens,
             get_spec_total_num_forward_ct=lambda: self.metrics_reporter.spec_total_num_forward_ct,
         )
+
+    def get_num_running_reqs(self) -> int:
+        """Return this DP rank's decode requests across all PP slots."""
+        if self.ps.pp_size == 1:
+            return len(self.running_batch.reqs)
+        return self._pp_get_num_running_reqs()
 
     def init_output_streamer(self) -> None:
         self.output_streamer = SchedulerOutputStreamer(

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -40,7 +40,7 @@ class SchedulerLoadInquirer:
     tp_worker: BaseTpWorker
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator
     spec_algorithm: SpeculativeAlgorithm
-    get_running_batch: Callable
+    get_num_running_reqs: Callable
     get_waiting_queue: Callable
     get_stats: Callable
     get_chunked_req: Callable
@@ -87,7 +87,7 @@ class SchedulerLoadInquirer:
     def get_loads(self) -> LoadSnapshot:
         """Build the per-DP-rank load snapshot for DP balancing and /v1/loads."""
         stats = self.get_stats()
-        num_running_reqs = len(self.get_running_batch().reqs)
+        num_running_reqs = self.get_num_running_reqs()
 
         waiting_queues = [self.get_waiting_queue()]
         pending_token_queues = [self.get_waiting_queue()]

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -581,7 +581,7 @@ class SchedulerPPMixin:
 
     def _pp_get_num_running_reqs(self: Scheduler) -> int:
         """Return all decode sequences retained by PP microbatch slots."""
-        return sum(len(batch.reqs) for batch in self.running_mbs)
+        return sum(len(mb.reqs) for mb in self.running_mbs)
 
     def profile_and_init_predictor(self: Scheduler):
         """

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -579,6 +579,10 @@ class SchedulerPPMixin:
             defaultdict(deque)
         )
 
+    def _pp_get_num_running_reqs(self: Scheduler) -> int:
+        """Return all decode sequences retained by PP microbatch slots."""
+        return sum(len(batch.reqs) for batch in self.running_mbs)
+
     def profile_and_init_predictor(self: Scheduler):
         """
         Profile prefill latency for dynamic chunk sizing.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

fix issue #32158 
  
  In PP mode, the scheduler splits active decode work into pipeline microbatch slots. `running_mbs` is the persistent collection of those slots; each slot retains one currently active decode microbatch.

  The event loop temporarily assigns one slot to self.running_batch while processing it. Therefore, /v1/loads previously saw only that one slot. As the loop rotates through slots, this reports only a subset of the DP rank’s active decode requests and can under-report num_running_reqs.

## Modifications
  - Add a scheduler-level get_num_running_reqs() callback for load reporting.
  - In PP mode, sum requests across all persistent running_mbs slots. These slots represent the active decode microbatches of the PP pipeline;  _No deduplication_ is needed because each active decode request belongs to one running_mbs slot.

## PD note

  This change only fixes PP decode load reporting. In PD disaggregation, the prefill scheduler does not populate running_batch in the same way, so its /v1/loads
  num_running_reqs semantics may require a separate fix and are intentionally left unchanged here.

thanks [Bakerjc-bgner](https://github.com/Bakerjc-bgner) for reporting the bug and providing a fix!

CC @whybeyoung 

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30005390324](https://github.com/sgl-project/sglang/actions/runs/30005390324)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30005390191](https://github.com/sgl-project/sglang/actions/runs/30005390191)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->