### PR TITLE
[Bugfix] Allow DSV4 FP4 dequant with triton; fail early on unsupported combo

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -361,28 +361,40 @@ class Fp8Config(QuantizationConfig):
                 )
 
             fp8_method = Fp8MoEMethod(self)
+            moe_backend = get_moe_runner_backend()
 
+            # Dedicated MXFP4 quant methods (packed K//2 layout).
+            native_mxfp4_method = (
+                moe_backend.is_marlin()
+                or moe_backend.is_humming()
+                or moe_backend.is_flashinfer_mxfp4()
+            )
+
+            # Dequantize packed MXFP4 experts to block FP8 so generic FP8 MoE
+            # runners (auto/triton/deep_gemm/...) can consume full-K weights.
             if self.is_fp4_experts and self.dequant_fp4_to_fp8:
-                assert (
-                    get_moe_runner_backend().is_auto()
-                ), f"{get_moe_runner_backend()} is not compatible with SGLANG_DSV4_FP4_DEQUANT=1"
+                if native_mxfp4_method:
+                    raise ValueError(
+                        f"{moe_backend.value} natively supports MXFP4 experts; "
+                        "do not set SGLANG_DSV4_FP4_DEQUANT=1 with this backend."
+                    )
                 return fp8_method
 
-            if self.is_fp4_experts and get_moe_runner_backend().is_marlin():
+            if self.is_fp4_experts and moe_backend.is_marlin():
                 from sglang.srt.layers.quantization.mxfp4_marlin_moe import (
                     Mxfp4MarlinMoEMethod,
                 )
 
                 return Mxfp4MarlinMoEMethod(fp8_method, prefix=prefix)
 
-            if self.is_fp4_experts and get_moe_runner_backend().is_humming():
+            if self.is_fp4_experts and moe_backend.is_humming():
                 from sglang.srt.layers.quantization.mxfp4_humming_moe import (
                     Mxfp4HummingMoEMethod,
                 )
 
                 return Mxfp4HummingMoEMethod(fp8_method, prefix=prefix)
 
-            if self.is_fp4_experts and get_moe_runner_backend().is_flashinfer_mxfp4():
+            if self.is_fp4_experts and moe_backend.is_flashinfer_mxfp4():
                 # SM100 uses TRT-LLM; SM90 uses W4A16 and SM120 uses MXFP8xMXFP4.
                 if is_sm90_supported() or is_sm120_supported():
                     from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
@@ -396,6 +408,25 @@ class Fp8Config(QuantizationConfig):
                 )
 
                 return Mxfp4FlashinferTrtllmMoEMethod(fp8_method, prefix=prefix)
+
+            # Triton fused MoE expects full-K FP8/BF16 weights. MXFP4 experts
+            # store K packed as K//2, which later fails with a cryptic
+            # "Hidden size mismatch" assert in fused_moe.
+            # Note: deep_gemm (and auto, which may resolve to deep_gemm /
+            # flashinfer_mxfp4) still use Fp8MoEMethod with packed FP4 and
+            # must not be blocked here.
+            if self.is_fp4_experts and (
+                moe_backend.is_triton() or moe_backend.is_triton_kernels()
+            ):
+                raise ValueError(
+                    "DeepSeek-V4 MXFP4 routed experts are not supported with "
+                    f"--moe-runner-backend {moe_backend.value}. "
+                    "Use a native MXFP4 backend "
+                    "(--moe-runner-backend flashinfer_mxfp4, marlin, or humming), "
+                    "leave --moe-runner-backend auto (on SM120 this defaults to "
+                    "flashinfer_mxfp4), or set SGLANG_DSV4_FP4_DEQUANT=1 to "
+                    "dequantize experts to FP8 for generic runners such as triton."
+                )
             return fp8_method
         elif isinstance(layer, RadixAttention):
             return Fp8KVCacheMethod(self)


### PR DESCRIPTION
## Motivation

DeepSeek-V4-Flash uses MXFP4 packed routed experts (`is_fp4_experts=True`).
Expert weights store the K dimension as `K//2` (`torch.int8` packed layout).

Forcing Triton MoE with this layout leads to a **dead end** depending on
`SGLANG_DSV4_FP4_DEQUANT`:

### Bug 1: `DEQUANT=0` + `--moe-runner-backend triton`

Server loads, then crashes on the first MoE forward:

    AssertionError: Hidden size mismatch

Call path (abbreviated):

    DeepseekV4.forward
      -> FusedMoE / Fp8MoEMethod.apply
      -> fused_experts (triton)
      -> fused_experts_impl
      -> assert hidden_states.shape[1] == w1.shape[2] - padded_size
      -> AssertionError: Hidden size mismatch

Root cause: Triton fused MoE expects full-K FP8/BF16 weights
(`hidden_states.shape[1] == w1.shape[2]`), but MXFP4 experts keep packed K
(`w1.shape[2] == hidden // 2`).

### Bug 2: `DEQUANT=1` + `--moe-runner-backend triton`

Fails immediately during model init:

    AssertionError: MoeRunnerBackend.TRITON is not compatible with SGLANG_DSV4_FP4_DEQUANT=1

In `Fp8Config.get_quant_method`, dequant was incorrectly restricted to
`moe_runner_backend=auto` only:

    assert get_moe_runner_backend().is_auto(), (
        f"{get_moe_runner_backend()} is not compatible with SGLANG_DSV4_FP4_DEQUANT=1"
    )

After FP4->FP8 dequant, generic runners such as triton should be valid.

### Summary

| Config | Failure |
| --- | --- |
| `DEQUANT=0` + triton | Late `AssertionError: Hidden size mismatch` |
| `DEQUANT=1` + triton | Init `AssertionError: TRITON is not compatible with DEQUANT=1` |

## Modifications

`python/sglang/srt/layers/quantization/fp8.py` (`Fp8Config.get_quant_method`):

1. Allow `SGLANG_DSV4_FP4_DEQUANT=1` for generic FP8 MoE runners
   (`auto` / `triton` / `deep_gemm` / ...), not only `auto`.
2. Reject `DEQUANT=1` with native MXFP4 backends
   (`marlin` / `flashinfer_mxfp4` / `humming`).
3. If MXFP4 experts stay packed and backend is `triton` / `triton_kernel`,
   raise a clear `ValueError` instead of a late `Hidden size mismatch`.
4. Do not block `deep_gemm` / `auto` packed-FP4 paths.

## Accuracy Test Result

N/A for already-supported paths. Guard / dequant-compat only.
No intentional math change on correctly configured backends.

## Validation

Reproduced on DeepSeek-V4-Flash, TP=8 (e.g. RTX 6000D / SM120):

- Case A (`DEQUANT=0` + triton): `AssertionError: Hidden size mismatch`
- Case B (`DEQUANT=1` + triton): `AssertionError: MoeRunnerBackend.TRITON is not compatible with SGLANG_DSV4_FP4_DEQUANT=1`

Issue is backend/layout related, not SM120-specific.
pre-commit passed; `py_compile` on `fp8.py` OK.

## Checklist

- [x] Branch is not `main`
- [x] Minimal single-file change
- [x] pre-commit checks passed
- [x] Does not block deep_gemm / auto packed-FP4 paths
- [ ] Unit test (optional; happy to add if reviewers want)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30108124959](https://github.com/sgl-project/sglang/actions/runs/30108124959)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30108124756](https://github.com/sgl-project/sglang/actions/runs/30108124756)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->