### PR TITLE
[Fix] Strip whitespace when parsing legacy and Envs boolean/int fields

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -124,7 +124,7 @@ class EnvJSON(EnvField):
 
 class EnvBool(EnvField):
     def parse(self, value: str) -> bool:
-        value = value.lower()
+        value = value.strip().lower()
         if value in ["true", "1", "yes", "y"]:
             return True
         if value in ["false", "0", "no", "n"]:
@@ -135,7 +135,7 @@ class EnvBool(EnvField):
 class EnvInt(EnvField):
     def parse(self, value: str) -> int:
         try:
-            return int(value)
+            return int(value.strip())
         except ValueError:
             raise ValueError(f'"{value}" is not a valid integer value')
 

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1231,8 +1231,7 @@ _warned_bool_env_var_keys = set()
 
 def get_bool_env_var(name: str, default: str = "false") -> bool:
     # FIXME: move your environment variable to sglang.srt.environ
-    value = os.getenv(name, default)
-    value = value.lower()
+    value = os.getenv(name, default).strip().lower()
 
     truthy_values = ("true", "1")
     falsy_values = ("false", "0")
@@ -1255,7 +1254,7 @@ def get_int_env_var(name: str, default: int = 0) -> int:
     if value is None or not value.strip():
         return default
     try:
-        return int(value)
+        return int(value.strip())
     except ValueError:
         return default
 

--- a/test/registered/unit/utils/test_env_parsers.py
+++ b/test/registered/unit/utils/test_env_parsers.py
@@ -1,0 +1,61 @@
+import os
+import unittest
+import uuid
+from unittest.mock import patch
+
+from sglang.srt.environ import EnvBool, EnvInt
+from sglang.srt.utils import common as common_utils
+from sglang.srt.utils.common import get_bool_env_var, get_int_env_var
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestGetBoolEnvVar(CustomTestCase):
+    def setUp(self):
+        common_utils._warned_bool_env_var_keys.clear()
+
+    def test_strips_whitespace_for_truthy_values(self):
+        key = f"SGLANG_TEST_BOOL_{uuid.uuid4().hex}"
+        with patch.dict(os.environ, {key: "  true  "}):
+            self.assertTrue(get_bool_env_var(key))
+
+    def test_strips_whitespace_for_falsy_values(self):
+        key = f"SGLANG_TEST_BOOL_{uuid.uuid4().hex}"
+        with patch.dict(os.environ, {key: "\tfalse\n"}):
+            self.assertFalse(get_bool_env_var(key))
+
+    def test_whitespace_only_value_is_treated_as_false(self):
+        key = f"SGLANG_TEST_BOOL_{uuid.uuid4().hex}"
+        with patch.dict(os.environ, {key: "   "}):
+            self.assertFalse(get_bool_env_var(key))
+
+
+class TestGetIntEnvVar(CustomTestCase):
+    def test_strips_whitespace_before_parsing(self):
+        key = f"SGLANG_TEST_INT_{uuid.uuid4().hex}"
+        with patch.dict(os.environ, {key: "  42  "}):
+            self.assertEqual(get_int_env_var(key, default=0), 42)
+
+    def test_whitespace_only_value_returns_default(self):
+        key = f"SGLANG_TEST_INT_{uuid.uuid4().hex}"
+        with patch.dict(os.environ, {key: "   "}):
+            self.assertEqual(get_int_env_var(key, default=7), 7)
+
+
+class TestEnvFieldParsers(CustomTestCase):
+    def test_env_bool_strips_whitespace(self):
+        field = EnvBool(False)
+        field.name = "SGLANG_TEST_ENV_BOOL"
+        self.assertTrue(field.parse("  yes  "))
+        self.assertFalse(field.parse("\t0\n"))
+
+    def test_env_int_strips_whitespace(self):
+        field = EnvInt(0)
+        field.name = "SGLANG_TEST_ENV_INT"
+        self.assertEqual(field.parse("  128  "), 128)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Strip leading/trailing whitespace in `get_bool_env_var`, `get_int_env_var`, `EnvBool`, and `EnvInt` parsers.
- Fixes mis-parsed env vars from Kubernetes ConfigMaps and shell exports (e.g. `" true "` incorrectly treated as false).
- Add CPU unit tests in `test/registered/unit/utils/test_env_parsers.py`.

## Motivation
`EnvTuple` already strips comma-separated values, but boolean/int parsers did not, causing silent misconfiguration.

## Test plan
- [x] `pytest test/registered/unit/utils/test_env_parsers.py` (CPU, no GPU required)
- [x] CI `base-a-test-cpu` suite

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30092530643](https://github.com/sgl-project/sglang/actions/runs/30092530643)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30092530548](https://github.com/sgl-project/sglang/actions/runs/30092530548)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->