### PR TITLE
feat: add NCCL EP as optional moe-a2a-backend (low-latency decode)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -98,6 +98,8 @@ default = true
 [project.optional-dependencies]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
+# NCCL EP MoE A2A backend (low-latency decode); needs NCCL >= 2.29 + sm_90+.
+nccl_ep = ["nccl4py[cu13]"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -688,6 +688,7 @@ class Envs:
     SGLANG_DEEPEP_BF16_DISPATCH = EnvBool(False)  # This argument is deprecated
     SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK = EnvInt(128)
     SGLANG_DEEPEP_LL_COMBINE_SEND_NUM_SMS = EnvInt(32)
+    SGLANG_NCCL_EP_MAX_NUM_SMS = EnvInt(0)  # 0 = use default (20)
     SGLANG_BLACKWELL_OVERLAP_SHARED_EXPERTS_OUTSIDE_SBO = EnvBool(False)
     # Force dynamic Waterfill with runtime EP all-reduce instead of the default
     # static local-batch path.

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -283,6 +283,7 @@ def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
         or get_moe_a2a_backend().is_deepep()
         or get_moe_a2a_backend().is_mooncake()
         or get_moe_a2a_backend().is_nixl()
+        or get_moe_a2a_backend().is_nccl_ep()
     ):
         return DeepEPMoE
     return FusedMoE

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -144,6 +144,13 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
             num_local_experts=moe_runner_config.num_local_experts,
             hidden_size=moe_runner_config.hidden_size,
         )
+    elif a2a_backend.is_nccl_ep():
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+
+        return NcclEpDispatcher(
+            moe_runner_config=moe_runner_config,
+            ep_group=get_tp_group(),
+        )
     else:
         raise NotImplementedError(f"Unsupported a2a backend: {a2a_backend}")
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/nccl_ep.py
@@ -1,0 +1,603 @@
+"""NCCL EP low-latency MoE dispatch/combine backend (``--moe-a2a-backend nccl_ep``).
+
+Mirrors the DeepEP LL contract (DEEPEP_LL output, reuses DeepEPMoE.compute).
+NCCL EP carries bf16 on the wire, so we quantize the bf16 recv to fp8 (group 128)
+after dispatch. LL (decode) only; HT (prefill) is a follow-up.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from enum import Enum, auto
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.layers.moe.token_dispatcher.base import BaseDispatcher
+from sglang.srt.layers.moe.token_dispatcher.deepep import (
+    DeepEPLLCombineInput,
+    DeepEPLLDispatchOutput,
+    DeepEPPDispatchHooks,
+)
+from sglang.srt.layers.moe.topk import TopKOutput
+from sglang.srt.layers.moe.utils import (
+    get_nccl_ep_mode,
+    get_nccl_ep_num_max_dispatch_tokens_per_rank,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.distributed.parallel_state import GroupCoordinator
+    from sglang.srt.layers.moe.fused_moe_triton.layer import MoeRunnerConfig
+    from sglang.srt.layers.moe.token_dispatcher.base import DispatchOutput
+
+logger = logging.getLogger(__name__)
+
+# NCCL EP LL dispatch accepts only these hidden sizes (hardcoded in SWITCH_HIDDEN)
+# and requires hidden % 128 == 0.
+_NCCL_EP_LL_SUPPORTED_HIDDEN = {2048, 2560, 4096, 5120, 6144, 7168, 8192}
+
+# LL top-k upper bound (kNumMaxTopK). Models with topk>9 (e.g. Nemotron Super)
+# fall back to DeepEP LL — upstream issue #2103.
+_NCCL_EP_LL_MAX_TOPK = 9
+
+# Mirror DeepEP's per-rank dispatch budget cap.
+_NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP = 1024
+_NCCL_EP_DEFAULT_MAX_DISPATCH_TOKENS_PER_RANK = 1024
+
+# fp8 per-token-group quant block size for the LL GEMM path (cutlass w4a8 moe).
+_NCCL_EP_FP8_GROUP_SIZE = 128
+
+
+def _parse_ver_str(s: str):
+    """Parse the leading ``X.Y.Z`` from a version string into a 3-tuple, or None."""
+    parts = s.split(".")
+    try:
+        return tuple(int(x) for x in parts[:3])
+    except ValueError:
+        return None
+
+
+def _nccl_runtime_version():
+    """Return the linked NCCL version as a (major, minor, patch) tuple, or None.
+
+    Prefers nccl4py's version query (may differ from torch's bundled NCCL via
+    LD_PRELOAD); falls back to torch.
+    """
+    try:
+        import nccl
+
+        # nccl.get_version() -> VersionInfo with a .nccl LibraryInfo carrying .version.
+        vi = nccl.get_version()
+        lib_info = getattr(vi, "nccl", None)
+        ver_obj = getattr(lib_info, "version", None) if lib_info is not None else None
+        if ver_obj is not None:
+            return _parse_ver_str(str(ver_obj))
+    except Exception:
+        pass
+    try:
+        v = torch.cuda.nccl.version()
+        if isinstance(v, (tuple, list)):
+            return tuple(int(x) for x in v[:3])
+    except Exception:
+        pass
+    return None
+
+
+def nccl_ep_unavailable_reason() -> str | None:
+    """Return why NCCL EP is unavailable (None = available), for fallback logs."""
+    if importlib.util.find_spec("nccl.ep") is None:
+        return "nccl4py (nccl.ep) not importable"
+    if not torch.cuda.is_available():
+        return "no CUDA device"
+    cc = torch.cuda.get_device_capability(0)[0]  # Hopper (sm_90) or Blackwell.
+    if cc < 9:
+        return f"GPU arch sm_{cc}x not supported (need Hopper/Blackwell sm_90+)"
+    ver = _nccl_runtime_version()
+    if ver is None:
+        return "could not read NCCL version"
+    if (ver[0], ver[1]) < (2, 29):
+        return f"NCCL {'.'.join(map(str, ver))} < 2.29 (need Device API/GIN)"
+    return None
+
+
+def is_nccl_ep_available() -> bool:
+    """Whether nccl4py + NCCL >= 2.29 + Hopper/Blackwell are usable here."""
+    return nccl_ep_unavailable_reason() is None
+
+
+# ----------------------------- Buffer (Group/Handle lifecycle) -----------------------------
+
+_nccl_ep_runtime = None  # cached import of nccl.ep / nccl.core
+
+
+def _load_nccl_ep():
+    global _nccl_ep_runtime
+    if _nccl_ep_runtime is not None:
+        return _nccl_ep_runtime
+    import nccl.core as nccl_core
+    import nccl.ep as nccl_ep
+
+    _nccl_ep_runtime = (nccl_core, nccl_ep)
+    return _nccl_ep_runtime
+
+
+class NcclEpBuffer:
+    """Process-wide NCCL EP group + static recv buffers (mirrors DeepEPBuffer).
+
+    State lives on ``ctx.resources.buffers["nccl_ep_state"]``; the group is
+    created once from the sglang EP group's ``ncclComm_t``.
+    """
+
+    @classmethod
+    def _state(cls):
+        from types import SimpleNamespace
+
+        from sglang.srt.runtime_context import get_resources
+
+        buffers = get_resources().buffers
+        state = buffers.get("nccl_ep_state")
+        if state is None:
+            state = SimpleNamespace(
+                group=None,
+                num_experts=None,
+                num_local_experts=None,
+                hidden_size=None,
+                max_dispatch_tokens_per_rank=None,
+                max_recv_tokens_per_rank=None,
+                # Pre-allocated scratch (fixed shapes); reused per dispatch/combine step.
+                recv_tokens=None,
+                expert_counters=None,
+                expert_offsets=None,
+                recv_total=None,
+                combined=None,
+            )
+            buffers["nccl_ep_state"] = state
+        return state
+
+    @classmethod
+    def get_buffer(
+        cls,
+        ep_group: "GroupCoordinator",
+        hidden_size: int,
+        num_experts: int,
+        num_local_experts: int,
+        max_dispatch_tokens_per_rank: int,
+    ) -> "NcclEpBuffer":
+        state = cls._state()
+        if state.group is None:
+            state.num_experts = num_experts
+            state.num_local_experts = num_local_experts
+            state.hidden_size = hidden_size
+            state.max_dispatch_tokens_per_rank = max_dispatch_tokens_per_rank
+            # LL auto = nRanks * max_dispatch_tokens_per_rank.
+            world_size = ep_group.world_size
+            state.max_recv_tokens_per_rank = world_size * max_dispatch_tokens_per_rank
+            cls._create_group(state, ep_group)
+        return state
+
+    @classmethod
+    def _create_group(cls, state, ep_group: "GroupCoordinator"):
+        nccl_core, nccl_ep = _load_nccl_ep()
+
+        pynccl = ep_group.pynccl_comm
+        if pynccl is None or not getattr(pynccl, "available", False):
+            raise RuntimeError(
+                "NCCL EP requires a live PyNccl communicator on the EP group "
+                "(pynccl_comm unavailable)."
+            )
+        comm_ptr = pynccl.comm.value  # ncclComm_t (c_void_p) -> int
+        wrapped_comm = nccl_core.Communicator(ptr=comm_ptr)
+
+        # Explicit rdma_buffer_size keeps create_handle local (no collective/realloc).
+        rdma_buffer_size = cls._low_latency_rdma_size_hint(
+            nccl_ep, state, ep_group.world_size
+        )
+        cfg = nccl_ep.GroupConfig(
+            algorithm=nccl_ep.Algorithm.LOW_LATENCY,
+            num_experts=state.num_experts,
+            max_dispatch_tokens_per_rank=state.max_dispatch_tokens_per_rank,
+            max_recv_tokens_per_rank=0,  # 0 = auto = nRanks * max_dispatch
+            max_token_bytes=state.hidden_size * 2,  # bf16 = 2 bytes/elem
+            rdma_buffer_size=rdma_buffer_size,
+            max_num_sms=cls._resolve_max_num_sms(state.num_experts),
+        )
+        state.group = nccl_ep.Group.create(wrapped_comm, cfg)
+        logger.info(
+            "NCCL EP group created: num_experts=%d world_size=%d hidden=%d "
+            "max_dispatch_tokens_per_rank=%d rdma_buffer_size=%d",
+            state.num_experts,
+            ep_group.world_size,
+            state.hidden_size,
+            state.max_dispatch_tokens_per_rank,
+            rdma_buffer_size,
+        )
+        cls._alloc_scratch(state, ep_group.device)
+
+    @staticmethod
+    def _alloc_scratch(state, device: torch.device):
+        """Allocate fixed-shape dispatch/combine scratch once, reused across steps
+        (counters re-zeroed per dispatch). recv_tokens need not be cleared — the
+        kernel writes the valid region, bounded downstream by expert_counters.
+        """
+        e_local = state.num_local_experts
+        h = state.hidden_size
+        max_recv = state.max_recv_tokens_per_rank
+        max_send = state.max_dispatch_tokens_per_rank
+        state.recv_tokens = torch.empty(
+            (e_local, max_recv, h), dtype=torch.bfloat16, device=device
+        )
+        state.expert_counters = torch.zeros(
+            (e_local,), dtype=torch.int32, device=device
+        )
+        state.expert_offsets = torch.zeros(
+            (e_local + 1,), dtype=torch.int32, device=device
+        )
+        state.recv_total = torch.zeros((1,), dtype=torch.int32, device=device)
+        # Upper bound = max dispatch tokens per rank; sliced to [:t] per combine.
+        state.combined = torch.empty(
+            (max_send, h), dtype=torch.bfloat16, device=device
+        )
+
+    @staticmethod
+    def _low_latency_rdma_size_hint(nccl_ep, state, world_size: int) -> int:
+        """Worst-case RDMA buffer size for LL (explicit so handle init is local).
+
+        Prefers a nccl4py native hint; falls back to a conservative upper bound
+        from the max recv footprint (E_local * max_recv * H * 2 bytes bf16), x4
+        for send+recv+slack.
+        """
+        hint_fn = getattr(nccl_ep, "get_low_latency_rdma_size_hint", None)
+        if callable(hint_fn):
+            try:
+                return int(
+                    hint_fn(
+                        state.max_dispatch_tokens_per_rank,
+                        state.hidden_size,
+                        world_size,
+                        state.num_experts,
+                    )
+                )
+            except Exception:
+                pass  # signature mismatch; fall through to the bound below
+        per_slot = state.num_local_experts * state.max_recv_tokens_per_rank
+        per_slot *= state.hidden_size * 2  # bf16 bytes
+        return int(per_slot * 4)
+
+    @staticmethod
+    def _resolve_max_num_sms(num_experts: int) -> int:
+        """Cap LL EP-group SMs so overlap compute can run alongside dispatch.
+
+        LL requires ceil(num_experts / max_num_sms) <= 14, i.e. a floor of
+        ceil(num_experts / 14). Default 20 (leaves most SMs for compute, like
+        DeepEP's communicate_num_sms); overridable via SGLANG_NCCL_EP_MAX_NUM_SMS.
+        """
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_NCCL_EP_MAX_NUM_SMS.is_set() and envs.SGLANG_NCCL_EP_MAX_NUM_SMS.get() > 0:
+            val = envs.SGLANG_NCCL_EP_MAX_NUM_SMS.get()
+        else:
+            val = 20  # conservative default for H100 (132 SMs)
+
+        min_required = (num_experts + 13) // 14  # ceil(num_experts / 14)
+        if val < min_required:
+            logger.warning(
+                "NCCL EP max_num_sms=%d below LL minimum %d (num_experts=%d); "
+                "clamping to %d.",
+                val,
+                min_required,
+                num_experts,
+                min_required,
+            )
+            val = min_required
+        return val
+
+    @classmethod
+    def destroy(cls):
+        state = cls._state()
+        g = state.group
+        if g is not None:
+            try:
+                g.destroy()
+            except Exception:
+                pass
+            state.group = None
+
+
+# ----------------------------- Dispatcher (LL path) -----------------------------
+
+
+class _Stage(Enum):
+    INITIAL = auto()
+    AFTER_DISPATCH_A = auto()
+    AFTER_DISPATCH_B = auto()
+    AFTER_COMBINE_A = auto()
+
+
+class NcclEpDispatcher(BaseDispatcher):
+    """NCCL EP low-latency token dispatcher.
+
+    Mirrors the DeepEP LL contract: ``dispatch`` returns a
+    ``DeepEPLLDispatchOutput`` (DEEPEP_LL format), reusing the DeepEP compute
+    path. NCCL EP carries bf16 on the wire; we quantize bf16->fp8 (group 128)
+    after dispatch to feed ``apply_deepep_ll``.
+    """
+
+    def __init__(self, moe_runner_config: "MoeRunnerConfig", ep_group: "GroupCoordinator"):
+        super().__init__()
+        nccl_core, nccl_ep = _load_nccl_ep()
+        self._nccl_ep = nccl_ep
+
+        self.ep_group = ep_group
+        self.router_topk = moe_runner_config.top_k
+        self.num_experts = moe_runner_config.num_experts
+        self.num_local_experts = moe_runner_config.num_local_experts
+        self.hidden_size = moe_runner_config.hidden_size
+        self.params_dtype = moe_runner_config.params_dtype
+        self.world_size = ep_group.world_size
+
+        # Resolve dispatch mode. LOW_LATENCY only this PR; HT raises at resolve() time.
+        self.mode = get_nccl_ep_mode().resolve(is_extend_in_batch=False)
+
+        # Blackwell guard: our fp8 post-quant emits float32 group scales, which
+        # diverge from DeepEP's UE8M0 scales under DEEPGEMM_BLACKWELL. Fail fast
+        # rather than silently mis-quantize.
+        try:
+            from sglang.srt.layers import deep_gemm_wrapper
+
+            if getattr(deep_gemm_wrapper, "DEEPGEMM_BLACKWELL", False):
+                raise NotImplementedError(
+                    "NCCL EP LL fp8 post-quant emits float32 group scales, which diverge "
+                    "from DeepEP's UE8M0 scales when DEEPGEMM_BLACKWELL is set. Fall back "
+                    "to --moe-a2a-backend deepep on Blackwell for now."
+                )
+        except ImportError:
+            pass  # deep_gemm_wrapper absent -> DeepGEMM-Blackwell path not active.
+
+        # Deterministic-inference guard: NCCL EP is not determinism-audited yet.
+        try:
+            from sglang.srt.runtime_context import get_exec
+
+            if get_exec().deterministic.enable_deterministic_inference:
+                raise NotImplementedError(
+                    "NCCL EP is not deterministic-inference-audited yet. Use "
+                    "--moe-a2a-backend deepep with --enable-deterministic-inference, "
+                    "or remove the flag (deterministic support tracked as a follow-up)."
+                )
+        except (ImportError, AttributeError):
+            pass  # exec flags not materialized yet; gated in server_args post-processing.
+
+        # Per-rank dispatch budget.
+        budget = get_nccl_ep_num_max_dispatch_tokens_per_rank()
+        if budget <= 0:
+            budget = _NCCL_EP_DEFAULT_MAX_DISPATCH_TOKENS_PER_RANK
+        assert (
+            budget <= _NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP
+        ), f"NCCL EP max_dispatch_tokens_per_rank {budget} exceeds cap {_NCCL_EP_MAX_DISPATCH_TOKENS_PER_RANK_CAP}"
+        self.num_max_dispatch_tokens_per_rank = budget
+
+        # Validate LL hard constraints early (fail fast at init, not at first dispatch).
+        if self.hidden_size not in _NCCL_EP_LL_SUPPORTED_HIDDEN:
+            raise ValueError(
+                f"NCCL EP LL only supports hidden in {sorted(_NCCL_EP_LL_SUPPORTED_HIDDEN)} "
+                f"(got {self.hidden_size}); use --moe-a2a-backend deepep for this model."
+            )
+        if self.router_topk > _NCCL_EP_LL_MAX_TOPK:
+            raise ValueError(
+                f"NCCL EP LL supports topk <= {_NCCL_EP_LL_MAX_TOPK} (got {self.router_topk}); "
+                f"fall back to DeepEP LL (upstream nccl_ep issue #2103)."
+            )
+
+        self.buffer = NcclEpBuffer.get_buffer(
+            ep_group,
+            self.hidden_size,
+            self.num_experts,
+            self.num_local_experts,
+            self.num_max_dispatch_tokens_per_rank,
+        )
+
+        self.handle = None
+
+        # Staged execution state machine (mirrors deepep.py _Stage).
+        self._stage = _Stage.INITIAL
+        self._dispatch_intermediate_state = None
+        self._combine_intermediate_state = None
+
+        # SBO dispatch hook: deepseek_v2.py registers a hook via
+        # register_deepep_dispatch_hook to run shared experts between
+        # dispatch_a (send_only) and dispatch_b (complete).
+        self._dispatch_hooks = DeepEPPDispatchHooks()
+
+        # Lazily imported; fp8 quant is only needed for the fp8 (w4afp8) GEMM path.
+        self._quant_fp8 = None
+
+    def set_quant_config(self, quant_config: dict) -> None:
+        self.quant_config = quant_config
+
+    # _Stage state machine: guards a/b call order. handle's continue_fn is a
+    # single slot — calling combine(send_only=1) before dispatch_b (complete)
+    # would overwrite the dispatch continue_fn.
+    def _update_stage(self, old_stage, new_stage):
+        assert self._stage == old_stage, (
+            f"NCCL EP stage mismatch: expected {old_stage}, got {self._stage}"
+        )
+        self._stage = new_stage
+
+    def register_deepep_dispatch_hook(self, hook):
+        return self._dispatch_hooks.register_hook(hook)
+
+    # ---- three-phase dispatch/combine (staged execution) ----
+    def dispatch(
+        self, hidden_states: torch.Tensor, topk_output: TopKOutput
+    ) -> DispatchOutput:
+        self.dispatch_a(hidden_states, topk_output)
+        if self._dispatch_hooks is not None:
+            self._dispatch_hooks(self)
+        return self.dispatch_b()
+
+    def dispatch_a(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
+        self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+
+        nccl_ep = self._nccl_ep
+        topk_weights = topk_output.topk_weights.to(torch.float32)
+        topk_ids = topk_output.topk_ids.to(torch.int64)
+
+        t = hidden_states.shape[0]
+        if t > self.num_max_dispatch_tokens_per_rank:
+            raise ValueError(
+                f"NCCL EP: decode batch ({t}) exceeds per-rank dispatch budget "
+                f"{self.num_max_dispatch_tokens_per_rank}; increase "
+                f"--nccl-ep-num-max-dispatch-tokens-per-rank or reduce batch."
+            )
+
+        if self.handle is not None:
+            try:
+                self.handle.destroy()
+            except Exception:
+                pass
+            self.handle = None
+
+        state = self.buffer
+
+        stream = torch.cuda.current_stream()
+
+        handle = state.group.create_handle(
+            layout=nccl_ep.Layout.EXPERT_MAJOR,
+            topk_idx=nccl_ep.Tensor(topk_ids),
+            config=nccl_ep.HandleConfig(),
+            stream=stream.cuda_stream,
+        )
+        self.handle = handle
+
+        # Reuse pre-allocated scratch; counters re-zeroed each dispatch.
+        recv_tokens = state.recv_tokens
+        expert_counters = state.expert_counters.zero_()
+        expert_offsets = state.expert_offsets.zero_()
+        recv_total = state.recv_total.zero_()
+
+        inputs = nccl_ep.DispatchInputs(tokens=nccl_ep.Tensor(hidden_states))
+        outputs = nccl_ep.DispatchOutputs(tokens=nccl_ep.Tensor(recv_tokens))
+        layout_info = nccl_ep.LayoutInfo(
+            expert_counters=nccl_ep.Tensor(expert_counters),
+            expert_offsets=nccl_ep.Tensor(expert_offsets),
+            recv_total_counter=nccl_ep.Tensor(recv_total),
+        )
+        handle.dispatch(
+            inputs,
+            outputs,
+            layout_info=layout_info,
+            config=nccl_ep.DispatchConfig(send_only=1),
+            stream=stream.cuda_stream,
+        )
+
+        self._dispatch_intermediate_state = (
+            recv_tokens,
+            expert_counters,
+            topk_ids,
+            topk_weights,
+            t,
+            hidden_states,
+        )
+
+    def dispatch_b(self) -> DispatchOutput:
+        self._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+
+        (
+            recv_tokens,
+            expert_counters,
+            topk_ids,
+            topk_weights,
+            t,
+            hidden_states,
+        ) = self._dispatch_intermediate_state
+        del self._dispatch_intermediate_state
+
+        stream = torch.cuda.current_stream()
+        self.handle.complete(config=0, stream=stream.cuda_stream)
+
+        hs_fp8, hs_scale = self._quantize_fp8(recv_tokens, expert_counters)
+
+        expected_m = (
+            hidden_states.shape[0] * self.world_size * topk_ids.shape[1]
+            + self.num_experts
+        ) // self.num_experts
+
+        self._dispatched_topk_weights = topk_weights
+        self._dispatched_t = t
+
+        return DeepEPLLDispatchOutput(
+            hs_fp8,
+            hs_scale,
+            topk_ids,
+            topk_weights,
+            expert_counters,
+            expected_m,
+        )
+
+    def _quantize_fp8(self, recv_tokens_bf16: torch.Tensor, masked_m: torch.Tensor):
+        if self._quant_fp8 is None:
+            from sglang.kernels.ops.quantization.fp8_kernel import (
+                sglang_per_token_group_quant_fp8,
+            )
+
+            self._quant_fp8 = sglang_per_token_group_quant_fp8
+        # recv_tokens_bf16 is 3D [E_local, max_recv, H]; the quant helper supports
+        # 3D + masked_m. masked_m=expert_counters matches DeepEPLLDispatchOutput.
+        return self._quant_fp8(
+            recv_tokens_bf16,
+            group_size=_NCCL_EP_FP8_GROUP_SIZE,
+            masked_m=masked_m,
+        )
+
+    def combine(self, combine_input) -> torch.Tensor:
+        self.combine_a(combine_input)
+        return self.combine_b()
+
+    def combine_a(self, combine_input):
+        self._update_stage(_Stage.AFTER_DISPATCH_B, _Stage.AFTER_COMBINE_A)
+
+        nccl_ep = self._nccl_ep
+        if isinstance(combine_input, DeepEPLLCombineInput):
+            expert_outputs = combine_input.hidden_states
+            topk_weights = combine_input.topk_weights
+        else:
+            expert_outputs = combine_input
+            topk_weights = self._dispatched_topk_weights
+
+        t = self._dispatched_t  # bounded in dispatch_a.
+
+        # Reuse pre-allocated [max_send, H] buffer.
+        combined = self.buffer.combined[:t]
+
+        stream = torch.cuda.current_stream()
+        inputs = nccl_ep.CombineInputs(tokens=nccl_ep.Tensor(expert_outputs))
+        outputs = nccl_ep.CombineOutputs(
+            tokens=nccl_ep.Tensor(combined),
+            topk_weights=nccl_ep.Tensor(topk_weights),
+        )
+        self.handle.combine(
+            inputs,
+            outputs,
+            config=nccl_ep.CombineConfig(send_only=1),
+            stream=stream.cuda_stream,
+        )
+
+        self._combine_intermediate_state = combined
+
+    def combine_b(self) -> torch.Tensor:
+        self._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
+
+        combined = self._combine_intermediate_state
+        del self._combine_intermediate_state
+
+        stream = torch.cuda.current_stream()
+        try:
+            self.handle.complete(config=0, stream=stream.cuda_stream)
+        finally:
+            if self.handle is not None:
+                try:
+                    self.handle.destroy()
+                except Exception:
+                    pass
+                self.handle = None
+        return combined

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -36,6 +36,7 @@ class MoeA2ABackend(Enum):
     ASCEND_TP = "ascend_tp"
     FLASHINFER = "flashinfer"
     MEGAMOE = "megamoe"
+    NCCL_EP = "nccl_ep"
     CUSTOMIZED = "customized"
 
     @classmethod
@@ -76,6 +77,9 @@ class MoeA2ABackend(Enum):
 
     def is_customized(self):
         return self == MoeA2ABackend.CUSTOMIZED
+
+    def is_nccl_ep(self):
+        return self == MoeA2ABackend.NCCL_EP
 
     def supports_aiter(self) -> bool:
         return self in (
@@ -197,6 +201,25 @@ class DeepEPMode(Enum):
         return self == DeepEPMode.AUTO
 
 
+class NcclEpMode(Enum):
+    """NCCL EP dispatch algorithm. Only LOW_LATENCY is implemented; HT is a follow-up."""
+
+    LOW_LATENCY = "low_latency"
+    HIGH_THROUGHPUT = "high_throughput"
+    AUTO = "auto"
+
+    def resolve(self, is_extend_in_batch: bool) -> "NcclEpMode":
+        if self == NcclEpMode.HIGH_THROUGHPUT:
+            raise NotImplementedError(
+                "NCCL EP high-throughput (prefill) path is not implemented yet; "
+                "use --nccl-ep-mode low_latency (or auto) for decode."
+            )
+        return NcclEpMode.LOW_LATENCY
+
+    def is_low_latency(self) -> bool:
+        return self == NcclEpMode.LOW_LATENCY
+
+
 class DispatcherOutputDtype(Enum):
     """
     Describes the dispatch output data type for DeepEP.
@@ -301,6 +324,10 @@ def initialize_moe_config(server_args: ServerArgs):
     )
     moe.deepep_mode = DeepEPMode(server_args.deepep_mode)
     moe.deepep_config = server_args.deepep_config or ""
+    moe.nccl_ep_mode = NcclEpMode(server_args.nccl_ep_mode)
+    moe.nccl_ep_num_max_dispatch_tokens_per_rank = int(
+        server_args.nccl_ep_num_max_dispatch_tokens_per_rank or 0
+    )
     moe.tbo_enabled = server_args.enable_two_batch_overlap
     moe.sbo_enabled = server_args.enable_single_batch_overlap
     if moe.sbo_enabled and is_cuda():
@@ -355,6 +382,18 @@ def get_deepep_mode() -> DeepEPMode:
     return moe.deepep_mode
 
 
+def get_nccl_ep_mode() -> NcclEpMode:
+    moe = get_flags().moe
+    if moe.nccl_ep_mode is None:
+        moe.nccl_ep_mode = NcclEpMode.LOW_LATENCY
+    return moe.nccl_ep_mode
+
+
+def get_nccl_ep_num_max_dispatch_tokens_per_rank() -> int:
+    moe = get_flags().moe
+    return moe.nccl_ep_num_max_dispatch_tokens_per_rank or 0
+
+
 def get_deepep_config() -> str:
     moe = get_flags().moe
     if moe.deepep_config is None:
@@ -378,9 +417,9 @@ def is_sbo_enabled() -> bool:
 
 
 def is_deepep_class_backend() -> bool:
-    """Check if the MoE backend is DeepEP-family (DeepEP, Mooncake, or Mori)."""
+    """Check if the MoE backend is DeepEP-family (DeepEP, Mooncake, Mori, NCCL EP)."""
     b = get_moe_a2a_backend()
-    return b.is_deepep() or b.is_mooncake() or b.is_mori()
+    return b.is_deepep() or b.is_mooncake() or b.is_mori() or b.is_nccl_ep()
 
 
 def uses_per_rank_fused_shared_slots() -> bool:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -710,6 +710,7 @@ class DeepseekV2MoE(nn.Module):
             # not divisible by the global TP size.
             _shared_expert_use_tp1 = (
                 get_moe_a2a_backend().is_deepep()
+                or get_moe_a2a_backend().is_nccl_ep()
                 or get_moe_a2a_backend().is_mooncake()
                 or get_moe_a2a_backend().is_nixl()
                 or get_moe_a2a_backend().is_mori()
@@ -818,6 +819,7 @@ class DeepseekV2MoE(nn.Module):
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
             or get_moe_a2a_backend().is_flashinfer()
+            or get_moe_a2a_backend().is_nccl_ep()
         )
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
 
@@ -913,6 +915,9 @@ class DeepseekV2MoE(nn.Module):
                     skip_shared_experts=skip_shared_experts,
                 )
         else:
+            # NCCL EP: use forward_deepep (LL path) for both prefill and decode,
+            # matching DeepEP behavior. The LL dispatch/combine handles arbitrary
+            # batch sizes (bounded by num_max_dispatch_tokens_per_rank).
             return self.forward_deepep(
                 hidden_states, forward_batch, input_ids_global=input_ids_global
             )
@@ -1277,7 +1282,11 @@ class DeepseekV2MoE(nn.Module):
                 self.experts.clear_overlap_args()
                 post_combine_hook_handle.remove()
 
-            assert isinstance(self.experts.dispatcher, MaybeTboDeepEPDispatcher)
+            from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+            assert isinstance(
+                self.experts.dispatcher,
+                (MaybeTboDeepEPDispatcher, NcclEpDispatcher),
+            )
             deepep_dispatch_hook_handle = (
                 self.experts.dispatcher.register_deepep_dispatch_hook(
                     _deepep_dispatch_hook
@@ -1410,7 +1419,10 @@ class DeepseekV2MoE(nn.Module):
             x = shared_output
             # aiter moe call will handle routed_scaling_factor in the function
             # so add _use_aiter condition to eliminate to use self.routed_scaling_factor in add_ call
-            if self.experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter:
+            if (
+                self.experts.should_fuse_routed_scaling_factor_in_topk
+                or _use_aiter
+            ):
                 x.add_(final_hidden_states)
             else:
                 x.add_(final_hidden_states, alpha=self.routed_scaling_factor)

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -367,6 +367,8 @@ class MoeFlags(_FlagGroupBase):
     tbo_token_distribution_threshold: float | None = None
     disable_fp4_allgather: bool | None = None
     quantization: str | None = None
+    nccl_ep_mode: Any = None  # NcclEpMode | None (typed Any to avoid import cycle)
+    nccl_ep_num_max_dispatch_tokens_per_rank: int = 0
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -277,7 +277,13 @@ MOE_A2A_BACKEND_CHOICES = [
     "flashinfer",
     "megamoe",
     "ascend_tp",
+    "nccl_ep",
 ]
+
+
+def _deepep_importable() -> bool:
+    """Whether the deep_ep package is importable."""
+    return importlib.util.find_spec("deep_ep") is not None
 
 MXFP8_MOE_RUNNER_BACKEND_CHOICES = [
     "cutlass",
@@ -2199,6 +2205,7 @@ class ServerArgs:
             "flashinfer",
             "megamoe",
             "ascend_tp",
+            "nccl_ep",
         ],
         Arg(
             help="Choose the backend for MoE A2A.",
@@ -2282,6 +2289,16 @@ class ServerArgs:
         "Tuned DeepEP config suitable for your own cluster. It can be either a string with JSON content or a file path.",
         NS("exec.moe"),
     ] = None
+    nccl_ep_mode: A[
+        Literal["low_latency", "auto"],
+        "NCCL EP dispatch algorithm. Only `low_latency` is implemented; `auto` resolves to it. The high-throughput (prefill) path is a follow-up.",
+        NS("exec.moe"),
+    ] = "low_latency"
+    nccl_ep_num_max_dispatch_tokens_per_rank: A[
+        int,
+        "Per-rank dispatch token budget for the NCCL EP group. 0 = use the backend default (capped at 1024).",
+        NS("exec.moe"),
+    ] = 0
     moe_dense_tp_size: A[
         Optional[int],
         Arg(
@@ -6279,6 +6296,23 @@ class ServerArgs:
         # invoked here at the legacy write slots.
         run_post_process_pass(self, _a2a_fusion_adjustments)
 
+        # NCCL EP capability check + fallback — done early so a 'deepep' fallback
+        # flows through the deepep-specific blocks below.
+        if resolved_view(self).moe_a2a_backend == "nccl_ep":
+            from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+                nccl_ep_unavailable_reason,
+            )
+
+            reason = nccl_ep_unavailable_reason()
+            if reason is not None:
+                fallback = "deepep" if _deepep_importable() else "none"
+                logger.warning(
+                    f"NCCL EP MoE requested but unavailable ({reason}); "
+                    f"falling back to moe_a2a_backend='{fallback}'. "
+                    f"Install nccl4py[cu13] on a CUDA13 + NCCL>=2.29 Hopper/Blackwell box."
+                )
+                self.moe_a2a_backend = fallback
+
         a2a_backend = resolved_view(self).moe_a2a_backend
         if self.enable_waterfill:
             self.enforce_shared_experts_fusion = True
@@ -6363,6 +6397,13 @@ class ServerArgs:
                     "must be >= the per-rank MoRI dispatch tokens "
                     "(chunked_prefill_size by default)"
                 )
+
+        if a2a_backend == "nccl_ep":
+            logger.warning(
+                f"NCCL EP MoE is enabled. The expert parallel size is adjusted "
+                f"to be the same as the tensor parallel size[{self.tp_size}]. "
+                f"Only the low-latency (LL) path is implemented; prefill and decode both run through LL."
+            )
 
     def _required_mori_dispatch_tokens_per_rank(self) -> int:
         """Max tokens a single rank dispatches through MoRI in one forward."""

--- a/test/registered/unit/layers/moe/test_nccl_ep_prefill_fallback.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_prefill_fallback.py
@@ -1,0 +1,420 @@
+"""Unit tests for NCCL EP staged execution.
+
+Tests the three-phase dispatch/combine split (dispatch_a/dispatch_b,
+combine_a/combine_b), the _Stage state machine, and the DeepEPPDispatchHooks
+mechanism.
+
+CPU-only; no GPU or NCCL required. Uses mocks for parallel state.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import torch
+
+
+class TestNcclEpStageStateMachine(unittest.TestCase):
+    """Test the _Stage enum and _update_stage guard."""
+
+    def test_stage_enum_has_four_states(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import _Stage
+
+        self.assertEqual(len(_Stage), 4)
+        self.assertIn("INITIAL", [s.name for s in _Stage])
+        self.assertIn("AFTER_DISPATCH_A", [s.name for s in _Stage])
+        self.assertIn("AFTER_DISPATCH_B", [s.name for s in _Stage])
+        self.assertIn("AFTER_COMBINE_A", [s.name for s in _Stage])
+
+    def test_update_stage_correct_transition(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._stage = _Stage.INITIAL
+        dispatcher._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+        self.assertEqual(dispatcher._stage, _Stage.AFTER_DISPATCH_A)
+        dispatcher._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+        self.assertEqual(dispatcher._stage, _Stage.AFTER_DISPATCH_B)
+        dispatcher._update_stage(_Stage.AFTER_DISPATCH_B, _Stage.AFTER_COMBINE_A)
+        self.assertEqual(dispatcher._stage, _Stage.AFTER_COMBINE_A)
+        dispatcher._update_stage(_Stage.AFTER_COMBINE_A, _Stage.INITIAL)
+        self.assertEqual(dispatcher._stage, _Stage.INITIAL)
+
+    def test_update_stage_wrong_transition_raises(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._stage = _Stage.INITIAL
+        with self.assertRaises(AssertionError):
+            dispatcher._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+
+    def test_combine_a_before_dispatch_b_raises(self):
+        """combine_a requires stage AFTER_DISPATCH_B; calling from INITIAL
+        must raise to prevent silent data corruption."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._stage = _Stage.INITIAL
+        dispatcher._dispatched_t = 1
+        dispatcher._dispatched_topk_weights = MagicMock()
+        dispatcher._handle = MagicMock()
+        dispatcher._nccl_ep = MagicMock()
+        dispatcher.hidden_size = 64
+        dispatcher.num_max_dispatch_tokens_per_rank = 128
+
+        with self.assertRaises(AssertionError):
+            dispatcher.combine_a(MagicMock())
+
+
+class TestNcclEpDispatchHooks(unittest.TestCase):
+    """Test the DeepEPPDispatchHooks mechanism for SBO."""
+
+    def test_dispatch_hooks_initialized(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPPDispatchHooks,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._dispatch_hooks = DeepEPPDispatchHooks()
+        self.assertIsInstance(dispatcher._dispatch_hooks, DeepEPPDispatchHooks)
+
+    def test_register_deepep_dispatch_hook(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPPDispatchHooks,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._dispatch_hooks = DeepEPPDispatchHooks()
+
+        called = []
+        handle = dispatcher.register_deepep_dispatch_hook(
+            lambda d: called.append(d)
+        )
+        self.assertEqual(len(called), 0)
+
+        dispatcher._dispatch_hooks(dispatcher)
+        self.assertEqual(len(called), 1)
+        self.assertIs(called[0], dispatcher)
+        handle.remove()
+
+    def test_dispatch_calls_hooks_between_a_and_b(self):
+        """dispatch() must call hooks after dispatch_a and before dispatch_b."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            NcclEpDispatcher,
+            _Stage,
+        )
+        from sglang.srt.layers.moe.token_dispatcher.deepep import (
+            DeepEPPDispatchHooks,
+        )
+
+        dispatcher = object.__new__(NcclEpDispatcher)
+        dispatcher._dispatch_hooks = DeepEPPDispatchHooks()
+        dispatcher._stage = _Stage.INITIAL
+
+        call_order = []
+
+        def mock_dispatch_a(self, hs, topk_output):
+            call_order.append("dispatch_a")
+            self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
+            self._dispatch_intermediate_state = ()
+
+        def mock_dispatch_b(self):
+            call_order.append("dispatch_b")
+            self._update_stage(_Stage.AFTER_DISPATCH_A, _Stage.AFTER_DISPATCH_B)
+            return "dispatch_output"
+
+        dispatcher.dispatch_a = mock_dispatch_a.__get__(dispatcher)
+        dispatcher.dispatch_b = mock_dispatch_b.__get__(dispatcher)
+
+        dispatcher.register_deepep_dispatch_hook(
+            lambda d: call_order.append("hook")
+        )
+
+        result = dispatcher.dispatch(
+            torch.randn(4, 64, dtype=torch.bfloat16),
+            SimpleNamespace(),
+        )
+        self.assertEqual(result, "dispatch_output")
+        self.assertEqual(call_order, ["dispatch_a", "hook", "dispatch_b"])
+
+
+class TestMaxNumSmsResolution(unittest.TestCase):
+    """Test NcclEpBuffer._resolve_max_num_sms."""
+
+    def test_default_value(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = False
+            result = NcclEpBuffer._resolve_max_num_sms(256)
+            self.assertEqual(result, 20)
+
+    def test_env_override(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = True
+            mock_env.get.return_value = 40
+            result = NcclEpBuffer._resolve_max_num_sms(256)
+            self.assertEqual(result, 40)
+
+    def test_minimum_for_large_expert_count(self):
+        """256 experts need at least ceil(256/14)=19 SMs (nccl_ep.cc:1305)."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = True
+            mock_env.get.return_value = 1  # too low
+            result = NcclEpBuffer._resolve_max_num_sms(256)
+            self.assertEqual(result, 19)  # clamped to minimum
+
+    def test_minimum_for_small_expert_count(self):
+        """64 experts need at least ceil(64/14)=5 SMs."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+
+        with patch(
+            "sglang.srt.environ.envs.SGLANG_NCCL_EP_MAX_NUM_SMS"
+        ) as mock_env:
+            mock_env.is_set.return_value = True
+            mock_env.get.return_value = 1
+            result = NcclEpBuffer._resolve_max_num_sms(64)
+            self.assertEqual(result, 5)
+
+
+class TestSBOAssertAcceptsNcclEp(unittest.TestCase):
+    """Test that the SBO assert in deepseek_v2.py accepts NcclEpDispatcher."""
+
+    def test_nccl_ep_dispatcher_is_accepted(self):
+        """The assert isinstance(..., (MaybeTboDeepEPDispatcher, NcclEpDispatcher))
+        should pass for NcclEpDispatcher instances."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpDispatcher
+        from sglang.srt.batch_overlap.two_batch_overlap import (
+            MaybeTboDeepEPDispatcher,
+        )
+
+        # Create a bare NcclEpDispatcher (no __init__)
+        dispatcher = object.__new__(NcclEpDispatcher)
+        self.assertIsInstance(
+            dispatcher,
+            (MaybeTboDeepEPDispatcher, NcclEpDispatcher),
+        )
+
+
+class TestForwardNormalSkipArConsistency(unittest.TestCase):
+    """Test skip_ar behavior for nccl_ep backend."""
+
+    def test_skip_ar_false_for_nccl_ep(self):
+        from sglang.srt.layers.moe.utils import should_skip_post_experts_all_reduce
+        from sglang.srt.layers.moe.moe_runner.base import MoeA2ABackend
+
+        with patch(
+            "sglang.srt.layers.moe.utils.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.NCCL_EP,
+        ):
+            with patch(
+                "sglang.srt.layers.moe.utils.should_skip_mlp_all_reduce",
+                return_value=False,
+            ):
+                with patch(
+                    "sglang.srt.layers.moe.utils.should_use_dp_reduce_scatterv",
+                    return_value=False,
+                ):
+                    with patch(
+                        "sglang.srt.layers.moe.utils.get_server_args"
+                    ) as mock_sa:
+                        mock_sa.return_value = SimpleNamespace(dwdp_size=1)
+                        result = should_skip_post_experts_all_reduce(
+                            is_tp_path=True
+                        )
+
+        self.assertFalse(result)
+
+
+class TestNcclEpFuseAllreduceBehavior(unittest.TestCase):
+    """Test NCCL EP backend causes fuse_mlp_allreduce=False."""
+
+    def test_aiter_fusion_requires_a2a_none(self):
+        from sglang.srt.layers.moe.moe_runner.base import MoeA2ABackend
+
+        self.assertFalse(MoeA2ABackend.NCCL_EP.is_none())
+        self.assertTrue(MoeA2ABackend.NONE.is_none())
+
+
+class TestNcclEpDispatcherEpGroupType(unittest.TestCase):
+    """Test that create_moe_dispatcher passes get_tp_group() as ep_group."""
+
+    def test_create_moe_dispatcher_passes_tp_group_as_ep_group(self):
+        from sglang.srt.layers.moe.fused_moe_triton.layer import (
+            create_moe_dispatcher,
+        )
+        from sglang.srt.layers.moe.moe_runner.base import MoeA2ABackend, MoeRunnerConfig
+
+        cfg = MoeRunnerConfig(
+            num_experts=256,
+            num_local_experts=32,
+            hidden_size=6144,
+            top_k=8,
+            params_dtype=torch.bfloat16,
+        )
+
+        tp_group_mock = MagicMock(world_size=8)
+
+        with patch(
+            "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.NCCL_EP,
+        ):
+            with patch(
+                "sglang.srt.layers.moe.fused_moe_triton.layer.get_tp_group",
+                return_value=tp_group_mock,
+            ):
+                with patch(
+                    "sglang.srt.layers.moe.token_dispatcher.nccl_ep.NcclEpDispatcher"
+                ) as mock_disp_class:
+                    create_moe_dispatcher(cfg)
+
+                    call_kwargs = mock_disp_class.call_args
+                    self.assertIn("ep_group", call_kwargs.kwargs)
+                    self.assertIs(call_kwargs.kwargs["ep_group"], tp_group_mock)
+
+
+class TestNcclRuntimeVersionParsing(unittest.TestCase):
+    """Test _nccl_runtime_version() handles nccl4py 0.3.x VersionInfo format."""
+
+    def test_returns_none_when_no_nccl4py(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _nccl_runtime_version,
+        )
+
+        with patch.dict("sys.modules", {"nccl": None, "nccl.core": None}):
+            with patch("torch.cuda.nccl.version", side_effect=Exception):
+                result = _nccl_runtime_version()
+                # Should return None or fall through gracefully
+                # (may still return torch's version if import fails silently)
+                self.assertTrue(result is None or isinstance(result, tuple))
+
+    def test_parses_versioninfo_namedtuple(self):
+        """nccl4py 0.3.x returns VersionInfo(nccl=LibraryInfo(version=<Version('2.30.7')>...))."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _nccl_runtime_version,
+        )
+
+        mock_version_info = SimpleNamespace(
+            nccl=SimpleNamespace(
+                version="2.30.7"
+            )
+        )
+
+        with patch.dict("sys.modules", {"nccl": MagicMock(), "nccl.core": MagicMock()}):
+            import sys
+            mock_nccl = MagicMock()
+            mock_nccl.get_version.return_value = mock_version_info
+            sys.modules["nccl"] = mock_nccl
+
+            mock_core = MagicMock()
+            mock_core.get_version.return_value = ""
+            sys.modules["nccl.core"] = mock_core
+
+            with patch("torch.cuda.nccl.version", return_value=(2, 28, 9)):
+                result = _nccl_runtime_version()
+                self.assertEqual(result, (2, 30, 7))
+
+    def test_falls_back_to_torch_version(self):
+        """When nccl4py returns unparseable data, fall back to torch.cuda.nccl.version."""
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _nccl_runtime_version,
+        )
+
+        with patch.dict("sys.modules", {"nccl": MagicMock(), "nccl.core": MagicMock()}):
+            import sys
+            mock_nccl = MagicMock()
+            mock_nccl.get_version.return_value = None
+            sys.modules["nccl"] = mock_nccl
+
+            mock_core = MagicMock()
+            mock_core.get_version.return_value = None
+            sys.modules["nccl.core"] = mock_core
+
+            with patch("torch.cuda.nccl.version", return_value=(2, 28, 9)):
+                result = _nccl_runtime_version()
+                self.assertEqual(result, (2, 28, 9))
+
+
+class TestNcclEpCapabilityCheck(unittest.TestCase):
+    """Test is_nccl_ep_available() and nccl_ep_unavailable_reason()."""
+
+    def test_unavailable_reason_returns_str_or_none(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            nccl_ep_unavailable_reason,
+        )
+
+        reason = nccl_ep_unavailable_reason()
+        self.assertTrue(reason is None or isinstance(reason, str))
+
+    def test_is_nccl_ep_available_returns_bool(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            is_nccl_ep_available,
+        )
+
+        result = is_nccl_ep_available()
+        self.assertIsInstance(result, bool)
+
+
+class TestNcclEpHiddenAllowlist(unittest.TestCase):
+    """Test that NcclEpDispatcher enforces the hidden size allowlist."""
+
+    def test_allowed_hidden_sizes(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _NCCL_EP_LL_SUPPORTED_HIDDEN,
+        )
+
+        # DeepSeek-V2/V3 family hidden sizes
+        for h in [5120, 6144, 7168]:
+            self.assertIn(h, _NCCL_EP_LL_SUPPORTED_HIDDEN)
+
+    def test_disallowed_hidden_sizes(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _NCCL_EP_LL_SUPPORTED_HIDDEN,
+        )
+
+        for h in [1024, 3072]:
+            self.assertNotIn(h, _NCCL_EP_LL_SUPPORTED_HIDDEN)
+
+
+class TestNcclEpTopkGuard(unittest.TestCase):
+    """Test that NcclEpDispatcher enforces topk <= 9 guard."""
+
+    def test_topk_guard_constant(self):
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            _NCCL_EP_LL_MAX_TOPK,
+        )
+
+        self.assertEqual(_NCCL_EP_LL_MAX_TOPK, 9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/moe/test_nccl_ep_synthetic.py
+++ b/test/registered/unit/layers/moe/test_nccl_ep_synthetic.py
@@ -1,0 +1,486 @@
+"""Synthetic NCCL EP dispatch/combine verification (4-GPU, no model weights).
+
+Runs via torchrun on 4 GPUs. Validates the real NcclEpDispatcher code path
+(comm init -> dispatch A2A -> bf16->fp8 post-quant -> combine A2A -> destroy)
+without loading any model, using synthetic bf16 inputs.
+
+Usage (on a 4-GPU node with NCCL >= 2.29):
+
+    CUDA_VISIBLE_DEVICES=4,5,6,7 \
+    LD_PRELOAD=/usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2 \
+    torchrun --nproc_per_node=4 \
+        test/registered/unit/layers/moe/test_nccl_ep_synthetic.py
+
+Covers:
+    1. NCCL EP group creation (LL, no-IB RDMA buffer init)
+    2. dispatch A2A real send/recv correctness
+    3. bf16->fp8 post-quant numerical correctness (vs reference)
+    4. combine A2A real send/recv + budget assert + handle destroy
+    5. constraint guards (hidden allowlist, topk<=9) fail-fast
+    6. dispatch->combine round-trip consistency (identity expert)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+from types import SimpleNamespace
+from typing import Optional
+
+import torch
+import torch.distributed as dist
+from unittest.mock import patch, MagicMock
+
+# ---- sglang imports (must come after env setup) ----
+from sglang.srt.distributed.device_communicators.pynccl import PyNcclCommunicator
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+    NcclEpDispatcher,
+    is_nccl_ep_available,
+    nccl_ep_unavailable_reason,
+    _nccl_runtime_version,
+)
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+# ---- monkey-patch runtime_context: NcclEpDispatcher.__init__ calls
+# get_exec().deterministic.enable_deterministic_inference, but we don't
+# run the full sglang server bootstrap. Patch it to return a mock that
+# reports deterministic=False (the safe default for a synthetic test).
+import sglang.srt.runtime_context as _rtc
+
+class _MockDeterministic:
+    enable_deterministic_inference = False
+
+class _MockExec:
+    deterministic = _MockDeterministic()
+
+_original_get_exec = _rtc.get_exec
+
+
+def _mocked_get_exec():
+    return _MockExec()
+
+
+_rtc.get_exec = _mocked_get_exec
+
+# ---- test config (mirrors DeepSeek-V3 / GLM-5.2 W4AFP8 constraints) ----
+NUM_EXPERTS = 256
+TOPK = 8
+HIDDEN = 7168          # in LL allowlist; 6144 also works
+NUM_LAYERS = 1         # synthetic: single MoE layer
+BATCH_TOKENS = 128     # per-rank decode tokens (< 1024 budget)
+
+
+def log(rank: int, msg: str):
+    """Rank-0 tagged log, but each rank prints its own PASS/FAIL."""
+    prefix = f"[rank {rank}]"
+    print(f"{prefix} {msg}", flush=True)
+
+
+def setup_distributed():
+    """Init gloo backend (for metadata) + create NCCL communicator via PyNccl."""
+    dist.init_process_group(backend="gloo")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+
+    torch.cuda.set_device(local_rank)
+
+    # Create a gloo sub-group (PyNcclCommunicator requires non-NCCL backend).
+    cpu_group = dist.new_group(backend="gloo")
+
+    # Build a real NCCL communicator bound to this GPU.
+    pynccl_comm = PyNcclCommunicator(group=cpu_group, device=local_rank)
+
+    # Minimal ep_group mock: NcclEpDispatcher only needs world_size + pynccl_comm.
+    # _create_group reads ep_group.pynccl_comm.comm.value (ncclComm_t ptr).
+    ep_group = SimpleNamespace(
+        world_size=world_size,
+        rank=rank,
+        rank_in_group=rank,
+        pynccl_comm=pynccl_comm,
+    )
+    return rank, world_size, local_rank, ep_group
+
+
+def make_moe_runner_config(hidden: int = HIDDEN, topk: int = TOPK):
+    """Build a minimal MoeRunnerConfig for NcclEpDispatcher.__init__."""
+    return MoeRunnerConfig(
+        num_experts=NUM_EXPERTS,
+        num_local_experts=NUM_EXPERTS // dist.get_world_size(),
+        hidden_size=hidden,
+        top_k=topk,
+        params_dtype=torch.bfloat16,
+    )
+
+
+def make_synthetic_inputs(
+    rank: int, batch: int, hidden: int, num_experts: int, topk: int, device: torch.device
+):
+    """Create deterministic synthetic hidden_states + topk routing.
+
+    Each token routes to `topk` experts. Routing is deterministic per-rank so
+    cross-rank results are reproducible. We use a simple hash: expert_id =
+    (token_idx * 7 + rank * 13) % num_experts, cycled for topk picks.
+    """
+    torch.manual_seed(42 + rank)
+    hidden_states = torch.randn(batch, hidden, dtype=torch.bfloat16, device=device)
+
+    topk_ids = torch.zeros(batch, topk, dtype=torch.int64, device=device)
+    for t in range(batch):
+        for k in range(topk):
+            topk_ids[t, k] = (t * 7 + rank * 13 + k * 31) % num_experts
+
+    # Uniform weights (will be renormalized by dispatcher anyway).
+    topk_weights = torch.ones(batch, topk, dtype=torch.float32, device=device) / topk
+
+    topk_output = StandardTopKOutput(
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        router_logits=torch.zeros(batch, num_experts, dtype=torch.float32, device=device),
+    )
+    return hidden_states, topk_output
+
+
+def reference_fp8_quant(x: torch.Tensor, group_size: int = 128):
+    """Reference per-token-group fp8 (e4m3) quantization in pure PyTorch.
+
+    Mirrors sglang_per_token_group_quant_fp8: scale = max(|x_group|) / 448,
+    x_q = round(x / scale) clamped to fp8 range, cast to fp8_e4m3fn.
+    """
+    assert x.shape[-1] % group_size == 0
+    orig_shape = x.shape
+    n_groups = orig_shape[-1] // group_size
+    x_2d = x.reshape(-1, group_size)
+    # max abs per group -> scale
+    group_max = x_2d.abs().amax(dim=-1, keepdim=True).clamp(min=1e-10)
+    scale = group_max / 448.0
+    x_scaled = (x_2d / scale).round().clamp(-448.0, 448.0)
+    x_q = x_scaled.reshape(orig_shape).to(torch.float8_e4m3fn)
+    scale = scale.reshape(*orig_shape[:-1], n_groups)
+    return x_q, scale
+
+
+def test_1_gate_and_env(rank: int):
+    """Verify is_nccl_ep_available() returns True with LD_PRELOAD'd NCCL >= 2.29."""
+    ver = _nccl_runtime_version()
+    available = is_nccl_ep_available()
+    reason = nccl_ep_unavailable_reason()
+    log(rank, f"[1] NCCL runtime={ver} available={available} reason='{reason}'")
+    assert available, f"NCCL EP not available: {reason}. Need LD_PRELOAD NCCL >= 2.29."
+    assert ver is not None and (ver[0], ver[1]) >= (2, 29), f"NCCL {ver} < 2.29"
+    log(rank, "[1] PASS: gate check (NCCL >= 2.29, sm_90, nccl4py importable)")
+
+
+def test_2_group_creation(rank: int, ep_group, hidden: int):
+    """Verify NCCL EP LOW_LATENCY group can be created (the no-IB RDMA init test)."""
+    cfg = make_moe_runner_config(hidden=hidden)
+    # StandardDispatcher.__init__ calls get_parallel().moe_ep_size which requires
+    # a fully initialized sglang parallel state. In this synthetic test we don't
+    # run the full server bootstrap, so mock StandardDispatcher to avoid the
+    # dependency.
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        try:
+            dispatcher = NcclEpDispatcher(cfg, ep_group)
+        except Exception as e:
+            log(rank, f"[2] FAIL: group creation raised: {e}")
+            raise
+    log(rank, "[2] PASS: NCCL EP LOW_LATENCY group created (RDMA buffer init OK)")
+    return dispatcher
+
+
+def test_3_dispatch(rank: int, dispatcher: NcclEpDispatcher, hidden: int):
+    """Verify dispatch A2A: real bf16 send/recv across 4 ranks."""
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+    hs, topk_output = make_synthetic_inputs(
+        rank, BATCH_TOKENS, hidden, NUM_EXPERTS, TOPK, device
+    )
+
+    dispatch_output = dispatcher.dispatch(hs, topk_output)
+
+    # Check output types/shapes
+    assert dispatch_output.hidden_states.dtype == torch.float8_e4m3fn, (
+        f"expected fp8_e4m3fn, got {dispatch_output.hidden_states.dtype}"
+    )
+    assert dispatch_output.hidden_states.is_cuda, "hidden_states not on GPU"
+    assert dispatch_output.hidden_states_scale.dtype == torch.float32, (
+        f"expected float32 scale, got {dispatch_output.hidden_states_scale.dtype}"
+    )
+
+    # masked_m should reflect actual recv counts (non-zero in general).
+    total_recv = dispatch_output.masked_m.sum().item()
+    log(
+        rank,
+        f"[3] dispatch OK: hs_fp8={tuple(dispatch_output.hidden_states.shape)} "
+        f"scale={tuple(dispatch_output.hidden_states_scale.shape)} "
+        f"total_recv_tokens={total_recv} expected_m={dispatch_output.expected_m}",
+    )
+    return dispatch_output, hs, topk_output
+
+
+def test_4_fp8_quant_correctness(
+    rank: int, dispatcher: NcclEpDispatcher, dispatch_output, hidden: int
+):
+    """Verify bf16->fp8 post-quant matches reference quantization.
+
+    The dispatcher already ran _quantize_fp8 internally during dispatch.
+    We re-run the reference on a known small tensor and compare to the sglang
+    kernel directly, to validate the quant path used by NCCL EP.
+    """
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+    group_size = 128
+
+    # Small deterministic test tensor
+    torch.manual_seed(123)
+    test_x = torch.randn(4, hidden, dtype=torch.bfloat16, device=device)
+
+    # sglang kernel (same one NCCL EP calls)
+    q_kernel, s_kernel = sglang_per_token_group_quant_fp8(
+        test_x, group_size=group_size
+    )
+    # reference
+    q_ref, s_ref = reference_fp8_quant(test_x, group_size=group_size)
+
+    # Scales should match closely (both compute max/448)
+    scale_diff = (s_kernel - s_ref.to(device)).abs().max().item()
+    # Quantized values: allow small rounding diff (kernel may use slightly
+    # different rounding). Check correlation: dequant should be close.
+    # scale is [4, 56] (7168/128=56 groups), need to expand to [4, 7168] for broadcast
+    s_kernel_expanded = s_kernel.repeat_interleave(group_size, dim=-1).to(torch.float32)
+    s_ref_expanded = s_ref.to(device).repeat_interleave(group_size, dim=-1).to(torch.float32)
+    dq_kernel = q_kernel.to(torch.float32) * s_kernel_expanded
+    dq_ref = q_ref.to(torch.float32) * s_ref_expanded
+    max_err = (dq_kernel - dq_ref).abs().max().item()
+
+    log(
+        rank,
+        f"[4] fp8 quant: scale_diff={scale_diff:.2e} dequant_max_err={max_err:.2e}",
+    )
+    assert scale_diff < 1e-3, f"scale mismatch: {scale_diff}"
+    assert max_err < 0.5, f"dequant error too large: {max_err}"
+    log(rank, "[4] PASS: bf16->fp8 post-quant matches reference")
+
+
+def test_5_combine(rank: int, dispatcher: NcclEpDispatcher, dispatch_output, topk_output):
+    """Verify combine A2A: real bf16 send/recv back + handle destroy."""
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+
+    # For synthetic test, we don't have real expert weights/GEMM.
+    # The combine needs expert_outputs in DeepEPLLCombineInput format.
+    # We feed back a zero tensor of the expected shape to verify combine
+    # mechanics (A2A communication + handle lifecycle) without GEMM.
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
+
+    # dispatch_output.hidden_states is [E_local, max_recv, H] fp8.
+    # combine expects expert_outputs of compatible shape.
+    # Use the fp8 tensor cast back to bf16 as a stand-in (mechanical test).
+    expert_outputs = dispatch_output.hidden_states.to(torch.bfloat16)
+
+    combine_input = DeepEPLLCombineInput(
+        hidden_states=expert_outputs,
+        topk_ids=dispatch_output.topk_ids,
+        topk_weights=dispatch_output.topk_weights,
+    )
+
+    combined = dispatcher.combine(combine_input)
+    assert combined.dtype == torch.bfloat16, f"expected bf16, got {combined.dtype}"
+    assert combined.is_cuda, "combined not on GPU"
+    assert combined.shape[1] == dispatcher.hidden_size
+
+    log(
+        rank,
+        f"[5] combine OK: combined={tuple(combined.shape)} "
+        f"mean={combined.float().mean().item():.4f} "
+        f"handle_destroyed={dispatcher.handle is None}",
+    )
+    assert dispatcher.handle is None, "handle not destroyed after combine"
+    log(rank, "[5] PASS: combine A2A + handle destroy")
+
+
+def test_6_roundtrip_identity(rank: int, ep_group, hidden: int):
+    """Round-trip consistency with identity expert.
+
+    Re-create a fresh dispatcher. Dispatch bf16 input, then for combine feed
+    back the *dispatched bf16 tokens* directly (identity expert = no GEMM).
+    The combine should return tokens in original order with topk weighting.
+
+    This is the strongest end-to-end correctness signal for the A2A layer.
+    """
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+    world_size = dist.get_world_size()
+
+    # Fresh dispatcher (previous one destroyed its handle/group)
+    # NcclEpBuffer is process-global singleton; reuse same group.
+    cfg = make_moe_runner_config(hidden=hidden)
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        dispatcher = NcclEpDispatcher(cfg, ep_group)
+
+    batch = BATCH_TOKENS
+    hs, topk_output = make_synthetic_inputs(
+        rank, batch, hidden, NUM_EXPERTS, TOPK, device
+    )
+
+    dispatch_output = dispatcher.dispatch(hs, topk_output)
+
+    # Identity expert: feed the dispatched bf16 tokens back as "expert output".
+    # recv_tokens shape is [E_local, max_recv, H]; combine sends these back.
+    # We use the fp8->bf16 cast (dispatch already quantized; we unquantize).
+    expert_outputs = dispatch_output.hidden_states.to(torch.bfloat16)
+
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPLLCombineInput
+
+    combine_input = DeepEPLLCombineInput(
+        hidden_states=expert_outputs,
+        topk_ids=dispatch_output.topk_ids,
+        topk_weights=dispatch_output.topk_weights,
+    )
+    combined = dispatcher.combine(combine_input)
+
+    # With identity expert + uniform 1/topk weights, combined should be
+    # proportional to the original input (modulo quantization noise + the
+    # fact that combine sums topk weighted copies).
+    # Check: combined is finite (no NaN/Inf from broken A2A).
+    assert torch.isfinite(combined).all(), "combined has NaN/Inf"
+
+    # Check shape: [batch, hidden]
+    assert combined.shape[0] == batch, f"expected batch={batch}, got {combined.shape[0]}"
+    assert combined.shape[1] == hidden
+
+    log(
+        rank,
+        f"[6] roundtrip OK: combined={tuple(combined.shape)} "
+        f"finite=True "
+        f"||combined||={combined.float().norm().item():.2f} "
+        f"||input||={hs.float().norm().item():.2f}",
+    )
+    log(rank, "[6] PASS: dispatch->combine round-trip (identity expert, finite output)")
+
+
+def test_7_guard_hidden_allowlist(rank: int, ep_group):
+    """Verify hidden allowlist guard fires for unsupported hidden size."""
+    cfg = make_moe_runner_config(hidden=3072)  # NOT in allowlist
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        try:
+            NcclEpDispatcher(cfg, ep_group)
+            log(rank, "[7] FAIL: expected ValueError for hidden=3072 (not in allowlist)")
+            assert False, "should have raised"
+        except ValueError as e:
+            assert "NCCL EP LL only supports hidden" in str(e)
+            log(rank, f"[7] PASS: hidden allowlist guard fired (hidden=3072 rejected)")
+        except Exception as e:
+            log(rank, f"[7] FAIL: wrong exception type: {type(e).__name__}: {e}")
+            raise
+
+
+def test_8_guard_topk(rank: int, ep_group):
+    """Verify topk<=9 guard fires for topk=10."""
+    cfg = make_moe_runner_config(hidden=HIDDEN, topk=10)
+    with patch(
+        "sglang.srt.layers.moe.token_dispatcher.standard.StandardDispatcher"
+    ) as mock_sd:
+        mock_sd.return_value = MagicMock()
+        try:
+            NcclEpDispatcher(cfg, ep_group)
+            log(rank, "[8] FAIL: expected ValueError for topk=10 (>9)")
+            assert False, "should have raised"
+        except ValueError as e:
+            assert "topk" in str(e).lower()
+            log(rank, f"[8] PASS: topk guard fired (topk=10 rejected)")
+        except Exception as e:
+            log(rank, f"[8] FAIL: wrong exception type: {type(e).__name__}: {e}")
+            raise
+
+
+def main():
+    rank, world_size, local_rank, ep_group = setup_distributed()
+    device = torch.device(f"cuda:{local_rank}")
+
+    log(rank, f"=== NCCL EP Synthetic Verification (world_size={world_size}) ===")
+    log(rank, f"    device={device} hidden={HIDDEN} experts={NUM_EXPERTS} topk={TOPK}")
+    log(rank, f"    batch_tokens_per_rank={BATCH_TOKENS}")
+
+    results = []
+    tests = [
+        ("gate+env", lambda: test_1_gate_and_env(rank)),
+        ("group creation", lambda: test_2_group_creation(rank, ep_group, HIDDEN)),
+        ("dispatch A2A", lambda: None),  # handled inside, needs dispatcher
+        ("fp8 quant", lambda: None),
+        ("combine A2A", lambda: None),
+        ("roundtrip", lambda: None),
+        ("guard hidden", lambda: test_7_guard_hidden_allowlist(rank, ep_group)),
+        ("guard topk", lambda: test_8_guard_topk(rank, ep_group)),
+    ]
+
+    try:
+        # Test 1: gate + environment
+        test_1_gate_and_env(rank)
+        results.append(("1. gate+env", True))
+
+        # Test 2: group creation (returns dispatcher for tests 3-5)
+        dispatcher = test_2_group_creation(rank, ep_group, HIDDEN)
+        results.append(("2. group creation", True))
+
+        # Test 3: dispatch
+        dispatch_output, hs, topk_output = test_3_dispatch(rank, dispatcher, HIDDEN)
+        results.append(("3. dispatch A2A", True))
+
+        # Test 4: fp8 quant correctness
+        test_4_fp8_quant_correctness(rank, dispatcher, dispatch_output, HIDDEN)
+        results.append(("4. fp8 quant", True))
+
+        # Test 5: combine
+        test_5_combine(rank, dispatcher, dispatch_output, topk_output)
+        results.append(("5. combine A2A", True))
+
+        # Test 6: roundtrip (fresh dispatcher, reuses process-global group)
+        test_6_roundtrip_identity(rank, ep_group, HIDDEN)
+        results.append(("6. roundtrip", True))
+
+        # Test 7: guard - hidden allowlist
+        test_7_guard_hidden_allowlist(rank, ep_group)
+        results.append(("7. guard hidden", True))
+
+        # Test 8: guard - topk
+        test_8_guard_topk(rank, ep_group)
+        results.append(("8. guard topk", True))
+
+    except Exception as e:
+        log(rank, f"!!! TEST FAILED: {e}")
+        traceback.print_exc()
+        results.append(("FAILED", False))
+    finally:
+        # Cleanup
+        try:
+            from sglang.srt.layers.moe.token_dispatcher.nccl_ep import NcclEpBuffer
+            NcclEpBuffer.destroy()
+        except Exception:
+            pass
+        dist.barrier()
+        dist.destroy_process_group()
+
+    # Summary
+    log(rank, "=== RESULTS ===")
+    for name, ok in results:
+        log(rank, f"  {'PASS' if ok else 'FAIL'}: {name}")
+
+    all_pass = all(ok for _, ok in results)
+    log(rank, f"=== {'ALL PASS' if all_pass else 'SOME FAILED'} ===")
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1134,6 +1134,51 @@ class TestWaterfillArgs(CustomTestCase):
         self.assertTrue(server_args.enforce_shared_experts_fusion)
 
 
+class TestNcclEpArgs(CustomTestCase):
+    """NCCL EP MoE A2A backend (--moe-a2a-backend nccl_ep).
+
+    Capability detection falls back to none/deepep when nccl4py is unavailable
+    (the CPU CI case). On a CUDA13 + Hopper/Blackwell box with nccl4py[cu13]
+    installed, the backend stays nccl_ep.
+    """
+
+    def test_nccl_ep_flag_accepted(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="nccl_ep",
+            nccl_ep_mode="low_latency",
+            nccl_ep_num_max_dispatch_tokens_per_rank=1024,
+        )
+        # dummy-model path short-circuits __post_init__; invoke the handler directly.
+        server_args._handle_a2a_moe()
+
+        self.assertEqual(server_args.nccl_ep_mode, "low_latency")
+        self.assertEqual(
+            server_args.nccl_ep_num_max_dispatch_tokens_per_rank, 1024
+        )
+
+    def test_nccl_ep_falls_back_when_unavailable(self):
+        # On CPU CI (no nccl4py / no CUDA), is_nccl_ep_available() is False and
+        # the backend must degrade to 'none' (or 'deepep' if deep_ep importable).
+        from sglang.srt.layers.moe.token_dispatcher.nccl_ep import (
+            is_nccl_ep_available,
+        )
+
+        server_args = ServerArgs(
+            model_path="dummy",
+            moe_a2a_backend="nccl_ep",
+        )
+        server_args._handle_a2a_moe()
+
+        if is_nccl_ep_available():
+            self.assertEqual(server_args.moe_a2a_backend, "nccl_ep")
+        else:
+            self.assertIn(
+                server_args.moe_a2a_backend, ("none", "deepep"),
+                f"expected fallback to none/deepep, got {server_args.moe_a2a_backend}",
+            )
+
+
 class TestPrefillOnlyDisableKvCache(unittest.TestCase):
     """Validation for --prefill-only-disable-kv-cache.
 


### PR DESCRIPTION
### Summary

This PR adds **NCCL EP** as an optional `--moe-a2a-backend nccl_ep` choice, implementing the low-latency decode path with correctness parity against DeepEP.

This is the first phase of the [Roadmap: Integrate NCCL 2.30 Features into SGLang](https://github.com/sgl-project/sglang/issues/32328), leveraging NCCL EP's optimized MoE communication on Hopper/Blackwell GPUs.

### Changes

- **Enum**: Added `NCCL_EP` to `MoeA2ABackend` + `is_nccl_ep()` accessor
- **Server Args**: Added `--nccl-ep-mode` + capability fallback logic
- **Capability Detection**: `is_nccl_ep_available()` + `nccl_ep_capability_reason()`
- **NcclEpBuffer**: Process-wide group + static recv buffers (mirrors DeepEPBuffer)
- **NcclEpDispatcher**: LL dispatch/combine with bf16→fp8 post-quant
- **Wiring**: `create_moe_dispatcher` + `get_moe_impl_class` integration
- **Packaging**: Optional `nccl_ep = ["nccl4py[cu13]"]` dependency

### Key Design

- Emits `DEEPEP_LL`-format output, reusing `run_moe_core` + `apply_deepep_ll` unchanged
- bf16 dispatch + Python-side post-quant (fp8 wire un-QA'd by NVIDIA)

### Usage

```bash
pip install "sglang[nccl_ep]"
python -m sglang.launch_server --model-path <model> --moe-a2a-backend nccl_ep
```

### Follow-up Items (Future PRs)

- HT prefill path
- CUDA Graph capture
- EPLB, SBO/TBO, deterministic fallback

### Dependencies

- Optional: `nccl4py[cu13]`
- Runtime: NCCL ≥ 2.29 (may require `nvidia-nccl-cu13` + `LD_PRELOAD`)

Closes #32328

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30510954556](https://github.com/sgl-project/sglang/actions/runs/30510954556)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30510954453](https://github.com/sgl-project/sglang/actions/runs/30510954453)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->