### PR TITLE
[Fix] Resolve MiniMax-M3 top-level oneOf parameter schemas

### DIFF
--- a/python/sglang/srt/function_call/minimax_m3.py
+++ b/python/sglang/srt/function_call/minimax_m3.py
@@ -379,6 +379,15 @@ class MinimaxM3Detector(BaseFormatDetector):
             child_schema = properties[child_tag]
             return child_schema if isinstance(child_schema, dict) else None
 
+        one_of = parent_schema.get("oneOf")
+        if isinstance(one_of, list):
+            for option_schema in one_of:
+                child_schema = self._get_child_schema(
+                    option_schema, child_tag, parent_value
+                )
+                if child_schema is not None:
+                    return child_schema
+
         additional_properties = parent_schema.get("additionalProperties")
         if isinstance(additional_properties, dict):
             return additional_properties

--- a/test/registered/unit/function_call/test_minimax_m3_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m3_detector.py
@@ -104,6 +104,42 @@ def _make_tools():
                 },
             ),
         ),
+        Tool(
+            type="function",
+            function=Function(
+                name="one_of_top_level",
+                description="Exercise a top-level oneOf parameters schema",
+                parameters={
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"number": {"type": "number"}},
+                            "required": ["number"],
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "stringList": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                }
+                            },
+                            "required": ["stringList"],
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "numberList": {
+                                    "type": "array",
+                                    "items": {"type": "number"},
+                                }
+                            },
+                            "required": ["numberList"],
+                        },
+                    ]
+                },
+            ),
+        ),
     ]
 
 
@@ -466,6 +502,43 @@ class TestMinimaxM3Streaming(CustomTestCase):
                 non_stream, _ = _parse_segments(segments, self.tools)
                 stream = _stream_segments(segments, self.tools)
                 self.assertEqual(non_stream, stream)
+
+    def test_top_level_one_of_parameter_schema(self):
+        segments = (
+            "<tool_call>",
+            '<invoke name="one_of_top_level">',
+            "<number>42",
+            "</number>",
+            "</invoke>",
+            '<invoke name="one_of_top_level">',
+            "<stringList>",
+            "<item>12",
+            "</item>",
+            "<item>34",
+            "</item>",
+            "</stringList>",
+            "</invoke>",
+            '<invoke name="one_of_top_level">',
+            "<numberList>",
+            "<item>12",
+            "</item>",
+            "<item>34",
+            "</item>",
+            "</numberList>",
+            "</invoke>",
+            "</tool_call>",
+        )
+        self.assertEqual(
+            _stream_segments(segments, self.tools),
+            [
+                {"name": "one_of_top_level", "args": {"number": 42}},
+                {
+                    "name": "one_of_top_level",
+                    "args": {"stringList": ["12", "34"]},
+                },
+                {"name": "one_of_top_level", "args": {"numberList": [12, 34]}},
+            ],
+        )
 
     def test_streaming_sequential_tool_index(self):
         segments = (


### PR DESCRIPTION
## Motivation

Fixes #32286.

The MiniMax-M3 tool-call parser only looked for parameter schemas in direct
`properties`. When a tool used a top-level `oneOf`, the parser could not find
the selected property's schema, so numbers were emitted as strings and arrays
leaked raw MiniMax parser tags.

## Modifications

- Resolve child parameter schemas recursively from top-level `oneOf` branches.
- Add a streaming CPU regression test covering number, string-array, and
  number-array branches from the reported failure.

## Accuracy Tests

Not applicable. This changes deterministic tool-call argument parsing and does
not modify model inference or generated token output. The parser output is
covered by the regression unit test below.

## Speed Tests and Profiling

Not applicable. The change adds a bounded schema lookup when a direct property
is not found and does not affect model execution.

## Validation

- MiniMax-M3 detector unit tests: 24 passed.
- `python3 -m py_compile` on the changed source and test.
- Black 26.1.0, Ruff 0.15.1, and isort 7.0.0 checks.
- `git diff --check`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: no API or user-facing behavior documentation changed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A: parser-only bug fix.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30080151515](https://github.com/sgl-project/sglang/actions/runs/30080151515)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30080151468](https://github.com/sgl-project/sglang/actions/runs/30080151468)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->