### PR TITLE
Update audio container test time estimate

### DIFF
--- a/test/registered/unit/multimodal/test_audio_container_decode.py
+++ b/test/registered/unit/multimodal/test_audio_container_decode.py
@@ -24,7 +24,7 @@ from sglang.srt.utils.common import load_audio
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 def _tone(*, sample_rate: int, channels: int = 1) -> np.ndarray:


### PR DESCRIPTION
## Motivation

Use the expected runtime for the audio container CPU test so CI partitioning does not over-allocate it.

## Modifications

Change `register_cpu_ci`'s `est_time` from 15 seconds to 5 seconds. Test behavior is unchanged.

## Accuracy Tests

Not applicable; this only changes CI scheduling metadata.

## Speed Tests and Profiling

- `pre-commit run --files test/registered/unit/multimodal/test_audio_container_decode.py` (passed)
- The targeted test was not run locally because PyAV (`av`) is not installed in the current environment.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Unit tests, documentation, accuracy tests, and benchmarks are not applicable to this CI metadata-only change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30176070994](https://github.com/sgl-project/sglang/actions/runs/30176070994)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30176070890](https://github.com/sgl-project/sglang/actions/runs/30176070890)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->