### PR TITLE
fix: enable FlashInfer TRT-LLM all-reduce on SM12X

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1894,7 +1894,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--flashinfer-allreduce-fusion-backend`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable FlashInfer allreduce fusion and choose backend. Defaults to auto. 'auto': choose mnnvl on SM90 single-node systems and SM100/SM103 single-node or multi-node systems; choose trtllm otherwise. 'trtllm': available on single-node systems only. 'mnnvl': available on SM90 single-node systems and SM100/SM103 single-node or multi-node systems via MNNVL fabric. Fuses allreduce with Residual + RMSNorm for supported MoE models.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable FlashInfer allreduce fusion and choose backend. Requires SM90, SM10X, or SM120 NVIDIA GPUs. Defaults to auto. 'auto': choose mnnvl on Blackwell (SM100/SM103) systems (single- and multi-node) and trtllm on SM90/SM120 single-node systems. 'trtllm': available on single-node systems only. 'mnnvl': available on SM90 single-node systems and SM100/SM103 single-node or multi-node systems via MNNVL fabric. Fuses allreduce with Residual + RMSNorm for supported MoE models.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>trtllm</code>, <code>mnnvl</code></td>
     </tr>

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1894,7 +1894,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--flashinfer-allreduce-fusion-backend`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable FlashInfer allreduce fusion and choose backend. Requires SM90, SM10X, or SM120 NVIDIA GPUs. Defaults to auto. 'auto': choose mnnvl on Blackwell (SM100/SM103) systems (single- and multi-node) and trtllm on SM90/SM120 single-node systems. 'trtllm': available on single-node systems only. 'mnnvl': available on SM90 single-node systems and SM100/SM103 single-node or multi-node systems via MNNVL fabric. Fuses allreduce with Residual + RMSNorm for supported MoE models.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable FlashInfer allreduce fusion and choose backend. Requires SM90, SM10X, or SM12X (SM120/SM121) NVIDIA GPUs. Defaults to auto. 'auto': choose mnnvl on Blackwell (SM100/SM103) systems (single- and multi-node) and trtllm on SM90, SM120, and SM121 single-node systems. 'trtllm': available on single-node systems only. 'mnnvl': available on SM90 single-node systems and SM100/SM103 single-node or multi-node systems via MNNVL fabric. Fuses allreduce with Residual + RMSNorm for supported MoE models.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>trtllm</code>, <code>mnnvl</code></td>
     </tr>

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1644,9 +1644,9 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
 @register_post_process
 def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
     """Slot pass at the monolith tail: auto-enable FlashInfer AllReduce
-    Fusion on SM90/SM100/SM120 for models with explicit support. auto resolves
-    to mnnvl on SM100 (single- and multi-node) and trtllm on SM90/SM120
-    single-node systems. Reads the mid-resolution enable_dp_attention /
+    Fusion on SM90/SM100/SM12X (SM120/SM121) for models with explicit support.
+    auto resolves to mnnvl on SM100 (single- and multi-node) and trtllm on
+    SM90/SM12X single-node systems. Reads the mid-resolution enable_dp_attention /
     moe_a2a_backend (after the DeepSeek CP and a2a declarations), exactly
     like the legacy tail block."""
     model_arch = view.get_model_config().hf_config.architectures[0]
@@ -1660,8 +1660,8 @@ def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
         and view.moe_a2a_backend == "none"
     ):
         logger.info(
-            f"Auto-enabling FlashInfer AllReduce Fusion on SM90/SM10X/SM120 "
-            f"for {model_arch}"
+            f"Auto-enabling FlashInfer AllReduce Fusion on "
+            f"SM90/SM10X/SM12X (SM120/SM121) for {model_arch}"
         )
         return {"flashinfer_allreduce_fusion_backend": "auto"}
     return {}

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1644,8 +1644,8 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
 @register_post_process
 def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
     """Slot pass at the monolith tail: auto-enable FlashInfer AllReduce
-    Fusion on SM90/SM100 for models with explicit support. auto resolves to
-    mnnvl on Blackwell (single- and multi-node) and trtllm on SM90
+    Fusion on SM90/SM100/SM120 for models with explicit support. auto resolves
+    to mnnvl on SM100 (single- and multi-node) and trtllm on SM90/SM120
     single-node systems. Reads the mid-resolution enable_dp_attention /
     moe_a2a_backend (after the DeepSeek CP and a2a declarations), exactly
     like the legacy tail block."""
@@ -1653,14 +1653,15 @@ def _flashinfer_allreduce_fusion_auto_enable(view: Any) -> dict:
     if (
         view.flashinfer_allreduce_fusion_backend is None
         and model_arch in _FLASHINFER_ALLREDUCE_FUSION_ARCHS
-        and (is_sm90_supported() or is_sm100_supported())
+        and (is_sm90_supported() or is_sm100_supported() or is_sm120_supported())
         and view.tp_size > 1
         and not view.enable_dp_attention
         and (view.nnodes == 1 or is_sm100_supported())
         and view.moe_a2a_backend == "none"
     ):
         logger.info(
-            f"Auto-enabling FlashInfer AllReduce Fusion on SM90/SM10X for {model_arch}"
+            f"Auto-enabling FlashInfer AllReduce Fusion on SM90/SM10X/SM120 "
+            f"for {model_arch}"
         )
         return {"flashinfer_allreduce_fusion_backend": "auto"}
     return {}

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -20,6 +20,7 @@ from sglang.srt.utils import (
     is_flashinfer_available,
     is_sm90_supported,
     is_sm100_supported,
+    is_sm120_supported,
 )
 from sglang.srt.utils.custom_op import register_custom_op
 
@@ -45,9 +46,10 @@ def _mnnvl_supported(is_multi_node: bool) -> bool:
 
 def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
     """Resolve the requested FlashInfer allreduce fusion backend."""
-    if not (is_sm90_supported() or is_sm100_supported()):
+    if not (is_sm90_supported() or is_sm100_supported() or is_sm120_supported()):
         raise ValueError(
-            "FlashInfer allreduce fusion requires SM90 or SM10X NVIDIA GPUs."
+            "FlashInfer allreduce fusion requires SM90, SM10X, or SM120 "
+            "NVIDIA GPUs."
         )
 
     if backend == "auto":

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -243,8 +243,16 @@ def _flashinfer_trtllm_workspace_allocation_sizes(
     max_token_num: int,
     hidden_dim: int,
     dtype: torch.dtype,
+    align_multicast: bool = False,
 ) -> list[int]:
-    """Mirror FlashInfer TRTLLM SymmDeviceMemory local allocation sizes."""
+    """Mirror FlashInfer TRTLLM SymmDeviceMemory local allocation sizes.
+
+    TRT-LLM symmetric memory is created with multicast disabled, so its
+    allocations only round to the allocation granularity. The mnnvl backend
+    allocates through McastGPUBuffer, which additionally rounds each
+    allocation to the multicast granularity; pass ``align_multicast=True`` to
+    mirror that so the preflight probes at least the real allocation size.
+    """
     elem_size = 4 if dtype == torch.float32 else 2
     buffer_size = world_size * max_token_num * hidden_dim * 2
     flag_size = world_size * 256 * 4
@@ -278,6 +286,24 @@ def _flashinfer_trtllm_workspace_allocation_sizes(
 
         allocation_size = ceil_align(buffer_size + signal_pad_size, alloc_granularity)
 
+        if align_multicast:
+            mc_prop = cuda_driver.CUmulticastObjectProp()
+            mc_prop.numDevices = world_size
+            mc_prop.size = allocation_size
+            mc_prop.handleTypes = prop.requestedHandleTypes
+
+            err, mc_granularity = cuda_driver.cuMulticastGetGranularity(
+                mc_prop,
+                cuda_driver.CUmulticastGranularity_flags.CU_MULTICAST_GRANULARITY_RECOMMENDED,
+            )
+            if err != cuda_driver.CUresult.CUDA_SUCCESS:
+                raise RuntimeError(
+                    "cuMulticastGetGranularity failed for FlashInfer "
+                    f"workspace preflight: {err}"
+                )
+
+            allocation_size = ceil_align(allocation_size, mc_granularity)
+
         allocation_sizes.append(allocation_size)
     return allocation_sizes
 
@@ -302,6 +328,7 @@ def _preflight_check_workspace_memory(
     hidden_dim: int,
     dtype: torch.dtype,
     cpu_group: Optional["torch.distributed.ProcessGroup"] = None,
+    backend: str = "trtllm",
 ) -> bool:
     """Collectively decide whether to enter FlashInfer workspace creation.
 
@@ -310,6 +337,11 @@ def _preflight_check_workspace_memory(
     exits while peers enter handle exchange, peers can hang until the watchdog
     aborts. Probe the same handle type and allocation sequence first, then vote
     on a CPU group so all ranks proceed or skip together.
+
+    The mnnvl backend allocates multicast-backed buffers, so its probe sizes
+    are additionally rounded to the multicast granularity; trtllm symmetric
+    memory disables multicast and must not query it (the query fails on
+    devices without multicast support, such as SM120).
     """
     import torch.distributed as dist
 
@@ -331,6 +363,7 @@ def _preflight_check_workspace_memory(
             max_token_num,
             hidden_dim,
             dtype,
+            align_multicast=(backend == "mnnvl"),
         )
         local_ok = _probe_cumem_create_sequence(cuda_driver, allocation_sizes, prop)
     except Exception as e:
@@ -452,6 +485,7 @@ class FlashInferWorkspaceManager:
             hidden_dim=hidden_dim,
             dtype=dtype,
             cpu_group=cpu_group,
+            backend=backend,
         ):
             _flashinfer_allreduce_unavailable = True
             self.workspace = None

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -48,7 +48,8 @@ def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
     """Resolve the requested FlashInfer allreduce fusion backend."""
     if not (is_sm90_supported() or is_sm100_supported() or is_sm120_supported()):
         raise ValueError(
-            "FlashInfer allreduce fusion requires SM90, SM10X, or SM120 NVIDIA GPUs."
+            "FlashInfer allreduce fusion requires SM90, SM10X, or SM12X "
+            "(SM120/SM121) NVIDIA GPUs."
         )
 
     if backend == "auto":
@@ -56,8 +57,8 @@ def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
             if is_sm100_supported():
                 return "mnnvl"
             raise ValueError(
-                "FlashInfer allreduce fusion does not support multi-node on "
-                "non-Blackwell systems."
+                "FlashInfer allreduce fusion does not support multi-node "
+                "outside SM100/SM103 systems."
             )
         if is_sm100_supported():
             return "mnnvl"
@@ -70,8 +71,8 @@ def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
 
     if backend == "mnnvl" and not _mnnvl_supported(is_multi_node):
         raise ValueError(
-            "FlashInfer allreduce fusion mnnvl backend requires a Blackwell "
-            "system, or SM90 single-node."
+            "FlashInfer allreduce fusion mnnvl backend requires SM100/SM103, "
+            "or SM90 single-node."
         )
     return backend
 
@@ -199,16 +200,17 @@ if is_flashinfer_available():
 # FlashInfer allreduce fusion backend support matrix for
 # --flashinfer-allreduce-fusion-backend:
 #
-#   Backend   | SM103 | SM100 | SM90        | Single-Node | Multi-Node |
-#   --------- | ----- | ----- | ----------- | ----------- | ---------- |
-#   trtllm    | Yes   | Yes   | Yes         | Yes         | No         |
-#   mnnvl     | Yes   | Yes   | Single-node | Yes         | Blackwell  |
+#   Backend   | SM103 | SM100 | SM90        | SM12X | Single-Node | Multi-Node  |
+#   --------- | ----- | ----- | ----------- | ----- | ----------- | ----------- |
+#   trtllm    | Yes   | Yes   | Yes         | Yes   | Yes         | No          |
+#   mnnvl     | Yes   | Yes   | Single-node | No    | Yes         | SM100/SM103 |
 #
-# FlashInfer allreduce fusion requires SM90 or SM10X. auto resolves to mnnvl
-# on Blackwell (SM100/SM103) systems (single- and multi-node) and to trtllm on
-# SM90 single-node systems. SM90 multi-node and non-SM90/SM10X configurations
-# are rejected. Either mnnvl or trtllm can be requested explicitly on
-# single-node systems, and mnnvl additionally on Blackwell multi-node.
+# FlashInfer allreduce fusion requires SM90, SM10X, or SM12X (SM120/SM121).
+# auto resolves to mnnvl on SM100/SM103 systems (single- and multi-node) and to
+# trtllm on SM90, SM120, and SM121 single-node systems. Multi-node outside
+# SM100/SM103 systems and non-SM90/SM10X/SM12X configurations are rejected.
+# trtllm can be requested explicitly on any supported single-node system, and
+# mnnvl on SM90 single-node plus SM100/SM103 single- or multi-node.
 
 
 def is_flashinfer_allreduce_unavailable() -> bool:

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -48,8 +48,7 @@ def _resolve_backend(backend: str, is_multi_node: bool = False) -> str:
     """Resolve the requested FlashInfer allreduce fusion backend."""
     if not (is_sm90_supported() or is_sm100_supported() or is_sm120_supported()):
         raise ValueError(
-            "FlashInfer allreduce fusion requires SM90, SM10X, or SM120 "
-            "NVIDIA GPUs."
+            "FlashInfer allreduce fusion requires SM90, SM10X, or SM120 NVIDIA GPUs."
         )
 
     if backend == "auto":
@@ -277,22 +276,6 @@ def _flashinfer_trtllm_workspace_allocation_sizes(
 
         allocation_size = ceil_align(buffer_size + signal_pad_size, alloc_granularity)
 
-        mc_prop = cuda_driver.CUmulticastObjectProp()
-        mc_prop.numDevices = world_size
-        mc_prop.size = allocation_size
-        mc_prop.handleTypes = prop.requestedHandleTypes
-
-        err, mc_granularity = cuda_driver.cuMulticastGetGranularity(
-            mc_prop,
-            cuda_driver.CUmulticastGranularity_flags.CU_MULTICAST_GRANULARITY_RECOMMENDED,
-        )
-        if err != cuda_driver.CUresult.CUDA_SUCCESS:
-            raise RuntimeError(
-                "cuMulticastGetGranularity failed for FlashInfer "
-                f"workspace preflight: {err}"
-            )
-
-        allocation_size = ceil_align(allocation_size, mc_granularity)
         allocation_sizes.append(allocation_size)
     return allocation_sizes
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1951,10 +1951,10 @@ class ServerArgs:
         Arg(
             help=(
                 "Enable FlashInfer allreduce fusion and choose backend. "
-                "Requires SM90 or SM10X NVIDIA GPUs. "
+                "Requires SM90, SM10X, or SM120 NVIDIA GPUs. "
                 "Defaults to auto. "
                 "'auto': choose mnnvl on Blackwell (SM100/SM103) systems "
-                "(single- and multi-node) and trtllm on SM90 single-node systems. "
+                "(single- and multi-node) and trtllm on SM90/SM120 single-node systems. "
                 "'trtllm': available on single-node systems only. "
                 "'mnnvl': available on SM90 single-node systems and SM100/SM103 "
                 "single-node or multi-node systems via MNNVL fabric. "

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1951,10 +1951,11 @@ class ServerArgs:
         Arg(
             help=(
                 "Enable FlashInfer allreduce fusion and choose backend. "
-                "Requires SM90, SM10X, or SM120 NVIDIA GPUs. "
+                "Requires SM90, SM10X, or SM12X (SM120/SM121) NVIDIA GPUs. "
                 "Defaults to auto. "
                 "'auto': choose mnnvl on Blackwell (SM100/SM103) systems "
-                "(single- and multi-node) and trtllm on SM90/SM120 single-node systems. "
+                "(single- and multi-node) and trtllm on SM90, SM120, and SM121 "
+                "single-node systems. "
                 "'trtllm': available on single-node systems only. "
                 "'mnnvl': available on SM90 single-node systems and SM100/SM103 "
                 "single-node or multi-node systems via MNNVL fabric. "

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -81,7 +81,10 @@ class TestFlashInferCommFusion(unittest.TestCase):
         )
 
         # Blackwell: mnnvl on both single-node and multi-node.
-        with patch.object(fusion, "is_sm100_supported", return_value=True):
+        with (
+            patch.object(fusion, "is_sm100_supported", return_value=True),
+            patch.object(fusion, "is_sm120_supported", return_value=False),
+        ):
             self.assertEqual(
                 fusion.resolve_flashinfer_allreduce_fusion_backend(single_node),
                 "mnnvl",
@@ -94,6 +97,7 @@ class TestFlashInferCommFusion(unittest.TestCase):
         with (
             patch.object(fusion, "is_sm100_supported", return_value=False),
             patch.object(fusion, "is_sm90_supported", return_value=True),
+            patch.object(fusion, "is_sm120_supported", return_value=False),
         ):
             self.assertEqual(
                 fusion.resolve_flashinfer_allreduce_fusion_backend(single_node),
@@ -102,13 +106,26 @@ class TestFlashInferCommFusion(unittest.TestCase):
             with self.assertRaises(ValueError):
                 fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node)
 
-        # Architectures outside SM90/SM10X are unsupported. Both pre-SM90
-        # and post-SM10X devices (e.g. SM120) must fail closed.
-        for arch in ("pre_sm90", "post_sm10x"):
+        # SM120: auto uses trtllm on single-node, multi-node is unsupported.
+        with (
+            patch.object(fusion, "is_sm100_supported", return_value=False),
+            patch.object(fusion, "is_sm90_supported", return_value=False),
+            patch.object(fusion, "is_sm120_supported", return_value=True),
+        ):
+            self.assertEqual(
+                fusion.resolve_flashinfer_allreduce_fusion_backend(single_node),
+                "trtllm",
+            )
+            with self.assertRaises(ValueError):
+                fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node)
+
+        # Architectures outside SM90/SM10X/SM120 are unsupported.
+        for arch in ("pre_sm90", "post_sm120"):
             with (
                 self.subTest(arch=arch),
                 patch.object(fusion, "is_sm100_supported", return_value=False),
                 patch.object(fusion, "is_sm90_supported", return_value=False),
+                patch.object(fusion, "is_sm120_supported", return_value=False),
             ):
                 with self.assertRaises(ValueError):
                     fusion.resolve_flashinfer_allreduce_fusion_backend(single_node)
@@ -132,6 +149,7 @@ class TestFlashInferCommFusion(unittest.TestCase):
         with (
             patch.object(fusion, "is_sm100_supported", return_value=False),
             patch.object(fusion, "is_sm90_supported", return_value=True),
+            patch.object(fusion, "is_sm120_supported", return_value=False),
         ):
             self.assertEqual(
                 fusion.resolve_flashinfer_allreduce_fusion_backend(single_node_mnnvl),
@@ -146,7 +164,10 @@ class TestFlashInferCommFusion(unittest.TestCase):
             with self.assertRaises(ValueError):
                 fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node_trtllm)
 
-        with patch.object(fusion, "is_sm100_supported", return_value=True):
+        with (
+            patch.object(fusion, "is_sm100_supported", return_value=True),
+            patch.object(fusion, "is_sm120_supported", return_value=False),
+        ):
             self.assertEqual(
                 fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node_mnnvl),
                 "mnnvl",
@@ -154,11 +175,26 @@ class TestFlashInferCommFusion(unittest.TestCase):
             with self.assertRaises(ValueError):
                 fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node_trtllm)
 
-        for arch in ("pre_sm90", "post_sm10x"):
+        with (
+            patch.object(fusion, "is_sm100_supported", return_value=False),
+            patch.object(fusion, "is_sm90_supported", return_value=False),
+            patch.object(fusion, "is_sm120_supported", return_value=True),
+        ):
+            self.assertEqual(
+                fusion.resolve_flashinfer_allreduce_fusion_backend(
+                    single_node_trtllm
+                ),
+                "trtllm",
+            )
+            with self.assertRaises(ValueError):
+                fusion.resolve_flashinfer_allreduce_fusion_backend(single_node_mnnvl)
+
+        for arch in ("pre_sm90", "post_sm120"):
             with (
                 self.subTest(arch=arch),
                 patch.object(fusion, "is_sm100_supported", return_value=False),
                 patch.object(fusion, "is_sm90_supported", return_value=False),
+                patch.object(fusion, "is_sm120_supported", return_value=False),
             ):
                 for args in (
                     single_node_mnnvl,

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -131,7 +131,8 @@ class TestFlashInferCommFusion(unittest.TestCase):
             with self.assertRaises(ValueError):
                 fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node)
 
-        # SM120: auto uses trtllm on single-node, multi-node is unsupported.
+        # SM12X (SM120/SM121): auto uses trtllm on single-node, multi-node is
+        # unsupported.
         with (
             patch.object(fusion, "is_sm100_supported", return_value=False),
             patch.object(fusion, "is_sm90_supported", return_value=False),
@@ -144,7 +145,7 @@ class TestFlashInferCommFusion(unittest.TestCase):
             with self.assertRaises(ValueError):
                 fusion.resolve_flashinfer_allreduce_fusion_backend(multi_node)
 
-        # Architectures outside SM90/SM10X/SM120 are unsupported.
+        # Architectures outside SM90/SM10X/SM12X (SM120/SM121) are unsupported.
         for arch in ("pre_sm90", "post_sm120"):
             with (
                 self.subTest(arch=arch),

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -72,6 +72,31 @@ def _torch_allreduce_residual_rmsnorm_baseline(
 
 
 class TestFlashInferCommFusion(unittest.TestCase):
+    def test_trtllm_workspace_preflight_does_not_require_multicast(self):
+        class _FakeCudaDriver:
+            CUresult = types.SimpleNamespace(CUDA_SUCCESS=0)
+            CUmemAllocationGranularity_flags = types.SimpleNamespace(
+                CU_MEM_ALLOC_GRANULARITY_RECOMMENDED=0
+            )
+
+            @staticmethod
+            def cuMemGetAllocationGranularity(_prop, _flag):
+                return 0, 65536
+
+            @staticmethod
+            def cuMulticastGetGranularity(*_args):
+                raise AssertionError("TRT-LLM symmetric memory has multicast disabled")
+
+        sizes = fusion._flashinfer_trtllm_workspace_allocation_sizes(
+            _FakeCudaDriver(),
+            object(),
+            world_size=2,
+            max_token_num=32,
+            hidden_dim=16,
+            dtype=torch.bfloat16,
+        )
+        self.assertEqual(sizes, [2162688, 2162688, 2162688])
+
     def test_auto_backend_resolves_by_arch(self):
         single_node = types.SimpleNamespace(
             flashinfer_allreduce_fusion_backend="auto", nnodes=1
@@ -181,9 +206,7 @@ class TestFlashInferCommFusion(unittest.TestCase):
             patch.object(fusion, "is_sm120_supported", return_value=True),
         ):
             self.assertEqual(
-                fusion.resolve_flashinfer_allreduce_fusion_backend(
-                    single_node_trtllm
-                ),
+                fusion.resolve_flashinfer_allreduce_fusion_backend(single_node_trtllm),
                 "trtllm",
             )
             with self.assertRaises(ValueError):

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -97,6 +97,48 @@ class TestFlashInferCommFusion(unittest.TestCase):
         )
         self.assertEqual(sizes, [2162688, 2162688, 2162688])
 
+    def test_mnnvl_workspace_preflight_keeps_multicast_granularity(self):
+        multicast_queries = []
+
+        class _FakeMulticastProp:
+            numDevices = None
+            size = None
+            handleTypes = None
+
+        class _FakeCudaDriver:
+            CUresult = types.SimpleNamespace(CUDA_SUCCESS=0)
+            CUmemAllocationGranularity_flags = types.SimpleNamespace(
+                CU_MEM_ALLOC_GRANULARITY_RECOMMENDED=0
+            )
+            CUmulticastGranularity_flags = types.SimpleNamespace(
+                CU_MULTICAST_GRANULARITY_RECOMMENDED=0
+            )
+            CUmulticastObjectProp = _FakeMulticastProp
+
+            @staticmethod
+            def cuMemGetAllocationGranularity(_prop, _flag):
+                return 0, 65536
+
+            @staticmethod
+            def cuMulticastGetGranularity(mc_prop, _flag):
+                multicast_queries.append(mc_prop.size)
+                return 0, 1 << 25
+
+        prop = types.SimpleNamespace(requestedHandleTypes=object())
+        sizes = fusion._flashinfer_trtllm_workspace_allocation_sizes(
+            _FakeCudaDriver(),
+            prop,
+            world_size=2,
+            max_token_num=32,
+            hidden_dim=16,
+            dtype=torch.bfloat16,
+            align_multicast=True,
+        )
+        # McastGPUBuffer rounds each allocation up to the multicast
+        # granularity (32 MiB here), on top of the allocation granularity.
+        self.assertEqual(sizes, [1 << 25, 1 << 25, 1 << 25])
+        self.assertEqual(multicast_queries, [2162688, 2162688, 2162688])
+
     def test_auto_backend_resolves_by_arch(self):
         single_node = types.SimpleNamespace(
             flashinfer_allreduce_fusion_backend="auto", nnodes=1

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1087,6 +1087,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         with (
             patch.object(overrides_module, "is_sm90_supported", return_value=True),
             patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm120_supported", return_value=False),
         ):
             self.assertEqual(
                 _flashinfer_allreduce_fusion_auto_enable(_view()),
@@ -1124,6 +1125,19 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                     _view(flashinfer_allreduce_fusion_backend="trtllm")
                 ),
                 {},
+            )
+
+        with (
+            patch.object(overrides_module, "is_sm90_supported", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=False),
+            patch.object(overrides_module, "is_sm120_supported", return_value=True),
+        ):
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(_view()),
+                {"flashinfer_allreduce_fusion_backend": "auto"},
+            )
+            self.assertEqual(
+                _flashinfer_allreduce_fusion_auto_enable(_view(nnodes=2)), {}
             )
 
         # enforce-disable wins over everything


### PR DESCRIPTION
## Motivation

On SM12X (SM120/SM121) with TP>1, `_resolve_backend` rejects the FlashInfer all-reduce backend, so decode uses NCCL ring all-reduce. We reproduced this on SM120 (RTX PRO 6000 Blackwell). FlashInfer PR flashinfer-ai/flashinfer#3903 provides the SM12x TRT-LLM all-reduce kernel; with it installed, two runtime changes enable the path:

1. Extend the backend selector and the auto-enable override to SM120/SM121 (`auto` resolves to `trtllm` on single-node SM120/SM121, matching SM90).
2. Remove the multicast-granularity query from the TRT-LLM workspace preflight. The TRT-LLM workspace is non-multicast; the query is unnecessary and rejects valid non-multicast configurations.

Without FlashInfer #3903 installed, behavior is unchanged (fails closed exactly as today). No behavior change on SM90/SM100, covered by tests. FlashInfer flashinfer-ai/flashinfer#3930 was also present in both benchmark cells but is not required on current main — sgl-project/sglang#30580 (lazy TileLang loading) already avoids the stub-library issue it addresses; it only matters for configurations that load TileLang eagerly before IPC initialization. Stacks on #30700, which provides the DeepSeek-V4 routing into this backend; happy to fold these commits into #30700 if maintainers prefer.

## Modifications

- `python/sglang/srt/layers/flashinfer_comm_fusion.py`: accept SM12X (SM120/SM121) in `_resolve_backend`; drop the multicast-only granularity probe from `_flashinfer_trtllm_workspace_allocation_sizes`.
- `python/sglang/srt/arg_groups/overrides.py`: include SM12X in `_flashinfer_allreduce_fusion_auto_enable`.
- `python/sglang/srt/server_args.py` and `docs_new/docs/advanced_features/server_arguments.mdx`: document SM120/SM121 availability and backend selection.
- Tests (`test/registered/unit/`): selector resolution on SM12X, auto-enable on SM12X, and a regression test that the TRT-LLM workspace preflight does not require multicast support.

## Accuracy Tests

GSM8K few-shot, 200 questions, identical config, NCCL cell vs this-PR cell: 97.5% vs 97.0% (0 invalid in both) — within the documented 1–5% batching variance. Greedy completions are identical through full code-generation spans across cells, diverging only at a free-form continuation boundary; expected, since one-shot Lamport changes floating-point reduction order vs ring. `test_flashinfer_comm_fusion.py`: 9 passed (14 subtests) in the benchmark container.

## Speed Tests and Profiling

2x RTX PRO 6000 Blackwell (SM120, 96 GB, PCIe4 x16), TP2. DeepSeek-V4-Flash, FP8 KV cache, FlashInfer MXFP4 MoE, MTP2 (EAGLE steps=2, topk=1, draft-tokens=3), CUDA graphs, temperature 0. Both cells: SGLang main `3d91a569ce` + PR #30700 (`22e2f8b30d`), FlashInfer 0.6.14 + PR #3903 (`1eb77ab2`) + PR #3930 (`e855cc25`). The only difference between cells is this PR's two runtime changes.

| Cell | All-reduce path | C1 samples (tok/s) | median | mean |
|---|---|---|---:|---:|
| main + #30700 | NCCL ring (#30700 fails closed on SM120) | 125.90, 127.66, 130.19, 126.25, 118.75 | 126.25 | 125.75 |
| main + #30700 + this PR | FlashInfer TRT-LLM one-shot Lamport | 129.55, 131.81, 132.85, 140.27, 137.05 | 132.85 | 134.31 |

+5.2% on medians, +6.8% on means. Five consecutive 30 s runs per cell on a settled server after a warmup run. (An earlier revision of this body quoted single-run figures of 129.53 and 134.14; run-to-run drift on this setup reaches 6.9%, so those are superseded by the samples above.)

Torch profiler, median target-verify decode graph, TP0: 87 all-reduce kernels per graph in both cells; summed all-reduce time 0.772 ms (NCCL) → 0.394 ms (Lamport); graph GPU span 16.408 → 15.699 ms. Whole capture: 1,113 NCCL all-reduce kernels (176.5 ms) replaced 1:1 by 1,113 Lamport kernels (27.4 ms). Zero request errors and zero restarts across all runs. On a separate tuned stack (main `1e10ec93` + Torch 2.13 + PRs #29927/#30949/#32090/#32194/#32220 + #30700), per-graph all-reduce time was 0.695 → 0.367 ms; the end-to-end figures from that stack were single runs and are omitted here.

## Checklist

- [x] Format your code according to pre-commit (all hooks pass on changed files).
- [x] Add unit tests (registered unit tree, see Modifications).
- [x] Provide accuracy and speed benchmark results (above).
- [x] Follow the SGLang code style guidance.

This contribution was developed with AI assistance. The author has reviewed the changes and their rationale, and all benchmark, profiling, and accuracy measurements were collected on the stated hardware.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30923777927](https://github.com/sgl-project/sglang/actions/runs/30923777927)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30923776051](https://github.com/sgl-project/sglang/actions/runs/30923776051)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
