### PR TITLE
Support Gemma 4 language-only startup

### DIFF
--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -190,7 +190,7 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
 
         # Vision/audio encoders + their projection embedders are only consumed
         # at the input-embedding stage, so they live on the first PP rank only.
-        if self.pp_group.is_first_rank:
+        if self.pp_group.is_first_rank and not getattr(config, "language_only", False):
             self.vision_tower = Gemma4VisionEncoder(
                 config=config.vision_config,
                 quant_config=quant_config,

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -421,6 +421,11 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                 ):
                     all_embeds.append(pv.to(self.language_model.device))
                     continue
+                if isinstance(vt, PPMissingLayer):
+                    raise ValueError(
+                        "Gemma 4 language-only mode requires precomputed image "
+                        "embeddings; local multimodal fallback is unavailable."
+                    )
 
                 if pv_idx >= len(all_position_ids) or all_position_ids[pv_idx] is None:
                     raise ValueError(
@@ -484,6 +489,11 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                 ):
                     all_embeds.append(pv.to(self.language_model.device))
                     continue
+                if isinstance(vt, PPMissingLayer):
+                    raise ValueError(
+                        "Gemma 4 language-only mode requires precomputed video "
+                        "embeddings; local multimodal fallback is unavailable."
+                    )
 
                 if pv_idx >= len(all_position_ids) or all_position_ids[pv_idx] is None:
                     raise ValueError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6926,7 +6926,7 @@ class ServerArgs:
         # Validate model type for encoder disaggregation
         hf_config = self.get_model_config().hf_config
         model_arch = hf_config.architectures[0]
-        supported_architectures = [
+        if (self.encoder_only or self.language_only) and model_arch not in [
             "Qwen2VLForConditionalGeneration",
             "Qwen3VLForConditionalGeneration",
             "Qwen2_5_VLForConditionalGeneration",
@@ -6940,20 +6940,10 @@ class ServerArgs:
             "KimiVLForConditionalGeneration",
             "KimiK25ForConditionalGeneration",
             "MiMoV2ForCausalLM",
-        ]
-        supported_names = (
-            "Qwen2VL, Qwen3VL, Qwen3.5, InternS2, Qwen2Audio, "
-            "Qwen2.5Omni, Kimi, MiMoV2"
-        )
-        if self.language_only:
-            supported_architectures.append("Gemma4ForConditionalGeneration")
-            supported_names += ", Gemma4"
-        if (self.encoder_only or self.language_only) and model_arch not in (
-            supported_architectures
-        ):
+        ] + (["Gemma4ForConditionalGeneration"] if self.language_only else []):
             raise ValueError(
                 f"Model type {model_arch} is not supported for encoder disaggregation. "
-                f"Supported architectures: {supported_names}."
+                f"Supported architectures: Qwen2VL, Qwen3VL, Qwen3.5, InternS2, Qwen2Audio, Qwen2.5Omni, Kimi, MiMoV2."
             )
 
     def _validate_ib_devices(self, device_str: Optional[str]) -> Optional[str]:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6940,10 +6940,11 @@ class ServerArgs:
             "KimiVLForConditionalGeneration",
             "KimiK25ForConditionalGeneration",
             "MiMoV2ForCausalLM",
+            "Gemma4ForConditionalGeneration",
         ]:
             raise ValueError(
                 f"Model type {model_arch} is not supported for encoder disaggregation. "
-                f"Supported architectures: Qwen2VL, Qwen3VL, Qwen3.5, InternS2, Qwen2Audio, Qwen2.5Omni, Kimi, MiMoV2."
+                f"Supported architectures: Qwen2VL, Qwen3VL, Qwen3.5, InternS2, Qwen2Audio, Qwen2.5Omni, Kimi, MiMoV2, Gemma4."
             )
 
     def _validate_ib_devices(self, device_str: Optional[str]) -> Optional[str]:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6926,7 +6926,7 @@ class ServerArgs:
         # Validate model type for encoder disaggregation
         hf_config = self.get_model_config().hf_config
         model_arch = hf_config.architectures[0]
-        if (self.encoder_only or self.language_only) and model_arch not in [
+        supported_architectures = [
             "Qwen2VLForConditionalGeneration",
             "Qwen3VLForConditionalGeneration",
             "Qwen2_5_VLForConditionalGeneration",
@@ -6940,11 +6940,20 @@ class ServerArgs:
             "KimiVLForConditionalGeneration",
             "KimiK25ForConditionalGeneration",
             "MiMoV2ForCausalLM",
-            "Gemma4ForConditionalGeneration",
-        ]:
+        ]
+        supported_names = (
+            "Qwen2VL, Qwen3VL, Qwen3.5, InternS2, Qwen2Audio, "
+            "Qwen2.5Omni, Kimi, MiMoV2"
+        )
+        if self.language_only:
+            supported_architectures.append("Gemma4ForConditionalGeneration")
+            supported_names += ", Gemma4"
+        if (self.encoder_only or self.language_only) and model_arch not in (
+            supported_architectures
+        ):
             raise ValueError(
                 f"Model type {model_arch} is not supported for encoder disaggregation. "
-                f"Supported architectures: Qwen2VL, Qwen3VL, Qwen3.5, InternS2, Qwen2Audio, Qwen2.5Omni, Kimi, MiMoV2, Gemma4."
+                f"Supported architectures: {supported_names}."
             )
 
     def _validate_ib_devices(self, device_str: Optional[str]) -> Optional[str]:

--- a/test/registered/unit/models/test_gemma4_language_only.py
+++ b/test/registered/unit/models/test_gemma4_language_only.py
@@ -5,6 +5,7 @@ from torch import nn
 from transformers import PreTrainedModel
 
 from sglang.srt.models.gemma4_mm import Gemma4ForConditionalGeneration
+from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
@@ -45,3 +46,19 @@ def test_language_only_does_not_construct_multimodal_encoders():
         model = Gemma4ForConditionalGeneration(config)
 
     assert model.language_model is text_model
+
+
+def test_language_only_accepts_gemma4_architecture():
+    server_args = object.__new__(ServerArgs)
+    server_args.enable_prefix_mm_cache = False
+    server_args.encoder_only = False
+    server_args.language_only = True
+    server_args.encoder_urls = []
+    server_args.disaggregation_transfer_backend = "zmq_to_scheduler"
+    server_args.disaggregation_mode = "null"
+    server_args.encoder_transfer_backend = "zmq_to_scheduler"
+    server_args.get_model_config = lambda: SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=["Gemma4ForConditionalGeneration"])
+    )
+
+    server_args._handle_encoder_disaggregation()

--- a/test/registered/unit/models/test_gemma4_language_only.py
+++ b/test/registered/unit/models/test_gemma4_language_only.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from torch import nn
 from transformers import PreTrainedModel
 
@@ -48,11 +49,11 @@ def test_language_only_does_not_construct_multimodal_encoders():
     assert model.language_model is text_model
 
 
-def test_language_only_accepts_gemma4_architecture():
+def _server_args(*, language_only, encoder_only):
     server_args = object.__new__(ServerArgs)
     server_args.enable_prefix_mm_cache = False
-    server_args.encoder_only = False
-    server_args.language_only = True
+    server_args.encoder_only = encoder_only
+    server_args.language_only = language_only
     server_args.encoder_urls = []
     server_args.disaggregation_transfer_backend = "zmq_to_scheduler"
     server_args.disaggregation_mode = "null"
@@ -60,5 +61,17 @@ def test_language_only_accepts_gemma4_architecture():
     server_args.get_model_config = lambda: SimpleNamespace(
         hf_config=SimpleNamespace(architectures=["Gemma4ForConditionalGeneration"])
     )
+    return server_args
+
+
+def test_language_only_accepts_gemma4_architecture():
+    server_args = _server_args(language_only=True, encoder_only=False)
 
     server_args._handle_encoder_disaggregation()
+
+
+def test_encoder_only_still_rejects_gemma4_architecture():
+    server_args = _server_args(language_only=False, encoder_only=True)
+
+    with pytest.raises(ValueError, match="not supported"):
+        server_args._handle_encoder_disaggregation()

--- a/test/registered/unit/models/test_gemma4_language_only.py
+++ b/test/registered/unit/models/test_gemma4_language_only.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 from torch import nn
 from transformers import PreTrainedModel
 
@@ -15,11 +16,18 @@ register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 def test_language_only_does_not_construct_multimodal_encoders():
     config = SimpleNamespace(
         language_only=True,
-        text_config=SimpleNamespace(vocab_size=32, tie_word_embeddings=True),
+        text_config=SimpleNamespace(
+            vocab_size=32, hidden_size=32, tie_word_embeddings=True
+        ),
         vision_config=SimpleNamespace(),
         audio_config=SimpleNamespace(),
     )
-    text_model = SimpleNamespace(embed_tokens=MagicMock())
+    text_model = SimpleNamespace(
+        embed_tokens=MagicMock(),
+        device=torch.device("cpu"),
+        config=SimpleNamespace(hidden_size=32),
+        dtype=lambda: torch.float32,
+    )
     pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True, world_size=1)
 
     with (
@@ -47,6 +55,24 @@ def test_language_only_does_not_construct_multimodal_encoders():
         model = Gemma4ForConditionalGeneration(config)
 
     assert model.language_model is text_model
+    image = SimpleNamespace(
+        feature=torch.zeros(2, 4), image_position_ids=torch.zeros(2, 2)
+    )
+    video = SimpleNamespace(
+        feature=torch.zeros(2, 4), video_position_ids=torch.zeros(2, 2)
+    )
+    with pytest.raises(ValueError, match="precomputed image embeddings"):
+        model.get_image_feature([image])
+    with pytest.raises(ValueError, match="precomputed video embeddings"):
+        model.get_video_feature([video])
+
+    precomputed = torch.ones(2, 32)
+    assert torch.equal(
+        model.get_image_feature([SimpleNamespace(feature=precomputed)]), precomputed
+    )
+    assert torch.equal(
+        model.get_video_feature([SimpleNamespace(feature=precomputed)]), precomputed
+    )
 
 
 def _server_args(*, language_only, encoder_only):

--- a/test/registered/unit/models/test_gemma4_language_only.py
+++ b/test/registered/unit/models/test_gemma4_language_only.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from torch import nn
+from transformers import PreTrainedModel
+
+from sglang.srt.models.gemma4_mm import Gemma4ForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def test_language_only_does_not_construct_multimodal_encoders():
+    config = SimpleNamespace(
+        language_only=True,
+        text_config=SimpleNamespace(vocab_size=32, tie_word_embeddings=True),
+        vision_config=SimpleNamespace(),
+        audio_config=SimpleNamespace(),
+    )
+    text_model = SimpleNamespace(embed_tokens=MagicMock())
+    pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True, world_size=1)
+
+    with (
+        patch.object(
+            PreTrainedModel,
+            "__init__",
+            lambda self, config: nn.Module.__init__(self),
+        ),
+        patch.object(PreTrainedModel, "post_init"),
+        patch("sglang.srt.models.gemma4_mm.get_pp_group", return_value=pp_group),
+        patch(
+            "sglang.srt.models.gemma4_mm.Gemma4VisionEncoder",
+            side_effect=AssertionError("vision encoder constructed"),
+        ),
+        patch(
+            "sglang.srt.models.gemma4_mm.Gemma4AudioEncoder",
+            side_effect=AssertionError("audio encoder constructed"),
+        ),
+        patch(
+            "sglang.srt.models.gemma4_mm.Gemma4TextModel",
+            return_value=text_model,
+        ),
+        patch("sglang.srt.models.gemma4_mm.LogitsProcessor"),
+    ):
+        model = Gemma4ForConditionalGeneration(config)
+
+    assert model.language_model is text_model


### PR DESCRIPTION
## Summary

- allow `Gemma4ForConditionalGeneration` through server validation only in `--language-only` mode
- avoid constructing Gemma 4 vision/audio towers and embedders in that mode
- keep Gemma 4 `--encoder-only` rejected because the model does not implement that mode
- preserve precomputed image/video embeddings and fail clearly if raw inputs reach unavailable local fallback

`ModelConfig` already propagates `ServerArgs.language_only` onto the HF config consumed by the model constructor. Gemma 4 language-only therefore supports text and remotely precomputed multimodal embeddings; it deliberately does not claim local multimodal fallback without towers.

## Validation

On current upstream (`b98a577fb`):

- focused CPU tests: 3 passed
- pre-commit hooks pass
- restoring unconditional first-rank tower construction fails the constructor test
- removing language-only validation permission fails startup validation
- broadening permission to encoder-only fails the rejection test
- raw image/video fallback fails with actionable errors while precomputed embeddings remain accepted

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30026628888](https://github.com/sgl-project/sglang/actions/runs/30026628888)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30026628497](https://github.com/sgl-project/sglang/actions/runs/30026628497)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->