### PR TITLE
Use exact paged-KV accounting at context boundary

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -52,6 +52,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchPrefixParams,
     zero_match_result,
 )
+from sglang.srt.mem_cache.common import new_tokens_for_alloc
 from sglang.srt.mem_cache.multi_ended_allocator import (
     UnifiedMambaTokenToKVPoolAllocator,
 )
@@ -713,21 +714,19 @@ class PrefillAdder:
         retracted_stain: bool,
         mamba_gap_reserve: int = 0,
     ):
-        # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
-        extend_input_len = self.ceil_paged_tokens(extend_input_len)
-
-        # alloc_extend reserves an extra page_size per request to make sure the budget doesn't over-commit
-        page_overhead = self.page_size
+        output_kv_tokens = max(max_new_tokens - 1, 0)
+        new_extend_tokens = new_tokens_for_alloc(
+            prefix_len, extend_input_len, self.page_size
+        )
+        new_full_tokens = new_tokens_for_alloc(
+            prefix_len, extend_input_len + output_kv_tokens, self.page_size
+        )
         # `mamba_gap_reserve` (shared Mamba pool only; 0 otherwise) charges the new
         # mamba state's shared-gap cost to BOTH full budgets: the slot is allocated
         # immediately (counts against `cur_rem`) and held for the request lifetime
         # (counts against `rem_total`). See `_mamba_gap_budget_for_req`.
-        self.rem_total_token_offset += (
-            extend_input_len + max_new_tokens + page_overhead + mamba_gap_reserve
-        )
-        self.cur_rem_token_offset += (
-            extend_input_len + page_overhead + mamba_gap_reserve
-        )
+        self.rem_total_token_offset += new_full_tokens + mamba_gap_reserve
+        self.cur_rem_token_offset += new_extend_tokens + mamba_gap_reserve
         # The new mamba slot also consumes one mamba-recoverable slot (gated
         # separately so full_evictable can't cover it — see __init__).
         if mamba_gap_reserve and self.rem_mamba_slots is not None:
@@ -864,7 +863,7 @@ class PrefillAdder:
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
         self._update_prefill_budget(
-            0,
+            req.kv_committed_len,
             req.extend_range.length,
             (
                 min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
@@ -1024,9 +1023,6 @@ class PrefillAdder:
         if req.sampling_params.ignore_eos and getattr(self.tree_cache, "disable", True):
             return self.add_one_req_ignore_eos(req)
 
-        # Reserve page_size for page-alignment overhead: the paged allocator may
-        # consume one extra page per request (see alloc_extend), which
-        # _update_prefill_budget also deducts.
         max_new = min(
             max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
             CLIP_MAX_NEW_TOKENS,
@@ -1034,17 +1030,18 @@ class PrefillAdder:
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
-        total_tokens = cand_extend_input_len + max_new + self.page_size
+        prefix_len = len(req.prefix_indices)
+        total_tokens = new_tokens_for_alloc(
+            prefix_len,
+            cand_extend_input_len + max(max_new - 1, 0),
+            self.page_size,
+        )
         # Shared Mamba pool: fold the new mamba state's shared-gap cost into
         # `total_tokens` so both `rem_total_tokens` gates reflect the joint budget.
         total_tokens += self._mamba_gap_budget_for_req(req)
 
-        # adjusting the input_tokens based on host_hit_length and page_size
         real_input_tokens = cand_extend_input_len - req.host_hit_length
-        real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
-        prefix_len = len(req.prefix_indices)
-
-        if total_tokens >= self.rem_total_tokens:
+        if total_tokens > self.rem_total_tokens:
             return AddReqResult.NO_TOKEN
 
         chunk_tokens_limit = self.rem_chunk_tokens
@@ -1073,7 +1070,7 @@ class PrefillAdder:
 
         with self._lock_node(req.last_node):
             # self.rem_total_tokens may decrease after the lock acquisition
-            if total_tokens >= self.rem_total_tokens:
+            if total_tokens > self.rem_total_tokens:
                 return AddReqResult.NO_TOKEN
 
             if self.is_hybrid_swa:
@@ -1113,9 +1110,7 @@ class PrefillAdder:
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
 
-            input_tokens = self.ceil_paged_tokens(
-                len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
-            )
+            input_tokens = len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
 
             if (
                 self.rem_chunk_tokens is None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1916,18 +1916,13 @@ class Scheduler(
                 )
             max_new_tokens = min(max_new_tokens, self.max_new_tokens_limit)
 
-        # Keep this bound consistent with PrefillAdder's admission budget:
-        # ceil_page(input_len) + max_new_tokens + page_size must be strictly
-        # smaller than max_total_num_tokens. Otherwise a request can be accepted
-        # into the waiting queue but can never be scheduled, blocking the queue
-        # and eventually making health checks fail.
-        paged_input_len = -(-input_len // self.page_size) * self.page_size
+        # The final sampled token is returned without being written to KV cache.
         req.sampling_params.max_new_tokens = max(
             0,
             min(
                 max_new_tokens,
-                self.max_req_len - input_len - 1,
-                self.max_total_num_tokens - paged_input_len - self.page_size - 1,
+                self.max_req_len - input_len + 1,
+                self.max_total_num_tokens - input_len + 1,
             ),
         )
         # Clipping above can push max_new_tokens below min_new_tokens, which

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -35,7 +35,7 @@ from sglang.srt.utils import (
     next_power_of_2,
     support_triton,
 )
-from sglang.srt.utils.common import is_pin_memory_available
+from sglang.srt.utils.common import get_num_new_pages, is_pin_memory_available
 
 _is_hip = is_hip()
 _is_npu = is_npu()
@@ -198,9 +198,15 @@ def alloc_paged_token_slots_extend(
     dsv4_state_lens: Optional[DSV4StateLens] = None,
     batch=None,
 ):
-    # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
-    num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
+    num_tokens = (
+        get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=allocator.page_size,
+            prefix_lens=prefix_lens_cpu,
+        )
+        * allocator.page_size
+    )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     state = None
@@ -496,8 +502,24 @@ def alloc_paged_token_slots_decode(
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
-    # Over estimate the number of tokens: assume each request needs a new page.
-    num_tokens = len(seq_lens) * allocator.page_size
+    if token_per_req == 1:
+        num_tokens = (
+            get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=allocator.page_size,
+                decode=True,
+            )
+            * allocator.page_size
+        )
+    else:
+        num_tokens = (
+            get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=allocator.page_size,
+                prefix_lens=seq_lens_cpu - token_per_req,
+            )
+            * allocator.page_size
+        )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     # DSV4-NPU allocator also needs req_pool_indices + per-req state lens and

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -198,8 +198,8 @@ def alloc_paged_token_slots_extend(
     dsv4_state_lens: Optional[DSV4StateLens] = None,
     batch=None,
 ):
-    allocator = tree_cache.token_to_kv_pool_allocator
     # Over estimate the number of tokens: assume each request needs a new page.
+    allocator = tree_cache.token_to_kv_pool_allocator
     num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
     evict_from_tree_cache(tree_cache, num_tokens)
 

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -35,7 +35,7 @@ from sglang.srt.utils import (
     next_power_of_2,
     support_triton,
 )
-from sglang.srt.utils.common import get_num_new_pages, is_pin_memory_available
+from sglang.srt.utils.common import is_pin_memory_available
 
 _is_hip = is_hip()
 _is_npu = is_npu()
@@ -199,14 +199,8 @@ def alloc_paged_token_slots_extend(
     batch=None,
 ):
     allocator = tree_cache.token_to_kv_pool_allocator
-    num_tokens = (
-        get_num_new_pages(
-            seq_lens=seq_lens_cpu,
-            page_size=allocator.page_size,
-            prefix_lens=prefix_lens_cpu,
-        )
-        * allocator.page_size
-    )
+    # Over estimate the number of tokens: assume each request needs a new page.
+    num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
     evict_from_tree_cache(tree_cache, num_tokens)
 
     state = None
@@ -502,24 +496,8 @@ def alloc_paged_token_slots_decode(
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
-    if token_per_req == 1:
-        num_tokens = (
-            get_num_new_pages(
-                seq_lens=seq_lens_cpu,
-                page_size=allocator.page_size,
-                decode=True,
-            )
-            * allocator.page_size
-        )
-    else:
-        num_tokens = (
-            get_num_new_pages(
-                seq_lens=seq_lens_cpu,
-                page_size=allocator.page_size,
-                prefix_lens=seq_lens_cpu - token_per_req,
-            )
-            * allocator.page_size
-        )
+    # Over estimate the number of tokens: assume each request needs a new page.
+    num_tokens = len(seq_lens) * allocator.page_size
     evict_from_tree_cache(tree_cache, num_tokens)
 
     # DSV4-NPU allocator also needs req_pool_indices + per-req state lens and

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -25,6 +25,23 @@ if TYPE_CHECKING:
 
 # Needs 2 + 1 slots for mamba request with prefix cache. 2 for ping pong cache, 1 for running mamba state.
 MAMBA_STATE_PER_REQ_PREFIX_CACHE = 3
+
+
+def new_pages_for_alloc(allocated_len: int, next_alloc_len: int, page_size: int) -> int:
+    if page_size == 1:
+        return next_alloc_len
+    return (
+        ceil_align(allocated_len + next_alloc_len, page_size)
+        - ceil_align(allocated_len, page_size)
+    ) // page_size
+
+
+def new_tokens_for_alloc(
+    allocated_len: int, next_alloc_len: int, page_size: int
+) -> int:
+    return new_pages_for_alloc(allocated_len, next_alloc_len, page_size) * page_size
+
+
 # Lazy mode: 1 + 1 slots (1 ping-pong + 1 running), second ping-pong allocated on demand at boundary.
 MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY = 2
 MAMBA_STATE_PER_REQ_NO_CACHE = 1

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -27,19 +27,12 @@ if TYPE_CHECKING:
 MAMBA_STATE_PER_REQ_PREFIX_CACHE = 3
 
 
-def new_pages_for_alloc(allocated_len: int, next_alloc_len: int, page_size: int) -> int:
-    if page_size == 1:
-        return next_alloc_len
-    return (
-        ceil_align(allocated_len + next_alloc_len, page_size)
-        - ceil_align(allocated_len, page_size)
-    ) // page_size
-
-
 def new_tokens_for_alloc(
     allocated_len: int, next_alloc_len: int, page_size: int
 ) -> int:
-    return new_pages_for_alloc(allocated_len, next_alloc_len, page_size) * page_size
+    return ceil_align(allocated_len + next_alloc_len, page_size) - ceil_align(
+        allocated_len, page_size
+    )
 
 
 # Lazy mode: 1 + 1 slots (1 ping-pong + 1 running), second ping-pong allocated on demand at boundary.

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -788,6 +788,7 @@ class TestPrefillAdder(CustomTestCase):
         scheduler.max_req_len = 262143
         scheduler.max_total_num_tokens = 262144
         scheduler.max_new_tokens_limit = None
+        scheduler.page_size = 64
 
         req = SimpleNamespace(
             origin_input_ids=range(262137),

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
+from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefResult,
     IncLockRefResult,
@@ -484,6 +485,7 @@ class TestPrefillAdder(CustomTestCase):
 
         req = self.create_mock_req("chunked", priority=0, max_new_tokens=128)
         req.prefix_indices = []
+        req.kv_committed_len = 0
         req.full_untruncated_fill_ids = list(range(extend_input_len))
         # set_extend_range is the only writer of extend_range; the production
         # path reads req.extend_range.length right after calling it, so the mock
@@ -693,6 +695,70 @@ class TestPrefillAdder(CustomTestCase):
         self.assertIsNone(result)
         req.set_extend_range.assert_called_once_with(0, 200)
         self.assertIn(req, adder.can_run_list)
+
+    def test_exact_context_budget_counts_no_kv_for_final_sample(self):
+        self.mock_token_allocator.available_size.return_value = 262144
+        adder = self.create_adder(
+            self.create_running_batch(), page_size=64, rem_chunk_tokens=1024
+        )
+
+        adder._update_prefill_budget(
+            prefix_len=0,
+            extend_input_len=262136,
+            max_new_tokens=8,
+            retracted_stain=False,
+        )
+
+        self.assertEqual(adder.rem_total_token_offset, 262144)
+
+    def test_full_kv_page_boundary_admission(self):
+        capacity = 262144
+        self.mock_token_allocator.available_size.return_value = capacity
+        self.mock_token_allocator.full_available_size.return_value = capacity
+
+        def result(input_len, max_new_tokens=8):
+            adder = self.create_adder(
+                self.create_running_batch(), page_size=64, rem_chunk_tokens=1024
+            )
+            req = self.create_mock_req(
+                f"boundary-{input_len}", priority=0, max_new_tokens=max_new_tokens
+            )
+            req.prefix_indices = torch.empty(0, dtype=torch.int64)
+            req.full_untruncated_fill_ids = range(input_len)
+            req.host_hit_length = 0
+            req.mamba_host_hit_length = 0
+            req.last_node = self.mock_tree_cache.root_node
+            req.best_match_node = None
+            req.sampling_params.ignore_eos = False
+            req.set_extend_range = MagicMock(
+                side_effect=lambda start, end: setattr(
+                    req, "extend_range", Range(start, end)
+                )
+            )
+            return adder.add_one_req(
+                req, has_chunked_req=False, truncation_align_size=None
+            )
+
+        self.assertNotEqual(result(262073), AddReqResult.NO_TOKEN)
+        self.assertNotEqual(result(262137), AddReqResult.NO_TOKEN)
+        self.assertEqual(result(262138), AddReqResult.NO_TOKEN)
+
+    def test_max_new_tokens_clamped_at_exact_context_boundary(self):
+        scheduler = object.__new__(Scheduler)
+        scheduler.max_req_len = 262143
+        scheduler.max_total_num_tokens = 262144
+        scheduler.max_new_tokens_limit = None
+
+        for input_len, expected in ((262135, 9), (262136, 8), (262137, 7)):
+            with self.subTest(input_len=input_len):
+                req = SimpleNamespace(
+                    origin_input_ids=range(input_len),
+                    sampling_params=SimpleNamespace(
+                        max_new_tokens=10, min_new_tokens=0
+                    ),
+                )
+                scheduler.init_req_max_new_tokens(req)
+                self.assertEqual(req.sampling_params.max_new_tokens, expected)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -2,6 +2,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import torch
+
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.managers.scheduler import Scheduler
@@ -667,6 +669,7 @@ class TestPrefillAdder(CustomTestCase):
 
     def _create_delayer_req(self, num_tokens: int):
         req = self.create_mock_req("delayer_req", priority=0, max_new_tokens=8)
+        req.kv_committed_len = 0
         req.full_untruncated_fill_ids = list(range(num_tokens))
         req.host_hit_length = 0
         req.last_node = MagicMock()
@@ -710,6 +713,23 @@ class TestPrefillAdder(CustomTestCase):
         )
 
         self.assertEqual(adder.rem_total_token_offset, 262144)
+
+    def test_chunked_req_charges_only_new_pages_after_committed_prefix(self):
+        self.mock_token_allocator.available_size.return_value = 1024
+        self.mock_token_allocator.full_available_size.return_value = 1024
+
+        def charge(committed_len):
+            adder = self.create_adder(
+                self.create_running_batch(), page_size=64, rem_chunk_tokens=1024
+            )
+            req = self._create_delayer_req(1)
+            req.kv_committed_len = committed_len
+            req.sampling_params.max_new_tokens = 0
+            adder.add_chunked_req(req)
+            return adder.rem_total_token_offset
+
+        self.assertEqual(charge(63), 0)
+        self.assertEqual(charge(64), 64)
 
     def test_full_kv_page_boundary_admission(self):
         capacity = 262144

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -731,6 +731,27 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(charge(63), 0)
         self.assertEqual(charge(64), 64)
 
+    def test_non_aligned_input_uses_logical_prefill_budget(self):
+        self.mock_token_allocator.available_size.return_value = 1024
+        self.mock_token_allocator.full_available_size.return_value = 1024
+        adder = self.create_adder(
+            self.create_running_batch(),
+            page_size=64,
+            rem_input_tokens=100,
+            rem_chunk_tokens=None,
+        )
+        adder.can_run_list.append(MagicMock())
+        req = self._create_delayer_req(65)
+        req.mamba_host_hit_length = 0
+
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertNotEqual(result, AddReqResult.OTHER)
+        self.assertIn(req, adder.can_run_list)
+        self.assertEqual(adder.rem_input_tokens, 35)
+
     def test_full_kv_page_boundary_admission(self):
         capacity = 262144
         self.mock_token_allocator.available_size.return_value = capacity
@@ -759,7 +780,6 @@ class TestPrefillAdder(CustomTestCase):
                 req, has_chunked_req=False, truncation_align_size=None
             )
 
-        self.assertNotEqual(result(262073), AddReqResult.NO_TOKEN)
         self.assertNotEqual(result(262137), AddReqResult.NO_TOKEN)
         self.assertEqual(result(262138), AddReqResult.NO_TOKEN)
 
@@ -769,16 +789,12 @@ class TestPrefillAdder(CustomTestCase):
         scheduler.max_total_num_tokens = 262144
         scheduler.max_new_tokens_limit = None
 
-        for input_len, expected in ((262135, 9), (262136, 8), (262137, 7)):
-            with self.subTest(input_len=input_len):
-                req = SimpleNamespace(
-                    origin_input_ids=range(input_len),
-                    sampling_params=SimpleNamespace(
-                        max_new_tokens=10, min_new_tokens=0
-                    ),
-                )
-                scheduler.init_req_max_new_tokens(req)
-                self.assertEqual(req.sampling_params.max_new_tokens, expected)
+        req = SimpleNamespace(
+            origin_input_ids=range(262137),
+            sampling_params=SimpleNamespace(max_new_tokens=10, min_new_tokens=0),
+        )
+        scheduler.init_req_max_new_tokens(req)
+        self.assertEqual(req.sampling_params.max_new_tokens, 7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- account only KV pages newly opened by a request, including an existing committed prefix
- exclude the final sampled token, which is returned without entering KV cache
- keep logical prefill-token limits unrounded while retaining page-rounded KV capacity accounting
- clamp scheduler admission to the same exact context boundary used by `PrefillAdder`

## Motivation

The previous conservative formula rounded input, added a full page per request, and charged every output token. A request that exactly fit a 262,144-token KV capacity could enter the waiting queue but never be admitted.

## Validation

On current upstream (`b98a577fb`):

- `test_prefill_adder.py`: 22 passed, 6 subtests passed
- pre-commit hooks pass for all changed files
- reverting the accounting mechanism fails the exact-budget and exact-admission tests
- independently restoring either removed input-page rounding fails the non-aligned logical-prefill test
- changing chunked accounting back to a zero committed prefix fails the committed-prefix page-crossing test

On an 8x H100 Gemma 4 deployment, a 262,137-token prompt plus 7 generated tokens completed against a 262,144-token context limit with no service restart.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30025996934](https://github.com/sgl-project/sglang/actions/runs/30025996934)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30025996728](https://github.com/sgl-project/sglang/actions/runs/30025996728)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->