### PR TITLE
[Apple Silicon] [MLX] Set launch_ts crash in the overlap scheduler loop

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
+++ b/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
@@ -16,6 +16,7 @@ the GPU runs both steps back-to-back with no idle gap.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
@@ -153,6 +154,10 @@ class SchedulerMlxOverlapMixin:
         pending_next: Optional[MlxPendingJob] = None
 
         def _launch_fresh(batch: ScheduleBatch) -> MlxPendingJob:
+            # This loop bypasses run_batch(), which is where launch_ts is
+            # normally set, so _record_step_counters would read None. Set it
+            # here at the same "about to launch" point run_batch uses.
+            batch.launch_ts = time.monotonic()
             # Materialize batch.input_ids from CPU staging (prefill) or the
             # FutureMap relay (decode) before the forward. With deferred input
             # materialization, get_next_batch_to_run leaves input_ids unset; the
@@ -181,14 +186,19 @@ class SchedulerMlxOverlapMixin:
             )
             # Composition is identical to prev: reuse a fresh batch copy
             # of the same underlying ScheduleBatch so process_batch_result
-            # updates the same req objects with the new token.
+            # updates the same req objects with the new token. This is a
+            # real, separate launch though, so it gets its own launch_ts
+            # rather than inheriting prev's (which would collapse the
+            # decode-step interval _record_step_counters computes to zero).
+            batch_copy = prev.batch_copy.copy()
+            batch_copy.launch_ts = time.monotonic()
             return MlxPendingJob(
                 lazy_tokens=lazy_tokens,
                 prefills=prefills,
                 extends=extends,
                 decode=decode,
                 mode=mode,
-                batch_copy=prev.batch_copy.copy(),
+                batch_copy=batch_copy,
                 schedule_batch=prev.schedule_batch,
                 reqs=prev.reqs,
             )

--- a/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
+++ b/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
@@ -13,11 +13,17 @@ scheduler_mixin requires ``mlx.core``).
 
 from __future__ import annotations
 
+import dataclasses
 import importlib.util
 import platform
 import unittest
-from unittest.mock import MagicMock
+from collections import deque
+from unittest.mock import MagicMock, patch
 
+import torch
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -72,6 +78,142 @@ class TestFinalizeMlxPendingJob(unittest.TestCase):
 
         self.assertEqual(
             scheduler.profiler_manager._profile_batch_predicate.call_count, 3
+        )
+
+
+class _FakeReq:
+    def finished(self):
+        return False
+
+
+def _make_fake_schedule_batch(forward_mode) -> ScheduleBatch:
+    # Auto-fill every List/Tensor field so ScheduleBatch.copy() (which reads
+    # ~30 fields) doesn't hit an unset attribute; unlisted fields keep their
+    # dataclass default.
+    batch = ScheduleBatch(reqs=[_FakeReq()])
+    for field in dataclasses.fields(ScheduleBatch):
+        annotation = str(field.type)
+        if "List" in annotation or "list[" in annotation:
+            setattr(batch, field.name, [])
+        elif "Tensor" in annotation:
+            setattr(batch, field.name, torch.zeros(1, dtype=torch.int64))
+    batch.forward_mode = forward_mode
+    # Make resolve_forward_inputs() a no-op: skip both its H2D-copy and
+    # FutureMap-relay branches.
+    batch.prefill_input_ids_cpu = None
+    batch.input_ids = torch.zeros(1, dtype=torch.int64)
+    batch.enable_overlap = False
+    return batch
+
+
+@unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
+class TestEventLoopOverlapMlxSetsLaunchTs(unittest.TestCase):
+    """event_loop_overlap_mlx bypasses run_batch(), which is where launch_ts is
+    normally stamped, so _launch_fresh/_launch_chained must set it directly.
+    Without that, _record_step_counters crashes on time.monotonic() - None for
+    the very first batch (see the scheduler.py call it feeds).
+    """
+
+    class _StopLoop(Exception):
+        pass
+
+    def _make_scheduler(self):
+        from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+            SchedulerMlxOverlapMixin,
+        )
+
+        scheduler = MagicMock()
+        scheduler.waiting_queue = []
+        scheduler.running_batch = None
+        scheduler.last_batch = None
+        scheduler._engine_paused = False
+        scheduler.result_queue = deque()
+        scheduler.tp_worker.finalize_mlx_result.return_value = MagicMock(
+            next_token_ids=None
+        )
+        # Route the loop's self._finalize_mlx_pending_job(...) call to the
+        # real mixin method (bound to this mock) instead of an auto-mock, so
+        # process_batch_result actually gets invoked with the launched batch.
+        scheduler._finalize_mlx_pending_job = (
+            lambda pending: SchedulerMlxOverlapMixin._finalize_mlx_pending_job(
+                scheduler, pending
+            )
+        )
+        return scheduler, SchedulerMlxOverlapMixin
+
+    def test_fresh_launch_sets_launch_ts_before_process_batch_result(self):
+        scheduler, mixin_cls = self._make_scheduler()
+        fresh_batch = _make_fake_schedule_batch(ForwardMode.EXTEND)
+
+        scheduler.get_next_batch_to_run.side_effect = [
+            MagicMock(batch_to_run=fresh_batch, running_batch=None),
+            MagicMock(batch_to_run=None, running_batch=None),
+        ]
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            MagicMock(),  # lazy_tokens
+            [],  # prefills
+            [],  # extends
+            None,  # decode
+            "extend",  # mode
+        )
+        scheduler.request_receiver.recv_requests.side_effect = [
+            [],
+            [],
+            self._StopLoop(),
+        ]
+
+        with self.assertRaises(self._StopLoop):
+            mixin_cls.event_loop_overlap_mlx(scheduler)
+
+        scheduler.process_batch_result.assert_called_once()
+        finalized_batch = scheduler.process_batch_result.call_args[0][0]
+        self.assertIsNotNone(
+            finalized_batch.launch_ts,
+            "_launch_fresh must set launch_ts; the MLX overlap loop never "
+            "calls run_batch(), which is where it's normally set.",
+        )
+
+    def test_chained_launch_gets_its_own_launch_ts(self):
+        scheduler, mixin_cls = self._make_scheduler()
+        fresh_batch = _make_fake_schedule_batch(ForwardMode.DECODE)
+
+        scheduler.get_next_batch_to_run.return_value = MagicMock(
+            batch_to_run=fresh_batch, running_batch=None
+        )
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            MagicMock(),  # decode: non-None so chaining is eligible
+            "decode",
+        )
+        scheduler.tp_worker.async_chained_decode_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            MagicMock(),
+            "decode",
+        )
+        scheduler.request_receiver.recv_requests.side_effect = [
+            [],
+            [],
+            self._StopLoop(),
+        ]
+
+        with patch("time.monotonic", side_effect=[100.0, 200.0, 300.0, 400.0]):
+            with self.assertRaises(self._StopLoop):
+                mixin_cls.event_loop_overlap_mlx(scheduler)
+
+        scheduler.process_batch_result.assert_called_once()
+        fresh_launch_ts = scheduler.process_batch_result.call_args[0][0].launch_ts
+        chained_job = scheduler.result_queue.pop()
+        self.assertIsNotNone(chained_job.batch_copy.launch_ts)
+        self.assertNotEqual(
+            chained_job.batch_copy.launch_ts,
+            fresh_launch_ts,
+            "a chained step is a real, separate launch and must get its own "
+            "launch_ts rather than inheriting prev's, or the decode-step "
+            "interval _record_step_counters computes collapses to zero.",
         )
 
 


### PR DESCRIPTION
## Motivation

`SGLANG_USE_MLX=1` is broken on main. The scheduler process dies on its first batch through `event_loop_overlap_mlx`. By default, the failing batch is the startup warmup, so the server never starts. Passing `--skip-server-warmup` gets the server ready and it dies on the first client request instead. Every MLX backend user hits this at startup, not on some rare input.

#32245 (commit `8727d10`) introduced the break. It added a busy time counter to `_record_step_counters`, which reads `batch.launch_ts` unconditionally. Only `Scheduler.run_batch()` assigns `launch_ts`. `event_loop_overlap_mlx` never calls `run_batch()`; it drives the forward pass directly through `tp_worker.async_forward_batch_generation_mlx` and `tp_worker.async_chained_decode_mlx`, so `launch_ts` stays `None` and the first real batch subtracts against `None`.

Traceback, reproduced on current `upstream/main` (`3863612023`):

```
Scheduler hit an exception: Traceback (most recent call last):
  File "python/sglang/srt/managers/scheduler.py", line 4727, in run_scheduler_process
    scheduler.run_event_loop()
  File "python/sglang/srt/managers/scheduler.py", line 1510, in run_event_loop
    dispatch_event_loop(self)
  File "python/sglang/srt/managers/scheduler.py", line 4576, in dispatch_event_loop
    scheduler.event_loop_overlap_mlx()
  File ".../torch/utils/_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
  File "python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py", line 220, in event_loop_overlap_mlx
    self._finalize_mlx_pending_job(pending_curr)
  File "python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py", line 110, in _finalize_mlx_pending_job
    self.process_batch_result(pending.batch_copy, result)
  File "python/sglang/srt/utils/nvtx_utils.py", line 109, in wrapper
    return func(*args, **kwargs)
  File "python/sglang/srt/managers/scheduler.py", line 3640, in process_batch_result
    self._record_step_counters(batch, result)
  File "python/sglang/srt/managers/scheduler.py", line 3663, in _record_step_counters
    span_us = int((time.monotonic() - batch.launch_ts) * 1e6)
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```

Reproduction:

```
PYTHONPATH=<clone>/python SGLANG_USE_MLX=1 HF_HUB_OFFLINE=1 \
  python -m sglang.launch_server \
  --model-path mlx-community/Qwen3-0.6B-4bit \
  --host 127.0.0.1 --port 30001
```

## Modifications

Two fixes are possible: set `launch_ts` on the MLX launch path, or let `_record_step_counters` tolerate a missing value. I took the first. `ScheduleBatch.copy()` already threads `launch_ts` through (`launch_ts=self.launch_ts`, schedule_batch.py:3093), so the only gap is the MLX loop never setting it before `process_batch_result` reads the copy. Tolerating `None` would quietly zero the metric #32245 added rather than close the gap.

`python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py`:

- `_launch_fresh`: sets `batch.launch_ts = time.monotonic()` before `resolve_forward_inputs`, mirroring `run_batch()`, which sets it as its first statement.
- `_launch_chained`: builds its own `batch_copy` and stamps it with a fresh `time.monotonic()` rather than copying `prev.batch_copy` unchanged. A chained step is a separate GPU launch (`async_chained_decode_mlx`, dispatched via `mx.async_eval`), so it needs its own timestamp. Inheriting the previous one would collapse the decode interval to zero on every chained step, dropping most decode steps from `decode_moment_totals` silently rather than crashing.

No other backend or code path reads `launch_ts`. It is written in `run_batch()` (and now here) and read only in `_record_step_counters`.

## Accuracy Tests

`uv run python test/run_suite.py --hw mlx --suite stage-a-unit-test-mlx`: 7/9 files pass, including the new test. The one failure, `test_metal_profiler.py::test_start_profile_success_with_mock_capture`, predates this branch. The same file fails identically against unmodified `upstream/main`.

Added `TestEventLoopOverlapMlxSetsLaunchTs` to `test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py`. Two tests drive `event_loop_overlap_mlx` directly against a mocked scheduler and a minimally constructed `ScheduleBatch`:

- `test_fresh_launch_sets_launch_ts_before_process_batch_result`: asserts the batch handed to `process_batch_result` after a fresh launch has a `launch_ts` that is not `None`.
- `test_chained_launch_gets_its_own_launch_ts`: asserts a chained step's `launch_ts` differs from the step it chained off.

Both fail before the fix and pass after. I verified by stashing the fix, keeping the tests and rerunning:

```
FF..
FAIL: test_chained_launch_gets_its_own_launch_ts
FAIL: test_fresh_launch_sets_launch_ts_before_process_batch_result
Ran 4 tests in 0.009s
FAILED (failures=2)
```

Verified end to end on hardware (Apple Silicon, `mlx-community/Qwen3-0.6B-4bit`):

- Default args: server completes warmup, becomes ready, and answers a `/generate` request with HTTP 200.
- `--skip-server-warmup`: the server becomes ready immediately and answers the first `/generate` request with HTTP 200 (this is the path that used to crash on the first request).
- The counter #32245 added now produces sane values: prefill `span_us=36699`, decode `step_us` between roughly 1900 to 4300 across 19 steps. None are `None`, zero, or absurd.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

cc @cctry: I fixed the launch path rather than guard `_record_step_counters` against a missing `launch_ts`. If you would rather guard the read instead, happy to switch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30232297206](https://github.com/sgl-project/sglang/actions/runs/30232297206)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30232297207](https://github.com/sgl-project/sglang/actions/runs/30232297207)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->