### PR TITLE
[Bugfix] Emit cached token metric before first cache hit

### DIFF
--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1688,6 +1688,12 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
                 # Fallback for backward compatibility
                 labels_total = {**labels, "cache_source": "total"}
                 self.cached_tokens_total.labels(**labels_total).inc(cached_tokens)
+        else:
+            # Register an explicit zero-valued series so PromQL expressions
+            # combining prompt and cached-token counters retain this label set
+            # before the first cache hit.
+            labels_total = {**labels, "cache_source": "total"}
+            self.cached_tokens_total.labels(**labels_total).inc(0)
 
         self.num_requests_total.labels(**labels).inc(1)
         if has_grammar:

--- a/test/registered/observability/test_metrics.py
+++ b/test/registered/observability/test_metrics.py
@@ -126,6 +126,24 @@ class TestEnableMetrics(CustomTestCase):
             response = requests.post(
                 f"{DEFAULT_URL_FOR_TEST}/generate",
                 json={
+                    "text": "A unique cold-cache metrics request. " * 64,
+                    "sampling_params": {"temperature": 0, "max_new_tokens": 1},
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+
+            # A cold request must expose a zero cached-token counter so PromQL
+            # vector arithmetic retains the prompt-token series before a hit.
+            metrics_response = requests.get(f"{DEFAULT_URL_FOR_TEST}/metrics")
+            self.assertEqual(metrics_response.status_code, 200)
+            cold_metrics = _parse_prometheus_metrics(metrics_response.text)
+            cached_samples = cold_metrics.get("sglang:cached_tokens_total", [])
+            self.assertTrue(cached_samples)
+            self.assertEqual(sum(sample.value for sample in cached_samples), 0)
+
+            response = requests.post(
+                f"{DEFAULT_URL_FOR_TEST}/generate",
+                json={
                     "text": ["The capital of France is"] * 20,
                     "sampling_params": {
                         "temperature": 0,


### PR DESCRIPTION
## Summary

- emit `sglang:cached_tokens_total{cache_source="total"} 0` after a completed request with no cache hit
- keep the cached-token label set available for PromQL vector arithmetic before the first positive cache hit
- extend the existing metrics integration test to verify the cold-request zero series

Without an explicit zero series, queries such as `prompt_tokens_total - cached_tokens_total` drop the entire label set until a cache hit occurs.

## Testing

- `uvx pre-commit run --files python/sglang/srt/observability/metrics_collector.py test/registered/observability/test_metrics.py`
- `python3 -m py_compile python/sglang/srt/observability/metrics_collector.py test/registered/observability/test_metrics.py`
- The GPU-backed metrics integration test is registered in `stage-b-test-1-gpu-small` for CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30118866791](https://github.com/sgl-project/sglang/actions/runs/30118866791)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30118866591](https://github.com/sgl-project/sglang/actions/runs/30118866591)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->