### PR TITLE
refactor(dsv4): use explicit speculative forward state

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1147,11 +1147,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             state_types = self.kv_manager.kv_args.state_types
             state_indices: Optional[List] = []
             if StateType.C128_STATE in state_types:
-                clear_c128_state = getattr(
-                    self.token_to_kv_pool, "clear_c128_req_state", None
+                assert isinstance(
+                    self.token_to_kv_pool, DeepSeekV4TokenToKVPool
                 )
-                if clear_c128_state is not None:
-                    clear_c128_state(int(decode_req.req.req_pool_idx))
+                self.token_to_kv_pool.clear_c128_req_state(
+                    int(decode_req.req.req_pool_idx)
+                )
             for st in state_types:
                 if st == StateType.MAMBA:
                     state_indices.append(_mamba_payload())

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -990,7 +990,7 @@ def setup_state_kv_args(
                         ring_lens,
                         ring_item_lens,
                     )
-            if hasattr(token_to_kv_pool, "get_c128_state_buf_infos"):
+            if isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool):
                 c128_ptrs, c128_lens, c128_item_lens = (
                     token_to_kv_pool.get_c128_state_buf_infos()
                 )

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -60,6 +60,8 @@ from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_parallel
+from sglang.srt.speculative.dflash_info import DFlashVerifyInput
+from sglang.srt.speculative.eagle_info import EagleVerifyInput
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
@@ -90,19 +92,6 @@ C4_TOPK = 512
 PAGE_INDEX_ALIGNED_SIZE = 64
 
 
-def _get_logical_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
-    # IDLE is a real per-DP-rank mode. Do not let a stale _original_forward_mode
-    # from a reused/padded ForwardBatch turn an empty rank into TARGET_VERIFY.
-    if forward_batch.forward_mode.is_idle():
-        return forward_batch.forward_mode
-    if forward_batch.forward_mode == ForwardMode.EXTEND:
-        return forward_batch.forward_mode
-    return (
-        getattr(forward_batch, "_original_forward_mode", None)
-        or forward_batch.forward_mode
-    )
-
-
 def _get_target_verify_bs(forward_batch: ForwardBatch) -> int:
     actual_forward_mode = getattr(
         forward_batch, "actual_forward_mode", forward_batch.forward_mode
@@ -110,9 +99,11 @@ def _get_target_verify_bs(forward_batch: ForwardBatch) -> int:
     if actual_forward_mode.is_idle():
         return 0
 
-    spec_info = getattr(forward_batch, "spec_info", None)
-    draft_token_num = getattr(spec_info, "draft_token_num", 0)
-    draft_token = getattr(spec_info, "draft_token", None)
+    spec_info = forward_batch.spec_info
+    if not isinstance(spec_info, (EagleVerifyInput, DFlashVerifyInput)):
+        return forward_batch.batch_size
+    draft_token_num = spec_info.draft_token_num
+    draft_token = spec_info.draft_token
     if draft_token is None:
         return forward_batch.batch_size
     if draft_token_num <= 0:
@@ -1350,8 +1341,7 @@ class DeepseekV4AttnBackend(
             )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch) -> None:
-        logical_forward_mode = _get_logical_forward_mode(forward_batch)
-        if self.mtp_enabled and logical_forward_mode.is_idle():
+        if self.mtp_enabled and forward_batch.forward_mode.is_idle():
             self.online_c128_mtp.clear()
             return
 
@@ -1365,7 +1355,7 @@ class DeepseekV4AttnBackend(
         max_seq_len_override: Optional[int] = None,
         use_prefill_cuda_graph: bool = False,
     ):
-        logical_forward_mode = _get_logical_forward_mode(forward_batch)
+        forward_mode = forward_batch.forward_mode
         req_pool_indices = forward_batch.req_pool_indices
         seq_lens = forward_batch.seq_lens.to(torch.int32)
         # Regular prefill batches already carry scheduler-maintained CPU lengths.
@@ -1385,13 +1375,13 @@ class DeepseekV4AttnBackend(
             max_seq_len = self.MAX_SEQ_LEN_FOR_CAPTURE
         verify_bs = _get_target_verify_bs(forward_batch)
         online_c128_state_slot_offset = self.online_c128_mtp.prepare_forward(
-            logical_forward_mode,
+            forward_mode,
             req_pool_indices,
             seq_lens,
             verify_bs=verify_bs,
         )
 
-        if logical_forward_mode.is_decode_or_idle():
+        if forward_mode.is_decode_or_idle():
             # DSv4 bakes this step's KV write target (c4/c128) into metadata,
             # so slice the shared multi-step out_cache_loc now, not at forward time.
             out_cache_loc = forward_batch.out_cache_loc
@@ -1408,7 +1398,7 @@ class DeepseekV4AttnBackend(
                 seq_lens=seq_lens,
                 out_cache_loc=out_cache_loc,
             )
-        elif self.is_dspark_draft and logical_forward_mode.is_target_verify():
+        elif self.is_dspark_draft and forward_mode.is_target_verify():
             block_size = int(forward_batch.spec_info.draft_token_num)
             metadata = self.init_forward_metadata_dspark_draft_block(
                 max_seq_len=max_seq_len,
@@ -1418,7 +1408,7 @@ class DeepseekV4AttnBackend(
                 out_cache_loc=forward_batch.out_cache_loc,
                 block_size=block_size,
             )
-        elif logical_forward_mode.is_target_verify():
+        elif forward_mode.is_target_verify():
             ragged_layout = self._resolve_verify_layout(forward_batch, bs=len(seq_lens))
             metadata = self.init_forward_metadata_target_verify(
                 max_seq_len=max_seq_len,
@@ -1429,7 +1419,7 @@ class DeepseekV4AttnBackend(
                 online_c128_state_slot_offset=online_c128_state_slot_offset,
                 ragged_layout=ragged_layout,
             )
-        elif logical_forward_mode.is_draft_extend_v2():
+        elif forward_mode.is_draft_extend_v2():
             num_tokens_per_req = self.speculative_num_draft_tokens
             assert num_tokens_per_req > 0
             metadata = self.init_forward_metadata_draft_extend(
@@ -1438,7 +1428,7 @@ class DeepseekV4AttnBackend(
                 num_tokens_per_req=num_tokens_per_req,
                 out_cache_loc=forward_batch.out_cache_loc,
             )
-        elif logical_forward_mode.is_prefill():
+        elif forward_mode.is_prefill():
             extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
             extend_seq_lens = forward_batch.extend_seq_lens
             assert (

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -274,10 +274,7 @@ class CompressorBackendMixin:
                 layer_id=layer_id,
                 compressor=compressor,
                 kv_score_input=kv_score_input,
-                logical_forward_mode=getattr(
-                    forward_batch, "_original_forward_mode", None
-                )
-                or forward_batch.forward_mode,
+                logical_forward_mode=forward_batch.forward_mode,
             )
 
     def _forward_unified_hip(

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -8,6 +8,7 @@ from sglang.kernels.ops.speculative.cache_locs import (
     assign_draft_cache_locs_contiguous,
 )
 from sglang.kernels.ops.speculative.eagle import fill_bonus_tokens_func
+from sglang.srt.configs.model_config import is_deepseek_v4
 from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.model_executor.forward_batch_info import (
@@ -583,13 +584,17 @@ def run_eagle_verify(
         accept_index,
     ) = eagle_sample(verify_input, batch, logits_output, grammar_mask)
     new_seq_lens = batch.seq_lens + accept_lens
-    clear_unaccepted_c128 = getattr(
-        token_to_kv_pool_allocator.get_kvcache(),
-        "clear_unaccepted_c128_draft_states",
-        None,
-    )
-    if clear_unaccepted_c128 is not None and not batch.forward_mode.is_idle():
-        clear_unaccepted_c128(
+    if (
+        is_deepseek_v4(target_worker.model_config.hf_config)
+        and not batch.forward_mode.is_idle()
+    ):
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
+            DeepSeekV4TokenToKVPool,
+        )
+
+        target_kv_cache = token_to_kv_pool_allocator.get_kvcache()
+        assert isinstance(target_kv_cache, DeepSeekV4TokenToKVPool)
+        target_kv_cache.clear_unaccepted_c128_draft_states(
             batch.req_pool_indices,
             batch.seq_lens,
             accept_lens,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

PR #31705 established that DSV4 metadata should follow the forward mode actually being executed. In particular, DP padding can convert an idle rank into a dummy `EXTEND`, so restoring `_original_forward_mode` can build incorrect attention metadata.

The existing `_get_logical_forward_mode` helper and the compressor-side fallback could still resolve the mode differently.

Additionally, `_get_target_verify_bs` used defensive `getattr` calls for fields guaranteed by speculative verify input types, contrary to the current `no-getattr-defensive` rule.

## Changes

- Remove `_get_logical_forward_mode`.
- Use `forward_batch.forward_mode` consistently for DSV4 metadata planning.
- Use the same current forward mode for online C128 MTP prefix-state writes.
- Narrow `spec_info` to `EagleVerifyInput` or `DFlashVerifyInput`.
- Access `draft_token` and `draft_token_num` directly after type narrowing.
- Replace defensive C128 pool method discovery with explicit DSV4 type narrowing.
- Make invalid C128 state/pool combinations fail fast instead of silently skipping cleanup or transfer registration.

This keeps metadata planning and online C128 state handling consistent for DP dummy-extend, EAGLE verify paths.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30185549888](https://github.com/sgl-project/sglang/actions/runs/30185549888)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30185549777](https://github.com/sgl-project/sglang/actions/runs/30185549777)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->