### PR TITLE
[Model] Serve bare Qwen3Model backbone natively as an embedding model

### DIFF
--- a/docs_new/docs/supported-models/embedding_models.mdx
+++ b/docs_new/docs/supported-models/embedding_models.mdx
@@ -152,6 +152,12 @@ print("Embedding:", response["data"][0]["embedding"])
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Latest Qwen3-based text embedding model for semantic representation</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Qwen3 (bare backbone)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`microsoft/harrier-oss-v1-0.6b`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Bare <code>Qwen3Model</code> backbone (no LM head); served natively on SGLang's fused Qwen3 kernels and auto-classified as an embedding model</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>BGE</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`BAAI/bge-large-en-v1.5`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1683,6 +1683,7 @@ def is_generation_model(model_architectures: List[str], is_embedding: bool = Fal
         or "Qwen3ForRewardModel" in model_architectures
         or "Qwen2ForSequenceClassification" in model_architectures
         or "Qwen3ForSequenceClassification" in model_architectures
+        or "Qwen3Model" in model_architectures
         or "CLIPModel" in model_architectures
         or "BertModel" in model_architectures
         or "Contriever" in model_architectures

--- a/python/sglang/srt/models/qwen3_embedding.py
+++ b/python/sglang/srt/models/qwen3_embedding.py
@@ -1,0 +1,124 @@
+import logging
+from typing import Iterable, Optional, Tuple
+
+import torch
+from torch import nn
+
+from sglang.srt.layers.pooler import EmbeddingPoolerOutput, Pooler, PoolingType
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+)
+from sglang.srt.models.qwen3 import Qwen3Model as Qwen3TransformerModel
+from sglang.srt.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+
+class Qwen3Model(nn.Module):
+    """Bare Qwen3 backbone (no LM head) served as an embedding model.
+
+    Checkpoints exported as architectures=["Qwen3Model"], e.g.
+    microsoft/harrier-oss-v1-0.6b, have no native implementation to resolve to
+    and fall back to the Transformers backend. Registering the arch here runs
+    them on the native fused Qwen3 kernels instead.
+    """
+
+    def __init__(
+        self,
+        config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.quant_config = quant_config
+        self.model = Qwen3TransformerModel(
+            config, quant_config=quant_config, prefix=add_prefix("model", prefix)
+        )
+        # Use LAST + normalize=True for qwen3 embedding based on official implementation
+        # Reference: https://github.com/QwenLM/Qwen3-Embedding/blob/main/examples/qwen3_embedding_transformers.py#L55
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.model.get_input_embeddings()
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        get_embedding: bool = True,
+    ) -> EmbeddingPoolerOutput:
+        assert get_embedding, f"{self.__class__.__name__} is only used for embedding"
+
+        hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
+        return self.pooler(hidden_states, forward_batch)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            # Bare-backbone checkpoints omit the "model." prefix of the backbone
+            if not name.startswith("model.") and (
+                name.startswith("layers.")
+                or name.startswith("embed_tokens.")
+                or name.startswith("norm.")
+            ):
+                name = add_prefix(name, "model")
+
+            # Skip rotary embeddings and other non-parameter tensors
+            if "rotary_emb.inv_freq" in name or "projector" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                # Models trained using ColossalAI may include these tensors in
+                # the checkpoint. Skip them.
+                continue
+
+            # Skip lm_head weights a non-tied checkpoint may carry (no LM head here)
+            if name.startswith("lm_head"):
+                continue
+
+            # Normalize kv cache scale names of quantized checkpoints
+            if "scale" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+
+                if name in params_dict:
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                else:
+                    logger.warning(f"Parameter {name} not found in params_dict")
+
+
+EntryClass = Qwen3Model

--- a/test/registered/unit/models/test_qwen3_embedding_registration.py
+++ b/test/registered/unit/models/test_qwen3_embedding_registration.py
@@ -1,0 +1,61 @@
+"""Unit tests for native registration of the bare ``Qwen3Model`` embedding arch.
+
+Checkpoints such as ``microsoft/harrier-oss-v1-0.6b`` declare
+``architectures=["Qwen3Model"]`` (a bare Qwen3 backbone). These must resolve to
+the native SGLang implementation (``sglang.srt.models.qwen3_embedding.Qwen3Model``)
+and be served as an embedding model, NOT fall back to the Transformers backend.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+import unittest
+
+from sglang.srt.configs.model_config import is_generation_model
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestQwen3ModelEmbeddingRegistration(CustomTestCase):
+    def test_entry_class_is_native_qwen3model(self):
+        """The bare arch string maps to a native EntryClass named 'Qwen3Model'."""
+        from sglang.srt.models import qwen3_embedding
+
+        entry = qwen3_embedding.EntryClass
+        self.assertEqual(entry.__name__, "Qwen3Model")
+        self.assertEqual(entry.__module__, "sglang.srt.models.qwen3_embedding")
+        # It carries a LAST-token / normalized pooler, i.e. an embedding head.
+        self.assertTrue(hasattr(entry, "forward"))
+        self.assertTrue(hasattr(entry, "load_weights"))
+
+    def test_registry_resolves_native_not_transformers_fallback(self):
+        """ModelRegistry resolves 'Qwen3Model' to the native class, not the
+        TransformersForCausalLM fallback."""
+        from sglang.srt.models.registry import ModelRegistry
+
+        model_cls, resolved_arch = ModelRegistry.resolve_model_cls("Qwen3Model")
+        self.assertEqual(resolved_arch, "Qwen3Model")
+        self.assertEqual(model_cls.__name__, "Qwen3Model")
+        self.assertEqual(model_cls.__module__, "sglang.srt.models.qwen3_embedding")
+        self.assertNotIn("Transformers", model_cls.__name__)
+
+    def test_bare_qwen3model_classified_as_embedding(self):
+        """'Qwen3Model' is non-generative regardless of the --is-embedding flag."""
+        self.assertFalse(is_generation_model(["Qwen3Model"]))
+        self.assertFalse(is_generation_model(["Qwen3Model"], is_embedding=False))
+        self.assertFalse(is_generation_model(["Qwen3Model"], is_embedding=True))
+
+    def test_existing_qwen3_archs_unaffected(self):
+        """The generative / classification archs keep their prior behavior."""
+        # Qwen3ForCausalLM is generative by default, embedding only with the flag
+        # (this is how Qwen3-Embedding-0.6B is served).
+        self.assertTrue(is_generation_model(["Qwen3ForCausalLM"]))
+        self.assertTrue(is_generation_model(["Qwen3ForCausalLM"], is_embedding=False))
+        self.assertFalse(is_generation_model(["Qwen3ForCausalLM"], is_embedding=True))
+        # Sequence-classification / reward archs stay non-generative.
+        self.assertFalse(is_generation_model(["Qwen3ForSequenceClassification"]))
+        self.assertFalse(is_generation_model(["Qwen3ForRewardModel"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Checkpoints that declare `architectures=["Qwen3Model"]` — a bare Qwen3 backbone with no LM head — have no native SGLang implementation registered. `ModelRegistry` is keyed by `EntryClass.__name__`, so the lookup misses and the model silently falls back to the generic Transformers backend:

```
Qwen3Model has no SGLang implementation, falling back to Transformers implementation.
```

This is an INFO line, the server starts normally and the embeddings are correct, so the only symptom is throughput. The fallback runs HF's eager `modeling_qwen3.py`, which means none of SGLang's fused kernels execute — a profile of that path is dominated by `CatArrayBatchedCopy` (HF's `rotate_half` `torch.cat`) and the `apply_rotary_pos_emb` elementwise chain, with GEMM down to ~14% of GPU time.

Exporting an embedding model as the bare `AutoModel` architecture is a common convention (the sentence-transformers export path), so this affects a class of checkpoints, not one model. `microsoft/harrier-oss-v1-0.6b` is a public example. Note `Qwen/Qwen3-Embedding-*` is **not** affected — it ships as `Qwen3ForCausalLM` and already takes the native path.

## Modifications

- **Add `python/sglang/srt/models/qwen3_embedding.py`** — a `Qwen3Model` class that wraps the native SGLang Qwen3 backbone with a LAST-token / L2-normalized `Pooler` (the harrier / Qwen3-Embedding convention). `load_weights` remaps bare-checkpoint prefixes (`layers.` / `embed_tokens.` / `norm.` → `model.*`), skips an absent `lm_head`, and applies the usual stacked `qkv_proj` / `gate_up_proj` mapping. `EntryClass = Qwen3Model`.
  A separate file is required because the registry key is the class name and `qwen3.py` already defines an (unregistered) internal class of the same name.
- **Whitelist `"Qwen3Model"` in `is_generation_model`** (`configs/model_config.py`, 1 line) so the arch is served as an embedding model regardless of the `--is-embedding` flag.
- **Add `test/registered/unit/models/test_qwen3_embedding_registration.py`** — 4 CPU tests: the EntryClass resolves natively, `ModelRegistry.resolve_model_cls("Qwen3Model")` does not hit the Transformers fallback, the arch is classified non-generative under every flag combination, and existing Qwen3 archs are unaffected.
- **Document the arch** in the supported embedding models list.

This mirrors the existing bare-backbone embedding precedents — `LlamaEmbeddingModel` for the `MistralModel` arch, and `BertModel` — which are registered and classified as embedding in the same way.

## Accuracy Tests

Embeddings are unchanged. `microsoft/harrier-oss-v1-0.6b`, 1×H200, fp8, fixed documents:

| reference | cosine vs this PR's output |
|---|---|
| HF `AutoModel` bf16 + last-token pooling + L2 norm | min **0.998222** / mean 0.998569 |
| SGLang Transformers-fallback path (fp8) | min **0.998738** / mean 0.998875 |

dim 1024, L2 norm 0.998–1.002, no NaN/Inf, 0 errors. The residual delta against the HF reference is fp8-vs-bf16 quantization; semantic structure is preserved (paraphrase pair 0.899 vs unrelated pairs 0.31–0.49).

Unit tests on this PR's base: `pytest test/registered/unit/models/test_qwen3_embedding_registration.py` → **4 passed**. The file is also picked up correctly by the registered-test collector (`base-a-test-cpu` suite).

Regression probe: `Qwen/Qwen3-Embedding-0.6B` on the patched build still loads as `type=Qwen3ForCausalLM` — the new EntryClass does not hijack the existing arch — and returns sane 1024-d embeddings (paraphrase 0.959 vs unrelated 0.281). The same model without `--is-embedding` still resolves as a generative model and generates normally, i.e. the `is_generation_model` edit does not disturb the generative path.

## Speed Tests and Profiling

1×H200, fp8, `/v1/embeddings`, 32 docs/request, concurrency 16, steady-state window.

| | docs/s | tokens/s |
|---|---|---|
| before — Transformers fallback (unpatched) | 237.5 | 323k |
| after — native (this PR, re-measured on this PR's base) | **314.3** | **427.8k** |
| | **+32%** | **+32%** |

Startup log after the patch shows `type=Qwen3Model`, and neither the `falling back to Transformers` line nor the `Disable piecewise CUDA graph because some layers do not apply Standard GQA` line (the latter is a downstream artifact of the fallback: the HF layers expose no `self_attn.attn`, so the layer-count probe collects zero attention layers).

Kernel-level effect of taking the native path, from a torch profile of the same load: `CatArrayBatchedCopy` 10.6% → 0.0%, elementwise/copy bucket 35.7% → 8.8%, and the run flips from copy-bound (duty 98%) to GEMM-bound (GEMM 56%).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes for reviewers

- **Pooling is hardcoded to LAST + L2-normalize**, matching the harrier / Qwen3-Embedding convention and the existing `Qwen3ForCausalLM` embedding path. A mean-pooled bare-Qwen3 checkpoint would need a different `PoolingType`; reading `1_Pooling/config.json` to select pooling automatically would be a good follow-up for all embedding archs, not just this one.
- **No PP layer filtering**, matching the scope of a ~0.6B embedding backbone; the class does not declare PP support (`forward` has no `pp_proxy_tensors`), so `--pp-size > 1` is rejected before use.
- `load_weights` deliberately uses `continue` (not `return`) in every skip branch, since `weights` is a one-shot generator.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30233042075](https://github.com/sgl-project/sglang/actions/runs/30233042075)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30233041942](https://github.com/sgl-project/sglang/actions/runs/30233041942)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->