### PR TITLE
feat: Add per-component cache-source breakdown for DeepSeek V4 (FULL/SWA)

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -447,6 +447,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             completion_tokens=recv_obj.completion_tokens,
             cached_tokens=recv_obj.cached_tokens,
             cached_tokens_details=recv_obj.cached_tokens_details,
+            cached_tokens_by_component=recv_obj.cached_tokens_by_component,
             image_tokens=recv_obj.image_tokens,
             audio_tokens=recv_obj.audio_tokens,
             video_tokens=recv_obj.video_tokens,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1274,6 +1274,10 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     customized_info: Optional[PickleWrapper] = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
     cached_tokens_details: Optional[List[Optional[CachedTokensDetails]]] = None
+    # Cached token counts grouped by cache component and source.
+    cached_tokens_by_component: Optional[List[Optional[Dict[str, Dict[str, int]]]]] = (
+        None
+    )
     # DP rank of the scheduler that processed each request
     dp_ranks: Optional[List[Optional[int]]] = None
 
@@ -1356,6 +1360,10 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
     customized_info: Optional[PickleWrapper] = None
     # Detailed breakdown of cached tokens by source (device/host/storage)
     cached_tokens_details: Optional[List[Optional[CachedTokensDetails]]] = None
+    # Cached token counts grouped by cache component and source.
+    cached_tokens_by_component: Optional[List[Optional[Dict[str, Dict[str, int]]]]] = (
+        None
+    )
     # DP rank of the scheduler that processed each request
     dp_ranks: Optional[List[Optional[int]]] = None
 

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -192,6 +192,9 @@ def _handle_output_by_index(output, i):
             cached_tokens_details=_extract_field_by_index(
                 output, "cached_tokens_details", i
             ),
+            cached_tokens_by_component=_extract_field_by_index(
+                output, "cached_tokens_by_component", i
+            ),
             image_tokens=_extract_field_by_index(output, "image_tokens", i),
             audio_tokens=_extract_field_by_index(output, "audio_tokens", i),
             video_tokens=_extract_field_by_index(output, "video_tokens", i),
@@ -299,6 +302,9 @@ def _handle_output_by_index(output, i):
             cached_tokens=_extract_field_by_index(output, "cached_tokens", i),
             cached_tokens_details=_extract_field_by_index(
                 output, "cached_tokens_details", i
+            ),
+            cached_tokens_by_component=_extract_field_by_index(
+                output, "cached_tokens_by_component", i
             ),
             image_tokens=_extract_field_by_index(output, "image_tokens", i),
             audio_tokens=_extract_field_by_index(output, "audio_tokens", i),

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -898,6 +898,7 @@ class Req(ReqDllmMixin):
         self.host_hit_length = 0
         self.swa_host_hit_length = 0
         self.mamba_host_hit_length = 0
+        self.matched_tokens_by_component: Dict[str, Dict[str, int]] = {}
         # Total cached prefix length (on-device prefix_indices + host_hit_length),
         # capped at the max allowed prefix. Set during prefix matching at schedule
         # time and used to estimate uncached tokens / sort by longest prefix for
@@ -905,6 +906,7 @@ class Req(ReqDllmMixin):
         self.num_matched_prefix_tokens = 0
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
+        self.storage_hit_tokens_by_component: Dict[str, int] = {}
         # The node to lock until for swa radix tree lock ref
         self.swa_uuid_for_lock: Optional[int] = None
         # Whether the prefill-time SWA tree lock has been released early
@@ -1006,6 +1008,7 @@ class Req(ReqDllmMixin):
         self.cached_tokens_device = 0  # Tokens from device cache (GPU)
         self.cached_tokens_host = 0  # Tokens from host cache (CPU memory)
         self.cached_tokens_storage = 0  # Tokens from L3 storage backend
+        self.cached_tokens_by_component: Dict[str, Dict[str, int]] = {}
         self._cache_breakdown_computed = (
             False  # Track if breakdown was already computed
         )
@@ -1270,6 +1273,9 @@ class Req(ReqDllmMixin):
                 match_result.swa_host_hit_length,
                 match_result.mamba_host_hit_length,
                 match_result.mamba_branching_seqlen,
+            )
+            self.matched_tokens_by_component = (
+                match_result.matched_tokens_by_component or {}
             )
             if match_result.cache_protected_len is not None:
                 self.cache_protected_len = match_result.cache_protected_len
@@ -2302,6 +2308,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     req.cached_tokens_device = device_portion
                     req.cached_tokens_host = host_portion
                     req.cached_tokens_storage = storage_portion
+                    req.cached_tokens_by_component = (
+                        self.tree_cache.build_cached_tokens_by_component(
+                            req,
+                            device=device_portion,
+                            host=host_portion,
+                            storage=storage_portion,
+                        )
+                    )
                     req._cache_breakdown_computed = True
 
                 req.already_computed = seq_len

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -133,6 +133,7 @@ def match_prefix_for_req(
         match_result.swa_host_hit_length,
         match_result.mamba_host_hit_length,
     )
+    req.matched_tokens_by_component = match_result.matched_tokens_by_component or {}
     max_len = req._compute_max_prefix_len(len(token_ids))
     req.num_matched_prefix_tokens = min(
         len(req.prefix_indices) + req.host_hit_length, max_len

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3007,6 +3007,11 @@ class Scheduler(
                 loaded_tokens = self.tree_cache.pop_prefetch_loaded_tokens(req.rid)
                 if loaded_tokens > 0:
                     req.storage_hit_length = loaded_tokens
+                loaded_tokens_by_component = (
+                    self.tree_cache.pop_prefetch_loaded_tokens_by_component(req.rid)
+                )
+                if loaded_tokens_by_component:
+                    req.storage_hit_tokens_by_component = loaded_tokens_by_component
 
             req.init_next_round_input(self.tree_cache)
             res = adder.add_one_req(

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -83,6 +83,10 @@ class SchedulerOutputStreamer:
 
         return None
 
+    @staticmethod
+    def get_cached_tokens_by_component(req: Req) -> Optional[dict]:
+        return req.cached_tokens_by_component or None
+
     def stream_output(
         self,
         reqs: List[Req],
@@ -271,6 +275,7 @@ class _GenerationStreamAccumulator:
     cached_tokens_details: list = field(
         default_factory=list
     )  # Detailed breakdown by cache source
+    cached_tokens_by_component: list = field(default_factory=list)
     image_tokens: list = field(default_factory=list)
     audio_tokens: list = field(default_factory=list)
     video_tokens: list = field(default_factory=list)
@@ -388,6 +393,9 @@ class _GenerationStreamAccumulator:
 
         # Collect detailed cache breakdown if available
         self.cached_tokens_details.append(self.get_cached_tokens_details(req))
+        self.cached_tokens_by_component.append(
+            SchedulerOutputStreamer.get_cached_tokens_by_component(req)
+        )
 
         # Multimodal prompt token counts. In disagg decode mode the prefill node
         # already computed these and transferred them via the metadata buffer
@@ -574,6 +582,7 @@ class _GenerationStreamAccumulator:
             completion_tokens=self.completion_tokens,
             cached_tokens=self.cached_tokens,
             cached_tokens_details=self.cached_tokens_details,
+            cached_tokens_by_component=self.cached_tokens_by_component,
             image_tokens=self.image_tokens,
             audio_tokens=self.audio_tokens,
             video_tokens=self.video_tokens,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2520,11 +2520,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if state.finished:
             # Get detailed cache breakdown if available
             cached_tokens_details = None
+            cached_tokens_by_component = None
             if (
                 hasattr(recv_obj, "cached_tokens_details")
                 and recv_obj.cached_tokens_details
             ):
                 cached_tokens_details = recv_obj.cached_tokens_details[i]
+            if (
+                hasattr(recv_obj, "cached_tokens_by_component")
+                and recv_obj.cached_tokens_by_component
+            ):
+                cached_tokens_by_component = recv_obj.cached_tokens_by_component[i]
 
             spec_verify_ct = (
                 recv_obj.spec_verify_ct[i]
@@ -2541,7 +2547,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 recv_obj.cached_tokens[i],
                 state.time_stats.get_e2e_latency(),
                 self._request_has_grammar(state.obj),
-                cached_tokens_details,
+                cached_tokens_details=cached_tokens_details,
+                cached_tokens_by_component=cached_tokens_by_component,
                 spec_verify_ct=spec_verify_ct,
             )
 

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -174,6 +174,9 @@ class MatchResult(NamedTuple):
                             window) and will be load-back into the SWA device pool.
         mamba_host_hit_length:   Number of Mamba slots that hit on host and will be load-back
                             into the Mamba device pool. Typically 0 or 1.
+        matched_tokens_by_component: Cached token counts matched for each cache
+                            component and device/host source. Storage attribution
+                            is added separately after async prefetch completes.
         mamba_branching_seqlen: The mamba radix cache branching point, which is the longest
                                 page-aligned position that could've been cache hit if there
                                 exists a mamba state.
@@ -186,8 +189,21 @@ class MatchResult(NamedTuple):
     host_hit_length: int = 0
     swa_host_hit_length: int = 0
     mamba_host_hit_length: int = 0
+    matched_tokens_by_component: Optional[dict[str, dict[str, int]]] = None
     mamba_branching_seqlen: Optional[int] = None
     cache_protected_len: Optional[int] = None
+
+    def with_matched_tokens(self, component: str, **sources: int) -> MatchResult:
+        breakdown = {
+            name: dict(source_counts)
+            for name, source_counts in (self.matched_tokens_by_component or {}).items()
+        }
+        source_counts = {name: value for name, value in sources.items() if value > 0}
+        if source_counts:
+            breakdown[component] = source_counts
+        else:
+            breakdown.pop(component, None)
+        return self._replace(matched_tokens_by_component=breakdown or None)
 
 
 def zero_match_result(tree_cache, match_result: MatchResult) -> MatchResult:
@@ -205,6 +221,7 @@ def zero_match_result(tree_cache, match_result: MatchResult) -> MatchResult:
         host_hit_length=0,
         swa_host_hit_length=0,
         mamba_host_hit_length=0,
+        matched_tokens_by_component=None,
     )
 
 
@@ -336,6 +353,39 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
 
     def supports_mamba(self) -> bool:
         return False
+
+    @staticmethod
+    def _nonzero_cache_sources(**sources: int) -> dict[str, int]:
+        return {source: value for source, value in sources.items() if value > 0}
+
+    @classmethod
+    def _cached_tokens_for_component(
+        cls,
+        component: str,
+        *,
+        device: int,
+        host: int,
+        storage: int,
+    ) -> dict[str, dict[str, int]]:
+        sources = cls._nonzero_cache_sources(
+            device=device,
+            host=host,
+            storage=storage,
+        )
+        return {component: sources} if sources else {}
+
+    def build_cached_tokens_by_component(
+        self,
+        req: Req,
+        *,
+        device: int,
+        host: int,
+        storage: int,
+    ) -> dict[str, dict[str, int]]:
+        return {}
+
+    def pop_prefetch_loaded_tokens_by_component(self, req_id: str) -> dict[str, int]:
+        return {}
 
     def supports_streaming_session(self) -> bool:
         return False

--- a/python/sglang/srt/mem_cache/pure_swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/pure_swa_radix_cache.py
@@ -39,6 +39,17 @@ class PureSWARadixCache(RadixCache):
         ), "sliding_window_size must be set for PureSWARadixCache"
         return True
 
+    def build_cached_tokens_by_component(
+        self,
+        req: Req,
+        *,
+        device: int,
+        host: int,
+        storage: int,
+    ) -> dict[str, dict[str, int]]:
+        # Pure-SWA does not define component-specific source attribution yet.
+        return {}
+
     def swa_evictable_size(self):
         return self.evictable_size_
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -328,6 +328,21 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
 
     ##### Public API #####
 
+    def build_cached_tokens_by_component(
+        self,
+        req: Req,
+        *,
+        device: int,
+        host: int,
+        storage: int,
+    ) -> dict[str, dict[str, int]]:
+        return self._cached_tokens_for_component(
+            "full",
+            device=device,
+            host=host,
+            storage=storage,
+        )
+
     def reset(self):
         # Initialize root with minimum priority so any real priority overrides it
         self.root_node = TreeNode(priority=-sys.maxsize)

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -77,6 +77,21 @@ class RadixCacheCpp(BasePrefixCache):
 
         raise NotImplementedError("Host cache is not supported yet")
 
+    def build_cached_tokens_by_component(
+        self,
+        req: Req,
+        *,
+        device: int,
+        host: int,
+        storage: int,
+    ) -> dict[str, dict[str, int]]:
+        return self._cached_tokens_for_component(
+            "full",
+            device=device,
+            host=host,
+            storage=storage,
+        )
+
     def _merge_tensor(self, l: List[torch.Tensor]) -> torch.Tensor:
         """
         Merge a list of tensors into a single tensor.

--- a/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/swa_component.py
@@ -150,12 +150,15 @@ class SWAComponent(TreeComponent):
     ) -> MatchResult:
         ct = self.component_type
         n_swa = 0
+        swa_device_hit = 0
         swa_host_hit = 0
+        swa_host_tokens = 0
         node = result.best_match_node
         root = self.cache.root_node
         while node is not root and n_swa < self.sliding_window_size:
             cd = node.component_data[ct]
             if cd.value is not None:
+                swa_device_hit += min(len(cd.value), self.sliding_window_size - n_swa)
                 n_swa += len(cd.value)
             elif cd.host_value is not None:
                 # TODO(hzh): load_back may currently restore a full host-tombstone
@@ -164,14 +167,19 @@ class SWAComponent(TreeComponent):
                 # worth of pages, cap swa_host_hit at sliding_window_size
                 # here so the scheduler budget matches the actual device-pool
                 # consumption.
+                swa_host_tokens += min(
+                    len(cd.host_value), self.sliding_window_size - n_swa
+                )
                 swa_host_hit += len(cd.host_value)
                 n_swa += len(cd.host_value)
             else:
                 break
             node = node.parent
-        if swa_host_hit > 0:
-            return result._replace(
-                swa_host_hit_length=max(result.swa_host_hit_length, swa_host_hit)
+        if swa_device_hit > 0 or swa_host_tokens > 0:
+            return result.with_matched_tokens(
+                str(ct), device=swa_device_hit, host=swa_host_tokens
+            )._replace(
+                swa_host_hit_length=max(result.swa_host_hit_length, swa_host_hit),
             )
         return result
 
@@ -721,7 +729,7 @@ class SWAComponent(TreeComponent):
         *,
         insert_result: Optional[InsertResult] = None,
         pool_storage_result: Optional[PoolTransferResult] = None,
-    ) -> None:
+    ) -> int:
         ct = self.component_type
 
         if phase == CacheTransferPhase.BACKUP_HOST:
@@ -729,7 +737,7 @@ class SWAComponent(TreeComponent):
                 cd = node.component_data[ct]
                 if cd.host_value is None:
                     cd.host_value = transfers[0].host_indices.clone()
-            return
+            return 0
 
         if phase == CacheTransferPhase.LOAD_BACK:
             assert transfers and transfers[0].device_indices is not None
@@ -749,16 +757,16 @@ class SWAComponent(TreeComponent):
                 allocator.set_full_to_swa_mapping(cd_full_n.value, swa_chunk)
                 offset += n_tokens
             assert offset == len(xfer.host_indices)
-            return
+            return 0
 
         if phase == CacheTransferPhase.PREFETCH:
-            self._commit_prefetch(
+            return self._commit_prefetch(
                 node,
                 transfers,
                 insert_result=insert_result,
                 pool_storage_result=pool_storage_result,
             )
-            return
+        return 0
 
     def _release_swa_host(self, host_indices: torch.Tensor) -> None:
         if host_indices is not None and host_indices.numel() > 0:
@@ -787,7 +795,7 @@ class SWAComponent(TreeComponent):
         *,
         insert_result: Optional[InsertResult] = None,
         pool_storage_result: Optional[PoolTransferResult] = None,
-    ) -> None:
+    ) -> int:
         """Fill the prefetched SWA window onto the leaf→anchor path.
 
         All-or-nothing over one full window: ``loaded_pages`` is the cross-rank
@@ -797,7 +805,7 @@ class SWAComponent(TreeComponent):
         tombstones and releasing slices that already have host_value.
         """
         if not transfers:
-            return
+            return 0
         ct = self.component_type
         page_size = self.cache.page_size
         host_indices = transfers[0].host_indices
@@ -816,12 +824,14 @@ class SWAComponent(TreeComponent):
             or loaded_pages < window_require_pages
         ):
             self._release_swa_host(host_indices)
-            return
+            return 0
 
         # Buffer covers token range [loaded_start, total_len).
         loaded_start = insert_result.total_len - window_require_pages * page_size
+        active_window_start = insert_result.total_len - self.sliding_window_size
 
         # Walk leaf → anchor; ``pos`` is the right edge of ``cur`` in tokens.
+        committed_tokens = 0
         pos, cur = insert_result.total_len, target
         while cur is not anchor and pos > loaded_start:
             node_start = pos - len(cur.key)
@@ -833,10 +843,14 @@ class SWAComponent(TreeComponent):
 
             cd = cur.component_data[ct]
             if cd.host_value is None and fill_len > 0:
-                # Tombstone: split off the in-buffer tail if needed, then fill.
+                served_from_device = cd.value is not None
+                # Split off the in-buffer tail if needed, then retain its host copy.
                 if fill_start > node_start:
                     self.cache._split_node(cur.key, cur, fill_start - node_start)
                 self._attach_swa_host_value(cur, slice_)
+                if not served_from_device:
+                    attributed_start = max(fill_start, active_window_start)
+                    committed_tokens += max(0, pos - attributed_start)
             else:
                 # Already has SWA (or empty overlap): drop this slice.
                 self._release_swa_host(slice_)
@@ -847,6 +861,7 @@ class SWAComponent(TreeComponent):
         # Buffer prefix that fell outside the anchor→leaf path.
         if pos > loaded_start:
             self._release_swa_host(host_indices[: pos - loaded_start])
+        return committed_tokens
 
     def drive_host_eviction(
         self, num_tokens: int, tracker: dict[ComponentType, int]

--- a/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache_components/tree_component.py
@@ -168,7 +168,8 @@ class TreeComponent(ABC):
         best_value_len: int,
     ) -> MatchResult:
         """Post-process the match result after prefix matching completes.
-        - Full & SWA: pass through unchanged.
+        - Full: passes through unchanged.
+        - SWA: records device/host token attribution for its active window.
         - Mamba: performs copy-on-write — allocates a new mamba slot, copies
           the matched node's mamba state into the request pool, and records
           branching_seqlen in result."""
@@ -402,9 +403,13 @@ class TreeComponent(ABC):
         *,
         insert_result: Optional[InsertResult] = None,
         pool_storage_result: Optional[PoolTransferResult] = None,
-    ) -> None:
-        """Post-transfer bookkeeping: store host indices, update LRU, etc."""
-        pass
+    ) -> Optional[int]:
+        """Post-transfer bookkeeping: store indices, update LRU, etc.
+
+        For PREFETCH, token-backed components may return the number of cached
+        tokens attributed to storage. Other components and phases may return None.
+        """
+        return None
 
     def drive_host_eviction(
         self, num_tokens: int, tracker: dict[ComponentType, int]

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -33,6 +33,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     PoolHitPolicy,
     PoolName,
     PoolTransfer,
+    PoolTransferResult,
     SidecarPoolSpec,
 )
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
@@ -477,6 +478,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         self.ongoing_load_back: dict[int, _OngoingLoadBack] = {}
         self.enable_storage = False
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
+        self.prefetch_loaded_tokens_by_component_by_reqid: dict[str, dict[str, int]] = (
+            {}
+        )
         self.ongoing_prefetch: dict[str, _OngoingPrefetch] = {}
         self.ongoing_backup: dict[int, tuple[UnifiedTreeNode, DecLockRefParams]] = {}
 
@@ -1984,6 +1988,29 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
         operation_terminated = states[1].item() == 1
         return can_terminate or operation_terminated
 
+    def _commit_prefetched_component_tokens(
+        self,
+        last_host_node: UnifiedTreeNode,
+        comp_xfers: dict[ComponentType, list[PoolTransfer]],
+        insert_result: InsertResult,
+        pool_storage_result: Optional[PoolTransferResult],
+    ) -> dict[str, int]:
+        committed_tokens = {}
+        for component_type, transfers in comp_xfers.items():
+            count = (
+                self.components[component_type].commit_hicache_transfer(
+                    last_host_node,
+                    CacheTransferPhase.PREFETCH,
+                    transfers,
+                    insert_result=insert_result,
+                    pool_storage_result=pool_storage_result,
+                )
+                or 0
+            )
+            if count > 0:
+                committed_tokens[str(component_type)] = count
+        return committed_tokens
+
     def check_prefetch_progress(self, req_id: str) -> bool:
         if req_id not in self.ongoing_prefetch:
             return True
@@ -2029,14 +2056,12 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
             hash_value[: min_completed_tokens // self.page_size],
         )
 
-        for ct, xfers in comp_xfers.items():
-            self.components[ct].commit_hicache_transfer(
-                last_host_node,
-                CacheTransferPhase.PREFETCH,
-                xfers,
-                insert_result=insert_result,
-                pool_storage_result=operation.pool_storage_result,
-            )
+        committed_component_tokens = self._commit_prefetched_component_tokens(
+            last_host_node,
+            comp_xfers,
+            insert_result,
+            operation.pool_storage_result,
+        )
 
         self.cache_controller.mem_pool_host.free(
             host_indices[: insert_result.prefix_len]
@@ -2050,6 +2075,9 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
         loaded_from_storage = min_completed_tokens - insert_result.prefix_len
         self.prefetch_loaded_tokens_by_reqid[req_id] = loaded_from_storage
+        self.prefetch_loaded_tokens_by_component_by_reqid[req_id] = (
+            committed_component_tokens
+        )
         logger.info(
             "HiCache prefetch success req=%s completed_local=%d completed_synced=%d matched=%d loaded=%d tail_release=%d occupied=%d",
             req_id,
@@ -2154,8 +2182,12 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
     def pop_prefetch_loaded_tokens(self, req_id: str) -> int:
         return self.prefetch_loaded_tokens_by_reqid.pop(req_id, 0)
 
+    def pop_prefetch_loaded_tokens_by_component(self, req_id: str) -> dict[str, int]:
+        return self.prefetch_loaded_tokens_by_component_by_reqid.pop(req_id, {})
+
     def release_aborted_request(self, rid: str) -> None:
         self.prefetch_loaded_tokens_by_reqid.pop(rid, None)
+        self.prefetch_loaded_tokens_by_component_by_reqid.pop(rid, None)
         if rid not in self.ongoing_prefetch:
             return
 
@@ -2626,6 +2658,42 @@ class UnifiedRadixCache(KVCacheEventMixin, BasePrefixCache):
 
     def supports_mamba(self) -> bool:
         return ComponentType.MAMBA in self.components
+
+    def build_cached_tokens_by_component(
+        self,
+        req: Req,
+        *,
+        device: int,
+        host: int,
+        storage: int,
+    ) -> dict[str, dict[str, int]]:
+        breakdown = self._cached_tokens_for_component(
+            str(ComponentType.FULL),
+            device=device,
+            host=host,
+            storage=storage,
+        )
+
+        if self.supports_swa():
+            component = str(ComponentType.SWA)
+            matched_sources = req.matched_tokens_by_component.get(component, {})
+            host = max(0, matched_sources.get("host", 0))
+            storage = min(
+                host,
+                max(
+                    0,
+                    req.storage_hit_tokens_by_component.get(component, 0),
+                ),
+            )
+            sources = self._nonzero_cache_sources(
+                device=max(0, matched_sources.get("device", 0)),
+                host=host - storage,
+                storage=storage,
+            )
+            if sources:
+                breakdown[component] = sources
+
+        return breakdown
 
     # ---- Streaming session API (delegates to composed StreamingSession) ----
 

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1526,6 +1526,11 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
             documentation="Number of cached prompt tokens by source (device/host/storage).",
             labelnames=list(labels.keys()) + ["cache_source"],
         )
+        self.cached_tokens_by_component_total = Counter(
+            name="sglang:cached_tokens_by_component_total",
+            documentation="Number of cached tokens by cache component and source.",
+            labelnames=list(labels.keys()) + ["component", "cache_source"],
+        )
 
         self.num_requests_total = Counter(
             name="sglang:num_requests_total",
@@ -1657,6 +1662,7 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         e2e_latency: float,
         has_grammar: bool,
         cached_tokens_details: Optional[Dict[str, Any]] = None,
+        cached_tokens_by_component: Optional[Dict[str, Dict[str, int]]] = None,
         spec_verify_ct: int = 0,
     ):
         self.prompt_tokens_total.labels(**labels).inc(prompt_tokens)
@@ -1688,6 +1694,30 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
                 # Fallback for backward compatibility
                 labels_total = {**labels, "cache_source": "total"}
                 self.cached_tokens_total.labels(**labels_total).inc(cached_tokens)
+
+        # In PD, prefill owns cache-source attribution. Skip decode-local values
+        # to avoid double-counting the same request across both engines.
+        if cached_tokens_by_component and labels.get("engine_type") != "decode":
+            storage_backend = "unknown"
+            if cached_tokens_details:
+                storage_backend = (
+                    cached_tokens_details.get("storage_backend") or "unknown"
+                )
+            for component, source_counts in cached_tokens_by_component.items():
+                for source, value in source_counts.items():
+                    if value <= 0:
+                        continue
+                    source_label = (
+                        f"storage_{storage_backend}" if source == "storage" else source
+                    )
+                    component_labels = {
+                        **labels,
+                        "component": component,
+                        "cache_source": source_label,
+                    }
+                    self.cached_tokens_by_component_total.labels(
+                        **component_labels
+                    ).inc(value)
 
         self.num_requests_total.labels(**labels).inc(1)
         if has_grammar:

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -55,6 +55,10 @@ def _make_batch_str_output() -> BatchStrOutput:
             {"device": 3, "host": 0},
             {"device": 1, "host": 3},
         ],
+        cached_tokens_by_component=[
+            {"full": {"device": 3}},
+            {"full": {"device": 1, "host": 3}, "swa": {"device": 2}},
+        ],
         input_token_logprobs_val=[[], []],
         input_token_logprobs_idx=[[], []],
         output_token_logprobs_val=[[], []],
@@ -90,6 +94,10 @@ class TestMultiTokenizerMixin(unittest.TestCase):
         self.assertEqual(
             single_output.cached_tokens_details,
             [{"device": 1, "host": 3}],
+        )
+        self.assertEqual(
+            single_output.cached_tokens_by_component,
+            [{"full": {"device": 1, "host": 3}, "swa": {"device": 2}}],
         )
 
     def test_get_tokenizer_worker_class_uses_default(self):

--- a/test/registered/unit/mem_cache/test_cached_tokens_by_component.py
+++ b/test/registered/unit/mem_cache/test_cached_tokens_by_component.py
@@ -1,0 +1,395 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.base_prefix_cache import (  # noqa: E402
+    InsertResult,
+    MatchPrefixParams,
+    MatchResult,
+    zero_match_result,
+)
+from sglang.srt.mem_cache.chunk_cache import ChunkCache  # noqa: E402
+from sglang.srt.mem_cache.hicache_storage import (  # noqa: E402
+    PoolName,
+    PoolTransfer,
+    PoolTransferResult,
+)
+from sglang.srt.mem_cache.pure_swa_radix_cache import (  # noqa: E402
+    PureSWARadixCache,
+)
+from sglang.srt.mem_cache.radix_cache import RadixCache  # noqa: E402
+from sglang.srt.mem_cache.unified_cache_components.swa_component import (  # noqa: E402
+    SWAComponent,
+)
+from sglang.srt.mem_cache.unified_cache_components.tree_component import (  # noqa: E402
+    ComponentData,
+    ComponentType,
+)
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache  # noqa: E402
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestCachedTokensByComponent(unittest.TestCase):
+    @staticmethod
+    def _unified_cache(*component_types: ComponentType) -> UnifiedRadixCache:
+        cache = object.__new__(UnifiedRadixCache)
+        cache.components = {
+            component_type: object() for component_type in component_types
+        }
+        return cache
+
+    def test_base_cache_component_accounting_is_neutral(self):
+        cache = object.__new__(ChunkCache)
+        self.assertEqual(
+            cache.build_cached_tokens_by_component(
+                SimpleNamespace(),
+                device=10,
+                host=20,
+                storage=30,
+            ),
+            {},
+        )
+
+    def test_radix_cache_reports_full_tokens_only(self):
+        cache = RadixCache.create_simulated()
+        self.assertEqual(
+            cache.build_cached_tokens_by_component(
+                SimpleNamespace(),
+                device=10,
+                host=20,
+                storage=30,
+            ),
+            {"full": {"device": 10, "host": 20, "storage": 30}},
+        )
+
+    def test_pure_swa_cache_keeps_component_accounting_neutral(self):
+        cache = object.__new__(PureSWARadixCache)
+        self.assertEqual(
+            cache.build_cached_tokens_by_component(
+                SimpleNamespace(),
+                device=10,
+                host=20,
+                storage=30,
+            ),
+            {},
+        )
+
+    def test_unified_cache_splits_full_and_swa_sources(self):
+        cache = self._unified_cache(
+            ComponentType.FULL,
+            ComponentType.SWA,
+        )
+        req = SimpleNamespace(
+            matched_tokens_by_component={
+                "swa": {"device": 16, "host": 12},
+            },
+            storage_hit_tokens_by_component={"swa": 4},
+        )
+        self.assertEqual(
+            cache.build_cached_tokens_by_component(
+                req,
+                device=10,
+                host=20,
+                storage=30,
+            ),
+            {
+                "full": {"device": 10, "host": 20, "storage": 30},
+                "swa": {"device": 16, "host": 8, "storage": 4},
+            },
+        )
+
+    def test_storage_prefetch_counts_only_committed_swa_tokens(self):
+        cache = self._unified_cache(ComponentType.SWA)
+        cache.page_size = 2
+        cache.host_lru_lists = {
+            ComponentType.SWA: SimpleNamespace(
+                in_list=lambda node: False,
+                insert_mru=lambda node: None,
+            )
+        }
+        cache._update_evictable_leaf_sets = lambda node: None
+        cache._split_node = lambda *args: self.fail("unexpected node split")
+        released = []
+        cache.cache_controller = SimpleNamespace(
+            append_host_mem_release=lambda **kwargs: released.append(kwargs)
+        )
+        component = object.__new__(SWAComponent)
+        component.cache = cache
+        component.sliding_window_size = 4
+        cache.components[ComponentType.SWA] = component
+        anchor = SimpleNamespace()
+        transfer = PoolTransfer(
+            name=PoolName.SWA,
+            host_indices=torch.arange(4),
+        )
+        pool_result = PoolTransferResult(
+            kv_hit_pages=2,
+            extra_pool_hit_pages={PoolName.SWA: 2},
+        )
+
+        self.assertEqual(
+            cache._commit_prefetched_component_tokens(
+                anchor,
+                comp_xfers={
+                    ComponentType.SWA: [transfer],
+                },
+                insert_result=InsertResult(
+                    prefix_len=0,
+                    total_len=4,
+                    inserted_host_node=SimpleNamespace(
+                        key=torch.arange(4),
+                        parent=anchor,
+                        component_data={ComponentType.SWA: ComponentData()},
+                    ),
+                ),
+                pool_storage_result=pool_result,
+            ),
+            {"swa": 4},
+        )
+
+        self.assertEqual(
+            cache._commit_prefetched_component_tokens(
+                anchor,
+                comp_xfers={
+                    ComponentType.SWA: [transfer],
+                },
+                insert_result=InsertResult(
+                    prefix_len=4,
+                    total_len=4,
+                    inserted_host_node=SimpleNamespace(
+                        key=torch.arange(4),
+                        parent=anchor,
+                        component_data={
+                            ComponentType.SWA: ComponentData(host_value=torch.arange(4))
+                        },
+                    ),
+                ),
+                pool_storage_result=pool_result,
+            ),
+            {},
+        )
+        self.assertEqual(len(released), 1)
+
+    def test_storage_prefetch_counts_only_tokens_in_active_swa_window(self):
+        cache = self._unified_cache(ComponentType.SWA)
+        cache.page_size = 2
+        cache.host_lru_lists = {
+            ComponentType.SWA: SimpleNamespace(
+                in_list=lambda node: False,
+                insert_mru=lambda node: None,
+            )
+        }
+        cache._update_evictable_leaf_sets = lambda node: None
+        cache._split_node = lambda *args: self.fail("unexpected node split")
+        cache.cache_controller = SimpleNamespace(
+            append_host_mem_release=lambda **kwargs: None
+        )
+        component = object.__new__(SWAComponent)
+        component.cache = cache
+        component.sliding_window_size = 3
+        cache.components[ComponentType.SWA] = component
+
+        anchor = SimpleNamespace()
+        storage_node = SimpleNamespace(
+            key=torch.arange(2),
+            parent=anchor,
+            component_data={ComponentType.SWA: ComponentData()},
+        )
+        existing_host_node = SimpleNamespace(
+            key=torch.arange(2),
+            parent=storage_node,
+            component_data={
+                ComponentType.SWA: ComponentData(host_value=torch.arange(2))
+            },
+        )
+
+        committed = cache._commit_prefetched_component_tokens(
+            anchor,
+            comp_xfers={
+                ComponentType.SWA: [
+                    PoolTransfer(
+                        name=PoolName.SWA,
+                        host_indices=torch.arange(4),
+                    )
+                ],
+            },
+            insert_result=InsertResult(
+                prefix_len=2,
+                total_len=4,
+                inserted_host_node=existing_host_node,
+            ),
+            pool_storage_result=PoolTransferResult(
+                kv_hit_pages=2,
+                extra_pool_hit_pages={PoolName.SWA: 2},
+            ),
+        )
+
+        self.assertEqual(committed, {"swa": 1})
+        self.assertEqual(
+            cache.build_cached_tokens_by_component(
+                SimpleNamespace(
+                    matched_tokens_by_component={"swa": {"host": 3}},
+                    storage_hit_tokens_by_component=committed,
+                ),
+                device=0,
+                host=0,
+                storage=0,
+            ),
+            {"swa": {"host": 2, "storage": 1}},
+        )
+
+    def test_storage_prefetch_excludes_tokens_served_from_device(self):
+        cache = self._unified_cache(ComponentType.SWA)
+        cache.page_size = 2
+        cache.host_lru_lists = {
+            ComponentType.SWA: SimpleNamespace(
+                in_list=lambda node: False,
+                insert_mru=lambda node: None,
+            )
+        }
+        cache._update_evictable_leaf_sets = lambda node: None
+        cache._split_node = lambda *args: self.fail("unexpected node split")
+        cache.cache_controller = SimpleNamespace(
+            append_host_mem_release=lambda **kwargs: None
+        )
+        component = object.__new__(SWAComponent)
+        component.cache = cache
+        component.sliding_window_size = 4
+        cache.components[ComponentType.SWA] = component
+
+        anchor = SimpleNamespace()
+        existing_host_node = SimpleNamespace(
+            key=torch.arange(2),
+            parent=anchor,
+            component_data={
+                ComponentType.SWA: ComponentData(host_value=torch.arange(2))
+            },
+        )
+        device_node = SimpleNamespace(
+            key=torch.arange(2),
+            parent=existing_host_node,
+            component_data={ComponentType.SWA: ComponentData(value=torch.arange(2))},
+        )
+
+        committed = cache._commit_prefetched_component_tokens(
+            anchor,
+            comp_xfers={
+                ComponentType.SWA: [
+                    PoolTransfer(
+                        name=PoolName.SWA,
+                        host_indices=torch.arange(4),
+                    )
+                ],
+            },
+            insert_result=InsertResult(
+                prefix_len=2,
+                total_len=4,
+                inserted_host_node=device_node,
+            ),
+            pool_storage_result=PoolTransferResult(
+                kv_hit_pages=2,
+                extra_pool_hit_pages={PoolName.SWA: 2},
+            ),
+        )
+
+        self.assertEqual(committed, {})
+        self.assertEqual(
+            cache.build_cached_tokens_by_component(
+                SimpleNamespace(
+                    matched_tokens_by_component={
+                        "swa": {"device": 2, "host": 2},
+                    },
+                    storage_hit_tokens_by_component=committed,
+                ),
+                device=0,
+                host=0,
+                storage=0,
+            ),
+            {"swa": {"device": 2, "host": 2}},
+        )
+
+    def test_storage_token_attribution_is_popped_and_cleared_on_abort(self):
+        cache = self._unified_cache(ComponentType.FULL, ComponentType.SWA)
+        cache.prefetch_loaded_tokens_by_reqid = {"aborted": 8}
+        cache.prefetch_loaded_tokens_by_component_by_reqid = {
+            "done": {"swa": 4},
+            "aborted": {"swa": 4},
+        }
+        cache.ongoing_prefetch = {}
+
+        self.assertEqual(
+            cache.pop_prefetch_loaded_tokens_by_component("done"),
+            {"swa": 4},
+        )
+        self.assertEqual(cache.pop_prefetch_loaded_tokens_by_component("done"), {})
+
+        cache.release_aborted_request("aborted")
+        self.assertNotIn("aborted", cache.prefetch_loaded_tokens_by_reqid)
+        self.assertNotIn("aborted", cache.prefetch_loaded_tokens_by_component_by_reqid)
+
+    def test_force_miss_clears_matched_component_tokens(self):
+        root = object()
+        tree_cache = SimpleNamespace(
+            is_chunk_cache=lambda: False,
+            root_node=root,
+        )
+        result = zero_match_result(
+            tree_cache,
+            MatchResult(
+                device_indices=torch.tensor([1]),
+                last_device_node=object(),
+                last_host_node=object(),
+                best_match_node=object(),
+                matched_tokens_by_component={"swa": {"device": 1}},
+            ),
+        )
+
+        self.assertIsNone(result.matched_tokens_by_component)
+        self.assertEqual(result.device_indices.numel(), 0)
+
+    def test_swa_component_caps_window_tokens_but_preserves_load_back_length(self):
+        component = object.__new__(SWAComponent)
+        component.sliding_window_size = 4
+        root = SimpleNamespace()
+        host_node = SimpleNamespace(
+            parent=root,
+            component_data={
+                ComponentType.SWA: ComponentData(host_value=torch.tensor([3, 4, 5]))
+            },
+        )
+        device_node = SimpleNamespace(
+            parent=host_node,
+            component_data={
+                ComponentType.SWA: ComponentData(value=torch.tensor([1, 2]))
+            },
+        )
+        component.cache = SimpleNamespace(root_node=root)
+
+        result = component.finalize_match_result(
+            result=MatchResult(
+                device_indices=torch.empty((0,), dtype=torch.int64),
+                last_device_node=device_node,
+                last_host_node=host_node,
+                best_match_node=device_node,
+            ),
+            params=MatchPrefixParams(key=None),
+            value_chunks=[],
+            best_value_len=0,
+        )
+
+        self.assertEqual(
+            result.matched_tokens_by_component,
+            {"swa": {"device": 2, "host": 2}},
+        )
+        self.assertEqual(result.swa_host_hit_length, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/observability/test_stat_loggers_di.py
+++ b/test/registered/unit/observability/test_stat_loggers_di.py
@@ -52,6 +52,11 @@ class _StubArgs:
         self.stat_loggers = stat_loggers
 
 
+class _TokenizerArgs(_StubArgs):
+    prompt_tokens_buckets = None
+    generation_tokens_buckets = None
+
+
 class TestCollectorClassAttrs(unittest.TestCase):
     """All five collectors expose four DI hook class attrs, all defaulting to
     None so the existing prometheus_client backend is used unchanged."""
@@ -127,9 +132,49 @@ class TestResolveCollectorClass(unittest.TestCase):
         self.assertEqual(STAT_LOGGER_ROLE_EXPERT_DISPATCH, "expert_dispatch")
 
 
+class _RecordingGauge:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.calls = []
+        self._labels = {}
+        type(self).instances.append(self)
+
+    def labels(self, **kwargs):
+        self._labels = kwargs
+        return self
+
+    def set(self, value):
+        self.calls.append(("set", self._labels, value))
+
+    def inc(self, amount=1):
+        self.calls.append(("inc", self._labels, amount))
+
+
+class _RecordingCounter(_RecordingGauge):
+    pass
+
+
+class _RecordingHistogram(_RecordingGauge):
+    def observe(self, value):
+        self.calls.append(("observe", self._labels, value))
+
+
+class _RecordingSummary(_RecordingGauge):
+    def observe(self, value):
+        self.calls.append(("observe", self._labels, value))
+
+
 class TestDefaultBackend(unittest.TestCase):
-    """Without any subclass override, collectors instantiate the real
-    prometheus_client classes; the existing behavior is unchanged."""
+    """Collector backend behavior and component cache metric emissions."""
+
+    def setUp(self):
+        _RecordingGauge.instances = []
+        _RecordingCounter.instances = []
+        _RecordingHistogram.instances = []
+        _RecordingSummary.instances = []
 
     def test_default_path_uses_prometheus_client(self):
         labels = {"cache_type": "test_default"}
@@ -138,6 +183,93 @@ class TestDefaultBackend(unittest.TestCase):
         self.assertIsInstance(
             collector.eviction_duration_seconds, prometheus_client.Histogram
         )
+
+    def test_tokenizer_cached_tokens_by_component_metric_reports_sources(self):
+        class RaySwapTokenizer(TokenizerMetricsCollector):
+            _counter_cls = _RecordingCounter
+            _histogram_cls = _RecordingHistogram
+
+        collector = RaySwapTokenizer(server_args=_TokenizerArgs(), labels={})
+        collector.observe_one_finished_request(
+            labels={},
+            prompt_tokens=10,
+            generation_tokens=1,
+            cached_tokens=10,
+            e2e_latency=0.1,
+            has_grammar=False,
+            cached_tokens_details={
+                "device": 6,
+                "host": 0,
+                "storage": 4,
+                "storage_backend": "MooncakeStore",
+            },
+            cached_tokens_by_component={
+                "full": {"device": 6, "storage": 4},
+                "swa": {"device": 3, "host": 2},
+            },
+        )
+
+        component_counter = next(
+            c
+            for c in _RecordingCounter.instances
+            if c.kwargs["name"] == "sglang:cached_tokens_by_component_total"
+        )
+        self.assertEqual(
+            component_counter.calls,
+            [
+                (
+                    "inc",
+                    {"component": "full", "cache_source": "device"},
+                    6,
+                ),
+                (
+                    "inc",
+                    {"component": "full", "cache_source": "storage_MooncakeStore"},
+                    4,
+                ),
+                ("inc", {"component": "swa", "cache_source": "device"}, 3),
+                ("inc", {"component": "swa", "cache_source": "host"}, 2),
+            ],
+        )
+        cached_tokens_counter = next(
+            c
+            for c in _RecordingCounter.instances
+            if c.kwargs["name"] == "sglang:cached_tokens_total"
+        )
+        full_component_calls = [
+            (method, {"cache_source": labels["cache_source"]}, value)
+            for method, labels, value in component_counter.calls
+            if labels["component"] == "full"
+        ]
+        self.assertEqual(full_component_calls, cached_tokens_counter.calls)
+
+    def test_tokenizer_cached_tokens_by_component_metric_skips_decode_engine(self):
+        class RaySwapTokenizer(TokenizerMetricsCollector):
+            _counter_cls = _RecordingCounter
+            _histogram_cls = _RecordingHistogram
+
+        collector = RaySwapTokenizer(
+            server_args=_TokenizerArgs(), labels={"engine_type": ""}
+        )
+        collector.observe_one_finished_request(
+            labels={"engine_type": "decode"},
+            prompt_tokens=10,
+            generation_tokens=1,
+            cached_tokens=10,
+            e2e_latency=0.1,
+            has_grammar=False,
+            cached_tokens_details={"storage_backend": "MooncakeStore"},
+            cached_tokens_by_component={
+                "full": {"device": 6, "storage": 4},
+            },
+        )
+
+        component_counter = next(
+            c
+            for c in _RecordingCounter.instances
+            if c.kwargs["name"] == "sglang:cached_tokens_by_component_total"
+        )
+        self.assertEqual(component_counter.calls, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The existing `cached_tokens_total` metric shows whether cached tokens came from device, host, or storage, but does not distinguish cache components.

Hybrid models such as DeepSeek V4 can reuse Full Attention and SWA cache from different sources. Exposing this breakdown makes it possible to monitor source distribution independently for each component.

## Modifications

- Add `sglang:cached_tokens_by_component_total` with `component` and `cache_source` labels.
- Track Full Attention and SWA cached tokens through the cache, scheduler, and tokenizer metric pipeline.
- Account for SWA tokens within the active sliding window.
- Attribute SWA storage hits after asynchronous prefetch completes.
- Keep the shared cache interface neutral so unsupported components can opt in later.
- Add tests for source attribution, storage prefetch, metric emission, and output transport.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30040658690](https://github.com/sgl-project/sglang/actions/runs/30040658690)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30040656418](https://github.com/sgl-project/sglang/actions/runs/30040656418)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->