### PR TITLE
Propagate memory saver to hybrid-SWA KV pools

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1047,6 +1047,7 @@ class KVCacheConfigurator:
             swa_attention_layer_ids=self.model_config.swa_attention_layer_ids,
             full_attention_layer_ids=self.model_config.full_attention_layer_ids,
             device=self.device,
+            enable_memory_saver=self.server_args.enable_memory_saver,
             token_to_kv_pool_class=NPUMHATokenToKVPool,
             **kwargs,
         )
@@ -1229,6 +1230,7 @@ class KVCacheConfigurator:
             swa_attention_layer_ids=swa_attention_layer_ids,
             full_attention_layer_ids=full_attention_layer_ids,
             device=self.device,
+            enable_memory_saver=self.server_args.enable_memory_saver,
             enable_kv_cache_copy=(self.server_args.speculative_algorithm is not None),
             token_to_kv_pool_class=swa_pool_class,
             **kwargs,

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -47,7 +47,7 @@ class SWAKVPool(BaseSWAKVPool):
         self.layer_transfer_counter = None
 
         kwargs["page_size"] = page_size
-        kwargs["enable_memory_saver"] = False
+        kwargs.setdefault("enable_memory_saver", False)
         kwargs["head_num"] = head_num
         kwargs["head_dim"] = head_dim
         kwargs["device"] = device

--- a/test/registered/unit/mem_cache/test_swa_memory_saver.py
+++ b/test/registered/unit/mem_cache/test_swa_memory_saver.py
@@ -27,7 +27,10 @@ class TestSWAKVPoolMemorySaver(CustomTestCase):
     def setUp(self):
         RecordingKVPool.calls = []
 
-    def _build_pool(self, enable_memory_saver):
+    def _build_pool(self, enable_memory_saver=None):
+        kwargs = {}
+        if enable_memory_saver is not None:
+            kwargs["enable_memory_saver"] = enable_memory_saver
         with patch(
             "sglang.srt.mem_cache.swa_memory_pool.maybe_init_custom_mem_pool",
             return_value=(False, None, None),
@@ -42,37 +45,19 @@ class TestSWAKVPoolMemorySaver(CustomTestCase):
                 swa_attention_layer_ids=[0],
                 full_attention_layer_ids=[1],
                 device="cpu",
-                enable_memory_saver=enable_memory_saver,
                 token_to_kv_pool_class=RecordingKVPool,
+                **kwargs,
             )
 
     def test_forwards_memory_saver_setting_to_both_subpools(self):
-        for enabled in (False, True):
-            with self.subTest(enabled=enabled):
-                RecordingKVPool.calls = []
-                self._build_pool(enabled)
-                self.assertEqual(
-                    [call["enable_memory_saver"] for call in RecordingKVPool.calls],
-                    [enabled, enabled],
-                )
+        self._build_pool(True)
+        self.assertEqual(
+            [call["enable_memory_saver"] for call in RecordingKVPool.calls],
+            [True, True],
+        )
 
     def test_defaults_memory_saver_off_for_existing_callers(self):
-        with patch(
-            "sglang.srt.mem_cache.swa_memory_pool.maybe_init_custom_mem_pool",
-            return_value=(False, None, None),
-        ):
-            SWAKVPool(
-                size=8,
-                size_swa=4,
-                page_size=1,
-                dtype=torch.float16,
-                head_num=2,
-                head_dim=4,
-                swa_attention_layer_ids=[0],
-                full_attention_layer_ids=[1],
-                device="cpu",
-                token_to_kv_pool_class=RecordingKVPool,
-            )
+        self._build_pool()
         self.assertEqual(
             [call["enable_memory_saver"] for call in RecordingKVPool.calls],
             [False, False],
@@ -93,30 +78,30 @@ class TestSWAKVPoolMemorySaver(CustomTestCase):
             get_num_kv_heads=lambda _tp_size: 2,
         )
 
-        for enabled in (False, True):
-            with self.subTest(enabled=enabled):
-                configurator.server_args = SimpleNamespace(
-                    page_size=1,
-                    kv_cache_dtype="auto",
-                    enable_memory_saver=enabled,
-                    speculative_algorithm=None,
-                )
-                with (
-                    patch(
-                        "sglang.srt.mem_cache.kv_cache_configurator.get_parallel",
-                        return_value=SimpleNamespace(attn_tp_size=1),
-                    ),
-                    patch(
-                        "sglang.srt.mem_cache.kv_cache_configurator.SWAKVPool"
-                    ) as pool_cls,
-                ):
-                    configurator._build_hybrid_swa_kv_pool(
-                        full_max_total_num_tokens=8,
-                        swa_max_total_num_tokens=4,
-                        mha_pool_class=RecordingKVPool,
-                    )
+        configurator.server_args = SimpleNamespace(
+            page_size=1,
+            kv_cache_dtype="auto",
+            enable_memory_saver=True,
+            speculative_algorithm=None,
+        )
+        with (
+            patch(
+                "sglang.srt.mem_cache.kv_cache_configurator.get_parallel",
+                return_value=SimpleNamespace(attn_tp_size=1),
+            ),
+            patch(
+                "sglang.srt.mem_cache.kv_cache_configurator.get_model",
+                return_value=SimpleNamespace(kv_cache_dtype="auto"),
+            ),
+            patch("sglang.srt.mem_cache.kv_cache_configurator.SWAKVPool") as pool_cls,
+        ):
+            configurator._build_hybrid_swa_kv_pool(
+                full_max_total_num_tokens=8,
+                swa_max_total_num_tokens=4,
+                mha_pool_class=RecordingKVPool,
+            )
 
-                self.assertIs(pool_cls.call_args.kwargs["enable_memory_saver"], enabled)
+        self.assertIs(pool_cls.call_args.kwargs["enable_memory_saver"], True)
 
     def test_ascend_configurator_forwards_server_setting(self):
         configurator = object.__new__(KVCacheConfigurator)
@@ -130,39 +115,29 @@ class TestSWAKVPoolMemorySaver(CustomTestCase):
             full_attention_layer_ids=[1],
             get_num_kv_heads=lambda _tp_size: 2,
         )
-        fake_npu_pool = object()
         npu_module = ModuleType("sglang.srt.hardware_backend.npu.memory_pool_npu")
-        npu_module.NPUMHATokenToKVPool = fake_npu_pool
+        npu_module.NPUMHATokenToKVPool = object()
+        configurator.server_args = SimpleNamespace(
+            page_size=1,
+            enable_memory_saver=True,
+        )
+        with (
+            patch.dict(
+                sys.modules,
+                {"sglang.srt.hardware_backend.npu.memory_pool_npu": npu_module},
+            ),
+            patch(
+                "sglang.srt.mem_cache.kv_cache_configurator.get_parallel",
+                return_value=SimpleNamespace(attn_tp_size=1),
+            ),
+            patch("sglang.srt.mem_cache.kv_cache_configurator.SWAKVPool") as pool_cls,
+        ):
+            configurator._build_ascend_swa_kv_pool(
+                full_max_total_num_tokens=8,
+                swa_max_total_num_tokens=4,
+            )
 
-        for enabled in (False, True):
-            with self.subTest(enabled=enabled):
-                configurator.server_args = SimpleNamespace(
-                    page_size=1,
-                    enable_memory_saver=enabled,
-                )
-                with (
-                    patch.dict(
-                        sys.modules,
-                        {"sglang.srt.hardware_backend.npu.memory_pool_npu": npu_module},
-                    ),
-                    patch(
-                        "sglang.srt.mem_cache.kv_cache_configurator.get_parallel",
-                        return_value=SimpleNamespace(attn_tp_size=1),
-                    ),
-                    patch(
-                        "sglang.srt.mem_cache.kv_cache_configurator.SWAKVPool"
-                    ) as pool_cls,
-                ):
-                    configurator._build_ascend_swa_kv_pool(
-                        full_max_total_num_tokens=8,
-                        swa_max_total_num_tokens=4,
-                    )
-
-                self.assertIs(pool_cls.call_args.kwargs["enable_memory_saver"], enabled)
-                self.assertIs(
-                    pool_cls.call_args.kwargs["token_to_kv_pool_class"],
-                    fake_npu_pool,
-                )
+        self.assertIs(pool_cls.call_args.kwargs["enable_memory_saver"], True)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_swa_memory_saver.py
+++ b/test/registered/unit/mem_cache/test_swa_memory_saver.py
@@ -1,0 +1,169 @@
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class RecordingKVPool:
+    calls = []
+
+    def __init__(self, **kwargs):
+        self.calls.append(kwargs)
+
+    def get_kv_size_bytes(self):
+        return 0, 0
+
+
+class TestSWAKVPoolMemorySaver(CustomTestCase):
+    def setUp(self):
+        RecordingKVPool.calls = []
+
+    def _build_pool(self, enable_memory_saver):
+        with patch(
+            "sglang.srt.mem_cache.swa_memory_pool.maybe_init_custom_mem_pool",
+            return_value=(False, None, None),
+        ):
+            return SWAKVPool(
+                size=8,
+                size_swa=4,
+                page_size=1,
+                dtype=torch.float16,
+                head_num=2,
+                head_dim=4,
+                swa_attention_layer_ids=[0],
+                full_attention_layer_ids=[1],
+                device="cpu",
+                enable_memory_saver=enable_memory_saver,
+                token_to_kv_pool_class=RecordingKVPool,
+            )
+
+    def test_forwards_memory_saver_setting_to_both_subpools(self):
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                RecordingKVPool.calls = []
+                self._build_pool(enabled)
+                self.assertEqual(
+                    [call["enable_memory_saver"] for call in RecordingKVPool.calls],
+                    [enabled, enabled],
+                )
+
+    def test_defaults_memory_saver_off_for_existing_callers(self):
+        with patch(
+            "sglang.srt.mem_cache.swa_memory_pool.maybe_init_custom_mem_pool",
+            return_value=(False, None, None),
+        ):
+            SWAKVPool(
+                size=8,
+                size_swa=4,
+                page_size=1,
+                dtype=torch.float16,
+                head_num=2,
+                head_dim=4,
+                swa_attention_layer_ids=[0],
+                full_attention_layer_ids=[1],
+                device="cpu",
+                token_to_kv_pool_class=RecordingKVPool,
+            )
+        self.assertEqual(
+            [call["enable_memory_saver"] for call in RecordingKVPool.calls],
+            [False, False],
+        )
+
+    def test_configurator_forwards_server_setting(self):
+        configurator = object.__new__(KVCacheConfigurator)
+        configurator.kv_cache_dtype = torch.float16
+        configurator.post_capture_kv_active = False
+        configurator.is_hybrid_swa_compress = False
+        configurator.is_inkling_mtp_draft = False
+        configurator.draft_swa_full_capacity = False
+        configurator.device = "cpu"
+        configurator.model_config = SimpleNamespace(
+            head_dim=4,
+            swa_attention_layer_ids=[0],
+            full_attention_layer_ids=[1],
+            get_num_kv_heads=lambda _tp_size: 2,
+        )
+
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                configurator.server_args = SimpleNamespace(
+                    page_size=1,
+                    kv_cache_dtype="auto",
+                    enable_memory_saver=enabled,
+                    speculative_algorithm=None,
+                )
+                with (
+                    patch(
+                        "sglang.srt.mem_cache.kv_cache_configurator.get_parallel",
+                        return_value=SimpleNamespace(attn_tp_size=1),
+                    ),
+                    patch(
+                        "sglang.srt.mem_cache.kv_cache_configurator.SWAKVPool"
+                    ) as pool_cls,
+                ):
+                    configurator._build_hybrid_swa_kv_pool(
+                        full_max_total_num_tokens=8,
+                        swa_max_total_num_tokens=4,
+                        mha_pool_class=RecordingKVPool,
+                    )
+
+                self.assertIs(pool_cls.call_args.kwargs["enable_memory_saver"], enabled)
+
+    def test_ascend_configurator_forwards_server_setting(self):
+        configurator = object.__new__(KVCacheConfigurator)
+        configurator.kv_cache_dtype = torch.float16
+        configurator.post_capture_kv_active = False
+        configurator.is_hybrid_swa_compress = False
+        configurator.device = "npu"
+        configurator.model_config = SimpleNamespace(
+            head_dim=4,
+            swa_attention_layer_ids=[0],
+            full_attention_layer_ids=[1],
+            get_num_kv_heads=lambda _tp_size: 2,
+        )
+        fake_npu_pool = object()
+        npu_module = ModuleType("sglang.srt.hardware_backend.npu.memory_pool_npu")
+        npu_module.NPUMHATokenToKVPool = fake_npu_pool
+
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                configurator.server_args = SimpleNamespace(
+                    page_size=1,
+                    enable_memory_saver=enabled,
+                )
+                with (
+                    patch.dict(
+                        sys.modules,
+                        {"sglang.srt.hardware_backend.npu.memory_pool_npu": npu_module},
+                    ),
+                    patch(
+                        "sglang.srt.mem_cache.kv_cache_configurator.get_parallel",
+                        return_value=SimpleNamespace(attn_tp_size=1),
+                    ),
+                    patch(
+                        "sglang.srt.mem_cache.kv_cache_configurator.SWAKVPool"
+                    ) as pool_cls,
+                ):
+                    configurator._build_ascend_swa_kv_pool(
+                        full_max_total_num_tokens=8,
+                        swa_max_total_num_tokens=4,
+                    )
+
+                self.assertIs(pool_cls.call_args.kwargs["enable_memory_saver"], enabled)
+                self.assertIs(
+                    pool_cls.call_args.kwargs["token_to_kv_pool_class"],
+                    fake_npu_pool,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- propagate `enable_memory_saver` through both generic and Ascend hybrid-SWA pool constructors
- preserve the existing disabled default for direct `SWAKVPool` callers while allowing an explicit setting to reach both internal pools

## Why

`SWAKVPool` unconditionally replaced `enable_memory_saver` with `False`, and its configurator call sites did not pass the server setting. Hybrid sliding-window deployments therefore could not release either the full-attention or SWA KV allocation through the memory-saver path even when the server option was enabled.

## Validation

Four focused tests cover the four distinct boundaries:

- explicit `True` reaches both internal pools
- an omitted option retains the existing `False` default
- the generic hybrid-SWA configurator forwards `True`
- the Ascend hybrid-SWA configurator forwards `True`

On the current upstream base all four tests pass on the production dependency stack. A planted negative control removing the three production edits makes the direct-True and both configurator tests fail while the compatibility-default test continues to pass. All pre-commit hooks pass.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30010530065](https://github.com/sgl-project/sglang/actions/runs/30010530065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30010530462](https://github.com/sgl-project/sglang/actions/runs/30010530462)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->