### PR TITLE
fix: top_logprobs entries silently collapse on decode-text collision

### DIFF
--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -33,9 +33,18 @@ def to_openai_style_logprobs(
     def append_top_logprobs(top_logprobs):
         for tokens in top_logprobs:
             if tokens is not None:
-                ret_logprobs.top_logprobs.append(
-                    {token[2]: token[0] for token in tokens}
-                )
+                # `tokens` is ranked best-logprob-first (torch.topk default).
+                # Byte-fallback tokenizers can give two distinct token ids the
+                # same decoded text (e.g. multiple replacement-character
+                # fragments of one multi-byte sequence); a plain dict
+                # comprehension keeps whichever entry comes LAST, silently
+                # replacing the top candidate's logprob with a lower-ranked
+                # one. setdefault keeps the first (highest-ranked) entry for
+                # each decoded string instead.
+                entry: Dict[str, float] = {}
+                for logprob, _, token_text in tokens:
+                    entry.setdefault(token_text, logprob)
+                ret_logprobs.top_logprobs.append(entry)
             else:
                 ret_logprobs.top_logprobs.append(None)
 

--- a/test/registered/unit/entrypoints/openai/test_utils.py
+++ b/test/registered/unit/entrypoints/openai/test_utils.py
@@ -1,0 +1,64 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests for sglang.srt.entrypoints.openai.utils"""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.utils import to_openai_style_logprobs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestToOpenAIStyleLogprobs(unittest.TestCase):
+    def test_top_logprobs_decode_collision_keeps_highest_ranked(self):
+        """Two distinct top-k token ids that decode to the same text (routine
+        with byte-fallback tokenizers emitting multiple U+FFFD fragments)
+        must not let a lower-ranked candidate silently overwrite the
+        higher-ranked one's logprob for that text.
+        """
+        # Ranked best-logprob-first, as torch.topk returns them: token ids
+        # 111 and 222 both decode to "�".
+        output_top_logprobs = [
+            [
+                (-0.5, 111, "�"),
+                (-2.5, 222, "�"),
+                (-3.0, 333, "ok"),
+            ]
+        ]
+
+        result = to_openai_style_logprobs(output_top_logprobs=output_top_logprobs)
+
+        self.assertEqual(len(result.top_logprobs), 1)
+        entry = result.top_logprobs[0]
+        # The colliding text keeps the higher-ranked candidate's logprob.
+        self.assertEqual(entry["�"], -0.5)
+        self.assertEqual(entry["ok"], -3.0)
+
+    def test_top_logprobs_no_collision_unaffected(self):
+        output_top_logprobs = [
+            [
+                (-0.1, 1, "a"),
+                (-0.2, 2, "b"),
+            ],
+            None,
+        ]
+
+        result = to_openai_style_logprobs(output_top_logprobs=output_top_logprobs)
+
+        self.assertEqual(result.top_logprobs, [{"a": -0.1, "b": -0.2}, None])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

`append_top_logprobs()` in `openai/utils.py` builds each position's `top_logprobs`
dict keyed by decoded token text (`token[2]`), not token id. `torch.topk` returns
candidates ranked best-logprob-first, so when two distinct top-k token ids decode
to the same string, a plain dict comprehension keeps whichever entry comes last in
iteration order: the top candidate's logprob is silently replaced by a lower-ranked
one's. This happens routinely with byte-fallback tokenizers, where multiple distinct
token ids can each decode to the same replacement-character fragment of a
multi-byte UTF-8 sequence.

## Modifications

Build the dict with `setdefault` instead of a comprehension, so the first
(highest-ranked) occurrence of a decoded string wins and a later, lower-ranked
collision cannot overwrite it. The response can still report fewer
`top_logprobs` entries than requested when two candidates collide (the
OpenAI-compatible schema keys this field by string, so two ids sharing text
cannot both be represented), but the surviving value for that key is now
always the best-ranked candidate's.

Added `test/registered/unit/entrypoints/openai/test_utils.py`, registered for
`base-a-test-cpu`. It calls the real `to_openai_style_logprobs()` with two
top-k token ids that decode to the same text: on main the test fails
(`-2.5 != -0.5`, the lower-ranked candidate's logprob survives); with the fix
it passes.

## Verification

Ran in a clean `python:3.12-slim` Docker container against a fresh clone of
this branch:
- `to_openai_style_logprobs` imported and exercised directly (not a
  reimplementation) via the real module path.
- The new test fails on `main` at `f5155d9` with the exact wrong-survivor
  value, and passes on this branch.
- `isort`, `ruff`, `black-jupyter`, `codespell` (this repo's pre-commit
  hooks) all pass on both changed files.

Not verified: I did not run the broader `test_serving_chat.py` /
`test_serving_completions.py` suites. They import the GPU-only dependency
chain (`flash-attn`, `flashinfer`, the distributed backend) that this
environment cannot build or run, so I could not exercise those end to end.
The fix only changes `append_top_logprobs`'s internal dict-building logic,
not its signature or return shape, so the callers in `serving_chat.py` /
`serving_completions.py` are unaffected by construction, but that claim is
from reading the call sites, not from running them.

Fixes #32290

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30150184261](https://github.com/sgl-project/sglang/actions/runs/30150184261)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30150184176](https://github.com/sgl-project/sglang/actions/runs/30150184176)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->