### PR TITLE
[MLX] Stamp launch_ts/forward_iter in the overlap loop; fix scheduler crash on first request

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
+++ b/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
@@ -16,6 +16,7 @@ the GPU runs both steps back-to-back with no idle gap.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
@@ -94,6 +95,10 @@ class SchedulerMlxOverlapMixin:
         # forward_ct, so `--profile-steps` (and the server /start_profile
         # num_steps path) only takes effect once the counter moves here.
         self.forward_ct += 1
+        # forward_iter mirrors run_batch's assignment; the metrics reporter and
+        # SWA maintenance key off it and treat None as "skip this batch".
+        pending.batch_copy.forward_iter = self.forward_ct
+        pending.schedule_batch.forward_iter = self.forward_ct
         self.profiler_manager._profile_batch_predicate(pending.schedule_batch)
 
         result = self.tp_worker.finalize_mlx_result(
@@ -160,6 +165,12 @@ class SchedulerMlxOverlapMixin:
             # loop must do it too, otherwise async_forward_batch_generation_mlx
             # dereferences a None input_ids.
             resolve_forward_inputs(batch, self.future_map)
+            # run_batch stamps launch_ts on every scheduler-built forward; the
+            # MLX overlap loop bypasses run_batch, and process_batch_result ->
+            # _record_step_counters subtracts launch_ts unconditionally for
+            # prefill/decode batches. Stamp before batch.copy() so the copy
+            # handed to process_batch_result carries it too.
+            batch.launch_ts = time.monotonic()
             lazy_tokens, prefills, extends, decode, mode = (
                 self.tp_worker.async_forward_batch_generation_mlx(batch)
             )
@@ -182,13 +193,17 @@ class SchedulerMlxOverlapMixin:
             # Composition is identical to prev: reuse a fresh batch copy
             # of the same underlying ScheduleBatch so process_batch_result
             # updates the same req objects with the new token.
+            batch_copy = prev.batch_copy.copy()
+            # Each chained step is its own launch for _record_step_counters'
+            # decode inter-step timing; don't reuse prev's stamp.
+            batch_copy.launch_ts = time.monotonic()
             return MlxPendingJob(
                 lazy_tokens=lazy_tokens,
                 prefills=prefills,
                 extends=extends,
                 decode=decode,
                 mode=mode,
-                batch_copy=prev.batch_copy.copy(),
+                batch_copy=batch_copy,
                 schedule_batch=prev.schedule_batch,
                 reqs=prev.reqs,
             )

--- a/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
+++ b/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
@@ -74,6 +74,155 @@ class TestFinalizeMlxPendingJob(unittest.TestCase):
             scheduler.profiler_manager._profile_batch_predicate.call_count, 3
         )
 
+    def test_finalize_stamps_forward_iter_like_run_batch(self):
+        from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+            SchedulerMlxOverlapMixin,
+        )
+
+        scheduler = self._make_scheduler()
+        pending = MagicMock()
+
+        SchedulerMlxOverlapMixin._finalize_mlx_pending_job(scheduler, pending)
+
+        # run_batch assigns batch.forward_iter = forward_ct; the metrics
+        # reporter and SWA maintenance skip batches where it is None, so the
+        # MLX loop must stamp it on the batch handed to process_batch_result.
+        self.assertEqual(pending.batch_copy.forward_iter, 1)
+        self.assertEqual(pending.schedule_batch.forward_iter, 1)
+
+
+class _StopLoop(Exception):
+    """Sentinel to break out of the event loop's ``while True``."""
+
+
+@unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
+class TestOverlapLoopStampsLaunchTs(unittest.TestCase):
+    """Every batch the MLX overlap loop launches must carry ``launch_ts``.
+
+    ``Scheduler.run_batch`` stamps ``batch.launch_ts`` on every forward, and
+    ``process_batch_result`` -> ``_record_step_counters`` subtracts it
+    unconditionally for prefill/decode batches.  The MLX overlap loop bypasses
+    ``run_batch``, so if its launch paths skip the stamp, the first real
+    request's result processing raises ``TypeError: float - NoneType`` and
+    kills the scheduler (health-check requests are filtered from the counters,
+    which keeps ``/health_generate`` green while every real request crashes).
+    """
+
+    def _make_scheduler(self, *, recv_side_effect):
+        from collections import deque
+
+        scheduler = MagicMock()
+        scheduler.forward_ct = 0
+        scheduler._engine_paused = False
+        scheduler.waiting_queue = []
+        scheduler.result_queue = deque()
+        scheduler.request_receiver.recv_requests.side_effect = recv_side_effect
+        result = MagicMock()
+        result.next_token_ids = None
+        scheduler.tp_worker.finalize_mlx_result.return_value = result
+        return scheduler
+
+    def test_fresh_launch_stamps_launch_ts_before_copy(self):
+        from unittest.mock import patch
+
+        from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+            SchedulerMlxOverlapMixin,
+        )
+
+        scheduler = self._make_scheduler(recv_side_effect=[[], _StopLoop()])
+
+        batch = MagicMock()
+        launch_ts_at_copy_time = []
+        batch.copy.side_effect = lambda: (
+            launch_ts_at_copy_time.append(batch.launch_ts),
+            MagicMock(),
+        )[1]
+        plan = MagicMock()
+        plan.batch_to_run = batch
+        scheduler.get_next_batch_to_run.return_value = plan
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            None,
+            [],
+            [],
+            None,
+            "extend",
+        )
+
+        with patch(
+            "sglang.srt.hardware_backend.mlx.scheduler_mixin.resolve_forward_inputs"
+        ):
+            with self.assertRaises(_StopLoop):
+                SchedulerMlxOverlapMixin.event_loop_overlap_mlx(scheduler)
+
+        self.assertEqual(len(launch_ts_at_copy_time), 1)
+        self.assertIsInstance(
+            launch_ts_at_copy_time[0],
+            float,
+            msg=(
+                "MLX overlap loop launched a batch without stamping "
+                "launch_ts before batch.copy(); process_batch_result -> "
+                "_record_step_counters will crash on float - None."
+            ),
+        )
+
+    def test_chained_launch_restamps_launch_ts(self):
+        from unittest.mock import patch
+
+        from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+            SchedulerMlxOverlapMixin,
+        )
+
+        # Iteration 1: fresh decode launch.  Iteration 2: chain a second
+        # decode on top of it.  Iteration 3: stop.
+        scheduler = self._make_scheduler(recv_side_effect=[[], [], _StopLoop()])
+
+        req = MagicMock()
+        req.finished.return_value = False
+        batch = MagicMock()
+        batch.reqs = [req]
+        fresh_copy = MagicMock()
+        batch.copy.return_value = fresh_copy
+        chained_copy = MagicMock()
+        chained_copy.launch_ts = None
+        fresh_copy.copy.return_value = chained_copy
+        plan = MagicMock()
+        plan.batch_to_run = batch
+        scheduler.get_next_batch_to_run.return_value = plan
+
+        pending_decode = MagicMock()
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            pending_decode,
+            "decode",
+        )
+        scheduler.tp_worker.async_chained_decode_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            MagicMock(),
+            "decode",
+        )
+
+        with patch(
+            "sglang.srt.hardware_backend.mlx.scheduler_mixin.resolve_forward_inputs"
+        ):
+            with self.assertRaises(_StopLoop):
+                SchedulerMlxOverlapMixin.event_loop_overlap_mlx(scheduler)
+
+        scheduler.tp_worker.async_chained_decode_mlx.assert_called_once()
+        self.assertIsInstance(
+            chained_copy.launch_ts,
+            float,
+            msg=(
+                "Chained decode launches must re-stamp launch_ts on their own "
+                "batch copy; inheriting the previous step's stamp skews "
+                "_record_step_counters' decode inter-step timing, and a None "
+                "stamp crashes result processing."
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# [MLX] Stamp launch_ts/forward_iter in the overlap loop; fix scheduler crash on first request

## Motivation

On current main, the default MLX serving path (`SGLANG_USE_MLX=1`, overlap on) crashes the scheduler on the **first real request**:

```
File "python/sglang/srt/managers/scheduler.py", line 3663, in _record_step_counters
    span_us = int((time.monotonic() - batch.launch_ts) * 1e6)
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```

`Scheduler.run_batch` is where `batch.launch_ts` (and `batch.forward_iter`) get stamped, but `event_loop_overlap_mlx` deliberately bypasses `run_batch` — the same reason `_finalize_mlx_pending_job` already compensates `forward_ct` manually. `process_batch_result -> _record_step_counters` subtracts `launch_ts` unconditionally for prefill/decode batches, so the first prefill result kills the scheduler.

Two properties make this regression sneaky:

- Health-check generate requests are filtered out of the step counters (`is_health_check_generate_req`), so `/health_generate` stays green while every real request crashes.
- The decode branch's subtraction is guarded by `_prev_decode_launch_ts is not None`, which stays `None` forever on MLX — so pure-decode steps don't crash, they just silently record no metrics. The crash needs a prefill result, i.e. any real request.

Reproduced on an M5 Pro (macOS 26.5.2, mlx 0.32.0) with
`SGLANG_USE_MLX=1 python -m sglang.launch_server --model-path mlx-community/Qwen3-0.6B-4bit ...` — the first `/generate` request produces the traceback above and the server goes 503.

## Modifications

Mirror `run_batch`'s bookkeeping at the MLX overlap loop's equivalent points:

- `_launch_fresh` stamps `batch.launch_ts = time.monotonic()` before `batch.copy()`, so the copy handed to `process_batch_result` carries it (prefill busy-span semantics match `run_batch` entry -> result processed).
- `_launch_chained` re-stamps its own batch copy, so `_record_step_counters`' decode inter-step timing measures per-step spacing instead of inheriting the chain root's stamp.
- `_finalize_mlx_pending_job` stamps `forward_iter = forward_ct` next to the existing `forward_ct` compensation. The metrics reporter and SWA maintenance treat `forward_iter is None` as "skip"; with this, step metrics work on MLX instead of being silently dropped.

After the fix, the same server serves the first and subsequent requests normally; verified with a mixed prefill/decode/abort load test (32 unique prompts x concurrency 12, streaming aborts mid-flight, radix + overlap on) with no scheduler errors.

## Test

`test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py` (existing file, stage-a model-free suite):

- `test_fresh_launch_stamps_launch_ts_before_copy` — drives one iteration of the real `event_loop_overlap_mlx` with a mocked tp_worker and captures `batch.launch_ts` at `batch.copy()` time.
- `test_chained_launch_restamps_launch_ts` — two iterations (fresh decode -> chained decode), asserts the chained step's batch copy got its own float stamp.
- `test_finalize_stamps_forward_iter_like_run_batch` — asserts finalize assigns `forward_iter = forward_ct` on both batch objects.

Reverting the `scheduler_mixin.py` change turns all three red (`TypeError`-guard tests fail on `None`); with the fix the file's 5 tests pass on Apple Silicon.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30211529987](https://github.com/sgl-project/sglang/actions/runs/30211529987)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30211529903](https://github.com/sgl-project/sglang/actions/runs/30211529903)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->