### PR TITLE
fix(gemma4): validate precomputed image token counts

### DIFF
--- a/python/sglang/srt/multimodal/processors/gemma4.py
+++ b/python/sglang/srt/multimodal/processors/gemma4.py
@@ -78,6 +78,21 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         first_stride = _SSCP_CONV_STRIDE_SIZES[0][0]
         return hop * first_stride
 
+    @staticmethod
+    def _validate_precomputed_image_token_counts(mm_items) -> None:
+        for item in mm_items:
+            if not item.is_image() or not item.is_precomputed_embedding():
+                continue
+
+            embedding = torch.as_tensor(item.feature)
+            num_embeddings = embedding.reshape(-1, embedding.shape[-1]).shape[0]
+            num_placeholders = sum(end - start + 1 for start, end in item.offsets)
+            if num_placeholders != num_embeddings:
+                raise ValueError(
+                    "Gemma4 precomputed image token count mismatch: "
+                    f"placeholders={num_placeholders}, embeddings={num_embeddings}"
+                )
+
     def _video_decoder_to_tensor(self, vdw: VideoDecoderWrapper) -> torch.Tensor:
         """Convert a VideoDecoderWrapper to a (sampled_frames, C, H, W) uint8 tensor.
 
@@ -148,6 +163,7 @@ class Gemma4SGLangProcessor(SGLangBaseProcessor):
         mm_items, input_ids, _ = self.process_and_combine_mm_data(
             base_output, self.mm_tokens
         )
+        self._validate_precomputed_image_token_counts(mm_items)
 
         return MultimodalProcessorOutput(
             input_ids=input_ids.tolist(),

--- a/test/registered/unit/multimodal/test_gemma4_precomputed_image_token_counts.py
+++ b/test/registered/unit/multimodal/test_gemma4_precomputed_image_token_counts.py
@@ -1,0 +1,40 @@
+import unittest
+
+import torch
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputFormat,
+)
+from sglang.srt.multimodal.processors.gemma4 import Gemma4SGLangProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def make_item(num_placeholders, num_embeddings):
+    return MultimodalDataItem(
+        modality=Modality.IMAGE,
+        offsets=[(0, num_placeholders - 1)],
+        feature=torch.zeros((num_embeddings, 4)),
+        format=MultimodalInputFormat.PRECOMPUTED_EMBEDDING,
+    )
+
+
+class TestGemma4PrecomputedImageTokenCounts(CustomTestCase):
+    def test_accepts_matching_count(self):
+        Gemma4SGLangProcessor._validate_precomputed_image_token_counts(
+            [make_item(4, 4)]
+        )
+
+    def test_rejects_mismatched_count(self):
+        with self.assertRaisesRegex(ValueError, r"placeholders=526, embeddings=517"):
+            Gemma4SGLangProcessor._validate_precomputed_image_token_counts(
+                [make_item(526, 517)]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Caller-supplied Gemma4 precomputed image embeddings can contain fewer rows than the image placeholder span. The mismatch is currently detected during scheduler execution, where it raises an internal error and terminates the server process.

Validate the row count during multimodal preprocessing so the invalid request fails before scheduler admission, KV allocation, or transfer.

## Modifications

- Validate precomputed image embedding row counts against their placeholder spans.
- Report a mismatch as a request-level `ValueError`.
- Add focused CPU unit tests for matching counts and the observed `526` placeholder / `517` embedding mismatch.

## Accuracy Tests

No change for valid requests. The validation only rejects precomputed image embeddings whose row count differs from their placeholder span.

Focused CPU unit tests cover matching and mismatched precomputed image counts.

## Speed Tests and Profiling

No inference hot path changes. Validation adds one CPU-side row-count comparison during request preprocessing. No speed benchmark was run.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable: no user-facing API or configuration changes.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable: valid model execution is unchanged.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
