### PR TITLE
[Model] Fix BF16 MTP shared head loading for Step-3.7-Flash-NVFP4

### DIFF
--- a/python/sglang/srt/models/step3p5_mtp.py
+++ b/python/sglang/srt/models/step3p5_mtp.py
@@ -79,7 +79,15 @@ class Step3p5AMultiTokenPredictor(nn.Module):
         self.enorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
         self.hnorm = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
         self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
-        self.shared_head = SharedHead(config=config, quant_config=quant_config)
+        # Step-3.7 NVFP4 stores the grafted shared-head tensor in BF16. Its
+        # rewritten draft name does not match ModelOpt's layer exclusions.
+        qname = str(quant_config.get_name()) if quant_config is not None else ""
+        shared_head_quant_config = (
+            None if "fp4" in qname.lower() else quant_config
+        )
+        self.shared_head = SharedHead(
+            config=config, quant_config=shared_head_quant_config
+        )
         self.mtp_block = Step3p5DecoderLayer(
             config=config, layer_id=layer_id, prefix=f"{prefix}.mtp_block"
         )


### PR DESCRIPTION
## Summary

Fix Step-3.7-Flash-NVFP4 MTP draft loading when ModelOpt NVFP4 is enabled.

The target-model shards load normally, but loading the final
model-mtp-bf16.safetensors shard fails:

    RuntimeError: The size of tensor a (2048) must match the size of tensor b
    (4096) at non-singleton dimension 1

## Root cause

The Step-3.7 NVFP4 checkpoint keeps the grafted MTP shared-head tensor in
BF16. Its ModelOpt exclude rule is written in the original checkpoint
namespace, model.layers.45.*.

Step3p5MTP rewrites that name into model.shared_head.* while loading the draft
model. The exclusion therefore no longer matches. SharedHead receives the
ModelOpt quant config and creates an NVFP4 packed ParallelLMHead with width
2048 instead of the BF16 4096-wide parameter in the checkpoint.

## Fix

When quant_config.get_name() contains fp4, create SharedHead with
quant_config=None.

The target model remains NVFP4. mtp_block is intentionally unchanged: the
SGLang constructor already gives it quant_config=None. Passing a conditional
config to mtp_block would be redundant for NVFP4 and would alter the existing
FP8 path.

## Test

The isolated change passes the BF16 MTP-shard load and reaches the first draft
decode. That decode then hits the separate multimodal embedding OOB fixed by
the companion PR.

The following is the end-to-end result with both independent patches applied.
It is not an isolated speed claim for this loader fix.

Environment:

- NVIDIA B300, TP=1
- SGLang 0.5.15.post2.dev622+g246b3c3ea
- Step-3.7-Flash-NVFP4, modelopt_fp4, FP8 E4M3 KV cache
- EAGLE: 3 steps, top-k 1, 4 draft tokens, multi-layer EAGLE
- Official SGLang custom benchmark: 200 Gutenberg prompts, 46K input tokens
  each, 2201 generated tokens, temperature 1.0, top-p 1.0, concurrency 10,
  warmup requests 0, one random 1080p image per request

    ============ Serving Benchmark Result ============
    Backend:                                 sglang
    Traffic request rate:                    inf
    Max request concurrency:                 10
    Successful requests:                     200
    Benchmark duration (s):                  443.07
    Total input tokens:                      9200000
    Total input text tokens:                 9200000
    Total generated tokens:                  440200
    Total generated tokens (retokenized):    411213
    Request throughput (req/s):              0.45
    Input token throughput (tok/s):          20764.15
    Output token throughput (tok/s):         993.52
    Peak output token throughput (tok/s):    1378.00
    Peak concurrent requests:                13
    Total token throughput (tok/s):          21757.67
    Concurrency:                             9.89
    Accept length:                           1.80
    Mean E2E Latency (ms):                   21905.04
    Median E2E Latency (ms):                 22418.28
    P90 E2E Latency (ms):                    24363.31
    P95 E2E Latency (ms):                    24962.30
    P99 E2E Latency (ms):                    25899.99
    Mean TTFT (ms):                          409.09
    Median TTFT (ms):                        324.91
    P90 TTFT (ms):                           433.76
    P95 TTFT (ms):                           653.51
    P99 TTFT (ms):                           2291.82
    Mean TPOT (ms):                          9.77
    Median TPOT (ms):                        10.03
    P90 TPOT (ms):                           10.87
    P95 TPOT (ms):                           11.03
    P99 TPOT (ms):                           11.40
    Mean ITL (ms):                           9.77
    Median ITL (ms):                         7.82
    P90 ITL (ms):                            15.98
    P95 ITL (ms):                            16.30
    P99 ITL (ms):                            50.89
    Max ITL (ms):                            2029.29
    Total prompt tokens:                     9200000
    Total cached tokens:                     7360000
      Device:                                7360000
      Host:                                  0
    Cache hit rate:                          80.0%
      Device:                                100.0%
      Host:                                  0.0%

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30098801879](https://github.com/sgl-project/sglang/actions/runs/30098801879)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30098801761](https://github.com/sgl-project/sglang/actions/runs/30098801761)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->