### PR TITLE
Guard the min-new-tokens penalizer against a raw None min_new_tokens

### DIFF
--- a/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
+++ b/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
@@ -9,14 +9,23 @@ class BatchedMinNewTokensPenalizer(_BatchedPenalizer):
     """
 
     def _is_required(self) -> bool:
+        # A request in the batch may carry a raw `None` min_new_tokens that
+        # bypassed `SamplingParams.__post_init__`'s None->0 normalization
+        # (e.g. an internally-constructed request). `or 0` mirrors that
+        # normalization defensively so the comparison can't raise.
         return any(
-            req.sampling_params.min_new_tokens > 0 for req in self.orchestrator.reqs()
+            (req.sampling_params.min_new_tokens or 0) > 0
+            for req in self.orchestrator.reqs()
         )
 
     def _prepare(self):
+        # See `_is_required`: a heterogeneous None/int batch would otherwise
+        # crash the tensor build with
+        # "TypeError: 'NoneType' object cannot be interpreted as an integer".
         self.min_new_tokens = torch.tensor(
             data=[
-                req.sampling_params.min_new_tokens for req in self.orchestrator.reqs()
+                (req.sampling_params.min_new_tokens or 0)
+                for req in self.orchestrator.reqs()
             ],
             dtype=torch.int32,
             device=self.orchestrator.device,


### PR DESCRIPTION
> **Draft** — small crash-guard, opening for review. Found and fixed internally; posting upstream so it doesn't have to be carried as a patch.

## Motivation

`BatchedMinNewTokensPenalizer._is_required` and `._prepare` read `req.sampling_params.min_new_tokens` directly. `SamplingParams.__post_init__` normalizes `None -> 0`, but a request whose `sampling_params` bypassed that normalization (e.g. an internally-constructed request that sets fields directly) can carry a raw `None`.

Under continuous batching, a single such request in an otherwise-integer batch crashes tensor construction for the whole batch:

```
TypeError: 'NoneType' object cannot be interpreted as an integer
  File ".../srt/sampling/penaltylib/min_new_tokens.py", in _prepare
    torch.tensor(data=[req.sampling_params.min_new_tokens for req in ...])
```

This was hit live under real traffic (all TP ranks crashed on the first batch).

## Modifications

Mirror the `__post_init__` normalization defensively with `or 0` in both the `_is_required` check and the `_prepare` tensor build, so a heterogeneous `None`/`int` batch cannot crash the sampler. No behavior change for well-formed requests (a real `min_new_tokens` of `0` and a `None` are already equivalent after normalization).

## Checklist

- [ ] format (`pre-commit run --all-files`) — not yet run in this draft
- [ ] a unit test for a batch mixing `None` and integer `min_new_tokens`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30138202726](https://github.com/sgl-project/sglang/actions/runs/30138202726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30138202674](https://github.com/sgl-project/sglang/actions/runs/30138202674)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->