### PR TITLE
[LoRA] Warn instead of silently dropping one-sided MoE expert LoRA targets

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -405,11 +405,11 @@ class LoRAManager:
         """
         for layer_id, layer_modules in enumerate(self.lora_modules):
             for module_name, module in layer_modules.items():
-                if (
-                    isinstance(module, FusedMoEWithLoRA)
-                    or getattr(module, "is_shared_fused_moe", False)
-                ) and all(
-                    x in self.target_modules for x in ["gate_up_proj", "down_proj"]
+                # A fused-MoE / batch-dense LoRA module only exists when
+                # init_lora_modules found both expert projections targeted, so
+                # no target-module re-check is needed here.
+                if isinstance(module, FusedMoEWithLoRA) or getattr(
+                    module, "is_shared_fused_moe", False
                 ):
                     base_layer = getattr(module, "base_layer", module)
                     suffix = "_shared_moe" if base_layer.is_shared_fused_moe else "_moe"
@@ -818,6 +818,8 @@ class LoRAManager:
 
         self.embed_tokens_module: Optional[BaseLayerWithLoRA] = None
         self.lm_head_module: Optional[BaseLayerWithLoRA] = None
+        # One fused layer's worth of warning is enough; the condition is model-wide.
+        warned_one_sided_moe_targets = False
 
         # When tie_word_embeddings=True, lm_head is the same Python object as
         # embed_tokens. PyTorch's named_modules() deduplicates by object identity,
@@ -909,9 +911,37 @@ class LoRAManager:
                 )
                 continue
 
-            if isinstance(module, (FusedMoE, InklingBatchDenseMLP)) and all(
-                x in self.target_modules for x in ["gate_up_proj", "down_proj"]
-            ):
+            if isinstance(module, (FusedMoE, InklingBatchDenseMLP)):
+                expert_projections = ("gate_up_proj", "down_proj")
+                missing = [
+                    x for x in expert_projections if x not in self.target_modules
+                ]
+                if len(missing) == 1 and not warned_one_sided_moe_targets:
+                    warned_one_sided_moe_targets = True
+                    # The fused LoRA hooks inject a delta after gate_up and after
+                    # down together, so wrapping for only one of them is not
+                    # implemented and the layer stays unwrapped. Adapters that only
+                    # train the dense/shared MLP still work, but one that carries
+                    # expert weights for the targeted projection has them loaded
+                    # into the pool and never applied. Warn once — silently
+                    # dropping part of an adapter reads as a serving/training
+                    # mismatch with no symptom.
+                    present = next(x for x in expert_projections if x != missing[0])
+                    logger.warning(
+                        "LoRA target modules include %r but not %r, so fused MoE / "
+                        "batch-dense layers (e.g. %s) get no adapter at all: LoRA on "
+                        "these layers needs both projections. Any %r expert weights in "
+                        "a loaded adapter will be ignored. Add %r to the target modules "
+                        "to enable LoRA here — an adapter that does not train it keeps "
+                        "zero-filled buffers and contributes no delta.",
+                        present,
+                        missing[0],
+                        module_name,
+                        present,
+                        missing[0],
+                    )
+                if missing:
+                    continue
                 layer_id = get_layer_id(module_name)
                 if layer_id is None:
                     # FusedMoE submodules outside the decoder layer hierarchy


### PR DESCRIPTION
## Motivation

A `FusedMoE` (or Inkling `InklingBatchDenseMLP`) layer is only wrapped with LoRA when **both** `gate_up_proj` and `down_proj` are in the target modules, because the fused LoRA hooks inject the two deltas together. Targeting only one left the layer unwrapped with no diagnostic: the adapter's expert weights for the targeted projection were loaded into the memory pool (`init_buffers` allocates the `*_moe` buffers per target module, without requiring both) but never applied. For RL rollouts that means the serving policy silently diverges from the trained one.

## Modifications

- Emit a one-shot warning naming the fused module and the missing projection. Kept a warning rather than a startup error: adapters that only train the dense or shared-expert MLP legitimately target one projection and keep working unchanged.
- Drop the always-true target-module re-check in `update_lora_info` — a `FusedMoEWithLoRA` / `is_shared_fused_moe` module only exists in `self.lora_modules` when `init_lora_modules` already found both projections targeted (`update_lora_info` has a single call site, immediately after `init_lora_modules`, and `self.target_modules` is fixed before either runs).

No behavioural change beyond the log line; the wrap/skip decision is unchanged (the fused-layer block is the last statement in the module scan loop, so `continue` on a one-sided target is equivalent to the previous fall-through).

Same change as the one merged to the `sglang-miles` branch in #32376, adapted to `main`'s `InklingBatchDenseMLP` / `is_shared_fused_moe` handling.

## Accuracy Test

No accuracy impact — the wrapping decision and all kernels are untouched. The change adds a log line and removes a condition that is always true at its call site.

## Benchmarking and Profiling

No performance impact: the removed re-check ran once per fused layer at startup, and the warning fires at most once per process.

## Checklist

- [x] Format the code with pre-commit (black-clean).
- [ ] Tests: diagnostic-only change; existing LoRA tests cover both the wrapped (both projections) and unwrapped (neither projection) paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30174529032](https://github.com/sgl-project/sglang/actions/runs/30174529032)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30174528963](https://github.com/sgl-project/sglang/actions/runs/30174528963)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->