### PR TITLE
Replace ngram FULL_MASK Python for-loop with Triton kernel

### DIFF
--- a/python/sglang/kernels/ops/speculative/__init__.py
+++ b/python/sglang/kernels/ops/speculative/__init__.py
@@ -16,6 +16,7 @@ _TRITON_KERNELS = [
     ("eagle", "fill_accept_out_cache_loc"),
     ("gather_spec_extras", "gather_spec_extras"),
     ("multi_layer_eagle", "rotate_input_ids"),
+    ("ngram_mask", "build_ngram_full_tree_mask"),
     ("spec_tree", "sgl_build_tree_kernel_efficient_triton"),
     ("spec_tree", "verify_tree_greedy_kernel_triton"),
     ("topk1", "draft_topk1_postprocess"),

--- a/python/sglang/kernels/ops/speculative/ngram_mask.py
+++ b/python/sglang/kernels/ops/speculative/ngram_mask.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+def build_ngram_full_tree_mask_ref(
+    draft_mask: torch.Tensor,
+    seq_lens: torch.Tensor,
+    draft_token_num: int,
+) -> torch.Tensor:
+    """Reference implementation (same semantics as the old Python loop)."""
+    assert draft_mask.dim() == 3
+    bs, d1, d2 = draft_mask.shape
+    assert d1 == d2 == draft_token_num
+    device = draft_mask.device
+    seq_lens_list = seq_lens.tolist()
+
+    pieces = []
+    for i in range(bs):
+        seq_len = int(seq_lens_list[i])
+        left = torch.ones((draft_token_num, seq_len), dtype=torch.bool, device=device)
+        right = draft_mask[i].to(dtype=torch.bool)
+        pieces.append(torch.cat((left, right), dim=1).reshape(-1))
+    if not pieces:
+        return torch.empty(0, dtype=torch.bool, device=device)
+    return torch.cat(pieces, dim=0)
+
+
+@triton.jit
+def _build_ngram_full_tree_mask_kernel(
+    draft_mask_ptr,  # (bs, D, D) bool/uint8, contiguous
+    seq_lens_ptr,  # (bs,) int32
+    offsets_ptr,  # (bs,) int32, start of each req in out
+    out_ptr,  # (total,) bool/uint8
+    D: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+):
+    bid = tl.program_id(0)  # request
+    rid = tl.program_id(1)  # draft row
+
+    seq_len = tl.load(seq_lens_ptr + bid)
+    offset = tl.load(offsets_ptr + bid)
+    row_width = seq_len + D
+    row_base = offset + rid * row_width
+
+    # ---- left: history visible (all True) ----
+    cols = tl.arange(0, BLOCK_S)
+    for start in tl.range(0, seq_len, BLOCK_S):
+        c = start + cols
+        tl.store(
+            out_ptr + row_base + c,
+            tl.full((BLOCK_S,), 1, dtype=out_ptr.dtype.element_ty),
+            mask=c < seq_len,
+        )
+
+    # ---- right: draft_mask[bid, rid, :] ----
+    dcols = tl.arange(0, BLOCK_D)
+    in_range = dcols < D
+    vals = tl.load(
+        draft_mask_ptr + (bid * D + rid) * D + dcols,
+        mask=in_range,
+        other=0,
+    )
+    tl.store(
+        out_ptr + row_base + seq_len + dcols,
+        vals,
+        mask=in_range,
+    )
+
+
+def build_ngram_full_tree_mask(
+    draft_mask: torch.Tensor,
+    seq_lens: torch.Tensor,
+    draft_token_num: int,
+    *,
+    block_s: int = 128,
+) -> torch.Tensor:
+    """Build flattened FULL custom_mask for an ngram verify batch.
+
+    Args:
+        draft_mask: (bs, D, D) bool CUDA tensor. draft-to-draft visibility.
+        seq_lens: (bs,) int tensor (CPU or CUDA). history length per req.
+        draft_token_num: D.
+        block_s: Triton block size for the history fill loop.
+
+    Returns:
+        (total,) bool CUDA tensor, total = sum_b D * (seq_lens[b] + D).
+    """
+    if draft_mask.numel() == 0:
+        return torch.empty(0, dtype=torch.bool, device=draft_mask.device)
+
+    assert draft_mask.is_cuda, "draft_mask must be on CUDA"
+    assert draft_mask.dim() == 3, draft_mask.shape
+    bs, d1, d2 = draft_mask.shape
+    assert d1 == d2 == draft_token_num, (draft_mask.shape, draft_token_num)
+    assert seq_lens.numel() == bs, (seq_lens.shape, bs)
+
+    device = draft_mask.device
+    # Kernel loads bytes; bool is 1-byte. Force contiguous bool.
+    draft_mask = draft_mask.to(dtype=torch.bool).contiguous()
+    seq = seq_lens.to(device=device, dtype=torch.int32, non_blocking=True).contiguous()
+
+    # sizes[b] = D * (seq_lens[b] + D)
+    sizes = draft_token_num * (seq + draft_token_num)
+    offsets = torch.empty(bs, dtype=torch.int32, device=device)
+    offsets[0] = 0
+    if bs > 1:
+        torch.cumsum(sizes[:-1], dim=0, out=offsets[1:])
+
+    total = int(sizes.sum().item())
+    out = torch.empty(total, dtype=torch.bool, device=device)
+
+    block_d = triton.next_power_of_2(draft_token_num)
+    grid = (bs, draft_token_num)
+    _build_ngram_full_tree_mask_kernel[grid](
+        draft_mask,
+        seq,
+        offsets,
+        out,
+        D=draft_token_num,
+        BLOCK_D=block_d,
+        BLOCK_S=block_s,
+    )
+    return out

--- a/python/sglang/kernels/ops/speculative/ngram_mask.py
+++ b/python/sglang/kernels/ops/speculative/ngram_mask.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 import torch
 import triton
 import triton.language as tl
@@ -15,7 +17,7 @@ def build_ngram_full_tree_mask_ref(
     bs, d1, d2 = draft_mask.shape
     assert d1 == d2 == draft_token_num
     device = draft_mask.device
-    seq_lens_list = seq_lens.tolist()
+    seq_lens_list = seq_lens.detach().cpu().tolist()
 
     pieces = []
     for i in range(bs):
@@ -32,7 +34,7 @@ def build_ngram_full_tree_mask_ref(
 def _build_ngram_full_tree_mask_kernel(
     draft_mask_ptr,  # (bs, D, D) bool/uint8, contiguous
     seq_lens_ptr,  # (bs,) int32
-    offsets_ptr,  # (bs,) int32, start of each req in out
+    offsets_ptr,  # (bs,) int32 — exclusive prefix sum
     out_ptr,  # (total,) bool/uint8
     D: tl.constexpr,
     BLOCK_D: tl.constexpr,
@@ -46,7 +48,7 @@ def _build_ngram_full_tree_mask_kernel(
     row_width = seq_len + D
     row_base = offset + rid * row_width
 
-    # ---- left: history visible (all True) ----
+    # history: all True
     cols = tl.arange(0, BLOCK_S)
     for start in tl.range(0, seq_len, BLOCK_S):
         c = start + cols
@@ -56,7 +58,7 @@ def _build_ngram_full_tree_mask_kernel(
             mask=c < seq_len,
         )
 
-    # ---- right: draft_mask[bid, rid, :] ----
+    # draft block
     dcols = tl.arange(0, BLOCK_D)
     in_range = dcols < D
     vals = tl.load(
@@ -74,45 +76,56 @@ def _build_ngram_full_tree_mask_kernel(
 def build_ngram_full_tree_mask(
     draft_mask: torch.Tensor,
     seq_lens: torch.Tensor,
+    offsets: torch.Tensor,
     draft_token_num: int,
     *,
+    required_numel: int,
+    tree_mask_buf: Optional[torch.Tensor] = None,
     block_s: int = 128,
 ) -> torch.Tensor:
-    """Build flattened FULL custom_mask for an ngram verify batch.
+    """Build a flattened FULL custom mask.
 
-    Args:
-        draft_mask: (bs, D, D) bool CUDA tensor. draft-to-draft visibility.
-        seq_lens: (bs,) int tensor (CPU or CUDA). history length per req.
-        draft_token_num: D.
-        block_s: Triton block size for the history fill loop.
+    Caller provides:
+    - ``seq_lens``: GPU sequence lengths, shape ``(bs,)``.
+    - ``offsets``: GPU exclusive prefix sum of
+        ``D * (seq_lens[b] + D)``, shape ``(bs,)``.
+    - ``required_numel``: exact number of valid output elements.
+    - ``tree_mask_buf``: optional preallocated output buffer.
 
     Returns:
-        (total,) bool CUDA tensor, total = sum_b D * (seq_lens[b] + D).
+        A flattened output buffer. If ``tree_mask_buf`` is provided,
+        the returned tensor may be larger than ``required_numel``.
     """
     if draft_mask.numel() == 0:
+        if tree_mask_buf is not None:
+            return tree_mask_buf
         return torch.empty(0, dtype=torch.bool, device=draft_mask.device)
 
-    assert draft_mask.is_cuda, "draft_mask must be on CUDA"
-    assert draft_mask.dim() == 3, draft_mask.shape
-    bs, d1, d2 = draft_mask.shape
-    assert d1 == d2 == draft_token_num, (draft_mask.shape, draft_token_num)
-    assert seq_lens.numel() == bs, (seq_lens.shape, bs)
+    assert (
+        draft_mask.dim() == 3
+        and draft_mask.shape[1] == draft_mask.shape[2] == draft_token_num
+    ), draft_mask.shape
+    bs = draft_mask.shape[0]
 
-    device = draft_mask.device
-    # Kernel loads bytes; bool is 1-byte. Force contiguous bool.
     draft_mask = draft_mask.to(dtype=torch.bool).contiguous()
-    seq = seq_lens.to(device=device, dtype=torch.int32, non_blocking=True).contiguous()
+    seq = seq_lens.to(dtype=torch.int32).contiguous()
+    offsets = offsets.to(dtype=torch.int32).contiguous()
 
-    # sizes[b] = D * (seq_lens[b] + D)
-    sizes = draft_token_num * (seq + draft_token_num)
-    offsets = torch.empty(bs, dtype=torch.int32, device=device)
-    offsets[0] = 0
-    if bs > 1:
-        torch.cumsum(sizes[:-1], dim=0, out=offsets[1:])
+    if tree_mask_buf is None:
+        out = torch.empty(
+            required_numel,
+            dtype=torch.bool,
+            device=draft_mask.device,
+        )
+    else:
+        assert tree_mask_buf.numel() >= required_numel, (
+            tree_mask_buf.shape,
+            required_numel,
+        )
+        assert tree_mask_buf.dtype in (torch.bool, torch.uint8), tree_mask_buf.dtype
+        out = tree_mask_buf.contiguous()
 
-    total = int(sizes.sum().item())
-    out = torch.empty(total, dtype=torch.bool, device=device)
-
+    block_s = triton.next_power_of_2(max(1, block_s))
     block_d = triton.next_power_of_2(draft_token_num)
     grid = (bs, draft_token_num)
     _build_ngram_full_tree_mask_kernel[grid](

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -329,17 +329,39 @@ class NGRAMWorker(BaseSpecWorker):
         # NOTE: QLEN_MASK is faster than FULL_MASK, but requires corresponding changes in flashinfer.
         # Testing shows about 8% performance improvement (the effect is roughly proportional to batch size).
         if USE_FULL_MASK and not _is_cpu:
-            draft_mask = (
-                torch.from_numpy(mask)
-                .to(device=self.device, dtype=torch.bool, non_blocking=True)
-                .reshape(bs, self.draft_token_num, self.draft_token_num)
-                .contiguous()
+            D = self.draft_token_num
+            draft_mask = tree_mask.view(bs, D, D)
+
+            assert (
+                batch.seq_lens_cpu is not None
+            ), "NGRAM FULL_MASK requires batch.seq_lens_cpu"
+
+            tree_mask_buf, _ = (
+                self.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
             )
-            tree_mask = build_ngram_full_tree_mask(
+
+            host_seq_lens_sum = (
+                int(batch.seq_lens_sum)
+                if batch.seq_lens_sum is not None
+                else int(batch.seq_lens_cpu.sum().item())
+            )
+            exact = D * host_seq_lens_sum + D * D * bs
+
+            seq = batch.seq_lens.to(dtype=torch.int32)
+            sizes = D * (seq + D)
+            offsets = torch.zeros(bs, dtype=torch.int32, device=self.device)
+            if bs > 1:
+                torch.cumsum(sizes[:-1], dim=0, out=offsets[1:])
+
+            out = build_ngram_full_tree_mask(
                 draft_mask,
-                batch.seq_lens_cpu,
-                self.draft_token_num,
+                seq,
+                offsets,
+                D,
+                required_numel=exact,
+                tree_mask_buf=tree_mask_buf,
             )
+            tree_mask = out[:exact]
 
         batch.forward_mode = ForwardMode.TARGET_VERIFY
         batch.input_ids = draft_tokens

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -8,6 +8,7 @@ from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 from sglang.kernels.ops.speculative.cache_locs import (
     assign_extend_cache_locs_func as assign_extend_cache_locs_func,
 )
+from sglang.kernels.ops.speculative.ngram_mask import build_ngram_full_tree_mask
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
@@ -328,25 +329,17 @@ class NGRAMWorker(BaseSpecWorker):
         # NOTE: QLEN_MASK is faster than FULL_MASK, but requires corresponding changes in flashinfer.
         # Testing shows about 8% performance improvement (the effect is roughly proportional to batch size).
         if USE_FULL_MASK and not _is_cpu:
-            tree_mask = []
-            mask = mask.reshape(bs, self.draft_token_num, self.draft_token_num)
-            # TODO(siyuan): the for loop here leads to significant overhead in large batch size. Can be written into a kernel.
-            for i in range(bs):
-                seq_len = batch.seq_lens_cpu[i]
-                req_mask = torch.ones(
-                    (self.draft_token_num, seq_len), device=self.device
-                )
-                req_mask = torch.cat(
-                    (
-                        req_mask,
-                        torch.from_numpy(mask[i]).to(
-                            device=self.device, non_blocking=True
-                        ),
-                    ),
-                    dim=1,
-                ).to(torch.bool)
-                tree_mask.append(req_mask.flatten())
-            tree_mask = torch.cat(tree_mask, dim=0)
+            draft_mask = (
+                torch.from_numpy(mask)
+                .to(device=self.device, dtype=torch.bool, non_blocking=True)
+                .reshape(bs, self.draft_token_num, self.draft_token_num)
+                .contiguous()
+            )
+            tree_mask = build_ngram_full_tree_mask(
+                draft_mask,
+                batch.seq_lens_cpu,
+                self.draft_token_num,
+            )
 
         batch.forward_mode = ForwardMode.TARGET_VERIFY
         batch.input_ids = draft_tokens

--- a/test/registered/kernels/ops/speculative/test_ngram_full_tree_mask.py
+++ b/test/registered/kernels/ops/speculative/test_ngram_full_tree_mask.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+
+from sglang.kernels.ops.speculative.ngram_mask import (
+    build_ngram_full_tree_mask,
+    build_ngram_full_tree_mask_ref,
+)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("bs", [1, 2, 8, 32])
+@pytest.mark.parametrize("draft_token_num", [4, 8])
+@pytest.mark.parametrize("seq_mode", ["equal", "mixed", "long"])
+def test_bit_identical(bs, draft_token_num, seq_mode):
+    torch.manual_seed(0)
+    D = draft_token_num
+    if seq_mode == "equal":
+        seq_lens = torch.full((bs,), 128, dtype=torch.int32)
+    elif seq_mode == "mixed":
+        base = torch.tensor([1, 7, 16, 64, 128, 257, 512, 1023], dtype=torch.int32)
+        seq_lens = base[torch.arange(bs) % len(base)]
+    else:
+        seq_lens = torch.full((bs,), 4096, dtype=torch.int32)
+
+    # random draft-draft mask
+    draft_mask = torch.randint(0, 2, (bs, D, D), device="cuda", dtype=torch.bool)
+    # lower-triangular-ish variant also covered when bs>=1: force one case
+    if bs >= 2:
+        draft_mask[1] = torch.tril(torch.ones(D, D, device="cuda", dtype=torch.bool))
+
+    ref = build_ngram_full_tree_mask_ref(draft_mask, seq_lens, D)
+    out = build_ngram_full_tree_mask(draft_mask, seq_lens, D)
+    assert out.dtype == torch.bool
+    assert out.shape == ref.shape
+    assert torch.equal(out, ref), (
+        f"mismatch bs={bs} D={D} seq_mode={seq_mode} "
+        f"diff={(out != ref).sum().item()} / {out.numel()}"
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_empty_batch():
+    draft_mask = torch.empty(0, 8, 8, dtype=torch.bool, device="cuda")
+    seq_lens = torch.empty(0, dtype=torch.int32)
+    out = build_ngram_full_tree_mask(draft_mask, seq_lens, 8)
+    assert out.numel() == 0

--- a/test/registered/kernels/ops/speculative/test_ngram_full_tree_mask.py
+++ b/test/registered/kernels/ops/speculative/test_ngram_full_tree_mask.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import torch
 
@@ -5,6 +7,28 @@ from sglang.kernels.ops.speculative.ngram_mask import (
     build_ngram_full_tree_mask,
     build_ngram_full_tree_mask_ref,
 )
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=10, stage="jit-kernel-unit", runner_config="amd")
+
+
+def _make_offsets(seq_lens: torch.Tensor, draft_token_num: int) -> torch.Tensor:
+    """Exclusive prefix sum of D * (seq + D) — same geometry as the worker."""
+    bs = seq_lens.numel()
+    seq = seq_lens.to(dtype=torch.int32)
+    sizes = draft_token_num * (seq + draft_token_num)
+    offsets = torch.zeros(bs, dtype=torch.int32, device=seq_lens.device)
+    if bs > 1:
+        torch.cumsum(sizes[:-1], dim=0, out=offsets[1:])
+    return offsets
+
+
+def _required_numel(seq_lens_cpu: torch.Tensor, draft_token_num: int) -> int:
+    """exact = D * sum(seq) + D * D * bs"""
+    bs = seq_lens_cpu.numel()
+    D = draft_token_num
+    return D * int(seq_lens_cpu.sum().item()) + D * D * bs
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
@@ -15,22 +39,33 @@ def test_bit_identical(bs, draft_token_num, seq_mode):
     torch.manual_seed(0)
     D = draft_token_num
     if seq_mode == "equal":
-        seq_lens = torch.full((bs,), 128, dtype=torch.int32)
+        seq_lens_cpu = torch.full((bs,), 128, dtype=torch.int32)
     elif seq_mode == "mixed":
         base = torch.tensor([1, 7, 16, 64, 128, 257, 512, 1023], dtype=torch.int32)
-        seq_lens = base[torch.arange(bs) % len(base)]
+        seq_lens_cpu = base[torch.arange(bs) % len(base)]
     else:
-        seq_lens = torch.full((bs,), 4096, dtype=torch.int32)
+        seq_lens_cpu = torch.full((bs,), 4096, dtype=torch.int32)
 
-    # random draft-draft mask
+    seq_lens = seq_lens_cpu.cuda()
     draft_mask = torch.randint(0, 2, (bs, D, D), device="cuda", dtype=torch.bool)
-    # lower-triangular-ish variant also covered when bs>=1: force one case
     if bs >= 2:
         draft_mask[1] = torch.tril(torch.ones(D, D, device="cuda", dtype=torch.bool))
 
-    ref = build_ngram_full_tree_mask_ref(draft_mask, seq_lens, D)
-    out = build_ngram_full_tree_mask(draft_mask, seq_lens, D)
+    offsets = _make_offsets(seq_lens, D)
+    required_numel = _required_numel(seq_lens_cpu, D)
+
+    ref = build_ngram_full_tree_mask_ref(draft_mask, seq_lens_cpu, D)
+    out = build_ngram_full_tree_mask(
+        draft_mask,
+        seq_lens,
+        offsets,
+        D,
+        required_numel=required_numel,
+        tree_mask_buf=None,
+    )
+
     assert out.dtype == torch.bool
+    assert out.numel() == required_numel
     assert out.shape == ref.shape
     assert torch.equal(out, ref), (
         f"mismatch bs={bs} D={D} seq_mode={seq_mode} "
@@ -40,7 +75,71 @@ def test_bit_identical(bs, draft_token_num, seq_mode):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_empty_batch():
-    draft_mask = torch.empty(0, 8, 8, dtype=torch.bool, device="cuda")
-    seq_lens = torch.empty(0, dtype=torch.int32)
-    out = build_ngram_full_tree_mask(draft_mask, seq_lens, 8)
+    D = 8
+    draft_mask = torch.empty(0, D, D, dtype=torch.bool, device="cuda")
+    seq_lens = torch.empty(0, dtype=torch.int32, device="cuda")
+    offsets = torch.empty(0, dtype=torch.int32, device="cuda")
+    out = build_ngram_full_tree_mask(
+        draft_mask,
+        seq_lens,
+        offsets,
+        D,
+        required_numel=0,
+        tree_mask_buf=None,
+    )
     assert out.numel() == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("buf_dtype", [torch.bool, torch.uint8])
+def test_preallocated_buffer(buf_dtype):
+    """Oversized tree_mask_buf is filled in-place (EAGLE-style)."""
+    bs, D = 2, 4
+    seq_lens_cpu = torch.tensor([5, 10], dtype=torch.int32)
+    seq_lens = seq_lens_cpu.cuda()
+    draft_mask = torch.tril(torch.ones(bs, D, D, device="cuda", dtype=torch.bool))
+    offsets = _make_offsets(seq_lens, D)
+    required_numel = _required_numel(seq_lens_cpu, D)
+
+    buf = torch.empty(required_numel + 128, dtype=buf_dtype, device="cuda")
+    out = build_ngram_full_tree_mask(
+        draft_mask,
+        seq_lens,
+        offsets,
+        D,
+        required_numel=required_numel,
+        tree_mask_buf=buf,
+    )
+    ref = build_ngram_full_tree_mask_ref(draft_mask, seq_lens_cpu, D)
+
+    assert out.data_ptr() == buf.data_ptr()
+    # Compare the exact prefix (worker does out[:exact]).
+    got = out[:required_numel]
+    if got.dtype != torch.bool:
+        got = got.to(torch.bool)
+    assert torch.equal(got, ref)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_preallocated_buffer_too_small_asserts():
+    bs, D = 1, 4
+    seq_lens_cpu = torch.tensor([8], dtype=torch.int32)
+    seq_lens = seq_lens_cpu.cuda()
+    draft_mask = torch.ones(bs, D, D, device="cuda", dtype=torch.bool)
+    offsets = _make_offsets(seq_lens, D)
+    required_numel = _required_numel(seq_lens_cpu, D)
+
+    short = torch.empty(max(required_numel - 1, 0), dtype=torch.bool, device="cuda")
+    with pytest.raises(AssertionError):
+        build_ngram_full_tree_mask(
+            draft_mask,
+            seq_lens,
+            offsets,
+            D,
+            required_numel=required_numel,
+            tree_mask_buf=short,
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
Replace ngram FULL_MASK Python for-loop with Triton kernel

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`NGRAMWorker._prepare_for_speculative_decoding` has an explicit TODO from the original author. The `FULL_MASK` path builds the per-request `(D, seq_len + D)` tree mask with a Python `for` loop over the batch, issuing `bs` separate `torch.ones` + `torch.cat` + H2D copies per decode step. At large batch sizes this host-side loop becomes a non-trivial portion of the verify-step overhead.

This PR replaces that loop with a single Triton kernel launch.

Refs #21052.

## Modifications

- **New kernel** `python/sglang/kernels/ops/speculative/ngram_mask.py`:
  - `build_ngram_full_tree_mask` — Triton kernel. Grid `(bs, D)`, one program per draft row. Each program fills the `seq_len` history columns with `1` (tiled via `BLOCK_S`) and copies the `draft_mask[b]` block for the right-side `D` columns. Output is a flat `1 x sum(D * (seq_len_i + D))` `bool` tensor (ragged, offsets via exclusive prefix sum of row sizes).
  - `build_ngram_full_tree_mask_ref` — pure-PyTorch reference used by the unit test for bit-identical validation.
- **Worker wiring** `python/sglang/srt/speculative/ngram_worker.py`:
  - Import the new kernel.
  - Replace the `for i in range(bs)` loop with a single `build_ngram_full_tree_mask(draft_mask, seq_lens_cpu, D)` call.
- **Registry**
`python/sglang/kernels/ops/speculative/__init__.py`: registered the kernel metadata.
- **Tests** `test/registered/kernels/ops/speculative/test_ngram_full_tree_mask.py`: bit-identical test against the PyTorch reference across `bs ∈ {1, 2, 8, 32}`, `D ∈ {4, 8}`, mixed `seq_lens`, `seq_len = 0` edge case, and empty-batch guard.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

The FULL mask is a deterministic construction (history = all-ones, right block = draft mask), so correctness is validated by **bit-identical** comparison against the PyTorch reference (`torch.equal`), not by end-to-end generation quality.
```
bs=1   D=4 seq=[0]                            ✅ PASS
bs=1   D=4 seq=[10]                           ✅ PASS
bs=1   D=8 seq=[128]                          ✅ PASS
bs=2   D=4 seq=[5, 20]                        ✅ PASS
bs=8   D=4 seq=[1, 7, 16, 64, 128, 257, 512,  ✅ PASS
bs=32  D=8 seq=[16, 32, 48, 64, 80, 96, 112,  ✅ PASS
```
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

- Results from the latest run (Rev 3):

Microbenchmark on **NVIDIA A100-SXM4-40GB**, torch `2.11.0+cu128`, D=8, warmup=50, iters=200.

| bs | seq_len | elems | Python ref (ms) | Triton e2e (ms) | speedup | Triton+buf (ms) | speedup (buf) |
|----|---------|-------|-----------------|-----------------|---------|-----------------|----------------|
| 1 | 128 | 1,088 | 0.065 | 0.089 | **0.73x** | 0.084 | 0.77x |
| 8 | 256 | 16,896 | 0.308 | 0.131 | **2.35x** | 0.128 | 2.40x |
| 32 | 512 | 133,120 | 1.165 | 0.132 | **8.80x** | 0.124 | 9.37x |
| 64 | 512 | 266,240 | 2.298 | 0.131 | **17.56x** | 0.124 | 18.58x |
| 32 | 2048 | 526,336 | 1.163 | 0.131 | **8.85x** | 0.125 | 9.33x |

**Notes**
- `Python ref` = previous for-loop semantics (`build_ngram_full_tree_mask_ref`).
- `Triton e2e` = per-call `offsets` cumsum + kernel + `empty(required_numel)`.
- `Triton+buf` = same but writes into a preallocated buffer.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30337219846](https://github.com/sgl-project/sglang/actions/runs/30337219846)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30337219709](https://github.com/sgl-project/sglang/actions/runs/30337219709)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->