### PR TITLE
Make memory release admission safe

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1738,7 +1738,8 @@ class ReleaseMemoryOccupationReqInput(BaseReq, kw_only=True):
 
 
 class ReleaseMemoryOccupationReqOutput(BaseReq, kw_only=True):
-    pass
+    success: bool = True
+    message: str = ""
 
 
 class ResumeMemoryOccupationReqInput(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -672,6 +672,10 @@ class TokenizerWorker(TokenizerManager):
         )
 
     async def pause_generation(self, obj: PauseGenerationReqInput):
+        if obj.mode == "in_place":
+            raise RuntimeError(
+                "In-place pause is not supported with multiple tokenizer workers."
+            )
         loop = asyncio.get_event_loop()
         self._pause_continue_future = loop.create_future()
         # Send to router which will broadcast to all workers

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -184,9 +184,11 @@ class SchedulerWeightUpdaterManager:
         return GetWeightsByNameReqOutput(parameter=parameter)
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
-        assert (
-            self.is_fully_idle()
-        ), "release_memory_occupation should be called only when server is idle."
+        if not self.is_fully_idle():
+            return ReleaseMemoryOccupationReqOutput(
+                success=False,
+                message="release_memory_occupation requires an idle scheduler.",
+            )
 
         tags = recv_req.tags
 

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -760,7 +760,10 @@ class TokenizerControlMixin:
         request: Optional[fastapi.Request] = None,
     ):
         self.auto_create_handle_loop()
-        await self.release_memory_occupation_communicator(obj)
+        results = await self.release_memory_occupation_communicator(obj)
+        success, message = FanOutCommunicator.merge_results(results)
+        if not success:
+            raise RuntimeError(message)
 
     async def resume_memory_occupation(
         self: TokenizerManager,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -687,11 +687,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
     async def _acquire_generation_reader(self):
         """Atomically pass the pause gate and join the admitted request set."""
-        reader_lock = self.model_update_lock.reader_lock
-        async with self.is_pause_cond:
-            await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+        while True:
+            async with self.is_pause_cond:
+                await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+
+            reader_lock = self.model_update_lock.reader_lock
             await reader_lock.__aenter__()
-        return reader_lock
+            async with self.is_pause_cond:
+                if not self.is_pause:
+                    return reader_lock
+            await reader_lock.__aexit__(None, None, None)
 
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool
@@ -1742,9 +1747,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
     async def pause_generation(self, obj: PauseGenerationReqInput):
         async with self.is_pause_cond:
+            was_paused = self.is_pause
             self.is_pause = True
             if obj.mode == "in_place" and await self.model_update_lock.is_locked():
-                self.is_pause = False
+                self.is_pause = was_paused
                 self.is_pause_cond.notify_all()
                 raise RuntimeError(
                     "Cannot pause generation in place while requests are active."
@@ -1754,7 +1760,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     await self._async_dispatch_to_scheduler(obj)
                 except Exception:
                     if obj.mode == "in_place":
-                        self.is_pause = False
+                        self.is_pause = was_paused
                         self.is_pause_cond.notify_all()
                     raise
             else:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -692,11 +692,18 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 await self.is_pause_cond.wait_for(lambda: not self.is_pause)
 
             reader_lock = self.model_update_lock.reader_lock
-            await reader_lock.__aenter__()
-            async with self.is_pause_cond:
-                if not self.is_pause:
-                    return reader_lock
-            await reader_lock.__aexit__(None, None, None)
+            reader_acquired = False
+            keep_reader = False
+            try:
+                await self.model_update_lock.acquire_reader()
+                reader_acquired = True
+                async with self.is_pause_cond:
+                    if not self.is_pause:
+                        keep_reader = True
+                        return reader_lock
+            finally:
+                if reader_acquired and not keep_reader:
+                    await reader_lock.__aexit__(None, None, None)
 
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -651,10 +651,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # Log the request
             self.request_logger.log_received_request(obj, self.tokenizer, request)
 
-            async with self.is_pause_cond:
-                await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+            # Admission and the reader-lock acquisition must be atomic with
+            # respect to pause_generation. Otherwise pause can close the gate
+            # after a request passes it but before that request owns the lock,
+            # acknowledge the pause, and let the request reach a paused engine.
+            reader_lock = await self._acquire_generation_reader()
 
-            async with self.model_update_lock.reader_lock:
+            try:
                 await self._validate_and_resolve_lora(obj)
 
                 # Tokenize the request and send it to the scheduler
@@ -669,6 +672,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 else:
                     async for response in self._handle_batch_request(obj, request):
                         yield response
+            finally:
+                await reader_lock.__aexit__(None, None, None)
         except Exception:
             # _init_req_state created a rid_to_state entry per (sub-)request up
             # front. The normal remover is the scheduler-response path
@@ -679,6 +684,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             # path are left untouched (pop is a no-op).
             self._discard_pending_req_states(obj)
             raise
+
+    async def _acquire_generation_reader(self):
+        """Atomically pass the pause gate and join the admitted request set."""
+        reader_lock = self.model_update_lock.reader_lock
+        async with self.is_pause_cond:
+            await self.is_pause_cond.wait_for(lambda: not self.is_pause)
+            await reader_lock.__aenter__()
+        return reader_lock
 
     def _detect_input_format(
         self, texts: Union[str, List[str]], is_cross_encoder: bool
@@ -1730,8 +1743,20 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     async def pause_generation(self, obj: PauseGenerationReqInput):
         async with self.is_pause_cond:
             self.is_pause = True
+            if obj.mode == "in_place" and await self.model_update_lock.is_locked():
+                self.is_pause = False
+                self.is_pause_cond.notify_all()
+                raise RuntimeError(
+                    "Cannot pause generation in place while requests are active."
+                )
             if obj.mode != "abort":
-                await self._async_dispatch_to_scheduler(obj)
+                try:
+                    await self._async_dispatch_to_scheduler(obj)
+                except Exception:
+                    if obj.mode == "in_place":
+                        self.is_pause = False
+                        self.is_pause_cond.notify_all()
+                    raise
             else:
                 # we are using the model_update_lock to check if there is still on-going requests.
                 while True:

--- a/test/registered/unit/managers/test_memory_release_barrier.py
+++ b/test/registered/unit/managers/test_memory_release_barrier.py
@@ -1,0 +1,92 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from sglang.srt.managers.io_struct import (
+    PauseGenerationReqInput,
+    ReleaseMemoryOccupationReqInput,
+)
+from sglang.srt.managers.scheduler_components.weight_updater import (
+    SchedulerWeightUpdaterManager,
+)
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.utils.aio_rwlock import RWLock
+
+
+def _bare_tokenizer_manager():
+    tm = object.__new__(TokenizerManager)
+    tm.is_pause = False
+    tm.is_pause_cond = asyncio.Condition()
+    tm.model_update_lock = RWLock()
+    tm._async_dispatch_to_scheduler = AsyncMock()
+    return tm
+
+
+@pytest.mark.asyncio
+async def test_in_place_pause_refuses_active_request_without_pausing():
+    tm = _bare_tokenizer_manager()
+    await tm.model_update_lock.acquire_reader()
+
+    with pytest.raises(RuntimeError, match="requests are active"):
+        await tm.pause_generation(PauseGenerationReqInput(mode="in_place"))
+
+    assert tm.is_pause is False
+    tm._async_dispatch_to_scheduler.assert_not_awaited()
+    await tm.model_update_lock.release_reader()
+
+
+@pytest.mark.asyncio
+async def test_request_admission_cannot_be_liminal_during_pause():
+    tm = _bare_tokenizer_manager()
+    original_acquire_reader = tm.model_update_lock.acquire_reader
+    admission_entered = asyncio.Event()
+    admission_release = asyncio.Event()
+
+    async def delayed_acquire_reader():
+        admission_entered.set()
+        await admission_release.wait()
+        await original_acquire_reader()
+
+    tm.model_update_lock.acquire_reader = delayed_acquire_reader
+    admission_task = asyncio.create_task(tm._acquire_generation_reader())
+    await admission_entered.wait()
+    pause_task = asyncio.create_task(
+        tm.pause_generation(PauseGenerationReqInput(mode="in_place"))
+    )
+    await asyncio.sleep(0)
+    assert not pause_task.done(), "pause crossed a request still being admitted"
+
+    admission_release.set()
+    reader_lock = await admission_task
+
+    with pytest.raises(RuntimeError, match="requests are active"):
+        await pause_task
+    assert tm.is_pause is False
+    tm._async_dispatch_to_scheduler.assert_not_awaited()
+    await reader_lock.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_failed_in_place_pause_reopens_admission():
+    tm = _bare_tokenizer_manager()
+    tm._async_dispatch_to_scheduler.side_effect = RuntimeError("dispatch failed")
+
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        await tm.pause_generation(PauseGenerationReqInput(mode="in_place"))
+
+    assert tm.is_pause is False
+    reader_lock = await asyncio.wait_for(tm._acquire_generation_reader(), timeout=1)
+    await reader_lock.__aexit__(None, None, None)
+
+
+def test_busy_release_returns_failure_instead_of_asserting():
+    updater = object.__new__(SchedulerWeightUpdaterManager)
+    updater.is_fully_idle = Mock(return_value=False)
+
+    result = updater.release_memory_occupation(
+        ReleaseMemoryOccupationReqInput(tags=["kv_cache"])
+    )
+
+    assert result.success is False
+    assert "idle scheduler" in result.message

--- a/test/registered/unit/managers/test_memory_release_barrier.py
+++ b/test/registered/unit/managers/test_memory_release_barrier.py
@@ -43,6 +43,19 @@ async def test_in_place_pause_refuses_active_request_without_pausing():
 
 
 @pytest.mark.asyncio
+async def test_in_place_refusal_preserves_existing_pause():
+    tm = _bare_tokenizer_manager()
+    tm.is_pause = True
+    await tm.model_update_lock.acquire_reader()
+
+    with pytest.raises(RuntimeError, match="requests are active"):
+        await tm.pause_generation(PauseGenerationReqInput(mode="in_place"))
+
+    assert tm.is_pause is True
+    await tm.model_update_lock.release_reader()
+
+
+@pytest.mark.asyncio
 async def test_request_admission_cannot_be_liminal_during_pause():
     tm = _bare_tokenizer_manager()
     original_acquire_reader = tm.model_update_lock.acquire_reader
@@ -60,17 +73,50 @@ async def test_request_admission_cannot_be_liminal_during_pause():
     pause_task = asyncio.create_task(
         tm.pause_generation(PauseGenerationReqInput(mode="in_place"))
     )
-    await asyncio.sleep(0)
-    assert not pause_task.done(), "pause crossed a request still being admitted"
+    await asyncio.wait_for(pause_task, timeout=0.1)
+    tm._async_dispatch_to_scheduler.assert_awaited_once()
 
     admission_release.set()
-    reader_lock = await admission_task
+    await asyncio.sleep(0)
+    assert not admission_task.done(), "request crossed the closed pause gate"
 
-    with pytest.raises(RuntimeError, match="requests are active"):
-        await pause_task
-    assert tm.is_pause is False
-    tm._async_dispatch_to_scheduler.assert_not_awaited()
+    async with tm.is_pause_cond:
+        tm.is_pause = False
+        tm.is_pause_cond.notify_all()
+    reader_lock = await admission_task
     await reader_lock.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_waiting_writer_does_not_block_abort_from_closing_gate():
+    tm = _bare_tokenizer_manager()
+    abort_called = asyncio.Event()
+    tm.abort_request = Mock(side_effect=lambda **_: abort_called.set())
+    await tm.model_update_lock.acquire_reader()
+
+    writer_release = asyncio.Event()
+
+    async def hold_writer():
+        async with tm.model_update_lock.writer_lock:
+            await writer_release.wait()
+
+    writer_task = asyncio.create_task(hold_writer())
+    while tm.model_update_lock._waiting_writers == 0:
+        await asyncio.sleep(0)
+
+    admission_task = asyncio.create_task(tm._acquire_generation_reader())
+    pause_task = asyncio.create_task(
+        tm.pause_generation(PauseGenerationReqInput(mode="abort"))
+    )
+    await asyncio.wait_for(abort_called.wait(), timeout=0.1)
+    tm.abort_request.assert_called_with(abort_all=True)
+
+    pause_task.cancel()
+    admission_task.cancel()
+    await asyncio.gather(pause_task, admission_task, return_exceptions=True)
+    await tm.model_update_lock.release_reader()
+    writer_release.set()
+    await writer_task
 
 
 @pytest.mark.asyncio

--- a/test/registered/unit/managers/test_memory_release_barrier.py
+++ b/test/registered/unit/managers/test_memory_release_barrier.py
@@ -73,7 +73,7 @@ async def test_request_admission_cannot_be_liminal_during_pause():
     pause_task = asyncio.create_task(
         tm.pause_generation(PauseGenerationReqInput(mode="in_place"))
     )
-    await asyncio.wait_for(pause_task, timeout=0.1)
+    await asyncio.wait_for(pause_task, timeout=1)
     tm._async_dispatch_to_scheduler.assert_awaited_once()
 
     admission_release.set()
@@ -108,7 +108,7 @@ async def test_waiting_writer_does_not_block_abort_from_closing_gate():
     pause_task = asyncio.create_task(
         tm.pause_generation(PauseGenerationReqInput(mode="abort"))
     )
-    await asyncio.wait_for(abort_called.wait(), timeout=0.1)
+    await asyncio.wait_for(abort_called.wait(), timeout=1)
     tm.abort_request.assert_called_with(abort_all=True)
 
     pause_task.cancel()
@@ -117,6 +117,29 @@ async def test_waiting_writer_does_not_block_abort_from_closing_gate():
     await tm.model_update_lock.release_reader()
     writer_release.set()
     await writer_task
+
+
+@pytest.mark.asyncio
+async def test_cancelled_admission_releases_acquired_reader():
+    tm = _bare_tokenizer_manager()
+    acquired = asyncio.Event()
+    proceed = asyncio.Event()
+    original_acquire_reader = tm.model_update_lock.acquire_reader
+
+    async def observed_acquire_reader():
+        await original_acquire_reader()
+        acquired.set()
+        await proceed.wait()
+
+    tm.model_update_lock.acquire_reader = observed_acquire_reader
+    admission_task = asyncio.create_task(tm._acquire_generation_reader())
+    await acquired.wait()
+    async with tm.is_pause_cond:
+        proceed.set()
+        await asyncio.sleep(0)
+        admission_task.cancel()
+        await asyncio.gather(admission_task, return_exceptions=True)
+        assert await tm.model_update_lock.is_locked() is False
 
 
 @pytest.mark.asyncio
@@ -130,6 +153,11 @@ async def test_failed_in_place_pause_reopens_admission():
     assert tm.is_pause is False
     reader_lock = await asyncio.wait_for(tm._acquire_generation_reader(), timeout=1)
     await reader_lock.__aexit__(None, None, None)
+
+    tm.is_pause = True
+    with pytest.raises(RuntimeError, match="dispatch failed"):
+        await tm.pause_generation(PauseGenerationReqInput(mode="in_place"))
+    assert tm.is_pause is True
 
 
 @pytest.mark.asyncio

--- a/test/registered/unit/managers/test_memory_release_barrier.py
+++ b/test/registered/unit/managers/test_memory_release_barrier.py
@@ -92,7 +92,10 @@ async def test_multi_tokenizer_rejects_in_place_pause_before_dispatch():
     worker._dispatch_to_scheduler = Mock()
 
     with pytest.raises(RuntimeError, match="multiple tokenizer workers"):
-        await worker.pause_generation(PauseGenerationReqInput(mode="in_place"))
+        await asyncio.wait_for(
+            worker.pause_generation(PauseGenerationReqInput(mode="in_place")),
+            timeout=1,
+        )
 
     worker._dispatch_to_scheduler.assert_not_called()
 

--- a/test/registered/unit/managers/test_memory_release_barrier.py
+++ b/test/registered/unit/managers/test_memory_release_barrier.py
@@ -6,12 +6,18 @@ import pytest
 from sglang.srt.managers.io_struct import (
     PauseGenerationReqInput,
     ReleaseMemoryOccupationReqInput,
+    ReleaseMemoryOccupationReqOutput,
 )
+from sglang.srt.managers.multi_tokenizer_mixin import TokenizerWorker
 from sglang.srt.managers.scheduler_components.weight_updater import (
     SchedulerWeightUpdaterManager,
 )
+from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.srt.utils.aio_rwlock import RWLock
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 def _bare_tokenizer_manager():
@@ -78,6 +84,34 @@ async def test_failed_in_place_pause_reopens_admission():
     assert tm.is_pause is False
     reader_lock = await asyncio.wait_for(tm._acquire_generation_reader(), timeout=1)
     await reader_lock.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_multi_tokenizer_rejects_in_place_pause_before_dispatch():
+    worker = object.__new__(TokenizerWorker)
+    worker._dispatch_to_scheduler = Mock()
+
+    with pytest.raises(RuntimeError, match="multiple tokenizer workers"):
+        await worker.pause_generation(PauseGenerationReqInput(mode="in_place"))
+
+    worker._dispatch_to_scheduler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_release_surfaces_fanout_failure():
+    manager = object.__new__(TokenizerManager)
+    manager.auto_create_handle_loop = Mock()
+    manager.release_memory_occupation_communicator = AsyncMock(
+        return_value=[
+            ReleaseMemoryOccupationReqOutput(),
+            ReleaseMemoryOccupationReqOutput(success=False, message="rank busy"),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="rank busy"):
+        await TokenizerControlMixin.release_memory_occupation(
+            manager, ReleaseMemoryOccupationReqInput(tags=["kv_cache"])
+        )
 
 
 def test_busy_release_returns_failure_instead_of_asserting():


### PR DESCRIPTION
## Summary

- make request admission and pause-gate revalidation atomic without holding the pause condition while waiting behind an RW-lock writer
- reject unsafe in-place pause while requests are active, preserving any prior paused state
- release an acquired admission reader on retry, exception, or cancellation
- propagate busy release failures through scheduler fanout instead of asserting or reporting success
- reject unsupported in-place pause with multiple tokenizer workers before dispatch

## Validation

On current upstream (`b98a577fb`):

- focused CPU regression suite: 9 passed
- pre-commit hooks pass
- restoring lock acquisition under the pause condition makes both admission/abort concurrency tests time out
- removing cancellation cleanup leaves the RW lock held and fails the ownership assertion
- clearing a pre-existing pause in either refusal or dispatch-failure branch fails the state tests
- restoring the scheduler assertion/fanout behavior fails the busy-release tests

On an 8x H100 Gemma 4 deployment, an active request caused in-place release to refuse; the request completed; three subsequent release/resume cycles succeeded; queued wake-up returned normally; and the service recorded no restart.
