### PR TITLE
[hicache] Propagate override_kv_cache_dim to the draft host KV pool

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -116,7 +116,16 @@ def maybe_register_hicache_draft(
     if isinstance(pool, MHATokenToKVPool):
         draft_host_pool = get_mha_host_pool_cls(pool)(pool, **kw)
     elif isinstance(pool, MLATokenToKVPool):
-        draft_host_pool = MLATokenToKVPoolHost(pool, **kw)
+        # The target host pool may use a scaled KV layout (fp8 storage with
+        # per-block scales plus rope dims kept in the original dtype), whose
+        # per-token stride differs from the one derived from the device pool
+        # alone. Propagate that override so the draft host pool keeps the same
+        # per-token stride -- otherwise the host indices that are 1-to-1 by
+        # construction address slots of a different size.
+        override_dim = getattr(primary, "override_kv_cache_dim", None)
+        draft_host_pool = MLATokenToKVPoolHost(
+            pool, **kw, override_kv_cache_dim=override_dim
+        )
     else:
         logger.warning(
             "Draft pool type %s not supported for HiCache, skipping.",

--- a/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
+++ b/test/registered/unit/mem_cache/test_dsa_pool_host_unit.py
@@ -163,5 +163,68 @@ class TestDSAHiCacheTransfer(unittest.TestCase):
         self._run_device_to_host_indexer_copy(io_backend="direct")
 
 
+class TestDraftHostPoolStrideParity(unittest.TestCase):
+    """The draft host pool must keep the target host pool's per-token stride.
+
+    ``maybe_register_hicache_draft`` allocates the draft host pool with the same
+    slot count as the target host pool so that host indices stay 1-to-1. That
+    only holds if both sides also agree on bytes-per-token, which the target can
+    change through ``override_kv_cache_dim`` (the scaled fp8 KV layout).
+    """
+
+    def setUp(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required to build a device pool.")
+        if is_npu() or is_xpu():
+            self.skipTest("Host pool tests only support CUDA/ROCm.")
+        if not (is_cuda() or is_hip()):
+            self.skipTest("CUDA/ROCm not available.")
+
+    def test_draft_pool_inherits_target_override(self):
+        page_size = 1 if is_hip() else 64
+        device_pool = DSATokenToKVPool(
+            size=page_size * 4,
+            page_size=page_size,
+            kv_lora_rank=128,
+            dtype=torch.bfloat16,
+            qk_rope_head_dim=32,
+            layer_num=2,
+            device="cuda",
+            enable_memory_saver=False,
+            kv_cache_dim=576,
+            index_head_dim=128,
+        )
+        common = dict(
+            host_to_device_ratio=2.0,
+            host_size=0,
+            page_size=page_size,
+            layout="layer_first",
+            pin_memory=False,
+            device="cpu",
+            allocator_type="default",
+        )
+
+        target = MLATokenToKVPoolHost(
+            device_pool=device_pool,
+            override_kv_cache_dim=device_pool.kv_cache_dim,
+            **common,
+        )
+        draft = MLATokenToKVPoolHost(
+            device_pool=device_pool,
+            override_kv_cache_dim=getattr(target, "override_kv_cache_dim", None),
+            **common,
+        )
+        self.assertEqual(target.get_size_per_token(), draft.get_size_per_token())
+
+        # Guard against the assertion above passing for the wrong reason: with
+        # the override dropped, the draft side derives kv_lora_rank +
+        # qk_rope_head_dim instead, which is exactly what breaks the 1-to-1
+        # host index assumption.
+        without_override = MLATokenToKVPoolHost(device_pool=device_pool, **common)
+        self.assertNotEqual(
+            target.get_size_per_token(), without_override.get_size_per_token()
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`maybe_register_hicache_draft()` creates the draft host KV pool with the same
slot count as the target host pool, and the comment states the intent:

```python
# Create host pool for draft with the same slot count as the target host pool,
# so that host indices stay 1-to-1 between target and draft KV caches.
```

The per-token **stride** is not kept in sync, though. The target host pool can be
constructed with `override_kv_cache_dim` (see `build_kv_host_pool()` in
`hybrid_pool_assembler.py`), which is how the scaled fp8 KV layout is expressed:
`kv_lora_rank + kv_lora_rank // quant_block_size * 4 + qk_rope_head_dim *
rope_storage_dtype.itemsize`.

`maybe_register_hicache_draft()` does not forward it, so `MLATokenToKVPoolHost`
falls back to its default in `get_size_per_token()`:

```python
self.kv_cache_dim = self.override_kv_cache_dim or (
    self.kv_lora_rank + self.qk_rope_head_dim
)
```

Result: with fp8 KV + hierarchical cache + a draft (MTP/EAGLE) worker, the target
and draft host pools disagree on bytes-per-token while their host indices are
1-to-1 by construction. A host index therefore addresses slots of two different
sizes on the two sides.

The failure is layout-dependent rather than immediate: light load mostly touches
the region where the two strides still overlap, so it surfaces as sporadic
garbage in restored draft KV, and as batched host↔device copy failures once
enough concurrent requests push transfers past the smaller stride. This matches
the symptom reported in #31600 (fp8 KV + L2/L3 hierarchical cache), which has no
fix on `main` today.

## Modification

Forward the target host pool's `override_kv_cache_dim` when constructing the
draft host pool, so both sides derive the same per-token stride.

Scoped to the MLA branch, since `override_kv_cache_dim` is an
`MLATokenToKVPoolHost` parameter. `getattr(..., None)` keeps the call safe for
target pools that were built without an override — that path is unchanged.

## Tests

Added `TestDraftHostPoolStrideParity` to
`test/registered/unit/mem_cache/test_dsa_pool_host_unit.py`, alongside the
existing DSA host-pool unit tests and using the same fixture and CUDA/ROCm
guards.

It asserts that a draft host pool built with the target's override reports the
same `get_size_per_token()` as the target, and — so the parity assertion cannot
pass for the wrong reason — that dropping the override changes it.

## Checklist

- [x] Behavior is unchanged when the target pool has no override (`None` is the
      existing default).
- [x] No new configuration or flags.
- [x] Unit test added next to the existing host-pool tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30185616949](https://github.com/sgl-project/sglang/actions/runs/30185616949)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30185616851](https://github.com/sgl-project/sglang/actions/runs/30185616851)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->