### PR TITLE
[Perf] Fuse Gemma3RMSNorm CUDA path into gemma_rmsnorm kernel

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1071,6 +1071,19 @@ class Gemma3RMSNorm(MultiPlatformOp):
         return self.forward_native(x)
 
     def forward_cuda(self, x):
+        if x.numel() == 0:
+            return x
+        # Fused kernel needs a contiguous buffer; forcing .contiguous() on the
+        # transposed q/k norm views would reorder memory and break a downstream
+        # permute().view(), so fall back to forward_native for those.
+        if x.is_contiguous():
+            if x.dim() == 2:
+                return gemma_rmsnorm(x, self.weight.data, self.eps)
+            original_shape = x.shape
+            out = gemma_rmsnorm(
+                x.reshape(-1, original_shape[-1]), self.weight.data, self.eps
+            )
+            return out.reshape(original_shape)
         return self.forward_native(x)
 
     def forward_npu(self, x):

--- a/test/manual/layers/test_layernorm.py
+++ b/test/manual/layers/test_layernorm.py
@@ -3,7 +3,12 @@ import unittest
 
 import torch
 
-from sglang.srt.layers.layernorm import GemmaRMSNorm, LayerNorm, RMSNorm
+from sglang.srt.layers.layernorm import (
+    Gemma3RMSNorm,
+    GemmaRMSNorm,
+    LayerNorm,
+    RMSNorm,
+)
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -107,6 +112,94 @@ class TestGemmaRMSNorm(CustomTestCase):
                 seed=params[4],
             ):
                 self._run_gemma_rms_norm_test(*params)
+
+
+class TestGemma3RMSNorm(CustomTestCase):
+    """Guards Gemma3RMSNorm.forward_cuda, which routes contiguous inputs to the
+    fused gemma_rmsnorm kernel and falls back to forward_native otherwise.
+
+    Two failure modes are covered:
+    1. Numerical: the fused kernel must match the fp32 native reference.
+    2. Layout: for the non-contiguous transposed q/k tensors that
+       Gemma3Attention feeds in, forward_cuda must preserve the input's
+       memory layout. An earlier fused implementation used .contiguous(),
+       which silently re-laid-out memory to standard order; the values stayed
+       correct but a downstream permute().view() (the attention KV write)
+       then failed with a stride error. Comparing only values would not catch
+       this, so we also assert stride parity and replay that permute().view().
+    """
+
+    DTYPES = [torch.half, torch.bfloat16]
+    NUM_TOKENS = [7, 83, 4096]
+    HIDDEN_SIZES = [768, 2560, 5376]
+    SEEDS = [0]
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+        torch.set_default_device("cuda")
+
+    def _make_layer(self, dim, dtype):
+        layer = Gemma3RMSNorm(dim).to(dtype=dtype)
+        # Gemma weights are zero-centered (kernel applies the +1 internally).
+        layer.weight.data.normal_(mean=0.0, std=0.1)
+        return layer
+
+    def test_contiguous_matches_native(self):
+        # 2D hidden-size norms (the common, fused path).
+        for num_tokens, hidden_size, dtype, seed in itertools.product(
+            self.NUM_TOKENS, self.HIDDEN_SIZES, self.DTYPES, self.SEEDS
+        ):
+            with self.subTest(
+                num_tokens=num_tokens,
+                hidden_size=hidden_size,
+                dtype=dtype,
+                seed=seed,
+            ):
+                torch.manual_seed(seed)
+                layer = self._make_layer(hidden_size, dtype)
+                x = torch.randn(num_tokens, hidden_size, dtype=dtype) / (
+                    2 * hidden_size
+                )
+                with torch.inference_mode():
+                    ref = layer.forward_native(x)
+                    out = layer(x)
+                self.assertTrue(torch.allclose(out, ref, atol=1e-2, rtol=1e-2))
+                self.assertEqual(out.stride(), ref.stride())
+
+    def test_transposed_qk_layout_preserved(self):
+        # Reproduces the exact non-contiguous q/k tensor Gemma3Attention builds:
+        # [s, h*d] -> unflatten -> [s, h, d] -> transpose(0,1).unsqueeze(0)
+        #   -> [1, h, s, d]  (non-contiguous view over [s, h, d] memory)
+        head_dim = 256
+        for num_tokens, num_heads, dtype in itertools.product(
+            [7, 83], [4, 8], self.DTYPES
+        ):
+            with self.subTest(num_tokens=num_tokens, num_heads=num_heads, dtype=dtype):
+                torch.manual_seed(0)
+                layer = self._make_layer(head_dim, dtype)
+                flat = torch.randn(num_tokens, num_heads * head_dim, dtype=dtype)
+                x = flat.unflatten(-1, (num_heads, head_dim))
+                x = x.transpose(0, 1).unsqueeze(0)
+                self.assertFalse(x.is_contiguous())
+                with torch.inference_mode():
+                    ref = layer.forward_native(x)
+                    out = layer(x)
+                # values match ...
+                self.assertTrue(torch.allclose(out, ref, atol=1e-2, rtol=1e-2))
+                # ... and the memory layout is preserved (the regression guard).
+                self.assertEqual(out.stride(), ref.stride())
+                # the downstream op that crashed on the buggy layout must work.
+                permuted = out.permute(0, 2, 1, 3)
+                permuted.reshape(-1, num_heads, head_dim).view(-1, num_heads * head_dim)
+
+    def test_empty_input(self):
+        layer = self._make_layer(2560, torch.bfloat16)
+        x = torch.empty(0, 2560, dtype=torch.bfloat16)
+        with torch.inference_mode():
+            out = layer(x)
+        self.assertEqual(out.shape, x.shape)
 
 
 class TestLayerNorm(CustomTestCase):


### PR DESCRIPTION
## Motivation

`Gemma3RMSNorm.forward_cuda` dispatched straight to `forward_native`, running the RMSNorm as ~9 eager elementwise/reduction kernels per call. Its sibling `Gemma4RMSNorm.forward_cuda` already routes the **identical** math to the fused `gemma_rmsnorm` `sgl_kernel`.

In the default CUDA-graph decode path the small-batch step is dominated by the sheer *count* of tiny kernel nodes, so collapsing ~9 launches per norm into 1 is a meaningful win.

## Modifications

- `Gemma3RMSNorm.forward_cuda`: route **contiguous** inputs to the fused `gemma_rmsnorm` kernel; fall back to `forward_native` for non-contiguous inputs.
  - The contiguity guard is load-bearing. The kernel needs a standard-contiguous 2D buffer, and forcing one via `.contiguous()` on the transposed `[1, H, S, D]` q/k views silently re-lays-out memory to standard order. The *values* stay correct, but a later `permute().view()` in the attention KV write then fails with a stride error. `forward_native` preserves strides, so non-contiguous inputs take that path (this is strictly safer than the current `Gemma4RMSNorm.forward_cuda`, which uses an unconditional `.contiguous()`).
- Adds `TestGemma3RMSNorm` in `test/manual/layers/test_layernorm.py`.

## Accuracy Tests

Fused vs native output on H100, across Gemma-3 hidden sizes and the transposed q/k shapes, fp16 + bf16: **max abs error ≤ 7.8e-3** (bf16 ULP level; the kernel and native path both accumulate in fp32).

The added unit test asserts both numerical equivalence *and* memory-layout parity (`out.stride() == ref.stride()`) and replays the exact `permute().view()` that a naive `.contiguous()` implementation crashed on. Verified the test is a real guard: it passes on `forward_native` and on the fix, and **fails** on the unconditional-`.contiguous()` variant with the stride mismatch.

## Speed Tests and Profiling

Kernel microbenchmark (H100, bf16): the fused kernel is **4–6×** faster per op than the eager native chain.

End-to-end decode, Gemma-3-4B (`--load-format dummy`), fa3 backend, CUDA graph on (the default decode path), in=512 / out=64:

| batch size | baseline | patched | speedup |
|-----------:|---------:|--------:|--------:|
| 1  | 8.40 ms/step | 4.77 ms/step | **1.76×** |
| 16 | 9.96 ms/step | 6.71 ms/step | **1.48×** |
| 64 | 11.68 ms/step | 8.26 ms/step | **1.41×** |

The relative gain is largest at small batch (the decode graph is dominated by tiny norm kernel nodes there) and shrinks as batch size and model size grow (larger matmuls take a bigger share of the step). Measured with dummy weights — the kernel structure is identical to a real Gemma-3, and weight values don't affect timing.

## Checklist

- [x] Add unit tests according to the contribution guide.
- [x] Provide accuracy and speed benchmark results.
- [x] Format your code according to pre-commit.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30050364804](https://github.com/sgl-project/sglang/actions/runs/30050364804)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30050364616](https://github.com/sgl-project/sglang/actions/runs/30050364616)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
