### PR TITLE
[WIP][MLX][Spec] Add Gemma 4 Frozen-KV MTP on Apple Silicon

### DIFF
--- a/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
+++ b/docs_new/cookbook/autoregressive/Google/Gemma4.mdx
@@ -183,6 +183,14 @@ sglang serve --model-path google/gemma-4-26B-A4B-it \
 
 Each Gemma 4 variant ships with a paired `*-assistant` draft model for NEXTN multi-token prediction. Use the commands below to enable MTP for the corresponding target model. These match the configuration generated when you toggle **Speculative Decoding (MTP) → Enabled** in the [interactive selector](#3-1-basic-configuration).
 
+<Note>
+The commands in this section describe the GPU implementation. Apple Silicon
+currently has a separate experimental E2B-only path with one-token drafting,
+pinned MLX checkpoints, and stricter native-cache limits. Follow the
+[Apple Silicon Gemma 4 MTP guide](/docs/hardware-platforms/apple_metal#experimental-gemma-4-frozen-kv-mtp)
+instead of using the commands below on a Mac.
+</Note>
+
 ```bash Command
 # Gemma 4 E2B + MTP
 sglang serve \

--- a/docs_new/docs/advanced_features/speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/speculative_decoding.mdx
@@ -395,6 +395,14 @@ print(response.choices[0].message.content)
 
 We support [MTP (Multi-Token Prediction)](https://arxiv.org/pdf/2404.19737) in SGLang by using speculative decoding. We use `XiaomiMiMo/MiMo-7B-RL` as an example here (for DeepSeek MTP usage, refer to [DeepSeek-V3.2 cookbook §4.2.3](/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2#4-2-3-multi-token-prediction-eagle-speculative-decoding)).
 
+<Note>
+Gemma 4 E2B also has an experimental, one-token Frozen-KV MTP path on Apple
+Silicon. It uses fixed native-cache guardrails and a separately pinned
+assistant checkpoint, so do not adapt the CUDA-oriented example below. Follow
+the [Apple Silicon Gemma 4 MTP guide](/docs/hardware-platforms/apple_metal#experimental-gemma-4-frozen-kv-mtp)
+for its exact command, limitations, and activation checks.
+</Note>
+
 ```bash Command
 python3 -m sglang.launch_server \
     --model XiaomiMiMo/MiMo-7B-RL \

--- a/docs_new/docs/hardware-platforms/apple_metal.mdx
+++ b/docs_new/docs/hardware-platforms/apple_metal.mdx
@@ -87,6 +87,133 @@ The MLX backend supports two quantization paths on Apple Silicon:
    ```
    The MLX backend silently ignores `--quantization mlx_q4` when the model is already quantized in its HF config (path 1), so the same flag is safe to pass either way.
 
+## Experimental Gemma 4 Frozen-KV MTP
+
+SGLang includes a correctness-first Frozen-KV MTP prototype for Gemma 4 on
+Apple Silicon. The assistant proposes one token, and the target model verifies
+it before SGLang emits any output. Greedy output token IDs therefore remain
+identical to target-only decoding.
+
+<Warning>
+This Level 1 prototype is experimental, E2B-only, and not production-ready. It
+does not claim a throughput improvement. Batching, overlap scheduling,
+radix/prefix reuse, paged KV cache, and performance work remain gated behind
+later correctness milestones.
+</Warning>
+
+### Prerequisites
+
+Use macOS on Apple Silicon and install SGLang from source with the `all_mps`
+extra shown above. Gemma 4 MTP requires the pinned assistant provider:
+
+```bash
+uv pip install "mlx-vlm==0.5.0"
+```
+
+The tested model pair is:
+
+- Target: `mlx-community/gemma-4-e2b-it-4bit` at revision
+  `238767527555cb75a05732a84dff5d6ba0dd6809`
+- Assistant: `mlx-community/gemma-4-E2B-it-assistant-bf16` at revision
+  `a7770799b560135ebdbfae8b7f468947415003bc`
+
+### Launch the server
+
+Use the complete command below to preserve the validated Level 1
+configuration:
+
+```bash
+SGLANG_USE_MLX=1 python -m sglang.launch_server \
+  --model-path mlx-community/gemma-4-e2b-it-4bit \
+  --revision 238767527555cb75a05732a84dff5d6ba0dd6809 \
+  --speculative-algorithm FROZEN_KV_MTP \
+  --speculative-draft-model-path mlx-community/gemma-4-E2B-it-assistant-bf16 \
+  --speculative-draft-model-revision a7770799b560135ebdbfae8b7f468947415003bc \
+  --speculative-num-steps 1 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 2 \
+  --disable-radix-cache \
+  --disable-overlap-schedule \
+  --chunked-prefill-size -1 \
+  --max-running-requests 1 \
+  --context-length 2048 \
+  --max-total-tokens 2048 \
+  --host 127.0.0.1 \
+  --port 30000
+```
+
+Do not add `--language-only`. The MLX Gemma 4 path already disables
+multimodal execution; `--language-only` configures encoder disaggregation and
+is not supported for this model.
+
+### Send a greedy request
+
+Every request must set `temperature` to `0` explicitly. For the native API:
+
+```bash
+curl -s http://127.0.0.1:30000/generate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "text": "Explain why the sky appears blue in two sentences.",
+    "sampling_params": {
+      "temperature": 0,
+      "max_new_tokens": 16
+    }
+  }' | jq '{
+    output_ids,
+    speculative: (.meta_info | {
+      spec_num_correct_drafts,
+      spec_num_proposed_drafts,
+      spec_correct_drafts_histogram
+    })
+  }'
+```
+
+For a non-streaming OpenAI chat request, set `return_meta_info: true` to expose
+the exact generated IDs as `choices[0].output_token_ids` and the same
+per-request speculative counters under `choices[0].meta_info`. This extension
+does not enable logprobs.
+
+### Verify that MTP is active
+
+Inspect the worker state after a request:
+
+```bash
+curl -s http://127.0.0.1:30000/server_info \
+  | jq '.internal_states[0].speculative_worker'
+```
+
+An active MTP run reports
+`implementation: "mlx_gemma4_frozen_kv_mtp"`, with positive
+`proposed_tokens` and `verified_tokens`. The response also includes accepted
+draft counts, target/assistant timing, the assistant fingerprint and load
+count, request lifecycle counts, and MLX active/cache/peak memory. After a
+request finishes or is aborted, `active_request_count`, `native_request_count`,
+and `assistant_request_binding_count` must return to zero.
+
+`POST /flush_cache` clears request state and bindings but retains the assistant
+weights. You can confirm this by checking that `assistant_fingerprint` and
+`assistant_load_count` do not change across the flush.
+
+### Level 1 restrictions
+
+The server rejects unsupported configurations before loading assistant weights
+and rejects unsupported request features before mutating target cache state.
+Keep all of these constraints in place:
+
+- Text-only Gemma 4 E2B with the exact matching assistant; E4B, 12B, 31B,
+  26B-A4B, and multimodal inputs are unsupported.
+- Greedy decoding only, with one proposal, one draft step, top-k 1, and verify
+  width 2. Requests must use `temperature=0` and `n=1`.
+- One running request on one Apple host. TP, DP, PP, DP attention,
+  disaggregation, sessions, and LoRA are unsupported.
+- Context length and `max_total_tokens` no greater than 2,048.
+- Synchronous scheduling with radix cache, overlap scheduling, chunked
+  prefill, and mixed chunked prefill disabled.
+- No sampling or repetition penalties, `min_new_tokens`, logit bias, logprobs,
+  grammar/structured output, custom logits processors, returned hidden states,
+  or returned sampling masks.
+
 ## Benchmarking with Requests
 
 `sglang.benchmark_one_batch` calls the synchronous prefill/decode methods directly without going through the scheduler and the overlap code path.

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -142,6 +142,7 @@ diffusion_musa = [
 srt_mps = [
     "mlx",
     "mlx-lm",
+    "mlx-vlm==0.5.0",
     "sglang[runtime_common]",
     "torch==2.11.0",
     "torchao==0.9.0",

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -584,6 +584,7 @@ class _MlxBenchRunner:
         # standalone bench mode where no scheduler is present.
         init_kwargs = dict(
             model_path=server_args.model_path,
+            revision=server_args.revision,
             trust_remote_code=server_args.trust_remote_code,
             disable_radix_cache=True,
             mem_fraction_static=server_args.mem_fraction_static,

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -57,6 +57,7 @@ from sglang.srt.utils.common import (
     is_xpu,
     xpu_has_xmx_support,
 )
+from sglang.srt.utils.tensor_bridge import use_mlx
 
 logger = logging.getLogger(__name__)
 
@@ -707,7 +708,12 @@ def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
 )
 def _gemma4_overrides(server_args: Any, hf_config: Any) -> dict:
     overrides: Dict[str, Any] = {}
-    default_attention_backend = "trtllm_mha" if is_sm100_supported() else "triton"
+    if use_mlx():
+        # The MLX runner owns attention execution; torch_native keeps generic
+        # scheduler allocation on its portable PyTorch path.
+        default_attention_backend = "torch_native"
+    else:
+        default_attention_backend = "trtllm_mha" if is_sm100_supported() else "triton"
     if server_args.is_attention_backend_not_set():
         logger.info(
             f"Use {default_attention_backend} as default attention backend for Gemma4"

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -5,6 +5,8 @@ import logging
 import os
 from typing import TYPE_CHECKING, Optional
 
+from sglang.srt.utils.tensor_bridge import use_mlx
+
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
 
@@ -25,22 +27,51 @@ def _resolve_speculative_algorithm_alias(
     speculative_algorithm: Optional[str],
     speculative_draft_model_path: Optional[str],
     trust_remote_code: bool = False,
-    kwargs: Optional[dict] = {},
+    kwargs: Optional[dict] = None,
+    speculative_draft_model_revision: Optional[str] = None,
 ) -> Optional[str]:
     """Resolve CLI speculative algorithm; NEXTN/EAGLE may become FROZEN_KV_MTP for Gemma4 assistant drafts."""
 
     is_gemma4_draft = False
     if speculative_draft_model_path:
-        from sglang.srt.utils.hf_transformers_utils import get_config
+        kwargs = dict(kwargs or {})
+        # Transformers does not know ``gemma4_assistant`` yet.  Read its JSON
+        # metadata through the MLX-local parser before falling back to the
+        # generic AutoConfig path used by every other draft model.
+        try:
+            from sglang.srt.hardware_backend.mlx.spec_config import (
+                is_gemma4_assistant_config,
+                load_assistant_config_dict,
+            )
 
-        cfg = get_config(
-            speculative_draft_model_path, trust_remote_code=trust_remote_code, **kwargs
-        )
-        draft_archs = getattr(cfg, "architectures", None) or []
-        is_gemma4_draft = any(
-            arch in ("Gemma4AssistantForCausalLM", "Gemma4UnifiedAssistantForCausalLM")
-            for arch in draft_archs
-        )
+            raw_config = load_assistant_config_dict(
+                speculative_draft_model_path,
+                revision=speculative_draft_model_revision,
+                configuration_file=kwargs.get("_configuration_file"),
+            )
+            is_gemma4_draft = is_gemma4_assistant_config(raw_config)
+        except ValueError:
+            is_gemma4_draft = False
+
+        if not is_gemma4_draft:
+            from sglang.srt.utils.hf_transformers_utils import get_config
+
+            if speculative_draft_model_revision is not None:
+                kwargs.setdefault("revision", speculative_draft_model_revision)
+            cfg = get_config(
+                speculative_draft_model_path,
+                trust_remote_code=trust_remote_code,
+                **kwargs,
+            )
+            draft_archs = getattr(cfg, "architectures", None) or []
+            is_gemma4_draft = any(
+                arch
+                in (
+                    "Gemma4AssistantForCausalLM",
+                    "Gemma4UnifiedAssistantForCausalLM",
+                )
+                for arch in draft_archs
+            )
 
     if speculative_algorithm == "EAGLE3" and is_gemma4_draft:
         raise ValueError(
@@ -100,6 +131,7 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
         server_args.speculative_draft_model_path,
         trust_remote_code=server_args.trust_remote_code,
         kwargs=kwargs,
+        speculative_draft_model_revision=(server_args.speculative_draft_model_revision),
     )
 
     # Validate --speculative-draft-window-size once, regardless of algorithm.
@@ -475,6 +507,30 @@ def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
 
 
 def _handle_frozen_kv_mtp(server_args: ServerArgs) -> None:
+    if use_mlx():
+        if not server_args.disable_overlap_schedule:
+            server_args.disable_overlap_schedule = True
+            logger.warning(
+                "MLX Frozen-KV MTP forces synchronous scheduling; disabling "
+                "overlap scheduling."
+            )
+        if server_args.max_running_requests is None:
+            server_args.max_running_requests = 1
+            logger.warning("MLX Frozen-KV MTP defaults --max-running-requests to 1.")
+        if server_args.speculative_eagle_topk is None:
+            server_args.speculative_eagle_topk = 1
+        if server_args.speculative_num_steps is None:
+            server_args.speculative_num_steps = 1
+        if server_args.speculative_num_draft_tokens is None:
+            server_args.speculative_num_draft_tokens = 2
+
+        from sglang.srt.hardware_backend.mlx.spec_config import (
+            validate_mlx_frozen_kv_mtp_args,
+        )
+
+        validate_mlx_frozen_kv_mtp_args(server_args)
+        return
+
     if server_args.max_running_requests is None:
         server_args.max_running_requests = 48
         logger.warning(

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -38,6 +38,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     get_sparse_attention_config,
 )
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
+from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
@@ -308,6 +309,15 @@ class ModelConfig:
         )
 
         # Set enable_multimodal
+        model_arch = self.hf_config.architectures[0]
+        is_mlx_text_only_model = (
+            use_mlx() and model_arch == "Gemma4ForConditionalGeneration"
+        )
+        if is_mlx_text_only_model and enable_multimodal:
+            raise NotImplementedError(
+                "Gemma 4 multimodal inputs are not supported by the MLX backend yet. "
+                "Remove --enable-multimodal to use the text-only prototype."
+            )
         if enable_multimodal is None:
             mm_disabled_models = [
                 "Gemma3ForConditionalGeneration",
@@ -315,8 +325,15 @@ class ModelConfig:
                 "Step3VLForConditionalGeneration",
                 "InklingForConditionalGeneration",
             ]
-            if (
-                self.hf_config.architectures[0] in mm_disabled_models
+            if is_mlx_text_only_model:
+                enable_multimodal = False
+                logger.info(
+                    "Multimodal is disabled for %s on the MLX backend; "
+                    "the initial Gemma 4 Apple Silicon path is text-only.",
+                    self.hf_config.model_type,
+                )
+            elif (
+                model_arch in mm_disabled_models
                 and self.model_impl != ModelImpl.TRANSFORMERS
             ):
                 enable_multimodal = False

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1056,6 +1056,7 @@ class ChatCompletionResponseChoice(BaseModel):
     matched_stop: Union[None, int, str] = None
     hidden_states: Optional[object] = None
     prompt_token_ids: Optional[List[int]] = None
+    output_token_ids: Optional[List[int]] = None
     meta_info: Optional[Dict[str, Any]] = None
 
     @model_serializer(mode="wrap")
@@ -1065,6 +1066,8 @@ class ChatCompletionResponseChoice(BaseModel):
             data.pop("hidden_states", None)
         if self.prompt_token_ids is None:
             data.pop("prompt_token_ids", None)
+        if self.output_token_ids is None:
+            data.pop("output_token_ids", None)
         if self.meta_info is None:
             data.pop("meta_info", None)
         return data

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1546,6 +1546,9 @@ class OpenAIServingChat(OpenAIServingBase):
             choice_meta_info = (
                 ret_item["meta_info"] if request.return_meta_info else None
             )
+            choice_output_token_ids = (
+                ret_item.get("output_ids") if request.return_meta_info else None
+            )
             # NOTE: content should not be None but empty string to make sure retokenize consistency.
             reasoning_text, tool_calls = self._get_parsed_response_fields(
                 reasoning_text, tool_calls
@@ -1568,6 +1571,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 ),
                 hidden_states=hidden_states,
                 prompt_token_ids=choice_prompt_token_ids,
+                output_token_ids=choice_output_token_ids,
                 meta_info=choice_meta_info,
             )
             choices.append(choice_data)

--- a/python/sglang/srt/hardware_backend/mlx/gemma4_mtp.py
+++ b/python/sglang/srt/hardware_backend/mlx/gemma4_mtp.py
@@ -1,0 +1,664 @@
+"""Gemma 4 assistant loading, lifecycle, and read-only target-KV sharing.
+
+The MVP uses ``mlx-vlm==0.5.0`` as the narrow assistant provider.  All
+provider details stay behind :class:`Gemma4MTPAssistantRuntime`; scheduler and
+worker code see only generation-bound seeds, request-bound KV views, and a
+single ``propose_one`` operation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from sglang.srt.hardware_backend.mlx.model_adapter import MlxTargetSeed
+from sglang.srt.hardware_backend.mlx.spec_config import load_assistant_config_dict
+
+logger = logging.getLogger(__name__)
+
+_ASSISTANT_MODEL_TYPES = frozenset({"gemma4_assistant"})
+_ASSISTANT_ARCHITECTURES = frozenset(
+    {"Gemma4AssistantForCausalLM", "Gemma4UnifiedAssistantForCausalLM"}
+)
+_TARGET_MODEL_TYPES = frozenset({"gemma4", "gemma4_text"})
+_LAYER_TYPES = frozenset({"sliding_attention", "full_attention"})
+
+
+def _text_target(model: Any) -> tuple[Any, Any, Any]:
+    causal = getattr(model, "language_model", model)
+    backbone = getattr(causal, "model", None)
+    args = getattr(causal, "args", None) or getattr(backbone, "config", None)
+    if backbone is None or args is None:
+        raise TypeError("expected an mlx-lm Gemma 4 text target")
+    model_type = getattr(causal, "model_type", None) or getattr(
+        args, "model_type", None
+    )
+    if model_type not in _TARGET_MODEL_TYPES:
+        raise ValueError(
+            f"Gemma 4 MTP target family must be one of {sorted(_TARGET_MODEL_TYPES)}; "
+            f"got {model_type!r}"
+        )
+    return causal, backbone, args
+
+
+def _reject_remote_hooks(config: Mapping[str, Any], prefix: str = "config") -> None:
+    for key, value in config.items():
+        path = f"{prefix}.{key}"
+        if key in {"auto_map", "model_file"} and value not in (None, {}, [], ""):
+            raise ValueError(
+                f"Gemma 4 assistant custom/remote code hook {path!r} is not allowed"
+            )
+        if isinstance(value, Mapping):
+            _reject_remote_hooks(value, path)
+
+
+@dataclass(frozen=True)
+class Gemma4MTPAssistantMetadata:
+    model_type: str
+    architecture: str
+    target_family: str
+    vocab_size: int
+    backbone_hidden_size: int
+    assistant_hidden_size: int
+    num_hidden_layers: int
+    layer_types: tuple[str, ...]
+    tie_word_embeddings: bool
+    use_ordered_embeddings: bool
+    num_centroids: int
+    centroid_intermediate_top_k: int
+    sliding_window: int
+    head_dim: int
+    global_head_dim: int
+    num_key_value_heads: int
+    num_global_key_value_heads: int | None
+    final_logit_softcapping: float | None
+
+    def head_dim_for(self, layer_type: str) -> int:
+        return self.global_head_dim if layer_type == "full_attention" else self.head_dim
+
+
+def validate_gemma4_assistant_config(
+    config: Mapping[str, Any], target_model: Any
+) -> Gemma4MTPAssistantMetadata:
+    """Validate provider-independent assistant/target compatibility."""
+
+    _reject_remote_hooks(config)
+    model_type = str(config.get("model_type", ""))
+    if model_type not in _ASSISTANT_MODEL_TYPES:
+        raise ValueError("assistant model_type must be 'gemma4_assistant'")
+
+    architectures = tuple(config.get("architectures") or ())
+    if len(architectures) != 1 or architectures[0] not in _ASSISTANT_ARCHITECTURES:
+        raise ValueError(
+            "assistant architecture must be Gemma4AssistantForCausalLM "
+            "(or the explicit Gemma4UnifiedAssistantForCausalLM compatibility alias)"
+        )
+    text = config.get("text_config")
+    if not isinstance(text, Mapping):
+        raise ValueError("assistant config requires a text_config object")
+    if text.get("model_type") != "gemma4_text":
+        raise ValueError("assistant text_config.model_type must be 'gemma4_text'")
+
+    causal, _backbone, target = _text_target(target_model)
+    target_layers = tuple(getattr(target, "layer_types", ()) or ())
+    layer_types = tuple(text.get("layer_types") or ())
+    num_layers = int(text.get("num_hidden_layers", -1))
+    if num_layers <= 0 or len(layer_types) != num_layers:
+        raise ValueError("assistant layer_types must match num_hidden_layers")
+    if any(layer_type not in _LAYER_TYPES for layer_type in layer_types):
+        raise ValueError("assistant contains an unsupported attention layer type")
+    if (
+        len(target_layers) < num_layers
+        or tuple(target_layers[-num_layers:]) != layer_types
+    ):
+        raise ValueError(
+            "assistant sliding/full layer layout must match the target's final tail"
+        )
+
+    vocab_size = int(text.get("vocab_size", -1))
+    target_vocab = int(getattr(target, "vocab_size", -1))
+    if vocab_size <= 0 or vocab_size != target_vocab:
+        raise ValueError(
+            f"assistant vocab_size {vocab_size} does not match target {target_vocab}"
+        )
+    backbone_hidden = int(config.get("backbone_hidden_size", -1))
+    target_hidden = int(getattr(target, "hidden_size", -1))
+    if backbone_hidden <= 0 or backbone_hidden != target_hidden:
+        raise ValueError(
+            "assistant backbone_hidden_size must match the target hidden_size"
+        )
+    assistant_hidden = int(text.get("hidden_size", -1))
+    if assistant_hidden <= 0:
+        raise ValueError("assistant hidden_size must be positive")
+
+    tie = bool(config.get("tie_word_embeddings", False))
+    if tie != bool(text.get("tie_word_embeddings", tie)):
+        raise ValueError(
+            "top-level and text assistant tied-embedding metadata disagree"
+        )
+    if tie != bool(getattr(causal, "tie_word_embeddings", True)):
+        raise ValueError("target and assistant tied-embedding settings must match")
+    if int(text.get("num_kv_shared_layers", 0)) != num_layers:
+        raise ValueError("every assistant layer must be query-only/KV-shared")
+
+    head_dim = int(text.get("head_dim", -1))
+    global_head_dim = int(text.get("global_head_dim", head_dim))
+    if head_dim != int(getattr(target, "head_dim", -1)):
+        raise ValueError("assistant sliding-attention head_dim does not match target")
+    if global_head_dim != int(getattr(target, "global_head_dim", head_dim)):
+        raise ValueError("assistant full-attention head_dim does not match target")
+    sliding_window = int(text.get("sliding_window", -1))
+    if sliding_window != int(getattr(target, "sliding_window", -1)):
+        raise ValueError("assistant sliding_window does not match target")
+
+    ordered = bool(config.get("use_ordered_embeddings", False))
+    centroids = int(config.get("num_centroids", 0))
+    centroid_topk = int(config.get("centroid_intermediate_top_k", 0))
+    if ordered:
+        if centroids <= 0 or vocab_size % centroids:
+            raise ValueError(
+                "ordered assistant vocabulary must be divisible by num_centroids"
+            )
+        if centroid_topk <= 0 or centroid_topk > centroids:
+            raise ValueError(
+                "centroid_intermediate_top_k must be in [1, num_centroids]"
+            )
+    elif centroids < 0 or centroid_topk < 0:
+        raise ValueError("centroid metadata cannot be negative")
+
+    return Gemma4MTPAssistantMetadata(
+        model_type=model_type,
+        architecture=architectures[0],
+        target_family=str(getattr(causal, "model_type", "gemma4_text")),
+        vocab_size=vocab_size,
+        backbone_hidden_size=backbone_hidden,
+        assistant_hidden_size=assistant_hidden,
+        num_hidden_layers=num_layers,
+        layer_types=layer_types,
+        tie_word_embeddings=tie,
+        use_ordered_embeddings=ordered,
+        num_centroids=centroids,
+        centroid_intermediate_top_k=centroid_topk,
+        sliding_window=sliding_window,
+        head_dim=head_dim,
+        global_head_dim=global_head_dim,
+        num_key_value_heads=int(text.get("num_key_value_heads", 1)),
+        num_global_key_value_heads=(
+            None
+            if text.get("num_global_key_value_heads") is None
+            else int(text["num_global_key_value_heads"])
+        ),
+        final_logit_softcapping=(
+            None
+            if text.get("final_logit_softcapping") is None
+            else float(text["final_logit_softcapping"])
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class Gemma4MTPKVSharingPlan:
+    """Assistant layer -> target logical owner -> compact cache index."""
+
+    assistant_layer_types: tuple[str, ...]
+    target_logical_layers: tuple[int, ...]
+    target_owner_layers: tuple[int, ...]
+    compact_cache_indices: tuple[int, ...]
+    compact_owner_layers: tuple[int, ...]
+
+    @classmethod
+    def from_target(
+        cls, target_model: Any, metadata: Gemma4MTPAssistantMetadata
+    ) -> Gemma4MTPKVSharingPlan:
+        _causal, backbone, target = _text_target(target_model)
+        layers = tuple(backbone.layers)
+        target_types = tuple(getattr(target, "layer_types", ()) or ())
+        if len(layers) != len(target_types):
+            raise ValueError("target layer metadata cardinality is inconsistent")
+        if tuple(target_types[-metadata.num_hidden_layers :]) != metadata.layer_types:
+            raise ValueError("assistant layout is not the target's final layer tail")
+
+        previous = tuple(getattr(backbone, "previous_kvs", ()))
+        if len(previous) != len(layers):
+            raise ValueError("target does not expose complete YOCO owner metadata")
+        compact_owners = tuple(
+            index
+            for index, layer in enumerate(layers)
+            if bool(getattr(layer.self_attn, "has_kv", True))
+        )
+        owner_to_compact = {owner: index for index, owner in enumerate(compact_owners)}
+
+        logical_layers: list[int] = []
+        owner_layers: list[int] = []
+        compact_indices: list[int] = []
+        for layer_type in metadata.layer_types:
+            candidates = [
+                index for index, value in enumerate(target_types) if value == layer_type
+            ]
+            if not candidates:
+                raise ValueError(f"target has no {layer_type!r} layer for assistant")
+            logical = candidates[-1]
+            owner = int(previous[logical])
+            if owner < 0 or owner >= len(layers):
+                raise ValueError("target YOCO owner is out of range")
+            if int(previous[owner]) != owner:
+                raise ValueError("nested/shared YOCO owners are not supported")
+            if target_types[owner] != layer_type:
+                raise ValueError("target YOCO owner changes the attention layer type")
+            if owner not in owner_to_compact:
+                raise ValueError("target YOCO owner has no compact native cache entry")
+            logical_layers.append(logical)
+            owner_layers.append(owner)
+            compact_indices.append(owner_to_compact[owner])
+
+        return cls(
+            assistant_layer_types=metadata.layer_types,
+            target_logical_layers=tuple(logical_layers),
+            target_owner_layers=tuple(owner_layers),
+            compact_cache_indices=tuple(compact_indices),
+            compact_owner_layers=compact_owners,
+        )
+
+    @property
+    def expected_cache_entries(self) -> int:
+        return len(self.compact_owner_layers)
+
+
+class _RuntimeToken:
+    def __init__(self, runtime: Gemma4MTPAssistantRuntime, request_id: str):
+        self.runtime = runtime
+        self.generation = runtime.generation
+        self.request_id = request_id
+        self.active = True
+
+    def validate(self) -> None:
+        self.runtime._validate_generation(self.generation)
+        if not self.active:
+            raise RuntimeError(
+                f"stale Gemma 4 MTP request binding for {self.request_id!r}"
+            )
+
+    def invalidate(self) -> None:
+        self.active = False
+
+
+class Gemma4MTPKVView:
+    """Generation- and request-bound read-only view over compact native caches."""
+
+    def __init__(
+        self,
+        token: _RuntimeToken,
+        cache: Sequence[Any],
+        plan: Gemma4MTPKVSharingPlan,
+        metadata: Gemma4MTPAssistantMetadata,
+    ):
+        if len(cache) != plan.expected_cache_entries:
+            raise ValueError(
+                "native target cache cardinality does not match the KV sharing plan: "
+                f"{len(cache)} != {plan.expected_cache_entries}"
+            )
+        self._token = token
+        self._cache = tuple(cache)
+        self._plan = plan
+        self._metadata = metadata
+
+    @property
+    def request_id(self) -> str:
+        return self._token.request_id
+
+    @property
+    def position(self) -> int:
+        self._token.validate()
+        offsets = {int(entry.offset) for entry in self._cache}
+        if len(offsets) != 1:
+            raise RuntimeError(
+                f"native target cache offsets disagree: {sorted(offsets)}"
+            )
+        return offsets.pop()
+
+    @staticmethod
+    def _logical_kv(entry: Any) -> tuple[mx.array, mx.array]:
+        keys = getattr(entry, "keys", None)
+        values = getattr(entry, "values", None)
+        if keys is None or values is None:
+            raise RuntimeError("assistant cannot bind an empty target KV cache")
+        offset = int(entry.offset)
+        if hasattr(entry, "_temporal_order"):
+            keys = entry._temporal_order(keys)
+            values = entry._temporal_order(values)
+            valid = min(offset, int(entry.max_size))
+            keys = keys[..., -valid:, :] if valid else keys[..., :0, :]
+            values = values[..., -valid:, :] if valid else values[..., :0, :]
+            # Provider masks index K/V positions from zero while RoPE uses the
+            # absolute query offset.  Restore absolute positions with a zero
+            # prefix; its mask hides the prefix and exposes only the window.
+            padding = offset - valid
+            if padding > 0:
+                k_pad = mx.zeros(
+                    (*keys.shape[:-2], padding, keys.shape[-1]), keys.dtype
+                )
+                v_pad = mx.zeros(
+                    (*values.shape[:-2], padding, values.shape[-1]), values.dtype
+                )
+                keys = mx.concatenate((k_pad, keys), axis=-2)
+                values = mx.concatenate((v_pad, values), axis=-2)
+            return keys, values
+        return keys[..., :offset, :], values[..., :offset, :]
+
+    def shared_kv_states(self) -> dict[str, tuple[mx.array, mx.array]]:
+        self._token.validate()
+        shared: dict[str, tuple[mx.array, mx.array]] = {}
+        for layer_type, cache_index in zip(
+            self._plan.assistant_layer_types, self._plan.compact_cache_indices
+        ):
+            if cache_index < 0 or cache_index >= len(self._cache):
+                raise RuntimeError(
+                    "KV sharing plan contains an out-of-range cache index"
+                )
+            if layer_type in shared:
+                continue
+            keys, values = self._logical_kv(self._cache[cache_index])
+            expected_dim = self._metadata.head_dim_for(layer_type)
+            if keys.shape[-1] != expected_dim or values.shape[-1] != expected_dim:
+                raise ValueError(
+                    f"{layer_type} target KV head width does not match assistant: "
+                    f"K={keys.shape[-1]}, V={values.shape[-1]}, expected={expected_dim}"
+                )
+            shared[layer_type] = (keys, values)
+        return shared
+
+
+class Gemma4MTPProposerSeed:
+    def __init__(self, token: _RuntimeToken, target_seed: MlxTargetSeed):
+        self._token = token
+        self.target_seed = target_seed
+
+    @property
+    def request_id(self) -> str:
+        return self._token.request_id
+
+    def validate(self) -> None:
+        self._token.validate()
+
+
+class Gemma4MTPModelHandle:
+    """Guarded model handle; retained handles cannot use unloaded weights."""
+
+    def __init__(self, runtime: Gemma4MTPAssistantRuntime):
+        self._runtime = runtime
+
+    @property
+    def fingerprint(self) -> str:
+        self._runtime._validate_generation(self._runtime.generation)
+        return self._runtime.fingerprint
+
+
+class Gemma4MTPAssistantRuntime:
+    """Provider-independent, generation-checked one-token assistant runtime."""
+
+    def __init__(
+        self,
+        *,
+        owner: Gemma4MTPAssistantLoader,
+        generation: int,
+        model: Any,
+        metadata: Gemma4MTPAssistantMetadata,
+        sharing_plan: Gemma4MTPKVSharingPlan,
+        fingerprint: str,
+        checkpoint: str,
+        revision: str | None,
+    ):
+        self._owner = owner
+        self.generation = generation
+        self._model = model
+        self.metadata = metadata
+        self.sharing_plan = sharing_plan
+        self.fingerprint = fingerprint
+        self.checkpoint = checkpoint
+        self.revision = revision
+        self._active = True
+        self._request_tokens: dict[str, list[_RuntimeToken]] = {}
+        self.model_handle = Gemma4MTPModelHandle(self)
+
+    def _validate_generation(self, generation: int) -> None:
+        if (
+            not self._active
+            or generation != self.generation
+            or self._owner.generation != self.generation
+            or self._owner.runtime is not self
+        ):
+            raise RuntimeError(
+                f"stale Gemma 4 MTP runtime generation {generation}; "
+                f"current generation is {self._owner.generation}"
+            )
+
+    def _new_token(self, request_id: str) -> _RuntimeToken:
+        self._validate_generation(self.generation)
+        token = _RuntimeToken(self, request_id)
+        self._request_tokens.setdefault(request_id, []).append(token)
+        return token
+
+    def bind_request(self, request_id: str, cache: Sequence[Any]) -> Gemma4MTPKVView:
+        return Gemma4MTPKVView(
+            self._new_token(request_id), cache, self.sharing_plan, self.metadata
+        )
+
+    def bind_seed(
+        self, request_id: str, target_seed: MlxTargetSeed
+    ) -> Gemma4MTPProposerSeed:
+        return Gemma4MTPProposerSeed(self._new_token(request_id), target_seed)
+
+    def release_request(self, request_id: str) -> None:
+        for token in self._request_tokens.pop(request_id, ()):
+            token.invalidate()
+
+    def clear_request_bindings(self) -> None:
+        for request_id in tuple(self._request_tokens):
+            self.release_request(request_id)
+
+    @property
+    def request_binding_count(self) -> int:
+        return sum(
+            token.active for values in self._request_tokens.values() for token in values
+        )
+
+    def invalidate(self) -> None:
+        self.clear_request_bindings()
+        self._active = False
+
+    def propose_one(self, seed: Gemma4MTPProposerSeed, kv_view: Gemma4MTPKVView) -> int:
+        self._validate_generation(self.generation)
+        seed.validate()
+        # Accessing shared K/V validates the view and its request lifecycle.
+        if seed.request_id != kv_view.request_id:
+            raise ValueError("assistant seed and KV view belong to different requests")
+        target_seed = seed.target_seed
+        hidden = target_seed.hidden_state
+        embedding = target_seed.token_embedding
+        expected = (1, 1, self.metadata.backbone_hidden_size)
+        if tuple(hidden.shape) != expected or tuple(embedding.shape) != expected:
+            raise ValueError(
+                "assistant seed hidden/embedding shapes must both be "
+                f"{expected}; got {hidden.shape} and {embedding.shape}"
+            )
+        shared = kv_view.shared_kv_states()
+        inputs = mx.concatenate((embedding, hidden), axis=-1)
+        positions = mx.array([[kv_view.position]], dtype=mx.int32)
+        _projected, logits = self._model(inputs, shared, positions)
+        if self.metadata.final_logit_softcapping is not None:
+            cap = self.metadata.final_logit_softcapping
+            logits = mx.tanh(logits / cap) * cap
+        token = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(token)
+        return int(token.item())
+
+
+def _resolve_checkpoint(path_or_repo: str, revision: str | None) -> Path:
+    local = Path(path_or_repo).expanduser()
+    if local.is_dir():
+        return local.resolve()
+    if local.is_file():
+        return local.parent.resolve()
+    from huggingface_hub import snapshot_download
+
+    return Path(
+        snapshot_download(
+            repo_id=path_or_repo,
+            revision=revision,
+            allow_patterns=("config.json", "*.safetensors", "*.safetensors.index.json"),
+        )
+    )
+
+
+def _load_strict_provider_model(
+    checkpoint: Path, config: Mapping[str, Any], target_model: Any
+) -> tuple[Any, str]:
+    try:
+        from mlx_vlm.speculative.drafters.gemma4_assistant.config import (
+            Gemma4AssistantConfig,
+        )
+        from mlx_vlm.speculative.drafters.gemma4_assistant.gemma4_assistant import (
+            Gemma4AssistantDraftModel,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "Gemma 4 MTP requires the MLX optional dependency mlx-vlm==0.5.0"
+        ) from exc
+
+    provider_config = Gemma4AssistantConfig.from_dict(dict(config))
+    model = Gemma4AssistantDraftModel(provider_config)
+    weight_files = sorted(checkpoint.glob("*.safetensors"))
+    if not weight_files:
+        raise FileNotFoundError(
+            f"no assistant .safetensors files found in {checkpoint}"
+        )
+    weights: dict[str, mx.array] = {}
+    duplicates: list[str] = []
+    for weight_file in weight_files:
+        for name, value in mx.load(str(weight_file)).items():
+            if name in weights:
+                duplicates.append(name)
+            weights[name] = value
+    if duplicates:
+        raise ValueError(
+            "duplicate assistant weights: " + ", ".join(sorted(set(duplicates)))
+        )
+    weights = model.sanitize(weights)
+    expected = dict(tree_flatten(model.parameters()))
+    missing = sorted(set(expected) - set(weights))
+    unexpected = sorted(set(weights) - set(expected))
+    wrong_shape = sorted(
+        name
+        for name in set(expected) & set(weights)
+        if tuple(expected[name].shape) != tuple(weights[name].shape)
+    )
+    if missing or unexpected or wrong_shape:
+        parts = []
+        if missing:
+            parts.append("missing=" + ",".join(missing))
+        if unexpected:
+            parts.append("unexpected=" + ",".join(unexpected))
+        if wrong_shape:
+            details = ",".join(
+                f"{name}:{tuple(weights[name].shape)}!={tuple(expected[name].shape)}"
+                for name in wrong_shape
+            )
+            parts.append("wrong_shape=" + details)
+        raise ValueError("assistant weight validation failed: " + "; ".join(parts))
+
+    model.load_weights(list(weights.items()), strict=True)
+    model.bind(target_model)
+    model.eval()
+    mx.eval(model.parameters())
+
+    digest = hashlib.sha256()
+    for name in sorted(weights):
+        value = weights[name]
+        digest.update(name.encode())
+        digest.update(str(tuple(value.shape)).encode())
+        if value.size:
+            sample = value.reshape(-1)[mx.array([0, value.size - 1])]
+            mx.eval(sample)
+            digest.update(repr(sample.tolist()).encode())
+    return model, digest.hexdigest()
+
+
+class Gemma4MTPAssistantLoader:
+    """Strict assistant loader with monotonic lifecycle invalidation."""
+
+    def __init__(self, target_model: Any):
+        _text_target(target_model)
+        self.target_model = target_model
+        self.generation = 0
+        self.runtime: Gemma4MTPAssistantRuntime | None = None
+        self.load_count = 0
+        self._provider_cache: dict[Any, Any] = {}
+        self._model_cache: dict[Any, Any] = {}
+
+    def _invalidate_current(self) -> None:
+        if self.runtime is not None:
+            self.runtime.invalidate()
+        self.runtime = None
+        self._provider_cache.clear()
+        self._model_cache.clear()
+        self.generation += 1
+
+    def load(
+        self, path_or_repo: str, *, revision: str | None = None
+    ) -> Gemma4MTPAssistantRuntime:
+        # Compatibility is checked from JSON before the old generation is
+        # invalidated or any new weights are materialized.
+        config = load_assistant_config_dict(path_or_repo, revision=revision)
+        metadata = validate_gemma4_assistant_config(config, self.target_model)
+        plan = Gemma4MTPKVSharingPlan.from_target(self.target_model, metadata)
+
+        self._invalidate_current()
+        checkpoint = _resolve_checkpoint(path_or_repo, revision)
+        try:
+            model, fingerprint = _load_strict_provider_model(
+                checkpoint, config, self.target_model
+            )
+        except BaseException:
+            # The previous generation is already invalid by design; leave no
+            # partially constructed provider/model cache behind.
+            self._provider_cache.clear()
+            self._model_cache.clear()
+            raise
+
+        runtime = Gemma4MTPAssistantRuntime(
+            owner=self,
+            generation=self.generation,
+            model=model,
+            metadata=metadata,
+            sharing_plan=plan,
+            fingerprint=fingerprint,
+            checkpoint=path_or_repo,
+            revision=revision,
+        )
+        self.runtime = runtime
+        self._model_cache[(path_or_repo, revision, self.generation)] = model
+        self.load_count += 1
+        return runtime
+
+    def reload_assistant(self) -> Gemma4MTPAssistantRuntime:
+        if self.runtime is None:
+            raise RuntimeError("cannot reload an assistant before it is loaded")
+        return self.load(self.runtime.checkpoint, revision=self.runtime.revision)
+
+    def replace_assistant(
+        self, path_or_repo: str, *, revision: str | None = None
+    ) -> Gemma4MTPAssistantRuntime:
+        return self.load(path_or_repo, revision=revision)
+
+    def unload_assistant(self) -> None:
+        self._invalidate_current()
+
+    def clear_request_bindings(self) -> None:
+        if self.runtime is not None:
+            self.runtime.clear_request_bindings()

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/layout.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/layout.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from typing import Any, Sequence
 
 
@@ -20,6 +20,10 @@ class MlxModelCacheLayout:
     attention_layer_indices: tuple[int, ...]
     auxiliary_layer_indices: tuple[int, ...]
     attention_pool_index_by_layer: dict[int, int]
+    # Native Gemma 4 cache metadata. Logical YOCO-shared layers resolve to an
+    # owning logical layer, and only owners receive compact cache-list slots.
+    native_cache_owner_by_layer: tuple[int, ...] = ()
+    native_cache_index_by_owner: dict[int, int] = field(default_factory=dict)
 
     @classmethod
     def from_attention_discovery(
@@ -91,3 +95,29 @@ class MlxModelCacheLayout:
             [request_cache[layer_idx] for request_cache in caches_by_request]
             for layer_idx in self.attention_layer_indices
         ]
+
+    def with_native_cache_owners(
+        self,
+        owner_by_layer: Sequence[int],
+        cache_index_by_owner: dict[int, int],
+    ) -> MlxModelCacheLayout:
+        if len(owner_by_layer) != self.num_layers:
+            raise ValueError(
+                "native cache owner metadata must cover every logical layer"
+            )
+        return replace(
+            self,
+            native_cache_owner_by_layer=tuple(int(owner) for owner in owner_by_layer),
+            native_cache_index_by_owner=dict(cache_index_by_owner),
+        )
+
+    def native_cache_index(self, logical_layer_idx: int) -> int:
+        if not self.native_cache_owner_by_layer:
+            raise RuntimeError("model layout has no native-cache owner metadata")
+        try:
+            owner = self.native_cache_owner_by_layer[logical_layer_idx]
+            return self.native_cache_index_by_owner[owner]
+        except (IndexError, KeyError) as exc:
+            raise KeyError(
+                f"logical layer {logical_layer_idx} has no compact native cache owner"
+            ) from exc

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/native_transaction.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/native_transaction.py
@@ -1,0 +1,190 @@
+"""Transactional verification for mlx-lm native request caches.
+
+Gemma 4 mixes ordinary and rotating caches, and a rotating cache is no longer
+trimmable after it wraps.  Verification therefore runs on a fully isolated
+clone.  Commit replays only the accepted query prefix on the original cache;
+if replay raises, a pre-replay clone restores every array and ring field.
+"""
+
+from __future__ import annotations
+
+import copy
+from enum import Enum, auto
+from typing import Any, Callable, Iterable, Sequence
+
+import mlx.core as mx
+
+
+class _TransactionState(Enum):
+    NEW = auto()
+    ACTIVE = auto()
+    COMMITTED = auto()
+    ABORTED = auto()
+
+
+def _clone_value(value: Any) -> Any:
+    if isinstance(value, mx.array):
+        # MLX arrays are immutable values.  Constructing a new array gives the
+        # clone its own value when later slice assignments rebind cache fields.
+        return mx.array(value)
+    if isinstance(value, list):
+        return [_clone_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_clone_value(item) for item in value)
+    if isinstance(value, dict):
+        return {key: _clone_value(item) for key, item in value.items()}
+    return copy.deepcopy(value)
+
+
+def clone_native_cache_entry(entry: Any) -> Any:
+    """Clone one cache object, including provider-specific ring metadata."""
+
+    clone = type(entry).__new__(type(entry))
+    if hasattr(entry, "__dict__"):
+        clone.__dict__.update(_clone_value(entry.__dict__))
+    else:
+        slots: list[str] = []
+        for cls in type(entry).__mro__:
+            declared = getattr(cls, "__slots__", ())
+            if isinstance(declared, str):
+                slots.append(declared)
+            else:
+                slots.extend(declared)
+        for name in slots:
+            if name not in {"__dict__", "__weakref__"} and hasattr(entry, name):
+                setattr(clone, name, _clone_value(getattr(entry, name)))
+    return clone
+
+
+def clone_native_cache(cache: Sequence[Any]) -> list[Any]:
+    """Deep-clone all arrays, offsets, valid lengths, and ring metadata."""
+
+    cloned = [clone_native_cache_entry(entry) for entry in cache]
+    arrays = list(_iter_arrays(cloned))
+    if arrays:
+        mx.eval(*arrays)
+    return cloned
+
+
+def replace_native_cache_contents(
+    destination: Sequence[Any], source: Sequence[Any]
+) -> None:
+    """Replace cache state while preserving destination entry identities."""
+
+    if len(destination) != len(source):
+        raise ValueError(
+            f"native cache cardinality changed: {len(destination)} != {len(source)}"
+        )
+    for dest, src in zip(destination, source):
+        if type(dest) is not type(src):
+            raise TypeError(
+                "native cache entry type changed during transaction: "
+                f"{type(dest).__name__} != {type(src).__name__}"
+            )
+        cloned = clone_native_cache_entry(src)
+        if hasattr(dest, "__dict__"):
+            dest.__dict__.clear()
+            dest.__dict__.update(cloned.__dict__)
+            continue
+        for cls in type(dest).__mro__:
+            declared = getattr(cls, "__slots__", ())
+            if isinstance(declared, str):
+                declared = (declared,)
+            for name in declared:
+                if name not in {"__dict__", "__weakref__"} and hasattr(cloned, name):
+                    setattr(dest, name, getattr(cloned, name))
+
+
+def _iter_arrays(value: Any) -> Iterable[mx.array]:
+    if isinstance(value, mx.array):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_arrays(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_arrays(item)
+    else:
+        state = getattr(value, "state", None)
+        if state is not None:
+            yield from _iter_arrays(state)
+
+
+ReplayForward = Callable[[Sequence[Any], tuple[int, ...]], Any]
+
+
+class MlxNativeCacheTransaction:
+    """Single-use clone/verify/replay transaction for one native request."""
+
+    def __init__(
+        self,
+        cache: Sequence[Any],
+        query_token_ids: Sequence[int],
+        replay_forward: ReplayForward,
+    ) -> None:
+        if not query_token_ids:
+            raise ValueError("a native-cache transaction requires at least one query")
+        if any(int(token) < 0 for token in query_token_ids):
+            raise ValueError("verification queries cannot contain negative token IDs")
+        self._cache = cache
+        self._queries = tuple(int(token) for token in query_token_ids)
+        self._replay_forward = replay_forward
+        self._state = _TransactionState.NEW
+        self._speculative_cache: list[Any] | None = None
+        self._committed_count: int | None = None
+
+    @property
+    def active(self) -> bool:
+        return self._state is _TransactionState.ACTIVE
+
+    @property
+    def committed_count(self) -> int | None:
+        return self._committed_count
+
+    def begin(self) -> list[Any]:
+        if self._state is not _TransactionState.NEW:
+            raise RuntimeError("native-cache transaction begin() is single-use")
+        self._speculative_cache = clone_native_cache(self._cache)
+        self._state = _TransactionState.ACTIVE
+        return self._speculative_cache
+
+    def commit(self, count: int) -> Any:
+        if self._state is not _TransactionState.ACTIVE:
+            raise RuntimeError("only an active native-cache transaction can commit")
+        if count < 0 or count > len(self._queries):
+            raise ValueError(
+                f"commit count {count} is outside [0, {len(self._queries)}]"
+            )
+
+        backup = clone_native_cache(self._cache)
+        try:
+            result = None
+            if count:
+                result = self._replay_forward(self._cache, self._queries[:count])
+                arrays = list(_iter_arrays(result)) + list(_iter_arrays(self._cache))
+                if arrays:
+                    mx.eval(*arrays)
+        except BaseException:
+            replace_native_cache_contents(self._cache, backup)
+            self._speculative_cache = None
+            self._state = _TransactionState.ABORTED
+            raise
+
+        self._committed_count = count
+        self._speculative_cache = None
+        self._state = _TransactionState.COMMITTED
+        return result
+
+    def abort(self) -> None:
+        if self._state is not _TransactionState.ACTIVE:
+            raise RuntimeError("only an active native-cache transaction can abort")
+        self._speculative_cache = None
+        self._state = _TransactionState.ABORTED
+
+    def __enter__(self) -> list[Any]:
+        return self.begin()
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        if self._state is _TransactionState.ACTIVE:
+            self.abort()
+        return False

--- a/python/sglang/srt/hardware_backend/mlx/model_adapter.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_adapter.py
@@ -1,0 +1,114 @@
+"""Optional Gemma 4 target outputs needed by the MLX MTP proposer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+
+
+@dataclass(frozen=True)
+class MlxTargetForwardOutput:
+    logits: mx.array
+    hidden_states: mx.array | None = None
+
+
+@dataclass(frozen=True)
+class MlxTargetSeed:
+    """Request-private assistant seed from a committed target query row."""
+
+    token_id: int
+    hidden_state: mx.array
+    token_embedding: mx.array
+
+
+def _extract_logits(model_output: Any) -> mx.array:
+    return model_output[0] if isinstance(model_output, tuple) else model_output
+
+
+class Gemma4TargetAdapter:
+    """Capture Gemma 4 backbone output without changing normal target math."""
+
+    def __init__(self, model: Any):
+        self.model = model
+        self.causal_model = getattr(model, "language_model", model)
+        self.backbone = getattr(self.causal_model, "model", None)
+        if self.backbone is None or not hasattr(self.backbone, "embed_tokens"):
+            raise TypeError(
+                "Gemma4TargetAdapter requires an mlx-lm Gemma 4 text model "
+                "or conditional-generation wrapper"
+            )
+
+    @property
+    def hidden_size(self) -> int:
+        return int(self.backbone.config.hidden_size)
+
+    @property
+    def vocab_size(self) -> int:
+        return int(self.backbone.config.vocab_size)
+
+    @property
+    def embed_scale(self) -> float:
+        return float(getattr(self.backbone, "embed_scale", 1.0))
+
+    def input_embeddings(self, input_ids: mx.array) -> mx.array:
+        """Return the scaled target-trunk embeddings used by normal forward."""
+
+        return self.backbone.embed_tokens(input_ids) * self.embed_scale
+
+    def forward(
+        self,
+        input_ids: mx.array,
+        *,
+        cache: list[Any] | None = None,
+        collect_hidden_states: bool = False,
+    ) -> MlxTargetForwardOutput:
+        if not collect_hidden_states:
+            return MlxTargetForwardOutput(
+                logits=_extract_logits(self.model(input_ids, cache=cache))
+            )
+
+        # This is the same trunk and LM-head sequence as gemma4_text.Model;
+        # only the already-computed normalized trunk output is retained.
+        hidden = self.backbone(input_ids, cache=cache)
+        if bool(getattr(self.causal_model, "tie_word_embeddings", False)):
+            logits = self.backbone.embed_tokens.as_linear(hidden)
+        else:
+            logits = self.causal_model.lm_head(hidden)
+
+        softcap = getattr(self.causal_model, "final_logit_softcapping", None)
+        if softcap is not None:
+            # Keep this expression identical to mlx-lm's compiled logit_softcap.
+            logits = mx.tanh(logits / softcap) * softcap
+        return MlxTargetForwardOutput(logits=logits, hidden_states=hidden)
+
+    def make_seed(
+        self,
+        output: MlxTargetForwardOutput,
+        *,
+        hidden_row_index: int,
+        emitted_token_id: int,
+    ) -> MlxTargetSeed:
+        if output.hidden_states is None:
+            raise ValueError("target output did not collect hidden states")
+        hidden = output.hidden_states
+        if hidden.ndim != 3:
+            raise ValueError(
+                "target hidden states must have shape [batch, query, hidden]"
+            )
+        if hidden_row_index < 0 or hidden_row_index >= hidden.shape[1]:
+            raise IndexError(
+                f"hidden row {hidden_row_index} is outside query width {hidden.shape[1]}"
+            )
+        if emitted_token_id < 0 or emitted_token_id >= self.vocab_size:
+            raise ValueError("assistant seed token is outside the target vocabulary")
+
+        hidden_row = hidden[:, hidden_row_index : hidden_row_index + 1, :]
+        token_ids = mx.array([[emitted_token_id]], dtype=mx.int32)
+        embedding = self.input_embeddings(token_ids)
+        return MlxTargetSeed(
+            token_id=int(emitted_token_id),
+            hidden_state=hidden_row,
+            token_embedding=embedding,
+        )

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -111,6 +111,38 @@ _MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
 }
 _MLX_KV_FLOAT_DTYPES = {mx.float16, mx.bfloat16, mx.float32}
 
+# Gemma 4's mlx-lm cache contract cannot yet be represented by SGLang's
+# uniform attention pool.  In particular, it combines per-layer sliding
+# windows, heterogeneous head dimensions, and YOCO layers that reuse K/V from
+# earlier layers (and therefore do not own cache entries).  Keep the initial
+# support narrow and correctness-first: let mlx-lm own those caches until the
+# SGLang pool grows the corresponding per-layer metadata.
+_NATIVE_CACHE_FALLBACK_MODEL_TYPES = frozenset({"gemma4", "gemma4_text"})
+_NATIVE_CACHE_FALLBACK_DEFAULT_POOL_SIZE = 2048
+
+
+def _mlx_model_type(model: Any) -> str | None:
+    """Return the mlx-lm model type from a text or conditional wrapper."""
+    for candidate in (model, getattr(model, "language_model", None)):
+        if candidate is None:
+            continue
+        model_type = getattr(candidate, "model_type", None)
+        if model_type:
+            return str(model_type)
+        args = getattr(candidate, "args", None)
+        model_type = getattr(args, "model_type", None)
+        if model_type:
+            return str(model_type)
+    return None
+
+
+def _mlx_text_model_args(model: Any) -> Any | None:
+    """Return the text-backbone args, unwrapping mlx-lm's Gemma 4 shell."""
+    language_model = getattr(model, "language_model", None)
+    if language_model is not None and getattr(language_model, "args", None) is not None:
+        return language_model.args
+    return getattr(model, "args", None)
+
 
 class MlxModelRunner:
     """MLX model runner with radix-cache prefix sharing."""
@@ -140,6 +172,17 @@ class MlxModelRunner:
 
         self._load_model()
 
+        self._native_cache_fallback = (
+            _mlx_model_type(self.model) in _NATIVE_CACHE_FALLBACK_MODEL_TYPES
+        )
+        if self._native_cache_fallback and not self.disable_radix_cache:
+            raise NotImplementedError(
+                "Gemma 4 on the MLX backend currently requires "
+                "--disable-radix-cache. Its YOCO sharing, mixed head dimensions, "
+                "and sliding-window cache cannot be represented by the uniform "
+                "SGLang MLX radix pool yet."
+            )
+
         # Pin MLX allocations to prevent OS paging
         device_info = mx.device_info()
         max_wired = int(device_info.get("max_recommended_working_set_size", 0))
@@ -147,7 +190,13 @@ class MlxModelRunner:
             mx.set_wired_limit(max_wired)
             logger.info(f"Wired memory limit set to {max_wired / (1024**3):.1f} GB")
 
-        patch_model_attention(self.model)
+        if self._native_cache_fallback:
+            logger.info(
+                "Using mlx-lm native caches for Gemma 4 text generation "
+                "(radix reuse and batched attention are disabled)"
+            )
+        else:
+            patch_model_attention(self.model)
 
         layer_list, attn_attrs = find_attention_layers(self.model)
         self._cache_layout = MlxModelCacheLayout.from_attention_discovery(
@@ -162,7 +211,7 @@ class MlxModelRunner:
             raise RuntimeError(
                 "MLX models with auxiliary cache state require model.make_cache()."
             )
-        if self._cache_layout.has_auxiliary_state:
+        if self._cache_layout.has_auxiliary_state and not self._native_cache_fallback:
             self._model_embed, self._model_norm, self._model_lm_head = (
                 self._extract_model_components()
             )
@@ -189,6 +238,8 @@ class MlxModelRunner:
 
     def _new_cache_skeleton(self) -> list[Any]:
         """Create a model-shaped cache list before attention cache wiring."""
+        if self.native_cache_fallback:
+            return list(self.model.make_cache())
         if self._cache_layout.has_auxiliary_state:
             cache = self.model.make_cache()
             if len(cache) != self._cache_layout.num_layers:
@@ -203,12 +254,16 @@ class MlxModelRunner:
     def _new_native_cache(self) -> list[Any]:
         """Create a model-shaped cache list with attention KV adapters."""
         cache = self._new_cache_skeleton()
+        if self.native_cache_fallback:
+            return cache
         for layer_idx in self._cache_layout.attention_layer_indices:
             cache[layer_idx] = ContiguousAttentionKVCache(max_seq_len=self._max_seq_len)
         return cache
 
     def _acquire_cache(self) -> list[Any]:
         """Get a reusable cache list from the pool, or create a new one."""
+        if self.native_cache_fallback:
+            return self._new_native_cache()
         if not self._cache_layout.has_auxiliary_state and self._cache_pool:
             cache = self._cache_pool.pop()
             for c in cache:
@@ -218,6 +273,8 @@ class MlxModelRunner:
 
     def _release_cache(self, cache: list[Any]) -> None:
         """Return a cache list to the pool for reuse."""
+        if self.native_cache_fallback:
+            return
         if not self._cache_layout.has_auxiliary_state:
             self._cache_pool.append(cache)
 
@@ -550,6 +607,27 @@ class MlxModelRunner:
         """Determine pool slot count (auto-size from available memory if needed)."""
         if explicit_size is not None:
             return explicit_size
+        if self.native_cache_fallback:
+            # Native caches grow per request and do not allocate an SGLang KV
+            # pool.  The scheduler still needs a finite token capacity for its
+            # CPU-side slot allocator. Keep the prototype default conservative:
+            # Gemma 4 advertises a 131k context, which would otherwise combine
+            # with the generic request-count default to allocate a very large
+            # CPU ReqToTokenPool. Production launches can raise this explicitly
+            # with --max-total-tokens.
+            args = _mlx_text_model_args(self.model)
+            context_len = int(getattr(args, "max_position_embeddings", 4096))
+            pool_size = min(
+                context_len,
+                _NATIVE_CACHE_FALLBACK_DEFAULT_POOL_SIZE,
+            )
+            logger.info(
+                "Using conservative native-cache scheduler capacity: %d tokens "
+                "(model context=%d; override with --max-total-tokens)",
+                pool_size,
+                context_len,
+            )
+            return pool_size
         n_kv_heads, head_dim, dtype = self._get_attn_config()
         num_layers = self._cache_layout.num_attention_layers
         sys_available = psutil.virtual_memory().available
@@ -579,8 +657,15 @@ class MlxModelRunner:
     def pool_size(self) -> int:
         return self._pool_size
 
+    @property
+    def native_cache_fallback(self) -> bool:
+        """Whether inference uses model-owned caches instead of SGLang's pool."""
+        return getattr(self, "_native_cache_fallback", False)
+
     def _build_aot_kernels(self) -> MlxAOTKernelSet:
         """Build model-level set of optional registered AOT kernels."""
+        if self.native_cache_fallback:
+            return MlxAOTKernelSet()
         if self._cache_layout.num_attention_layers == 0:
             return MlxAOTKernelSet()
         layer_idx = self._cache_layout.first_attention_layer_index
@@ -1167,7 +1252,12 @@ class MlxModelRunner:
         last_tokens = [self._req_token_ids[rid][-1] for rid in req_ids]
         batched_input = mx.array(last_tokens, dtype=mx.int32)[:, None]
 
-        if self._cache_layout.has_auxiliary_state:
+        if self.native_cache_fallback:
+            lazy_tokens = self._decode_with_native_cache(
+                caches,
+                [batched_input[i : i + 1] for i in range(len(caches))],
+            )
+        elif self._cache_layout.has_auxiliary_state:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, list(req_ids)
             )
@@ -1212,7 +1302,12 @@ class MlxModelRunner:
         # So layer-0 offsets reflect the position the NEW token will
         # be written at in step N+1 (and equivalently the RoPE offset).
         batched_input = prev.lazy_tokens[:, None]
-        if self._cache_layout.has_auxiliary_state:
+        if self.native_cache_fallback:
+            lazy_tokens = self._decode_with_native_cache(
+                caches,
+                [batched_input[i : i + 1] for i in range(len(caches))],
+            )
+        elif self._cache_layout.has_auxiliary_state:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, prev.req_ids
             )

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -70,6 +70,7 @@ class MlxPendingPrefill:
     full_token_ids: list[int]
     req_pool_idx: int
     synced_offset: int
+    target_output: Any | None = None
 
 
 @dataclass
@@ -102,6 +103,17 @@ class MlxPendingDecode:
     lazy_tokens: mx.array
     req_ids: list[str]
     caches: list[list[Any]]
+
+
+@dataclass
+class MlxPendingVerify:
+    """Isolated native-cache verification awaiting an accept decision."""
+
+    req_id: str
+    query_token_ids: tuple[int, ...]
+    transaction: Any
+    speculative_cache: list[Any]
+    target_output: Any
 
 
 _MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
@@ -150,6 +162,7 @@ class MlxModelRunner:
     def __init__(
         self,
         model_path: str,
+        revision: str | None = None,
         trust_remote_code: bool = False,
         disable_radix_cache: bool = False,
         pool_size: int | None = None,
@@ -157,6 +170,7 @@ class MlxModelRunner:
         quantization: str | None = None,
     ):
         self.model_path = model_path
+        self.revision = revision
         self.trust_remote_code = trust_remote_code
         self.model = None
         self.disable_radix_cache = disable_radix_cache
@@ -175,6 +189,13 @@ class MlxModelRunner:
         self._native_cache_fallback = (
             _mlx_model_type(self.model) in _NATIVE_CACHE_FALLBACK_MODEL_TYPES
         )
+        self._target_adapter = None
+        if self._native_cache_fallback:
+            from sglang.srt.hardware_backend.mlx.model_adapter import (
+                Gemma4TargetAdapter,
+            )
+
+            self._target_adapter = Gemma4TargetAdapter(self.model)
         if self._native_cache_fallback and not self.disable_radix_cache:
             raise NotImplementedError(
                 "Gemma 4 on the MLX backend currently requires "
@@ -203,6 +224,23 @@ class MlxModelRunner:
             layer_list,
             attn_attrs,
         )
+        if self._native_cache_fallback:
+            text_root = getattr(self.model, "language_model", self.model)
+            backbone = getattr(text_root, "model", None)
+            previous_kvs = tuple(getattr(backbone, "previous_kvs", ()))
+            if len(previous_kvs) == self._cache_layout.num_layers:
+                compact_owners = tuple(
+                    idx
+                    for idx, layer in enumerate(self._cache_layout.layers)
+                    if bool(getattr(layer.self_attn, "has_kv", True))
+                )
+                self._cache_layout = self._cache_layout.with_native_cache_owners(
+                    previous_kvs,
+                    {
+                        owner: cache_idx
+                        for cache_idx, owner in enumerate(compact_owners)
+                    },
+                )
         if self._cache_layout.num_attention_layers == 0:
             raise RuntimeError("MLX model has no supported attention layers")
         if self._cache_layout.has_auxiliary_state and not hasattr(
@@ -468,6 +506,7 @@ class MlxModelRunner:
             self.model_path,
             tokenizer_config={"trust_remote_code": self.trust_remote_code},
             return_config=True,
+            revision=self.revision,
         )
         self.model, _tokenizer, config = loaded
 
@@ -724,6 +763,41 @@ class MlxModelRunner:
         self._eval_with_cache(pending.lazy_token, pending.cache)
         return self.prefill_finalize(pending)
 
+    def prefill_for_mtp(
+        self,
+        req_id: str,
+        new_token_ids: list[int],
+        full_token_ids: list[int],
+        prefix_slot_ids: list[int],
+        new_slot_ids: list[int],
+        req_pool_idx: int,
+        req: Any | None = None,
+    ) -> tuple[int, Any]:
+        """Prefill native Gemma 4 and retain only this call's target hidden rows."""
+
+        if not self.native_cache_fallback:
+            raise RuntimeError("Gemma 4 MTP prefill requires the native-cache path")
+        pending = self.prefill_start(
+            req_id=req_id,
+            new_token_ids=new_token_ids,
+            full_token_ids=full_token_ids,
+            prefix_slot_ids=prefix_slot_ids,
+            new_slot_ids=new_slot_ids,
+            req_pool_idx=req_pool_idx,
+            req=req,
+            collect_hidden_states=True,
+        )
+        assert pending.target_output is not None
+        hidden = pending.target_output.hidden_states
+        arrays = [pending.lazy_token]
+        if hidden is not None:
+            arrays.append(hidden)
+        arrays.extend(self._cache_state_arrays([pending.cache]))
+        mx.eval(*arrays)
+        token = self.prefill_finalize(pending)
+        self._assert_native_history_lag(req_id)
+        return token, pending.target_output
+
     def extend(
         self,
         req_id: str,
@@ -807,6 +881,147 @@ class MlxModelRunner:
         mx.eval(pending.lazy_tokens, *cache_arrays)
         return self.decode_batch_finalize(pending)
 
+    def verify_start(
+        self,
+        req_id: str,
+        query_token_ids: list[int] | tuple[int, ...],
+    ) -> MlxPendingVerify:
+        """Run target verification on an isolated native-cache clone."""
+
+        if not self.native_cache_fallback or self._target_adapter is None:
+            raise RuntimeError("native Gemma 4 verification is unavailable")
+        if req_id not in self._req_caches:
+            raise KeyError(f"verify_start called for unknown request {req_id!r}")
+        queries = tuple(int(token) for token in query_token_ids)
+
+        from sglang.srt.hardware_backend.mlx.kv_cache.native_transaction import (
+            MlxNativeCacheTransaction,
+        )
+
+        def replay_forward(cache, accepted_queries):
+            return self._forward_native_queries_sequential(
+                cache,
+                accepted_queries,
+                collect_hidden_states=False,
+            ).logits
+
+        transaction = MlxNativeCacheTransaction(
+            self._req_caches[req_id], queries, replay_forward
+        )
+        speculative_cache = transaction.begin()
+        try:
+            output = self._forward_native_queries_sequential(
+                speculative_cache,
+                queries,
+                collect_hidden_states=True,
+            )
+        except BaseException:
+            transaction.abort()
+            raise
+        return MlxPendingVerify(
+            req_id=req_id,
+            query_token_ids=queries,
+            transaction=transaction,
+            speculative_cache=speculative_cache,
+            target_output=output,
+        )
+
+    def _forward_native_queries_sequential(
+        self,
+        cache: list[Any] | tuple[Any, ...],
+        query_token_ids: tuple[int, ...],
+        *,
+        collect_hidden_states: bool,
+    ) -> Any:
+        """Run verification with the same one-token shape as normal decode.
+
+        MLX kernels can make slightly different floating-point choices for a
+        two-token prefill-shaped forward than for two one-token decode calls.
+        Greedy verification must reproduce the target-only decode path exactly,
+        including near-tied logits, so both speculative evaluation and commit
+        replay advance one query at a time.
+        """
+
+        if self._target_adapter is None:
+            raise RuntimeError("native Gemma 4 target adapter is unavailable")
+        if not query_token_ids:
+            raise ValueError("native verification requires at least one query")
+
+        outputs = []
+        for token_id in query_token_ids:
+            outputs.append(
+                self._target_adapter.forward(
+                    mx.array([[int(token_id)]], dtype=mx.int32),
+                    cache=list(cache),
+                    collect_hidden_states=collect_hidden_states,
+                )
+            )
+
+        from sglang.srt.hardware_backend.mlx.model_adapter import (
+            MlxTargetForwardOutput,
+        )
+
+        hidden_states = None
+        if collect_hidden_states:
+            hidden_rows = [output.hidden_states for output in outputs]
+            if any(hidden is None for hidden in hidden_rows):
+                raise RuntimeError("target adapter omitted requested hidden states")
+            hidden_states = mx.concatenate(hidden_rows, axis=1)
+        return MlxTargetForwardOutput(
+            logits=mx.concatenate([output.logits for output in outputs], axis=1),
+            hidden_states=hidden_states,
+        )
+
+    def verify_materialize(self, pending: MlxPendingVerify) -> tuple[int, ...]:
+        """Materialize all verification rows without changing visible cache state."""
+
+        arrays = [pending.target_output.logits]
+        if pending.target_output.hidden_states is not None:
+            arrays.append(pending.target_output.hidden_states)
+        arrays.extend(self._cache_state_arrays([pending.speculative_cache]))
+        mx.eval(*arrays)
+        target_ids = mx.argmax(pending.target_output.logits, axis=-1)
+        mx.eval(target_ids)
+        return tuple(int(token) for token in target_ids.reshape(-1).tolist())
+
+    def verify_finalize(self, pending: MlxPendingVerify, decision: Any) -> None:
+        """Commit accepted query KV and append the full emitted run privately."""
+
+        if pending.req_id != decision.request_id:
+            pending.transaction.abort()
+            raise ValueError("verification decision belongs to a different request")
+        if len(decision.emitted_token_ids) != decision.committed_query_count:
+            pending.transaction.abort()
+            raise ValueError(
+                "linear verification must emit one token per committed query"
+            )
+        pending.transaction.commit(decision.committed_query_count)
+        self._req_token_ids[pending.req_id].extend(decision.emitted_token_ids)
+        self._assert_native_history_lag(pending.req_id)
+
+    @staticmethod
+    def verify_abort(pending: MlxPendingVerify) -> None:
+        if pending.transaction.active:
+            pending.transaction.abort()
+
+    def _assert_native_history_lag(self, req_id: str) -> None:
+        if not self.native_cache_fallback:
+            return
+        cache = self._req_caches[req_id]
+        offsets = {int(entry.offset) for entry in cache}
+        if len(offsets) != 1:
+            raise RuntimeError(
+                f"native target cache offsets disagree for request {req_id!r}: "
+                f"{sorted(offsets)}"
+            )
+        cache_length = offsets.pop()
+        history_length = len(self._req_token_ids[req_id])
+        if history_length != cache_length + 1:
+            raise RuntimeError(
+                "native Gemma 4 token history must remain one token ahead of "
+                f"target KV: history={history_length}, cache={cache_length}"
+            )
+
     def prefill_start(
         self,
         req_id: str,
@@ -816,6 +1031,8 @@ class MlxModelRunner:
         new_slot_ids: list[int],
         req_pool_idx: int,
         req: Any | None = None,
+        *,
+        collect_hidden_states: bool = False,
     ) -> MlxPendingPrefill:
         """Queue a prefill forward pass without evaluating.
 
@@ -831,8 +1048,21 @@ class MlxModelRunner:
         if self.disable_radix_cache:
             cache = self._acquire_cache()
             input_ids = mx.array([new_token_ids], dtype=mx.int32)
-            model_output = self.model(input_ids, cache=cache)
-            logits = self._extract_logits(model_output)
+            target_output = None
+            if collect_hidden_states:
+                if self._target_adapter is None:
+                    raise RuntimeError(
+                        "optional MLX target hidden states require native Gemma 4"
+                    )
+                target_output = self._target_adapter.forward(
+                    input_ids,
+                    cache=cache,
+                    collect_hidden_states=True,
+                )
+                logits = target_output.logits
+            else:
+                model_output = self.model(input_ids, cache=cache)
+                logits = self._extract_logits(model_output)
             lazy_token = mx.argmax(logits[:, -1, :], axis=-1)
             return MlxPendingPrefill(
                 lazy_token=lazy_token,
@@ -841,6 +1071,7 @@ class MlxModelRunner:
                 full_token_ids=list(full_token_ids),
                 req_pool_idx=req_pool_idx,
                 synced_offset=0,
+                target_output=target_output,
             )
 
         assert self._attention_kv_pool is not None

--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -105,8 +105,15 @@ class MlxModelRunnerStub(ModelRunner):
     # that path working instead of raising AttributeError.
     prefill_aware_swa = False
 
-    def __init__(self, *args, mlx_pool_size: int | None = None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        mlx_pool_size: int | None = None,
+        mlx_native_cache_fallback: bool = False,
+        **kwargs,
+    ):
         self._mlx_pool_size = mlx_pool_size
+        self._mlx_native_cache_fallback = mlx_native_cache_fallback
         super().__init__(*args, **kwargs)
 
     def load_model(self):
@@ -167,9 +174,25 @@ class MlxModelRunnerStub(ModelRunner):
         requested = get_schedule().max_running_requests
         if requested is None:
             requested_per_worker = None
-            resolved = min(capacity_cap, 4096)
+            # The initial Gemma 4 path executes each request through its own
+            # model-native cache rather than SGLang's batched attention path.
+            # Default to one live request so a 131k advertised context does not
+            # create a needlessly large CPU ReqToTokenPool. Users can opt into
+            # more independent requests with --max-running-requests.
+            default_max_requests = (
+                1 if getattr(self, "_mlx_native_cache_fallback", False) else 4096
+            )
+            resolved = min(capacity_cap, default_max_requests)
         else:
-            requested_per_worker = requested // self.dp_size
+            # Match the canonical KV-cache resolver: requests are split only
+            # across attention-DP workers. Pure data-parallel replicas each
+            # need the full local limit.
+            attn_dp_size = getattr(
+                getattr(self, "ps", None),
+                "attn_dp_size",
+                1,
+            )
+            requested_per_worker = requested // attn_dp_size
             resolved = min(requested_per_worker, capacity_cap)
 
         aux_state_size = get_schedule().max_mamba_cache_size

--- a/python/sglang/srt/hardware_backend/mlx/spec_config.py
+++ b/python/sglang/srt/hardware_backend/mlx/spec_config.py
@@ -1,0 +1,296 @@
+"""Configuration and request guardrails for MLX Frozen-KV MTP.
+
+This module intentionally has no import-time dependency on MLX.  Server
+argument normalization runs before the MLX worker is constructed and must
+remain safe on non-Apple hosts running generic speculative tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+MLX_GEMMA4_MTP_MAX_CONTEXT = 2048
+MLX_GEMMA4_MTP_VERIFY_WIDTH = 2
+MLX_GEMMA4_MTP_TARGET_ARCH = "Gemma4ForConditionalGeneration"
+MLX_GEMMA4_MTP_ASSISTANT_ARCH = "Gemma4AssistantForCausalLM"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open(encoding="utf-8") as file:
+            value = json.load(file)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Cannot read Gemma 4 assistant config {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"Gemma 4 assistant config {path} must contain a JSON object")
+    return value
+
+
+def load_assistant_config_dict(
+    path_or_repo: str,
+    *,
+    revision: Optional[str] = None,
+    configuration_file: Optional[str] = None,
+) -> dict[str, Any]:
+    """Load only assistant JSON metadata, never model code or weights."""
+
+    if not path_or_repo:
+        raise ValueError("MLX Gemma 4 MTP requires --speculative-draft-model-path.")
+
+    config_name = configuration_file or "config.json"
+    local = Path(path_or_repo).expanduser()
+    if local.is_file():
+        return _read_json(local)
+    if local.is_dir():
+        return _read_json(local / config_name)
+
+    try:
+        from huggingface_hub import hf_hub_download
+
+        config_path = hf_hub_download(
+            repo_id=path_or_repo,
+            filename=config_name,
+            revision=revision,
+        )
+    except Exception as exc:
+        raise ValueError(
+            "Cannot resolve Gemma 4 assistant config for "
+            f"{path_or_repo!r} at revision {revision!r}: {exc}"
+        ) from exc
+    return _read_json(Path(config_path))
+
+
+def is_gemma4_assistant_config(config: dict[str, Any]) -> bool:
+    architectures = config.get("architectures") or []
+    return config.get("model_type") == "gemma4_assistant" or (
+        MLX_GEMMA4_MTP_ASSISTANT_ARCH in architectures
+    )
+
+
+def _attr(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _validate_target_config(server_args: ServerArgs) -> None:
+    model_config = server_args.get_model_config()
+    hf_config = model_config.hf_config
+    text_config = _attr(hf_config, "text_config")
+    architectures = _attr(hf_config, "architectures", []) or []
+
+    if (
+        _attr(hf_config, "model_type") != "gemma4"
+        or MLX_GEMMA4_MTP_TARGET_ARCH not in architectures
+        or text_config is None
+    ):
+        raise ValueError(
+            "MLX Frozen-KV MTP currently supports only the Gemma 4 E2B text "
+            f"target ({MLX_GEMMA4_MTP_TARGET_ARCH})."
+        )
+
+    e2b_shape = (
+        _attr(text_config, "model_type") == "gemma4_text"
+        and int(_attr(text_config, "hidden_size", -1)) == 1536
+        and int(_attr(text_config, "num_hidden_layers", -1)) == 35
+        and int(_attr(text_config, "vocab_size", -1)) == 262144
+    )
+    if not e2b_shape:
+        raise ValueError(
+            "MLX Frozen-KV MTP MVP supports only the Gemma 4 E2B target "
+            "(hidden_size=1536, num_hidden_layers=35, vocab_size=262144)."
+        )
+
+    if bool(_attr(model_config, "is_multimodal", False)) and not bool(
+        getattr(server_args, "language_only", True)
+    ):
+        raise ValueError(
+            "MLX Frozen-KV MTP is text-only and does not support multimodal "
+            "Gemma 4 execution."
+        )
+
+
+def _validate_assistant_config(server_args: ServerArgs, config: dict[str, Any]) -> None:
+    if config.get("model_type") != "gemma4_assistant":
+        raise ValueError(
+            "MLX Frozen-KV MTP requires assistant model_type='gemma4_assistant'."
+        )
+    architectures = config.get("architectures") or []
+    if architectures != [MLX_GEMMA4_MTP_ASSISTANT_ARCH]:
+        raise ValueError(
+            "MLX Frozen-KV MTP requires architecture "
+            f"{MLX_GEMMA4_MTP_ASSISTANT_ARCH!r}; got {architectures!r}."
+        )
+    if any(key in config for key in ("auto_map", "model_file")):
+        raise ValueError(
+            "MLX Gemma 4 MTP does not load remote/custom assistant model code."
+        )
+    if int(config.get("backbone_hidden_size", -1)) != 1536:
+        raise ValueError("Gemma 4 E2B assistant backbone_hidden_size must equal 1536.")
+    text = config.get("text_config") or {}
+    if (
+        text.get("model_type") != "gemma4_text"
+        or int(text.get("hidden_size", -1)) != 256
+        or int(text.get("num_hidden_layers", -1)) != 4
+        or int(text.get("vocab_size", -1)) != 262144
+    ):
+        raise ValueError(
+            "MLX Frozen-KV MTP requires the matching four-layer E2B assistant."
+        )
+    layer_types = list(text.get("layer_types") or [])
+    if layer_types != [
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    ]:
+        raise ValueError(
+            "Gemma 4 E2B assistant must have three sliding-attention layers "
+            "followed by one full-attention layer."
+        )
+    if not bool(config.get("use_ordered_embeddings")):
+        raise ValueError("Gemma 4 E2B assistant requires ordered embeddings.")
+    if int(config.get("num_centroids", -1)) != 2048:
+        raise ValueError("Gemma 4 E2B assistant num_centroids must equal 2048.")
+    if int(config.get("centroid_intermediate_top_k", -1)) != 32:
+        raise ValueError(
+            "Gemma 4 E2B assistant centroid_intermediate_top_k must equal 32."
+        )
+    if 262144 % int(config["num_centroids"]) != 0:
+        raise ValueError("Assistant vocabulary must be divisible by num_centroids.")
+
+
+def validate_mlx_frozen_kv_mtp_args(server_args: ServerArgs) -> None:
+    """Validate the exact Level-1 server shape before assistant weights load."""
+
+    if getattr(server_args, "speculative_draft_model_path", None) is None:
+        raise ValueError("MLX Frozen-KV MTP requires --speculative-draft-model-path.")
+    if int(getattr(server_args, "speculative_eagle_topk", -1)) != 1:
+        raise ValueError("MLX Frozen-KV MTP requires speculative_eagle_topk/topk=1.")
+    if int(getattr(server_args, "speculative_num_steps", -1)) != 1:
+        raise ValueError(
+            "MLX Frozen-KV MTP requires speculative_num_steps/num_steps=1."
+        )
+    if int(getattr(server_args, "speculative_num_draft_tokens", -1)) != 2:
+        raise ValueError(
+            "MLX Frozen-KV MTP requires speculative_num_draft_tokens/draft_tokens=2 "
+            "(root query plus one proposal)."
+        )
+    if bool(getattr(server_args, "speculative_use_rejection_sampling", False)):
+        raise ValueError("MLX Frozen-KV MTP does not support rejection sampling.")
+    if not bool(getattr(server_args, "disable_overlap_schedule", False)):
+        raise ValueError("MLX Frozen-KV MTP requires synchronous scheduling.")
+    if not bool(getattr(server_args, "disable_radix_cache", False)):
+        raise NotImplementedError("MLX Frozen-KV MTP requires --disable-radix-cache.")
+    if int(getattr(server_args, "chunked_prefill_size", 0)) != -1:
+        raise NotImplementedError(
+            "MLX Frozen-KV MTP requires --chunked-prefill-size -1."
+        )
+    if bool(getattr(server_args, "enable_mixed_chunk", False)):
+        raise NotImplementedError(
+            "MLX Frozen-KV MTP does not support mixed chunked prefill."
+        )
+    if int(getattr(server_args, "max_running_requests", 0)) != 1:
+        raise NotImplementedError(
+            "MLX Frozen-KV MTP requires --max-running-requests 1."
+        )
+
+    context_length = getattr(server_args, "context_length", None)
+    if context_length is None:
+        context_length = server_args.get_model_config().context_len
+    if int(context_length) > MLX_GEMMA4_MTP_MAX_CONTEXT:
+        raise NotImplementedError(
+            "MLX Frozen-KV MTP supports a context length no greater than 2,048."
+        )
+    max_total_tokens = getattr(server_args, "max_total_tokens", None)
+    if max_total_tokens is not None and int(max_total_tokens) > 2048:
+        raise NotImplementedError(
+            "MLX Frozen-KV MTP requires --max-total-tokens no greater than 2,048."
+        )
+
+    for field, flag in (
+        ("tp_size", "tp-size"),
+        ("dp_size", "dp-size"),
+        ("pp_size", "pp-size"),
+    ):
+        if int(getattr(server_args, field, 1)) != 1:
+            raise NotImplementedError(f"MLX Frozen-KV MTP requires --{flag} 1.")
+    if int(getattr(server_args, "nnodes", 1)) != 1:
+        raise NotImplementedError("MLX Frozen-KV MTP supports one Apple host only.")
+    if bool(getattr(server_args, "enable_dp_attention", False)):
+        raise NotImplementedError("MLX Frozen-KV MTP does not support DP attention.")
+    disagg = str(getattr(server_args, "disaggregation_mode", "null")).lower()
+    if disagg not in ("null", "none") and not disagg.endswith(".null"):
+        raise NotImplementedError("MLX Frozen-KV MTP does not support disaggregation.")
+
+    _validate_target_config(server_args)
+    assistant_config = load_assistant_config_dict(
+        server_args.speculative_draft_model_path,
+        revision=getattr(server_args, "speculative_draft_model_revision", None),
+    )
+    _validate_assistant_config(server_args, assistant_config)
+    setattr(server_args, "_mlx_gemma4_mtp_assistant_config", assistant_config)
+
+
+def validate_mlx_frozen_kv_mtp_request(
+    req: Req, *, has_multimodal: bool = False
+) -> Optional[str]:
+    """Return an admission error for request features outside the MVP."""
+
+    params = req.sampling_params
+    if int(params.top_k) != 1:
+        return (
+            "MLX Frozen-KV MTP requires greedy requests with temperature=0 "
+            "(normalized top_k must equal 1)."
+        )
+    if (
+        float(params.frequency_penalty) != 0.0
+        or float(params.presence_penalty) != 0.0
+        or float(params.repetition_penalty) != 1.0
+        or int(params.min_new_tokens) != 0
+    ):
+        return "MLX Frozen-KV MTP does not support sampling penalties."
+    if params.logit_bias is not None:
+        return "MLX Frozen-KV MTP does not support logit bias."
+    if any(
+        bool(value)
+        for value in (
+            params.json_schema,
+            params.regex,
+            params.ebnf,
+            params.structural_tag,
+            getattr(params, "stop_regex_strs", None),
+        )
+    ):
+        return "MLX Frozen-KV MTP does not support grammar-constrained decoding."
+    if int(params.n) != 1:
+        return "MLX Frozen-KV MTP supports one completion per request."
+    if getattr(params, "custom_params", None):
+        return "MLX Frozen-KV MTP does not support custom sampling parameters."
+    if bool(getattr(req, "return_logprob", False)):
+        return "MLX Frozen-KV MTP does not support logprobs."
+    if bool(getattr(req, "return_hidden_states", False)):
+        return "MLX Frozen-KV MTP does not return target hidden states."
+    if bool(getattr(req, "return_sampling_mask", False)):
+        return "MLX Frozen-KV MTP does not return sampling masks."
+    if getattr(req, "custom_logit_processor", None) is not None:
+        return "MLX Frozen-KV MTP does not support custom logits processors."
+    if (
+        getattr(req, "session", None) is not None
+        or getattr(req, "session_id", None) is not None
+    ):
+        return "MLX Frozen-KV MTP does not support sessions."
+    if getattr(req, "lora_id", None) is not None:
+        return "MLX Frozen-KV MTP does not support LoRA requests."
+    if has_multimodal or getattr(req, "multimodal_inputs", None) is not None:
+        return "MLX Frozen-KV MTP is text-only."
+    return None

--- a/python/sglang/srt/hardware_backend/mlx/spec_decode.py
+++ b/python/sglang/srt/hardware_backend/mlx/spec_decode.py
@@ -1,0 +1,157 @@
+"""Backend-local contracts for linear MLX speculative verification.
+
+The first Gemma 4 MTP implementation deliberately proposes a single linear
+token rather than a tree.  Keeping the acceptance policy here makes it easy to
+test without importing MLX, model weights, or scheduler state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class MlxVerifySegment:
+    """One request's fixed-width draft row and target verification results.
+
+    ``draft_tokens`` contains ``draft_slot_width`` entries.  Only the explicit
+    ``valid_draft_count`` prefix is a draft; every remaining entry must be the
+    ``-1`` padding sentinel.  ``target_token_ids`` has one row for the pending
+    root query plus one row for each valid draft.
+    """
+
+    request_id: str
+    draft_tokens: tuple[int, ...]
+    valid_draft_count: int
+    target_token_ids: tuple[int, ...]
+    invalid_draft_count: int | None = None
+    verification_query_count: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "draft_tokens", tuple(self.draft_tokens))
+        object.__setattr__(self, "target_token_ids", tuple(self.target_token_ids))
+
+        width = len(self.draft_tokens)
+        valid = self.valid_draft_count
+        if valid < 0:
+            raise ValueError("valid_draft_count must be non-negative")
+        if valid > width:
+            raise ValueError(
+                f"valid_draft_count {valid} exceeds draft row width {width}"
+            )
+
+        valid_prefix = self.draft_tokens[:valid]
+        if any(token < 0 for token in valid_prefix):
+            raise ValueError(
+                "negative draft token found inside the declared valid prefix"
+            )
+        padded_suffix = self.draft_tokens[valid:]
+        if any(token != -1 for token in padded_suffix):
+            raise ValueError("every unused draft slot must contain exactly -1")
+
+        if self.invalid_draft_count is not None:
+            if self.invalid_draft_count < 0:
+                raise ValueError("invalid_draft_count must be non-negative")
+            if valid + self.invalid_draft_count != width:
+                raise ValueError(
+                    "valid_draft_count + invalid_draft_count must equal the "
+                    "fixed draft row width"
+                )
+
+        expected_queries = valid + 1
+        if len(self.target_token_ids) != expected_queries:
+            raise ValueError(
+                "target verification rows must equal valid_draft_count + 1: "
+                f"expected {expected_queries}, got {len(self.target_token_ids)}"
+            )
+        if self.verification_query_count is not None and (
+            self.verification_query_count != expected_queries
+        ):
+            raise ValueError(
+                "verification_query_count must equal valid_draft_count + 1"
+            )
+        if any(token < 0 for token in self.target_token_ids):
+            raise ValueError("target verification token IDs must be non-negative")
+
+    @property
+    def draft_slot_width(self) -> int:
+        return len(self.draft_tokens)
+
+    @property
+    def valid_draft_tokens(self) -> tuple[int, ...]:
+        """Return only the explicit valid prefix; padding never escapes here."""
+
+        return self.draft_tokens[: self.valid_draft_count]
+
+
+@dataclass(frozen=True)
+class MlxVerifyDecision:
+    """Lossless greedy acceptance decision for one request."""
+
+    request_id: str
+    emitted_token_ids: tuple[int, ...]
+    accepted_draft_count: int
+    committed_query_count: int
+    seed_hidden_row_index: int
+
+    @property
+    def accept_len(self) -> int:
+        """Scheduler-visible emitted width (accepted drafts plus one target)."""
+
+        return len(self.emitted_token_ids)
+
+
+def verify_greedy_segment(segment: MlxVerifySegment) -> MlxVerifyDecision:
+    """Accept the longest exact draft prefix and append the target continuation."""
+
+    drafts = segment.valid_draft_tokens
+    targets = segment.target_token_ids
+    accepted = 0
+    for draft, target in zip(drafts, targets):
+        if draft != target:
+            break
+        accepted += 1
+
+    emitted = drafts[:accepted] + (targets[accepted],)
+    # Query row zero is the pending previously-emitted token.  Each accepted
+    # draft makes one additional verification query part of the visible cache.
+    committed_queries = accepted + 1
+    return MlxVerifyDecision(
+        request_id=segment.request_id,
+        emitted_token_ids=emitted,
+        accepted_draft_count=accepted,
+        committed_query_count=committed_queries,
+        # The newly sampled mismatch/bonus has not been queried.  The assistant
+        # seed therefore uses the last committed query row.
+        seed_hidden_row_index=committed_queries - 1,
+    )
+
+
+def verify_greedy_segments(
+    segments: Iterable[MlxVerifySegment],
+    *,
+    expected_request_ids: Sequence[str] | None = None,
+) -> tuple[MlxVerifyDecision, ...]:
+    """Verify an ordered batch while rejecting ambiguous request alignment."""
+
+    materialized = tuple(segments)
+    request_ids = tuple(segment.request_id for segment in materialized)
+    if len(set(request_ids)) != len(request_ids):
+        raise ValueError("verification segments contain duplicate request IDs")
+    if expected_request_ids is not None and request_ids != tuple(expected_request_ids):
+        raise ValueError(
+            "verification request ordering does not match target row ordering: "
+            f"segments={request_ids}, target={tuple(expected_request_ids)}"
+        )
+    return tuple(verify_greedy_segment(segment) for segment in materialized)
+
+
+def build_linear_verify_queries(
+    root_token: int, segment: MlxVerifySegment
+) -> tuple[int, ...]:
+    """Build target queries after validated padding has been removed."""
+
+    if root_token < 0:
+        raise ValueError("root verification token must be non-negative")
+    return (root_token,) + segment.valid_draft_tokens

--- a/python/sglang/srt/hardware_backend/mlx/speculative_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/speculative_worker.py
@@ -1,0 +1,477 @@
+"""Synchronous MLX-native Gemma 4 Frozen-KV MTP worker."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.hardware_backend.mlx.gemma4_mtp import (
+    Gemma4MTPAssistantLoader,
+    Gemma4MTPAssistantRuntime,
+)
+from sglang.srt.hardware_backend.mlx.spec_decode import (
+    MlxVerifySegment,
+    build_linear_verify_queries,
+    verify_greedy_segment,
+)
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+
+if TYPE_CHECKING:
+    from sglang.srt.hardware_backend.mlx.model_adapter import MlxTargetSeed
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.server_args import ServerArgs
+
+
+class MlxFrozenKVMTPDraftInput(SpecInput):
+    """CPU-only scheduler relay; MLX hidden/KV state remains worker-owned."""
+
+    def __init__(
+        self,
+        *,
+        request_ids: tuple[str, ...],
+        draft_token_ids: torch.Tensor,
+        valid_draft_counts: torch.Tensor,
+        bonus_tokens: torch.Tensor,
+        new_seq_lens: torch.Tensor,
+        accept_tokens: torch.Tensor,
+        accept_lens: torch.Tensor,
+    ) -> None:
+        super().__init__(SpecInputType.FROZEN_KV_MTP_DRAFT)
+        size = len(request_ids)
+        for name, value in (
+            ("draft_token_ids", draft_token_ids),
+            ("valid_draft_counts", valid_draft_counts),
+            ("bonus_tokens", bonus_tokens),
+            ("new_seq_lens", new_seq_lens),
+            ("accept_lens", accept_lens),
+        ):
+            if value.ndim != 1 or len(value) != size:
+                raise ValueError(f"{name} must be a flat tensor of length {size}")
+        if accept_tokens.ndim != 1 or len(accept_tokens) != size * 2:
+            raise ValueError("accept_tokens must use the fixed MLX result width of two")
+        self.request_ids = tuple(request_ids)
+        self.draft_token_ids = draft_token_ids.to(dtype=torch.long, device="cpu")
+        self.valid_draft_counts = valid_draft_counts.to(dtype=torch.int32, device="cpu")
+        self.bonus_tokens = bonus_tokens.to(dtype=torch.long, device="cpu")
+        self.new_seq_lens = new_seq_lens
+        self.accept_tokens = accept_tokens.to(dtype=torch.long, device="cpu")
+        self.accept_lens = accept_lens.to(dtype=torch.int32, device="cpu")
+        self.num_tokens_per_req = 2
+        self.num_tokens_for_logprob_per_req = 2
+        self.topk_p = None
+        self.topk_index = None
+        self.hidden_states = None
+        self.draft_probs = None
+        self.dsa_topk_indices = None
+        self.future_indices = None
+
+    @property
+    def draft_token(self) -> torch.Tensor:
+        return self.draft_token_ids
+
+    def filter_batch(
+        self,
+        new_indices: torch.Tensor,
+        has_been_filtered: bool = True,
+        new_indices_cpu: Optional[list[int]] = None,
+    ) -> None:
+        del has_been_filtered
+        indices_cpu = (
+            list(new_indices_cpu)
+            if new_indices_cpu is not None
+            else [int(index) for index in new_indices.to("cpu").tolist()]
+        )
+        indices = torch.tensor(indices_cpu, dtype=torch.long, device="cpu")
+        self.request_ids = tuple(self.request_ids[index] for index in indices_cpu)
+        self.draft_token_ids = self.draft_token_ids[indices]
+        self.valid_draft_counts = self.valid_draft_counts[indices]
+        self.bonus_tokens = self.bonus_tokens[indices]
+        self.new_seq_lens = self.new_seq_lens[new_indices.to(self.new_seq_lens.device)]
+        self.accept_tokens = self.accept_tokens.reshape(-1, 2)[indices].reshape(-1)
+        self.accept_lens = self.accept_lens[indices]
+        if self.future_indices is not None:
+            self.future_indices = self.future_indices[new_indices]
+
+    def merge_batch(self, other: MlxFrozenKVMTPDraftInput) -> None:
+        if not isinstance(other, MlxFrozenKVMTPDraftInput):
+            raise TypeError("cannot merge a non-MLX Frozen-KV draft input")
+        self.request_ids += other.request_ids
+        self.draft_token_ids = torch.cat((self.draft_token_ids, other.draft_token_ids))
+        self.valid_draft_counts = torch.cat(
+            (self.valid_draft_counts, other.valid_draft_counts)
+        )
+        self.bonus_tokens = torch.cat((self.bonus_tokens, other.bonus_tokens))
+        self.new_seq_lens = torch.cat((self.new_seq_lens, other.new_seq_lens))
+        self.accept_tokens = torch.cat((self.accept_tokens, other.accept_tokens))
+        self.accept_lens = torch.cat((self.accept_lens, other.accept_lens))
+        if self.future_indices is not None or other.future_indices is not None:
+            if self.future_indices is None or other.future_indices is None:
+                raise ValueError("future-index relay state must agree when merging")
+            self.future_indices = torch.cat((self.future_indices, other.future_indices))
+
+
+@dataclass
+class MlxGemma4MTPMetrics:
+    proposed_tokens: int = 0
+    verified_tokens: int = 0
+    accepted_draft_tokens: int = 0
+    target_verify_seconds: float = 0.0
+    assistant_propose_seconds: float = 0.0
+    transaction_commit_seconds: float = 0.0
+
+
+class MlxGemma4MTPProposer:
+    def __init__(self, runtime: Gemma4MTPAssistantRuntime):
+        self.runtime = runtime
+
+    @staticmethod
+    def needs_target_hidden_states() -> bool:
+        return True
+
+    def propose_one(self, request_id: str, seed: MlxTargetSeed, cache) -> int:
+        # One live view and seed per RID bounds lifecycle state across long runs.
+        self.runtime.release_request(request_id)
+        bound_seed = self.runtime.bind_seed(request_id, seed)
+        view = self.runtime.bind_request(request_id, cache)
+        return self.runtime.propose_one(bound_seed, view)
+
+
+class MlxFrozenKVMTPWorker(BaseSpecWorker):
+    """One-proposal, greedy, BS=1 native-cache spec-v2 orchestration."""
+
+    def __init__(self, server_args: ServerArgs, gpu_id, ps, nccl_port, target_worker):
+        del gpu_id, ps, nccl_port
+        if not hasattr(target_worker, "_mlx_runner"):
+            raise TypeError("MlxFrozenKVMTPWorker requires MlxTpModelWorker")
+        if not target_worker._mlx_runner.native_cache_fallback:
+            raise ValueError("MLX Frozen-KV MTP requires native Gemma 4 target caches")
+        self.server_args = server_args
+        self._target_worker = target_worker
+        self.model_runner = target_worker.model_runner
+        self._draft_worker = None
+        self.speculative_num_draft_tokens = 2
+        self._native_runner = target_worker._mlx_runner
+        self._target_adapter = self._native_runner._target_adapter
+        self._assistant_loader = Gemma4MTPAssistantLoader(self._native_runner.model)
+        self._assistant_runtime = self._assistant_loader.load(
+            server_args.speculative_draft_model_path,
+            revision=getattr(server_args, "speculative_draft_model_revision", None),
+        )
+        self._proposer = MlxGemma4MTPProposer(self._assistant_runtime)
+        self.metrics = MlxGemma4MTPMetrics()
+        self._active_rids: set[str] = set()
+
+    @property
+    def draft_worker(self):
+        return None
+
+    def carries_draft_hidden_states(self) -> bool:
+        return False
+
+    def get_draft_kv_pool(self):
+        """The assistant reads target KV and deliberately allocates no pool."""
+
+        return None
+
+    def get_speculative_internal_state(self) -> dict[str, object]:
+        """Return JSON-safe activation and lifecycle state for ``/server_info``."""
+
+        import mlx.core as mx
+
+        runtime = self._assistant_loader.runtime
+        return {
+            "implementation": "mlx_gemma4_frozen_kv_mtp",
+            "proposed_tokens": self.metrics.proposed_tokens,
+            "verified_tokens": self.metrics.verified_tokens,
+            "accepted_draft_tokens": self.metrics.accepted_draft_tokens,
+            "target_verify_seconds": self.metrics.target_verify_seconds,
+            "assistant_propose_seconds": self.metrics.assistant_propose_seconds,
+            "transaction_commit_seconds": self.metrics.transaction_commit_seconds,
+            "assistant_load_count": self._assistant_loader.load_count,
+            "assistant_generation": self._assistant_loader.generation,
+            "assistant_fingerprint": None if runtime is None else runtime.fingerprint,
+            "active_request_count": len(self._active_rids),
+            "native_request_count": len(self._native_runner._req_caches),
+            "assistant_request_binding_count": (
+                0 if runtime is None else runtime.request_binding_count
+            ),
+            "mlx_active_memory_bytes": int(mx.get_active_memory()),
+            "mlx_cache_memory_bytes": int(mx.get_cache_memory()),
+            "mlx_peak_memory_bytes": int(mx.get_peak_memory()),
+        }
+
+    def alloc_memory_pool(
+        self,
+        memory_pool_config=None,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+    ) -> None:
+        del memory_pool_config
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+
+    def init_attention_backends(self) -> None:
+        # The target worker is initialized independently by Scheduler; this
+        # worker owns no second attention backend.
+        return None
+
+    def init_cuda_graphs(self) -> None:
+        # Native MLX verification is synchronous and captures no Torch graphs.
+        return None
+
+    def _cleanup_departed(self, current_rids: set[str]) -> None:
+        for rid in self._active_rids - current_rids:
+            self._assistant_runtime.release_request(rid)
+        self._active_rids = set(current_rids)
+
+    @staticmethod
+    def _padded_tokens(emitted: tuple[int, ...]) -> torch.Tensor:
+        if len(emitted) not in (1, 2):
+            raise ValueError("MLX MTP emitted width must be one or two")
+        row = list(emitted) + [-1] * (2 - len(emitted))
+        return torch.tensor(row, dtype=torch.long, device="cpu")
+
+    def _make_draft_input(
+        self,
+        *,
+        request_id: str,
+        proposal: int,
+        bonus_token: int,
+        new_seq_lens: torch.Tensor,
+        accept_tokens: torch.Tensor,
+        accept_len: int,
+    ) -> MlxFrozenKVMTPDraftInput:
+        return MlxFrozenKVMTPDraftInput(
+            request_ids=(request_id,),
+            draft_token_ids=torch.tensor([proposal], dtype=torch.long),
+            valid_draft_counts=torch.tensor(
+                [0 if proposal == -1 else 1], dtype=torch.int32
+            ),
+            bonus_tokens=torch.tensor([bonus_token], dtype=torch.long),
+            new_seq_lens=new_seq_lens,
+            accept_tokens=accept_tokens,
+            accept_lens=torch.tensor([accept_len], dtype=torch.int32),
+        )
+
+    def _propose_from_output(
+        self,
+        request_id: str,
+        target_output,
+        hidden_row_index: int,
+        emitted_token_id: int,
+    ) -> int:
+        seed = self._target_adapter.make_seed(
+            target_output,
+            hidden_row_index=hidden_row_index,
+            emitted_token_id=emitted_token_id,
+        )
+        start = time.perf_counter()
+        proposal = self._proposer.propose_one(
+            request_id, seed, self._native_runner._req_caches[request_id]
+        )
+        self.metrics.assistant_propose_seconds += time.perf_counter() - start
+        self.metrics.proposed_tokens += 1
+        return proposal
+
+    def _forward_prefill(self, batch: ScheduleBatch) -> GenerationBatchResult:
+        target_result, target_output = (
+            self._target_worker.forward_batch_generation_mtp_prefill(batch)
+        )
+        request = batch.reqs[0]
+        token = int(target_result.next_token_ids[0])
+        proposal = self._propose_from_output(
+            request.rid,
+            target_output,
+            hidden_row_index=target_output.hidden_states.shape[1] - 1,
+            emitted_token_id=token,
+        )
+        new_seq_lens = batch.seq_lens.clone()
+        padded = self._padded_tokens((token,))
+        target_result.next_draft_input = self._make_draft_input(
+            request_id=request.rid,
+            proposal=proposal,
+            bonus_token=token,
+            new_seq_lens=new_seq_lens,
+            accept_tokens=padded,
+            accept_len=1,
+        )
+        target_result.new_seq_lens = new_seq_lens
+        target_result.speculative_num_draft_tokens = 2
+        return target_result
+
+    def _forward_decode(self, batch: ScheduleBatch) -> GenerationBatchResult:
+        from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+
+        if len(batch.reqs) != 1:
+            raise ValueError("MLX Frozen-KV MTP MVP supports batch size one")
+        draft_input = batch.spec_info
+        if not isinstance(draft_input, MlxFrozenKVMTPDraftInput):
+            raise TypeError("MLX Frozen-KV MTP decode requires its native draft input")
+        request = batch.reqs[0]
+        if draft_input.request_ids != (request.rid,):
+            raise ValueError("MLX MTP draft handoff request ordering is stale")
+        root = int(self._native_runner._req_token_ids[request.rid][-1])
+        if int(draft_input.bonus_tokens[0]) != root:
+            raise ValueError("MLX MTP draft handoff bonus token is stale")
+        valid = int(draft_input.valid_draft_counts[0])
+        draft = int(draft_input.draft_token_ids[0])
+        if valid not in (0, 1) or (valid == 0) != (draft == -1):
+            raise ValueError("MLX MTP draft sentinel/count metadata is malformed")
+
+        placeholder = MlxVerifySegment(
+            request_id=request.rid,
+            draft_tokens=(draft,),
+            valid_draft_count=valid,
+            invalid_draft_count=1 - valid,
+            target_token_ids=(0,) * (valid + 1),
+            verification_query_count=valid + 1,
+        )
+        queries = build_linear_verify_queries(root, placeholder)
+        pending = None
+        verify_start = time.perf_counter()
+        try:
+            pending = self._native_runner.verify_start(request.rid, queries)
+            target_ids = self._native_runner.verify_materialize(pending)
+            segment = MlxVerifySegment(
+                request_id=request.rid,
+                draft_tokens=(draft,),
+                valid_draft_count=valid,
+                invalid_draft_count=1 - valid,
+                target_token_ids=target_ids,
+                verification_query_count=len(queries),
+            )
+            decision = verify_greedy_segment(segment)
+            self.metrics.target_verify_seconds += time.perf_counter() - verify_start
+            commit_start = time.perf_counter()
+            self._native_runner.verify_finalize(pending, decision)
+            self.metrics.transaction_commit_seconds += (
+                time.perf_counter() - commit_start
+            )
+        except BaseException:
+            if pending is not None:
+                self._native_runner.verify_abort(pending)
+            self._assistant_runtime.release_request(request.rid)
+            raise
+
+        emitted = decision.emitted_token_ids
+        padded = self._padded_tokens(emitted)
+        accept_lens = torch.tensor([len(emitted)], dtype=torch.int32, device="cpu")
+        new_seq_lens = batch.seq_lens + accept_lens.to(batch.seq_lens.device)
+        proposal = self._propose_from_output(
+            request.rid,
+            pending.target_output,
+            hidden_row_index=decision.seed_hidden_row_index,
+            emitted_token_id=emitted[-1],
+        )
+        next_input = self._make_draft_input(
+            request_id=request.rid,
+            proposal=proposal,
+            bonus_token=emitted[-1],
+            new_seq_lens=new_seq_lens,
+            accept_tokens=padded,
+            accept_len=len(emitted),
+        )
+        self.metrics.verified_tokens += valid
+        self.metrics.accepted_draft_tokens += decision.accepted_draft_count
+        return GenerationBatchResult(
+            logits_output=LogitsProcessorOutput(next_token_logits=None),
+            next_token_ids=padded,
+            num_correct_drafts=decision.accepted_draft_count,
+            num_correct_drafts_per_req_cpu=[decision.accepted_draft_count],
+            can_run_cuda_graph=False,
+            accept_lens=accept_lens,
+            new_seq_lens=new_seq_lens,
+            next_draft_input=next_input,
+            speculative_num_draft_tokens=2,
+        )
+
+    def _forward_idle(self, batch: ScheduleBatch) -> GenerationBatchResult:
+        from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+
+        empty_long = torch.empty((0,), dtype=torch.long, device="cpu")
+        empty_int = torch.empty((0,), dtype=torch.int32, device="cpu")
+        empty_seq = batch.seq_lens.clone()
+        draft_input = MlxFrozenKVMTPDraftInput(
+            request_ids=(),
+            draft_token_ids=empty_long,
+            valid_draft_counts=empty_int,
+            bonus_tokens=empty_long,
+            new_seq_lens=empty_seq,
+            accept_tokens=empty_long,
+            accept_lens=empty_int,
+        )
+        return GenerationBatchResult(
+            logits_output=LogitsProcessorOutput(next_token_logits=None),
+            next_token_ids=empty_long,
+            accept_lens=empty_int,
+            new_seq_lens=empty_seq,
+            next_draft_input=draft_input,
+            speculative_num_draft_tokens=2,
+            can_run_cuda_graph=False,
+        )
+
+    def forward_batch_generation(self, batch: ScheduleBatch, on_publish=None, **kwargs):
+        del kwargs
+        current_rids = {request.rid for request in batch.reqs}
+        self._cleanup_departed(current_rids)
+        if batch.forward_mode.is_idle():
+            result = self._forward_idle(batch)
+        elif batch.forward_mode.is_extend():
+            if len(batch.reqs) != 1:
+                raise ValueError("MLX Frozen-KV MTP MVP supports batch size one")
+            result = self._forward_prefill(batch)
+        elif batch.forward_mode.is_decode():
+            result = self._forward_decode(batch)
+        else:
+            raise ValueError(f"MLX Frozen-KV MTP does not support {batch.forward_mode}")
+        self._active_rids = current_rids
+        if on_publish is not None and result.new_seq_lens is not None:
+            on_publish(result.new_seq_lens)
+        return result
+
+    def note_request_finished(self, *, rid: str, natural_stop: bool) -> None:
+        del natural_stop
+        self._assistant_runtime.release_request(rid)
+        self._active_rids.discard(rid)
+
+    def prepare_for_kv_cache_release(self, req) -> None:
+        self._assistant_runtime.release_request(req.rid)
+        self._active_rids.discard(req.rid)
+        self._target_worker.prepare_for_kv_cache_release(req)
+
+    def clear_cache_pool(self) -> None:
+        self._target_worker.clear_cache_pool()
+        self._assistant_loader.clear_request_bindings()
+        self._active_rids.clear()
+
+    def unload_assistant(self) -> None:
+        self._assistant_loader.unload_assistant()
+
+    def replace_assistant(self, checkpoint: str, revision: str | None = None) -> None:
+        self._assistant_runtime = self._assistant_loader.replace_assistant(
+            checkpoint, revision=revision
+        )
+        self._proposer = MlxGemma4MTPProposer(self._assistant_runtime)
+
+    @staticmethod
+    def _unsupported_weight_update():
+        return (
+            False,
+            "MLX Frozen-KV MTP cannot infer an assistant checkpoint/revision "
+            "from generic weight-update requests; restart an idle server with "
+            "both revisions pinned.",
+        )
+
+    def update_weights_from_disk(self, recv_req):
+        return self._unsupported_weight_update()
+
+    def update_weights_from_ipc(self, recv_req):
+        return self._unsupported_weight_update()
+
+    def update_weights_from_tensor(self, recv_req):
+        return self._unsupported_weight_update()

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -62,6 +62,24 @@ class MlxTpModelWorker(TpModelWorker):
             init_kwargs["pool_size"] = get_schedule().max_total_tokens
         self._mlx_runner = MlxModelRunner(**init_kwargs)
 
+        if self._mlx_runner.native_cache_fallback:
+            if not get_schedule().disable_overlap_schedule:
+                raise NotImplementedError(
+                    "Gemma 4 on the MLX backend currently requires "
+                    "--disable-overlap-schedule."
+                )
+            if get_schedule().chunked_prefill_size != -1:
+                raise NotImplementedError(
+                    "Gemma 4 on the MLX backend currently requires "
+                    "--chunked-prefill-size -1."
+                )
+            if self.model_config.context_len > self._mlx_runner.pool_size:
+                raise NotImplementedError(
+                    "Gemma 4 on the MLX backend currently requires "
+                    "--context-length to be no larger than --max-total-tokens "
+                    "(2048 is the validated prototype setting)."
+                )
+
         self._model_runner = MlxModelRunnerStub(
             model_config=self.model_config,
             mem_fraction_static=get_schedule().mem_fraction_static,
@@ -74,6 +92,7 @@ class MlxTpModelWorker(TpModelWorker):
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             memory_pool_config=self.memory_pool_config,
             mlx_pool_size=self._mlx_runner.pool_size,
+            mlx_native_cache_fallback=self._mlx_runner.native_cache_fallback,
         )
 
         self._mlx_active_rids: set[str] = set()
@@ -131,6 +150,13 @@ class MlxTpModelWorker(TpModelWorker):
             # Prefer the just-snapshotted live auxiliary state for the final
             # insert. Any older tracked slot is released during component cleanup.
             req.mamba_last_track_seqlen = None
+            if self._mlx_runner.native_cache_fallback:
+                # Native-cache fallback requires overlap scheduling to be off,
+                # so no later in-flight graph can still reference this request.
+                # Release here rather than waiting for a future decode batch:
+                # a request may finish during prefill and the server may go idle.
+                self._mlx_runner.remove_request(req.rid)
+                self._mlx_active_rids.discard(req.rid)
 
     def _route_extend_request(self, rid: str, decoding_rids: set[str]) -> str:
         """Classify a request within an extend / mixed batch.

--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -53,6 +53,7 @@ class MlxTpModelWorker(TpModelWorker):
         logger.info("Initializing MlxModelRunner for end-to-end MLX inference")
         init_kwargs = dict(
             model_path=get_model().model_path,
+            revision=getattr(self.server_args, "revision", None),
             trust_remote_code=get_model().trust_remote_code,
             disable_radix_cache=get_memory().disable_radix_cache,
             mem_fraction_static=get_schedule().mem_fraction_static,
@@ -157,6 +158,63 @@ class MlxTpModelWorker(TpModelWorker):
                 # a request may finish during prefill and the server may go idle.
                 self._mlx_runner.remove_request(req.rid)
                 self._mlx_active_rids.discard(req.rid)
+
+    def clear_cache_pool(self) -> None:
+        """Clear native request state; scheduler-owned stub pools clear separately."""
+
+        self._mlx_runner.clear()
+        self._mlx_active_rids.clear()
+
+    @staticmethod
+    def _unsupported_weight_update():
+        return (
+            False,
+            "MLX native target/assistant weight updates are unsupported; "
+            "restart an idle server with explicitly pinned target and assistant revisions.",
+        )
+
+    def update_weights_from_disk(self, recv_req):
+        return self._unsupported_weight_update()
+
+    def update_weights_from_ipc(self, recv_req):
+        return self._unsupported_weight_update()
+
+    def update_weights_from_tensor(self, recv_req):
+        return self._unsupported_weight_update()
+
+    def forward_batch_generation_mtp_prefill(self, batch: ScheduleBatch):
+        """Run the BS=1 final prefill while retaining target hidden rows privately."""
+
+        from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+
+        self._ensure_mlx_pool_initialized()
+        if not batch.forward_mode.is_extend() or len(batch.reqs) != 1:
+            raise ValueError("MLX Gemma 4 MTP prefill requires one extend request")
+        req = batch.reqs[0]
+        self._cleanup_stale_rids(batch.forward_mode, {req.rid})
+        if self._mlx_runner.has_request(req.rid):
+            raise ValueError("MLX Gemma 4 MTP does not support chunked prefill")
+
+        input_ids = batch.input_ids.cpu().tolist()
+        if len(input_ids) != int(batch.extend_lens[0]):
+            raise ValueError("MLX Gemma 4 MTP prefill input length is inconsistent")
+        new_slots = batch.out_cache_loc.cpu().tolist()
+        token, target_output = self._mlx_runner.prefill_for_mtp(
+            req_id=req.rid,
+            new_token_ids=input_ids,
+            full_token_ids=list(req.get_fill_ids()),
+            prefix_slot_ids=req.prefix_indices.tolist(),
+            new_slot_ids=new_slots,
+            req_pool_idx=req.req_pool_idx,
+            req=req,
+        )
+        self._mlx_active_rids.add(req.rid)
+        result = GenerationBatchResult(
+            logits_output=LogitsProcessorOutput(next_token_logits=None),
+            next_token_ids=torch.tensor([token], dtype=torch.long, device="cpu"),
+            can_run_cuda_graph=False,
+        )
+        return result, target_output
 
     def _route_extend_request(self, rid: str, decoding_rids: set[str]) -> str:
         """Classify a request within an extend / mixed batch.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1140,7 +1140,13 @@ class Scheduler(
             server_args=self.server_args,
         )
 
-        if self.spec_algorithm.carries_draft_hidden_states():
+        worker_carries_draft_hidden = getattr(
+            self.draft_worker, "carries_draft_hidden_states", lambda: True
+        )()
+        if (
+            self.spec_algorithm.carries_draft_hidden_states()
+            and worker_carries_draft_hidden
+        ):
             # `draft_runner` aliases `draft_runner_list[0]` in the multi-layer
             # worker, so a single accessor covers both shapes.
             draft_runner = self.draft_worker.draft_worker.draft_runner
@@ -2223,6 +2229,20 @@ class Scheduler(
             self.init_req_max_new_tokens(req)
             self._add_request_to_queue(req)
             return
+
+        if self.spec_algorithm.is_frozen_kv_mtp() and use_mlx():
+            from sglang.srt.hardware_backend.mlx.spec_config import (
+                validate_mlx_frozen_kv_mtp_request,
+            )
+
+            error_msg = validate_mlx_frozen_kv_mtp_request(
+                req, has_multimodal=recv_req.mm_inputs is not None
+            )
+            if error_msg is not None:
+                req.set_finish_with_abort(error_msg)
+                self.init_req_max_new_tokens(req)
+                self._add_request_to_queue(req)
+                return
 
         self._maybe_namespace_elastic_radix_cache(req)
 
@@ -3935,6 +3955,12 @@ class Scheduler(
                 self.metrics_reporter.spec_total_num_accept_tokens
                 / self.metrics_reporter.spec_total_num_forward_ct
             )
+
+        get_speculative_state = getattr(
+            self.draft_worker, "get_speculative_internal_state", None
+        )
+        if callable(get_speculative_state):
+            ret["speculative_worker"] = get_speculative_state()
 
         if RECORD_STEP_TIME:
             ret["step_time_dict"] = self.metrics_reporter.step_time_dict

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -230,8 +230,20 @@ class SchedulerBatchResultProcessor:
 
                     req.update_finish_state()
                     if req.finished():
+                        if isinstance(self.draft_worker, BaseSpecWorker):
+                            self.draft_worker.note_request_finished(
+                                rid=req.rid,
+                                natural_stop=isinstance(
+                                    req.finished_reason, FINISH_MATCHED_TOKEN
+                                ),
+                            )
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
+                        prepare_release = getattr(
+                            self.model_worker, "prepare_for_kv_cache_release", None
+                        )
+                        if callable(prepare_release):
+                            prepare_release(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -16,7 +16,7 @@ from sglang.srt.state_capturer.base import TopkCaptureOutput
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import GenerationBatchResult
-    from sglang.srt.speculative.eagle_info import EagleDraftInput
+    from sglang.srt.speculative.spec_info import SpecInput
 
 
 logger = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ class GenerationBatchResult:
     new_seq_lens: Optional[torch.Tensor] = None
 
     # relay path: forward stream -> next step forward
-    next_draft_input: Optional[EagleDraftInput] = None
+    next_draft_input: Optional[SpecInput] = None
 
     # Refs the worker wants scheduler to keep alive for the same 2-iter window
     # as batch_record_buf. Used for cross-stream tensor lifetime (e.g. a spec

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -646,6 +646,21 @@ def assign_req_to_token_pool_func(
             req_to_token.shape[1],
         )
         return
+    if req_to_token.device.type == "cpu":
+        # The MLX backend intentionally keeps scheduler bookkeeping in a
+        # lightweight CPU pool even though its execution device is MPS.  A
+        # Triton launch is neither available nor appropriate for that pool.
+        cursor = 0
+        for index in range(batch_size):
+            req_index = int(req_pool_indices[index].item())
+            start = int(start_offset[index].item())
+            end = int(end_offset[index].item())
+            length = end - start
+            req_to_token[req_index, start:end] = out_cache_loc[
+                cursor : cursor + length
+            ].to(device=req_to_token.device, dtype=req_to_token.dtype)
+            cursor += length
+        return
     assign_req_to_token_pool[(batch_size,)](
         req_pool_indices,
         req_to_token,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -62,6 +62,14 @@ def get_draft_kv_pool(
     if draft_worker is None or spec_algorithm.is_ngram():
         return None
 
+    # Backends that share the target KV cache (the MLX Frozen-KV MTP MVP in
+    # particular) own no draft cache pool.  Let the worker state that
+    # explicitly instead of assuming every speculative worker wraps a Torch
+    # ``draft_runner``.
+    get_worker_pool = getattr(draft_worker, "get_draft_kv_pool", None)
+    if get_worker_pool is not None:
+        return get_worker_pool()
+
     # V2 workers nest the draft runner under `.draft_worker`.
     if server_args.enable_multi_layer_eagle:
         draft_runner = draft_worker.draft_worker.draft_runner_list[0]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5099,12 +5099,21 @@ class ServerArgs:
             # Default attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _gemma4_overrides).
             prefill_backend, decode_backend = self._resolved_attention_backends()
-            accepted_backends = ("trtllm_mha", "triton", "ascend", "intel_xpu")
+            accepted_backends = (
+                "trtllm_mha",
+                "triton",
+                "ascend",
+                "intel_xpu",
+            )
+            if use_mlx():
+                # The MLX runner owns execution; torch_native is a
+                # scheduler-facing placeholder accepted on Apple Silicon.
+                accepted_backends += ("torch_native",)
             assert (
                 prefill_backend in accepted_backends
                 and decode_backend in accepted_backends
             ), (
-                "Gemma4 only supports trtllm_mha, triton, or intel_xpu attention backend, "
+                f"Gemma4 only supports {accepted_backends} attention backends, "
                 f"got prefill={prefill_backend}, decode={decode_backend}"
             )
 

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -43,6 +43,16 @@ class EagleDraftWorkerBase(ABC):
 
 
 class BaseSpecWorker(ABC):
+    def carries_draft_hidden_states(self) -> bool:
+        """Whether disaggregation may dereference a Torch draft runner.
+
+        Existing EAGLE-family workers preserve the historical ``True``
+        default.  Backend-native workers with no Torch draft model override
+        this capability.
+        """
+
+        return True
+
     @property
     def target_worker(self) -> TpModelWorker:
         return self._target_worker

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -264,6 +264,15 @@ class SpeculativeAlgorithm(Enum):
             return DSparkWorkerV2
 
         if self.is_frozen_kv_mtp():
+            from sglang.srt.utils.tensor_bridge import use_mlx
+
+            if use_mlx():
+                from sglang.srt.hardware_backend.mlx.speculative_worker import (
+                    MlxFrozenKVMTPWorker,
+                )
+
+                return MlxFrozenKVMTPWorker
+
             # V2 worker drives both overlap and non-overlap (scheduler runs it
             # synchronously when overlap is disabled), same as EAGLE.
             from sglang.srt.speculative.frozen_kv_mtp_worker_v2 import (

--- a/test/registered/mlx/models_e2e/test_gemma4_mtp_mlx_correctness.py
+++ b/test/registered/mlx/models_e2e/test_gemma4_mtp_mlx_correctness.py
@@ -1,0 +1,360 @@
+"""Pinned real-model correctness gate for MLX Gemma 4 Frozen-KV MTP.
+
+This Stage B test intentionally launches target-only and MTP in separate fresh
+processes.  It is not part of the offline per-PR Stage A lane.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import platform
+import threading
+import time
+import unittest
+from contextlib import contextmanager
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+    try_cached_model,
+)
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=8, suite="stage-b-e2e-mlx")
+
+TARGET = os.environ.get("SGLANG_MLX_GEMMA4_TARGET", "mlx-community/gemma-4-e2b-it-4bit")
+TARGET_REVISION = os.environ.get(
+    "SGLANG_MLX_GEMMA4_TARGET_REVISION",
+    "238767527555cb75a05732a84dff5d6ba0dd6809",
+)
+ASSISTANT = os.environ.get(
+    "SGLANG_MLX_GEMMA4_ASSISTANT",
+    "mlx-community/gemma-4-E2B-it-assistant-bf16",
+)
+ASSISTANT_REVISION = os.environ.get(
+    "SGLANG_MLX_GEMMA4_ASSISTANT_REVISION",
+    "a7770799b560135ebdbfae8b7f468947415003bc",
+)
+
+SHORT_PROMPT = "Explain why the sky appears blue in two sentences."
+CROSS_WINDOW_PROMPT = (
+    "Read this repeated context carefully. "
+    + ("blue green amber violet " * 140)
+    + "Now state the first color in one sentence."
+)
+
+_HAS_RUNTIME = (
+    platform.system() == "Darwin"
+    and platform.machine() == "arm64"
+    and importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_vlm.speculative.drafters.gemma4_assistant")
+    is not None
+)
+
+
+@unittest.skipUnless(_HAS_RUNTIME, "requires Apple Silicon, MLX, and mlx-vlm")
+class TestGemma4MTPMlxCorrectness(CustomTestCase):
+    base_url = DEFAULT_URL_FOR_TEST
+    maxDiff = None
+
+    @classmethod
+    @contextmanager
+    def _server(cls, *, mtp: bool):
+        model = try_cached_model(TARGET)
+        args = [
+            "--revision",
+            TARGET_REVISION,
+            "--served-model-name",
+            TARGET,
+            "--disable-radix-cache",
+            "--disable-overlap-schedule",
+            "--chunked-prefill-size",
+            "-1",
+            "--max-running-requests",
+            "1",
+            "--context-length",
+            "2048",
+            "--max-total-tokens",
+            "2048",
+            "--log-level",
+            "warning",
+        ]
+        if mtp:
+            args.extend(
+                [
+                    "--speculative-algorithm",
+                    "FROZEN_KV_MTP",
+                    "--speculative-draft-model-path",
+                    try_cached_model(ASSISTANT),
+                    "--speculative-draft-model-revision",
+                    ASSISTANT_REVISION,
+                    "--speculative-num-steps",
+                    "1",
+                    "--speculative-eagle-topk",
+                    "1",
+                    "--speculative-num-draft-tokens",
+                    "2",
+                ]
+            )
+        env = os.environ.copy()
+        env["SGLANG_USE_MLX"] = "1"
+        process = popen_launch_server(
+            model,
+            cls.base_url,
+            timeout=max(DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH, 600),
+            other_args=args,
+            env=env,
+        )
+        try:
+            yield
+        finally:
+            kill_process_tree(process.pid)
+
+    @classmethod
+    def _raw(cls, prompt: str, horizon: int, *, ignore_eos: bool) -> dict:
+        payload = {
+            "text": prompt,
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": horizon,
+                "ignore_eos": ignore_eos,
+            },
+        }
+        response = requests.post(f"{cls.base_url}/generate", json=payload, timeout=180)
+        response.raise_for_status()
+        result = response.json()
+        assert len(result["output_ids"]) <= horizon
+        return result
+
+    @classmethod
+    def _chat(cls, prompt: str, horizon: int, *, ignore_eos: bool) -> dict:
+        payload = {
+            "model": TARGET,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+            "max_tokens": horizon,
+            "ignore_eos": ignore_eos,
+            # SGLang's non-streaming extension exposes exact output token IDs
+            # when metadata is requested; logprobs remain disabled.
+            "return_meta_info": True,
+        }
+        response = requests.post(
+            f"{cls.base_url}/v1/chat/completions", json=payload, timeout=180
+        )
+        response.raise_for_status()
+        result = response.json()
+        choice = result["choices"][0]
+        assert len(choice["output_token_ids"]) <= horizon
+        return result
+
+    @classmethod
+    def _spec_state(cls) -> dict:
+        response = requests.get(f"{cls.base_url}/server_info", timeout=30)
+        response.raise_for_status()
+        states = response.json()["internal_states"]
+        assert len(states) == 1
+        return states[0]["speculative_worker"]
+
+    @classmethod
+    def _wait_for_clean_state(cls, timeout: float = 15) -> dict:
+        deadline = time.monotonic() + timeout
+        last = None
+        while time.monotonic() < deadline:
+            last = cls._spec_state()
+            if (
+                last["active_request_count"] == 0
+                and last["native_request_count"] == 0
+                and last["assistant_request_binding_count"] == 0
+            ):
+                return last
+            time.sleep(0.05)
+        raise AssertionError(f"MLX MTP request state did not drain: {last}")
+
+    @classmethod
+    def _abort_streaming_request(cls) -> None:
+        rid = "gemma4-mtp-e2e-abort"
+        opened = threading.Event()
+        result: dict[str, object] = {}
+        errors: list[Exception] = []
+
+        def generate() -> None:
+            try:
+                with requests.post(
+                    f"{cls.base_url}/generate",
+                    json={
+                        "rid": rid,
+                        "text": "Count upward forever, one integer per line.",
+                        "sampling_params": {
+                            "temperature": 0,
+                            "max_new_tokens": 1024,
+                            "ignore_eos": True,
+                        },
+                        "stream": True,
+                    },
+                    stream=True,
+                    timeout=180,
+                ) as response:
+                    result["status"] = response.status_code
+                    opened.set()
+                    result["body"] = b"\n".join(response.iter_lines())
+            except Exception as exc:  # surfaced on the test thread below
+                errors.append(exc)
+                opened.set()
+
+        thread = threading.Thread(target=generate, daemon=True)
+        thread.start()
+        if not opened.wait(30):
+            raise AssertionError("stream did not produce a response")
+        abort = requests.post(
+            f"{cls.base_url}/abort_request", json={"rid": rid}, timeout=30
+        )
+        abort.raise_for_status()
+        thread.join(30)
+        if thread.is_alive():
+            raise AssertionError("aborted stream did not terminate")
+        if errors:
+            raise errors[0]
+        if result.get("status") != 200:
+            raise AssertionError(f"aborted stream returned {result.get('status')}")
+        if b'"type":"abort"' not in result.get("body", b""):
+            raise AssertionError("stream did not report an abort finish reason")
+
+    @staticmethod
+    def _raw_signature(result: dict) -> tuple[list[int], str, str]:
+        return (
+            result["output_ids"],
+            result["text"],
+            result["meta_info"]["finish_reason"]["type"],
+        )
+
+    @staticmethod
+    def _chat_signature(result: dict) -> tuple[list[int], str, str]:
+        choice = result["choices"][0]
+        return (
+            choice["output_token_ids"],
+            choice["message"]["content"],
+            choice["finish_reason"],
+        )
+
+    def test_target_only_and_mtp_exact_server_parity(self):
+        prompts = {"short": SHORT_PROMPT, "cross_window": CROSS_WINDOW_PROMPT}
+        fixed_cases = [
+            (endpoint, prompt_name, horizon)
+            for endpoint in ("raw", "chat")
+            for prompt_name in prompts
+            for horizon in (1, 16, 64)
+        ]
+        target: dict[tuple[str, str, int], tuple[list[int], str, str]] = {}
+
+        with self._server(mtp=False):
+            for endpoint, prompt_name, horizon in fixed_cases:
+                if endpoint == "raw":
+                    result = self._raw(prompts[prompt_name], horizon, ignore_eos=True)
+                    signature = self._raw_signature(result)
+                    prompt_tokens = result["meta_info"]["prompt_tokens"]
+                else:
+                    result = self._chat(prompts[prompt_name], horizon, ignore_eos=True)
+                    signature = self._chat_signature(result)
+                    prompt_tokens = result["usage"]["prompt_tokens"]
+                self.assertEqual(len(signature[0]), horizon)
+                self.assertEqual(signature[2], "length")
+                if prompt_name == "cross_window":
+                    self.assertGreater(prompt_tokens, 512)
+                target[(endpoint, prompt_name, horizon)] = signature
+
+            natural = self._chat(
+                "Reply with exactly one word: OK", 64, ignore_eos=False
+            )
+            target[("chat", "natural_stop", 64)] = self._chat_signature(natural)
+            self.assertEqual(target[("chat", "natural_stop", 64)][2], "stop")
+            repeated = self._raw(SHORT_PROMPT, 16, ignore_eos=True)
+            self.assertEqual(
+                self._raw_signature(repeated), target[("raw", "short", 16)]
+            )
+
+        with self._server(mtp=True):
+            observed_accept = 0
+            observed_proposed = 0
+            accept_and_reject = False
+            for endpoint, prompt_name, horizon in fixed_cases:
+                if endpoint == "raw":
+                    result = self._raw(prompts[prompt_name], horizon, ignore_eos=True)
+                    signature = self._raw_signature(result)
+                    meta = result["meta_info"]
+                else:
+                    result = self._chat(prompts[prompt_name], horizon, ignore_eos=True)
+                    signature = self._chat_signature(result)
+                    meta = result["choices"][0]["meta_info"]
+                self.assertEqual(
+                    signature,
+                    target[(endpoint, prompt_name, horizon)],
+                    (endpoint, prompt_name, horizon),
+                )
+                observed_accept += int(meta.get("spec_num_correct_drafts", 0))
+                observed_proposed += int(meta.get("spec_num_proposed_drafts", 0))
+                histogram = meta.get("spec_correct_drafts_histogram") or []
+                if len(histogram) >= 2 and histogram[0] > 0 and histogram[1] > 0:
+                    accept_and_reject = True
+
+            natural = self._chat(
+                "Reply with exactly one word: OK", 64, ignore_eos=False
+            )
+            self.assertEqual(
+                self._chat_signature(natural),
+                target[("chat", "natural_stop", 64)],
+            )
+            repeated = self._raw(SHORT_PROMPT, 16, ignore_eos=True)
+            self.assertEqual(
+                self._raw_signature(repeated), target[("raw", "short", 16)]
+            )
+            self.assertGreater(observed_proposed, 0)
+            self.assertGreater(observed_accept, 0)
+            self.assertTrue(accept_and_reject)
+
+            self._abort_streaming_request()
+            before_flush = self._wait_for_clean_state()
+            self.assertGreater(before_flush["proposed_tokens"], 0)
+            self.assertGreater(before_flush["verified_tokens"], 0)
+            self.assertGreaterEqual(
+                before_flush["proposed_tokens"], before_flush["verified_tokens"]
+            )
+            self.assertLessEqual(
+                before_flush["accepted_draft_tokens"],
+                before_flush["verified_tokens"],
+            )
+
+            fingerprint = before_flush["assistant_fingerprint"]
+            load_count = before_flush["assistant_load_count"]
+            flush = requests.post(f"{self.base_url}/flush_cache", timeout=30)
+            flush.raise_for_status()
+            after_flush = self._wait_for_clean_state()
+            self.assertEqual(after_flush["assistant_fingerprint"], fingerprint)
+            self.assertEqual(after_flush["assistant_load_count"], load_count)
+
+            post_flush = self._raw(SHORT_PROMPT, 16, ignore_eos=True)
+            self.assertEqual(
+                self._raw_signature(post_flush), target[("raw", "short", 16)]
+            )
+
+            # Active MLX memory must settle after warmup/request churn.  The
+            # allocator cache may remain populated and is intentionally not
+            # required to return to its initial value.
+            memory_samples = []
+            for _ in range(5):
+                self._raw(SHORT_PROMPT, 16, ignore_eos=True)
+                memory_samples.append(
+                    self._wait_for_clean_state()["mlx_active_memory_bytes"]
+                )
+            allowance = max(256 * 1024 * 1024, memory_samples[0] // 10)
+            self.assertLessEqual(memory_samples[-1], memory_samples[0] + allowance)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -492,6 +492,7 @@ class TestModelSerialization(unittest.TestCase):
         )
         default_data = default_choice.model_dump()
         self.assertNotIn("prompt_token_ids", default_data)
+        self.assertNotIn("output_token_ids", default_data)
         self.assertNotIn("meta_info", default_data)
 
         choice = ChatCompletionResponseChoice(
@@ -499,10 +500,12 @@ class TestModelSerialization(unittest.TestCase):
             message=ChatMessage(role="assistant", content="Hello"),
             finish_reason="stop",
             prompt_token_ids=[1, 2, 3],
+            output_token_ids=[4, 5],
             meta_info={"prompt_tokens": 3},
         )
         data = choice.model_dump()
         self.assertEqual(data["prompt_token_ids"], [1, 2, 3])
+        self.assertEqual(data["output_token_ids"], [4, 5])
         self.assertEqual(data["meta_info"], {"prompt_tokens": 3})
 
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1668,6 +1668,7 @@ class ServingChatTestCase(unittest.TestCase):
         ret = [
             {
                 "text": "Answer",
+                "output_ids": [42],
                 "prompt_token_ids": [11, 12, 13],
                 "meta_info": {
                     "id": "chatcmpl-token-ids",
@@ -1684,9 +1685,11 @@ class ServingChatTestCase(unittest.TestCase):
         choice = response.choices[0]
 
         self.assertEqual(choice.prompt_token_ids, [11, 12, 13])
+        self.assertEqual(choice.output_token_ids, [42])
         self.assertEqual(choice.meta_info, ret[0]["meta_info"])
         dumped_choice = response.model_dump()["choices"][0]
         self.assertEqual(dumped_choice["prompt_token_ids"], [11, 12, 13])
+        self.assertEqual(dumped_choice["output_token_ids"], [42])
         self.assertEqual(dumped_choice["meta_info"], ret[0]["meta_info"])
 
     def test_streaming_cached_tokens_details_emits_sglext(self):

--- a/test/registered/unit/hardware_backend/mlx/gemma4_test_utils.py
+++ b/test/registered/unit/hardware_backend/mlx/gemma4_test_utils.py
@@ -1,0 +1,217 @@
+"""Shared tiny Gemma 4 fixtures for offline MLX architecture tests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from unittest import mock
+
+import mlx.core as mx
+import numpy as np
+from mlx_lm.models import gemma4, gemma4_text
+
+from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+
+
+def tiny_gemma4(*, wrapped: bool = False):
+    """Build a four-layer model containing every target cache quirk."""
+
+    args = gemma4_text.ModelArgs(
+        hidden_size=16,
+        num_hidden_layers=4,
+        intermediate_size=32,
+        num_attention_heads=2,
+        head_dim=4,
+        global_head_dim=8,
+        vocab_size=32,
+        vocab_size_per_layer_input=32,
+        num_key_value_heads=1,
+        num_global_key_value_heads=1,
+        num_kv_shared_layers=2,
+        hidden_size_per_layer_input=0,
+        sliding_window=8,
+        sliding_window_pattern=2,
+        max_position_embeddings=4096,
+        attention_k_eq_v=True,
+        use_double_wide_mlp=False,
+        layer_types=[
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+    )
+    model = (
+        gemma4.Model(
+            gemma4.ModelArgs(
+                text_config=asdict(args),
+                vocab_size=args.vocab_size,
+            )
+        )
+        if wrapped
+        else gemma4_text.Model(args)
+    )
+    mx.eval(model.parameters())
+    return model
+
+
+def build_runner(model, **kwargs):
+    options = {
+        "model_path": "tiny-gemma4",
+        "disable_radix_cache": True,
+        "pool_size": 64,
+    }
+    options.update(kwargs)
+    with mock.patch.object(
+        MlxModelRunner,
+        "_load_model",
+        new=lambda runner: setattr(runner, "model", model),
+    ):
+        return MlxModelRunner(**options)
+
+
+def reference_tokens(model, prompt: list[int], steps: int) -> list[int]:
+    cache = model.make_cache()
+    input_ids = mx.array([prompt], dtype=mx.int32)
+    output = []
+    for _ in range(steps):
+        logits = model(input_ids, cache=cache)
+        token = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(token, *[value for entry in cache for value in entry.state])
+        output.append(int(token.item()))
+        input_ids = token[:, None]
+    return output
+
+
+def cache_logical_length(cache) -> int:
+    offsets = {int(entry.offset) for entry in cache}
+    if len(offsets) != 1:
+        raise AssertionError(f"native cache offsets disagree: {sorted(offsets)}")
+    return offsets.pop()
+
+
+def native_cache_snapshot(cache):
+    """Capture logical K/V in temporal order plus all visible ring metadata."""
+
+    snapshot = []
+    for entry in cache:
+        keys = getattr(entry, "keys", None)
+        values = getattr(entry, "values", None)
+        if keys is None:
+            logical_keys = logical_values = None
+        elif hasattr(entry, "_temporal_order"):
+            logical_keys = entry._temporal_order(keys)
+            logical_values = entry._temporal_order(values)
+            valid = min(int(entry.offset), int(entry.max_size))
+            logical_keys = (
+                logical_keys[..., -valid:, :] if valid else logical_keys[..., :0, :]
+            )
+            logical_values = (
+                logical_values[..., -valid:, :] if valid else logical_values[..., :0, :]
+            )
+        else:
+            valid = int(entry.offset)
+            logical_keys = keys[..., :valid, :]
+            logical_values = values[..., :valid, :]
+
+        arrays = [item for item in (logical_keys, logical_values) if item is not None]
+        if arrays:
+            mx.eval(*arrays)
+        snapshot.append(
+            {
+                "type": type(entry).__name__,
+                "offset": int(entry.offset),
+                "idx": getattr(entry, "_idx", None),
+                "keep": getattr(entry, "keep", None),
+                "max_size": getattr(entry, "max_size", None),
+                "keys": None if logical_keys is None else np.array(logical_keys),
+                "values": None if logical_values is None else np.array(logical_values),
+            }
+        )
+    return snapshot
+
+
+def assert_native_cache_equal(testcase, actual, expected) -> None:
+    actual_snapshot = native_cache_snapshot(actual)
+    expected_snapshot = native_cache_snapshot(expected)
+    testcase.assertEqual(len(actual_snapshot), len(expected_snapshot))
+    for index, (left, right) in enumerate(zip(actual_snapshot, expected_snapshot)):
+        with testcase.subTest(cache_index=index):
+            for key in ("type", "offset", "idx", "keep", "max_size"):
+                testcase.assertEqual(left[key], right[key], key)
+            if left["keys"] is None or right["keys"] is None:
+                testcase.assertIs(left["keys"], right["keys"])
+                testcase.assertIs(left["values"], right["values"])
+            else:
+                np.testing.assert_array_equal(left["keys"], right["keys"])
+                np.testing.assert_array_equal(left["values"], right["values"])
+
+
+def tiny_assistant_config(*, ordered: bool = False) -> dict:
+    return {
+        "architectures": ["Gemma4AssistantForCausalLM"],
+        "model_type": "gemma4_assistant",
+        "backbone_hidden_size": 16,
+        "use_ordered_embeddings": ordered,
+        "num_centroids": 4 if ordered else 0,
+        "centroid_intermediate_top_k": 2 if ordered else 0,
+        "tie_word_embeddings": True,
+        "text_config": {
+            "model_type": "gemma4_text",
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 2,
+            "head_dim": 4,
+            "global_head_dim": 8,
+            "vocab_size": 32,
+            "vocab_size_per_layer_input": 0,
+            "num_key_value_heads": 1,
+            "num_global_key_value_heads": 1,
+            "num_kv_shared_layers": 4,
+            "hidden_size_per_layer_input": 0,
+            "sliding_window": 8,
+            "sliding_window_pattern": 2,
+            "max_position_embeddings": 4096,
+            "attention_k_eq_v": False,
+            "use_double_wide_mlp": False,
+            "final_logit_softcapping": None,
+            "tie_word_embeddings": True,
+            "layer_types": [
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+        },
+    }
+
+
+def write_tiny_assistant_checkpoint(
+    directory: Path,
+    *,
+    ordered: bool = False,
+    weight_delta: float = 0.0,
+) -> dict:
+    """Materialize deterministic-shaped local provider weights for Stage A."""
+
+    from mlx.utils import tree_flatten
+    from mlx_vlm.speculative.drafters.gemma4_assistant.config import (
+        Gemma4AssistantConfig,
+    )
+    from mlx_vlm.speculative.drafters.gemma4_assistant.gemma4_assistant import (
+        Gemma4AssistantDraftModel,
+    )
+
+    directory.mkdir(parents=True, exist_ok=True)
+    config = tiny_assistant_config(ordered=ordered)
+    (directory / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    provider_config = Gemma4AssistantConfig.from_dict(config)
+    model = Gemma4AssistantDraftModel(provider_config)
+    weights = dict(tree_flatten(model.parameters()))
+    if weight_delta:
+        first = sorted(weights)[0]
+        weights[first] = weights[first] + weight_delta
+    mx.save_safetensors(str(directory / "model.safetensors"), weights)
+    return config

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_cache_transaction.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_cache_transaction.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+
+from sglang.test.ci.ci_register import register_mlx_ci
+
+register_mlx_ci(est_time=2, suite="stage-a-unit-test-mlx")
+
+_HAS_MLX = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_lm.models.gemma4_text") is not None
+)
+
+if _HAS_MLX:
+    import mlx.core as mx
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        assert_native_cache_equal,
+        cache_logical_length,
+        native_cache_snapshot,
+        tiny_gemma4,
+    )
+
+    from sglang.srt.hardware_backend.mlx.kv_cache.native_transaction import (
+        MlxNativeCacheTransaction,
+        clone_native_cache,
+    )
+    from sglang.srt.hardware_backend.mlx.spec_decode import (
+        MlxVerifySegment,
+        verify_greedy_segment,
+    )
+
+
+@unittest.skipUnless(_HAS_MLX, "requires MLX and mlx-lm Gemma 4")
+class TestGemma4NativeCacheTransaction(unittest.TestCase):
+    def setUp(self):
+        self.model = tiny_gemma4()
+
+    def _forward(self, cache, tokens):
+        return self.model(mx.array([tokens], dtype=mx.int32), cache=cache)
+
+    def _prefill(self, prompt):
+        cache = self.model.make_cache()
+        logits = self._forward(cache, tuple(prompt))
+        root = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(root, *[item for entry in cache for item in entry.state])
+        return cache, int(root.item())
+
+    def _correct_draft(self, cache, root):
+        probe = clone_native_cache(cache)
+        logits = self._forward(probe, (root,))
+        token = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(token)
+        return int(token.item())
+
+    def _exercise(self, prompt, *, accept):
+        cache, root = self._prefill(prompt)
+        draft = self._correct_draft(cache, root)
+        if not accept:
+            draft = (draft + 1) % self.model.args.vocab_size
+
+        transaction = MlxNativeCacheTransaction(cache, (root, draft), self._forward)
+        speculative = transaction.begin()
+        logits = self._forward(speculative, (root, draft))
+        target_ids = tuple(
+            int(item) for item in mx.argmax(logits, axis=-1).reshape(-1).tolist()
+        )
+        decision = verify_greedy_segment(
+            MlxVerifySegment("r", (draft,), 1, target_ids, 0, 2)
+        )
+        transaction.commit(decision.committed_query_count)
+
+        reference, reference_root = self._prefill(prompt)
+        self.assertEqual(root, reference_root)
+        self._forward(reference, (root, draft)[: decision.committed_query_count])
+        mx.eval(*[item for entry in reference for item in entry.state])
+        assert_native_cache_equal(self, cache, reference)
+
+        token_history = list(prompt) + [root] + list(decision.emitted_token_ids)
+        self.assertEqual(len(token_history), cache_logical_length(cache) + 1)
+        return cache
+
+    def test_accept_and_reject_match_target_only(self):
+        self._exercise([1, 2, 3], accept=True)
+        self._exercise([1, 2, 3], accept=False)
+
+    def test_before_at_after_and_multiple_window_rotations(self):
+        for prompt_len in (7, 8, 9, 17, 25):
+            for accept in (False, True):
+                with self.subTest(prompt_len=prompt_len, accept=accept):
+                    prompt = [1 + (index % 29) for index in range(prompt_len)]
+                    cache = self._exercise(prompt, accept=accept)
+                    self.assertEqual(len(cache), 2)  # compact YOCO owner list
+                    self.assertEqual(
+                        [type(entry).__name__ for entry in cache],
+                        ["RotatingKVCache", "KVCache"],
+                    )
+
+    def test_abort_and_forward_failure_restore_original(self):
+        cache, root = self._prefill(list(range(1, 12)))
+        before = clone_native_cache(cache)
+        draft = self._correct_draft(cache, root)
+
+        transaction = MlxNativeCacheTransaction(cache, (root, draft), self._forward)
+        speculative = transaction.begin()
+        self._forward(speculative, (root, draft))
+        transaction.abort()
+        assert_native_cache_equal(self, cache, before)
+
+        def failing_replay(target_cache, tokens):
+            result = self._forward(target_cache, tokens)
+            mx.eval(result, *[item for entry in target_cache for item in entry.state])
+            raise RuntimeError("synthetic target failure")
+
+        transaction = MlxNativeCacheTransaction(cache, (root,), failing_replay)
+        transaction.begin()
+        with self.assertRaisesRegex(RuntimeError, "synthetic target failure"):
+            transaction.commit(1)
+        assert_native_cache_equal(self, cache, before)
+
+    def test_transactions_are_single_use_and_request_isolated(self):
+        cache_a, root_a = self._prefill([1, 2])
+        cache_b, _ = self._prefill([7, 8, 9])
+        before_b = native_cache_snapshot(cache_b)
+        transaction = MlxNativeCacheTransaction(cache_a, (root_a,), self._forward)
+        transaction.begin()
+        with self.assertRaisesRegex(RuntimeError, "single-use"):
+            transaction.begin()
+        transaction.commit(1)
+        with self.assertRaisesRegex(RuntimeError, "active"):
+            transaction.commit(1)
+        self.assertEqual(transaction.committed_count, 1)
+
+        after_b = native_cache_snapshot(cache_b)
+        for left, right in zip(before_b, after_b):
+            self.assertEqual(left["offset"], right["offset"])
+            self.assertTrue((left["keys"] == right["keys"]).all())
+
+        abort_txn = MlxNativeCacheTransaction(cache_b, (0,), self._forward)
+        abort_txn.begin()
+        abort_txn.abort()
+        with self.assertRaisesRegex(RuntimeError, "active"):
+            abort_txn.abort()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_kv_sharing.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_kv_sharing.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from sglang.test.ci.ci_register import register_mlx_ci
+
+register_mlx_ci(est_time=2, suite="stage-a-unit-test-mlx")
+
+_HAS_PROVIDER = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_vlm.speculative.drafters.gemma4_assistant")
+    is not None
+)
+
+if _HAS_PROVIDER:
+    import mlx.core as mx
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        build_runner,
+        tiny_gemma4,
+        write_tiny_assistant_checkpoint,
+    )
+
+    from sglang.srt.hardware_backend.mlx.gemma4_mtp import (
+        Gemma4MTPAssistantLoader,
+        Gemma4MTPKVSharingPlan,
+    )
+
+
+@unittest.skipUnless(_HAS_PROVIDER, "requires mlx-vlm Gemma 4 assistant provider")
+class TestGemma4MTPKVSharing(unittest.TestCase):
+    def _runtime(self, root: Path):
+        target = tiny_gemma4()
+        write_tiny_assistant_checkpoint(root)
+        loader = Gemma4MTPAssistantLoader(target)
+        return target, loader, loader.load(str(root))
+
+    def test_logical_owner_compact_mapping_and_runner_layout(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target, _loader, runtime = self._runtime(Path(temp))
+            plan = runtime.sharing_plan
+            self.assertEqual(plan.target_logical_layers, (2, 3, 2, 3))
+            self.assertEqual(plan.target_owner_layers, (0, 1, 0, 1))
+            self.assertEqual(plan.compact_cache_indices, (0, 1, 0, 1))
+            self.assertEqual(plan.compact_owner_layers, (0, 1))
+
+            runner = build_runner(target)
+            self.assertEqual(
+                runner._cache_layout.native_cache_owner_by_layer, (0, 1, 0, 1)
+            )
+            self.assertEqual(runner._cache_layout.native_cache_index(2), 0)
+            self.assertEqual(runner._cache_layout.native_cache_index(3), 1)
+
+    def test_nested_or_out_of_range_owner_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target, _loader, runtime = self._runtime(Path(temp))
+            backbone = target.model
+            original = list(backbone.previous_kvs)
+            for invalid in ([0, 1, 3, 1], [0, 1, 99, 1]):
+                with self.subTest(invalid=invalid):
+                    backbone.previous_kvs = invalid
+                    with self.assertRaises(ValueError):
+                        Gemma4MTPKVSharingPlan.from_target(target, runtime.metadata)
+            backbone.previous_kvs = original
+
+    def test_rotating_view_restores_absolute_positions_without_mutation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target, _loader, runtime = self._runtime(Path(temp))
+            cache = target.make_cache()
+            prompt = list(range(1, 18))
+            target(mx.array([prompt], dtype=mx.int32), cache=cache)
+            mx.eval(*[item for entry in cache for item in entry.state])
+            identities = tuple(map(id, cache))
+            offsets = tuple(entry.offset for entry in cache)
+            ring_indices = tuple(getattr(entry, "_idx", None) for entry in cache)
+
+            view = runtime.bind_request("r", cache)
+            shared = view.shared_kv_states()
+            local_k, local_v = shared["sliding_attention"]
+            full_k, full_v = shared["full_attention"]
+            mx.eval(local_k, local_v, full_k, full_v)
+
+            self.assertEqual(view.position, 17)
+            self.assertEqual(local_k.shape[-2], 17)
+            self.assertEqual(full_k.shape[-2], 17)
+            # The first nine local positions are masked padding; the temporal
+            # target window occupies the absolute suffix.
+            np.testing.assert_array_equal(np.array(local_k[..., :9, :]), 0)
+            self.assertEqual(tuple(map(id, cache)), identities)
+            self.assertEqual(tuple(entry.offset for entry in cache), offsets)
+            self.assertEqual(
+                tuple(getattr(entry, "_idx", None) for entry in cache), ring_indices
+            )
+
+    def test_request_isolation_and_lifecycle_invalidation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            target, loader, runtime = self._runtime(Path(temp))
+            cache_a = target.make_cache()
+            cache_b = target.make_cache()
+            target(mx.array([[1, 2, 3]], dtype=mx.int32), cache=cache_a)
+            target(mx.array([[7, 8, 9, 10]], dtype=mx.int32), cache=cache_b)
+            view_a = runtime.bind_request("a", cache_a)
+            view_b = runtime.bind_request("b", cache_b)
+            self.assertEqual(view_a.position, 3)
+            self.assertEqual(view_b.position, 4)
+            self.assertFalse(
+                np.array_equal(
+                    np.array(view_a.shared_kv_states()["full_attention"][0]),
+                    np.array(view_b.shared_kv_states()["full_attention"][0]),
+                )
+            )
+
+            runtime.release_request("a")
+            with self.assertRaisesRegex(RuntimeError, "stale"):
+                _ = view_a.position
+            self.assertEqual(view_b.position, 4)
+            loader.clear_request_bindings()
+            with self.assertRaisesRegex(RuntimeError, "stale"):
+                _ = view_b.position
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_loader.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_loader.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.test.ci.ci_register import register_mlx_ci
+
+register_mlx_ci(est_time=2, suite="stage-a-unit-test-mlx")
+
+_HAS_PROVIDER = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_vlm.speculative.drafters.gemma4_assistant")
+    is not None
+)
+
+if _HAS_PROVIDER:
+    import mlx.core as mx
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        tiny_assistant_config,
+        tiny_gemma4,
+        write_tiny_assistant_checkpoint,
+    )
+
+    from sglang.srt.hardware_backend.mlx.gemma4_mtp import (
+        Gemma4MTPAssistantLoader,
+        validate_gemma4_assistant_config,
+    )
+    from sglang.srt.hardware_backend.mlx.model_adapter import Gemma4TargetAdapter
+
+
+@unittest.skipUnless(_HAS_PROVIDER, "requires mlx-vlm Gemma 4 assistant provider")
+class TestGemma4MTPConfigAndLoader(unittest.TestCase):
+    def setUp(self):
+        self.target = tiny_gemma4()
+
+    def test_canonical_and_compatibility_architectures(self):
+        config = tiny_assistant_config()
+        metadata = validate_gemma4_assistant_config(config, self.target)
+        self.assertEqual(metadata.backbone_hidden_size, 16)
+        self.assertEqual(metadata.assistant_hidden_size, 8)
+        self.assertEqual(
+            metadata.layer_types, tuple(config["text_config"]["layer_types"])
+        )
+
+        alias = copy.deepcopy(config)
+        alias["architectures"] = ["Gemma4UnifiedAssistantForCausalLM"]
+        self.assertEqual(
+            validate_gemma4_assistant_config(alias, self.target).architecture,
+            "Gemma4UnifiedAssistantForCausalLM",
+        )
+
+    def test_incompatible_metadata_fails_before_loading(self):
+        base = tiny_assistant_config(ordered=True)
+        mutations = {
+            "target_config": lambda value: value.update(model_type="gemma4_text"),
+            "remote_hook": lambda value: value.update(auto_map={"AutoModel": "x.py"}),
+            "vocab": lambda value: value["text_config"].update(vocab_size=31),
+            "backbone": lambda value: value.update(backbone_hidden_size=15),
+            "assistant_hidden": lambda value: value["text_config"].update(
+                hidden_size=0
+            ),
+            "layer_count": lambda value: value["text_config"].update(
+                num_hidden_layers=3
+            ),
+            "tail": lambda value: value["text_config"]["layer_types"].reverse(),
+            "tied": lambda value: value["text_config"].update(
+                tie_word_embeddings=False
+            ),
+            "centroids": lambda value: value.update(num_centroids=3),
+            "centroid_topk": lambda value: value.update(centroid_intermediate_top_k=5),
+            "window": lambda value: value["text_config"].update(sliding_window=9),
+            "head_dim": lambda value: value["text_config"].update(head_dim=5),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                config = copy.deepcopy(base)
+                mutate(config)
+                with self.assertRaises(ValueError):
+                    validate_gemma4_assistant_config(config, self.target)
+
+    def test_strict_weight_diagnostics(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            write_tiny_assistant_checkpoint(root)
+            loader = Gemma4MTPAssistantLoader(self.target)
+            runtime = loader.load(str(root))
+            self.assertEqual(loader.load_count, 1)
+            self.assertEqual(runtime.metadata.vocab_size, 32)
+
+            weight_file = root / "model.safetensors"
+            original = dict(mx.load(str(weight_file)))
+            cases = {}
+            missing = dict(original)
+            missing.pop(sorted(missing)[0])
+            cases["missing"] = missing
+            unexpected = dict(original)
+            unexpected["unexpected.weight"] = mx.zeros((1,))
+            cases["unexpected"] = unexpected
+            wrong = dict(original)
+            first = sorted(wrong)[0]
+            wrong[first] = wrong[first].reshape(-1)[:1]
+            cases["wrong_shape"] = wrong
+
+            for expected_message, weights in cases.items():
+                with self.subTest(expected_message=expected_message):
+                    mx.save_safetensors(str(weight_file), weights)
+                    with self.assertRaisesRegex(ValueError, expected_message):
+                        loader.load(str(root))
+
+            # Duplicate names in separate shards are rejected explicitly.
+            mx.save_safetensors(str(weight_file), original)
+            duplicate_name = sorted(original)[0]
+            mx.save_safetensors(
+                str(root / "model-00002.safetensors"),
+                {duplicate_name: original[duplicate_name]},
+            )
+            with self.assertRaisesRegex(ValueError, "duplicate"):
+                loader.load(str(root))
+
+    def test_reload_replace_unload_invalidate_every_old_handle(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            checkpoint_a = root / "a"
+            checkpoint_b = root / "b"
+            write_tiny_assistant_checkpoint(checkpoint_a)
+            write_tiny_assistant_checkpoint(checkpoint_b, weight_delta=2.0)
+            loader = Gemma4MTPAssistantLoader(self.target)
+            runtime_a = loader.load(str(checkpoint_a), revision="revision-a")
+            handle_a = runtime_a.model_handle
+
+            cache = self.target.make_cache()
+            adapter = Gemma4TargetAdapter(self.target)
+            output = adapter.forward(
+                mx.array([[1, 2, 3]], dtype=mx.int32),
+                cache=cache,
+                collect_hidden_states=True,
+            )
+            token = int(mx.argmax(output.logits[:, -1, :], axis=-1).item())
+            target_seed = adapter.make_seed(
+                output, hidden_row_index=2, emitted_token_id=token
+            )
+            view_a = runtime_a.bind_request("request", cache)
+            seed_a = runtime_a.bind_seed("request", target_seed)
+            fingerprint_a = runtime_a.fingerprint
+
+            # Same path/revision reload after changing the provider payload must
+            # materialize fresh tensors and invalidate all generation-A objects.
+            write_tiny_assistant_checkpoint(checkpoint_a, weight_delta=1.0)
+            runtime_a2 = loader.load(str(checkpoint_a), revision="revision-a")
+            self.assertNotEqual(runtime_a2.fingerprint, fingerprint_a)
+            self.assertGreater(runtime_a2.generation, runtime_a.generation)
+            for operation in (
+                lambda: runtime_a.bind_request("late", cache),
+                lambda: view_a.position,
+                seed_a.validate,
+                lambda: handle_a.fingerprint,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "stale"):
+                    operation()
+
+            # Replacing A with B invalidates A2 even without an explicit unload.
+            stale_a2 = runtime_a2.model_handle
+            runtime_b = loader.replace_assistant(
+                str(checkpoint_b), revision="revision-b"
+            )
+            self.assertNotEqual(runtime_b.fingerprint, runtime_a2.fingerprint)
+            with self.assertRaisesRegex(RuntimeError, "stale"):
+                _ = stale_a2.fingerprint
+
+            generation_b = runtime_b.generation
+            loader.unload_assistant()
+            self.assertIsNone(loader.runtime)
+            self.assertGreater(loader.generation, generation_b)
+            with self.assertRaisesRegex(RuntimeError, "stale"):
+                runtime_b.bind_request("late", cache)
+
+    def test_request_flush_retains_loaded_weights(self):
+        with tempfile.TemporaryDirectory() as temp:
+            checkpoint = Path(temp)
+            write_tiny_assistant_checkpoint(checkpoint)
+            loader = Gemma4MTPAssistantLoader(self.target)
+            runtime = loader.load(str(checkpoint))
+            cache = self.target.make_cache()
+            self.target(mx.array([[1]], dtype=mx.int32), cache=cache)
+            view = runtime.bind_request("r", cache)
+            fingerprint = runtime.fingerprint
+            load_count = loader.load_count
+            loader.clear_request_bindings()
+
+            self.assertEqual(loader.runtime.fingerprint, fingerprint)
+            self.assertEqual(loader.load_count, load_count)
+            self.assertEqual(runtime.request_binding_count, 0)
+            with self.assertRaisesRegex(RuntimeError, "stale"):
+                _ = view.position
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_model.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_model.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from sglang.test.ci.ci_register import register_mlx_ci
+
+register_mlx_ci(est_time=2, suite="stage-a-unit-test-mlx")
+
+_HAS_PROVIDER = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_vlm.speculative.drafters.gemma4_assistant")
+    is not None
+)
+
+if _HAS_PROVIDER:
+    import mlx.core as mx
+    from mlx_vlm.speculative.drafters.gemma4_assistant.masks import (
+        make_drafter_masks,
+    )
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        native_cache_snapshot,
+        tiny_gemma4,
+        write_tiny_assistant_checkpoint,
+    )
+
+    from sglang.srt.hardware_backend.mlx.gemma4_mtp import (
+        Gemma4MTPAssistantLoader,
+    )
+    from sglang.srt.hardware_backend.mlx.model_adapter import (
+        Gemma4TargetAdapter,
+        MlxTargetSeed,
+    )
+
+
+def _eager_reference(model, target_seed, shared, position, softcap):
+    inputs = mx.concatenate(
+        (target_seed.token_embedding, target_seed.hidden_state), axis=-1
+    )
+    h = model.pre_projection(inputs)
+    masks = make_drafter_masks(
+        shared,
+        query_len=1,
+        query_offset=position,
+        sliding_window=model.config.text_config.sliding_window,
+        dtype=h.dtype,
+    )
+    offset = mx.array(position)
+    for layer in model.model.layers:
+        h, _, _ = layer(
+            h,
+            mask=masks[layer.layer_type],
+            cache=None,
+            per_layer_input=None,
+            shared_kv=shared[layer.layer_type],
+            offset=offset,
+        )
+    h = model.model.norm(h)
+    _projected = model.post_projection(h)
+    logits = model._lm_head_fn(h)
+    if softcap is not None:
+        logits = mx.tanh(logits / softcap) * softcap
+    token = mx.argmax(logits[:, -1, :], axis=-1)
+    mx.eval(token)
+    return int(token.item())
+
+
+@unittest.skipUnless(_HAS_PROVIDER, "requires mlx-vlm Gemma 4 assistant provider")
+class TestGemma4MTPModel(unittest.TestCase):
+    def _loaded_case(self, root: Path, *, ordered: bool, prompt_len: int = 11):
+        target = tiny_gemma4()
+        write_tiny_assistant_checkpoint(root, ordered=ordered)
+        runtime = Gemma4MTPAssistantLoader(target).load(str(root))
+        adapter = Gemma4TargetAdapter(target)
+        prompt = [1 + (index % 29) for index in range(prompt_len)]
+        cache = target.make_cache()
+        output = adapter.forward(
+            mx.array([prompt], dtype=mx.int32),
+            cache=cache,
+            collect_hidden_states=True,
+        )
+        token = int(mx.argmax(output.logits[:, -1, :], axis=-1).item())
+        seed = runtime.bind_seed(
+            "request",
+            adapter.make_seed(
+                output,
+                hidden_row_index=len(prompt) - 1,
+                emitted_token_id=token,
+            ),
+        )
+        view = runtime.bind_request("request", cache)
+        return runtime, cache, seed, view
+
+    def test_dense_and_ordered_tokens_match_eager_q_only_reference(self):
+        for ordered in (False, True):
+            with self.subTest(ordered=ordered), tempfile.TemporaryDirectory() as temp:
+                runtime, cache, seed, view = self._loaded_case(
+                    Path(temp), ordered=ordered
+                )
+                before = native_cache_snapshot(cache)
+                shared = view.shared_kv_states()
+                expected = _eager_reference(
+                    runtime._model,
+                    seed.target_seed,
+                    shared,
+                    view.position,
+                    runtime.metadata.final_logit_softcapping,
+                )
+                actual = runtime.propose_one(seed, view)
+                self.assertEqual(actual, expected)
+
+                after = native_cache_snapshot(cache)
+                for left, right in zip(before, after):
+                    self.assertEqual(
+                        (left["offset"], left["idx"]),
+                        (right["offset"], right["idx"]),
+                    )
+                    np.testing.assert_array_equal(left["keys"], right["keys"])
+                    np.testing.assert_array_equal(left["values"], right["values"])
+
+    def test_seed_shape_and_request_identity_validation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            runtime, cache, seed, view = self._loaded_case(Path(temp), ordered=False)
+            bad_target_seed = MlxTargetSeed(
+                token_id=seed.target_seed.token_id,
+                hidden_state=mx.zeros((1, 2, 16)),
+                token_embedding=seed.target_seed.token_embedding,
+            )
+            bad_seed = runtime.bind_seed("request", bad_target_seed)
+            with self.assertRaisesRegex(ValueError, "shapes"):
+                runtime.propose_one(bad_seed, view)
+
+            other_view = runtime.bind_request("other", cache)
+            with self.assertRaisesRegex(ValueError, "different requests"):
+                runtime.propose_one(seed, other_view)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_worker.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_mtp_worker.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.test.ci.ci_register import register_mlx_ci
+
+register_mlx_ci(est_time=3, suite="stage-a-unit-test-mlx")
+
+_HAS_PROVIDER = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_vlm.speculative.drafters.gemma4_assistant")
+    is not None
+)
+
+if _HAS_PROVIDER:
+    import mlx.core as mx
+    import torch
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        build_runner,
+        cache_logical_length,
+        native_cache_snapshot,
+        reference_tokens,
+        tiny_gemma4,
+        write_tiny_assistant_checkpoint,
+    )
+
+    from sglang.srt.hardware_backend.mlx.kv_cache.native_transaction import (
+        clone_native_cache,
+    )
+    from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+    from sglang.srt.hardware_backend.mlx.speculative_worker import (
+        MlxFrozenKVMTPDraftInput,
+        MlxFrozenKVMTPWorker,
+        MlxGemma4MTPProposer,
+    )
+    from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+    from sglang.srt.mem_cache.allocation import assign_req_to_token_pool_func
+    from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+
+class _OracleProposer:
+    def __init__(self, model, *, correct: bool):
+        self.model = model
+        self.correct = correct
+
+    def propose_one(self, request_id, seed, cache):
+        del request_id
+        probe = clone_native_cache(cache)
+        logits = self.model(mx.array([[seed.token_id]], dtype=mx.int32), cache=probe)
+        token = int(mx.argmax(logits[:, -1, :], axis=-1).item())
+        return token if self.correct else (token + 1) % self.model.args.vocab_size
+
+
+@unittest.skipUnless(_HAS_PROVIDER, "requires mlx-vlm Gemma 4 assistant provider")
+class TestMlxFrozenKVMTPWorker(unittest.TestCase):
+    def test_target_loader_receives_pinned_revision(self):
+        runner = MlxModelRunner.__new__(MlxModelRunner)
+        runner.model_path = "target"
+        runner.revision = "pinned-target-revision"
+        runner.trust_remote_code = False
+        runner._quantization = None
+        fake_model = SimpleNamespace(parameters=lambda: ())
+        with (
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner.mlx_lm_load",
+                return_value=(fake_model, None, {}),
+            ) as load,
+            mock.patch("sglang.srt.hardware_backend.mlx.model_runner.mx.eval"),
+        ):
+            runner._load_model()
+        self.assertEqual(load.call_args.kwargs["revision"], "pinned-target-revision")
+
+    def test_cpu_stub_slot_assignment_uses_no_triton(self):
+        req_to_token = torch.zeros((3, 8), dtype=torch.int32)
+        assign_req_to_token_pool_func(
+            req_pool_indices=torch.tensor([1, 2], dtype=torch.int32),
+            req_to_token=req_to_token,
+            start_offset=torch.tensor([2, 1], dtype=torch.int32),
+            end_offset=torch.tensor([4, 4], dtype=torch.int32),
+            out_cache_loc=torch.tensor([10, 11, 20, 21, 22], dtype=torch.int64),
+            batch_size=2,
+        )
+        self.assertEqual(req_to_token[1, 2:4].tolist(), [10, 11])
+        self.assertEqual(req_to_token[2, 1:4].tolist(), [20, 21, 22])
+
+    def _make_worker(self, checkpoint: Path, *, correct: bool):
+        model = tiny_gemma4()
+        runner = build_runner(model)
+        target_worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
+        target_worker._mlx_runner = runner
+        target_worker._mlx_active_rids = set()
+        target_worker._mlx_pool_initialized = True
+        target_worker._model_runner = SimpleNamespace()
+        server_args = SimpleNamespace(
+            speculative_draft_model_path=str(checkpoint),
+            speculative_draft_model_revision=None,
+        )
+        worker = MlxFrozenKVMTPWorker(
+            server_args=server_args,
+            gpu_id=0,
+            ps=SimpleNamespace(),
+            nccl_port=0,
+            target_worker=target_worker,
+        )
+        worker._proposer = _OracleProposer(model, correct=correct)
+        return model, runner, target_worker, worker
+
+    @staticmethod
+    def _request(prompt):
+        return SimpleNamespace(
+            rid="request",
+            req_pool_idx=0,
+            prefix_indices=torch.empty((0,), dtype=torch.long),
+            get_fill_ids=lambda: list(prompt),
+            mamba_last_track_seqlen=None,
+        )
+
+    def _prefill_batch(self, request, prompt):
+        return SimpleNamespace(
+            reqs=[request],
+            forward_mode=ForwardMode.EXTEND,
+            input_ids=torch.tensor(prompt, dtype=torch.long),
+            out_cache_loc=torch.arange(len(prompt), dtype=torch.long),
+            extend_lens=[len(prompt)],
+            seq_lens=torch.tensor([len(prompt)], dtype=torch.int32),
+            spec_info=None,
+        )
+
+    @staticmethod
+    def _decode_batch(request, prefill_batch, draft_input):
+        return SimpleNamespace(
+            reqs=[request],
+            forward_mode=ForwardMode.DECODE,
+            seq_lens=prefill_batch.seq_lens.clone(),
+            spec_info=draft_input,
+        )
+
+    def _run_round(self, *, correct: bool, prompt_len: int = 11):
+        with tempfile.TemporaryDirectory() as temp:
+            checkpoint = Path(temp)
+            write_tiny_assistant_checkpoint(checkpoint)
+            model, runner, target_worker, worker = self._make_worker(
+                checkpoint, correct=correct
+            )
+            prompt = [1 + (index % 29) for index in range(prompt_len)]
+            expected = reference_tokens(model, prompt, steps=3)
+            request = self._request(prompt)
+            prefill_batch = self._prefill_batch(request, prompt)
+            prefill = worker.forward_batch_generation(prefill_batch)
+
+            self.assertEqual(prefill.next_token_ids.tolist(), expected[:1])
+            self.assertIsNone(prefill.accept_lens)
+            self.assertIsInstance(prefill.next_draft_input, MlxFrozenKVMTPDraftInput)
+            decode_batch = self._decode_batch(
+                request, prefill_batch, prefill.next_draft_input
+            )
+            decode = worker.forward_batch_generation(decode_batch)
+
+            if correct:
+                self.assertEqual(decode.next_token_ids.tolist(), expected[1:3])
+                self.assertEqual(decode.accept_lens.tolist(), [2])
+                self.assertEqual(decode.num_correct_drafts, 1)
+            else:
+                self.assertEqual(decode.next_token_ids[0].item(), expected[1])
+                self.assertEqual(decode.next_token_ids[1].item(), -1)
+                self.assertEqual(decode.accept_lens.tolist(), [1])
+                self.assertEqual(decode.num_correct_drafts, 0)
+            self.assertEqual(
+                decode.new_seq_lens.tolist(),
+                [prompt_len + int(decode.accept_lens[0])],
+            )
+            self.assertEqual(decode.speculative_num_draft_tokens, 2)
+            self.assertEqual(
+                len(runner._req_token_ids[request.rid]),
+                cache_logical_length(runner._req_caches[request.rid]) + 1,
+            )
+            self.assertGreater(worker.metrics.proposed_tokens, 0)
+            self.assertEqual(worker.metrics.verified_tokens, 1)
+            return decode
+
+    def test_all_accept_and_all_reject_match_target_only(self):
+        self._run_round(correct=True)
+        self._run_round(correct=False)
+
+    def test_worker_parity_past_rotation(self):
+        self._run_round(correct=True, prompt_len=25)
+        self._run_round(correct=False, prompt_len=25)
+
+    def test_seedless_target_only_step_and_malformed_handoff(self):
+        with tempfile.TemporaryDirectory() as temp:
+            checkpoint = Path(temp)
+            write_tiny_assistant_checkpoint(checkpoint)
+            model, runner, _target_worker, worker = self._make_worker(
+                checkpoint, correct=True
+            )
+            prompt = [1, 2, 3]
+            expected = reference_tokens(model, prompt, steps=2)
+            request = self._request(prompt)
+            prefill_batch = self._prefill_batch(request, prompt)
+            prefill = worker.forward_batch_generation(prefill_batch)
+            draft_input = prefill.next_draft_input
+            draft_input.draft_token_ids[0] = -1
+            draft_input.valid_draft_counts[0] = 0
+            decode = worker.forward_batch_generation(
+                self._decode_batch(request, prefill_batch, draft_input)
+            )
+            self.assertEqual(decode.next_token_ids[0].item(), expected[1])
+            self.assertEqual(decode.accept_lens.tolist(), [1])
+
+            next_input = decode.next_draft_input
+            next_input.draft_token_ids[0] = -1
+            next_input.valid_draft_counts[0] = 1
+            before = native_cache_snapshot(runner._req_caches[request.rid])
+            with self.assertRaisesRegex(ValueError, "malformed"):
+                worker.forward_batch_generation(
+                    self._decode_batch(request, prefill_batch, next_input)
+                )
+            after = native_cache_snapshot(runner._req_caches[request.rid])
+            self.assertEqual(
+                [item["offset"] for item in before], [item["offset"] for item in after]
+            )
+
+    def test_target_exception_aborts_transaction(self):
+        with tempfile.TemporaryDirectory() as temp:
+            checkpoint = Path(temp)
+            write_tiny_assistant_checkpoint(checkpoint)
+            _model, runner, _target_worker, worker = self._make_worker(
+                checkpoint, correct=True
+            )
+            prompt = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            request = self._request(prompt)
+            prefill_batch = self._prefill_batch(request, prompt)
+            prefill = worker.forward_batch_generation(prefill_batch)
+            before = native_cache_snapshot(runner._req_caches[request.rid])
+            original_forward = runner._target_adapter.forward
+            verify_calls = 0
+
+            def fail_verify(*args, **kwargs):
+                nonlocal verify_calls
+                if kwargs.get("collect_hidden_states"):
+                    verify_calls += 1
+                    if verify_calls == 2:
+                        raise RuntimeError("synthetic verify failure")
+                return original_forward(*args, **kwargs)
+
+            runner._target_adapter.forward = fail_verify
+            with self.assertRaisesRegex(RuntimeError, "synthetic verify failure"):
+                worker.forward_batch_generation(
+                    self._decode_batch(request, prefill_batch, prefill.next_draft_input)
+                )
+            after = native_cache_snapshot(runner._req_caches[request.rid])
+            self.assertEqual(
+                [item["offset"] for item in before], [item["offset"] for item in after]
+            )
+
+    def test_lifecycle_delegation_clears_request_state_but_retains_weights(self):
+        with tempfile.TemporaryDirectory() as temp:
+            checkpoint = Path(temp)
+            write_tiny_assistant_checkpoint(checkpoint)
+            _model, runner, target_worker, worker = self._make_worker(
+                checkpoint, correct=True
+            )
+            worker._proposer = MlxGemma4MTPProposer(worker._assistant_runtime)
+            request = self._request([1, 2, 3])
+            prefill = worker.forward_batch_generation(
+                self._prefill_batch(request, [1, 2, 3])
+            )
+            fingerprint = worker._assistant_runtime.fingerprint
+            load_count = worker._assistant_loader.load_count
+            self.assertTrue(runner.has_request(request.rid))
+            self.assertGreater(worker._assistant_runtime.request_binding_count, 0)
+            active = worker.get_speculative_internal_state()
+            self.assertEqual(active["implementation"], "mlx_gemma4_frozen_kv_mtp")
+            self.assertGreater(active["proposed_tokens"], 0)
+            self.assertEqual(active["native_request_count"], 1)
+            self.assertGreater(active["assistant_request_binding_count"], 0)
+            self.assertIsNone(worker.get_draft_kv_pool())
+
+            worker.prepare_for_kv_cache_release(request)
+            self.assertFalse(runner.has_request(request.rid))
+            self.assertEqual(worker._assistant_runtime.request_binding_count, 0)
+            self.assertEqual(worker._assistant_runtime.fingerprint, fingerprint)
+            self.assertEqual(worker._assistant_loader.load_count, load_count)
+            released = worker.get_speculative_internal_state()
+            self.assertEqual(released["native_request_count"], 0)
+            self.assertEqual(released["assistant_request_binding_count"], 0)
+            self.assertEqual(released["assistant_load_count"], load_count)
+            self.assertEqual(released["assistant_fingerprint"], fingerprint)
+
+            worker.clear_cache_pool()
+            self.assertEqual(runner._req_token_ids, {})
+            self.assertEqual(target_worker._mlx_active_rids, set())
+            success, message = worker.update_weights_from_disk(object())
+            self.assertFalse(success)
+            self.assertIn("assistant checkpoint", message)
+
+    def test_draft_input_filter_and_merge_preserve_alignment(self):
+        def make(rid, token):
+            return MlxFrozenKVMTPDraftInput(
+                request_ids=(rid,),
+                draft_token_ids=torch.tensor([token]),
+                valid_draft_counts=torch.tensor([1]),
+                bonus_tokens=torch.tensor([token - 1]),
+                new_seq_lens=torch.tensor([10]),
+                accept_tokens=torch.tensor([token - 1, -1]),
+                accept_lens=torch.tensor([1]),
+            )
+
+        left = make("a", 4)
+        left.merge_batch(make("b", 8))
+        self.assertEqual(left.request_ids, ("a", "b"))
+        left.filter_batch(torch.tensor([1]), new_indices_cpu=[1])
+        self.assertEqual(left.request_ids, ("b",))
+        self.assertEqual(left.draft_token_ids.tolist(), [8])
+        self.assertIsNone(left.hidden_states)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_native_cache.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_native_cache.py
@@ -1,0 +1,226 @@
+"""Correctness-first Gemma 4 coverage for the MLX native-cache fallback.
+
+The initial Apple Silicon path intentionally delegates cache semantics to
+``mlx-lm``.  Gemma 4 combines YOCO K/V sharing, sliding attention, K=V full
+attention, and heterogeneous head dimensions; the uniform SGLang MLX radix
+pool cannot represent that layout yet.  These tests use a tiny randomly
+initialised Gemma 4 model, so they exercise the real architecture without a
+checkpoint download.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from dataclasses import asdict
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+_HAS_GEMMA4_MLX = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_lm.models.gemma4_text") is not None
+)
+_SKIP_REASON = "requires mlx-lm with Gemma 4 support"
+
+if _HAS_GEMMA4_MLX:
+    import mlx.core as mx
+    from mlx_lm.models import gemma4, gemma4_text
+
+    from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+    from sglang.srt.hardware_backend.mlx.model_runner_stub import MlxModelRunnerStub
+    from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+
+
+def _tiny_gemma4(*, wrapped: bool = False):
+    """Build a four-layer model containing every target cache quirk."""
+    args = gemma4_text.ModelArgs(
+        hidden_size=16,
+        num_hidden_layers=4,
+        intermediate_size=32,
+        num_attention_heads=2,
+        head_dim=4,
+        global_head_dim=8,
+        vocab_size=32,
+        vocab_size_per_layer_input=32,
+        num_key_value_heads=1,
+        num_global_key_value_heads=1,
+        num_kv_shared_layers=2,
+        hidden_size_per_layer_input=0,
+        sliding_window=8,
+        sliding_window_pattern=2,
+        max_position_embeddings=4096,
+        attention_k_eq_v=True,
+        use_double_wide_mlp=False,
+        layer_types=[
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+    )
+    model = (
+        gemma4.Model(
+            gemma4.ModelArgs(
+                text_config=asdict(args),
+                vocab_size=args.vocab_size,
+            )
+        )
+        if wrapped
+        else gemma4_text.Model(args)
+    )
+    mx.eval(model.parameters())
+    return model
+
+
+def _build_runner(model, **kwargs):
+    options = {
+        "model_path": "tiny-gemma4",
+        "disable_radix_cache": True,
+        "pool_size": 64,
+    }
+    options.update(kwargs)
+    with mock.patch.object(
+        MlxModelRunner,
+        "_load_model",
+        new=lambda runner: setattr(runner, "model", model),
+    ):
+        return MlxModelRunner(**options)
+
+
+def _reference_tokens(model, prompt: list[int], steps: int) -> list[int]:
+    cache = model.make_cache()
+    input_ids = mx.array([prompt], dtype=mx.int32)
+    output = []
+    for _ in range(steps):
+        logits = model(input_ids, cache=cache)
+        token = mx.argmax(logits[:, -1, :], axis=-1)
+        mx.eval(token, *[value for entry in cache for value in entry.state])
+        output.append(int(token.item()))
+        input_ids = token[:, None]
+    return output
+
+
+@unittest.skipUnless(_HAS_GEMMA4_MLX, _SKIP_REASON)
+class TestGemma4NativeCacheFallback(unittest.TestCase):
+    def test_wrapped_model_cross_window_matches_raw_mlx_lm(self):
+        # Exercise mlx-lm's conditional-generation shell as loaded from the
+        # public checkpoints, and cross the synthetic sliding window boundary.
+        model = _tiny_gemma4(wrapped=True)
+        prompt = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        expected = _reference_tokens(model, prompt, steps=3)
+        runner = _build_runner(model)
+
+        first = runner.prefill(
+            req_id="request",
+            new_token_ids=prompt,
+            full_token_ids=prompt,
+            prefix_slot_ids=[],
+            new_slot_ids=[],
+            req_pool_idx=0,
+        )
+        actual = [first]
+        for _ in range(2):
+            actual.append(runner.decode_batch(["request"])[0])
+
+        self.assertTrue(runner.native_cache_fallback)
+        self.assertEqual(actual, expected)
+        # Four transformer layers own only two caches; the remaining YOCO
+        # layers reuse the most recent sliding/full cache respectively.
+        self.assertEqual(len(runner._req_caches["request"]), 2)
+
+    def test_multi_request_decode_preserves_cache_isolation(self):
+        model = _tiny_gemma4()
+        expected_a = _reference_tokens(model, [1, 2], steps=2)
+        expected_b = _reference_tokens(model, [3, 4, 5], steps=2)
+        runner = _build_runner(model)
+
+        first_a = runner.prefill("a", [1, 2], [1, 2], [], [], 0)
+        first_b = runner.prefill("b", [3, 4, 5], [3, 4, 5], [], [], 1)
+        second_a, second_b = runner.decode_batch(["a", "b"])
+
+        self.assertEqual([first_a, second_a], expected_a)
+        self.assertEqual([first_b, second_b], expected_b)
+
+    def test_radix_cache_fails_with_actionable_message(self):
+        model = _tiny_gemma4()
+        with self.assertRaisesRegex(NotImplementedError, "disable-radix-cache"):
+            _build_runner(
+                model,
+                disable_radix_cache=False,
+            )
+
+    def test_default_scheduler_capacity_is_conservative(self):
+        model = _tiny_gemma4()
+        runner = _build_runner(model, pool_size=None)
+
+        self.assertEqual(runner.pool_size, 2048)
+
+    def test_native_cache_defaults_to_one_live_request(self):
+        stub = MlxModelRunnerStub.__new__(MlxModelRunnerStub)
+        stub._mlx_native_cache_fallback = True
+        stub.max_total_num_tokens = 2048
+        stub.model_config = SimpleNamespace()
+        schedule = SimpleNamespace(
+            max_running_requests=None,
+            max_mamba_cache_size=None,
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.get_schedule",
+                return_value=schedule,
+            ),
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.mambaish_config",
+                return_value=None,
+            ),
+        ):
+            self.assertEqual(stub._resolve_max_running_requests(), 1)
+
+    def test_explicit_concurrency_uses_attention_dp_width(self):
+        stub = MlxModelRunnerStub.__new__(MlxModelRunnerStub)
+        stub._mlx_native_cache_fallback = True
+        stub.max_total_num_tokens = 2048
+        stub.model_config = SimpleNamespace()
+        stub.ps = SimpleNamespace(attn_dp_size=2)
+        schedule = SimpleNamespace(
+            max_running_requests=8,
+            max_mamba_cache_size=None,
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.get_schedule",
+                return_value=schedule,
+            ),
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.model_runner_stub.mambaish_config",
+                return_value=None,
+            ),
+        ):
+            self.assertEqual(stub._resolve_max_running_requests(), 4)
+
+    def test_finished_native_request_is_released_immediately(self):
+        worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
+        worker._mlx_runner = mock.Mock(native_cache_fallback=True)
+        worker._mlx_runner.has_request.return_value = True
+        worker._mlx_active_rids = {"done"}
+        req = SimpleNamespace(rid="done", mamba_last_track_seqlen=128)
+
+        worker.prepare_for_kv_cache_release(req)
+
+        worker._mlx_runner.store_auxiliary_state_for_request.assert_called_once_with(
+            "done"
+        )
+        worker._mlx_runner.remove_request.assert_called_once_with("done")
+        self.assertNotIn("done", worker._mlx_active_rids)
+        self.assertIsNone(req.mamba_last_track_seqlen)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_native_cache.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_native_cache.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import importlib.util
 import unittest
-from dataclasses import asdict
 from types import SimpleNamespace
 from unittest import mock
 
@@ -28,81 +27,18 @@ _HAS_GEMMA4_MLX = (
 _SKIP_REASON = "requires mlx-lm with Gemma 4 support"
 
 if _HAS_GEMMA4_MLX:
-    import mlx.core as mx
-    from mlx_lm.models import gemma4, gemma4_text
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        build_runner as _build_runner,
+    )
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        reference_tokens as _reference_tokens,
+    )
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        tiny_gemma4 as _tiny_gemma4,
+    )
 
-    from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
     from sglang.srt.hardware_backend.mlx.model_runner_stub import MlxModelRunnerStub
     from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
-
-
-def _tiny_gemma4(*, wrapped: bool = False):
-    """Build a four-layer model containing every target cache quirk."""
-    args = gemma4_text.ModelArgs(
-        hidden_size=16,
-        num_hidden_layers=4,
-        intermediate_size=32,
-        num_attention_heads=2,
-        head_dim=4,
-        global_head_dim=8,
-        vocab_size=32,
-        vocab_size_per_layer_input=32,
-        num_key_value_heads=1,
-        num_global_key_value_heads=1,
-        num_kv_shared_layers=2,
-        hidden_size_per_layer_input=0,
-        sliding_window=8,
-        sliding_window_pattern=2,
-        max_position_embeddings=4096,
-        attention_k_eq_v=True,
-        use_double_wide_mlp=False,
-        layer_types=[
-            "sliding_attention",
-            "full_attention",
-            "sliding_attention",
-            "full_attention",
-        ],
-    )
-    model = (
-        gemma4.Model(
-            gemma4.ModelArgs(
-                text_config=asdict(args),
-                vocab_size=args.vocab_size,
-            )
-        )
-        if wrapped
-        else gemma4_text.Model(args)
-    )
-    mx.eval(model.parameters())
-    return model
-
-
-def _build_runner(model, **kwargs):
-    options = {
-        "model_path": "tiny-gemma4",
-        "disable_radix_cache": True,
-        "pool_size": 64,
-    }
-    options.update(kwargs)
-    with mock.patch.object(
-        MlxModelRunner,
-        "_load_model",
-        new=lambda runner: setattr(runner, "model", model),
-    ):
-        return MlxModelRunner(**options)
-
-
-def _reference_tokens(model, prompt: list[int], steps: int) -> list[int]:
-    cache = model.make_cache()
-    input_ids = mx.array([prompt], dtype=mx.int32)
-    output = []
-    for _ in range(steps):
-        logits = model(input_ids, cache=cache)
-        token = mx.argmax(logits[:, -1, :], axis=-1)
-        mx.eval(token, *[value for entry in cache for value in entry.state])
-        output.append(int(token.item()))
-        input_ids = token[:, None]
-    return output
 
 
 @unittest.skipUnless(_HAS_GEMMA4_MLX, _SKIP_REASON)

--- a/test/registered/unit/hardware_backend/mlx/test_gemma4_target_adapter.py
+++ b/test/registered/unit/hardware_backend/mlx/test_gemma4_target_adapter.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+
+import numpy as np
+
+from sglang.test.ci.ci_register import register_mlx_ci
+
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+_HAS_MLX = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_lm.models.gemma4_text") is not None
+)
+
+if _HAS_MLX:
+    import mlx.core as mx
+    from registered.unit.hardware_backend.mlx.gemma4_test_utils import (
+        assert_native_cache_equal,
+        tiny_gemma4,
+    )
+
+from sglang.srt.hardware_backend.mlx.model_adapter import (
+    Gemma4TargetAdapter,
+    MlxTargetForwardOutput,
+)
+from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+
+
+@unittest.skipUnless(_HAS_MLX, "requires MLX and mlx-lm Gemma 4")
+class TestGemma4TargetAdapter(unittest.TestCase):
+    def test_verify_queries_preserve_one_token_decode_shape(self):
+        calls = []
+
+        class RecordingAdapter:
+            def forward(self, input_ids, *, cache, collect_hidden_states):
+                calls.append((tuple(input_ids.shape), collect_hidden_states))
+                width = input_ids.shape[1]
+                return MlxTargetForwardOutput(
+                    logits=mx.zeros((1, width, 7)),
+                    hidden_states=(
+                        mx.zeros((1, width, 5)) if collect_hidden_states else None
+                    ),
+                )
+
+        runner = object.__new__(MlxModelRunner)
+        runner._target_adapter = RecordingAdapter()
+        output = runner._forward_native_queries_sequential(
+            [], (11, 12), collect_hidden_states=True
+        )
+        self.assertEqual(calls, [((1, 1), True), ((1, 1), True)])
+        self.assertEqual(output.logits.shape, (1, 2, 7))
+        self.assertEqual(output.hidden_states.shape, (1, 2, 5))
+
+        calls.clear()
+        output = runner._forward_native_queries_sequential(
+            [], (13, 14), collect_hidden_states=False
+        )
+        self.assertEqual(calls, [((1, 1), False), ((1, 1), False)])
+        self.assertEqual(output.logits.shape, (1, 2, 7))
+        self.assertIsNone(output.hidden_states)
+
+    def test_wrapped_and_unwrapped_capture_preserve_exact_logits(self):
+        for wrapped in (False, True):
+            with self.subTest(wrapped=wrapped):
+                model = tiny_gemma4(wrapped=wrapped)
+                adapter = Gemma4TargetAdapter(model)
+                ids = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+
+                normal_cache = model.make_cache()
+                normal = model(ids, cache=normal_cache)
+                uncaptured_cache = model.make_cache()
+                uncaptured = adapter.forward(ids, cache=uncaptured_cache)
+                captured_cache = model.make_cache()
+                captured = adapter.forward(
+                    ids, cache=captured_cache, collect_hidden_states=True
+                )
+                mx.eval(
+                    normal, uncaptured.logits, captured.logits, captured.hidden_states
+                )
+
+                np.testing.assert_array_equal(
+                    np.array(normal), np.array(uncaptured.logits)
+                )
+                np.testing.assert_array_equal(
+                    np.array(normal), np.array(captured.logits)
+                )
+                np.testing.assert_array_equal(
+                    np.array(mx.argmax(normal, axis=-1)),
+                    np.array(mx.argmax(captured.logits, axis=-1)),
+                )
+                self.assertIsNone(uncaptured.hidden_states)
+                self.assertEqual(captured.hidden_states.shape, (1, 4, 16))
+                assert_native_cache_equal(self, uncaptured_cache, normal_cache)
+                assert_native_cache_equal(self, captured_cache, normal_cache)
+
+    def test_scaled_embeddings_and_seed_row_selection(self):
+        model = tiny_gemma4()
+        adapter = Gemma4TargetAdapter(model)
+        ids = mx.array([[1, 2, 3]], dtype=mx.int32)
+        output = adapter.forward(
+            ids, cache=model.make_cache(), collect_hidden_states=True
+        )
+
+        scaled = adapter.input_embeddings(ids)
+        expected = model.model.embed_tokens(ids) * model.model.embed_scale
+        seed = adapter.make_seed(output, hidden_row_index=1, emitted_token_id=7)
+        mx.eval(scaled, expected, seed.hidden_state, seed.token_embedding)
+
+        np.testing.assert_array_equal(np.array(scaled), np.array(expected))
+        np.testing.assert_array_equal(
+            np.array(seed.hidden_state), np.array(output.hidden_states[:, 1:2, :])
+        )
+        self.assertEqual(seed.hidden_state.shape, (1, 1, 16))
+        self.assertEqual(seed.token_embedding.shape, (1, 1, 16))
+
+    def test_final_prefill_and_verify_seed_semantics(self):
+        model = tiny_gemma4()
+        adapter = Gemma4TargetAdapter(model)
+        prefill = adapter.forward(
+            mx.array([[1, 2, 3]], dtype=mx.int32),
+            cache=model.make_cache(),
+            collect_hidden_states=True,
+        )
+        prefill_seed = adapter.make_seed(
+            prefill,
+            hidden_row_index=prefill.hidden_states.shape[1] - 1,
+            emitted_token_id=4,
+        )
+        self.assertEqual(prefill_seed.hidden_state.shape, (1, 1, 16))
+
+        verify = adapter.forward(
+            mx.array([[4, 5]], dtype=mx.int32),
+            cache=model.make_cache(),
+            collect_hidden_states=True,
+        )
+        # Rejection commits row 0 and pairs it with the sampled mismatch;
+        # acceptance commits row 1 and pairs it with the sampled bonus.
+        reject_seed = adapter.make_seed(verify, hidden_row_index=0, emitted_token_id=6)
+        accept_seed = adapter.make_seed(verify, hidden_row_index=1, emitted_token_id=7)
+        np.testing.assert_array_equal(
+            np.array(reject_seed.hidden_state),
+            np.array(verify.hidden_states[:, 0:1, :]),
+        )
+        np.testing.assert_array_equal(
+            np.array(accept_seed.hidden_state),
+            np.array(verify.hidden_states[:, 1:2, :]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_spec_decode.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_spec_decode.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import unittest
+
+from sglang.srt.hardware_backend.mlx.spec_decode import (
+    MlxVerifySegment,
+    build_linear_verify_queries,
+    verify_greedy_segment,
+    verify_greedy_segments,
+)
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+
+class TestMlxGreedyVerifier(unittest.TestCase):
+    def test_accept_reject_and_plain_segments(self):
+        cases = (
+            # draft row, valid count, target rows, emitted, accepted
+            ((-1,), 0, (7,), (7,), 0),
+            ((5,), 1, (5, 9), (5, 9), 1),
+            ((5,), 1, (6, 9), (6,), 0),
+            ((2, 3, 4), 3, (2, 3, 4, 8), (2, 3, 4, 8), 3),
+            ((2, 3, 4), 3, (2, 7, 9, 8), (2, 7), 1),
+            ((2, 3, 4), 3, (9, 7, 8, 6), (9,), 0),
+        )
+        for draft, valid, targets, emitted, accepted in cases:
+            with self.subTest(draft=draft, targets=targets):
+                segment = MlxVerifySegment(
+                    request_id="r",
+                    draft_tokens=draft,
+                    valid_draft_count=valid,
+                    invalid_draft_count=len(draft) - valid,
+                    target_token_ids=targets,
+                    verification_query_count=valid + 1,
+                )
+                decision = verify_greedy_segment(segment)
+                self.assertEqual(decision.emitted_token_ids, emitted)
+                self.assertEqual(decision.accepted_draft_count, accepted)
+                self.assertEqual(decision.committed_query_count, accepted + 1)
+                self.assertEqual(decision.seed_hidden_row_index, len(emitted) - 1)
+
+    def test_padding_is_removed_before_target_query_construction(self):
+        segment = MlxVerifySegment("r", (11, -1, -1), 1, (11, 12), 2)
+        self.assertEqual(segment.valid_draft_tokens, (11,))
+        self.assertEqual(build_linear_verify_queries(10, segment), (10, 11))
+
+    def test_mixed_plain_and_drafted_order_is_explicit(self):
+        segments = (
+            MlxVerifySegment("plain", (-1,), 0, (3,), 1),
+            MlxVerifySegment("drafted", (4,), 1, (4, 5), 0),
+        )
+        decisions = verify_greedy_segments(
+            segments, expected_request_ids=("plain", "drafted")
+        )
+        self.assertEqual([item.accept_len for item in decisions], [1, 2])
+        with self.assertRaisesRegex(ValueError, "ordering"):
+            verify_greedy_segments(segments, expected_request_ids=("drafted", "plain"))
+
+    def test_invalid_count_and_sentinel_metadata_is_rejected(self):
+        invalid = (
+            ((1,), -1, (2,)),
+            ((1,), 2, (2, 3, 4)),
+            ((-1,), 1, (2, 3)),
+            ((1, 2), 1, (2, 3)),
+        )
+        for draft, valid, targets in invalid:
+            with self.subTest(draft=draft, valid=valid):
+                with self.assertRaises(ValueError):
+                    MlxVerifySegment("r", draft, valid, targets)
+
+        with self.assertRaisesRegex(ValueError, "invalid_draft_count"):
+            MlxVerifySegment("r", (1, -1), 1, (1, 2), 0)
+        with self.assertRaisesRegex(ValueError, "verification_query_count"):
+            MlxVerifySegment("r", (1,), 1, (1, 2), 0, 1)
+        with self.assertRaisesRegex(ValueError, "verification rows"):
+            MlxVerifySegment("r", (1,), 1, (1,), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_spec_guardrails.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_spec_guardrails.py
@@ -1,0 +1,306 @@
+"""Guardrails for the Gemma 4 Frozen-KV MTP MLX prototype."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.arg_groups.speculative_hook import (
+    _handle_frozen_kv_mtp,
+    _resolve_speculative_algorithm_alias,
+)
+from sglang.srt.hardware_backend.mlx.spec_config import (
+    validate_mlx_frozen_kv_mtp_args,
+    validate_mlx_frozen_kv_mtp_request,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+
+def _target_config():
+    text = SimpleNamespace(
+        model_type="gemma4_text",
+        hidden_size=1536,
+        num_hidden_layers=35,
+        vocab_size=262144,
+        num_kv_shared_layers=20,
+        layer_types=["sliding_attention"] * 34 + ["full_attention"],
+    )
+    hf = SimpleNamespace(
+        model_type="gemma4",
+        architectures=["Gemma4ForConditionalGeneration"],
+        text_config=text,
+    )
+    return SimpleNamespace(hf_config=hf, context_len=2048, is_multimodal=False)
+
+
+def _assistant_config() -> dict:
+    return {
+        "model_type": "gemma4_assistant",
+        "architectures": ["Gemma4AssistantForCausalLM"],
+        "backbone_hidden_size": 1536,
+        "use_ordered_embeddings": True,
+        "num_centroids": 2048,
+        "centroid_intermediate_top_k": 32,
+        "tie_word_embeddings": True,
+        "text_config": {
+            "model_type": "gemma4_text",
+            "hidden_size": 256,
+            "num_hidden_layers": 4,
+            "vocab_size": 262144,
+            "num_kv_shared_layers": 4,
+            "layer_types": [
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            "sliding_window": 512,
+            "tie_word_embeddings": True,
+        },
+    }
+
+
+def _server_args(**overrides):
+    values = dict(
+        speculative_algorithm="FROZEN_KV_MTP",
+        speculative_draft_model_path="assistant",
+        speculative_draft_model_revision="revision",
+        speculative_eagle_topk=1,
+        speculative_num_steps=1,
+        speculative_num_draft_tokens=2,
+        speculative_use_rejection_sampling=False,
+        max_running_requests=1,
+        disable_overlap_schedule=True,
+        disable_radix_cache=True,
+        chunked_prefill_size=-1,
+        enable_mixed_chunk=False,
+        context_length=2048,
+        max_total_tokens=2048,
+        tp_size=1,
+        pp_size=1,
+        dp_size=1,
+        nnodes=1,
+        disaggregation_mode="null",
+        enable_dp_attention=False,
+        model_path="target",
+        revision="target-revision",
+        trust_remote_code=False,
+        get_model_config=_target_config,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class TestMlxGemma4Alias(unittest.TestCase):
+    def test_local_unknown_transformers_config_resolves_before_get_config(self):
+        with tempfile.TemporaryDirectory() as directory:
+            Path(directory, "config.json").write_text(
+                json.dumps(_assistant_config()), encoding="utf-8"
+            )
+            with mock.patch(
+                "sglang.srt.utils.hf_transformers_utils.get_config",
+                side_effect=AssertionError("Transformers must not load this config"),
+            ):
+                self.assertEqual(
+                    _resolve_speculative_algorithm_alias("NEXTN", directory),
+                    "FROZEN_KV_MTP",
+                )
+
+    def test_eagle3_is_rejected_for_gemma4_assistant(self):
+        with tempfile.TemporaryDirectory() as directory:
+            Path(directory, "config.json").write_text(
+                json.dumps(_assistant_config()), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ValueError, "EAGLE3"):
+                _resolve_speculative_algorithm_alias("EAGLE3", directory)
+
+
+class TestMlxWorkerDispatch(unittest.TestCase):
+    def test_mlx_frozen_kv_uses_mlx_worker(self):
+        with mock.patch("sglang.srt.utils.tensor_bridge.use_mlx", return_value=True):
+            worker = SpeculativeAlgorithm.FROZEN_KV_MTP.create_worker(_server_args())
+        self.assertEqual(worker.__name__, "MlxFrozenKVMTPWorker")
+
+    def test_non_mlx_frozen_kv_keeps_generic_worker(self):
+        with mock.patch("sglang.srt.utils.tensor_bridge.use_mlx", return_value=False):
+            worker = SpeculativeAlgorithm.FROZEN_KV_MTP.create_worker(_server_args())
+        self.assertEqual(worker.__name__, "FrozenKVMTPWorkerV2")
+
+
+class TestMlxServerGuardrails(unittest.TestCase):
+    def test_handler_normalizes_safe_defaults(self):
+        args = _server_args(
+            max_running_requests=None,
+            disable_overlap_schedule=False,
+            speculative_eagle_topk=None,
+            speculative_num_steps=None,
+            speculative_num_draft_tokens=None,
+        )
+        with (
+            mock.patch(
+                "sglang.srt.arg_groups.speculative_hook.use_mlx", return_value=True
+            ),
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.spec_config.load_assistant_config_dict",
+                return_value=_assistant_config(),
+            ),
+            self.assertLogs(level="WARNING"),
+        ):
+            _handle_frozen_kv_mtp(args)
+        self.assertEqual(args.max_running_requests, 1)
+        self.assertTrue(args.disable_overlap_schedule)
+        self.assertEqual(args.speculative_eagle_topk, 1)
+        self.assertEqual(args.speculative_num_steps, 1)
+        self.assertEqual(args.speculative_num_draft_tokens, 2)
+
+    def test_supported_shape_passes(self):
+        with mock.patch(
+            "sglang.srt.hardware_backend.mlx.spec_config.load_assistant_config_dict",
+            return_value=_assistant_config(),
+        ):
+            validate_mlx_frozen_kv_mtp_args(_server_args())
+
+    def test_each_unsupported_server_dimension_fails(self):
+        cases = [
+            ({"speculative_draft_model_path": None}, "draft-model-path"),
+            ({"disable_radix_cache": False}, "disable-radix-cache"),
+            ({"chunked_prefill_size": 64}, "chunked-prefill-size -1"),
+            ({"enable_mixed_chunk": True}, "mixed chunked prefill"),
+            ({"speculative_eagle_topk": 2}, "topk"),
+            ({"speculative_num_steps": 2}, "num_steps"),
+            ({"speculative_num_draft_tokens": 3}, "draft_tokens"),
+            ({"max_running_requests": 2}, "max-running-requests 1"),
+            ({"context_length": 2049}, "2,048"),
+            ({"max_total_tokens": 2049}, "max-total-tokens"),
+            ({"tp_size": 2}, "tp-size 1"),
+            ({"dp_size": 2}, "dp-size 1"),
+            ({"pp_size": 2}, "pp-size 1"),
+            ({"nnodes": 2}, "one Apple host"),
+            ({"enable_dp_attention": True}, "DP attention"),
+            ({"disaggregation_mode": "prefill"}, "disaggregation"),
+            ({"disable_overlap_schedule": False}, "synchronous scheduling"),
+            ({"speculative_use_rejection_sampling": True}, "rejection sampling"),
+        ]
+        for changes, message in cases:
+            with self.subTest(changes=changes):
+                with (
+                    mock.patch(
+                        "sglang.srt.hardware_backend.mlx.spec_config.load_assistant_config_dict",
+                        return_value=_assistant_config(),
+                    ),
+                    self.assertRaisesRegex((ValueError, NotImplementedError), message),
+                ):
+                    validate_mlx_frozen_kv_mtp_args(_server_args(**changes))
+
+    def test_wrong_target_or_assistant_fails_before_load(self):
+        wrong_target = _target_config()
+        wrong_target.hf_config.text_config.hidden_size = 2048
+        with (
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.spec_config.load_assistant_config_dict",
+                return_value=_assistant_config(),
+            ),
+            self.assertRaisesRegex(ValueError, "E2B"),
+        ):
+            validate_mlx_frozen_kv_mtp_args(
+                _server_args(get_model_config=lambda: wrong_target)
+            )
+
+        wrong_assistant = _assistant_config()
+        wrong_assistant["model_type"] = "gemma4"
+        with (
+            mock.patch(
+                "sglang.srt.hardware_backend.mlx.spec_config.load_assistant_config_dict",
+                return_value=wrong_assistant,
+            ),
+            self.assertRaisesRegex(ValueError, "gemma4_assistant"),
+        ):
+            validate_mlx_frozen_kv_mtp_args(_server_args())
+
+
+class TestMlxRequestGuardrails(unittest.TestCase):
+    def _request(self, sampling_params=None, **overrides):
+        values = dict(
+            sampling_params=sampling_params or SamplingParams(temperature=0),
+            return_logprob=False,
+            return_hidden_states=False,
+            return_sampling_mask=False,
+            custom_logit_processor=None,
+            session=None,
+            session_id=None,
+            multimodal_inputs=None,
+        )
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    def test_greedy_request_passes(self):
+        self.assertIsNone(validate_mlx_frozen_kv_mtp_request(self._request()))
+
+    def test_normalized_empty_grammar_fields_are_not_constraints(self):
+        params = SamplingParams(temperature=0)
+        # Endpoint/model defaults may retain irrelevant nucleus values after
+        # temperature=0 normalizes top_k to one.
+        params.top_p = 0.95
+        params.min_p = 0.1
+        params.stop_regex_strs = []
+        self.assertIsNone(validate_mlx_frozen_kv_mtp_request(self._request(params)))
+
+    def test_unsupported_request_features_return_actionable_errors(self):
+        cases = [
+            (SamplingParams(temperature=0.5), {}, "temperature=0"),
+            (SamplingParams(temperature=0, frequency_penalty=0.5), {}, "penalties"),
+            (SamplingParams(temperature=0, presence_penalty=0.5), {}, "penalties"),
+            (SamplingParams(temperature=0, repetition_penalty=1.1), {}, "penalties"),
+            (SamplingParams(temperature=0, min_new_tokens=1), {}, "penalties"),
+            (SamplingParams(temperature=0, logit_bias={"1": 1.0}), {}, "logit bias"),
+            (SamplingParams(temperature=0, regex="a+"), {}, "grammar"),
+            (SamplingParams(temperature=0, n=2), {}, "one completion"),
+            (
+                SamplingParams(temperature=0, custom_params={"sampler": "custom"}),
+                {},
+                "custom sampling",
+            ),
+            (SamplingParams(temperature=0), {"return_logprob": True}, "logprobs"),
+            (
+                SamplingParams(temperature=0),
+                {"return_hidden_states": True},
+                "hidden states",
+            ),
+            (
+                SamplingParams(temperature=0),
+                {"return_sampling_mask": True},
+                "sampling masks",
+            ),
+            (
+                SamplingParams(temperature=0),
+                {"custom_logit_processor": "processor"},
+                "custom logits",
+            ),
+            (SamplingParams(temperature=0), {"session_id": "session"}, "sessions"),
+            (SamplingParams(temperature=0), {"lora_id": "adapter"}, "LoRA"),
+            (
+                SamplingParams(temperature=0),
+                {"multimodal_inputs": object()},
+                "text-only",
+            ),
+        ]
+        for params, overrides, message in cases:
+            with self.subTest(message=message):
+                error = validate_mlx_frozen_kv_mtp_request(
+                    self._request(params, **overrides)
+                )
+                self.assertIsNotNone(error)
+                self.assertIn(message, error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_mlx_spec_batch_result.py
+++ b/test/registered/unit/managers/test_mlx_spec_batch_result.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.managers.schedule_batch import FINISH_MATCHED_TOKEN
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+
+def _request(committed):
+    return SimpleNamespace(
+        rid="request",
+        is_retracted=False,
+        finished=lambda: False,
+        grammar=None,
+        kv_committed_len=committed,
+        spec_verify_ct=0,
+        spec_num_correct_drafts=0,
+        spec_num_block_accept_tokens=0,
+        spec_num_cap_tokens=0,
+        update_spec_correct_drafts_histogram=mock.Mock(),
+        update_spec_cap_lens_histogram=mock.Mock(),
+    )
+
+
+def _processor(worker=None):
+    worker = worker or mock.Mock()
+    worker.on_verify_complete_cpu.return_value = None
+    return SchedulerBatchResultProcessor(
+        is_generation=True,
+        disaggregation_mode=DisaggregationMode.NULL,
+        enable_overlap=False,
+        enable_overlap_mlx=False,
+        server_args=mock.Mock(),
+        model_config=mock.Mock(),
+        token_to_kv_pool_allocator=mock.Mock(),
+        tree_cache=mock.Mock(),
+        hisparse_coordinator=None,
+        req_to_token_pool=mock.Mock(),
+        decode_offload_manager=None,
+        metrics_collector=mock.Mock(),
+        metrics_reporter=mock.Mock(),
+        draft_worker=worker,
+        model_worker=worker,
+        logprob_result_processor=mock.Mock(),
+        output_streamer=mock.Mock(),
+        abort_request=mock.Mock(),
+    )
+
+
+class TestMlxSpecBatchResult(unittest.TestCase):
+    def test_prefill_finish_invokes_spec_and_native_release_hooks(self):
+        worker = BaseSpecWorker()
+        worker.note_request_finished = mock.Mock()
+        worker.prepare_for_kv_cache_release = mock.Mock()
+        worker.on_verify_complete_cpu = mock.Mock()
+        processor = _processor(worker)
+        finished = False
+
+        def update_finish_state():
+            nonlocal finished
+            finished = True
+            request.finished_reason = FINISH_MATCHED_TOKEN(matched=7)
+
+        request = SimpleNamespace(
+            rid="prefill-finish",
+            finished=lambda: finished,
+            finished_reason=None,
+            inflight_middle_chunks=0,
+            is_retracted=False,
+            time_stats=mock.Mock(),
+            output_ids=[],
+            require_reasoning=False,
+            update_finish_state=update_finish_state,
+            return_routed_experts=False,
+            return_sampling_mask=False,
+            return_hidden_states=False,
+            grammar=None,
+        )
+        batch = SimpleNamespace(
+            reqs=[request],
+            return_logprob=False,
+            decoding_reqs=None,
+            prefill_stats=mock.Mock(),
+            dp_cooperation_info=None,
+        )
+        result = GenerationBatchResult(
+            logits_output=LogitsProcessorOutput(next_token_logits=None),
+            next_token_ids=torch.tensor([7], dtype=torch.long),
+        )
+        with mock.patch(
+            "sglang.srt.managers.scheduler_components.batch_result_processor.release_kv_cache"
+        ) as release:
+            processor.process_batch_result_prefill(batch, result)
+
+        worker.note_request_finished.assert_called_once_with(
+            rid=request.rid, natural_stop=True
+        )
+        worker.prepare_for_kv_cache_release.assert_called_once_with(request)
+        release.assert_called_once_with(request, processor.tree_cache)
+
+    def test_processor_commits_accept_length_exactly_once(self):
+        processor = _processor()
+        for padded, accept_len, expected_tokens in (
+            ([11, 12], 2, [11, 12]),
+            ([13, -1], 1, [13]),
+        ):
+            with self.subTest(accept_len=accept_len):
+                request = _request(committed=7)
+                batch = SimpleNamespace(
+                    reqs=[request],
+                    has_grammar=False,
+                    forward_mode=SimpleNamespace(
+                        is_decode=lambda: True, is_extend=lambda: False
+                    ),
+                )
+                result = GenerationBatchResult(
+                    next_token_ids=torch.tensor(padded, dtype=torch.long),
+                    accept_lens=torch.tensor([accept_len], dtype=torch.int32),
+                    speculative_num_draft_tokens=2,
+                )
+
+                # The MLX worker/native runner owns private token/cache state but
+                # intentionally leaves scheduler ownership untouched.
+                self.assertEqual(request.kv_committed_len, 7)
+                tokens = processor._resolve_spec_v2_tokens(result, batch)
+                self.assertEqual(tokens, [expected_tokens])
+                self.assertEqual(request.kv_committed_len, 7 + accept_len)
+                self.assertEqual(request.spec_verify_ct, 1)
+                self.assertEqual(request.spec_num_correct_drafts, accept_len - 1)
+
+    def test_stride_prevents_rejected_padding_from_escaping(self):
+        processor = _processor()
+        requests = [_request(3), _request(4)]
+        requests[1].rid = "second"
+        batch = SimpleNamespace(
+            reqs=requests,
+            has_grammar=False,
+            forward_mode=SimpleNamespace(
+                is_decode=lambda: True, is_extend=lambda: False
+            ),
+        )
+        result = GenerationBatchResult(
+            next_token_ids=torch.tensor([8, -1, 9, 10]),
+            accept_lens=torch.tensor([1, 2], dtype=torch.int32),
+            speculative_num_draft_tokens=2,
+        )
+        self.assertEqual(
+            processor._resolve_spec_v2_tokens(result, batch), [[8], [9, 10]]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1708,9 +1708,11 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             self.assertEqual(
                 _llama4_overrides(_args(attention_backend="fa3"), None), {}
             )
-            self.assertEqual(
-                _gemma4_overrides(_args(), None), {"attention_backend": "trtllm_mha"}
-            )
+            with patch.object(overrides_module, "use_mlx", return_value=False):
+                self.assertEqual(
+                    _gemma4_overrides(_args(), None),
+                    {"attention_backend": "trtllm_mha"},
+                )
             self.assertEqual(
                 _minicpm_v4_6_overrides(_args(), None),
                 {"attention_backend": "triton"},
@@ -1740,9 +1742,11 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 self.assertEqual(
                     _llama4_overrides(_args(), None), {"attention_backend": "fa3"}
                 )
-            self.assertEqual(
-                _gemma4_overrides(_args(), None), {"attention_backend": "triton"}
-            )
+            with patch.object(overrides_module, "use_mlx", return_value=False):
+                self.assertEqual(
+                    _gemma4_overrides(_args(), None),
+                    {"attention_backend": "triton"},
+                )
         # Glm4Moe: unconditional tf32 declaration + (sm100) quant/moe absorption
         with patch.object(overrides_module, "is_sm100_supported", return_value=False):
             self.assertEqual(
@@ -1767,6 +1771,42 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     "enable_tf32_matmul": True,
                 },
             )
+
+    def test_gemma4_mlx_uses_torch_native_attention(self):
+        from sglang.srt.arg_groups.overrides import _gemma4_overrides
+
+        def _args(*, device="cuda", attention_backend=None, backend_not_set=True):
+            return SimpleNamespace(
+                device=device,
+                attention_backend=attention_backend,
+                is_attention_backend_not_set=lambda: backend_not_set,
+                moe_runner_backend="triton",
+                quantization=None,
+            )
+
+        with patch.object(overrides_module, "is_sm100_supported", return_value=True):
+            with patch.object(overrides_module, "use_mlx", return_value=False):
+                self.assertEqual(
+                    _gemma4_overrides(_args(device="mps"), None),
+                    {"attention_backend": "trtllm_mha"},
+                )
+                self.assertEqual(
+                    _gemma4_overrides(
+                        _args(
+                            device="mps",
+                            attention_backend="torch_native",
+                            backend_not_set=False,
+                        ),
+                        None,
+                    ),
+                    {},
+                )
+
+            with patch.object(overrides_module, "use_mlx", return_value=True):
+                self.assertEqual(
+                    _gemma4_overrides(_args(), None),
+                    {"attention_backend": "torch_native"},
+                )
 
     def test_deepseek_moe_quant_slot_pass(self):
         from sglang.srt.arg_groups.overrides import (


### PR DESCRIPTION
## Summary

This is a stacked draft on top of #32102 (`129479f20`). It implements the correctness-first Level 1 Gemma 4 Frozen-KV MTP path for SGLang's MLX backend on Apple Silicon.

The initial scope is deliberately narrow: text-only E2B, greedy decoding, one proposal, one active request, synchronous scheduling, native `mlx-lm` target caches, and a separately pinned Gemma 4 assistant. It makes no performance or production-readiness claim.

Part of #32101 and #19137; related to the Gemma 4 roadmap in #26596.

## Modifications

- Dispatch `FROZEN_KV_MTP`/Gemma 4 `NEXTN` to an MLX-native worker without constructing Torch, Triton, or CUDA draft machinery.
- Validate the complete server/request MVP contract before assistant loading or target-cache mutation.
- Add a pure linear greedy verifier and transactional native-cache clone/verify/replay path that remains correct after rotating-cache compaction.
- Advance verification and commit replay one query at a time so greedy IDs exactly match the normal MLX decode numerical path.
- Capture target hidden states and scaled embeddings only for MTP seeds while preserving target logits and cache state.
- Load the assistant strictly through pinned `mlx-vlm==0.5.0`, with revision-aware fingerprints and generation-based unload/reload/replacement invalidation.
- Execute query-only assistant attention over read-only target KV.
- Map assistant layers through target logical layer, YOCO owner, and compact native-cache index explicitly.
- Implement the synchronous spec-v2 worker, scheduler bookkeeping handoff, finish/abort/flush cleanup, and unsupported weight-update behavior.
- Expose activation, acceptance, timing, lifecycle, fingerprint, and MLX-memory state through `/server_info`.
- Expose non-streaming OpenAI `output_token_ids` when `return_meta_info=true` for exact E2E comparisons.
- Add offline Stage A coverage, a pinned Stage B server test, and experimental Apple Silicon documentation.

## Supported configuration

- Target: `mlx-community/gemma-4-e2b-it-4bit` at `238767527555cb75a05732a84dff5d6ba0dd6809`
- Assistant: `mlx-community/gemma-4-E2B-it-assistant-bf16` at `a7770799b560135ebdbfae8b7f468947415003bc`
- `FROZEN_KV_MTP`, one step, top-k 1, verify width 2
- Explicit `temperature=0`, batch size/max-running-requests 1
- Context and total-token limits no greater than 2,048
- Radix cache, overlap scheduling, and chunked prefill disabled
- Single-node TP/DP/PP 1, with no disaggregation, grammar, penalties, logprobs, LoRA, or multimodal inputs

Later gates cover concurrency, overlap, heterogeneous paged KV/radix integration, and performance. This PR intentionally retains those guardrails.

## Validation

Test host: Apple Silicon arm64, macOS 26.5.2, `mlx==0.32.0`, `mlx-lm==0.31.3`, and `mlx-vlm==0.5.0`.

- Offline Stage A: `166 passed`, `154 subtests passed`
- Generic speculative/scheduler regressions: `187 passed`, `11 skipped`, `20 subtests passed`
- Pinned fresh-process Stage B E2E: `1 passed`
  - raw generation and OpenAI chat
  - exact target-only/MTP IDs at 1, 16, and 64-token horizons
  - prompt crossing the real sliding window
  - accept/reject mix, natural stop, max-token completion, repeat, abort, and flush
  - activation/lifecycle counters and bounded active-memory plateau
- Black, isort, selected Ruff rules, codespell, TOML parsing, MDX internal links, and `git diff --check` pass.

Mintlify CLI validation was not run locally because Node.js is unavailable; `docs.json` and modified internal MDX links/anchors were validated directly.

## Dependency

This branch descends from #32102. Keep this PR in draft while the native-cache baseline is under review; rebase it onto `main` after #32102 lands.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->