### PR TITLE
[sglang-miles] Allow load_lora_adapter_from_distributed under dp attention

### DIFF
--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -773,9 +773,13 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
+            # Same contract as load_lora_adapter / load_lora_adapter_from_tensors and
+            # update_weights_from_distributed: the tokenizer->scheduler broadcast and
+            # the weight-update NCCL group both cover every dp-attention rank, so dp>1
+            # is fine as long as dp attention is enabled.
             assert (
-                self.server_args.dp_size == 1
-            ), "dp_size must be 1 for dynamic lora loading"
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
             logger.info(
                 "Start load Lora adapter from distributed. Lora name=%s, group=%s",
                 obj.lora_name,


### PR DESCRIPTION
## Motivation

`load_lora_adapter_from_distributed` was the only LoRA update endpoint still asserting `dp_size == 1`. Its three siblings — `load_lora_adapter`, `load_lora_adapter_from_tensors`, `unload_lora_adapter` — were all relaxed to `dp_size == 1 or dp attention must be enabled`, as was `update_weights_from_distributed` for base weights.

The stale assert blocked the one route that supports **upsert** (the disaggregated RL weight-sync path) on every dp-attention serving config — GLM-5.2's standard recipe (`--enable-dp-attention --dp-size N` with NSA attention) among them. Colocate single-LoRA runs never hit it because they load adapters from tensors; disaggregated multi-LoRA dies at the first slot load.

## Modifications

Relax the assert to match the sibling endpoints: `dp_size == 1 or enable_dp_attention`. All four LoRA routes share `update_lora_adapter_communicator` for the tokenizer→scheduler broadcast, and the weight-update NCCL group already covers every dp-attention rank (the same topology `update_weights_from_distributed` relies on), so no other change is needed.

## Accuracy Test

Verified by a GLM-5.2_5layer multi-LoRA e2e (miles, disaggregated 4 train + 4 rollout GPUs, 2 engines with dp-attention `ep=dp=2`): both DP ranks of both engines receive the initial slot load and the per-step upserts (3 rounds, all `200 OK`), and the run completes 3 training steps end-to-end with correct rollouts.

## Benchmarking and Profiling

No performance impact — one assert condition at the endpoint entry.

## Checklist

- [x] Format the code with pre-commit.
- [ ] Tests: one-line assert relaxation matching three sibling endpoints; covered by the e2e above. Existing `test_lora_upsert.py` continues to cover the dp_size=1 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30187943315](https://github.com/sgl-project/sglang/actions/runs/30187943315)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30187943137](https://github.com/sgl-project/sglang/actions/runs/30187943137)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->