### PR TITLE
Fix false SM120 sparse-prefill test failures for the expected dense fallback

### DIFF
--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsv4_attention.py
@@ -37,6 +37,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.utils.common import is_sm120_supported
 
 # DSV4 backend pre-resolves attention TP at construction; pin to single-rank.
 _parallel_override = get_parallel().override(
@@ -1616,9 +1617,12 @@ def run_dsv4_compress_attention_case(
     against an independent pure-PyTorch SWA + extra reference that reads the
     SAME cache bytes and metadata indices.
 
-    `sparse_prefill` pins `SGLANG_OPT_FLASHMLA_SPARSE_PREFILL`, selecting the
-    dense `flash_mla_with_kvcache` extend path or `_forward_prefill_sparse`;
-    the C4 seeding dispatches on the same flag.
+    `sparse_prefill` pins `SGLANG_OPT_FLASHMLA_SPARSE_PREFILL`, *requesting*
+    `_forward_prefill_sparse`. When `is_sm120_supported()` is true the
+    production guard intentionally selects the dense
+    `flash_mla_with_kvcache_sm120` extend path instead, because
+    `sparse_prefill_fwd` is unsupported there; the C4 seeding and the
+    post-forward path assertion follow the selected path, not the request.
     """
     assert case.compress_ratio in (
         4,
@@ -1635,7 +1639,14 @@ def run_dsv4_compress_attention_case(
         device=device,
         compression_ratios=[case.compress_ratio],
     )
-    fixture.seed_c4_for_sparse_prefill = sparse_prefill
+    # `sparse_prefill_fwd` is unsupported on SM120, so the backend keeps the
+    # dense extend path there even when the env var requests sparse. The env
+    # override below still applies the caller's request unchanged: if the SM120
+    # guard is ever removed or relaxed, the sparse path becomes eligible and the
+    # post-forward assertion below fails instead of silently passing. Everything
+    # downstream keys off the path actually taken.
+    expect_sparse_prefill = sparse_prefill and not is_sm120_supported()
+    fixture.seed_c4_for_sparse_prefill = expect_sparse_prefill
     runner = fixture.runner
     max_context_len = runner.req_to_token_pool.req_to_token.shape[1]
 
@@ -1663,9 +1674,16 @@ def run_dsv4_compress_attention_case(
         # Only `_forward_prefill_sparse` populates `sparse_prefill_cache`;
         # verify the intended path ran before the reference rebuilds metadata.
         sparse_cache = fixture.backend.forward_metadata.sparse_prefill_cache
-        if sparse_prefill:
+        if expect_sparse_prefill:
             testcase.assertIsNotNone(
                 sparse_cache, f"{case.name} did not take _forward_prefill_sparse"
+            )
+        elif sparse_prefill:
+            testcase.assertIsNone(
+                sparse_cache,
+                f"{case.name} took _forward_prefill_sparse on SM120, where "
+                "sparse_prefill_fwd is unsupported and the dense "
+                "flash_mla_with_kvcache_sm120 path must be used instead",
             )
         else:
             testcase.assertIsNone(


### PR DESCRIPTION
## Motivation

`test_compress_attention_cases_sparse_prefill` enables sparse prefill and expects `_forward_prefill_sparse` to populate `sparse_prefill_cache`. On SM120, production intentionally stays on the dense `flash_mla_with_kvcache_sm120` path because `sparse_prefill_fwd` is not supported. The test therefore fails at the path assertion even though the backend selected the expected implementation.

This comes up when running the registered DSV4 attention test directly on an SM120 system, or when trying to add that test to an SM120 runner. No unusual server configuration is required: the test sets the sparse-prefill override itself. Production correctly ignores that request on SM120, but the fixture still seeds metadata for the sparse path and then asserts that its cache was populated. The failure happens before the output is compared with the PyTorch reference.

We are continuing to expand SM120 coverage around DSV4 attention and compression. Follow-up SM120 kernel and dispatch changes need the existing C4/C128 reference test as a quality gate. Without this fix, those changes hit a known false failure before the reference comparison, so the test cannot distinguish a real output regression from the expected fallback. This gives future PRs a usable baseline for proving that SM120 performance work preserves output quality. It also keeps the current limitation explicit: if sparse prefill gains SM120 support later, the path assertion will fail until the test is deliberately updated for that new behavior.

SM120 is not one of the registered runners for this test today. I hit this while running the registered test directly on an RTX PRO 6000 Blackwell.

## Modifications

Use `is_sm120_supported()` when deciding which path to seed and assert. The sparse-prefill env override is still enabled, so the test will fail if the SM120 guard is removed and sparse prefill becomes eligible.

Behavior on non-SM120 systems is unchanged. No serving code is modified.

## Accuracy Tests

RTX PRO 6000 Blackwell (SM120):

```text
TestDSV4AttentionBackendCorrectness.test_compress_attention_cases_sparse_prefill
Ran 1 test in 21.404s
OK
```

Also passed `py_compile`, registered-test validation, Black, isort, Ruff, and `git diff --check`.

## Speed Tests and Profiling

Not applicable; this only changes test setup and assertions.

## Checklist

- [x] Code is formatted and linted.
- [x] The targeted registered test passes on SM120.
- [x] Documentation and speed benchmarks are not applicable to this test-only change.

Prepared with AI assistance.