### PR TITLE
[sglang-miles] Warn instead of silently dropping one-sided MoE expert LoRA targets

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -444,10 +444,10 @@ class LoRAManager:
         """
         for layer_id, layer_modules in enumerate(self.lora_modules):
             for module_name, module in layer_modules.items():
-                # Hack for FusedMoE layer
-                if isinstance(module, FusedMoEWithLoRA) and all(
-                    x in self.target_modules for x in ["gate_up_proj", "down_proj"]
-                ):
+                # Hack for FusedMoE layer. A FusedMoEWithLoRA only exists when
+                # init_lora_modules found both expert projections targeted, so no
+                # target-module re-check is needed here.
+                if isinstance(module, FusedMoEWithLoRA):
                     gate_up_key = (
                         "gate_up_proj_moe"
                         if "gate_up_proj_moe" in self.memory_pool.A_buffer
@@ -917,6 +917,8 @@ class LoRAManager:
 
         self.embed_tokens_module: Optional[BaseLayerWithLoRA] = None
         self.lm_head_module: Optional[BaseLayerWithLoRA] = None
+        # One MoE layer's worth of warning is enough; the condition is model-wide.
+        warned_one_sided_moe_targets = False
 
         # When tie_word_embeddings=True, lm_head is the same Python object as
         # embed_tokens. PyTorch's named_modules() deduplicates by object identity,
@@ -1006,9 +1008,36 @@ class LoRAManager:
                 )
                 continue
 
-            if isinstance(module, FusedMoE) and all(
-                x in self.target_modules for x in ["gate_up_proj", "down_proj"]
-            ):
+            if isinstance(module, FusedMoE):
+                expert_projections = ("gate_up_proj", "down_proj")
+                missing = [
+                    x for x in expert_projections if x not in self.target_modules
+                ]
+                if len(missing) == 1 and not warned_one_sided_moe_targets:
+                    warned_one_sided_moe_targets = True
+                    # The MoE-LoRA hooks inject a delta after gate_up and after
+                    # down together, so wrapping for only one of them is not
+                    # implemented and the layer stays unwrapped. Adapters that only
+                    # train the dense/shared MLP still work, but one that carries
+                    # expert weights for the targeted projection has them loaded
+                    # into the pool and never applied. Warn once — silently
+                    # dropping part of an adapter reads as a serving/training
+                    # mismatch with no symptom.
+                    present = next(x for x in expert_projections if x != missing[0])
+                    logger.warning(
+                        "LoRA target modules include %r but not %r, so MoE expert layers "
+                        "(e.g. %s) get no adapter at all: expert LoRA needs both projections. "
+                        "Any %r expert weights in a loaded adapter will be ignored. Add %r to "
+                        "the target modules to enable expert LoRA — an adapter that does not "
+                        "train it keeps zero-filled buffers and contributes no delta.",
+                        present,
+                        missing[0],
+                        module_name,
+                        present,
+                        missing[0],
+                    )
+                if missing:
+                    continue
                 layer_id = get_layer_id(module_name)
                 if layer_id is None:
                     # FusedMoE submodules outside the decoder layer hierarchy


### PR DESCRIPTION
## Motivation

A `FusedMoE` layer is only wrapped with LoRA when **both** `gate_up_proj` and `down_proj` are in the target modules, because the MoE-LoRA hooks inject the two deltas together. Targeting only one left the layer unwrapped with no diagnostic: the adapter's expert weights for the targeted projection were loaded into the memory pool but never applied. For RL rollouts that means the serving policy silently diverges from the trained one.

## Modifications

- Emit a one-shot warning naming the MoE module and the missing projection. Kept a warning rather than a startup error: adapters that only train the dense or shared-expert MLP legitimately target one projection and keep working unchanged.
- Drop the always-true target-module re-check in `update_lora_info` — a `FusedMoEWithLoRA` only exists when `init_lora_modules` already found both projections targeted.

No behavioural change beyond the log line; no accuracy or performance impact.

## Checklist

- [x] Format the code with pre-commit.
- [ ] Tests: diagnostic-only change; existing LoRA tests cover both the wrapped and unwrapped paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30170262739](https://github.com/sgl-project/sglang/actions/runs/30170262739)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30170262678](https://github.com/sgl-project/sglang/actions/runs/30170262678)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
