### PR TITLE
Fix compressed-tensors NVFP4 MoE W13 layout

### DIFF
--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1035,6 +1035,7 @@ class CompressedTensorsFusedMoEMethod(FusedMoEMethodBase):
         the necessary parameters for the layer. See LinearMethodBase for param
         details
         """
+        self.load_up_proj_weight_first = layer.scheme.load_up_proj_weight_first
         layer.scheme.create_weights(
             layer=layer,
             num_experts=num_experts,

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_scheme.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_scheme.py
@@ -68,6 +68,8 @@ class CompressedTensorsMoEScheme(BaseMoEScheme):
     of different quantization schemes supported by CompressedTensors.
     """
 
+    load_up_proj_weight_first = False
+
     @classmethod
     def get_min_capability(cls) -> int:
         """

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4_moe.py
@@ -42,6 +42,11 @@ class CompressedTensorsW4A4Nvfp4MoE(CompressedTensorsMoEScheme):
         self.group_size = 16
         self.use_flashinfer_trtllm = get_moe_runner_backend().is_flashinfer_trtllm()
 
+    @property
+    def load_up_proj_weight_first(self) -> bool:
+        """Load W13 as ``[up; gate]`` for CUTLASS; TRT-LLM reorders post-load."""
+        return not self.use_flashinfer_trtllm
+
     @classmethod
     def get_min_capability(cls) -> int:
         # Requires sm100(blackwell) architecture


### PR DESCRIPTION
## Motivation

When the native CUTLASS NVFP4 MoE path was replaced with FlashInfer CUTLASS in PR #30448, one weight-layout difference was missed: the old kernel consumed W13 as `[gate; up]`, while FlashInfer CUTLASS expects `[up; gate]`.

The compressed-tensors scheme owns this setting, but the weight loader reads it from the outer `CompressedTensorsFusedMoEMethod`. Since the wrapper did not forward it, CUTLASS received the default `[gate; up]` layout.

For SwiGLU, swapping the halves changes `silu(gate) * up` into `silu(up) * gate` and pairs the block scales with the wrong weights. The tensors remain valid, but the expert output is incorrect.

## Modifications

- Added a default `load_up_proj_weight_first = False` contract to `CompressedTensorsMoEScheme`.
- Overrode it in `CompressedTensorsW4A4Nvfp4MoE`: CUTLASS loads `[up; gate]`, while TRT-LLM keeps its existing post-load reorder.
- Forwarded the scheme's value through `CompressedTensorsFusedMoEMethod` to the weight loader.

## Accuracy Tests

I ran the full GSM8K dataset with `nm-testing/nvfp4_moe-e2e` on an NVIDIA RTX PRO 6000 Blackwell Server Edition, comparing main before this change with this PR.

| Metric            |   Before |    After |
|-------------------|---------:|---------:|
| Examples          |    1,319 |    1,319 |
| Accuracy          |    0.00% |   93.93% |
| Normal stop rate  |    0.00% |   99.24% |
| Truncated rate    |  100.00% |    0.76% |
| Error rate        |    0.00% |    0.00% |
| Runtime           | 60.735 s | 33.089 s |
| Completion tokens |  675,328 |  254,457 |

Server command:

```bash
sglang serve \
  --model-path nm-testing/nvfp4_moe-e2e \
  --default-chat-template-kwargs '{"enable_thinking": false}' \
  --trust-remote-code
```

Evaluation command:

```bash
sgl-eval run gsm8k \
  --base-url http://127.0.0.1:30000/v1 \
  --num-threads 256 \
  --max-tokens 512
```

## Speed Tests and Profiling

This only changes weight placement during model loading and adds no runtime work. Throughput is not directly comparable because the broken baseline generated to the 512-token limit for every sample, while the corrected model stopped normally.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation changes are required for this internal correctness fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30191286636](https://github.com/sgl-project/sglang/actions/runs/30191286636)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30191289623](https://github.com/sgl-project/sglang/actions/runs/30191289623)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->