### PR TITLE
[comm] Add zero-copy NVLS multicast to custom-AR v2

### DIFF
--- a/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
+++ b/python/sglang/kernels/jit/csrc/distributed/custom_all_reduce.cuh
@@ -37,10 +37,13 @@ using host::distributed::CommunicatorRef;
 
 inline constexpr uint32_t kMaxWorldSize = device::distributed::kMaxWorldSize;
 
+// Graph* reduce the registered graph inputs in place (cuda-graph only, zero-copy);
+// Eager* stage the input through the pull workspace; *Multicast use NVLS multimem.
 enum class PullMode {
   Graph,
   Eager,
-  Multicast,  // also eager
+  GraphMulticast,
+  EagerMulticast,
 };
 
 template <typename T>
@@ -405,7 +408,7 @@ struct AllReducePullImpl {
     const auto num_threads = blockDim.x * gridDim.x;
     const auto global_tid = blockIdx.x * blockDim.x + threadIdx.x;
     for (auto vid = global_tid; vid < num_vecs; vid += num_threads) {
-      if constexpr (kMode == PullMode::Multicast) {
+      if constexpr (kMode == PullMode::EagerMulticast || kMode == PullMode::GraphMulticast) {
         vec_t out_vec;
         ld_multimem_16B(out_vec, mc_addr, vid);
         if constexpr (kIs2shot) {
@@ -476,7 +479,15 @@ struct AllReducePullImpl {
       }
     }
     const auto counter = sync_enter_pull<false>(params);
-    const auto mc_addr = reinterpret_cast<vec_t*>(params.pull_mc_workspace) + local_vec_bias;
+    // GraphMulticast reduces the registered input's own multicast VA in place (zero
+    // copy); EagerMulticast reduces the staged pull_mc_workspace.
+    void* mc_base;
+    if constexpr (kMode == PullMode::GraphMulticast) {
+      mc_base = params.graph_params[0];
+    } else {
+      mc_base = params.pull_mc_workspace;
+    }
+    const auto mc_addr = reinterpret_cast<vec_t*>(mc_base) + local_vec_bias;
     reduce_impl<true>(local_num_vecs, data, params.output, mc_addr);
     sync_exit_pull<true>(params, counter);
   }
@@ -535,7 +546,8 @@ struct AllReduceKernel {
   static constexpr auto kernel_push = all_reduce_kernel<AllReducePushImpl<T, kWorldSize, kUsePDL>, kWorldSize, kShot>;
 
  public:
-  static Tensor run(CommunicatorRef ref, Tensor in_, std::string algo, std::variant<TensorView, bool> pull_arg) {
+  static Tensor
+  run(CommunicatorRef ref, Tensor in_, std::string algo, std::variant<TensorView, bool> pull_arg, bool multicast) {
     using namespace host;
     const auto& data = *ref.get();
     RuntimeCheck(algo == "1shot_pull" || algo == "2shot_pull" || algo == "1shot_push", "Invalid algo: ", algo);
@@ -586,8 +598,9 @@ struct AllReduceKernel {
 
     using enum PullMode;
     RuntimeCheck(nbytes <= data.pull_bytes, "Input size ", nbytes, " exceeds pull workspace size ", data.pull_bytes);
-    const auto pull_mode = use_graph ? Graph : std::get<bool>(pull_arg) ? Multicast : Eager;
-    RuntimeCheck(pull_mode != Multicast || data.pull_mc_workspace != nullptr, "Multicast requires an mc workspace");
+    const auto pull_mode = use_graph ? (multicast ? GraphMulticast : Graph) : (multicast ? EagerMulticast : Eager);
+    RuntimeCheck(
+        pull_mode != EagerMulticast || data.pull_mc_workspace != nullptr, "EagerMulticast requires an mc workspace");
 
     const uint32_t num_blocks = data.num_pull_blocks;
     const auto cuda_memcpy = [&](void* dst, const void* src) {
@@ -614,7 +627,7 @@ struct AllReduceKernel {
       if (!use_graph) cuda_memcpy(local_workspace, in_.data_ptr());
       const auto kernel = (pull_mode == Graph) ? kernel_pull<1, Graph>
                           : pull_mode == Eager ? kernel_pull<1, Eager>
-                                               : kernel_pull<1, Multicast>;
+                                               : kernel_pull<1, EagerMulticast>;
       // then launch kernel to reduce and write to output
       LaunchKernel(num_blocks, choose_block_size(num_vecs), stream)  //
           .enable_pdl(kUsePDL)(kernel, params);
@@ -623,10 +636,11 @@ struct AllReduceKernel {
       // first copy to workspace
       if (!use_graph) cuda_memcpy(local_workspace, in_.data_ptr());
       // then launch kernel to reduce in workspace
-      const auto kernel = (pull_mode == Graph) ? kernel_pull<2, Graph>
-                          : pull_mode == Eager ? kernel_pull<2, Eager>
-                                               : kernel_pull<2, Multicast>;
-      if (pull_mode == Multicast) {
+      const auto kernel = (pull_mode == Graph)          ? kernel_pull<2, Graph>
+                          : pull_mode == Eager          ? kernel_pull<2, Eager>
+                          : pull_mode == EagerMulticast ? kernel_pull<2, EagerMulticast>
+                                                        : kernel_pull<2, GraphMulticast>;
+      if (pull_mode == EagerMulticast || pull_mode == GraphMulticast) {
         const auto max_blocks = data.num_multicast_blocks;
         constexpr uint32_t kMulticastNumThreads = 512u;
         // NOTE: too much traffic will degrade performance in multicast
@@ -645,8 +659,12 @@ struct AllReduceKernel {
 
 template <typename T, uint32_t kWorldSize, bool kUsePDL>
 tvm::ffi::Tensor custom_all_reduce(
-    CommunicatorRef comm, tvm::ffi::Tensor input, std::string algo, std::variant<tvm::ffi::TensorView, bool> pull_arg) {
-  return AllReduceKernel<T, kWorldSize, kUsePDL>::run(comm, input, algo, pull_arg);
+    CommunicatorRef comm,
+    tvm::ffi::Tensor input,
+    std::string algo,
+    std::variant<tvm::ffi::TensorView, bool> pull_arg,
+    bool multicast) {
+  return AllReduceKernel<T, kWorldSize, kUsePDL>::run(comm, input, algo, pull_arg, multicast);
 }
 
 }  // namespace

--- a/python/sglang/kernels/ops/communication/all_reduce.py
+++ b/python/sglang/kernels/ops/communication/all_reduce.py
@@ -36,8 +36,9 @@ _ALGO_NAMES = {
     AllReduceAlgo.TWO_SHOT_PULL: "2shot_pull",
 }
 
-# ``pull_arg`` of the all-reduce kernel: a row of the graph-params pointer
-# table selects graph mode; a plain bool selects multicast (True) / eager.
+# ``pull_arg``: a row of the graph-params pointer table selects graph mode (the
+# registered peer VAs, or a 1-wide multicast-VA row); a plain bool selects eager.
+# The ``multicast`` flag (NVLS multimem vs SM pull) is orthogonal.
 PullArg = Union[torch.Tensor, bool]
 
 if TYPE_CHECKING:
@@ -155,9 +156,10 @@ def custom_all_reduce(
     input: torch.Tensor,
     algo: AllReduceAlgo,
     pull_arg: PullArg,
+    multicast: bool = False,
 ) -> tvm_ffi.Tensor:
     module = get_all_reduce_module(input.dtype, comm.world_size)
-    return module.all_reduce(comm, input, algo.algo_name, pull_arg)
+    return module.all_reduce(comm, input, algo.algo_name, pull_arg, multicast)
 
 
 @cache_once

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -43,6 +43,7 @@ from .custom_all_reduce_utils import (
     is_one_nvlink_clique,
     is_weak_contiguous,
 )
+from .fabric_multicast import FabricMulticastRegistry
 from .vmm_utils import (
     VmmGraphInputManager,
     compute_graph_capture_bases,
@@ -61,9 +62,10 @@ _DEFAULT_MAX_SIZE = envs.SGLANG_CUSTOM_ALL_REDUCE_V2_MAX_SIZE_KB.get() * 1024
 
 
 class _PullMode(enum.Enum):
-    EAGER = enum.auto()  # pull_arg = False (also used for 1shot_push)
-    MULTICAST = enum.auto()  # pull_arg = True
-    GRAPH = enum.auto()  # pull_arg = a graph_params row
+    EAGER = enum.auto()  # pull_arg=False, multicast=False (also 1shot_push)
+    EAGER_MULTICAST = enum.auto()  # pull_arg=False, multicast=True
+    GRAPH = enum.auto()  # pull_arg=graph_params row, multicast=False
+    GRAPH_MULTICAST = enum.auto()  # pull_arg=graph_mc_params row, multicast=True
 
 
 def _ceil_align(nbytes: int, align: int) -> int:
@@ -118,6 +120,7 @@ class CustomAllReduceV2:
         self.device = device
         self.rank = dist.get_rank(group=self.group)
         self.world_size = dist.get_world_size(group=self.group)
+        self.multi_node = not all(in_the_same_node_as(self.group, source_rank=0))
         base_config = get_all_reduce_config(self.world_size)
         if max_pull_size is None:
             max_pull_size = min(base_config.max_pull_bytes, max_size)
@@ -158,6 +161,19 @@ class CustomAllReduceV2:
         self._graph_inputs: List[Tuple[int, int]] = []  # (data_ptr, nbytes)
         self._graph_counter = 0
         self._graph_mode_allowed = False
+        self._warned_non_vmm_staging = False
+        # GraphMulticast path: per-input multicast VAs (one each, vs graph_params'
+        # world_size peer row), bound post-capture by the fabric mc registry.
+        self.graph_mc_params = torch.zeros(
+            (_MAX_GRAPH_INPUTS, 1), dtype=torch.uint64, device=self.device
+        )
+        self._graph_mc_inputs: List[Tuple[int, int]] = []  # (data_ptr, nbytes)
+        self._graph_mc_counter = 0
+        self._fabric_mc_registry = (
+            FabricMulticastRegistry(self.group)
+            if self.config.num_mc_blocks is not None
+            else None
+        )
         self.disabled = False
 
     def _init_workspace(self) -> None:
@@ -278,7 +294,10 @@ class CustomAllReduceV2:
         if nbytes <= heuristic.one_shot_pull_threshold:
             return AllReduceAlgo.ONE_SHOT_PULL, default_mode
         if use_multicast and heuristic.mc.contains(nbytes):
-            return AllReduceAlgo.TWO_SHOT_PULL, _PullMode.MULTICAST
+            if can_use_graph and self._fabric_mc_registry is not None:
+                # zero-copy: multicast-reduce the registered input in place, no staging
+                return AllReduceAlgo.TWO_SHOT_PULL, _PullMode.GRAPH_MULTICAST
+            return AllReduceAlgo.TWO_SHOT_PULL, _PullMode.EAGER_MULTICAST
         if nbytes <= heuristic.two_shot_pull_threshold:
             return AllReduceAlgo.TWO_SHOT_PULL, default_mode
         return None, _PullMode.EAGER
@@ -312,11 +331,33 @@ class CustomAllReduceV2:
         else:
             algo, mode = self._pick_algo(nbytes, can_use_graph=can_use_graph)
             assert algo is not None, f"No algo for {nbytes} bytes"
+        mode = self._stage_if_non_vmm(mode, input)
         if mode == _PullMode.GRAPH:
             pull_arg: torch.Tensor | bool = self._allocate_graph_row(input, nbytes)
+        elif mode == _PullMode.GRAPH_MULTICAST:
+            pull_arg = self._allocate_graph_mc_row(input, nbytes)
         else:
-            pull_arg = mode == _PullMode.MULTICAST
-        return torch.from_dlpack(custom_all_reduce(self.obj, input, algo, pull_arg))
+            pull_arg = False  # eager: no graph row; the multicast flag carries mc-ness
+        multicast = mode in (_PullMode.EAGER_MULTICAST, _PullMode.GRAPH_MULTICAST)
+        return torch.from_dlpack(
+            custom_all_reduce(self.obj, input, algo, pull_arg, multicast)
+        )
+
+    def _stage_if_non_vmm(self, mode: _PullMode, input: torch.Tensor) -> _PullMode:
+        if mode not in (_PullMode.GRAPH, _PullMode.GRAPH_MULTICAST):
+            return mode
+        if not self.multi_node or is_vmm_pointer(input.data_ptr()):
+            return mode
+        if not self._warned_non_vmm_staging:
+            logger.warning(
+                "custom-AR-v2: multi-node graph input is not VMM-backed "
+                "(expandable_segments off) -> staging through the workspace; set "
+                "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True for zero-copy."
+            )
+            self._warned_non_vmm_staging = True
+        if mode == _PullMode.GRAPH_MULTICAST:
+            return _PullMode.EAGER_MULTICAST
+        return _PullMode.EAGER
 
     def _allocate_graph_row(self, input: torch.Tensor, nbytes: int) -> torch.Tensor:
         index = self._graph_counter + len(self._graph_inputs)
@@ -325,6 +366,14 @@ class CustomAllReduceV2:
         ), "Graph input table overflow, increase _MAX_GRAPH_INPUTS!"
         self._graph_inputs.append((input.data_ptr(), nbytes))
         return self.graph_params[index]
+
+    def _allocate_graph_mc_row(self, input: torch.Tensor, nbytes: int) -> torch.Tensor:
+        index = self._graph_mc_counter + len(self._graph_mc_inputs)
+        assert (
+            index < _MAX_GRAPH_INPUTS
+        ), "Graph mc input table overflow, increase _MAX_GRAPH_INPUTS!"
+        self._graph_mc_inputs.append((input.data_ptr(), nbytes))
+        return self.graph_mc_params[index]
 
     # ------------------------------------------------------------------
     # CUDA-graph input registration
@@ -346,14 +395,41 @@ class CustomAllReduceV2:
         self._register_graph_inputs()
 
     def _register_graph_inputs(self) -> None:
-        if not self._graph_inputs:
+        if self._graph_inputs:
+            first_ptr = self._graph_inputs[0][0]
+            if is_vmm_pointer(first_ptr):
+                # calls back into get_graph_capture_bases / register_peer_mapped_inputs
+                self._vmm_graph_input_manager.register_graph_inputs()
+            elif self.multi_node:
+                # Unreachable: custom_all_reduce stages non-VMM multi-node inputs
+                # (eager) rather than registering them. Fail loud if that breaks.
+                raise RuntimeError(
+                    "custom-AR-v2: non-VMM multi-node graph input reached "
+                    "registration; should have been staged in custom_all_reduce"
+                )
+            else:
+                self._register_graph_inputs_ipc()
+        self._register_graph_mc_inputs()
+
+    def _register_graph_mc_inputs(self) -> None:
+        if not self._graph_mc_inputs:
             return
-        first_ptr = self._graph_inputs[0][0]
-        if is_vmm_pointer(first_ptr):
-            # calls back into get_graph_capture_bases / register_peer_mapped_inputs
-            self._vmm_graph_input_manager.register_graph_inputs()
-        else:
-            self._register_graph_inputs_ipc()
+        assert self._fabric_mc_registry is not None
+        count = len(self._graph_mc_inputs)
+        mc_addrs = [
+            self._fabric_mc_registry.register_ptr(dp, nbytes)
+            for dp, nbytes in self._graph_mc_inputs
+        ]
+        rows = torch.tensor(mc_addrs, dtype=torch.uint64, device=self.device).view(
+            count, 1
+        )
+        self.graph_mc_params[
+            self._graph_mc_counter : self._graph_mc_counter + count
+        ].copy_(rows)
+        # the rows must be visible before any (PDL-chained) graph replay
+        torch.cuda.synchronize()
+        self._graph_mc_counter += count
+        self._graph_mc_inputs.clear()
 
     def _register_graph_inputs_ipc(self) -> None:
         """Register graph capture inputs via cudaIpc handles.
@@ -404,6 +480,11 @@ class CustomAllReduceV2:
             del self.obj  # drop the pointer holder before the workspace tensors
         if hasattr(self, "_vmm_graph_input_manager"):
             self._vmm_graph_input_manager.close()
+        if (
+            hasattr(self, "_fabric_mc_registry")
+            and self._fabric_mc_registry is not None
+        ):
+            self._fabric_mc_registry.release()
 
     def __del__(self):
         self.close()

--- a/python/sglang/srt/distributed/device_communicators/fabric_multicast.py
+++ b/python/sglang/srt/distributed/device_communicators/fabric_multicast.py
@@ -1,0 +1,218 @@
+"""FABRIC multicast registration for regular VMM tensors (NVLS zero-copy AR).
+
+Binds a regular (``expandable_segments``/VMM) tensor into a CUDA multicast object so
+the two-shot ``multimem.ld_reduce``/``.st`` all-reduce reduces it in place -- no
+stage-in/out through the pull workspace. The multicast analog of
+``VmmGraphInputManager``'s peer mapping (which ``cuMemMap``s a peer's chunk for the
+unicast graph-pull path): rank 0 ``cuMulticastCreate``s the object + shares its
+FABRIC handle, then every rank ``cuMulticastBindMem``s its own chunk and maps a
+local multicast VA.
+
+Requires VMM + FABRIC (one NVLS clique). The bind is a driver call, so run it
+outside CUDA-graph capture (register the captured graph-input bases post-capture).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import cuda.bindings.driver as drv
+import torch
+import torch.distributed as dist
+
+from sglang.srt.distributed.device_communicators.vmm_utils import (
+    check_drv,
+    is_vmm_pointer,
+    make_rw_access_desc,
+)
+
+_FABRIC = drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+
+
+def _align_up(x: int, a: int) -> int:
+    return -(-x // a) * a
+
+
+def _addr_range(addr: int) -> Tuple[int, int]:
+    """(base, size) of the VMM allocation containing ``addr``."""
+    r = drv.cuMemGetAddressRange(addr)
+    if r[0] != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuMemGetAddressRange(0x{addr:x}): {r[0]}")
+    return int(r[1]), int(r[2])
+
+
+class FabricMulticastRegistry:
+    """Per-process registry: regular VMM tensor -> its NVLS multicast address.
+
+    ``register(t)`` binds ``t``'s local allocation into a per-allocation multicast
+    object shared across the clique and returns the multicast VA for ``t``. The
+    result is stable for the allocation's lifetime and cached by ``data_ptr``
+    (revalidated against the live allocation, since the caching allocator recycles
+    pointers). Collective: all ranks must call ``register`` in the same order over
+    ``group`` -- the custom-AR's non-NCCL, CPU-capable process group (same group the
+    graph-input handle exchange uses).
+    """
+
+    def __init__(self, group) -> None:
+        self.group = group
+        self.rank = dist.get_rank(group=self.group)
+        self.world = dist.get_world_size(group=self.group)
+        self.device_id = torch.cuda.current_device()
+        # data_ptr -> (mc_addr, mc_handle, va, bind_size, base, base_size)
+        self._cache: Dict[int, Tuple] = {}
+
+    def register(self, t: torch.Tensor) -> int:
+        """Return the NVLS multicast address of ``t`` (cached). Collective."""
+        return self.register_ptr(int(t.data_ptr()), t.numel() * t.element_size())
+
+    def register_ptr(self, data_ptr: int, nbytes: int) -> int:
+        """Return the NVLS multicast address of ``[data_ptr, data_ptr+nbytes)``
+        (cached). Collective. Used by the post-capture hook, which only has the
+        recorded pointer (not the tensor) of the graph's captured AR buffer.
+
+        Raises on a non-VMM (cudaMalloc) pointer -- multicast binding needs a VMM
+        allocation handle to bind. Must run outside CUDA-graph capture.
+        """
+        key = int(data_ptr)
+        if not is_vmm_pointer(key):
+            raise RuntimeError(
+                "FABRIC multicast register requires a VMM (expandable_segments) "
+                "pointer; got a cudaMalloc pointer with no allocation handle to bind."
+            )
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "FabricMulticastRegistry.register must run outside capture"
+            )
+        base, base_size = _addr_range(key)
+        offset = key - base
+        cached = self._cache.get(key)
+        if cached is not None:
+            mc_addr, _mc, _va, _bs, c_base, c_bsize = cached
+            if c_base == base and c_bsize == base_size:
+                return mc_addr
+            self._release_entry(cached)  # allocator recycled this data_ptr
+        # A live activation (unlike a symm arena) isn't guaranteed to sit at the
+        # same offset on every rank, which multicast reduction needs -- verify.
+        self._assert_symmetric_offset(offset)
+        entry = self._register_alloc(base, base_size, offset, int(nbytes))
+        self._cache[key] = entry
+        return entry[0]
+
+    def _assert_symmetric_offset(self, offset: int) -> None:
+        """Raise unless ``offset`` (activation position within its VMM allocation)
+        is identical on every rank -- the precondition for an in-place multicast
+        all-reduce to combine matching elements. Collective."""
+        buf = torch.tensor([int(offset)], dtype=torch.int64)
+        gathered = [torch.empty_like(buf) for _ in range(self.world)]
+        dist.all_gather(gathered, buf, group=self.group)
+        offs = [int(g.item()) for g in gathered]
+        if any(o != offs[0] for o in offs):
+            raise RuntimeError(
+                "in-place multicast all-reduce requires a symmetric activation "
+                f"offset across ranks, got {offs}; the per-rank allocation diverged "
+                "(the staged path is offset-agnostic -- drop the registered path)."
+            )
+
+    def _register_alloc(
+        self, base: int, base_size: int, offset: int, nbytes: int
+    ) -> Tuple:
+        """Bind ``[base, base+bind_size)`` on every rank into one multicast object,
+        map a local multicast VA, and return the cache entry. A captured activation
+        can span several expandable_segments chunks (each its own cuMemCreate
+        handle at a contiguous VA); bind every chunk in the range at its matching
+        multicast offset. Collective."""
+        prop = drv.CUmulticastObjectProp()
+        prop.numDevices = self.world
+        prop.handleTypes = int(_FABRIC)
+        prop.flags = 0
+        prop.size = max(1, offset + nbytes)
+        # MINIMUM (not RECOMMENDED): RECOMMENDED scales with the size and can be
+        # ~512 MB, so aligning a small activation's bind up to it overflows its chunk.
+        gran = int(
+            check_drv(
+                drv.cuMulticastGetGranularity(
+                    prop,
+                    drv.CUmulticastGranularity_flags.CU_MULTICAST_GRANULARITY_MINIMUM,
+                ),
+                "cuMulticastGetGranularity",
+            )
+        )
+        bind_size = _align_up(offset + nbytes, gran)
+        prop.size = bind_size
+
+        # Rank 0 creates the object + shares its FABRIC handle; peers import.
+        mc_handle = self._make_shared_mc(prop)
+        check_drv(
+            drv.cuMulticastAddDevice(mc_handle, self.device_id), "cuMulticastAddDevice"
+        )
+        # Bind each physical chunk covering [base, base+bind_size) at its offset from
+        # base; symmetric offsets (verified above) make mcOffset k every rank's elem k.
+        bound = 0
+        while bound < bind_size:
+            c_base, c_size = _addr_range(base + bound)
+            n = min(c_size - (base + bound - c_base), bind_size - bound)
+            mem_h = check_drv(
+                drv.cuMemRetainAllocationHandle(c_base), "cuMemRetainAllocationHandle"
+            )
+            try:
+                check_drv(
+                    drv.cuMulticastBindMem(
+                        mc_handle, bound, mem_h, base + bound - c_base, n, 0
+                    ),
+                    "cuMulticastBindMem",
+                )
+            finally:
+                check_drv(drv.cuMemRelease(mem_h), "cuMemRelease(local mem)")
+            bound += n
+
+        # Reserve + map a local VA over the multicast object -> the multicast alias.
+        va = int(
+            check_drv(
+                drv.cuMemAddressReserve(bind_size, gran, 0, 0),
+                "cuMemAddressReserve(mc)",
+            )
+        )
+        check_drv(drv.cuMemMap(va, bind_size, 0, mc_handle, 0), "cuMemMap(mc)")
+        check_drv(
+            drv.cuMemSetAccess(va, bind_size, [make_rw_access_desc(self.device_id)], 1),
+            "cuMemSetAccess(mc)",
+        )
+        return (va + offset, mc_handle, va, bind_size, base, base_size)
+
+    def _make_shared_mc(self, prop) -> int:
+        """Create the multicast object on rank 0, share its FABRIC handle over the
+        clique, and return this rank's handle to the SAME object."""
+        handle_bytes = b""
+        if self.rank == 0:
+            mc = check_drv(drv.cuMulticastCreate(prop), "cuMulticastCreate")
+            fabric_h = check_drv(
+                drv.cuMemExportToShareableHandle(mc, _FABRIC, 0),
+                "cuMemExportToShareableHandle(mc, FABRIC)",
+            )
+            handle_bytes = bytes(fabric_h.data)
+        # all_gather the 64-byte handle; every rank imports rank 0's object.
+        buf = torch.frombuffer(
+            bytearray(handle_bytes.ljust(64, b"\0")), dtype=torch.uint8
+        ).clone()
+        gathered = [torch.empty_like(buf) for _ in range(self.world)]
+        dist.all_gather(gathered, buf, group=self.group)
+        if self.rank == 0:
+            return mc
+        return check_drv(
+            drv.cuMemImportFromShareableHandle(
+                bytes(gathered[0].numpy().tobytes()), _FABRIC
+            ),
+            "cuMemImportFromShareableHandle(mc)",
+        )
+
+    def _release_entry(self, entry: Tuple) -> None:
+        _mc_addr, mc_handle, va, bind_size, _base, _bsize = entry
+        check_drv(drv.cuMemUnmap(va, bind_size), "cuMemUnmap(mc)")
+        check_drv(drv.cuMemAddressFree(va, bind_size), "cuMemAddressFree(mc)")
+        check_drv(drv.cuMemRelease(mc_handle), "cuMemRelease(mc)")
+
+    def release(self) -> None:
+        """Unmap + free all multicast VAs and drop the cache."""
+        for entry in self._cache.values():
+            self._release_entry(entry)
+        self._cache.clear()


### PR DESCRIPTION
## Motivation

Custom all-reduce v2's two-shot multicast path stages the input in/out through the
pull workspace before/after the `multimem.ld_reduce`/`.st` reduction. For a
captured CUDA-graph input that is already VMM-backed (`expandable_segments`) on a
single NVLink clique, that copy is avoidable — the input can be reduced in place
over its own multicast alias.

## Changes

- Split the `Multicast` pull mode into **`GraphMulticast`** (zero-copy: reduce the
  registered graph input in place over its multicast VA) and **`EagerMulticast`**
  (the existing staged path). The `multicast` flag is now orthogonal to graph vs
  eager selection.
- Add `fabric_multicast.py` — `FabricMulticastRegistry`, the multicast analog of
  the VMM peer-mapping used for the unicast graph-pull path: rank 0
  `cuMulticastCreate`s the object and shares its FABRIC handle; every rank
  `cuMulticastBindMem`s its own chunk and maps a local multicast VA. It verifies a
  symmetric per-rank allocation offset (the precondition for an in-place multicast
  reduction) and caches by `data_ptr`.
- Multi-node graph inputs that are **not** VMM-backed fall back to the staged
  (eager) path with a one-time warning, since cross-node sharing needs a VMM
  allocation handle.

## Testing

Verified on an internal multi-node NVLink (single-clique) setup: custom-AR output
matches NCCL all-reduce in eager and CUDA-graph modes across algos; the
GraphMulticast path is exercised for VMM-backed graph inputs and falls back
cleanly otherwise.

## Original commits

- `5c929e1b7`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30190312109](https://github.com/sgl-project/sglang/actions/runs/30190312109)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30190311989](https://github.com/sgl-project/sglang/actions/runs/30190311989)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->