### PR TITLE
[Spec][DSpark] Remove overlap scheduler host syncs for pure TP

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -928,9 +928,7 @@ class DeepseekV4AttnBackend(
             seq_lens_casual = self._dspark_seq_lens_casual(
                 seq_lens=seq_lens, block_size=block_size
             )
-            req_pool_indices_repeated = req_pool_indices.repeat_interleave(
-                block_size
-            )
+            req_pool_indices_repeated = req_pool_indices.repeat_interleave(block_size)
             core_attn_metadata = self.make_core_attn_metadata(
                 req_to_token=self.req_to_token,
                 req_pool_indices_repeated=req_pool_indices_repeated,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -925,9 +925,25 @@ class DeepseekV4AttnBackend(
         block_size: int,
     ) -> DSV4Metadata:
         if seq_lens_cpu is None:
-            seq_lens_cpu_list = seq_lens.tolist()
-        else:
-            seq_lens_cpu_list = [int(x) for x in seq_lens_cpu.tolist()]
+            seq_lens_casual = self._dspark_seq_lens_casual(
+                seq_lens=seq_lens, block_size=block_size
+            )
+            req_pool_indices_repeated = req_pool_indices.repeat_interleave(
+                block_size
+            )
+            core_attn_metadata = self.make_core_attn_metadata(
+                req_to_token=self.req_to_token,
+                req_pool_indices_repeated=req_pool_indices_repeated,
+                seq_lens_casual=seq_lens_casual,
+                max_seq_len=max_seq_len,
+                out_loc=out_cache_loc,
+                need_compress=False,
+                is_prefill=True,
+                dspark_block_size=block_size,
+            )
+            return DSV4Metadata(core_attn_metadata, indexer_metadata=None)
+
+        seq_lens_cpu_list = [int(x) for x in seq_lens_cpu.tolist()]
         lengths = compute_uniform_extend_lengths(
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens_cpu_list,

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -87,6 +87,12 @@ def resolve_forward_inputs(batch: ScheduleBatch, future_map: FutureMap) -> None:
     - Prefill: H2D copy from pinned CPU staging (prefill_input_ids_cpu).
     - Decode/spec_v2: gather from FutureMap (last iter's sampled token).
     """
+    # Backends that do not consume a CPU sequence-length mirror resolve the
+    # exact accepted lengths here, on the forward stream. The scheduler can
+    # therefore stay ahead using request-side reserved bounds without waiting
+    # for the previous speculative accept/finalize step on the host.
+    future_map.resolve_seq_lens_device(batch)
+
     if batch.prefill_input_ids_cpu is not None:
         prefill_gpu = batch.prefill_input_ids_cpu.to(batch.device, non_blocking=True)
         if batch.mix_running_indices is not None:
@@ -156,11 +162,23 @@ class ConfidenceRelay(msgspec.Struct):
     req_pool_size: int
     pool: Any
     confidence_buf: Optional[torch.Tensor] = None
+    confidence_snapshot_ring: Optional[torch.Tensor] = None
     conf_ring: Optional[torch.Tensor] = None
     gen_ring: Optional[torch.Tensor] = None
+    snapshot_ready: Optional[list] = None
     copy_done: Optional[list] = None
+    copy_issued: Optional[list] = None
+    last_snapshot_slot: int = -1
     ring_pos: int = 0
     initialized: bool = False
+
+    def reset(self) -> None:
+        # req_generation restarts when the request pool is flushed. Forget
+        # every pre-flush publication so an old generation cannot match a
+        # newly allocated request slot (ABA).
+        self.ring_pos = 0
+        if self.gen_ring is not None:
+            self.gen_ring.fill_(-1)
 
     def _lazy_init(self, confidence: torch.Tensor) -> None:
         self.initialized = True
@@ -168,32 +186,58 @@ class ConfidenceRelay(msgspec.Struct):
         self.confidence_buf = torch.empty(
             (self.req_pool_size, gamma), dtype=torch.float32, device=self.device
         )
-        if _is_cuda:
+        if _is_cuda or _is_hip:
             depth = CONFIDENCE_RELAY_RING_DEPTH
+            self.confidence_snapshot_ring = torch.empty(
+                (depth, self.req_pool_size, gamma),
+                dtype=torch.float32,
+                device=self.device,
+            )
             self.conf_ring = torch.empty(
                 (depth, self.req_pool_size, gamma),
                 dtype=torch.float32,
                 pin_memory=True,
             )
             self.gen_ring = torch.zeros((depth, self.req_pool_size), dtype=torch.int64)
-            self.copy_done = [
-                torch.get_device_module(self.device).Event() for _ in range(depth)
-            ]
+            device_module = torch.get_device_module(self.device)
+            self.snapshot_ready = [device_module.Event() for _ in range(depth)]
+            self.copy_done = [device_module.Event() for _ in range(depth)]
+            self.copy_issued = [False] * depth
 
     def scatter(self, indices: torch.Tensor, confidence: torch.Tensor) -> None:
         if not self.initialized:
             self._lazy_init(confidence)
         self.confidence_buf[indices] = confidence.to(self.confidence_buf.dtype)
 
-    def issue_ring_copy(self, *, stream, publish_ready) -> None:
-        if not self.initialized or stream is None or publish_ready is None:
+    def wait_for_previous_snapshot(self, stream) -> None:
+        if not self.initialized or stream is None or self.last_snapshot_slot < 0:
+            return
+        stream.wait_event(self.snapshot_ready[self.last_snapshot_slot])
+
+    def issue_ring_copy(self, *, stream, publish_stream) -> None:
+        if not self.initialized or stream is None or publish_stream is None:
             return
         slot = self.ring_pos % CONFIDENCE_RELAY_RING_DEPTH
-        stream.wait_event(publish_ready)
-        with torch.get_device_module(self.device).stream(stream):
-            self.conf_ring[slot].copy_(self.confidence_buf, non_blocking=True)
+        device_module = torch.get_device_module(self.device)
+
+        # Reusing a snapshot slot must wait for its prior D2H reader. Keep this
+        # as a device dependency: reset() can wrap back to slot zero while a
+        # pre-flush copy is still in flight.
+        if self.copy_issued[slot]:
+            publish_stream.wait_event(self.copy_done[slot])
+        with device_module.stream(publish_stream):
+            self.confidence_snapshot_ring[slot].copy_(self.confidence_buf)
+            self.snapshot_ready[slot].record()
+        self.last_snapshot_slot = slot
+
+        stream.wait_event(self.snapshot_ready[slot])
+        with device_module.stream(stream):
+            self.conf_ring[slot].copy_(
+                self.confidence_snapshot_ring[slot], non_blocking=True
+            )
             self.copy_done[slot].record()
         self.gen_ring[slot].copy_(self.pool.req_generation)
+        self.copy_issued[slot] = True
         self.ring_pos += 1
 
     def resolve(
@@ -268,10 +312,10 @@ class FutureMap:
                 (self.req_pool_size,), dtype=torch.int64, device=self.device
             )
         # Pinned host copy of new_seq_lens_buf + private stream for fwd-prepare
-        # D2H pulls (gated only on publish, off the schedule stream). CUDA-only:
-        # recovers occupancy lost to the WAR barrier (also CUDA-only); other
-        # platforms have no barrier and use the plain .cpu() bootstrap path.
-        if _is_cuda:
+        # D2H pulls (gated only on publish, off the schedule stream). CUDA-like
+        # devices share the pinned relay; other platforms use the plain .cpu()
+        # bootstrap path.
+        if _is_cuda or _is_hip:
             self.new_seq_lens_cpu_pinned = torch.empty(
                 (self.req_pool_size,), dtype=torch.int64, pin_memory=True
             )
@@ -284,6 +328,7 @@ class FutureMap:
         self.dsa_topk_indices_buf = None
 
         self.publish_ready = None  # lazy device.Event(); only spec_v2 needs it
+        self._publish_stream = None
         # Debug consume-once state: armed by a recording publish, consumed by
         # resolve; arm/consume strictly alternate across all batch interleavings.
         self._publish_fresh = False
@@ -420,6 +465,15 @@ class FutureMap:
         fi = draft_input.future_indices
         if fi is None:
             return
+
+        if not self.needs_cpu_seq_lens:
+            # Exact lengths are gathered later on the forward stream by
+            # resolve_seq_lens_device(). Do not make the schedule stream wait
+            # for the previous forward merely to install a device tensor view.
+            batch.seq_lens_cpu = None
+            batch.seq_lens_sum = None
+            return
+
         if self.publish_ready is not None:
             if _DEBUG_ASSERT:
                 # Consume-once: every event wait must be re-armed by a fresh
@@ -432,18 +486,6 @@ class FutureMap:
             else:
                 self.publish_ready.wait()
         batch.seq_lens = self.new_seq_lens_buf[fi]
-
-        if not self.needs_cpu_seq_lens:
-            # GPU gather above is kept (SB.seq_lens must advance each verify);
-            # skip the .cpu() D2H. Downstream takes the GPU-only path.
-            batch.seq_lens_cpu = None
-            batch.seq_lens_sum = None
-            if _DEBUG_ASSERT:
-                # Poison consumed rows: each row must be re-published/seeded
-                # before the next resolve gathers it (safe here: the forward's
-                # re-publish is fenced behind this stream via wait_stream).
-                _assert_nonneg_and_invalidate(batch.seq_lens, self.new_seq_lens_buf, fi)
-            return
 
         if self.fwd_prepare_d2h_stream is None or self.publish_ready is None:
             batch.seq_lens_cpu = batch.seq_lens.cpu()  # bootstrap / non-CUDA
@@ -467,6 +509,47 @@ class FutureMap:
             # mirror is not poisoned.
             _assert_nonneg_and_invalidate(batch.seq_lens, self.new_seq_lens_buf, fi)
 
+    def resolve_seq_lens_device(self, batch: ScheduleBatch) -> None:
+        """Gather exact speculative lengths without blocking the host.
+
+        This is the GPU-only counterpart of resolve_seq_lens_cpu(). It runs
+        inside the persistent forward-stream context. A device event wait is
+        sufficient for bootstrap/off-stream publications; in steady decode the
+        event was recorded by the preceding forward on this same stream.
+        """
+        if self.needs_cpu_seq_lens:
+            return
+        draft_input = batch.spec_info
+        if draft_input is None:
+            return
+        fi = draft_input.future_indices
+        if fi is None:
+            return
+
+        if self.publish_ready is not None:
+            if _DEBUG_ASSERT:
+                assert self._publish_fresh, "resolve without a fresh forward publish"
+                self._publish_fresh = False
+            current_stream = torch.get_device_module(self.device).current_stream()
+            if (
+                self._publish_stream is not None
+                and current_stream != self._publish_stream
+            ):
+                # Bootstrap/off-stream seeding still needs a device dependency;
+                # steady speculative decode publishes and consumes on the same
+                # forward stream and therefore needs no HIP event wait at all.
+                current_stream.wait_event(self.publish_ready)
+        batch.seq_lens = self.new_seq_lens_buf[fi]
+        if _DEBUG_ASSERT:
+            _assert_nonneg_and_invalidate(batch.seq_lens, self.new_seq_lens_buf, fi)
+
+    def reset(self) -> None:
+        """Drop cross-iteration publications after an idle cache flush."""
+        self.publish_ready = None
+        self._publish_stream = None
+        self._publish_fresh = False
+        self.confidence_relay.reset()
+
     def publish(
         self,
         future_indices: torch.Tensor,
@@ -476,27 +559,39 @@ class FutureMap:
         indices = future_indices
         if indices.shape[0] == 0:
             return  # DP idle
-        self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
         publish_confidence = self.needs_confidence_relay and confidence is not None
-        if publish_confidence:
-            self.confidence_relay.scatter(indices, confidence)
-        # Only spec_v2 needs the event; it gates the seq_lens D2H on the private stream.
+        current_stream = None
+
+        # Chain off-stream publishers before they touch shared relay buffers.
+        # The event is recorded below only after the confidence snapshot has
+        # been enqueued, so the next publisher cannot overtake that snapshot.
         if self.spec_algo.is_some():
             device_module = torch.get_device_module(self.device)
+            current_stream = device_module.current_stream()
             if self.publish_ready is None:
                 self.publish_ready = device_module.Event()
-            else:
+            elif (
+                self._publish_stream is not None
+                and current_stream != self._publish_stream
+            ):
                 # Chain the records: event fire implies every prior publish is
                 # visible, so an off-forward-stream publish (PD-decode prebuilt
                 # seeding) cannot drop the in-flight forward's fence.
-                device_module.current_stream().wait_event(self.publish_ready)
-            self.publish_ready.record()
-            self._publish_fresh = True
+                current_stream.wait_event(self.publish_ready)
+
+        self.new_seq_lens_buf[indices] = new_seq_lens.to(self.new_seq_lens_buf.dtype)
         if publish_confidence:
+            self.confidence_relay.wait_for_previous_snapshot(current_stream)
+            self.confidence_relay.scatter(indices, confidence)
             self.confidence_relay.issue_ring_copy(
                 stream=self.fwd_prepare_d2h_stream,
-                publish_ready=self.publish_ready,
+                publish_stream=current_stream,
             )
+
+        if self.spec_algo.is_some():
+            self.publish_ready.record()
+            self._publish_stream = current_stream
+            self._publish_fresh = True
 
     def stash(self, future_indices: torch.Tensor, payload: RelayPayload) -> None:
         if self.spec_algo.is_ngram():

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3932,6 +3932,7 @@ class Scheduler(
             self.last_batch = None
             self.tree_cache.reset()
             self.req_to_token_pool.clear()
+            self.future_map.reset()
             self.token_to_kv_pool_allocator.clear()
             self.grammar_manager.clear()
             self.metrics_reporter.reset_metrics()

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -389,11 +389,12 @@ class DraftBlockProposer:
         if batch.seq_lens_cpu is not None:
             draft_seq_lens_cpu = batch.seq_lens_cpu + gamma
             draft_seq_lens_sum = int(draft_seq_lens_cpu.sum())
-        elif draft_input.reserved_seq_lens_cpu is not None:
-            draft_seq_lens_cpu = draft_input.reserved_seq_lens_cpu
-            draft_seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
         else:
-            raise RuntimeError("DSpark decode expected batch.seq_lens_cpu, got None")
+            # Backends that opted out of host lengths consume the exact prefix
+            # directly from the device tensor. Reserved host lengths are only
+            # allocation bounds and must not replace the accepted lengths.
+            draft_seq_lens_cpu = None
+            draft_seq_lens_sum = None
 
         draft_forward_batch = ForwardBatch(
             forward_mode=ForwardMode.TARGET_VERIFY,

--- a/python/sglang/srt/speculative/dspark_components/dspark_observability.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_observability.py
@@ -750,8 +750,9 @@ class DsparkStepObservers:
             verify_num_draft_tokens=verify_num_draft_tokens,
             tp_rank=tp_rank,
         )
+        self._info_components = resolve_enabled_components()
         self._info_dumper = DsparkInfoDumper(
-            components=resolve_enabled_components(),
+            components=self._info_components,
             gamma=gamma,
             verify_num_draft_tokens=verify_num_draft_tokens,
             attn_tp_rank=get_parallel().attn_tp_rank,
@@ -770,6 +771,14 @@ class DsparkStepObservers:
             )
         self._sts_collect_path = envs.SGLANG_DSPARK_STS_COLLECT_PATH.get()
         self._sts_recorder: Optional[StsDataRecorder] = None
+
+    @property
+    def needs_budget_telemetry(self) -> bool:
+        return (
+            bool(self._info_components)
+            or envs.SGLANG_DSPARK_LOG_SPS_PRED_INTERVAL.get() > 0
+            or envs.SGLANG_DSPARK_DEBUG_CONFIDENCE_PREFIX_SCHEDULER.get()
+        )
 
     # --- step lifecycle -------------------------------------------------
 

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -300,27 +300,79 @@ class DSparkVerifyPlanner:
             return
         if draft_input is None:
             local_tier_num_tokens = 0 if batch.batch_size() == 0 else -1
-            self._maybe_gather_dp_verify_tier(
+            self._coordinate_verify_tier(
                 batch=batch, local_tier_num_tokens=local_tier_num_tokens
             )
             return
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._budget_planner.note_non_decode_step()
-            self._maybe_gather_dp_verify_tier(batch=batch, local_tier_num_tokens=0)
+            self._coordinate_verify_tier(batch=batch, local_tier_num_tokens=0)
             return
         resolved = future_map.resolve_confidence_cpu(batch)
         draft_input.verify_token_budget = self._budget_from_resolved(
             resolved=resolved, req_pool_indices_cpu=batch.req_pool_indices_cpu
         )
-        batch.spec_verify_tier_num_tokens = local_verify_tier_num_tokens(
+        local_tier_num_tokens = local_verify_tier_num_tokens(
             bs=batch.batch_size(),
             verify_token_budget=draft_input.verify_token_budget,
             verify_num_draft_tokens=self.verify_num_draft_tokens,
             min_verify_len=self._schedule_cfg.min_verify_len,
         )
-        self._maybe_gather_dp_verify_tier(
-            batch=batch, local_tier_num_tokens=batch.spec_verify_tier_num_tokens
+        self._coordinate_verify_tier(
+            batch=batch, local_tier_num_tokens=local_tier_num_tokens
         )
+
+    def _coordinate_verify_tier(
+        self, *, batch: ScheduleBatch, local_tier_num_tokens: int
+    ) -> None:
+        broadcast_group, broadcast_group_size = verify_lens_broadcast_group(
+            tp_size=self.server_args.tp_size
+        )
+        needs_tp_coordination = (
+            not getattr(self, "_is_verify_all", False)
+            or getattr(self._budget_planner, "forced_budget_frac", None) is not None
+        )
+        if broadcast_group_size > 1 and needs_tp_coordination:
+            if not is_dp_attention_enabled():
+                local_tier_num_tokens = self._conservative_tp_verify_tier(
+                    batch=batch,
+                    local_tier_num_tokens=local_tier_num_tokens,
+                )
+            else:
+                tier_tensor = torch.tensor(
+                    [
+                        int(local_tier_num_tokens)
+                        if broadcast_group.rank_in_group == 0
+                        else -1
+                    ],
+                    dtype=torch.int64,
+                )
+                torch.distributed.broadcast(
+                    tier_tensor,
+                    src=broadcast_group.ranks[0],
+                    group=broadcast_group.cpu_group,
+                )
+                local_tier_num_tokens = int(tier_tensor[0])
+        batch.spec_verify_tier_num_tokens = int(local_tier_num_tokens)
+        self._maybe_gather_dp_verify_tier(
+            batch=batch,
+            local_tier_num_tokens=batch.spec_verify_tier_num_tokens,
+        )
+
+    def _conservative_tp_verify_tier(
+        self, *, batch: ScheduleBatch, local_tier_num_tokens: int
+    ) -> int:
+        """Choose a TP-consistent graph tier without a host collective.
+
+        The exact non-uniform verify lengths are still broadcast on the device
+        during target verify.  Graph selection is host-side, so pure TP uses the
+        deterministic full-width tier and accepts padding instead of rendezvousing
+        scheduler ranks through Gloo on every decode step.
+        """
+        batch_size = int(batch.batch_size())
+        if local_tier_num_tokens == 0 or batch_size == 0:
+            return 0
+        return batch_size * int(self.verify_num_draft_tokens)
 
     def _maybe_gather_dp_verify_tier(
         self, *, batch: ScheduleBatch, local_tier_num_tokens: int
@@ -347,6 +399,10 @@ class DSparkVerifyPlanner:
     def set_forced_budget_frac(self, frac) -> None:
         if self._budget_planner is not None:
             self._budget_planner.forced_budget_frac = frac
+
+    def reset_runtime_state(self) -> None:
+        if self._budget_planner is not None:
+            self._budget_planner.reset_runtime_state()
 
     def compute_budget_sync(
         self,
@@ -395,6 +451,16 @@ class DSparkVerifyPlanner:
             return None
         return self.prepare_verify_budget
 
+    @property
+    def needs_confidence_publication(self) -> bool:
+        """Whether overlap scheduling can consume a relayed confidence block."""
+        if not self.schedules_verify_budget:
+            return False
+        return not (
+            getattr(self, "_is_verify_all", False)
+            and getattr(self._budget_planner, "forced_budget_frac", None) is None
+        )
+
     def _budget_from_resolved(
         self,
         *,
@@ -426,6 +492,7 @@ class DSparkVerifyPlanner:
         budget: Optional[int],
         global_num_reqs: Optional[int] = None,
         dp_tier_num_tokens: Optional[int] = None,
+        tp_tier_num_tokens: Optional[int] = None,
     ) -> Optional[RaggedVerifyLayout]:
         if self._ragged_verify_mode is RaggedVerifyMode.STATIC:
             return None
@@ -444,6 +511,9 @@ class DSparkVerifyPlanner:
                     tier_num_reqs=global_num_reqs,
                 )
             return self._uniform_layout_cache[key]
+        broadcast_group, broadcast_group_size = verify_lens_broadcast_group(
+            tp_size=self.server_args.tp_size
+        )
         verify_lens = self._schedule_verify_lens(
             req_pool_indices=req_pool_indices,
             prefix_lens=prefix_lens,
@@ -455,6 +525,8 @@ class DSparkVerifyPlanner:
                 global_num_reqs=global_num_reqs,
                 dp_tier_num_tokens=dp_tier_num_tokens,
             ),
+            broadcast_group=broadcast_group,
+            broadcast_group_size=broadcast_group_size,
         )
         if verify_lens is None:
             assert dp_tier_num_tokens is None, (
@@ -479,6 +551,10 @@ class DSparkVerifyPlanner:
                 "keying the tier off the local bs diverges across ranks"
             )
             tier_num_tokens = dp_tier_num_tokens
+        elif tp_tier_num_tokens is not None:
+            tier_num_tokens = (
+                int(tp_tier_num_tokens) if int(tp_tier_num_tokens) >= 0 else None
+            )
         elif self._dynamic_graph_tier and budget is not None:
             tier_num_tokens = local_verify_tier_num_tokens(
                 bs=tier_num_reqs,
@@ -582,16 +658,35 @@ class DSparkVerifyPlanner:
         device: torch.device,
         confidence: Optional[torch.Tensor],
         budget: Optional[int],
+        broadcast_group=None,
+        broadcast_group_size: int = 1,
     ) -> Optional[torch.Tensor]:
-        if self._budget_planner is None or confidence is None or budget is None:
+        ready = (
+            self._budget_planner is not None
+            and confidence is not None
+            and budget is not None
+        )
+        is_source = (
+            broadcast_group_size == 1 or broadcast_group.rank_in_group == 0
+        )
+        if broadcast_group_size == 1 and not ready:
             return None
-        verify_lens = ScheduleVerifyLensTopk.execute(
-            confidence=confidence,
-            budget=budget,
-            cfg=self._schedule_cfg,
-        ).to(device=device, dtype=torch.int32)
 
-        if resolve_level() >= InvariantCheckLevel.WARN:
+        if is_source and ready:
+            verify_lens = ScheduleVerifyLensTopk.execute(
+                confidence=confidence,
+                budget=budget,
+                cfg=self._schedule_cfg,
+            ).to(device=device, dtype=torch.int32)
+        else:
+            verify_lens = torch.full(
+                (int(req_pool_indices.shape[0]),),
+                self.verify_num_draft_tokens,
+                dtype=torch.int32,
+                device=device,
+            )
+
+        if is_source and ready and resolve_level() >= InvariantCheckLevel.WARN:
             verify_lens_64 = verify_lens.to(torch.int64)
             effective_floor = max(self._schedule_cfg.min_verify_len, 1)
             expect(
@@ -600,7 +695,11 @@ class DSparkVerifyPlanner:
                 msg=f"budget={budget}",
             )
 
-        if envs.SGLANG_DSPARK_DEBUG_CONFIDENCE_PREFIX_SCHEDULER.get():
+        if (
+            is_source
+            and ready
+            and envs.SGLANG_DSPARK_DEBUG_CONFIDENCE_PREFIX_SCHEDULER.get()
+        ):
             self._log_verify_lens_decision(
                 req_pool_indices=req_pool_indices,
                 prefix_lens=prefix_lens,
@@ -609,10 +708,7 @@ class DSparkVerifyPlanner:
                 verify_lens=verify_lens,
             )
 
-        broadcast_group, group_size = verify_lens_broadcast_group(
-            tp_size=self.server_args.tp_size
-        )
-        if group_size > 1:
+        if broadcast_group_size > 1:
             broadcast_group.broadcast(verify_lens, src=0)
 
         return verify_lens
@@ -1042,6 +1138,12 @@ class HostConfidenceBudgetPlanner:
         self.carry_steps = max(self.lag_steps - int(relay_lag_steps), 0)
         self._carry_confidence: Optional[torch.Tensor] = None
         self._carry_generation: Optional[torch.Tensor] = None
+        self._carry_pos = 0
+
+    def reset_runtime_state(self) -> None:
+        self.last_decision = None
+        self._carry_confidence = None
+        self._carry_generation = None
         self._carry_pos = 0
 
     def compute_budget(

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -341,9 +341,11 @@ class DSparkVerifyPlanner:
             else:
                 tier_tensor = torch.tensor(
                     [
-                        int(local_tier_num_tokens)
-                        if broadcast_group.rank_in_group == 0
-                        else -1
+                        (
+                            int(local_tier_num_tokens)
+                            if broadcast_group.rank_in_group == 0
+                            else -1
+                        )
                     ],
                     dtype=torch.int64,
                 )
@@ -673,9 +675,7 @@ class DSparkVerifyPlanner:
             and confidence is not None
             and budget is not None
         )
-        is_source = (
-            broadcast_group_size == 1 or broadcast_group.rank_in_group == 0
-        )
+        is_source = broadcast_group_size == 1 or broadcast_group.rank_in_group == 0
         if broadcast_group_size == 1 and not ready:
             return None
 

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -551,7 +551,7 @@ class DSparkVerifyPlanner:
                 "keying the tier off the local bs diverges across ranks"
             )
             tier_num_tokens = dp_tier_num_tokens
-        elif tp_tier_num_tokens is not None:
+        elif tp_tier_num_tokens is not None and not is_dp_attention_enabled():
             tier_num_tokens = (
                 int(tp_tier_num_tokens) if int(tp_tier_num_tokens) >= 0 else None
             )
@@ -589,10 +589,19 @@ class DSparkVerifyPlanner:
             # this as a conservative packing capacity. Both can keep the exact
             # per-request lengths device-resident; the full-block capacity avoids
             # a D2H reduction solely to discover the exact token count.
-            return RaggedVerifyLayout.from_verify_lens_device(
+            graph_num_tokens = bs * self.verify_num_draft_tokens
+            layout = RaggedVerifyLayout.from_verify_lens_device(
                 verify_lens=verify_lens,
-                graph_num_tokens=bs * self.verify_num_draft_tokens,
+                graph_num_tokens=graph_num_tokens,
             )
+            if self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
+                # Eager compact consumers allocate metadata from this field. The
+                # exact total is device-only, so advertise the conservative packing
+                # capacity instead of synchronizing to materialize it on the host.
+                return msgspec.structs.replace(
+                    layout, total_verify_tokens=graph_num_tokens
+                )
+            return layout
         verify_lens_cpu = verify_lens.to("cpu").tolist()
         grid = verify_layout_grid(
             verify_lens_cpu=verify_lens_cpu,

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -454,12 +454,10 @@ class DSparkVerifyPlanner:
     @property
     def needs_confidence_publication(self) -> bool:
         """Whether overlap scheduling can consume a relayed confidence block."""
-        if not self.schedules_verify_budget:
-            return False
-        return not (
-            getattr(self, "_is_verify_all", False)
-            and getattr(self._budget_planner, "forced_budget_frac", None) is None
-        )
+        # Keep the relay warm even while the current policy verifies all tokens.
+        # A live forced-budget update can then consume an already-published block
+        # instead of waiting for the relay ring to fill from cold.
+        return self.schedules_verify_budget
 
     def _budget_from_resolved(
         self,
@@ -583,6 +581,15 @@ class DSparkVerifyPlanner:
             graph_num_tokens = round_up_grid(graph_num_tokens_floor, capture_num_tokens)
             return RaggedVerifyLayout.from_verify_lens_device(
                 verify_lens=verify_lens, graph_num_tokens=graph_num_tokens
+            )
+        if not is_dp_attention_enabled():
+            # Cap-accept verifies the full target block, while compact eager uses
+            # this as a conservative packing capacity. Both can keep the exact
+            # per-request lengths device-resident; the full-block capacity avoids
+            # a D2H reduction solely to discover the exact token count.
+            return RaggedVerifyLayout.from_verify_lens_device(
+                verify_lens=verify_lens,
+                graph_num_tokens=bs * self.verify_num_draft_tokens,
             )
         verify_lens_cpu = verify_lens.to("cpu").tolist()
         grid = verify_layout_grid(

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -239,9 +239,6 @@ class TargetVerifyExecutor:
             if seq_lens_cpu_backup is not None:
                 batch.seq_lens_cpu = seq_lens_cpu_backup + verify_w
                 batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
-            elif draft_input.reserved_seq_lens_cpu is not None:
-                batch.seq_lens_cpu = draft_input.reserved_seq_lens_cpu
-                batch.seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
 
         result = self._forward_prepared_verify(
             batch=batch,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -336,7 +336,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
 
     def clear_cache_pool(self):
-        pass
+        self._verify_planner.reset_runtime_state()
 
     def set_dspark_forced_budget_frac(self, frac: Optional[float]) -> None:
         self._forced_budget_frac = frac
@@ -553,6 +553,11 @@ class DSparkWorkerV2(BaseSpecWorker):
             and batch.global_num_tokens is not None
             else None
         )
+        tp_tier_num_tokens = (
+            int(batch.spec_verify_tier_num_tokens)
+            if not self.server_args.disable_overlap_schedule
+            else None
+        )
         layout = self._verify_planner.schedule_layout(
             req_pool_indices=batch.req_pool_indices,
             prefix_lens=prefix_lens,
@@ -561,6 +566,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             budget=verify_token_budget,
             global_num_reqs=global_num_reqs,
             dp_tier_num_tokens=self._dp_verify_tier_num_tokens(batch),
+            tp_tier_num_tokens=tp_tier_num_tokens,
         )
         run_compact = self._verify_planner.should_run_compact(layout=layout)
 
@@ -613,7 +619,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             draft_tokens=draft_tokens,
         )
         if on_publish is not None:
-            if confidence is not None:
+            if self._should_publish_confidence(confidence):
                 on_publish(accept.new_seq_lens, confidence=confidence)
             else:
                 on_publish(accept.new_seq_lens)
@@ -671,6 +677,14 @@ class DSparkWorkerV2(BaseSpecWorker):
             next_draft_input=next_draft_input,
             speculative_num_draft_tokens=int(self.verify_num_draft_tokens),
             new_seq_lens=accept.new_seq_lens,
+        )
+
+    def _should_publish_confidence(
+        self, confidence: Optional[torch.Tensor]
+    ) -> bool:
+        return confidence is not None and (
+            self._verify_planner.needs_confidence_publication
+            or self._observers.needs_budget_telemetry
         )
 
     def get_confidence_budget_prepare(self):

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -679,9 +679,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             new_seq_lens=accept.new_seq_lens,
         )
 
-    def _should_publish_confidence(
-        self, confidence: Optional[torch.Tensor]
-    ) -> bool:
+    def _should_publish_confidence(self, confidence: Optional[torch.Tensor]) -> bool:
         return confidence is not None and (
             self._verify_planner.needs_confidence_publication
             or self._observers.needs_budget_telemetry

--- a/test/registered/unit/layers/attention/test_dsv4_dspark_device_lengths.py
+++ b/test/registered/unit/layers/attention/test_dsv4_dspark_device_lengths.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+class _DeviceSeqLensGuard:
+    def cpu(self):
+        raise AssertionError("device seq_lens must not be copied to the host")
+
+    def item(self):
+        raise AssertionError("device seq_lens must not be scalarized on the host")
+
+    def tolist(self):
+        raise AssertionError("device seq_lens must not be materialized on the host")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "GPU-backed DSV4 import is required")
+class TestDSV4DSparkDeviceLengths(unittest.TestCase):
+    def test_device_only_draft_block_never_materializes_seq_lens_on_host(self):
+        from sglang.srt.layers.attention.deepseek_v4_backend import (
+            DSV4Metadata,
+            DeepseekV4AttnBackend,
+        )
+
+        backend = object.__new__(DeepseekV4AttnBackend)
+        backend.req_to_token = object()
+        seq_lens = _DeviceSeqLensGuard()
+        seq_lens_casual = torch.tensor([11, 12, 13, 21, 22, 23])
+        core_attn_metadata = object()
+        backend._dspark_seq_lens_casual = mock.Mock(return_value=seq_lens_casual)
+        backend.make_core_attn_metadata = mock.Mock(return_value=core_attn_metadata)
+
+        metadata = backend.init_forward_metadata_dspark_draft_block(
+            max_seq_len=4096,
+            req_pool_indices=torch.tensor([4, 7]),
+            seq_lens=seq_lens,
+            seq_lens_cpu=None,
+            out_cache_loc=torch.arange(6),
+            block_size=3,
+        )
+
+        self.assertIsInstance(metadata, DSV4Metadata)
+        self.assertIs(metadata.core_attn_metadata, core_attn_metadata)
+        self.assertIsNone(metadata.indexer_metadata)
+        backend._dspark_seq_lens_casual.assert_called_once_with(
+            seq_lens=seq_lens, block_size=3
+        )
+        kwargs = backend.make_core_attn_metadata.call_args.kwargs
+        torch.testing.assert_close(
+            kwargs["req_pool_indices_repeated"], torch.tensor([4, 4, 4, 7, 7, 7])
+        )
+        self.assertIs(kwargs["seq_lens_casual"], seq_lens_casual)
+        self.assertFalse(kwargs["need_compress"])
+        self.assertTrue(kwargs["is_prefill"])
+        self.assertEqual(kwargs["dspark_block_size"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsv4_dspark_device_lengths.py
+++ b/test/registered/unit/layers/attention/test_dsv4_dspark_device_lengths.py
@@ -23,8 +23,8 @@ class _DeviceSeqLensGuard:
 class TestDSV4DSparkDeviceLengths(unittest.TestCase):
     def test_device_only_draft_block_never_materializes_seq_lens_on_host(self):
         from sglang.srt.layers.attention.deepseek_v4_backend import (
-            DSV4Metadata,
             DeepseekV4AttnBackend,
+            DSV4Metadata,
         )
 
         backend = object.__new__(DeepseekV4AttnBackend)

--- a/test/registered/unit/managers/test_overlap_future_map_hostsync.py
+++ b/test/registered/unit/managers/test_overlap_future_map_hostsync.py
@@ -284,6 +284,5 @@ class TestFutureMapHostSync(unittest.TestCase):
             self.assertEqual(event.synchronize_calls, 0)
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_overlap_future_map_hostsync.py
+++ b/test/registered/unit/managers/test_overlap_future_map_hostsync.py
@@ -1,0 +1,289 @@
+import contextlib
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.managers.overlap_utils import (
+    CONFIDENCE_RELAY_RING_DEPTH,
+    ConfidenceRelay,
+    FutureMap,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeEvent:
+    def __init__(self, name=None, log=None):
+        self.name = name
+        self.log = log
+        self.wait_calls = 0
+        self.synchronize_calls = 0
+        self.record_calls = 0
+
+    def wait(self):
+        self.wait_calls += 1
+
+    def synchronize(self):
+        self.synchronize_calls += 1
+
+    def record(self):
+        self.record_calls += 1
+        if self.log is not None:
+            self.log.append((self.name, "record"))
+
+    def query(self):
+        return True
+
+
+class _FakeStream:
+    def __init__(self, name=None, log=None):
+        self.name = name
+        self.log = log
+        self.waited_events = []
+
+    def wait_event(self, event):
+        self.waited_events.append(event)
+        if self.log is not None:
+            self.log.append((self.name, "wait", event.name))
+
+
+class _FakeDeviceModule:
+    def __init__(self, stream):
+        self._current_stream = stream
+
+    def current_stream(self):
+        return self._current_stream
+
+    def stream(self, stream):
+        return contextlib.nullcontext()
+
+    def Event(self):
+        return _FakeEvent()
+
+
+class _RecordingConfidenceRelay:
+    def __init__(self, log):
+        self.log = log
+
+    def scatter(self, indices, confidence):
+        self.log.append(("relay", "scatter"))
+
+    def wait_for_previous_snapshot(self, stream):
+        self.log.append(("relay", "wait_snapshot"))
+
+    def issue_ring_copy(self, *, stream, publish_stream):
+        self.log.append(("relay", "snapshot"))
+
+
+def _future_map(*, needs_cpu_seq_lens, publish_stream):
+    future_map = object.__new__(FutureMap)
+    future_map.device = torch.device("cpu")
+    future_map.needs_cpu_seq_lens = needs_cpu_seq_lens
+    future_map.publish_ready = _FakeEvent()
+    future_map._publish_stream = publish_stream
+    future_map._publish_fresh = True
+    future_map.new_seq_lens_buf = torch.tensor([0, 11, 22], dtype=torch.int64)
+    future_map.new_seq_lens_cpu_pinned = None
+    future_map.fwd_prepare_d2h_stream = None
+    return future_map
+
+
+def _batch():
+    return SimpleNamespace(
+        spec_info=SimpleNamespace(future_indices=torch.tensor([1, 2])),
+        seq_lens=torch.tensor([-1, -1], dtype=torch.int64),
+        seq_lens_cpu=torch.tensor([-1, -1], dtype=torch.int64),
+        seq_lens_sum=-2,
+        req_pool_indices_cpu=torch.tensor([1, 2], dtype=torch.int64),
+    )
+
+
+class TestFutureMapHostSync(unittest.TestCase):
+    def test_gpu_only_scheduler_path_does_not_wait_or_gather(self):
+        publish_stream = _FakeStream()
+        future_map = _future_map(
+            needs_cpu_seq_lens=False, publish_stream=publish_stream
+        )
+        batch = _batch()
+
+        future_map.resolve_seq_lens_cpu(batch)
+
+        self.assertEqual(future_map.publish_ready.wait_calls, 0)
+        self.assertEqual(future_map.publish_ready.synchronize_calls, 0)
+        self.assertTrue(torch.equal(batch.seq_lens, torch.tensor([-1, -1])))
+        self.assertIsNone(batch.seq_lens_cpu)
+        self.assertIsNone(batch.seq_lens_sum)
+
+    def test_same_forward_stream_gather_needs_no_event_wait(self):
+        forward_stream = _FakeStream()
+        future_map = _future_map(
+            needs_cpu_seq_lens=False, publish_stream=forward_stream
+        )
+        batch = _batch()
+
+        with mock.patch(
+            "sglang.srt.managers.overlap_utils.torch.get_device_module",
+            return_value=_FakeDeviceModule(forward_stream),
+        ):
+            future_map.resolve_seq_lens_device(batch)
+
+        self.assertEqual(forward_stream.waited_events, [])
+        self.assertTrue(torch.equal(batch.seq_lens, torch.tensor([11, 22])))
+
+    def test_off_stream_seed_uses_device_wait_not_host_wait(self):
+        publish_stream = _FakeStream()
+        forward_stream = _FakeStream()
+        future_map = _future_map(
+            needs_cpu_seq_lens=False, publish_stream=publish_stream
+        )
+        batch = _batch()
+
+        with mock.patch(
+            "sglang.srt.managers.overlap_utils.torch.get_device_module",
+            return_value=_FakeDeviceModule(forward_stream),
+        ):
+            future_map.resolve_seq_lens_device(batch)
+
+        self.assertEqual(forward_stream.waited_events, [future_map.publish_ready])
+        self.assertEqual(future_map.publish_ready.wait_calls, 0)
+        self.assertEqual(future_map.publish_ready.synchronize_calls, 0)
+
+    def test_legacy_cpu_consumer_keeps_existing_wait_and_copy(self):
+        publish_stream = _FakeStream()
+        future_map = _future_map(needs_cpu_seq_lens=True, publish_stream=publish_stream)
+        batch = _batch()
+
+        future_map.resolve_seq_lens_cpu(batch)
+
+        total_waits = (
+            future_map.publish_ready.wait_calls
+            + future_map.publish_ready.synchronize_calls
+        )
+        self.assertEqual(total_waits, 1)
+        self.assertTrue(torch.equal(batch.seq_lens_cpu, torch.tensor([11, 22])))
+        self.assertEqual(batch.seq_lens_sum, 33)
+
+    def test_flush_reset_invalidates_publication_and_confidence_ring(self):
+        relay = ConfidenceRelay(
+            device=torch.device("cpu"),
+            req_pool_size=3,
+            pool=SimpleNamespace(),
+        )
+        relay.ring_pos = 7
+        relay.gen_ring = torch.tensor([[1, 2, 3]], dtype=torch.int64)
+        future_map = _future_map(needs_cpu_seq_lens=False, publish_stream=_FakeStream())
+        future_map.confidence_relay = relay
+
+        future_map.reset()
+
+        self.assertIsNone(future_map.publish_ready)
+        self.assertIsNone(future_map._publish_stream)
+        self.assertFalse(future_map._publish_fresh)
+        self.assertEqual(relay.ring_pos, 0)
+        self.assertTrue(torch.equal(relay.gen_ring, torch.full((1, 3), -1)))
+
+    def test_publish_waits_before_scatter_and_records_after_snapshot(self):
+        log = []
+        previous_stream = _FakeStream("previous", log)
+        publish_stream = _FakeStream("publish", log)
+        publish_ready = _FakeEvent("publish_ready", log)
+        future_map = _future_map(
+            needs_cpu_seq_lens=False, publish_stream=previous_stream
+        )
+        future_map.publish_ready = publish_ready
+        future_map.spec_algo = SimpleNamespace(is_some=lambda: True)
+        future_map.needs_confidence_relay = True
+        future_map.confidence_relay = _RecordingConfidenceRelay(log)
+        future_map.fwd_prepare_d2h_stream = _FakeStream("d2h", log)
+
+        with mock.patch(
+            "sglang.srt.managers.overlap_utils.torch.get_device_module",
+            return_value=_FakeDeviceModule(publish_stream),
+        ):
+            future_map.publish(
+                torch.tensor([1, 2]),
+                torch.tensor([13, 24]),
+                torch.ones((2, 2)),
+            )
+
+        self.assertEqual(
+            log,
+            [
+                ("publish", "wait", "publish_ready"),
+                ("relay", "wait_snapshot"),
+                ("relay", "scatter"),
+                ("relay", "snapshot"),
+                ("publish_ready", "record"),
+            ],
+        )
+        self.assertEqual(publish_ready.wait_calls, 0)
+        self.assertEqual(publish_ready.synchronize_calls, 0)
+
+    def test_confidence_snapshot_and_slot_reuse_use_device_events(self):
+        depth = CONFIDENCE_RELAY_RING_DEPTH
+        log = []
+        publish_stream = _FakeStream("publish", log)
+        d2h_stream = _FakeStream("d2h", log)
+        snapshot_ready = [_FakeEvent(f"snapshot-{slot}", log) for slot in range(depth)]
+        copy_done = [_FakeEvent(f"copy-{slot}", log) for slot in range(depth)]
+        relay = ConfidenceRelay(
+            device=torch.device("cpu"),
+            req_pool_size=2,
+            pool=SimpleNamespace(req_generation=torch.tensor([4, 5])),
+            confidence_buf=torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+            confidence_snapshot_ring=torch.empty((depth, 2, 2)),
+            conf_ring=torch.empty((depth, 2, 2)),
+            gen_ring=torch.zeros((depth, 2), dtype=torch.int64),
+            snapshot_ready=snapshot_ready,
+            copy_done=copy_done,
+            copy_issued=[False] * depth,
+            initialized=True,
+        )
+
+        with mock.patch(
+            "sglang.srt.managers.overlap_utils.torch.get_device_module",
+            return_value=_FakeDeviceModule(publish_stream),
+        ):
+            relay.issue_ring_copy(stream=d2h_stream, publish_stream=publish_stream)
+            first_snapshot = relay.confidence_snapshot_ring[0].clone()
+            first_host_copy = relay.conf_ring[0].clone()
+
+            # Flush rewinds the logical ring but must preserve its physical
+            # in-flight-copy fence before slot zero is overwritten.
+            relay.reset()
+            self.assertEqual(relay.last_snapshot_slot, 0)
+            relay.wait_for_previous_snapshot(publish_stream)
+            relay.confidence_buf.fill_(9)
+            relay.issue_ring_copy(stream=d2h_stream, publish_stream=publish_stream)
+
+        self.assertTrue(
+            torch.equal(first_snapshot, torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+        )
+        self.assertTrue(
+            torch.equal(first_host_copy, torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+        )
+        self.assertTrue(torch.equal(relay.conf_ring[0], torch.full((2, 2), 9.0)))
+        self.assertEqual(
+            log,
+            [
+                ("snapshot-0", "record"),
+                ("d2h", "wait", "snapshot-0"),
+                ("copy-0", "record"),
+                ("publish", "wait", "snapshot-0"),
+                ("publish", "wait", "copy-0"),
+                ("snapshot-0", "record"),
+                ("d2h", "wait", "snapshot-0"),
+                ("copy-0", "record"),
+            ],
+        )
+        for event in snapshot_ready + copy_done:
+            self.assertEqual(event.wait_calls, 0)
+            self.assertEqual(event.synchronize_calls, 0)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_overlap_future_map_streams.py
+++ b/test/registered/unit/managers/test_overlap_future_map_streams.py
@@ -1,0 +1,142 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.overlap_utils import ConfidenceRelay, FutureMap
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=5, suite="stage-b-test-1-gpu-small-amd")
+
+
+_STREAM_DELAY_CYCLES = 50_000_000
+
+
+def _delay_current_stream(multiplier=1):
+    torch.cuda._sleep(_STREAM_DELAY_CYCLES * multiplier)
+
+
+def _make_relay(device, req_pool_size=2, gamma=2):
+    relay = ConfidenceRelay(
+        device=device,
+        req_pool_size=req_pool_size,
+        pool=SimpleNamespace(
+            req_generation=torch.arange(req_pool_size, dtype=torch.int64)
+        ),
+    )
+    relay._lazy_init(torch.empty((req_pool_size, gamma), device=device))
+    relay.confidence_buf.fill_(-101)
+    relay.confidence_snapshot_ring.fill_(-202)
+    relay.conf_ring.fill_(-303)
+    return relay
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA or ROCm required")
+class TestOverlapFutureMapStreams(unittest.TestCase):
+    def setUp(self):
+        self.device = torch.device("cuda", 0)
+        self.indices = torch.arange(2, dtype=torch.int64, device=self.device)
+
+    def test_confidence_snapshot_waits_for_publish_stream(self):
+        relay = _make_relay(self.device)
+        publish_stream = torch.cuda.Stream(device=self.device)
+        d2h_stream = torch.cuda.Stream(device=self.device)
+        expected = torch.tensor(
+            [[11.0, 12.0], [13.0, 14.0]], device=self.device
+        )
+        setup_ready = torch.cuda.Event()
+        setup_ready.record()
+        publish_stream.wait_event(setup_ready)
+        d2h_stream.wait_event(setup_ready)
+
+        with torch.cuda.stream(publish_stream):
+            relay.scatter(self.indices, expected)
+            _delay_current_stream()
+            relay.issue_ring_copy(
+                stream=d2h_stream, publish_stream=publish_stream
+            )
+
+        torch.cuda.synchronize(self.device)
+        self.assertTrue(torch.equal(relay.conf_ring[0], expected.cpu()))
+
+    def test_confidence_reset_rewind_fences_scatter_and_slot_reuse(self):
+        relay = _make_relay(self.device)
+        first_publish_stream = torch.cuda.Stream(device=self.device)
+        second_publish_stream = torch.cuda.Stream(device=self.device)
+        d2h_stream = torch.cuda.Stream(device=self.device)
+        first = torch.tensor([[21.0, 22.0], [23.0, 24.0]], device=self.device)
+        second = torch.tensor([[31.0, 32.0], [33.0, 34.0]], device=self.device)
+        setup_ready = torch.cuda.Event()
+        first_scatter_ready = torch.cuda.Event()
+        setup_ready.record()
+
+        # Hold the snapshot and its D2H reader independently across the rewind.
+        for stream in (first_publish_stream, second_publish_stream, d2h_stream):
+            stream.wait_event(setup_ready)
+        with torch.cuda.stream(d2h_stream):
+            _delay_current_stream(multiplier=8)
+        with torch.cuda.stream(first_publish_stream):
+            relay.scatter(self.indices, first)
+            first_scatter_ready.record()
+            _delay_current_stream()
+            relay.issue_ring_copy(
+                stream=d2h_stream, publish_stream=first_publish_stream
+            )
+
+        first_host_ring = relay.conf_ring
+        relay.conf_ring = torch.empty(
+            first_host_ring.shape, dtype=first_host_ring.dtype, pin_memory=True
+        )
+        relay.reset()
+
+        with torch.cuda.stream(second_publish_stream):
+            second_publish_stream.wait_event(first_scatter_ready)
+            relay.wait_for_previous_snapshot(second_publish_stream)
+            relay.scatter(self.indices, second)
+            relay.issue_ring_copy(
+                stream=d2h_stream, publish_stream=second_publish_stream
+            )
+
+        torch.cuda.synchronize(self.device)
+        self.assertTrue(torch.equal(first_host_ring[0], first.cpu()))
+        self.assertTrue(torch.equal(relay.conf_ring[0], second.cpu()))
+
+    def test_future_map_resolves_off_publish_stream_on_device(self):
+        future_map = object.__new__(FutureMap)
+        future_map.device = self.device
+        future_map.spec_algo = SimpleNamespace(is_some=lambda: True)
+        future_map.needs_cpu_seq_lens = False
+        future_map.needs_confidence_relay = False
+        future_map.new_seq_lens_buf = torch.full(
+            (4,), -1, dtype=torch.int64, device=self.device
+        )
+        future_map.publish_ready = None
+        future_map._publish_stream = None
+        future_map._publish_fresh = False
+
+        publish_stream = torch.cuda.Stream(device=self.device)
+        resolve_stream = torch.cuda.Stream(device=self.device)
+        expected = torch.tensor([41, 42], dtype=torch.int64, device=self.device)
+        batch = SimpleNamespace(
+            spec_info=SimpleNamespace(future_indices=self.indices),
+            seq_lens=None,
+        )
+        setup_ready = torch.cuda.Event()
+        setup_ready.record()
+        publish_stream.wait_event(setup_ready)
+        resolve_stream.wait_event(setup_ready)
+
+        with torch.cuda.stream(publish_stream):
+            _delay_current_stream()
+            future_map.publish(self.indices, expected)
+        with torch.cuda.stream(resolve_stream):
+            future_map.resolve_seq_lens_device(batch)
+            observed = batch.seq_lens.clone()
+
+        torch.cuda.synchronize(self.device)
+        self.assertTrue(torch.equal(observed.cpu(), expected.cpu()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_overlap_future_map_streams.py
+++ b/test/registered/unit/managers/test_overlap_future_map_streams.py
@@ -42,9 +42,7 @@ class TestOverlapFutureMapStreams(unittest.TestCase):
         relay = _make_relay(self.device)
         publish_stream = torch.cuda.Stream(device=self.device)
         d2h_stream = torch.cuda.Stream(device=self.device)
-        expected = torch.tensor(
-            [[11.0, 12.0], [13.0, 14.0]], device=self.device
-        )
+        expected = torch.tensor([[11.0, 12.0], [13.0, 14.0]], device=self.device)
         setup_ready = torch.cuda.Event()
         setup_ready.record()
         publish_stream.wait_event(setup_ready)
@@ -53,9 +51,7 @@ class TestOverlapFutureMapStreams(unittest.TestCase):
         with torch.cuda.stream(publish_stream):
             relay.scatter(self.indices, expected)
             _delay_current_stream()
-            relay.issue_ring_copy(
-                stream=d2h_stream, publish_stream=publish_stream
-            )
+            relay.issue_ring_copy(stream=d2h_stream, publish_stream=publish_stream)
 
         torch.cuda.synchronize(self.device)
         self.assertTrue(torch.equal(relay.conf_ring[0], expected.cpu()))

--- a/test/registered/unit/spec/test_dspark_zero_overhead.py
+++ b/test/registered/unit/spec/test_dspark_zero_overhead.py
@@ -52,9 +52,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
         planner.server_args = SimpleNamespace(tp_size=2)
         planner.verify_num_draft_tokens = 4
         group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32))
-        batch = SimpleNamespace(
-            spec_verify_tier_num_tokens=-1, batch_size=lambda: 2
-        )
+        batch = SimpleNamespace(spec_verify_tier_num_tokens=-1, batch_size=lambda: 2)
 
         with (
             mock.patch(
@@ -74,9 +72,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
             ),
             mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
         ):
-            planner._coordinate_verify_tier(
-                batch=batch, local_tier_num_tokens=3
-            )
+            planner._coordinate_verify_tier(batch=batch, local_tier_num_tokens=3)
 
         self.assertEqual(batch.spec_verify_tier_num_tokens, 8)
         gather.assert_called_once_with(batch=batch, local_tier_num_tokens=8)
@@ -151,9 +147,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
             ) as tier_broadcast,
             mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
         ):
-            planner._coordinate_verify_tier(
-                batch=batch, local_tier_num_tokens=-1
-            )
+            planner._coordinate_verify_tier(batch=batch, local_tier_num_tokens=-1)
 
         self.assertEqual(batch.spec_verify_tier_num_tokens, 3)
         tier_broadcast.assert_called_once()
@@ -164,9 +158,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
         planner.verify_num_draft_tokens = 4
         batch = SimpleNamespace(batch_size=lambda: 2)
         self.assertEqual(
-            planner._conservative_tp_verify_tier(
-                batch=batch, local_tier_num_tokens=0
-            ),
+            planner._conservative_tp_verify_tier(batch=batch, local_tier_num_tokens=0),
             0,
         )
 
@@ -199,9 +191,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
             ),
             mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
         ):
-            planner._coordinate_verify_tier(
-                batch=batch, local_tier_num_tokens=8
-            )
+            planner._coordinate_verify_tier(batch=batch, local_tier_num_tokens=8)
 
         self.assertEqual(batch.spec_verify_tier_num_tokens, 8)
         gather.assert_called_once_with(batch=batch, local_tier_num_tokens=8)
@@ -213,9 +203,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
         planner._is_verify_all = True
         planner._budget_planner = SimpleNamespace(forced_budget_frac=0.5)
         group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32))
-        batch = SimpleNamespace(
-            spec_verify_tier_num_tokens=-1, batch_size=lambda: 2
-        )
+        batch = SimpleNamespace(spec_verify_tier_num_tokens=-1, batch_size=lambda: 2)
 
         with (
             mock.patch(
@@ -235,9 +223,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
             ),
             mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
         ):
-            planner._coordinate_verify_tier(
-                batch=batch, local_tier_num_tokens=-1
-            )
+            planner._coordinate_verify_tier(batch=batch, local_tier_num_tokens=-1)
 
         self.assertEqual(batch.spec_verify_tier_num_tokens, 8)
         gather.assert_called_once_with(batch=batch, local_tier_num_tokens=8)
@@ -272,9 +258,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
         planner = object.__new__(DSparkVerifyPlanner)
         planner._budget_planner = object()
         planner.verify_num_draft_tokens = 4
-        group = _FakeBroadcastGroup(
-            torch.empty(0, dtype=torch.int32), rank_in_group=0
-        )
+        group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32), rank_in_group=0)
 
         with mock.patch.object(
             ScheduleVerifyLensTopk,
@@ -332,7 +316,9 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
             mock.patch.object(
                 RaggedVerifyLayout,
                 "from_verify_lens",
-                side_effect=AssertionError("dynamic compact graph materialized lengths"),
+                side_effect=AssertionError(
+                    "dynamic compact graph materialized lengths"
+                ),
             ),
             mock.patch.object(
                 RaggedVerifyLayout,
@@ -382,9 +368,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
             )
 
         self.assertIs(result, layout)
-        self.assertEqual(
-            unavailable_assemble.call_args.kwargs["graph_num_tokens"], 8
-        )
+        self.assertEqual(unavailable_assemble.call_args.kwargs["graph_num_tokens"], 8)
 
     def _assert_eager_tp_layout_stays_device_side(
         self, *, mode: RaggedVerifyMode
@@ -446,9 +430,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
         self.assertEqual(assemble.call_args.kwargs["graph_num_tokens"], 8)
 
     def test_cap_accept_tp_fallback_stays_device_side(self):
-        self._assert_eager_tp_layout_stays_device_side(
-            mode=RaggedVerifyMode.CAP_ACCEPT
-        )
+        self._assert_eager_tp_layout_stays_device_side(mode=RaggedVerifyMode.CAP_ACCEPT)
 
     def test_compact_eager_tp_fallback_stays_device_side(self):
         self._assert_eager_tp_layout_stays_device_side(mode=RaggedVerifyMode.COMPACT)
@@ -508,9 +490,7 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
 
     def test_worker_confidence_publication_gate(self):
         worker = object.__new__(DSparkWorkerV2)
-        worker._verify_planner = SimpleNamespace(
-            needs_confidence_publication=False
-        )
+        worker._verify_planner = SimpleNamespace(needs_confidence_publication=False)
         worker._observers = SimpleNamespace(needs_budget_telemetry=False)
         self.assertFalse(worker._should_publish_confidence(None))
         self.assertFalse(worker._should_publish_confidence(torch.ones(1)))
@@ -605,9 +585,7 @@ class TestDSparkDeviceOnlyLengths(unittest.TestCase):
         self.assertIsNone(seen["seq_lens_sum"])
 
     def test_draft_retains_eager_cpu_mirror_fallback(self):
-        seen = self._run_draft(
-            seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int32)
-        )
+        seen = self._run_draft(seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int32))
         self.assertEqual(seen["seq_lens_cpu"].tolist(), [14, 24])
         self.assertEqual(seen["seq_lens_sum"], 38)
 

--- a/test/registered/unit/spec/test_dspark_zero_overhead.py
+++ b/test/registered/unit/spec/test_dspark_zero_overhead.py
@@ -386,15 +386,88 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
             unavailable_assemble.call_args.kwargs["graph_num_tokens"], 8
         )
 
+    def _assert_eager_tp_layout_stays_device_side(
+        self, *, mode: RaggedVerifyMode
+    ) -> None:
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._align_verify_tokens_to_graph_tier = False
+        planner._budget_planner = object()
+        planner._dynamic_graph_tier = False
+        planner._is_verify_all = False
+        planner._ragged_verify_mode = mode
+        planner._schedule_cfg = DSparkScheduleConfig(gamma=3)
+        planner._uniform_layout_cache = {}
+        planner.verify_num_draft_tokens = 4
+        planner.model_runner = SimpleNamespace(decode_cuda_graph_runner=None)
+        planner.server_args = SimpleNamespace(tp_size=2)
+        source_lens = torch.tensor([1, 2], dtype=torch.int32)
+        group = _FakeBroadcastGroup(source_lens)
+        layout = object()
 
-    def test_verify_all_skips_confidence_until_forced_budget_needs_it(self):
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "is_dp_attention_enabled",
+                return_value=False,
+            ),
+            mock.patch.object(
+                ScheduleVerifyLensTopk,
+                "execute",
+                side_effect=AssertionError("non-source rank must not schedule"),
+            ),
+            mock.patch.object(
+                RaggedVerifyLayout,
+                "from_verify_lens",
+                side_effect=AssertionError("pure TP materialized verify lengths"),
+            ),
+            mock.patch.object(
+                RaggedVerifyLayout,
+                "from_verify_lens_device",
+                return_value=layout,
+            ) as assemble,
+        ):
+            result = planner.schedule_layout(
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+                device=torch.device("cpu"),
+                confidence=None,
+                budget=None,
+            )
+
+        self.assertIs(result, layout)
+        self.assertTrue(
+            torch.equal(assemble.call_args.kwargs["verify_lens"], source_lens)
+        )
+        self.assertEqual(assemble.call_args.kwargs["graph_num_tokens"], 8)
+
+    def test_cap_accept_tp_fallback_stays_device_side(self):
+        self._assert_eager_tp_layout_stays_device_side(
+            mode=RaggedVerifyMode.CAP_ACCEPT
+        )
+
+    def test_compact_eager_tp_fallback_stays_device_side(self):
+        self._assert_eager_tp_layout_stays_device_side(mode=RaggedVerifyMode.COMPACT)
+
+    def test_verify_all_to_forced_budget_keeps_confidence_relay_warm(self):
         planner = object.__new__(DSparkVerifyPlanner)
         planner._budget_planner = SimpleNamespace(forced_budget_frac=None)
         planner._is_verify_all = True
-        self.assertFalse(planner.needs_confidence_publication)
+        worker = object.__new__(DSparkWorkerV2)
+        worker._verify_planner = planner
+        worker._observers = SimpleNamespace(needs_budget_telemetry=False)
+
+        confidence = torch.ones(1)
+        self.assertTrue(planner.needs_confidence_publication)
+        self.assertTrue(worker._should_publish_confidence(confidence))
 
         planner._budget_planner.forced_budget_frac = 0.5
         self.assertTrue(planner.needs_confidence_publication)
+        self.assertTrue(worker._should_publish_confidence(confidence))
 
         planner._budget_planner.forced_budget_frac = None
         planner._is_verify_all = False

--- a/test/registered/unit/spec/test_dspark_zero_overhead.py
+++ b/test/registered/unit/spec/test_dspark_zero_overhead.py
@@ -1,0 +1,587 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.kernels.ops.speculative.dspark.dspark_schedule import (
+    ScheduleVerifyLensTopk,
+)
+from sglang.srt.environ import envs
+from sglang.srt.speculative.dflash_info import DFlashVerifyInput
+from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockProposer
+from sglang.srt.speculative.dspark_components.dspark_observability import (
+    DsparkStepObservers,
+    InfoComponent,
+)
+from sglang.srt.speculative.dspark_components.dspark_planner import (
+    DSparkScheduleConfig,
+    DSparkVerifyPlanner,
+)
+from sglang.srt.speculative.dspark_components.dspark_verify import (
+    TargetVerifyExecutor,
+)
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import (
+    DSparkWorkerV2,
+)
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout, RaggedVerifyMode
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=10, stage="stage-b", runner_config="1-gpu-small-amd")
+
+
+class _FakeBroadcastGroup:
+    def __init__(self, payload: torch.Tensor, *, rank_in_group: int = 1):
+        self.rank_in_group = rank_in_group
+        self.payload = payload
+        self.calls = 0
+        self.ranks = [0, 1]
+        self.cpu_group = object()
+
+    def broadcast(self, tensor: torch.Tensor, src: int) -> None:
+        self.calls += 1
+        self.assert_source = src
+        if self.rank_in_group != src:
+            tensor.copy_(self.payload)
+
+
+class TestDSparkPlannerZeroOverhead(unittest.TestCase):
+    def test_tp_dynamic_tier_is_deterministic_without_cpu_collective(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner.server_args = SimpleNamespace(tp_size=2)
+        planner.verify_num_draft_tokens = 4
+        group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32))
+        batch = SimpleNamespace(
+            spec_verify_tier_num_tokens=-1, batch_size=lambda: 2
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "is_dp_attention_enabled",
+                return_value=False,
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "torch.distributed.broadcast",
+                side_effect=AssertionError("pure TP must not coordinate on CPU"),
+            ),
+            mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
+        ):
+            planner._coordinate_verify_tier(
+                batch=batch, local_tier_num_tokens=3
+            )
+
+        self.assertEqual(batch.spec_verify_tier_num_tokens, 8)
+        gather.assert_called_once_with(batch=batch, local_tier_num_tokens=8)
+
+    def test_tp_prepare_path_uses_no_cpu_collective(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner.server_args = SimpleNamespace(tp_size=4)
+        planner.verify_num_draft_tokens = 4
+        planner._budget_planner = SimpleNamespace(forced_budget_frac=0.5)
+        planner._is_verify_all = True
+        planner._dp_tier_gather_enabled = False
+        group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32))
+        batch = SimpleNamespace(
+            spec_info=None,
+            spec_verify_tier_num_tokens=-1,
+            batch_size=lambda: 2,
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 4),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "is_dp_attention_enabled",
+                return_value=False,
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "torch.distributed.broadcast",
+                side_effect=AssertionError("pure TP must not broadcast on CPU"),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "torch.distributed.all_gather_into_tensor",
+                side_effect=AssertionError("pure TP must not all-gather on CPU"),
+            ),
+        ):
+            planner.prepare_verify_budget(batch, future_map=mock.Mock())
+
+        self.assertEqual(batch.spec_verify_tier_num_tokens, 8)
+
+    def test_dp_attention_keeps_cpu_tier_coordination(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner.server_args = SimpleNamespace(tp_size=2)
+        group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32))
+        batch = SimpleNamespace(spec_verify_tier_num_tokens=-1)
+
+        def broadcast(tensor, *, src, group):
+            self.assertEqual(src, 0)
+            self.assertIs(group, group_ref.cpu_group)
+            tensor.fill_(3)
+
+        group_ref = group
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "is_dp_attention_enabled",
+                return_value=True,
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "torch.distributed.broadcast",
+                side_effect=broadcast,
+            ) as tier_broadcast,
+            mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
+        ):
+            planner._coordinate_verify_tier(
+                batch=batch, local_tier_num_tokens=-1
+            )
+
+        self.assertEqual(batch.spec_verify_tier_num_tokens, 3)
+        tier_broadcast.assert_called_once()
+        gather.assert_called_once_with(batch=batch, local_tier_num_tokens=3)
+
+    def test_conservative_tp_tier_preserves_non_decode_zero(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner.verify_num_draft_tokens = 4
+        batch = SimpleNamespace(batch_size=lambda: 2)
+        self.assertEqual(
+            planner._conservative_tp_verify_tier(
+                batch=batch, local_tier_num_tokens=0
+            ),
+            0,
+        )
+
+        empty_batch = SimpleNamespace(batch_size=lambda: 0)
+        self.assertEqual(
+            planner._conservative_tp_verify_tier(
+                batch=empty_batch, local_tier_num_tokens=-1
+            ),
+            0,
+        )
+
+    def test_verify_all_skips_tp_tier_collective(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner.server_args = SimpleNamespace(tp_size=2)
+        planner._is_verify_all = True
+        planner._budget_planner = SimpleNamespace(forced_budget_frac=None)
+        group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32))
+        batch = SimpleNamespace(spec_verify_tier_num_tokens=-1)
+
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "torch.distributed.broadcast",
+                side_effect=AssertionError("verify-all must not coordinate TP tier"),
+            ),
+            mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
+        ):
+            planner._coordinate_verify_tier(
+                batch=batch, local_tier_num_tokens=8
+            )
+
+        self.assertEqual(batch.spec_verify_tier_num_tokens, 8)
+        gather.assert_called_once_with(batch=batch, local_tier_num_tokens=8)
+
+    def test_verify_all_forced_budget_uses_conservative_tp_tier(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner.server_args = SimpleNamespace(tp_size=2)
+        planner.verify_num_draft_tokens = 4
+        planner._is_verify_all = True
+        planner._budget_planner = SimpleNamespace(forced_budget_frac=0.5)
+        group = _FakeBroadcastGroup(torch.empty(0, dtype=torch.int32))
+        batch = SimpleNamespace(
+            spec_verify_tier_num_tokens=-1, batch_size=lambda: 2
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "is_dp_attention_enabled",
+                return_value=False,
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "torch.distributed.broadcast",
+                side_effect=AssertionError("pure TP must not coordinate on CPU"),
+            ),
+            mock.patch.object(planner, "_maybe_gather_dp_verify_tier") as gather,
+        ):
+            planner._coordinate_verify_tier(
+                batch=batch, local_tier_num_tokens=-1
+            )
+
+        self.assertEqual(batch.spec_verify_tier_num_tokens, 8)
+        gather.assert_called_once_with(batch=batch, local_tier_num_tokens=8)
+
+    def test_tp_non_source_broadcasts_without_local_confidence(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._budget_planner = object()
+        planner.verify_num_draft_tokens = 4
+        source_lens = torch.tensor([2, 3], dtype=torch.int32)
+        group = _FakeBroadcastGroup(source_lens)
+
+        with mock.patch.object(
+            ScheduleVerifyLensTopk,
+            "execute",
+            side_effect=AssertionError("non-source rank must not schedule"),
+        ):
+            verify_lens = planner._schedule_verify_lens(
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+                device=torch.device("cpu"),
+                confidence=None,
+                budget=None,
+                broadcast_group=group,
+                broadcast_group_size=2,
+            )
+
+        self.assertTrue(torch.equal(verify_lens, source_lens))
+        self.assertEqual(group.calls, 1)
+        self.assertEqual(group.assert_source, 0)
+
+    def test_tp_source_missing_readiness_broadcasts_full_verify(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._budget_planner = object()
+        planner.verify_num_draft_tokens = 4
+        group = _FakeBroadcastGroup(
+            torch.empty(0, dtype=torch.int32), rank_in_group=0
+        )
+
+        with mock.patch.object(
+            ScheduleVerifyLensTopk,
+            "execute",
+            side_effect=AssertionError("missing readiness must use full verify"),
+        ):
+            verify_lens = planner._schedule_verify_lens(
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+                device=torch.device("cpu"),
+                confidence=None,
+                budget=None,
+                broadcast_group=group,
+                broadcast_group_size=2,
+            )
+
+        self.assertTrue(
+            torch.equal(verify_lens, torch.tensor([4, 4], dtype=torch.int32))
+        )
+        self.assertEqual(group.calls, 1)
+
+    def test_dynamic_compact_tp_layout_stays_device_side(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._align_verify_tokens_to_graph_tier = False
+        planner._budget_planner = object()
+        planner._dynamic_graph_tier = True
+        planner._is_verify_all = False
+        planner._ragged_verify_mode = RaggedVerifyMode.COMPACT
+        planner._schedule_cfg = DSparkScheduleConfig(gamma=3)
+        planner._uniform_layout_cache = {}
+        planner.verify_num_draft_tokens = 4
+        planner.model_runner = SimpleNamespace(
+            decode_cuda_graph_runner=SimpleNamespace(
+                ragged_verify_mode=True,
+                capture_num_tokens=[4, 8, 16],
+                max_bs=8,
+            )
+        )
+        planner.server_args = SimpleNamespace(tp_size=2)
+        source_lens = torch.tensor([1, 2], dtype=torch.int32)
+        group = _FakeBroadcastGroup(source_lens)
+        layout = object()
+
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch.object(
+                ScheduleVerifyLensTopk,
+                "execute",
+                side_effect=AssertionError("non-source rank must not schedule"),
+            ),
+            mock.patch.object(
+                RaggedVerifyLayout,
+                "from_verify_lens",
+                side_effect=AssertionError("dynamic compact graph materialized lengths"),
+            ),
+            mock.patch.object(
+                RaggedVerifyLayout,
+                "from_verify_lens_device",
+                return_value=layout,
+            ) as assemble,
+        ):
+            result = planner.schedule_layout(
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+                device=torch.device("cpu"),
+                confidence=None,
+                budget=None,
+                tp_tier_num_tokens=3,
+            )
+
+        self.assertIs(result, layout)
+        self.assertTrue(
+            torch.equal(assemble.call_args.kwargs["verify_lens"], source_lens)
+        )
+        self.assertEqual(assemble.call_args.kwargs["graph_num_tokens"], 4)
+
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch.object(
+                ScheduleVerifyLensTopk,
+                "execute",
+                side_effect=AssertionError("non-source rank must not schedule"),
+            ),
+            mock.patch.object(
+                RaggedVerifyLayout,
+                "from_verify_lens_device",
+                return_value=layout,
+            ) as unavailable_assemble,
+        ):
+            result = planner.schedule_layout(
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+                device=torch.device("cpu"),
+                confidence=None,
+                budget=0,
+                tp_tier_num_tokens=-1,
+            )
+
+        self.assertIs(result, layout)
+        self.assertEqual(
+            unavailable_assemble.call_args.kwargs["graph_num_tokens"], 8
+        )
+
+
+    def test_verify_all_skips_confidence_until_forced_budget_needs_it(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._budget_planner = SimpleNamespace(forced_budget_frac=None)
+        planner._is_verify_all = True
+        self.assertFalse(planner.needs_confidence_publication)
+
+        planner._budget_planner.forced_budget_frac = 0.5
+        self.assertTrue(planner.needs_confidence_publication)
+
+        planner._budget_planner.forced_budget_frac = None
+        planner._is_verify_all = False
+        self.assertTrue(planner.needs_confidence_publication)
+
+        planner._budget_planner = None
+        self.assertFalse(planner.needs_confidence_publication)
+
+    def test_observability_modes_preserve_confidence_publication(self):
+        observers = object.__new__(DsparkStepObservers)
+        observers._info_components = set()
+        with (
+            mock.patch.object(
+                envs.SGLANG_DSPARK_LOG_SPS_PRED_INTERVAL, "get", return_value=0
+            ),
+            mock.patch.object(
+                envs.SGLANG_DSPARK_DEBUG_CONFIDENCE_PREFIX_SCHEDULER,
+                "get",
+                return_value=False,
+            ),
+        ):
+            self.assertFalse(observers.needs_budget_telemetry)
+            observers._info_components = {InfoComponent.REQS}
+            self.assertTrue(observers.needs_budget_telemetry)
+            observers._info_components = set()
+
+        with mock.patch.object(
+            envs.SGLANG_DSPARK_LOG_SPS_PRED_INTERVAL, "get", return_value=8
+        ):
+            self.assertTrue(observers.needs_budget_telemetry)
+
+        with mock.patch.object(
+            envs.SGLANG_DSPARK_DEBUG_CONFIDENCE_PREFIX_SCHEDULER,
+            "get",
+            return_value=True,
+        ):
+            self.assertTrue(observers.needs_budget_telemetry)
+
+    def test_worker_confidence_publication_gate(self):
+        worker = object.__new__(DSparkWorkerV2)
+        worker._verify_planner = SimpleNamespace(
+            needs_confidence_publication=False
+        )
+        worker._observers = SimpleNamespace(needs_budget_telemetry=False)
+        self.assertFalse(worker._should_publish_confidence(None))
+        self.assertFalse(worker._should_publish_confidence(torch.ones(1)))
+
+        worker._verify_planner.needs_confidence_publication = True
+        self.assertTrue(worker._should_publish_confidence(torch.ones(1)))
+        worker._verify_planner.needs_confidence_publication = False
+        worker._observers.needs_budget_telemetry = True
+        self.assertTrue(worker._should_publish_confidence(torch.ones(1)))
+
+    def test_planner_reset_forwards_to_budget_state(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._budget_planner = mock.Mock()
+
+        planner.reset_runtime_state()
+
+        planner._budget_planner.reset_runtime_state.assert_called_once_with()
+
+    def test_worker_cache_clear_resets_planner_state(self):
+        worker = object.__new__(DSparkWorkerV2)
+        worker._verify_planner = mock.Mock()
+
+        worker.clear_cache_pool()
+
+        worker._verify_planner.reset_runtime_state.assert_called_once_with()
+
+
+class _FakeTargetWorker:
+    def __init__(self):
+        self.model_runner = SimpleNamespace(attn_backend=SimpleNamespace())
+
+    def forward_batch_generation(self, **kwargs):
+        return SimpleNamespace(
+            logits_output=SimpleNamespace(next_token_logits=torch.empty(0)),
+            can_run_cuda_graph=False,
+        )
+
+
+class TestDSparkDeviceOnlyLengths(unittest.TestCase):
+    def _run_draft(self, *, seq_lens_cpu):
+        seen = {}
+        gamma = 4
+        bs = 2
+
+        class FakeDraftRunner:
+            device = "cpu"
+
+            def forward(self, forward_batch):
+                seen["seq_lens_cpu"] = forward_batch.seq_lens_cpu
+                seen["seq_lens_sum"] = forward_batch.seq_lens_sum
+                return SimpleNamespace(
+                    logits_output=SimpleNamespace(
+                        hidden_states=torch.empty((bs * gamma, 16))
+                    ),
+                    can_run_graph=False,
+                )
+
+        proposer = DraftBlockProposer(
+            draft_model=SimpleNamespace(),
+            draft_model_runner=FakeDraftRunner(),
+            gamma=gamma,
+            mask_token_id=0,
+            draft_block_spec_info=SimpleNamespace(),
+        )
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_cpu=seq_lens_cpu,
+            seq_lens_sum=None if seq_lens_cpu is None else int(seq_lens_cpu.sum()),
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+            global_num_tokens=None,
+        )
+        proposer._run_forward(
+            batch=batch,
+            draft_input=SimpleNamespace(
+                bonus_tokens=torch.tensor([7, 8], dtype=torch.int64),
+                reserved_seq_lens_cpu=torch.tensor([18, 28], dtype=torch.int32),
+                reserved_seq_lens_sum=46,
+            ),
+            verify_window=SimpleNamespace(
+                positions_2d=torch.arange(bs * gamma).view(bs, gamma),
+                verify_cache_loc_2d=torch.arange(bs * gamma).view(bs, gamma),
+            ),
+            bs=bs,
+            device="cpu",
+            embed_module=torch.nn.Embedding(16, 16),
+        )
+        return seen
+
+    def test_draft_ignores_reserved_host_bound_without_cpu_mirror(self):
+        seen = self._run_draft(seq_lens_cpu=None)
+        self.assertIsNone(seen["seq_lens_cpu"])
+        self.assertIsNone(seen["seq_lens_sum"])
+
+    def test_draft_retains_eager_cpu_mirror_fallback(self):
+        seen = self._run_draft(
+            seq_lens_cpu=torch.tensor([10, 20], dtype=torch.int32)
+        )
+        self.assertEqual(seen["seq_lens_cpu"].tolist(), [14, 24])
+        self.assertEqual(seen["seq_lens_sum"], 38)
+
+    def test_target_verify_ignores_reserved_bound_without_cpu_mirror(self):
+        target_worker = _FakeTargetWorker()
+        executor = TargetVerifyExecutor(
+            target_worker=target_worker,
+            gamma=3,
+            verify_num_draft_tokens=4,
+            model_runner=target_worker.model_runner,
+            kv_injector=SimpleNamespace(),
+        )
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([10, 20], dtype=torch.int32),
+            seq_lens_cpu=None,
+            seq_lens_sum=None,
+            out_cache_loc=None,
+        )
+        seen = {}
+
+        def capture_prepare(_verify_input, verify_batch, _target_worker):
+            seen["seq_lens_cpu"] = verify_batch.seq_lens_cpu
+            seen["seq_lens_sum"] = verify_batch.seq_lens_sum
+            return SimpleNamespace(), False
+
+        with mock.patch.object(
+            DFlashVerifyInput, "prepare_for_verify", new=capture_prepare
+        ):
+            executor.run_non_compact(
+                batch=batch,
+                draft_input=SimpleNamespace(
+                    reserved_seq_lens_cpu=torch.tensor([18, 28], dtype=torch.int32),
+                    reserved_seq_lens_sum=46,
+                ),
+                verify_ids_2d=torch.ones((2, 4), dtype=torch.int64),
+                verify_window=SimpleNamespace(
+                    positions_2d=torch.arange(8).view(2, 4),
+                    verify_cache_loc=torch.arange(8),
+                ),
+                sampling_info=None,
+            )
+
+        self.assertIsNone(seen["seq_lens_cpu"])
+        self.assertIsNone(seen["seq_lens_sum"])
+        self.assertIsNone(batch.seq_lens_cpu)
+        self.assertIsNone(batch.seq_lens_sum)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dspark_zero_overhead.py
+++ b/test/registered/unit/spec/test_dspark_zero_overhead.py
@@ -370,9 +370,74 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
         self.assertIs(result, layout)
         self.assertEqual(unavailable_assemble.call_args.kwargs["graph_num_tokens"], 8)
 
-    def _assert_eager_tp_layout_stays_device_side(
+    def test_dp_layout_uses_only_dp_global_tier_hint(self):
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._align_verify_tokens_to_graph_tier = False
+        planner._budget_planner = object()
+        planner._dynamic_graph_tier = False
+        planner._is_verify_all = False
+        planner._ragged_verify_mode = RaggedVerifyMode.COMPACT
+        planner._schedule_cfg = DSparkScheduleConfig(gamma=3)
+        planner._uniform_layout_cache = {}
+        planner.verify_num_draft_tokens = 4
+        planner.model_runner = SimpleNamespace(
+            decode_cuda_graph_runner=SimpleNamespace(
+                ragged_verify_mode=True,
+                capture_num_tokens=[4, 8],
+                max_bs=8,
+            )
+        )
+        planner.server_args = SimpleNamespace(tp_size=2)
+        source_lens = torch.tensor([1, 2], dtype=torch.int32)
+        group = _FakeBroadcastGroup(source_lens)
+
+        with (
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "verify_lens_broadcast_group",
+                return_value=(group, 2),
+            ),
+            mock.patch(
+                "sglang.srt.speculative.dspark_components.dspark_planner."
+                "is_dp_attention_enabled",
+                return_value=True,
+            ),
+            mock.patch.object(
+                ScheduleVerifyLensTopk,
+                "execute",
+                side_effect=AssertionError("non-source rank must not schedule"),
+            ),
+        ):
+            local_graph_tiers = {
+                planner.schedule_layout(
+                    req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                    prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+                    device=torch.device("cpu"),
+                    confidence=None,
+                    budget=None,
+                    global_num_reqs=2,
+                    dp_tier_num_tokens=None,
+                    tp_tier_num_tokens=local_tier,
+                ).graph_num_tokens
+                for local_tier in (3, 5)
+            }
+            gathered_layout = planner.schedule_layout(
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                prefix_lens=torch.tensor([10, 20], dtype=torch.int64),
+                device=torch.device("cpu"),
+                confidence=None,
+                budget=None,
+                global_num_reqs=2,
+                dp_tier_num_tokens=3,
+                tp_tier_num_tokens=5,
+            )
+
+        self.assertEqual(local_graph_tiers, {8})
+        self.assertEqual(gathered_layout.graph_num_tokens, 4)
+
+    def _eager_tp_layout_stays_device_side(
         self, *, mode: RaggedVerifyMode
-    ) -> None:
+    ) -> RaggedVerifyLayout:
         planner = object.__new__(DSparkVerifyPlanner)
         planner._align_verify_tokens_to_graph_tier = False
         planner._budget_planner = object()
@@ -386,7 +451,6 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
         planner.server_args = SimpleNamespace(tp_size=2)
         source_lens = torch.tensor([1, 2], dtype=torch.int32)
         group = _FakeBroadcastGroup(source_lens)
-        layout = object()
 
         with (
             mock.patch(
@@ -409,11 +473,6 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
                 "from_verify_lens",
                 side_effect=AssertionError("pure TP materialized verify lengths"),
             ),
-            mock.patch.object(
-                RaggedVerifyLayout,
-                "from_verify_lens_device",
-                return_value=layout,
-            ) as assemble,
         ):
             result = planner.schedule_layout(
                 req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
@@ -423,17 +482,42 @@ class TestDSparkPlannerZeroOverhead(unittest.TestCase):
                 budget=None,
             )
 
-        self.assertIs(result, layout)
-        self.assertTrue(
-            torch.equal(assemble.call_args.kwargs["verify_lens"], source_lens)
-        )
-        self.assertEqual(assemble.call_args.kwargs["graph_num_tokens"], 8)
+        self.assertTrue(torch.equal(result.verify_lens, source_lens))
+        self.assertIsNone(result.verify_lens_cpu)
+        self.assertEqual(result.graph_num_tokens, 8)
+        return result
 
     def test_cap_accept_tp_fallback_stays_device_side(self):
-        self._assert_eager_tp_layout_stays_device_side(mode=RaggedVerifyMode.CAP_ACCEPT)
+        layout = self._eager_tp_layout_stays_device_side(
+            mode=RaggedVerifyMode.CAP_ACCEPT
+        )
+        self.assertIsNone(layout.total_verify_tokens)
 
-    def test_compact_eager_tp_fallback_stays_device_side(self):
-        self._assert_eager_tp_layout_stays_device_side(mode=RaggedVerifyMode.COMPACT)
+    def test_compact_eager_tp_fallback_supplies_consumer_allocation_total(self):
+        layout = self._eager_tp_layout_stays_device_side(mode=RaggedVerifyMode.COMPACT)
+        self.assertEqual(int(layout.verify_lens.sum()), 3)
+        self.assertEqual(layout.total_verify_tokens, layout.graph_num_tokens)
+
+        kernel = mock.MagicMock()
+        kernel.__getitem__.return_value = mock.Mock()
+        verify_input = DFlashVerifyInput(
+            draft_token=torch.ones(8, dtype=torch.int64),
+            positions=torch.arange(8, dtype=torch.int64),
+            draft_token_num=4,
+            ragged_verify_layout=layout,
+        )
+        with mock.patch(
+            "sglang.srt.speculative.dflash_info." "create_flashinfer_kv_indices_triton",
+            kernel,
+        ):
+            kv_indices, _, _, _ = verify_input.generate_attn_arg_prefill(
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                paged_kernel_lens=torch.tensor([10, 20], dtype=torch.int32),
+                paged_kernel_lens_sum=30,
+                req_to_token=torch.zeros((2, 32), dtype=torch.int32),
+            )
+
+        self.assertEqual(kv_indices.numel(), 30 + layout.graph_num_tokens)
 
     def test_verify_all_to_forced_budget_keeps_confidence_relay_warm(self):
         planner = object.__new__(DSparkVerifyPlanner)


### PR DESCRIPTION
## Summary

- Keep speculative sequence lengths and DSpark verify planning device-resident in the overlap path.
- Preserve the two-publication-back confidence relay without blocking the scheduler on the current forward.
- Use deterministic pure-TP graph-tier coordination instead of a per-step CPU/Gloo broadcast.
- Reset relay/planner generations on cache flush and keep source/non-source TP readiness safe.
- Keep cap-accept and eager compact verify lengths on device, and avoid D2H materialization in the DSV4 DSpark draft metadata path.

This follows the spec-v2 run-ahead design from #31468. It also removes the pure-TP per-step CPU tier synchronization used by #31195; DP-attention still keeps conservative CPU coordination and is explicitly out of scope.

## Scope

- Pure TP / non-DP only.
- No SPS table tuning, target-accept policy, or dry-run policy changes.
- DP-attention host coordination remains follow-up work.

## Validation

- Clean MI350 GPU suite before rebase: `55 passed`, `18 subtests passed`.
- Cumulative S1b/S2 MI350 suite with the same production delta: `143 passed`, `35 subtests passed`.
- Rebase range-diff is unchanged: `ea3866819 = 5fb4eea25`, `28ed43334 = 35789fec6`.
- `git diff --check` and focused compile checks pass.

## Before Ready

- [ ] Rerun the focused MI350 suite on exact rebased head `35789fec6`.
- [ ] Add warmed fixed-seed UltraChat ~2K-ISL, exact-512-OSL c1 overlap ON/OFF evidence.
- [ ] Add c16 throughput, AR/AL, target-verify graph, folded accept/commit, and one-forward guard evidence.

Roadmap: #30734.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30141995501](https://github.com/sgl-project/sglang/actions/runs/30141995501)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30141995451](https://github.com/sgl-project/sglang/actions/runs/30141995451)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->