### PR TITLE
[Fix] Report which limit bound `max_running_requests`

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -200,8 +200,10 @@ class MlxModelRunnerStub(ModelRunner):
         if has_aux_state:
             ratio = self._aux_state_slots_per_request()
             limits.append(
+                # Same bound as the base resolver's mamba_state_pool, but sized
+                # from the unsharded flag value, so it keeps its own remedy.
                 ConcurrencyLimit(
-                    source="aux_state_pool",
+                    source="mamba_state_pool",
                     value=aux_state_size // ratio,
                     detail=f"max_mamba_cache_size={aux_state_size} / {ratio} "
                     f"slots per request",

--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -14,6 +14,13 @@ from sglang.srt.hardware_backend.mlx.kv_cache.auxiliary_state import (
     MlxAuxiliaryStateReqToTokenPool,
 )
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.concurrency_limit import (
+    ConcurrencyLimit,
+    format_concurrency_report,
+    kv_capacity_limit,
+    resolve_concurrency_limit,
+    user_request_limit,
+)
 from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.model_executor.model_runner_components.layer_setup import (
@@ -30,6 +37,8 @@ logger = logging.getLogger(__name__)
 # _resolve_max_running_requests so the two cannot drift apart. See
 # _aux_state_slots_per_request for the radix-disabled case.
 MLX_AUX_STATE_SIZE_MAX_RUNNING_REQUESTS_RATIO = 4
+# Concurrency cap when --max-running-requests is unset.
+MLX_DEFAULT_MAX_RUNNING_REQUESTS = 4096
 
 
 class _DummyKVCache(KVCache):
@@ -151,53 +160,75 @@ class MlxModelRunnerStub(ModelRunner):
     def _resolve_max_running_requests(self) -> int:
         """Concurrency cap handed to the scheduler.
 
-        Honors ``--max-running-requests``, mirroring the base runner's clamp
-        (``model_runner_kv_cache_mixin._resolve_max_num_reqs``): the requested
-        value is split per dp worker and capped by the KV pool capacity. When
-        the flag is unset, fall back to a capacity-based default.
+        Honors ``--max-running-requests``: the requested value is split per dp
+        worker and capped by the KV pool capacity. When the flag is unset, fall
+        back to a flat default rather than the base resolver's context-length
+        heuristic -- the bounds here are deliberately simpler than
+        ``KVCacheConfigurator.resolve_max_num_reqs``, only the reporting is
+        shared.
 
         On hybrid / linear-attention models the concurrency is additionally
         bounded by the auxiliary-state pool: each running request allocates one
         slot out of ``max_mamba_cache_size`` (asserting when exhausted), so a
         cap the pool cannot back would crash mid-serving instead of failing
-        at startup. Mirrors the base resolver's mamba bound and zero-reject.
+        at startup.
 
         Requires ``self.max_total_num_tokens`` to already be set.
         """
-        capacity_cap = self.max_total_num_tokens // 2
         requested = self.server_args.max_running_requests
+        limits = []
+        requested_limit = None
+        if requested is not None:
+            requested_limit = user_request_limit(requested, self.dp_size)
+            limits.append(requested_limit)
+        limits.append(kv_capacity_limit(self.max_total_num_tokens))
         if requested is None:
-            requested_per_worker = None
-            resolved = min(capacity_cap, 4096)
-        else:
-            requested_per_worker = requested // self.dp_size
-            resolved = min(requested_per_worker, capacity_cap)
+            limits.append(
+                ConcurrencyLimit(
+                    source="default_cap",
+                    value=MLX_DEFAULT_MAX_RUNNING_REQUESTS,
+                    detail="MLX default when --max-running-requests is unset",
+                    remedy="set --max-running-requests explicitly",
+                )
+            )
 
         aux_state_size = self.server_args.max_mamba_cache_size
-        if (
+        has_aux_state = (
             mambaish_config(self.model_config) is not None
             and aux_state_size is not None
-        ):
+        )
+        if has_aux_state:
             ratio = self._aux_state_slots_per_request()
-            resolved = min(resolved, aux_state_size // ratio)
-            if resolved <= 0:
-                raise RuntimeError(
-                    f"MLX auxiliary-state cache is too small to serve any "
-                    f"requests: max_mamba_cache_size={aux_state_size} backs "
-                    f"only {aux_state_size // ratio} concurrent requests "
-                    f"({ratio} slots per request). Increase "
-                    f"--max-mamba-cache-size to at least {ratio}, or leave it "
-                    f"unset to size the pool from the concurrency cap."
+            limits.append(
+                ConcurrencyLimit(
+                    source="aux_state_pool",
+                    value=aux_state_size // ratio,
+                    detail=f"max_mamba_cache_size={aux_state_size} / {ratio} "
+                    f"slots per request",
+                    remedy="raise --max-mamba-cache-size, or leave it unset to "
+                    "size the pool from the concurrency cap",
                 )
-
-        if requested_per_worker is not None and resolved < requested_per_worker:
-            logger.warning(
-                "max_running_requests was reduced from the requested %d to %d "
-                "(per dp worker) due to the available KV cache or "
-                "auxiliary-state capacity.",
-                requested_per_worker,
-                resolved,
             )
+
+        binding = resolve_concurrency_limit(limits)
+        resolved = binding.value
+        if has_aux_state and resolved <= 0:
+            raise RuntimeError(
+                f"MLX auxiliary-state cache is too small to serve any "
+                f"requests: max_mamba_cache_size={aux_state_size} backs "
+                f"only {aux_state_size // ratio} concurrent requests "
+                f"({ratio} slots per request). Increase "
+                f"--max-mamba-cache-size to at least {ratio}, or leave it "
+                f"unset to size the pool from the concurrency cap."
+            )
+
+        is_downgrade, message = format_concurrency_report(
+            binding, limits, requested_limit
+        )
+        if is_downgrade:
+            logger.warning(message)
+        else:
+            logger.info(message)
         return resolved
 
     def initialize(self):

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -78,22 +78,19 @@ def state_pool_limit(
     invent are either one request more than today or far past what fits.
     """
     if target is None:
-        sizing = (
-            "set --max-running-requests to the concurrency you want (the log then "
-            "reports the exact size), or try a larger --mamba-full-memory-ratio"
-        )
+        sizing = "--max-running-requests to state a target and get an exact size"
     else:
         sizing = (
-            f"try one of: --max-mamba-cache-size "
-            f"{target * slots_per_request * attn_dp_size}, a larger "
-            f"--mamba-full-memory-ratio"
+            f"--max-mamba-cache-size "
+            f"{target * slots_per_request * attn_dp_size} (memory permitting)"
         )
     return ConcurrencyLimit(
         source="mamba_state_pool",
         value=per_shard_pool_size // slots_per_request,
         detail=f"max_mamba_cache_size={per_shard_pool_size} per shard / "
         f"{slots_per_request} slots per request",
-        remedy=f"{sizing}, or --mamba-ssm-dtype bfloat16",
+        remedy=f"try one of: {sizing}, a larger --mamba-full-memory-ratio, "
+        f"or --mamba-ssm-dtype bfloat16",
     )
 
 

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -11,6 +11,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
+# Each running request is assumed to need at least this many KV tokens.
+KV_TOKENS_PER_REQUEST = 2
+# Heuristic ceiling used when the user did not ask for a specific value.
+HEURISTIC_TOKENS_PER_REQUEST = 512
+HEURISTIC_BOUNDS = (2048, 4096)
+
 
 @dataclass(frozen=True)
 class ConcurrencyLimit:
@@ -22,6 +28,58 @@ class ConcurrencyLimit:
     detail: str
     # Flags that raise this bound; None for the user's own request.
     remedy: Optional[str] = None
+
+
+def user_request_limit(
+    max_running_requests: int, attn_dp_size: int
+) -> ConcurrencyLimit:
+    return ConcurrencyLimit(
+        source="max_running_requests",
+        value=max_running_requests // attn_dp_size,
+        detail=f"--max-running-requests={max_running_requests}",
+    )
+
+
+def kv_capacity_limit(token_capacity: int) -> ConcurrencyLimit:
+    return ConcurrencyLimit(
+        source="kv_capacity",
+        value=token_capacity // KV_TOKENS_PER_REQUEST,
+        detail=f"max_total_num_tokens={token_capacity} / {KV_TOKENS_PER_REQUEST}",
+        remedy="raise --mem-fraction-static or lower the context length",
+    )
+
+
+def heuristic_limit(token_capacity: int, context_len: int) -> ConcurrencyLimit:
+    lo, hi = HEURISTIC_BOUNDS
+    estimated = int(token_capacity / context_len * HEURISTIC_TOKENS_PER_REQUEST)
+    return ConcurrencyLimit(
+        source="estimate",
+        value=max(min(estimated, hi), lo),
+        detail=f"token_capacity / context_len * {HEURISTIC_TOKENS_PER_REQUEST}, "
+        f"clamped to [{lo}, {hi}]",
+        remedy="set --max-running-requests explicitly",
+    )
+
+
+def state_pool_limit(
+    max_mamba_cache_size: int, slots_per_request: int, target: Optional[int] = None
+) -> ConcurrencyLimit:
+    """Hybrid (mamba / linear-attention) state pool bound.
+
+    `target` is the concurrency the remedy should size for; defaults to one
+    more than the pool currently allows.
+    """
+    value = max_mamba_cache_size // slots_per_request
+    target = target or (value + 1)
+    return ConcurrencyLimit(
+        source="mamba_state_pool",
+        value=value,
+        detail=f"max_mamba_cache_size={max_mamba_cache_size} / "
+        f"{slots_per_request} slots per request",
+        remedy=f"set --max-mamba-cache-size {target * slots_per_request}, raise "
+        f"--mamba-full-memory-ratio, or halve the state size with "
+        f"--mamba-ssm-dtype bfloat16",
+    )
 
 
 def resolve_concurrency_limit(

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -35,10 +35,13 @@ class ConcurrencyLimit:
 def user_request_limit(
     max_running_requests: int, attn_dp_size: int
 ) -> ConcurrencyLimit:
+    detail = f"--max-running-requests={max_running_requests}"
+    if attn_dp_size > 1:
+        detail += f" / {attn_dp_size} dp workers"
     return ConcurrencyLimit(
         source="max_running_requests",
         value=max_running_requests // attn_dp_size,
-        detail=f"--max-running-requests={max_running_requests}",
+        detail=detail,
     )
 
 
@@ -47,7 +50,7 @@ def kv_capacity_limit(token_capacity: int) -> ConcurrencyLimit:
         source="kv_capacity",
         value=token_capacity // KV_TOKENS_PER_REQUEST,
         detail=f"max_total_num_tokens={token_capacity} / {KV_TOKENS_PER_REQUEST}",
-        remedy="raise --mem-fraction-static or lower the context length",
+        remedy="raise --mem-fraction-static or use GPUs with more memory",
     )
 
 
@@ -59,7 +62,7 @@ def heuristic_limit(token_capacity: int, context_len: int) -> ConcurrencyLimit:
         value=max(min(estimated, hi), lo),
         detail=f"token_capacity / context_len * {HEURISTIC_TOKENS_PER_REQUEST}, "
         f"clamped to [{lo}, {hi}]",
-        remedy="set --max-running-requests explicitly",
+        remedy="set --max-running-requests explicitly, or lower the context length",
     )
 
 
@@ -78,7 +81,7 @@ def state_pool_limit(
     invent are either one request more than today or far past what fits.
     """
     if target is None:
-        sizing = "--max-running-requests to state a target and get an exact size"
+        sizing = "--max-running-requests <target> (the log then reports the exact size)"
     else:
         sizing = (
             f"--max-mamba-cache-size "
@@ -104,7 +107,7 @@ def resolve_concurrency_limit(limits: List[ConcurrencyLimit]) -> ConcurrencyLimi
 def format_concurrency_report(
     binding: ConcurrencyLimit,
     limits: List[ConcurrencyLimit],
-    requested: Optional[int] = None,
+    requested: Optional[ConcurrencyLimit] = None,
 ) -> Tuple[bool, str]:
     """Render the resolution as (is_downgrade, message). A downgrade means the
     user asked for more than they got; log those at WARNING, the rest at INFO."""
@@ -114,11 +117,11 @@ def format_concurrency_report(
     others = f"; other limits: {others}" if others else ""
     remedy = f" To raise it: {binding.remedy}." if binding.remedy else ""
 
-    if requested is not None and binding.value < requested:
+    if requested is not None and binding.value < requested.value:
         return True, (
-            f"max_running_requests reduced from the requested {requested} to "
-            f"{binding.value} (per dp worker), bound by {binding.source} "
-            f"({binding.detail}){others}.{remedy}"
+            f"max_running_requests reduced from the requested {requested.value} to "
+            f"{binding.value} (per dp worker; {requested.detail}), bound by "
+            f"{binding.source} ({binding.detail}){others}.{remedy}"
         )
     return False, (
         f"max_running_requests={binding.value} (per dp worker), bound by "

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -4,8 +4,8 @@ Independent bounds (user request, KV capacity, hybrid state pool, ...) compete
 for the concurrency ceiling. Carrying them as data instead of nested `min()`
 calls lets the server report which one bound the result and how to raise it.
 
-The remedies name user-facing CLI flags, so renaming a flag means updating them
-here too.
+The remedies below name user-facing CLI flags, so renaming a flag means updating
+them here; callers that build a `ConcurrencyLimit` inline carry their own.
 """
 
 from __future__ import annotations

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -1,9 +1,8 @@
 """Attribution for the resolved `max_running_requests`.
 
-Several independent bounds compete for the concurrency ceiling (the user's
-request, KV capacity, the hybrid state pool, ...). Collecting them as data
-rather than folding them into nested `min()` calls lets the server report
-*which* one bound the result and how to raise it.
+Independent bounds (user request, KV capacity, hybrid state pool, ...) compete
+for the concurrency ceiling. Carrying them as data instead of nested `min()`
+calls lets the server report which one bound the result and how to raise it.
 """
 
 from __future__ import annotations
@@ -11,9 +10,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
-# Each running request is assumed to need at least this many KV tokens.
+# Minimum KV tokens assumed per running request.
 KV_TOKENS_PER_REQUEST = 2
-# Heuristic ceiling used when the user did not ask for a specific value.
+# Heuristic ceiling, used only when the user did not ask for a value.
 HEURISTIC_TOKENS_PER_REQUEST = 512
 HEURISTIC_BOUNDS = (2048, 4096)
 
@@ -24,7 +23,7 @@ class ConcurrencyLimit:
 
     source: str
     value: int
-    # Where the number comes from, e.g. "max_mamba_cache_size=131 / 5 per request".
+    # How the value was derived, e.g. "max_mamba_cache_size=131 / 5 per request".
     detail: str
     # Flags that raise this bound; None for the user's own request.
     remedy: Optional[str] = None
@@ -64,11 +63,8 @@ def heuristic_limit(token_capacity: int, context_len: int) -> ConcurrencyLimit:
 def state_pool_limit(
     max_mamba_cache_size: int, slots_per_request: int, target: Optional[int] = None
 ) -> ConcurrencyLimit:
-    """Hybrid (mamba / linear-attention) state pool bound.
-
-    `target` is the concurrency the remedy should size for; defaults to one
-    more than the pool currently allows.
-    """
+    """Hybrid (mamba / linear-attention) state pool bound. `target` is the
+    concurrency the remedy sizes for, defaulting to one more than fits."""
     value = max_mamba_cache_size // slots_per_request
     target = target or (value + 1)
     return ConcurrencyLimit(
@@ -85,11 +81,8 @@ def state_pool_limit(
 def resolve_concurrency_limit(
     limits: List[ConcurrencyLimit],
 ) -> Tuple[int, ConcurrencyLimit]:
-    """Return the effective ceiling and the limit that bound it.
-
-    Ties resolve to the first entry, so callers should list limits in the
-    order they want reported.
-    """
+    """Return the effective ceiling and the limit that bound it. Ties resolve
+    to the first entry, so list limits in the order they should be reported."""
     assert limits, "at least one concurrency limit is required"
     binding = min(limits, key=lambda limit: limit.value)
     return binding.value, binding
@@ -101,11 +94,8 @@ def format_concurrency_report(
     limits: List[ConcurrencyLimit],
     requested: Optional[int] = None,
 ) -> Tuple[bool, str]:
-    """Render the resolution as (is_downgrade, message).
-
-    `is_downgrade` is True when the user explicitly asked for more than they
-    got; callers should log those at WARNING and the rest at INFO.
-    """
+    """Render the resolution as (is_downgrade, message). A downgrade means the
+    user asked for more than they got; log those at WARNING, the rest at INFO."""
     others = ", ".join(
         f"{limit.source}={limit.value}" for limit in limits if limit is not binding
     )

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -26,7 +26,7 @@ class ConcurrencyLimit:
 
     source: str
     value: int
-    # How the value was derived, e.g. "max_mamba_cache_size=131 / 5 per request".
+    # How the value was derived, e.g. "max_mamba_cache_size=131 per shard / 5 ...".
     detail: str
     # Flags that raise this bound; None for the user's own request.
     remedy: Optional[str] = None
@@ -73,20 +73,27 @@ def state_pool_limit(
 
     `per_shard_pool_size` is the resolved per-DP-shard slot count, so the remedy
     scales back up: --max-mamba-cache-size is a global value that the server
-    divides by `attn_dp_size`. `target` is the concurrency the remedy sizes for,
-    defaulting to one more request than currently fits.
+    divides by `attn_dp_size`. `target` is the concurrency to size for; without
+    one the remedy names the flags but no number, since the only sizes we could
+    invent are either one request more than today or far past what fits.
     """
-    value = per_shard_pool_size // slots_per_request
     if target is None:
-        target = value + 1
+        sizing = (
+            "set --max-running-requests to the concurrency you want (the log then "
+            "reports the exact size), or try a larger --mamba-full-memory-ratio"
+        )
+    else:
+        sizing = (
+            f"try one of: --max-mamba-cache-size "
+            f"{target * slots_per_request * attn_dp_size}, a larger "
+            f"--mamba-full-memory-ratio"
+        )
     return ConcurrencyLimit(
         source="mamba_state_pool",
-        value=value,
+        value=per_shard_pool_size // slots_per_request,
         detail=f"max_mamba_cache_size={per_shard_pool_size} per shard / "
         f"{slots_per_request} slots per request",
-        remedy=f"try one of: --max-mamba-cache-size "
-        f"{target * slots_per_request * attn_dp_size}, a larger "
-        f"--mamba-full-memory-ratio, or --mamba-ssm-dtype bfloat16",
+        remedy=f"{sizing}, or --mamba-ssm-dtype bfloat16",
     )
 
 

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -1,0 +1,67 @@
+"""Attribution for the resolved `max_running_requests`.
+
+Several independent bounds compete for the concurrency ceiling (the user's
+request, KV capacity, the hybrid state pool, ...). Collecting them as data
+rather than folding them into nested `min()` calls lets the server report
+*which* one bound the result and how to raise it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ConcurrencyLimit:
+    """One upper bound on `max_running_requests`."""
+
+    source: str
+    value: int
+    # Where the number comes from, e.g. "max_mamba_cache_size=131 / 5 per request".
+    detail: str
+    # Flags that raise this bound; None for the user's own request.
+    remedy: Optional[str] = None
+
+
+def resolve_concurrency_limit(
+    limits: List[ConcurrencyLimit],
+) -> Tuple[int, ConcurrencyLimit]:
+    """Return the effective ceiling and the limit that bound it.
+
+    Ties resolve to the first entry, so callers should list limits in the
+    order they want reported.
+    """
+    assert limits, "at least one concurrency limit is required"
+    binding = min(limits, key=lambda limit: limit.value)
+    return binding.value, binding
+
+
+def format_concurrency_report(
+    resolved: int,
+    binding: ConcurrencyLimit,
+    limits: List[ConcurrencyLimit],
+    requested: Optional[int] = None,
+) -> Tuple[bool, str]:
+    """Render the resolution as (is_downgrade, message).
+
+    `is_downgrade` is True when the user explicitly asked for more than they
+    got; callers should log those at WARNING and the rest at INFO.
+    """
+    others = ", ".join(
+        f"{limit.source}={limit.value}" for limit in limits if limit is not binding
+    )
+    others = f"; other limits: {others}" if others else ""
+
+    is_downgrade = requested is not None and resolved < requested
+    if is_downgrade:
+        remedy = f" To raise it: {binding.remedy}." if binding.remedy else ""
+        return True, (
+            f"max_running_requests reduced from the requested {requested} to "
+            f"{resolved} (per dp worker), bound by {binding.source} "
+            f"({binding.detail}){others}.{remedy}"
+        )
+    return False, (
+        f"max_running_requests={resolved} (per dp worker), bound by "
+        f"{binding.source} ({binding.detail}){others}."
+    )

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -111,8 +111,12 @@ def format_concurrency_report(
 ) -> Tuple[bool, str]:
     """Render the resolution as (is_downgrade, message). A downgrade means the
     user asked for more than they got; log those at WARNING, the rest at INFO."""
+    # The binding limit and the user's request are both spelled out above, so
+    # "other limits" lists only the bounds not mentioned yet.
     others = ", ".join(
-        f"{limit.source}={limit.value}" for limit in limits if limit is not binding
+        f"{limit.source}={limit.value}"
+        for limit in limits
+        if limit is not binding and limit is not requested
     )
     others = f"; other limits: {others}" if others else ""
     remedy = f" To raise it: {binding.remedy}." if binding.remedy else ""

--- a/python/sglang/srt/mem_cache/concurrency_limit.py
+++ b/python/sglang/srt/mem_cache/concurrency_limit.py
@@ -3,6 +3,9 @@
 Independent bounds (user request, KV capacity, hybrid state pool, ...) compete
 for the concurrency ceiling. Carrying them as data instead of nested `min()`
 calls lets the server report which one bound the result and how to raise it.
+
+The remedies name user-facing CLI flags, so renaming a flag means updating them
+here too.
 """
 
 from __future__ import annotations
@@ -52,7 +55,7 @@ def heuristic_limit(token_capacity: int, context_len: int) -> ConcurrencyLimit:
     lo, hi = HEURISTIC_BOUNDS
     estimated = int(token_capacity / context_len * HEURISTIC_TOKENS_PER_REQUEST)
     return ConcurrencyLimit(
-        source="estimate",
+        source="heuristic_estimate",
         value=max(min(estimated, hi), lo),
         detail=f"token_capacity / context_len * {HEURISTIC_TOKENS_PER_REQUEST}, "
         f"clamped to [{lo}, {hi}]",
@@ -61,35 +64,40 @@ def heuristic_limit(token_capacity: int, context_len: int) -> ConcurrencyLimit:
 
 
 def state_pool_limit(
-    max_mamba_cache_size: int, slots_per_request: int, target: Optional[int] = None
+    per_shard_pool_size: int,
+    slots_per_request: int,
+    attn_dp_size: int,
+    target: Optional[int] = None,
 ) -> ConcurrencyLimit:
-    """Hybrid (mamba / linear-attention) state pool bound. `target` is the
-    concurrency the remedy sizes for, defaulting to one more than fits."""
-    value = max_mamba_cache_size // slots_per_request
-    target = target or (value + 1)
+    """Hybrid (mamba / linear-attention) state pool bound.
+
+    `per_shard_pool_size` is the resolved per-DP-shard slot count, so the remedy
+    scales back up: --max-mamba-cache-size is a global value that the server
+    divides by `attn_dp_size`. `target` is the concurrency the remedy sizes for,
+    defaulting to one more request than currently fits.
+    """
+    value = per_shard_pool_size // slots_per_request
+    if target is None:
+        target = value + 1
     return ConcurrencyLimit(
         source="mamba_state_pool",
         value=value,
-        detail=f"max_mamba_cache_size={max_mamba_cache_size} / "
+        detail=f"max_mamba_cache_size={per_shard_pool_size} per shard / "
         f"{slots_per_request} slots per request",
-        remedy=f"set --max-mamba-cache-size {target * slots_per_request}, raise "
-        f"--mamba-full-memory-ratio, or halve the state size with "
-        f"--mamba-ssm-dtype bfloat16",
+        remedy=f"try one of: --max-mamba-cache-size "
+        f"{target * slots_per_request * attn_dp_size}, a larger "
+        f"--mamba-full-memory-ratio, or --mamba-ssm-dtype bfloat16",
     )
 
 
-def resolve_concurrency_limit(
-    limits: List[ConcurrencyLimit],
-) -> Tuple[int, ConcurrencyLimit]:
-    """Return the effective ceiling and the limit that bound it. Ties resolve
-    to the first entry, so list limits in the order they should be reported."""
+def resolve_concurrency_limit(limits: List[ConcurrencyLimit]) -> ConcurrencyLimit:
+    """Return the limit that bound the ceiling; its value is the resolution.
+    Ties resolve to the first entry, so list limits in reporting order."""
     assert limits, "at least one concurrency limit is required"
-    binding = min(limits, key=lambda limit: limit.value)
-    return binding.value, binding
+    return min(limits, key=lambda limit: limit.value)
 
 
 def format_concurrency_report(
-    resolved: int,
     binding: ConcurrencyLimit,
     limits: List[ConcurrencyLimit],
     requested: Optional[int] = None,
@@ -100,16 +108,15 @@ def format_concurrency_report(
         f"{limit.source}={limit.value}" for limit in limits if limit is not binding
     )
     others = f"; other limits: {others}" if others else ""
+    remedy = f" To raise it: {binding.remedy}." if binding.remedy else ""
 
-    is_downgrade = requested is not None and resolved < requested
-    if is_downgrade:
-        remedy = f" To raise it: {binding.remedy}." if binding.remedy else ""
+    if requested is not None and binding.value < requested:
         return True, (
             f"max_running_requests reduced from the requested {requested} to "
-            f"{resolved} (per dp worker), bound by {binding.source} "
+            f"{binding.value} (per dp worker), bound by {binding.source} "
             f"({binding.detail}){others}.{remedy}"
         )
     return False, (
-        f"max_running_requests={resolved} (per dp worker), bound by "
-        f"{binding.source} ({binding.detail}){others}."
+        f"max_running_requests={binding.value} (per dp worker), bound by "
+        f"{binding.source} ({binding.detail}){others}.{remedy}"
     )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1627,51 +1627,57 @@ class KVCacheConfigurator:
 
         return token_capacity
 
-    def resolve_max_num_reqs(self, token_capacity: int) -> int:
+    def resolve_max_num_reqs(self, token_capacity: int, report: bool = True) -> int:
         """Compute max concurrent requests (per dp worker) from the finalized
-        token capacity."""
-        limits = [kv_capacity_limit(token_capacity)]
-
+        token capacity. `report` logs which limit bound the result; the
+        post-capture resize caller opts out because it logs its own summary."""
+        # Order matters: ties are attributed to the first limit listed.
+        limits = []
         requested_per_worker = None
         if self.server_args.max_running_requests is not None:
             requested = user_request_limit(
                 self.server_args.max_running_requests, self.ps.attn_dp_size
             )
             requested_per_worker = requested.value
-            limits.insert(0, requested)
-        else:
+            limits.append(requested)
+        limits.append(kv_capacity_limit(token_capacity))
+        if requested_per_worker is None:
             limits.append(
                 heuristic_limit(token_capacity, self.model_config.context_len)
             )
 
         if self.mambaish_config is not None:
+            ratio = self._calculate_mamba_ratio()
             limits.append(
                 state_pool_limit(
                     self.server_args.max_mamba_cache_size,
-                    self._calculate_mamba_ratio(),
+                    ratio,
+                    self.ps.attn_dp_size,
                     requested_per_worker,
                 )
             )
 
-        max_num_reqs, binding = resolve_concurrency_limit(limits)
+        binding = resolve_concurrency_limit(limits)
+        max_num_reqs = binding.value
 
         if self.mambaish_config is not None and max_num_reqs <= 0:
             raise RuntimeError(
                 f"Hybrid (mamba/linear-attention) state cache is too small to serve "
                 f"any requests. max_mamba_cache_size={self.server_args.max_mamba_cache_size}, "
-                f"mamba_ratio={self._calculate_mamba_ratio()}, resulting max_num_reqs={max_num_reqs}. "
+                f"mamba_ratio={ratio}, resulting max_num_reqs={max_num_reqs}. "
                 f"Try: (1) reduce --max-running-requests, "
                 f"(2) increase --mem-fraction-static, or "
                 f"(3) use GPUs with more memory."
             )
 
-        is_downgrade, message = format_concurrency_report(
-            max_num_reqs, binding, limits, requested_per_worker
-        )
-        if is_downgrade:
-            logger.warning(message)
-        else:
-            logger.info(message)
+        if report:
+            is_downgrade, message = format_concurrency_report(
+                binding, limits, requested_per_worker
+            )
+            if is_downgrade:
+                logger.warning(message)
+            else:
+                logger.info(message)
         return max_num_reqs
 
     def _resolve_memory_pool_config(

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -40,9 +40,12 @@ from sglang.srt.mem_cache.allocator.swa import (
     SWATokenToKVPoolAllocator,
 )
 from sglang.srt.mem_cache.concurrency_limit import (
-    ConcurrencyLimit,
     format_concurrency_report,
+    heuristic_limit,
+    kv_capacity_limit,
     resolve_concurrency_limit,
+    state_pool_limit,
+    user_request_limit,
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
@@ -1627,53 +1630,26 @@ class KVCacheConfigurator:
     def resolve_max_num_reqs(self, token_capacity: int) -> int:
         """Compute max concurrent requests (per dp worker) from the finalized
         token capacity."""
-        limits = [
-            ConcurrencyLimit(
-                source="kv_capacity",
-                value=token_capacity // 2,
-                detail=f"max_total_num_tokens={token_capacity} / 2",
-                remedy="raise --mem-fraction-static or lower the context length",
-            )
-        ]
+        limits = [kv_capacity_limit(token_capacity)]
 
         requested_per_worker = None
         if self.server_args.max_running_requests is not None:
-            requested_per_worker = (
-                self.server_args.max_running_requests // self.ps.attn_dp_size
+            requested = user_request_limit(
+                self.server_args.max_running_requests, self.ps.attn_dp_size
             )
-            limits.insert(
-                0,
-                ConcurrencyLimit(
-                    source="max_running_requests",
-                    value=requested_per_worker,
-                    detail=f"--max-running-requests={self.server_args.max_running_requests}",
-                ),
-            )
+            requested_per_worker = requested.value
+            limits.insert(0, requested)
         else:
-            # Heuristic ceiling, only when the user did not ask for a value.
-            estimated = int(token_capacity / self.model_config.context_len * 512)
             limits.append(
-                ConcurrencyLimit(
-                    source="estimate",
-                    value=max(min(estimated, 4096), 2048),
-                    detail="token_capacity / context_len * 512, clamped to [2048, 4096]",
-                    remedy="set --max-running-requests explicitly",
-                )
+                heuristic_limit(token_capacity, self.model_config.context_len)
             )
 
         if self.mambaish_config is not None:
-            ratio = self._calculate_mamba_ratio()
-            mamba_cap = self.server_args.max_mamba_cache_size // ratio
-            target = requested_per_worker or (mamba_cap + 1)
             limits.append(
-                ConcurrencyLimit(
-                    source="mamba_state_pool",
-                    value=mamba_cap,
-                    detail=f"max_mamba_cache_size="
-                    f"{self.server_args.max_mamba_cache_size} / {ratio} slots per request",
-                    remedy=f"set --max-mamba-cache-size {target * ratio}, raise "
-                    f"--mamba-full-memory-ratio, or halve the state size with "
-                    f"--mamba-ssm-dtype bfloat16",
+                state_pool_limit(
+                    self.server_args.max_mamba_cache_size,
+                    self._calculate_mamba_ratio(),
+                    requested_per_worker,
                 )
             )
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1646,8 +1646,10 @@ class KVCacheConfigurator:
                 heuristic_limit(token_capacity, self.model_config.context_len)
             )
 
-        if self.mambaish_config is not None:
-            ratio = self._calculate_mamba_ratio()
+        ratio = (
+            self._calculate_mamba_ratio() if self.mambaish_config is not None else None
+        )
+        if ratio is not None:
             limits.append(
                 state_pool_limit(
                     self.server_args.max_mamba_cache_size,
@@ -1660,7 +1662,7 @@ class KVCacheConfigurator:
         binding = resolve_concurrency_limit(limits)
         max_num_reqs = binding.value
 
-        if self.mambaish_config is not None and max_num_reqs <= 0:
+        if ratio is not None and max_num_reqs <= 0:
             raise RuntimeError(
                 f"Hybrid (mamba/linear-attention) state cache is too small to serve "
                 f"any requests. max_mamba_cache_size={self.server_args.max_mamba_cache_size}, "

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1633,13 +1633,14 @@ class KVCacheConfigurator:
         post-capture resize caller opts out because it logs its own summary."""
         # Order matters: ties are attributed to the first limit listed.
         limits = []
+        requested = None
         requested_per_worker = None
         if self.server_args.max_running_requests is not None:
             requested = user_request_limit(
                 self.server_args.max_running_requests, self.ps.attn_dp_size
             )
-            requested_per_worker = requested.value
             limits.append(requested)
+            requested_per_worker = requested.value
         limits.append(kv_capacity_limit(token_capacity))
         if requested_per_worker is None:
             limits.append(
@@ -1674,7 +1675,7 @@ class KVCacheConfigurator:
 
         if report:
             is_downgrade, message = format_concurrency_report(
-                binding, limits, requested_per_worker
+                binding, limits, requested
             )
             if is_downgrade:
                 logger.warning(message)

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -39,6 +39,11 @@ from sglang.srt.mem_cache.allocator.swa import (
     PureSWATokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
 )
+from sglang.srt.mem_cache.concurrency_limit import (
+    ConcurrencyLimit,
+    format_concurrency_report,
+    resolve_concurrency_limit,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
@@ -1622,40 +1627,75 @@ class KVCacheConfigurator:
     def resolve_max_num_reqs(self, token_capacity: int) -> int:
         """Compute max concurrent requests (per dp worker) from the finalized
         token capacity."""
-        # Estimate pool size (used as upper bound when user specifies max_running_requests)
-        estimated = int(token_capacity / self.model_config.context_len * 512)
-        estimated = max(min(estimated, 4096), 2048)
+        limits = [
+            ConcurrencyLimit(
+                source="kv_capacity",
+                value=token_capacity // 2,
+                detail=f"max_total_num_tokens={token_capacity} / 2",
+                remedy="raise --mem-fraction-static or lower the context length",
+            )
+        ]
 
-        max_num_reqs = self.server_args.max_running_requests
-        if max_num_reqs is not None:
-            requested_per_worker = max_num_reqs // self.ps.attn_dp_size
-            max_num_reqs = min(requested_per_worker, token_capacity // 2)
+        requested_per_worker = None
+        if self.server_args.max_running_requests is not None:
+            requested_per_worker = (
+                self.server_args.max_running_requests // self.ps.attn_dp_size
+            )
+            limits.insert(
+                0,
+                ConcurrencyLimit(
+                    source="max_running_requests",
+                    value=requested_per_worker,
+                    detail=f"--max-running-requests={self.server_args.max_running_requests}",
+                ),
+            )
         else:
-            requested_per_worker = None
-            max_num_reqs = min(estimated, token_capacity // 2)
+            # Heuristic ceiling, only when the user did not ask for a value.
+            estimated = int(token_capacity / self.model_config.context_len * 512)
+            limits.append(
+                ConcurrencyLimit(
+                    source="estimate",
+                    value=max(min(estimated, 4096), 2048),
+                    detail="token_capacity / context_len * 512, clamped to [2048, 4096]",
+                    remedy="set --max-running-requests explicitly",
+                )
+            )
 
         if self.mambaish_config is not None:
             ratio = self._calculate_mamba_ratio()
-            max_num_reqs = min(
-                max_num_reqs, self.server_args.max_mamba_cache_size // ratio
+            mamba_cap = self.server_args.max_mamba_cache_size // ratio
+            target = requested_per_worker or (mamba_cap + 1)
+            limits.append(
+                ConcurrencyLimit(
+                    source="mamba_state_pool",
+                    value=mamba_cap,
+                    detail=f"max_mamba_cache_size="
+                    f"{self.server_args.max_mamba_cache_size} / {ratio} slots per request",
+                    remedy=f"set --max-mamba-cache-size {target * ratio}, raise "
+                    f"--mamba-full-memory-ratio, or halve the state size with "
+                    f"--mamba-ssm-dtype bfloat16",
+                )
             )
 
-            if max_num_reqs <= 0:
-                raise RuntimeError(
-                    f"Hybrid (mamba/linear-attention) state cache is too small to serve "
-                    f"any requests. max_mamba_cache_size={self.server_args.max_mamba_cache_size}, "
-                    f"mamba_ratio={ratio}, resulting max_num_reqs={max_num_reqs}. "
-                    f"Try: (1) reduce --max-running-requests, "
-                    f"(2) increase --mem-fraction-static, or "
-                    f"(3) use GPUs with more memory."
-                )
-        if requested_per_worker is not None and max_num_reqs < requested_per_worker:
-            logger.warning(
-                "max_running_requests was reduced from the requested %d to %d "
-                "(per dp worker) due to the available KV cache capacity.",
-                requested_per_worker,
-                max_num_reqs,
+        max_num_reqs, binding = resolve_concurrency_limit(limits)
+
+        if self.mambaish_config is not None and max_num_reqs <= 0:
+            raise RuntimeError(
+                f"Hybrid (mamba/linear-attention) state cache is too small to serve "
+                f"any requests. max_mamba_cache_size={self.server_args.max_mamba_cache_size}, "
+                f"mamba_ratio={self._calculate_mamba_ratio()}, resulting max_num_reqs={max_num_reqs}. "
+                f"Try: (1) reduce --max-running-requests, "
+                f"(2) increase --mem-fraction-static, or "
+                f"(3) use GPUs with more memory."
             )
+
+        is_downgrade, message = format_concurrency_report(
+            max_num_reqs, binding, limits, requested_per_worker
+        )
+        if is_downgrade:
+            logger.warning(message)
+        else:
+            logger.info(message)
         return max_num_reqs
 
     def _resolve_memory_pool_config(

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1654,7 +1654,7 @@ class KVCacheConfigurator:
                     self.server_args.max_mamba_cache_size,
                     ratio,
                     self.ps.attn_dp_size,
-                    requested.value if requested else None,
+                    requested.value if requested is not None else None,
                 )
             )
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1634,15 +1634,13 @@ class KVCacheConfigurator:
         # Order matters: ties are attributed to the first limit listed.
         limits = []
         requested = None
-        requested_per_worker = None
         if self.server_args.max_running_requests is not None:
             requested = user_request_limit(
                 self.server_args.max_running_requests, self.ps.attn_dp_size
             )
             limits.append(requested)
-            requested_per_worker = requested.value
         limits.append(kv_capacity_limit(token_capacity))
-        if requested_per_worker is None:
+        if requested is None:
             limits.append(
                 heuristic_limit(token_capacity, self.model_config.context_len)
             )
@@ -1656,7 +1654,7 @@ class KVCacheConfigurator:
                     self.server_args.max_mamba_cache_size,
                     ratio,
                     self.ps.attn_dp_size,
-                    requested_per_worker,
+                    requested.value if requested else None,
                 )
             )
 

--- a/python/sglang/srt/model_executor/model_runner_components/kv_pool_runtime.py
+++ b/python/sglang/srt/model_executor/model_runner_components/kv_pool_runtime.py
@@ -92,7 +92,7 @@ def compute_post_capture_kv_resize(
         capped_reqs = min(
             model_runner.max_running_requests,
             model_runner.kv_cache_configurator.resolve_max_num_reqs(
-                config.max_total_num_tokens
+                config.max_total_num_tokens, report=False
             ),
         )
         if capped_reqs < model_runner.max_running_requests:

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -763,8 +763,8 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 self.requested_max_running_requests_per_worker
             )
 
-        # Same bounds resolve_max_num_reqs applies; the pool is not sized yet,
-        # so only the capacity-independent ones are known here.
+        # Mirrors the no-request branch of resolve_max_num_reqs; token_capacity
+        # is still provisional here.
         binding = resolve_concurrency_limit(
             [
                 kv_capacity_limit(token_capacity),

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -31,6 +31,11 @@ from sglang.srt.configs.model_config import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
+from sglang.srt.mem_cache.concurrency_limit import (
+    heuristic_limit,
+    kv_capacity_limit,
+    resolve_concurrency_limit,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.runtime_context import get_model, get_parallel
@@ -758,10 +763,15 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 self.requested_max_running_requests_per_worker
             )
 
-        estimated = int(token_capacity / self.context_len * 512)
-        estimated = max(min(estimated, 4096), 2048)
-        max_running_requests = min(estimated, token_capacity // 2)
-        return self._get_c128_state_fixed_bytes(max_running_requests)
+        # Same bounds resolve_max_num_reqs applies; the pool is not sized yet,
+        # so only the capacity-independent ones are known here.
+        binding = resolve_concurrency_limit(
+            [
+                kv_capacity_limit(token_capacity),
+                heuristic_limit(token_capacity, self.context_len),
+            ]
+        )
+        return self._get_c128_state_fixed_bytes(binding.value)
 
     def _to_config(self, sizes: _DSV4PoolSizes) -> MemoryPoolConfig:
         full = sizes.full_max_total_num_tokens

--- a/test/registered/unit/mem_cache/test_concurrency_limit.py
+++ b/test/registered/unit/mem_cache/test_concurrency_limit.py
@@ -65,6 +65,15 @@ class TestConcurrencyLimit(CustomTestCase):
         # The user's own request carries no remedy.
         self.assertNotIn("To raise it", message)
 
+    def test_downgrade_keeps_the_global_request_visible(self):
+        requested = user_request_limit(296, attn_dp_size=4)
+        limits = [requested, _limit("mamba_state_pool", 26)]
+        _, message = format_concurrency_report(
+            resolve_concurrency_limit(limits), limits, requested
+        )
+        self.assertIn("reduced from the requested 74", message)
+        self.assertIn("--max-running-requests=296 / 4 dp workers", message)
+
     def test_sole_limit_omits_the_other_limits_clause(self):
         limits = [_limit("kv_capacity", 400)]
         _, message = format_concurrency_report(
@@ -93,15 +102,6 @@ class TestLimitConstructors(CustomTestCase):
             user_request_limit(128, attn_dp_size=1).detail,
             "--max-running-requests=128",
         )
-
-    def test_downgrade_keeps_the_global_request_visible(self):
-        requested = user_request_limit(296, attn_dp_size=4)
-        limits = [requested, _limit("mamba_state_pool", 26)]
-        _, message = format_concurrency_report(
-            resolve_concurrency_limit(limits), limits, requested
-        )
-        self.assertIn("reduced from the requested 74", message)
-        self.assertIn("--max-running-requests=296 / 4 dp workers", message)
 
     def test_kv_capacity_halves_the_token_pool(self):
         self.assertEqual(kv_capacity_limit(798208).value, 399104)

--- a/test/registered/unit/mem_cache/test_concurrency_limit.py
+++ b/test/registered/unit/mem_cache/test_concurrency_limit.py
@@ -42,7 +42,9 @@ class TestConcurrencyLimit(CustomTestCase):
             _limit("mamba_state_pool", 26, remedy="--max-mamba-cache-size 370"),
         ]
         binding = resolve_concurrency_limit(limits)
-        is_downgrade, message = format_concurrency_report(binding, limits, requested=74)
+        is_downgrade, message = format_concurrency_report(
+            binding, limits, requested=limits[0]
+        )
         self.assertTrue(is_downgrade)
         self.assertIn("reduced from the requested 74 to 26", message)
         self.assertIn("bound by mamba_state_pool", message)
@@ -55,7 +57,9 @@ class TestConcurrencyLimit(CustomTestCase):
             _limit("kv_capacity", 400),
         ]
         binding = resolve_concurrency_limit(limits)
-        is_downgrade, message = format_concurrency_report(binding, limits, requested=32)
+        is_downgrade, message = format_concurrency_report(
+            binding, limits, requested=limits[0]
+        )
         self.assertFalse(is_downgrade)
         self.assertIn("bound by max_running_requests", message)
         # The user's own request carries no remedy.
@@ -80,7 +84,24 @@ class TestConcurrencyLimit(CustomTestCase):
 
 class TestLimitConstructors(CustomTestCase):
     def test_user_request_is_per_dp_worker(self):
-        self.assertEqual(user_request_limit(128, attn_dp_size=4).value, 32)
+        limit = user_request_limit(128, attn_dp_size=4)
+        self.assertEqual(limit.value, 32)
+        self.assertIn("--max-running-requests=128 / 4 dp workers", limit.detail)
+
+    def test_user_request_detail_omits_the_dp_split_when_single(self):
+        self.assertEqual(
+            user_request_limit(128, attn_dp_size=1).detail,
+            "--max-running-requests=128",
+        )
+
+    def test_downgrade_keeps_the_global_request_visible(self):
+        requested = user_request_limit(296, attn_dp_size=4)
+        limits = [requested, _limit("mamba_state_pool", 26)]
+        _, message = format_concurrency_report(
+            resolve_concurrency_limit(limits), limits, requested
+        )
+        self.assertIn("reduced from the requested 74", message)
+        self.assertIn("--max-running-requests=296 / 4 dp workers", message)
 
     def test_kv_capacity_halves_the_token_pool(self):
         self.assertEqual(kv_capacity_limit(798208).value, 399104)

--- a/test/registered/unit/mem_cache/test_concurrency_limit.py
+++ b/test/registered/unit/mem_cache/test_concurrency_limit.py
@@ -3,7 +3,11 @@ import unittest
 from sglang.srt.mem_cache.concurrency_limit import (
     ConcurrencyLimit,
     format_concurrency_report,
+    heuristic_limit,
+    kv_capacity_limit,
     resolve_concurrency_limit,
+    state_pool_limit,
+    user_request_limit,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -65,6 +69,29 @@ class TestConcurrencyLimit(CustomTestCase):
         self.assertFalse(is_downgrade)
         self.assertEqual(resolved, 400)
         self.assertIn("bound by kv_capacity", message)
+
+
+class TestLimitConstructors(CustomTestCase):
+    def test_user_request_is_per_dp_worker(self):
+        self.assertEqual(user_request_limit(128, attn_dp_size=4).value, 32)
+
+    def test_kv_capacity_halves_the_token_pool(self):
+        self.assertEqual(kv_capacity_limit(798208).value, 399104)
+
+    def test_heuristic_is_clamped(self):
+        # 2M tokens / 1M context * 512 = 1024, raised to the 2048 floor.
+        self.assertEqual(heuristic_limit(2 * 1024**2, 1024**2).value, 2048)
+        # A short context would overshoot; capped at 4096.
+        self.assertEqual(heuristic_limit(10**7, 1024).value, 4096)
+
+    def test_state_pool_remedy_sizes_for_the_target(self):
+        limit = state_pool_limit(131, slots_per_request=5, target=74)
+        self.assertEqual(limit.value, 26)
+        self.assertIn("--max-mamba-cache-size 370", limit.remedy)
+
+    def test_state_pool_remedy_defaults_to_one_more_request(self):
+        limit = state_pool_limit(131, slots_per_request=5)
+        self.assertIn("--max-mamba-cache-size 135", limit.remedy)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_concurrency_limit.py
+++ b/test/registered/unit/mem_cache/test_concurrency_limit.py
@@ -23,30 +23,30 @@ def _limit(source, value, remedy="raise it"):
 
 class TestConcurrencyLimit(CustomTestCase):
     def test_binds_to_the_smallest_limit(self):
-        limits = [_limit("kv_capacity", 400), _limit("mamba_state_pool", 26)]
-        resolved, binding = resolve_concurrency_limit(limits)
-        self.assertEqual(resolved, 26)
+        binding = resolve_concurrency_limit(
+            [_limit("kv_capacity", 400), _limit("mamba_state_pool", 26)]
+        )
+        self.assertEqual(binding.value, 26)
         self.assertEqual(binding.source, "mamba_state_pool")
 
     def test_ties_report_the_first_listed(self):
-        limits = [_limit("max_running_requests", 74), _limit("kv_capacity", 74)]
-        _, binding = resolve_concurrency_limit(limits)
+        binding = resolve_concurrency_limit(
+            [_limit("max_running_requests", 74), _limit("kv_capacity", 74)]
+        )
         self.assertEqual(binding.source, "max_running_requests")
 
     def test_downgrade_names_the_binding_limit_and_remedy(self):
         limits = [
             ConcurrencyLimit("max_running_requests", 74, "--max-running-requests=74"),
             _limit("kv_capacity", 400),
-            _limit("mamba_state_pool", 26, remedy="set --max-mamba-cache-size 370"),
+            _limit("mamba_state_pool", 26, remedy="--max-mamba-cache-size 370"),
         ]
-        resolved, binding = resolve_concurrency_limit(limits)
-        is_downgrade, message = format_concurrency_report(
-            resolved, binding, limits, requested=74
-        )
+        binding = resolve_concurrency_limit(limits)
+        is_downgrade, message = format_concurrency_report(binding, limits, requested=74)
         self.assertTrue(is_downgrade)
         self.assertIn("reduced from the requested 74 to 26", message)
-        self.assertIn("mamba_state_pool", message)
-        self.assertIn("set --max-mamba-cache-size 370", message)
+        self.assertIn("bound by mamba_state_pool", message)
+        self.assertIn("--max-mamba-cache-size 370", message)
         self.assertIn("kv_capacity=400", message)
 
     def test_request_honored_is_not_a_downgrade(self):
@@ -54,26 +54,28 @@ class TestConcurrencyLimit(CustomTestCase):
             ConcurrencyLimit("max_running_requests", 32, "--max-running-requests=32"),
             _limit("kv_capacity", 400),
         ]
-        resolved, binding = resolve_concurrency_limit(limits)
-        is_downgrade, message = format_concurrency_report(
-            resolved, binding, limits, requested=32
-        )
+        binding = resolve_concurrency_limit(limits)
+        is_downgrade, message = format_concurrency_report(binding, limits, requested=32)
         self.assertFalse(is_downgrade)
         self.assertIn("bound by max_running_requests", message)
+        # The user's own request carries no remedy.
+        self.assertNotIn("To raise it", message)
 
     def test_sole_limit_omits_the_other_limits_clause(self):
         limits = [_limit("kv_capacity", 400)]
-        resolved, binding = resolve_concurrency_limit(limits)
-        _, message = format_concurrency_report(resolved, binding, limits)
+        _, message = format_concurrency_report(
+            resolve_concurrency_limit(limits), limits
+        )
         self.assertNotIn("other limits", message)
 
-    def test_no_request_still_reports_the_binding_limit(self):
-        limits = [_limit("kv_capacity", 400), _limit("estimate", 2048)]
-        resolved, binding = resolve_concurrency_limit(limits)
-        is_downgrade, message = format_concurrency_report(resolved, binding, limits)
+    def test_no_request_still_reports_binding_and_remedy(self):
+        limits = [_limit("kv_capacity", 400), _limit("heuristic_estimate", 2048)]
+        binding = resolve_concurrency_limit(limits)
+        is_downgrade, message = format_concurrency_report(binding, limits)
         self.assertFalse(is_downgrade)
-        self.assertEqual(resolved, 400)
+        self.assertEqual(binding.value, 400)
         self.assertIn("bound by kv_capacity", message)
+        self.assertIn("To raise it", message)
 
 
 class TestLimitConstructors(CustomTestCase):
@@ -89,13 +91,25 @@ class TestLimitConstructors(CustomTestCase):
         self.assertEqual(heuristic_limit(10**7, 1024).value, 4096)
 
     def test_state_pool_remedy_sizes_for_the_target(self):
-        limit = state_pool_limit(131, slots_per_request=5, target=74)
+        limit = state_pool_limit(131, slots_per_request=5, attn_dp_size=1, target=74)
         self.assertEqual(limit.value, 26)
         self.assertIn("--max-mamba-cache-size 370", limit.remedy)
 
+    def test_state_pool_remedy_scales_back_to_the_global_flag(self):
+        # The pool size read from server_args is per shard, but
+        # --max-mamba-cache-size is global and gets divided by attn_dp_size.
+        limit = state_pool_limit(131, slots_per_request=5, attn_dp_size=4, target=74)
+        self.assertEqual(limit.value, 26)
+        self.assertIn("--max-mamba-cache-size 1480", limit.remedy)
+        self.assertIn("per shard", limit.detail)
+
     def test_state_pool_remedy_defaults_to_one_more_request(self):
-        limit = state_pool_limit(131, slots_per_request=5)
+        limit = state_pool_limit(131, slots_per_request=5, attn_dp_size=1)
         self.assertIn("--max-mamba-cache-size 135", limit.remedy)
+
+    def test_state_pool_target_zero_is_not_treated_as_unset(self):
+        limit = state_pool_limit(131, slots_per_request=5, attn_dp_size=1, target=0)
+        self.assertIn("--max-mamba-cache-size 0", limit.remedy)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_concurrency_limit.py
+++ b/test/registered/unit/mem_cache/test_concurrency_limit.py
@@ -1,0 +1,71 @@
+import unittest
+
+from sglang.srt.mem_cache.concurrency_limit import (
+    ConcurrencyLimit,
+    format_concurrency_report,
+    resolve_concurrency_limit,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _limit(source, value, remedy="raise it"):
+    return ConcurrencyLimit(
+        source=source, value=value, detail=f"{source} detail", remedy=remedy
+    )
+
+
+class TestConcurrencyLimit(CustomTestCase):
+    def test_binds_to_the_smallest_limit(self):
+        limits = [_limit("kv_capacity", 400), _limit("mamba_state_pool", 26)]
+        resolved, binding = resolve_concurrency_limit(limits)
+        self.assertEqual(resolved, 26)
+        self.assertEqual(binding.source, "mamba_state_pool")
+
+    def test_ties_report_the_first_listed(self):
+        limits = [_limit("max_running_requests", 74), _limit("kv_capacity", 74)]
+        _, binding = resolve_concurrency_limit(limits)
+        self.assertEqual(binding.source, "max_running_requests")
+
+    def test_downgrade_names_the_binding_limit_and_remedy(self):
+        limits = [
+            ConcurrencyLimit("max_running_requests", 74, "--max-running-requests=74"),
+            _limit("kv_capacity", 400),
+            _limit("mamba_state_pool", 26, remedy="set --max-mamba-cache-size 370"),
+        ]
+        resolved, binding = resolve_concurrency_limit(limits)
+        is_downgrade, message = format_concurrency_report(
+            resolved, binding, limits, requested=74
+        )
+        self.assertTrue(is_downgrade)
+        self.assertIn("reduced from the requested 74 to 26", message)
+        self.assertIn("mamba_state_pool", message)
+        self.assertIn("set --max-mamba-cache-size 370", message)
+        # The non-binding limits stay visible for context.
+        self.assertIn("kv_capacity=400", message)
+
+    def test_request_honored_is_not_a_downgrade(self):
+        limits = [
+            ConcurrencyLimit("max_running_requests", 32, "--max-running-requests=32"),
+            _limit("kv_capacity", 400),
+        ]
+        resolved, binding = resolve_concurrency_limit(limits)
+        is_downgrade, message = format_concurrency_report(
+            resolved, binding, limits, requested=32
+        )
+        self.assertFalse(is_downgrade)
+        self.assertIn("max_running_requests=32", message)
+
+    def test_no_request_still_reports_the_binding_limit(self):
+        limits = [_limit("kv_capacity", 400), _limit("estimate", 2048)]
+        resolved, binding = resolve_concurrency_limit(limits)
+        is_downgrade, message = format_concurrency_report(resolved, binding, limits)
+        self.assertFalse(is_downgrade)
+        self.assertEqual(resolved, 400)
+        self.assertIn("bound by kv_capacity", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_concurrency_limit.py
+++ b/test/registered/unit/mem_cache/test_concurrency_limit.py
@@ -103,9 +103,11 @@ class TestLimitConstructors(CustomTestCase):
         self.assertIn("--max-mamba-cache-size 1480", limit.remedy)
         self.assertIn("per shard", limit.detail)
 
-    def test_state_pool_remedy_defaults_to_one_more_request(self):
+    def test_state_pool_without_a_target_suggests_no_size(self):
+        # Any size we could invent is either +1 request or far past what fits.
         limit = state_pool_limit(131, slots_per_request=5, attn_dp_size=1)
-        self.assertIn("--max-mamba-cache-size 135", limit.remedy)
+        self.assertNotIn("--max-mamba-cache-size", limit.remedy)
+        self.assertIn("--max-running-requests", limit.remedy)
 
     def test_state_pool_target_zero_is_not_treated_as_unset(self):
         limit = state_pool_limit(131, slots_per_request=5, attn_dp_size=1, target=0)

--- a/test/registered/unit/mem_cache/test_concurrency_limit.py
+++ b/test/registered/unit/mem_cache/test_concurrency_limit.py
@@ -47,7 +47,6 @@ class TestConcurrencyLimit(CustomTestCase):
         self.assertIn("reduced from the requested 74 to 26", message)
         self.assertIn("mamba_state_pool", message)
         self.assertIn("set --max-mamba-cache-size 370", message)
-        # The non-binding limits stay visible for context.
         self.assertIn("kv_capacity=400", message)
 
     def test_request_honored_is_not_a_downgrade(self):
@@ -60,7 +59,13 @@ class TestConcurrencyLimit(CustomTestCase):
             resolved, binding, limits, requested=32
         )
         self.assertFalse(is_downgrade)
-        self.assertIn("max_running_requests=32", message)
+        self.assertIn("bound by max_running_requests", message)
+
+    def test_sole_limit_omits_the_other_limits_clause(self):
+        limits = [_limit("kv_capacity", 400)]
+        resolved, binding = resolve_concurrency_limit(limits)
+        _, message = format_concurrency_report(resolved, binding, limits)
+        self.assertNotIn("other limits", message)
 
     def test_no_request_still_reports_the_binding_limit(self):
         limits = [_limit("kv_capacity", 400), _limit("estimate", 2048)]
@@ -79,9 +84,8 @@ class TestLimitConstructors(CustomTestCase):
         self.assertEqual(kv_capacity_limit(798208).value, 399104)
 
     def test_heuristic_is_clamped(self):
-        # 2M tokens / 1M context * 512 = 1024, raised to the 2048 floor.
+        # 2M / 1M * 512 = 1024 -> floor; 10M / 1K * 512 = 5M -> ceiling.
         self.assertEqual(heuristic_limit(2 * 1024**2, 1024**2).value, 2048)
-        # A short context would overshoot; capped at 4096.
         self.assertEqual(heuristic_limit(10**7, 1024).value, 4096)
 
     def test_state_pool_remedy_sizes_for_the_target(self):


### PR DESCRIPTION
## Summary

- `resolve_max_num_reqs` folds several independent bounds into nested `min()` calls and then attributes the outcome to a single hard-coded cause: `"reduced from the requested N to M due to the available KV cache capacity"`. When the hybrid state pool is what bound it (the common case for mamba/GDN models), that message points at the wrong resource
- It is also silent whenever the user did not pass `--max-running-requests` — the heuristic ceiling (`token_capacity / context_len * 512`, clamped to `[2048, 4096]`) can be the binding limit with nothing logged
- Collect the bounds as data (`ConcurrencyLimit`: value + where it comes from + how to raise it), pick the min, and report the one that actually bound the result — WARNING when the user asked for more than they got, INFO otherwise

## Example

Before (hybrid model, state pool binding):

```
max_running_requests was reduced from the requested 74 to 26 (per dp worker) due to the available KV cache capacity.
```

After:

```
max_running_requests reduced from the requested 74 to 26 (per dp worker), bound by mamba_state_pool
(max_mamba_cache_size=131 / 5 slots per request); other limits: max_running_requests=74, kv_capacity=399104.
To raise it: set --max-mamba-cache-size 370, raise --mamba-full-memory-ratio, or halve the state size
with --mamba-ssm-dtype bfloat16.
```

The remedy carries the concrete value needed for the requested concurrency, so raising the ceiling no longer requires deriving `slots x per-request` by hand.

## Changes

- New `mem_cache/concurrency_limit.py`: `ConcurrencyLimit` + `resolve_concurrency_limit` + `format_concurrency_report`, pure functions with no runtime dependencies
- `resolve_max_num_reqs` builds the limit list (user request / KV capacity / heuristic estimate / mamba state pool) and delegates; resolution arithmetic is unchanged, and the fail-loud path for a zero-capacity state pool is preserved
- CPU unit test covering binding selection, tie order, downgrade vs honored-request messages, and the no-request case

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30154211841](https://github.com/sgl-project/sglang/actions/runs/30154211841)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30154211783](https://github.com/sgl-project/sglang/actions/runs/30154211783)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->