### PR TITLE
Support XQA backend for SpecDec verify

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -193,6 +193,53 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         #   KV fp8: q_type = fp8, out_type=model_runner.dtype
         self.is_xqa_impl = is_sm90_supported() or is_sm120_supported()
 
+        # The XQA impl requires an explicit bit-packed causal mask for
+        # speculative-decode verify (q_len_per_req > 1); trtllm-gen does not.
+        # Preallocate at init so CUDA-graph capture never allocates.
+        self._xqa_spec_dec_masks = {}
+        if (
+            self.is_xqa_impl
+            and model_runner.server_args.speculative_algorithm is not None
+            and model_runner.server_args.speculative_num_draft_tokens is not None
+        ):
+            draft_len = model_runner.server_args.speculative_num_draft_tokens
+            self._xqa_spec_dec_masks[draft_len] = self._build_xqa_spec_dec_causal_mask(
+                max_bs=model_runner.req_to_token_pool.size,
+                q_len=draft_len,
+                device=model_runner.device,
+            )
+
+    @staticmethod
+    def _build_xqa_spec_dec_causal_mask(
+        max_bs: int, q_len: int, device
+    ) -> torch.Tensor:
+        """Bit-packed causal mask for XQA spec-dec verify.
+
+        Shape [max_bs, q_len, ceil(q_len/32)*2] uint16 (32-bit aligned rows);
+        bit j of row i is set iff draft token i attends draft position j
+        (j <= i). Chain speculation (eagle-topk 1) is exactly causal, so the
+        mask is constant and shared across batch entries.
+        """
+        assert q_len <= 63, "spec-dec draft length > 63 not supported by mask build"
+        words_per_row = (q_len + 31) // 32 * 2
+        row_bits = (1 << (torch.arange(q_len, dtype=torch.int64) + 1)) - 1
+        u16 = torch.empty(q_len, words_per_row, dtype=torch.int32)
+        for w in range(words_per_row):
+            u16[:, w] = (row_bits >> (16 * w)) & 0xFFFF
+        mask = u16.to(torch.uint16).unsqueeze(0).expand(max_bs, -1, -1).contiguous()
+        return mask.to(device)
+
+    def _get_xqa_spec_dec_mask(self, bs: int, q_len: int) -> torch.Tensor:
+        mask = self._xqa_spec_dec_masks.get(q_len)
+        if mask is None:
+            # Every spec path reaching this backend uses exactly
+            # speculative_num_draft_tokens per request, preallocated at init.
+            raise RuntimeError(
+                f"XQA spec-dec mask for q_len={q_len} was not preallocated "
+                f"at init (have {sorted(self._xqa_spec_dec_masks)})."
+            )
+        return mask[:bs]
+
     def _check_decode_kv_access(self) -> None:
         supported_kinds = {
             KVCacheAttentionAccessKind.PLAIN,
@@ -1145,6 +1192,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
                     out_dtype=self.q_data_type,
                     q_len_per_req=self.forward_metadata.max_seq_len_q,
+                    mask=(
+                        self._get_xqa_spec_dec_mask(
+                            bs=forward_batch.batch_size,
+                            q_len=self.forward_metadata.max_seq_len_q,
+                        )
+                        if self.is_xqa_impl and self.forward_metadata.max_seq_len_q > 1
+                        else None
+                    ),
                 )
         else:
 

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -261,6 +261,52 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             "trtllm_mha_default_kv_scale",
             lambda: torch.ones(1, dtype=torch.float32, device=self.device),
         )
+        # The XQA impl requires an explicit bit-packed causal mask for
+        # speculative-decode verify (q_len_per_req > 1); trtllm-gen does not.
+        # Preallocate at init so CUDA-graph capture never allocates.
+        self._xqa_spec_dec_masks = {}
+        if (
+            self.is_xqa_impl
+            and model_runner.server_args.speculative_algorithm is not None
+            and model_runner.server_args.speculative_num_draft_tokens is not None
+        ):
+            draft_len = model_runner.server_args.speculative_num_draft_tokens
+            self._xqa_spec_dec_masks[draft_len] = self._build_xqa_spec_dec_causal_mask(
+                max_bs=model_runner.req_to_token_pool.size,
+                q_len=draft_len,
+                device=model_runner.device,
+            )
+
+    @staticmethod
+    def _build_xqa_spec_dec_causal_mask(
+        max_bs: int, q_len: int, device
+    ) -> torch.Tensor:
+        """Bit-packed causal mask for XQA spec-dec verify.
+
+        Shape [max_bs, q_len, ceil(q_len/32)*2] uint16 (32-bit aligned rows);
+        bit j of row i is set iff draft token i attends draft position j
+        (j <= i). Chain speculation (eagle-topk 1) is exactly causal, so the
+        mask is constant and shared across batch entries.
+        """
+        assert q_len <= 63, "spec-dec draft length > 63 not supported by mask build"
+        words_per_row = (q_len + 31) // 32 * 2
+        row_bits = (1 << (torch.arange(q_len, dtype=torch.int64) + 1)) - 1
+        u16 = torch.empty(q_len, words_per_row, dtype=torch.int32)
+        for w in range(words_per_row):
+            u16[:, w] = (row_bits >> (16 * w)) & 0xFFFF
+        mask = u16.to(torch.uint16).unsqueeze(0).expand(max_bs, -1, -1).contiguous()
+        return mask.to(device)
+
+    def _get_xqa_spec_dec_mask(self, bs: int, q_len: int) -> torch.Tensor:
+        mask = self._xqa_spec_dec_masks.get(q_len)
+        if mask is None:
+            # Every spec path reaching this backend uses exactly
+            # speculative_num_draft_tokens per request, preallocated at init.
+            raise RuntimeError(
+                f"XQA spec-dec mask for q_len={q_len} was not preallocated "
+                f"at init (have {sorted(self._xqa_spec_dec_masks)})."
+            )
+        return mask[:bs]
 
     def _check_decode_kv_access(self) -> None:
         supported_kinds = {
@@ -1341,6 +1387,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     out_dtype=self.q_data_type,
                     q_len_per_req=self.forward_metadata.max_seq_len_q,
                     multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
+                    mask=(
+                        self._get_xqa_spec_dec_mask(
+                            bs=forward_batch.batch_size,
+                            q_len=self.forward_metadata.max_seq_len_q,
+                        )
+                        if self.is_xqa_impl and self.forward_metadata.max_seq_len_q > 1
+                        else None
+                    ),
                 )
         else:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Adds support for TRT-LLM XQA decode backend for SM90/120 speculative decoding, by building a causal mask it requires for the verify forward pass (more than 1 q token).

Agent generated summary:

Before: pure `--attention-backend trtllm_mha` + NEXTN on SM90/120 died at server startup during decode CUDA-graph capture — verify routes to the XQA decode kernel, which demands a mask for `q_len > 1` that the backend never passed:
```
  File "/SGL/flashinfer/flashinfer/xqa.py", line 332, in xqa                                                       
      assert mask is not None, "Mask is required for speculative decoding"                                         
  AssertionError: Mask is required for speculative decoding 
```

Never caught before because the verify→decode-kernel routing was written for SM100 (trtllm-gen needs no mask); XQA enablement for SM90/120 came later and nobody ran spec decoding on that combo.
                                                                                                                   

## Modifications

Fix/After: precompute XQA's bit-packed causal mask (constant for chain/topk=1 speculation) at init and pass it on verify — flashinfer already plumbed the argument. 

## Accuracy Tests

Validated: boots through capture, GPQA-10 0.70, acceptance 2.20/0.40 matching the FA3-verify reference (see MTP data reported in https://github.com/sgl-project/sglang/pull/23112).

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31565406415](https://github.com/sgl-project/sglang/actions/runs/31565406415)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32235862831](https://github.com/sgl-project/sglang/actions/runs/32235862831)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->