### PR TITLE
[AMD] WIP-MiniMax-M3: support cross-layer sparse index sharing

### DIFF
--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -18,11 +18,13 @@ from sglang.srt.layers.attention.minimax_sparse_ops.minimax_sparse import (
 )
 from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.utils import is_hip
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+_is_hip = is_hip()
 
 
 class MiniMaxSparseAttnBackend(AttentionBackend):
@@ -42,6 +44,23 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             get_minimax_sparse_disable_value_layer_ids(sparse_cfg)
         )
         self.score_type: str = get_minimax_sparse_score_type(sparse_cfg)
+        text_config = getattr(hf_config, "text_config", hf_config)
+        refresh_interval = int(
+            getattr(
+                text_config,
+                "sparse_index_refresh_interval",
+                getattr(hf_config, "sparse_index_refresh_interval", 1),
+            )
+            or 1
+        )
+        share_pattern = getattr(
+            text_config,
+            "sparse_index_share_pattern",
+            getattr(hf_config, "sparse_index_share_pattern", None),
+        )
+        self.sparse_index_sharing_enabled = _is_hip and (
+            refresh_interval > 1 or share_pattern is not None
+        )
 
         # Plain Python int so it is safe inside CUDA graphs (no .item() at graph time).
         self._max_seqlen_q: int = 1
@@ -158,6 +177,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             f"[MiniMaxSparse] Backend initialized "
             f"(score_type={self.score_type!r}, "
             f"main_attn={'MSA' if self.use_msa else 'triton'}, "
+            f"sparse_index_sharing={self.sparse_index_sharing_enabled}, "
             f"disable_value_layers={sorted(self.disable_value_layer_ids)})"
         )
 
@@ -237,6 +257,63 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         layer_ids = forward_batch.minimax_m3_precached_sparse_layers
         return layer_ids is not None and layer_id in layer_ids
 
+    @staticmethod
+    def _shares_sparse_index(layer) -> bool:
+        return bool(getattr(layer, "share_sparse_index", False))
+
+    def _sparse_index_share_key(
+        self, mode: str, q: torch.Tensor, forward_batch: ForwardBatch
+    ) -> tuple:
+        return (
+            mode,
+            tuple(q.shape),
+            q.dtype,
+            q.device,
+            tuple(forward_batch.req_pool_indices.shape),
+            tuple(forward_batch.seq_lens.shape),
+            self.topk_blocks,
+            self.init_blocks,
+            self.local_blocks,
+            self._max_seqlen_q,
+            self._max_seqlen_k,
+        )
+
+    def _sparse_index_share_state(self, forward_batch: ForwardBatch):
+        if not self.sparse_index_sharing_enabled:
+            return None
+        state = getattr(forward_batch, "_minimax_sparse_index_share_state", None)
+        if state is None:
+            state = {}
+            setattr(forward_batch, "_minimax_sparse_index_share_state", state)
+        return state
+
+    def _load_shared_sparse_index(
+        self, layer, forward_batch: ForwardBatch, key: tuple
+    ):
+        if not self._shares_sparse_index(layer):
+            return None
+        state = self._sparse_index_share_state(forward_batch)
+        if state is None:
+            return None
+        entry = state.get("selection")
+        if entry is None or entry.get("key") != key:
+            return None
+        return entry["value"]
+
+    def _store_shared_sparse_index(
+        self, layer, forward_batch: ForwardBatch, key: tuple, value
+    ) -> None:
+        state = self._sparse_index_share_state(forward_batch)
+        if state is not None:
+            state["selection"] = {
+                "key": key,
+                "value": value,
+                "layer_id": layer.layer_id,
+                "sparse_layer_ordinal": getattr(
+                    layer, "sparse_layer_ordinal", -1
+                ),
+            }
+
     def forward(
         self,
         q,
@@ -249,13 +326,16 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
     ):
         if forward_batch.forward_mode.is_idle():
             idx_q = kwargs.get("idx_q")
-            num_idx_heads = idx_q.shape[1]
             disable_value = layer.layer_id in self.disable_value_layer_ids
-            idx_out: Optional[torch.Tensor] = (
-                None
-                if disable_value
-                else q.new_zeros(q.shape[0], num_idx_heads * self.idx_head_dim)
-            )
+            if self._shares_sparse_index(layer):
+                idx_out = None
+            else:
+                num_idx_heads = idx_q.shape[1]
+                idx_out = (
+                    None
+                    if disable_value
+                    else q.new_zeros(q.shape[0], num_idx_heads * self.idx_head_dim)
+                )
             out = q.new_zeros(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
             return idx_out, out
         else:
@@ -272,25 +352,34 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         forward_batch: ForwardBatch,
         save_kv_cache=True,
         *,
-        idx_q: torch.Tensor,
-        idx_k: torch.Tensor,
+        idx_q: Optional[torch.Tensor],
+        idx_k: Optional[torch.Tensor],
         idx_v: Optional[torch.Tensor],
     ):
         disable_value = layer.layer_id in self.disable_value_layer_ids
+        share_sparse_index = self._shares_sparse_index(layer)
         kv_cached_by_fusion = self._is_sparse_kv_cached_by_fusion(
             forward_batch, layer.layer_id
         )
         if not kv_cached_by_fusion:
-            self.kv_pool.set_fused_kv_index_buffer(
-                layer,
-                forward_batch.out_cache_loc,
-                k,
-                v,
-                idx_k,
-                None if disable_value else idx_v,
-            )
+            if share_sparse_index:
+                self.kv_pool.set_kv_buffer(
+                    layer, forward_batch.out_cache_loc, k, v
+                )
+            else:
+                assert idx_k is not None
+                self.kv_pool.set_fused_kv_index_buffer(
+                    layer,
+                    forward_batch.out_cache_loc,
+                    k,
+                    v,
+                    idx_k,
+                    None if disable_value else idx_v,
+                )
         k_cache, v_cache = self.kv_pool.get_kv_buffer(layer.layer_id)
-        if disable_value:
+        if share_sparse_index:
+            idx_k_cache = idx_v_cache = None
+        elif disable_value:
             idx_k_cache = self.kv_pool.get_index_k_buffer(layer.layer_id)
             idx_v_cache = None
         else:
@@ -319,9 +408,21 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         original_num_tokens = q.shape[0]
         if actual_num_tokens < original_num_tokens:
             q = q[:actual_num_tokens]
-            idx_q = idx_q[:actual_num_tokens]
+            if idx_q is not None:
+                idx_q = idx_q[:actual_num_tokens]
 
-        idx_o, o = minimax_sparse_prefill(
+        share_key = None
+        shared_topk_idx = None
+        if self.sparse_index_sharing_enabled:
+            share_key = self._sparse_index_share_key("prefill", q, forward_batch)
+            shared_topk_idx = self._load_shared_sparse_index(
+                layer, forward_batch, share_key
+            )
+            if share_sparse_index and shared_topk_idx is None:
+                raise RuntimeError(
+                    "MiniMax-M3 sparse index selection missing on a sharing layer"
+                )
+        idx_o, o, topk_idx = minimax_sparse_prefill(
             q,
             k_cache,
             v_cache,
@@ -346,7 +447,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             disable_index_value=disable_value,
             use_msa=self.use_msa,
             seqlens_cpu=forward_batch.extend_seq_lens_cpu,
+            shared_topk_idx=shared_topk_idx,
         )
+        if self.sparse_index_sharing_enabled and not share_sparse_index:
+            assert share_key is not None
+            self._store_shared_sparse_index(
+                layer, forward_batch, share_key, topk_idx
+            )
 
         if actual_num_tokens < original_num_tokens:
             pad_len = original_num_tokens - actual_num_tokens
@@ -410,23 +517,36 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         forward_batch: ForwardBatch,
         save_kv_cache: bool = True,
         *,
-        idx_q: torch.Tensor,
-        idx_k: torch.Tensor,
+        idx_q: Optional[torch.Tensor],
+        idx_k: Optional[torch.Tensor],
         idx_v: Optional[torch.Tensor],
         **kwargs,
     ):
         assert len(kwargs) == 0
         disable_value = layer.layer_id in self.disable_value_layer_ids
-        self.kv_pool.set_fused_kv_index_buffer(
-            layer,
-            forward_batch.out_cache_loc,
-            k,
-            v,
-            idx_k,
-            None if disable_value else idx_v,
+        share_sparse_index = self._shares_sparse_index(layer)
+        kv_cached_by_fusion = self._is_sparse_kv_cached_by_fusion(
+            forward_batch, layer.layer_id
         )
+        if not kv_cached_by_fusion:
+            if share_sparse_index:
+                self.kv_pool.set_kv_buffer(
+                    layer, forward_batch.out_cache_loc, k, v
+                )
+            else:
+                assert idx_k is not None
+                self.kv_pool.set_fused_kv_index_buffer(
+                    layer,
+                    forward_batch.out_cache_loc,
+                    k,
+                    v,
+                    idx_k,
+                    None if disable_value else idx_v,
+                )
         k_cache, v_cache = self.kv_pool.get_kv_buffer(layer.layer_id)
-        if disable_value:
+        if share_sparse_index:
+            idx_k_cache = idx_v_cache = None
+        elif disable_value:
             idx_k_cache = self.kv_pool.get_index_k_buffer(layer.layer_id)
             idx_v_cache = None
         else:
@@ -458,7 +578,18 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                     "did not prepare the plan for this forward (gate mismatch)."
                 )
 
-        idx_o, o = minimax_sparse_decode(
+        share_key = None
+        shared_indexer_output = None
+        if self.sparse_index_sharing_enabled:
+            share_key = self._sparse_index_share_key("decode", q, forward_batch)
+            shared_indexer_output = self._load_shared_sparse_index(
+                layer, forward_batch, share_key
+            )
+            if share_sparse_index and shared_indexer_output is None:
+                raise RuntimeError(
+                    "MiniMax-M3 sparse index selection missing on a sharing layer"
+                )
+        idx_o, o, indexer_output = minimax_sparse_decode(
             q,
             None,
             k_cache,
@@ -483,7 +614,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             use_msa=self._use_msa_decode,
             msa_kv_indices=msa_kv_indices,
             msa_plan=msa_plan,
+            shared_indexer_output=shared_indexer_output,
         )
+        if self.sparse_index_sharing_enabled and not share_sparse_index:
+            assert share_key is not None
+            self._store_shared_sparse_index(
+                layer, forward_batch, share_key, indexer_output
+            )
         return (
             None if idx_o is None else idx_o.reshape(q.shape[0], -1).contiguous(),
             o.reshape(q.shape[0], -1).contiguous(),

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -40,8 +40,12 @@ def minimax_sparse_prefill(
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (paged main)
     v_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (paged main)
     sink: Optional[torch.Tensor],  # [num_q_heads, qk_head_dim]
-    idx_q: torch.Tensor,  # [total_extend_tokens, num_idx_heads, idx_head_dim]
-    idx_k_cache: torch.Tensor,  # [max_slots, 1, idx_head_dim] (paged index)
+    idx_q: Optional[
+        torch.Tensor
+    ],  # [total_extend_tokens, num_idx_heads, idx_head_dim]
+    idx_k_cache: Optional[
+        torch.Tensor
+    ],  # [max_slots, 1, idx_head_dim] (paged index)
     idx_v_cache: Optional[
         torch.Tensor
     ],  # [max_slots, 1, idx_head_dim] (paged index); None when disable_index_value
@@ -67,7 +71,8 @@ def minimax_sparse_prefill(
     max_seqblock_q: Optional[int] = None,
     all_seqblock_q: Optional[int] = None,
     seqlens_cpu: Optional[List[int]] = None,
-):
+    shared_topk_idx: Optional[torch.Tensor] = None,
+) -> Tuple[Optional[torch.Tensor], torch.Tensor, torch.Tensor]:
     """Run MiniMax-M3 sparse prefill.
 
     ``cu_seqblocks_q``, ``max_seqblock_q``, and ``all_seqblock_q`` are optional
@@ -81,40 +86,53 @@ def minimax_sparse_prefill(
             cu_seqlens, max_seqlen_q, block_size_q, block_size_k, seqlens_cpu
         )
 
-    # All seqlen is less than topk, use full attention
-    # Step 1: Flash attention with topk index (using index head)
-    idx_o, topk_idx = flash_prefill_with_topk_index(
-        q=idx_q,
-        k_cache=idx_k_cache,
-        v_cache=idx_v_cache,
-        sink=idx_sink,
-        req_to_token=req_to_token,
-        slot_ids=slot_ids,
-        cu_seqlens=cu_seqlens,
-        seq_lens=seq_lens,
-        prefix_lens=prefix_lens,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        block_size_q=block_size_q,
-        block_size_k=block_size_k,
-        topk=topk,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
-        sm_scale=idx_sm_scale,
-        score_type=score_type,
-        disable_index_value=disable_index_value,
-        cu_seqblocks_q=cu_seqblocks_q,
-        max_seqblock_q=max_seqblock_q,
-        all_seqblock_q=all_seqblock_q,
-    )
-    # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
-    num_idx_heads = idx_q.shape[1]
-    num_kv_heads = k_cache.shape[1]
-    idx_group_size = num_idx_heads // num_kv_heads
-    if idx_group_size > 1:
-        topk_idx = topk_index_reduce(
-            topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
+    if shared_topk_idx is None:
+        if idx_q is None or idx_k_cache is None:
+            raise RuntimeError(
+                "MiniMax-M3 sparse index selection missing on a sharing layer"
+            )
+        # All seqlen is less than topk, use full attention
+        # Step 1: Flash attention with topk index (using index head)
+        idx_o, topk_idx = flash_prefill_with_topk_index(
+            q=idx_q,
+            k_cache=idx_k_cache,
+            v_cache=idx_v_cache,
+            sink=idx_sink,
+            req_to_token=req_to_token,
+            slot_ids=slot_ids,
+            cu_seqlens=cu_seqlens,
+            seq_lens=seq_lens,
+            prefix_lens=prefix_lens,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            block_size_q=block_size_q,
+            block_size_k=block_size_k,
+            topk=topk,
+            init_blocks=init_blocks,
+            local_blocks=local_blocks,
+            sm_scale=idx_sm_scale,
+            score_type=score_type,
+            disable_index_value=disable_index_value,
+            cu_seqblocks_q=cu_seqblocks_q,
+            max_seqblock_q=max_seqblock_q,
+            all_seqblock_q=all_seqblock_q,
         )
+        # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
+        num_idx_heads = idx_q.shape[1]
+        num_kv_heads = k_cache.shape[1]
+        idx_group_size = num_idx_heads // num_kv_heads
+        if idx_group_size > 1:
+            topk_idx = topk_index_reduce(
+                topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
+            )
+    else:
+        if not disable_index_value:
+            raise RuntimeError(
+                "MiniMax-M3 sparse index sharing requires the index-value path "
+                "to be disabled"
+            )
+        idx_o = None
+        topk_idx = shared_topk_idx
     # Step 3: Sparse attention using topk index (main head). The MSA path only
     # replaces this step; the indexer above is unchanged. MSA has no attn-sink
     # input, so keep the Triton path when sink is present.
@@ -174,7 +192,7 @@ def minimax_sparse_prefill(
             cu_seqblocks_q=cu_seqblocks_q,
             max_seqblock_q=max_seqblock_q,
         )
-    return idx_o, o
+    return idx_o, o, topk_idx
 
 
 def minimax_sparse_decode(
@@ -182,9 +200,11 @@ def minimax_sparse_decode(
     sink: Optional[torch.Tensor],  # [num_q_heads, qk_head_dim]
     k_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (paged)
     v_cache: torch.Tensor,  # [max_slots, num_kv_heads, head_dim] (paged)
-    idx_q: torch.Tensor,  # [batch_size, num_idx_heads, idx_head_dim], num_idx_heads >= num_kv_heads
+    idx_q: Optional[
+        torch.Tensor
+    ],  # [batch_size, num_idx_heads, idx_head_dim], num_idx_heads >= num_kv_heads
     idx_sink: Optional[torch.Tensor],  # [num_idx_heads, idx_head_dim]
-    idx_k_cache: torch.Tensor,  # [max_slots, 1, idx_head_dim] (paged)
+    idx_k_cache: Optional[torch.Tensor],  # [max_slots, 1, idx_head_dim] (paged)
     idx_v_cache: Optional[
         torch.Tensor
     ],  # [max_slots, 1, idx_head_dim] (paged); None when disable_index_value
@@ -208,42 +228,63 @@ def minimax_sparse_decode(
         torch.Tensor
     ] = None,  # per-forward MSA page table (cached)
     msa_plan=None,  # per-forward MSA fmha_sm100 plan (cached)
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    # Step 1: Flash decode with topk index (using index head). When the dense main
-    # attention is used, the indexer emits the page table directly (fused
-    # transform) instead of block ids, plus the per-query effective KV length.
-    idx_o, topk_idx, real_seq_lens = flash_decode_with_topk_idx(
-        q=idx_q,
-        sink=idx_sink,
-        k_cache=idx_k_cache,
-        v_cache=idx_v_cache,
-        req_to_token=req_to_token,
-        seq_lens=seq_lens,
-        max_seqlen=max_seqlen,
-        slot_ids=slot_ids,
-        block_size=block_size_k,
-        topk=topk,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
-        sm_scale=idx_sm_scale,
-        score_type=score_type,
-        disable_index_value=disable_index_value,
-        use_dense_main_attn=dense_main_attn_fn is not None,
-        page_size=page_size,
-    )
-    num_idx_heads = idx_q.shape[1]
-    num_kv_heads = k_cache.shape[1]
-    idx_group_size = num_idx_heads // num_kv_heads
-    if dense_main_attn_fn is not None:
-        # topk_idx is the page table; real_seq_lens is the per-query cache_seqlens
-        assert idx_group_size == 1
-        o = dense_main_attn_fn(q, topk_idx, real_seq_lens)
-    else:
-        # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
-        if idx_group_size > 1:
+    shared_indexer_output: Optional[
+        Tuple[torch.Tensor, Optional[torch.Tensor]]
+    ] = None,
+) -> Tuple[
+    Optional[torch.Tensor],
+    torch.Tensor,
+    Tuple[torch.Tensor, Optional[torch.Tensor]],
+]:
+    if shared_indexer_output is None:
+        if idx_q is None or idx_k_cache is None:
+            raise RuntimeError(
+                "MiniMax-M3 sparse index selection missing on a sharing layer"
+            )
+        # Step 1: Flash decode with topk index (using index head). When the dense main
+        # attention is used, the indexer emits the page table directly (fused
+        # transform) instead of block ids, plus the per-query effective KV length.
+        idx_o, topk_idx, real_seq_lens = flash_decode_with_topk_idx(
+            q=idx_q,
+            sink=idx_sink,
+            k_cache=idx_k_cache,
+            v_cache=idx_v_cache,
+            req_to_token=req_to_token,
+            seq_lens=seq_lens,
+            max_seqlen=max_seqlen,
+            slot_ids=slot_ids,
+            block_size=block_size_k,
+            topk=topk,
+            init_blocks=init_blocks,
+            local_blocks=local_blocks,
+            sm_scale=idx_sm_scale,
+            score_type=score_type,
+            disable_index_value=disable_index_value,
+            use_dense_main_attn=dense_main_attn_fn is not None,
+            page_size=page_size,
+        )
+        num_idx_heads = idx_q.shape[1]
+        num_kv_heads = k_cache.shape[1]
+        idx_group_size = num_idx_heads // num_kv_heads
+        if dense_main_attn_fn is None and idx_group_size > 1:
+            # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads.
             topk_idx = topk_index_reduce(
                 topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
             )
+    else:
+        if not disable_index_value:
+            raise RuntimeError(
+                "MiniMax-M3 sparse index sharing requires the index-value path "
+                "to be disabled"
+            )
+        idx_o = None
+        topk_idx, real_seq_lens = shared_indexer_output
+
+    if dense_main_attn_fn is not None:
+        # topk_idx is the page table; real_seq_lens is the per-query cache_seqlens
+        assert real_seq_lens is not None
+        o = dense_main_attn_fn(q, topk_idx, real_seq_lens)
+    else:
         # Step 3: Sparse attention using topk index (main head). The MSA path
         # only replaces this step; keep the Triton path when sink is present.
         if use_msa and sink is None:
@@ -290,4 +331,4 @@ def minimax_sparse_decode(
                 topk_idx=topk_idx,
                 sm_scale=sm_scale,
             )
-    return idx_o, o
+    return idx_o, o, (topk_idx, real_seq_lens)

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -104,6 +104,52 @@ _FP8_KV_DTYPES = (
 # equal the CUDA warp size (32) so each warp norms+ropes one head in one pass.
 _M3_FUSED_QKNORM_ROPE_ROTARY_DIM = 64
 
+def _sparse_attention_layer_ids_for_topk(config: PretrainedConfig) -> set[int]:
+    sparse_cfg = getattr(config, "sparse_attention_config", None)
+    if not sparse_cfg:
+        return set()
+    freq = sparse_cfg.get("sparse_attention_freq")
+    if freq is None:
+        return set()
+    return {i for i, enabled in enumerate(freq) if enabled != 0}
+
+
+def _sparse_attention_layer_ordinals(config: PretrainedConfig) -> dict[int, int]:
+    return {
+        layer_id: ordinal
+        for ordinal, layer_id in enumerate(
+            sorted(_sparse_attention_layer_ids_for_topk(config))
+        )
+    }
+
+
+def _should_share_minimax_m3_sparse_index(
+    config: PretrainedConfig, layer_id: int
+) -> tuple[bool, int]:
+    sparse_ordinal = _sparse_attention_layer_ordinals(config).get(layer_id, -1)
+    if sparse_ordinal < 0:
+        return False, sparse_ordinal
+    if not _is_hip:
+        return False, sparse_ordinal
+    refresh_interval = int(
+        getattr(config, "sparse_index_refresh_interval", 1) or 1
+    )
+    share_pattern = getattr(config, "sparse_index_share_pattern", None)
+    if share_pattern is not None:
+        if 0 <= sparse_ordinal < len(share_pattern):
+            return share_pattern[sparse_ordinal] == "S", sparse_ordinal
+        return False, sparse_ordinal
+
+    if refresh_interval <= 0:
+        raise ValueError("sparse_index_refresh_interval must be a positive integer")
+    if refresh_interval == 1:
+        return False, sparse_ordinal
+
+    # MiniMax-M3 schedules sharing by sparse-layer ordinal, not absolute layer id.
+    offset = int(getattr(config, "sparse_index_refresh_offset", 0))
+    return max(sparse_ordinal - offset, 0) % refresh_interval != 0, sparse_ordinal
+
+
 _has_rocm_qk_norm_rope = False
 if _is_hip:
     try:
@@ -466,6 +512,8 @@ class MiniMaxM3Attention(nn.Module):
         self.hidden_size = config.hidden_size
         self.is_sparse_attention_layer = is_sparse_attention_layer
         self.disable_index_value = is_sparse_attention_layer and disable_index_value
+        self.share_sparse_index = False
+        self.sparse_layer_ordinal = -1
 
         attn_tp_rank = get_parallel().attn_tp_rank
         attn_tp_size = get_parallel().attn_tp_size
@@ -519,6 +567,14 @@ class MiniMaxM3Attention(nn.Module):
             self.idx_replica_size = attn_tp_size // self.idx_head_tp_size
             self.idx_head_rank = attn_tp_rank // self.idx_replica_size
             self.num_idx_heads = self.total_idx_heads // self.idx_head_tp_size
+            self.share_sparse_index, self.sparse_layer_ordinal = (
+                _should_share_minimax_m3_sparse_index(config, layer_id)
+            )
+            if self.share_sparse_index and not self.disable_index_value:
+                raise ValueError(
+                    "MiniMax-M3 sparse index sharing requires the index-value "
+                    "path to be disabled"
+                )
 
         self.qkv_proj = QKVParallelLinear(
             self.hidden_size,
@@ -643,6 +699,10 @@ class MiniMaxM3Attention(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("attn", prefix),
         )
+        # The shared sparse backend receives RadixAttention rather than this model
+        # module, so carry the per-layer sharing schedule on the layer handle.
+        self.attn.share_sparse_index = self.share_sparse_index
+        self.attn.sparse_layer_ordinal = self.sparse_layer_ordinal
 
         self._use_fused_qknorm_rope = (
             _is_cuda
@@ -1002,7 +1062,7 @@ class MiniMaxM3Attention(nn.Module):
             fused_out = self.fused_qkv_index_proj(hidden_states)
             qkv = fused_out[:, : self._fused_main_size]
 
-            if self._combined_qknorm_ok:
+            if self._combined_qknorm_ok and not self.share_sparse_index:
                 from sglang.kernels.ops.attention.minimax_qknorm_rope import (
                     minimax_qknorm_rope_grouped,
                 )
@@ -1050,7 +1110,13 @@ class MiniMaxM3Attention(nn.Module):
             else:
                 idx_qkv, _ = self.index_qkv_proj(hidden_states)
 
-            if main_qk_already_normed:
+            if self.share_sparse_index:
+                if not main_qk_already_normed:
+                    q, k = self._qk_norm_rope(positions, q, k)
+                # Keep the packed projection columns for ABI and weight-layout
+                # compatibility, but skip index norm/RoPE/cache insertion and top-k.
+                idx_q = idx_k = idx_v = None
+            elif main_qk_already_normed:
                 use_fused_index_norm_rope = (
                     self._use_fused_qknorm_rope
                     and self.idx_head_dim == 128
@@ -1097,10 +1163,14 @@ class MiniMaxM3Attention(nn.Module):
             q = q.view(q.shape[0], self.num_heads, self.head_dim)
             k = k.view(k.shape[0], self.num_kv_heads, self.head_dim)
             v = v.view(v.shape[0], self.num_kv_heads, self.head_dim)
-            idx_q = idx_q.reshape(idx_q.shape[0], self.num_idx_heads, self.idx_head_dim)
-            idx_k = idx_k.reshape(idx_k.shape[0], 1, self.idx_head_dim)
-            if idx_v is not None:
-                idx_v = idx_v.reshape(idx_v.shape[0], 1, self.idx_head_dim)
+            if not self.share_sparse_index:
+                assert idx_q is not None and idx_k is not None
+                idx_q = idx_q.reshape(
+                    idx_q.shape[0], self.num_idx_heads, self.idx_head_dim
+                )
+                idx_k = idx_k.reshape(idx_k.shape[0], 1, self.idx_head_dim)
+                if idx_v is not None:
+                    idx_v = idx_v.reshape(idx_v.shape[0], 1, self.idx_head_dim)
             idx_o, attn_output = self.attn(
                 q, k, v, forward_batch, idx_q=idx_q, idx_k=idx_k, idx_v=idx_v
             )


### PR DESCRIPTION
<!-- Suggested PR title: [AMD] MiniMax-M3: support cross-layer sparse index sharing -->

Add config-driven cross-layer sparse index sharing for MiniMax-M3 on ROCm. With `sparse_index_refresh_interval=N`, one sparse layer refreshes the index score/top-k selection every `N` sparse layers, while the intermediate layers share the latest selection.

`sparse_index_refresh_interval=4` changes the 57 sparse layers from 57 index-selection producers to 15 producers + 42 sharing layers.

Default behavior is unchanged: `sparse_index_refresh_interval=1` refreshes index score/top-k in every sparse layer exactly as before. The feature is opt-in through model override arguments.

```python
refresh_interval = int(
    getattr(config, "sparse_index_refresh_interval", 1) or 1
)
offset = int(getattr(config, "sparse_index_refresh_offset", 0))
share_sparse_index = (
    max(sparse_layer_ordinal - offset, 0) % refresh_interval != 0
)
```

The shared result is scoped to each `ForwardBatch`. Producers store `(topk_idx, real_seq_lens)` together with a forward-shape/config key; consumers fail loudly on a missing or mismatched entry instead of silently using stale metadata.

## Motivation

Other sparse-attention models already use cross-layer index sharing: designated layers refresh the sparse index selection, while neighboring layers consume the shared selection instead of running the indexer again. This provides a practical model-level pattern for reducing redundant sparse index computation.

MiniMax-M3 currently recomputes index score and block top-k in each of its 57 sparse layers. This PR makes cross-layer sharing configurable for MiniMax-M3. With `sparse_index_refresh_interval=4`, 42 layers share the latest producer output and skip repeated index norm/cache/score/top-k work. Full GSM8K evaluation and long-context serving tests validate that this policy does not regress aggregate inference quality while improving high-concurrency end-to-end performance.

Sharing layers still execute the existing packed projection. This PR targets index preprocessing, cache insertion, score, and top-k; it does not claim projection FLOP savings and does not introduce a new kernel or KV-cache layout.

## Results

### Server command

`INTERVAL=1` is the baseline and `INTERVAL=4` enables one index-selection producer every four sparse layers.

```bash
INTERVAL=4

HIP_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_USE_AITER=1 \
SGLANG_OPT_USE_BF16_ROUTER_GEMM=0 \
SGLANG_FORCE_MXFP8_BLOCK_CONVERT=1 \
SGLANG_MXFP8_MOE_KEEP_NATIVE=1 \
SGLANG_USE_AITER_MOE_GU_ITLV=1 \
SGLANG_M3_ALLOW_CUSTOM_AR=1 \
ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=1 \
python3 -m sglang.launch_server \
  --model-path /models/MiniMaxAI/MiniMax-M3-MXFP8 \
  --quantization mxfp8 \
  --dtype bfloat16 \
  --tp 4 \
  --trust-remote-code \
  --attention-backend aiter \
  --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend aiter \
  --disable-radix-cache \
  --chunked-prefill-size 8192 \
  --mem-fraction-static 0.90 \
  --context-length 32768 \
  --watchdog-timeout 1200 \
  --json-model-override-args "{\"sparse_index_refresh_interval\":${INTERVAL}}" \
  --host 127.0.0.1 \
  --port 30000
```

### End-to-end benchmark

`sglang.bench_serving` with random ISL 8192 / OSL 1024, `random-range-ratio=0.8`, ignore-eos, request rate `inf`, seed `20260723`, and `num_prompts = concurrency × 10`.

Both sides used the same model, image, code, GPU0-3, launch flags, prompt seed, and input/output token totals. Only `sparse_index_refresh_interval` changed.

#### Concurrency 4 

| Metric | interval1 baseline | interval4 sharing | Δ |
|---|---:|---:|---:|
| Total token throughput | 2014.11 tok/s | 2003.27 tok/s | −0.54% |
| Output token throughput | 223.14 tok/s | 221.94 tok/s | −0.54% |
| Mean TPOT | 17.31 ms | 17.40 ms | +0.51% |
| Median TTFT | 367.77 ms | 371.13 ms | +0.91% |
| Mean E2EL | 16345.93 ms | 16430.48 ms | +0.52% |

The paired concurrency-4 run did not show a speedup.

#### Concurrency 64 
| Metric | interval1 baseline | interval4 sharing | Δ |
|---|---:|---:|---:|
| Total token throughput | 10376.94 tok/s | 10866.50 tok/s | +4.72% |
| Output token throughput | 1152.06 tok/s | 1206.41 tok/s | +4.72% |
| Mean TPOT | 52.89 ms | 50.45 ms | −4.61% |
| Median TTFT | 496.82 ms | 487.69 ms | −1.84% |
| Mean E2EL | 50289.80 ms | 48040.19 ms | −4.47% |

### Accuracy — GSM8K, 1319 questions, 5-shot, temperature 0

Full GSM8K was run on GPU4-7 with `max_new_tokens=512` and `parallel=128`.

| Metric | interval1 baseline | interval4 sharing | Δ |
|---|---:|---:|---:|
| Correct | 1127 / 1319 | 1131 / 1319 | +4 |
| Accuracy | 85.444% | 85.747% | +0.303 pp |
| Invalid | 1 | 0 | −1 |




## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #30067965022](https://github.com/sgl-project/sglang/actions/runs/30067965022)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #30067964886](https://github.com/sgl-project/sglang/actions/runs/30067964886)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->