### PR TITLE
[CI] Fix Mamba ServerArgs namespace

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2389,6 +2389,7 @@ class ServerArgs:
         "(-1 means unlimited). When enabled, after each insert the shallowest eligible "
         "interior states beyond the cap are removed while their full KV remains. "
         "Tail, fork, and locked nodes are preserved. Must be -1 or a positive integer.",
+        NS("exec.mamba"),
     ] = -1
     enable_mamba_cache_stochastic_rounding: A[
         bool,


### PR DESCRIPTION
## Summary

- assign `mamba_max_states_per_path` to the `exec.mamba` runtime configuration namespace
- restore the `ServerArgs` namespace coverage invariant

## Root cause

PR #31230 added `ServerArgs.mamba_max_states_per_path` without the required `NS(...)` metadata. As a result, `test_server_args_namespaces.py` failed on `main` because the new field was absent from the generated namespace map.

## Impact

The Mamba path-state cap is now published with the other Mamba execution settings, and the CPU unit-test partition no longer fails its `ServerArgs` namespace coverage check.

## Validation

- `python3 test/registered/unit/test_server_args_namespaces.py` — 3 tests passed
- commit-time pre-commit hooks passed
- `git diff --check` passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30009764242](https://github.com/sgl-project/sglang/actions/runs/30009764242)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30009764004](https://github.com/sgl-project/sglang/actions/runs/30009764004)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->