### PR TITLE
[Profile] Disambiguate draft-worker forward spans in profiler traces

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1148,7 +1148,9 @@ class ModelRunner:
             self.msprobe_debugger.start(model=self.model, rank_id=rank_id)
 
         # Step span
-        step_span_ctx = profile_range(build_step_span_name(forward_batch))
+        step_span_ctx = profile_range(
+            build_step_span_name(forward_batch, self.is_draft_worker)
+        )
 
         canary_ctx = (
             context_tuple(

--- a/python/sglang/srt/utils/profile_utils.py
+++ b/python/sglang/srt/utils/profile_utils.py
@@ -414,11 +414,19 @@ class _ProfilerRPD(_ProfilerConcreteBase):
             rpd_to_chrome_trace("trace.rpd", self.rpd_profile_path)
 
 
-def build_step_span_name(forward_batch: ForwardBatch) -> str:
-    """Build a profile-trace span name for one forward step."""
+def build_step_span_name(forward_batch: ForwardBatch, is_draft: bool = False) -> str:
+    """Build a profile-trace span name for one forward step.
+
+    When ``is_draft`` is set the span gets a ``draft `` prefix. A speculative
+    draft proposer runs on its own ``ModelRunner`` (``is_draft_worker=True``) but
+    reuses a target ``ForwardMode`` (e.g. EAGLE proposes with ``DECODE`` /
+    ``TARGET_VERIFY``), so without the prefix its span is indistinguishable from
+    the target model's forward of the same mode in the trace.
+    """
+    prefix = "draft " if is_draft else ""
     mode = forward_batch.forward_mode
     bs = forward_batch.batch_size
     if mode == ForwardMode.EXTEND:
         ext_toks = forward_batch.extend_num_tokens or 0
-        return f"step[EXTEND bs={bs} toks={ext_toks}]"
-    return f"step[{mode.name} bs={bs}]"
+        return f"{prefix}step[EXTEND bs={bs} toks={ext_toks}]"
+    return f"{prefix}step[{mode.name} bs={bs}]"

--- a/test/registered/unit/utils/test_step_span_name.py
+++ b/test/registered/unit/utils/test_step_span_name.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for build_step_span_name (profiler trace span naming).
+
+Usage:
+    python test_step_span_name.py
+    python -m unittest test_step_span_name.py -v
+"""
+
+import types
+import unittest
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.utils.profile_utils import build_step_span_name
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=2, suite="base-c-test-cpu")
+
+
+def _fake_forward_batch(mode: ForwardMode, bs: int, extend_num_tokens=None):
+    # build_step_span_name only reads these three attributes, so a lightweight
+    # stub avoids constructing a real (GPU/tensor-backed) ForwardBatch.
+    return types.SimpleNamespace(
+        forward_mode=mode,
+        batch_size=bs,
+        extend_num_tokens=extend_num_tokens,
+    )
+
+
+class TestBuildStepSpanName(CustomTestCase):
+    def test_target_forward_has_no_prefix(self):
+        fb = _fake_forward_batch(ForwardMode.DECODE, bs=32)
+        self.assertEqual(build_step_span_name(fb), "step[DECODE bs=32]")
+        self.assertEqual(build_step_span_name(fb, is_draft=False), "step[DECODE bs=32]")
+
+    def test_draft_forward_gets_draft_prefix(self):
+        fb = _fake_forward_batch(ForwardMode.DECODE, bs=32)
+        self.assertEqual(
+            build_step_span_name(fb, is_draft=True), "draft step[DECODE bs=32]"
+        )
+
+    def test_draft_and_target_spans_are_distinct(self):
+        # The bug this guards against: a draft proposer reuses a target
+        # ForwardMode, so without the prefix the two spans collide.
+        fb = _fake_forward_batch(ForwardMode.TARGET_VERIFY, bs=8)
+        target = build_step_span_name(fb, is_draft=False)
+        draft = build_step_span_name(fb, is_draft=True)
+        self.assertNotEqual(target, draft)
+        self.assertEqual(target, "step[TARGET_VERIFY bs=8]")
+        self.assertEqual(draft, "draft step[TARGET_VERIFY bs=8]")
+
+    def test_extend_includes_token_count(self):
+        fb = _fake_forward_batch(ForwardMode.EXTEND, bs=4, extend_num_tokens=100)
+        self.assertEqual(build_step_span_name(fb), "step[EXTEND bs=4 toks=100]")
+        self.assertEqual(
+            build_step_span_name(fb, is_draft=True),
+            "draft step[EXTEND bs=4 toks=100]",
+        )
+
+    def test_extend_none_token_count_defaults_to_zero(self):
+        fb = _fake_forward_batch(ForwardMode.EXTEND, bs=4, extend_num_tokens=None)
+        self.assertEqual(build_step_span_name(fb), "step[EXTEND bs=4 toks=0]")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

A speculative **draft** proposer runs on its own `ModelRunner` (`is_draft_worker=True`) but reuses a **target** `ForwardMode` for its forward pass — e.g. EAGLE proposes with `ForwardMode.DECODE` (`eagle_draft_cuda_graph_runner.py:404`), and other spec workers reuse `TARGET_VERIFY`. Because `build_step_span_name` derives the trace span name purely from `forward_mode.name`, the draft forward emits a span (`step[DECODE bs=N]`) that is **byte-for-byte identical** to the target model's forward of the same mode.

In a Perfetto / chrome trace this makes it impossible to:
- tell draft vs. target forwards apart visually, and
- filter/aggregate them in SQL (`SELECT ... WHERE name = 'step[DECODE bs=N]'` returns both), so per-phase latency breakdowns for speculative decoding are wrong.

## Modifications

Add an `is_draft` flag to `build_step_span_name` that prepends a `draft ` prefix, and pass `self.is_draft_worker` through at the single common call site in `ModelRunner.forward`.

Before → after (trace span names):

| forward | before | after |
|---|---|---|
| target decode | `step[DECODE bs=32]` | `step[DECODE bs=32]` |
| draft propose  | `step[DECODE bs=32]` | `draft step[DECODE bs=32]` |

### Why the common entry point

The fix lives at the shared `ModelRunner.forward` span, so it covers **every** speculative algorithm that routes its draft forward through a draft `ModelRunner` (EAGLE / EAGLE3, MTP, and downstream spec workers) with no per-algorithm changes.

## Accuracy Tests

- Added `test/registered/unit/utils/test_step_span_name.py` — CPU-only unit test, 5 cases: target has no prefix, draft gets the `draft ` prefix, draft/target spans of the same `ForwardMode` are distinct (the collision this fixes), `EXTEND` includes the token count, and `EXTEND` with `extend_num_tokens=None` defaults to `toks=0`.
- Non-spec run: span names unchanged (`is_draft` defaults to `False`).
- Spec run (EAGLE): draft forwards now appear as `draft step[...]`; target forwards unchanged. Verified draft/target phases are separately filterable in the exported chrome trace.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30010099190](https://github.com/sgl-project/sglang/actions/runs/30010099190)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30010098886](https://github.com/sgl-project/sglang/actions/runs/30010098886)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->