### PR TITLE
[MLX] Release per-request state on extend batches; fix unbounded prefill-only leak

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/tp_worker.py
+++ b/python/sglang/srt/hardware_backend/mlx/tp_worker.py
@@ -78,6 +78,12 @@ class MlxTpModelWorker(TpModelWorker):
         )
 
         self._mlx_active_rids: set[str] = set()
+        # Requests whose KV-cache release point has passed (finished or
+        # aborted) but whose MLX per-request state may still be referenced by
+        # an in-flight overlap pending job.  Actually released by
+        # _cleanup_stale_rids on the next scheduler-built forward, by which
+        # point every pending job containing them has been finalized.
+        self._mlx_released_rids: set[str] = set()
         self._mlx_pool_initialized = False
 
     def get_pad_input_ids_func(self):
@@ -116,14 +122,31 @@ class MlxTpModelWorker(TpModelWorker):
         )
 
     def _cleanup_stale_rids(self, forward_mode, current_rids: set[str]) -> None:
-        """Remove MLX state for decode-mode requests that dropped out of the batch."""
+        """Remove MLX state for requests that dropped out of the batch.
+
+        Decode batches drop every request not in the current composition.
+        Extend batches release only requests explicitly marked at their KV
+        release point (prepare_for_kv_cache_release): without this, workloads
+        that never form a decode batch (prefill-only traffic, e.g.
+        max_new_tokens=1 classification/scoring) leak one per-request
+        ContiguousAttentionKVCache list per request, unbounded.
+
+        Both paths run at the start of a scheduler-built forward, after every
+        previously launched overlap pending job has been finalized, so no
+        in-flight chained decode can still reference the removed state.
+        """
         if forward_mode.is_decode():
             stale_rids = self._mlx_active_rids - current_rids
             for rid in stale_rids:
                 self._mlx_runner.remove_request(rid)
             self._mlx_active_rids = current_rids
+            self._mlx_released_rids -= stale_rids
         else:
-            self._mlx_active_rids |= current_rids
+            releasable = self._mlx_released_rids - current_rids
+            for rid in releasable:
+                self._mlx_runner.remove_request(rid)
+            self._mlx_released_rids -= releasable
+            self._mlx_active_rids = (self._mlx_active_rids | current_rids) - releasable
 
     def prepare_for_kv_cache_release(self, req) -> None:
         """Snapshot MLX auxiliary state at the scheduler's radix insert point."""
@@ -132,6 +155,11 @@ class MlxTpModelWorker(TpModelWorker):
             # Prefer the just-snapshotted live auxiliary state for the final
             # insert. Any older tracked slot is released during component cleanup.
             req.mamba_last_track_seqlen = None
+            # Mark for deferred release; see _cleanup_stale_rids. Removing
+            # here would break overlap: a chained pending job launched before
+            # this request was known to be finished may still reference its
+            # per-request caches and token list.
+            self._mlx_released_rids.add(req.rid)
 
     def _route_extend_request(self, rid: str, decoding_rids: set[str]) -> str:
         """Classify a request within an extend / mixed batch.

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -239,6 +239,7 @@ class SchedulerBatchResultProcessor:
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
+                        self._prepare_model_worker_kv_release(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
@@ -328,6 +329,7 @@ class SchedulerBatchResultProcessor:
                     req.update_finish_state()
 
                     if req.finished():
+                        self._prepare_model_worker_kv_release(req)
                         release_kv_cache(req, self.tree_cache)
                         req.time_stats.set_completion_time()
                     else:
@@ -926,6 +928,20 @@ class SchedulerBatchResultProcessor:
             None if logprobs is None else logprobs[i]
         )
 
+    def _prepare_model_worker_kv_release(self, req: Req) -> None:
+        """Give the model worker a pre-release hook for a finished request.
+
+        Backends with worker-owned per-request state (MLX) snapshot and mark
+        it for release here, while the request's bookkeeping is still valid.
+        Called on every finish path — prefill-finished requests included —
+        right before release_kv_cache. No-op for workers without the hook.
+        """
+        prepare_release = getattr(
+            self.model_worker, "prepare_for_kv_cache_release", None
+        )
+        if callable(prepare_release):
+            prepare_release(req)
+
     def _handle_finish_state_updated_req(
         self,
         req: Req,
@@ -966,11 +982,7 @@ class SchedulerBatchResultProcessor:
             else:
                 if self.server_args.enable_hisparse:
                     self.hisparse_coordinator.request_finished(req)
-                prepare_release = getattr(
-                    self.model_worker, "prepare_for_kv_cache_release", None
-                )
-                if callable(prepare_release):
-                    prepare_release(req)
+                self._prepare_model_worker_kv_release(req)
                 is_insert = (
                     req.mamba_lazy_is_insert
                     if get_server_args().enable_mamba_extra_buffer_lazy()

--- a/test/registered/unit/hardware_backend/mlx/test_tp_worker_request_release.py
+++ b/test/registered/unit/hardware_backend/mlx/test_tp_worker_request_release.py
@@ -1,0 +1,189 @@
+"""Unit tests for MLX per-request state release in ``MlxTpModelWorker``.
+
+Regression guard for the prefill-only request-state leak:
+``MlxModelRunner.remove_request`` (the only entry point that frees a
+request's per-layer ``ContiguousAttentionKVCache`` list back to the reuse
+pool) used to be called exclusively from ``_cleanup_stale_rids``'s
+decode branch. Workloads that never form a decode batch — prefill-only
+traffic such as max_new_tokens=1 classification/scoring — therefore
+leaked one full per-request cache list per unique request, unbounded
+(~2 * num_layers * n_kv_heads * max_seq_len * head_dim * dtype bytes
+each; ~0.44 GB/request measured for Qwen3-0.6B).
+
+The fix marks a request at its KV release point
+(``prepare_for_kv_cache_release``) and releases it on the next
+scheduler-built forward of either mode. Release must NOT happen inside
+``prepare_for_kv_cache_release`` itself: an overlap chained decode
+launched before the request was known to be finished may still reference
+its caches and token list, and finalizing it after an eager removal
+would KeyError.
+
+Tests mock the MLX runner and load no model. Apple-Silicon-only because
+``tp_worker`` imports ``mlx.core`` at module load.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+# CPU marker is AST-parsed "this test exists"; actual CPU-side execution is
+# gated by the @skipUnless guard below. MLX marker runs for real on the MLX
+# lane's stage-a (model-free: mocks the runner, loads no model).
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_mlx_ci(est_time=5, suite="stage-a-unit-test-mlx")
+
+_IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+_SKIP_REASON = "Apple-Silicon-only (tp_worker imports mlx.core at module load)"
+
+
+class _FakeRunner:
+    """Tracks live request state and remove_request calls."""
+
+    def __init__(self, known_rids):
+        self._known = set(known_rids)
+        self.removed: list[str] = []
+        self.aux_stored: list[str] = []
+
+    def has_request(self, rid):
+        return rid in self._known
+
+    def remove_request(self, rid):
+        self.removed.append(rid)
+        self._known.discard(rid)
+
+    def store_auxiliary_state_for_request(self, rid):
+        self.aux_stored.append(rid)
+
+
+def _make_worker(known_rids):
+    from sglang.srt.hardware_backend.mlx.tp_worker import MlxTpModelWorker
+
+    worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
+    worker._mlx_runner = _FakeRunner(known_rids)
+    worker._mlx_active_rids = set(known_rids)
+    worker._mlx_released_rids = set()
+    return worker
+
+
+def _finish(worker, rid):
+    """Drive the scheduler's per-finished-request release hook."""
+    req = SimpleNamespace(rid=rid, mamba_last_track_seqlen="stale")
+    worker.prepare_for_kv_cache_release(req)
+    return req
+
+
+@unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
+class TestPrefillOnlyRequestRelease(unittest.TestCase):
+    """Finished requests must be released without waiting for a decode batch."""
+
+    def test_finished_request_released_on_next_extend_batch(self):
+        # Request A finishes at prefill (max_new_tokens=1); the next
+        # scheduler forward is another prefill (extend mode) for request B.
+        # A's state must be released there — prefill-only traffic never
+        # forms a decode batch.
+        worker = _make_worker({"A"})
+        _finish(worker, "A")
+        self.assertEqual(worker._mlx_runner.removed, [])  # deferred, not eager
+
+        worker._cleanup_stale_rids(ForwardMode.EXTEND, {"B"})
+
+        self.assertEqual(worker._mlx_runner.removed, ["A"])
+        self.assertNotIn("A", worker._mlx_active_rids)
+        self.assertIn("B", worker._mlx_active_rids)
+        self.assertEqual(worker._mlx_released_rids, set())
+
+    def test_release_is_deferred_not_eager(self):
+        # Removing inside prepare_for_kv_cache_release would break overlap:
+        # a chained pending job launched before the finish was known may
+        # still reference the request's caches and token list.
+        worker = _make_worker({"A"})
+        req = _finish(worker, "A")
+
+        self.assertEqual(worker._mlx_runner.removed, [])
+        self.assertTrue(worker._mlx_runner.has_request("A"))
+        self.assertIn("A", worker._mlx_released_rids)
+        # Existing contract of the hook is preserved.
+        self.assertEqual(worker._mlx_runner.aux_stored, ["A"])
+        self.assertIsNone(req.mamba_last_track_seqlen)
+
+    def test_marked_rid_still_in_batch_is_not_released(self):
+        # Safety: never remove state for a request that is part of the
+        # forward being launched.
+        worker = _make_worker({"A"})
+        _finish(worker, "A")
+
+        worker._cleanup_stale_rids(ForwardMode.EXTEND, {"A"})
+
+        self.assertEqual(worker._mlx_runner.removed, [])
+        self.assertIn("A", worker._mlx_released_rids)
+
+    def test_unmarked_active_requests_survive_extend_batches(self):
+        # A chunked-prefill continuation or still-decoding request (not
+        # marked released) must not be dropped by an unrelated prefill.
+        worker = _make_worker({"A"})
+
+        worker._cleanup_stale_rids(ForwardMode.EXTEND, {"B"})
+
+        self.assertEqual(worker._mlx_runner.removed, [])
+        self.assertEqual(worker._mlx_active_rids, {"A", "B"})
+
+    def test_decode_branch_still_drops_stale_and_purges_marks(self):
+        # Existing decode-branch behavior is unchanged, and released marks
+        # for rids dropped there don't linger.
+        worker = _make_worker({"A", "B"})
+        _finish(worker, "A")
+
+        worker._cleanup_stale_rids(ForwardMode.DECODE, {"B"})
+
+        self.assertEqual(worker._mlx_runner.removed, ["A"])
+        self.assertEqual(worker._mlx_active_rids, {"B"})
+        self.assertEqual(worker._mlx_released_rids, set())
+
+
+@unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
+class TestPrepareModelWorkerKvRelease(unittest.TestCase):
+    """The result processor's pre-release hook must reach the MLX worker.
+
+    The leak's second half: prepare_for_kv_cache_release used to be invoked
+    only from the decode result path, so requests finishing at prefill (the
+    prefill-only workloads that leak) never reached the worker hook at all.
+    process_batch_result_prefill now routes every finished request through
+    _prepare_model_worker_kv_release before release_kv_cache.
+    """
+
+    def _processor(self, model_worker):
+        from sglang.srt.managers.scheduler_components.batch_result_processor import (
+            SchedulerBatchResultProcessor,
+        )
+
+        processor = SchedulerBatchResultProcessor.__new__(SchedulerBatchResultProcessor)
+        # Frozen dataclass; bypass __setattr__ for the partial test object.
+        object.__setattr__(processor, "model_worker", model_worker)
+        return processor
+
+    def test_helper_invokes_worker_hook(self):
+        worker = _make_worker({"A"})
+        processor = self._processor(worker)
+        req = SimpleNamespace(rid="A", mamba_last_track_seqlen=None)
+
+        processor._prepare_model_worker_kv_release(req)
+
+        self.assertIn("A", worker._mlx_released_rids)
+        self.assertEqual(worker._mlx_runner.aux_stored, ["A"])
+
+    def test_helper_is_noop_without_hook(self):
+        processor = self._processor(SimpleNamespace())  # no hook attribute
+        req = SimpleNamespace(rid="A")
+
+        processor._prepare_model_worker_kv_release(req)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
+++ b/test/registered/unit/hardware_backend/mlx/test_tp_worker_routing.py
@@ -170,6 +170,7 @@ class TestMlxExtendRouting(unittest.TestCase):
         worker = MlxTpModelWorker.__new__(MlxTpModelWorker)
         worker._mlx_runner = _FakeRunner(known_rids)
         worker._mlx_active_rids = set()
+        worker._mlx_released_rids = set()
         return worker
 
     # ---------- the shared decision helper ----------


### PR DESCRIPTION
# [MLX] Release per-request state on extend batches; fix unbounded prefill-only leak

## Motivation

`MlxModelRunner.remove_request` — the only code path that frees a request's per-layer `ContiguousAttentionKVCache` list back to the reuse pool (`_cache_pool`) — is called exclusively from `MlxTpModelWorker._cleanup_stale_rids`'s **decode branch**. Extend batches only union rids into `_mlx_active_rids` and never release anything.

Any workload that never forms a decode batch therefore leaks one full per-request cache list per unique request, unbounded. The most common shape is prefill-only traffic: `max_new_tokens=1` classification/scoring, TTFT-only benchmarks. Each leaked list is `2 * num_layers * n_kv_heads * max_seq_len * head_dim * dtype_size` bytes.

Measured live on an M5 Pro (48 GB, macOS 26.5.2, mlx 0.32.0) serving `mlx-community/Qwen3-0.6B-4bit` with default args (radix + overlap on), sending unique prefill-only requests at concurrency 2 and logging `len(_req_caches)` / `len(_cache_pool)` / `mx.get_active_memory()` on every extend flush:

```
req_caches=11 cache_pool=0 active_mem_gb=7.26
req_caches=12 cache_pool=0 active_mem_gb=7.70
req_caches=13 cache_pool=0 active_mem_gb=8.14
...
req_caches=22 cache_pool=0 active_mem_gb=12.07
```

Monotonic ~**0.44 GB per request** on a 0.6B model, with the reuse pool pinned at zero. The leak is invisible to the scheduler's own pool-leak checks: `token_to_kv_pool_allocator` and `req_to_token_pool` are released normally; only the MLX-side per-request state lingers.

## Modifications

- `prepare_for_kv_cache_release` (called by the batch result processor for every finished request, while its bookkeeping is still valid) now **marks** the request in a new `_mlx_released_rids` set.
- `_cleanup_stale_rids` — which runs at the start of every scheduler-built forward, in both modes — releases marked requests that are not part of the current batch. The decode branch is unchanged apart from purging marks for rids it already drops.

Release is deliberately **deferred, not eager**: an overlap chained decode launched before the request was known to be finished may still reference its caches and token list, and `decode_batch_finalize` on that pending job would `KeyError` after an eager removal (the same failure family as #22632). By the time the next forward launches, the loop has finalized every previously launched pending job, so the deferred point is safe.

`remove_request` keeps its existing semantics (including the decode-KV pool sync) at the deferred release point, exactly as the decode branch already does; the sync-window correctness of that path is being fixed independently in #30147, and the two changes compose without overlap.

After the fix, the same probe plateaus at the in-flight request count with the reuse pool absorbing released caches, and active memory stops growing.

## Test

New `test/registered/unit/hardware_backend/mlx/test_tp_worker_request_release.py` (model-free, stage-a):

- finished prefill-only request is released on the next extend batch (the regression);
- release is deferred, never eager inside `prepare_for_kv_cache_release` (overlap safety), and the hook's existing aux-snapshot contract is preserved;
- a marked rid still present in the launching batch is not released;
- unmarked active requests (chunked-prefill continuations, still-decoding reqs) survive extend batches;
- decode-branch behavior unchanged + marks purged.

`test_tp_worker_routing.py`'s fixture gained the new attribute (it builds the worker via `__new__`). Existing MLX unit suites pass on Apple Silicon.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30211534988](https://github.com/sgl-project/sglang/actions/runs/30211534988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30211534868](https://github.com/sgl-project/sglang/actions/runs/30211534868)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->