### PR TITLE
fix(model): apply Gemma4 local/global head-dim remap to standalone gemma4_text configs

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -72,6 +72,38 @@ def _try_load_longcat_config(model, revision: Optional[str], **kwargs):
     )
 
 
+def _remap_gemma4_local_global_head_dims(target) -> None:
+    """Remap Gemma4's local/global attention head-dim naming in place.
+
+    Gemma4 configs (both the multimodal `text_config` and standalone
+    `gemma4_text` checkpoints) use base attributes (`head_dim`,
+    `num_key_value_heads`) for the sliding-window (local) layers and
+    `global_*` variants for the full-attention layers. SGLang's Gemma4
+    model code expects the opposite convention: base attributes hold the
+    full-attention values and `swa_*` variants hold the sliding-window
+    overrides.
+    """
+    global_head_dim = getattr(target, "global_head_dim", None)
+    global_kv_heads = getattr(target, "num_global_key_value_heads", None)
+
+    swa_head_dim = target.head_dim
+    swa_kv_heads = target.num_key_value_heads
+
+    target.swa_head_dim = swa_head_dim
+    target.swa_v_head_dim = swa_head_dim
+    target.swa_num_key_value_heads = swa_kv_heads
+
+    if global_head_dim is not None:
+        target.head_dim = global_head_dim
+    if global_kv_heads is not None:
+        target.num_key_value_heads = global_kv_heads
+
+    if not hasattr(target, "v_head_dim"):
+        target.v_head_dim = target.head_dim
+    if not hasattr(target, "swa_v_head_dim"):
+        target.swa_v_head_dim = target.swa_head_dim
+
+
 @register_model_config_parser("hf")
 class HfModelConfigParser(ModelConfigParserBase):
     def parse(
@@ -162,29 +194,7 @@ class HfModelConfigParser(ModelConfigParserBase):
             "gemma4_unified",
             "gemma4_unified_assistant",
         ):
-            # Gemma4 configs use base attributes for SWA layers and `global_*`
-            # variants for full-attention layers.  SGLang expects the opposite:
-            # base = full-attention, `swa_*` = sliding-window overrides.
-            text_config = config.text_config
-            global_head_dim = getattr(text_config, "global_head_dim", None)
-            global_kv_heads = getattr(text_config, "num_global_key_value_heads", None)
-
-            swa_head_dim = text_config.head_dim
-            swa_kv_heads = text_config.num_key_value_heads
-
-            text_config.swa_head_dim = swa_head_dim
-            text_config.swa_v_head_dim = swa_head_dim
-            text_config.swa_num_key_value_heads = swa_kv_heads
-
-            if global_head_dim is not None:
-                text_config.head_dim = global_head_dim
-            if global_kv_heads is not None:
-                text_config.num_key_value_heads = global_kv_heads
-
-            if not hasattr(text_config, "v_head_dim"):
-                text_config.v_head_dim = text_config.head_dim
-            if not hasattr(text_config, "swa_v_head_dim"):
-                text_config.swa_v_head_dim = text_config.swa_head_dim
+            _remap_gemma4_local_global_head_dims(config.text_config)
 
             # Unified Gemma4 names the end-of-audio token `eoa_token_index`,
             # but the multimodal processor expects `eoa_token_id`.
@@ -192,6 +202,12 @@ class HfModelConfigParser(ModelConfigParserBase):
                 config, "eoa_token_index"
             ):
                 config.eoa_token_id = config.eoa_token_index
+        elif config.model_type == "gemma4_text":
+            # Standalone text-only Gemma4 checkpoints (`Gemma4ForCausalLM`,
+            # e.g. a multimodal checkpoint with the vision tower dropped)
+            # carry the same local/global naming inversion directly on the
+            # top-level config -- there is no nested `text_config` here.
+            _remap_gemma4_local_global_head_dims(config)
 
         if config.model_type == "longcat_flash":
             _set_architectures(config, "LongcatFlashForCausalLM")

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -26,6 +26,10 @@ from sglang.srt.utils.hf_transformers.common import (
     get_hf_text_config,
     get_rope_config,
 )
+from sglang.srt.utils.hf_transformers.config import (
+    _remap_gemma4_local_global_head_dims,
+    get_config,
+)
 from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
 from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -634,6 +638,99 @@ class TestPatchNemotronHPattern(unittest.TestCase):
             self.assertEqual(result, ["mamba", "moe", "attention"])
         except ImportError:
             self.skipTest("NemotronHConfig not available in this transformers version")
+
+
+# ---------------------------------------------------------------------------
+# config: _remap_gemma4_local_global_head_dims
+# ---------------------------------------------------------------------------
+
+
+class TestRemapGemma4LocalGlobalHeadDims(unittest.TestCase):
+    def test_swaps_local_and_global_values(self):
+        # Shape of a Gemma4 `text_config`: base attrs hold the local
+        # (sliding-window) values, `global_*` holds the full-attention
+        # override -- the inverse of what SGLang's Gemma4 model code reads.
+        cfg = SimpleNamespace(
+            head_dim=256,
+            num_key_value_heads=16,
+            global_head_dim=512,
+            num_global_key_value_heads=4,
+        )
+        _remap_gemma4_local_global_head_dims(cfg)
+
+        self.assertEqual(cfg.head_dim, 512)
+        self.assertEqual(cfg.num_key_value_heads, 4)
+        self.assertEqual(cfg.swa_head_dim, 256)
+        self.assertEqual(cfg.swa_num_key_value_heads, 16)
+        self.assertEqual(cfg.v_head_dim, 512)
+        self.assertEqual(cfg.swa_v_head_dim, 256)
+
+    def test_no_op_for_global_fields_when_absent(self):
+        # A config with no `global_*` override (e.g. a uniform-attention
+        # variant) keeps its base head_dim/num_key_value_heads unchanged --
+        # only the swa_* mirror is populated.
+        cfg = SimpleNamespace(head_dim=128, num_key_value_heads=8)
+        _remap_gemma4_local_global_head_dims(cfg)
+
+        self.assertEqual(cfg.head_dim, 128)
+        self.assertEqual(cfg.num_key_value_heads, 8)
+        self.assertEqual(cfg.swa_head_dim, 128)
+        self.assertEqual(cfg.swa_num_key_value_heads, 8)
+        self.assertEqual(cfg.v_head_dim, 128)
+        self.assertEqual(cfg.swa_v_head_dim, 128)
+
+    def test_preserves_existing_v_head_dim(self):
+        cfg = SimpleNamespace(
+            head_dim=256,
+            num_key_value_heads=16,
+            global_head_dim=512,
+            num_global_key_value_heads=4,
+            v_head_dim=999,
+        )
+        _remap_gemma4_local_global_head_dims(cfg)
+
+        self.assertEqual(cfg.v_head_dim, 999)
+
+
+class TestGetConfigGemma4TextIntegration(unittest.TestCase):
+    """End-to-end check through the real `get_config()` entrypoint (the one
+    the model loader actually calls), not just the helper in isolation --
+    this exercises the `model_type == "gemma4_text"` dispatch branch itself,
+    `AutoConfig.from_pretrained` round-tripping through a saved config.json,
+    and the `HfModelConfigParser.parse()` glue in between.
+    """
+
+    def test_standalone_text_config_remapped_on_load(self):
+        try:
+            from transformers.models.gemma4.configuration_gemma4 import (
+                Gemma4TextConfig,
+            )
+        except ImportError:
+            self.skipTest("Gemma4TextConfig not available in this transformers version")
+
+        cfg = Gemma4TextConfig(
+            num_hidden_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=16,
+            global_head_dim=32,
+            num_global_key_value_heads=2,
+            layer_types=["sliding_attention", "full_attention"],
+            architectures=["Gemma4ForCausalLM"],
+        )
+        self.assertEqual(cfg.model_type, "gemma4_text")
+
+        with tempfile.TemporaryDirectory() as d:
+            cfg.save_pretrained(d)
+            loaded = get_config(d, trust_remote_code=False)
+
+        self.assertEqual(loaded.head_dim, 32)
+        self.assertEqual(loaded.num_key_value_heads, 2)
+        self.assertEqual(loaded.swa_head_dim, 16)
+        self.assertEqual(loaded.swa_num_key_value_heads, 4)
+        self.assertEqual(loaded.v_head_dim, 32)
+        self.assertEqual(loaded.swa_v_head_dim, 16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Gemma4's local/global attention head-dim remap (`python/sglang/srt/utils/hf_transformers/config.py`, added alongside the original Gemma4 model support in #21952) only fires for the multimodal config `model_type`s (`gemma4`, `gemma4_assistant`, `gemma4_unified`, `gemma4_unified_assistant`), where it descends into `config.text_config`.

Standalone text-only Gemma4 checkpoints — served by `Gemma4ForCausalLM`, which SGLang already implements and registers (`python/sglang/srt/models/gemma4_causal.py`) — load via `Gemma4TextConfig`, whose `model_type` is `"gemma4_text"`. That's a flat config with no nested `text_config`, and it isn't in the remap's condition, so:

- `head_dim` / `num_key_value_heads` are left holding the **local** (sliding-window) values instead of being promoted to the full-attention values.
- `swa_head_dim` / `swa_num_key_value_heads` / `v_head_dim` / `swa_v_head_dim` are never populated at all.

Concretely, this makes the hybrid-SWA KV-cache pool construction use the wrong K/V head_dim and head count for the full-attention layers, and the QKV projection in the full-attention decoder layers silently uses the wrong Q/K head_dim — both diverging from the checkpoint's actual weight shapes. We hit this running a standalone `Gemma4ForCausalLM` checkpoint (vision tower stripped from a multimodal Gemma4 export) through the rollout engine — it reliably crashes at the first full-attention layer's KV-cache write with a shape mismatch (`value tensor of shape [..., 512] cannot be broadcast to indexing result of shape [..., 256]`, i.e. local head_dim=256 leaking into a slot sized for the global head_dim=512).

## Modifications

- Factor the existing remap logic out of the multimodal branch into a small helper, `_remap_gemma4_local_global_head_dims(target)`.
- Apply it to `config.text_config` for the multimodal `model_type`s (unchanged behavior).
- Apply it directly to the top-level config when `model_type == "gemma4_text"` (new).

No behavior change for any already-supported Gemma4 config shape — this only fixes the previously-unhandled standalone `gemma4_text` case.

## Accuracy Tests

Not run against a live model in this PR (would need a Gemma4 checkpoint + GPU). Verified the remapped values against a real 31B-dense Gemma4 text-only config by hand:

| field | before | after (expected & actual) |
|---|---|---|
| `head_dim` | 256 | 512 |
| `num_key_value_heads` | 16 | 4 |
| `swa_head_dim` | (unset) | 256 |
| `swa_num_key_value_heads` | (unset) | 16 |
| `v_head_dim` | (unset) | 512 |
| `swa_v_head_dim` | (unset) | 256 |

## Speed Tests and Profiling

N/A — config-loading-time change only, no runtime/kernel impact.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) (`pre-commit run` passes clean on the changed files).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) guidance — added `TestRemapGemma4LocalGlobalHeadDims` to `test/registered/unit/utils/test_hf_transformers.py` (3 new tests, all passing; full file: 63 passed).
- [ ] Update documentation — N/A, no user-facing behavior/API change.
- [ ] Provide accuracy and speed benchmark results — see above; no live-model run available in this environment.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30043214265](https://github.com/sgl-project/sglang/actions/runs/30043214265)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30043214173](https://github.com/sgl-project/sglang/actions/runs/30043214173)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->