### PR TITLE
[MHA] Support HND KV cache layout in CPU offload

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1794,6 +1794,11 @@ class MHATokenToKVPool(KVCache):
         self.quant_method = (
             quant_method if quant_method is not None else UnquantizedKVCacheMethod()
         )
+        if self.use_hnd and self.is_quantized_kv_cache:
+            raise ValueError(
+                "Quantized KV cache does not support SGLANG_USE_HND_KVCACHE. "
+                "Quantized KV buffers and their scale buffers use NHD slot-row layout."
+            )
 
         self._create_buffers()
 
@@ -2170,10 +2175,6 @@ class MHATokenToKVPool(KVCache):
         return ptrs, lens, item_lens
 
     def get_cpu_copy(self, indices, mamba_indices=None):
-        assert not self.use_hnd, (
-            "CPU KV offload indexes by slot (NHD); HND KV cache "
-            "(SGLANG_USE_HND_KVCACHE) is not supported with CPU offload yet."
-        )
         current_platform.synchronize()
         kv_cache_cpu = []
         chunk_size = self.cpu_offloading_chunk_size
@@ -2181,35 +2182,74 @@ class MHATokenToKVPool(KVCache):
             kv_cache_cpu.append([])
             for i in range(0, len(indices), chunk_size):
                 chunk_indices = indices[i : i + chunk_size]
-                k_cpu = self.k_buffer[layer_id][chunk_indices].to(
-                    "cpu", non_blocking=True
-                )
-                v_cpu = self.v_buffer[layer_id][chunk_indices].to(
-                    "cpu", non_blocking=True
-                )
-                kv_cache_cpu[-1].append([k_cpu, v_cpu])
+                if self.use_hnd:
+                    # A slot is [page, :, off, :] (not a contiguous row); gather by
+                    # (page, off) into an NHD-style (N, head_num, head_dim) tensor.
+                    pages = chunk_indices // self.page_size
+                    offs = chunk_indices % self.page_size
+                    k_cpu = self.k_buffer[layer_id][pages, :, offs, :].to(
+                        "cpu", non_blocking=True
+                    )
+                    v_cpu = self.v_buffer[layer_id][pages, :, offs, :].to(
+                        "cpu", non_blocking=True
+                    )
+                else:
+                    k_cpu = self.k_buffer[layer_id][chunk_indices].to(
+                        "cpu", non_blocking=True
+                    )
+                    v_cpu = self.v_buffer[layer_id][chunk_indices].to(
+                        "cpu", non_blocking=True
+                    )
+                chunk_cpu = [k_cpu, v_cpu]
+                if self.is_quantized_kv_cache and self.k_scale_buffer is not None:
+                    # Packed FP4 data is unusable without its per-token block scales.
+                    k_scale_cpu = self.k_scale_buffer[layer_id][chunk_indices].to(
+                        "cpu", non_blocking=True
+                    )
+                    v_scale_cpu = self.v_scale_buffer[layer_id][chunk_indices].to(
+                        "cpu", non_blocking=True
+                    )
+                    chunk_cpu.extend([k_scale_cpu, v_scale_cpu])
+                kv_cache_cpu[-1].append(chunk_cpu)
         current_platform.synchronize()
         return kv_cache_cpu
 
     def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        assert not self.use_hnd, (
-            "CPU KV offload indexes by slot (NHD); HND KV cache "
-            "(SGLANG_USE_HND_KVCACHE) is not supported with CPU offload yet."
-        )
         current_platform.synchronize()
         chunk_size = self.cpu_offloading_chunk_size
         for layer_id in range(self.layer_num):
             for i in range(0, len(indices), chunk_size):
                 chunk_indices = indices[i : i + chunk_size]
-                k_cpu, v_cpu = (
-                    kv_cache_cpu[layer_id][i // chunk_size][0],
-                    kv_cache_cpu[layer_id][i // chunk_size][1],
-                )
+                chunk_cpu = kv_cache_cpu[layer_id][i // chunk_size]
+                k_cpu, v_cpu = chunk_cpu[:2]
                 assert k_cpu.shape[0] == v_cpu.shape[0] == len(chunk_indices)
                 k_chunk = k_cpu.to(self.k_buffer[0].device, non_blocking=True)
                 v_chunk = v_cpu.to(self.v_buffer[0].device, non_blocking=True)
-                self.k_buffer[layer_id][chunk_indices] = k_chunk
-                self.v_buffer[layer_id][chunk_indices] = v_chunk
+                if self.use_hnd:
+                    # Mirror get_cpu_copy: scatter the NHD-style chunk back by (page, off).
+                    pages = chunk_indices // self.page_size
+                    offs = chunk_indices % self.page_size
+                    self.k_buffer[layer_id][pages, :, offs, :] = k_chunk
+                    self.v_buffer[layer_id][pages, :, offs, :] = v_chunk
+                else:
+                    self.k_buffer[layer_id][chunk_indices] = k_chunk
+                    self.v_buffer[layer_id][chunk_indices] = v_chunk
+                if self.is_quantized_kv_cache and self.k_scale_buffer is not None:
+                    assert len(chunk_cpu) == 4
+                    k_scale_cpu, v_scale_cpu = chunk_cpu[2:]
+                    assert (
+                        k_scale_cpu.shape[0]
+                        == v_scale_cpu.shape[0]
+                        == len(chunk_indices)
+                    )
+                    k_scale_chunk = k_scale_cpu.to(
+                        self.k_scale_buffer[0].device, non_blocking=True
+                    )
+                    v_scale_chunk = v_scale_cpu.to(
+                        self.v_scale_buffer[0].device, non_blocking=True
+                    )
+                    self.k_scale_buffer[layer_id][chunk_indices] = k_scale_chunk
+                    self.v_scale_buffer[layer_id][chunk_indices] = v_scale_chunk
         current_platform.synchronize()
 
     def _get_key_buffer(self, layer_id: int):

--- a/python/sglang/srt/mem_cache/swa_memory_pool.py
+++ b/python/sglang/srt/mem_cache/swa_memory_pool.py
@@ -236,15 +236,17 @@ class SWAKVPool(BaseSWAKVPool):
                 filtered.append([])
                 continue
 
-            k_cpu = torch.cat([chunk[0] for chunk in layer_chunks], dim=0)
-            v_cpu = torch.cat([chunk[1] for chunk in layer_chunks], dim=0)
-            k_cpu = k_cpu[row_mask]
-            v_cpu = v_cpu[row_mask]
+            tensor_count = len(layer_chunks[0])
+            assert all(len(chunk) == tensor_count for chunk in layer_chunks)
+            tensors_cpu = [
+                torch.cat([chunk[j] for chunk in layer_chunks], dim=0)[row_mask]
+                for j in range(tensor_count)
+            ]
 
             filtered_layer = []
-            for i in range(0, len(k_cpu), chunk_size):
+            for i in range(0, len(tensors_cpu[0]), chunk_size):
                 filtered_layer.append(
-                    [k_cpu[i : i + chunk_size], v_cpu[i : i + chunk_size]]
+                    [tensor[i : i + chunk_size] for tensor in tensors_cpu]
                 )
             filtered.append(filtered_layer)
         return filtered

--- a/test/registered/unit/mem_cache/test_mha_pool_cpu_offload_hnd.py
+++ b/test/registered/unit/mem_cache/test_mha_pool_cpu_offload_hnd.py
@@ -1,0 +1,271 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0
+
+"""Round-trip tests for MHATokenToKVPool CPU offload under both KV layouts.
+
+`get_cpu_copy` / `load_cpu_copy` move KV cache between device and host by slot
+id. The NHD layout stores a slot as a contiguous row `[slot, :, :]`, while the
+HND layout (SGLANG_USE_HND_KVCACHE) folds (page, head) and stores a slot as
+`[page, :, off, :]`. These tests write sentinel values, offload to CPU, clear
+the device buffers, load back, and assert the original values are restored for
+both layouts.
+
+    python -m pytest \
+        test/registered/unit/mem_cache/test_mha_pool_cpu_offload_hnd.py -v
+"""
+
+import types
+import unittest
+
+import torch
+
+from sglang.srt import environ as srt_environ
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestMHAPoolCPUOffload(unittest.TestCase):
+    def _build_pool(
+        self,
+        use_hnd: bool,
+        page_size: int,
+        device: str = "cpu",
+        v_head_dim: int | None = None,
+    ):
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+        with srt_environ.envs.SGLANG_USE_HND_KVCACHE.override(use_hnd):
+            pool = MHATokenToKVPool(
+                size=16,
+                page_size=page_size,
+                dtype=torch.bfloat16,
+                head_num=2,
+                head_dim=8,
+                v_head_dim=v_head_dim,
+                layer_num=2,
+                device=device,
+                enable_memory_saver=False,
+            )
+        self.assertEqual(pool.use_hnd, use_hnd)
+        return pool
+
+    def _fill_sentinels(self, pool, indices):
+        layer = types.SimpleNamespace(layer_id=0)
+        n = len(indices)
+        for layer_id in range(pool.layer_num):
+            layer.layer_id = layer_id
+            token_values = torch.arange(n, dtype=torch.float32, device=pool.device)[
+                :, None, None
+            ]
+            head_values = torch.arange(
+                pool.head_num, dtype=torch.float32, device=pool.device
+            )[None, :, None]
+            cache_k = token_values * 24 + head_values * pool.head_dim
+            cache_k = (
+                cache_k
+                + torch.arange(pool.head_dim, dtype=torch.float32, device=pool.device)[
+                    None, None, :
+                ]
+            )
+            cache_v = token_values * 24 + head_values * pool.v_head_dim
+            cache_v = (
+                cache_v
+                + torch.arange(
+                    pool.v_head_dim, dtype=torch.float32, device=pool.device
+                )[None, None, :]
+            )
+            cache_k = (cache_k + layer_id * 128).to(torch.bfloat16)
+            cache_v = (-cache_v - layer_id * 128 - 1).to(torch.bfloat16)
+            pool.set_kv_buffer(layer, indices, cache_k.clone(), cache_v.clone())
+
+    def _read_slots(self, pool, indices):
+        out = []
+        for layer_id in range(pool.layer_num):
+            out.append(
+                (
+                    pool.get_key_buffer(layer_id)[indices].clone(),
+                    pool.get_value_buffer(layer_id)[indices].clone(),
+                )
+                if not pool.use_hnd
+                else (
+                    pool.get_key_buffer(layer_id)[
+                        indices // pool.page_size, :, indices % pool.page_size, :
+                    ].clone(),
+                    pool.get_value_buffer(layer_id)[
+                        indices // pool.page_size, :, indices % pool.page_size, :
+                    ].clone(),
+                )
+            )
+        return out
+
+    def _run_round_trip(
+        self,
+        use_hnd: bool,
+        page_size: int,
+        device: str = "cpu",
+        chunk_size: int = 8192,
+        v_head_dim: int | None = None,
+    ):
+        pool = self._build_pool(
+            use_hnd, page_size, device=device, v_head_dim=v_head_dim
+        )
+        pool.cpu_offloading_chunk_size = chunk_size
+        indices = torch.tensor([0, 3, 5, 8, 11], dtype=torch.int64, device=pool.device)
+
+        self._fill_sentinels(pool, indices)
+        expected = self._read_slots(pool, indices)
+
+        kv_cache_cpu = pool.get_cpu_copy(indices)
+        for layer_chunks in kv_cache_cpu:
+            for chunk_cpu in layer_chunks:
+                k_cpu, v_cpu = chunk_cpu[:2]
+                self.assertEqual(k_cpu.device.type, "cpu")
+                self.assertEqual(v_cpu.device.type, "cpu")
+
+        for layer_id in range(pool.layer_num):
+            pool.k_buffer[layer_id].zero_()
+            pool.v_buffer[layer_id].zero_()
+
+        pool.load_cpu_copy(kv_cache_cpu, indices)
+        restored = self._read_slots(pool, indices)
+
+        for layer_id in range(pool.layer_num):
+            self.assertTrue(
+                torch.equal(restored[layer_id][0], expected[layer_id][0]),
+                f"K mismatch layer={layer_id} use_hnd={use_hnd} ps={page_size}",
+            )
+            self.assertTrue(
+                torch.equal(restored[layer_id][1], expected[layer_id][1]),
+                f"V mismatch layer={layer_id} use_hnd={use_hnd} ps={page_size}",
+            )
+
+    def test_round_trip_nhd(self):
+        self._run_round_trip(use_hnd=False, page_size=1)
+
+    def test_round_trip_hnd_page_size_1(self):
+        self._run_round_trip(use_hnd=True, page_size=1)
+
+    def test_round_trip_hnd_page_size_4(self):
+        self._run_round_trip(use_hnd=True, page_size=4)
+
+    def test_round_trip_hnd_different_value_head_dim(self):
+        self._run_round_trip(use_hnd=True, page_size=4, v_head_dim=4)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_round_trip_hnd_cuda_chunked(self):
+        self._run_round_trip(use_hnd=True, page_size=4, device="cuda", chunk_size=2)
+
+    def test_hnd_matches_nhd(self):
+        """HND and NHD must offload/restore identical logical KV values."""
+        page_size = 4
+        indices = torch.tensor([0, 3, 5, 8, 11], dtype=torch.int64)
+
+        pool_nhd = self._build_pool(use_hnd=False, page_size=page_size)
+        pool_hnd = self._build_pool(use_hnd=True, page_size=page_size)
+        self._fill_sentinels(pool_nhd, indices)
+        self._fill_sentinels(pool_hnd, indices)
+
+        cpu_nhd = pool_nhd.get_cpu_copy(indices)
+        cpu_hnd = pool_hnd.get_cpu_copy(indices)
+        for layer_id in range(pool_nhd.layer_num):
+            for chunk_nhd, chunk_hnd in zip(cpu_nhd[layer_id], cpu_hnd[layer_id]):
+                self.assertTrue(torch.equal(chunk_nhd[0], chunk_hnd[0]))
+                self.assertTrue(torch.equal(chunk_nhd[1], chunk_hnd[1]))
+
+    def test_hnd_rejects_quantized_kv_cache(self):
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+        with srt_environ.envs.SGLANG_USE_HND_KVCACHE.override(True):
+            with self.assertRaisesRegex(
+                ValueError, "Quantized KV cache does not support"
+            ):
+                MHATokenToKVPool(
+                    size=16,
+                    page_size=4,
+                    dtype=torch.bfloat16,
+                    head_num=2,
+                    head_dim=8,
+                    layer_num=2,
+                    device="cpu",
+                    enable_memory_saver=False,
+                    quant_method=object(),
+                )
+
+    def test_quantized_nhd_round_trip_restores_scales(self):
+        from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
+            FP4MXBlock16KVCacheMethod,
+        )
+        from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+        with srt_environ.envs.SGLANG_USE_HND_KVCACHE.override(False):
+            pool = MHATokenToKVPool(
+                size=16,
+                page_size=1,
+                dtype=torch.bfloat16,
+                head_num=2,
+                head_dim=16,
+                layer_num=2,
+                device="cpu",
+                enable_memory_saver=False,
+                quant_method=FP4MXBlock16KVCacheMethod(),
+            )
+        pool.cpu_offloading_chunk_size = 2
+        indices = torch.tensor([1, 3, 7], dtype=torch.int64)
+
+        expected = []
+        for layer_id in range(pool.layer_num):
+            buffers = (
+                pool.k_buffer[layer_id],
+                pool.v_buffer[layer_id],
+                pool.k_scale_buffer[layer_id],
+                pool.v_scale_buffer[layer_id],
+            )
+            for value, buffer in enumerate(buffers, start=1):
+                buffer[indices] = value + layer_id
+            expected.append(tuple(buffer[indices].clone() for buffer in buffers))
+
+        cpu_copy = pool.get_cpu_copy(indices)
+        self.assertTrue(all(len(chunk) == 4 for chunks in cpu_copy for chunk in chunks))
+
+        for layer_id in range(pool.layer_num):
+            pool.k_buffer[layer_id][indices] = 0
+            pool.v_buffer[layer_id][indices] = 0
+            pool.k_scale_buffer[layer_id][indices] = 0
+            pool.v_scale_buffer[layer_id][indices] = 0
+
+        pool.load_cpu_copy(cpu_copy, indices)
+
+        for layer_id in range(pool.layer_num):
+            restored = (
+                pool.k_buffer[layer_id][indices],
+                pool.v_buffer[layer_id][indices],
+                pool.k_scale_buffer[layer_id][indices],
+                pool.v_scale_buffer[layer_id][indices],
+            )
+            for actual, wanted in zip(restored, expected[layer_id]):
+                self.assertTrue(torch.equal(actual, wanted))
+
+    def test_swa_filter_preserves_quantized_scale_chunks(self):
+        from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+
+        pool = object.__new__(SWAKVPool)
+        pool.swa_kv_pool = types.SimpleNamespace(cpu_offloading_chunk_size=2)
+        layer_chunks = [
+            [torch.arange(3) + offset for offset in (0, 10, 20, 30)],
+            [torch.arange(3, 6) + offset for offset in (0, 10, 20, 30)],
+        ]
+        row_mask = torch.tensor([True, False, True, False, True, True])
+
+        filtered = pool._filter_swa_cpu_copy([layer_chunks], row_mask)
+
+        self.assertTrue(all(len(chunk) == 4 for chunk in filtered[0]))
+        for tensor_id, offset in enumerate((0, 10, 20, 30)):
+            actual = torch.cat([chunk[tensor_id] for chunk in filtered[0]])
+            expected = (torch.arange(6) + offset)[row_mask]
+            self.assertTrue(torch.equal(actual, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

CPU KV cache offloading previously assumed that each token slot was stored as a contiguous row in NHD layout. When `SGLANG_USE_HND_KVCACHE` was enabled,
`get_cpu_copy` and `load_cpu_copy` rejected CPU offloading because HND stores a token slot as `[page, head, offset, dim]`.

This PR adds CPU offloading support for HND KV cache layout while preserving existing NHD behavior.

## Modifications

- Support gathering HND KV cache slots into NHD-shaped CPU tensors during offloading.
- Support scattering CPU tensors back into the corresponding HND page and offset during loading.
- Preserve chunked CPU offloading and asymmetric K/V head dimensions.
- Include quantized KV cache scale buffers in NHD CPU copies.
- Explicitly reject the unsupported combination of HND layout and quantized KV cache.
- Update SWA CPU-copy filtering to preserve all tensors in each chunk, including quantization scales.
- Add unit tests for:
  - NHD and HND round trips.
  - HND with page sizes 1 and 4.
  - Asymmetric K/V head dimensions.
  - Chunked CUDA transfers.
  - Quantized NHD data and scale restoration.
  - SWA filtering with quantized scale chunks.
  - Rejection of HND with quantized KV cache.

## Accuracy Tests

This change does not modify attention computation or model arithmetic.

Round-trip tests use exact sentinel comparisons to verify that K/V data and quantization scales are restored without modification.

Tests were run on an NVIDIA L20 GPU:

- PR-specific CPU offload tests: `9 passed`
- Memory pool, layout, and quantized KV cache tests: `39 passed`
- SWA memory pool and lifecycle tests: `38 passed`, plus `18 subtests passed`
- FP4 KV cache tests: `16 passed, 1 skipped`
  - The skipped test requires Blackwell NVFP4 support and is expected on L20.
- Additional CUDA integration checks:
  - Quantized NHD data and scale CPU round trip: passed.
  - Quantized SWA partial-mapping data and scale round trip: passed.

Overall pytest result: `102 passed, 1 expected skip`.

## Speed Tests and Profiling

N/A. This change only affects CPU KV cache offload and restore operations and does not modify the inference hot path.

## Checklist

- [x] Format the code with `pre-commit run --all-files --show-diff-on-failure`.
- [x] Add unit tests for the modified behavior.
- [x] Documentation update is not required because no user-facing API or configuration is added.
- [x] Accuracy and speed impact have been evaluated.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30214012847](https://github.com/sgl-project/sglang/actions/runs/30214012847)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30214012831](https://github.com/sgl-project/sglang/actions/runs/30214012831)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->