### PR TITLE
[CI] Fix XPU platform test on machines without the XPU sgl-kernel op

### DIFF
--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -264,11 +264,22 @@ class TestXpuDeviceMixin(CustomTestCase):
         self.assertEqual(base.get_device(2), torch.device("xpu", 2))
 
     # TODO: @patch("torch.xpu.get_device_capability", return_value=(9, 0))
-    @patch("torch.ops.sgl_kernel.query_device.default", return_value=(9, 0))
-    def test_default_get_device_capability_uses_xpu(self, mock_get_device_capability):
+    def test_default_get_device_capability_uses_xpu(self):
+        # torch.ops.sgl_kernel.query_device is only registered by XPU builds
+        # of sgl-kernel, so patch the op namespace attribute with create=True
+        # (a dotted @patch target would fail to import on CPU/CUDA machines).
+        # torch.xpu.current_device() likewise needs an XPU device; mock it.
         base = XpuSRTPlatform()
-        self.assertEqual(base.get_device_capability(0), DeviceCapability(9, 0))
-        mock_get_device_capability.assert_called_once_with(0)
+        fake_query_device = MagicMock()
+        fake_query_device.default.return_value = (9, 0)
+        with (
+            patch("torch.xpu.current_device", return_value=0),
+            patch.object(
+                torch.ops.sgl_kernel, "query_device", fake_query_device, create=True
+            ),
+        ):
+            self.assertEqual(base.get_device_capability(0), DeviceCapability(9, 0))
+        fake_query_device.default.assert_called_once_with(0)
 
     def test_pin_memory_available_for_xpu_targets(self):
         base = XpuSRTPlatform()


### PR DESCRIPTION
## Motivation

Since #31949, `base-a-test-cpu (3)` fails on every PR: `test_default_get_device_capability_uses_xpu` patches the dotted path `torch.ops.sgl_kernel.query_device.default`, and `mock.patch` tries to import it. The op is only registered by XPU builds of sgl-kernel, so on CPU/CUDA runners the decorator raises `ModuleNotFoundError: No module named 'torch.ops.sgl_kernel'` before the test body runs.

## Modifications

Patch the op namespace attribute with `patch.object(torch.ops.sgl_kernel, "query_device", ..., create=True)` instead — the namespace object itself resolves lazily everywhere, only the op attribute lookup fails. Also mock `torch.xpu.current_device()`, which `get_device_capability` calls and which also needs an XPU device.

Verified on a CUDA-only machine (same failure mode as the CPU runners): before the fix the file fails with the exact CI error, after the fix all 60 tests pass.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30077943953](https://github.com/sgl-project/sglang/actions/runs/30077943953)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #30077943868](https://github.com/sgl-project/sglang/actions/runs/30077943868)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->