### PR TITLE
[LoRA] Fix gated MoE-LoRA under virtual experts; compressed-tensors runner detection and EP expert map

### DIFF
--- a/python/sglang/kernels/ops/moe/virtual_experts.py
+++ b/python/sglang/kernels/ops/moe/virtual_experts.py
@@ -517,7 +517,7 @@ def _merged_experts_fused_moe_lora_add_impl(
     output: torch.Tensor,
     hidden_states: torch.Tensor,
     lora_a: torch.Tensor,
-    lora_b: torch.Tensor,
+    lora_b: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     token_lora_mapping: torch.Tensor,
@@ -531,8 +531,28 @@ def _merged_experts_fused_moe_lora_add_impl(
     2. Flatten LoRA weights from [max_loras, num_experts, ...] to [max_loras * num_experts, ...].
     3. Run regular SGLang fused-MoE kernels for LoRA A and LoRA B.
     4. Mask out tokens with token_lora_mapping == -1 on the add path.
+
+    ``lora_b`` accepts either a single tensor or a length-2 sequence (the gated
+    gate_up case): A holds gate's and up's ranks concatenated (``2*r``) while
+    each B has rank ``r``. The shrink runs once over the full ``2*r`` rank; the
+    expand runs once per B, each reading its half of the intermediate and
+    writing to its slice of ``output``.
     """
+    lora_b_list: list[torch.Tensor] = (
+        list(lora_b) if isinstance(lora_b, (list, tuple)) else [lora_b]
+    )
+    n_b = len(lora_b_list)
+    assert n_b in (1, 2), f"lora_b must be length 1 or 2, got {n_b}"
+    b_rank = lora_b_list[0].shape[3]
+    for b in lora_b_list[1:]:
+        assert (
+            b.shape == lora_b_list[0].shape
+        ), f"all lora_b tensors must share shape; got {[tuple(t.shape) for t in lora_b_list]}"
+
     max_loras, _, max_lora_rank, _ = lora_a.shape
+    assert (
+        max_lora_rank == n_b * b_rank
+    ), f"lora_a rank {max_lora_rank} != n_b ({n_b}) * lora_b rank {b_rank}"
     input_top_k = 1 if hidden_states.shape[0] == topk_ids.numel() else topk_ids.shape[1]
 
     def _merge_lora_expert_weight(t: torch.Tensor) -> torch.Tensor:
@@ -644,9 +664,10 @@ def _merged_experts_fused_moe_lora_add_impl(
     )
 
     lora_a_virtual = _merge_lora_expert_weight(lora_a)
-    lora_b_virtual = _merge_lora_expert_weight(lora_b)
+    lora_b_virtuals = [_merge_lora_expert_weight(b) for b in lora_b_list]
     num_experts_a = lora_a.shape[1]
-    num_experts_b = lora_b.shape[1]
+    num_experts_b = lora_b_list[0].shape[1]
+    half_out = lora_b_list[0].shape[2]
 
     intermediate = torch.zeros(
         [token_lora_mapping.shape[0], topk_ids.shape[1], max_lora_rank],
@@ -680,7 +701,7 @@ def _merged_experts_fused_moe_lora_add_impl(
         a_stage_config,
     )
 
-    b_stage_config = _get_stage_config(lora_b_virtual, 1)
+    b_stage_config = _get_stage_config(lora_b_virtuals[0], 1)
     (
         sorted_token_ids,
         expert_ids,
@@ -694,33 +715,51 @@ def _merged_experts_fused_moe_lora_add_impl(
         b_stage_config["BLOCK_SIZE_M"],
     )
 
-    invoke_fused_moe_kernel(
-        intermediate.view(-1, max_lora_rank),
-        lora_b_virtual,
-        None,
-        output,
-        None,
-        None,
-        None,
-        topk_weights,
-        topk_ids,
-        sorted_token_ids,
-        expert_ids,
-        num_tokens_post_padded,
-        mul_routed_weight,
-        1,
-        b_stage_config,
-        tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
-        False,
-        False,
-        False,
-        False,
-        False,
-        None,
-        fuse_add_to_output=True,
-        add_output_mask=token_lora_mask,
-        router_topk=topk_ids.shape[1],
-    )
+    # n_b expands. For length 1: K = b_rank covers the full intermediate and the
+    # kernel writes the full output. For length 2 (gate_up): split the
+    # intermediate along rank into contiguous [gate, up] halves (K = r each)
+    # and the output along the last dim into [gate, up] slices of width
+    # half_out; each B is its own half's weight tensor.
+    for b_idx, b_virtual in enumerate(lora_b_virtuals):
+        if n_b == 1:
+            inter_arg = intermediate.view(-1, b_rank)
+            out_arg = output
+        else:
+            inter_arg = (
+                intermediate[..., b_idx * b_rank : (b_idx + 1) * b_rank]
+                .contiguous()
+                .view(-1, b_rank)
+            )
+            out_arg = output[..., b_idx * half_out : (b_idx + 1) * half_out].contiguous()
+        invoke_fused_moe_kernel(
+            inter_arg,
+            b_virtual,
+            None,
+            out_arg,
+            None,
+            None,
+            None,
+            topk_weights,
+            topk_ids,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            1,
+            b_stage_config,
+            tl.bfloat16 if hidden_states.dtype == torch.bfloat16 else tl.float16,
+            False,
+            False,
+            False,
+            False,
+            False,
+            None,
+            fuse_add_to_output=True,
+            add_output_mask=token_lora_mask,
+            router_topk=topk_ids.shape[1],
+        )
+        if n_b != 1:
+            output[..., b_idx * half_out : (b_idx + 1) * half_out].copy_(out_arg)
 
 
 def _merged_experts_fused_moe_lora_add_op(
@@ -763,7 +802,7 @@ def merged_experts_fused_moe_lora_add(
     output: torch.Tensor,
     hidden_states: torch.Tensor,
     lora_a: torch.Tensor,
-    lora_b: torch.Tensor,
+    lora_b: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor, ...],
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     token_lora_mapping: torch.Tensor,
@@ -772,7 +811,12 @@ def merged_experts_fused_moe_lora_add(
     experts_shared_outer_loras_b: bool,
     routing_cache: dict | None = None,
 ) -> None:
-    """Public API: wraps the registered op with routing_cache support."""
+    """Public API: wraps the registered op with routing_cache support.
+
+    ``lora_b`` accepts a length-2 sequence for the gated gate_up case (each B
+    holds one half of the stacked output at rank ``r``, with A at rank ``2*r``);
+    the down case passes a single tensor.
+    """
     _merged_experts_fused_moe_lora_add_impl(
         output,
         hidden_states,

--- a/python/sglang/kernels/ops/moe/virtual_experts.py
+++ b/python/sglang/kernels/ops/moe/virtual_experts.py
@@ -730,7 +730,9 @@ def _merged_experts_fused_moe_lora_add_impl(
                 .contiguous()
                 .view(-1, b_rank)
             )
-            out_arg = output[..., b_idx * half_out : (b_idx + 1) * half_out].contiguous()
+            out_arg = output[
+                ..., b_idx * half_out : (b_idx + 1) * half_out
+            ].contiguous()
         invoke_fused_moe_kernel(
             inter_arg,
             b_virtual,

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -953,6 +953,14 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
             and base_layer.quant_method.runner is not None
         ):
             runner_backend = base_layer.quant_method.runner.runner_backend
+        elif (
+            hasattr(base_layer, "scheme")
+            and getattr(base_layer.scheme, "runner", None) is not None
+        ):
+            # compressed-tensors attaches the MoeRunner to the layer's scheme,
+            # not to quant_method; without this WNA16 models silently fall
+            # back to the Triton runner in auto mode.
+            runner_backend = base_layer.scheme.runner.runner_backend
         else:
             runner_backend = MoeRunnerBackend.TRITON
 
@@ -1112,6 +1120,15 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
         # Use pre-computed quant info (doesn't change so not sure why we need to pass it in every time)
         quant_info = self._quant_info
+
+        # EP: the dispatcher builds its global->local expert mapping lazily on
+        # the first dispatch, so construction-time quant info can miss it.
+        # Refresh here; global_num_experts is the mapping's domain size.
+        if hasattr(quant_info, "expert_map"):
+            expert_map = getattr(base_layer.dispatcher, "local_expert_mapping", None)
+            if expert_map is not None:
+                quant_info.expert_map = expert_map
+                quant_info.global_num_experts = expert_map.numel()
 
         # ===== TO BE REFACTORED ====
         if self._lora_runner_backend.is_experimental_sgl_trtllm():

--- a/python/sglang/srt/lora/lora_moe_runners.py
+++ b/python/sglang/srt/lora/lora_moe_runners.py
@@ -338,6 +338,8 @@ def _add_lora_gate_up_delta(
     if is_gated:
         inter_size = gate_up_b.shape[2] // 2
         lora_a_stacked = [gate_up_a[:, :, :r, :], gate_up_a[:, :, r : 2 * r, :]]
+        # The B halves are also the tuple form the virtual-experts kernel
+        # expects for the gated case (one shrink at K=2*r, two expands at K=r).
         lora_b_stacked = [
             gate_up_b[:, :, :inter_size, :],
             gate_up_b[:, :, inter_size:, :],
@@ -351,7 +353,7 @@ def _add_lora_gate_up_delta(
             output=intermediate_cache,
             hidden_states=hidden_states,
             lora_a=gate_up_a,
-            lora_b=gate_up_b,
+            lora_b=tuple(lora_b_stacked) if is_gated else gate_up_b,
             topk_ids=topk_ids,
             topk_weights=topk_weights,
             token_lora_mapping=token_lora_mapping,


### PR DESCRIPTION
Ports the residual of Kimi 2.5/6 LoRA support (#25141, sglang-miles) that isn't already covered by the #31520–#31525 series or by main's own evolution — the rest of that commit is superseded and intentionally left out.

Three pieces:
- **Gated virtual-experts fix (the important one):** the gated gate_up path passes the full stacked B to `merged_experts_fused_moe_lora_add` while A carries gate+up ranks concatenated (2·r), so gated (SwiGLU) MoE LoRA is numerically wrong on main whenever `lora_use_virtual_experts` is set. The kernel now accepts a length-2 B: one shrink over the full 2·r rank, one expand per half into its own output slice.
- **Runner detection:** compressed-tensors attaches the MoeRunner to the layer's `scheme`, not `quant_method`, so WNA16 models silently fell back to the Triton runner in auto mode.
- **EP expert map:** refresh `quant_info.expert_map`/`global_num_experts` per forward from the dispatcher's lazily-built `local_expert_mapping`, for quant schemes whose `get_marlin_quant_info` doesn't populate them.

Supersedes the kernel half of #28564 (rebased to the moved kernel location under `sglang/kernels/ops/moe/`); the remaining #28564/#28562 content is carried in better form by #31520/#31523/#31524/#31525.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30043811407](https://github.com/sgl-project/sglang/actions/runs/30043811407)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30043810693](https://github.com/sgl-project/sglang/actions/runs/30043810693)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->