### PR TITLE
[Fix] Scope Gemma 4 image masks to sliding attention

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -105,6 +105,9 @@ class ForwardMetadata:
     # PHYSICAL full-attn write target for the unified pool (eager: translated tensor;
     # cuda-graph: capture-stable buffer view). None for non-unified pools.
     out_cache_loc_full_physical: Optional[torch.Tensor] = None
+    # Optional custom-mask override for sliding-attention layers.
+    sliding_custom_mask: torch.Tensor | None = None
+    sliding_mask_indptr: torch.Tensor | None = None
 
 
 class TritonAttnBackend(AttentionBackend):
@@ -1317,6 +1320,8 @@ class TritonAttnBackend(AttentionBackend):
             kv_indices = self.forward_metadata.kv_indices
             window_kv_offsets = None
 
+        custom_mask, mask_indptr = self._get_custom_mask_for_layer(layer)
+
         if layer.k_scale is not None and layer.v_scale is not None:
             k_descale = layer.k_scale_float
             v_descale = layer.v_scale_float
@@ -1372,9 +1377,9 @@ class TritonAttnBackend(AttentionBackend):
             self.forward_metadata.qo_indptr,
             kv_indptr,
             kv_indices,
-            self.forward_metadata.custom_mask,
+            custom_mask,
             causal,
-            self.forward_metadata.mask_indptr,
+            mask_indptr,
             self.forward_metadata.max_extend_len,
             k_descale,
             v_descale,
@@ -1523,6 +1528,22 @@ class TritonAttnBackend(AttentionBackend):
         out = prefix_out * prefix_scale + current_out * current_scale
         return out.reshape(-1, layer.tp_q_head_num * layer.v_head_dim).to(q.dtype)
 
+    def _get_custom_mask_for_layer(
+        self, layer: RadixAttention
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        if (
+            layer.sliding_window_size >= 0
+            and self.forward_metadata.sliding_custom_mask is not None
+        ):
+            return (
+                self.forward_metadata.sliding_custom_mask,
+                self.forward_metadata.sliding_mask_indptr,
+            )
+        return (
+            self.forward_metadata.custom_mask,
+            self.forward_metadata.mask_indptr,
+        )
+
     def _forward_extend_unified(
         self,
         q: torch.Tensor,
@@ -1637,6 +1658,7 @@ class TritonAttnBackend(AttentionBackend):
             v_descale = 1.0
 
         # Call unified kernel
+        custom_mask, mask_indptr = self._get_custom_mask_for_layer(layer)
         self.extend_attention_fwd_unified(
             q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
             o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
@@ -1649,8 +1671,8 @@ class TritonAttnBackend(AttentionBackend):
             unified_kv_indices,
             prefix_lens,
             self.forward_metadata.max_extend_len,
-            custom_mask=self.forward_metadata.custom_mask,
-            mask_indptr=self.forward_metadata.mask_indptr,
+            custom_mask=custom_mask,
+            mask_indptr=mask_indptr,
             sm_scale=layer.scaling,
             logit_cap=logits_soft_cap,
             is_causal=causal,

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -399,10 +399,12 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             )
         if bidirectional_attn_masks_list:
             bidirectional_attn_masks = torch.cat(bidirectional_attn_masks_list, dim=0)
-            get_attn_backend().forward_metadata.mask_indptr = (
+            get_attn_backend().forward_metadata.sliding_mask_indptr = (
                 bidirectional_attn_mask_indptr
             )
-            get_attn_backend().forward_metadata.custom_mask = bidirectional_attn_masks
+            get_attn_backend().forward_metadata.sliding_custom_mask = (
+                bidirectional_attn_masks
+            )
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         vt = self.vision_tower

--- a/test/registered/unit/layers/attention/test_gemma4_attention_mask.py
+++ b/test/registered/unit/layers/attention/test_gemma4_attention_mask.py
@@ -1,0 +1,123 @@
+"""Regression tests for Gemma 4 full/sliding attention mask selection."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
+from sglang.srt.managers.schedule_batch import ForwardMode
+from sglang.srt.models.gemma4_mm import (
+    Gemma4ForConditionalGeneration,
+)
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+class _FakeTritonBackend:
+    def __init__(self):
+        self.forward_metadata = SimpleNamespace(
+            custom_mask=None,
+            mask_indptr=None,
+            sliding_custom_mask=None,
+            sliding_mask_indptr=None,
+        )
+
+
+class _FakeImage:
+    offsets = ((1, 3),)
+
+    @staticmethod
+    def is_image():
+        return True
+
+
+class TestGemma4AttentionMask(CustomTestCase):
+    def test_image_mask_applies_only_to_sliding_attention(self):
+        backend = _FakeTritonBackend()
+        forward_batch = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            batch_size=1,
+            extend_seq_lens=[6],
+            extend_prefix_lens=[0],
+            mm_inputs=[SimpleNamespace(mm_items=[_FakeImage()])],
+        )
+
+        with (
+            patch(
+                "sglang.srt.models.gemma4_mm.TritonAttnBackend",
+                _FakeTritonBackend,
+            ),
+            patch(
+                "sglang.srt.models.gemma4_mm.get_attn_backend",
+                return_value=backend,
+            ),
+        ):
+            Gemma4ForConditionalGeneration.prepare_attn_masks(
+                None,
+                forward_batch,
+                input_ids=torch.arange(6),
+                mask_dtype=torch.bool,
+            )
+
+        full_mask, full_mask_indptr = TritonAttnBackend._get_custom_mask_for_layer(
+            backend,
+            SimpleNamespace(sliding_window_size=-1),
+        )
+        self.assertIsNone(full_mask)
+        self.assertIsNone(full_mask_indptr)
+
+        sliding_window_size = 2
+        sliding_mask, sliding_mask_indptr = (
+            TritonAttnBackend._get_custom_mask_for_layer(
+                backend,
+                SimpleNamespace(sliding_window_size=sliding_window_size),
+            )
+        )
+        self.assertIs(sliding_mask, backend.forward_metadata.sliding_custom_mask)
+        self.assertIs(
+            sliding_mask_indptr,
+            backend.forward_metadata.sliding_mask_indptr,
+        )
+
+        causal_mask = torch.ones(6, 6, dtype=torch.bool).tril()
+        same_image_block = torch.zeros(6, 6, dtype=torch.bool)
+        same_image_block[1:4, 1:4] = True
+        positions = torch.arange(6)
+        sliding_window_mask = positions[:, None] <= (
+            positions[None, :] + sliding_window_size
+        )
+        expected_sliding_mask = (causal_mask | same_image_block) & sliding_window_mask
+        actual_sliding_mask = sliding_mask.view(6, 6) & sliding_window_mask
+        torch.testing.assert_close(actual_sliding_mask, expected_sliding_mask)
+
+    def test_sliding_attention_falls_back_to_generic_custom_mask(self):
+        generic_mask = torch.tensor([True, False])
+        generic_mask_indptr = torch.tensor([0, 2], dtype=torch.int64)
+        backend = SimpleNamespace(
+            forward_metadata=SimpleNamespace(
+                custom_mask=generic_mask,
+                mask_indptr=generic_mask_indptr,
+                sliding_custom_mask=None,
+                sliding_mask_indptr=None,
+            )
+        )
+
+        selected_mask, selected_mask_indptr = (
+            TritonAttnBackend._get_custom_mask_for_layer(
+                backend,
+                SimpleNamespace(sliding_window_size=2),
+            )
+        )
+        self.assertIs(selected_mask, generic_mask)
+        self.assertIs(selected_mask_indptr, generic_mask_indptr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Gemma 4 expects different attention-mask semantics by layer type([code reference](https://github.com/google-deepmind/gemma/blob/bdbfebf29b453dcea5268ddfd7a8b56dc9f7061d/gemma/gm/nn/gemma4/_config.py#L129)):
- Full attention: `causal`
- Sliding attention: `(causal OR same_image_block) AND sliding_window`

SGLang applied the bidirectional same-image mask to both layer types, allowing full-attention image tokens to attend to future tokens.
## Modifications
- Added optional sliding-attention custom-mask metadata to the Triton backend.
- Updated both regular and deterministic Triton extend paths to select masks by layer type.
- Stored Gemma 4 image masks as sliding-attention overrides.
- Added CPU regression tests covering:
  - causal masking for full-attention layers
  - bidirectional same-image masking within sliding attention
  - fallback to generic custom masks
## Accuracy Tests
Added and passed:
```bash
python test/registered/unit/layers/attention/test_gemma4_attention_mask.py
```
Both regression tests pass. Full model accuracy evaluation was not run.
## Speed Tests and Profiling
Not run. This change only selects between existing mask references before kernel dispatch and does not add kernel computation or tensor allocation.
## Checklist
- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Documentation is not required because there is no user-facing API change.
- [ ] Provide full model accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30080928548](https://github.com/sgl-project/sglang/actions/runs/30080928548)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30080928464](https://github.com/sgl-project/sglang/actions/runs/30080928464)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->