### PR TITLE
[bugfix] Classify client cancel/disconnect aborts as HTTP 499 (not a successful finish)

### DIFF
--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -112,7 +112,9 @@ class GrammarManager:
                 logger.debug(f"Abort grammar queue request. {req.rid=}")
                 if isinstance(req.grammar, futures.Future) and req.grammar:
                     req.grammar.cancel()
-                req.set_finish_with_abort("Aborted by AbortReq.")
+                req.set_finish_with_abort(
+                    "Aborted by AbortReq.", recv_req.finished_reason
+                )
 
     def _get_request_thinking_budget(self, req: Req) -> int | None:
         custom_params = req.sampling_params.custom_params

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -15,6 +15,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from pydantic import ValidationError
 
+from sglang.srt.managers.schedule_batch import client_cancel_finish_reason
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 
 logger = logging.getLogger(__name__)
@@ -106,11 +107,15 @@ class RuntimeHandle:
         return status is not None and status == type(status).Closed
 
     def _abort_request_id(self, rid) -> None:
+        # A gRPC per-request abort is a client cancel/disconnect.
+        reason = client_cancel_finish_reason()
         if isinstance(rid, list):
             for single_rid in rid:
-                self.tokenizer_manager.abort_request(rid=single_rid)
+                self.tokenizer_manager.abort_request(
+                    rid=single_rid, finished_reason=reason
+                )
         else:
-            self.tokenizer_manager.abort_request(rid=rid)
+            self.tokenizer_manager.abort_request(rid=rid, finished_reason=reason)
 
     async def _send_with_backpressure(
         self,
@@ -350,7 +355,11 @@ class RuntimeHandle:
             running_loop = None
 
         if running_loop is loop:
-            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            self.tokenizer_manager.abort_request(
+                rid=rid,
+                abort_all=abort_all,
+                finished_reason=None if abort_all else client_cancel_finish_reason(),
+            )
             return
 
         future = asyncio.run_coroutine_threadsafe(
@@ -370,7 +379,11 @@ class RuntimeHandle:
             )
 
     async def _abort_async(self, rid: str, abort_all: bool) -> None:
-        self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+        self.tokenizer_manager.abort_request(
+            rid=rid,
+            abort_all=abort_all,
+            finished_reason=None if abort_all else client_cancel_finish_reason(),
+        )
 
     def get_model_info(self) -> str:
         model_config = self.tokenizer_manager.model_config

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -152,6 +152,7 @@ from sglang.srt.managers.multi_tokenizer_mixin import (
     read_from_shared_memory,
     write_data_for_multi_tokenizer,
 )
+from sglang.srt.managers.schedule_batch import client_cancel_finish_reason
 from sglang.srt.managers.tokenizer_manager import ServerStatus, TokenizerManager
 from sglang.srt.observability.func_timer import enable_func_timer
 from sglang.srt.observability.trace import (
@@ -1546,8 +1547,12 @@ async def configure_logging(
 async def abort_request(obj: Annotated[AbortReq, Body()], request: Request):
     """Abort a request."""
     try:
+        # A specific-rid abort via this endpoint is a client-initiated cancel;
+        # abort_all is an operational/admin action and keeps its default status.
         _global_state.tokenizer_manager.abort_request(
-            rid=obj.rid, abort_all=obj.abort_all
+            rid=obj.rid,
+            abort_all=obj.abort_all,
+            finished_reason=(None if obj.abort_all else client_cancel_finish_reason()),
         )
         return Response(status_code=200)
     except Exception as e:

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -70,6 +70,7 @@ from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
 from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.schedule_batch import client_cancel_finish_reason
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils import random_uuid
 
@@ -1262,8 +1263,11 @@ class OpenAIServingResponses(OpenAIServingChat):
             # Update the status to "cancelled"
             response.status = "cancelled"
 
-        # The response_id is the same as the rid used when submitting the request
-        self.tokenizer_manager.abort_request(rid=response_id)
+        # The response_id is the same as the rid used when submitting the request.
+        # An explicit cancel is a client action, so mark it as a client cancel.
+        self.tokenizer_manager.abort_request(
+            rid=response_id, finished_reason=client_cancel_finish_reason()
+        )
 
         if task := self.background_tasks.get(response_id):
             task.cancel()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -201,6 +201,13 @@ class FINISH_LENGTH(BaseFinishReason):
         }
 
 
+# nginx's "client closed request" status. Python's http.HTTPStatus has no 499,
+# so it is defined here. Marks an abort caused by the client disconnecting or
+# cancelling, so downstream can tell it apart from a server-side abort (which
+# keeps its own status, e.g. a 5xx service error).
+CLIENT_CLOSED_REQUEST = 499
+
+
 class FINISH_ABORT(BaseFinishReason):
     def __init__(self, message=None, status_code=None, err_type=None):
         super().__init__()
@@ -215,6 +222,28 @@ class FINISH_ABORT(BaseFinishReason):
             "status_code": self.status_code,
             "err_type": self.err_type,
         }
+
+    @classmethod
+    def from_json(cls, data: dict) -> FINISH_ABORT:
+        """Rebuild from a ``to_json()`` dict, e.g. a reason carried on AbortReq."""
+        return cls(
+            message=data.get("message"),
+            status_code=data.get("status_code"),
+            err_type=data.get("err_type"),
+        )
+
+
+def client_cancel_finish_reason(
+    message: str = "The client cancelled or disconnected the request.",
+) -> dict:
+    """Abort reason for a client-initiated cancel/disconnect.
+
+    Carries the client-closed status so downstream (the HTTP response and
+    metrics) can tell it apart from a server-side abort. Server-side aborts
+    (pause, weight update, ``abort_all``) do not use this and keep their own
+    status.
+    """
+    return FINISH_ABORT(message, CLIENT_CLOSED_REQUEST, "client_cancel").to_json()
 
 
 class Modality(Enum):
@@ -1642,7 +1671,7 @@ class Req(ReqDllmMixin):
         logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
         self.has_log_time_stats = True
 
-    def set_finish_with_abort(self, error_msg: str):
+    def set_finish_with_abort(self, error_msg: str, finished_reason: dict = None):
         if get_parallel().tp_rank == 0:
             logger.error(f"{error_msg}, {self.rid=}")
         self.multimodal_inputs = None
@@ -1652,8 +1681,12 @@ class Req(ReqDllmMixin):
         )  # set it to one token to skip the long prefill
         self.return_logprob = False
         self.logprob_start_len = -1
-        self.to_finish = FINISH_ABORT(
-            error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError"
+        # Honor an abort reason threaded from the tokenizer (e.g. a client
+        # cancel); otherwise default to a bad-request abort.
+        self.to_finish = (
+            FINISH_ABORT.from_json(finished_reason)
+            if finished_reason
+            else FINISH_ABORT(error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError")
         )
 
     def update_reasoning_tokens(self, token_id, think_end_id):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4136,7 +4136,9 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
-            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+            self.ipc_channels.send_to_tokenizer.send_output(
+                AbortReq(rid=req.rid, finished_reason=recv_req.finished_reason), req
+            )
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 release_kv_cache(req, self.tree_cache)
@@ -4169,7 +4171,8 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     self.tree_cache.release_aborted_request(req.rid)
                 self.ipc_channels.send_to_tokenizer.send_output(
-                    AbortReq(rid=req.rid), req
+                    AbortReq(rid=req.rid, finished_reason=recv_req.finished_reason),
+                    req,
                 )
                 if (
                     req.req_pool_idx is not None
@@ -4224,7 +4227,11 @@ class Scheduler(
                         assert hasattr(decode_req, "kv_cache_cpu")
                         del decode_req.kv_cache_cpu
                         self.ipc_channels.send_to_tokenizer.send_output(
-                            AbortReq(rid=decode_req.rid), decode_req
+                            AbortReq(
+                                rid=decode_req.rid,
+                                finished_reason=recv_req.finished_reason,
+                            ),
+                            decode_req,
                         )
                     else:
                         remaining_retracted.append(decode_req)
@@ -4245,7 +4252,14 @@ class Scheduler(
                 # The request will still run one decode forward pass.
                 # Then we reuse all existing code to clean up the KV cache allocation.
                 logger.debug(f"Abort running request. {req.rid=}")
-                req.to_finish = FINISH_ABORT()
+                # Honor a reason the tokenizer attached to the abort (e.g. a
+                # client cancel/disconnect) so the finish carries the correct
+                # status at the source instead of a bare, status-less abort.
+                req.to_finish = (
+                    FINISH_ABORT.from_json(recv_req.finished_reason)
+                    if recv_req.finished_reason
+                    else FINISH_ABORT()
+                )
 
     def _pause_engine(self) -> Tuple[List[Req], int]:
         raise NotImplementedError()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -89,7 +89,11 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.load_snapshot import create_load_snapshot_reader
 from sglang.srt.managers.mm_utils import TensorTransportMode, wrap_shm_features
 from sglang.srt.managers.multimodal_processor import get_mm_processor, import_processors
-from sglang.srt.managers.schedule_batch import MultimodalDataItem
+from sglang.srt.managers.schedule_batch import (
+    CLIENT_CLOSED_REQUEST,
+    MultimodalDataItem,
+    client_cancel_finish_reason,
+)
 from sglang.srt.managers.scheduler_input_blocker import input_blocker_guard_region
 from sglang.srt.managers.tokenizer_control_mixin import TokenizerControlMixin
 from sglang.srt.managers.tokenizer_manager_score_mixin import TokenizerManagerScoreMixin
@@ -1467,6 +1471,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         ) in (
             HTTPStatus.SERVICE_UNAVAILABLE,
             HTTPStatus.INTERNAL_SERVER_ERROR,
+            CLIENT_CLOSED_REQUEST,
         ):
             # Delete the key to prevent resending abort request to the scheduler and
             # to ensure aborted request state is cleaned up.
@@ -1506,7 +1511,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     and await request.is_disconnected()
                 ):
                     # Abort the request for disconnected requests (non-streaming, waiting queue)
-                    self.abort_request(obj.rid)
+                    self.abort_request(
+                        obj.rid, finished_reason=client_cancel_finish_reason()
+                    )
                     # Use exception to kill the whole call stack and asyncio task
                     raise ValueError(
                         f"Request is disconnected from the client side (type 1). Abort request {obj.rid=}"
@@ -1587,7 +1594,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     and await request.is_disconnected()
                 ):
                     # Abort the request for disconnected requests (non-streaming, running)
-                    self.abort_request(obj.rid)
+                    self.abort_request(
+                        obj.rid, finished_reason=client_cancel_finish_reason()
+                    )
                     # Use exception to kill the whole call stack and asyncio task
                     raise ValueError(
                         f"Request is disconnected from the client side (type 3). Abort request {obj.rid=}"
@@ -1714,7 +1723,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     except StopAsyncIteration:
                         pass
 
-    def abort_request(self, rid: str = "", abort_all: bool = False):
+    def abort_request(
+        self, rid: str = "", abort_all: bool = False, finished_reason=None
+    ):
         # Empty rid would startswith-match every request on the scheduler.
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
@@ -1725,7 +1736,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             and rid not in self.rid_to_state
         ):
             return
-        req = AbortReq(rid=rid, abort_all=abort_all)
+        # `finished_reason` (a FINISH_ABORT.to_json() dict) lets the caller record
+        # WHY the request is aborted (e.g. a client cancel/disconnect, via
+        # `client_cancel_finish_reason`). The scheduler uses it to set the correct
+        # status on the resulting FINISH_ABORT instead of a bare, status-less abort.
+        req = AbortReq(rid=rid, abort_all=abort_all, finished_reason=finished_reason)
         self._dispatch_to_scheduler(req)
         if self.enable_metrics:
             # TODO: also use custom_labels from the request
@@ -1852,11 +1867,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Abort the request if the client is disconnected.
         async def abort_request():
             await asyncio.sleep(2)
+            # Fires when the client connection has closed -> a client cancel.
+            reason = client_cancel_finish_reason()
             if obj.is_single:
-                self.abort_request(obj.rid)
+                self.abort_request(obj.rid, finished_reason=reason)
             else:
                 for rid in obj.rid:
-                    self.abort_request(rid)
+                    self.abort_request(rid, finished_reason=reason)
 
         background_tasks = BackgroundTasks()
         background_tasks.add_task(abort_request)
@@ -2517,6 +2534,21 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 state.last_completion_tokens = completion_tokens
 
         if state.finished:
+            # A client cancel/disconnect is not a completed request. It is already
+            # counted via observe_one_aborted_request in abort_request(), so exclude
+            # it from the finished (success) request metric rather than counting it
+            # as a normal finish.
+            finish_reason_i = (
+                recv_obj.finished_reasons[i]
+                if getattr(recv_obj, "finished_reasons", None)
+                else None
+            )
+            is_client_cancel = (
+                isinstance(finish_reason_i, dict)
+                and finish_reason_i.get("type") == "abort"
+                and finish_reason_i.get("status_code") == CLIENT_CLOSED_REQUEST
+            )
+
             # Get detailed cache breakdown if available
             cached_tokens_details = None
             if (
@@ -2533,16 +2565,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 else 0
             )
 
-            self.metrics_collector.observe_one_finished_request(
-                labels,
-                recv_obj.prompt_tokens[i],
-                completion_tokens,
-                recv_obj.cached_tokens[i],
-                state.time_stats.get_e2e_latency(),
-                self._request_has_grammar(state.obj),
-                cached_tokens_details,
-                spec_verify_ct=spec_verify_ct,
-            )
+            if not is_client_cancel:
+                self.metrics_collector.observe_one_finished_request(
+                    labels,
+                    recv_obj.prompt_tokens[i],
+                    completion_tokens,
+                    recv_obj.cached_tokens[i],
+                    state.time_stats.get_e2e_latency(),
+                    self._request_has_grammar(state.obj),
+                    cached_tokens_details,
+                    spec_verify_ct=spec_verify_ct,
+                )
 
     def dump_requests(self, state: ReqState, out_dict: dict):
         if self.dump_requests_exclude_meta_keys and isinstance(


### PR DESCRIPTION
When a client disconnects or explicitly cancels a request, the abort was finished with a bare, status-less `FINISH_ABORT()`. Downstream this looked indistinguishable from a normal completion: it was reported as a successful finished request in the metrics, and the HTTP response carried no status telling it apart from a server-side abort.

This threads an optional abort reason from the tokenizer to the scheduler so a client-initiated cancel/disconnect is represented explicitly, as both:
- status_code 499 (nginx's CLIENT_CLOSED_REQUEST; Python's http.HTTPStatus has no 499), and
- err_type "client_cancel".

Changes:
- schedule_batch.py: add `CLIENT_CLOSED_REQUEST = 499`, `FINISH_ABORT.from_json`, and a `client_cancel_finish_reason()` helper. `set_finish_with_abort` honors a threaded reason.
- The client-facing abort entry points (HTTP `/abort_request` for a specific rid, gRPC per-request abort, OpenAI responses cancel, and tokenizer disconnect detection) tag the abort with `client_cancel_finish_reason()`. Server-side/admin aborts (`abort_all`, pause, weight update) keep their default status.
- tokenizer_manager.py carries the reason on `AbortReq`, treats 499 like the other terminal abort statuses when cleaning up state, and no longer counts a client cancel as a finished (success) request in the metrics (it is already counted as an aborted request).
- scheduler.py propagates the reason back onto the echoed `AbortReq` and into the running-request `FINISH_ABORT`.
- grammar_manager.py forwards the reason when aborting queued grammar requests.

Success-rate metrics now reflect real server faults rather than client-caused cancellations.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30226645576](https://github.com/sgl-project/sglang/actions/runs/30226645576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #30226645379](https://github.com/sgl-project/sglang/actions/runs/30226645379)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->