### PR TITLE
Support EAGLE/MTP with HybridAttnBackend

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -36,6 +36,9 @@ class HybridAttnBackend(AttentionBackend):
         self.needs_cpu_seq_lens = (
             prefill_backend.needs_cpu_seq_lens or decode_backend.needs_cpu_seq_lens
         )
+        # Speculative-decoding helpers (build_eagle_verify_input) read these off
+        # model_runner.attn_backend directly, so mirror the sub-backends here.
+        self.max_context_len = model_runner.model_config.context_len
 
     def _select_backend(self, forward_mode: ForwardMode) -> AttentionBackend:
         """
@@ -91,6 +94,17 @@ class HybridAttnBackend(AttentionBackend):
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self.decode_backend.get_cuda_graph_seq_len_fill_value()
+
+    def _spec_verify_backend(self) -> AttentionBackend:
+        return self.decode_backend if self.spec_attn_is_decode else self.prefill_backend
+
+    def get_verify_buffers_to_fill_after_draft(self):
+        return self._spec_verify_backend().get_verify_buffers_to_fill_after_draft()
+
+    def update_verify_buffers_to_fill_after_draft(self, spec_info, cuda_graph_bs):
+        self._spec_verify_backend().update_verify_buffers_to_fill_after_draft(
+            spec_info, cuda_graph_bs
+        )
 
     def forward(
         self,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enables EAGLE/MTP style speculative decoding to work with mixed prefill and decode backends (HybridAttnBackend)

Agent generated summary:

Before: any `--prefill-attention-backend X --decode-attention-backend Y` + EAGLE-family spec decoding crashed on the first speculative batch (found while using the split-backend workaround for the bug above):
```
  File ".../speculative/eagle_worker_common.py", line 356, in build_eagle_verify_input
      seq_lens_sum = batch.seq_lens.shape[0] * max_context_len
  TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```                       

  Root cause: eagle-v2 reads `max_context_len` + two verify-buffer hooks directly off `model_runner.attn_backend`; every concrete backend implements them, `HybridAttnBackend` implemented none — so it crashes here, and (more insidiously) the base-class no-op `update_verify_buffers_to_fill_after_draft` would leave stale tree-mask buffers during graph replay.
                                                                                                                   
## Modifications

Fix/After: mirror `max_context_len` and delegate both hooks to the spec-verify sub-backend. This fix is backend-agnostic, enabling all hybrid combos. 

## Accuracy Tests

Validated at full scale: GPQA 198x8 = 0.721 (FA3+MTP reference 0.734, within repeat noise), acceptance 2.45/0.48 vs 2.37/0.46 (see MTP data reported in https://github.com/sgl-project/sglang/pull/23112).

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30060442180](https://github.com/sgl-project/sglang/actions/runs/30060442180)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30060442015](https://github.com/sgl-project/sglang/actions/runs/30060442015)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->