### PR TITLE
[fmha_v2] perf: use non-interleaved paged KV input for trtllm sm90/120 prefill

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -45,7 +45,7 @@ from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
 )
-from sglang.srt.utils import is_flashinfer_available
+from sglang.srt.utils import is_flashinfer_available, print_warning_once
 from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
 
 logger = logging.getLogger(__name__)
@@ -84,6 +84,8 @@ class TRTLLMMHAMetadata:
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: torch.Tensor = None
     is_ragged_verify: bool = False
+    # Per-forward memoization of pre-expanded [B, 2, M] fmha_v2 block tables
+    fmha_v2_block_tables: Optional[dict] = None
 
 
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
@@ -202,6 +204,40 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         # fmha_v2 prefill kernel supports SM90 and SM120
         self.use_fmha_v2 = is_sm90_supported() or is_sm120_supported()
+
+    def _fmha_v2_paged_inputs(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        page_table: torch.Tensor,
+    ):
+        """Build (qkv, block_tables) for trtllm_fmha_v2_prefill.
+
+        The kernel addresses K and V blocks from k_cache's base pointer via
+        int32 block offsets. When V sits at a block-aligned offset from K
+        (the fused pool halves), pass the views with pre-expanded [B, 2, M]
+        offsets, avoiding an expensive copy of KV caches.
+        """
+        block_bytes = k_cache.stride(0) * k_cache.element_size()
+        delta, rem = divmod(v_cache.data_ptr() - k_cache.data_ptr(), block_bytes)
+        if rem != 0 or not 0 < delta < torch.iinfo(torch.int32).max // 2:
+            print_warning_once(
+                "fmha_v2 prefill: KV pool is not fused block-aligned, so the forward "
+                "copies the full per-layer KV pool on every prefill call (slow)."
+            )
+            return (q, torch.stack([k_cache, v_cache], dim=1)), page_table
+
+        tables = self.forward_metadata.fmha_v2_block_tables
+        if tables is None:
+            tables = self.forward_metadata.fmha_v2_block_tables = {}
+        key = (page_table.data_ptr(), tuple(page_table.shape), delta)
+        expanded = tables.get(key)
+        if expanded is None:
+            expanded = tables[key] = torch.stack(
+                [page_table, page_table + delta], dim=1
+            )
+        return (q, (k_cache, v_cache)), expanded
 
     def _check_decode_kv_access(self) -> None:
         supported_kinds = {
@@ -1167,9 +1203,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif self.use_fmha_v2 and not cp_v2_active:
             # CP-v2 must go through cp_strategy.run_attention (per-shard
             # masking); the plain-causal fmha_v2 call below would be wrong.
-            paged_kv = torch.stack([k_cache, v_cache], dim=1)
+            qkv, fmha_v2_block_tables = self._fmha_v2_paged_inputs(
+                q=q, k_cache=k_cache, v_cache=v_cache, page_table=page_table
+            )
             o = flashinfer.prefill.trtllm_fmha_v2_prefill(
-                (q, paged_kv),
+                qkv,
                 input_layout="Q_PAGED_KV_NHD",
                 workspace_buffer=self.workspace_buffer,
                 seq_lens=self.forward_metadata.cache_seqlens_int32,
@@ -1180,7 +1218,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 batch_size=forward_batch.batch_size,
                 cum_seq_lens_q=self.forward_metadata.cu_seqlens_q,
                 cum_seq_lens_kv=self.forward_metadata.cu_seqlens_k,
-                block_tables=page_table,
+                block_tables=fmha_v2_block_tables,
                 out_dtype=self.q_data_type,
                 mask_mode="causal",
                 window_left=layer.sliding_window_size,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 """
 Support attention backend for TRTLLM MHA kernels from flashinfer.
-The kernel supports sm100 only, with sliding window and attention sink features.
+
+Prefill dispatch:
+  - SM90 / SM120: trtllm_fmha_v2_prefill (Q_PAGED_KV_NHD layout)
+  - SM100:        trtllm_batch_context_with_kv_cache (HND layout)
+
+Decode: uses XQA on SM90 and SM120, TRTLLM-GEN on SM100.
+
+Sliding window and attention sink features are supported.
 """
 
 import logging
@@ -192,6 +199,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         #   KV bf16: q_type = bf16, out_type=model_runner.dtype
         #   KV fp8: q_type = fp8, out_type=model_runner.dtype
         self.is_xqa_impl = is_sm90_supported() or is_sm120_supported()
+
+        # fmha_v2 prefill kernel supports SM90 and SM120
+        self.use_fmha_v2 = is_sm90_supported() or is_sm120_supported()
 
     def _check_decode_kv_access(self) -> None:
         supported_kinds = {
@@ -1085,33 +1095,41 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             and not use_fused_qkv
         ):
             q = q.to(torch.float8_e4m3fn)
-        q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
-        # [num_pages, page_size, num_kv_heads, head_dim] -> [num_pages, num_kv_heads, page_size, head_dim]
-        k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
-        k_cache = k_cache.view(
-            -1, self.page_size, layer.tp_k_head_num, layer.head_dim
-        ).permute(0, 2, 1, 3)
-        v_cache = v_cache.view(
-            -1, self.page_size, layer.tp_v_head_num, layer.head_dim
-        ).permute(0, 2, 1, 3)
 
-        if layer.tp_k_head_num == 1:
-            k_cache = canonicalize_stride(k_cache)
-        if layer.tp_v_head_num == 1:
-            v_cache = canonicalize_stride(v_cache)
+        if self.use_fmha_v2:
+            q = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+        else:
+            q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
+
+        # NHD layout (native pool format): [num_pages, page_size, num_kv_heads, head_dim]
+        k_cache_raw, v_cache_raw = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+
+        is_decode_mode = (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        )
+
+        if not self.use_fmha_v2 or is_decode_mode:
+            # Decode and SM100 batch_context kernels require HND layout.
+            k_cache, v_cache = self._reshape_paged_kv_cache(
+                k_cache_raw, v_cache_raw, layer, layer.head_dim
+            )
+        else:
+            k_cache = k_cache_raw.view(
+                -1, self.page_size, layer.tp_k_head_num, layer.head_dim
+            )
+            v_cache = v_cache_raw.view(
+                -1, self.page_size, layer.tp_v_head_num, layer.head_dim
+            )
 
         kv_cache = (k_cache, v_cache)
-
         # sink: additional value per head in the denominator of the softmax.
         attention_sink = kwargs.get("sinks", None)
         bmm1_scale, bmm2_scale = self._get_bmm_scales(layer, q_scale)
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        if (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
+        if is_decode_mode:
             if self.forward_metadata.is_ragged_verify:
                 o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                     query=q,
@@ -1146,6 +1164,30 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     out_dtype=self.q_data_type,
                     q_len_per_req=self.forward_metadata.max_seq_len_q,
                 )
+        elif self.use_fmha_v2 and not cp_v2_active:
+            # CP-v2 must go through cp_strategy.run_attention (per-shard
+            # masking); the plain-causal fmha_v2 call below would be wrong.
+            paged_kv = torch.stack([k_cache, v_cache], dim=1)
+            o = flashinfer.prefill.trtllm_fmha_v2_prefill(
+                (q, paged_kv),
+                input_layout="Q_PAGED_KV_NHD",
+                workspace_buffer=self.workspace_buffer,
+                seq_lens=self.forward_metadata.cache_seqlens_int32,
+                max_q_len=self.forward_metadata.max_seq_len_q,
+                max_kv_len=self.max_context_len,
+                bmm1_scale=bmm1_scale,
+                bmm2_scale=bmm2_scale,
+                batch_size=forward_batch.batch_size,
+                cum_seq_lens_q=self.forward_metadata.cu_seqlens_q,
+                cum_seq_lens_kv=self.forward_metadata.cu_seqlens_k,
+                block_tables=page_table,
+                out_dtype=self.q_data_type,
+                mask_mode="causal",
+                window_left=layer.sliding_window_size,
+                sinks=attention_sink,
+                skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get()
+                or 0.0,
+            )
         else:
 
             def _trtllm_context_attn(

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -50,7 +50,7 @@ from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
 )
-from sglang.srt.utils import is_flashinfer_available
+from sglang.srt.utils import is_flashinfer_available, print_warning_once
 from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
 
 logger = logging.getLogger(__name__)
@@ -98,6 +98,8 @@ class TRTLLMMHAMetadata:
     encoder_cache_seqlens: torch.Tensor = None
     encoder_page_table: torch.Tensor = None
     encoder_row_map: torch.Tensor = None
+    # Per-forward memoization of pre-expanded [B, 2, M] fmha_v2 block tables
+    fmha_v2_block_tables: Optional[dict] = None
 
 
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
@@ -277,6 +279,40 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 "SGLANG_TRTLLM_MHA_DECODE_SEQ_LEN_SPLITS must be at least 1, "
                 f"got {self.decode_seq_len_splits}"
             )
+        
+    def _fmha_v2_paged_inputs(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        page_table: torch.Tensor,
+    ):
+        """Build (qkv, block_tables) for trtllm_fmha_v2_prefill.
+
+        The kernel addresses K and V blocks from k_cache's base pointer via
+        int32 block offsets. When V sits at a block-aligned offset from K
+        (the fused pool halves), pass the views with pre-expanded [B, 2, M]
+        offsets, avoiding an expensive copy of KV caches.
+        """
+        block_bytes = k_cache.stride(0) * k_cache.element_size()
+        delta, rem = divmod(v_cache.data_ptr() - k_cache.data_ptr(), block_bytes)
+        if rem != 0 or not 0 < delta < torch.iinfo(torch.int32).max // 2:
+            print_warning_once(
+                "fmha_v2 prefill: KV pool is not fused block-aligned, so the forward "
+                "copies the full per-layer KV pool on every prefill call (slow)."
+            )
+            return (q, torch.stack([k_cache, v_cache], dim=1)), page_table
+
+        tables = self.forward_metadata.fmha_v2_block_tables
+        if tables is None:
+            tables = self.forward_metadata.fmha_v2_block_tables = {}
+        key = (page_table.data_ptr(), tuple(page_table.shape), delta)
+        expanded = tables.get(key)
+        if expanded is None:
+            expanded = tables[key] = torch.stack(
+                [page_table, page_table + delta], dim=1
+            )
+        return (q, (k_cache, v_cache)), expanded
 
     def _check_decode_kv_access(self) -> None:
         supported_kinds = {
@@ -1426,9 +1462,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif self.use_fmha_v2 and not cp_v2_active:
             # CP-v2 must go through cp_strategy.run_attention (per-shard
             # masking); the plain-causal fmha_v2 call below would be wrong.
-            paged_kv = torch.stack([k_cache, v_cache], dim=1)
+            qkv, fmha_v2_block_tables = self._fmha_v2_paged_inputs(
+                q=q, k_cache=k_cache, v_cache=v_cache, page_table=page_table
+            )
             o = flashinfer.prefill.trtllm_fmha_v2_prefill(
-                (q, paged_kv),
+                qkv,
                 input_layout="Q_PAGED_KV_NHD",
                 workspace_buffer=self.workspace_buffer,
                 seq_lens=self.forward_metadata.cache_seqlens_int32,
@@ -1439,7 +1477,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 batch_size=forward_batch.batch_size,
                 cum_seq_lens_q=self.forward_metadata.cu_seqlens_q,
                 cum_seq_lens_kv=self.forward_metadata.cu_seqlens_k,
-                block_tables=page_table,
+                block_tables=fmha_v2_block_tables,
                 out_dtype=self.q_data_type,
                 mask_mode="causal",
                 window_left=layer.sliding_window_size,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -76,6 +76,7 @@ from sglang.srt.mem_cache.utils import (
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import (
+    ceil_align,
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
@@ -2032,14 +2033,31 @@ class MHATokenToKVPool(KVCache):
                     ]
                 else:
                     k_shape, v_shape = self._kv_buffer_shapes()
-                    self.k_buffer = [
-                        torch.zeros(k_shape, dtype=self.store_dtype, device=self.device)
-                        for _ in range(self.layer_num)
-                    ]
-                    self.v_buffer = [
-                        torch.zeros(v_shape, dtype=self.store_dtype, device=self.device)
-                        for _ in range(self.layer_num)
-                    ]
+
+                    def _zeros(shape):
+                        return torch.zeros(
+                            shape, dtype=self.store_dtype, device=self.device
+                        )
+
+                    if k_shape == v_shape:
+                        # Store K and V as block-aligned halves of one allocation
+                        # so paged kernels with a single pool base can reach V
+                        # via block offsets. Each half keeps its standalone
+                        # shape/strides. NHD rows are token slots and get
+                        # padded to whole pages; HND rows already are pages.
+                        rows = k_shape[0]
+                        padded = (
+                            rows if self.use_hnd else ceil_align(rows, self.page_size)
+                        )
+                        fused = [
+                            _zeros((2, padded, *k_shape[1:]))
+                            for _ in range(self.layer_num)
+                        ]
+                        self.k_buffer = [buf[0, :rows] for buf in fused]
+                        self.v_buffer = [buf[1, :rows] for buf in fused]
+                    else:
+                        self.k_buffer = [_zeros(k_shape) for _ in range(self.layer_num)]
+                        self.v_buffer = [_zeros(v_shape) for _ in range(self.layer_num)]
 
     # -- post-capture VA backing (opt-in; overridable per layout) --------------
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -76,6 +76,7 @@ from sglang.srt.mem_cache.utils import (
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import (
+    ceil_align,
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
@@ -2103,14 +2104,31 @@ class MHATokenToKVPool(KVCache):
                     ]
                 else:
                     k_shape, v_shape = self._kv_buffer_shapes()
-                    self.k_buffer = [
-                        torch.zeros(k_shape, dtype=self.store_dtype, device=self.device)
-                        for _ in range(self.layer_num)
-                    ]
-                    self.v_buffer = [
-                        torch.zeros(v_shape, dtype=self.store_dtype, device=self.device)
-                        for _ in range(self.layer_num)
-                    ]
+
+                    def _zeros(shape):
+                        return torch.zeros(
+                            shape, dtype=self.store_dtype, device=self.device
+                        )
+
+                    if k_shape == v_shape:
+                        # Store K and V as block-aligned halves of one allocation
+                        # so paged kernels with a single pool base can reach V
+                        # via block offsets. Each half keeps its standalone
+                        # shape/strides. NHD rows are token slots and get
+                        # padded to whole pages; HND rows already are pages.
+                        rows = k_shape[0]
+                        padded = (
+                            rows if self.use_hnd else ceil_align(rows, self.page_size)
+                        )
+                        fused = [
+                            _zeros((2, padded, *k_shape[1:]))
+                            for _ in range(self.layer_num)
+                        ]
+                        self.k_buffer = [buf[0, :rows] for buf in fused]
+                        self.v_buffer = [buf[1, :rows] for buf in fused]
+                    else:
+                        self.k_buffer = [_zeros(k_shape) for _ in range(self.layer_num)]
+                        self.v_buffer = [_zeros(v_shape) for _ in range(self.layer_num)]
 
     # -- post-capture VA backing (opt-in; overridable per layout) --------------
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5478,15 +5478,28 @@ class ServerArgs:
 
         prefill_backend, decode_backend = self._resolved_attention_backends()
         if "trtllm_mha" in (prefill_backend, decode_backend):
-            if prefill_backend == "trtllm_mha" and not is_sm100_supported():
+            if prefill_backend == "trtllm_mha" and not (
+                is_sm90_supported() or is_sm100_supported() or is_sm120_supported()
+            ):
                 raise ValueError(
-                    "TRTLLM MHA backend for prefill is only supported on Blackwell GPUs (SM100). Please use a different prefill backend."
+                    "TRTLLM MHA backend for prefill requires Hopper (SM90), Blackwell (SM100), or SM120 GPUs. "
+                    "Please use a different prefill backend."
                 )
             if decode_backend == "trtllm_mha" and not (
                 is_sm90_supported() or is_sm100_supported() or is_sm120_supported()
             ):
                 raise ValueError(
                     "TRTLLM MHA backend for decode is only supported on Hopper (SM90), Blackwell (SM100) and (SM120) GPUs. Please use a different decode backend."
+                )
+            if (
+                prefill_backend == "trtllm_mha"
+                and not is_sm100_supported()
+                and (self.enable_prefill_context_parallel or self.attn_cp_size > 1)
+            ):
+                raise ValueError(
+                    "Prefill context parallelism with the TRTLLM MHA prefill backend "
+                    "requires SM100 (trtllm-gen context kernel): the SM90/SM120 "
+                    "fmha_v2 prefill path does not implement CP shard masking."
                 )
 
         run_post_process_pass(self, _attention_backend_fa3_fp8_fallback)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Dependent on https://github.com/sgl-project/sglang/pull/23112 and https://github.com/flashinfer-ai/flashinfer/pull/4124. Improves TRT-LLM SM90/120 prefill performance to beat FA3 by removing an expensive copy-operation that was previously needed to pass interleaved KV to the kernel API.

## Modifications

Allocate KV together (no functional change to any other backend), allowing us to use the new indexing mode to read data efficiently for fmha_v2.

> the below accuracy/perf data was collected and summarized by Claude

## Accuracy Tests

PQA Diamond, 198 questions x 8 repeats (1,584 rollouts per config), temperature 0.6,
top-k 20, max-tokens 81920.

**Qwen3-Next-80B-A3B-Thinking-FP8:**

| Config | KV dtype | Score | Repeat range |
|---|---|---|---|
| FA3 | bf16 | 0.725 | 0.712-0.742 |
| fmha_v2 (trtllm_mha) | bf16 | 0.723 | 0.702-0.753 |
| FA3 + MTP | bf16 | 0.734 | 0.712-0.758 |
| fmha_v2 prefill + MTP (fa3 verify) | bf16 | 0.721 | 0.707-0.732 |
| FA3 | fp8_e4m3 | 0.727 | 0.707-0.747 |
| **fmha_v2 (trtllm_mha)** | **fp8_e4m3** | **0.724** | 0.682-0.753 |

Per-repeat std is ~0.015, so every row is a tie. The fp8 fmha_v2 row ran the
**zero-copy path in this PR**, making it a 1,584-rollout validation of the new KV
addressing against the e4m3 kernel.

**Qwen3-32B-FP8, fp8 KV:**

| Config | Score | Range |
|---|---|---|
| FA3 | 0.630 | 0.606-0.677 |
| fmha_v2 | **0.630** | 0.606-0.657 |

Exact tie.

**MTP acceptance** (draft/target property -- matching rates show fmha_v2 prefill does
not perturb the target distribution):

| Config | Accept len | Accept rate |
|---|---|---|
| FA3 + MTP (bf16) | 2.37 | 0.46 |
| fmha_v2 prefill + MTP (bf16) | 2.45 | 0.48 |

<details>
<summary>Repro</summary>

```bash
python3 -m sglang.test.run_eval --port 30000 --eval-name gpqa \
  --num-examples 198 --repeat 8 --num-threads 16 \
  --max-tokens 81920 --thinking-mode qwen-3 --temperature 0.6 --top-k 20
```

</details>

## Speed Tests and Profiling

**Before/after on identical config** (Qwen3-Next-80B-A3B-Thinking-FP8, bf16 KV,
`--chunked-prefill-size 2048`). "Before" is the original `torch.stack([k_cache, v_cache], dim=1)`
full-pool copy; "after" is this PR's non-interleaved zero-copy path.

| ISL | metric | before (stack) | after (zero-copy) | FA3 |
|---|---|---|---|---|
| 1k | total tok/s | 11017 | **14940** | 14833 |
| 1k | median TTFT (ms) | 1696 | **719** | 841 |
| 8k | input tok/s | 13853 | **22266** | 22982 |
| 8k | median TTFT (ms) | 6566 | **2952** | 2713 |
| 128k | input tok/s | 14859 | **25506** | 29363 |
| 128k | median TTFT (ms) | 11215 | **5706** | 4764 |

**Root cause of the "before" column** (torch profiler, 2.7k-token request,
24 prefill / 384 decode layer-calls):

| | fmha_v2 (stack) | FA3 |
|---|---|---|
| prefill attention | 1.59 ms | 0.98 ms |
| decode attention | 15.4 ms (bf16 XQA) | 6.8 ms |
| KV-pool stack copy | **120.5 ms** (`direct_copy_kernel`, 1008 calls) | -- |

The stack copied the entire per-layer KV pool (~4 GB, ~5 ms) per prefill layer call,
per chunk, regardless of batch size. Causality check -- only the pool size varies:

| mem-fraction-static | KV pool per side | input tok/s @8k | median TTFT (ms) |
|---|---|---|---|
| 0.8 | 24.0 GB | 13853 | 6566 |
| 0.55 | 15.0 GB | 19292 | 3809 |

**At the default chunk size** (fp8 KV, `--chunked-prefill-size 8192`; code pinned via
git worktrees, sglang@3c02143bb7 + flashinfer fmha_v2_test = perf_qtile@2a14301a +
cherry-picked 49b01545). Cells: input tok/s / median TTFT ms / median TPOT ms.

| ISL | FA3 | fmha_v2 zero-copy | ratio |
|---|---|---|---|
| 64k | 40368 / 2459 / 15.3 | **40918 / 2581 / 14.85** | 1.01 |
| 128k | 38643 / 3236 / 13.9 | **39309 / 3299 / 13.10** | 1.02 |

Confirmation trace (`wt_fmhav2_fp8_64k`): zero pool-sized `aten::cat` ops, GPU busy
1.38 s (FA3: 1.39 s), fmha_v2 kernel 81.6 ms.

**Dense model** (Qwen3-32B-FP8, 64 layers / 8 KV heads / head_dim 128, TP=4 -> 16q:2kv
per rank, YaRN x4 for 128k, chunk 8192, mem 0.85). Cells: input tok/s / TTFT ms / TPOT ms.

| ISL | FA3 | fmha_v2 |
|---|---|---|
| 8k | 21992 / 3473 / 16.5 | **23113 / 3471 / 15.4** (+5.1%) |
| 32k | 18661 / 5169 / 17.3 | **19324 / 4955 / 16.8** (+3.6%) |
| 128k | 12462 / 13869 / 27.7 | **13568 / 12662 / 25.4** (+8.9%) |

Full fp8 ISL sweep at chunk 2048 (1k-128k) is in the linked results doc; parity within
~1.5% for 1k-32k, -6% at 64k and -11% at 128k at that non-default chunk size only.

<details>
<summary>Repro</summary>

```bash
export PYTHONPATH=/SGL/sglang/python:/SGL/flashinfer
export FLASHINFER_DISABLE_VERSION_CHECK=1

python3 -m sglang.launch_server --model <MODEL> --tp 4 --mem-fraction-static 0.8 \
  --disable-radix-cache --mamba-ssm-dtype float32 --moe-runner-backend deep_gemm \
  --attention-backend trtllm_mha --trust-remote-code --port 30000
# fp8 KV: add --kv-cache-dtype fp8_e4m3

python3 -m sglang.bench_serving --backend sglang --host 127.0.0.1 --port 30000 \
  --model <MODEL> --dataset-name random --random-input-len <ISL> \
  --random-output-len <OSL> --random-range-ratio 1.0 \
  --num-prompts <N> --max-concurrency <C> --warmup-requests 2
```
Per-ISL (N, C, OSL): 1k=(200,64,256), 4k=(96,32,512), 8k=(64,32,512), 16k=(32,16,512),
32k=(16,8,512), 64k=(12,4,256), 128k=(8,2,256). The 64k/128k rows are latency-bound at
low concurrency (C=4/2), not throughput-saturated.

</details>

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32542951602](https://github.com/sgl-project/sglang/actions/runs/32542951602)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32542951489](https://github.com/sgl-project/sglang/actions/runs/32542951489)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32542951576](https://github.com/sgl-project/sglang/actions/runs/32542951576)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->