### PR TITLE
[EAGLE] Handle NaNs in fused top-k=1

### DIFF
--- a/python/sglang/kernels/ops/speculative/topk1.py
+++ b/python/sglang/kernels/ops/speculative/topk1.py
@@ -27,6 +27,8 @@ def _draft_topk1_partial_argmax_kernel(
         mask=mask,
         other=-float("inf"),
     ).to(tl.float32)
+    # Keep NaNs on valid lanes from selecting the masked tail.
+    vals = tl.where(vals == vals, vals, -1e30)
 
     max_val = tl.max(vals, axis=0)
     local_index = tl.argmax(vals, axis=0)


### PR DESCRIPTION
Fixes #32182.

The invalid-token regression was introduced by #30947. Its fused EAGLE top-k=1 kernel can select a masked tail lane when draft logits contain NaNs, returning `token_id == vocab_size`.

Map NaNs to a finite floor before argmax. Verified with the existing top-k1 tests and a CUDA OOB A/B.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30156588135](https://github.com/sgl-project/sglang/actions/runs/30156588135)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30413476694](https://github.com/sgl-project/sglang/actions/runs/30413476694)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->