### PR TITLE
Fix PD decode hang with DP attention and GLM-5.2 MTP

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2113,6 +2113,11 @@ class SchedulerDisaggregationDecodeMixin:
             running_batch = self.update_running_batch(running_batch)
             ret = running_batch if not running_batch.is_empty() else None
 
+        if ret is not None and self.draft_worker is not None:
+            ret.force_disable_cuda_graph = (
+                self.draft_worker.requires_dp_attention_eager_forward(ret)
+            )
+
         ret = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(ret)
         if ret:
             set_schedule_time_batch(ret)

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2114,7 +2114,7 @@ class SchedulerDisaggregationDecodeMixin:
             ret = running_batch if not running_batch.is_empty() else None
 
         if ret is not None and self.draft_worker is not None:
-            ret.force_disable_cuda_graph = (
+            ret.force_disable_draft_cuda_graph = (
                 self.draft_worker.requires_dp_attention_eager_forward(ret)
             )
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -138,6 +138,19 @@ GRAPH_WEIGHTS_PROJ_LORA_ERROR = (
 )
 
 
+def _make_eager_idle_topk_result(
+    x: torch.Tensor, index_topk: int, return_indices: bool
+) -> Optional[torch.Tensor]:
+    if not return_indices:
+        return None
+    return torch.full(
+        (x.shape[0], index_topk),
+        -1,
+        dtype=torch.int32,
+        device=x.device,
+    )
+
+
 def _is_in_piecewise_or_breakable_cuda_graph() -> bool:
     return is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph()
 
@@ -1733,6 +1746,27 @@ class Indexer(MultiPlatformOp):
         layer_id: int,
         return_indices: bool = True,
     ) -> Optional[torch.Tensor]:
+        # When upstream uses fused FP8 RMSNorm+quant, activations may be passed as
+        # a tuple like (x_fp8, x_scale[, y]). Use `x_meta` for shape/device queries.
+        x_meta = x[0] if isinstance(x, tuple) else x
+
+        # A DP-attention idle rank can be physically padded with dummy tokens so
+        # it participates in the eager MLP/EP collectives of active ranks. It has
+        # no real request rows, however, so its DSA page table remains empty.
+        # Calling DeepGEMM paged-MQA with the padded q rows then violates its
+        # block-table batch contract (`_batch_size == batch_size`). CUDA graphs
+        # already capture graph-shaped idle metadata; keep that path unchanged.
+        if (
+            _is_cuda
+            and forward_batch.forward_mode.is_idle()
+            and not get_is_capture_mode()
+        ):
+            topk_result = _make_eager_idle_topk_result(
+                x_meta, self.index_topk, return_indices
+            )
+            topk_result = _broadcast_indexer_topk_from_rank0(topk_result)
+            return maybe_capture_indexer_topk(layer_id, topk_result)
+
         if _is_hip:
             from sglang.kernels.ops.attention.dsa.tilelang_kernel import act_quant
         elif not _is_npu:
@@ -1740,10 +1774,6 @@ class Indexer(MultiPlatformOp):
 
         if TYPE_CHECKING:
             assert isinstance(get_token_to_kv_pool(), DSATokenToKVPool)
-
-        # When upstream uses fused FP8 RMSNorm+quant, activations may be passed as
-        # a tuple like (x_fp8, x_scale[, y]). Use `x_meta` for shape/device queries.
-        x_meta = x[0] if isinstance(x, tuple) else x
 
         in_piecewise_or_breakable_cuda_graph = (
             _is_in_piecewise_or_breakable_cuda_graph()

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -146,6 +146,57 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
     return seqlens_32.contiguous().view(-1, 1)
 
 
+def _trim_trtllm_decode_dp_padding(
+    q_all: torch.Tensor,
+    topk_indices: Optional[torch.Tensor],
+    real_batch_size: int,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], int]:
+    """Keep pre-planned DSA decode metadata aligned with its real request rows.
+
+    Eager DP-attention pads model activations to the largest token count across
+    ranks, but an MTP draft batch can carry DSA metadata that was deliberately
+    planned before that padding.  The metadata page table therefore has
+    ``real_batch_size`` rows while q/top-k have the larger physical row count.
+    Attention has no DP collective, so it should run only on the real prefix;
+    the output is padded back before the following MLP collectives.
+    """
+    physical_batch_size = q_all.shape[0]
+    assert real_batch_size <= physical_batch_size, (
+        f"DSA metadata batch size ({real_batch_size}) exceeds q batch size "
+        f"({physical_batch_size})"
+    )
+
+    if topk_indices is not None:
+        assert real_batch_size <= topk_indices.shape[0], (
+            f"DSA metadata batch size ({real_batch_size}) exceeds topk batch size "
+            f"({topk_indices.shape[0]})"
+        )
+
+    num_padding_rows = physical_batch_size - real_batch_size
+    if num_padding_rows == 0:
+        return q_all, topk_indices, 0
+
+    return (
+        q_all[:real_batch_size],
+        (topk_indices[:real_batch_size] if topk_indices is not None else topk_indices),
+        num_padding_rows,
+    )
+
+
+def _restore_trtllm_decode_dp_padding(
+    output: torch.Tensor, num_padding_rows: int
+) -> torch.Tensor:
+    if num_padding_rows == 0:
+        return output
+    return torch.cat(
+        [
+            output,
+            output.new_zeros((num_padding_rows, *output.shape[1:])),
+        ],
+        dim=0,
+    )
+
+
 @dataclass(frozen=True)
 class DSAFlashMLAMetadata:
     """Metadata only needed by FlashMLA"""
@@ -2892,9 +2943,22 @@ class DeepseekSparseAttnBackend(
         else:
             q_all = q.view(-1, layer.tp_q_head_num, layer.head_dim)
 
+        # Fused top-k always consumes a dense q-aligned tensor. Decode does too
+        # before we trim any eager DP padding to the pre-planned metadata rows.
+        if (self.use_fused_topk or not is_prefill) and topk_indices is not None:
+            topk_indices = self._pad_topk_indices(topk_indices, q.shape[0])
+
+        num_decode_padding_rows = 0
+        if not is_prefill:
+            q_all, topk_indices, num_decode_padding_rows = (
+                _trim_trtllm_decode_dp_padding(
+                    q_all,
+                    topk_indices,
+                    metadata.cache_seqlens_int32.shape[0],
+                )
+            )
+
         if self.use_fused_topk:
-            if topk_indices is not None:
-                topk_indices = self._pad_topk_indices(topk_indices, q.shape[0])
             page_table_1 = self._get_fused_topk_page_table(topk_indices)
         elif is_prefill:
             page_table_1 = transform_index_page_table_prefill(
@@ -2910,8 +2974,6 @@ class DeepseekSparseAttnBackend(
                 cu_seqlens_q=metadata.cu_seqlens_q,
             )
         else:
-            if topk_indices is not None:
-                topk_indices = self._pad_topk_indices(topk_indices, q.shape[0])
             page_table_1 = transform_index_page_table_decode(
                 page_table=metadata.page_table_1,
                 topk_indices=topk_indices,
@@ -2969,7 +3031,7 @@ class DeepseekSparseAttnBackend(
             multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
         )
 
-        return out
+        return _restore_trtllm_decode_dp_padding(out, num_decode_padding_rows)
 
     def _pad_topk_indices(
         self, topk_indices: torch.Tensor, num_tokens: int

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1935,6 +1935,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     is_extend_in_batch: bool = False
     can_run_dp_cuda_graph: bool = False
     can_run_dp_breakable_cuda_graph: bool = False
+    # Rank-local speculative fallback. DP attention folds this into its
+    # existing can-run-graph all-gather so every MLP/EP rank takes the same
+    # eager-vs-graph path for the current forward.
+    force_disable_cuda_graph: bool = False
     tbo_split_seq_index: Optional[int] = None
     # Rank-consistent forward mode for the recv skipper, derived from the MLP
     # sync all-gather (the TBO-only `global_forward_mode` is None without TBO).
@@ -3070,6 +3074,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             global_num_tokens_for_logprob=self.global_num_tokens_for_logprob,
             can_run_dp_cuda_graph=self.can_run_dp_cuda_graph,
             can_run_dp_breakable_cuda_graph=self.can_run_dp_breakable_cuda_graph,
+            force_disable_cuda_graph=self.force_disable_cuda_graph,
             is_extend_in_batch=self.is_extend_in_batch,
             is_prefill_only=self.is_prefill_only,
             seq_lens_cpu=self.seq_lens_cpu,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1934,11 +1934,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # For DP attention
     is_extend_in_batch: bool = False
     can_run_dp_cuda_graph: bool = False
+    # Rank-consistent gate for speculative draft graph replay.  This is kept
+    # separate from can_run_dp_cuda_graph so a seedless DSA draft only falls
+    # back for the draft phase; target verify and draft-extend can still replay
+    # their graphs.
+    can_run_dp_draft_cuda_graph: bool = False
     can_run_dp_breakable_cuda_graph: bool = False
-    # Rank-local speculative fallback. DP attention folds this into its
-    # existing can-run-graph all-gather so every MLP/EP rank takes the same
-    # eager-vs-graph path for the current forward.
-    force_disable_cuda_graph: bool = False
+    # Rank-local speculative draft fallback. DP attention folds this into a
+    # dedicated all-gathered draft graph gate so every MLP/EP rank takes the
+    # same draft eager-vs-graph path for the current forward.
+    force_disable_draft_cuda_graph: bool = False
     tbo_split_seq_index: Optional[int] = None
     # Rank-consistent forward mode for the recv skipper, derived from the MLP
     # sync all-gather (the TBO-only `global_forward_mode` is None without TBO).
@@ -3073,8 +3078,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             global_num_tokens=self.global_num_tokens,
             global_num_tokens_for_logprob=self.global_num_tokens_for_logprob,
             can_run_dp_cuda_graph=self.can_run_dp_cuda_graph,
+            can_run_dp_draft_cuda_graph=self.can_run_dp_draft_cuda_graph,
             can_run_dp_breakable_cuda_graph=self.can_run_dp_breakable_cuda_graph,
-            force_disable_cuda_graph=self.force_disable_cuda_graph,
+            force_disable_draft_cuda_graph=self.force_disable_draft_cuda_graph,
             is_extend_in_batch=self.is_extend_in_batch,
             is_prefill_only=self.is_prefill_only,
             seq_lens_cpu=self.seq_lens_cpu,

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -260,6 +260,10 @@ def prepare_mlp_sync_batch_raw(
         or local_batch.forward_mode.is_decode_or_idle()
         or local_batch.forward_mode.is_prebuilt()
     ) and not disable_cuda_graph
+    if local_batch is not None and getattr(
+        local_batch, "force_disable_cuda_graph", False
+    ):
+        can_cuda_graph = False
     # Idle/None ranks are permissive (like can_cuda_graph): the all-gather
     # min()-reduces this across DP ranks, so a prefill batch with idle ranks
     # still resolves to True (idle ranks become a padded dummy extend).

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -83,6 +83,7 @@ class MLPSyncBatchInfo:
     num_tokens: int
     num_tokens_for_logprob: int
     can_cuda_graph: bool
+    can_draft_cuda_graph: bool
     is_extend_in_batch: bool
     local_can_run_tbo: bool
     local_forward_mode: int
@@ -106,6 +107,7 @@ class MLPSyncBatchInfo:
                 int(self.local_can_run_tbo),
                 self.local_forward_mode,
                 int(self.can_run_breakable_cuda_graph),
+                int(self.can_draft_cuda_graph),
             ],
             device=device,
             dtype=dtype,
@@ -121,6 +123,7 @@ class MLPSyncBatchInfo:
                 1,  # local_can_run_tbo
                 ForwardMode.IDLE.value,  # local_forward_mode
                 0,  # can_run_breakable_cuda_graph
+                1,  # can_draft_cuda_graph
             ],
             device=device,
             dtype=dtype,
@@ -186,6 +189,7 @@ class MLPSyncBatchInfo:
         self.can_cuda_graph = bool(tp0_info[:, 2].min().item())
         self.is_extend_in_batch = bool(tp0_info[:, 3].max().item())
         self.can_run_breakable_cuda_graph = bool(tp0_info[:, 6].min().item())
+        self.can_draft_cuda_graph = bool(tp0_info[:, 7].min().item())
         if _ENABLE_METRICS_DP_ATTENTION:
             self.dp_cooperation_info = DPCooperationInfo.create(tp0_info[:, 5].tolist())
 
@@ -212,6 +216,7 @@ def _update_gather_batch(
 
     # Check forward mode for cuda graph
     batch.can_run_dp_cuda_graph = mlp_sync_info.can_cuda_graph
+    batch.can_run_dp_draft_cuda_graph = mlp_sync_info.can_draft_cuda_graph
     batch.can_run_dp_breakable_cuda_graph = mlp_sync_info.can_run_breakable_cuda_graph
 
 
@@ -260,10 +265,10 @@ def prepare_mlp_sync_batch_raw(
         or local_batch.forward_mode.is_decode_or_idle()
         or local_batch.forward_mode.is_prebuilt()
     ) and not disable_cuda_graph
-    if local_batch is not None and getattr(
-        local_batch, "force_disable_cuda_graph", False
-    ):
-        can_cuda_graph = False
+    can_draft_cuda_graph = not (
+        local_batch is not None
+        and getattr(local_batch, "force_disable_draft_cuda_graph", False)
+    )
     # Idle/None ranks are permissive (like can_cuda_graph): the all-gather
     # min()-reduces this across DP ranks, so a prefill batch with idle ranks
     # still resolves to True (idle ranks become a padded dummy extend).
@@ -311,6 +316,7 @@ def prepare_mlp_sync_batch_raw(
         num_tokens=num_tokens,
         num_tokens_for_logprob=num_tokens_for_logprob,
         can_cuda_graph=can_cuda_graph,
+        can_draft_cuda_graph=can_draft_cuda_graph,
         is_extend_in_batch=is_extend_in_batch,
         local_can_run_tbo=local_can_run_tbo,
         local_forward_mode=local_forward_mode,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -436,6 +436,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For DP attention
     is_extend_in_batch: bool = False
     can_run_dp_cuda_graph: bool = False
+    can_run_dp_draft_cuda_graph: bool = False
     can_run_dp_breakable_cuda_graph: bool = False
     global_forward_mode: Optional[ForwardMode] = None
 
@@ -738,6 +739,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             return_logprob=batch.return_logprob,
             is_extend_in_batch=batch.is_extend_in_batch,
             can_run_dp_cuda_graph=batch.can_run_dp_cuda_graph,
+            can_run_dp_draft_cuda_graph=batch.can_run_dp_draft_cuda_graph,
             can_run_dp_breakable_cuda_graph=batch.can_run_dp_breakable_cuda_graph,
             global_forward_mode=batch.global_forward_mode,
             is_prefill_only=batch.is_prefill_only,

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -132,6 +132,15 @@ class BaseSpecWorker(ABC):
         """
         pass
 
+    def requires_dp_attention_eager_forward(self, batch) -> bool:
+        """Whether this rank needs the current DP-attention step to run eagerly.
+
+        The scheduler folds this into the existing DP MLP-sync all-gather so a
+        rank-local speculative fallback is applied consistently to every rank
+        participating in the MoE forward.
+        """
+        return False
+
     def activate_step_by_batch(self, batch_size: int) -> None:
         """Activate the optimal adaptive step for the current batch size.
 

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -316,7 +316,11 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
         )
 
         if self.require_mlp_sync:
-            is_bs_supported = is_bs_supported and forward_batch.can_run_dp_cuda_graph
+            is_bs_supported = (
+                is_bs_supported
+                and forward_batch.can_run_dp_cuda_graph
+                and forward_batch.can_run_dp_draft_cuda_graph
+            )
 
         return is_bs_supported
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1118,11 +1118,15 @@ class EAGLEWorkerV2(BaseSpecWorker):
         if draft_input is None:
             return False
 
-        has_seed_now = getattr(draft_input, "dsa_topk_indices", None) is not None
-        has_future_seed = getattr(
-            draft_input, "future_dsa_topk_indices_available", False
-        )
-        return not (has_seed_now or has_future_seed)
+        # Under overlap scheduling, FutureMap resolves the inputs after this
+        # scheduler-side graph vote. The current tensor may be stale after a
+        # seeded running batch merges a seedless prebuilt batch, while the
+        # future flag already reflects the merged batch.
+        if getattr(draft_input, "future_indices", None) is not None:
+            has_seed = getattr(draft_input, "future_dsa_topk_indices_available", False)
+        else:
+            has_seed = getattr(draft_input, "dsa_topk_indices", None) is not None
+        return not has_seed
 
     @property
     def spec_v2_attn_backends(self) -> tuple:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1077,6 +1077,21 @@ class EAGLEWorkerV2(BaseSpecWorker):
         # draft_extend, which runs on the draft runner.
         return self._draft_worker.draft_runner
 
+    def requires_dp_attention_eager_forward(self, batch: ScheduleBatch) -> bool:
+        """Keep seedless GLM MTP draft fallback rank-consistent under DP attention."""
+        if not self.draft_worker.seed_dsa_topk_from_draft_extend:
+            return False
+
+        draft_input = batch.spec_info
+        if draft_input is None:
+            return False
+
+        has_seed_now = getattr(draft_input, "dsa_topk_indices", None) is not None
+        has_future_seed = getattr(
+            draft_input, "future_dsa_topk_indices_available", False
+        )
+        return not (has_seed_now or has_future_seed)
+
     @property
     def spec_v2_attn_backends(self) -> tuple:
         # Every attn backend a spec_v2 forward touches; consumed by

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -117,6 +117,31 @@ _is_xpu = is_xpu()
 logger = logging.getLogger(__name__)
 
 
+def _slice_draft_output_to_local_tokens(
+    next_token_logits: torch.Tensor,
+    hidden_states: Optional[torch.Tensor],
+    positions: torch.Tensor,
+    num_local_tokens: int,
+) -> tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    """Discard DP-attention padding rows before eager draft postprocessing."""
+    for name, tensor in (
+        ("next_token_logits", next_token_logits),
+        ("hidden_states", hidden_states),
+        ("positions", positions),
+    ):
+        if tensor is not None and tensor.shape[0] < num_local_tokens:
+            raise RuntimeError(
+                f"EAGLE draft {name} has {tensor.shape[0]} rows, "
+                f"but {num_local_tokens} local tokens need postprocessing"
+            )
+
+    return (
+        next_token_logits[:num_local_tokens],
+        hidden_states[:num_local_tokens] if hidden_states is not None else None,
+        positions[:num_local_tokens],
+    )
+
+
 class EagleDraftWorker(EagleDraftWorkerBase):
     def __init__(
         self,
@@ -636,6 +661,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 break
 
             # Set inputs
+            num_local_tokens = input_ids.shape[0]
             forward_batch.input_ids = input_ids
             # Qwen3-MoE MTP uses a fused RoPE + KV-store path whose cache_loc
             # argument must be contiguous.
@@ -664,47 +690,53 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 canary_index_ctx,
             ):
                 logits_output = self.draft_runner.forward(forward_batch).logits_output
-            maybe_detect_nan(logits_output.next_token_logits, f"draft_forward step {i}")
-            maybe_detect_inf(logits_output.next_token_logits, f"draft_forward step {i}")
+            next_token_logits, next_hidden_states, local_positions = (
+                _slice_draft_output_to_local_tokens(
+                    logits_output.next_token_logits,
+                    logits_output.hidden_states,
+                    forward_batch.positions,
+                    num_local_tokens,
+                )
+            )
+            maybe_detect_nan(next_token_logits, f"draft_forward step {i}")
+            maybe_detect_inf(next_token_logits, f"draft_forward step {i}")
             if self.server_args.speculative_use_rejection_sampling:
                 probs, topk_p, topk_index = sample_draft_proposal(
-                    logits_output.next_token_logits,
+                    next_token_logits,
                     forward_batch.sampling_info.temperatures,
                 )
                 draft_probs_list.append(probs)
-                forward_batch.positions.add_(1)
+                local_positions.add_(1)
             elif self.topk == 1 and not _is_hip:
                 if _is_cuda:
                     # The positions advance is fused into the kernel.
                     topk_p, topk_index = draft_topk1_postprocess(
-                        logits_output.next_token_logits,
-                        forward_batch.positions,
+                        next_token_logits,
+                        local_positions,
                         draft_tokens_topk1,
                         i + 1,
                     )
                 else:
-                    topk_index = torch.argmax(
-                        logits_output.next_token_logits, dim=-1, keepdim=True
-                    )
+                    topk_index = torch.argmax(next_token_logits, dim=-1, keepdim=True)
                     topk_p = torch.ones_like(topk_index, dtype=torch.float32)
-                    forward_batch.positions.add_(1)
+                    local_positions.add_(1)
             else:
                 probs = renorm_draft_probs(
-                    logits_output.next_token_logits,
+                    next_token_logits,
                     forward_batch.sampling_info,
                     self.server_args.speculative_use_rejection_sampling,
                 )
                 topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
-                forward_batch.positions.add_(1)
+                local_positions.add_(1)
             maybe_detect_oob(
                 topk_index,
                 0,
-                logits_output.next_token_logits.shape[-1],
-                f"draft_forward step {i}: topk_index OOB vs vocab_size={logits_output.next_token_logits.shape[-1]}",
+                next_token_logits.shape[-1],
+                f"draft_forward step {i}: topk_index OOB vs vocab_size={next_token_logits.shape[-1]}",
             )
             if self.hot_token_id is not None:
                 topk_index = self.hot_token_id[topk_index]
-            hidden_states = logits_output.hidden_states
+            hidden_states = next_hidden_states
 
         if self.index_share_for_mtp_iteration:
             spec_info.dsa_topk_indices = None

--- a/test/registered/unit/layers/attention/test_dsa_backend_dp_padding.py
+++ b/test/registered/unit/layers/attention/test_dsa_backend_dp_padding.py
@@ -1,0 +1,162 @@
+import unittest
+from types import MethodType, ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa_backend import (
+    DeepseekSparseAttnBackend,
+    _restore_trtllm_decode_dp_padding,
+    _trim_trtllm_decode_dp_padding,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDSABackendDPPadding(unittest.TestCase):
+    def test_trim_and_restore_eager_decode_dp_padding(self):
+        q_all = torch.arange(4 * 2 * 3).view(4, 2, 3)
+        topk_indices = torch.arange(4 * 8, dtype=torch.int32).view(4, 8)
+
+        real_q, real_topk, num_padding_rows = _trim_trtllm_decode_dp_padding(
+            q_all,
+            topk_indices,
+            real_batch_size=2,
+        )
+
+        self.assertTrue(torch.equal(real_q, q_all[:2]))
+        self.assertTrue(torch.equal(real_topk, topk_indices[:2]))
+        self.assertEqual(num_padding_rows, 2)
+
+        real_output = torch.ones((2, 1, 2, 5), dtype=torch.bfloat16)
+        output = _restore_trtllm_decode_dp_padding(real_output, num_padding_rows)
+        self.assertEqual(output.shape, (4, 1, 2, 5))
+        self.assertTrue(torch.equal(output[:2], real_output))
+        self.assertTrue(torch.all(output[2:] == 0))
+
+    def test_no_padding_keeps_existing_tensors(self):
+        q_all = torch.empty((2, 2, 3))
+        topk_indices = torch.empty((2, 8), dtype=torch.int32)
+
+        real_q, real_topk, num_padding_rows = _trim_trtllm_decode_dp_padding(
+            q_all,
+            topk_indices,
+            real_batch_size=2,
+        )
+
+        self.assertIs(real_q, q_all)
+        self.assertIs(real_topk, topk_indices)
+        self.assertEqual(num_padding_rows, 0)
+        self.assertIs(
+            _restore_trtllm_decode_dp_padding(real_q, num_padding_rows),
+            real_q,
+        )
+
+    def test_rejects_metadata_larger_than_physical_batch(self):
+        with self.assertRaisesRegex(
+            AssertionError, "metadata batch size \\(3\\) exceeds q batch size \\(2\\)"
+        ):
+            _trim_trtllm_decode_dp_padding(
+                torch.empty((2, 2, 3)),
+                torch.empty((2, 8), dtype=torch.int32),
+                real_batch_size=3,
+            )
+
+    def test_trtllm_decode_runs_real_rows_then_restores_physical_batch(self):
+        metadata = SimpleNamespace(
+            cache_seqlens_int32=torch.tensor([8, 12], dtype=torch.int32),
+            page_table_1=torch.zeros((2, 12), dtype=torch.int32),
+            max_seq_len_k=12,
+        )
+        backend = SimpleNamespace(
+            forward_metadata=metadata,
+            kv_cache_dtype=torch.bfloat16,
+            token_to_kv_pool=SimpleNamespace(
+                get_key_buffer=lambda _layer_id: torch.zeros((24, 3))
+            ),
+            real_page_size=1,
+            kv_cache_dim=3,
+            use_fused_topk=False,
+            qk_nope_head_dim=2,
+            kv_lora_rank=2,
+            qk_rope_head_dim=1,
+            workspace_buffer=None,
+            dsa_index_topk=2,
+            _multi_ctas_kv_counter_buffer=None,
+            device="cpu",
+            num_q_heads=2,
+        )
+        backend._pad_topk_indices = MethodType(
+            DeepseekSparseAttnBackend._pad_topk_indices, backend
+        )
+
+        layer = SimpleNamespace(
+            layer_id=0,
+            tp_q_head_num=2,
+            head_dim=3,
+            k_scale_float=None,
+            scaling=1.0,
+        )
+        forward_batch = SimpleNamespace()
+        q = torch.arange(4 * 2 * 3, dtype=torch.float32).view(4, 2, 3)
+        topk_indices = torch.arange(4 * 2, dtype=torch.int32).view(4, 2)
+
+        flashinfer = ModuleType("flashinfer")
+        flashinfer_decode = ModuleType("flashinfer.decode")
+        captured = {}
+
+        def fake_decode(**kwargs):
+            captured.update(kwargs)
+            return torch.ones((2, 1, 2, 2), dtype=torch.bfloat16)
+
+        flashinfer_decode.trtllm_batch_decode_with_kv_cache_mla = fake_decode
+        flashinfer.decode = flashinfer_decode
+
+        def fake_transform(*, page_table, topk_indices, page_size):
+            self.assertEqual(page_table.shape[0], 2)
+            self.assertEqual(topk_indices.shape[0], 2)
+            self.assertEqual(page_size, 1)
+            return torch.zeros((2, 2), dtype=torch.int32)
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "flashinfer": flashinfer,
+                    "flashinfer.decode": flashinfer_decode,
+                },
+            ),
+            patch(
+                "sglang.srt.layers.attention.dsa_backend.transform_index_page_table_decode",
+                side_effect=fake_transform,
+            ),
+            patch(
+                "sglang.srt.layers.attention.dsa_backend.dsa_use_prefill_cp",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.layers.attention.dsa_backend.grow_multi_ctas_kv_counter_buffer_if_needed",
+                return_value=None,
+            ),
+        ):
+            output = DeepseekSparseAttnBackend._forward_trtllm(
+                backend,
+                q=q,
+                k=torch.empty((4, 1, 2)),
+                v=torch.empty((4, 1, 2)),
+                layer=layer,
+                forward_batch=forward_batch,
+                seq_lens=metadata.cache_seqlens_int32,
+                save_kv_cache=False,
+                topk_indices=topk_indices,
+            )
+
+        self.assertEqual(captured["query"].shape, (2, 1, 2, 3))
+        self.assertEqual(output.shape, (4, 1, 2, 2))
+        self.assertTrue(torch.all(output[:2] == 1))
+        self.assertTrue(torch.all(output[2:] == 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsa_indexer_idle.py
+++ b/test/registered/unit/layers/attention/test_dsa_indexer_idle.py
@@ -1,0 +1,70 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa.dsa_indexer import (
+    Indexer,
+    _make_eager_idle_topk_result,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_INDEXER = "sglang.srt.layers.attention.dsa.dsa_indexer"
+
+
+class TestDSAIndexerIdle(unittest.TestCase):
+    def test_builds_invalid_topk_rows_for_padded_idle_tokens(self):
+        result = _make_eager_idle_topk_result(
+            torch.empty((2, 16)),
+            index_topk=8,
+            return_indices=True,
+        )
+
+        self.assertEqual(result.shape, (2, 8))
+        self.assertEqual(result.dtype, torch.int32)
+        self.assertTrue(torch.all(result == -1))
+
+    def test_returns_none_when_indices_are_not_consumed(self):
+        self.assertIsNone(
+            _make_eager_idle_topk_result(
+                torch.empty((2, 16)),
+                index_topk=8,
+                return_indices=False,
+            )
+        )
+
+    def test_eager_idle_short_circuits_before_paged_mqa(self):
+        indexer = SimpleNamespace(index_topk=8)
+        batch = SimpleNamespace(forward_mode=ForwardMode.IDLE)
+
+        with (
+            patch(f"{_INDEXER}._is_cuda", True),
+            patch(f"{_INDEXER}.get_is_capture_mode", return_value=False),
+            patch(
+                f"{_INDEXER}._broadcast_indexer_topk_from_rank0",
+                side_effect=lambda result: result,
+            ),
+            patch(
+                f"{_INDEXER}.maybe_capture_indexer_topk",
+                side_effect=lambda _layer_id, result: result,
+            ),
+        ):
+            result = Indexer.forward_cuda(
+                indexer,
+                x=torch.empty((2, 16)),
+                q_lora=torch.empty((2, 16)),
+                positions=torch.empty((2,), dtype=torch.int64),
+                forward_batch=batch,
+                layer_id=3,
+            )
+
+        self.assertEqual(result.shape, (2, 8))
+        self.assertTrue(torch.all(result == -1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_pd_dp_fallback.py
+++ b/test/registered/unit/spec/test_eagle_pd_dp_fallback.py
@@ -1,0 +1,97 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.speculative.eagle_worker_v2 import (
+    EAGLEWorkerV2,
+    _slice_draft_output_to_local_tokens,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestEaglePDDPFallback(CustomTestCase):
+    def test_seedless_pd_draft_requests_rank_consistent_eager_forward(self):
+        worker = object.__new__(EAGLEWorkerV2)
+        worker._draft_worker = SimpleNamespace(seed_dsa_topk_from_draft_extend=True)
+
+        for seed, future_seed, expect_eager in (
+            (None, False, True),
+            (torch.ones((1, 1)), False, False),
+            (None, True, False),
+        ):
+            with self.subTest(
+                seed_present=seed is not None,
+                future_seed=future_seed,
+            ):
+                batch = SimpleNamespace(
+                    spec_info=SimpleNamespace(
+                        dsa_topk_indices=seed,
+                        future_dsa_topk_indices_available=future_seed,
+                    )
+                )
+                self.assertEqual(
+                    worker.requires_dp_attention_eager_forward(batch),
+                    expect_eager,
+                )
+
+        worker._draft_worker.seed_dsa_topk_from_draft_extend = False
+        self.assertFalse(
+            worker.requires_dp_attention_eager_forward(
+                SimpleNamespace(spec_info=SimpleNamespace(dsa_topk_indices=None))
+            )
+        )
+
+    def test_eager_draft_discards_dp_padding_rows(self):
+        logits = torch.arange(24, dtype=torch.float32).reshape(3, 8)
+        hidden_states = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        positions = torch.tensor([7, 100, 100])
+
+        local_logits, local_hidden_states, local_positions = (
+            _slice_draft_output_to_local_tokens(
+                logits,
+                hidden_states,
+                positions,
+                num_local_tokens=1,
+            )
+        )
+
+        self.assertEqual(local_logits.shape, (1, 8))
+        self.assertEqual(local_hidden_states.shape, (1, 4))
+        self.assertEqual(local_positions.tolist(), [7])
+        local_positions.add_(1)
+        self.assertEqual(positions.tolist(), [8, 100, 100])
+
+    def test_idle_eager_draft_discards_all_dp_padding_rows(self):
+        logits = torch.empty((2, 8))
+        hidden_states = torch.empty((2, 4))
+        positions = torch.tensor([100, 100])
+
+        local_logits, local_hidden_states, local_positions = (
+            _slice_draft_output_to_local_tokens(
+                logits,
+                hidden_states,
+                positions,
+                num_local_tokens=0,
+            )
+        )
+
+        self.assertEqual(local_logits.shape, (0, 8))
+        self.assertEqual(local_hidden_states.shape, (0, 4))
+        self.assertEqual(local_positions.shape, (0,))
+
+    def test_eager_draft_rejects_missing_local_rows(self):
+        with self.assertRaisesRegex(RuntimeError, "next_token_logits has 0 rows"):
+            _slice_draft_output_to_local_tokens(
+                torch.empty((0, 8)),
+                torch.empty((1, 4)),
+                torch.tensor([7]),
+                num_local_tokens=1,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_pd_dp_fallback.py
+++ b/test/registered/unit/spec/test_eagle_pd_dp_fallback.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import torch
 
+from sglang.srt.speculative.eagle_info import EagleDraftInput
 from sglang.srt.speculative.eagle_worker_v2 import (
     EAGLEWorkerV2,
     _slice_draft_output_to_local_tokens,
@@ -18,18 +19,21 @@ class TestEaglePDDPFallback(CustomTestCase):
         worker = object.__new__(EAGLEWorkerV2)
         worker._draft_worker = SimpleNamespace(seed_dsa_topk_from_draft_extend=True)
 
-        for seed, future_seed, expect_eager in (
-            (None, False, True),
-            (torch.ones((1, 1)), False, False),
-            (None, True, False),
+        for seed, future_indices, future_seed, expect_eager in (
+            (None, None, False, True),
+            (torch.ones((1, 1)), None, False, False),
+            (torch.ones((1, 1)), torch.tensor([1]), False, True),
+            (None, torch.tensor([1]), True, False),
         ):
             with self.subTest(
                 seed_present=seed is not None,
+                overlap=future_indices is not None,
                 future_seed=future_seed,
             ):
                 batch = SimpleNamespace(
                     spec_info=SimpleNamespace(
                         dsa_topk_indices=seed,
+                        future_indices=future_indices,
                         future_dsa_topk_indices_available=future_seed,
                     )
                 )
@@ -42,6 +46,32 @@ class TestEaglePDDPFallback(CustomTestCase):
         self.assertFalse(
             worker.requires_dp_attention_eager_forward(
                 SimpleNamespace(spec_info=SimpleNamespace(dsa_topk_indices=None))
+            )
+        )
+
+    def test_seeded_running_batch_merged_with_seedless_prebuilt_forces_eager(self):
+        worker = object.__new__(EAGLEWorkerV2)
+        worker._draft_worker = SimpleNamespace(seed_dsa_topk_from_draft_extend=True)
+
+        running_input = EagleDraftInput(
+            dsa_topk_indices=torch.ones((1, 2), dtype=torch.int64),
+            future_indices=torch.tensor([1]),
+            future_dsa_topk_indices_available=True,
+        )
+        prebuilt_input = EagleDraftInput(
+            dsa_topk_indices=None,
+            future_indices=torch.tensor([2]),
+            future_dsa_topk_indices_available=False,
+        )
+        running_input.merge_batch(prebuilt_input)
+
+        self.assertFalse(running_input.future_dsa_topk_indices_available)
+        # merge_batch intentionally leaves the currently materialized tensor
+        # untouched; FutureMap will clear it immediately before the forward.
+        self.assertIsNotNone(running_input.dsa_topk_indices)
+        self.assertTrue(
+            worker.requires_dp_attention_eager_forward(
+                SimpleNamespace(spec_info=running_input)
             )
         )
 

--- a/test/registered/unit/spec/test_eagle_pd_dp_fallback.py
+++ b/test/registered/unit/spec/test_eagle_pd_dp_fallback.py
@@ -3,6 +3,11 @@ from types import SimpleNamespace
 
 import torch
 
+from sglang.srt.managers.scheduler_components.dp_attn import MLPSyncBatchInfo
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative.eagle_draft_cuda_graph_runner import (
+    EAGLEDraftCudaGraphRunner,
+)
 from sglang.srt.speculative.eagle_info import EagleDraftInput
 from sglang.srt.speculative.eagle_worker_v2 import (
     EAGLEWorkerV2,
@@ -15,6 +20,49 @@ register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestEaglePDDPFallback(CustomTestCase):
+    def test_draft_graph_gate_has_independent_dp_vote(self):
+        sync_info = MLPSyncBatchInfo(
+            dp_size=1,
+            tp_size=1,
+            cp_size=1,
+            num_tokens=1,
+            num_tokens_for_logprob=1,
+            can_cuda_graph=True,
+            can_draft_cuda_graph=False,
+            is_extend_in_batch=False,
+            local_can_run_tbo=True,
+            local_forward_mode=ForwardMode.DECODE.value,
+            can_run_breakable_cuda_graph=False,
+        )
+
+        local = sync_info._get_local_tensor(device="cpu")
+        fallback = sync_info._get_fallback_tensor(device="cpu")
+        self.assertEqual(local[2].item(), 1)
+        self.assertEqual(local[7].item(), 0)
+        # Idle/inactive DP ranks remain permissive for the draft vote.
+        self.assertEqual(fallback[7].item(), 1)
+
+    def test_seedless_gate_only_disables_draft_graph(self):
+        runner = object.__new__(EAGLEDraftCudaGraphRunner)
+        runner.require_mlp_tp_gather = False
+        runner.require_mlp_sync = True
+        runner.disable_padding = False
+        runner.captured_req_width = 1
+        runner.max_bs = 8
+
+        forward_batch = SimpleNamespace(
+            spec_info=SimpleNamespace(num_tokens_per_req=1),
+            batch_size=1,
+            can_run_dp_cuda_graph=True,
+            can_run_dp_draft_cuda_graph=False,
+        )
+        self.assertFalse(runner.can_run_graph(forward_batch))
+
+        # The ordinary DP graph gate remains enabled for target verify and
+        # draft-extend; only the draft runner consumes the extra gate.
+        forward_batch.can_run_dp_draft_cuda_graph = True
+        self.assertTrue(runner.can_run_graph(forward_batch))
+
     def test_seedless_pd_draft_requests_rank_consistent_eager_forward(self):
         worker = object.__new__(EAGLEWorkerV2)
         worker._draft_worker = SimpleNamespace(seed_dsa_topk_from_draft_extend=True)

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -145,6 +145,37 @@ class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
 
 
 class TestEagleWorkerV2BackendFallback(CustomTestCase):
+    def test_seedless_pd_draft_requests_rank_consistent_eager_forward(self):
+        worker = object.__new__(EAGLEWorkerV2)
+        worker._draft_worker = SimpleNamespace(seed_dsa_topk_from_draft_extend=True)
+
+        for seed, future_seed, expect_eager in (
+            (None, False, True),
+            (torch.ones((1, 1)), False, False),
+            (None, True, False),
+        ):
+            with self.subTest(
+                seed_present=seed is not None,
+                future_seed=future_seed,
+            ):
+                batch = SimpleNamespace(
+                    spec_info=SimpleNamespace(
+                        dsa_topk_indices=seed,
+                        future_dsa_topk_indices_available=future_seed,
+                    )
+                )
+                self.assertEqual(
+                    worker.requires_dp_attention_eager_forward(batch),
+                    expect_eager,
+                )
+
+        worker._draft_worker.seed_dsa_topk_from_draft_extend = False
+        self.assertFalse(
+            worker.requires_dp_attention_eager_forward(
+                SimpleNamespace(spec_info=SimpleNamespace(dsa_topk_indices=None))
+            )
+        )
+
     def test_missing_seed_cuda_graph_fallback(self):
         graph_result = (
             [],

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -145,37 +145,6 @@ class TestEagleWorkerV2Topk1FastPath(CustomTestCase):
 
 
 class TestEagleWorkerV2BackendFallback(CustomTestCase):
-    def test_seedless_pd_draft_requests_rank_consistent_eager_forward(self):
-        worker = object.__new__(EAGLEWorkerV2)
-        worker._draft_worker = SimpleNamespace(seed_dsa_topk_from_draft_extend=True)
-
-        for seed, future_seed, expect_eager in (
-            (None, False, True),
-            (torch.ones((1, 1)), False, False),
-            (None, True, False),
-        ):
-            with self.subTest(
-                seed_present=seed is not None,
-                future_seed=future_seed,
-            ):
-                batch = SimpleNamespace(
-                    spec_info=SimpleNamespace(
-                        dsa_topk_indices=seed,
-                        future_dsa_topk_indices_available=future_seed,
-                    )
-                )
-                self.assertEqual(
-                    worker.requires_dp_attention_eager_forward(batch),
-                    expect_eager,
-                )
-
-        worker._draft_worker.seed_dsa_topk_from_draft_extend = False
-        self.assertFalse(
-            worker.requires_dp_attention_eager_forward(
-                SimpleNamespace(spec_info=SimpleNamespace(dsa_topk_indices=None))
-            )
-        )
-
     def test_missing_seed_cuda_graph_fallback(self):
         graph_result = (
             [],


### PR DESCRIPTION
## Motivation

A PD-disaggregated nvidia/GLM-5.2-NVFP4 deployment can hang or crash after decode requests when DP attention and EAGLE MTP are enabled together. The equivalent non-disaggregated deployment completes the same requests.

This is a follow-up to #30839. A minimal reproduction uses the following relevant arguments. Mooncake and RDMA arguments may need adjustment for the local network.

Prefill:

    python -m sglang.launch_server \
      --model-path nvidia/GLM-5.2-NVFP4 \
      --trust-remote-code \
      --quantization modelopt_fp4 \
      --moe-runner-backend flashinfer_trtllm \
      --disaggregation-mode prefill \
      --disaggregation-bootstrap-port 8998 \
      --disaggregation-transfer-backend mooncake \
      --tp 8 \
      --dsa-prefill-backend trtllm \
      --host 0.0.0.0 \
      --port 30000

Decode:

    python -m sglang.launch_server \
      --model-path nvidia/GLM-5.2-NVFP4 \
      --trust-remote-code \
      --quantization modelopt_fp4 \
      --moe-runner-backend flashinfer_trtllm \
      --disaggregation-mode decode \
      --disaggregation-bootstrap-port 8998 \
      --disaggregation-transfer-backend mooncake \
      --tp 8 \
      --dp-size 8 \
      --enable-dp-attention \
      --dsa-decode-backend trtllm \
      --speculative-algorithm EAGLE \
      --speculative-num-steps 3 \
      --speculative-eagle-topk 1 \
      --speculative-num-draft-tokens 4 \
      --host 0.0.0.0 \
      --port 30001

Five related failure modes or follow-up issues were observed.

First, the rank receiving the real request can enter the eager MTP draft path while idle DP ranks replay the target verification CUDA graph. The ranks then reach different collective phases and the scheduler eventually triggers the watchdog.

For GLM-5.2 IndexShare, a PD decode round can arrive without dsa_topk_indices. The old fallback disabled graph replay only on the active rank. Idle ranks remained graph-eligible even though all ranks participate in the same DP and EP forward.

Second, overlap scheduling can make the graph vote observe stale DSA seed state. When a seeded running batch merges a seedless prebuilt batch, future_dsa_topk_indices_available becomes false while the materialized dsa_topk_indices tensor can remain non-empty. The future flag must be authoritative whenever future inputs exist, otherwise the active rank falls back only after the DP-wide vote.

Third, after synchronizing eager fallback, DP padding exposed an eager draft postprocessing mismatch:

    draft_topk1_postprocess
      assert positions.shape[0] == next_token_logits.shape[0]

EAGLE postprocessing must consume only rank-local token rows rather than padded logits.

Fourth, idle eager ranks and active padded ranks exposed two DSA shape mismatches. Idle ranks do not have real page-table rows and must skip sparse index selection. Active ranks must trim padded query and top-k rows to the real batch described by pre-planned metadata, run attention on that prefix, then restore the physical DP shape before later MLP and EP collectives.

Fifth, the correctness-first fix originally folded seedless fallback into the generic DP graph gate. This kept ranks consistent but also forced target verification and draft-extend eager whenever only the EAGLE draft phase lacked a DSA seed. Under the reproduced workload, about 9.7% of reported decode batches lost generic CUDA graph replay, creating an avoidable performance regression.

## Modifications

- Add a speculative-worker hook that reports when a batch requires rank-consistent eager draft execution.
- Detect the GLM-5.2 seedless IndexShare condition before DP MLP synchronization in disaggregated decode.
- Treat future_dsa_topk_indices_available as authoritative under overlap scheduling.
- Append a dedicated draft-graph eligibility vote to the existing DP MLP-sync all-gather. No additional collective is introduced.
- Make EAGLEDraftCudaGraphRunner consume both the generic graph vote and the draft-specific vote.
- Keep target verification and draft-extend on their normal CUDA graph path when only draft seed state is missing.
- Slice eager draft logits, hidden states, and positions to the local draft-token count.
- Short-circuit eager DSA index selection on idle DP ranks with all-invalid top-k rows.
- Trim TRT-LLM DSA attention inputs to the real metadata batch and zero-pad the output back to the physical DP shape.
- Add regression coverage for current and future seed states, overlap batch merging, independent generic and draft graph votes, active and idle DP padding, DSA idle indexing, and TRT-LLM page-table alignment.

## Accuracy and Stability Tests

The changes synchronize control flow and isolate DP padding from metadata that describes only real request rows. Model math for real tokens is unchanged.

- Repository pre-commit hooks pass for all modified files.
- Focused local suite: 14 tests passed, plus 4 subtests.
- The patch was hot-applied to the reproduced PD decode deployment with TP8, DP8, DP attention, TRT-LLM DSA, NVFP4, and EAGLE MTP.
- Under mirrored and validation traffic, all 8 scheduler ranks remained alive.
- 2,019 reported decode batches completed with generic CUDA graph enabled: 2,019 true and 0 false.
- Per-rank running batch size reached 7 during observation.
- No scheduler exception, assertion, watchdog, or CUDA graph collective hang occurred.

## Speed Tests and Profiling

The draft-specific gate preserves the required rank-consistent eager fallback but limits it to the EAGLE draft phase.

Before this follow-up, approximately 9.7% of reported decode batches disabled the generic graph path because a seedless draft also disabled target verification and draft-extend graphs. After this follow-up, the observed deployment reported 0 generic graph fallbacks across 2,019 decode batch samples.

This is an operational validation rather than a controlled end-to-end throughput benchmark. The expected gain is workload-dependent and proportional to the frequency of seedless draft rounds; no extra DP collective is added.

## Checklist

- [x] Format the code with repository pre-commit hooks.
- [x] Add unit regression tests.
- [x] Follow the SGLang code style guidance.
- [x] Validate on the reproduced PD + DP attention + EAGLE deployment.
- [ ] Documentation update (not applicable; no user-facing API change).
- [ ] Controlled accuracy and speed benchmark tables.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30020688468](https://github.com/sgl-project/sglang/actions/runs/30020688468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30020688547](https://github.com/sgl-project/sglang/actions/runs/30020688547)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->