### PR TITLE
[MLX] Move fused swiglu tests to test/registered so CI collects them

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_fused_swiglu.py
+++ b/test/registered/unit/hardware_backend/mlx/test_fused_swiglu.py
@@ -5,19 +5,45 @@ Two groups:
     the fused gate_qmv + silu + ×x_up kernel against the unfused reference
     (``mx.gather_qmm`` + ``nn.silu(gate) * x_up``) on both the unsorted and
     sorted paths. Gated by SGLANG_MLX_TEST_MODEL so CI hosts without a model
-    cache skip them.
+    cache skip them (stage-a sets HF_HUB_OFFLINE=1, so they stay skipped there).
   * Synthetic eligibility (no model, MLX only): the learned-bias fallback. The
     fused kernel recomputes the gate matmul and has no slot for the per-expert
     learned bias QuantizedSwitchLinear adds after the matmul, so ``can_fuse``
     must exclude a gate carrying one, and the patch must leave such a layer
-    unfused. These run whenever MLX is importable.
+    unfused. These run wherever MLX is available (Apple Silicon).
+
+Registered on the CPU suite but skipped wherever mlx is absent; runs for real
+only on Apple Silicon via stage-a-unit-test-mlx.
 """
 
+import importlib.util
 import os
+import platform
+import sys
 
 import pytest
 
-mx = pytest.importorskip("mlx.core")
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_mlx_ci(est_time=45, suite="stage-a-unit-test-mlx")
+
+_IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
+_HAS_MLX = (
+    importlib.util.find_spec("mlx") is not None
+    and importlib.util.find_spec("mlx_lm") is not None
+)
+
+# Module-level skip (not pytest.importorskip): the CI runner executes this file
+# as `python3 file.py`, where a top-level Skipped from importorskip would escape
+# uncaught and exit non-zero before pytest.main() ever runs.
+pytestmark = pytest.mark.skipif(
+    not (_IS_APPLE_SILICON and _HAS_MLX),
+    reason="Apple-Silicon-only test (requires Darwin/arm64 + mlx + mlx_lm)",
+)
+
+if _HAS_MLX:
+    import mlx.core as mx
 
 
 # Model-based tests need a real checkpoint; synthetic tests below do not.
@@ -462,3 +488,7 @@ def test_forced_kernel_rejection_falls_back_correctly(monkeypatch):
                 atol=1e-6,
             ).item()
         ), f"forced rejection {label}: max_abs={max_abs:.3e} rel={rel:.2%}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

`python/sglang/srt/hardware_backend/mlx/moe/tests/test_fused_swiglu.py` (11 cases, including the only numerical-correctness check for the handwritten fused-swiglu Metal kernel, `test_fused_matches_unfused_synthetic`) is currently invisible to CI because two rules combine against it:

- `test/run_suite.py` only collects `test/registered/**`, so a file inside the package is never run;
- the `check-no-registered-tests-in-package` pre-commit hook rejects any `register_*_ci` call under `python/sglang/`, so the file cannot be registered where it sits.

So it is dead code in CI, and since it lives inside the package it also ships in the wheel with a top-level `import pytest`.

## Modifications

- Move the file to `test/registered/unit/hardware_backend/mlx/test_fused_swiglu.py` (git detects the rename; test bodies are unchanged) and delete the now-empty `.../moe/tests/` package directory.
- Add `register_cpu_ci(est_time=1, suite="base-a-test-cpu")` and `register_mlx_ci(est_time=45, suite="stage-a-unit-test-mlx")` (est_time from a measured ~43 s cold run), plus the `if __name__ == "__main__": sys.exit(pytest.main([__file__, "-v"]))` entry that `collect_tests` requires.
- Replace the top-level `mx = pytest.importorskip("mlx.core")` with a `find_spec` guard + module-level `pytestmark` skipif (same Darwin/arm64 + mlx + mlx_lm gate as the neighboring `test_quantization.py`). This is needed for the CPU registration: the CI runner executes registered files as `python3 file.py`, and outside a pytest session the `Skipped` raised by a top-level `importorskip` escapes uncaught and exits non-zero on mlx-less hosts (verified empirically).

The two `@requires_model` cases stay gated on `SGLANG_MLX_TEST_MODEL` and remain skipped in stage-a (`HF_HUB_OFFLINE=1`), as before.

Verified on Apple Silicon (M5 Pro, macOS 26.5):

- `pytest` on the moved file: 9 passed, 2 model-gated skipped — the Metal kernel executes for real.
- CI invocation `python3 test/registered/unit/hardware_backend/mlx/test_fused_swiglu.py`: exit 0.
- Simulated mlx-less host (`find_spec` blocked): 11 skipped, exit 0.
- `collect_tests(sanity_check=True)` + `validate_all_suites` over all 1896 registries pass; the file lands in `stage-a-unit-test-mlx` and `base-a-test-cpu`.
- `scripts/ci/check_registered_tests.py`, `scripts/ci/check_no_registered_tests_in_package.py`, and black/isort/ruff at the pre-commit pinned versions all pass.

## Accuracy Tests

N/A — test-infrastructure move only; no runtime code changed.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30258918822](https://github.com/sgl-project/sglang/actions/runs/30258918822)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30258918577](https://github.com/sgl-project/sglang/actions/runs/30258918577)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->