### PR TITLE
[diffusion] fix: preserve tensor stride when offloading rollout weights to pinned host memory

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/memory_occupation_controller.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/memory_occupation_controller.py
@@ -20,7 +20,16 @@ def _module_to_pinned_cpu(module: torch.nn.Module) -> None:
     # Async D2H into pinned host memory; caller synchronizes once after the batch.
     for t in list(module.parameters()) + list(module.buffers()):
         if t.device.type == "cuda":
-            pin = torch.empty(t.shape, dtype=t.dtype, device="cpu", pin_memory=True)
+            # Mirror stride/layout like srt/utils/offloader.py: torch.empty() would force
+            # contiguous and silently drop channels_last_3d VAE weights.
+            pin = torch.empty_strided(
+                size=t.size(),
+                stride=t.stride(),
+                dtype=t.dtype,
+                layout=t.layout,
+                device="cpu",
+                pin_memory=True,
+            )
             pin.copy_(t.data, non_blocking=True)
             t.data = pin
 


### PR DESCRIPTION
## Motivation

#32032 allocates the pinned host buffer with `torch.empty(t.shape, ...)`, which is always
contiguous, so `channels_last_3d` VAE weights lose their layout on the first offload/onload cycle.

Caught by a downstream RL trainer whose LTX-2 end-to-end CI compares 8 rollout/train metric
series against a recorded standard with **zero tolerance**.

### What the e2e CI shows

| image | sglang | this patch | LTX-2 e2e | SD3.5 e2e |
| --- | --- | --- | --- | --- |
| A | `f5155d960` | no | pass (bitwise) | pass |
| B (rebuilt) | `5f330004b` | no | **16 mismatches** | pass |
| B (rerun, same job) | `5f330004b` | no | **same 16 values, bit for bit** | — |
| B | `f5155d960` (pinned back) | no | pass (bitwise) | pass |
| B | `main` @ `2cbddb8` | **yes** | **pass (bitwise)** | pass |

<details>
<summary>the 16 mismatching values</summary>

| metric | got | standard |
| --- | --- | --- |
| `rollout/reward/raw_mean[0]` | 0.6850658655166626 | 0.6850860714912415 |
| `rollout/reward/raw_mean[1]` | 0.6818724274635315 | 0.6819055080413818 |
| `rollout/reward/raw_median[0]` | 0.6865472197532654 | 0.6864451766014099 |
| `rollout/reward/raw_median[1]` | 0.6884157657623291 | 0.6862333416938782 |
| `rollout/reward/raw_std[0]` | 0.04092217609286308 | 0.04088980332016945 |
| `rollout/reward/raw_std[1]` | 0.0413697324693203 | 0.042159032076597214 |
| `train/log_prob_new_idx_0[1]` | -0.84808050096035 | -0.8480804711580276 |
| `train/log_prob_new_idx_0[2]` | -0.773220106959343 | -0.7732202410697937 |
| `train/log_prob_new_idx_0[3]` | -0.7731630802154541 | -0.773162916302681 |
| `train/log_prob_mean_abs_diff[1]` | 1.2026479083715458e-06 | 1.1889885058735672e-06 |
| `train/log_prob_mean_abs_diff[2]` | 1.844639598402864e-06 | 1.822287885033802e-06 |
| `train/log_prob_mean_abs_diff[3]` | 1.7341226907774399e-06 | 1.7614414389299782e-06 |
| `train/grad_norm[0]` | 1.1415144399506971e-05 | 1.147376860899385e-05 |
| `train/grad_norm[1]` | 1.3577490790339652e-05 | 1.245457497134339e-05 |
| `train/grad_norm[2]` | 2.1241405192995444e-05 | 2.025627691182308e-05 |
| `train/grad_norm[3]` | 2.229028359579388e-05 | 1.9314091332489625e-05 |

`rollout/reward/raw_num_samples` matched, and `raw_mean[0]` is the first rollout, before any
training step.
</details>

### What isolates the cause

| check | result |
| --- | --- |
| changed files under `multimodal_gen/` in `f5155d960...5f330004b` | exactly 1 — this one |
| base image digest and `kernels lock` FA3 revision across A and B | identical |
| SD3.5 (2D VAE, not in `_should_use_channels_last_3d`) | green in every run |
| rerun on an unchanged environment | bit-for-bit identical, so not flakiness |

### Chain

| step | code | effect |
| --- | --- | --- |
| load | `vae_loader.py` → `_convert_conv3d_weights_to_channels_last_3d` | Conv3d weights stored as `channels_last_3d` |
| offload | `torch.empty(t.shape, ...)` + `copy_` | host buffer contiguous, stride dropped |
| onload | `module.to(device)` | preserves what CPU holds, i.e. contiguous |
| forward | `ltx_2_vae._weight_is_channels_last_3d()` → `False` | cuDNN NDHWC → NCDHW, different accumulation order |

Scope per `_should_use_channels_last_3d`: QwenImage always; Wan / LTX-2 when `num_gpus == 1`.

## Modifications

| | allocation |
| --- | --- |
| before | `torch.empty(t.shape, dtype=...)` |
| after | `torch.empty_strided(size=, stride=, dtype=, layout=, device="cpu", pin_memory=True)` |

Same allocation `srt/utils/offloader.py` already uses, including its note that
`torch.empty_like` takes no `pin_memory` argument. The buffer stays pinned, so the async
D2H/H2D benefit of #32032 is unaffected.

## Checklist

| item | status |
| --- | --- |
| format / lint | done |
| verified on a real workload | LTX-2 GRPO rollout, 4x single-GPU engines — last row of the table above |
| unit test | not added — the branch only runs for CUDA tensors, so a CPU runner cannot reach it. Happy to add a GPU test asserting `weight.stride()` survives an offload/onload cycle |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30187048336](https://github.com/sgl-project/sglang/actions/runs/30187048336)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30187048257](https://github.com/sgl-project/sglang/actions/runs/30187048257)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->