### PR TITLE
[scheduler] Fix prefill delayer timeout rank divergence

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -174,7 +174,7 @@ class PrefillDelayer:
         # Each rank creates start_time independently. Reduce the deadline
         # decision across every participant so TP ranks cannot straddle it and
         # choose prefill versus decode on the same scheduler pass.
-        global_queue_timeout_expired = global_info[:, :, 5].max().item() > 0
+        global_queue_timeout_expired = global_info[:, :, 5].max() > 0
 
         # Compute derived global states
         if global_prefillable.min().item() > 0:

--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -95,9 +95,9 @@ class PrefillDelayer:
 
         # Fields packed per rank into the all-gather tensor: prefillable,
         # token_watermark_force_allow, running_batch, max_prefill_bs,
-        # waiting_queue_len.
+        # waiting_queue_len, queue_timeout_expired.
         self._global_info_buffer = torch.empty(
-            (dp_size_dim, attn_tp_size, 5),
+            (dp_size_dim, attn_tp_size, 6),
             dtype=torch.int64,
             device=self._gather_device,
         )
@@ -144,25 +144,37 @@ class PrefillDelayer:
         waiting_queue_len: int = 0,
     ) -> _NegotiateOutput:
         # Compute local states
+        now = time.perf_counter()
         local_token_watermark_force_allow = (
             local_prefillable
             and ((x := self._token_usage_low_watermark) is not None)
             and (token_usage < x)
         )
+        local_queue_timeout_expired = (
+            self._queue_trigger_enabled
+            and prev_state is not None
+            and (now - prev_state.start_time) * 1000.0 >= self._max_delay_ms
+        )
 
         # Gather global states
-        tp0_info = self._gather_info(
+        global_info = self._gather_info(
             local_prefillable=local_prefillable,
             local_token_watermark_force_allow=local_token_watermark_force_allow,
+            local_queue_timeout_expired=local_queue_timeout_expired,
             running_batch=running_batch,
             max_prefill_bs=max_prefill_bs,
             waiting_queue_len=waiting_queue_len,
         )
+        tp0_info = global_info[:, 0, :]
         global_prefillable = tp0_info[:, 0]
         global_token_watermark_force_allow = tp0_info[:, 1]
         global_running_batch = tp0_info[:, 2]
         global_max_prefill_bs = tp0_info[:, 3]
         global_waiting_queue_len = tp0_info[:, 4]
+        # Each rank creates start_time independently. Reduce the deadline
+        # decision across every participant so TP ranks cannot straddle it and
+        # choose prefill versus decode on the same scheduler pass.
+        global_queue_timeout_expired = global_info[:, :, 5].max().item() > 0
 
         # Compute derived global states
         if global_prefillable.min().item() > 0:
@@ -185,9 +197,7 @@ class PrefillDelayer:
         # the defaults (0) since the wait isn't finished and isn't observed.
         wait_info = dict(
             wait_forward_passes=prev_state.delayed_count if prev_state else 0,
-            wait_seconds=(
-                (time.perf_counter() - prev_state.start_time) if prev_state else 0.0
-            ),
+            wait_seconds=((now - prev_state.start_time) if prev_state else 0.0),
         )
 
         # Compute outputs
@@ -227,10 +237,8 @@ class PrefillDelayer:
                     queue_min_effective > 0
                     and global_waiting_queue_max < queue_min_effective
                 )
-                if queue_condition and prev_state is not None:
-                    elapsed_ms = (time.perf_counter() - prev_state.start_time) * 1000.0
-                    if elapsed_ms >= self._max_delay_ms:
-                        queue_condition = False
+                if queue_condition and global_queue_timeout_expired:
+                    queue_condition = False
 
             slot_condition = (
                 max_running_requests - global_running_batch_max
@@ -304,6 +312,7 @@ class PrefillDelayer:
         self,
         local_prefillable: bool,
         local_token_watermark_force_allow: bool,
+        local_queue_timeout_expired: bool,
         running_batch: int = 0,
         max_prefill_bs: int = 0,
         waiting_queue_len: int = 0,
@@ -315,6 +324,7 @@ class PrefillDelayer:
                 running_batch,
                 max_prefill_bs,
                 waiting_queue_len,
+                int(local_queue_timeout_expired),
             ],
             device=self._gather_device,
             dtype=torch.int64,
@@ -324,8 +334,7 @@ class PrefillDelayer:
             local_info,
             group=self._gather_group,
         )
-        tp0_info = self._global_info_buffer[:, 0, :]
-        return tp0_info
+        return self._global_info_buffer
 
 
 class PrefillDelayerSinglePassExecutor:

--- a/test/registered/scheduler/test_prefill_delayer.py
+++ b/test/registered/scheduler/test_prefill_delayer.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 import unittest
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from types import SimpleNamespace
 from typing import List, Optional
 
@@ -126,6 +126,59 @@ def _run_negotiate_test(rank, test_cases):
                 assert (
                     result.wait_seconds > 0.0
                 ), f"Case {case.name} rank {rank}: wait_seconds not surfaced"
+
+
+def _run_tp_queue_timeout_uniformity_test(rank):
+    world_size = torch.distributed.get_world_size()
+    cpu_group = torch.distributed.new_group(backend="gloo")
+    delayer = PrefillDelayer(
+        dp_size=1,
+        attn_tp_size=world_size,
+        cpu_group=cpu_group,
+        server_args=SimpleNamespace(
+            enable_dp_attention=False,
+            disaggregation_mode="null",
+            disable_overlap_schedule=False,
+            prefill_delayer_queue_min_ratio=0.5,
+            prefill_delayer_max_delay_ms=1000,
+        ),
+        max_delay_passes=100,
+        token_usage_low_watermark=None,
+    )
+    delayer.skip_first_delayer = False
+
+    negotiate_kwargs = dict(
+        local_prefillable=True,
+        token_usage=0.9,
+        running_batch=100,
+        max_prefill_bs=80,
+        max_running_requests=1024,
+        waiting_queue_len=10,
+    )
+    first_result = delayer._negotiate_should_allow_prefill(**negotiate_kwargs)
+    assert not first_result.output_allow
+    assert delayer._curr_state is not None
+
+    # Reproduce ranks straddling the wall-clock deadline on the same scheduler
+    # pass. Without a collective timeout decision, the last rank admits a
+    # prefill while its peer continues decoding.
+    delayer._curr_state = replace(
+        delayer._curr_state,
+        start_time=time.perf_counter() - (2.0 if rank == world_size - 1 else 0.0),
+    )
+    result = delayer._negotiate_should_allow_prefill(**negotiate_kwargs)
+
+    outcomes = [None] * world_size
+    torch.distributed.all_gather_object(
+        outcomes,
+        (
+            result.output_allow,
+            result.output_reason,
+            delayer._curr_state is None,
+        ),
+        group=cpu_group,
+    )
+    assert outcomes == [(True, "wait_success", True)] * world_size
 
 
 _NEGOTIATE_TEST_CASES = [
@@ -381,6 +434,13 @@ class TestPrefillDelayerNegotiate(unittest.TestCase):
             world_size=4,
             backend="gloo",
             test_cases=_NEGOTIATE_TEST_CASES,
+        )
+
+    def test_tp_queue_timeout_is_rank_uniform(self):
+        run_distributed_test(
+            _run_tp_queue_timeout_uniformity_test,
+            world_size=2,
+            backend="gloo",
         )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Each TP rank uses it's own, rank independent, clock. This means that each rank can disagree on if the timer has expired in the prefill delayer's max delay limit. When this happens, some ranks will admit prefill while other stay on decode and the result is a hang.

## Modifications

Gather the queue timeout decision with the existing scheduler state so every tensor-parallel rank releases delayed prefill on the same pass. Add a distributed regression test for ranks straddling the timeout boundary.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30285518710](https://github.com/sgl-project/sglang/actions/runs/30285518710)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30285518552](https://github.com/sgl-project/sglang/actions/runs/30285518552)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->