### PR TITLE
[Spec] Clamp Step3p5MTP multimodal pad sentinels in draft embedding

### DIFF
--- a/python/sglang/srt/models/step3p5_mtp.py
+++ b/python/sglang/srt/models/step3p5_mtp.py
@@ -93,6 +93,9 @@ class Step3p5AMultiTokenPredictor(nn.Module):
         input_embeds: torch.Tensor = None,
     ) -> torch.Tensor:
         if input_embeds is None:
+            # The speculative path can contain a multimodal pad sentinel
+            # before target hidden states overwrite that placeholder position.
+            input_ids = input_ids.clamp(min=0, max=self.config.vocab_size - 1)
             hidden_states = self.embed_tokens(input_ids)
         else:
             hidden_states = input_embeds
@@ -127,6 +130,7 @@ class Step3p5AMultiTokenPredictor(nn.Module):
         return hidden_states, hidden_states_before_norm
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        input_ids = input_ids.clamp(min=0, max=self.config.vocab_size - 1)
         return self.embed_tokens(input_ids)
 
 


### PR DESCRIPTION
## Summary

Extend #27512's multimodal-pad handling to Step3p5MTP.

After Step-3.7 NVFP4 MTP loads, the first draft decode can feed multimodal pad
sentinel 127631530 into Step3p5AMultiTokenPredictor.embed_tokens. The ID is
outside the text vocabulary and triggers vectorized_gather_kernel
out-of-bounds errors followed by a device-side assert.

## Root cause

The target model clamps multimodal placeholders before embedding and replaces
those positions with visual features. The speculative draft receives the target
hidden states for the same positions, so its temporary embedding at those
positions is unused.

MiMo-V2 had the same failure mode and was fixed in #27512. Step3p5MTP has two
direct embedding lookup paths that were not covered by that model-specific
change.

## Fix

- Clamp input_ids to the text-vocabulary range before embed_tokens in
  Step3p5AMultiTokenPredictor.forward.
- Apply the same clamp in Step3p5AMultiTokenPredictor.embed_input_ids.

The existing maybe_detect_oob check in MultiLayerEagleDraftWorker is unchanged.
It continues to surface invalid generated next-token IDs before a clamp could
hide them.

## Test

Before this change, the first draft decode after successful MTP loading hit the
embedding OOB/device-side-assert failure above.

The following is the end-to-end result with this patch and the independent
BF16 shared-head loader fix applied.

Environment:

- NVIDIA B300, TP=1
- SGLang 0.5.15.post2.dev622+g246b3c3ea
- Step-3.7-Flash-NVFP4, modelopt_fp4, FP8 E4M3 KV cache
- EAGLE: 3 steps, top-k 1, 4 draft tokens, multi-layer EAGLE
- Official SGLang custom benchmark: 200 Gutenberg prompts, 46K input tokens
  each, 2201 generated tokens, temperature 1.0, top-p 1.0, concurrency 10,
  warmup requests 0, one random 1080p image per request

    ============ Serving Benchmark Result ============
    Backend:                                 sglang
    Traffic request rate:                    inf
    Max request concurrency:                 10
    Successful requests:                     200
    Benchmark duration (s):                  443.07
    Total input tokens:                      9200000
    Total input text tokens:                 9200000
    Total generated tokens:                  440200
    Total generated tokens (retokenized):    411213
    Request throughput (req/s):              0.45
    Input token throughput (tok/s):          20764.15
    Output token throughput (tok/s):         993.52
    Peak output token throughput (tok/s):    1378.00
    Peak concurrent requests:                13
    Total token throughput (tok/s):          21757.67
    Concurrency:                             9.89
    Accept length:                           1.80
    Mean E2E Latency (ms):                   21905.04
    Median E2E Latency (ms):                 22418.28
    P90 E2E Latency (ms):                    24363.31
    P95 E2E Latency (ms):                    24962.30
    P99 E2E Latency (ms):                    25899.99
    Mean TTFT (ms):                          409.09
    Median TTFT (ms):                        324.91
    P90 TTFT (ms):                           433.76
    P95 TTFT (ms):                           653.51
    P99 TTFT (ms):                           2291.82
    Mean TPOT (ms):                          9.77
    Median TPOT (ms):                        10.03
    P90 TPOT (ms):                           10.87
    P95 TPOT (ms):                           11.03
    P99 TPOT (ms):                           11.40
    Mean ITL (ms):                           9.77
    Median ITL (ms):                         7.82
    P90 ITL (ms):                            15.98
    P95 ITL (ms):                            16.30
    P99 ITL (ms):                            50.89
    Max ITL (ms):                            2029.29
    Total prompt tokens:                     9200000
    Total cached tokens:                     7360000
      Device:                                7360000
      Host:                                  0
    Cache hit rate:                          80.0%
      Device:                                100.0%
      Host:                                  0.0%

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30099082488](https://github.com/sgl-project/sglang/actions/runs/30099082488)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30099082327](https://github.com/sgl-project/sglang/actions/runs/30099082327)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->