### PR TITLE
[CI] Remove redundant Rust cache save-if settings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           workspaces: rust
           shared-key: "rust-workspace-lint"
-          save-if: true
 
       - name: Run pre-commit checks
         run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           workspaces: rust
           shared-key: "rust-workspace-lint"
+          save-if: true
 
       - name: Run pre-commit checks
         run: SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/pr-benchmark-rust.yml
+++ b/.github/workflows/pr-benchmark-rust.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           workspaces: sgl-model-gateway
           shared-key: "rust-cache"
-          save-if: true
           cache-all-crates: true
           cache-on-failure: true
 
@@ -111,7 +110,6 @@ jobs:
           shared-key: "rust-cache"
           cache-all-crates: true
           cache-on-failure: true
-          save-if: true
 
       - name: Run benchmark
         timeout-minutes: 30

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -64,7 +64,6 @@ jobs:
           shared-key: "rust-cache"
           cache-all-crates: true
           cache-on-failure: true
-          save-if: true
 
       - name: Build python binding
         run: |
@@ -154,7 +153,6 @@ jobs:
           shared-key: "rust-cache"
           cache-all-crates: true
           cache-on-failure: true
-          save-if: true
 
       - name: Run lint
         run: |


### PR DESCRIPTION
## Motivation

Remove Rust cache configuration that redundantly restates the `Swatinem/rust-cache@v2` default.

## Modifications

Remove `save-if: true` from four Rust cache steps in `.github/workflows/pr-test-rust.yml` and `.github/workflows/pr-benchmark-rust.yml`.

`save-if` defaults to `true`, so cache restore and save behavior is unchanged. Conditional `save-if` expressions in other workflows remain intact.

## Accuracy Tests

Not applicable; this does not affect model outputs.

## Speed Tests and Profiling

Not applicable; cache behavior is unchanged.

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Unit tests are not applicable to this workflow-only configuration change.
- [x] Documentation updates are not applicable.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Validation

- `pre-commit run check-yaml --files .github/workflows/lint.yml .github/workflows/pr-benchmark-rust.yml .github/workflows/pr-test-rust.yml`
- `uv run --with pyyaml python3 scripts/ci/check_workflow_job_names.py`
- `git diff --check origin/main...HEAD`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30052739710](https://github.com/sgl-project/sglang/actions/runs/30052739710)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30052739547](https://github.com/sgl-project/sglang/actions/runs/30052739547)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->