### PR TITLE
[Spec] Consolidate the grammar sync decision into ScheduleBatch.grammar_needs_sync

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2043,11 +2043,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         return self.dllm_config is not None
 
     def grammar_needs_sync(self) -> bool:
-        """Whether this batch's grammar work forces the synchronous path, i.e. the
-        previous batch's result is resolved before this forward. True when the spec
-        algorithm cannot advance the FSM inside verify() (see
-        SpeculativeAlgorithm.supports_grammar_overlap); the scheduler gates overlap
-        on it and NGRAM's host draft relies on the resulting ordering."""
+        """Whether grammar forces this batch onto the synchronous path, i.e. the
+        previous batch's result is resolved before this forward. The scheduler gates
+        overlap on it; NGRAM's host draft relies on the resulting ordering."""
         return self.has_grammar and not self.spec_algorithm.supports_grammar_overlap()
 
     def prepare_encoder_info_extend(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2044,8 +2044,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def grammar_needs_sync(self) -> bool:
         """Whether grammar forces this batch onto the synchronous path, i.e. the
-        previous batch's result is resolved before this forward. The scheduler gates
-        overlap on it; NGRAM's host draft relies on the resulting ordering."""
+        previous batch's result is resolved before this forward."""
         return self.has_grammar and not self.spec_algorithm.supports_grammar_overlap()
 
     def prepare_encoder_info_extend(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2042,6 +2042,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def is_dllm(self):
         return self.dllm_config is not None
 
+    def grammar_needs_sync(self) -> bool:
+        """Whether this batch's grammar work forces the synchronous path, i.e. the
+        previous batch's result is resolved before this forward. True when the spec
+        algorithm cannot advance the FSM inside verify() (see
+        SpeculativeAlgorithm.supports_grammar_overlap); the scheduler gates overlap
+        on it and NGRAM's host draft relies on the resulting ordering."""
+        return self.has_grammar and not self.spec_algorithm.supports_grammar_overlap()
+
     def prepare_encoder_info_extend(
         self, input_ids: List[array[int]], seq_lens: List[int]
     ):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1672,10 +1672,9 @@ class Scheduler(
             and last_batch_is_extend
         )
 
-        # Grammar decode on a spec algorithm without a GPU draft phase (see
-        # supports_grammar_overlap) runs synchronously: the FSM advance must land
-        # before the next batch's bitmask, with no target-verify forward to hide it
-        # under. Permanent path for host-draft algorithms (NGRAM), not a pending
+        # Grammar decode without overlap support runs synchronously so the FSM
+        # advance lands before the next batch's bitmask. Permanent path for
+        # host-draft algorithms (see supports_grammar_overlap), not a pending
         # migration.
         need_grammar_sync = (
             batch

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1672,9 +1672,11 @@ class Scheduler(
             and last_batch_is_extend
         )
 
-        # Spec algorithms that don't advance the grammar FSM inside verify() (see
-        # supports_grammar_overlap) still need overlap forced off for grammar decode
-        # batches, so the FSM is advanced before the next batch's bitmask.
+        # Grammar decode on a spec algorithm without a GPU draft phase (see
+        # supports_grammar_overlap) runs synchronously: the FSM advance must land
+        # before the next batch's bitmask, with no target-verify forward to hide it
+        # under. Permanent path for host-draft algorithms (NGRAM), not a pending
+        # migration.
         need_grammar_sync = (
             batch
             and not batch.spec_algorithm.is_none()
@@ -1686,8 +1688,8 @@ class Scheduler(
 
         # Algorithms that support grammar overlap advance the FSM inside verify()
         # via the grammar barrier (overlapping the target forward), which resolves
-        # whatever result is still pending in the queue — including the
-        # extend->decode boundary — so no grammar-specific overlap disable is needed.
+        # whatever result is still pending in the queue -- including the
+        # extend->decode boundary -- so no grammar-specific overlap disable is needed.
         return disable_overlap_for_batch or need_grammar_sync
 
     def _advance_pending_grammar(self):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1680,8 +1680,7 @@ class Scheduler(
         need_grammar_sync = (
             batch
             and not batch.spec_algorithm.is_none()
-            and not batch.spec_algorithm.supports_grammar_overlap()
-            and batch.has_grammar
+            and batch.grammar_needs_sync()
             and batch.forward_mode.is_decode()
             and len(self.result_queue) > 0
         )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1672,10 +1672,8 @@ class Scheduler(
             and last_batch_is_extend
         )
 
-        # Grammar decode without overlap support runs synchronously so the FSM
-        # advance lands before the next batch's bitmask. Permanent path for
-        # host-draft algorithms (see supports_grammar_overlap), not a pending
-        # migration.
+        # Sync so the FSM advance lands before the next batch's bitmask. Permanent
+        # path for host-draft algorithms, not a pending migration.
         need_grammar_sync = (
             batch
             and not batch.spec_algorithm.is_none()
@@ -1686,8 +1684,8 @@ class Scheduler(
 
         # Algorithms that support grammar overlap advance the FSM inside verify()
         # via the grammar barrier (overlapping the target forward), which resolves
-        # whatever result is still pending in the queue -- including the
-        # extend->decode boundary -- so no grammar-specific overlap disable is needed.
+        # whatever result is still pending in the queue — including the
+        # extend->decode boundary — so no grammar-specific overlap disable is needed.
         return disable_overlap_for_batch or need_grammar_sync
 
     def _advance_pending_grammar(self):

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -202,6 +202,12 @@ class NGRAMWorker(BaseSpecWorker):
         if self.adaptive_controller is not None:
             self.adaptive_controller.on_verify_complete(num_correct_drafts_per_req)
 
+    @staticmethod
+    def _grammar_forces_sync(batch: ScheduleBatch) -> bool:
+        """Whether the scheduler ran this grammar batch synchronously, i.e. resolved
+        the previous result before this forward (Scheduler.need_grammar_sync)."""
+        return batch.has_grammar and not batch.spec_algorithm.supports_grammar_overlap()
+
     def _prepare_draft_tokens(
         self, batch: ScheduleBatch
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -231,11 +237,11 @@ class NGRAMWorker(BaseSpecWorker):
         # results before the next draft prep, so output_ids is already
         # complete and splicing would duplicate the tail.
         #
-        # Grammar batches are synchronous by design, not by omission: this draft
-        # runs on the host, so the scheduler keeps NGRAM on need_grammar_sync
-        # (supports_grammar_overlap is False) and the corpus lookup below already
-        # sees the previous batch's committed tokens.
-        use_prev_tokens = self.enable_overlap and not batch.has_grammar
+        # The grammar half mirrors the scheduler's need_grammar_sync gate, so read
+        # the same capability instead of assuming grammar always means sync: this
+        # draft runs on the host, which is what keeps NGRAM off grammar overlap
+        # (by design, not pending migration -- see supports_grammar_overlap).
+        use_prev_tokens = self.enable_overlap and not self._grammar_forces_sync(batch)
         i = 0
         for req in batch.reqs:
             prev_tokens = (
@@ -347,10 +353,9 @@ class NGRAMWorker(BaseSpecWorker):
     def _update_ngram_corpus(self, batch: ScheduleBatch):
         batch_tokens = []
         i, stride = 0, self.draft_token_num
-        # Same splice condition as _prepare_draft_tokens (see there for why
-        # grammar batches are synchronous by design): only overlap mode has
-        # accepted tokens missing from req.output_ids.
-        use_prev_tokens = self.enable_overlap and not batch.has_grammar
+        # Same splice condition as _prepare_draft_tokens (see there): only overlap
+        # mode has accepted tokens missing from req.output_ids.
+        use_prev_tokens = self.enable_overlap and not self._grammar_forces_sync(batch)
         for req in batch.reqs:
             # FIXME: Whether to insert 'extend' into the cache or not, after testing,
             # there is not much difference, so we will not insert it for now.

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -229,8 +229,7 @@ class NGRAMWorker(BaseSpecWorker):
         # round's accepted tokens are not yet in req.output_ids and must be
         # spliced in from spec_info. Sync mode and grammar batches process
         # results before the next draft prep, so output_ids is already
-        # complete and splicing would duplicate the tail. The host corpus lookup
-        # below is why grammar keeps NGRAM synchronous.
+        # complete and splicing would duplicate the tail.
         use_prev_tokens = self.enable_overlap and not batch.grammar_needs_sync()
         i = 0
         for req in batch.reqs:

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -230,7 +230,7 @@ class NGRAMWorker(BaseSpecWorker):
         # spliced in from spec_info. Sync mode and grammar batches process
         # results before the next draft prep, so output_ids is already
         # complete and splicing would duplicate the tail. The host corpus lookup
-        # below is why grammar keeps NGRAM synchronous in the first place.
+        # below is why grammar keeps NGRAM synchronous.
         use_prev_tokens = self.enable_overlap and not batch.grammar_needs_sync()
         i = 0
         for req in batch.reqs:
@@ -343,8 +343,8 @@ class NGRAMWorker(BaseSpecWorker):
     def _update_ngram_corpus(self, batch: ScheduleBatch):
         batch_tokens = []
         i, stride = 0, self.draft_token_num
-        # Same splice condition as _prepare_draft_tokens (see there): only overlap
-        # mode has accepted tokens missing from req.output_ids.
+        # Same splice condition as _prepare_draft_tokens: only overlap mode
+        # has accepted tokens missing from req.output_ids.
         use_prev_tokens = self.enable_overlap and not batch.grammar_needs_sync()
         for req in batch.reqs:
             # FIXME: Whether to insert 'extend' into the cache or not, after testing,

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -230,6 +230,11 @@ class NGRAMWorker(BaseSpecWorker):
         # spliced in from spec_info. Sync mode and grammar batches process
         # results before the next draft prep, so output_ids is already
         # complete and splicing would duplicate the tail.
+        #
+        # Grammar batches are synchronous by design, not by omission: this draft
+        # runs on the host, so the scheduler keeps NGRAM on need_grammar_sync
+        # (supports_grammar_overlap is False) and the corpus lookup below already
+        # sees the previous batch's committed tokens.
         use_prev_tokens = self.enable_overlap and not batch.has_grammar
         i = 0
         for req in batch.reqs:
@@ -342,8 +347,9 @@ class NGRAMWorker(BaseSpecWorker):
     def _update_ngram_corpus(self, batch: ScheduleBatch):
         batch_tokens = []
         i, stride = 0, self.draft_token_num
-        # Same splice condition as _prepare_draft_tokens: only overlap mode
-        # has accepted tokens missing from req.output_ids.
+        # Same splice condition as _prepare_draft_tokens (see there for why
+        # grammar batches are synchronous by design): only overlap mode has
+        # accepted tokens missing from req.output_ids.
         use_prev_tokens = self.enable_overlap and not batch.has_grammar
         for req in batch.reqs:
             # FIXME: Whether to insert 'extend' into the cache or not, after testing,

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -202,12 +202,6 @@ class NGRAMWorker(BaseSpecWorker):
         if self.adaptive_controller is not None:
             self.adaptive_controller.on_verify_complete(num_correct_drafts_per_req)
 
-    @staticmethod
-    def _grammar_forces_sync(batch: ScheduleBatch) -> bool:
-        """Whether the scheduler ran this grammar batch synchronously, i.e. resolved
-        the previous result before this forward (Scheduler.need_grammar_sync)."""
-        return batch.has_grammar and not batch.spec_algorithm.supports_grammar_overlap()
-
     def _prepare_draft_tokens(
         self, batch: ScheduleBatch
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -235,13 +229,9 @@ class NGRAMWorker(BaseSpecWorker):
         # round's accepted tokens are not yet in req.output_ids and must be
         # spliced in from spec_info. Sync mode and grammar batches process
         # results before the next draft prep, so output_ids is already
-        # complete and splicing would duplicate the tail.
-        #
-        # The grammar half mirrors the scheduler's need_grammar_sync gate, so read
-        # the same capability instead of assuming grammar always means sync: this
-        # draft runs on the host, which is what keeps NGRAM off grammar overlap
-        # (by design, not pending migration -- see supports_grammar_overlap).
-        use_prev_tokens = self.enable_overlap and not self._grammar_forces_sync(batch)
+        # complete and splicing would duplicate the tail. The host corpus lookup
+        # below is why grammar keeps NGRAM synchronous in the first place.
+        use_prev_tokens = self.enable_overlap and not batch.grammar_needs_sync()
         i = 0
         for req in batch.reqs:
             prev_tokens = (
@@ -355,7 +345,7 @@ class NGRAMWorker(BaseSpecWorker):
         i, stride = 0, self.draft_token_num
         # Same splice condition as _prepare_draft_tokens (see there): only overlap
         # mode has accepted tokens missing from req.output_ids.
-        use_prev_tokens = self.enable_overlap and not self._grammar_forces_sync(batch)
+        use_prev_tokens = self.enable_overlap and not batch.grammar_needs_sync()
         for req in batch.reqs:
             # FIXME: Whether to insert 'extend' into the cache or not, after testing,
             # there is not much difference, so we will not insert it for now.

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -133,25 +133,19 @@ class SpeculativeAlgorithm(Enum):
         graphs in the decode cuda graph runner."""
         return self.is_dspark()
 
-    def has_gpu_draft(self) -> bool:
-        """Whether the draft phase is a GPU forward. NGRAM builds its tree from a
-        host n-gram corpus lookup instead, so it has no draft forward to overlap CPU
-        work with and its draft reads the previous batch's committed tokens from
-        CPU; see supports_grammar_overlap."""
-        return not self.is_ngram()
-
     def supports_grammar_overlap(self) -> bool:
         """Whether spec + grammar decode keeps cross-batch overlap on, with the worker
         advancing the grammar FSM inside verify() via the scheduler's grammar barrier.
+        The negation drives ScheduleBatch.grammar_needs_sync.
 
-        Two conditions: a GPU draft phase, so the grammar CPU work (FSM advance +
-        bitmask build) has a target-verify forward to hide under, and a worker that
-        threads the barrier through verify(). A host draft disqualifies outright --
-        it stays synchronous (need_grammar_sync) by design, not pending migration.
+        The precondition is a GPU draft phase: the grammar CPU work (FSM advance +
+        bitmask build) hides under the target-verify forward. NGRAM drafts from a
+        host n-gram corpus lookup, which has no such window and reads the previous
+        batch's committed tokens from CPU anyway, so it stays synchronous by design
+        rather than as a pending migration.
+
         STANDALONE inherits the EAGLE V2 worker's verify path, barrier included.
         """
-        if not self.has_gpu_draft():
-            return False
         return self.is_eagle() or self.is_standalone()
 
     def has_draft_kv(self) -> bool:

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -136,13 +136,12 @@ class SpeculativeAlgorithm(Enum):
     def supports_grammar_overlap(self) -> bool:
         """Whether spec + grammar decode keeps cross-batch overlap on, with the worker
         advancing the grammar FSM inside verify() via the scheduler's grammar barrier.
-        The negation drives ScheduleBatch.grammar_needs_sync.
 
         The precondition is a GPU draft phase: the grammar CPU work (FSM advance +
-        bitmask build) hides under the target-verify forward. NGRAM drafts from a
-        host n-gram corpus lookup, which has no such window and reads the previous
-        batch's committed tokens from CPU anyway, so it stays synchronous by design
-        rather than as a pending migration.
+        bitmask build) hides under the target-verify forward. NGRAM drafts from a host
+        n-gram corpus lookup, which has no such window and reads the previous batch's
+        committed tokens from CPU anyway, so it stays synchronous by design rather
+        than as a pending migration.
 
         STANDALONE inherits the EAGLE V2 worker's verify path, barrier included.
         """

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -134,9 +134,17 @@ class SpeculativeAlgorithm(Enum):
         return self.is_dspark()
 
     def supports_grammar_overlap(self) -> bool:
-        # Whether the worker advances the grammar FSM inside verify() (via the
-        # scheduler's grammar barrier), letting spec + grammar decode overlap.
-        # STANDALONE inherits the EAGLE V2 worker's verify path, barrier included.
+        """Whether spec + grammar decode keeps cross-batch overlap on, with the worker
+        advancing the grammar FSM inside verify() via the scheduler's grammar barrier.
+
+        The precondition is a GPU draft phase: the grammar CPU work (FSM advance +
+        bitmask build) hides under the target-verify forward. A host draft has no
+        such window, and it consumes the previous batch's committed tokens from CPU
+        anyway, so it stays synchronous (need_grammar_sync) by design -- NGRAM's
+        n-gram corpus lookup is the case today.
+
+        STANDALONE inherits the EAGLE V2 worker's verify path, barrier included.
+        """
         return self.is_eagle() or self.is_standalone()
 
     def has_draft_kv(self) -> bool:

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -134,17 +134,11 @@ class SpeculativeAlgorithm(Enum):
         return self.is_dspark()
 
     def supports_grammar_overlap(self) -> bool:
-        """Whether spec + grammar decode keeps cross-batch overlap on, with the worker
-        advancing the grammar FSM inside verify() via the scheduler's grammar barrier.
-
-        The precondition is a GPU draft phase: the grammar CPU work (FSM advance +
-        bitmask build) hides under the target-verify forward. NGRAM drafts from a host
-        n-gram corpus lookup, which has no such window and reads the previous batch's
-        committed tokens from CPU anyway, so it stays synchronous by design rather
-        than as a pending migration.
-
-        STANDALONE inherits the EAGLE V2 worker's verify path, barrier included.
-        """
+        # Whether the worker advances the grammar FSM inside verify() (via the
+        # scheduler's grammar barrier), letting spec + grammar decode overlap.
+        # Needs a GPU draft phase to hide the grammar CPU work under: NGRAM drafts
+        # from a host corpus lookup, so it stays synchronous by design.
+        # STANDALONE inherits the EAGLE V2 worker's verify path, barrier included.
         return self.is_eagle() or self.is_standalone()
 
     def has_draft_kv(self) -> bool:

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -133,18 +133,25 @@ class SpeculativeAlgorithm(Enum):
         graphs in the decode cuda graph runner."""
         return self.is_dspark()
 
+    def has_gpu_draft(self) -> bool:
+        """Whether the draft phase is a GPU forward. NGRAM builds its tree from a
+        host n-gram corpus lookup instead, so it has no draft forward to overlap CPU
+        work with and its draft reads the previous batch's committed tokens from
+        CPU; see supports_grammar_overlap."""
+        return not self.is_ngram()
+
     def supports_grammar_overlap(self) -> bool:
         """Whether spec + grammar decode keeps cross-batch overlap on, with the worker
         advancing the grammar FSM inside verify() via the scheduler's grammar barrier.
 
-        The precondition is a GPU draft phase: the grammar CPU work (FSM advance +
-        bitmask build) hides under the target-verify forward. A host draft has no
-        such window, and it consumes the previous batch's committed tokens from CPU
-        anyway, so it stays synchronous (need_grammar_sync) by design -- NGRAM's
-        n-gram corpus lookup is the case today.
-
+        Two conditions: a GPU draft phase, so the grammar CPU work (FSM advance +
+        bitmask build) has a target-verify forward to hide under, and a worker that
+        threads the barrier through verify(). A host draft disqualifies outright --
+        it stays synchronous (need_grammar_sync) by design, not pending migration.
         STANDALONE inherits the EAGLE V2 worker's verify path, barrier included.
         """
+        if not self.has_gpu_draft():
+            return False
         return self.is_eagle() or self.is_standalone()
 
     def has_draft_kv(self) -> bool:

--- a/python/sglang/srt/speculative/spec_registry.py
+++ b/python/sglang/srt/speculative/spec_registry.py
@@ -95,10 +95,6 @@ class CustomSpecAlgo:
     def supports_ragged_verify(self) -> bool:
         return False
 
-    def has_gpu_draft(self) -> bool:
-        # Custom algorithms draft with a model forward by default.
-        return True
-
     def supports_grammar_overlap(self) -> bool:
         # Whether the worker advances the grammar FSM inside verify() (via the
         # scheduler's grammar barrier), letting spec + grammar decode overlap.

--- a/python/sglang/srt/speculative/spec_registry.py
+++ b/python/sglang/srt/speculative/spec_registry.py
@@ -95,6 +95,10 @@ class CustomSpecAlgo:
     def supports_ragged_verify(self) -> bool:
         return False
 
+    def has_gpu_draft(self) -> bool:
+        # Custom algorithms draft with a model forward by default.
+        return True
+
     def supports_grammar_overlap(self) -> bool:
         # Whether the worker advances the grammar FSM inside verify() (via the
         # scheduler's grammar barrier), letting spec + grammar decode overlap.


### PR DESCRIPTION
Comments only, no behavior change. State the actual criterion for supports_grammar_overlap -- a GPU draft phase, whose target-verify forward hides the grammar CPU work -- and record that host-draft algorithms (NGRAM) stay on the synchronous grammar path by design rather than as a pending migration, both at the scheduler gate and at NGRAM's two prev-token splice sites.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30142264275](https://github.com/sgl-project/sglang/actions/runs/30142264275)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30142264226](https://github.com/sgl-project/sglang/actions/runs/30142264226)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->