### PR TITLE
[Bug] [PD][NIXL] Qwen3.5 TP1-attention prefill -> TP4 decode fails in prepXferDlist with NIXL_ERR_NOT_FOUND

### DIFF
--- a/python/sglang/srt/disaggregation/common/staging_buffer.py
+++ b/python/sglang/srt/disaggregation/common/staging_buffer.py
@@ -21,6 +21,10 @@ import torch
 import triton
 import triton.language as tl
 
+# Head-slice math lives in common.utils (pure integer math, no torch/triton) so
+# the direct-slice transfer paths can share it without importing these kernels.
+from sglang.srt.disaggregation.common.utils import compute_head_slice_params
+
 logger = logging.getLogger(__name__)
 
 # TODO(yangminl): remove torch fallback implementations once the Triton kernels
@@ -681,42 +685,6 @@ def scatter_staging_to_kv(
         dst_tp_rank,
         total_kv_heads,
     )
-
-
-def compute_head_slice_params(
-    src_attn_tp_size: int,
-    dst_attn_tp_size: int,
-    src_tp_rank: int,
-    dst_tp_rank: int,
-    total_kv_heads: int,
-) -> Tuple[int, int, int, int]:
-    """Compute head slicing parameters for heterogeneous TP transfer.
-
-    Returns:
-        (src_head_start, num_heads_to_send, dst_head_start, num_heads_to_send)
-    """
-    src_heads_per_rank = max(1, total_kv_heads // src_attn_tp_size)
-    dst_heads_per_rank = max(1, total_kv_heads // dst_attn_tp_size)
-
-    local_tp_rank = src_tp_rank % src_attn_tp_size
-    dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
-
-    if src_attn_tp_size > dst_attn_tp_size:
-        src_head_start = 0
-        num_heads_to_send = src_heads_per_rank
-        src_replication = max(1, src_attn_tp_size // total_kv_heads)
-        unique_head_idx = local_tp_rank // src_replication
-        dst_head_start = (unique_head_idx * src_heads_per_rank) % dst_heads_per_rank
-    else:
-        # GQA replication: consecutive decode ranks share a KV head
-        # (tp_rank // num_kv_head_replicas), so map by integer division not modulo.
-        dst_replication = max(1, dst_attn_tp_size // total_kv_heads)
-        unique_dst_head_idx = dst_tp_rank_in_group // dst_replication
-        src_head_start = (unique_dst_head_idx * dst_heads_per_rank) % src_heads_per_rank
-        num_heads_to_send = dst_heads_per_rank
-        dst_head_start = 0
-
-    return src_head_start, num_heads_to_send, dst_head_start, num_heads_to_send
 
 
 def compute_staging_layout(

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -127,3 +127,43 @@ def group_concurrent_contiguous(
     dst_groups = [g.tolist() for g in dst_groups]
 
     return src_groups, dst_groups
+
+
+def compute_head_slice_params(
+    src_attn_tp_size: int,
+    dst_attn_tp_size: int,
+    src_tp_rank: int,
+    dst_tp_rank: int,
+    total_kv_heads: int,
+) -> Tuple[int, int, int, int]:
+    """Compute head slicing parameters for heterogeneous TP transfer.
+
+    Kept here (pure integer math, no torch/triton) rather than in
+    staging_buffer.py so the direct-slice transfer paths can share it without
+    importing the staging-buffer Triton kernels.
+
+    Returns:
+        (src_head_start, num_heads_to_send, dst_head_start, num_heads_to_send)
+    """
+    src_heads_per_rank = max(1, total_kv_heads // src_attn_tp_size)
+    dst_heads_per_rank = max(1, total_kv_heads // dst_attn_tp_size)
+
+    local_tp_rank = src_tp_rank % src_attn_tp_size
+    dst_tp_rank_in_group = dst_tp_rank % dst_attn_tp_size
+
+    if src_attn_tp_size > dst_attn_tp_size:
+        src_head_start = 0
+        num_heads_to_send = src_heads_per_rank
+        src_replication = max(1, src_attn_tp_size // total_kv_heads)
+        unique_head_idx = local_tp_rank // src_replication
+        dst_head_start = (unique_head_idx * src_heads_per_rank) % dst_heads_per_rank
+    else:
+        # GQA replication: consecutive decode ranks share a KV head
+        # (tp_rank // num_kv_head_replicas), so map by integer division not modulo.
+        dst_replication = max(1, dst_attn_tp_size // total_kv_heads)
+        unique_dst_head_idx = dst_tp_rank_in_group // dst_replication
+        src_head_start = (unique_dst_head_idx * dst_heads_per_rank) % src_heads_per_rank
+        num_heads_to_send = dst_heads_per_rank
+        dst_head_start = 0
+
+    return src_head_start, num_heads_to_send, dst_head_start, num_heads_to_send

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -768,12 +768,29 @@ class NixlKVManager(CommonKVManager):
         else:
             # One prefill rank feeds multiple decode ranks: interleave num_groups
             # head-groups in the src dlist so each decode rank picks its slice.
-            dst_tp_rank_in_group = decode_kv_args.decode_tp_rank % decode_tp_size
-            num_groups = decode_tp_size // prefill_tp_size
-            num_heads_to_send = dst_heads_per_rank
-            src_head_start = (
-                dst_tp_rank_in_group * dst_heads_per_rank
-            ) % src_heads_per_rank
+            #
+            # num_groups is the number of distinct dst-head-groups that fit in
+            # one prefill rank's head span, NOT decode_tp_size // prefill_tp_size.
+            # Under GQA replication (total_kv_heads < decode_tp_size) several
+            # decode ranks share the same KV head, so the source holds fewer
+            # groups than there are decode ranks. Using the tp-size ratio makes
+            # the shared src dlist address past the registered source heads and
+            # fails prep_xfer_dlist with NIXL_ERR_NOT_FOUND.
+            num_groups = max(1, src_heads_per_rank // dst_heads_per_rank)
+            # Reuse the canonical head-slice mapping (integer division under
+            # replication, not modulo) so this direct-slice path stays in sync
+            # with the staging path.
+            from sglang.srt.disaggregation.common.staging_buffer import (
+                compute_head_slice_params,
+            )
+
+            src_head_start, num_heads_to_send, _, _ = compute_head_slice_params(
+                prefill_tp_size,
+                decode_tp_size,
+                self.kv_args.engine_rank,
+                decode_kv_args.decode_tp_rank,
+                total_kv_heads,
+            )
             head_group_idx = src_head_start // dst_heads_per_rank
             dst_head_offset = 0
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -28,6 +28,7 @@ from sglang.srt.disaggregation.common.staging_handler import StagingRegisterInfo
 from sglang.srt.disaggregation.common.utils import (
     FastQueue,
     TransferKVChunk,
+    compute_head_slice_params,
     group_concurrent_contiguous,
     pack_int_lists,
     unpack_int_lists,
@@ -780,10 +781,6 @@ class NixlKVManager(CommonKVManager):
             # Reuse the canonical head-slice mapping (integer division under
             # replication, not modulo) so this direct-slice path stays in sync
             # with the staging path.
-            from sglang.srt.disaggregation.common.staging_buffer import (
-                compute_head_slice_params,
-            )
-
             src_head_start, num_heads_to_send, _, _ = compute_head_slice_params(
                 prefill_tp_size,
                 decode_tp_size,

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -693,6 +693,118 @@ class TestNixlNodeFailure(CustomTestCase):
         self.assertNotIn(9, mgr.request_status)
 
 
+class DlistCaptureAgent:
+    """Records prep_xfer_dlist arrays so tests can inspect the descriptors."""
+
+    def __init__(self):
+        self.calls = []  # list of (peer_name, np.ndarray, mem_kind)
+
+    def prep_xfer_dlist(self, peer_name, array, mem_kind):
+        self.calls.append((peer_name, np.asarray(array), mem_kind))
+        return f"handle_{len(self.calls)}"
+
+
+class TestNixlHeteroTpPrepHandle(CustomTestCase):
+    """Regression guard for issue #31295.
+
+    Prefill attention-TP1 -> decode TP4 with a 2-KV-head model forces GQA
+    replication (two decode ranks share each KV head). The shared source dlist
+    must interleave only as many head-groups as fit in one prefill rank's head
+    span (2), and the per-peer head_group_idx must map replicated decode ranks
+    to the correct source head via integer division. The pre-fix code used
+    ``decode_tp // prefill_tp`` groups (=4) -- addressing 2x past the registered
+    source region, which NIXL rejects with NIXL_ERR_NOT_FOUND -- and a plain
+    modulo head mapping (0,1,0,1 instead of 0,0,1,1).
+    """
+
+    # Model geometry: 2 KV heads, one prefill attn rank holds both, each decode
+    # rank (TP4) holds one replicated head.
+    TOTAL_KV_HEADS = 2
+    DECODE_TP = 4
+    PAGE_SIZE = 1
+    NUM_SLOTS = 4
+    BYTES_PER_HEAD = 128  # head_dim * dtype_size, per token
+    SRC_KV_ITEM_LEN = TOTAL_KV_HEADS * BYTES_PER_HEAD  # both heads on prefill
+    DST_KV_ITEM_LEN = BYTES_PER_HEAD  # one head per decode rank
+    SRC_PTRS = [0x10000, 0x20000]  # K, V for the single local layer
+    REGION_LEN = NUM_SLOTS * SRC_KV_ITEM_LEN
+
+    def _make_manager(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.agent = DlistCaptureAgent()
+        mgr.attn_tp_size = 1  # prefill attention TP = 1 (DP attention)
+        mgr.prep_handle_slice_src = None
+        mgr.prep_handles_slice_dst = {}
+        mgr.kv_args = SimpleNamespace(
+            gpu_id=0,
+            engine_rank=0,
+            page_size=self.PAGE_SIZE,
+            total_kv_head_num=self.TOTAL_KV_HEADS,
+            kv_head_num=self.TOTAL_KV_HEADS,
+            kv_item_lens=[self.SRC_KV_ITEM_LEN, self.SRC_KV_ITEM_LEN],
+            kv_data_ptrs=list(self.SRC_PTRS),
+            kv_data_lens=[self.REGION_LEN, self.REGION_LEN],
+            prefill_start_layer=0,
+        )
+        return mgr
+
+    def _decode_args(self, decode_tp_rank):
+        return SimpleNamespace(
+            agent_name=f"decode_{decode_tp_rank}",
+            decode_tp_size=self.DECODE_TP,
+            decode_tp_rank=decode_tp_rank,
+            dst_kv_item_len=self.DST_KV_ITEM_LEN,
+            dst_kv_ptrs=[0x30000, 0x40000],
+            dst_num_slots=self.NUM_SLOTS,
+            gpu_id=0,
+        )
+
+    def test_src_dlist_stays_within_registered_source_region(self):
+        mgr = self._make_manager()
+
+        mgr._init_hetero_tp_prep_handle("decode_0", self._decode_args(0))
+
+        src_calls = [c for c in mgr.agent.calls if c[0] == ""]
+        self.assertEqual(len(src_calls), 1)
+        _, src_array, _ = src_calls[0]
+
+        # num_groups must match the head-groups that fit in the source, not the
+        # decode/prefill tp ratio.
+        _, num_groups, _, _ = mgr.prep_handle_slice_src
+        self.assertEqual(num_groups, 2)
+
+        # Every descriptor [addr, addr + length) must lie inside the registered
+        # region of the base pointer it belongs to. A too-large num_groups spills
+        # past the region end (the NIXL_ERR_NOT_FOUND crash).
+        for addr, length, _dev in src_array:
+            addr = int(addr)
+            length = int(length)
+            base = max(p for p in self.SRC_PTRS if p <= addr)
+            self.assertLessEqual(
+                addr + length,
+                base + self.REGION_LEN,
+                msg=f"descriptor addr=0x{addr:x} len={length} spills past "
+                f"base=0x{base:x} region end=0x{base + self.REGION_LEN:x}",
+            )
+
+    def test_head_group_idx_maps_replicated_ranks_by_integer_division(self):
+        mgr = self._make_manager()
+
+        # decode_tp=4 with 2 KV heads => replication factor 2, so ranks
+        # (0,1)->head 0 and (2,3)->head 1.
+        expected_head_group = {0: 0, 1: 0, 2: 1, 3: 1}
+        for decode_tp_rank, expected in expected_head_group.items():
+            peer = f"decode_{decode_tp_rank}"
+            mgr._init_hetero_tp_prep_handle(peer, self._decode_args(decode_tp_rank))
+            _handle, _num_slots, head_group_idx = mgr.prep_handles_slice_dst[peer]
+            self.assertEqual(
+                head_group_idx,
+                expected,
+                msg=f"decode rank {decode_tp_rank} should read source head "
+                f"group {expected}, got {head_group_idx}",
+            )
+
+
 class TestNixlStaging(CustomTestCase):
     def _make_manager(self, agent=None):
         mgr = object.__new__(NixlKVManager)


### PR DESCRIPTION
# Issue #31295 — NIXL PD heterogeneous-TP prefill→decode fails in prepXferDlist with NIXL_ERR_NOT_FOUND

## 1. Root cause

Repro config: **prefill attention-TP = 1** (TP4 + DP-attention, so effective
attn_tp per rank is 1), **decode TP = 4** (DP-attention off), model with only
**2 KV heads** (Qwen3.5-A17B). Because `decode_tp (4) > total_kv_heads (2)`, the
decode side uses **GQA KV-head replication**: two consecutive decode ranks share
each physical KV head (ranks 0,1 → head 0; ranks 2,3 → head 1).

The failure is in the NIXL direct-slice path
`NixlKVManager._init_hetero_tp_prep_handle`
(`python/sglang/srt/disaggregation/nixl/conn.py`), specifically the
`prefill_tp <= decode_tp` branch, which builds the shared **source** descriptor
list once via `agent.prep_xfer_dlist("", ...)`. Two defects:

1. **`num_groups = decode_tp_size // prefill_tp_size` (= 4)** — this is the count
   of decode ranks per prefill rank, not the number of distinct head-groups that
   actually exist in one prefill rank's KV region. One prefill rank holds
   `src_heads_per_rank = total_kv_heads // prefill_tp = 2` head-slices, so only
   **2** groups fit. Interleaving 4 groups makes the source dlist address
   `4 × bytes_per_head_slice = 2 ×` the registered per-token source bytes, i.e.
   the descriptors run past the end of the registered KV region. NIXL cannot map
   those descriptors to any registered memory and raises
   `prepXferDlist: failed to prepare the descriptors ... for agent ''`
   → `nixlNotFoundError: NIXL_ERR_NOT_FOUND`. This is the reported crash, and it
   happens at bootstrap time (`_add_remote_peer → _prepare_payload_xfer →
   _init_hetero_tp_prep_handle → prep_xfer_dlist`), before any real transfer.

2. **`src_head_start = (dst_tp_rank_in_group * dst_heads_per_rank) % src_heads_per_rank`**
   uses a plain modulo of the raw decode rank. Under replication this maps decode
   ranks 0,1,2,3 → source heads 0,1,0,1 — wrong, because ranks 0,1 both replicate
   head 0 and ranks 2,3 both replicate head 1 (correct mapping is 0,0,1,1). Even
   if the crash were avoided, decode ranks 1 and 2 would receive the wrong KV
   head — a silent correctness bug.

The canonical head-slice helper `compute_head_slice_params` in
`python/sglang/srt/disaggregation/common/staging_buffer.py` already handles this
correctly for the **staging** path — its comment literally says *"GQA
replication: consecutive decode ranks share a KV head ... map by integer division
not modulo."* The direct-slice path in `conn.py` had drifted and never received
that fix.

Verified numerically (standalone reproduction of the dlist math):
`OLD num_groups=4 → 4 out-of-bounds descriptors`, head mapping `0,1,0,1`;
`NEW num_groups=2 → 0 out-of-bounds`, head mapping `0,0,1,1`.

## 2. The fix and why

In the `prefill_tp <= decode_tp` branch of `_init_hetero_tp_prep_handle`:

- Compute `num_groups = max(1, src_heads_per_rank // dst_heads_per_rank)` — the
  number of dst-head-groups that genuinely fit in one prefill rank's head span.
  When there is no replication (`total_kv_heads >= decode_tp`) this equals the
  old `decode_tp // prefill_tp`, so existing homogeneous/GQA-without-replication
  setups are unchanged; it only differs (and only shrinks) under replication,
  which is exactly the crashing case.
- Reuse the canonical `compute_head_slice_params(...)` to derive `src_head_start`
  and `num_heads_to_send` instead of the local modulo expression. This makes the
  direct-slice path and the staging path share one head-mapping implementation so
  they cannot drift apart again (the root of this bug).

Both `num_groups` and `head_group_idx` are stored together in
`prep_handle_slice_src` / `prep_handles_slice_dst` and consumed by
`send_kvcache_slice` via `expand_page_indices_for_slice`, so the index math on
the send path stays consistent with the corrected dlist geometry automatically.

Scope is intentionally limited to this one branch. The `prefill_tp > decode_tp`
branch already matches `compute_head_slice_params` (uses `src_replication` and
integer division) and is not touched.

## 3. Files changed

- `python/sglang/srt/disaggregation/nixl/conn.py`
  — `_init_hetero_tp_prep_handle`, `prefill_tp <= decode_tp` branch: fix
  `num_groups`; reuse `compute_head_slice_params` for the head mapping.
- `test/registered/unit/disaggregation/test_nixl_backend_basic.py`
  — new `TestNixlHeteroTpPrepHandle` (CPU unit test) guarding both defects.

## 4. Risk / uncertainty

- **Low risk, well-scoped.** For any config without KV-head replication
  (`total_kv_heads >= decode_tp`), the new `num_groups` and `src_head_start` are
  numerically identical to the old code, so those paths are behavior-preserving.
- The correctness of head_group_idx=`0,0,1,1` under replication relies on
  SGLang's KV-head replication assigning consecutive TP ranks to the same head
  (`rank // replication_factor`). This is the same assumption the already-fixed
  staging path (`compute_head_slice_params`) encodes, so the two paths now agree.
- I could not execute the full test suite in this environment (missing runtime
  deps `orjson`/`torch`), so the NIXL agent path was not exercised end-to-end on
  real hardware. The dlist/head math the test asserts was verified independently
  with a standalone numpy reproduction (see §1) and both changed files
  byte-compile cleanly.

## 5. How I verified it

1. Traced the crash from the issue's stack trace to
   `_init_hetero_tp_prep_handle`'s `prep_xfer_dlist("", ...)` and identified the
   over-counted `num_groups` as the source of out-of-bounds descriptors.
2. Cross-checked against the canonical `compute_head_slice_params`, whose comment
   documents the exact integer-division-vs-modulo fix that the direct-slice path
   was missing.
3. Standalone numpy reproduction of the source-dlist construction for the
   reported config (2 KV heads, prefill_tp=1, decode_tp=4): confirmed the old
   formula yields `num_groups=4` with 4 descriptors addressing past the
   registered region, and the fix yields `num_groups=2` with zero out-of-bounds
   descriptors and the correct `0,0,1,1` head mapping.
4. Added `TestNixlHeteroTpPrepHandle` which drives the real
   `_init_hetero_tp_prep_handle` with a descriptor-capturing fake agent and
   asserts (a) `num_groups == 2`, (b) every source descriptor
   `[addr, addr+len)` lies inside its base pointer's registered region, and
   (c) `head_group_idx` maps decode ranks 0,1,2,3 → 0,0,1,1. These assertions
   fail on the pre-fix code (num_groups=4 spills the region; modulo gives
   0,1,0,1) and pass on the fixed code.
5. `python3 -m py_compile` on both changed files — clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30397893068](https://github.com/sgl-project/sglang/actions/runs/30397893068)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30397892782](https://github.com/sgl-project/sglang/actions/runs/30397892782)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->