### PR TITLE
[Spec] Derive NGRAM grammar tree links on the host instead of reading back `retrive_next_token`

### DIFF
--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -44,10 +44,8 @@ def _derive_tree_links(
     """Host-side (retrive_next_token, retrive_next_sibling), matching what
     reconstruct_indices_from_tree_mask produces on device.
 
-    ``mask[b, i, j]`` marks node j as an ancestor of node i, so i's immediate
-    parent is the largest such j < i. First child and next sibling then follow
-    from the parents alone: the first child of i is the smallest k > i parented
-    by i, and i's next sibling is the smallest k > i sharing i's parent.
+    ``mask[b, i, j]`` marks node j as an ancestor of node i, so i's immediate parent
+    is the largest such j < i, and both links follow from the parents alone.
     """
     tree = mask.reshape(bs, draft_token_num, draft_token_num)
     node_order = np.arange(draft_token_num)
@@ -104,7 +102,6 @@ class NGRAMWorker(BaseSpecWorker):
         # rids of the last decode batch; used to erase corpus match state for
         # requests that left the batch (see forward_batch_generation).
         self._prev_decode_rids: set = set()
-        # Host draft tree staged for the grammar bitmask; see _prepare_for_speculative_decoding.
         self.grammar_tree_host: Optional[tuple] = None
 
         self.ngram_corpus = NgramCorpus(
@@ -312,9 +309,7 @@ class NGRAMWorker(BaseSpecWorker):
         tree_mask.copy_(torch.from_numpy(mask), non_blocking=True)
         draft_tokens.copy_(torch.from_numpy(req_drafts), non_blocking=True)
 
-        # Grammar walks this tree on the host to build its bitmask. Stash the host
-        # arrays it needs; the links are derived from them after the verify forward
-        # is launched, so no device round trip and nothing runs while the GPU idles.
+        # Staged for the grammar bitmask, derived after the verify launch below.
         self.grammar_tree_host = (mask, req_drafts) if batch.has_grammar else None
 
         # generate positions and some indices using tree_mask
@@ -429,8 +424,8 @@ class NGRAMWorker(BaseSpecWorker):
             verify_input: NgramVerifyInput = batch.spec_info
             vocab_mask = None
             if batch.has_grammar:
-                # Derived here, under the verify forward, from the host tree: no
-                # device round trip and nothing to wait on.
+                # From the host tree rather than the device output: no readback to
+                # wait on, and deriving here keeps it under the verify forward.
                 mask, req_drafts = self.grammar_tree_host
                 retrieve_next_token_cpu, retrieve_next_sibling_cpu = _derive_tree_links(
                     mask, bs, self.draft_token_num
@@ -449,8 +444,8 @@ class NGRAMWorker(BaseSpecWorker):
 
                 if vocab_mask is not None:
                     assert verify_input.grammar is not None
-                    # non_blocking is safe here: the bitmask source is pinned and
-                    # stream order keeps the copy ahead of apply_vocab_mask.
+                    # non_blocking is safe: the bitmask source is pinned, and stream
+                    # order keeps the copy ahead of apply_vocab_mask.
                     vocab_mask = vocab_mask.to(
                         verify_input.retrieve_next_token.device, non_blocking=True
                     )

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -13,6 +13,7 @@ from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.managers.utils import _async_d2h
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.server_args import ServerArgs
@@ -380,13 +381,22 @@ class NGRAMWorker(BaseSpecWorker):
         accept_lens = torch.ones(bs, dtype=torch.int32, device=self.device)
 
         if batch.forward_mode.is_target_verify():
-            # Prepare grammar data on CPU if needed
+            # Prepare grammar data on CPU if needed. Async pinned D2H, waited on
+            # just before the bitmask traversal reads it, so the copies and the
+            # traversal both overlap the target verify forward.
+            grammar_copy_done = None
             if batch.has_grammar:
-                retrieve_next_token_cpu = verify_input.retrieve_next_token.cpu()
-                retrieve_next_sibling_cpu = verify_input.retrieve_next_sibling.cpu()
-                draft_tokens_cpu = verify_input.draft_token.view(
-                    verify_input.retrieve_next_token.shape
-                ).cpu()
+                retrieve_next_token_cpu = _async_d2h(verify_input.retrieve_next_token)
+                retrieve_next_sibling_cpu = _async_d2h(
+                    verify_input.retrieve_next_sibling
+                )
+                draft_tokens_cpu = _async_d2h(
+                    verify_input.draft_token.view(
+                        verify_input.retrieve_next_token.shape
+                    )
+                )
+                grammar_copy_done = torch.get_device_module(self.device).Event()
+                grammar_copy_done.record()
 
             batch_result = self.target_worker.forward_batch_generation(
                 batch, is_verify=True
@@ -400,6 +410,7 @@ class NGRAMWorker(BaseSpecWorker):
             verify_input: NgramVerifyInput = batch.spec_info
             vocab_mask = None
             if batch.has_grammar:
+                grammar_copy_done.synchronize()
                 # Generate the logit mask for structured output.
                 # Overlap the CPU operations for bitmask generation with the forward pass.
                 vocab_mask = generate_token_bitmask(
@@ -413,7 +424,11 @@ class NGRAMWorker(BaseSpecWorker):
 
                 if vocab_mask is not None:
                     assert verify_input.grammar is not None
-                    vocab_mask = vocab_mask.to(verify_input.retrieve_next_token.device)
+                    # non_blocking is safe here: the bitmask source is pinned and
+                    # stream order keeps the copy ahead of apply_vocab_mask.
+                    vocab_mask = vocab_mask.to(
+                        verify_input.retrieve_next_token.device, non_blocking=True
+                    )
                     # NOTE (sk): otherwise, this vocab mask will be the one from the previous extend stage
                     # and will be applied to produce wrong results
                     batch.sampling_info.vocab_mask = None

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -13,7 +13,6 @@ from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
-from sglang.srt.managers.utils import _async_d2h
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.server_args import ServerArgs
@@ -37,6 +36,36 @@ logger = logging.getLogger(__name__)
 
 
 USE_FULL_MASK = True
+
+
+def _derive_tree_links(
+    mask: np.ndarray, bs: int, draft_token_num: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Host-side (retrive_next_token, retrive_next_sibling), matching what
+    reconstruct_indices_from_tree_mask produces on device.
+
+    ``mask[b, i, j]`` marks node j as an ancestor of node i, so i's immediate
+    parent is the largest such j < i. First child and next sibling then follow
+    from the parents alone: the first child of i is the smallest k > i parented
+    by i, and i's next sibling is the smallest k > i sharing i's parent.
+    """
+    tree = mask.reshape(bs, draft_token_num, draft_token_num)
+    node_order = np.arange(draft_token_num)
+    ancestors = tree & (node_order < node_order[:, None])
+    parents = np.where(ancestors.any(-1), (ancestors * node_order).argmax(-1), -1)
+
+    next_token = np.full((bs, draft_token_num), -1, dtype=np.int64)
+    next_sibling = np.full((bs, draft_token_num), -1, dtype=np.int64)
+    for b in range(bs):
+        # Descending scan, so every k > i is already recorded when i is reached.
+        earliest_child_of = {}
+        for i in reversed(range(draft_token_num)):
+            next_token[b, i] = earliest_child_of.get(i, -1)
+            parent = int(parents[b, i])
+            if parent >= 0:
+                next_sibling[b, i] = earliest_child_of.get(parent, -1)
+                earliest_child_of[parent] = i
+    return torch.from_numpy(next_token), torch.from_numpy(next_sibling)
 
 
 class NGRAMWorker(BaseSpecWorker):
@@ -75,6 +104,8 @@ class NGRAMWorker(BaseSpecWorker):
         # rids of the last decode batch; used to erase corpus match state for
         # requests that left the batch (see forward_batch_generation).
         self._prev_decode_rids: set = set()
+        # Host draft tree staged for the grammar bitmask; see _prepare_for_speculative_decoding.
+        self.grammar_tree_host: Optional[tuple] = None
 
         self.ngram_corpus = NgramCorpus(
             min_bfs_breadth=server_args.speculative_ngram_min_bfs_breadth,
@@ -281,6 +312,11 @@ class NGRAMWorker(BaseSpecWorker):
         tree_mask.copy_(torch.from_numpy(mask), non_blocking=True)
         draft_tokens.copy_(torch.from_numpy(req_drafts), non_blocking=True)
 
+        # Grammar walks this tree on the host to build its bitmask. Stash the host
+        # arrays it needs; the links are derived from them after the verify forward
+        # is launched, so no device round trip and nothing runs while the GPU idles.
+        self.grammar_tree_host = (mask, req_drafts) if batch.has_grammar else None
+
         # generate positions and some indices using tree_mask
         reconstruct_indices_from_tree_mask(
             tree_mask,
@@ -381,23 +417,6 @@ class NGRAMWorker(BaseSpecWorker):
         accept_lens = torch.ones(bs, dtype=torch.int32, device=self.device)
 
         if batch.forward_mode.is_target_verify():
-            # Prepare grammar data on CPU if needed. Async pinned D2H, waited on
-            # just before the bitmask traversal reads it, so the copies and the
-            # traversal both overlap the target verify forward.
-            grammar_copy_done = None
-            if batch.has_grammar:
-                retrieve_next_token_cpu = _async_d2h(verify_input.retrieve_next_token)
-                retrieve_next_sibling_cpu = _async_d2h(
-                    verify_input.retrieve_next_sibling
-                )
-                draft_tokens_cpu = _async_d2h(
-                    verify_input.draft_token.view(
-                        verify_input.retrieve_next_token.shape
-                    )
-                )
-                grammar_copy_done = torch.get_device_module(self.device).Event()
-                grammar_copy_done.record()
-
             batch_result = self.target_worker.forward_batch_generation(
                 batch, is_verify=True
             )
@@ -410,9 +429,15 @@ class NGRAMWorker(BaseSpecWorker):
             verify_input: NgramVerifyInput = batch.spec_info
             vocab_mask = None
             if batch.has_grammar:
-                grammar_copy_done.synchronize()
-                # Generate the logit mask for structured output.
-                # Overlap the CPU operations for bitmask generation with the forward pass.
+                # Derived here, under the verify forward, from the host tree: no
+                # device round trip and nothing to wait on.
+                mask, req_drafts = self.grammar_tree_host
+                retrieve_next_token_cpu, retrieve_next_sibling_cpu = _derive_tree_links(
+                    mask, bs, self.draft_token_num
+                )
+                draft_tokens_cpu = (
+                    torch.from_numpy(req_drafts).to(torch.int64).view(bs, -1)
+                )
                 vocab_mask = generate_token_bitmask(
                     batch.reqs,
                     verify_input,

--- a/test/registered/spec/test_spec_ngram.py
+++ b/test/registered/spec/test_spec_ngram.py
@@ -2,16 +2,26 @@ import unittest
 
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
+from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
 from sglang.test.kits.spec_server_kits import SpecLogprobKit
 from sglang.test.server_fixtures.ngram_fixture import NgramServerBase
 
 # Per-commit: Paged backend only.
 # - FA3 base test archived to test/manual/spec/test_spec_ngram_fa3.py
 # - Triton + Flashinfer moved to test_spec_ngram_extra.py
-register_cuda_ci(est_time=400, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=460, stage="base-b", runner_config="1-gpu-large")
 
 
-class TestNgramSpeculativeDecodingPaged(NgramServerBase, GSM8KMixin, SpecLogprobKit):
+class TestNgramSpeculativeDecodingPaged(
+    NgramServerBase,
+    GSM8KMixin,
+    SpecLogprobKit,
+    RegexConstrainedMixin,
+    JSONConstrainedMixin,
+):
+    # Constrained mixins reuse this server; they cover the grammar verify path,
+    # where the bitmask is built by walking the host draft tree.
     attention_backend = "flashinfer"
     extra_args = ["--page-size", "64"]
 


### PR DESCRIPTION
## Summary

- Derive `retrive_next_token` / `retrive_next_sibling` on the host in `_derive_tree_links` instead of reading the device kernel's output back, removing three blocking `.cpu()` calls from the NGRAM grammar verify path
- Run the derivation and the bitmask traversal after the target verify forward is launched, so both overlap it
- Make the vocab-mask H2D `non_blocking` (source is already pinned via `xgrammar_backend._allocate_token_bitmask`, so it silently downgraded to a blocking copy)

## Background

- NGRAM builds its draft tree on the host — `ngram_corpus.batch_get` returns numpy — uploads it, then derives the tree links with `reconstruct_indices_from_tree_mask` on device
- The grammar path copied those links plus `draft_token` back with blocking `.cpu()`: a host -> device -> host round trip for data the host already had
- Those copies were issued *before* the verify forward was launched, so the GPU drained waiting on them, and the bitmask traversal after them had no forward to hide under — despite the comment there claiming it overlapped

## Notes for reviewers

- `mask[b, i, j]` marks node j as an ancestor of node i, so a node's immediate parent is the largest such `j < i`; first child and next sibling follow from the parents alone
- The device kernel still runs — attention needs its `positions` / `retrive_index` outputs — so this only removes the readback
- Placement is pinned between the two launches: earlier lands in the GPU-idle window, later is too late for `eagle_sample` to consume the mask

## Accuracy Tests

- `_derive_tree_links` diffed element-wise against `reconstruct_indices_from_tree_mask` over 20 random trees for each `(bs, draft_token_num)` in {(1,4), (1,16), (3,16), (8,16), (48,16), (2,32), (5,64)}, plus single-node trees: identical on every element

## Benchmarking and Profiling

Qwen2.5-Coder-7B-Instruct, NGRAM (16 draft tokens), single-batch JSON-schema-constrained decode, 3 runs of 8192 tokens. `sglang:fwd_occupancy` is the GPU busy share.

| build | occ median | occ mean | occ min | tok/s | accept length |
|---|---|---|---|---|---|
| main | 85.85% | 84.15% | 72.1% | 670.3 | 7.97 |
| this PR | 92.21% | 91.29% | 85.5% | 725.7 | 7.97 |

- **+8.3% throughput**; per-step time 11.89ms -> 10.98ms
- Accept length is identical across builds, so generation is unchanged and the delta carries no draft-quality confound
- Run-to-run spread under 0.2pp on both builds
- Hiding the readback alone (async pinned D2H + event, the treatment #31488 applied to EAGLE) reached 91.50%; removing it entirely and deriving under the forward accounts for the rest

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30151721118](https://github.com/sgl-project/sglang/actions/runs/30151721118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30151721077](https://github.com/sgl-project/sglang/actions/runs/30151721077)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->