### PR TITLE
[PD] Reconnect prefill-to-decode status notification sockets

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -690,7 +690,6 @@ class CommonKVManager(BaseKVManager):
             sock = self._zmq_ctx.socket(zmq.PUSH)
             if is_ipv6:
                 sock.setsockopt(zmq.IPV6, 1)
-            sock.setsockopt(zmq.RECONNECT_IVL, -1)
             sock.setsockopt(zmq.SNDTIMEO, 30000)
             sock.setsockopt(zmq.LINGER, 0)
             sock.setsockopt(zmq.TCP_KEEPALIVE, 1)

--- a/test/registered/unit/disaggregation/test_common_zmq_reconnect.py
+++ b/test/registered/unit/disaggregation/test_common_zmq_reconnect.py
@@ -1,0 +1,28 @@
+import threading
+import unittest
+from unittest.mock import MagicMock, call
+
+import zmq
+
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestCommonKVManagerConnect(unittest.TestCase):
+    def test_status_socket_keeps_automatic_reconnect_enabled(self):
+        manager = object.__new__(CommonKVManager)
+        manager._socket_lock = threading.Lock()
+        manager._socket_cache = {}
+        manager._monitor_cache = {}
+        manager._zmq_ctx = MagicMock()
+        socket = manager._zmq_ctx.socket.return_value
+
+        manager._connect("tcp://127.0.0.1:12345")
+
+        self.assertNotIn(call(zmq.RECONNECT_IVL, -1), socket.setsockopt.call_args_list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

PR #29570 disabled ZeroMQ automatic reconnect on both cached PUSH socket paths. PRs #31025 and #31306 restored reconnect for `CommonKVReceiver`, but `CommonKVManager._connect()` still sets `RECONNECT_IVL=-1`.

`MooncakeKVManager.sync_status_to_decode_endpoint()` uses the manager socket to send `KVPoll.Success` and `KVPoll.Failed` notifications from prefill to decode. If a decode process restarts, a send can race ahead of monitor-based disconnect detection and use the existing disconnected socket. Because reconnect is disabled, that request can lose its completion notification permanently even though the KV transfer completed. Decode then remains in the transfer queue until its request timeout.

## Modifications

- Remove `RECONNECT_IVL=-1` from `CommonKVManager._connect()` so prefill-to-decode status sockets retain ZeroMQ automatic reconnect.
- Keep the existing monitor-based socket replacement, TCP keepalive, `SNDTIMEO`, and zero-linger behavior.
- Add a focused CPU unit test covering the manager status socket configuration.

## Accuracy Tests

N/A. This does not change model execution or outputs. It restores delivery of disaggregation completion and failure notifications after connection loss.

## Speed Tests and Profiling

N/A. The steady-state path still reuses one cached socket per endpoint. Automatic reconnect only affects connection failure and recovery.

## Validation

- SGLang pre-commit hooks passed for the production change and test commit.
- `python3 -m py_compile` passed for both changed Python files.
- The focused unit test is registered for CPU CI. Local execution was blocked during collection by an incompatible locally installed `transformers` package.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30052835189](https://github.com/sgl-project/sglang/actions/runs/30052835189)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30052834998](https://github.com/sgl-project/sglang/actions/runs/30052834998)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->