### PR TITLE
Expose accelerator name in /v1/loads JSON

### DIFF
--- a/python/sglang/srt/entrypoints/v1_loads.py
+++ b/python/sglang/srt/entrypoints/v1_loads.py
@@ -20,14 +20,22 @@ metrics for load balancing, monitoring, and capacity planning.
 
 import time
 from datetime import datetime, timezone
+from functools import lru_cache
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 
+from sglang.srt.utils import get_device_name
 from sglang.version import __version__
 
 router = APIRouter()
+
+
+@lru_cache(maxsize=1)
+def _accelerator_name() -> Optional[str]:
+    """Return the accelerator name, or None if unavailable."""
+    return get_device_name()
 
 
 def _get_tokenizer_manager():
@@ -87,7 +95,7 @@ async def get_loads(
         format: Response format - 'json' (default) or 'prometheus'
 
     Returns:
-        JSON response with timestamp, version, and per-DP-rank loads
+        JSON response with timestamp, version, accelerator, and per-DP-rank loads
     """
     include_list = [s.strip() for s in include.split(",")] if include else None
 
@@ -119,5 +127,6 @@ async def get_loads(
     return {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "version": __version__,
+        "accelerator": _accelerator_name(),
         "loads": loads,
     }

--- a/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
+++ b/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
@@ -5,9 +5,11 @@ import os
 import tempfile
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 import msgspec.msgpack
 
+from sglang.srt.entrypoints import v1_loads
 from sglang.srt.entrypoints.v1_loads import get_loads
 from sglang.srt.managers.load_snapshot import (
     HEADER_STRUCT,
@@ -89,6 +91,17 @@ class TestLoadsResponse(CustomTestCase):
         self.assertNotIn("num_total_reqs", response["loads"][0])
         self.assertEqual(response["loads"][0]["num_running_reqs"], 3)
         self.assertEqual(response["loads"][0]["num_waiting_reqs"], 2)
+
+
+class TestLoadsAcceleratorField(CustomTestCase):
+    def test_accelerator_reported_in_json(self):
+        manager = _FakeHttpTokenizerManager([LoadSnapshot(dp_rank=0)])
+
+        with mock.patch.object(
+            v1_loads, "_accelerator_name", return_value="Test Accelerator"
+        ):
+            response = asyncio.run(get_loads(tokenizer_manager=manager))
+            self.assertEqual(response["accelerator"], "Test Accelerator")
 
 
 class TestGetLoads(CustomTestCase):


### PR DESCRIPTION
## Summary

- add the detected accelerator name to the JSON envelope returned by `/v1/loads`
- cache device-name detection for the server lifetime
- cover the new response field with a unit test

## Testing

- `pre-commit run --files python/sglang/srt/entrypoints/v1_loads.py test/registered/unit/entrypoints/test_v1_loads_aggregate.py`
- `python test/registered/unit/entrypoints/test_v1_loads_aggregate.py`

## Original commits

- `485ab4c31`
- `e3df19b21`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30036899479](https://github.com/sgl-project/sglang/actions/runs/30036899479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30036899409](https://github.com/sgl-project/sglang/actions/runs/30036899409)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->