### PR TITLE
Fix stale flashinfer-MLA fallback poisoning spec verify capture (trtllm_mla + tc_piecewise)

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -857,8 +857,17 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         llama_4_scaling: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
+        # The fallback belongs to genuine extend forwards only. Target-verify /
+        # draft-extend must never honor it: `forward_prefill_metadata` is a
+        # stale leftover from the last prefill there (eager init clears it,
+        # but decode-graph capture does not), and capturing verify through the
+        # flashinfer path binds the graph to prefill-planned wrapper buffers,
+        # which fault (illegal address) at replay.
         if (
-            self.forward_prefill_metadata is not None
+            forward_batch.forward_mode.is_extend()
+            and not forward_batch.forward_mode.is_target_verify()
+            and not forward_batch.forward_mode.is_draft_extend_v2()
+            and self.forward_prefill_metadata is not None
             and self.forward_prefill_metadata.fallback_to_flashinfer_impl
         ):
             return super().forward_extend(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4176,19 +4176,6 @@ class ServerArgs:
                 "decode context parallel (dcp_size > 1)",
                 lambda: self.dcp_size > 1,
             ),
-            # TcPiecewise makes the trtllm_mla prefill fall back to the
-            # flashinfer-MLA implementation, which faults (illegal address)
-            # on an FP8 KV cache.
-            (
-                "MLA attention with FP8 KV cache",
-                lambda: self.kv_cache_dtype.startswith("fp8")
-                and (
-                    _resolved_view(self).attention_backend
-                    in ("trtllm_mla", "flashinfer_mla")
-                    or _resolved_view(self).prefill_attention_backend
-                    in ("trtllm_mla", "flashinfer_mla")
-                ),
-            ),
         ]
         for _name, predicate in rules:
             if predicate():


### PR DESCRIPTION
## Motivation

Follow-up to #32239. The kimi_k26 (Kimi-K2.6-NVFP4 + DFLASH, trtllm_mla, tc_piecewise) server hangs/crashes at serving: CUDA coredump shows a deterministic all-rank `Warp Illegal Address` in `flashinfer::mla::BatchMLAPagedAttentionKernel`.

Root defect: `TRTLLMMLABackend.forward_extend` routes to the flashinfer-MLA implementation based on `forward_prefill_metadata.fallback_to_flashinfer_impl` — persistent state left behind by the last prefill (tc_piecewise prefill always sets it). Target-verify / draft-extend forwards also enter `forward_extend` and can consume that stale flag; by design they must never take this fallback (the eager `init_forward_metadata` explicitly clears the stale metadata for them — see the code comment there — but not every execution path goes through that clear).

Empirical scoping (single-variable CI runs on the un-mitigated base):
- bf16 KV + DFLASH: fails identically (run 30067229264) — KV dtype irrelevant
- fp8 KV without spec: passes (run 30067230045)
- Kimi-K2.5-NVFP4 + EAGLE3 (tokenspeed_mla, same inherited `forward_extend`, piecewise default): passes nightly — the observed trigger is DFLASH x tc_piecewise; the exact interleaving that spares EAGLE3 (likely the DFLASH run-ahead overlap from #31468, which landed inside the window where this test was masked by the recompile-limit crash) is tracked as a follow-up.

## Modifications

- Gate the flashinfer fallback in `forward_extend` to genuine extend modes (mirrors the eager `init_forward_metadata` delegation condition), so target-verify / draft-extend never consume the stale prefill flag in any execution path.
- Remove the "MLA attention with FP8 KV cache" tc_piecewise disable rule added in #32239: it was a mis-scoped mitigation (missed bf16+DFLASH, needlessly disabled prefill CG for spec-free fp8 configs). With the root fix these configs keep tc_piecewise.

## Validation

`/rerun-test registered/quant/test_kimi_k26_nvfp4_dflash.py` on this branch — tc_piecewise active, no disable rule — **success** (run 30073413418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ibyV8b1ULTKUkzkTUWuXG

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30116952561](https://github.com/sgl-project/sglang/actions/runs/30116952561)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30117341338](https://github.com/sgl-project/sglang/actions/runs/30117341338)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->