### PR TITLE
[docs][router] Kubernetes deployment recipes for sgl-router (plain + PD)

### DIFF
--- a/docs_new/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs_new/docs/advanced_features/pd_disaggregation.mdx
@@ -28,6 +28,8 @@ When you need to profile prefill or decode workers in PD disaggregation mode, pl
 
 For deploying PD disaggregation at scale with load balancing and fault tolerance, SGLang provides a router. The router can distribute requests between prefill and decode instances using various routing policies. For detailed information on setting up routing with PD disaggregation, including configuration options and deployment patterns, see the [SGLang Model Gateway (former Router)](./sgl_model_gateway#prefill-decode-disaggregation).
 
+For a **Kubernetes-native deployment** of `sgl-router` in PD mode — with EndpointSlice service discovery, RBAC, and ready-to-apply manifests — see the [Router Kubernetes Deployment](./router_k8s_deployment) guide.
+
 
 ## Mooncake
 ### Requirements

--- a/docs_new/docs/advanced_features/router_k8s_deployment.mdx
+++ b/docs_new/docs/advanced_features/router_k8s_deployment.mdx
@@ -1,0 +1,208 @@
+---
+title: "Router Kubernetes Deployment"
+metatags:
+    description: "Deploy sgl-router with SGLang engines on Kubernetes — plain mode and prefill/decode disaggregation. Reference manifests, RBAC, service discovery, and PD bootstrap-room wiring."
+---
+
+Deployment recipes for running [sgl-router](https://github.com/sgl-project/sglang/tree/main/experimental/sgl-router) with SGLang engines on Kubernetes, for both plain routing and prefill/decode (PD) disaggregation. Reference manifests live in [`experimental/sgl-router/deploy/k8s/`](https://github.com/sgl-project/sglang/tree/main/experimental/sgl-router/deploy/k8s).
+
+Related pages:
+
+- [SGLang Model Gateway](./sgl_model_gateway) — the Python multi-model gateway (SMG). This page is about the single-model Rust `sgl-router` under `experimental/`.
+- [PD Disaggregation](./pd_disaggregation) — engine-side design and transfer-engine (Mooncake / NIXL) setup.
+
+## Overview
+
+The router runs as a single Deployment in front of SGLang worker pods. It watches Kubernetes `EndpointSlice` resources for its worker pool and dispatches requests via a configurable policy (`cache_aware_zmq`, `power_of_two`, `sticky`, `round_robin`, `random`, `load_based`).
+
+Two shapes:
+
+- **Plain mode** — one pool of workers. Router picks one worker per request. Simplest and covers most single-model deployments.
+- **PD mode** — two pools (prefill and decode) with distinct pod labels. Router picks a prefill worker, resolves a decode peer (same-host preferred), injects `bootstrap_{host,port,room}` into the request body, and fans the same body to both. The decode response is what the client sees.
+
+```
+┌────────┐
+│ Client │──── POST /v1/chat/completions ─────┐
+└────────┘                                    ▼
+                                       ┌────────────┐
+                                       │ sgl-router │──watch EndpointSlices──┐
+                                       └────────────┘                        │
+                                          │                                  ▼
+                                          │              ┌──────────────────────────┐
+        Plain:  pick a worker, forward    │              │ EndpointSlice / K8s API  │
+        PD:     dual-send to prefill+decode              └──────────────────────────┘
+                                          │
+                                          ├───► worker (plain)      OR
+                                          │
+                                          ├───► prefill worker  ────┐  (bootstrap_room shared
+                                          │                         ▼   in request body;
+                                          └───► decode worker  ◄── KV via NIXL/Mooncake)
+                                                                    ▲
+                                                                    └── prefill.bootstrap_host:port
+```
+
+## Prerequisites
+
+- Kubernetes ≥ v1.28 (EndpointSlice API stable)
+- A GPU operator that produces node labels the manifests target — the reference manifests use `nvidia.com/gpu.present=true` (NVIDIA GPU Operator). For AMD, swap the nodeSelector to `feature.node.kubernetes.io/amd-gpu=true` and use a ROCm SGLang image.
+- Cluster egress to HuggingFace Hub (or a pre-populated model cache PVC)
+- For PD mode: pod-to-pod networking allowing the decode worker to reach the prefill's `--disaggregation-bootstrap-port` (default `8998`). No cross-node restrictions in the reference manifests; add a NetworkPolicy for prod.
+
+## Plain-mode deployment
+
+Reference manifests: [`deploy/k8s/plain/`](https://github.com/sgl-project/sglang/tree/main/experimental/sgl-router/deploy/k8s/plain).
+
+Apply:
+
+```bash
+kubectl apply -k experimental/sgl-router/deploy/k8s/plain
+```
+
+What gets created (namespace `sglang`):
+
+| Resource | Purpose |
+| --- | --- |
+| `Deployment/sglang-engine` | 2 SGLang worker pods (Qwen3-32B, TP=2). Pod label `app: engines-qwen3` is what the router matches. |
+| `Service/sglang-engine` (headless) | Emits EndpointSlices per pod. Headless (`clusterIP: None`) makes per-pod dispatch the obvious intent. |
+| `Deployment/sgl-router` | 1 router pod, image `lmsysorg/sglang-router`, `--service-discovery` enabled. |
+| `Service/sgl-router` | Client entrypoint, port `30000`. Change type to `LoadBalancer` for a cloud external IP. |
+| `ServiceAccount` + `Role` + `RoleBinding` | `get,list,watch` on `endpointslices.discovery.k8s.io` — the minimum the router needs. |
+
+### Router flags used
+
+```
+--host=0.0.0.0
+--port=30000
+--model-id=Qwen/Qwen3-32B
+--policy=cache_aware_zmq          # or power_of_two, sticky, round_robin, random, load_based
+--service-discovery
+--service-discovery-namespace=sglang
+--selector app=engines-qwen3      # matches the engine Deployment's pod label
+--cb-threshold=5                  # circuit breaker opens after 5 consecutive failures
+--cb-cool-down-secs=30
+--request-timeout-secs=600        # per-request upstream budget
+--stale-request-timeout-secs=1800 # janitor reaps orphaned load entries
+--log-format=json                 # aggregator-friendly
+```
+
+`--tokenizer-path` is omitted, so the router downloads the tokenizer for `--model-id` from HuggingFace at startup (honors `HF_TOKEN`).
+
+### Verify
+
+```bash
+# Router is ready
+kubectl -n sglang wait --for=condition=Ready pod -l app.kubernetes.io/name=sgl-router --timeout=180s
+
+# Engines are ready (long delay for model download + CUDA graph capture)
+kubectl -n sglang wait --for=condition=Ready pod -l app=engines-qwen3 --timeout=1800s
+
+# Router sees both engines as EndpointSlice members
+kubectl -n sglang get endpointslices -l app=engines-qwen3
+
+# Try a request
+kubectl -n sglang port-forward svc/sgl-router 8080:30000 &
+curl -s http://localhost:8080/v1/models | jq
+curl -s http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-32B","messages":[{"role":"user","content":"hi"}]}' | jq
+```
+
+## PD-mode deployment
+
+Reference manifests: [`deploy/k8s/pd/`](https://github.com/sgl-project/sglang/tree/main/experimental/sgl-router/deploy/k8s/pd).
+
+Apply:
+
+```bash
+kubectl apply -k experimental/sgl-router/deploy/k8s/pd
+```
+
+What changes vs plain mode:
+
+1. **Two worker Deployments**, labeled `role: prefill` and `role: decode`. The `app: engines-deepseek-v3` label is shared; `role` is the discriminator.
+2. **Two headless Services**, one per role. The prefill Service exposes the bootstrap port (`8998`) in addition to HTTP.
+3. **Prefill engine args** include `--disaggregation-mode=prefill` and `--disaggregation-bootstrap-port=8998`; decode args include `--disaggregation-mode=decode`. Both use `--disaggregation-transfer-backend=mooncake` (swap for `nixl` per your cluster's transport).
+4. **Router args** replace `--selector` with `--prefill-selector` and `--decode-selector`:
+
+    ```
+    --prefill-selector app=engines-deepseek-v3,role=prefill
+    --decode-selector  app=engines-deepseek-v3,role=decode
+    ```
+
+### How a PD request flows
+
+1. Client sends `POST /v1/chat/completions` to the router.
+2. Router parses the model, picks a **prefill worker** from the prefill pool via `--policy` (e.g. `cache_aware_zmq`).
+3. Router picks a **decode peer** via host-affinity (same-node preferred, else min-load).
+4. Router generates a 63-bit `bootstrap_room` ID and injects three top-level fields into the request body:
+    ```json
+    {
+      "bootstrap_host": "<prefill-pod-ip>",
+      "bootstrap_port": 8998,
+      "bootstrap_room": <u64>,
+      ...original body
+    }
+    ```
+5. Router **spawns** the prefill request (detached — outlives the client HTTP connection to avoid cancel-race with NIXL RPC teardown) and **awaits** the decode request. Decode's response is what the client sees.
+6. Engine side: the decode worker's admission path reads the bootstrap fields, opens a NIXL/Mooncake connection to `bootstrap_host:bootstrap_port`, and pulls the KV cache keyed by `bootstrap_room`. Prefill's bootstrap server matches the room and streams KV back.
+
+If prefill fails: decode times out on `bootstrap_room` after ~30–60 s (engine-side default). The router does not fail fast; this matches the shipping shape of peer HTTP-PD routers (llm-d, aibrix). See [PD Disaggregation](./pd_disaggregation) for the engine-side setup.
+
+### Router timing knobs for PD
+
+PD KV transfers on large models take tens of seconds. The reference manifest bumps the router's per-request budget:
+
+```
+--request-timeout-secs=1200          # 20 min per upstream request
+--stale-request-timeout-secs=3600    # 1 h before janitor reaps in-flight entries
+```
+
+Adjust based on model size × concurrency.
+
+## Policy selection
+
+The router's `--policy` picks one of six worker-selection strategies:
+
+| Policy | Best for | Notes |
+| --- | --- | --- |
+| `cache_aware_zmq` | Any multi-request workload with prefix reuse | Router builds a distributed block-hash prefix trie from KV-events published by workers; picks the worker with the longest matching prefix. Falls back to load-based when match rate is low. Default for the reference manifests. |
+| `power_of_two` | Randomized load balancing with theoretical guarantees | Samples two random workers, picks less-loaded. O(log log n) max load (Mitzenmacher 2001). |
+| `sticky` | Session-scoped conversations (chat multi-turn) | Rendezvous hashing (HRW) on a client-provided `x-sgl-routing-key` header. Zero rebuild cost on worker membership change. |
+| `round_robin` | Uniform workloads, no prefix reuse | Atomic counter dispatch. |
+| `random` | Baseline | Uniform random. |
+| `load_based` | When workers publish load via KV-events / heartbeat | Router picks min-load using worker-reported metrics rather than router-tracked in-flight counts. |
+
+## Observability
+
+- **Prometheus**: router exposes `/metrics` on the HTTP port. Scrape via a ServiceMonitor (not included in the reference manifests to keep them CRD-independent — add one if you run kube-prometheus).
+- **Structured logs**: `--log-format=json` produces one JSON record per line for aggregators (Loki, Grafana Alloy, Fluent Bit).
+- **Log level**: `--log-level=info` default; override with `RUST_LOG=debug` env var for verbose traces.
+- **Health endpoints**: `/healthz` (liveness) and `/readyz` (readiness). Router reports `ready` once at least one healthy worker is registered.
+
+## Autoscaling notes
+
+The router itself is nearly stateless (in-memory sticky map + prefix trie, both reproducible from EndpointSlice state) — you can scale router replicas horizontally. Multiple router replicas will independently rebuild their in-memory state from the EndpointSlice watch; for sticky-session routing across multiple routers, use `sticky_fallback_policy=power_of_two` so the two routers converge on similar assignments even without shared state.
+
+Engine autoscaling should use a custom metric (e.g. `sgl_router_active_requests` divided by replica count, or `token_usage` from engine metrics), not the default CPU-based HPA — GPU inference load isn't reflected in CPU usage.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Router logs `no healthy workers for model X` | RBAC missing, wrong selector, or engines not ready | `kubectl auth can-i list endpointslices --as=system:serviceaccount:sglang:sgl-router`; verify `--selector` matches pod labels |
+| Client 504 `stale_request_expired` | `--stale-request-timeout-secs` too short for the workload | Bump the flag; check for engine pod OOM |
+| PD requests hang, no decode reply | Prefill can't reach decode's NIXL socket, or decode can't reach prefill's `bootstrap_port` | Check NetworkPolicies; verify `bootstrap_port` matches on router + prefill args |
+| Engine pod stuck `NotReady` for >20 min | Model download or CUDA graph capture still running | Extend `readinessProbe.initialDelaySeconds`; check `kubectl logs` for progress |
+
+## Downstream distributions
+
+Platforms that package SGLang as an opt-in application:
+
+- **clusterdOS** — see the [SGLang gitapp](https://gitlab.com/aranya-tech/public/clusterdos) (proposed) — same manifest shape, wrapped as a Helm chart consumable via ArgoCD.
+
+## Reference
+
+- Router source: [`experimental/sgl-router/src/`](https://github.com/sgl-project/sglang/tree/main/experimental/sgl-router/src)
+- K8s discovery backend: [`experimental/sgl-router/src/discovery/k8s.rs`](https://github.com/sgl-project/sglang/tree/main/experimental/sgl-router/src/discovery/k8s.rs)
+- PD dispatch handler: [`experimental/sgl-router/src/server/routes/chat.rs`](https://github.com/sgl-project/sglang/tree/main/experimental/sgl-router/src/server/routes/chat.rs)
+- CLI reference: run `sgl-router --help`

--- a/experimental/sgl-router/README.md
+++ b/experimental/sgl-router/README.md
@@ -50,6 +50,17 @@ Omit `--service-discovery-namespace` to watch all namespaces (requires
 cluster-wide RBAC). For prefill/decode disaggregation, replace `--selector`
 with `--prefill-selector` and `--decode-selector`.
 
+## Kubernetes deployment
+
+Ready-to-apply manifest sets for both routing shapes live under
+[`deploy/k8s/`](./deploy/k8s/):
+
+- `deploy/k8s/plain/` — one-pool routing (reference: Qwen3-32B, TP=2)
+- `deploy/k8s/pd/`    — prefill/decode disaggregation (reference: DeepSeek-V3, TP=8)
+
+Full walkthrough with prerequisites, RBAC, policies, and troubleshooting:
+[Router Kubernetes Deployment](../../docs_new/docs/advanced_features/router_k8s_deployment.mdx).
+
 ## License
 
 Apache-2.0.

--- a/experimental/sgl-router/deploy/k8s/README.md
+++ b/experimental/sgl-router/deploy/k8s/README.md
@@ -1,0 +1,31 @@
+# Kubernetes deployment recipes for sgl-router
+
+Working manifest sets for two deployment shapes:
+
+- [`plain/`](./plain/) — plain-mode routing: one pool of SGLang workers,
+  router does prefix-cache-aware / power-of-two / sticky dispatch.
+  Reference model: Qwen3-32B, TP=2, 2 replicas.
+- [`pd/`](./pd/) — prefill/decode disaggregation: two pools (prefill +
+  decode), router dual-sends the request body with an injected
+  `bootstrap_room`, decode's response is client-visible.
+  Reference model: DeepSeek-V3-Instruct, TP=8, 1 prefill + 1 decode.
+
+Both variants use `sgl-router --service-discovery` against the Kubernetes
+EndpointSlice API — no static worker URL list, no manual reconciliation.
+
+Apply with:
+
+```bash
+kubectl apply -k experimental/sgl-router/deploy/k8s/plain
+# or
+kubectl apply -k experimental/sgl-router/deploy/k8s/pd
+```
+
+For the full walkthrough with prerequisites, tuning, observability, and
+troubleshooting, see the
+[Router Kubernetes deployment guide](../../../../docs_new/docs/advanced_features/router_k8s_deployment.mdx).
+
+These manifests are documented recipes, not chart artifacts. For a
+Helm-based deployment integrated into a larger platform, adapt them into
+your own chart — or see downstream distributions such as clusterdOS which
+package this shape as an opt-in `gitapp`.

--- a/experimental/sgl-router/deploy/k8s/pd/decode-deployment.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/decode-deployment.yaml
@@ -1,0 +1,75 @@
+# Decode-role SGLang workers.
+#
+# Matches the router's `--decode-selector role=decode`. Decode workers
+# open NIXL / Mooncake connections OUTBOUND to the prefill worker's
+# bootstrap port to fetch KV, so they need no exposed bootstrap port
+# themselves.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-decode
+  namespace: sglang-pd
+  labels:
+    app.kubernetes.io/name: sglang-decode
+    app: engines-deepseek-v3
+    role: decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: engines-deepseek-v3
+      role: decode
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sglang-decode
+        app: engines-deepseek-v3
+        role: decode
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: engine
+          image: lmsysorg/sglang:latest
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-m", "sglang.launch_server"]
+          args:
+            - --model-path=deepseek-ai/DeepSeek-V3-Instruct
+            - --host=0.0.0.0
+            - --port=30000
+            - --tp-size=8
+            - --trust-remote-code
+            - --disaggregation-mode=decode
+            - --disaggregation-transfer-backend=mooncake
+          ports:
+            - name: http
+              containerPort: 30000
+          env:
+            - name: HF_HOME
+              value: /root/.cache/huggingface
+          resources:
+            limits:
+              nvidia.com/gpu: 8
+              memory: 1536Gi
+              cpu: "64"
+            requests:
+              nvidia.com/gpu: 8
+              memory: 1024Gi
+              cpu: "32"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 600
+            periodSeconds: 15
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /root/.cache/huggingface
+      volumes:
+        - name: hf-cache
+          emptyDir:
+            sizeLimit: 1500Gi

--- a/experimental/sgl-router/deploy/k8s/pd/kustomization.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - router-rbac.yaml
+  - prefill-deployment.yaml
+  - decode-deployment.yaml
+  - services.yaml
+  - router-deployment.yaml
+  - router-service.yaml

--- a/experimental/sgl-router/deploy/k8s/pd/namespace.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sglang-pd
+  labels:
+    app.kubernetes.io/part-of: sglang-inference

--- a/experimental/sgl-router/deploy/k8s/pd/prefill-deployment.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/prefill-deployment.yaml
@@ -1,0 +1,88 @@
+# Prefill-role SGLang workers.
+#
+# The `role: prefill` pod label is matched by the router's
+# `--prefill-selector role=prefill` flag; `app: engines-deepseek-v3`
+# is the shared model tag matched at the Service/EndpointSlice level.
+#
+# `--disaggregation-mode prefill` puts the engine into prefill role and
+# activates its bootstrap server on `--disaggregation-bootstrap-port`.
+# The decode worker connects to that port (host from the router's
+# injected `bootstrap_host`) to pull the KV cache via NIXL/Mooncake.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-prefill
+  namespace: sglang-pd
+  labels:
+    app.kubernetes.io/name: sglang-prefill
+    app: engines-deepseek-v3
+    role: prefill
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: engines-deepseek-v3
+      role: prefill
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sglang-prefill
+        app: engines-deepseek-v3
+        role: prefill
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: engine
+          image: lmsysorg/sglang:latest
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-m", "sglang.launch_server"]
+          args:
+            - --model-path=deepseek-ai/DeepSeek-V3-Instruct
+            - --host=0.0.0.0
+            - --port=30000
+            - --tp-size=8
+            - --trust-remote-code
+            - --disaggregation-mode=prefill
+            - --disaggregation-bootstrap-port=8998
+            - --disaggregation-transfer-backend=mooncake
+          ports:
+            - name: http
+              containerPort: 30000
+            - name: bootstrap
+              containerPort: 8998
+          env:
+            - name: HF_HOME
+              value: /root/.cache/huggingface
+          resources:
+            limits:
+              nvidia.com/gpu: 8
+              memory: 1536Gi
+              cpu: "64"
+            requests:
+              nvidia.com/gpu: 8
+              memory: 1024Gi
+              cpu: "32"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 600
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 900
+            periodSeconds: 60
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /root/.cache/huggingface
+      volumes:
+        - name: hf-cache
+          emptyDir:
+            sizeLimit: 1500Gi

--- a/experimental/sgl-router/deploy/k8s/pd/router-deployment.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/router-deployment.yaml
@@ -1,0 +1,73 @@
+# sgl-router in PD mode.
+#
+# `--prefill-selector` and `--decode-selector` are BOTH required for PD
+# routing; each takes label-selector terms that partition the workers
+# into two pools. The router's PdPoolResolver picks a prefill worker
+# via the configured `--policy`, then picks a decode peer via
+# host-affinity fallback logic (same-host preferred, min-load otherwise).
+#
+# The plain `--selector` flag MUST be omitted in PD mode — it's mutually
+# exclusive with the prefill/decode pair.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sgl-router
+  namespace: sglang-pd
+  labels:
+    app.kubernetes.io/name: sgl-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sgl-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sgl-router
+    spec:
+      serviceAccountName: sgl-router
+      containers:
+        - name: router
+          image: lmsysorg/sglang-router:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --host=0.0.0.0
+            - --port=30000
+            - --model-id=deepseek-ai/DeepSeek-V3-Instruct
+            - --policy=cache_aware_zmq
+            - --service-discovery
+            - --service-discovery-namespace=sglang-pd
+            - --prefill-selector
+            - app=engines-deepseek-v3,role=prefill
+            - --decode-selector
+            - app=engines-deepseek-v3,role=decode
+            - --cb-threshold=5
+            - --cb-cool-down-secs=30
+            # PD KV transfers can take tens of seconds on large models;
+            # give the request budget headroom over the plain-mode default.
+            - --request-timeout-secs=1200
+            - --stale-request-timeout-secs=3600
+            - --log-format=json
+          ports:
+            - name: http
+              containerPort: 30000
+          env:
+            - name: RUST_LOG
+              value: info
+          resources:
+            requests:
+              cpu: "1"
+              memory: 512Mi
+            limits:
+              cpu: "4"
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 30

--- a/experimental/sgl-router/deploy/k8s/pd/router-rbac.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/router-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sgl-router
+  namespace: sglang-pd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sgl-router
+  namespace: sglang-pd
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sgl-router
+  namespace: sglang-pd
+subjects:
+  - kind: ServiceAccount
+    name: sgl-router
+    namespace: sglang-pd
+roleRef:
+  kind: Role
+  name: sgl-router
+  apiGroup: rbac.authorization.k8s.io

--- a/experimental/sgl-router/deploy/k8s/pd/router-service.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/router-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sgl-router
+  namespace: sglang-pd
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sgl-router
+  ports:
+    - name: http
+      port: 30000
+      targetPort: 30000
+      protocol: TCP

--- a/experimental/sgl-router/deploy/k8s/pd/services.yaml
+++ b/experimental/sgl-router/deploy/k8s/pd/services.yaml
@@ -1,0 +1,41 @@
+# Two headless Services — one per role — so the router sees EndpointSlices
+# with the role label attached (prefill vs decode), which its
+# `--prefill-selector` and `--decode-selector` flags match against.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sglang-prefill
+  namespace: sglang-pd
+  labels:
+    app: engines-deepseek-v3
+    role: prefill
+spec:
+  clusterIP: None
+  selector:
+    app: engines-deepseek-v3
+    role: prefill
+  ports:
+    - name: http
+      port: 30000
+      targetPort: 30000
+    - name: bootstrap
+      port: 8998
+      targetPort: 8998
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sglang-decode
+  namespace: sglang-pd
+  labels:
+    app: engines-deepseek-v3
+    role: decode
+spec:
+  clusterIP: None
+  selector:
+    app: engines-deepseek-v3
+    role: decode
+  ports:
+    - name: http
+      port: 30000
+      targetPort: 30000

--- a/experimental/sgl-router/deploy/k8s/plain/engine-deployment.yaml
+++ b/experimental/sgl-router/deploy/k8s/plain/engine-deployment.yaml
@@ -1,0 +1,86 @@
+# SGLang worker Deployment for plain-mode (non-PD) routing.
+#
+# Replicas are the horizontal-scale unit; increase to add capacity behind
+# the router. The pod labels `app: engines-qwen3` are what the router's
+# `--selector app=engines-qwen3` matches; keep them in sync.
+#
+# TP size (--tp-size=2) matches the requested GPU count.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-engine
+  namespace: sglang
+  labels:
+    app.kubernetes.io/name: sglang-engine
+    app: engines-qwen3
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: engines-qwen3
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sglang-engine
+        app: engines-qwen3
+    spec:
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: engine
+          image: lmsysorg/sglang:latest
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-m", "sglang.launch_server"]
+          args:
+            - --model-path=Qwen/Qwen3-32B
+            - --host=0.0.0.0
+            - --port=30000
+            - --tp-size=2
+          ports:
+            - name: http
+              containerPort: 30000
+          env:
+            - name: HF_HOME
+              value: /root/.cache/huggingface
+            # Uncomment for gated models:
+            # - name: HF_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: hf-token
+            #       key: token
+          resources:
+            limits:
+              nvidia.com/gpu: 2
+              memory: 96Gi
+              cpu: "16"
+            requests:
+              nvidia.com/gpu: 2
+              memory: 64Gi
+              cpu: "8"
+          # Long initial delay to cover model download + CUDA graph capture.
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 300
+            periodSeconds: 30
+            timeoutSeconds: 10
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /root/.cache/huggingface
+      volumes:
+        # Prefer a shared PVC across pods in production so weights download once.
+        - name: hf-cache
+          emptyDir:
+            sizeLimit: 200Gi

--- a/experimental/sgl-router/deploy/k8s/plain/engine-service.yaml
+++ b/experimental/sgl-router/deploy/k8s/plain/engine-service.yaml
@@ -1,0 +1,21 @@
+# Headless Service. `clusterIP: None` makes Kubernetes emit an
+# EndpointSlice per matching pod carrying per-pod IPs, which is what
+# `sgl-router --service-discovery` watches. A ClusterIP Service would
+# also produce EndpointSlices, but the headless form makes it obvious
+# that direct per-pod dispatch is the intent.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sglang-engine
+  namespace: sglang
+  labels:
+    app: engines-qwen3
+spec:
+  clusterIP: None
+  selector:
+    app: engines-qwen3
+  ports:
+    - name: http
+      port: 30000
+      targetPort: 30000
+      protocol: TCP

--- a/experimental/sgl-router/deploy/k8s/plain/kustomization.yaml
+++ b/experimental/sgl-router/deploy/k8s/plain/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - router-rbac.yaml
+  - engine-deployment.yaml
+  - engine-service.yaml
+  - router-deployment.yaml
+  - router-service.yaml

--- a/experimental/sgl-router/deploy/k8s/plain/namespace.yaml
+++ b/experimental/sgl-router/deploy/k8s/plain/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sglang
+  labels:
+    app.kubernetes.io/part-of: sglang-inference

--- a/experimental/sgl-router/deploy/k8s/plain/router-deployment.yaml
+++ b/experimental/sgl-router/deploy/k8s/plain/router-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sgl-router
+  namespace: sglang
+  labels:
+    app.kubernetes.io/name: sgl-router
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sgl-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sgl-router
+    spec:
+      serviceAccountName: sgl-router
+      containers:
+        - name: router
+          image: lmsysorg/sglang-router:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --host=0.0.0.0
+            - --port=30000
+            - --model-id=Qwen/Qwen3-32B
+            # `--tokenizer-path` omitted → router downloads it from HuggingFace
+            # for `--model-id`. Set HF_TOKEN below for gated models.
+            - --policy=cache_aware_zmq
+            - --service-discovery
+            - --service-discovery-namespace=sglang
+            - --selector
+            - app=engines-qwen3
+            - --cb-threshold=5
+            - --cb-cool-down-secs=30
+            - --request-timeout-secs=600
+            - --stale-request-timeout-secs=1800
+            - --log-format=json
+          ports:
+            - name: http
+              containerPort: 30000
+          env:
+            # Uncomment for gated tokenizer downloads:
+            # - name: HF_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: hf-token
+            #       key: token
+            - name: RUST_LOG
+              value: info
+          resources:
+            requests:
+              cpu: "500m"
+              memory: 256Mi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 30

--- a/experimental/sgl-router/deploy/k8s/plain/router-rbac.yaml
+++ b/experimental/sgl-router/deploy/k8s/plain/router-rbac.yaml
@@ -1,0 +1,31 @@
+# The router watches EndpointSlices only — not Pods, not Services.
+# Grant the minimum verbs it needs.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sgl-router
+  namespace: sglang
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sgl-router
+  namespace: sglang
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sgl-router
+  namespace: sglang
+subjects:
+  - kind: ServiceAccount
+    name: sgl-router
+    namespace: sglang
+roleRef:
+  kind: Role
+  name: sgl-router
+  apiGroup: rbac.authorization.k8s.io

--- a/experimental/sgl-router/deploy/k8s/plain/router-service.yaml
+++ b/experimental/sgl-router/deploy/k8s/plain/router-service.yaml
@@ -1,0 +1,17 @@
+# Client-facing entrypoint. Change `type: LoadBalancer` for a
+# cloud-provisioned external IP, or add an Ingress in front of the
+# ClusterIP for TLS termination.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sgl-router
+  namespace: sglang
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sgl-router
+  ports:
+    - name: http
+      port: 30000
+      targetPort: 30000
+      protocol: TCP


### PR DESCRIPTION
## Motivation

The router README under \`experimental/sgl-router/\` covers CLI flags but has no end-to-end Kubernetes example, and \`docs_new/docs/advanced_features/pd_disaggregation.mdx\` currently points only at the older SGLang Model Gateway rather than the current experimental Rust router.

This PR fills the gap with a docs page + ready-to-apply manifest sets for both plain routing and prefill/decode disaggregation, so operators (including downstream platforms like clusterdOS) can consume a canonical deployment shape rather than reverse-engineering it from source.

## What's included

**New docs page** (\`docs_new/docs/advanced_features/router_k8s_deployment.mdx\`, 208 lines):

- Plain-mode: single pool + \`--selector\` + cache-aware-zmq policy. Reference model: Qwen3-32B, TP=2.
- PD mode: prefill/decode pools with \`--prefill-selector\`/\`--decode-selector\`, bootstrap-room rendezvous, host-affinity decode picker. Reference model: DeepSeek-V3-Instruct, TP=8.
- Policy comparison table (cache_aware_zmq / power_of_two / sticky / round_robin / random / load_based).
- Autoscaling, observability, troubleshooting.

**Reference manifests** (\`experimental/sgl-router/deploy/k8s/\`, 15 YAML files):

- \`plain/\` — 7-file Kustomize set: namespace, engine Deployment + headless Service, router Deployment + Service + RBAC.
- \`pd/\` — 8-file Kustomize set: namespace, prefill + decode Deployments, headless Services (prefill exposes \`--disaggregation-bootstrap-port\`), PD-configured router, RBAC.

Apply with \`kubectl apply -k experimental/sgl-router/deploy/k8s/plain\` (or \`pd\`).

**Wiring**:

- Router watches \`EndpointSlice\` (not Pods) — RBAC grants only \`get,list,watch\` on \`endpointslices.discovery.k8s.io\`.
- Headless Services (\`clusterIP: None\`) make per-pod EndpointSlice dispatch the obvious intent.
- All CLI flags in the manifests cross-checked against \`experimental/sgl-router/src/config/cli.rs\`.

**Docs cross-linking**:

- \`experimental/sgl-router/README.md\` — new \"Kubernetes deployment\" section links to \`deploy/k8s/\`.
- \`docs_new/docs/advanced_features/pd_disaggregation.mdx\` — Router Integration section now points to both the SMG page (existing) and this new K8s page.

## Test plan

- [x] \`kubectl apply --dry-run=client -k experimental/sgl-router/deploy/k8s/plain\` — all resources parse and validate against schema.
- [x] Same for \`pd/\`.
- [x] YAML syntax check via \`yaml.safe_load_all\` on all 15 manifests.
- [x] Pre-commit hooks pass (codespell, trailing whitespace, EOF, etc.).
- [ ] Live-cluster verification on GPU hardware — pending. The manifests are documented recipes cross-checked against the router CLI + K8s discovery code, not CI-tested; happy to add \`kubectl apply --dry-run=server\` as a CI step if maintainers want.

## Scope notes

- No code changes — docs + YAML only.
- Uses only stable Kubernetes APIs (v1 apps, v1 core, v1 rbac.authorization.k8s.io, v1 discovery.k8s.io). No CRDs, no operator dependencies beyond a GPU device plugin.
- Reference images are \`lmsysorg/sglang:latest\` and \`lmsysorg/sglang-router:latest\`. Operators should pin these to versioned tags in production; docs page notes this.

## Follow-ups (out of scope for this PR)

- Helm chart wrapping these manifests (feedback welcome on whether to ship in-tree or leave for downstream distributions).
- ServiceMonitor / PodMonitor for kube-prometheus users (kept out to keep the manifests CRD-independent).
- NetworkPolicy hardening for PD mode.

## Downstream

The clusterdOS project (\`gitlab.com/aranya-tech/public/clusterdos\`) has an in-progress proposal to package these as an ArgoCD-managed \`gitapp\`. That effort consumes this docs page as the authoritative deployment reference; there's no direct dependency the other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30081177733](https://github.com/sgl-project/sglang/actions/runs/30081177733)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30081177823](https://github.com/sgl-project/sglang/actions/runs/30081177823)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->