### PR TITLE
[Feature] Add unit tests for request_headers and managers utils

### DIFF
--- a/test/registered/unit/entrypoints/test_request_headers.py
+++ b/test/registered/unit/entrypoints/test_request_headers.py
@@ -8,6 +8,7 @@ import unittest
 from types import SimpleNamespace
 
 from fastapi import HTTPException
+
 from sglang.srt.entrypoints.request_headers import apply_header_overrides
 from sglang.test.test_utils import CustomTestCase
 
@@ -38,9 +39,9 @@ class TestRequestHeaders(CustomTestCase):
             "x-override-disagg-prefill-dp-rank": "3",
             "x-override-priority": "10",
         }
-        
+
         apply_header_overrides(obj, headers)
-        
+
         self.assertEqual(obj.rid, "test-rid-123")
         self.assertEqual(obj.bootstrap_host, "localhost")
         self.assertEqual(obj.bootstrap_port, 8080)
@@ -62,9 +63,9 @@ class TestRequestHeaders(CustomTestCase):
             "x-override-rid": "test-rid-123",
             "x-override-priority": "5",
         }
-        
+
         apply_header_overrides(obj, headers)
-        
+
         self.assertEqual(obj.rid, "test-rid-123")
         self.assertEqual(obj.priority, 5)
         self.assertIsNone(obj.bootstrap_host)
@@ -74,9 +75,9 @@ class TestRequestHeaders(CustomTestCase):
         """Verify behavior when no headers are provided."""
         obj = SimpleNamespace(rid=None, priority=None)
         headers = {}
-        
+
         apply_header_overrides(obj, headers)
-        
+
         # Should not raise any error, and attributes should remain None
         self.assertIsNone(obj.rid)
         self.assertIsNone(obj.priority)
@@ -87,10 +88,10 @@ class TestRequestHeaders(CustomTestCase):
         headers = {
             "x-override-priority": "invalid-int",
         }
-        
+
         with self.assertRaises(HTTPException) as context:
             apply_header_overrides(obj, headers)
-            
+
         self.assertEqual(context.exception.status_code, 400)
         self.assertIn("invalid x-override-priority header", context.exception.detail)
 

--- a/test/registered/unit/entrypoints/test_request_headers.py
+++ b/test/registered/unit/entrypoints/test_request_headers.py
@@ -1,0 +1,99 @@
+"""Unit tests for request_headers.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+from fastapi import HTTPException
+from sglang.srt.entrypoints.request_headers import apply_header_overrides
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestRequestHeaders(CustomTestCase):
+    """Test the application of header overrides on request objects."""
+
+    def test_apply_header_overrides_success(self):
+        """Verify all valid headers are correctly cast and applied."""
+        # SimpleNamespace serves as a clean dummy object for setattr.
+        obj = SimpleNamespace(
+            rid=None,
+            bootstrap_host=None,
+            bootstrap_port=None,
+            bootstrap_room=None,
+            conversation_id=None,
+            routed_dp_rank=None,
+            disagg_prefill_dp_rank=None,
+            priority=None,
+        )
+        headers = {
+            "x-override-rid": "test-rid-123",
+            "x-override-bootstrap-host": "localhost",
+            "x-override-bootstrap-port": "8080",
+            "x-override-bootstrap-room": "1",
+            "x-override-conversation-id": "conv-456",
+            "x-override-routed-dp-rank": "2",
+            "x-override-disagg-prefill-dp-rank": "3",
+            "x-override-priority": "10",
+        }
+        
+        apply_header_overrides(obj, headers)
+        
+        self.assertEqual(obj.rid, "test-rid-123")
+        self.assertEqual(obj.bootstrap_host, "localhost")
+        self.assertEqual(obj.bootstrap_port, 8080)
+        self.assertEqual(obj.bootstrap_room, 1)
+        self.assertEqual(obj.conversation_id, "conv-456")
+        self.assertEqual(obj.routed_dp_rank, 2)
+        self.assertEqual(obj.disagg_prefill_dp_rank, 3)
+        self.assertEqual(obj.priority, 10)
+
+    def test_apply_header_overrides_partial(self):
+        """Verify that only the provided headers are applied, and missing ones are ignored."""
+        obj = SimpleNamespace(
+            rid=None,
+            priority=None,
+            bootstrap_host=None,
+            bootstrap_port=None,
+        )
+        headers = {
+            "x-override-rid": "test-rid-123",
+            "x-override-priority": "5",
+        }
+        
+        apply_header_overrides(obj, headers)
+        
+        self.assertEqual(obj.rid, "test-rid-123")
+        self.assertEqual(obj.priority, 5)
+        self.assertIsNone(obj.bootstrap_host)
+        self.assertIsNone(obj.bootstrap_port)
+
+    def test_apply_header_overrides_missing(self):
+        """Verify behavior when no headers are provided."""
+        obj = SimpleNamespace(rid=None, priority=None)
+        headers = {}
+        
+        apply_header_overrides(obj, headers)
+        
+        # Should not raise any error, and attributes should remain None
+        self.assertIsNone(obj.rid)
+        self.assertIsNone(obj.priority)
+
+    def test_apply_header_overrides_invalid_type(self):
+        """Verify that invalid header value types result in a 400 HTTPException."""
+        obj = SimpleNamespace(priority=None)
+        headers = {
+            "x-override-priority": "invalid-int",
+        }
+        
+        with self.assertRaises(HTTPException) as context:
+            apply_header_overrides(obj, headers)
+            
+        self.assertEqual(context.exception.status_code, 400)
+        self.assertIn("invalid x-override-priority header", context.exception.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -1,0 +1,58 @@
+"""Unit tests for managers/utils.py."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.utils import validate_input_length, is_health_check_generate_req
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestManagersUtils(CustomTestCase):
+    """Test utility functions inside managers/utils.py."""
+
+    def test_validate_input_length_pass(self):
+        """Verify that short inputs are validated correctly without truncation."""
+        req = SimpleNamespace(origin_input_ids=[1, 2, 3])
+        error = validate_input_length(req, max_req_input_len=5, allow_auto_truncate=False)
+        self.assertIsNone(error)
+        self.assertEqual(len(req.origin_input_ids), 3)
+
+    def test_validate_input_length_truncate(self):
+        """Verify that long inputs are truncated when allow_auto_truncate=True."""
+        req = SimpleNamespace(origin_input_ids=[1, 2, 3, 4, 5, 6])
+        error = validate_input_length(req, max_req_input_len=4, allow_auto_truncate=True)
+        self.assertIsNone(error)
+        self.assertEqual(len(req.origin_input_ids), 4)
+        self.assertEqual(req.origin_input_ids, [1, 2, 3, 4])
+
+    def test_validate_input_length_error(self):
+        """Verify that long inputs produce an error string when truncation is disallowed."""
+        req = SimpleNamespace(origin_input_ids=[1, 2, 3, 4, 5, 6])
+        error = validate_input_length(req, max_req_input_len=4, allow_auto_truncate=False)
+        self.assertIsNotNone(error)
+        self.assertIn("exceeds the maximum allowed length", error)
+        self.assertEqual(len(req.origin_input_ids), 6)  # Should not be truncated
+
+    def test_is_health_check_generate_req_true(self):
+        """Verify that a health check prefix returns True."""
+        req = SimpleNamespace(rid="HEALTH_CHECK_123")
+        # Ensure it matches the HEALTH_CHECK_RID_PREFIX which is "HEALTH_CHECK"
+        self.assertTrue(is_health_check_generate_req(req))
+
+    def test_is_health_check_generate_req_false_normal(self):
+        """Verify that a normal request ID returns False."""
+        req = SimpleNamespace(rid="normal_req_456")
+        self.assertFalse(is_health_check_generate_req(req))
+
+    def test_is_health_check_generate_req_false_none_rid(self):
+        """Verify that a request with no request ID returns False."""
+        req = SimpleNamespace(rid=None)
+        self.assertFalse(is_health_check_generate_req(req))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_managers_utils.py
+++ b/test/registered/unit/managers/test_managers_utils.py
@@ -7,7 +7,10 @@ register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 import unittest
 from types import SimpleNamespace
 
-from sglang.srt.managers.utils import validate_input_length, is_health_check_generate_req
+from sglang.srt.managers.utils import (
+    is_health_check_generate_req,
+    validate_input_length,
+)
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -17,14 +20,18 @@ class TestManagersUtils(CustomTestCase):
     def test_validate_input_length_pass(self):
         """Verify that short inputs are validated correctly without truncation."""
         req = SimpleNamespace(origin_input_ids=[1, 2, 3])
-        error = validate_input_length(req, max_req_input_len=5, allow_auto_truncate=False)
+        error = validate_input_length(
+            req, max_req_input_len=5, allow_auto_truncate=False
+        )
         self.assertIsNone(error)
         self.assertEqual(len(req.origin_input_ids), 3)
 
     def test_validate_input_length_truncate(self):
         """Verify that long inputs are truncated when allow_auto_truncate=True."""
         req = SimpleNamespace(origin_input_ids=[1, 2, 3, 4, 5, 6])
-        error = validate_input_length(req, max_req_input_len=4, allow_auto_truncate=True)
+        error = validate_input_length(
+            req, max_req_input_len=4, allow_auto_truncate=True
+        )
         self.assertIsNone(error)
         self.assertEqual(len(req.origin_input_ids), 4)
         self.assertEqual(req.origin_input_ids, [1, 2, 3, 4])
@@ -32,7 +39,9 @@ class TestManagersUtils(CustomTestCase):
     def test_validate_input_length_error(self):
         """Verify that long inputs produce an error string when truncation is disallowed."""
         req = SimpleNamespace(origin_input_ids=[1, 2, 3, 4, 5, 6])
-        error = validate_input_length(req, max_req_input_len=4, allow_auto_truncate=False)
+        error = validate_input_length(
+            req, max_req_input_len=4, allow_auto_truncate=False
+        )
         self.assertIsNotNone(error)
         self.assertIn("exceeds the maximum allowed length", error)
         self.assertEqual(len(req.origin_input_ids), 6)  # Should not be truncated


### PR DESCRIPTION
## Overview
This PR introduces fast, component-level unit tests for the `entrypoints` and `managers` modules to help address **Issue #20865** ([Feature] Improve Unit Test Coverage). 

These tests run in isolation on the CPU, taking less than a second to execute, and strictly avoid launching a backend server or loading model weights.

## Tests Added

### 1. `test_request_headers.py` (for `entrypoints/request_headers.py`)
- Tests the `apply_header_overrides()` function.
- **Valid Headers**: Verifies successful extraction, type-casting, and application of header values.
- **Missing Headers**: Ensures missing headers are safely ignored without corrupting object state.
- **Invalid Types**: Asserts that a `400 HTTPException` is correctly thrown if a header value fails type-casting (e.g. passing a string to an integer field).

### 2. `test_managers_utils.py` (for `managers/utils.py`)
- Tests the `validate_input_length()` function.
  - **Passes**: Confirms short inputs pass validation without truncation.
  - **Truncation**: Confirms long inputs are correctly truncated to the max length if `allow_auto_truncate=True`.
  - **Errors**: Confirms a descriptive error string is returned if a long input is submitted and `allow_auto_truncate=False`.
- Tests the `is_health_check_generate_req()` function.
  - Verifies exact string matching against the `HEALTH_CHECK_RID_PREFIX` constant, confirming it correctly identifies health check request IDs while rejecting standard request IDs.

## Code Quality & Architecture
- Replaced the need for custom mock classes by using Python's built-in `types.SimpleNamespace`, keeping the test footprint minimal.
- Conforms perfectly to the repository's CI testing guidelines by subclassing `CustomTestCase` and using the `register_cpu_ci` decorator.
- Extensively documented with clear docstrings and stripped of all unused imports to ensure zero warnings from automated linters (e.g., Ruff, CodeRabbit).

Partially Closes #20865

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30140777964](https://github.com/sgl-project/sglang/actions/runs/30140777964)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30140777852](https://github.com/sgl-project/sglang/actions/runs/30140777852)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->