### PR TITLE
Add oulgen to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1042,6 +1042,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "oulgen": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "pansicheng": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
Add `oulgen` to `.github/CI_PERMISSIONS.json` with CI permissions (tag run CI label, rerun failed CI, rerun stage, 0 min cooldown).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30217994419](https://github.com/sgl-project/sglang/actions/runs/30217994419)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30217994379](https://github.com/sgl-project/sglang/actions/runs/30217994379)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->