### PR TITLE
[AMD] Enable gfx1250 sgl-kernel builds

### DIFF
--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
@@ -77,12 +77,23 @@ union BufferResource {
   };
 };
 
+// llvm.amdgcn.raw.buffer.* instructions do not exist on RDNA4 (gfx12).
+// QuickReduce remains runtime-disabled on gfx1250; these stubs only allow the
+// shared ROCm extension to compile for that target.
+#if !defined(__gfx1250__)
 __quickreduce_device_inline__ static int32x4_t buffer_load_dwordx4(
     int32x4_t srsrc, int32_t voffset, int32_t soffset, int32_t aux) __asm("llvm.amdgcn.raw.buffer.load.v4i32");
 
 __quickreduce_device_inline__ static void
 buffer_store_dwordx4(int32x4_t data, int32x4_t srsrc, int32_t voffset, int32_t soffset, int32_t aux) __asm(
     "llvm.amdgcn.raw.buffer.store.v4i32");
+#else
+__quickreduce_device_inline__ static int32x4_t
+buffer_load_dwordx4(int32x4_t srsrc, int32_t voffset, int32_t soffset, int32_t aux) {}
+
+__quickreduce_device_inline__ static void
+buffer_store_dwordx4(int32x4_t data, int32x4_t srsrc, int32_t voffset, int32_t soffset, int32_t aux) {}
+#endif
 
 __quickreduce_device_inline__ static void set_fp16_ovfl(bool const value) {
 #if defined(__gfx942__)

--- a/python/sglang/kernels/aot/setup_rocm.py
+++ b/python/sglang/kernels/aot/setup_rocm.py
@@ -74,9 +74,9 @@ if torch.cuda.is_available():
 else:
     print(f"Warning: torch.cuda not available. Using default target: {amdgpu_target}")
 
-if amdgpu_target not in ["gfx942", "gfx950"]:
+if amdgpu_target not in ["gfx942", "gfx950", "gfx1250"]:
     print(
-        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942' or 'gfx950'."
+        f"Warning: Unsupported GPU architecture detected '{amdgpu_target}'. Expected 'gfx942', 'gfx950', or 'gfx1250'."
     )
     sys.exit(1)
 
@@ -87,7 +87,7 @@ fp8_macro = (
 # Dynamic shared-memory budget for the TopK kernels.
 # - gfx942 (MI300/MI325): LDS is typically 64KB per workgroup -> keep dynamic smem <= ~48KB
 #   (leaves room for static shared allocations in the kernel).
-# - gfx95x (MI350): LDS is larger (e.g. 160KB per CU) -> allow the original 128KB dynamic smem.
+# - gfx95x (MI350) and gfx1250: LDS is larger -> allow the original 128KB dynamic smem.
 topk_dynamic_smem_bytes = 48 * 1024 if amdgpu_target == "gfx942" else 32 * 1024 * 4
 
 hipcc_flags = [
@@ -126,5 +126,4 @@ setup(
     package_dir={"": "python"},
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension.with_options(use_ninja=True)},
-    options={"bdist_wheel": {"py_limited_api": "cp39"}},
 )


### PR DESCRIPTION
## Motivation

The ROCm `sgl-kernel` build rejects gfx1250, and its QuickReduce translation unit references raw-buffer intrinsics that are unavailable on gfx12. The ROCm wheel is also tagged as ABI3 even though `common_ops` is CPython-specific.

## Modifications

- Allow `gfx1250` as an `AMDGPU_TARGET`, using E4M3 and the existing 128 KiB TopK shared-memory budget.
- Guard the unavailable raw-buffer intrinsics when compiling for gfx1250. QuickReduce remains runtime-disabled on this architecture.
- Let wheel tooling emit the correct CPython-specific tag instead of forcing `cp39-abi3`.

## Accuracy Tests

No model execution behavior changes. The ROCm extension was built and imported on gfx1250, and its basic GPU operator smoke tests passed.

Additional checks:

- Focused pre-commit hooks passed.
- `setup_rocm.py` syntax validation passed.
- Setup metadata validation confirmed the gfx1250 target, E4M3 mode, 128 KiB TopK shared-memory budget, and non-ABI3 extension metadata.
- QuickReduce's runtime architecture gate remains unchanged and excludes gfx1250.

## Speed Tests and Profiling

Not applicable; this changes build support and packaging metadata only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31129329697](https://github.com/sgl-project/sglang/actions/runs/31129329697)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #31129329631](https://github.com/sgl-project/sglang/actions/runs/31129329631)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->