### PR TITLE
[Perf] Halve the non-finite sanitization overhead in per_token_group_quant

### DIFF
--- a/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
@@ -48,14 +48,16 @@ struct WeightTrait<fp8_e4m3_t> {
   using packed2_t = fp8x2_e4m3_t;
   static constexpr float kMaxValue = DTypeTrait<fp8_e4m3_t>::kFloatMax;
   // SATFINITE saturates +-inf / out-of-range values, but converts NaN to an
-  // fp8 NaN code. IEEE fminf/fmaxf return the non-NaN operand, so clamping
-  // first quantizes non-finite inputs to +-448 -- matching the v1/v2/Triton
-  // kernels. CUDA-graph capture warmup runs the model on whatever the
-  // (reused, uninitialized) buffers contain, and relies on this: an fp8 NaN
-  // code would poison the downstream GEMM and trip the sampler NaN check.
-  // For finite inputs the clamp is bit-identical to bare SATFINITE.
+  // fp8 NaN code. A single upper clamp is enough to sanitize: IEEE fminf
+  // returns the non-NaN operand, so NaN / +inf quantize to +448, and -inf
+  // passes through for SATFINITE to saturate to -448 -- non-finite inputs
+  // never reach an fp8 NaN code, matching the v1/v2/Triton kernels.
+  // CUDA-graph capture warmup runs the model on whatever the (reused,
+  // uninitialized) buffers contain, and relies on this: an fp8 NaN code would
+  // poison the downstream GEMM and trip the sampler NaN check. For finite
+  // inputs the clamp is bit-identical to bare SATFINITE.
   SGL_DEVICE static packed2_t quant(const float2 v) {
-    return packed2_t{float2{fminf(fmaxf(v.x, -kMaxValue), kMaxValue), fminf(fmaxf(v.y, -kMaxValue), kMaxValue)}};
+    return packed2_t{float2{fminf(v.x, kMaxValue), fminf(v.y, kMaxValue)}};
   }
 };
 
@@ -291,13 +293,14 @@ struct QuantTrait {
       const float quant_scale = inv_scale_ue8m0(exp);
       const auto scale2 = cast<T2>(float2{quant_scale, quant_scale});
       // Finite scaled values already lie in +-448 (2^exp >= amax/448), so the
-      // clamp only sanitizes non-finite inputs (see WeightTrait<fp8_e4m3_t>);
-      // __hmin2/__hmax2 return the non-NaN operand.
-      const auto lo2 = cast<T2>(float2{-kMaxValue, -kMaxValue});
-      const auto hi2 = cast<T2>(float2{kMaxValue, kMaxValue});
+      // single __hmin2 only sanitizes NaN / +inf (it returns the non-NaN
+      // operand); -inf saturates to -448 via the SATFINITE fp8 cast (see
+      // WeightTrait<fp8_e4m3_t>).
+      const auto max_clip = cast<T>(kMaxValue);
+      const auto max_clip2 = T2{max_clip, max_clip};
 #pragma unroll
       for (uint32_t i = 0; i < kVecSize / 2; ++i) {
-        out[i] = static_cast<Q2>(__hmin2(__hmax2(__hmul2(in[i], scale2), lo2), hi2));
+        out[i] = static_cast<Q2>(__hmin2(__hmul2(in[i], scale2), max_clip2));
       }
     } else {
       // fp32 scale: multiply in fp32 (hmul2 brings too much precision loss)
@@ -330,12 +333,12 @@ __global__ __launch_bounds__(Trait::kBlockSize) void per_token_group_quant_flat_
   const auto global_warp_id = global_tid / kWarpThreads;
   const auto total_work = params.num_tokens * num_groups;
   if (global_warp_id * kWorkPerWarp >= total_work) return;
-  PDLWaitPrimary<kUsePDL>();
   // the last partial warp duplicates the tail work (identical-byte stores)
   const auto work_id = min(global_tid / kNumLanes, total_work - 1);
   const auto lane_id = threadIdx.x % kNumLanes;
   const auto token_idx = work_id / num_groups;
   const auto group_idx = work_id % num_groups;
+  PDLWaitPrimary<kUsePDL>();
   Trait::run(params, 0, token_idx, group_idx, lane_id);
   PDLTriggerSecondary<kUsePDL>();
 }
@@ -351,8 +354,8 @@ __global__ __launch_bounds__(Trait::kBlockSize) void per_token_group_quant_maske
   constexpr uint32_t kNumLanes = Trait::kNumLanes;
   constexpr uint32_t kWorkPerWarp = kWarpThreads / kNumLanes;
   const auto num_groups = params.base.scale.num_groups;
-  PDLWaitPrimary<kUsePDL>();
   const auto expert_idx = blockIdx.y;
+  PDLWaitPrimary<kUsePDL>();
   const auto num_expert_tokens = params.masked_m[expert_idx * params.masked_m_stride];
   for (uint32_t global_tid = blockIdx.x * Trait::kBlockSize + threadIdx.x;;  // initial grid; loop
        global_tid += gridDim.x * Trait::kBlockSize) {

--- a/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant.py
+++ b/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant.py
@@ -68,7 +68,6 @@ def benchmark(group_size: int, layout: str, num_tokens: int, impl: str):
     return marker.do_bench(
         FN[impl],
         input_args=(group_size, x, x_q, x_s, scale_ue8m0),
-        graph_clone_args=(1,),
         memory_args=(x,),
         memory_output=(x_q, x_s),
     )


### PR DESCRIPTION
## Motivation

#32188 fixed the H100 deepep TBO CI break by sanitizing non-finite quant inputs with a **two-sided clamp** before the fp8 conversion. That fix is correct, but it costs more than it needs to: the trait-driven quant kernel is latency-bound at decode batch sizes, and the clamp added 16 `HMNMX2` (ue8m0 path) resp. 32 `FMNMX` (fp32-scale path) per bf16 group-of-128 — a 10–17% instruction-count increase on a kernel that runs twice per layer.

The lower clamp is redundant:

- **NaN / +inf**: IEEE `fminf` / `__hmin2` return the non-NaN operand, so a single upper `min(v, 448)` already maps them to +448.
- **-inf**: passes through the min, but the fp8 `cvt.satfinite` conversion saturates it to -448 on its own.

So a single-sided min preserves the sanitization contract (non-finite inputs never reach an fp8 NaN code) at half the added cost. The only behavior delta: NaN now quantizes to +448 instead of -448 — both finite, which is the property the #32188 tests pin.

## Modifications

- `WeightTrait<fp8_e4m3_t>::quant` (fp32-scale path): `fminf(fmaxf(v, -448), 448)` → `fminf(v, 448)`.
- ue8m0 half path: `__hmin2(__hmax2(x, lo2), hi2)` → `__hmin2(x, max_clip2)`.
- Both flat and masked kernels: move `PDLWaitPrimary` below the pure index arithmetic. This is codegen-neutral today (ptxas schedules the `ACQBULK` identically on sm_90a and sm_100a since the wait only orders memory ops), but keeps the source honest about what the wait actually protects: the first dependent global read (`in.load` / `masked_m[...]`), not the arithmetic.
- Updated the sanitization comments to describe the min + SATFINITE split.
- `bench_per_token_group_quant.py`: drop the `graph_clone_args=(1,)` override — fall back to `do_bench`'s default of cloning every input arg per graph iteration, so the quant outputs also rotate buffers between iterations.

## SASS evidence (bf16, gs=128, flat kernel, `--use_fast_math`)

Instruction counts of the whole kernel; clamp column counts only the sanitization min/max (the 4 amax-reduction `HMNMX2` / 1 eps `FMNMX` are excluded):

| arch | path | pre-#32188 | main (#32188) | this PR |
|---|---|---|---|---|
| sm_100a | ue8m0 | 128 insns / 0 clamp | 144 / 16 `HMNMX2` | 136 / 8 `HMNMX2` |
| sm_100a | fp32 scale | 184 / 0 | 216 / 32 `FMNMX` | 200 / 16 `FMNMX` |
| sm_90a | ue8m0 | 192 / 0 | 216 / 16 `HMNMX2` | 200 / 8 `HMNMX2` |
| sm_90a | fp32 scale | 192 / 0 | 224 / 32 `FMNMX` | 208 / 16 `FMNMX` |

## Benchmark (B200, `bench_per_token_group_quant.py`, this PR vs main)

126 configs (gs 32/64/128 × row/col fp32 / col ue8m0 × 1–8192 tokens): **geomean 1.009x, max 1.029x, min 0.993x, no config slower than noise**. The win concentrates in the latency-bound 1–512 token range (1–3%); large batches are bandwidth-bound and unchanged. The `jit_v2` baseline column drifted ≤1% between the two runs, so the comparison is clean.

## Test

`test/registered/kernels/ops/quantization/test_per_token_group_quant.py`: 105/105 pass on B200, including the 12 non-finite sanitization cases (NaN / ±inf × ue8m0/fp32 × flat/masked) added by #32188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30077678531](https://github.com/sgl-project/sglang/actions/runs/30077678531)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30077678071](https://github.com/sgl-project/sglang/actions/runs/30077678071)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
