### PR TITLE
[Fix] Take the attention backend name from the backend instead of `server_args`

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -11,7 +11,7 @@ from sglang.srt.utils.common import is_npu
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.dsa.dsa_indexer import BaseIndexerMetadata
     from sglang.srt.layers.radix_attention import RadixAttention
-    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
     from sglang.srt.speculative.spec_info import SpecInput
 
 
@@ -38,9 +38,20 @@ class AttentionBackend(ABC):
     those must migrate to ``init_forward_metadata_out_graph(fb, in_capture)``.
     """
 
-    # Resolved per-mode backend names, stamped by ModelRunner.init_attention_backend
-    prefill_attention_backend_str: Optional[str] = None
-    decode_attention_backend_str: Optional[str] = None
+    # Registry name of this backend, stamped where the name-to-object binding is
+    # made (attention_backend_setup for the target runner, DraftBackendFactory
+    # for the draft one).
+    backend_name: Optional[str] = None
+
+    def resolved_backend_name(self, forward_mode: ForwardMode) -> Optional[str]:
+        """Name of the backend that actually serves this forward.
+
+        Model-level dispatch keys its forward-method choice on this instead of
+        re-deriving a name from server_args, which would read the target's knobs
+        on a draft runner and would duplicate the wrapper's own routing rule.
+        Wrappers that own several backends override this to delegate.
+        """
+        return self.backend_name
 
     supports_ragged_verify_graph: bool = False
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -143,25 +143,7 @@ def _is_in_piecewise_or_breakable_cuda_graph() -> bool:
 
 
 def _uses_dsa_attention_backend(forward_batch: ForwardBatch) -> bool:
-    attn_backend = get_attn_backend()
-    server_args = get_server_args()
-    prefill_backend = attn_backend.prefill_attention_backend_str
-    decode_backend = attn_backend.decode_attention_backend_str
-
-    if forward_batch.forward_mode.is_decode_or_idle():
-        backend_name = decode_backend
-    elif (
-        forward_batch.forward_mode.is_target_verify()
-        or forward_batch.forward_mode.is_draft_extend_v2()
-    ):
-        backend_name = (
-            decode_backend
-            if server_args.speculative_attention_mode == "decode"
-            else prefill_backend
-        )
-    else:
-        backend_name = prefill_backend
-
+    backend_name = get_attn_backend().resolved_backend_name(forward_batch.forward_mode)
     return backend_name in ("dsa", "nsa")
 
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -145,13 +145,8 @@ def _is_in_piecewise_or_breakable_cuda_graph() -> bool:
 def _uses_dsa_attention_backend(forward_batch: ForwardBatch) -> bool:
     attn_backend = get_attn_backend()
     server_args = get_server_args()
-    prefill_backend, decode_backend = server_args.get_attention_backends()
-    prefill_backend = (
-        getattr(attn_backend, "prefill_attention_backend_str", None) or prefill_backend
-    )
-    decode_backend = (
-        getattr(attn_backend, "decode_attention_backend_str", None) or decode_backend
-    )
+    prefill_backend = attn_backend.prefill_attention_backend_str
+    decode_backend = attn_backend.decode_attention_backend_str
 
     if forward_batch.forward_mode.is_decode_or_idle():
         backend_name = decode_backend

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -63,6 +63,9 @@ class HybridAttnBackend(AttentionBackend):
         else:
             return self.prefill_backend
 
+    def resolved_backend_name(self, forward_mode: ForwardMode) -> Optional[str]:
+        return self._select_backend(forward_mode).resolved_backend_name(forward_mode)
+
     def init_forward_metadata_out_graph(
         self,
         forward_batch: ForwardBatch,

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -840,6 +840,11 @@ class HybridLinearAttnBackend(AttentionBackend):
     def data_type(self):
         return self.full_attn_backend.data_type
 
+    def resolved_backend_name(self, forward_mode: ForwardMode) -> Optional[str]:
+        # Model dispatch asks about the full-attention side; the linear sidecar
+        # is picked per layer, not per forward mode.
+        return self.full_attn_backend.resolved_backend_name(forward_mode)
+
     def _is_full_attn(
         self, layer: Optional[RadixAttention], layer_id: Optional[int] = None
     ) -> bool:

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -502,6 +502,11 @@ class MiniMaxHybridAttnBackend(AttentionBackend):
         self.sparse_layer_ids = sparse_layer_ids
         self.sparse.dense_backend = dense_backend
 
+    def resolved_backend_name(self, forward_mode) -> Optional[str]:
+        # The sparse side is picked per layer, so the dense backend is the one
+        # model dispatch is asking about.
+        return self.dense.resolved_backend_name(forward_mode)
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         self.sparse.init_forward_metadata(forward_batch)
         self.dense.init_forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -5,7 +5,7 @@ from sglang.srt.batch_overlap import two_batch_overlap
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 
 if TYPE_CHECKING:
-    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 
 
 class TboAttnBackend(AttentionBackend):
@@ -38,6 +38,11 @@ class TboAttnBackend(AttentionBackend):
         is unaffected; only the *_graph paths are gated.
         """
         return getattr(self.primary, "tbo_supports_cuda_graph", True)
+
+    def resolved_backend_name(self, forward_mode: "ForwardMode"):
+        # __getattr__ cannot cover this: the base class defines the method, so
+        # normal lookup succeeds on the wrapper and never delegates.
+        return self.primary.resolved_backend_name(forward_mode)
 
     def init_forward_metadata_out_graph(
         self,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -854,8 +854,6 @@ class ModelRunner:
         self.attn_backend = backends.attn_backend
         self.decode_attn_backend = backends.decode_attn_backend
         self.decode_attn_backend_group = backends.decode_attn_backend_group
-        self.prefill_attention_backend_str = backends.prefill_attention_backend_str
-        self.decode_attention_backend_str = backends.decode_attention_backend_str
 
         if self.server_args.dcp_size > 1 and self.server_args.dcp_replicate_q_proj:
             self._prepare_replicated_q_proj()

--- a/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
@@ -123,7 +123,9 @@ def build_attention_backends(*, model_runner: ModelRunner) -> AttentionBackends:
             get_world_group().cpu_group,
         )
 
-    # Record resolved per-mode backends on the backend for model dispatch.
+    # TboAttnBackend is built around _build_resolved_backend rather than by it,
+    # and it subclasses AttentionBackend, so the class-attribute default shadows
+    # its __getattr__ delegation -- stamp the wrapper itself too.
     attn_backend.prefill_attention_backend_str = resolved.prefill
     attn_backend.decode_attention_backend_str = resolved.decode
 
@@ -221,6 +223,13 @@ def _build_resolved_backend(
             backend_str=model_runner.server_args.attention_backend,
             init_new_workspace=init_new_workspace,
         )
+    # Stamp here rather than at the caller so every construction path carries the
+    # name: the pdmux per-stream group, the TBO children, and
+    # get_attention_backend() for the spec target runner all land in this
+    # function.  Model dispatch reads these off the backend instead of
+    # re-deriving them from server_args.
+    attn_backend.prefill_attention_backend_str = resolved.prefill
+    attn_backend.decode_attention_backend_str = resolved.decode
     return attn_backend
 
 

--- a/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
@@ -32,8 +32,6 @@ class AttentionBackends(msgspec.Struct, frozen=True, kw_only=True):
     attn_backend: AttentionBackend
     decode_attn_backend: Optional[AttentionBackend]
     decode_attn_backend_group: list[AttentionBackend]
-    prefill_attention_backend_str: str
-    decode_attention_backend_str: str
 
 
 def configure_aux_hidden_state_capture(
@@ -123,18 +121,10 @@ def build_attention_backends(*, model_runner: ModelRunner) -> AttentionBackends:
             get_world_group().cpu_group,
         )
 
-    # TboAttnBackend is built around _build_resolved_backend rather than by it,
-    # and it subclasses AttentionBackend, so the class-attribute default shadows
-    # its __getattr__ delegation -- stamp the wrapper itself too.
-    attn_backend.prefill_attention_backend_str = resolved.prefill
-    attn_backend.decode_attention_backend_str = resolved.decode
-
     return AttentionBackends(
         attn_backend=attn_backend,
         decode_attn_backend=decode_attn_backend,
         decode_attn_backend_group=decode_attn_backend_group,
-        prefill_attention_backend_str=resolved.prefill,
-        decode_attention_backend_str=resolved.decode,
     )
 
 
@@ -223,13 +213,6 @@ def _build_resolved_backend(
             backend_str=model_runner.server_args.attention_backend,
             init_new_workspace=init_new_workspace,
         )
-    # Stamp here rather than at the caller so every construction path carries the
-    # name: the pdmux per-stream group, the TBO children, and
-    # get_attention_backend() for the spec target runner all land in this
-    # function.  Model dispatch reads these off the backend instead of
-    # re-deriving them from server_args.
-    attn_backend.prefill_attention_backend_str = resolved.prefill
-    attn_backend.decode_attention_backend_str = resolved.decode
     return attn_backend
 
 
@@ -252,4 +235,9 @@ def _build_full_attention_backend_from_str(
     if backend_str not in ATTENTION_BACKENDS:
         raise ValueError(f"Invalid attention backend: {backend_str}")
     model_runner.init_new_workspace = init_new_workspace
-    return ATTENTION_BACKENDS[backend_str](model_runner)
+    backend = ATTENTION_BACKENDS[backend_str](model_runner)
+    # The only place a name-to-object binding is made on the target side, so the
+    # only place that needs to record it. Wrappers above delegate through
+    # resolved_backend_name() rather than carrying a name of their own.
+    backend.backend_name = backend_str
+    return backend

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1834,27 +1834,12 @@ class DeepseekV2AttentionMLA(
     def dispatch_attn_forward_method(
         self, forward_batch: ForwardBatch
     ) -> AttnForwardMethod:
-        # Per-mode backend names are stamped on the backend at construction, by
-        # attention_backend_setup for the target runner and by
-        # DraftBackendFactory for the draft one. Re-deriving them from
-        # server_args here would read the target's knobs on the draft runner.
-        backend = get_attn_backend()
-        server_args = get_server_args()
-        prefill_backend_str = backend.prefill_attention_backend_str
-        decode_backend_str = backend.decode_attention_backend_str
-        if forward_batch.forward_mode.is_decode_or_idle():
-            attention_backend = decode_backend_str
-        elif (
-            forward_batch.forward_mode.is_target_verify()
-            or forward_batch.forward_mode.is_draft_extend_v2()
-        ):
-            # Use the specified backend for speculative operations (both verify and draft extend)
-            if server_args.speculative_attention_mode == "decode":
-                attention_backend = decode_backend_str
-            else:  # default to prefill
-                attention_backend = prefill_backend_str
-        else:
-            attention_backend = prefill_backend_str
+        # The backend knows which of its own kernels serves this forward; asking
+        # it keeps that routing rule in one place instead of re-deriving it here
+        # from server_args, which describes the target runner's knobs.
+        attention_backend = get_attn_backend().resolved_backend_name(
+            forward_batch.forward_mode
+        )
         self.current_attention_backend = attention_backend
 
         handler = AttentionBackendRegistry.get_handler(attention_backend)

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1834,15 +1834,14 @@ class DeepseekV2AttentionMLA(
     def dispatch_attn_forward_method(
         self, forward_batch: ForwardBatch
     ) -> AttnForwardMethod:
-        # Determine attention backend name for current forward batch: prefer the
-        # name stamped per-runner on the backend object, else resolve from server args.
+        # Per-mode backend names are stamped on the backend at construction, by
+        # attention_backend_setup for the target runner and by
+        # DraftBackendFactory for the draft one. Re-deriving them from
+        # server_args here would read the target's knobs on the draft runner.
         backend = get_attn_backend()
         server_args = get_server_args()
-        default_prefill_str, default_decode_str = server_args.get_attention_backends()
-        prefill_backend_str = (
-            backend.prefill_attention_backend_str or default_prefill_str
-        )
-        decode_backend_str = backend.decode_attention_backend_str or default_decode_str
+        prefill_backend_str = backend.prefill_attention_backend_str
+        decode_backend_str = backend.decode_attention_backend_str
         if forward_batch.forward_mode.is_decode_or_idle():
             attention_backend = decode_backend_str
         elif (

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -156,29 +156,8 @@ for backend in CONCAT_ROPE_BACKENDS:
     AttentionBackendRegistry.register(backend, _handle_concat_rope_backend)
 
 
-def _current_backend_str(forward_batch: ForwardBatch) -> str:
-    """Backend name for this forward, read off the stamp the runner set.
-
-    Reading server_args instead would miss both the draft-worker override and
-    the speculative-attention-mode branch.
-    """
-    backend = get_attn_backend()
-    if forward_batch.forward_mode.is_decode_or_idle():
-        return backend.decode_attention_backend_str
-    if (
-        forward_batch.forward_mode.is_target_verify()
-        or forward_batch.forward_mode.is_draft_extend_v2()
-    ):
-        return (
-            backend.decode_attention_backend_str
-            if get_server_args().speculative_attention_mode == "decode"
-            else backend.prefill_attention_backend_str
-        )
-    return backend.prefill_attention_backend_str
-
-
 def get_attn_forward_method(forward_batch) -> AttnForwardMethod:
-    backend = _current_backend_str(forward_batch)
+    backend = get_attn_backend().resolved_backend_name(forward_batch.forward_mode)
     if forward_batch.forward_mode.is_extend_without_speculative() and backend == "fa3":
         return AttnForwardMethod.MHA_PREFILL
     return AttentionBackendRegistry.get_forward_method(backend, None, forward_batch)
@@ -624,7 +603,9 @@ class SarvamMoEMLAAttention(nn.Module):
     def _set_current_attention_backend(self, forward_batch: ForwardBatch) -> None:
         if self._server_args is None:
             self._server_args = get_server_args()
-        self.current_attention_backend = _current_backend_str(forward_batch)
+        self.current_attention_backend = get_attn_backend().resolved_backend_name(
+            forward_batch.forward_mode
+        )
 
     def _maybe_fp8_bmm(
         self,

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -156,17 +156,31 @@ for backend in CONCAT_ROPE_BACKENDS:
     AttentionBackendRegistry.register(backend, _handle_concat_rope_backend)
 
 
-def get_attn_forward_method(server_args, forward_batch) -> AttnForwardMethod:
-    is_decode = forward_batch.forward_mode.is_decode_or_idle()
-    if is_decode:
-        backend = server_args.decode_attention_backend or server_args.attention_backend
-    else:
-        backend = server_args.prefill_attention_backend or server_args.attention_backend
-        if (
-            forward_batch.forward_mode.is_extend_without_speculative()
-            and backend == "fa3"
-        ):
-            return AttnForwardMethod.MHA_PREFILL
+def _current_backend_str(forward_batch: ForwardBatch) -> str:
+    """Backend name for this forward, read off the stamp the runner set.
+
+    Reading server_args instead would miss both the draft-worker override and
+    the speculative-attention-mode branch.
+    """
+    backend = get_attn_backend()
+    if forward_batch.forward_mode.is_decode_or_idle():
+        return backend.decode_attention_backend_str
+    if (
+        forward_batch.forward_mode.is_target_verify()
+        or forward_batch.forward_mode.is_draft_extend_v2()
+    ):
+        return (
+            backend.decode_attention_backend_str
+            if get_server_args().speculative_attention_mode == "decode"
+            else backend.prefill_attention_backend_str
+        )
+    return backend.prefill_attention_backend_str
+
+
+def get_attn_forward_method(forward_batch) -> AttnForwardMethod:
+    backend = _current_backend_str(forward_batch)
+    if forward_batch.forward_mode.is_extend_without_speculative() and backend == "fa3":
+        return AttnForwardMethod.MHA_PREFILL
     return AttentionBackendRegistry.get_forward_method(backend, None, forward_batch)
 
 
@@ -610,16 +624,7 @@ class SarvamMoEMLAAttention(nn.Module):
     def _set_current_attention_backend(self, forward_batch: ForwardBatch) -> None:
         if self._server_args is None:
             self._server_args = get_server_args()
-        if forward_batch.forward_mode.is_decode_or_idle():
-            self.current_attention_backend = (
-                self._server_args.decode_attention_backend
-                or self._server_args.attention_backend
-            )
-        else:
-            self.current_attention_backend = (
-                self._server_args.prefill_attention_backend
-                or self._server_args.attention_backend
-            )
+        self.current_attention_backend = _current_backend_str(forward_batch)
 
     def _maybe_fp8_bmm(
         self,
@@ -768,7 +773,7 @@ class SarvamMoEMLAAttention(nn.Module):
             self._server_args = get_server_args()
         self._set_current_attention_backend(forward_batch)
 
-        forward_method = get_attn_forward_method(self._server_args, forward_batch)
+        forward_method = get_attn_forward_method(forward_batch)
 
         if forward_method == AttnForwardMethod.MHA_PREFILL:
             return self._run_mha_prefill(
@@ -881,7 +886,7 @@ class SarvamMoEMLAAttention(nn.Module):
         if self._server_args is None:
             self._server_args = get_server_args()
         self._set_current_attention_backend(forward_batch)
-        forward_method = get_attn_forward_method(self._server_args, forward_batch)
+        forward_method = get_attn_forward_method(forward_batch)
 
         if forward_method == AttnForwardMethod.MHA_PREFILL:
             output = self._run_mha_prefill(
@@ -940,7 +945,7 @@ class SarvamMoEMLAAttention(nn.Module):
             self._server_args = get_server_args()
         self._set_current_attention_backend(forward_batch)
 
-        forward_method = get_attn_forward_method(self._server_args, forward_batch)
+        forward_method = get_attn_forward_method(forward_batch)
 
         if forward_method == AttnForwardMethod.MLA_SEPARATE_ROPE:
             attn_output = self.attn_mqa(

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -10,15 +10,14 @@ from sglang.srt.utils.common import (
 
 
 def _stamp_backend_name(backend, backend_type: str) -> None:
-    """Record the resolved backend name so model dispatch reads it off the object.
+    """Record the resolved name so model dispatch reads it off the object.
 
-    Draft backends are built here, not by build_attention_backends, so without
-    this their per-mode name stays unset and consumers fall back to re-deriving
-    it from the target's server_args -- which is a different backend whenever
+    Draft backends are built here, not by attention_backend_setup, so without
+    this their name stays unset and dispatch has nothing to key on -- the draft
+    backend differs from the target's whenever
     --speculative-draft-attention-backend is in play.
     """
-    backend.prefill_attention_backend_str = backend_type
-    backend.decode_attention_backend_str = backend_type
+    backend.backend_name = backend_type
 
 
 class DraftBackendFactory:
@@ -88,7 +87,7 @@ class DraftBackendFactory:
         # forward context's backend, so the children are what model dispatch
         # actually reads. Every multi-step draft backend exposes attn_backends.
         for child in backend.attn_backends:
-            _stamp_backend_name(child, backend.decode_attention_backend_str)
+            _stamp_backend_name(child, backend.backend_name)
         return backend
 
     def create_draft_extend_backend(self):

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -9,6 +9,18 @@ from sglang.srt.utils.common import (
 )
 
 
+def _stamp_backend_name(backend, backend_type: str) -> None:
+    """Record the resolved backend name so model dispatch reads it off the object.
+
+    Draft backends are built here, not by build_attention_backends, so without
+    this their per-mode name stays unset and consumers fall back to re-deriving
+    it from the target's server_args -- which is a different backend whenever
+    --speculative-draft-attention-backend is in play.
+    """
+    backend.prefill_attention_backend_str = backend_type
+    backend.decode_attention_backend_str = backend_type
+
+
 class DraftBackendFactory:
     def __init__(
         self,
@@ -39,7 +51,9 @@ class DraftBackendFactory:
         if backend_type not in backend_map:
             raise ValueError(error_template.format(backend_type=backend_type))
 
-        return backend_map[backend_type]()
+        backend = backend_map[backend_type]()
+        _stamp_backend_name(backend, backend_type)
+        return backend
 
     def create_decode_backend(self):
         # No multi-step draft backend for steps=0 (nospec) or steps=1.
@@ -65,11 +79,17 @@ class DraftBackendFactory:
             "dsv4": self._create_dsv4_decode_backend,
         }
 
-        return self._create_backend(
+        backend = self._create_backend(
             "decode_attention_backend",
             backend_map,
             "EAGLE is not supported in decode attention backend {backend_type}",
         )
+        # draft_forward publishes the per-step child (not this wrapper) as the
+        # forward context's backend, so the children are what model dispatch
+        # actually reads. Every multi-step draft backend exposes attn_backends.
+        for child in backend.attn_backends:
+            _stamp_backend_name(child, backend.decode_attention_backend_str)
+        return backend
 
     def create_draft_extend_backend(self):
         backend_map = {

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -254,8 +254,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         )
         # Only non-factory draft backend construction; stamp it like
         # DraftBackendFactory does so model dispatch reads the name off it.
-        backend.prefill_attention_backend_str = "triton"
-        backend.decode_attention_backend_str = "triton"
+        backend.backend_name = "triton"
         return backend
 
     def _bind_kv_context(self) -> None:

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -247,11 +247,16 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         kv_indptr_buf = torch.zeros(
             (max_bs + 1,), dtype=torch.int32, device=self.draft_model_runner.device
         )
-        return TritonAttnBackend(
+        backend = TritonAttnBackend(
             self.draft_model_runner,
             skip_prefill=True,
             kv_indptr_buf=kv_indptr_buf,
         )
+        # Only non-factory draft backend construction; stamp it like
+        # DraftBackendFactory does so model dispatch reads the name off it.
+        backend.prefill_attention_backend_str = "triton"
+        backend.decode_attention_backend_str = "triton"
+        return backend
 
     def _bind_kv_context(self) -> None:
         draft_model = self.draft_model_runner.model


### PR DESCRIPTION
## Summary
- Add `AttentionBackend.backend_name` and `resolved_backend_name(forward_mode)`; wrappers that own several backends delegate through it
- Stamp the name where the name-to-object binding is made: `_build_full_attention_backend_from_str` on the target runner, `DraftBackendFactory` (plus its per-step children) on the draft one
- Collapse the `prefill_attention_backend_str` / `decode_attention_backend_str` pair into that single query and drop the `server_args` fallback in `deepseek_v2`, `dsa_indexer` and `sarvam_moe`

## Background
- Draft backends are built by `DraftBackendFactory`, which never recorded the resolved name, so both fields stayed `None` and dispatch always fell back to re-deriving a name from the target runner's `server_args`
- When `--speculative-draft-attention-backend` names a different backend than the target's, `DeepseekV2AttentionMLA.dispatch_attn_forward_method` then chose an `AttnForwardMethod` (and set `current_attention_backend`, which `forward_mla` keys on) for a backend that was not the one running. Reachable on DeepSeek-V3 + MTP, where the draft model reuses `DeepseekV2DecoderLayer`
- The field pair was also the wrong shape: a concrete backend is a single backend, only `HybridAttnBackend` owns two, and each of the three consumers only ever needed one name -- so all three re-implemented `HybridAttnBackend._select_backend`'s routing rule, `DRAFT_EXTEND_V2` included, where they had already drifted apart

## Changes
**Name resolution**
- `resolved_backend_name()` returns the backend's own name by default; `HybridAttnBackend` delegates through `_select_backend`, `HybridLinearAttnBackend` / `MiniMaxHybridAttnBackend` to their full-attention side, `TboAttnBackend` to `primary` (its `__getattr__` cannot cover a method the base class defines)
- `speculative_attention_mode` is now read only by `HybridAttnBackend` and `DraftBackendFactory`; model-level dispatch no longer branches on it
- Covers the construction paths that were previously unstamped as well: the pdmux per-stream `decode_attn_backend`, the TBO children, and `get_attention_backend()` for the spec target graph runner

**Cleanup**
- Drop `ModelRunner.prefill_attention_backend_str` / `decode_attention_backend_str` and the matching `AttentionBackends` fields, which nothing read
- Fold sarvam's two copies of the per-mode lookup into the single query; its verify path gains the speculative-mode branch it was missing

## Test plan
- No new unit test yet; the paths are covered by the existing speculative-decoding and DeepSeek MLA CI stages
- Worth exercising explicitly: EAGLE / MTP with `--speculative-draft-attention-backend` differing from the target backend, and a split `--prefill-attention-backend` / `--decode-attention-backend` pair so `HybridAttnBackend` delegation is on the path

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30152754810](https://github.com/sgl-project/sglang/actions/runs/30152754810)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30152754751](https://github.com/sgl-project/sglang/actions/runs/30152754751)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
