### PR TITLE
Make LMCache MP store non-blocking on request finish

### DIFF
--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -170,10 +170,10 @@ class LMCRadixCache(RadixCache):
 
         self._in_flight_nodes: list[TreeNode] = []
         # MP stores complete via a per-request daemon future rather than the
-        # shared store_stream, so they need their own in-flight list carrying
-        # (node, future, request_id). request_id rides along because the
-        # deferred reconcile also owes end_session for that request.
-        self._in_flight_mp_stores: list[tuple[TreeNode, MessagingFuture, str]] = []
+        # shared store_stream, so they need their own in-flight list. Only the
+        # unpin is deferred: session teardown has no dependency on the copy and
+        # fires in cache_finished_req, so no request_id needs to ride along.
+        self._in_flight_mp_stores: list[tuple[TreeNode, "MessagingFuture"]] = []
         self._node_lock = threading.Lock()
         self._mp_load_back_markers: dict[str, _LMCacheLoadBackMarker] = {}
 
@@ -181,6 +181,10 @@ class LMCRadixCache(RadixCache):
         super().reset()
         if hasattr(self, "_in_flight_nodes"):
             with self._node_lock:
+                # Dropped without unpinning on purpose: super().reset() has
+                # already rebuilt the root and zeroed evictable_size_ /
+                # protected_size_, so the pinned nodes belong to a discarded
+                # tree and dec_lock_ref would walk a stale parent chain.
                 self._in_flight_nodes.clear()
                 self._in_flight_mp_stores.clear()
         if hasattr(self, "_mp_load_back_markers"):
@@ -486,13 +490,16 @@ class LMCRadixCache(RadixCache):
             request_id=req.rid,
         )
         if self._mode is LMCacheMode.MP:
-            # The daemon copies out of these slots in another process; defer the
-            # unlock to evict()'s reconcile so the node stays pinned until the
-            # copy lands. Nothing downstream consumes the store result, so there
-            # is no reason to block the scheduler on it here.
+            # The daemon copies out of these slots in another process, so the
+            # node stays pinned until the copy lands and the unpin is deferred.
+            # Session teardown is not deferred with it: end_session has no
+            # dependency on the store future, and holding it until the copy
+            # completes leaves sessions to expire in the daemon.
             future = self.lmcache_connector.store_kv_async(store_md)
+            self._mp_load_back_markers.pop(req.rid, None)
+            self.lmcache_connector.end_session(req.rid)
             with self._node_lock:
-                self._in_flight_mp_stores.append((new_last_node, future, req.rid))
+                self._in_flight_mp_stores.append((new_last_node, future))
         elif self._mode is LMCacheMode.IP:
             with device_stream_context(self.store_stream):
                 self.lmcache_connector.store_kv(store_md)
@@ -500,30 +507,71 @@ class LMCRadixCache(RadixCache):
             with self._node_lock:
                 self._in_flight_nodes.append(new_last_node)
 
-    def _reconcile_mp_stores(self) -> None:
-        """Settle the MP stores submitted since the last reconcile.
+    def _settle_mp_store(self, node: TreeNode, future: "MessagingFuture") -> None:
+        """Unpin one node, logging whether its daemon store succeeded.
 
-        Waits on each daemon future, then unpins the node so its KV slots
-        become evictable again. A failed store is logged rather than raised:
-        this runs on the eviction path, where raising would turn a
-        recoverable cache-tier failure into a serving outage. The unpin
-        happens regardless of outcome -- skipping it would pin those slots
-        for the lifetime of the process, precisely when memory is scarce.
+        A failed store is logged rather than raised: this runs on the
+        scheduling and eviction paths, where raising would turn a recoverable
+        cache-tier failure into a serving outage. The unpin happens regardless
+        of outcome -- skipping it would pin those slots for the lifetime of the
+        process, precisely when memory is scarce.
+        """
+        try:
+            if not future.result():
+                logger.error("LMCache MP store failed")
+        except Exception:
+            logger.exception("LMCache MP store errored")
+        finally:
+            self.dec_lock_ref(node)
+
+    def _reap_completed_mp_stores(self) -> None:
+        """Unpin nodes whose daemon store has already finished. Never blocks.
+
+        ``MessagingFuture.query()`` reports completion without waiting, so
+        stores still in flight are left pinned and retried on the next call.
+        This is what makes the reap safe to run from ``evictable_size()``,
+        which the scheduler reads while deciding whether a batch fits.
+        """
+        with self._node_lock:
+            pending = self._in_flight_mp_stores
+            # query() once per entry: calling it in two comprehensions races
+            # with the daemon and can drop an entry from both lists.
+            done, still_pending = [], []
+            for entry in pending:
+                (done if entry[1].query() else still_pending).append(entry)
+            self._in_flight_mp_stores = still_pending
+
+        for node, future in done:
+            self._settle_mp_store(node, future)
+
+    def _reconcile_mp_stores(self) -> None:
+        """Settle every outstanding MP store, blocking until each one lands.
+
+        The hard backstop for ``_reap_completed_mp_stores``: used on the
+        eviction path, where the caller needs the pins released before base
+        eviction chooses victims rather than on some later scheduler step.
         """
         with self._node_lock:
             in_flight = self._in_flight_mp_stores
             self._in_flight_mp_stores = []
 
-        for node, future, rid in in_flight:
-            try:
-                if not future.result():
-                    logger.error("LMCache MP store failed for request %s", rid)
-            except Exception:
-                logger.exception("LMCache MP store errored for request %s", rid)
-            finally:
-                self.dec_lock_ref(node)
-                self._mp_load_back_markers.pop(rid, None)
-                self.lmcache_connector.end_session(rid)
+        for node, future in in_flight:
+            self._settle_mp_store(node, future)
+
+    def evictable_size(self):
+        """Reap finished MP stores before reporting evictable bytes.
+
+        ``inc_lock_ref`` moves a pinned node's bytes out of ``evictable_size_``
+        and into ``protected_size_``, and the scheduler derives its token
+        budget from ``available_size() + evictable_size()``. Releasing pins
+        only from ``evict()`` is therefore circular: pinned bytes shrink the
+        budget, the shrunken budget means no allocation is attempted, and
+        ``evict()`` -- which only runs when an allocation falls short -- is
+        never reached to release them. Reaping here puts the release upstream
+        of the decision instead of downstream of it.
+        """
+        self._reap_completed_mp_stores()
+        return super().evictable_size()
 
     def evict(self, params: EvictParams) -> EvictResult:
         """Before base eviction, wait for any outstanding stores and release locks."""
@@ -537,7 +585,9 @@ class LMCRadixCache(RadixCache):
                 self.dec_lock_ref(node)
             self._in_flight_nodes.clear()
 
-        # MP: each store carries its own daemon future.
+        # MP: each store carries its own daemon future. Block here -- unlike the
+        # reap in evictable_size(), this caller is about to pick eviction
+        # victims and wants every pin settled first.
         self._reconcile_mp_stores()
 
         return super().evict(params)

--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -34,6 +34,8 @@ except ImportError as e:
 
 
 if TYPE_CHECKING:
+    from lmcache.v1.multiprocess.futures import MessagingFuture
+
     from sglang.srt.configs.model_config import ModelConfig
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
@@ -167,6 +169,11 @@ class LMCRadixCache(RadixCache):
             kvcache.register_layer_transfer_counter(self.layer_done_executor)
 
         self._in_flight_nodes: list[TreeNode] = []
+        # MP stores complete via a per-request daemon future rather than the
+        # shared store_stream, so they need their own in-flight list carrying
+        # (node, future, request_id). request_id rides along because the
+        # deferred reconcile also owes end_session for that request.
+        self._in_flight_mp_stores: list[tuple[TreeNode, MessagingFuture, str]] = []
         self._node_lock = threading.Lock()
         self._mp_load_back_markers: dict[str, _LMCacheLoadBackMarker] = {}
 
@@ -175,6 +182,7 @@ class LMCRadixCache(RadixCache):
         if hasattr(self, "_in_flight_nodes"):
             with self._node_lock:
                 self._in_flight_nodes.clear()
+                self._in_flight_mp_stores.clear()
         if hasattr(self, "_mp_load_back_markers"):
             self._mp_load_back_markers.clear()
 
@@ -478,11 +486,13 @@ class LMCRadixCache(RadixCache):
             request_id=req.rid,
         )
         if self._mode is LMCacheMode.MP:
-            self.lmcache_connector.store_kv(store_md)
-            # MP store_kv blocks until the daemon's signal event fires, so the slots are safe to evict immediately.
-            self._mp_load_back_markers.pop(req.rid, None)
-            self.dec_lock_ref(new_last_node)
-            self.lmcache_connector.end_session(req.rid)
+            # The daemon copies out of these slots in another process; defer the
+            # unlock to evict()'s reconcile so the node stays pinned until the
+            # copy lands. Nothing downstream consumes the store result, so there
+            # is no reason to block the scheduler on it here.
+            future = self.lmcache_connector.store_kv_async(store_md)
+            with self._node_lock:
+                self._in_flight_mp_stores.append((new_last_node, future, req.rid))
         elif self._mode is LMCacheMode.IP:
             with device_stream_context(self.store_stream):
                 self.lmcache_connector.store_kv(store_md)
@@ -490,16 +500,45 @@ class LMCRadixCache(RadixCache):
             with self._node_lock:
                 self._in_flight_nodes.append(new_last_node)
 
+    def _reconcile_mp_stores(self) -> None:
+        """Settle the MP stores submitted since the last reconcile.
+
+        Waits on each daemon future, then unpins the node so its KV slots
+        become evictable again. A failed store is logged rather than raised:
+        this runs on the eviction path, where raising would turn a
+        recoverable cache-tier failure into a serving outage. The unpin
+        happens regardless of outcome -- skipping it would pin those slots
+        for the lifetime of the process, precisely when memory is scarce.
+        """
+        with self._node_lock:
+            in_flight = self._in_flight_mp_stores
+            self._in_flight_mp_stores = []
+
+        for node, future, rid in in_flight:
+            try:
+                if not future.result():
+                    logger.error("LMCache MP store failed for request %s", rid)
+            except Exception:
+                logger.exception("LMCache MP store errored for request %s", rid)
+            finally:
+                self.dec_lock_ref(node)
+                self._mp_load_back_markers.pop(rid, None)
+                self.lmcache_connector.end_session(rid)
+
     def evict(self, params: EvictParams) -> EvictResult:
         """Before base eviction, wait for any outstanding stores and release locks."""
         if self.disable:
             return EvictResult()
 
+        # IP: the store stream signals completion for every queued store.
         self.store_stream.synchronize()
         with self._node_lock:
             for node in self._in_flight_nodes:
                 self.dec_lock_ref(node)
             self._in_flight_nodes.clear()
+
+        # MP: each store carries its own daemon future.
+        self._reconcile_mp_stores()
 
         return super().evict(params)
 

--- a/test/registered/unit/mem_cache/test_lmc_mp_async_store.py
+++ b/test/registered/unit/mem_cache/test_lmc_mp_async_store.py
@@ -3,17 +3,20 @@ Unit tests for the deferred unlock of LMCache MP-mode async stores.
 
 In MP mode ``cache_finished_req`` submits the store to the LMCache daemon via
 ``store_kv_async`` and returns without waiting, leaving the radix node pinned.
-``evict()`` then settles those futures and unpins the nodes. These tests cover
-``LMCRadixCache._reconcile_mp_stores``, which owns that unpin:
+The pin is released in two places:
 
-1. Successful store    -> node unpinned, end_session fired, list drained.
-2. Failed store (False) -> node still unpinned (logged, not raised).
-3. Future raises        -> node still unpinned (logged, not raised).
-4. Reconcile with nothing in flight is a no-op.
+* ``_reap_completed_mp_stores`` -- non-blocking, called from
+  ``evictable_size()`` so pins are released *before* the scheduler decides a
+  batch does not fit.
+* ``_reconcile_mp_stores`` -- blocking, called from ``evict()`` as the backstop
+  when the caller is about to choose eviction victims.
 
-Cases 2 and 3 are the point of the file: a store failure that skipped
-``dec_lock_ref`` would pin those KV slots for the lifetime of the process,
-exactly when memory is already scarce.
+``test_evictable_size_releases_finished_stores`` is the regression test for a
+livelock observed under sustained load: pinning a node moves its bytes out of
+the evictable total, the scheduler derives its token budget from that total,
+and eviction only runs when an allocation falls short -- so releasing pins only
+from eviction is circular. The server stayed up, answered health checks, and
+scheduled nothing.
 
 Usage:
     python -m pytest test/registered/unit/mem_cache/test_lmc_mp_async_store.py -v
@@ -37,19 +40,26 @@ except Exception:
 
 
 class _FakeNode:
-    """Minimal stand-in for TreeNode: only lock_ref is exercised here."""
+    """Minimal stand-in for TreeNode: only lock_ref and byte size matter."""
 
-    def __init__(self):
+    def __init__(self, size=1):
         self.lock_ref = 0
+        self.size = size
 
 
 class _FakeFuture:
-    """Stand-in for MessagingFuture with a scripted result()."""
+    """Stand-in for MessagingFuture with a scripted query() and result()."""
 
-    def __init__(self, result=True, exc=None):
+    def __init__(self, result=True, exc=None, done=True):
         self._result = result
         self._exc = exc
+        self._done = done
         self.result_calls = 0
+        self.query_calls = 0
+
+    def query(self):
+        self.query_calls += 1
+        return self._done
 
     def result(self, timeout=None):
         self.result_calls += 1
@@ -62,7 +72,9 @@ def _make_cache():
     """Build an LMCRadixCache without running __init__.
 
     __init__ opens a real LMCache connector (MP needs a live daemon), so set
-    only the attributes _reconcile_mp_stores touches.
+    only the attributes the reap/reconcile paths touch. dec_lock_ref mirrors
+    RadixCache's bookkeeping: unpinning returns the node's bytes to
+    ``evictable_size_``, which is what the scheduler budget reads.
     """
     import threading
 
@@ -70,91 +82,150 @@ def _make_cache():
     cache._node_lock = threading.Lock()
     cache._in_flight_mp_stores = []
     cache._mp_load_back_markers = {}
+    cache.evictable_size_ = 0
     cache.lmcache_connector = MagicMock()
-    cache.dec_lock_ref = lambda node: setattr(node, "lock_ref", node.lock_ref - 1)
+
+    def _dec_lock_ref(node):
+        node.lock_ref -= 1
+        if node.lock_ref == 0:
+            cache.evictable_size_ += node.size
+
+    cache.dec_lock_ref = _dec_lock_ref
     return cache
+
+
+def _pin(cache, node, future):
+    """Simulate what cache_finished_req does to a node in MP mode."""
+    node.lock_ref += 1
+    cache._in_flight_mp_stores.append((node, future))
+
+
+@unittest.skipUnless(LMCACHE_AVAILABLE, "LMCache is not installed")
+class TestReapCompletedMPStores(unittest.TestCase):
+    """The non-blocking reap called from evictable_size()."""
+
+    def test_evictable_size_releases_finished_stores(self):
+        """A finished store must reach the scheduler budget without eviction.
+
+        Pre-fix, the unpin ran only from ``evict()``, which the scheduler
+        reaches only after an allocation falls short -- so a finished store
+        stayed invisible to the budget that decides whether to allocate at all.
+        """
+        cache = _make_cache()
+        node = _FakeNode(size=64)
+        _pin(cache, node, _FakeFuture(done=True))
+
+        self.assertEqual(cache.evictable_size(), 64)
+        self.assertEqual(node.lock_ref, 0)
+        self.assertEqual(cache._in_flight_mp_stores, [])
+
+    def test_unfinished_store_stays_pinned_without_blocking(self):
+        """Still-copying stores must not be waited on from the budget path."""
+        cache = _make_cache()
+        node = _FakeNode(size=64)
+        future = _FakeFuture(done=False)
+        _pin(cache, node, future)
+
+        self.assertEqual(cache.evictable_size(), 0)
+        self.assertEqual(node.lock_ref, 1)
+        self.assertEqual(cache._in_flight_mp_stores, [(node, future)])
+        # result() blocks; reaching it from evictable_size() would stall the
+        # scheduler on another process every step.
+        self.assertEqual(future.result_calls, 0)
+
+    def test_reap_queries_each_future_once(self):
+        """Two query() calls per entry race the daemon and can drop the entry.
+
+        Partitioning with two comprehensions lets a future that completes
+        between them fall into neither list, leaking the pin permanently.
+        """
+        cache = _make_cache()
+        future = _FakeFuture(done=False)
+        _pin(cache, _FakeNode(), future)
+
+        cache._reap_completed_mp_stores()
+
+        self.assertEqual(future.query_calls, 1)
+
+    def test_reap_settles_only_the_finished_ones(self):
+        cache = _make_cache()
+        done_node, pending_node = _FakeNode(size=8), _FakeNode(size=8)
+        pending_future = _FakeFuture(done=False)
+        _pin(cache, done_node, _FakeFuture(done=True))
+        _pin(cache, pending_node, pending_future)
+
+        cache._reap_completed_mp_stores()
+
+        self.assertEqual(done_node.lock_ref, 0)
+        self.assertEqual(pending_node.lock_ref, 1)
+        self.assertEqual(cache._in_flight_mp_stores, [(pending_node, pending_future)])
+
+    def test_failed_store_still_unpins(self):
+        """A store the daemon reports as failed must not leak its pin."""
+        cache = _make_cache()
+        node = _FakeNode()
+        _pin(cache, node, _FakeFuture(result=False, done=True))
+
+        cache._reap_completed_mp_stores()
+
+        self.assertEqual(node.lock_ref, 0)
+        self.assertEqual(cache._in_flight_mp_stores, [])
+
+    def test_raising_future_still_unpins(self):
+        """A dead daemon must not raise on a path the scheduler runs each step."""
+        cache = _make_cache()
+        node = _FakeNode()
+        _pin(cache, node, _FakeFuture(exc=RuntimeError("daemon died"), done=True))
+
+        cache._reap_completed_mp_stores()
+
+        self.assertEqual(node.lock_ref, 0)
+        self.assertEqual(cache._in_flight_mp_stores, [])
 
 
 @unittest.skipUnless(LMCACHE_AVAILABLE, "LMCache is not installed")
 class TestReconcileMPStores(unittest.TestCase):
-    def test_successful_store_unpins_and_ends_session(self):
+    """The blocking backstop called from evict()."""
+
+    def test_reconcile_settles_even_unfinished_stores(self):
+        """evict() is about to pick victims, so it waits rather than deferring."""
         cache = _make_cache()
         node = _FakeNode()
-        node.lock_ref = 1
-        future = _FakeFuture(result=True)
-        cache._mp_load_back_markers["req-0"] = object()
-        cache._in_flight_mp_stores.append((node, future, "req-0"))
+        future = _FakeFuture(done=False)
+        _pin(cache, node, future)
 
         cache._reconcile_mp_stores()
 
         self.assertEqual(future.result_calls, 1)
         self.assertEqual(node.lock_ref, 0)
         self.assertEqual(cache._in_flight_mp_stores, [])
-        self.assertNotIn("req-0", cache._mp_load_back_markers)
-        cache.lmcache_connector.end_session.assert_called_once_with("req-0")
 
-    def test_failed_store_still_unpins(self):
-        cache = _make_cache()
-        node = _FakeNode()
-        node.lock_ref = 1
-        cache._in_flight_mp_stores.append((node, _FakeFuture(result=False), "req-1"))
-
-        cache._reconcile_mp_stores()
-
-        # A failed store must not leak the lock, and must not raise on the
-        # eviction path.
-        self.assertEqual(node.lock_ref, 0)
-        self.assertEqual(cache._in_flight_mp_stores, [])
-        cache.lmcache_connector.end_session.assert_called_once_with("req-1")
-
-    def test_raising_future_still_unpins(self):
-        cache = _make_cache()
-        node = _FakeNode()
-        node.lock_ref = 1
-        future = _FakeFuture(exc=RuntimeError("daemon died"))
-        cache._in_flight_mp_stores.append((node, future, "req-2"))
-
-        cache._reconcile_mp_stores()
-
-        self.assertEqual(node.lock_ref, 0)
-        self.assertEqual(cache._in_flight_mp_stores, [])
-
-    def test_multiple_stores_all_settled(self):
+    def test_one_failed_store_does_not_strand_the_others(self):
         cache = _make_cache()
         nodes = []
         for i in range(3):
             node = _FakeNode()
-            node.lock_ref = 1
             nodes.append(node)
-            # Middle store fails; the others must be unaffected.
-            result = i != 1
-            cache._in_flight_mp_stores.append(
-                (node, _FakeFuture(result=result), f"req-{i}")
-            )
+            # Middle store fails; the others must still settle.
+            _pin(cache, node, _FakeFuture(result=i != 1))
 
         cache._reconcile_mp_stores()
 
         for node in nodes:
             self.assertEqual(node.lock_ref, 0)
         self.assertEqual(cache._in_flight_mp_stores, [])
-        self.assertEqual(cache.lmcache_connector.end_session.call_count, 3)
-
-    def test_empty_reconcile_is_noop(self):
-        cache = _make_cache()
-
-        cache._reconcile_mp_stores()
-
-        self.assertEqual(cache._in_flight_mp_stores, [])
-        cache.lmcache_connector.end_session.assert_not_called()
 
     def test_shared_node_unpinned_once_per_store(self):
-        # Concurrent requests can share a prefix node, so lock_ref is a count:
-        # two stores against one node must produce two dec_lock_ref calls.
+        """lock_ref is a count, not a flag: concurrent requests share prefixes.
+
+        Unpinning a shared node once per *node* rather than once per *store*
+        would free slots another in-flight store is still copying from.
+        """
         cache = _make_cache()
         node = _FakeNode()
-        node.lock_ref = 2
-        cache._in_flight_mp_stores.append((node, _FakeFuture(), "req-a"))
-        cache._in_flight_mp_stores.append((node, _FakeFuture(), "req-b"))
+        _pin(cache, node, _FakeFuture())
+        _pin(cache, node, _FakeFuture())
+        self.assertEqual(node.lock_ref, 2)
 
         cache._reconcile_mp_stores()
 

--- a/test/registered/unit/mem_cache/test_lmc_mp_async_store.py
+++ b/test/registered/unit/mem_cache/test_lmc_mp_async_store.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for the deferred unlock of LMCache MP-mode async stores.
+
+In MP mode ``cache_finished_req`` submits the store to the LMCache daemon via
+``store_kv_async`` and returns without waiting, leaving the radix node pinned.
+``evict()`` then settles those futures and unpins the nodes. These tests cover
+``LMCRadixCache._reconcile_mp_stores``, which owns that unpin:
+
+1. Successful store    -> node unpinned, end_session fired, list drained.
+2. Failed store (False) -> node still unpinned (logged, not raised).
+3. Future raises        -> node still unpinned (logged, not raised).
+4. Reconcile with nothing in flight is a no-op.
+
+Cases 2 and 3 are the point of the file: a store failure that skipped
+``dec_lock_ref`` would pin those KV slots for the lifetime of the process,
+exactly when memory is already scarce.
+
+Usage:
+    python -m pytest test/registered/unit/mem_cache/test_lmc_mp_async_store.py -v
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock
+
+# LMCache is an optional dependency and the module raises at import time when
+# it is absent; skip the whole file rather than fail collection.
+try:
+    from sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache import LMCRadixCache
+
+    LMCACHE_AVAILABLE = True
+except Exception:
+    LMCACHE_AVAILABLE = False
+
+
+class _FakeNode:
+    """Minimal stand-in for TreeNode: only lock_ref is exercised here."""
+
+    def __init__(self):
+        self.lock_ref = 0
+
+
+class _FakeFuture:
+    """Stand-in for MessagingFuture with a scripted result()."""
+
+    def __init__(self, result=True, exc=None):
+        self._result = result
+        self._exc = exc
+        self.result_calls = 0
+
+    def result(self, timeout=None):
+        self.result_calls += 1
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+def _make_cache():
+    """Build an LMCRadixCache without running __init__.
+
+    __init__ opens a real LMCache connector (MP needs a live daemon), so set
+    only the attributes _reconcile_mp_stores touches.
+    """
+    import threading
+
+    cache = object.__new__(LMCRadixCache)
+    cache._node_lock = threading.Lock()
+    cache._in_flight_mp_stores = []
+    cache._mp_load_back_markers = {}
+    cache.lmcache_connector = MagicMock()
+    cache.dec_lock_ref = lambda node: setattr(node, "lock_ref", node.lock_ref - 1)
+    return cache
+
+
+@unittest.skipUnless(LMCACHE_AVAILABLE, "LMCache is not installed")
+class TestReconcileMPStores(unittest.TestCase):
+    def test_successful_store_unpins_and_ends_session(self):
+        cache = _make_cache()
+        node = _FakeNode()
+        node.lock_ref = 1
+        future = _FakeFuture(result=True)
+        cache._mp_load_back_markers["req-0"] = object()
+        cache._in_flight_mp_stores.append((node, future, "req-0"))
+
+        cache._reconcile_mp_stores()
+
+        self.assertEqual(future.result_calls, 1)
+        self.assertEqual(node.lock_ref, 0)
+        self.assertEqual(cache._in_flight_mp_stores, [])
+        self.assertNotIn("req-0", cache._mp_load_back_markers)
+        cache.lmcache_connector.end_session.assert_called_once_with("req-0")
+
+    def test_failed_store_still_unpins(self):
+        cache = _make_cache()
+        node = _FakeNode()
+        node.lock_ref = 1
+        cache._in_flight_mp_stores.append((node, _FakeFuture(result=False), "req-1"))
+
+        cache._reconcile_mp_stores()
+
+        # A failed store must not leak the lock, and must not raise on the
+        # eviction path.
+        self.assertEqual(node.lock_ref, 0)
+        self.assertEqual(cache._in_flight_mp_stores, [])
+        cache.lmcache_connector.end_session.assert_called_once_with("req-1")
+
+    def test_raising_future_still_unpins(self):
+        cache = _make_cache()
+        node = _FakeNode()
+        node.lock_ref = 1
+        future = _FakeFuture(exc=RuntimeError("daemon died"))
+        cache._in_flight_mp_stores.append((node, future, "req-2"))
+
+        cache._reconcile_mp_stores()
+
+        self.assertEqual(node.lock_ref, 0)
+        self.assertEqual(cache._in_flight_mp_stores, [])
+
+    def test_multiple_stores_all_settled(self):
+        cache = _make_cache()
+        nodes = []
+        for i in range(3):
+            node = _FakeNode()
+            node.lock_ref = 1
+            nodes.append(node)
+            # Middle store fails; the others must be unaffected.
+            result = i != 1
+            cache._in_flight_mp_stores.append(
+                (node, _FakeFuture(result=result), f"req-{i}")
+            )
+
+        cache._reconcile_mp_stores()
+
+        for node in nodes:
+            self.assertEqual(node.lock_ref, 0)
+        self.assertEqual(cache._in_flight_mp_stores, [])
+        self.assertEqual(cache.lmcache_connector.end_session.call_count, 3)
+
+    def test_empty_reconcile_is_noop(self):
+        cache = _make_cache()
+
+        cache._reconcile_mp_stores()
+
+        self.assertEqual(cache._in_flight_mp_stores, [])
+        cache.lmcache_connector.end_session.assert_not_called()
+
+    def test_shared_node_unpinned_once_per_store(self):
+        # Concurrent requests can share a prefix node, so lock_ref is a count:
+        # two stores against one node must produce two dec_lock_ref calls.
+        cache = _make_cache()
+        node = _FakeNode()
+        node.lock_ref = 2
+        cache._in_flight_mp_stores.append((node, _FakeFuture(), "req-a"))
+        cache._in_flight_mp_stores.append((node, _FakeFuture(), "req-b"))
+
+        cache._reconcile_mp_stores()
+
+        self.assertEqual(node.lock_ref, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #31842. In MP mode, `cache_finished_req` blocked on `store_kv` until the LMCache daemon signalled completion. Nothing downstream consumes that result, so the scheduler sat idle waiting on it.

## Modifications

- `cache_finished_req` (MP branch): submit via `store_kv_async`, keep the node pinned, and defer only the unpin as `(node, future)`. `end_session(rid)` and load-back marker cleanup now run immediately since they do not depend on store completion.
- New `_reap_completed_mp_stores()`: non-blocking (uses `MessagingFuture.query()`), called from `evictable_size()` so pins are released before scheduling decisions. Releasing pins only from `evict()` is circular: pinned bytes shrink the token budget → no batch is formed → no allocation is attempted → `evict()` never runs → pins stay held. This caused a livelock where the server stayed healthy but GPU utilization dropped to 0%.
- `_reconcile_mp_stores()`: blocking backstop kept in `evict()`, settling every outstanding store before eviction. Failed or raising stores are logged (not raised) and still unpinned.
- Added unit tests in `test/registered/unit/mem_cache/test_lmc_mp_async_store.py` (registered CPU CI) covering the reap-vs-budget regression, non-blocking behavior, the single-`query()` race, failure and raising futures, shared-node refcounts, and blocking reconcile.

## E2E results

Configuration: `--max-total-tokens 8192`, 3 runs/version, cold LMCache + restart per run.

| Metric | Patched | Baseline |
|--------|---------:|---------:|
| Median throughput | 1587.3 tok/s | 1555.3 tok/s |
| Median latency | 20.49 s | 20.93 s |
| Accuracy range | 0.870–0.890 | 0.870–0.890 |

All six runs completed 200/200 questions. Before the fix, the async version stalled after ~30 questions at this pool size.

Depends on the LMCache-side `store_kv_async` (LMCache PR #4152, merged).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30863466119](https://github.com/sgl-project/sglang/actions/runs/30863466119)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30863465965](https://github.com/sgl-project/sglang/actions/runs/30863465965)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->