### PR TITLE
[core/loader] Fail fast when the presharded dump dir is not writable or shared

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -2003,34 +2003,44 @@ class PreshardedModelLoader(DefaultModelLoader):
             if hasattr(conv1d, "bias") and hasattr(attn, "bias"):
                 attn.bias = conv1d.bias
 
-    def _ensure_presharded_dir_writable(self, presharded_dir: str) -> None:
-        rank, _ = self._world_rank_and_size()
+    def _ensure_dir_writable_and_shared(self, presharded_dir: str) -> None:
+        # Fail before the weight load, not after. Shared matters because dedup
+        # has one rank load a file another rank wrote, so a per-host directory
+        # would otherwise fail only when rank 0 collects manifests.
+        rank, world_size = self._world_rank_and_size()
+        own_probe = os.path.join(presharded_dir, f".presharded_probe_{rank:05d}")
         try:
             os.makedirs(presharded_dir, exist_ok=True)
-            if rank == 0:
-                probe = os.path.join(presharded_dir, ".presharded_write_probe")
-                last_err: Optional[OSError] = None
-                for _ in range(5):
-                    try:
-                        with open(probe, "w") as f:
-                            f.write("ok")
-                        os.unlink(probe)
-                        last_err = None
-                        break
-                    except OSError as e:
-                        last_err = e
-                        os.makedirs(presharded_dir, exist_ok=True)
-                        time.sleep(0.05)
-                if last_err is not None:
-                    raise last_err
+            with open(own_probe, "w") as f:
+                f.write("ok")
         except OSError as e:
             raise RuntimeError(
-                f"Presharded dump directory is not writable: {presharded_dir}. "
-                "Set model_loader_extra_config "
-                '\'{"presharded_path": "..."}\' (or draft_presharded_path for '
-                "the draft model) to a writable shared filesystem path. "
+                f"Presharded dump directory is not writable by rank {rank}: "
+                f"{presharded_dir}. Set model_loader_extra_config "
+                '\'{"presharded_path": "..."}\' (or draft_presharded_path '
+                "for the draft model) to a writable shared filesystem path. "
                 f"Original error: {e}"
             ) from e
+        self._world_barrier()
+
+        if world_size > 1 and rank != 0:
+            rank0_probe = os.path.join(presharded_dir, ".presharded_probe_00000")
+            for _ in range(5):  # retry to absorb NFS metadata latency
+                if os.path.isfile(rank0_probe):
+                    break
+                time.sleep(0.05)
+            else:
+                raise RuntimeError(
+                    f"Presharded dump directory is not on a shared filesystem: "
+                    f"{presharded_dir}. Rank {rank} cannot see a file written "
+                    "by rank 0; all ranks must dump to one filesystem. Set "
+                    'model_loader_extra_config \'{"presharded_path": "..."}\' '
+                    "(or draft_presharded_path) to shared storage."
+                )
+        self._world_barrier()
+
+        with suppress(OSError):
+            os.unlink(own_probe)
         self._world_barrier()
 
     def _first_time_load_and_dump(
@@ -2040,7 +2050,7 @@ class PreshardedModelLoader(DefaultModelLoader):
         presharded_dir: str,
         shard_config: Dict[str, Any],
     ) -> nn.Module:
-        self._ensure_presharded_dir_writable(presharded_dir)
+        self._ensure_dir_writable_and_shared(presharded_dir)
         target_device = torch.device(device_config.device)
         quant_config = _get_quantization_config(model_config, self.load_config)
         with set_default_torch_dtype(model_config.dtype):

--- a/test/registered/unit/model_loader/test_presharded_loader.py
+++ b/test/registered/unit/model_loader/test_presharded_loader.py
@@ -531,7 +531,7 @@ class TestBuildDumpPlan(unittest.TestCase):
             self.assertIn("Rank 0", msg)
             self.assertIn("shared", msg.lower())
 
-    def test_ensure_presharded_dir_writable_rejects_readonly(self):
+    def test_ensure_dir_writable_and_shared_rejects_readonly(self):
         # Guard against spending a full source load before discovering a
         # read-only dump root (HF cache mounts). Mock OSError because root
         # can often still write to mode-0555 dirs under CAP_DAC_OVERRIDE.
@@ -542,20 +542,42 @@ class TestBuildDumpPlan(unittest.TestCase):
             "os.makedirs", side_effect=OSError("Read-only file system")
         ):
             with self.assertRaises(RuntimeError) as ctx:
-                loader._ensure_presharded_dir_writable("/ro/presharded")
+                loader._ensure_dir_writable_and_shared("/ro/presharded")
             self.assertIn("not writable", str(ctx.exception).lower())
             self.assertIn("presharded_path", str(ctx.exception))
 
-    def test_ensure_presharded_dir_writable_ok_rank0(self):
+    def test_ensure_dir_writable_and_shared_ok_rank0(self):
         loader = object.__new__(PreshardedModelLoader)
         with tempfile.TemporaryDirectory() as tmp:
             leaf = os.path.join(tmp, "TP-8-sig-test")
             with mock.patch.object(
                 loader, "_world_rank_and_size", return_value=(0, 1)
-            ), mock.patch.object(loader, "_world_barrier") as barrier:
-                loader._ensure_presharded_dir_writable(leaf)
+            ), mock.patch.object(loader, "_world_barrier"):
+                loader._ensure_dir_writable_and_shared(leaf)
             self.assertTrue(os.path.isdir(leaf))
-            barrier.assert_called_once()
+            # Probe files are cleaned up, not left behind.
+            self.assertEqual(
+                [p for p in os.listdir(leaf) if p.startswith(".presharded_probe")],
+                [],
+            )
+
+    def test_ensure_dir_writable_and_shared_rejects_per_host(self):
+        # Multi-node with a node-local dump dir: rank 1 writes its own probe
+        # fine but never sees rank 0's (different filesystem), so this must
+        # fail fast here, not after every rank has paid for a full weight load.
+        loader = object.__new__(PreshardedModelLoader)
+        with tempfile.TemporaryDirectory() as tmp:
+            leaf = os.path.join(tmp, "TP-8-sig-test")
+            os.makedirs(leaf)  # rank 1's own (empty) node-local copy
+            with mock.patch.object(
+                loader, "_world_rank_and_size", return_value=(1, 2)
+            ), mock.patch.object(loader, "_world_barrier"), mock.patch(
+                "time.sleep"
+            ), self.assertRaises(
+                RuntimeError
+            ) as ctx:
+                loader._ensure_dir_writable_and_shared(leaf)
+        self.assertIn("shared filesystem", str(ctx.exception).lower())
 
 
 class TestStructuralSignature(unittest.TestCase):


### PR DESCRIPTION
## Motivation

The presharded dump requires every rank to write into one shared filesystem:
each rank writes its own manifest and shard files, rank 0 collects all of them
to build the dedup plan, and at load time dedup has one rank read a file that
another rank wrote. A node-local dump directory (e.g. a per-host
`presharded_path` override, or a node-local mount) breaks this — but it only
failed once rank 0 went to collect manifests, after every rank had already paid
for a full weight load.

The existing pre-load probe only checked that rank 0 could write; it verified
neither that the *other* ranks can write nor that they share one filesystem.

## Modifications

Extend the pre-load probe (`_ensure_presharded_dir_writable` →
`_ensure_dir_writable_and_shared`) to catch both up front, before the weight
load:

- **Writable, every rank** — each rank writes its own `.presharded_probe_{rank}`.
  A rank that cannot write fails here (each rank writes manifests and shards at
  dump time, so each needs write access).
- **Shared** — every non-zero rank then reads rank 0's probe back. Not seeing it
  means the ranks are not on one filesystem. Reads retry to absorb NFS metadata
  latency. Single-node runs skip this half.

No change to the default dump location (`<model_path>/presharded`) or the cache
key. The error messages point at the `presharded_path` /
`draft_presharded_path` overrides for relocating to shared storage.

## Accuracy Tests

No forward or weight-loading logic changed — this only moves an existing
failure earlier and widens it to every rank.

## Speed Tests and Profiling

No inference-path impact. The probe is one small file write/read per rank at
startup.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30333254467](https://github.com/sgl-project/sglang/actions/runs/30333254467)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30333254354](https://github.com/sgl-project/sglang/actions/runs/30333254354)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

