### PR TITLE
[Perf] Route small bf16 TP all-reduces through FlashInfer kAllReduce (spec-decode draft NCCL ARs)

### DIFF
--- a/python/sglang/srt/distributed/communication_op.py
+++ b/python/sglang/srt/distributed/communication_op.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 import torch.distributed
 
+from sglang.srt.environ import envs
+
 from .parallel_state import (
     get_attn_tp_group,
     get_moe_ep_group,
@@ -17,6 +19,18 @@ from .parallel_state import (
 
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group."""
+    small_ar_max_bytes = envs.SGLANG_FLASHINFER_SMALL_AR_MAX_BYTES.get()
+    if (
+        small_ar_max_bytes > 0
+        and input_.dim() == 2
+        and input_.dtype == torch.bfloat16
+        and input_.numel() * input_.element_size() <= small_ar_max_bytes
+    ):
+        from sglang.srt.layers.flashinfer_comm_fusion import flashinfer_allreduce
+
+        output = flashinfer_allreduce(input_tensor=input_)
+        if output is not None:
+            return output
     return get_tp_group().all_reduce(input_)
 
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1034,6 +1034,14 @@ class Envs:
     SGLANG_FLASHINFER_AUTOTUNE_CACHE = EnvBool(True)
     SGLANG_ENABLE_MOE_DEFERRED_FINALIZE = EnvBool(False)
 
+    # Route small bf16 TP all-reduces (total bytes at or below this value)
+    # through the FlashInfer all-reduce workspace's plain kAllReduce pattern
+    # instead of NCCL. 0 disables. Targets the per-draft-forward NCCL
+    # all-reduces in speculative decoding, which NCCL RING_LL serves at
+    # ~26 us/call on cross-node MNNVL while the FlashInfer one-shot kernel
+    # serves equivalent shapes at ~8 us in the same graphs.
+    SGLANG_FLASHINFER_SMALL_AR_MAX_BYTES = EnvInt(0)
+
     # Plugin system
     SGLANG_PLATFORM = EnvStr("")
     SGLANG_PLUGINS = EnvStr("")

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -708,6 +708,67 @@ def ensure_workspace_initialized(
     return workspace_manager.initialized
 
 
+def flashinfer_allreduce(
+    input_tensor: torch.Tensor,
+    max_token_num: int = 2048,
+    use_oneshot: Optional[bool] = None,
+    use_attn_tp_group: bool = True,
+) -> Optional[torch.Tensor]:
+    """Plain all-reduce through the FlashInfer fusion workspace
+    (``AllReduceFusionPattern.kAllReduce``), sharing the workspace used by
+    ``flashinfer_allreduce_residual_rmsnorm``. Returns None whenever the
+    workspace/backend is unavailable so callers can fall back to NCCL.
+    """
+    if not is_flashinfer_available() or _flashinfer_comm is None:
+        return None
+
+    if use_attn_tp_group:
+        # Callers use this as a full-TP all-reduce; the attention-TP
+        # workspace only matches that contract when the groups coincide.
+        if get_parallel().attn_tp_size != get_parallel().tp_size:
+            return None
+        world_size = get_parallel().attn_tp_size
+    else:
+        if get_parallel().moe_ep_size > 1:
+            world_size = get_parallel().moe_ep_size
+        else:
+            world_size = get_parallel().moe_tp_size
+    if world_size <= 1:
+        return None
+
+    if input_tensor.shape[0] > max_token_num or not input_tensor.is_contiguous():
+        return None
+
+    if not ensure_workspace_initialized(
+        max_token_num=max_token_num,
+        hidden_dim=input_tensor.shape[-1],
+        use_fp32_lamport=(input_tensor.dtype == torch.float32),
+        dtype=input_tensor.dtype,
+        token_num=input_tensor.shape[0],
+        use_oneshot=use_oneshot,
+        use_attn_tp_group=use_attn_tp_group,
+    ):
+        return None
+
+    workspace_manager = _get_workspace_manager(use_attn_tp_group)
+    if workspace_manager.workspace is None:
+        return None
+
+    output = torch.empty_like(input_tensor)
+    kwargs = dict(
+        input=input_tensor,
+        workspace=workspace_manager.workspace,
+        pattern=_flashinfer_comm.AllReduceFusionPattern.kAllReduce,
+        launch_with_pdl=True,
+        output=output,
+        use_oneshot=use_oneshot,
+    )
+    if _flashinfer_allreduce_supports_trigger_completion:
+        kwargs["trigger_completion_at_end"] = False
+    _flashinfer_comm.allreduce_fusion(**kwargs)
+    return output
+
+
 def fake_flashinfer_allreduce_residual_rmsnorm(
     input_tensor: torch.Tensor,
     residual: torch.Tensor,


### PR DESCRIPTION
## Motivation

On multi-node NVLink (MNNVL) TP deployments with speculative decoding, the per-draft-forward plain tensor-parallel all-reduces (post-MoE and post-embedding in the NextN draft model) fall back to NCCL because the draft layer is `is_last_layer` (no next-layer norm to fuse into) and `VocabParallelEmbedding` reduces internally. NCCL `RING_LL` serves these tiny bf16 messages (1–6 tokens × hidden) at 23–33 µs/call over MNNVL, while the FlashInfer one-shot all-reduce kernel — already serving the 160 fused layer all-reduces per speculative step in the same CUDA graphs — handles equivalent shapes at ~8 µs.

## Modifications

- `SGLANG_FLASHINFER_SMALL_AR_MAX_BYTES` (EnvInt, default `0` = off): byte threshold for diverting small bf16 TP all-reduces.
- `flashinfer_allreduce(...)` in `flashinfer_comm_fusion.py`: plain `AllReduceFusionPattern.kAllReduce` through the existing fusion workspace; returns `None` (caller falls back to the regular dispatch) whenever FlashInfer/workspace/topology does not match, including when the attention-TP group differs from the full TP group.
- `tensor_model_parallel_all_reduce`: guarded dispatch for 2-D bf16 tensors at or below the threshold.

Default-off and fail-closed: with the env var unset there is zero behavior change.

## Benchmarks

GLM-5.2-FP8, bs=1, EAGLE 5-1-6, TP8 over 2×4 GB300 (MNNVL), `SGLANG_FLASHINFER_SMALL_AR_MAX_BYTES=196608`. Official protocol = serial 3×40 coding prompts, mean decode throughput.

| Metric | Before | After |
|---|---:|---:|
| Decode throughput (3×40, bs=1) | 374.83 tok/s | **381.85 tok/s (+1.87%)** |
| Spec accept length | 3.8636 | 3.8623 |
| TTFT p50 | 0.2187 s | 0.2107 s |
| NCCL all-reduces per spec step (TP0 trace) | 12 (0.450 ms) | 0 |
| MNNVL one-shot kernels per spec step | 160 (1.284 ms) | 172 (1.348 ms) |

| Accuracy | Before | After |
|---|---:|---:|
| GSM8K 200q (few-shot 5, greedy) | 0.980 | 0.985 |

Note: the one-shot all-reduce changes bf16 summation order, so greedy outputs are not guaranteed byte-identical; on the 3×40 protocol 111/120 responses are byte-identical and the divergences are deterministic (the same 3 prompts in every run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30229658976](https://github.com/sgl-project/sglang/actions/runs/30229658976)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30229658943](https://github.com/sgl-project/sglang/actions/runs/30229658943)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->