### PR TITLE
Fix PyPI release: drop the git-only sgl-eval dep from packaged metadata

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -152,12 +152,13 @@ test = [
   "jsonlines",
   "lm-eval[api]>=0.4.9.2",
   "matplotlib",
-  # Pin sgl-eval to a git SHA: upgrading changes zero-shot \boxed{} grading, so
-  # re-baseline MODEL_SCORE_THRESHOLDS in test_text_models_gsm8k_eval.py first.
-  # antlr4 4.9.3 is forced because latex2sympy2_extended raises ImportError on
-  # 4.7.x, and an older transitive pin can win during install.
+  # 4.9.3 is what sgl-eval's math_verify grader needs (latex2sympy2_extended
+  # raises ImportError on 4.7.x), so a `sglang[test]` environment is already
+  # compatible when sgl-eval is installed on top of it.
+  # Do NOT declare sgl-eval itself here: it is git-only, and PyPI rejects any
+  # uploaded distribution whose metadata carries a direct URL requirement.
+  # CUDA CI installs it in scripts/ci/cuda/ci_install_dependency.sh.
   "antlr4-python3-runtime==4.9.3",
-  "sgl-eval @ git+https://github.com/sgl-project/sgl-eval.git@b2a2703c42cae379bbcb8b7ff092df6601a61694",
   "pandas",
   "parameterized",
   "peft>=0.18.0",

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -471,6 +471,12 @@ stabilize_flashinfer_jit_paths() {
 install_extra_deps() {
     MOONCAKE_VERSION="0.3.11.post1"
     NIXL_VERSION="1.3.0"
+    # sgl-eval is git-only and cannot be declared in python/pyproject.toml (see
+    # the note there). The nightly GSM8K eval shells out to the sgl-eval CLI and
+    # fails without it. Bumping the SHA can change zero-shot \boxed{} grading, so
+    # re-baseline MODEL_SCORE_THRESHOLDS in
+    # test/registered/eval/test_text_models_gsm8k_eval.py first.
+    SGL_EVAL_REF="b2a2703c42cae379bbcb8b7ff092df6601a61694"
     if [ "$CU_MAJOR" = "13" ]; then
         MOONCAKE_PKG="mooncake-transfer-engine-cuda13==${MOONCAKE_VERSION}"
         MOONCAKE_STALE_PKG="mooncake-transfer-engine"
@@ -505,6 +511,8 @@ install_extra_deps() {
         $PIP_CMD install "nixl==${NIXL_VERSION}" "${NIXL_BIN_NAME}==${NIXL_VERSION}" \
             --no-deps --force-reinstall $PIP_INSTALL_SUFFIX
     fi
+
+    $PIP_CMD install "sgl-eval @ git+https://github.com/sgl-project/sgl-eval.git@${SGL_EVAL_REF}" $PIP_INSTALL_SUFFIX
 
     if [ "$IS_BLACKWELL" != "1" ]; then
         git clone --branch v0.5 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git


### PR DESCRIPTION
## Motivation

The `v0.5.16` PyPI release failed. All eight wheels built, then `twine upload` died on the first file:

```
Uploading sglang-0.5.16-cp310-cp310-manylinux_2_34_aarch64.whl
ERROR   HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
        Bad Request
```

([run 30124152880](https://github.com/sgl-project/sglang/actions/runs/30124152880/job/89596897649) — nothing was published; PyPI is still on `0.5.15.post1`.)

The cause is in the wheel's `METADATA`. Diffing it against the last successful release, the only structurally new entry is:

```
Requires-Dist: sgl-eval @ git+https://github.com/sgl-project/sgl-eval.git@b2a2703c... ; extra == "test"
```

That is a PEP 440 direct URL reference. Warehouse rejects any uploaded distribution whose metadata carries one — including inside an extra — and returns a 400 whose body gives no detail unless you pass `--verbose`. Every other metadata change in `0.5.16` is an ordinary version-pin bump.

It slipped through because the nightly and PR wheel indexes don't run this validation; only a tagged PyPI release does, i.e. after the tag is already cut.

## Modifications

- `python/pyproject.toml`: drop `sgl-eval` from the `test` extra. It is a git-only package, so it cannot be declared in packaged metadata at all. A comment marks it as a do-not-re-add.
- `scripts/ci/cuda/ci_install_dependency.sh`: install it in `install_extra_deps()` instead, keeping the SHA pin and the "re-baseline `MODEL_SCORE_THRESHOLDS` before bumping" note. It goes in ahead of the `lmms-eval` block so the existing `antlr4-python3-runtime==4.9.3` re-pin still lands last on the non-Blackwell path; on Blackwell that block is skipped and sgl-eval's own `math_verify[antlr4_9_3]` chain pins the same version.

`antlr4-python3-runtime==4.9.3` stays in the `test` extra so a `sglang[test]` environment is already compatible when sgl-eval is installed on top of it.

## Accuracy Test

No test loses coverage.

- The only consumer of the real package is `test/registered/eval/test_text_models_gsm8k_eval.py` (`register_cuda_ci(suite="nightly-eval-text-2-gpu")`), whose job installs deps via this script — so it still gets sgl-eval, at the same pinned SHA, in the same relative order as before.
- The CPU jobs that install `python[dev]` (`pr-test.yml`, `rerun-test.yml`) do lose it, but the only sgl-eval-touching tests there are hermetic: `test/registered/unit/test_eval_accuracy_kit_sgl_eval.py` mocks the import and `test/registered/unit/bench/test_simple_eval_gsm8k.py` mocks `subprocess.run`. They now skip a git clone.
- AMD / NPU / MUSA / MLX swap in their own pyproject, which never declared sgl-eval.

Verified locally that no requirement in `python/pyproject.toml` (126 across base + all extras) carries a URL. The remaining direct URLs under `3rdparty/amd/wheel/sglang/pyproject.toml` are ROCm repo wheels in a distribution that is never uploaded to PyPI.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Modify documentation as needed, see [Docs](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30133690469](https://github.com/sgl-project/sglang/actions/runs/30133690469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30133690382](https://github.com/sgl-project/sglang/actions/runs/30133690382)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->