### PR TITLE
[Test] Cover NPU MoE disk weight reload (#26794)

### DIFF
--- a/test/registered/ascend/basic_function/rl/test_npu_moe_update_weights_from_disk.py
+++ b/test/registered/ascend/basic_function/rl/test_npu_moe_update_weights_from_disk.py
@@ -1,0 +1,77 @@
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ascend.test_ascend_utils import QWEN3_30B_A3B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_npu_ci(est_time=120, suite="stage-b-test-1-npu-a2")
+
+
+class TestNPUMoEUpdateWeightsFromDisk(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = QWEN3_30B_A3B_WEIGHTS_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--trust-remote-code",
+                "--attention-backend",
+                "ascend",
+                "--dtype",
+                "bfloat16",
+                "--mem-fraction-static",
+                "0.95",
+                "--cuda-graph-backend-decode",
+                "disabled",
+                "--cuda-graph-backend-prefill",
+                "disabled",
+                "--max-running-requests",
+                "8",
+                "--tp-size",
+                "1",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None) is not None:
+            kill_process_tree(cls.process.pid)
+
+    def _generate(self):
+        response = requests.post(
+            self.base_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+            },
+            timeout=60,
+        )
+        response.raise_for_status()
+        return response.json()["text"]
+
+    def test_idempotent_moe_weight_reload(self):
+        expected = self._generate()
+        response = requests.post(
+            self.base_url + "/update_weights_from_disk",
+            json={"model_path": self.model, "flush_cache": True},
+            timeout=120,
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertTrue(response.json()["success"], response.text)
+        self.assertEqual(self._generate(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_npu_unquant_moe_reload.py
+++ b/test/registered/unit/layers/quantization/test_npu_unquant_moe_reload.py
@@ -1,0 +1,78 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import sglang.srt.hardware_backend.npu.quantization.moe_methods as npu_moe_methods
+import sglang.srt.layers.quantization.unquant as unquant
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestNPUUnquantMoEReload(CustomTestCase):
+    def test_postprocess_preserves_canonical_reload_layout(self):
+        num_experts, hidden_size, intermediate_size = 1, 8, 3
+        layer = SimpleNamespace(
+            w13_weight=torch.nn.Parameter(
+                torch.zeros(num_experts, 2 * intermediate_size, hidden_size),
+                requires_grad=False,
+            ),
+            w2_weight=torch.nn.Parameter(
+                torch.zeros(num_experts, hidden_size, intermediate_size),
+                requires_grad=False,
+            ),
+            w13_kernel=npu_moe_methods.NPUUnquantMoEMethod(),
+            w2_kernel=npu_moe_methods.NPUUnquantMoEMethod(),
+            dispatcher=MagicMock(),
+        )
+        backend = SimpleNamespace(is_flashinfer_cutlass=lambda: False)
+
+        with (
+            patch.object(unquant, "_is_cpu", False),
+            patch.object(unquant, "_is_npu", True),
+            patch.object(unquant, "_use_aiter", False),
+            patch.object(unquant, "get_moe_runner_backend", return_value=backend),
+            patch.object(
+                npu_moe_methods,
+                "npu_format_cast",
+                side_effect=lambda tensor: tensor.detach().clone(),
+            ),
+        ):
+            method = unquant.UnquantizedFusedMoEMethod()
+            method.process_weights_after_loading(layer)
+
+        self.assertEqual(
+            tuple(layer.w13_weight.shape),
+            (num_experts, 2 * intermediate_size, hidden_size),
+        )
+        self.assertEqual(
+            tuple(layer.w2_weight.shape),
+            (num_experts, hidden_size, intermediate_size),
+        )
+
+        loader = SimpleNamespace(
+            moe_runner_config=SimpleNamespace(is_gated=True),
+            quant_method=SimpleNamespace(load_up_proj_weight_first=False),
+            use_padded_loading=False,
+            use_presharded_weights=False,
+            use_triton_kernels=False,
+        )
+        gate = torch.full((intermediate_size, hidden_size), 1.0)
+        up = torch.full((intermediate_size, hidden_size), 2.0)
+        down = torch.full((hidden_size, intermediate_size), 3.0)
+
+        FusedMoE._load_w13(loader, layer.w13_weight[0], 0, "w1", gate, 0)
+        FusedMoE._load_w13(loader, layer.w13_weight[0], 0, "w3", up, 0)
+        FusedMoE._load_w2(loader, layer.w2_weight[0], 1, "w2", down, 0)
+
+        torch.testing.assert_close(layer.w13_weight[0, :intermediate_size], gate)
+        torch.testing.assert_close(layer.w13_weight[0, intermediate_size:], up)
+        torch.testing.assert_close(layer.w2_weight[0], down)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

#26794 reported that a second `update_weights_from_disk` load crashed for BF16 FusedMoE models on NPU. The failure was caused by NPU post-processing changing the logical expert-weight layout before the reload path computed its shards. Current `main` preserves the canonical layout after #26717 and #29503, but the regression was not covered in the repository test suite.

## Modifications

- Add a CPU regression test that runs the NPU unquantized MoE post-processing path and reloads separate gate, up, and down projections.
- Add a one-NPU integration test that reloads the same Qwen3 MoE checkpoint through `/update_weights_from_disk` and verifies deterministic generation before and after the update.

## Accuracy Tests

The integration test requires Ascend hardware and is registered in `stage-b-test-1-npu-a2`. Local validation completed:

- Pylance syntax validation: passed for both test files.
- Editor diagnostics: no errors.
- `git diff --check`: passed.

CPU and NPU execution results are pending CI.

## Speed Tests and Profiling

Not applicable. This PR changes tests only.

## Checklist

- [ ] Run repository formatting/pre-commit checks in CI.
- [x] Add focused unit and integration regression coverage.
- [x] No documentation update is required for this test-only change.
- [x] No production accuracy or performance behavior is changed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30069989911](https://github.com/sgl-project/sglang/actions/runs/30069989911)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30069989706](https://github.com/sgl-project/sglang/actions/runs/30069989706)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->