### PR TITLE
[Quantization] List only CPU-supported methods in validation error

### DIFF
--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -155,7 +155,7 @@ def get_quantization_config(quantization: str) -> Type[QuantizationConfig]:
         if quantization not in CPU_QUANTIZATION_METHODS:
             raise ValueError(
                 f"Invalid quantization method on CPU: {quantization}. "
-                f"Available methods on CPU: {list(QUANTIZATION_METHODS.keys())}"
+                f"Available methods on CPU: {list(CPU_QUANTIZATION_METHODS.keys())}"
             )
         else:
             return CPU_QUANTIZATION_METHODS[quantization]

--- a/test/registered/quant/test_quant_config_parsing.py
+++ b/test/registered/quant/test_quant_config_parsing.py
@@ -1,7 +1,16 @@
+import ast
+import re
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import sglang.srt.layers.quantization as quantization
+import sglang.srt.utils as srt_utils
 from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.layers.quantization import (
+    CPU_QUANTIZATION_METHODS,
+    QUANTIZATION_METHODS,
+    get_quantization_config,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -71,6 +80,40 @@ class TestQuantLogString(CustomTestCase):
         result = model_config.get_quantization_config_log_str()
         print(f"\n[Test No Quant] Result: {result}")
         self.assertIsNone(result)
+
+
+class TestCpuUnsupportedQuantizationMessage(CustomTestCase):
+    """The CPU rejection message must advertise only CPU-supported methods."""
+
+    def test_cpu_error_lists_only_cpu_methods(self):
+        # A method that exists in the registry but is not CPU-supported. This
+        # request must be rejected on CPU, and the rejection message must not
+        # advertise methods that CPU cannot serve.
+        method = "awq_marlin"
+        self.assertIn(method, QUANTIZATION_METHODS)
+        self.assertNotIn(method, CPU_QUANTIZATION_METHODS)
+
+        # Enter the real CPU validation branch by forcing only the two
+        # platform-detection predicates; get_quantization_config itself runs
+        # unmodified.
+        with (
+            patch.object(srt_utils, "is_cpu", return_value=True),
+            patch.object(quantization, "cpu_has_amx_support", return_value=True),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                get_quantization_config(method)
+
+        message = str(ctx.exception)
+        match = re.search(r"Available methods on CPU:\s*(\[.*\])", message)
+        self.assertIsNotNone(
+            match, f"CPU error message not in the expected form: {message!r}"
+        )
+        advertised = set(ast.literal_eval(match.group(1)))
+
+        # The advertised set must be exactly the CPU-supported methods, and in
+        # particular must not include the method that was just rejected.
+        self.assertEqual(advertised, set(CPU_QUANTIZATION_METHODS))
+        self.assertNotIn(method, advertised)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

When a registered quantization method is unsupported on CPU, `get_quantization_config` correctly rejects it, but the validation error says it is listing the available CPU methods while it actually interpolates every entry from `QUANTIZATION_METHODS`.

This can advertise methods that CPU cannot execute, including the method that was just rejected. For example, requesting `awq_marlin` on CPU is rejected, yet the message lists `awq_marlin` (and 22 other non-CPU methods) as "Available methods on CPU".

## Modifications

- Build the CPU validation message from `CPU_QUANTIZATION_METHODS` instead of `QUANTIZATION_METHODS`, so it lists only the methods CPU can actually serve.
- Add a regression test that enters the real CPU validation path (patching only the platform-detection predicates, not the function under test), parses the advertised list from the real exception, and asserts it equals `CPU_QUANTIZATION_METHODS` and excludes the rejected method.

Scope is limited to the CPU error message. `QUANTIZATION_CHOICES`, `QUANTIZATION_METHODS`, quantization registration, checkpoint override behavior, online quantization, and CPU capability support are unchanged.

## Accuracy Tests

Not applicable. This change only corrects the text of a validation error; it does not touch kernels or model forward code.

## Speed Tests and Profiling

Not applicable. The change is confined to an error-message string on the rejection path.

## Testing

The regression test fails on unmodified `main`: the advertised set contains 23 non-CPU methods, including the rejected `awq_marlin`.

With the fix:

```text
test_quant_config_parsing.py::TestCpuUnsupportedQuantizationMessage::test_cpu_error_lists_only_cpu_methods: 1 passed
test/registered/quant/test_quant_config_parsing.py: 6 passed
test/registered/quant/test_is_layer_skipped.py: 4 passed
```

Also run locally: Python compilation, `ruff check` on the changed test, `ruff format --check` on both files, `scripts/ci/check_registered_tests.py`, and `git diff --check`. `python/sglang/srt/layers/quantization/__init__.py` has pre-existing lint findings on unmodified `main`; this change introduces no new findings. Formatting was verified with Ruff's formatter rather than the full pre-commit hook set, which was not available in this environment.

Related to #31783.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30046350186](https://github.com/sgl-project/sglang/actions/runs/30046350186)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30046349786](https://github.com/sgl-project/sglang/actions/runs/30046349786)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->