### PR TITLE
[Feature] Add `--verify-attention-backend` for speculative target verify

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -29,9 +29,12 @@ class HybridAttnBackend(AttentionBackend):
         self.data_type = model_runner.kv_cache_dtype
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token_pool = model_runner.req_to_token_pool
-        # Only the backends the spec decode loop runs: decode + verify.
+        # The FutureMap seq_lens mirror exists for the spec loop's variable
+        # accept_len, and target_verify is the only forward this backend serves
+        # there (plain decode advances seq_lens by 1 on the host).
         self.needs_cpu_seq_lens = (
-            decode_backend.needs_cpu_seq_lens or self.verify_backend.needs_cpu_seq_lens
+            model_runner.server_args.speculative_algorithm is not None
+            and self.verify_backend.needs_cpu_seq_lens
         )
 
     def _select_backend(self, forward_mode: ForwardMode) -> AttentionBackend:

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -29,10 +29,10 @@ class HybridAttnBackend(AttentionBackend):
         self.data_type = model_runner.kv_cache_dtype
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token_pool = model_runner.req_to_token_pool
-        # The FutureMap seq_lens mirror exists for the spec loop's variable
-        # accept_len, and target_verify is the only forward this backend serves
-        # there (plain decode advances seq_lens by 1 on the host).
-        self.needs_cpu_seq_lens = (
+        # Backends the spec decode loop can route to: verify (target_verify) and
+        # decode (idle batches keep ForwardMode.IDLE). A prefill backend serves
+        # neither, so a host-plan prefill backend must not force the D2H.
+        self.needs_cpu_seq_lens = decode_backend.needs_cpu_seq_lens or (
             model_runner.server_args.speculative_algorithm is not None
             and self.verify_backend.needs_cpu_seq_lens
         )

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -27,14 +27,9 @@ class HybridAttnBackend(AttentionBackend):
         server_args = model_runner.server_args
         self.spec_attn_is_decode = server_args.speculative_attention_mode == "decode"
         self.spec_attn_is_prefill = server_args.speculative_attention_mode == "prefill"
-        # Backend that serves target_verify. --verify-attention-backend names it
-        # directly (must match one of the two composed slots); when unset it
-        # follows the deprecated --speculative-attention-mode routing.
         self.verify_backend = self._resolve_verify_backend(server_args)
-        # decide_needs_cpu_seq_lens ORs this flag across the backends the spec
-        # decode loop actually touches: the decode backend (decode steps) and the
-        # verify backend (target_verify steps). A cpu-seq-lens prefill backend
-        # that never serves the loop must not force a per-step seq_lens D2H sync.
+        # Only the backends the spec decode loop runs: decode + verify, not a
+        # prefill backend that never serves it (would force a per-step D2H sync).
         self.needs_cpu_seq_lens = (
             decode_backend.needs_cpu_seq_lens or self.verify_backend.needs_cpu_seq_lens
         )

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -17,56 +17,31 @@ class HybridAttnBackend(AttentionBackend):
         model_runner: ModelRunner,
         prefill_backend: AttentionBackend,
         decode_backend: AttentionBackend,
+        verify_backend: Optional[AttentionBackend] = None,
     ):
         self.model_runner = model_runner
         self.prefill_backend = prefill_backend
         self.decode_backend = decode_backend
+        # Independent target_verify backend; falls back to the decode backend.
+        self.verify_backend = (
+            verify_backend if verify_backend is not None else decode_backend
+        )
         self.data_type = model_runner.kv_cache_dtype
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token_pool = model_runner.req_to_token_pool
-        server_args = model_runner.server_args
-        self.spec_attn_is_decode = server_args.speculative_attention_mode == "decode"
-        self.spec_attn_is_prefill = server_args.speculative_attention_mode == "prefill"
-        self.verify_backend = self._resolve_verify_backend(server_args)
-        # Only the backends the spec decode loop runs: decode + verify, not a
-        # prefill backend that never serves it (would force a per-step D2H sync).
+        # Only the backends the spec decode loop runs: decode + verify.
         self.needs_cpu_seq_lens = (
             decode_backend.needs_cpu_seq_lens or self.verify_backend.needs_cpu_seq_lens
-        )
-
-    def _resolve_verify_backend(self, server_args) -> AttentionBackend:
-        verify_str = server_args.verify_attention_backend
-        if verify_str is None:
-            return (
-                self.decode_backend
-                if self.spec_attn_is_decode
-                else self.prefill_backend
-            )
-        prefill_str, decode_str = server_args.get_attention_backends()
-        if verify_str == decode_str:
-            return self.decode_backend
-        if verify_str == prefill_str:
-            return self.prefill_backend
-        raise ValueError(
-            f"--verify-attention-backend={verify_str!r} must match the decode "
-            f"({decode_str!r}) or prefill ({prefill_str!r}) attention backend"
         )
 
     def _select_backend(self, forward_mode: ForwardMode) -> AttentionBackend:
         """
         Select the appropriate attention backend based on the forward mode.
 
-        Args:
-            forward_mode: The current forward mode indicating the operation type
-
-        Returns:
-            The selected attention backend (prefill or decode)
-
         Note:
-            - decode_or_idle: Always uses decode backend
-            - target_verify: Uses the verify backend (--verify-attention-backend,
-              or the --speculative-attention-mode routing when unset)
-            - prefill: Always uses prefill backend
+            - decode_or_idle: decode backend
+            - target_verify: verify backend
+            - prefill/extend: prefill backend
         """
         if forward_mode.is_decode_or_idle():
             return self.decode_backend
@@ -95,11 +70,10 @@ class HybridAttnBackend(AttentionBackend):
         self.decode_backend.init_cuda_graph_state(max_bs, max_num_tokens)
         if (
             self.model_runner.server_args.speculative_algorithm is not None
-            and self.spec_attn_is_prefill
+            and self.verify_backend is not self.decode_backend
         ):
-            # When speculative decoding is enabled, we need to initialize the backend
-            # that will be used for target_verify.
-            self.prefill_backend.init_cuda_graph_state(max_bs, max_num_tokens)
+            # target_verify runs on a distinct backend; capture its graph too.
+            self.verify_backend.init_cuda_graph_state(max_bs, max_num_tokens)
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self.decode_backend.get_cuda_graph_seq_len_fill_value()
@@ -168,11 +142,7 @@ class HybridAttnBackend(AttentionBackend):
         return backend.get_indexer_metadata(layer_id, forward_batch)
 
     def update_mamba_state_after_mtp_verify(self, *args, **kwargs):
-        if self.spec_attn_is_decode:
-            backend = self.decode_backend
-        else:
-            backend = self.prefill_backend
-        return backend.update_mamba_state_after_mtp_verify(*args, **kwargs)
+        return self.verify_backend.update_mamba_state_after_mtp_verify(*args, **kwargs)
 
     def forward(
         self,

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -24,20 +24,37 @@ class HybridAttnBackend(AttentionBackend):
         self.data_type = model_runner.kv_cache_dtype
         self.token_to_kv_pool = model_runner.token_to_kv_pool
         self.req_to_token_pool = model_runner.req_to_token_pool
-        self.spec_attn_is_decode = (
-            model_runner.server_args.speculative_attention_mode == "decode"
-        )
-        self.spec_attn_is_prefill = (
-            model_runner.server_args.speculative_attention_mode == "prefill"
-        )
+        server_args = model_runner.server_args
+        self.spec_attn_is_decode = server_args.speculative_attention_mode == "decode"
+        self.spec_attn_is_prefill = server_args.speculative_attention_mode == "prefill"
+        # Backend that serves target_verify. --verify-attention-backend names it
+        # directly (must match one of the two composed slots); when unset it
+        # follows the deprecated --speculative-attention-mode routing.
+        self.verify_backend = self._resolve_verify_backend(server_args)
         # decide_needs_cpu_seq_lens ORs this flag across the backends the spec
-        # decode loop actually touches. The decode backend always runs (decode,
-        # and target_verify when speculative_attention_mode=decode); the prefill
-        # backend serves the loop only when mode=prefill routes target_verify to
-        # it. Counting a cpu-seq-lens prefill backend on decode-mode steps it
-        # never serves forces a needless per-step seq_lens D2H + host sync.
-        self.needs_cpu_seq_lens = decode_backend.needs_cpu_seq_lens or (
-            self.spec_attn_is_prefill and prefill_backend.needs_cpu_seq_lens
+        # decode loop actually touches: the decode backend (decode steps) and the
+        # verify backend (target_verify steps). A cpu-seq-lens prefill backend
+        # that never serves the loop must not force a per-step seq_lens D2H sync.
+        self.needs_cpu_seq_lens = (
+            decode_backend.needs_cpu_seq_lens or self.verify_backend.needs_cpu_seq_lens
+        )
+
+    def _resolve_verify_backend(self, server_args) -> AttentionBackend:
+        verify_str = server_args.verify_attention_backend
+        if verify_str is None:
+            return (
+                self.decode_backend
+                if self.spec_attn_is_decode
+                else self.prefill_backend
+            )
+        prefill_str, decode_str = server_args.get_attention_backends()
+        if verify_str == decode_str:
+            return self.decode_backend
+        if verify_str == prefill_str:
+            return self.prefill_backend
+        raise ValueError(
+            f"--verify-attention-backend={verify_str!r} must match the decode "
+            f"({decode_str!r}) or prefill ({prefill_str!r}) attention backend"
         )
 
     def _select_backend(self, forward_mode: ForwardMode) -> AttentionBackend:
@@ -52,17 +69,14 @@ class HybridAttnBackend(AttentionBackend):
 
         Note:
             - decode_or_idle: Always uses decode backend
-            - target_verify: Uses decode backend if speculative_attention_mode is "decode", otherwise prefill backend
+            - target_verify: Uses the verify backend (--verify-attention-backend,
+              or the --speculative-attention-mode routing when unset)
             - prefill: Always uses prefill backend
         """
         if forward_mode.is_decode_or_idle():
             return self.decode_backend
         elif forward_mode.is_target_verify():
-            return (
-                self.decode_backend
-                if self.spec_attn_is_decode
-                else self.prefill_backend
-            )
+            return self.verify_backend
         else:
             return self.prefill_backend
 

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -30,11 +30,14 @@ class HybridAttnBackend(AttentionBackend):
         self.spec_attn_is_prefill = (
             model_runner.server_args.speculative_attention_mode == "prefill"
         )
-        # decide_needs_cpu_seq_lens ORs this flag across backends; without the
-        # delegation the base-class default (True) forces a per-step seq_lens
-        # D2H + host sync even when both sub-backends opted out.
-        self.needs_cpu_seq_lens = (
-            prefill_backend.needs_cpu_seq_lens or decode_backend.needs_cpu_seq_lens
+        # decide_needs_cpu_seq_lens ORs this flag across the backends the spec
+        # decode loop actually touches. The decode backend always runs (decode,
+        # and target_verify when speculative_attention_mode=decode); the prefill
+        # backend serves the loop only when mode=prefill routes target_verify to
+        # it. Counting a cpu-seq-lens prefill backend on decode-mode steps it
+        # never serves forces a needless per-step seq_lens D2H + host sync.
+        self.needs_cpu_seq_lens = decode_backend.needs_cpu_seq_lens or (
+            self.spec_attn_is_prefill and prefill_backend.needs_cpu_seq_lens
         )
 
     def _select_backend(self, forward_mode: ForwardMode) -> AttentionBackend:

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -252,9 +252,6 @@ class KDAKernelDispatcher:
 class KDAAttnBackend(MambaAttnBackendBase):
     """Attention backend for KDA (Kimi Delta Attention) linear attention."""
 
-    # Decode/verify metadata is GPU-only (graph replay passes seq_lens_cpu=None).
-    needs_cpu_seq_lens: bool = False
-
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
         # mamba_cache.conv is [..., kernel-1, dim] while conv_states_shape expects the window length (kernel-1) at shape[-1], hence the transpose.

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -252,6 +252,11 @@ class KDAKernelDispatcher:
 class KDAAttnBackend(MambaAttnBackendBase):
     """Attention backend for KDA (Kimi Delta Attention) linear attention."""
 
+    # GPU-only decode/verify metadata (graph replay passes seq_lens_cpu=None);
+    # extend reads extend_seq_lens_cpu and mamba indices rebuild from req objects.
+    # Matches the other MambaAttnBackendBase subclasses (Mamba2/GDN/ShortConv).
+    needs_cpu_seq_lens: bool = False
+
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
         # mamba_cache.conv is [..., kernel-1, dim] while conv_states_shape expects the window length (kernel-1) at shape[-1], hence the transpose.

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -252,9 +252,7 @@ class KDAKernelDispatcher:
 class KDAAttnBackend(MambaAttnBackendBase):
     """Attention backend for KDA (Kimi Delta Attention) linear attention."""
 
-    # GPU-only decode/verify metadata (graph replay passes seq_lens_cpu=None);
-    # extend reads extend_seq_lens_cpu and mamba indices rebuild from req objects.
-    # Matches the other MambaAttnBackendBase subclasses (Mamba2/GDN/ShortConv).
+    # Decode/verify metadata is GPU-only (graph replay passes seq_lens_cpu=None).
     needs_cpu_seq_lens: bool = False
 
     def __init__(self, model_runner: ModelRunner):

--- a/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 class ResolvedAttentionBackendStr(msgspec.Struct, frozen=True, kw_only=True):
     prefill: str
     decode: str
+    verify: str
     is_draft_override: bool = False
 
 
@@ -157,14 +158,20 @@ def _resolve_attention_backend_strs(
     draft_attn_backend = server_args.speculative_draft_attention_backend
     if is_draft_worker and draft_attn_backend:
         logger.warning(f"Overriding draft attention backend to {draft_attn_backend}.")
-        # Single backend for all draft modes (no prefill/decode split).
+        # Single backend for all draft modes (no prefill/decode/verify split).
         return ResolvedAttentionBackendStr(
             prefill=draft_attn_backend,
             decode=draft_attn_backend,
+            verify=draft_attn_backend,
             is_draft_override=True,
         )
     prefill, decode = server_args.get_attention_backends()
-    return ResolvedAttentionBackendStr(prefill=prefill, decode=decode)
+    # Independent target-verify backend. --verify-attention-backend names it;
+    # unset falls back to the deprecated --speculative-attention-mode routing.
+    verify = server_args.verify_attention_backend or (
+        prefill if server_args.speculative_attention_mode == "prefill" else decode
+    )
+    return ResolvedAttentionBackendStr(prefill=prefill, decode=decode, verify=verify)
 
 
 def _build_resolved_backend(
@@ -179,37 +186,42 @@ def _build_resolved_backend(
             backend_str=resolved.prefill,
             init_new_workspace=init_new_workspace,
         )
-    elif resolved.decode != resolved.prefill:
+    elif resolved.decode != resolved.prefill or resolved.verify != resolved.decode:
         from sglang.srt.layers.attention.hybrid_attn_backend import (
             HybridAttnBackend,
         )
 
-        # Compose the two full-attention backends first, then apply model-level
+        # Build one backend per unique backend string, then apply model-level
         # wrappers once.  Wrapping each child independently duplicates the
         # linear/sparse side backend for hybrid models (for example, two GDN
         # dispatchers for Qwen3.5 when prefill and decode use different MHA
         # backends), duplicating initialization and associated state while only
         # one side backend can be active in a forward pass.
+        _built: dict[str, AttentionBackend] = {}
+
+        def _build_once(backend_str: str) -> AttentionBackend:
+            if backend_str not in _built:
+                _built[backend_str] = _build_full_attention_backend_from_str(
+                    model_runner=model_runner,
+                    backend_str=backend_str,
+                    init_new_workspace=init_new_workspace,
+                )
+            return _built[backend_str]
+
         attn_backend = attn_backend_wrapper(
             model_runner,
             HybridAttnBackend(
                 model_runner=model_runner,
-                decode_backend=_build_full_attention_backend_from_str(
-                    model_runner=model_runner,
-                    backend_str=resolved.decode,
-                    init_new_workspace=init_new_workspace,
-                ),
-                prefill_backend=_build_full_attention_backend_from_str(
-                    model_runner=model_runner,
-                    backend_str=resolved.prefill,
-                    init_new_workspace=init_new_workspace,
-                ),
+                decode_backend=_build_once(resolved.decode),
+                prefill_backend=_build_once(resolved.prefill),
+                verify_backend=_build_once(resolved.verify),
             ),
         )
         logger.info(
-            f"Using hybrid attention backend for decode and prefill: "
+            f"Using hybrid attention backend: "
             f"decode_backend={resolved.decode}, "
-            f"prefill_backend={resolved.prefill}."
+            f"prefill_backend={resolved.prefill}, "
+            f"verify_backend={resolved.verify}."
         )
         logger.warning(
             "Warning: Attention backend specified by --attention-backend or default backend might be overridden."

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2068,11 +2068,16 @@ class ServerArgs:
     speculative_attention_mode: A[
         str,
         Arg(
-            help="Attention backend for speculative decoding operations (both target verify and draft extend). Can be one of 'prefill' (default) or 'decode'.",
+            help="Deprecated for target verify: use --verify-attention-backend. Routes speculative operations (target verify and draft extend) to the 'prefill' (default) or 'decode' attention backend.",
             choices=["prefill", "decode"],
         ),
         NS("spec"),
     ] = "prefill"
+    verify_attention_backend: A[
+        Optional[str],
+        "Attention backend for speculative target verify. Must match the prefill or decode attention backend. Defaults to following the decode backend (the sync-free path on GPU-plan backends). Supersedes --speculative-attention-mode for verify.",
+        NS("spec"),
+    ] = None
     speculative_draft_attention_backend: A[
         Optional[str],
         "Attention backend for speculative decoding drafting.",
@@ -3791,24 +3796,24 @@ class ServerArgs:
             )
             self.smg_grpc_mode = True
 
-        # --speculative-attention-mode is a legacy routing knob: its
-        # 'prefill'/'decode' values select which existing attention backend
-        # serves target-verify rather than naming one directly. Its default
+        # --speculative-attention-mode routes target-verify by naming a phase
+        # ('prefill'/'decode') rather than the backend, and its default
         # 'prefill' combined with an explicit attention backend silently routes
-        # verify to the prefill backend, which can disable the sync-free decode
-        # path (a cpu-seq-lens prefill backend forces a per-step host sync).
+        # verify to the prefill backend, disabling the sync-free decode path (a
+        # cpu-seq-lens prefill backend forces a per-step host sync). Only warn
+        # when the user has not already moved to --verify-attention-backend.
         if (
             self.speculative_algorithm is not None
+            and self.verify_attention_backend is None
             and self.speculative_attention_mode == "prefill"
             and not self.is_attention_backend_not_set()
         ):
             logger.warning(
                 "--speculative-attention-mode is 'prefill' (default) while an "
                 "explicit attention backend is set: speculative target-verify "
-                "will run on the prefill backend. This legacy routing is "
-                "deprecated; pass --speculative-attention-mode decode to run "
-                "verify on the decode backend (the sync-free path on GPU-plan "
-                "backends such as trtllm_mla)."
+                "will run on the prefill backend. Set --verify-attention-backend "
+                "to the decode backend to run verify on the sync-free path on "
+                "GPU-plan backends such as trtllm_mla."
             )
 
         # Native gRPC tuning knob is env-only; --grpc-port (CLI) enables the

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3796,12 +3796,8 @@ class ServerArgs:
             )
             self.smg_grpc_mode = True
 
-        # --speculative-attention-mode routes target-verify by naming a phase
-        # ('prefill'/'decode') rather than the backend, and its default
-        # 'prefill' combined with an explicit attention backend silently routes
-        # verify to the prefill backend, disabling the sync-free decode path (a
-        # cpu-seq-lens prefill backend forces a per-step host sync). Only warn
-        # when the user has not already moved to --verify-attention-backend.
+        # Default 'prefill' silently routes verify to the prefill backend under
+        # an explicit attention backend, disabling the sync-free decode path.
         if (
             self.speculative_algorithm is not None
             and self.verify_attention_backend is None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3791,6 +3791,26 @@ class ServerArgs:
             )
             self.smg_grpc_mode = True
 
+        # --speculative-attention-mode is a legacy routing knob: its
+        # 'prefill'/'decode' values select which existing attention backend
+        # serves target-verify rather than naming one directly. Its default
+        # 'prefill' combined with an explicit attention backend silently routes
+        # verify to the prefill backend, which can disable the sync-free decode
+        # path (a cpu-seq-lens prefill backend forces a per-step host sync).
+        if (
+            self.speculative_algorithm is not None
+            and self.speculative_attention_mode == "prefill"
+            and not self.is_attention_backend_not_set()
+        ):
+            logger.warning(
+                "--speculative-attention-mode is 'prefill' (default) while an "
+                "explicit attention backend is set: speculative target-verify "
+                "will run on the prefill backend. This legacy routing is "
+                "deprecated; pass --speculative-attention-mode decode to run "
+                "verify on the decode backend (the sync-free path on GPU-plan "
+                "backends such as trtllm_mla)."
+            )
+
         # Native gRPC tuning knob is env-only; --grpc-port (CLI) enables the
         # native server, falling back to SGLANG_GRPC_PORT.
         self.grpc_worker_threads = envs.SGLANG_GRPC_WORKER_THREADS.get()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2075,7 +2075,7 @@ class ServerArgs:
     ] = "prefill"
     verify_attention_backend: A[
         Optional[str],
-        "Attention backend for speculative target verify. Must match the prefill or decode attention backend. Defaults to following the decode backend (the sync-free path on GPU-plan backends). Supersedes --speculative-attention-mode for verify.",
+        "Attention backend for speculative target verify, independent of prefill/decode. Defaults to following the decode backend (the sync-free path on GPU-plan backends). Supersedes --speculative-attention-mode for verify.",
         NS("spec"),
     ] = None
     speculative_draft_attention_backend: A[


### PR DESCRIPTION
## Summary
- Add `--verify-attention-backend`, a first-class attention backend for speculative target-verify, independent of the prefill / decode / draft backends.

## Background
- Target-verify has no attention backend of its own: `--speculative-attention-mode` (`prefill`/`decode`) picks which existing backend serves it, naming a phase rather than a backend.
- Its default `prefill` silently routes verify to the prefill backend; with a cpu-seq-lens prefill backend (e.g. flashinfer) that forces a per-step `seq_lens` D2H + host sync in the spec decode loop.

## Changes
- Add `--verify-attention-backend`: names the target-verify backend independently. Defaults to following the decode backend — the sync-free path on GPU-plan backends such as `trtllm_mla`.
- `HybridAttnBackend` becomes a 3-slot container (prefill / decode / verify). Each slot is built from its own resolved backend string (built once per unique string). `needs_cpu_seq_lens` now ORs only the backends the spec decode loop runs (decode + verify), and the verify backend's CUDA graph is captured when it differs from decode.
- Deprecate `--speculative-attention-mode` for verify routing (still the fallback when `--verify-attention-backend` is unset); warn when its default `prefill` silently routes verify to the prefill backend under an explicit attention backend.

Backward compatible: `--verify-attention-backend` defaults to `None` and follows the existing `--speculative-attention-mode` routing, so current configs are unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30126982839](https://github.com/sgl-project/sglang/actions/runs/30126982839)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30126982666](https://github.com/sgl-project/sglang/actions/runs/30126982666)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
