### PR TITLE
[Spec] Share the grammar mask build and verify-tree staging across spec workers

### DIFF
--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import torch
 
@@ -33,6 +33,30 @@ def _async_d2h(t: torch.Tensor) -> torch.Tensor:
     cpu_t.copy_(t, non_blocking=True)
     t.record_stream(torch.cuda.current_stream(t.device))
     return cpu_t
+
+
+class AsyncD2H:
+    """Async pinned D2H for a group of tensors, gated by one event.
+
+    Issue it before launching the device work that should hide the copies, then
+    call resolve() right where the host first reads them -- everything launched
+    in between overlaps the transfer instead of stalling on it.
+    """
+
+    def __init__(self, *tensors: torch.Tensor):
+        assert tensors, "AsyncD2H needs at least one tensor"
+        self._host = tuple(_async_d2h(t) for t in tensors)
+        device = tensors[0].device
+        self._done = (
+            torch.get_device_module(device).Event() if device.type != "cpu" else None
+        )
+        if self._done is not None:
+            self._done.record()
+
+    def resolve(self) -> Tuple[torch.Tensor, ...]:
+        if self._done is not None:
+            self._done.synchronize()
+        return self._host
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import torch
 
@@ -33,30 +33,6 @@ def _async_d2h(t: torch.Tensor) -> torch.Tensor:
     cpu_t.copy_(t, non_blocking=True)
     t.record_stream(torch.cuda.current_stream(t.device))
     return cpu_t
-
-
-class AsyncD2H:
-    """Async pinned D2H for a group of tensors, gated by one event.
-
-    Issue it before launching the device work that should hide the copies, then
-    call resolve() right where the host first reads them -- everything launched
-    in between overlaps the transfer instead of stalling on it.
-    """
-
-    def __init__(self, *tensors: torch.Tensor):
-        assert tensors, "AsyncD2H needs at least one tensor"
-        self._host = tuple(_async_d2h(t) for t in tensors)
-        device = tensors[0].device
-        self._done = (
-            torch.get_device_module(device).Event() if device.type != "cpu" else None
-        )
-        if self._done is not None:
-            self._done.record()
-
-    def resolve(self) -> Tuple[torch.Tensor, ...]:
-        if self._done is not None:
-            self._done.synchronize()
-        return self._host
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -9,7 +9,7 @@ from sglang.kernels.ops.speculative.cache_locs import (
 )
 from sglang.kernels.ops.speculative.eagle import fill_bonus_tokens_func
 from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
-from sglang.srt.managers.utils import AsyncD2H, GenerationBatchResult
+from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -23,6 +23,7 @@ from sglang.srt.speculative.eagle_utils import (
     eagle_sample,
 )
 from sglang.srt.speculative.spec_utils import (
+    StagedGrammarTree,
     build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
     move_accept_tokens_to_target_kvcache,
@@ -531,7 +532,7 @@ def run_eagle_verify(
     # The draft tree lives on device, so stage it now: the copies run right after
     # the draft, and the host resolves them only past the target verify launch.
     grammar_tree = (
-        AsyncD2H(
+        StagedGrammarTree(
             verify_input.retrieve_next_token,
             verify_input.retrieve_next_sibling,
             verify_input.draft_token.view(verify_input.retrieve_next_token.shape),

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -529,8 +529,7 @@ def run_eagle_verify(
             ),
         )
 
-    # The draft tree lives on device, so stage it now: the copies run right after
-    # the draft, and the host resolves them only past the target verify launch.
+    # Must stay ahead of the target verify launch below; resolved past it.
     grammar_tree = (
         StagedGrammarTree(
             verify_input.retrieve_next_token,

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -529,7 +529,7 @@ def run_eagle_verify(
             ),
         )
 
-    # Must stay ahead of the target verify launch below; resolved past it.
+    # Must stay ahead of the target verify launch below.
     grammar_tree = (
         GrammarTree.from_device(
             verify_input.retrieve_next_token,

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -23,7 +23,7 @@ from sglang.srt.speculative.eagle_utils import (
     eagle_sample,
 )
 from sglang.srt.speculative.spec_utils import (
-    StagedGrammarTree,
+    GrammarTree,
     build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
     move_accept_tokens_to_target_kvcache,
@@ -531,7 +531,7 @@ def run_eagle_verify(
 
     # Must stay ahead of the target verify launch below; resolved past it.
     grammar_tree = (
-        StagedGrammarTree(
+        GrammarTree.from_device(
             verify_input.retrieve_next_token,
             verify_input.retrieve_next_sibling,
             verify_input.draft_token.view(verify_input.retrieve_next_token.shape),
@@ -572,15 +572,10 @@ def run_eagle_verify(
         # overlap the target verify forward. No-op if there is nothing pending.
         if grammar_barrier is not None:
             grammar_barrier()
-        retrieve_next_token_cpu, retrieve_next_sibling_cpu, draft_tokens_cpu = (
-            grammar_tree.resolve()
-        )
         vocab_mask = build_grammar_vocab_mask(
             reqs=batch.reqs,
             verify_input=verify_input,
-            retrieve_next_token_cpu=retrieve_next_token_cpu,
-            retrieve_next_sibling_cpu=retrieve_next_sibling_cpu,
-            draft_tokens_cpu=draft_tokens_cpu,
+            tree=grammar_tree,
             sampling_info=batch.sampling_info,
             device=verify_input.retrieve_next_token.device,
         )

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -9,7 +9,7 @@ from sglang.kernels.ops.speculative.cache_locs import (
 )
 from sglang.kernels.ops.speculative.eagle import fill_bonus_tokens_func
 from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
-from sglang.srt.managers.utils import GenerationBatchResult, _async_d2h
+from sglang.srt.managers.utils import AsyncD2H, GenerationBatchResult
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
@@ -23,8 +23,8 @@ from sglang.srt.speculative.eagle_utils import (
     eagle_sample,
 )
 from sglang.srt.speculative.spec_utils import (
+    build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
-    generate_token_bitmask,
     move_accept_tokens_to_target_kvcache,
     record_stream_each,
     record_stream_for_v2_verify,
@@ -528,21 +528,17 @@ def run_eagle_verify(
             ),
         )
 
-    # Prepare grammar data on CPU if needed. Use async pinned D2H copies (not
-    # blocking .cpu()) and record an event. The copies are issued before the
-    # target verify launch below so they run right after the draft, but the
-    # host does not block here. We wait on grammar_copy_done only just before
-    # the CPU bitmask traversal reads the buffers, so the traversal (and these
-    # copies) overlap the target verify forward instead of stalling the GPU.
-    grammar_copy_done = None
-    if batch.has_grammar:
-        retrieve_next_token_cpu = _async_d2h(verify_input.retrieve_next_token)
-        retrieve_next_sibling_cpu = _async_d2h(verify_input.retrieve_next_sibling)
-        draft_tokens_cpu = _async_d2h(
-            verify_input.draft_token.view(verify_input.retrieve_next_token.shape)
+    # The draft tree lives on device, so stage it now: the copies run right after
+    # the draft, and the host resolves them only past the target verify launch.
+    grammar_tree = (
+        AsyncD2H(
+            verify_input.retrieve_next_token,
+            verify_input.retrieve_next_sibling,
+            verify_input.draft_token.view(verify_input.retrieve_next_token.shape),
         )
-        grammar_copy_done = torch.get_device_module(device).Event()
-        grammar_copy_done.record()
+        if batch.has_grammar
+        else None
+    )
 
     if metadata_ready_pre_pad:
         # Multi-layer eagle preserved-verbatim behavior: metadata init is
@@ -576,32 +572,18 @@ def run_eagle_verify(
         # overlap the target verify forward. No-op if there is nothing pending.
         if grammar_barrier is not None:
             grammar_barrier()
-        # Wait for the async draft/verify-input D2H copies above to land before
-        # the CPU traversal reads them. The event was recorded right after the
-        # copies (before the target verify launch), so this wait — and the
-        # traversal below — overlap the target verify forward.
-        grammar_copy_done.synchronize()
-        # Generate the logit mask for structured output.
-        vocab_mask = generate_token_bitmask(
-            batch.reqs,
-            verify_input,
-            retrieve_next_token_cpu,
-            retrieve_next_sibling_cpu,
-            draft_tokens_cpu,
-            batch.sampling_info.vocab_size,
+        retrieve_next_token_cpu, retrieve_next_sibling_cpu, draft_tokens_cpu = (
+            grammar_tree.resolve()
         )
-
-        if vocab_mask is not None:
-            assert verify_input.grammar is not None
-            # non_blocking H2D so the mask copy overlaps the tail of the target
-            # verify forward instead of syncing the host; stream ordering keeps
-            # it before eagle_sample's apply_vocab_mask below.
-            vocab_mask = vocab_mask.to(
-                verify_input.retrieve_next_token.device, non_blocking=True
-            )
-            # NOTE: otherwise, this vocab mask will be the one from the previous extend stage
-            # and will be applied to produce wrong results
-            batch.sampling_info.vocab_mask = None
+        vocab_mask = build_grammar_vocab_mask(
+            reqs=batch.reqs,
+            verify_input=verify_input,
+            retrieve_next_token_cpu=retrieve_next_token_cpu,
+            retrieve_next_sibling_cpu=retrieve_next_sibling_cpu,
+            draft_tokens_cpu=draft_tokens_cpu,
+            sampling_info=batch.sampling_info,
+            device=verify_input.retrieve_next_token.device,
+        )
 
     # Sample
     maybe_detect_nan(logits_output.next_token_logits, "verify: target model logits")

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -21,6 +21,7 @@ from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
 from sglang.srt.speculative.eagle_utils import eagle_sample
 from sglang.srt.speculative.ngram_info import NgramVerifyInput
 from sglang.srt.speculative.spec_utils import (
+    GrammarTree,
     build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
     move_accept_tokens_to_target_kvcache,
@@ -433,11 +434,11 @@ class NGRAMWorker(BaseSpecWorker):
                 vocab_mask = build_grammar_vocab_mask(
                     reqs=batch.reqs,
                     verify_input=verify_input,
-                    retrieve_next_token_cpu=retrieve_next_token_cpu,
-                    retrieve_next_sibling_cpu=retrieve_next_sibling_cpu,
-                    draft_tokens_cpu=torch.from_numpy(req_drafts)
-                    .to(torch.int64)
-                    .view(bs, -1),
+                    tree=GrammarTree.from_host(
+                        retrieve_next_token_cpu,
+                        retrieve_next_sibling_cpu,
+                        torch.from_numpy(req_drafts).to(torch.int64).view(bs, -1),
+                    ),
                     sampling_info=batch.sampling_info,
                     device=verify_input.retrieve_next_token.device,
                 )

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -21,8 +21,8 @@ from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
 from sglang.srt.speculative.eagle_utils import eagle_sample
 from sglang.srt.speculative.ngram_info import NgramVerifyInput
 from sglang.srt.speculative.spec_utils import (
+    build_grammar_vocab_mask,
     commit_mamba_states_after_verify,
-    generate_token_bitmask,
     move_accept_tokens_to_target_kvcache,
     prepare_mamba_track_for_verify,
     record_stream_for_v2_verify,
@@ -430,28 +430,17 @@ class NGRAMWorker(BaseSpecWorker):
                 retrieve_next_token_cpu, retrieve_next_sibling_cpu = _derive_tree_links(
                     mask, bs, self.draft_token_num
                 )
-                draft_tokens_cpu = (
-                    torch.from_numpy(req_drafts).to(torch.int64).view(bs, -1)
+                vocab_mask = build_grammar_vocab_mask(
+                    reqs=batch.reqs,
+                    verify_input=verify_input,
+                    retrieve_next_token_cpu=retrieve_next_token_cpu,
+                    retrieve_next_sibling_cpu=retrieve_next_sibling_cpu,
+                    draft_tokens_cpu=torch.from_numpy(req_drafts)
+                    .to(torch.int64)
+                    .view(bs, -1),
+                    sampling_info=batch.sampling_info,
+                    device=verify_input.retrieve_next_token.device,
                 )
-                vocab_mask = generate_token_bitmask(
-                    batch.reqs,
-                    verify_input,
-                    retrieve_next_token_cpu,
-                    retrieve_next_sibling_cpu,
-                    draft_tokens_cpu,
-                    batch.sampling_info.vocab_size,
-                )
-
-                if vocab_mask is not None:
-                    assert verify_input.grammar is not None
-                    # non_blocking is safe: the bitmask source is pinned, and stream
-                    # order keeps the copy ahead of apply_vocab_mask.
-                    vocab_mask = vocab_mask.to(
-                        verify_input.retrieve_next_token.device, non_blocking=True
-                    )
-                    # NOTE (sk): otherwise, this vocab mask will be the one from the previous extend stage
-                    # and will be applied to produce wrong results
-                    batch.sampling_info.vocab_mask = None
 
             # Sample
             maybe_detect_nan(

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -555,11 +555,8 @@ def generate_token_bitmask(
 class StagedGrammarTree:
     """The verify tree copied to the host for the grammar bitmask traversal.
 
-    Stage it where the tree becomes available -- before the target verify forward
-    is launched, so the copies run right after the draft -- and resolve() it where
-    build_grammar_vocab_mask needs the values. Everything launched in between
-    overlaps the transfer. Algorithms whose tree is already on the host (NGRAM
-    builds it there) skip this and pass their arrays straight through.
+    Stage before the target verify launch and resolve() after it, so the copies
+    run behind the draft and everything launched in between overlaps them.
     """
 
     def __init__(
@@ -597,10 +594,9 @@ def build_grammar_vocab_mask(
 ) -> Optional[torch.Tensor]:
     """Build the constrained-decoding bitmask over a verify tree and stage it on device.
 
-    Call it after the target verify forward is launched: the traversal is pure host
-    work over the already-known draft tree, so it overlaps that forward. The tree
-    arrays must be on the host by then -- see StagedGrammarTree for algorithms
-    whose tree lives on device.
+    Call it after the target verify launch: the traversal is pure host work, so it
+    overlaps that forward. The tree arrays must be on the host by then -- see
+    StagedGrammarTree for algorithms whose tree lives on device.
     """
     vocab_mask = generate_token_bitmask(
         reqs,
@@ -617,8 +613,7 @@ def build_grammar_vocab_mask(
     # non_blocking is safe: the bitmask is pinned (see xgrammar_backend), and stream
     # order keeps the copy ahead of the sampler's apply_vocab_mask.
     vocab_mask = vocab_mask.to(device, non_blocking=True)
-    # Otherwise the mask left over from the previous extend stage is applied instead,
-    # producing wrong results.
+    # Otherwise the extend stage's leftover mask is applied instead.
     sampling_info.vocab_mask = None
     return vocab_mask
 

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -570,12 +570,12 @@ class GrammarTree:
         retrieve_next_sibling: torch.Tensor,
         draft_token: torch.Tensor,
     ) -> GrammarTree:
-        host = tuple(
-            _async_d2h(t)
-            for t in (retrieve_next_token, retrieve_next_sibling, draft_token)
-        )
-        device = retrieve_next_token.device
-        if device.type == "cpu":
+        tensors = (retrieve_next_token, retrieve_next_sibling, draft_token)
+        host = tuple(_async_d2h(t) for t in tensors)
+        # Sources may be mixed -- an algorithm can synthesize part of the tree on
+        # the host -- so the event has to key off whichever one is on device.
+        device = next((t.device for t in tensors if t.device.type != "cpu"), None)
+        if device is None:
             return cls(host, None)
         done = torch.get_device_module(device).Event()
         done.record()

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -552,31 +552,47 @@ def generate_token_bitmask(
     return allocate_token_bitmask
 
 
-class StagedGrammarTree:
-    """The verify tree copied to the host for the grammar bitmask traversal.
+class GrammarTree:
+    """The verify tree the grammar bitmask is built over, on the host.
 
-    Stage before the target verify launch and resolve() after it, so the copies
-    run behind the draft and everything launched in between overlaps them.
+    ``from_device`` starts an async copy, so build it before the target verify
+    launch; build_grammar_vocab_mask waits on it past the launch, which is what
+    makes the copies and the traversal overlap that forward.
     """
 
-    def __init__(
-        self,
+    def __init__(self, host: Tuple[torch.Tensor, ...], done_event):
+        self._host = host
+        self._done = done_event
+
+    @classmethod
+    def from_device(
+        cls,
         retrieve_next_token: torch.Tensor,
         retrieve_next_sibling: torch.Tensor,
         draft_token: torch.Tensor,
-    ):
-        self._host = tuple(
+    ) -> GrammarTree:
+        host = tuple(
             _async_d2h(t)
             for t in (retrieve_next_token, retrieve_next_sibling, draft_token)
         )
         device = retrieve_next_token.device
-        self._done = (
-            torch.get_device_module(device).Event() if device.type != "cpu" else None
-        )
-        if self._done is not None:
-            self._done.record()
+        if device.type == "cpu":
+            return cls(host, None)
+        done = torch.get_device_module(device).Event()
+        done.record()
+        return cls(host, done)
 
-    def resolve(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    @classmethod
+    def from_host(
+        cls,
+        retrieve_next_token: torch.Tensor,
+        retrieve_next_sibling: torch.Tensor,
+        draft_token: torch.Tensor,
+    ) -> GrammarTree:
+        """For algorithms that build the tree on the host (NGRAM): nothing to wait on."""
+        return cls((retrieve_next_token, retrieve_next_sibling, draft_token), None)
+
+    def resolve(self) -> Tuple[torch.Tensor, ...]:
         if self._done is not None:
             self._done.synchronize()
         return self._host
@@ -586,24 +602,19 @@ def build_grammar_vocab_mask(
     *,
     reqs: List[Req],
     verify_input: SpecInput,
-    retrieve_next_token_cpu: torch.Tensor,
-    retrieve_next_sibling_cpu: torch.Tensor,
-    draft_tokens_cpu: torch.Tensor,
+    tree: GrammarTree,
     sampling_info: SamplingBatchInfo,
     device,
 ) -> Optional[torch.Tensor]:
     """Build the constrained-decoding bitmask over a verify tree and stage it on device.
 
     Call it after the target verify launch: the traversal is pure host work, so it
-    overlaps that forward. The tree arrays must be on the host by then -- see
-    StagedGrammarTree for algorithms whose tree lives on device.
+    overlaps that forward, and resolving the tree here keeps any wait past the launch.
     """
     vocab_mask = generate_token_bitmask(
         reqs,
         verify_input,
-        retrieve_next_token_cpu,
-        retrieve_next_sibling_cpu,
-        draft_tokens_cpu,
+        *tree.resolve(),
         sampling_info.vocab_size,
     )
     if vocab_mask is None:

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -556,8 +556,7 @@ class GrammarTree:
     """The verify tree the grammar bitmask is built over, on the host.
 
     ``from_device`` starts an async copy, so build it before the target verify
-    launch; build_grammar_vocab_mask waits on it past the launch, which is what
-    makes the copies and the traversal overlap that forward.
+    launch; ``from_host`` is for algorithms that build the tree there (NGRAM).
     """
 
     def __init__(self, host: Tuple[torch.Tensor, ...], done_event):
@@ -589,7 +588,6 @@ class GrammarTree:
         retrieve_next_sibling: torch.Tensor,
         draft_token: torch.Tensor,
     ) -> GrammarTree:
-        """For algorithms that build the tree on the host (NGRAM): nothing to wait on."""
         return cls((retrieve_next_token, retrieve_next_sibling, draft_token), None)
 
     def resolve(self) -> Tuple[torch.Tensor, ...]:
@@ -608,8 +606,8 @@ def build_grammar_vocab_mask(
 ) -> Optional[torch.Tensor]:
     """Build the constrained-decoding bitmask over a verify tree and stage it on device.
 
-    Call it after the target verify launch: the traversal is pure host work, so it
-    overlaps that forward, and resolving the tree here keeps any wait past the launch.
+    Call it after the target verify launch: resolving the tree and traversing it are
+    both host work, so both overlap that forward.
     """
     vocab_mask = generate_token_bitmask(
         reqs,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -38,6 +38,7 @@ from sglang.srt.distributed.parallel_state import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import set_mamba_track_indices_from_reqs
+from sglang.srt.managers.utils import _async_d2h
 from sglang.srt.mem_cache.allocation import (
     assign_req_to_token_pool as assign_req_to_token_pool,
 )
@@ -551,6 +552,39 @@ def generate_token_bitmask(
     return allocate_token_bitmask
 
 
+class StagedGrammarTree:
+    """The verify tree copied to the host for the grammar bitmask traversal.
+
+    Stage it where the tree becomes available -- before the target verify forward
+    is launched, so the copies run right after the draft -- and resolve() it where
+    build_grammar_vocab_mask needs the values. Everything launched in between
+    overlaps the transfer. Algorithms whose tree is already on the host (NGRAM
+    builds it there) skip this and pass their arrays straight through.
+    """
+
+    def __init__(
+        self,
+        retrieve_next_token: torch.Tensor,
+        retrieve_next_sibling: torch.Tensor,
+        draft_token: torch.Tensor,
+    ):
+        self._host = tuple(
+            _async_d2h(t)
+            for t in (retrieve_next_token, retrieve_next_sibling, draft_token)
+        )
+        device = retrieve_next_token.device
+        self._done = (
+            torch.get_device_module(device).Event() if device.type != "cpu" else None
+        )
+        if self._done is not None:
+            self._done.record()
+
+    def resolve(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self._done is not None:
+            self._done.synchronize()
+        return self._host
+
+
 def build_grammar_vocab_mask(
     *,
     reqs: List[Req],
@@ -565,8 +599,8 @@ def build_grammar_vocab_mask(
 
     Call it after the target verify forward is launched: the traversal is pure host
     work over the already-known draft tree, so it overlaps that forward. The tree
-    arrays must be on the host by then -- see AsyncD2H for algorithms whose tree
-    lives on device.
+    arrays must be on the host by then -- see StagedGrammarTree for algorithms
+    whose tree lives on device.
     """
     vocab_mask = generate_token_bitmask(
         reqs,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -69,8 +69,10 @@ if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
     from sglang.srt.managers.tp_worker import TpModelWorker
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+    from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
     from sglang.srt.server_args import ServerArgs
     from sglang.srt.speculative.eagle_info import EagleVerifyInput
+    from sglang.srt.speculative.spec_info import SpecInput
 
 
 if _is_cuda:
@@ -547,6 +549,44 @@ def generate_token_bitmask(
 
     verify_input.grammar = grammar
     return allocate_token_bitmask
+
+
+def build_grammar_vocab_mask(
+    *,
+    reqs: List[Req],
+    verify_input: SpecInput,
+    retrieve_next_token_cpu: torch.Tensor,
+    retrieve_next_sibling_cpu: torch.Tensor,
+    draft_tokens_cpu: torch.Tensor,
+    sampling_info: SamplingBatchInfo,
+    device,
+) -> Optional[torch.Tensor]:
+    """Build the constrained-decoding bitmask over a verify tree and stage it on device.
+
+    Call it after the target verify forward is launched: the traversal is pure host
+    work over the already-known draft tree, so it overlaps that forward. The tree
+    arrays must be on the host by then -- see AsyncD2H for algorithms whose tree
+    lives on device.
+    """
+    vocab_mask = generate_token_bitmask(
+        reqs,
+        verify_input,
+        retrieve_next_token_cpu,
+        retrieve_next_sibling_cpu,
+        draft_tokens_cpu,
+        sampling_info.vocab_size,
+    )
+    if vocab_mask is None:
+        return None
+
+    assert verify_input.grammar is not None
+    # non_blocking is safe: the bitmask is pinned (see xgrammar_backend), and stream
+    # order keeps the copy ahead of the sampler's apply_vocab_mask.
+    vocab_mask = vocab_mask.to(device, non_blocking=True)
+    # Otherwise the mask left over from the previous extend stage is applied instead,
+    # producing wrong results.
+    sampling_info.vocab_mask = None
+    return vocab_mask
 
 
 def load_token_map(token_map_path: str) -> List[int]:


### PR DESCRIPTION
## Summary

- Add `spec_utils.build_grammar_vocab_mask()` — bitmask build, `non_blocking` upload, and clearing the stale extend-stage mask, which EAGLE and NGRAM each spelled out separately
- Add `spec_utils.StagedGrammarTree` — the three verify-tree tensors copied D2H under one event, replacing the hand-rolled `_async_d2h` x3 + event + `synchronize()` in the EAGLE verify path
- No behavior change

## Background

- Grammar-constrained spec verify needs the draft tree on the host, then builds one bitmask row per verify position and uploads it before sampling
- Each worker reimplements the tail (`generate_token_bitmask` -> `.to(device, non_blocking=True)` -> clear `sampling_info.vocab_mask`), and the copy discipline that keeps it off the critical path is easy to get wrong: the copies must be staged before the target verify launch and resolved after it, and the upload must be `non_blocking` or the pinned bitmask silently degrades to a blocking copy
- Two more workers are adding grammar support (#30096, #31753); with these helpers they only need to supply their own tree

## Notes for reviewers

- `StagedGrammarTree` is deliberately narrow — it copies on the current stream and relies on `record_stream` rather than cloning, because the tree copies must stay ordered behind the draft kernels and ahead of the verify launch. The general side-stream variant is `kv_canary`s `FutureTensors`, whose clone-per-tensor and dedicated stream are wrong for a per-step verify path
- NGRAM does not stage anything — its tree is derived on the host (#32380) — so it calls the mask helper directly, which is what makes the split useful
- The device tree links stay: `eagle_sample` and the mamba / gdn / kda / hybrid-linear backends read them

## Accuracy Tests

- NGRAM + JSON-schema decode: occupancy 92.17% / 725.1 tok/s / accept length 7.97, matching the 92.21% / 725.7 / 7.97 measured before the refactor
- NGRAM constrained smoke on the final build: JSON schema yields `{ "name": "Paris", "population": 2148000 }`, a regex constraint yields an exactly-matching string, and unconstrained decode is unaffected

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30153858856](https://github.com/sgl-project/sglang/actions/runs/30153858856)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30153858796](https://github.com/sgl-project/sglang/actions/runs/30153858796)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->