### PR TITLE
Report accelerator type in /v1/loads

### DIFF
--- a/python/sglang/srt/entrypoints/v1_loads.py
+++ b/python/sglang/srt/entrypoints/v1_loads.py
@@ -20,14 +20,22 @@ metrics for load balancing, monitoring, and capacity planning.
 
 import time
 from datetime import datetime, timezone
+from functools import lru_cache
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 
+from sglang.srt.utils import get_device_name
 from sglang.version import __version__
 
 router = APIRouter()
+
+
+@lru_cache(maxsize=1)
+def _accelerator_name() -> Optional[str]:
+    """Accelerator marketing name (e.g. "NVIDIA GB300"), None if unavailable."""
+    return get_device_name()
 
 
 def _get_tokenizer_manager():
@@ -87,7 +95,7 @@ async def get_loads(
         format: Response format - 'json' (default) or 'prometheus'
 
     Returns:
-        JSON response with timestamp, version, and per-DP-rank loads
+        JSON response with timestamp, version, accelerator, and per-DP-rank loads
     """
     include_list = [s.strip() for s in include.split(",")] if include else None
 
@@ -119,5 +127,6 @@ async def get_loads(
     return {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "version": __version__,
+        "accelerator": _accelerator_name(),
         "loads": loads,
     }

--- a/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
+++ b/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
@@ -5,9 +5,11 @@ import os
 import tempfile
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 import msgspec.msgpack
 
+from sglang.srt.entrypoints import v1_loads
 from sglang.srt.entrypoints.v1_loads import get_loads
 from sglang.srt.managers.load_snapshot import (
     HEADER_STRUCT,
@@ -89,6 +91,19 @@ class TestLoadsResponse(CustomTestCase):
         self.assertNotIn("num_total_reqs", response["loads"][0])
         self.assertEqual(response["loads"][0]["num_running_reqs"], 3)
         self.assertEqual(response["loads"][0]["num_waiting_reqs"], 2)
+
+
+class TestLoadsAcceleratorField(CustomTestCase):
+    def test_accelerator_reported_in_json(self):
+        """Guards the response contract: the JSON envelope carries an
+        "accelerator" field with the detected device name."""
+        manager = _FakeHttpTokenizerManager([LoadSnapshot(dp_rank=0)])
+
+        with mock.patch.object(
+            v1_loads, "_accelerator_name", return_value="NVIDIA GB300"
+        ):
+            response = asyncio.run(get_loads(tokenizer_manager=manager))
+            self.assertEqual(response["accelerator"], "NVIDIA GB300")
 
 
 class TestGetLoads(CustomTestCase):


### PR DESCRIPTION
## Summary

Expose the accelerator name in the JSON `/v1/loads` response so clients can distinguish heterogeneous serving instances without an additional probe.

## Testing

- Changed-file pre-commit hooks
- Python syntax compilation
- Isolated endpoint response test

## Original commits

- `ef38816ba`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30126738923](https://github.com/sgl-project/sglang/actions/runs/30126738923)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #30126738764](https://github.com/sgl-project/sglang/actions/runs/30126738764)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->