### PR TITLE
Fix MistralLarge3EagleModel missing parent-contract attributes (use_dsa AttributeError)

### DIFF
--- a/python/sglang/srt/models/mistral_large_3_eagle.py
+++ b/python/sglang/srt/models/mistral_large_3_eagle.py
@@ -18,6 +18,7 @@ from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.models.deepseek_v2 import DeepseekV2DecoderLayer, DeepseekV2Model
 from sglang.srt.models.mistral_large_3 import MistralLarge3ForCausalLM
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import add_prefix
 
 
@@ -37,10 +38,16 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         self.vocab_size = config.vocab_size
         assert get_pp_group().world_size == 1
         self.pp_group = get_pp_group()
+        self.use_dsa = is_deepseek_dsa(config)
+        self.first_k_dense_replace = config.first_k_dense_replace
         self.dsa_enable_prefill_cp = is_dsa_enable_prefill_cp()
         self.mla_enable_prefill_cp = (
-            is_prefill_context_parallel_enabled() and not is_deepseek_dsa(config)
+            is_prefill_context_parallel_enabled() and not self.use_dsa
         )
+        if self.dsa_enable_prefill_cp or self.mla_enable_prefill_cp:
+            self.cp_size = get_parallel().attn_cp_size
+        else:
+            self.cp_size = None
 
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
@@ -63,6 +70,10 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         )
         self.start_layer = 0
         self.end_layer = self.config.num_hidden_layers
+        local_layer_ids = list(range(self.start_layer, self.end_layer))
+        self.next_full_attention_layer_id = dict(
+            zip(local_layer_ids, local_layer_ids[1:])
+        )
 
         self.fc = RowParallelLinear(
             self.config.hidden_size * 2,
@@ -74,6 +85,7 @@ class MistralLarge3EagleModel(DeepseekV2Model):
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.layers_to_capture = []
+        self.gemm_output_zero_allocator_size = 0
         self.llama_4_scaling_config = getattr(config, "llama_4_scaling", None)
 
     def forward(


### PR DESCRIPTION
## Motivation

Nightly `test_mistral_large3.py` Model 2 [TP8+MTP] crashes during EAGLE draft capture with
`AttributeError: 'MistralLarge3EagleModel' object has no attribute 'use_dsa'` (still failing in the 2026-07-24 nightly, run 30071922369 / general-8-gpu-b200 (2)).

Root cause: `MistralLarge3EagleModel.__init__` bypasses `DeepseekV2Model.__init__` (calls `nn.Module.__init__` directly) and maintains a manual subset of the parent's attributes; DSA/CP/TBO additions to `DeepseekV2Model.forward` gained attribute dependencies this subclass never received. `use_dsa` is the crash site; `next_full_attention_layer_id` is read unconditionally in the layer loop and would be the very next AttributeError.

## Modifications

Add the 5 missing parent-contract attributes to the eagle subclass, mirroring `DeepseekV2Model.__init__` / `deepseek_nextn.py`: `use_dsa`, `next_full_attention_layer_id`, `first_k_dense_replace`, `cp_size`, `gemm_output_zero_allocator_size` (an AST sweep of every `self.*` read in the parent's methods confirms the set is now complete).

Verified by instantiating the real draft config (`mistralai/Mistral-Large-3-675B-Instruct-2512-Eagle`, params.json-converted, 1-layer MoE with `first_k_dense_replace=0`): pre-fix reproduces the exact CI AttributeError, post-fix `_dsa_forward_uses_topk()` and all attributes resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ibyV8b1ULTKUkzkTUWuXG

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30116554682](https://github.com/sgl-project/sglang/actions/runs/30116554682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30116554306](https://github.com/sgl-project/sglang/actions/runs/30116554306)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->