### PR TITLE
fix(bench): chunk one_batch extend to fit eager prefill buffer

### DIFF
--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -478,20 +478,92 @@ class TreeCacheNamespace(SimpleNamespace):
         pass
 
 
-@torch.no_grad
-def extend(reqs, model_runner):
-    # Create dummy tree_cache for benchmarks (no prefix caching, just allocation)
-    dummy_tree_cache = TreeCacheNamespace(
+def _make_dummy_tree_cache(model_runner):
+    # No prefix caching in the offline bench path — only allocation + free.
+    return TreeCacheNamespace(
         page_size=model_runner.server_args.page_size,
         device=model_runner.device,
         token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
     )
 
+
+def _assign_chunked_extend_ranges(reqs, chunk_budget: int, page_size: int) -> int:
+    """Fill ``req.extend_range`` for one chunked-prefill iteration.
+
+    Splits ``chunk_budget`` evenly across unfinished reqs so every forward keeps
+    the full batch (needed so the final ``ScheduleBatch`` is decode-ready for
+    all requests). Page-aligns partial takes. Returns tokens scheduled this iter.
+    """
+    unfinished = []
+    for req in reqs:
+        done = len(req.prefix_indices)
+        need = len(req.full_untruncated_fill_ids) - done
+        if need <= 0:
+            req.set_extend_range(done, done)
+        else:
+            unfinished.append((req, done, need))
+
+    if not unfinished:
+        return 0
+
+    # Even split keeps all unfinished reqs in every forward (and thus in the
+    # final batch used for decode). Prefer at least one page per req when the
+    # budget allows; otherwise fall back to filling reqs sequentially.
+    per_req = chunk_budget // len(unfinished)
+    if page_size > 1:
+        per_req = (per_req // page_size) * page_size
+
+    total = 0
+    if per_req <= 0:
+        # Budget too small for an even split — fill sequentially like PrefillAdder.
+        rem = chunk_budget
+        for req, done, need in unfinished:
+            if rem <= 0:
+                req.set_extend_range(done, done)
+                continue
+            take = min(need, rem)
+            if take < need and page_size > 1:
+                take = (take // page_size) * page_size
+                if take <= 0:
+                    req.set_extend_range(done, done)
+                    continue
+            req.set_extend_range(done, done + take)
+            rem -= take
+            total += take
+        return total
+
+    for req, done, need in unfinished:
+        take = min(need, per_req)
+        if take < need and page_size > 1:
+            take = (take // page_size) * page_size
+            if take <= 0:
+                req.set_extend_range(done, done)
+                continue
+        req.set_extend_range(done, done + take)
+        total += take
+    return total
+
+
+def _advance_prefix_after_chunk(reqs, model_runner) -> None:
+    """Promote this chunk's KV into ``prefix_indices`` for the next chunk.
+
+    Same contract as ``ChunkCache.cache_unfinished_req`` (no radix insert).
+    """
+    req_to_token = model_runner.req_to_token_pool.req_to_token
+    for req in reqs:
+        if req.extend_range.length <= 0 or req.req_pool_idx is None:
+            continue
+        kv_indices = req_to_token[req.req_pool_idx, : req.extend_range.end]
+        req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
+
+
+@torch.no_grad
+def _extend_once(reqs, model_runner, tree_cache):
     batch = ScheduleBatch.init_new(
         reqs=reqs,
         req_to_token_pool=model_runner.req_to_token_pool,
         token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
-        tree_cache=dummy_tree_cache,
+        tree_cache=tree_cache,
         model_config=model_runner.model_config,
         enable_overlap=False,
         spec_algorithm=SpeculativeAlgorithm.NONE,
@@ -515,6 +587,70 @@ def extend(reqs, model_runner):
     logits_output = model_runner.forward(forward_batch).logits_output
     next_token_ids = model_runner.sample(logits_output, forward_batch)
     return next_token_ids, logits_output.next_token_logits, batch
+
+
+@torch.no_grad
+def extend(reqs, model_runner):
+    """Run extend / prefill for ``reqs``.
+
+    Eager static buffers are sized to ``chunked_prefill_size`` (not the full KV
+    pool). When the batch would exceed that budget, split into multiple chunked
+    forwards so each step fits the fixed buffer — same contract as the
+    scheduler (issue #30773).
+    """
+    tree_cache = _make_dummy_tree_cache(model_runner)
+    chunk_size = model_runner.server_args.chunked_prefill_size
+    page_size = model_runner.server_args.page_size or 1
+
+    # Chunking disabled: one unchunked forward (buffer sized to max_total).
+    if chunk_size is None or chunk_size <= 0:
+        return _extend_once(reqs, model_runner, tree_cache)
+
+    # Page-align the budget like PrefillAdder.
+    chunk_budget = (chunk_size // page_size) * page_size
+    if chunk_budget <= 0:
+        raise ValueError(
+            f"chunked_prefill_size={chunk_size} is smaller than page_size={page_size}"
+        )
+
+    next_token_ids = None
+    next_token_logits = None
+    batch = None
+
+    while True:
+        scheduled = _assign_chunked_extend_ranges(reqs, chunk_budget, page_size)
+        if scheduled <= 0:
+            unfinished = [
+                r
+                for r in reqs
+                if len(r.prefix_indices) < len(r.full_untruncated_fill_ids)
+            ]
+            if not unfinished:
+                break
+            raise RuntimeError(
+                f"one_batch chunked prefill made no progress "
+                f"(chunked_prefill_size={chunk_size}, page_size={page_size}, "
+                f"remaining tokens="
+                f"{[len(r.full_untruncated_fill_ids) - len(r.prefix_indices) for r in unfinished]}). "
+                f"Raise --chunked-prefill-size or set it to -1 for a single unchunked extend."
+            )
+
+        active = [r for r in reqs if r.extend_range.length > 0]
+        is_last = all(
+            r.extend_range.end >= len(r.full_untruncated_fill_ids) for r in reqs
+        )
+
+        next_token_ids, next_token_logits, batch = _extend_once(
+            active, model_runner, tree_cache
+        )
+        if is_last:
+            return next_token_ids, next_token_logits, batch
+
+        _advance_prefix_after_chunk(active, model_runner)
+
+    if batch is None:
+        raise RuntimeError("one_batch extend called with empty requests")
+    return next_token_ids, next_token_logits, batch
 
 
 @torch.no_grad

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -106,7 +106,14 @@ class EagerRunner(BaseRunner):
 
             max_bs = ceil_align(max_bs, self.attn_tp_size)
             max_bs = ceil_align(max_bs, get_cp_padding_align_size())
-        prefill_ceiling = max(mr.max_total_num_tokens, sa.max_prefill_buffer_tokens())
+        # Per-forward budget is chunked_prefill_size when chunking is on; not the
+        # KV-pool capacity. Callers that bypass the scheduler (one_batch) must
+        # chunk to this budget (issue #30773).
+        prefill_ceiling = (
+            sa.max_prefill_buffer_tokens()
+            if sa.chunked_prefill_size and sa.chunked_prefill_size > 0
+            else mr.max_total_num_tokens
+        )
         max_num_token = max(prefill_ceiling, max_bs * num_tokens_per_req)
         if require_mlp_sync(sa):
             max_num_token = ceil_align(max_num_token, self.attn_tp_size)


### PR DESCRIPTION
Eager static buffers are sized to chunked_prefill_size, not the KV pool. one_batch bypassed the scheduler and sent unchunked bs*input_len extends, causing fill_from shape mismatches (issue #30773). Split large extends into chunked forwards and restore the chunked prefill ceiling for eager sizing.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30131493564](https://github.com/sgl-project/sglang/actions/runs/30131493564)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30131493498](https://github.com/sgl-project/sglang/actions/runs/30131493498)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->