### PR TITLE
Evict only pages required by paged KV allocation

### DIFF
--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -35,7 +35,7 @@ from sglang.srt.utils import (
     next_power_of_2,
     support_triton,
 )
-from sglang.srt.utils.common import is_pin_memory_available
+from sglang.srt.utils.common import get_num_new_pages, is_pin_memory_available
 
 _is_hip = is_hip()
 _is_npu = is_npu()
@@ -198,9 +198,15 @@ def alloc_paged_token_slots_extend(
     dsv4_state_lens: Optional[DSV4StateLens] = None,
     batch=None,
 ):
-    # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
-    num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
+    num_tokens = (
+        get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=allocator.page_size,
+            prefix_lens=prefix_lens_cpu,
+        )
+        * allocator.page_size
+    )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     state = None
@@ -496,8 +502,24 @@ def alloc_paged_token_slots_decode(
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
-    # Over estimate the number of tokens: assume each request needs a new page.
-    num_tokens = len(seq_lens) * allocator.page_size
+    if token_per_req == 1:
+        num_tokens = (
+            get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=allocator.page_size,
+                decode=True,
+            )
+            * allocator.page_size
+        )
+    else:
+        num_tokens = (
+            get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=allocator.page_size,
+                prefix_lens=seq_lens_cpu - token_per_req,
+            )
+            * allocator.page_size
+        )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     # DSV4-NPU allocator also needs req_pool_indices + per-req state lens and

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -502,24 +502,14 @@ def alloc_paged_token_slots_decode(
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
-    if token_per_req == 1:
-        num_tokens = (
-            get_num_new_pages(
-                seq_lens=seq_lens_cpu,
-                page_size=allocator.page_size,
-                decode=True,
-            )
-            * allocator.page_size
+    num_tokens = (
+        get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=allocator.page_size,
+            prefix_lens=seq_lens_cpu - token_per_req,
         )
-    else:
-        num_tokens = (
-            get_num_new_pages(
-                seq_lens=seq_lens_cpu,
-                page_size=allocator.page_size,
-                prefix_lens=seq_lens_cpu - token_per_req,
-            )
-            * allocator.page_size
-        )
+        * allocator.page_size
+    )
     evict_from_tree_cache(tree_cache, num_tokens)
 
     # DSV4-NPU allocator also needs req_pool_indices + per-req state lens and

--- a/test/registered/unit/mem_cache/test_exact_paged_eviction.py
+++ b/test/registered/unit/mem_cache/test_exact_paged_eviction.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.allocation import (
+    alloc_paged_token_slots_decode,
+    alloc_paged_token_slots_extend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _tree_cache(page_size=8):
+    allocator = MagicMock(page_size=page_size)
+    allocator.alloc_extend.return_value = torch.tensor([1])
+    allocator.alloc_decode.return_value = torch.tensor([1])
+    return MagicMock(token_to_kv_pool_allocator=allocator)
+
+
+def test_extend_evicts_only_new_pages():
+    tree_cache = _tree_cache()
+    prefix = torch.tensor([5, 7])
+    seq = torch.tensor([6, 9])
+
+    with patch("sglang.srt.mem_cache.allocation.evict_from_tree_cache") as evict:
+        alloc_paged_token_slots_extend(
+            tree_cache,
+            prefix,
+            prefix,
+            seq,
+            seq,
+            torch.tensor([0, 0]),
+            extend_num_tokens=3,
+        )
+
+    evict.assert_called_once_with(tree_cache, 8)
+
+
+def test_single_token_decode_evicts_only_page_crossings():
+    tree_cache = _tree_cache()
+    seq = torch.tensor([9, 10, 17])
+
+    with patch("sglang.srt.mem_cache.allocation.evict_from_tree_cache") as evict:
+        alloc_paged_token_slots_decode(tree_cache, seq, seq, torch.tensor([0, 0, 0]))
+
+    evict.assert_called_once_with(tree_cache, 16)
+
+
+def test_multi_token_decode_can_stay_within_existing_pages():
+    tree_cache = _tree_cache()
+    seq = torch.tensor([7, 15])
+
+    with patch("sglang.srt.mem_cache.allocation.evict_from_tree_cache") as evict:
+        alloc_paged_token_slots_decode(
+            tree_cache,
+            seq,
+            seq,
+            torch.tensor([0, 0]),
+            token_per_req=2,
+        )
+
+    evict.assert_called_once_with(tree_cache, 0)

--- a/test/registered/unit/mem_cache/test_exact_paged_eviction.py
+++ b/test/registered/unit/mem_cache/test_exact_paged_eviction.py
@@ -11,8 +11,8 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
-def _tree_cache(page_size=8):
-    allocator = MagicMock(page_size=page_size)
+def _tree_cache():
+    allocator = MagicMock(page_size=8)
     allocator.alloc_extend.return_value = torch.tensor([1])
     allocator.alloc_decode.return_value = torch.tensor([1])
     return MagicMock(token_to_kv_pool_allocator=allocator)


### PR DESCRIPTION
## Summary

Use the allocator's existing `get_num_new_pages` primitive when deciding how much radix cache to evict before paged KV allocation. This covers extend, single-token decode, and multi-token decode.

The previous wrapper estimates assumed every request opened a full new page. Allocation itself already computes the exact page crossings, so the wrapper could evict reusable radix entries that were not needed to satisfy the allocation.

## Validation

On current upstream (`b98a577fb`):

- focused CPU regression tests: 3 passed
- pre-commit hooks pass
- restoring the old estimates makes all three tests fail independently:
  - extend requests 19 tokens instead of 8
  - single-token decode requests 24 instead of 16
  - multi-token decode requests 16 instead of 0

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30026415706](https://github.com/sgl-project/sglang/actions/runs/30026415706)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30026415212](https://github.com/sgl-project/sglang/actions/runs/30026415212)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->