### PR TITLE
fix(gemma4): quantize MTP bridge projections

### DIFF
--- a/python/sglang/srt/models/gemma4_mtp.py
+++ b/python/sglang/srt/models/gemma4_mtp.py
@@ -91,7 +91,7 @@ class Gemma4AssistantForCausalLM(Gemma4ForCausalLM):
             2 * self.backbone_hidden_size,
             self.hidden_size,
             bias=False,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=add_prefix("pre_projection", prefix),
         )
         self.model = Gemma4TextModel(
@@ -103,7 +103,7 @@ class Gemma4AssistantForCausalLM(Gemma4ForCausalLM):
             self.hidden_size,
             self.backbone_hidden_size,
             bias=False,
-            quant_config=None,
+            quant_config=quant_config,
             prefix=add_prefix("post_projection", prefix),
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The block-FP8 `gemma-4-31B-it-assistant` checkpoint gets a 0% draft-token acceptance rate, while the BF16 assistant gets approximately 65%.

The checkpoint stores `pre_projection` and `post_projection` as block-FP8 weights with corresponding `weight_scale` tensors. However, these layers were constructed with
  `quant_config=None`, causing the FP8 weights to load without their block scales and corrupting the MTP activations.

## Modifications

Pass the draft model's `quant_config` to the Gemma 4 MTP assistant's:
- `pre_projection`
- `post_projection`

The assistant transformer trunk already receives the correct `quant_config`.
This does not change BF16 behavior because `quant_config` remains `None` for unquantized checkpoints.

## Accuracy Tests

Before the fix:
  - BF16 MTP acceptance rate: approximately 65%
  - FP8 MTP acceptance rate: 0%
 
End-to-end acceptance results after the fix: 60%

## Speed Tests and Profiling
Not needed. This change only enables the quantization method already specified by the draft checkpoint.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32265514448](https://github.com/sgl-project/sglang/actions/runs/32265514448)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32265513879](https://github.com/sgl-project/sglang/actions/runs/32265513879)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->