### PR TITLE
[Attention] Snapshot TRTLLM MHA SWA write locations in graph metadata

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -291,8 +291,16 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if self._swa_kv_pool is not None:
             _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
             if is_swa:
-                assert self.forward_metadata.swa_out_cache_loc is not None
-                return self.forward_metadata.swa_out_cache_loc
+                swa_loc = self.forward_metadata.swa_out_cache_loc
+                assert (
+                    swa_loc is not None
+                    and swa_loc.shape[0] >= forward_batch.out_cache_loc.shape[0]
+                ), (
+                    "SWA write locations must be initialized before per-layer "
+                    "cache writes"
+                )
+                # Piecewise prefill uses a prefix of the padded snapshot.
+                return swa_loc[: forward_batch.out_cache_loc.shape[0]]
         return forward_batch.out_cache_loc
 
     def _bind_swa_page_table(
@@ -571,7 +579,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
             self.draft_extend_metadata[bs] = metadata
 
-        # Bind the SWA write-target buffer slice (refilled by the fused metadata kernel).
+        # Bind the SWA write-target buffer slice (refilled by in-graph metadata).
         if self.use_sliding_window_kv_pool:
             metadata.swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:num_tokens]
 
@@ -597,7 +605,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
     ):
-        """Shared capture+replay-preparation body for the cuda-graph init path.
+        """Shared capture+replay body for the cuda-graph init path.
 
         One fused triton kernel (update_trtllm_mha_graph_metadata) rebuilds
         cache_seqlens, cu_seqlens_k/q, the page table(s), and swa_out_cache_loc.
@@ -610,7 +618,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         bounds the actual KV reads by the on-device ``cache_seqlens``, so no
         runtime host max / seq_lens_cpu D2H sync is needed.
 
-        Public entry: :py:meth:`init_forward_metadata_out_graph`.
+        Public entry: :py:meth:`init_forward_metadata_in_graph`.
         """
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
@@ -637,13 +645,15 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 # Ragged verify: the per-request k-extension is not a
                 # uniform scalar seqlen_offset, so the fused kernel cannot
                 # rebuild this metadata. It is written eagerly on every
-                # capture/replay-prep in init_forward_metadata_out_graph.
+                # capture/replay-prep in init_forward_metadata_out_graph;
+                # record nothing here.
                 return
             seqlen_offset = metadata.max_seq_len_q
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
             # Static per-request query width, fixed by the captured graph shape.
-            # Do not inspect dynamic accept-token tensors during replay preparation.
+            # Do not inspect replay-time tensors here; this body is recorded into
+            # the CUDA graph.
             num_tokens_per_req = metadata.max_seq_len_q
             cu_seqlens_q = metadata.cu_seqlens_q
             q_stride = num_tokens_per_req
@@ -774,15 +784,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 f"Invalid forward mode: {forward_mode=} for CUDA Graph replay."
             )
 
-        self._apply_cuda_graph_metadata(
-            bs=bs,
-            req_pool_indices=forward_batch.req_pool_indices,
-            seq_lens=forward_batch.seq_lens,
-            forward_mode=forward_mode,
-            spec_info=spec_info,
-            out_cache_loc=forward_batch.out_cache_loc,
-        )
-
     def _assert_ragged_verify_supported(self) -> None:
         if self.is_xqa_impl:
             raise NotImplementedError(
@@ -801,9 +802,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         """Eagerly rebuild the target-verify graph metadata for ragged verify.
 
         The per-request verify lengths make the k-extension non-uniform, which
-        the fused metadata kernel cannot express (scalar ``seqlen_offset``
-        only), so this runs on every capture/replay-prep and
-        ``_apply_cuda_graph_metadata`` returns without rebuilding ragged batches.
+        the fused in-graph kernel cannot express (scalar ``seqlen_offset``
+        only), so this runs out-of-graph on every capture/replay-prep and
+        ``_apply_cuda_graph_metadata`` records nothing for ragged batches.
         """
         seq_lens = forward_batch.seq_lens[:bs]
         req_pool_indices = forward_batch.req_pool_indices[:bs]
@@ -819,7 +820,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self._fill_page_table_device(
             metadata, req_pool_indices, metadata.cache_seqlens_int32
         )
-        # The fused metadata kernel also skips ragged batches, so refill the
+        # The fused in-graph kernel also skips ragged batches, so refill the
         # SWA write-target buffer here (out_cache_loc -> SWA locs).
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             n = forward_batch.out_cache_loc.shape[0]
@@ -829,6 +830,16 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     forward_batch.out_cache_loc
                 )
             )
+
+    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
+        self._apply_cuda_graph_metadata(
+            bs=forward_batch.batch_size,
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens,
+            forward_mode=forward_batch.forward_mode,
+            spec_info=forward_batch.spec_info,
+            out_cache_loc=forward_batch.out_cache_loc,
+        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize the metadata for a forward pass."""

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -571,7 +571,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
             self.draft_extend_metadata[bs] = metadata
 
-        # Bind the SWA write-target buffer slice (refilled by in-graph metadata).
+        # Bind the SWA write-target buffer slice (refilled by the fused metadata kernel).
         if self.use_sliding_window_kv_pool:
             metadata.swa_out_cache_loc = self.cuda_graph_swa_out_cache_loc[:num_tokens]
 
@@ -597,7 +597,21 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
     ):
-        """Rebuild the static CUDA graph metadata before capture or replay."""
+        """Shared capture+replay-preparation body for the cuda-graph init path.
+
+        One fused triton kernel (update_trtllm_mha_graph_metadata) rebuilds
+        cache_seqlens, cu_seqlens_k/q, the page table(s), and swa_out_cache_loc.
+        The previous aten-op implementation issued ~25 host dispatches per graph
+        replay, whose per-rank jitter was paid as spin time inside the first
+        all-reduce of every replayed graph.
+
+        The page table is rewritten to the static ``max_num_pages`` width (the
+        same upper bound ``_fill_page_table_device`` uses); the kernel
+        bounds the actual KV reads by the on-device ``cache_seqlens``, so no
+        runtime host max / seq_lens_cpu D2H sync is needed.
+
+        Public entry: :py:meth:`init_forward_metadata_out_graph`.
+        """
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
 
@@ -620,12 +634,16 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
             if spec_info is not None and spec_info.ragged_verify_layout is not None:
-                # Ragged verify metadata is rebuilt by _write_ragged_verify_graph_metadata.
+                # Ragged verify: the per-request k-extension is not a
+                # uniform scalar seqlen_offset, so the fused kernel cannot
+                # rebuild this metadata. It is written eagerly on every
+                # capture/replay-prep in init_forward_metadata_out_graph.
                 return
             seqlen_offset = metadata.max_seq_len_q
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
-            # The per-request query width is fixed by the captured graph shape.
+            # Static per-request query width, fixed by the captured graph shape.
+            # Do not inspect dynamic accept-token tensors during replay preparation.
             num_tokens_per_req = metadata.max_seq_len_q
             cu_seqlens_q = metadata.cu_seqlens_q
             q_stride = num_tokens_per_req
@@ -783,9 +801,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         """Eagerly rebuild the target-verify graph metadata for ragged verify.
 
         The per-request verify lengths make the k-extension non-uniform, which
-        the fused in-graph kernel cannot express (scalar ``seqlen_offset``
-        only), so this runs out-of-graph on every capture/replay-prep and
-        ``_apply_cuda_graph_metadata`` records nothing for ragged batches.
+        the fused metadata kernel cannot express (scalar ``seqlen_offset``
+        only), so this runs on every capture/replay-prep and
+        ``_apply_cuda_graph_metadata`` returns without rebuilding ragged batches.
         """
         seq_lens = forward_batch.seq_lens[:bs]
         req_pool_indices = forward_batch.req_pool_indices[:bs]
@@ -801,7 +819,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self._fill_page_table_device(
             metadata, req_pool_indices, metadata.cache_seqlens_int32
         )
-        # Refill the SWA write-target buffer for ragged batches.
+        # The fused metadata kernel also skips ragged batches, so refill the
+        # SWA write-target buffer here (out_cache_loc -> SWA locs).
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             n = forward_batch.out_cache_loc.shape[0]
             self.cuda_graph_swa_out_cache_loc[n:].zero_()

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -291,9 +291,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if self._swa_kv_pool is not None:
             _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
             if is_swa:
-                return self._swa_kv_pool.translate_loc_from_full_to_swa(
-                    forward_batch.out_cache_loc
-                )
+                assert self.forward_metadata.swa_out_cache_loc is not None
+                return self.forward_metadata.swa_out_cache_loc
         return forward_batch.out_cache_loc
 
     def _bind_swa_page_table(
@@ -598,21 +597,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
     ):
-        """Shared capture+replay body for the cuda-graph init path.
-
-        One fused triton kernel (update_trtllm_mha_graph_metadata) rebuilds
-        cache_seqlens, cu_seqlens_k/q, the page table(s), and swa_out_cache_loc.
-        The previous aten-op implementation issued ~25 host dispatches per graph
-        replay, whose per-rank jitter was paid as spin time inside the first
-        all-reduce of every replayed graph.
-
-        The page table is rewritten to the static ``max_num_pages`` width (the
-        same upper bound ``_fill_page_table_device`` uses); the kernel
-        bounds the actual KV reads by the on-device ``cache_seqlens``, so no
-        runtime host max / seq_lens_cpu D2H sync is needed.
-
-        Public entry: :py:meth:`init_forward_metadata_in_graph`.
-        """
+        """Rebuild the static CUDA graph metadata before capture or replay."""
         seq_lens = seq_lens[:bs]
         req_pool_indices = req_pool_indices[:bs]
 
@@ -635,18 +620,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
             if spec_info is not None and spec_info.ragged_verify_layout is not None:
-                # Ragged verify: the per-request k-extension is not a
-                # uniform scalar seqlen_offset, so the fused kernel cannot
-                # rebuild this metadata. It is written eagerly on every
-                # capture/replay-prep in init_forward_metadata_out_graph;
-                # record nothing here.
+                # Ragged verify metadata is rebuilt by _write_ragged_verify_graph_metadata.
                 return
             seqlen_offset = metadata.max_seq_len_q
         elif forward_mode.is_draft_extend_v2():
             metadata = self.draft_extend_metadata[bs]
-            # Static per-request query width, fixed by the captured graph shape.
-            # Do not inspect replay-time tensors here; this body is recorded into
-            # the CUDA graph.
+            # The per-request query width is fixed by the captured graph shape.
             num_tokens_per_req = metadata.max_seq_len_q
             cu_seqlens_q = metadata.cu_seqlens_q
             q_stride = num_tokens_per_req
@@ -777,6 +756,15 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 f"Invalid forward mode: {forward_mode=} for CUDA Graph replay."
             )
 
+        self._apply_cuda_graph_metadata(
+            bs=bs,
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens,
+            forward_mode=forward_mode,
+            spec_info=spec_info,
+            out_cache_loc=forward_batch.out_cache_loc,
+        )
+
     def _assert_ragged_verify_supported(self) -> None:
         if self.is_xqa_impl:
             raise NotImplementedError(
@@ -813,8 +801,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self._fill_page_table_device(
             metadata, req_pool_indices, metadata.cache_seqlens_int32
         )
-        # The fused in-graph kernel also skips ragged batches, so refill the
-        # SWA write-target buffer here (out_cache_loc -> SWA locs).
+        # Refill the SWA write-target buffer for ragged batches.
         if self.use_sliding_window_kv_pool and forward_batch.out_cache_loc is not None:
             n = forward_batch.out_cache_loc.shape[0]
             self.cuda_graph_swa_out_cache_loc[n:].zero_()
@@ -823,16 +810,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     forward_batch.out_cache_loc
                 )
             )
-
-    def init_forward_metadata_in_graph(self, forward_batch: ForwardBatch):
-        self._apply_cuda_graph_metadata(
-            bs=forward_batch.batch_size,
-            req_pool_indices=forward_batch.req_pool_indices,
-            seq_lens=forward_batch.seq_lens,
-            forward_mode=forward_batch.forward_mode,
-            spec_info=forward_batch.spec_info,
-            out_cache_loc=forward_batch.out_cache_loc,
-        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize the metadata for a forward pass."""

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -49,7 +49,7 @@ def _make_backend_for_hook_test(speculative_num_draft_tokens=None):
     return backend
 
 
-def test_cuda_graph_metadata_launch_runs_in_graph_hook(monkeypatch):
+def test_cuda_graph_metadata_launch_runs_in_out_graph_hook(monkeypatch):
     calls = []
 
     def fake_update(**kwargs):
@@ -70,20 +70,21 @@ def test_cuda_graph_metadata_launch_runs_in_graph_hook(monkeypatch):
     )
 
     backend.init_forward_metadata_out_graph(fb, in_capture=True)
-    assert calls == []
+    assert len(calls) == 1
+    assert calls[0]["out_cache_loc"] is fb.out_cache_loc
     assert backend.forward_metadata is backend.decode_cuda_graph_metadata[2]
 
     backend.init_forward_metadata_in_graph(fb)
     assert len(calls) == 1
-    assert calls[0]["out_cache_loc"] is fb.out_cache_loc
 
     calls.clear()
     backend.init_forward_metadata_out_graph(fb)
-    assert calls == []
+    assert len(calls) == 1
+    assert calls[0]["out_cache_loc"] is fb.out_cache_loc
     assert backend.forward_metadata is backend.decode_cuda_graph_metadata[2]
 
 
-def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
+def test_draft_extend_out_graph_uses_captured_static_q_stride(monkeypatch):
     calls = []
 
     def fake_update(**kwargs):
@@ -91,7 +92,7 @@ def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
 
     class ExplodingAcceptTokens:
         def __getitem__(self, key):
-            raise AssertionError("in-graph metadata must not inspect accept tokens")
+            raise AssertionError("metadata must not inspect accept tokens")
 
     monkeypatch.setattr(
         trtllm_mha_backend, "update_trtllm_mha_graph_metadata", fake_update
@@ -111,9 +112,9 @@ def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
     )
 
     backend.init_forward_metadata_out_graph(fb, in_capture=True)
-    # The in-graph body must use the captured static stride, not replay-time state.
+    # Metadata is rebuilt at replay preparation; later spec_info mutations
+    # must not affect the captured static stride.
     fb.spec_info.num_tokens_per_req = 0
-    backend.init_forward_metadata_in_graph(fb)
 
     assert len(calls) == 1
     assert calls[0]["q_mode"] == Q_MODE_STRIDED
@@ -121,9 +122,7 @@ def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
 
 
 def test_hybrid_wrappers_forward_in_graph_hook():
-    """Hybrid wrappers must forward init_forward_metadata_in_graph to the
-    wrapped backend(s) — the inherited no-op would leave the fused metadata
-    rebuild out of the captured graph (stale page table on every replay)."""
+    """Hybrid wrappers forward the in-graph metadata hook to active children."""
     from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
     from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
         HybridLinearAttnBackend,
@@ -164,7 +163,7 @@ def test_hybrid_wrappers_forward_in_graph_hook():
     assert calls == ["full", "linear"]
 
 
-def test_metadata_update_records_inside_cuda_graph():
+def test_metadata_update_finishes_before_cuda_graph_replay():
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
 
@@ -188,14 +187,17 @@ def test_metadata_update_records_inside_cuda_graph():
     )
 
     backend.init_forward_metadata_out_graph(fb, in_capture=True)
-    backend.init_forward_metadata_in_graph(fb)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
+    graph_sentinel = torch.zeros(1, device=DEVICE)
     with torch.cuda.graph(graph):
         backend.init_forward_metadata_in_graph(fb)
+        graph_sentinel.add_(1)
 
     fb.seq_lens.copy_(torch.tensor([5, 6], dtype=torch.int32, device=DEVICE))
+    backend.init_forward_metadata_out_graph(fb)
+    fb.seq_lens.copy_(torch.tensor([7, 8], dtype=torch.int32, device=DEVICE))
     graph.replay()
     torch.cuda.synchronize()
 

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -122,7 +122,7 @@ def test_draft_extend_out_graph_uses_captured_static_q_stride(monkeypatch):
 
 
 def test_hybrid_wrappers_forward_in_graph_hook():
-    """Hybrid wrappers forward the in-graph metadata hook to active children."""
+    """Hybrid wrappers must forward init_forward_metadata_in_graph to wrapped backends."""
     from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
     from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
         HybridLinearAttnBackend,
@@ -207,6 +207,110 @@ def test_metadata_update_finishes_before_cuda_graph_replay():
         rtol=0,
         atol=0,
     )
+
+
+def test_graph_metadata_keeps_pre_boundary_slot_snapshot():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    backend = _make_backend_for_hook_test()
+    backend.device = torch.device(DEVICE)
+    backend.page_size = 2
+    backend.max_num_pages = 2
+    backend.use_sliding_window_kv_pool = True
+    backend._swa_kv_pool = object()
+    backend.req_to_token = torch.tensor(
+        [[0, 1, 2, 3], [8, 9, 10, 11]], dtype=torch.int32, device=DEVICE
+    )
+    backend._swa_full_to_swa_mapping = (
+        torch.arange(32, dtype=torch.int64, device=DEVICE) * 2
+    )
+    backend.init_cuda_graph_state(max_bs=1, max_num_tokens=1)
+
+    forward_batch = SimpleNamespace(
+        batch_size=1,
+        req_pool_indices=torch.tensor([0], dtype=torch.int64, device=DEVICE),
+        seq_lens=torch.tensor([4], dtype=torch.int32, device=DEVICE),
+        forward_mode=ForwardMode.DECODE,
+        spec_info=None,
+        positions=torch.tensor([0], dtype=torch.int64, device=DEVICE),
+        out_cache_loc=torch.tensor([3], dtype=torch.int64, device=DEVICE),
+    )
+
+    backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
+    backend.init_forward_metadata_in_graph(forward_batch)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    graph_sentinel = torch.zeros(1, device=DEVICE)
+    with torch.cuda.graph(graph):
+        backend.init_forward_metadata_in_graph(forward_batch)
+        graph_sentinel.add_(1)
+
+    backend.init_forward_metadata_out_graph(forward_batch)
+    expected_page_table = torch.tensor([[0, 1]], dtype=torch.int32, device=DEVICE)
+    expected_swa_page_table = torch.tensor([[0, 2]], dtype=torch.int32, device=DEVICE)
+    expected_swa_out_cache_loc = torch.tensor([6], dtype=torch.int64, device=DEVICE)
+
+    read_done = torch.cuda.Event()
+    mutation_done = torch.cuda.Event()
+    scheduler_stream = torch.cuda.Stream()
+    read_done.record()
+    with torch.cuda.stream(scheduler_stream):
+        scheduler_stream.wait_event(read_done)
+        backend.req_to_token.copy_(
+            torch.tensor(
+                [[8, 9, 10, 11], [0, 1, 2, 3]],
+                dtype=torch.int32,
+                device=DEVICE,
+            )
+        )
+        backend._swa_full_to_swa_mapping.copy_(
+            torch.arange(32, dtype=torch.int64, device=DEVICE) * 2 + 64
+        )
+        mutation_done.record()
+
+    torch.cuda.current_stream().wait_event(mutation_done)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        backend.forward_metadata.page_table,
+        expected_page_table,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        backend.forward_metadata.swa_page_table,
+        expected_swa_page_table,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        backend.forward_metadata.swa_out_cache_loc,
+        expected_swa_out_cache_loc,
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_swa_cache_write_uses_pre_boundary_slot_snapshot():
+    snapshot = torch.tensor([6], dtype=torch.int64)
+
+    def translate_live_mapping(_):
+        raise AssertionError("cache writes must not read the live SWA mapping")
+
+    backend = TRTLLMHAAttnBackend.__new__(TRTLLMHAAttnBackend)
+    backend._swa_kv_pool = SimpleNamespace(
+        layers_mapping={1: (0, True)},
+        translate_loc_from_full_to_swa=translate_live_mapping,
+    )
+    backend.forward_metadata = SimpleNamespace(swa_out_cache_loc=snapshot)
+    forward_batch = SimpleNamespace(out_cache_loc=torch.tensor([3], dtype=torch.int64))
+
+    cache_loc = backend._get_layer_cache_loc(SimpleNamespace(layer_id=1), forward_batch)
+
+    torch.testing.assert_close(cache_loc, snapshot, rtol=0, atol=0)
 
 
 def _build_inputs(bs, pool_size, max_num_pages, max_seq_pages, seq_max, seed):

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -49,7 +49,7 @@ def _make_backend_for_hook_test(speculative_num_draft_tokens=None):
     return backend
 
 
-def test_cuda_graph_metadata_launch_runs_in_out_graph_hook(monkeypatch):
+def test_cuda_graph_metadata_launch_runs_in_graph_hook(monkeypatch):
     calls = []
 
     def fake_update(**kwargs):
@@ -70,21 +70,20 @@ def test_cuda_graph_metadata_launch_runs_in_out_graph_hook(monkeypatch):
     )
 
     backend.init_forward_metadata_out_graph(fb, in_capture=True)
-    assert len(calls) == 1
-    assert calls[0]["out_cache_loc"] is fb.out_cache_loc
+    assert calls == []
     assert backend.forward_metadata is backend.decode_cuda_graph_metadata[2]
 
     backend.init_forward_metadata_in_graph(fb)
     assert len(calls) == 1
+    assert calls[0]["out_cache_loc"] is fb.out_cache_loc
 
     calls.clear()
     backend.init_forward_metadata_out_graph(fb)
-    assert len(calls) == 1
-    assert calls[0]["out_cache_loc"] is fb.out_cache_loc
+    assert calls == []
     assert backend.forward_metadata is backend.decode_cuda_graph_metadata[2]
 
 
-def test_draft_extend_out_graph_uses_captured_static_q_stride(monkeypatch):
+def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
     calls = []
 
     def fake_update(**kwargs):
@@ -92,7 +91,7 @@ def test_draft_extend_out_graph_uses_captured_static_q_stride(monkeypatch):
 
     class ExplodingAcceptTokens:
         def __getitem__(self, key):
-            raise AssertionError("metadata must not inspect accept tokens")
+            raise AssertionError("in-graph metadata must not inspect accept tokens")
 
     monkeypatch.setattr(
         trtllm_mha_backend, "update_trtllm_mha_graph_metadata", fake_update
@@ -112,9 +111,9 @@ def test_draft_extend_out_graph_uses_captured_static_q_stride(monkeypatch):
     )
 
     backend.init_forward_metadata_out_graph(fb, in_capture=True)
-    # Metadata is rebuilt at replay preparation; later spec_info mutations
-    # must not affect the captured static stride.
+    # The in-graph body must use the captured static stride, not replay-time state.
     fb.spec_info.num_tokens_per_req = 0
+    backend.init_forward_metadata_in_graph(fb)
 
     assert len(calls) == 1
     assert calls[0]["q_mode"] == Q_MODE_STRIDED
@@ -122,7 +121,9 @@ def test_draft_extend_out_graph_uses_captured_static_q_stride(monkeypatch):
 
 
 def test_hybrid_wrappers_forward_in_graph_hook():
-    """Hybrid wrappers must forward init_forward_metadata_in_graph to wrapped backends."""
+    """Hybrid wrappers must forward init_forward_metadata_in_graph to the
+    wrapped backend(s) — the inherited no-op would leave the fused metadata
+    rebuild out of the captured graph (stale page table on every replay)."""
     from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
     from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
         HybridLinearAttnBackend,
@@ -163,7 +164,7 @@ def test_hybrid_wrappers_forward_in_graph_hook():
     assert calls == ["full", "linear"]
 
 
-def test_metadata_update_finishes_before_cuda_graph_replay():
+def test_metadata_update_records_inside_cuda_graph():
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
 
@@ -187,17 +188,14 @@ def test_metadata_update_finishes_before_cuda_graph_replay():
     )
 
     backend.init_forward_metadata_out_graph(fb, in_capture=True)
+    backend.init_forward_metadata_in_graph(fb)
     torch.cuda.synchronize()
 
     graph = torch.cuda.CUDAGraph()
-    graph_sentinel = torch.zeros(1, device=DEVICE)
     with torch.cuda.graph(graph):
         backend.init_forward_metadata_in_graph(fb)
-        graph_sentinel.add_(1)
 
     fb.seq_lens.copy_(torch.tensor([5, 6], dtype=torch.int32, device=DEVICE))
-    backend.init_forward_metadata_out_graph(fb)
-    fb.seq_lens.copy_(torch.tensor([7, 8], dtype=torch.int32, device=DEVICE))
     graph.replay()
     torch.cuda.synchronize()
 
@@ -209,92 +207,7 @@ def test_metadata_update_finishes_before_cuda_graph_replay():
     )
 
 
-def test_graph_metadata_keeps_pre_boundary_slot_snapshot():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA required")
-
-    backend = _make_backend_for_hook_test()
-    backend.device = torch.device(DEVICE)
-    backend.page_size = 2
-    backend.max_num_pages = 2
-    backend.use_sliding_window_kv_pool = True
-    backend._swa_kv_pool = object()
-    backend.req_to_token = torch.tensor(
-        [[0, 1, 2, 3], [8, 9, 10, 11]], dtype=torch.int32, device=DEVICE
-    )
-    backend._swa_full_to_swa_mapping = (
-        torch.arange(32, dtype=torch.int64, device=DEVICE) * 2
-    )
-    backend.init_cuda_graph_state(max_bs=1, max_num_tokens=1)
-
-    forward_batch = SimpleNamespace(
-        batch_size=1,
-        req_pool_indices=torch.tensor([0], dtype=torch.int64, device=DEVICE),
-        seq_lens=torch.tensor([4], dtype=torch.int32, device=DEVICE),
-        forward_mode=ForwardMode.DECODE,
-        spec_info=None,
-        positions=torch.tensor([0], dtype=torch.int64, device=DEVICE),
-        out_cache_loc=torch.tensor([3], dtype=torch.int64, device=DEVICE),
-    )
-
-    backend.init_forward_metadata_out_graph(forward_batch, in_capture=True)
-    backend.init_forward_metadata_in_graph(forward_batch)
-    torch.cuda.synchronize()
-
-    graph = torch.cuda.CUDAGraph()
-    graph_sentinel = torch.zeros(1, device=DEVICE)
-    with torch.cuda.graph(graph):
-        backend.init_forward_metadata_in_graph(forward_batch)
-        graph_sentinel.add_(1)
-
-    backend.init_forward_metadata_out_graph(forward_batch)
-    expected_page_table = torch.tensor([[0, 1]], dtype=torch.int32, device=DEVICE)
-    expected_swa_page_table = torch.tensor([[0, 2]], dtype=torch.int32, device=DEVICE)
-    expected_swa_out_cache_loc = torch.tensor([6], dtype=torch.int64, device=DEVICE)
-
-    read_done = torch.cuda.Event()
-    mutation_done = torch.cuda.Event()
-    scheduler_stream = torch.cuda.Stream()
-    read_done.record()
-    with torch.cuda.stream(scheduler_stream):
-        scheduler_stream.wait_event(read_done)
-        backend.req_to_token.copy_(
-            torch.tensor(
-                [[8, 9, 10, 11], [0, 1, 2, 3]],
-                dtype=torch.int32,
-                device=DEVICE,
-            )
-        )
-        backend._swa_full_to_swa_mapping.copy_(
-            torch.arange(32, dtype=torch.int64, device=DEVICE) * 2 + 64
-        )
-        mutation_done.record()
-
-    torch.cuda.current_stream().wait_event(mutation_done)
-    graph.replay()
-    torch.cuda.synchronize()
-
-    torch.testing.assert_close(
-        backend.forward_metadata.page_table,
-        expected_page_table,
-        rtol=0,
-        atol=0,
-    )
-    torch.testing.assert_close(
-        backend.forward_metadata.swa_page_table,
-        expected_swa_page_table,
-        rtol=0,
-        atol=0,
-    )
-    torch.testing.assert_close(
-        backend.forward_metadata.swa_out_cache_loc,
-        expected_swa_out_cache_loc,
-        rtol=0,
-        atol=0,
-    )
-
-
-def test_swa_cache_write_uses_pre_boundary_slot_snapshot():
+def test_swa_cache_write_uses_metadata_slot_snapshot():
     snapshot = torch.tensor([6], dtype=torch.int64)
 
     def translate_live_mapping(_):


### PR DESCRIPTION
## Motivation
TRTLLM MHA already computes `swa_out_cache_loc` during forward metadata initialization, but each SWA attention layer ignored that snapshot and translated `out_cache_loc` through the live FULL-to-SWA mapping again.
Under overlap scheduling, the scheduler may update that mapping for the next batch after the WAR fence releases. A later per-layer translation can therefore observe new slot ownership and write KV data to the wrong SWA locations.

## Modifications
- Route SWA KV writes through `forward_metadata.swa_out_cache_loc`.
- Slice the padded snapshot for piecewise-prefill calls.
- Fail loudly if metadata initialization did not provide enough SWA write locations.
- Keep the fused metadata rebuild inside the captured CUDA graph.
- Add a regression test that rejects any fallback to the live FULL-to-SWA mapping.
A follow-up PR moves the WAR read-done event after captured metadata initialization, making that hook the final scheduler-shared read boundary.

## Accuracy Tests
No model output changes are expected for race-free executions. The change removes a possible source of incorrect KV writes under scheduler overlap.
- `test/registered/attention/test_trtllm_mha_graph_metadata.py`: 150 tests passed.
- The new SWA snapshot regression test fails if the write path consults the live mapping.
## Speed Tests and Profiling
The fused metadata kernel remains graph-recorded, so this change adds no eager kernel launch. SWA layers reuse the existing metadata snapshot instead of repeating the FULL-to-SWA translation.
No measurable end-to-end regression is expected.

## Checklist
- [x] Format your code according to the Format code with pre-commit guide.
- [x] Add unit tests according to the Run and add unit tests guide.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process
1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30652429281](https://github.com/sgl-project/sglang/actions/runs/30652429281)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30652429009](https://github.com/sgl-project/sglang/actions/runs/30652429009)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->