### PR TITLE
[misc] Expand the ruff pre-commit hook to the Pyflakes and pylint-error rule sets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,11 @@ repos:
     hooks:
       - id: ruff
         args:
-          - --select=F401,F821,UP037
+          - --select=F,PLE,UP037
+          # F403/F405: star imports, almost all in vendored third_party.
+          # F722: false positives on the `A[type, "help", NS(...)]` server-arg alias.
+          # F402/F541/F811/F823/F841/PLE0302: pre-existing hits, not yet triaged.
+          - --ignore=F402,F403,F405,F541,F722,F811,F823,F841,PLE0302
           - --fix
         files: ^(benchmark/|docs_new/|examples/|python/sglang/|sgl-model-gateway/py_*|test/)
         exclude: |

--- a/benchmark/hicache/bench_serving.py
+++ b/benchmark/hicache/bench_serving.py
@@ -619,14 +619,6 @@ async def benchmark(
             "std_itl_ms": metrics.std_itl_ms,
             "p99_itl_ms": metrics.p99_itl_ms,
             "concurrency": metrics.concurrency,
-            "input_throughput": metrics.input_throughput,
-            "output_throughput": metrics.output_throughput,
-            "fixed_output_len": args.fixed_output_len,
-            "random_input_len": args.random_input_len,
-            "random_output_len": args.random_output_len,
-            "random_range_ratio": args.random_range_ratio,
-            "duration": benchmark_duration,
-            "completed": metrics.completed,
         }
     else:
         print(f"Error running benchmark for request rate: {request_rate}")

--- a/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
@@ -176,10 +176,10 @@ class QuickAllReduce:
         regime_str = os.environ.get("ROCM_QUICK_REDUCE_QUANTIZATION", "NONE")
         if regime_str not in QuickReduceRegime.__members__:
             logger.warning(
-                "Custom quick allreduce:",
-                f"Invalid quantization level: {regime_str}. "
-                "Supported levels: "
-                f"{list(QuickReduceRegime.__members__.keys())}",
+                "Custom quick allreduce: Invalid quantization level: %s. "
+                "Supported levels: %s",
+                regime_str,
+                list(QuickReduceRegime.__members__.keys()),
             )
             return
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -714,7 +714,6 @@ async def model_info():
         "has_audio_understanding": model_config.is_audio_understandable_model,
         "model_type": getattr(model_config.hf_config, "model_type", None),
         "architectures": getattr(model_config.hf_config, "architectures", None),
-        "weight_version": _global_state.tokenizer_manager.server_args.weight_version,
         # "hf_config": model_config.hf_config.to_dict(),
     }
     return result

--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -29,7 +29,7 @@ def _call_once(fn: Callable):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         if getattr(fn, "_has_been_called", False):
-            logger.debug("Function {} has already been called.", fn.__name__)
+            logger.debug("Function %s has already been called.", fn.__name__)
             return
 
         fn._has_been_called = True

--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -170,7 +170,6 @@ REGISTER_MAPPING = {
     "register_musa_ci": HWBackend.MUSA,
     "register_npu_ci": HWBackend.NPU,
     "register_xpu_ci": HWBackend.XPU,
-    "register_musa_ci": HWBackend.MUSA,
     "register_mlx_ci": HWBackend.MLX,
 }
 

--- a/python/sglang/test/nightly_bench_utils.py
+++ b/python/sglang/test/nightly_bench_utils.py
@@ -72,7 +72,7 @@ Note: To view the traces through perfetto-ui, please:
             # Create a combined link or use the first available one
             trace_files = [self.profile_link_extend, self.profile_link_decode]
             if any(trace_file is None for trace_file in trace_files):
-                logger.error("Some trace files are None", f"{trace_files=}")
+                logger.error("Some trace files are None: %s", trace_files)
             trace_files_relay_links = [
                 (
                     f"[trace]({get_perfetto_relay_link_from_trace_file(trace_file)})"


### PR DESCRIPTION
Widens `--select` from `F401,F821,UP037` to `F,PLE,UP037`, activating ~47 additional always-a-bug rules (format-string arg mismatches, `assert (cond, "msg")` tuple asserts, misplaced `break`/`return`, bad dunder signatures, `raise NotImplemented`, ...). Rules with pre-existing hits are listed in `--ignore` with a comment so they can be triaged separately; the 13 violations that were left are fixed here (3 logging calls that raise internally and lose their message, 10 duplicate dict keys). `ruff check` over the full hook scope is clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30155144021](https://github.com/sgl-project/sglang/actions/runs/30155144021)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30155143902](https://github.com/sgl-project/sglang/actions/runs/30155143902)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->