### PR TITLE
 [Apple Silicon] Add MLX block paged attention decode

### DIFF
--- a/docs_new/docs/hardware-platforms/apple_metal.mdx
+++ b/docs_new/docs/hardware-platforms/apple_metal.mdx
@@ -60,8 +60,25 @@ SGLANG_USE_MLX=1 python -m sglang.launch_server \
 2. `--disable-cuda-graph` - Disables usage of CUDA graph, which is not relevant for Apple Metal.
 3. `--disable-overlap-schedule` - Disables overlap scheduling (enabled/not present by default) achieved using MLX's `async_eval()`
 4. `SGLANG_MLX_USE_CUSTOM_ROPE=1` - Enables the optional custom Metal RoPE kernel. It is disabled by default, so the MLX backend uses the standard RoPE path unless you opt in for A/B testing.
-5. `SGLANG_MLX_FUSE_SWIGLU=1` - Enables the use of fused Swish-Gated Linear Unit kernel (disabled by default)
-6. `SGLANG_MLX_CLEAR_CACHE_STEPS=256` - Sets the number of decode steps before clearing the MLX cache (256 by default)
+5. `SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION=1` - Enables the experimental Metal block-table paged-attention decode path and block KV pool. It is disabled by default, so MLX uses the legacy flat/contiguous KV cache with padded SDPA unless you opt in.
+6. `SGLANG_MLX_FUSE_SWIGLU=1` - Enables the use of fused Swish-Gated Linear Unit kernel (disabled by default)
+7. `SGLANG_MLX_CLEAR_CACHE_STEPS=256` - Sets the number of decode steps before clearing the MLX cache (256 by default)
+
+### Metal block paged attention
+
+Metal block-table paged attention is experimental and disabled by default. To
+enable the block KV pool and block-table decode kernel, set
+`SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION=1`. Unsupported cases fall back to padded
+SDPA.
+
+```bash
+SGLANG_USE_MLX=1 \
+SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION=1 \
+python -m sglang.launch_server \
+  --model-path <MODEL_ID_OR_PATH> \
+  --host 0.0.0.0 \
+  --port 30000
+```
 
 ## Quantization
 

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -197,6 +197,7 @@ class BenchArgs:
     run_name: str = "default"
     batch_size: Tuple[int] = (1,)
     input_len: Tuple[int] = (1024,)
+    skewed_input_lens: Tuple[int, ...] = ()
     output_len: Tuple[int] = (16,)
     prompt_filename: str = ""
     result_filename: str = "result.jsonl"
@@ -220,6 +221,18 @@ class BenchArgs:
         )
         parser.add_argument(
             "--input-len", type=int, nargs="+", default=BenchArgs.input_len
+        )
+        parser.add_argument(
+            "--skewed-input-lens",
+            type=int,
+            nargs="+",
+            default=BenchArgs.skewed_input_lens,
+            help=(
+                "Run one batch with per-request input lengths. For example, "
+                "`--skewed-input-lens 128 512 1024 2048` creates a batch of "
+                "four requests and uses the sum of these lengths for prefill "
+                "throughput accounting."
+            ),
         )
         parser.add_argument(
             "--output-len", type=int, nargs="+", default=BenchArgs.output_len
@@ -459,6 +472,16 @@ def prepare_synthetic_inputs_for_latency_test(
         reqs.append(req)
 
     return reqs
+
+
+def prepare_skewed_synthetic_inputs_for_latency_test(input_lens):
+    input_ids = [
+        np.random.randint(0, 10000, input_len, dtype=np.int32)
+        for input_len in input_lens
+    ]
+    return prepare_synthetic_inputs_for_latency_test(
+        len(input_ids), max(input_lens), custom_inputs=input_ids
+    )
 
 
 class TreeCacheNamespace(SimpleNamespace):
@@ -742,6 +765,7 @@ def latency_test_run_once(
     tp_rank,
     profile_start_step=None,
     profile_steps=None,
+    total_input_tokens=None,
 ):
     max_batch_size = model_runner.max_batch_size(input_len, output_len)
     if batch_size > max_batch_size:
@@ -758,6 +782,9 @@ def latency_test_run_once(
         "input_len": input_len,
         "output_len": output_len,
     }
+    if total_input_tokens is None:
+        total_input_tokens = input_len * batch_size
+    measurement_results["total_input_tokens"] = total_input_tokens
 
     tot_latency = 0
 
@@ -792,7 +819,7 @@ def latency_test_run_once(
         )
 
     tot_latency += prefill_latency
-    throughput = input_len * batch_size / prefill_latency
+    throughput = total_input_tokens / prefill_latency
     rank_print(
         f"Prefill. latency: {prefill_latency:6.5f} s, throughput: {throughput:9.2f} token/s"
     )
@@ -857,7 +884,7 @@ def latency_test_run_once(
         measurement_results["median_decode_latency"] = med_decode_latency
         measurement_results["median_decode_throughput"] = med_decode_throughput
 
-    throughput = (input_len + output_len) * batch_size / tot_latency
+    throughput = (total_input_tokens + output_len * batch_size) / tot_latency
     rank_print(
         f"Total. latency: {tot_latency:6.3f} s, throughput: {throughput:9.2f} token/s"
     )
@@ -888,14 +915,31 @@ def latency_test(
     # Configure the logger
     configure_logger(server_args, prefix=f" TP{tp_rank}")
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
+    skewed_input_lens = tuple(int(x) for x in bench_args.skewed_input_lens)
+    if skewed_input_lens:
+        if any(x <= 0 for x in skewed_input_lens):
+            raise ValueError("--skewed-input-lens values must be positive integers")
+        if bench_args.prompt_filename:
+            raise ValueError(
+                "--skewed-input-lens cannot be combined with --prompt-filename"
+            )
 
     # Load the model
     model_runner, tokenizer = load_model(server_args, port_args, gpu_id, tp_rank)
 
     # Prepare inputs for warm up
-    reqs = prepare_synthetic_inputs_for_latency_test(
-        bench_args.batch_size[0], bench_args.input_len[0]
-    )
+    if skewed_input_lens:
+        reqs = prepare_skewed_synthetic_inputs_for_latency_test(skewed_input_lens)
+        warmup_batch_size = len(skewed_input_lens)
+        warmup_input_len = max(skewed_input_lens)
+        warmup_total_input_tokens = sum(skewed_input_lens)
+    else:
+        reqs = prepare_synthetic_inputs_for_latency_test(
+            bench_args.batch_size[0], bench_args.input_len[0]
+        )
+        warmup_batch_size = bench_args.batch_size[0]
+        warmup_input_len = bench_args.input_len[0]
+        warmup_total_input_tokens = warmup_batch_size * warmup_input_len
 
     # Warm up
     rank_print("Warmup ...")
@@ -904,8 +948,8 @@ def latency_test(
         model_runner,
         rank_print,
         reqs,
-        bench_args.batch_size[0],
-        bench_args.input_len[0],
+        warmup_batch_size,
+        warmup_input_len,
         min(32, bench_args.output_len[0]),  # shorter decoding to speed up the warmup
         log_decode_step=0,
         profile=False,
@@ -916,6 +960,7 @@ def latency_test(
         tp_rank=tp_rank,
         profile_start_step=None,
         profile_steps=None,
+        total_input_tokens=warmup_total_input_tokens,
     )
 
     rank_print("Benchmark ...")
@@ -926,30 +971,47 @@ def latency_test(
 
     # Run the sweep
     result_list = []
-    for bs, il, ol in itertools.product(
-        bench_args.batch_size, bench_args.input_len, bench_args.output_len
-    ):
-        bs_aligned_inputs = []
-        if custom_inputs:
-            if custom_input_len == bs:
-                bs_aligned_inputs = custom_inputs
-            elif custom_input_len > bs:
-                rank_print(
-                    f"Custom input size ({custom_input_len}) is larger than batch_size ({bs}). "
-                    f"Using the first {bs} prompts."
-                )
-                bs_aligned_inputs = copy.deepcopy(custom_inputs[:bs])
-            else:
-                rank_print(
-                    f"Custom input size ({custom_input_len}) is smaller than batch_size ({bs}). "
-                    f"Pad to the desired batch_size with the last prompt."
-                )
-                bs_aligned_inputs = copy.deepcopy(custom_inputs)
-                bs_aligned_inputs.extend(
-                    [bs_aligned_inputs[-1]] * (bs - custom_input_len)
-                )
+    if skewed_input_lens:
+        sweep = [
+            (
+                len(skewed_input_lens),
+                max(skewed_input_lens),
+                ol,
+                prepare_skewed_synthetic_inputs_for_latency_test(skewed_input_lens),
+                sum(skewed_input_lens),
+            )
+            for ol in bench_args.output_len
+        ]
+        rank_print(f"Skewed input lengths: {list(skewed_input_lens)}")
+    else:
+        sweep = []
+        for bs, il, ol in itertools.product(
+            bench_args.batch_size, bench_args.input_len, bench_args.output_len
+        ):
+            bs_aligned_inputs = []
+            if custom_inputs:
+                if custom_input_len == bs:
+                    bs_aligned_inputs = custom_inputs
+                elif custom_input_len > bs:
+                    rank_print(
+                        f"Custom input size ({custom_input_len}) is larger than batch_size ({bs}). "
+                        f"Using the first {bs} prompts."
+                    )
+                    bs_aligned_inputs = copy.deepcopy(custom_inputs[:bs])
+                else:
+                    rank_print(
+                        f"Custom input size ({custom_input_len}) is smaller than batch_size ({bs}). "
+                        f"Pad to the desired batch_size with the last prompt."
+                    )
+                    bs_aligned_inputs = copy.deepcopy(custom_inputs)
+                    bs_aligned_inputs.extend(
+                        [bs_aligned_inputs[-1]] * (bs - custom_input_len)
+                    )
 
-        reqs = prepare_synthetic_inputs_for_latency_test(bs, il, bs_aligned_inputs)
+            reqs = prepare_synthetic_inputs_for_latency_test(bs, il, bs_aligned_inputs)
+            sweep.append((bs, il, ol, reqs, bs * il))
+
+    for bs, il, ol, reqs, total_input_tokens in sweep:
         ret = latency_test_run_once(
             bench_args.run_name,
             model_runner,
@@ -967,6 +1029,7 @@ def latency_test(
             tp_rank,
             bench_args.profile_start_step,
             bench_args.profile_steps,
+            total_input_tokens=total_input_tokens,
         )
         if ret is not None:
             result_list.append(ret)
@@ -986,7 +1049,10 @@ def main(server_args, bench_args):
     # Post-init write to the legacy cuda_graph_max_bs_decode field would
     # not propagate to cuda_graph_config; update the decode phase directly.
     if server_args.cuda_graph_config is not None:
-        server_args.cuda_graph_config[Phase.DECODE].max_bs = max(bench_args.batch_size)
+        max_decode_bs = max(bench_args.batch_size)
+        if bench_args.skewed_input_lens:
+            max_decode_bs = max(max_decode_bs, len(bench_args.skewed_input_lens))
+        server_args.cuda_graph_config[Phase.DECODE].max_bs = max_decode_bs
 
     _set_envs_and_config(server_args)
 

--- a/python/sglang/kernels/aot/csrc/metal/bindings.cpp
+++ b/python/sglang/kernels/aot/csrc/metal/bindings.cpp
@@ -1,7 +1,7 @@
-#include "metal_common.h"
-
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
+
+#include "metal_common.h"
 
 namespace nb = nanobind;
 

--- a/python/sglang/kernels/aot/csrc/metal/bindings.cpp
+++ b/python/sglang/kernels/aot/csrc/metal/bindings.cpp
@@ -1,0 +1,12 @@
+#include "metal_common.h"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+
+namespace nb = nanobind;
+
+NB_MODULE(_metal, m) {
+  m.def("register_library", &sglang::metal_common::register_library, nb::arg("path"));
+  register_rope_pool_fused(m);
+  register_paged_attention(m);
+}

--- a/python/sglang/kernels/aot/csrc/metal/metal_common.cpp
+++ b/python/sglang/kernels/aot/csrc/metal/metal_common.cpp
@@ -1,0 +1,65 @@
+#include "metal_common.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include "mlx/backend/metal/device.h"
+#include "mlx/mlx.h"
+
+namespace sglang::metal_common {
+
+constexpr const char* kLibraryName = "sgl_metal_kernels";
+
+MTL::Library* g_library = nullptr;
+
+const char* dtype_suffix(Dtype dt) {
+  switch (dt) {
+    case float16:
+      return "f16";
+    case bfloat16:
+      return "bf16";
+    case float32:
+      return "f32";
+    default:
+      throw std::runtime_error("sgl_metal: unsupported dtype");
+  }
+}
+
+void register_library(const std::string& path) {
+  if (path.empty()) {
+    throw std::runtime_error("register_library requires a non-empty path");
+  }
+  auto& d = metal::device(Device::gpu);
+  g_library = d.get_library(kLibraryName, path);
+  if (g_library == nullptr) {
+    throw std::runtime_error("failed to load .metallib from: " + path);
+  }
+}
+
+MTL::Size pick_tg(uint32_t gx, uint32_t gy, uint32_t gz) {
+  constexpr uint32_t kMaxThreads = 256;
+  uint32_t tx = std::min<uint32_t>(gx, 32u);
+  uint32_t ty = std::min<uint32_t>(gy, kMaxThreads / std::max<uint32_t>(tx, 1u));
+  uint32_t tz = std::min<uint32_t>(gz, kMaxThreads / std::max<uint32_t>(tx * ty, 1u));
+  while (ty > 1 && (gy % ty) != 0)
+    --ty;
+  while (tz > 1 && (gz % tz) != 0)
+    --tz;
+  return MTL::Size::Make(tx, std::max<uint32_t>(ty, 1u), std::max<uint32_t>(tz, 1u));
+}
+
+metal::CommandEncoder& command_encoder(Stream stream) {
+  return metal::get_command_encoder(stream);
+}
+
+nb::object wrap_array(array&& value) {
+  nb::module_ mx_core = nb::module_::import_("mlx.core");
+  nb::object py_array_type = mx_core.attr("array");
+  nb::object py_obj = py_array_type(0);
+  auto* dst = nb::inst_ptr<array>(py_obj);
+  new (dst) array(std::move(value));
+  nb::inst_mark_ready(py_obj);
+  return py_obj;
+}
+
+}  // namespace sglang::metal_common

--- a/python/sglang/kernels/aot/csrc/metal/metal_common.h
+++ b/python/sglang/kernels/aot/csrc/metal/metal_common.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+#include <cstdint>
+#include <string>
+
+#include "mlx/array.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/stream.h"
+
+namespace nb = nanobind;
+using namespace mlx::core;
+
+namespace sglang::metal_common {
+
+extern MTL::Library* g_library;
+
+const char* dtype_suffix(Dtype dt);
+void register_library(const std::string& path);
+MTL::Size pick_tg(uint32_t gx, uint32_t gy, uint32_t gz);
+metal::CommandEncoder& command_encoder(Stream stream);
+nb::object wrap_array(array&& value);
+
+}  // namespace sglang::metal_common
+
+void register_rope_pool_fused(nb::module_& m);
+void register_paged_attention(nb::module_& m);

--- a/python/sglang/kernels/aot/csrc/metal/paged_attention.cpp
+++ b/python/sglang/kernels/aot/csrc/metal/paged_attention.cpp
@@ -1,9 +1,8 @@
-#include "metal_common.h"
-
 #include <cmath>
 #include <stdexcept>
 #include <string>
 
+#include "metal_common.h"
 #include "mlx/allocator.h"
 #include "mlx/mlx.h"
 #include "mlx/primitives.h"
@@ -63,10 +62,9 @@ class BlockPagedAttentionDecode : public Primitive {
     };
 
     const std::string kname = std::string("block_paged_attention_decode_") + dtype_suffix(q.dtype());
-    const std::string hash = kname + "_hd" + std::to_string(head_dim_) + "_q" +
-                             std::to_string(num_qo_heads_) + "_k" + std::to_string(num_kv_heads_) +
-                             "_bs" + std::to_string(block_size_) + "_mb" + std::to_string(mb) + "_s" +
-                             std::to_string(static_cast<int>(sm_scale_ * 1000000.0f));
+    const std::string hash = kname + "_hd" + std::to_string(head_dim_) + "_q" + std::to_string(num_qo_heads_) + "_k" +
+                             std::to_string(num_kv_heads_) + "_bs" + std::to_string(block_size_) + "_mb" +
+                             std::to_string(mb) + "_s" + std::to_string(static_cast<int>(sm_scale_ * 1000000.0f));
     auto* pipe = d.get_kernel(kname, g_library, hash, consts);
     if (!pipe) {
       throw std::runtime_error("block_paged_attention_decode: failed to resolve kernel");
@@ -81,7 +79,7 @@ class BlockPagedAttentionDecode : public Primitive {
     enc.set_output_array(out, 5);
 
     const uint32_t batch = static_cast<uint32_t>(q.shape(0));
-    enc.dispatch_threads(MTL::Size::Make(batch, nq, 32), MTL::Size::Make(1, 1, 32));
+    enc.dispatch_threads(MTL::Size::Make(batch, nq, 256), MTL::Size::Make(1, 1, 256));
   }
 
   const char* name() const override {
@@ -144,14 +142,13 @@ nb::object block_paged_attention_decode_py(
     throw std::runtime_error("block_paged_attention_decode: metadata batch dimension must match q");
   if (num_qo_heads % num_kv_heads != 0)
     throw std::runtime_error("block_paged_attention_decode: num_qo_heads must be divisible by num_kv_heads");
-  if (head_dim > 128)
-    throw std::runtime_error("block_paged_attention_decode: head_dim > 128 is not supported by this kernel");
-  if (block_size <= 0)
-    throw std::runtime_error("block_paged_attention_decode: block_size must be positive");
+  if (head_dim > 256)
+    throw std::runtime_error("block_paged_attention_decode: head_dim > 256 is not supported by this kernel");
+  if (block_size <= 0) throw std::runtime_error("block_paged_attention_decode: block_size must be positive");
 
   auto stream = default_stream(Device::gpu);
-  auto primitive = std::make_shared<BlockPagedAttentionDecode>(
-      stream, head_dim, num_qo_heads, num_kv_heads, block_size, sm_scale);
+  auto primitive =
+      std::make_shared<BlockPagedAttentionDecode>(stream, head_dim, num_qo_heads, num_kv_heads, block_size, sm_scale);
   auto outs = array::make_arrays({q.shape()}, {q.dtype()}, primitive, {q, k_blocks, v_blocks, block_tables, seq_lens});
   return wrap_array(std::move(outs[0]));
 }

--- a/python/sglang/kernels/aot/csrc/metal/paged_attention.cpp
+++ b/python/sglang/kernels/aot/csrc/metal/paged_attention.cpp
@@ -1,0 +1,175 @@
+#include "metal_common.h"
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+
+#include "mlx/allocator.h"
+#include "mlx/mlx.h"
+#include "mlx/primitives.h"
+#include "mlx/stream.h"
+
+using namespace mlx::core;
+using namespace sglang::metal_common;
+
+namespace {
+
+class BlockPagedAttentionDecode : public Primitive {
+ public:
+  BlockPagedAttentionDecode(
+      Stream stream, int head_dim, int num_qo_heads, int num_kv_heads, int block_size, float sm_scale)
+      : Primitive(stream),
+        head_dim_(head_dim),
+        num_qo_heads_(num_qo_heads),
+        num_kv_heads_(num_kv_heads),
+        block_size_(block_size),
+        sm_scale_(sm_scale) {}
+
+  void eval_cpu(const std::vector<array>&, std::vector<array>&) override {
+    throw std::runtime_error("block_paged_attention_decode: CPU eval not supported");
+  }
+
+  void eval_gpu(const std::vector<array>& inputs, std::vector<array>& outputs) override {
+    if (g_library == nullptr) {
+      throw std::runtime_error("block_paged_attention_decode: register_library() not called yet");
+    }
+
+    auto& q = inputs[0];
+    auto& k_blocks = inputs[1];
+    auto& v_blocks = inputs[2];
+    auto& block_tables = inputs[3];
+    auto& seq_lens = inputs[4];
+    auto& out = outputs[0];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    auto& d = metal::device(stream().device);
+    auto& enc = command_encoder(stream());
+
+    const uint32_t hd = static_cast<uint32_t>(head_dim_);
+    const uint32_t nq = static_cast<uint32_t>(num_qo_heads_);
+    const uint32_t nk = static_cast<uint32_t>(num_kv_heads_);
+    const uint32_t bs = static_cast<uint32_t>(block_size_);
+    const uint32_t mb = static_cast<uint32_t>(block_tables.shape(1));
+    const float scale = sm_scale_;
+
+    auto consts = metal::MTLFCList{
+        {&hd, MTL::DataType::DataTypeUInt, 0},
+        {&nq, MTL::DataType::DataTypeUInt, 1},
+        {&nk, MTL::DataType::DataTypeUInt, 2},
+        {&scale, MTL::DataType::DataTypeFloat, 3},
+        {&bs, MTL::DataType::DataTypeUInt, 4},
+        {&mb, MTL::DataType::DataTypeUInt, 5},
+    };
+
+    const std::string kname = std::string("block_paged_attention_decode_") + dtype_suffix(q.dtype());
+    const std::string hash = kname + "_hd" + std::to_string(head_dim_) + "_q" +
+                             std::to_string(num_qo_heads_) + "_k" + std::to_string(num_kv_heads_) +
+                             "_bs" + std::to_string(block_size_) + "_mb" + std::to_string(mb) + "_s" +
+                             std::to_string(static_cast<int>(sm_scale_ * 1000000.0f));
+    auto* pipe = d.get_kernel(kname, g_library, hash, consts);
+    if (!pipe) {
+      throw std::runtime_error("block_paged_attention_decode: failed to resolve kernel");
+    }
+
+    enc.set_compute_pipeline_state(pipe);
+    enc.set_input_array(q, 0);
+    enc.set_input_array(k_blocks, 1);
+    enc.set_input_array(v_blocks, 2);
+    enc.set_input_array(block_tables, 3);
+    enc.set_input_array(seq_lens, 4);
+    enc.set_output_array(out, 5);
+
+    const uint32_t batch = static_cast<uint32_t>(q.shape(0));
+    enc.dispatch_threads(MTL::Size::Make(batch, nq, 32), MTL::Size::Make(1, 1, 32));
+  }
+
+  const char* name() const override {
+    return "BlockPagedAttentionDecode";
+  }
+
+  bool is_equivalent(const Primitive& other) const override {
+    auto* o = dynamic_cast<const BlockPagedAttentionDecode*>(&other);
+    return o != nullptr && o->head_dim_ == head_dim_ && o->num_qo_heads_ == num_qo_heads_ &&
+           o->num_kv_heads_ == num_kv_heads_ && o->block_size_ == block_size_ && o->sm_scale_ == sm_scale_;
+  }
+
+  std::vector<Shape> output_shapes(const std::vector<array>& inputs) override {
+    return {inputs[0].shape()};
+  }
+
+ private:
+  int head_dim_;
+  int num_qo_heads_;
+  int num_kv_heads_;
+  int block_size_;
+  float sm_scale_;
+};
+
+nb::object block_paged_attention_decode_py(
+    nb::handle q_h,
+    nb::handle k_blocks_h,
+    nb::handle v_blocks_h,
+    nb::handle block_tables_h,
+    nb::handle seq_lens_h,
+    int num_qo_heads,
+    int num_kv_heads,
+    int head_dim,
+    int block_size,
+    float sm_scale) {
+  auto& q = *nb::inst_ptr<array>(q_h);
+  auto& k_blocks = *nb::inst_ptr<array>(k_blocks_h);
+  auto& v_blocks = *nb::inst_ptr<array>(v_blocks_h);
+  auto& block_tables = *nb::inst_ptr<array>(block_tables_h);
+  auto& seq_lens = *nb::inst_ptr<array>(seq_lens_h);
+
+  if (q.ndim() != 3) throw std::runtime_error("block_paged_attention_decode: q must be 3-D");
+  if (k_blocks.ndim() != 4 || v_blocks.ndim() != 4)
+    throw std::runtime_error("block_paged_attention_decode: K/V blocks must be 4-D");
+  if (block_tables.ndim() != 2 || seq_lens.ndim() != 1)
+    throw std::runtime_error("block_paged_attention_decode: block_tables must be 2-D and seq_lens must be 1-D");
+  if (block_tables.dtype() != int32 || seq_lens.dtype() != int32)
+    throw std::runtime_error("block_paged_attention_decode: block_tables/seq_lens must be int32");
+  if (q.dtype() != k_blocks.dtype() || q.dtype() != v_blocks.dtype())
+    throw std::runtime_error("block_paged_attention_decode: q/k_blocks/v_blocks must share dtype");
+  if (q.shape(1) != num_qo_heads || q.shape(2) != head_dim)
+    throw std::runtime_error("block_paged_attention_decode: q shape must be [batch, num_qo_heads, head_dim]");
+  if (k_blocks.shape(1) != block_size || v_blocks.shape(1) != block_size || k_blocks.shape(2) != num_kv_heads ||
+      v_blocks.shape(2) != num_kv_heads || k_blocks.shape(3) != head_dim || v_blocks.shape(3) != head_dim)
+    throw std::runtime_error(
+        "block_paged_attention_decode: K/V layout must be [num_blocks, block_size, num_kv_heads, head_dim]");
+  if (v_blocks.shape(0) != k_blocks.shape(0))
+    throw std::runtime_error("block_paged_attention_decode: k_blocks and v_blocks must have same block count");
+  if (block_tables.shape(0) != q.shape(0) || seq_lens.shape(0) != q.shape(0))
+    throw std::runtime_error("block_paged_attention_decode: metadata batch dimension must match q");
+  if (num_qo_heads % num_kv_heads != 0)
+    throw std::runtime_error("block_paged_attention_decode: num_qo_heads must be divisible by num_kv_heads");
+  if (head_dim > 128)
+    throw std::runtime_error("block_paged_attention_decode: head_dim > 128 is not supported by this kernel");
+  if (block_size <= 0)
+    throw std::runtime_error("block_paged_attention_decode: block_size must be positive");
+
+  auto stream = default_stream(Device::gpu);
+  auto primitive = std::make_shared<BlockPagedAttentionDecode>(
+      stream, head_dim, num_qo_heads, num_kv_heads, block_size, sm_scale);
+  auto outs = array::make_arrays({q.shape()}, {q.dtype()}, primitive, {q, k_blocks, v_blocks, block_tables, seq_lens});
+  return wrap_array(std::move(outs[0]));
+}
+
+}  // namespace
+
+void register_paged_attention(nb::module_& m) {
+  m.def(
+      "block_paged_attention_decode",
+      &block_paged_attention_decode_py,
+      nb::arg("q"),
+      nb::arg("k_blocks"),
+      nb::arg("v_blocks"),
+      nb::arg("block_tables"),
+      nb::arg("seq_lens"),
+      nb::arg("num_qo_heads"),
+      nb::arg("num_kv_heads"),
+      nb::arg("head_dim"),
+      nb::arg("block_size"),
+      nb::arg("sm_scale"));
+}

--- a/python/sglang/kernels/aot/csrc/metal/paged_attention.cpp
+++ b/python/sglang/kernels/aot/csrc/metal/paged_attention.cpp
@@ -58,13 +58,12 @@ class BlockPagedAttentionDecode : public Primitive {
         {&nk, MTL::DataType::DataTypeUInt, 2},
         {&scale, MTL::DataType::DataTypeFloat, 3},
         {&bs, MTL::DataType::DataTypeUInt, 4},
-        {&mb, MTL::DataType::DataTypeUInt, 5},
     };
 
     const std::string kname = std::string("block_paged_attention_decode_") + dtype_suffix(q.dtype());
     const std::string hash = kname + "_hd" + std::to_string(head_dim_) + "_q" + std::to_string(num_qo_heads_) + "_k" +
-                             std::to_string(num_kv_heads_) + "_bs" + std::to_string(block_size_) + "_mb" +
-                             std::to_string(mb) + "_s" + std::to_string(static_cast<int>(sm_scale_ * 1000000.0f));
+                             std::to_string(num_kv_heads_) + "_bs" + std::to_string(block_size_) + "_s" +
+                             std::to_string(static_cast<int>(sm_scale_ * 1000000.0f));
     auto* pipe = d.get_kernel(kname, g_library, hash, consts);
     if (!pipe) {
       throw std::runtime_error("block_paged_attention_decode: failed to resolve kernel");
@@ -77,6 +76,7 @@ class BlockPagedAttentionDecode : public Primitive {
     enc.set_input_array(block_tables, 3);
     enc.set_input_array(seq_lens, 4);
     enc.set_output_array(out, 5);
+    enc.set_bytes(&mb, sizeof(uint32_t), 6);
 
     const uint32_t batch = static_cast<uint32_t>(q.shape(0));
     enc.dispatch_threads(MTL::Size::Make(batch, nq, 256), MTL::Size::Make(1, 1, 256));

--- a/python/sglang/kernels/aot/csrc/metal/paged_attention.metal
+++ b/python/sglang/kernels/aot/csrc/metal/paged_attention.metal
@@ -10,8 +10,10 @@ constant float SM_SCALE     [[function_constant(3)]];
 constant uint  BLOCK_SIZE   [[function_constant(4)]];
 constant uint  MAX_BLOCKS   [[function_constant(5)]];
 
-constant uint PAGED_ATTN_TG_SIZE = 32;
-constant uint PAGED_ATTN_MAX_HEAD_DIM = 128;
+constant uint PAGED_ATTN_NUM_THREADS = 256;
+constant uint PAGED_ATTN_SIMD_SIZE = 32;
+constant uint PAGED_ATTN_NUM_WARPS = PAGED_ATTN_NUM_THREADS / PAGED_ATTN_SIMD_SIZE;
+constant uint PAGED_ATTN_MAX_HEAD_DIM = 256;
 
 inline float simd_max_32(float value) {
     value = max(value, simd_shuffle_xor(value, ushort(16)));
@@ -31,6 +33,10 @@ inline float simd_sum_32(float value) {
     return value;
 }
 
+inline float warp_state_scale(float warp_max, float row_max) {
+    return warp_max == -INFINITY ? 0.0f : metal::exp(warp_max - row_max);
+}
+
 template <typename T>
 inline void block_paged_attention_decode_impl(
     const device T*       q,
@@ -39,12 +45,17 @@ inline void block_paged_attention_decode_impl(
     const device int32_t* block_tables,
     const device int32_t* seq_lens,
     device T*             out,
-    uint3 tid,
-    uint3 tg_pos
+    uint3 tg_pos,
+    uint simd_tid,
+    uint simd_lid,
+    threadgroup float*    warp_maxes,
+    threadgroup float*    warp_sums,
+    threadgroup float*    warp_accs
 ) {
     const uint batch_id = tg_pos.x;
     const uint q_head = tg_pos.y;
-    const uint lane = tid.z;
+    const uint warp = simd_tid;
+    const uint lane = simd_lid;
 
     const uint kv_group = NUM_QO_HEADS / NUM_KV_HEADS;
     const uint kv_head = q_head / kv_group;
@@ -58,7 +69,9 @@ inline void block_paged_attention_decode_impl(
         local_acc[d] = 0.0f;
     }
 
-    for (int32_t token_idx = int32_t(lane); token_idx < seq_len; token_idx += int32_t(PAGED_ATTN_TG_SIZE)) {
+    for (int32_t token_idx = int32_t(warp * PAGED_ATTN_SIMD_SIZE + lane);
+         token_idx < seq_len;
+         token_idx += int32_t(PAGED_ATTN_NUM_THREADS)) {
         const uint logical_block = uint(token_idx) / BLOCK_SIZE;
         const uint block_offset = uint(token_idx) - logical_block * BLOCK_SIZE;
         const int32_t physical_block = block_tables[batch_id * MAX_BLOCKS + logical_block];
@@ -105,17 +118,50 @@ inline void block_paged_attention_decode_impl(
         local_max = new_max;
     }
 
-    const float row_max = simd_max_32(local_max);
-    const float lane_scale = metal::exp(local_max - row_max);
-    const float row_sum = simd_sum_32(local_sum * lane_scale);
+    const float warp_max = simd_max_32(local_max);
+    const bool warp_has_tokens = warp_max != -INFINITY;
+    const float lane_scale = warp_has_tokens ? metal::exp(local_max - warp_max) : 0.0f;
+    const float warp_sum = warp_has_tokens ? simd_sum_32(local_sum * lane_scale) : 0.0f;
+
+    if (lane == 0) {
+        warp_maxes[warp] = warp_max;
+        warp_sums[warp] = warp_sum;
+    }
+    for (uint d = 0; d < HEAD_DIM; ++d) {
+        const float warp_acc = simd_sum_32(local_acc[d] * lane_scale);
+        if (lane == 0) {
+            warp_accs[warp * PAGED_ATTN_MAX_HEAD_DIM + d] =
+                warp_has_tokens ? warp_acc : 0.0f;
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (warp != 0) {
+        return;
+    }
+
+    float row_max = -INFINITY;
+    for (uint w = 0; w < PAGED_ATTN_NUM_WARPS; ++w) {
+        row_max = max(row_max, warp_maxes[w]);
+    }
+    if (row_max == -INFINITY) {
+        row_max = 0.0f;
+    }
+
+    float row_sum = 0.0f;
+    for (uint w = 0; w < PAGED_ATTN_NUM_WARPS; ++w) {
+        row_sum += warp_sums[w] * warp_state_scale(warp_maxes[w], row_max);
+    }
 
     const uint out_base = (batch_id * NUM_QO_HEADS + q_head) * HEAD_DIM;
     const float inv_sum = row_sum == 0.0f ? 0.0f : 1.0f / row_sum;
-    for (uint d = 0; d < HEAD_DIM; ++d) {
-        float acc = simd_sum_32(local_acc[d] * lane_scale);
-        if (lane == 0) {
-            out[out_base + d] = static_cast<T>(acc * inv_sum);
+    for (uint d = lane; d < HEAD_DIM; d += PAGED_ATTN_SIMD_SIZE) {
+        float acc = 0.0f;
+        for (uint w = 0; w < PAGED_ATTN_NUM_WARPS; ++w) {
+            acc += warp_accs[w * PAGED_ATTN_MAX_HEAD_DIM + d] *
+                   warp_state_scale(warp_maxes[w], row_max);
         }
+        out[out_base + d] = static_cast<T>(acc * inv_sum);
     }
 }
 
@@ -128,10 +174,15 @@ inline void block_paged_attention_decode_impl(
         const device int32_t* block_tables [[buffer(3)]],                               \
         const device int32_t* seq_lens     [[buffer(4)]],                               \
         device T*             out          [[buffer(5)]],                               \
-        uint3 tid [[thread_position_in_threadgroup]],                                   \
-        uint3 tg_pos [[threadgroup_position_in_grid]]) {                                \
+        uint3 tg_pos [[threadgroup_position_in_grid]],                                  \
+        uint simd_tid [[simdgroup_index_in_threadgroup]],                               \
+        uint simd_lid [[thread_index_in_simdgroup]]) {                                  \
+        threadgroup float warp_maxes[PAGED_ATTN_NUM_WARPS];                             \
+        threadgroup float warp_sums[PAGED_ATTN_NUM_WARPS];                              \
+        threadgroup float warp_accs[PAGED_ATTN_NUM_WARPS * PAGED_ATTN_MAX_HEAD_DIM];    \
         block_paged_attention_decode_impl<T>(q, k_blocks, v_blocks, block_tables,       \
-                                             seq_lens, out, tid, tg_pos);               \
+                                             seq_lens, out, tg_pos, simd_tid, simd_lid, \
+                                             warp_maxes, warp_sums, warp_accs);         \
     }
 
 INSTANTIATE_BLOCK(f16,  half)

--- a/python/sglang/kernels/aot/csrc/metal/paged_attention.metal
+++ b/python/sglang/kernels/aot/csrc/metal/paged_attention.metal
@@ -8,7 +8,6 @@ constant uint  NUM_QO_HEADS [[function_constant(1)]];
 constant uint  NUM_KV_HEADS [[function_constant(2)]];
 constant float SM_SCALE     [[function_constant(3)]];
 constant uint  BLOCK_SIZE   [[function_constant(4)]];
-constant uint  MAX_BLOCKS   [[function_constant(5)]];
 
 constant uint PAGED_ATTN_NUM_THREADS = 256;
 constant uint PAGED_ATTN_SIMD_SIZE = 32;
@@ -44,6 +43,7 @@ inline void block_paged_attention_decode_impl(
     const device T*       v_blocks,
     const device int32_t* block_tables,
     const device int32_t* seq_lens,
+    const constant uint&  max_blocks,
     device T*             out,
     uint3 tg_pos,
     uint simd_tid,
@@ -74,7 +74,7 @@ inline void block_paged_attention_decode_impl(
          token_idx += int32_t(PAGED_ATTN_NUM_THREADS)) {
         const uint logical_block = uint(token_idx) / BLOCK_SIZE;
         const uint block_offset = uint(token_idx) - logical_block * BLOCK_SIZE;
-        const int32_t physical_block = block_tables[batch_id * MAX_BLOCKS + logical_block];
+        const int32_t physical_block = block_tables[batch_id * max_blocks + logical_block];
         if (physical_block < 0) {
             continue;
         }
@@ -174,6 +174,7 @@ inline void block_paged_attention_decode_impl(
         const device int32_t* block_tables [[buffer(3)]],                               \
         const device int32_t* seq_lens     [[buffer(4)]],                               \
         device T*             out          [[buffer(5)]],                               \
+        const constant uint&  max_blocks   [[buffer(6)]],                               \
         uint3 tg_pos [[threadgroup_position_in_grid]],                                  \
         uint simd_tid [[simdgroup_index_in_threadgroup]],                               \
         uint simd_lid [[thread_index_in_simdgroup]]) {                                  \
@@ -181,8 +182,9 @@ inline void block_paged_attention_decode_impl(
         threadgroup float warp_sums[PAGED_ATTN_NUM_WARPS];                              \
         threadgroup float warp_accs[PAGED_ATTN_NUM_WARPS * PAGED_ATTN_MAX_HEAD_DIM];    \
         block_paged_attention_decode_impl<T>(q, k_blocks, v_blocks, block_tables,       \
-                                             seq_lens, out, tg_pos, simd_tid, simd_lid, \
-                                             warp_maxes, warp_sums, warp_accs);         \
+                                             seq_lens, max_blocks, out, tg_pos,         \
+                                             simd_tid, simd_lid, warp_maxes, warp_sums, \
+                                             warp_accs);                                \
     }
 
 INSTANTIATE_BLOCK(f16,  half)

--- a/python/sglang/kernels/aot/csrc/metal/paged_attention.metal
+++ b/python/sglang/kernels/aot/csrc/metal/paged_attention.metal
@@ -1,0 +1,139 @@
+// SGLang Apple Silicon Metal kernel: block-table paged decode attention.
+
+#include <metal_stdlib>
+using namespace metal;
+
+constant uint  HEAD_DIM     [[function_constant(0)]];
+constant uint  NUM_QO_HEADS [[function_constant(1)]];
+constant uint  NUM_KV_HEADS [[function_constant(2)]];
+constant float SM_SCALE     [[function_constant(3)]];
+constant uint  BLOCK_SIZE   [[function_constant(4)]];
+constant uint  MAX_BLOCKS   [[function_constant(5)]];
+
+constant uint PAGED_ATTN_TG_SIZE = 32;
+constant uint PAGED_ATTN_MAX_HEAD_DIM = 128;
+
+inline float simd_max_32(float value) {
+    value = max(value, simd_shuffle_xor(value, ushort(16)));
+    value = max(value, simd_shuffle_xor(value, ushort(8)));
+    value = max(value, simd_shuffle_xor(value, ushort(4)));
+    value = max(value, simd_shuffle_xor(value, ushort(2)));
+    value = max(value, simd_shuffle_xor(value, ushort(1)));
+    return value;
+}
+
+inline float simd_sum_32(float value) {
+    value += simd_shuffle_xor(value, ushort(16));
+    value += simd_shuffle_xor(value, ushort(8));
+    value += simd_shuffle_xor(value, ushort(4));
+    value += simd_shuffle_xor(value, ushort(2));
+    value += simd_shuffle_xor(value, ushort(1));
+    return value;
+}
+
+template <typename T>
+inline void block_paged_attention_decode_impl(
+    const device T*       q,
+    const device T*       k_blocks,
+    const device T*       v_blocks,
+    const device int32_t* block_tables,
+    const device int32_t* seq_lens,
+    device T*             out,
+    uint3 tid,
+    uint3 tg_pos
+) {
+    const uint batch_id = tg_pos.x;
+    const uint q_head = tg_pos.y;
+    const uint lane = tid.z;
+
+    const uint kv_group = NUM_QO_HEADS / NUM_KV_HEADS;
+    const uint kv_head = q_head / kv_group;
+    const int32_t seq_len = seq_lens[batch_id];
+    const uint q_base = (batch_id * NUM_QO_HEADS + q_head) * HEAD_DIM;
+
+    float local_max = -INFINITY;
+    float local_sum = 0.0f;
+    float local_acc[PAGED_ATTN_MAX_HEAD_DIM];
+    for (uint d = 0; d < HEAD_DIM; ++d) {
+        local_acc[d] = 0.0f;
+    }
+
+    for (int32_t token_idx = int32_t(lane); token_idx < seq_len; token_idx += int32_t(PAGED_ATTN_TG_SIZE)) {
+        const uint logical_block = uint(token_idx) / BLOCK_SIZE;
+        const uint block_offset = uint(token_idx) - logical_block * BLOCK_SIZE;
+        const int32_t physical_block = block_tables[batch_id * MAX_BLOCKS + logical_block];
+        if (physical_block < 0) {
+            continue;
+        }
+        const uint kv_base =
+            (((uint)physical_block * BLOCK_SIZE + block_offset) * NUM_KV_HEADS + kv_head) * HEAD_DIM;
+
+        float logit = 0.0f;
+        uint d = 0;
+        for (; d + 3 < HEAD_DIM; d += 4) {
+            const float4 qv = float4(
+                float(q[q_base + d + 0]),
+                float(q[q_base + d + 1]),
+                float(q[q_base + d + 2]),
+                float(q[q_base + d + 3]));
+            const float4 kv = float4(
+                float(k_blocks[kv_base + d + 0]),
+                float(k_blocks[kv_base + d + 1]),
+                float(k_blocks[kv_base + d + 2]),
+                float(k_blocks[kv_base + d + 3]));
+            logit += dot(qv, kv);
+        }
+        for (; d < HEAD_DIM; ++d) {
+            logit += float(q[q_base + d]) * float(k_blocks[kv_base + d]);
+        }
+        logit *= SM_SCALE;
+
+        const float new_max = max(local_max, logit);
+        const float old_scale = metal::exp(local_max - new_max);
+        const float weight = metal::exp(logit - new_max);
+        local_sum = local_sum * old_scale + weight;
+        d = 0;
+        for (; d + 3 < HEAD_DIM; d += 4) {
+            local_acc[d + 0] = local_acc[d + 0] * old_scale + weight * float(v_blocks[kv_base + d + 0]);
+            local_acc[d + 1] = local_acc[d + 1] * old_scale + weight * float(v_blocks[kv_base + d + 1]);
+            local_acc[d + 2] = local_acc[d + 2] * old_scale + weight * float(v_blocks[kv_base + d + 2]);
+            local_acc[d + 3] = local_acc[d + 3] * old_scale + weight * float(v_blocks[kv_base + d + 3]);
+        }
+        for (; d < HEAD_DIM; ++d) {
+            local_acc[d] = local_acc[d] * old_scale + weight * float(v_blocks[kv_base + d]);
+        }
+        local_max = new_max;
+    }
+
+    const float row_max = simd_max_32(local_max);
+    const float lane_scale = metal::exp(local_max - row_max);
+    const float row_sum = simd_sum_32(local_sum * lane_scale);
+
+    const uint out_base = (batch_id * NUM_QO_HEADS + q_head) * HEAD_DIM;
+    const float inv_sum = row_sum == 0.0f ? 0.0f : 1.0f / row_sum;
+    for (uint d = 0; d < HEAD_DIM; ++d) {
+        float acc = simd_sum_32(local_acc[d] * lane_scale);
+        if (lane == 0) {
+            out[out_base + d] = static_cast<T>(acc * inv_sum);
+        }
+    }
+}
+
+#define INSTANTIATE_BLOCK(NAME, T)                                                      \
+    [[host_name("block_paged_attention_decode_" #NAME)]] [[kernel]] void               \
+    block_paged_attention_decode_##NAME(                                                \
+        const device T*       q            [[buffer(0)]],                               \
+        const device T*       k_blocks     [[buffer(1)]],                               \
+        const device T*       v_blocks     [[buffer(2)]],                               \
+        const device int32_t* block_tables [[buffer(3)]],                               \
+        const device int32_t* seq_lens     [[buffer(4)]],                               \
+        device T*             out          [[buffer(5)]],                               \
+        uint3 tid [[thread_position_in_threadgroup]],                                   \
+        uint3 tg_pos [[threadgroup_position_in_grid]]) {                                \
+        block_paged_attention_decode_impl<T>(q, k_blocks, v_blocks, block_tables,       \
+                                             seq_lens, out, tid, tg_pos);               \
+    }
+
+INSTANTIATE_BLOCK(f16,  half)
+INSTANTIATE_BLOCK(bf16, bfloat)
+INSTANTIATE_BLOCK(f32,  float)

--- a/python/sglang/kernels/aot/csrc/metal/rope_pool_fused.cpp
+++ b/python/sglang/kernels/aot/csrc/metal/rope_pool_fused.cpp
@@ -2,7 +2,6 @@
 // 3-kernel + 3D-grid dispatch + fused KV pool write.
 
 #include <nanobind/nanobind.h>
-#include <nanobind/stl/string.h>
 
 #include <algorithm>
 #include <cmath>
@@ -10,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "metal_common.h"
 #include "mlx/allocator.h"
 #include "mlx/array.h"
 #include "mlx/backend/metal/device.h"
@@ -19,48 +19,9 @@
 
 namespace nb = nanobind;
 using namespace mlx::core;
+using namespace sglang::metal_common;
 
 namespace {
-
-constexpr const char* kLibraryName = "sgl_metal_kernels";
-
-MTL::Library* g_library = nullptr;
-
-const char* dtype_suffix(Dtype dt) {
-  switch (dt) {
-    case float16:
-      return "f16";
-    case bfloat16:
-      return "bf16";
-    case float32:
-      return "f32";
-    default:
-      throw std::runtime_error("rope_pool_fused: unsupported dtype");
-  }
-}
-
-void register_library_impl(const std::string& path) {
-  if (path.empty()) {
-    throw std::runtime_error("register_library requires a non-empty path");
-  }
-  auto& d = metal::device(Device::gpu);
-  g_library = d.get_library(kLibraryName, path);
-  if (g_library == nullptr) {
-    throw std::runtime_error("failed to load .metallib from: " + path);
-  }
-}
-
-MTL::Size pick_tg(uint32_t gx, uint32_t gy, uint32_t gz) {
-  constexpr uint32_t kMaxThreads = 256;
-  uint32_t tx = std::min<uint32_t>(gx, 32u);
-  uint32_t ty = std::min<uint32_t>(gy, kMaxThreads / std::max<uint32_t>(tx, 1u));
-  uint32_t tz = std::min<uint32_t>(gz, kMaxThreads / std::max<uint32_t>(tx * ty, 1u));
-  while (ty > 1 && (gy % ty) != 0)
-    --ty;
-  while (tz > 1 && (gz % tz) != 0)
-    --tz;
-  return MTL::Size::Make(tx, std::max<uint32_t>(ty, 1u), std::max<uint32_t>(tz, 1u));
-}
 
 uint32_t pick_heads_per_thread(uint32_t nh) {
   if (nh == 0) return 1;
@@ -146,7 +107,7 @@ class RopePoolFused : public Primitive {
     uint32_t hpt = std::min(hpt_q, hpt_k);
     if (nq % hpt != 0 || nk % hpt != 0) hpt = 1;
 
-    auto& enc = metal::get_command_encoder(stream());
+    auto& enc = command_encoder(stream());
 
     const bool use_rect_dispatch = q.dtype() == bfloat16 && hd >= 128 && nk >= 8 && num_tokens >= 256;
     if (use_rect_dispatch) {
@@ -288,26 +249,16 @@ nb::tuple rope_pool_fused_py(
       primitive,
       {q, k, v, positions, slots, k_pool, v_pool});
 
-  // Cross-module nb cast doesn't work cleanly - explicitly construct.
-  nb::module_ mx_core = nb::module_::import_("mlx.core");
-  nb::object py_array_type = mx_core.attr("array");
-
   nb::list result;
   for (auto& a : outs) {
-    nb::object py_obj = py_array_type(0);
-    auto* dst = nb::inst_ptr<array>(py_obj);
-    new (dst) array(std::move(a));
-    nb::inst_mark_ready(py_obj);
-    result.append(py_obj);
+    result.append(wrap_array(std::move(a)));
   }
   return nb::tuple(result);
 }
 
 }  // namespace
 
-NB_MODULE(_metal, m) {
-  m.def("register_library", &register_library_impl, nb::arg("path"));
-
+void register_rope_pool_fused(nb::module_& m) {
   m.def(
       "rope_pool_fused",
       &rope_pool_fused_py,

--- a/python/sglang/kernels/aot/python/sgl_kernel/metal.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/metal.py
@@ -170,9 +170,9 @@ def block_paged_attention_decode(
         raise ValueError("seq_lens must have one entry per batch item")
     if num_qo_heads % num_kv_heads != 0:
         raise ValueError("num_qo_heads must be divisible by num_kv_heads")
-    if head_dim > 128:
+    if head_dim > 256:
         raise ValueError(
-            "block_paged_attention_decode currently supports head_dim <= 128"
+            "block_paged_attention_decode currently supports head_dim <= 256"
         )
     if q.dtype != k_blocks.dtype or q.dtype != v_blocks.dtype:
         raise ValueError("q/k_blocks/v_blocks dtypes must match")

--- a/python/sglang/kernels/aot/python/sgl_kernel/metal.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/metal.py
@@ -113,18 +113,18 @@ def rope_pool_fused(
 
 
 def block_paged_attention_decode(
-    q: "mx.array",
-    k_blocks: "mx.array",
-    v_blocks: "mx.array",
-    block_tables: "mx.array",
-    seq_lens: "mx.array",
+    q: mx.array,
+    k_blocks: mx.array,
+    v_blocks: mx.array,
+    block_tables: mx.array,
+    seq_lens: mx.array,
     *,
     num_qo_heads: int,
     num_kv_heads: int,
     head_dim: int,
     block_size: int,
     sm_scale: float,
-) -> "mx.array":
+) -> mx.array:
     """Decode attention over a block-table MLX KV layout.
 
     Args:

--- a/python/sglang/kernels/aot/python/sgl_kernel/metal.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/metal.py
@@ -110,3 +110,82 @@ def rope_pool_fused(
         num_kv_heads,
         float(rope_base),
     )
+
+
+def block_paged_attention_decode(
+    q: "mx.array",
+    k_blocks: "mx.array",
+    v_blocks: "mx.array",
+    block_tables: "mx.array",
+    seq_lens: "mx.array",
+    *,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    block_size: int,
+    sm_scale: float,
+) -> "mx.array":
+    """Decode attention over a block-table MLX KV layout.
+
+    Args:
+        q: Query tensor with shape `[batch, num_qo_heads, head_dim]`.
+        k_blocks: Key blocks with shape
+            `[num_blocks, block_size, num_kv_heads, head_dim]`.
+        v_blocks: Value blocks with the same shape as `k_blocks`.
+        block_tables: int32 physical block IDs with shape
+            `[batch, max_num_blocks]`; `-1` entries are padding.
+        seq_lens: int32 visible sequence lengths with shape `[batch]`.
+
+    Returns:
+        Attention output with shape `[batch, num_qo_heads, head_dim]`.
+    """
+    if q.ndim != 3:
+        raise ValueError("block_paged_attention_decode expects q to be 3-D")
+    if k_blocks.ndim != 4 or v_blocks.ndim != 4:
+        raise ValueError("block_paged_attention_decode expects K/V blocks to be 4-D")
+    if block_tables.ndim != 2 or seq_lens.ndim != 1:
+        raise ValueError(
+            "block_paged_attention_decode expects block_tables to be 2-D and seq_lens to be 1-D"
+        )
+
+    q_shape = tuple(q.shape)
+    k_shape = tuple(k_blocks.shape)
+    v_shape = tuple(v_blocks.shape)
+    if q_shape[1:] != (num_qo_heads, head_dim):
+        raise ValueError(
+            "q shape must be [batch, num_qo_heads, head_dim], " f"got {q.shape}"
+        )
+    if k_shape[1:] != (block_size, num_kv_heads, head_dim):
+        raise ValueError(
+            "k_blocks must have shape [num_blocks, block_size, num_kv_heads, head_dim], "
+            f"got {k_blocks.shape}"
+        )
+    if v_shape != k_shape:
+        raise ValueError(
+            f"v_blocks shape must match k_blocks shape, got {v_blocks.shape} vs {k_blocks.shape}"
+        )
+    if tuple(block_tables.shape)[0] != q_shape[0]:
+        raise ValueError("block_tables must have one row per batch item")
+    if tuple(seq_lens.shape) != (q_shape[0],):
+        raise ValueError("seq_lens must have one entry per batch item")
+    if num_qo_heads % num_kv_heads != 0:
+        raise ValueError("num_qo_heads must be divisible by num_kv_heads")
+    if head_dim > 128:
+        raise ValueError(
+            "block_paged_attention_decode currently supports head_dim <= 128"
+        )
+    if q.dtype != k_blocks.dtype or q.dtype != v_blocks.dtype:
+        raise ValueError("q/k_blocks/v_blocks dtypes must match")
+
+    return _metal.block_paged_attention_decode(
+        q,
+        k_blocks,
+        v_blocks,
+        block_tables,
+        seq_lens,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        block_size,
+        float(sm_scale),
+    )

--- a/python/sglang/kernels/aot/setup_metal.py
+++ b/python/sglang/kernels/aot/setup_metal.py
@@ -96,9 +96,13 @@ metallib_name = "sgl_metal_kernels.metallib"
 # (compiled with `c++`). Add new kernels by appending to these lists.
 metal_shader_sources = [
     "csrc/metal/rope_pool_fused.metal",
+    "csrc/metal/paged_attention.metal",
 ]
 cxx_sources = [
+    "csrc/metal/metal_common.cpp",
     "csrc/metal/rope_pool_fused.cpp",
+    "csrc/metal/paged_attention.cpp",
+    "csrc/metal/bindings.cpp",
 ]
 
 # Header search paths shared by both the Metal shader compiler and the C++

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -598,6 +598,7 @@ class Envs:
     # MPS (Apple Silicon)
     SGLANG_USE_MLX = EnvBool(False)
     SGLANG_MLX_USE_CUSTOM_ROPE = EnvBool(False)
+    SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION = EnvBool(False)
     SGLANG_MLX_FUSE_SWIGLU = EnvBool(False)
     # Number of decode steps between periodic mx.clear_cache() calls.
     # Set to 0 to disable cache clearing entirely.

--- a/python/sglang/srt/hardware_backend/mlx/aot.py
+++ b/python/sglang/srt/hardware_backend/mlx/aot.py
@@ -208,7 +208,7 @@ def _build_rope_kernel(inputs: MlxAOTKernelBuildInputs) -> MlxAOTRoPEKernel:
 def _build_block_paged_attention_kernel(
     inputs: MlxAOTKernelBuildInputs,
 ) -> MlxAOTBlockPagedAttentionKernel:
-    if inputs.head_dim > 128:
+    if inputs.head_dim > 256:
         return MlxAOTBlockPagedAttentionKernel()
     try:
         block_paged_attention_decode = _load_metal_block_paged_attention_decode()

--- a/python/sglang/srt/hardware_backend/mlx/aot.py
+++ b/python/sglang/srt/hardware_backend/mlx/aot.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 def _load_metal_rope_pool_fused():
     try:
-        from sgl_kernel import metal
+        from sgl_kernel import metal  # type: ignore[import-not-found]
     except ImportError as exc:
         raise ImportError(
             "sgl_kernel.metal is not importable. Install sgl-kernel in the "
@@ -39,6 +39,27 @@ def _load_metal_rope_pool_fused():
     return metal.rope_pool_fused
 
 
+def _load_metal_block_paged_attention_decode():
+    try:
+        from sgl_kernel import metal  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImportError(
+            "sgl_kernel.metal is not importable. Install sgl-kernel in the "
+            "active environment before enabling SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION."
+        ) from exc
+
+    import_error = getattr(metal, "_IMPORT_ERROR", None)
+    if getattr(metal, "_metal", None) is None or import_error is not None:
+        reason = f" Reason: {import_error}." if import_error is not None else ""
+        raise ImportError(
+            "sgl_kernel.metal is importable, but the native Metal extension "
+            f"or metallib is not available.{reason} Install the Metal kernels "
+            "with `uv run sgl-kernel/setup_metal.py install` from the SGLang "
+            "repo root in the active environment."
+        ) from import_error
+    return metal.block_paged_attention_decode
+
+
 @dataclass
 class MlxAOTRoPEKernel:
     base: float = 0.0
@@ -50,6 +71,16 @@ class MlxAOTRoPEKernel:
         return (
             self.base > 0.0 and bool(self.config) and self.rope_pool_fused is not None
         )
+
+
+@dataclass
+class MlxAOTBlockPagedAttentionKernel:
+    block_paged_attention_decode: Optional[Any] = None
+    block_size: int = 16
+
+    @property
+    def enabled(self) -> bool:
+        return self.block_paged_attention_decode is not None
 
 
 @dataclass
@@ -70,6 +101,9 @@ class MlxAOTKernelSpec:
 @dataclass
 class MlxAOTKernelSet:
     rope: MlxAOTRoPEKernel = field(default_factory=MlxAOTRoPEKernel)
+    block_paged_attention: MlxAOTBlockPagedAttentionKernel = field(
+        default_factory=MlxAOTBlockPagedAttentionKernel
+    )
     selected_kernel_names: tuple[str, ...] = ()
 
 
@@ -171,6 +205,31 @@ def _build_rope_kernel(inputs: MlxAOTKernelBuildInputs) -> MlxAOTRoPEKernel:
     )
 
 
+def _build_block_paged_attention_kernel(
+    inputs: MlxAOTKernelBuildInputs,
+) -> MlxAOTBlockPagedAttentionKernel:
+    if inputs.head_dim > 128:
+        return MlxAOTBlockPagedAttentionKernel()
+    try:
+        block_paged_attention_decode = _load_metal_block_paged_attention_decode()
+    except Exception as exc:  # noqa: BLE001
+        logger.info(
+            "AOT Metal block paged attention kernel not available (%s) - "
+            "falling back to padded SDPA.",
+            exc,
+        )
+        return MlxAOTBlockPagedAttentionKernel()
+
+    logger.info(
+        f"AOT Metal block paged attention decode ENABLED: head_dim={inputs.head_dim}, "
+        f"n_kv={inputs.n_kv_heads}, block_size=16"
+    )
+    return MlxAOTBlockPagedAttentionKernel(
+        block_paged_attention_decode=block_paged_attention_decode,
+        block_size=16,
+    )
+
+
 MLX_AOT_KERNEL_REGISTRY = MlxAOTKernelRegistry(
     specs=(
         MlxAOTKernelSpec(
@@ -178,6 +237,12 @@ MLX_AOT_KERNEL_REGISTRY = MlxAOTKernelRegistry(
             kernel_attr="rope",
             is_enabled=lambda: envs.SGLANG_MLX_USE_CUSTOM_ROPE.get(),
             build=_build_rope_kernel,
+        ),
+        MlxAOTKernelSpec(
+            name="metal_block_paged_attention_decode",
+            kernel_attr="block_paged_attention",
+            is_enabled=lambda: envs.SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION.get(),
+            build=_build_block_paged_attention_kernel,
         ),
     )
 )
@@ -191,8 +256,15 @@ class MlxAOTRoPEContext:
 
 
 @dataclass
+class MlxAOTBlockPagedAttentionContext:
+    kernel: MlxAOTBlockPagedAttentionKernel
+    kv_pool: Any
+
+
+@dataclass
 class MlxAOTKernelContext:
     rope: Optional[MlxAOTRoPEContext] = None
+    block_paged_attention: Optional[MlxAOTBlockPagedAttentionContext] = None
 
     @classmethod
     def from_decode(
@@ -204,13 +276,18 @@ class MlxAOTKernelContext:
         req_pool_idx: dict[str, int],
         req_to_token_pool: Any | None,
         layer_caches: list[list[ContiguousAttentionKVCache]],
+        block_kv_pool: Any | None = None,
     ) -> MlxAOTKernelContext:
         """Build optional AOT context for one batched decode step."""
-        if not aot_kernels.rope.enabled or kv_pool is None:
+        if kv_pool is None and block_kv_pool is None:
             return cls()
 
         new_token_slots = None
-        if req_to_token_pool is not None:
+        if (
+            kv_pool is not None
+            and aot_kernels.rope.enabled
+            and req_to_token_pool is not None
+        ):
             try:
                 slot_ids = []
                 for req_idx, req_id in enumerate(req_ids):
@@ -231,10 +308,22 @@ class MlxAOTKernelContext:
                     exc,
                 )
 
-        return cls(
-            rope=MlxAOTRoPEContext(
+        rope_ctx = None
+        if kv_pool is not None and aot_kernels.rope.enabled:
+            rope_ctx = MlxAOTRoPEContext(
                 kernel=aot_kernels.rope,
                 kv_pool=kv_pool,
                 new_token_slots=new_token_slots,
             )
+
+        block_paged_ctx = None
+        if block_kv_pool is not None and aot_kernels.block_paged_attention.enabled:
+            block_paged_ctx = MlxAOTBlockPagedAttentionContext(
+                kernel=aot_kernels.block_paged_attention,
+                kv_pool=block_kv_pool,
+            )
+
+        return cls(
+            rope=rope_ctx,
+            block_paged_attention=block_paged_ctx,
         )

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/__init__.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/__init__.py
@@ -14,6 +14,7 @@ from sglang.srt.hardware_backend.mlx.kv_cache.attention_kv_cache import (
 )
 from sglang.srt.hardware_backend.mlx.kv_cache.attention_kv_pool import (
     MlxAttentionKVPool,
+    MlxBlockAttentionKVPool,
 )
 from sglang.srt.hardware_backend.mlx.kv_cache.attention_wrapper import (
     BatchedDecodeContext,
@@ -26,6 +27,10 @@ from sglang.srt.hardware_backend.mlx.kv_cache.auxiliary_state import (
     MlxAuxiliaryStateComponent,
     MlxAuxiliaryStatePool,
     MlxAuxiliaryStateReqToTokenPool,
+)
+from sglang.srt.hardware_backend.mlx.kv_cache.block_metadata import (
+    MLXBlockPagedAttentionMetadata,
+    build_decode_block_metadata,
 )
 from sglang.srt.hardware_backend.mlx.kv_cache.layout import MlxModelCacheLayout
 from sglang.srt.hardware_backend.mlx.kv_cache.model_patching import (
@@ -47,13 +52,16 @@ __all__ = [
     "get_num_kv_heads",
     "is_attention_module",
     "MLXAttentionWrapper",
+    "MLXBlockPagedAttentionMetadata",
     "MlxAttentionKVPool",
     "MlxAuxiliaryStateComponent",
     "MlxAuxiliaryStatePool",
     "MlxAuxiliaryStateReqToTokenPool",
+    "MlxBlockAttentionKVPool",
     "MlxModelCacheLayout",
     "patch_model_attention",
     "PoolBackedAttentionKVCache",
+    "build_decode_block_metadata",
     "set_context",
     "uses_sliding_window_attention",
 ]

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
@@ -84,3 +84,135 @@ class MlxAttentionKVPool:
         for i in range(self.num_layers):
             self.k_buffer[i] = mx.zeros(shape, dtype=self.dtype)
             self.v_buffer[i] = mx.zeros(shape, dtype=self.dtype)
+
+
+class MlxBlockAttentionKVPool:
+    """Pre-allocated block-table attention KV pool.
+    """
+
+    def __init__(
+        self,
+        num_blocks: int,
+        block_size: int,
+        num_layers: int,
+        n_kv_heads: int,
+        head_dim: int,
+        dtype: mx.Dtype = mx.float16,
+    ):
+        # Block 0 is reserved for padding/invalid use. Allocated request blocks start
+        # at physical block 1.
+        if num_blocks <= 0:
+            raise ValueError(f"num_blocks must be positive, got {num_blocks}")
+        if block_size <= 0:
+            raise ValueError(f"block_size must be positive, got {block_size}")
+
+        self.num_blocks = num_blocks
+        self.block_size = block_size
+        self.num_layers = num_layers
+        self.n_kv_heads = n_kv_heads
+        self.head_dim = head_dim
+        self.dtype = dtype
+        self._free_blocks: list[int] = list(range(1, num_blocks))
+        self._req_block_tables: dict[str, list[int]] = {}
+
+        shape = (num_blocks, block_size, n_kv_heads, head_dim)
+        self.k_buffer: list[mx.array] = [
+            mx.zeros(shape, dtype=dtype) for _ in range(num_layers)
+        ]
+        self.v_buffer: list[mx.array] = [
+            mx.zeros(shape, dtype=dtype) for _ in range(num_layers)
+        ]
+
+        mem_mb = (
+            num_blocks
+            * block_size
+            * n_kv_heads
+            * head_dim
+            * 2
+            * num_layers
+            * dtype.size
+        ) / (1024 * 1024)
+        logger.info(
+            f"MlxBlockAttentionKVPool: {num_blocks} blocks x block_size={block_size} "
+            f"x {num_layers} layers x {n_kv_heads} heads x {head_dim} dim, "
+            f"dtype={dtype}, ~{mem_mb:.1f} MB"
+        )
+
+    def alloc_blocks(self, req_id: str, num_blocks: int) -> list[int] | None:
+        """Allocate physical blocks for a request, or return None if full."""
+        if num_blocks < 0:
+            raise ValueError(f"num_blocks must be non-negative, got {num_blocks}")
+        if req_id in self._req_block_tables:
+            raise ValueError(f"request {req_id!r} already has allocated blocks")
+        if num_blocks > len(self._free_blocks):
+            return None
+        blocks = self._free_blocks[:num_blocks]
+        del self._free_blocks[:num_blocks]
+        self._req_block_tables[req_id] = blocks
+        return list(blocks)
+
+    def ensure_blocks(self, req_id: str, num_blocks: int) -> list[int] | None:
+        """Ensure a request owns at least ``num_blocks`` physical blocks."""
+        if num_blocks < 0:
+            raise ValueError(f"num_blocks must be non-negative, got {num_blocks}")
+        existing = self._req_block_tables.setdefault(req_id, [])
+        needed = num_blocks - len(existing)
+        if needed <= 0:
+            return list(existing)
+        if needed > len(self._free_blocks):
+            return None
+        new_blocks = self._free_blocks[:needed]
+        del self._free_blocks[:needed]
+        existing.extend(new_blocks)
+        return list(existing)
+
+    def block_table(self, req_id: str) -> list[int]:
+        """Return the physical block table for a request."""
+        return list(self._req_block_tables[req_id])
+
+    def free_request(self, req_id: str) -> None:
+        """Release a request's blocks back to the free list."""
+        blocks = self._req_block_tables.pop(req_id, None)
+        if not blocks:
+            return
+        self._free_blocks = sorted(blocks + self._free_blocks)
+
+    def set_kv(
+        self,
+        layer_id: int,
+        block_ids: mx.array,
+        block_offsets: mx.array,
+        k: mx.array,
+        v: mx.array,
+    ) -> None:
+        """Scatter K/V into ``[block_id, block_offset]`` locations."""
+        if block_ids.ndim != 1 or block_offsets.ndim != 1:
+            raise ValueError("block_ids and block_offsets must be 1-D")
+        if tuple(block_ids.shape) != tuple(block_offsets.shape):
+            raise ValueError("block_ids and block_offsets must have matching shape")
+        if tuple(k.shape) != (block_ids.shape[0], self.n_kv_heads, self.head_dim):
+            raise ValueError(
+                "k must have shape [num_tokens, n_kv_heads, head_dim], "
+                f"got {k.shape}"
+            )
+        if tuple(v.shape) != tuple(k.shape):
+            raise ValueError(f"v shape must match k shape, got {v.shape} vs {k.shape}")
+        self.k_buffer[layer_id][block_ids, block_offsets] = k
+        self.v_buffer[layer_id][block_ids, block_offsets] = v
+
+    def get_kv(self, layer_id: int) -> tuple[mx.array, mx.array]:
+        """Return full block K/V buffers for one layer."""
+        return self.k_buffer[layer_id], self.v_buffer[layer_id]
+
+    def all_buffers(self) -> list[mx.array]:
+        """Return all buffer arrays (for ``mx.eval``)."""
+        return self.k_buffer + self.v_buffer
+
+    def clear(self) -> None:
+        """Zero all buffers and clear request ownership."""
+        shape = (self.num_blocks, self.block_size, self.n_kv_heads, self.head_dim)
+        for i in range(self.num_layers):
+            self.k_buffer[i] = mx.zeros(shape, dtype=self.dtype)
+            self.v_buffer[i] = mx.zeros(shape, dtype=self.dtype)
+        self._free_blocks = list(range(1, self.num_blocks))
+        self._req_block_tables.clear()

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
@@ -154,7 +154,7 @@ class MlxBlockAttentionKVPool:
         """Ensure a request owns at least ``num_blocks`` physical blocks."""
         if num_blocks < 0:
             raise ValueError(f"num_blocks must be non-negative, got {num_blocks}")
-        existing = self._req_block_tables.setdefault(req_id, [])
+        existing = self._req_block_tables.get(req_id, [])
         needed = num_blocks - len(existing)
         if needed <= 0:
             return list(existing)
@@ -162,6 +162,9 @@ class MlxBlockAttentionKVPool:
             return None
         new_blocks = self._free_blocks[:needed]
         del self._free_blocks[:needed]
+        if req_id not in self._req_block_tables:
+            existing = []
+            self._req_block_tables[req_id] = existing
         existing.extend(new_blocks)
         return list(existing)
 

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
@@ -87,8 +87,7 @@ class MlxAttentionKVPool:
 
 
 class MlxBlockAttentionKVPool:
-    """Pre-allocated block-table attention KV pool.
-    """
+    """Pre-allocated block-table attention KV pool."""
 
     def __init__(
         self,

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_kv_pool.py
@@ -97,6 +97,7 @@ class MlxBlockAttentionKVPool:
         n_kv_heads: int,
         head_dim: int,
         dtype: mx.Dtype = mx.float16,
+        req_capacity: int | None = None,
     ):
         # Block 0 is reserved for padding/invalid use. Allocated request blocks start
         # at physical block 1.
@@ -111,8 +112,15 @@ class MlxBlockAttentionKVPool:
         self.n_kv_heads = n_kv_heads
         self.head_dim = head_dim
         self.dtype = dtype
+        self.req_capacity = max(
+            1, req_capacity if req_capacity is not None else num_blocks
+        )
         self._free_blocks: list[int] = list(range(1, num_blocks))
         self._req_block_tables: dict[str, list[int]] = {}
+        self._req_pool_rows: dict[str, int] = {}
+        self.req_to_block = (
+            mx.zeros((self.req_capacity, num_blocks), dtype=mx.int32) - 1
+        )
 
         shape = (num_blocks, block_size, n_kv_heads, head_dim)
         self.k_buffer: list[mx.array] = [
@@ -131,13 +139,39 @@ class MlxBlockAttentionKVPool:
             * num_layers
             * dtype.size
         ) / (1024 * 1024)
+        metadata_mem_mb = (self.req_capacity * num_blocks * mx.int32.size) / (
+            1024 * 1024
+        )
         logger.info(
             f"MlxBlockAttentionKVPool: {num_blocks} blocks x block_size={block_size} "
             f"x {num_layers} layers x {n_kv_heads} heads x {head_dim} dim, "
-            f"dtype={dtype}, ~{mem_mb:.1f} MB"
+            f"dtype={dtype}, ~{mem_mb:.1f} MB KV + "
+            f"~{metadata_mem_mb:.1f} MB req_to_block"
         )
 
-    def alloc_blocks(self, req_id: str, num_blocks: int) -> list[int] | None:
+    def _check_req_pool_idx(self, req_pool_idx: int) -> int:
+        row = int(req_pool_idx)
+        if row < 0 or row >= self.req_capacity:
+            raise ValueError(
+                f"req_pool_idx must be in [0, {self.req_capacity}), got {row}"
+            )
+        return row
+
+    def _set_req_to_block_row(self, req_id: str, req_pool_idx: int) -> None:
+        row = self._check_req_pool_idx(req_pool_idx)
+        existing = self._req_pool_rows.get(req_id)
+        if existing is not None and existing != row:
+            self.req_to_block[existing] = (
+                mx.zeros((self.num_blocks,), dtype=mx.int32) - 1
+            )
+        self._req_pool_rows[req_id] = row
+        blocks = self._req_block_tables.get(req_id, [])
+        row_values = blocks + [-1] * (self.num_blocks - len(blocks))
+        self.req_to_block[row] = mx.array(row_values, dtype=mx.int32)
+
+    def alloc_blocks(
+        self, req_id: str, num_blocks: int, req_pool_idx: int | None = None
+    ) -> list[int] | None:
         """Allocate physical blocks for a request, or return None if full."""
         if num_blocks < 0:
             raise ValueError(f"num_blocks must be non-negative, got {num_blocks}")
@@ -148,15 +182,21 @@ class MlxBlockAttentionKVPool:
         blocks = self._free_blocks[:num_blocks]
         del self._free_blocks[:num_blocks]
         self._req_block_tables[req_id] = blocks
+        if req_pool_idx is not None:
+            self._set_req_to_block_row(req_id, req_pool_idx)
         return list(blocks)
 
-    def ensure_blocks(self, req_id: str, num_blocks: int) -> list[int] | None:
+    def ensure_blocks(
+        self, req_id: str, num_blocks: int, req_pool_idx: int | None = None
+    ) -> list[int] | None:
         """Ensure a request owns at least ``num_blocks`` physical blocks."""
         if num_blocks < 0:
             raise ValueError(f"num_blocks must be non-negative, got {num_blocks}")
         existing = self._req_block_tables.get(req_id, [])
         needed = num_blocks - len(existing)
         if needed <= 0:
+            if req_pool_idx is not None:
+                self._set_req_to_block_row(req_id, req_pool_idx)
             return list(existing)
         if needed > len(self._free_blocks):
             return None
@@ -166,6 +206,8 @@ class MlxBlockAttentionKVPool:
             existing = []
             self._req_block_tables[req_id] = existing
         existing.extend(new_blocks)
+        if req_pool_idx is not None:
+            self._set_req_to_block_row(req_id, req_pool_idx)
         return list(existing)
 
     def block_table(self, req_id: str) -> list[int]:
@@ -175,6 +217,9 @@ class MlxBlockAttentionKVPool:
     def free_request(self, req_id: str) -> None:
         """Release a request's blocks back to the free list."""
         blocks = self._req_block_tables.pop(req_id, None)
+        row = self._req_pool_rows.pop(req_id, None)
+        if row is not None:
+            self.req_to_block[row] = mx.zeros((self.num_blocks,), dtype=mx.int32) - 1
         if not blocks:
             return
         self._free_blocks = sorted(blocks + self._free_blocks)
@@ -208,7 +253,11 @@ class MlxBlockAttentionKVPool:
 
     def all_buffers(self) -> list[mx.array]:
         """Return all buffer arrays (for ``mx.eval``)."""
-        return self.k_buffer + self.v_buffer
+        return self.k_buffer + self.v_buffer + [self.req_to_block]
+
+    def materialize(self) -> None:
+        """Force lazy block-pool buffers to be allocated before serving decode."""
+        mx.eval(*self.all_buffers())
 
     def clear(self) -> None:
         """Zero all buffers and clear request ownership."""
@@ -216,5 +265,9 @@ class MlxBlockAttentionKVPool:
         for i in range(self.num_layers):
             self.k_buffer[i] = mx.zeros(shape, dtype=self.dtype)
             self.v_buffer[i] = mx.zeros(shape, dtype=self.dtype)
+        self.req_to_block = (
+            mx.zeros((self.req_capacity, self.num_blocks), dtype=mx.int32) - 1
+        )
         self._free_blocks = list(range(1, self.num_blocks))
         self._req_block_tables.clear()
+        self._req_pool_rows.clear()

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any, Optional
 
 import mlx.core as mx
@@ -21,6 +22,10 @@ from sglang.srt.hardware_backend.mlx.kv_cache.attention_contract import (
 )
 from sglang.srt.hardware_backend.mlx.kv_cache.attention_kv_cache import (
     ContiguousAttentionKVCache,
+)
+from sglang.srt.hardware_backend.mlx.kv_cache.block_metadata import (
+    MLXBlockPagedAttentionMetadata,
+    build_decode_block_metadata,
 )
 
 _thread_local = threading.local()
@@ -41,6 +46,7 @@ class BatchedDecodeContext:
     # MLX decode path so future AOT kernels can be added without growing this
     # context one field at a time.
     aot: MlxAOTKernelContext = field(default_factory=MlxAOTKernelContext)
+    block_paged_metadata: MLXBlockPagedAttentionMetadata | None = None
 
     # Derived tensors/metadata, shared across all layers in one forward pass.
     offsets: mx.array = field(init=False)
@@ -57,7 +63,7 @@ class BatchedDecodeContext:
         self.max_len = max_seq_len + 1
         self.valid_lens = self.offsets + 1
         self.needs_padding = min(seq_lens) < max_seq_len
-        self.pad_sizes = [max_seq_len - s for s in seq_lens]
+        self.pad_sizes = [self.max_len - (s + 1) for s in seq_lens]
         self.positions = mx.arange(self.max_len) if self.needs_padding else None
         if not self.attention_pool_index_by_layer:
             self.attention_pool_index_by_layer = {
@@ -76,6 +82,8 @@ class BatchedDecodeContext:
         req_to_token_pool: Any | None,
         attention_layer_indices: list[int] | None = None,
         attention_pool_index_by_layer: dict[int, int] | None = None,
+        block_paged_attention_supported: bool = True,
+        block_kv_pool: Any | None = None,
     ) -> BatchedDecodeContext:
         batch_size = len(req_ids)
         if attention_layer_indices is None:
@@ -87,6 +95,25 @@ class BatchedDecodeContext:
             [caches[i][layer_idx] for i in range(batch_size)]
             for layer_idx in attention_layer_indices
         ]
+        block_paged_metadata = None
+        if block_paged_attention_supported and block_kv_pool is not None:
+            try:
+                tables = [block_kv_pool.block_table(req_id) for req_id in req_ids]
+                max_blocks = max((len(table) for table in tables), default=0)
+                req_to_block = mx.array(
+                    [table + [-1] * (max_blocks - len(table)) for table in tables],
+                    dtype=mx.int32,
+                )
+                block_paged_metadata = build_decode_block_metadata(
+                    req_ids=req_ids,
+                    req_pool_idx={req_id: idx for idx, req_id in enumerate(req_ids)},
+                    req_to_block_pool=SimpleNamespace(req_to_block=req_to_block),
+                    seq_lens_before_decode=seq_lens,
+                    block_size=block_kv_pool.block_size,
+                )
+            except Exception:  # noqa: BLE001
+                block_paged_metadata = None
+
         return cls(
             batch_size=batch_size,
             seq_lens=seq_lens,
@@ -95,11 +122,13 @@ class BatchedDecodeContext:
             aot=MlxAOTKernelContext.from_decode(
                 aot_kernels=aot_kernels,
                 kv_pool=kv_pool,
+                block_kv_pool=block_kv_pool,
                 req_ids=req_ids,
                 req_pool_idx=req_pool_idx,
                 req_to_token_pool=req_to_token_pool,
                 layer_caches=attention_layer_caches,
             ),
+            block_paged_metadata=block_paged_metadata,
         )
 
 
@@ -200,35 +229,77 @@ class MLXAttentionWrapper(nn.Module):
             keys = inner.rope(keys, offset=offsets)
 
         layer_caches = ctx.attention_layer_caches[attention_pool_idx]
-        pad_sizes = ctx.pad_sizes
+        use_block_paged_attention = (
+            ctx.aot.block_paged_attention is not None
+            and ctx.block_paged_metadata is not None
+        )
+
+        if use_block_paged_attention:
+            for i in range(B):
+                layer_caches[i].write_token(keys[i : i + 1], values[i : i + 1])
+
+            k_flat = keys[:, :, 0, :]
+            v_flat = values[:, :, 0, :]
+            block_ctx = ctx.aot.block_paged_attention
+            block_ctx.kv_pool.set_kv(
+                attention_pool_idx,
+                ctx.block_paged_metadata.block_ids,
+                ctx.block_paged_metadata.block_offsets,
+                k_flat,
+                v_flat,
+            )
+
+            output = self._block_paged_attention_aot(
+                queries,
+                attention_pool_idx,
+                block_ctx,
+                ctx.block_paged_metadata,
+                n_heads,
+                n_kv_heads,
+                head_dim,
+                inner.scale,
+            )
+            output = output.reshape(B, 1, -1)
+            if gate is not None:
+                output = output * mx.sigmoid(gate)
+            return inner.o_proj(output)
 
         # TODO: replace per-request loop with native batched/ragged
         # attention once mx.fast.scaled_dot_product_attention supports
         # variable-length sequences.
         all_k = []
         all_v = []
+        actual_lens = []
 
         for i in range(B):
             layer_caches[i].write_token(keys[i : i + 1], values[i : i + 1])
 
             k_all, v_all = layer_caches[i].get_kv()
+            actual_lens.append(k_all.shape[2])
+            all_k.append(k_all)
+            all_v.append(v_all)
 
-            pad = pad_sizes[i]
+        target_len = max(actual_lens)
+        padded_k = []
+        padded_v = []
+        for k_all, v_all, actual_len in zip(all_k, all_v, actual_lens):
+            pad = target_len - actual_len
             if pad > 0:
                 k_pad = mx.zeros((1, n_kv_heads, pad, head_dim), dtype=k_all.dtype)
                 v_pad = mx.zeros((1, n_kv_heads, pad, head_dim), dtype=v_all.dtype)
                 k_all = mx.concatenate([k_all, k_pad], axis=2)
                 v_all = mx.concatenate([v_all, v_pad], axis=2)
+            padded_k.append(k_all)
+            padded_v.append(v_all)
 
-            all_k.append(k_all)
-            all_v.append(v_all)
-
-        keys_b = mx.concatenate(all_k, axis=0)
-        values_b = mx.concatenate(all_v, axis=0)
+        keys_b = mx.concatenate(padded_k, axis=0)
+        values_b = mx.concatenate(padded_v, axis=0)
 
         attn_mask = None
-        if ctx.needs_padding:
-            mask_bool = ctx.positions[None, :] >= ctx.valid_lens[:, None]
+        if min(actual_lens) < target_len:
+            positions = mx.arange(target_len)
+            valid_lens = mx.array(actual_lens, dtype=mx.int32)
+            mask_bool = positions[None, :] >= valid_lens[:, None]
             attn_mask = mx.where(
                 mask_bool[:, None, None, :],
                 mx.array(mx.finfo(queries.dtype).min, dtype=queries.dtype),
@@ -296,3 +367,33 @@ class MLXAttentionWrapper(nn.Module):
 
         # (B, n_heads, head_dim) -> (B, n_heads, 1, head_dim) for SDPA path
         return q_rot[:, :, None, :], k_rot[:, :, None, :]
+
+    @staticmethod
+    def _block_paged_attention_aot(
+        queries: mx.array,
+        attention_pool_idx: int,
+        block_ctx: Any,
+        metadata: MLXBlockPagedAttentionMetadata,
+        n_heads: int,
+        n_kv_heads: int,
+        head_dim: int,
+        scale: float,
+    ) -> mx.array:
+        # (B, n_heads, 1, head_dim) -> (B, n_heads, head_dim)
+        q_flat = queries[:, :, 0, :]
+        k_blocks = block_ctx.kv_pool.k_buffer[attention_pool_idx]
+        v_blocks = block_ctx.kv_pool.v_buffer[attention_pool_idx]
+        if q_flat.dtype != k_blocks.dtype:
+            q_flat = q_flat.astype(k_blocks.dtype)
+        return block_ctx.kernel.block_paged_attention_decode(
+            q_flat,
+            k_blocks,
+            v_blocks,
+            metadata.block_tables,
+            metadata.seq_lens,
+            num_qo_heads=n_heads,
+            num_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            block_size=metadata.block_size,
+            sm_scale=float(scale),
+        )

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/attention_wrapper.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
-from types import SimpleNamespace
 from typing import Any, Optional
 
 import mlx.core as mx
@@ -98,16 +97,10 @@ class BatchedDecodeContext:
         block_paged_metadata = None
         if block_paged_attention_supported and block_kv_pool is not None:
             try:
-                tables = [block_kv_pool.block_table(req_id) for req_id in req_ids]
-                max_blocks = max((len(table) for table in tables), default=0)
-                req_to_block = mx.array(
-                    [table + [-1] * (max_blocks - len(table)) for table in tables],
-                    dtype=mx.int32,
-                )
                 block_paged_metadata = build_decode_block_metadata(
                     req_ids=req_ids,
-                    req_pool_idx={req_id: idx for idx, req_id in enumerate(req_ids)},
-                    req_to_block_pool=SimpleNamespace(req_to_block=req_to_block),
+                    req_pool_idx=req_pool_idx,
+                    req_to_block_pool=block_kv_pool,
                     seq_lens_before_decode=seq_lens,
                     block_size=block_kv_pool.block_size,
                 )

--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/block_metadata.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/block_metadata.py
@@ -1,0 +1,111 @@
+"""Block-table paged-attention metadata helpers for the MLX backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+
+
+@dataclass(frozen=True)
+class MLXBlockPagedAttentionMetadata:
+    """Metadata for one MLX block-table paged-attention decode call."""
+
+    block_tables: mx.array
+    seq_lens: mx.array
+    slot_mapping: mx.array
+    block_ids: mx.array
+    block_offsets: mx.array
+    block_size: int
+    max_seq_len: int
+    total_kv_tokens: int
+
+
+def _read_block_table(req_to_block: Any, row: int, col: int) -> int:
+    value = req_to_block[row, col]
+    if hasattr(value, "item"):
+        return int(value.item())
+    return int(value)
+
+
+def build_decode_block_metadata(
+    *,
+    req_ids: list[str],
+    req_pool_idx: dict[str, int],
+    req_to_block_pool: Any,
+    seq_lens_before_decode: list[int],
+    block_size: int = 16,
+    include_current_token: bool = True,
+) -> MLXBlockPagedAttentionMetadata:
+    """Build decode metadata for block-table paged attention.
+
+    ``req_to_block_pool.req_to_block[row, logical_block]`` is treated as the
+    source of truth for each request's physical block table. The returned table
+    is padded with ``-1`` to a rectangular batch shape.
+    """
+
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+    if len(req_ids) != len(seq_lens_before_decode):
+        raise ValueError(
+            "req_ids and seq_lens_before_decode must have the same length, "
+            f"got {len(req_ids)} and {len(seq_lens_before_decode)}"
+        )
+    if req_to_block_pool is None or not hasattr(req_to_block_pool, "req_to_block"):
+        raise ValueError("req_to_block_pool with req_to_block is required")
+
+    req_to_block = req_to_block_pool.req_to_block
+    per_req_tables: list[list[int]] = []
+    seq_lens: list[int] = []
+    slot_mapping: list[int] = []
+    block_ids: list[int] = []
+    block_offsets: list[int] = []
+
+    for batch_idx, req_id in enumerate(req_ids):
+        if req_id not in req_pool_idx:
+            raise KeyError(f"missing req_pool_idx for request {req_id!r}")
+
+        row = int(req_pool_idx[req_id])
+        before_len = int(seq_lens_before_decode[batch_idx])
+        if before_len < 0:
+            raise ValueError(f"negative sequence length for request {req_id!r}")
+
+        visible_len = before_len + 1 if include_current_token else before_len
+        needed_blocks = (visible_len + block_size - 1) // block_size
+        table: list[int] = []
+        for logical_block in range(needed_blocks):
+            physical_block = _read_block_table(req_to_block, row, logical_block)
+            if physical_block < 0:
+                raise ValueError(
+                    "missing block for visible token range "
+                    f"(request={req_id!r}, row={row}, logical_block={logical_block})"
+                )
+            table.append(physical_block)
+
+        per_req_tables.append(table)
+        seq_lens.append(visible_len)
+        slot_mapping.append(before_len)
+        if include_current_token:
+            current_logical_block = before_len // block_size
+            block_ids.append(table[current_logical_block])
+            block_offsets.append(before_len % block_size)
+        else:
+            block_ids.append(-1)
+            block_offsets.append(-1)
+
+    max_num_blocks = max((len(table) for table in per_req_tables), default=0)
+    padded_tables = [
+        table + [-1] * (max_num_blocks - len(table)) for table in per_req_tables
+    ]
+
+    return MLXBlockPagedAttentionMetadata(
+        block_tables=mx.array(padded_tables, dtype=mx.int32),
+        seq_lens=mx.array(seq_lens, dtype=mx.int32),
+        slot_mapping=mx.array(slot_mapping, dtype=mx.int32),
+        block_ids=mx.array(block_ids, dtype=mx.int32),
+        block_offsets=mx.array(block_offsets, dtype=mx.int32),
+        block_size=block_size,
+        max_seq_len=max(seq_lens, default=0),
+        total_kv_tokens=sum(seq_lens),
+    )

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -37,8 +37,8 @@ from sglang.srt.hardware_backend.mlx.kv_cache import (
     BatchedDecodeContext,
     ContiguousAttentionKVCache,
     MlxAttentionKVPool,
-    MlxBlockAttentionKVPool,
     MLXAttentionWrapper,
+    MlxBlockAttentionKVPool,
     MlxModelCacheLayout,
     PoolBackedAttentionKVCache,
     clear_context,
@@ -667,7 +667,9 @@ class MlxModelRunner:
         logical_blocks = positions // self._block_size
         block_offsets = positions - logical_blocks * self._block_size
         block_ids = mx.array(table, dtype=mx.int32)[logical_blocks]
-        for pool_idx, layer_idx in enumerate(self._cache_layout.attention_layer_indices):
+        for pool_idx, layer_idx in enumerate(
+            self._cache_layout.attention_layer_indices
+        ):
             k = cache[layer_idx].keys[0, :, start:end, :].transpose(1, 0, 2)
             v = cache[layer_idx].values[0, :, start:end, :].transpose(1, 0, 2)
             self._block_attention_kv_pool.set_kv(
@@ -990,7 +992,9 @@ class MlxModelRunner:
         prev_tokens.append(next_token)
 
         self._req_synced_offset[pending.req_id] = pending.new_synced_offset
-        self._sync_full_kv_to_block_pool(pending.req_id, self._req_caches[pending.req_id])
+        self._sync_full_kv_to_block_pool(
+            pending.req_id, self._req_caches[pending.req_id]
+        )
         self._store_auxiliary_state(
             self._req_pool_idx[pending.req_id],
             self._req_caches[pending.req_id],
@@ -1354,7 +1358,9 @@ class MlxModelRunner:
             if pending.pool_synced_offsets is not None:
                 self._req_synced_offset[rid] = pending.pool_synced_offsets[rid]
                 if self._block_attention_kv_pool is not None:
-                    self._req_block_synced_offset[rid] = pending.pool_synced_offsets[rid]
+                    self._req_block_synced_offset[rid] = pending.pool_synced_offsets[
+                        rid
+                    ]
 
         self._decode_step_ct += 1
         if self._clear_steps > 0 and self._decode_step_ct % self._clear_steps == 0:

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -620,7 +620,7 @@ class MlxModelRunner:
             if req_to_token_pool is not None:
                 req_capacity = int(req_to_token_pool.req_to_token.shape[0])
             else:
-                req_capacity = int(get_server_args().max_running_requests or 0)
+                req_capacity = max(1, int(get_server_args().max_running_requests or 0))
             token_blocks = (self._pool_size + self._block_size - 1) // self._block_size
             # Blocks are owned per request. Add one partial-block headroom block
             # per request row so token-slot admission does not over-admit many
@@ -633,7 +633,9 @@ class MlxModelRunner:
                 n_kv_heads=n_kv_heads,
                 head_dim=head_dim,
                 dtype=dtype,
+                req_capacity=req_capacity,
             )
+            self._block_attention_kv_pool.materialize()
             logger.info(
                 f"Block attention KV pool initialized: num_blocks={num_blocks} "
                 f"(block 0 reserved, token_blocks={token_blocks}, "
@@ -663,12 +665,16 @@ class MlxModelRunner:
             f"{n_kv_heads} kv_heads, {head_dim} head_dim"
         )
 
-    def _ensure_block_request_capacity(self, req_id: str, token_count: int) -> None:
+    def _ensure_block_request_capacity(
+        self, req_id: str, token_count: int, req_pool_idx: int
+    ) -> None:
         """Ensure block KV storage exists for ``token_count`` logical tokens."""
         if self._block_attention_kv_pool is None:
             return
         needed_blocks = (token_count + self._block_size - 1) // self._block_size
-        blocks = self._block_attention_kv_pool.ensure_blocks(req_id, needed_blocks)
+        blocks = self._block_attention_kv_pool.ensure_blocks(
+            req_id, needed_blocks, req_pool_idx=req_pool_idx
+        )
         if blocks is None:
             raise RuntimeError(
                 "MLX block paged attention KV pool exhausted while allocating "
@@ -685,7 +691,7 @@ class MlxModelRunner:
         """Sync contiguous attention KV into the block-table pool."""
         if self._block_attention_kv_pool is None or end <= start:
             return
-        self._ensure_block_request_capacity(req_id, end)
+        self._ensure_block_request_capacity(req_id, end, self._req_pool_idx[req_id])
         table = self._block_attention_kv_pool.block_table(req_id)
         positions = mx.arange(start, end, dtype=mx.int32)
         logical_blocks = positions // self._block_size
@@ -720,7 +726,9 @@ class MlxModelRunner:
         for req_id, cache in zip(req_ids, caches):
             # +1 for the current decode token that the attention wrapper will scatter.
             self._ensure_block_request_capacity(
-                req_id, self._first_attention_cache(cache).offset + 1
+                req_id,
+                self._first_attention_cache(cache).offset + 1,
+                self._req_pool_idx[req_id],
             )
 
     def prefill(
@@ -965,7 +973,9 @@ class MlxModelRunner:
         next_token = int(pending.lazy_token.item())
         if self._block_attention_kv_pool is not None:
             self._ensure_block_request_capacity(
-                pending.req_id, self._first_attention_cache(pending.cache).offset
+                pending.req_id,
+                self._first_attention_cache(pending.cache).offset,
+                pending.req_pool_idx,
             )
         self._req_token_ids[pending.req_id] = list(pending.full_token_ids) + [
             next_token
@@ -991,7 +1001,9 @@ class MlxModelRunner:
         cache = self._req_caches[req_id]
         if self._block_attention_kv_pool is not None:
             self._ensure_block_request_capacity(
-                req_id, self._first_attention_cache(cache).offset + len(new_token_ids)
+                req_id,
+                self._first_attention_cache(cache).offset + len(new_token_ids),
+                self._req_pool_idx[req_id],
             )
 
         input_ids = mx.array([new_token_ids], dtype=mx.int32)

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -37,6 +37,7 @@ from sglang.srt.hardware_backend.mlx.kv_cache import (
     BatchedDecodeContext,
     ContiguousAttentionKVCache,
     MlxAttentionKVPool,
+    MlxBlockAttentionKVPool,
     MLXAttentionWrapper,
     MlxModelCacheLayout,
     PoolBackedAttentionKVCache,
@@ -102,6 +103,7 @@ class MlxPendingDecode:
     lazy_tokens: mx.array
     req_ids: list[str]
     caches: list[list[Any]]
+    pool_synced_offsets: dict[str, int] | None = None
 
 
 _MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
@@ -173,9 +175,12 @@ class MlxModelRunner:
         self._cache_pool: list[list[Any]] = []  # reusable full-attention caches
 
         self._attention_kv_pool: MlxAttentionKVPool | None = None
+        self._block_attention_kv_pool: MlxBlockAttentionKVPool | None = None
+        self._block_size = 16
         self._req_to_token_pool: ReqToTokenPool | None = None
         self._req_pool_idx: dict[str, int] = {}
         self._req_synced_offset: dict[str, int] = {}
+        self._req_block_synced_offset: dict[str, int] = {}
 
         self._pool_size = self._compute_pool_size(pool_size)
         self._aot_kernels = self._build_aot_kernels()
@@ -522,7 +527,7 @@ class MlxModelRunner:
             if scales is not None and scales.dtype in _MLX_KV_FLOAT_DTYPES:
                 dtype = scales.dtype
             else:
-                dtype = mx.float32
+                dtype = mx.float16
         return n_kv_heads, head_dim, dtype
 
     def _get_attn_config(self) -> tuple[int, int, mx.Dtype]:
@@ -598,9 +603,27 @@ class MlxModelRunner:
     def init_cache_pools(self, req_to_token_pool: ReqToTokenPool | None) -> None:
         """Create attention KV pool (+1 for padding slot 0)."""
         self._req_to_token_pool = req_to_token_pool
+        n_kv_heads, head_dim, dtype = self._get_attn_config()
+        if envs.SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION.get():
+            num_blocks = (
+                self._pool_size + self._block_size - 1
+            ) // self._block_size + 1
+            self._block_attention_kv_pool = MlxBlockAttentionKVPool(
+                num_blocks=num_blocks,
+                block_size=self._block_size,
+                num_layers=self._cache_layout.num_attention_layers,
+                n_kv_heads=n_kv_heads,
+                head_dim=head_dim,
+                dtype=dtype,
+            )
+            logger.info(
+                f"Block attention KV pool initialized: num_blocks={num_blocks} "
+                f"(block 0 reserved), block_size={self._block_size}, "
+                f"{self._cache_layout.num_attention_layers} attention layers, "
+                f"{n_kv_heads} kv_heads, {head_dim} head_dim"
+            )
         if self.disable_radix_cache:
             return
-        n_kv_heads, head_dim, dtype = self._get_attn_config()
         # +1 for padding slot 0
         self._attention_kv_pool = MlxAttentionKVPool(
             pool_size=self._pool_size + 1,
@@ -615,6 +638,64 @@ class MlxModelRunner:
             f"{self._cache_layout.num_attention_layers} attention layers, "
             f"{n_kv_heads} kv_heads, {head_dim} head_dim"
         )
+
+    def _ensure_block_request_capacity(self, req_id: str, token_count: int) -> None:
+        """Ensure block KV storage exists for ``token_count`` logical tokens."""
+        if self._block_attention_kv_pool is None:
+            return
+        needed_blocks = (token_count + self._block_size - 1) // self._block_size
+        blocks = self._block_attention_kv_pool.ensure_blocks(req_id, needed_blocks)
+        if blocks is None:
+            raise RuntimeError(
+                "MLX block paged attention KV pool exhausted while allocating "
+                f"{needed_blocks} blocks for request {req_id!r}"
+            )
+
+    def _sync_kv_range_to_block_pool(
+        self,
+        cache: list[Any],
+        req_id: str,
+        start: int,
+        end: int,
+    ) -> None:
+        """Sync contiguous attention KV into the block-table pool."""
+        if self._block_attention_kv_pool is None or end <= start:
+            return
+        self._ensure_block_request_capacity(req_id, end)
+        table = self._block_attention_kv_pool.block_table(req_id)
+        positions = mx.arange(start, end, dtype=mx.int32)
+        logical_blocks = positions // self._block_size
+        block_offsets = positions - logical_blocks * self._block_size
+        block_ids = mx.array(table, dtype=mx.int32)[logical_blocks]
+        for pool_idx, layer_idx in enumerate(self._cache_layout.attention_layer_indices):
+            k = cache[layer_idx].keys[0, :, start:end, :].transpose(1, 0, 2)
+            v = cache[layer_idx].values[0, :, start:end, :].transpose(1, 0, 2)
+            self._block_attention_kv_pool.set_kv(
+                pool_idx,
+                block_ids=block_ids,
+                block_offsets=block_offsets,
+                k=k,
+                v=v,
+            )
+        self._req_block_synced_offset[req_id] = end
+
+    def _sync_full_kv_to_block_pool(self, req_id: str, cache: list[Any]) -> None:
+        if self._block_attention_kv_pool is None:
+            return
+        end = self._first_attention_cache(cache).offset
+        synced = self._req_block_synced_offset.get(req_id, 0)
+        self._sync_kv_range_to_block_pool(cache, req_id, synced, end)
+
+    def _ensure_block_capacity_for_decode(
+        self, req_ids: list[str], caches: list[list[Any]]
+    ) -> None:
+        if self._block_attention_kv_pool is None:
+            return
+        for req_id, cache in zip(req_ids, caches):
+            # +1 for the current decode token that the attention wrapper will scatter.
+            self._ensure_block_request_capacity(
+                req_id, self._first_attention_cache(cache).offset + 1
+            )
 
     def prefill(
         self,
@@ -862,6 +943,7 @@ class MlxModelRunner:
         self._req_caches[pending.req_id] = pending.cache
         self._req_pool_idx[pending.req_id] = pending.req_pool_idx
         self._req_synced_offset[pending.req_id] = pending.synced_offset
+        self._sync_full_kv_to_block_pool(pending.req_id, pending.cache)
         self._store_auxiliary_state(pending.req_pool_idx, pending.cache)
         return next_token
 
@@ -908,6 +990,7 @@ class MlxModelRunner:
         prev_tokens.append(next_token)
 
         self._req_synced_offset[pending.req_id] = pending.new_synced_offset
+        self._sync_full_kv_to_block_pool(pending.req_id, self._req_caches[pending.req_id])
         self._store_auxiliary_state(
             self._req_pool_idx[pending.req_id],
             self._req_caches[pending.req_id],
@@ -1121,7 +1204,8 @@ class MlxModelRunner:
         caches: list[list[Any]],
         batched_input: mx.array,
         req_ids: list[str],
-    ) -> mx.array:
+    ) -> tuple[mx.array, dict[str, int] | None]:
+        self._ensure_block_capacity_for_decode(req_ids, caches)
         ctx = self._build_batched_decode_context(caches, req_ids)
         seq_lens = ctx.seq_lens
         set_context(ctx)
@@ -1133,7 +1217,21 @@ class MlxModelRunner:
             ]
             model_output = self.model(batched_input, cache=shim_cache)
             logits = self._extract_logits(model_output)
-            return mx.argmax(logits[:, -1, :], axis=-1)
+            pool_synced_offsets = None
+            if ctx.aot.rope is not None and ctx.aot.rope.new_token_slots is not None:
+                pool_synced_offsets = {
+                    rid: self._first_attention_cache(cache).offset
+                    for rid, cache in zip(req_ids, caches)
+                }
+            if (
+                ctx.aot.block_paged_attention is not None
+                and ctx.block_paged_metadata is not None
+            ):
+                pool_synced_offsets = {
+                    rid: self._first_attention_cache(cache).offset
+                    for rid, cache in zip(req_ids, caches)
+                }
+            return mx.argmax(logits[:, -1, :], axis=-1), pool_synced_offsets
         finally:
             clear_context()
 
@@ -1148,12 +1246,14 @@ class MlxModelRunner:
             req_ids=req_ids,
             aot_kernels=self._aot_kernels,
             kv_pool=self._attention_kv_pool,
+            block_kv_pool=self._block_attention_kv_pool,
             req_pool_idx=self._req_pool_idx,
             req_to_token_pool=self._req_to_token_pool,
             attention_layer_indices=self._cache_layout.attention_layer_indices,
             attention_pool_index_by_layer=(
                 self._cache_layout.attention_pool_index_by_layer
             ),
+            block_paged_attention_supported=not self._cache_layout.has_auxiliary_state,
         )
 
     def decode_batch_start(self, req_ids: list[str]) -> MlxPendingDecode:
@@ -1171,8 +1271,9 @@ class MlxModelRunner:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, list(req_ids)
             )
+            pool_synced_offsets = None
         else:
-            lazy_tokens = self._decode_with_batched_attention(
+            lazy_tokens, pool_synced_offsets = self._decode_with_batched_attention(
                 caches, batched_input, list(req_ids)
             )
 
@@ -1180,6 +1281,7 @@ class MlxModelRunner:
             lazy_tokens=lazy_tokens,
             req_ids=list(req_ids),
             caches=caches,
+            pool_synced_offsets=pool_synced_offsets,
         )
 
     def decode_batch_start_chained(
@@ -1216,8 +1318,9 @@ class MlxModelRunner:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, prev.req_ids
             )
+            pool_synced_offsets = None
         else:
-            lazy_tokens = self._decode_with_batched_attention(
+            lazy_tokens, pool_synced_offsets = self._decode_with_batched_attention(
                 caches, batched_input, prev.req_ids
             )
 
@@ -1225,6 +1328,7 @@ class MlxModelRunner:
             lazy_tokens=lazy_tokens,
             req_ids=prev.req_ids,
             caches=caches,
+            pool_synced_offsets=pool_synced_offsets,
         )
 
     def decode_batch_finalize(
@@ -1247,6 +1351,10 @@ class MlxModelRunner:
 
         for i, rid in enumerate(pending.req_ids):
             self._req_token_ids[rid].append(next_tokens[i])
+            if pending.pool_synced_offsets is not None:
+                self._req_synced_offset[rid] = pending.pool_synced_offsets[rid]
+                if self._block_attention_kv_pool is not None:
+                    self._req_block_synced_offset[rid] = pending.pool_synced_offsets[rid]
 
         self._decode_step_ct += 1
         if self._clear_steps > 0 and self._decode_step_ct % self._clear_steps == 0:
@@ -1269,6 +1377,9 @@ class MlxModelRunner:
             self._release_cache(cache)
         self._req_pool_idx.pop(req_id, None)
         self._req_synced_offset.pop(req_id, None)
+        self._req_block_synced_offset.pop(req_id, None)
+        if self._block_attention_kv_pool is not None:
+            self._block_attention_kv_pool.free_request(req_id)
 
     def clear(self):
         """Clear all request states."""
@@ -1278,5 +1389,8 @@ class MlxModelRunner:
         self._req_caches.clear()
         self._req_pool_idx.clear()
         self._req_synced_offset.clear()
+        self._req_block_synced_offset.clear()
         if self._attention_kv_pool is not None:
             self._attention_kv_pool.clear()
+        if self._block_attention_kv_pool is not None:
+            self._block_attention_kv_pool.clear()

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -103,7 +103,8 @@ class MlxPendingDecode:
     lazy_tokens: mx.array
     req_ids: list[str]
     caches: list[list[Any]]
-    pool_synced_offsets: dict[str, int] | None = None
+    flat_pool_synced_offsets: dict[str, int] | None = None
+    block_pool_synced_offsets: dict[str, int] | None = None
 
 
 _MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
@@ -527,7 +528,7 @@ class MlxModelRunner:
             if scales is not None and scales.dtype in _MLX_KV_FLOAT_DTYPES:
                 dtype = scales.dtype
             else:
-                dtype = mx.float16
+                dtype = mx.float32
         return n_kv_heads, head_dim, dtype
 
     def _get_attn_config(self) -> tuple[int, int, mx.Dtype]:
@@ -604,10 +605,24 @@ class MlxModelRunner:
         """Create attention KV pool (+1 for padding slot 0)."""
         self._req_to_token_pool = req_to_token_pool
         n_kv_heads, head_dim, dtype = self._get_attn_config()
-        if envs.SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION.get():
-            num_blocks = (
+        block_paged_attention_enabled = (
+            envs.SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION.get()
+            and self._aot_kernels.block_paged_attention.enabled
+            and not self._cache_layout.has_auxiliary_state
+        )
+        if block_paged_attention_enabled:
+            req_capacity = (
+                int(req_to_token_pool.req_to_token.shape[0])
+                if req_to_token_pool is not None
+                else 0
+            )
+            token_blocks = (
                 self._pool_size + self._block_size - 1
-            ) // self._block_size + 1
+            ) // self._block_size
+            # Blocks are owned per request. Add one partial-block headroom block
+            # per request row so token-slot admission does not over-admit many
+            # short requests that each need a separate final block.
+            num_blocks = token_blocks + req_capacity + 1
             self._block_attention_kv_pool = MlxBlockAttentionKVPool(
                 num_blocks=num_blocks,
                 block_size=self._block_size,
@@ -618,9 +633,15 @@ class MlxModelRunner:
             )
             logger.info(
                 f"Block attention KV pool initialized: num_blocks={num_blocks} "
-                f"(block 0 reserved), block_size={self._block_size}, "
+                f"(block 0 reserved, token_blocks={token_blocks}, "
+                f"fragmentation_headroom={req_capacity}), block_size={self._block_size}, "
                 f"{self._cache_layout.num_attention_layers} attention layers, "
                 f"{n_kv_heads} kv_heads, {head_dim} head_dim"
+            )
+        elif envs.SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION.get():
+            logger.info(
+                "Block paged attention requested but unavailable for this model; "
+                "using legacy MLX KV cache with padded SDPA fallback."
             )
         if self.disable_radix_cache:
             return
@@ -939,6 +960,10 @@ class MlxModelRunner:
         that specific lazy scalar.
         """
         next_token = int(pending.lazy_token.item())
+        if self._block_attention_kv_pool is not None:
+            self._ensure_block_request_capacity(
+                pending.req_id, self._first_attention_cache(pending.cache).offset
+            )
         self._req_token_ids[pending.req_id] = list(pending.full_token_ids) + [
             next_token
         ]
@@ -961,6 +986,10 @@ class MlxModelRunner:
         ), f"extend_start called for unknown request {req_id}"
 
         cache = self._req_caches[req_id]
+        if self._block_attention_kv_pool is not None:
+            self._ensure_block_request_capacity(
+                req_id, self._first_attention_cache(cache).offset + len(new_token_ids)
+            )
 
         input_ids = mx.array([new_token_ids], dtype=mx.int32)
         model_output = self.model(input_ids, cache=cache)
@@ -1208,7 +1237,7 @@ class MlxModelRunner:
         caches: list[list[Any]],
         batched_input: mx.array,
         req_ids: list[str],
-    ) -> tuple[mx.array, dict[str, int] | None]:
+    ) -> tuple[mx.array, dict[str, int] | None, dict[str, int] | None]:
         self._ensure_block_capacity_for_decode(req_ids, caches)
         ctx = self._build_batched_decode_context(caches, req_ids)
         seq_lens = ctx.seq_lens
@@ -1221,21 +1250,26 @@ class MlxModelRunner:
             ]
             model_output = self.model(batched_input, cache=shim_cache)
             logits = self._extract_logits(model_output)
-            pool_synced_offsets = None
+            flat_pool_synced_offsets = None
             if ctx.aot.rope is not None and ctx.aot.rope.new_token_slots is not None:
-                pool_synced_offsets = {
+                flat_pool_synced_offsets = {
                     rid: self._first_attention_cache(cache).offset
                     for rid, cache in zip(req_ids, caches)
                 }
+            block_pool_synced_offsets = None
             if (
                 ctx.aot.block_paged_attention is not None
                 and ctx.block_paged_metadata is not None
             ):
-                pool_synced_offsets = {
+                block_pool_synced_offsets = {
                     rid: self._first_attention_cache(cache).offset
                     for rid, cache in zip(req_ids, caches)
                 }
-            return mx.argmax(logits[:, -1, :], axis=-1), pool_synced_offsets
+            return (
+                mx.argmax(logits[:, -1, :], axis=-1),
+                flat_pool_synced_offsets,
+                block_pool_synced_offsets,
+            )
         finally:
             clear_context()
 
@@ -1275,17 +1309,21 @@ class MlxModelRunner:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, list(req_ids)
             )
-            pool_synced_offsets = None
+            flat_pool_synced_offsets = None
+            block_pool_synced_offsets = None
         else:
-            lazy_tokens, pool_synced_offsets = self._decode_with_batched_attention(
-                caches, batched_input, list(req_ids)
-            )
+            (
+                lazy_tokens,
+                flat_pool_synced_offsets,
+                block_pool_synced_offsets,
+            ) = self._decode_with_batched_attention(caches, batched_input, list(req_ids))
 
         return MlxPendingDecode(
             lazy_tokens=lazy_tokens,
             req_ids=list(req_ids),
             caches=caches,
-            pool_synced_offsets=pool_synced_offsets,
+            flat_pool_synced_offsets=flat_pool_synced_offsets,
+            block_pool_synced_offsets=block_pool_synced_offsets,
         )
 
     def decode_batch_start_chained(
@@ -1322,17 +1360,21 @@ class MlxModelRunner:
             lazy_tokens = self._decode_with_hybrid_batching(
                 caches, batched_input, prev.req_ids
             )
-            pool_synced_offsets = None
+            flat_pool_synced_offsets = None
+            block_pool_synced_offsets = None
         else:
-            lazy_tokens, pool_synced_offsets = self._decode_with_batched_attention(
-                caches, batched_input, prev.req_ids
-            )
+            (
+                lazy_tokens,
+                flat_pool_synced_offsets,
+                block_pool_synced_offsets,
+            ) = self._decode_with_batched_attention(caches, batched_input, prev.req_ids)
 
         return MlxPendingDecode(
             lazy_tokens=lazy_tokens,
             req_ids=prev.req_ids,
             caches=caches,
-            pool_synced_offsets=pool_synced_offsets,
+            flat_pool_synced_offsets=flat_pool_synced_offsets,
+            block_pool_synced_offsets=block_pool_synced_offsets,
         )
 
     def decode_batch_finalize(
@@ -1355,12 +1397,12 @@ class MlxModelRunner:
 
         for i, rid in enumerate(pending.req_ids):
             self._req_token_ids[rid].append(next_tokens[i])
-            if pending.pool_synced_offsets is not None:
-                self._req_synced_offset[rid] = pending.pool_synced_offsets[rid]
-                if self._block_attention_kv_pool is not None:
-                    self._req_block_synced_offset[rid] = pending.pool_synced_offsets[
-                        rid
-                    ]
+            if pending.flat_pool_synced_offsets is not None:
+                self._req_synced_offset[rid] = pending.flat_pool_synced_offsets[rid]
+            if pending.block_pool_synced_offsets is not None:
+                self._req_block_synced_offset[rid] = pending.block_pool_synced_offsets[
+                    rid
+                ]
 
         self._decode_step_ct += 1
         if self._clear_steps > 0 and self._decode_step_ct % self._clear_steps == 0:

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -570,6 +570,12 @@ class MlxModelRunner:
             int(sys_available * self._mem_fraction_static),
         )
         bytes_per_slot = 2 * num_layers * n_kv_heads * head_dim * dtype.size
+        if envs.SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION.get():
+            # Block paged attention may keep both the legacy flat pool (for
+            # radix/prefix compatibility) and the block pool (for decode).
+            # Auto-size against both representations so opt-in block mode does
+            # not accidentally reserve roughly two KV budgets.
+            bytes_per_slot *= 2
         pool_size = max(kv_budget // bytes_per_slot, 256)
         logger.info(
             f"Auto-sized attention KV pool: "
@@ -611,14 +617,11 @@ class MlxModelRunner:
             and not self._cache_layout.has_auxiliary_state
         )
         if block_paged_attention_enabled:
-            req_capacity = (
-                int(req_to_token_pool.req_to_token.shape[0])
-                if req_to_token_pool is not None
-                else 0
-            )
-            token_blocks = (
-                self._pool_size + self._block_size - 1
-            ) // self._block_size
+            if req_to_token_pool is not None:
+                req_capacity = int(req_to_token_pool.req_to_token.shape[0])
+            else:
+                req_capacity = int(get_server_args().max_running_requests or 0)
+            token_blocks = (self._pool_size + self._block_size - 1) // self._block_size
             # Blocks are owned per request. Add one partial-block headroom block
             # per request row so token-slot admission does not over-admit many
             # short requests that each need a separate final block.
@@ -1316,7 +1319,9 @@ class MlxModelRunner:
                 lazy_tokens,
                 flat_pool_synced_offsets,
                 block_pool_synced_offsets,
-            ) = self._decode_with_batched_attention(caches, batched_input, list(req_ids))
+            ) = self._decode_with_batched_attention(
+                caches, batched_input, list(req_ids)
+            )
 
         return MlxPendingDecode(
             lazy_tokens=lazy_tokens,


### PR DESCRIPTION
## Summary
This PR adds an experimental block-table paged attention decode path for the MLX backend on Apple Silicon.

Part of the Apple Device Support roadmap (https://github.com/sgl-project/sglang/issues/19137).

The existing MLX decode path keeps legacy flat/contiguous KV cache behavior and uses padded SDPA by default. This PR adds an opt-in block KV pool and Metal decode kernel that read K/V through block tables instead of padding every request to the longest sequence in the batch.
## Motivation

Skewed decode batches waste work in the padded SDPA path because each request is padded to the batch maximum sequence length. Block-table paged attention lets decode read only visible KV tokens through request block tables:

```text
block_tables[batch, logical_block] -> physical_block
k/v[physical_block, block_offset, kv_head, head_dim]
```

This keeps legacy MLX behavior available while adding a path that is closer to standard block-table paged attention.

## Modifications

- Add `SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION`. set DISABLED by default.
- Add `MLXBlockPagedAttentionMetadata`.
- Add `MlxBlockAttentionKVPool`.
- Add `sgl_kernel.metal.block_paged_attention_decode(...)`.
- Implement the block decode kernel as a 256-thread multi-warp Metal kernel.
  - 8 SIMD groups per `(batch, q_head)`.
  - Per-warp online softmax state.
  - Threadgroup-memory merge of per-warp `(max, sum, accumulator)` state.
  - Supports `head_dim <= 256`.
- Add Metal AOT extension split:
  - `metal_common.{h,cpp}`
  - `bindings.cpp`
  - `paged_attention.{cpp,metal}`
- Keep legacy flat/contiguous MLX KV cache behavior as fallback/default.
- Extend `bench_one_batch` with `--skewed-input-lens` for skewed decode benchmarking.
- Update Apple Metal docs with the block paged attention opt-in flag.

## How to enable

```bash
SGLANG_USE_MLX=1 \
SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION=1 \
python -m sglang.launch_server \
  --model-path mlx-community/Qwen3-0.6B-4bit \
  --host 127.0.0.1 \
  --port 30000 \
  --disable-cuda-graph
```

To force legacy MLX behavior:

```bash
SGLANG_USE_MLX=1 \
SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION=0 \
python -m sglang.launch_server \
  --model-path mlx-community/Qwen3-0.6B-4bit \
  --host 127.0.0.1 \
  --port 30000 \
  --disable-cuda-graph
```

## Speed Tests and Profiling

Benchmark block path:

```bash
SGLANG_USE_MLX=1 \
SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION=1 \
.venv-mlx-dev/bin/python -m sglang.benchmark.one_batch \
  --model-path mlx-community/Qwen3-0.6B-4bit \
  --disable-cuda-graph \
  --tp-size 1 \
  --skewed-input-lens 128 512 1024 2048 \
  --output-len 64 \
  --run-name mlx_block_paged_attention \
  --result-filename ""
```


```bash
SGLANG_USE_MLX=1 \
SGLANG_MLX_USE_BLOCK_PAGED_ATTENTION=0 \
.venv-mlx-dev/bin/python -m sglang.benchmark.one_batch \
  --model-path mlx-community/Qwen3-0.6B-4bit \
  --disable-cuda-graph \
  --tp-size 1 \
  --skewed-input-lens 128 512 1024 2048 \
  --output-len 64 \
  --run-name mlx_padded_sdpa \
  --result-filename ""
```

Observed local block-path run:

```text
Skewed input lengths: [128, 512, 1024, 2048]
Prefill. latency: 0.83317 s, throughput: 4455.27 token/s
Decode.  median latency: 0.01825 s, median throughput: 219.15 token/s
Total. latency: 2.142 s, throughput: 1852.62 token/s
```

Kernel microbenchmarks:

```text
head_dim=128:
block_paged_ms=0.424
padded_total_ms=2.013
speedup=4.754x

head_dim=256:
block_paged_ms=0.752
padded_total_ms=2.148
speedup=2.857x
```

## Performance Notes

This PR should be interpreted as an opt-in block-table decode path, not as a universal replacement for the existing padded SDPA decode path yet.

The expected win is for skewed or fragmented decode batches, where padded SDPA wastes work by padding every request to the longest sequence in the batch. In those cases, block paged attention reads only the visible KV tokens through the request block table.

@jlee5814 Reviewer-reported median decode throughput `Qwen3-0.6B-4bit`, `--output-len 64`:

| Workload | Flag off | Flag on | Ratio |
|---|---:|---:|---:|
| `--batch-size 1 --input-len 128` | 301.12 | 239.22 | 0.79x |
| `--skewed-input-lens 128 512 1024 2048` | 133.98 | 209.23 | 1.56x |
| `--skewed-input-lens 32 64 512 2048` | 134.68 | 229.21 | 1.70x |

So the current result is workload-dependent:

- Uniform single-request decode regresses because there is little or no padding work to remove, while block-table metadata reads and the custom kernel dispatch still add fixed overhead.
- Skewed decode batches improve because the fallback path pads to the batch maximum sequence length, while the block path reads only each request's visible KV tokens.
- The win is expected to become more relevant for high-request-count and fragmented serving workloads, which are the workloads paged attention is primarily meant to address.

This PR is still an incremental decode-side step. Follow-up work is planned around prefill/radix integration and broader block-table plumbing, which should make the paged-attention path more representative of the intended high-fragmentation serving case.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30742993416](https://github.com/sgl-project/sglang/actions/runs/30742993416)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30742993357](https://github.com/sgl-project/sglang/actions/runs/30742993357)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->