### PR TITLE
feat(hicache): support Ascend Mamba host transfers

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -43,9 +43,6 @@ if _is_cuda:
         transfer_kv_mamba_lf_pf,
         transfer_kv_mamba_pf_lf,
     )
-if _is_npu:
-    pass
-
 logger = logging.getLogger(__name__)
 
 
@@ -379,6 +376,16 @@ class MambaPoolHost(HostKVCache):
                 layer_id=layer_id,
                 page_size=1,
             )
+        elif io_backend == "kernel_ascend":
+            host_indices = src_indices.to(dtype=torch.int64, device=src.device)
+            device_indices = dst_indices.to(dtype=torch.int64, device=dst.device)
+            # Host: [slot, layer, 1, *state]; device: [slot, *state].
+            values = (
+                src.select(1, layer_id)
+                .index_select(0, host_indices)
+                .select(1, 0)
+            )
+            dst.index_copy_(0, device_indices, values.to(device=dst.device))
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
 
@@ -422,6 +429,20 @@ class MambaPoolHost(HostKVCache):
                 dst_indices=dst_indices,
                 page_size=1,
             )
+        elif io_backend == "kernel_ascend":
+            device_indices = src_indices.to(
+                dtype=torch.int64, device=src_layers.device
+            )
+            host_indices = dst_indices.to(dtype=torch.int64, device=dst.device)
+            # Device: [layer, slot, *state]; host: [slot, layer, 1, *state].
+            values = (
+                src_layers.index_select(1, device_indices)
+                .movedim(0, 1)
+                .unsqueeze(2)
+                .contiguous()
+                .to(device=dst.device)
+            )
+            dst.index_copy_(0, host_indices, values)
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
 

--- a/test/registered/ascend/basic_function/HiCache/test_npu_hicache_mamba.py
+++ b/test/registered/ascend/basic_function/HiCache/test_npu_hicache_mamba.py
@@ -1,0 +1,188 @@
+"""Ascend NPU HiCache L3 coverage for hybrid Mamba models."""
+
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+TEST_MODEL_MATRIX = {
+    "/root/.cache/modelscope/hub/models/Qwen/Qwen3.5-0.8B": {
+        "target_token_id": 1000,
+    },
+}
+
+
+class TestAscendMambaHiCache(CustomTestCase):
+    """Exercise Mamba state write-back and L3 load-back on Ascend."""
+
+    # A reusable Mamba checkpoint must be strictly inside the prompt. Ending the
+    # prompt exactly at 1024 does not make that boundary reusable by a second
+    # identical request. 3200 leaves the 3072 checkpoint inside the prompt and
+    # also exercises the configured 1024-token chunked-prefill path.
+    prompt_tokens = 3200
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = TEST_MODEL_MATRIX.keys()
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.common_args = [
+            "--tp-size",
+            "1",
+            "--mem-fraction-static",
+            "0.20",
+            "--chunked-prefill-size",
+            "1024",
+            "--page-size",
+            "64",
+            "--enable-hierarchical-cache",
+            "--enable-cache-report",
+            "--hicache-size",
+            "1",
+            "--hicache-storage-backend",
+            "file",
+            "--hicache-storage-prefetch-policy",
+            "wait_complete",
+            "--hicache-write-policy",
+            "write_through",
+            "--hicache-io-backend",
+            "kernel",
+            "--hicache-mem-layout",
+            "page_first_direct",
+        ]
+
+    def _generate(self, token_id: int) -> dict:
+        response = requests.post(
+            f"{self.base_url}/generate",
+            json={
+                "input_ids": [token_id] * self.prompt_tokens,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 16,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=120,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    @staticmethod
+    def _storage_files(storage_dir: str) -> set[str]:
+        return {
+            os.path.relpath(os.path.join(root, name), storage_dir)
+            for root, _, names in os.walk(storage_dir)
+            for name in names
+            if os.path.getsize(os.path.join(root, name)) > 0
+        }
+
+    def _wait_for_mamba_storage_file(
+        self, storage_dir: str, files_before: set[str], timeout: float = 30
+    ) -> set[str]:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            files_after = self._storage_files(storage_dir)
+            new_files = files_after - files_before
+            if any("mamba" in name.lower() for name in new_files):
+                return files_after
+            time.sleep(0.1)
+        self.fail("Timed out waiting for a new Mamba HiCache storage file.")
+
+    def test_mamba_state_restores_from_l3(self):
+        for model in self.models:
+            with self.subTest(model=model):
+                storage_dir = tempfile.mkdtemp(prefix="npu_mamba_hicache_")
+                process = None
+                try:
+                    process = popen_launch_server(
+                        model,
+                        self.base_url,
+                        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                        other_args=self.common_args,
+                        env={
+                            **os.environ,
+                            "CUDA_VISIBLE_DEVICES": "0",
+                            "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR": storage_dir,
+                        },
+                    )
+                    target_token_id = TEST_MODEL_MATRIX[model]["target_token_id"]
+                    storage_files_before = self._storage_files(storage_dir)
+                    first = self._generate(target_token_id)
+                    first_meta = first["meta_info"]
+                    self.assertEqual(int(first_meta.get("cached_tokens", 0)), 0)
+
+                    # The first cache hit reaches write_through's hit-count
+                    # threshold and starts the asynchronous L1 -> L2 -> L3 copy.
+                    warm = self._generate(target_token_id)
+                    warm_details = (
+                        warm["meta_info"].get("cached_tokens_details") or {}
+                    )
+                    self.assertGreater(
+                        int(warm_details.get("device", 0) or 0),
+                        0,
+                        "Expected an L1 device hit; "
+                        f"got meta_info={warm['meta_info']}",
+                    )
+                    self.assertEqual(
+                        int(warm_details.get("host", 0) or 0),
+                        0,
+                        f"Expected no L2 contribution: {warm_details}",
+                    )
+                    self.assertEqual(
+                        int(warm_details.get("storage", 0) or 0),
+                        0,
+                        f"Expected no L3 contribution: {warm_details}",
+                    )
+
+                    # Do not infer persistence from the request response: wait
+                    # until the Mamba sidecar has physically reached the file
+                    # backend before clearing the in-memory cache levels.
+                    storage_files_after = self._wait_for_mamba_storage_file(
+                        storage_dir, storage_files_before
+                    )
+                    self.assertTrue(storage_files_after - storage_files_before)
+
+                    # Remove L1/L2 residency without clearing the file backend.
+                    flush = requests.post(
+                        f"{self.base_url}/flush_cache",
+                        params={"timeout": 30},
+                        timeout=40,
+                    )
+                    flush.raise_for_status()
+
+                    restored = self._generate(target_token_id)
+                    restored_meta = restored["meta_info"]
+                    details = restored_meta.get("cached_tokens_details") or {}
+
+                    self.assertGreater(
+                        int(details.get("storage", 0) or 0),
+                        0,
+                        "Expected an L3 storage hit; "
+                        f"got meta_info={restored_meta}",
+                    )
+                    self.assertEqual(
+                        restored["text"],
+                        first["text"],
+                        "Mamba L3 restore changed deterministic generation output.",
+                    )
+                finally:
+                    if process:
+                        kill_process_tree(process.pid)
+                    shutil.rmtree(storage_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -30,6 +30,7 @@ from sglang.srt.mem_cache.memory_pool_host import (
 from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=3, suite="base-a-test-cpu")
 
@@ -155,7 +156,7 @@ class _FakeDeviceModule:
         yield
 
 
-class TestHiCacheStagedWriteBackDispatch(unittest.TestCase):
+class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
     def _patched_transfers(self, src_registry=None, module=MEMORY_POOL_HOST_MODULE):
         staged_side_effect = None
         if src_registry is not None:
@@ -454,6 +455,83 @@ class TestHiCacheStagedWriteBackDispatch(unittest.TestCase):
         self.assertTrue(
             torch.equal(
                 device_pool.mamba_cache.conv[0][:, device_indices], expected_conv
+            )
+        )
+
+    def test_mamba_kernel_ascend_backup_then_load_roundtrip(self):
+        num_layers = 2
+        host_indices = torch.tensor([1, 3], dtype=torch.int64)
+        device_indices = torch.tensor([2, 5], dtype=torch.int64)
+        temporal = torch.arange(num_layers * 8 * 3, dtype=torch.float32).reshape(
+            num_layers, 8, 3
+        )
+        conv = (
+            torch.arange(num_layers * 8 * 2, dtype=torch.float32).reshape(
+                num_layers, 8, 2
+            )
+            / 8
+        ).to(torch.bfloat16)
+        device_pool = SimpleNamespace(
+            mamba_cache=SimpleNamespace(temporal=temporal.clone(), conv=[conv.clone()])
+        )
+        expected_temporal = device_pool.mamba_cache.temporal[:, device_indices].clone()
+        expected_conv = device_pool.mamba_cache.conv[0][:, device_indices].clone()
+
+        host = MambaPoolHost.__new__(MambaPoolHost)
+        host.layout = "page_first_direct"
+        host.num_mamba_layers = num_layers
+        host.temporal_state_elem_size = 3
+        host.temporal_buffer = torch.zeros(
+            8, num_layers, 1, 3, dtype=torch.float32
+        )
+        host.conv_state_shapes = [(2,)]
+        host.conv_buffer = [
+            torch.zeros(8, num_layers, 1, 2, dtype=torch.bfloat16)
+        ]
+        host.temporal_staging_buffer = None
+        host.conv_staging_buffers = [None]
+        host._temporal_can_use_jit = False
+        host._conv_can_use_jit = [False]
+        host.temporal_device_ptrs = torch.empty(0, dtype=torch.uint64)
+        host.conv_device_ptrs = [torch.empty(0, dtype=torch.uint64)]
+
+        host.backup_from_device_all_layer(
+            device_pool,
+            host_indices,
+            device_indices,
+            io_backend="kernel_ascend",
+        )
+        device_pool.mamba_cache.temporal.zero_()
+        device_pool.mamba_cache.conv[0].zero_()
+        for layer_id in range(num_layers):
+            host.load_to_device_per_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                layer_id,
+                io_backend="kernel_ascend",
+            )
+
+        self.assertTrue(
+            torch.equal(
+                device_pool.mamba_cache.temporal[:, device_indices], expected_temporal
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                device_pool.mamba_cache.conv[0][:, device_indices], expected_conv
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                host.temporal_buffer[host_indices].squeeze(2).transpose(0, 1),
+                expected_temporal,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                host.conv_buffer[0][host_indices].squeeze(2).transpose(0, 1),
+                expected_conv,
             )
         )
 


### PR DESCRIPTION
## Summary

- add `kernel_ascend` D2H/H2D transfer paths for page-first Mamba host pools
- preserve layer/slot/state dimensions and tensor dtypes during transfer
- add a CPU round-trip unit test for the Ascend dispatch path
- add an Ascend nightly E2E test covering Qwen3.5-0.8B Mamba write-through and L3 file restore

## Motivation

HiCache on Ascend selected `kernel_ascend`, but `MambaPoolHost` did not implement that backend. Hybrid Qwen3.5 requests therefore failed during device-to-host backup, and the initial implementation exposed a source/destination dimensionality mismatch.

## Validation

- Ascend NPU E2E test passed with a 3200-token prompt: L1 warm hit, Mamba file persistence, cache flush, and L3 restore
- restored deterministic output matches the initial generation
- `python -m py_compile` passed for the changed Python files
- `git diff --check` passed

The local development host does not provide PyTorch/Ascend hardware, so hardware validation was run in the external Ascend environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30062732094](https://github.com/sgl-project/sglang/actions/runs/30062732094)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30062732230](https://github.com/sgl-project/sglang/actions/runs/30062732230)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->