### PR TITLE
[MLX] Fix test_batched_decode_matches_solo failing past EOS

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
@@ -202,6 +202,20 @@ class TestMlxReferenceCorrectness(CustomTestCase):
         self.runner.remove_request(rid)
         return out
 
+    def _upto_eos(self, seq):
+        """Prefix of ``seq`` up to and including the first EOS (all of it if none).
+
+        Past EOS the model is off-distribution: it emits control-token filler
+        whose logits are frequently near-tied, so greedy ``argmax`` there is not
+        stable under the tiny (~1e-3 relative) numerical differences that any
+        change of batch shape produces.  Comparisons that must hold token-for-token
+        are therefore bounded at EOS -- see ``test_batched_decode_matches_solo``.
+        """
+        for i, tok in enumerate(seq):
+            if tok in self.eos_ids:
+                return seq[: i + 1]
+        return seq
+
     def _diff_msg(self, prompt, ref, sgl):
         horizon = min(len(ref), len(sgl))
         first = next((j for j in range(horizon) if ref[j] != sgl[j]), horizon)
@@ -225,6 +239,16 @@ class TestMlxReferenceCorrectness(CustomTestCase):
 
         Pins slot/cache isolation: ``decode_batch`` over several concurrent
         requests must not let one request's state bleed into another's.
+
+        The comparison is bounded at the first EOS.  Batching changes GEMM shapes
+        and therefore floating-point reduction order, which perturbs the logits by
+        ~1e-3 relative -- unavoidable, and *not* caused by padding: an equal-length
+        batch (no padding, no mask) shows the identical perturbation, and adding
+        ragged padding + the attention mask changes it by exactly zero.  Before EOS
+        the argmax margin dwarfs that perturbation, so tokens agree exactly and real
+        cross-request bleed still fails the assert.  After EOS the model emits
+        control-token filler with near-tied logits (observed top-2 margin 0.016),
+        where the same perturbation flips argmax for reasons unrelated to isolation.
         """
         ids_list = [prompt_ids for (_, prompt_ids, _) in self.cases]
 
@@ -247,9 +271,9 @@ class TestMlxReferenceCorrectness(CustomTestCase):
             self.runner.remove_request(rid)
 
         for i, (prompt, _, _) in enumerate(self.cases):
-            self.assertEqual(
-                batched[i], solo[i], self._diff_msg(prompt, solo[i], batched[i])
-            )
+            ref = self._upto_eos(solo[i])
+            got = batched[i][: len(ref)]
+            self.assertEqual(got, ref, self._diff_msg(prompt, ref, got))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_reference_correctness.py
@@ -261,6 +261,11 @@ class TestMlxReferenceCorrectness(CustomTestCase):
             self.runner.remove_request(f"solo-{i}")
             solo.append(seq)
 
+        self.assertTrue(
+            any(self.eos_ids.isdisjoint(seq) for seq in solo),
+            "at least one case must exercise the full batch horizon without EOS",
+        )
+
         # Batched: prefill all, then advance them together in one decode_batch.
         rids = [f"batch-{i}" for i in range(len(ids_list))]
         batched = [[self._prefill(rid, ids)] for rid, ids in zip(rids, ids_list)]


### PR DESCRIPTION
## Motivation

Fixes #32441.

`test_mlx_reference_correctness.py::test_batched_decode_matches_solo` fails on unmodified `main` (`e14068d`) on Apple Silicon. It decodes a fixed 24-step horizon and asserts a request's tokens are identical decoded solo vs. inside a `decode_batch`. That premise does not hold: bitwise-identical logits across two different batch shapes is not an achievable property of any batched backend.

The bookkeeping the test guards is fine. The test is over-strict, and it will redden the Apple Silicon lane the moment the self-hosted macOS runners land.

Observed failure — note the divergence is four tokens *past* EOS, while the answer itself is identical:

```
First differing element 6: 151645 != 151643
  prompt: 'What is the capital of France? Answer in one word.'
  ref text: 'Paris.<|im_end|>\n<|endoftext|>\n<|endoftext|>\n<|im_end|>\n...'
  sgl text: 'Paris.<|im_end|>\n<|endoftext|>\n<|im_end|>\n<|im_end|>\n...'
```

`test_greedy_matches_reference_exact` in the same file passes — it stops at EOS.

## Root cause

Three experiments driving `MlxModelRunner` directly and capturing full logits per step (M5 Pro, `Qwen1.5-MoE-A2.7B-Chat-4bit`):

| comparison | padding/mask active? | max&#124;dlogit&#124; over 5 steps |
|---|---|---|
| solo vs solo, same shape | n/a | **0.00000** — bitwise identical |
| solo vs **equal-length** batch | no | 0.027, 0.027, 0.033, 0.027, 0.039 |
| solo vs **ragged** batch (`seq_lens=[30,30,26]`, `pad=[0,0,4]`) | yes | 0.027, 0.027, 0.033, 0.027, 0.039 |

Rows 2 and 3 are byte-for-byte identical, so `BatchedDecodeContext.valid_lens`/`pad_sizes` and the `-inf` mask in `MLXAttentionWrapper` contribute **exactly zero** error — that path is exact. The residual ~1e-3 relative delta is fp16 GEMM reduction order changing with the batch dimension, which is inherent to batched inference.

Why that flips a token only past EOS — top-2 logit margin for the failing request:

| step | max&#124;dlogit&#124; | solo margin | batched margin | argmax |
|---|---|---|---|---|
| 1–5 | 0.027–0.039 | 0.84 – 13.95 | 0.84 – 13.95 | same |
| **6** | **1.273** | 0.789 | **0.016** | **flip** |

Before EOS the margin is orders of magnitude above the perturbation. Past EOS the model emits control-token filler with a 0.016 margin, and fp16 noise decides the argmax. (The step-6 jump in `max|dlogit|` is the MoE router: near-tied gate scores make top-k expert selection discontinuous.)

Across all three prompts, divergence is *always* strictly after EOS — the two that never reach EOS match for all 24 steps:

| case | first EOS | first divergence |
|---|---|---|
| 0 `List the first 10 prime numbers…` | none in 24 | none — identical |
| 1 `What is the capital of France?…` | 2 | 6 |
| 2 `Write one short sentence about the ocean.` | none in 24 | none — identical |

## Modifications

One test file. Adds `_upto_eos()` and bounds the solo-vs-batched comparison at the first EOS, mirroring what `test_greedy_matches_reference_exact` already does. Docstrings record why bitwise equality past EOS is not on offer, with the measured numbers, so this doesn't get "fixed" back later.

No source changes — nothing in `srt/` is wrong here.

## Accuracy Tests

The guard is not weakened. With the fix applied, three injected regressions each still turn the test red:

| mutation in `MLXAttentionWrapper` / `BatchedDecodeContext` | fixed test |
|---|---|
| baseline, no mutation | passes |
| padding mask disabled (`needs_padding` → `False`) | **fails** |
| `valid_lens` off by one (`offsets + 1` → `offsets`) | **fails** |
| cross-request bleed (reverse per-request cache order) | **fails** |

The last is exactly the "one request's state bleeds into another's" scenario the test exists for.

Full MLX unit suite on Apple Silicon:

```
before:  2 failed, 85 passed, 19 skipped
after:   1 failed, 86 passed, 19 skipped
```

The remaining failure is the already-tracked #30550 (`test_metal_profiler`), untouched by this PR.

## Speed Tests and Profiling

N/A — test-only change.

## Environment

```
Python 3.11.15 · macOS 26.5.2 · Apple M5 Pro · 48 GB unified
mlx 0.32.0 · mlx-lm 0.31.3 · torch 2.11.0 · transformers 5.12.1
sglang main @ e14068d
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *This PR is itself a unit-test fix; mutation results above show the assertion still catches real regressions.*
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *Rationale captured in the test docstrings.*

cc @LarrySimingDeng (author of the test, #29440) @jlee5814 @yeahdongcn @jonahbernard

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30270794070](https://github.com/sgl-project/sglang/actions/runs/30270794070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30270794064](https://github.com/sgl-project/sglang/actions/runs/30270794064)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->