### PR TITLE
Fix flaky test_sampling_mask: mask length can legitimately be top_k + 1

### DIFF
--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -102,8 +102,12 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
                 "ignore_eos": True,
             }
         )
+        # The mask keeps at most top_k tokens, plus possibly the actually
+        # sampled token when the sampling kernel picks one just outside the
+        # mask's topk reconstruction (fp cumsum divergence); see
+        # Sampler._attach_sampling_mask_to_output.
         for sampling_mask in top_p_sampling_masks:
-            self.assertLessEqual(len(sampling_mask), _TOP_K)
+            self.assertLessEqual(len(sampling_mask), _TOP_K + 1)
 
         top_k_sampling_masks = self._generate_sampling_masks(
             {
@@ -114,7 +118,7 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             }
         )
         for sampling_mask in top_k_sampling_masks:
-            self.assertEqual(len(sampling_mask), _TOP_K)
+            self.assertIn(len(sampling_mask), (_TOP_K, _TOP_K + 1))
 
         top_k_top_p_one_sampling_masks = self._generate_sampling_masks(
             {
@@ -126,7 +130,7 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             }
         )
         for sampling_mask in top_k_top_p_one_sampling_masks:
-            self.assertEqual(len(sampling_mask), _TOP_K)
+            self.assertIn(len(sampling_mask), (_TOP_K, _TOP_K + 1))
 
     def test_sampling_mask_matches_topk_logprobs(self):
         """Check the returned mask and its renormalized logprobs.


### PR DESCRIPTION
## Motivation

`test/registered/sampling/test_sampling_mask.py::TestSamplingMask.test_generate_returns_sampling_mask` is flaky. A recent CI run failed with:

```
File ".../test_sampling_mask.py", line 106, in test_generate_returns_sampling_mask
    self.assertLessEqual(len(sampling_mask), _TOP_K)
AssertionError: 11 not less than or equal to 10
```

### Root cause

The sampling-mask feature and this test were both introduced in the **same** PR, #27408, with a built-in contradiction:

- `Sampler._attach_sampling_mask_to_output` (`python/sglang/srt/layers/sampler.py`) **intentionally** appends the actually-sampled token to the mask when the sampling kernel selects a token that falls just outside the mask's `torch.topk` reconstruction. This is an fp `cumsum` divergence between the mask path and the sampling kernel, and the code comment documents it as deliberate ("the sampler is the source of truth for the rollout action space"). This makes a legitimate mask length of `top_k + 1`.
- The test asserted the mask length is `<= top_k` (and `== top_k` for the `top_k`-only / `top_p=1.0` cases).

So the test has been latent-flaky since it was added, tripping only on the rare numeric edge. It is unrelated to whatever PR happens to be running when it fires.

## Fix

The `+1` behavior is correct and must stay — the mask must contain the sampled token (already enforced by `assertIn(output_id, sampling_mask)` in the helper). This PR relaxes the test to match:

- `top_p` case: `assertLessEqual(len, _TOP_K + 1)`.
- `top_k`-only and `top_p=1.0` cases: `assertIn(len, (_TOP_K, _TOP_K + 1))` — keeps the lower-bound guarantee (a broken `top_k` filter is still caught) while tolerating the documented `+1`.

## Checklist

- [x] Test change only; no runtime behavior change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30177222929](https://github.com/sgl-project/sglang/actions/runs/30177222929)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30177222830](https://github.com/sgl-project/sglang/actions/runs/30177222830)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->