### PR TITLE
[MM] sglang-mm: turbojpeg + PNG streaming + buffer pool

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,12 @@ jobs:
           python -m pip install pre-commit
           pre-commit install
 
+      # sglang-mm's default turbojpeg-decode feature builds libjpeg-turbo from
+      # source, whose SIMD path needs the NASM assembler (cmake/gcc are already
+      # on the runner). The clippy-rust-workspace hook compiles this workspace.
+      - name: Install NASM (turbojpeg SIMD build)
+        run: sudo apt-get update && sudo apt-get install -y nasm
+
       # The clippy-rust-workspace pre-commit hook compiles the rust/ workspace
       # (debug profile); cache cargo registry + target across runs.
       - name: Rust cache (rust/ workspace)

--- a/rust/sglang-mm/Cargo.toml
+++ b/rust/sglang-mm/Cargo.toml
@@ -20,6 +20,10 @@ debug = false
 name = "sglang_mm_core"
 crate-type = ["cdylib"]
 
+[features]
+default = ["turbojpeg-decode"]
+turbojpeg-decode = ["dep:turbojpeg"]
+
 [dependencies]
 pyo3 = { workspace = true }
 
@@ -28,4 +32,6 @@ blake3 = "1"
 half = "2.4"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 numpy = "0.29"
+png = "0.17"
 rayon = "1.10"
+turbojpeg = { version = "1", optional = true }

--- a/rust/sglang-mm/src/common/mod.rs
+++ b/rust/sglang-mm/src/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod resize;
 pub mod transforms;
 
+use std::cell::RefCell;
 use std::sync::OnceLock;
 
 use numpy::{IntoPyArray, PyArray1, PyReadonlyArray3, PyUntypedArrayMethods};
@@ -23,16 +24,205 @@ pub fn pool() -> &'static rayon::ThreadPool {
     })
 }
 
+// ---- Thread-local buffer pools ----
+
+thread_local! {
+    static RGB_POOL: RefCell<Vec<u8>> = RefCell::new(Vec::with_capacity(1024 * 1024));
+}
+
+#[cfg(feature = "turbojpeg-decode")]
+thread_local! {
+    static JPEG_DECOMP: RefCell<Option<turbojpeg::Decompressor>> = const { RefCell::new(None) };
+}
+
+// ---- Format sniffing ----
+
+#[cfg(feature = "turbojpeg-decode")]
+#[inline]
+fn is_jpeg(bytes: &[u8]) -> bool {
+    bytes.len() >= 3 && bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF
+}
+
+#[inline]
+fn is_png(bytes: &[u8]) -> bool {
+    bytes.len() >= 8 && &bytes[..8] == b"\x89PNG\r\n\x1a\n"
+}
+
+// ---- JPEG decode via libjpeg-turbo (with scaled iDCT) ----
+
+#[cfg(feature = "turbojpeg-decode")]
+fn with_jpeg_decompressor<R>(
+    f: impl FnOnce(&mut turbojpeg::Decompressor) -> Result<R, String>,
+) -> Result<R, String> {
+    JPEG_DECOMP.with(|d| {
+        let mut slot = d.borrow_mut();
+        if slot.is_none() {
+            *slot =
+                Some(turbojpeg::Decompressor::new().map_err(|e| format!("turbojpeg init: {e}"))?);
+        }
+        f(slot.as_mut().unwrap())
+    })
+}
+
+#[cfg(feature = "turbojpeg-decode")]
+fn jpeg_header_dims(bytes: &[u8]) -> Result<(usize, usize), String> {
+    with_jpeg_decompressor(|decomp| {
+        let header = decomp
+            .read_header(bytes)
+            .map_err(|e| format!("jpeg header: {e}"))?;
+        Ok((header.height, header.width))
+    })
+}
+
+#[cfg(feature = "turbojpeg-decode")]
+fn decode_jpeg_into(
+    bytes: &[u8],
+    target: Option<(usize, usize)>,
+    buf: &mut Vec<u8>,
+) -> Result<(usize, usize), String> {
+    with_jpeg_decompressor(|decomp| {
+        let header = decomp
+            .read_header(bytes)
+            .map_err(|e| format!("jpeg header: {e}"))?;
+
+        let (scaled_h, scaled_w) = if let Some((th, tw)) = target {
+            let factors = turbojpeg::Decompressor::supported_scaling_factors();
+            let mut chosen = turbojpeg::ScalingFactor::new(1, 1);
+            for sf in factors.into_iter().rev() {
+                if sf.num() > sf.denom() {
+                    continue;
+                }
+                if sf.scale(header.height) >= th && sf.scale(header.width) >= tw {
+                    chosen = sf;
+                    break;
+                }
+            }
+            decomp
+                .set_scaling_factor(chosen)
+                .map_err(|e| format!("jpeg set_scaling_factor: {e}"))?;
+            (chosen.scale(header.height), chosen.scale(header.width))
+        } else {
+            decomp
+                .set_scaling_factor(turbojpeg::ScalingFactor::new(1, 1))
+                .map_err(|e| format!("jpeg set_scaling_factor: {e}"))?;
+            (header.height, header.width)
+        };
+
+        let needed = scaled_h * scaled_w * 3;
+        buf.clear();
+        buf.resize(needed, 0u8);
+
+        let image = turbojpeg::Image {
+            pixels: &mut buf[..needed],
+            width: scaled_w,
+            pitch: scaled_w * 3,
+            height: scaled_h,
+            format: turbojpeg::PixelFormat::RGB,
+        };
+        decomp
+            .decompress(bytes, image)
+            .map_err(|e| format!("jpeg decompress: {e}"))?;
+        Ok((scaled_h, scaled_w))
+    })
+}
+
+// ---- PNG streaming decode ----
+
+fn decode_png_into(bytes: &[u8], buf: &mut Vec<u8>) -> Result<(usize, usize), String> {
+    let mut decoder = png::Decoder::new(std::io::Cursor::new(bytes));
+    decoder.set_transformations(png::Transformations::EXPAND | png::Transformations::STRIP_16);
+    let mut reader = decoder.read_info().map_err(|e| format!("png: {e}"))?;
+    let w = reader.info().width as usize;
+    let h = reader.info().height as usize;
+    let (output_color, _) = reader.output_color_type();
+
+    let needed = w * h * 3;
+    buf.clear();
+    buf.resize(needed, 0u8);
+
+    let mut out_off = 0;
+    while let Some(row) = reader.next_row().map_err(|e| format!("png: {e}"))? {
+        let r = row.data();
+        match output_color {
+            png::ColorType::Rgb => {
+                buf[out_off..out_off + w * 3].copy_from_slice(&r[..w * 3]);
+                out_off += w * 3;
+            }
+            png::ColorType::Rgba => {
+                for i in 0..w {
+                    buf[out_off + i * 3] = r[i * 4];
+                    buf[out_off + i * 3 + 1] = r[i * 4 + 1];
+                    buf[out_off + i * 3 + 2] = r[i * 4 + 2];
+                }
+                out_off += w * 3;
+            }
+            png::ColorType::Grayscale => {
+                for i in 0..w {
+                    let v = r[i];
+                    buf[out_off + i * 3] = v;
+                    buf[out_off + i * 3 + 1] = v;
+                    buf[out_off + i * 3 + 2] = v;
+                }
+                out_off += w * 3;
+            }
+            png::ColorType::GrayscaleAlpha => {
+                for i in 0..w {
+                    let v = r[i * 2];
+                    buf[out_off + i * 3] = v;
+                    buf[out_off + i * 3 + 1] = v;
+                    buf[out_off + i * 3 + 2] = v;
+                }
+                out_off += w * 3;
+            }
+            _ => return decode_fallback_into(bytes, buf),
+        }
+    }
+    Ok((h, w))
+}
+
+// ---- Fallback via image crate ----
+
+fn decode_fallback_into(data: &[u8], buf: &mut Vec<u8>) -> Result<(usize, usize), String> {
+    let img = image::load_from_memory(data).map_err(|e| format!("image decode: {e}"))?;
+    let rgb = img.to_rgb8();
+    let (w, h) = rgb.dimensions();
+    let raw = rgb.into_raw();
+    buf.clear();
+    buf.extend_from_slice(&raw);
+    Ok((h as usize, w as usize))
+}
+
+// ---- Public decode API ----
+
+pub fn decode_rgb_into(
+    data: &[u8],
+    #[allow(unused_variables)] target: Option<(usize, usize)>,
+    buf: &mut Vec<u8>,
+) -> Result<(usize, usize), String> {
+    #[cfg(feature = "turbojpeg-decode")]
+    if is_jpeg(data) {
+        return decode_jpeg_into(data, target, buf);
+    }
+
+    if is_png(data) {
+        return decode_png_into(data, buf);
+    }
+
+    decode_fallback_into(data, buf)
+}
+
 pub fn sha256_u64(data: &[u8]) -> u64 {
     let digest = blake3::hash(data);
     u64::from_be_bytes(digest.as_bytes()[..8].try_into().unwrap())
 }
 
 pub fn decode_rgb(data: &[u8]) -> Result<(Vec<u8>, usize, usize), String> {
-    let img = image::load_from_memory(data).map_err(|e| format!("image decode: {e}"))?;
-    let rgb = img.to_rgb8();
-    let (w, h) = rgb.dimensions();
-    Ok((rgb.into_raw(), h as usize, w as usize))
+    RGB_POOL.with(|pool| {
+        let mut buf = pool.borrow_mut();
+        let (h, w) = decode_rgb_into(data, None, &mut buf)?;
+        let needed = h * w * 3;
+        Ok((buf[..needed].to_vec(), h, w))
+    })
 }
 
 pub fn decode_rescale(
@@ -40,12 +230,37 @@ pub fn decode_rescale(
     rescale_frac: Option<f64>,
     rescale_cap: Option<i64>,
 ) -> Result<(Vec<u8>, usize, usize), String> {
-    let (rgb, h, w) = decode_rgb(data)?;
-    let (tw, th) = resize::scaled_dims(w, h, rescale_frac, rescale_cap);
-    if (tw, th) == (w, h) {
-        return Ok((rgb, h, w));
-    }
-    Ok((resize::resize_lanczos_rgb(&rgb, h, w, th, tw), th, tw))
+    RGB_POOL.with(|pool| {
+        let mut buf = pool.borrow_mut();
+
+        #[cfg(feature = "turbojpeg-decode")]
+        if is_jpeg(data) {
+            if let Some(frac) = rescale_frac {
+                let (orig_h, orig_w) = jpeg_header_dims(data)?;
+                let (tw, th) = resize::scaled_dims(orig_w, orig_h, Some(frac), rescale_cap);
+                if (tw, th) == (orig_w, orig_h) {
+                    let (h, w) = decode_jpeg_into(data, None, &mut buf)?;
+                    return Ok((buf[..h * w * 3].to_vec(), h, w));
+                }
+                let (dh, dw) = decode_jpeg_into(data, Some((th, tw)), &mut buf)?;
+                if (dw, dh) == (tw, th) {
+                    return Ok((buf[..th * tw * 3].to_vec(), th, tw));
+                }
+                let resized = resize::resize_lanczos_rgb(&buf[..dh * dw * 3], dh, dw, th, tw);
+                return Ok((resized, th, tw));
+            }
+            let (h, w) = decode_jpeg_into(data, None, &mut buf)?;
+            return Ok((buf[..h * w * 3].to_vec(), h, w));
+        }
+
+        let (h, w) = decode_rgb_into(data, None, &mut buf)?;
+        let (tw, th) = resize::scaled_dims(w, h, rescale_frac, rescale_cap);
+        if (tw, th) == (w, h) {
+            return Ok((buf[..h * w * 3].to_vec(), h, w));
+        }
+        let resized = resize::resize_lanczos_rgb(&buf[..h * w * 3], h, w, th, tw);
+        Ok((resized, th, tw))
+    })
 }
 
 // --- Python-exposed functions ---


### PR DESCRIPTION
## Summary

Optimize the common decode layer in `rust/sglang-mm` with three changes ported from `scratch/bench-vlm-preproc` (`alexnails/rust-vlm-tile-preproc`):

- **JPEG decode via libjpeg-turbo** (`turbojpeg` crate) with scaled iDCT — picks the smallest M/8 factor whose output ≥ target, avoiding full-res decode for images that will be resized. Behind a `turbojpeg-decode` feature flag (default on).
- **PNG streaming decode** via the `png` crate's `next_row()`, writing RGB directly into a pooled buffer. Handles Rgb/Rgba/Grayscale/GrayscaleAlpha with fallback to the `image` crate for exotic formats.
- **Thread-local buffer pools** (`RGB_POOL`, `JPEG_DECOMP`) that eliminate per-request allocation after warm-up.

All existing Python API unchanged. Inkling module benefits automatically without code changes.

Based on the prototype in https://github.com/sgl-project/sglang/compare/alexnails/rust-vlm-tile-preproc

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30534456534](https://github.com/sgl-project/sglang/actions/runs/30534456534)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30534456068](https://github.com/sgl-project/sglang/actions/runs/30534456068)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->