### PR TITLE
fix: honor MiniMax thinking controls

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -717,6 +717,10 @@ ReasoningEffortType = Optional[
 ]
 
 
+class ChatCompletionThinkingParam(BaseModel):
+    type: Literal["disabled", "adaptive"]
+
+
 class ChatCompletionRequest(BaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
@@ -773,6 +777,11 @@ class ChatCompletionRequest(BaseModel):
         "'max' is an sglang extension to the OpenAI schema for "
         "models that expose a maximum-effort tier above 'high'; models that don't "
         "support it treat it the same as 'high'.",
+    )
+    thinking: Optional[ChatCompletionThinkingParam] = Field(
+        default=None,
+        description="MiniMax reasoning control. 'disabled' disables reasoning and "
+        "'adaptive' enables it.",
     )
     task: Optional[
         Literal["action", "query", "authority", "domain", "title", "read_url"]
@@ -877,6 +886,19 @@ class ChatCompletionRequest(BaseModel):
     def normalize_reasoning_inputs(cls, values: Dict):
         r = values.get("reasoning")
         thinking = None
+
+        minimax_thinking = values.get("thinking")
+        if isinstance(minimax_thinking, dict):
+            thinking_type = minimax_thinking.get("type")
+            if thinking_type in {"disabled", "adaptive"}:
+                ctk = values.get("chat_template_kwargs")
+                if not isinstance(ctk, dict):
+                    ctk = {}
+                ctk.setdefault(
+                    "thinking_mode",
+                    "disabled" if thinking_type == "disabled" else "enabled",
+                )
+                values["chat_template_kwargs"] = ctk
 
         if r is not None and isinstance(r, dict):
             effort = r.get("effort")

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -259,6 +259,42 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.chat_template_kwargs.get("thinking"))
         self.assertFalse(request.chat_template_kwargs.get("enable_thinking"))
 
+    def test_chat_completion_minimax_thinking_disabled(self):
+        request = ChatCompletionRequest(
+            model="MiniMaxAI/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hello"}],
+            thinking={"type": "disabled"},
+        )
+        self.assertEqual(request.thinking.type, "disabled")
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking_mode": "disabled"},
+        )
+
+    def test_chat_completion_minimax_thinking_adaptive(self):
+        request = ChatCompletionRequest(
+            model="MiniMaxAI/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hello"}],
+            thinking={"type": "adaptive"},
+        )
+        self.assertEqual(request.thinking.type, "adaptive")
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking_mode": "enabled"},
+        )
+
+    def test_chat_completion_minimax_thinking_keeps_explicit_template_mode(self):
+        request = ChatCompletionRequest(
+            model="MiniMaxAI/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hello"}],
+            thinking={"type": "adaptive"},
+            chat_template_kwargs={"thinking_mode": "disabled"},
+        )
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking_mode": "disabled"},
+        )
+
     def test_chat_completion_extended_reasoning_effort_levels(self):
         """Extended effort levels work in both supported request forms."""
         from pydantic import ValidationError


### PR DESCRIPTION
## Motivation

MiniMax-M3 exposes reasoning control through the OpenAI-compatible
`thinking: {"type": "disabled" | "adaptive"}` request field. SGLang did not
declare that field on `ChatCompletionRequest`, so Pydantic silently discarded
it and the model continued reasoning even when callers requested `disabled`.

Fixes #32276.

## Modifications

- Add a typed MiniMax thinking parameter to chat completion requests.
- Normalize `disabled` to `chat_template_kwargs.thinking_mode=disabled`.
- Normalize `adaptive` to the template's existing `enabled` mode.
- Preserve an explicitly supplied `thinking_mode` override.
- Add CPU-only protocol regression tests for both modes and precedence.

## Accuracy Tests

Not applicable. This change only maps the official request field to the
existing MiniMax-M3 chat-template control.

## Speed Tests and Profiling

Not applicable. No inference or kernel path changes.

## Validation

- `uvx pre-commit run --files python/sglang/srt/entrypoints/openai/protocol.py test/registered/unit/entrypoints/openai/test_protocol.py`
- `python3 -m compileall -q python/sglang/srt/entrypoints/openai/protocol.py test/registered/unit/entrypoints/openai/test_protocol.py`
- `git diff --check`

The focused pytest module could not be executed in this local environment
because the SGLang runtime dependencies, including PyTorch, are not installed.
The added cases are registered in the existing CPU test suite.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is needed for this compatibility fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable; no inference path changes.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30080557838](https://github.com/sgl-project/sglang/actions/runs/30080557838)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30080557702](https://github.com/sgl-project/sglang/actions/runs/30080557702)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->