### PR TITLE
Free draft's duplicate embed/lm_head before KV cache sizing

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -178,6 +178,19 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
+        # Share the target's embed/lm_head here rather than in
+        # alloc_memory_pool(): the scheduler only reaches that after
+        # init_target_memory_pool() has profiled free memory to size the KV
+        # cache, so the draft's own copies are still resident when the profile
+        # runs and are freed into a budget that is already fixed. On a large
+        # vocabulary that is several GB (248320 x 5120 fp16 is 2.54 GB each).
+        self.init_token_map()
+        self.init_lm_head()
+        # set_embed_and_head only drops the Parameter refs; without an explicit
+        # release the blocks stay in the caching allocator and still count as
+        # used.
+        torch.cuda.empty_cache()
+
     def alloc_memory_pool(
         self,
         memory_pool_config=None,
@@ -192,8 +205,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             req_to_token_pool=req_to_token_pool,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
-        self.init_token_map()
-        self.init_lm_head()
 
         if self.server_args.speculative_use_rejection_sampling:
             target_vocab_size = self.target_worker.model_config.vocab_size


### PR DESCRIPTION
## Problem

With EAGLE/NEXTN the draft model loads its own `embed_tokens` and `lm_head`, and `init_lm_head()` then frees them and repoints the draft at the target's tensors. Both calls sit at the end of `EagleDraftWorker.alloc_memory_pool()`, which the scheduler only reaches after `init_target_memory_pool()` has already profiled free VRAM to size the KV cache:

```python
def init_memory_pools(self):
    self.init_target_memory_pool()                 # profiles free memory here
    if self.draft_worker is not None:
        self.draft_worker.alloc_memory_pool(...)   # frees the duplicates here
```

So the duplicate vocab tensors are resident when free memory is measured, and are released a moment later into a budget that is already fixed.

At vocab 248320 and hidden size 5120 each of these tensors is 2.54 GB. The target already carries 5.1 GB of them by itself, and the draft's copies take the resident total to roughly 10 GB of vocabulary weights while the profile runs. The draft's half is what never reaches the KV pool.

## Fix

Move `init_token_map()` / `init_lm_head()` into `EagleDraftWorker.__init__`. Both models are constructed by the end of `__init__` and neither call touches a memory pool.

`torch.cuda.empty_cache()` is load-bearing rather than cosmetic: `set_embed_and_head` only drops the Parameter references, and without an explicit release the blocks stay in the caching allocator, where `get_available_gpu_memory()` still counts them as used.

## Test

Qwen3.6-27B (vocab 248320, hybrid GDN + attention), NEXTN, `--mem-fraction-static 0.93` unchanged throughout.

Sweeping `vocab_size` with `--load-format dummy` (32k / 128k / 200k / 248k), the KV cache recovered by the patch tracks `2 * vocab * hidden * dtype` to within 0.5%, so what comes back is exactly the two duplicated tensors. Dummy weights make this reproducible without the checkpoint.

`max_total_num_tokens`, same flags on either side:

- H800 80GB, dummy weights on an otherwise idle card: 258395 -> 336027. A real-weight run reproduced the patched figure exactly.
- V100 32GB: 2297 -> 21715 (where this turned up; a small card is just where it stops being invisible)

Greedy output is byte-identical before and after (128 tokens, temperature 0), as expected for a change that only moves when an existing assignment happens.

EAGLE3 recovers about half as much (236208 -> 272741, dummy weights). Drafts that set their own `draft_vocab_size`, which per the comment in `init_lm_head` is the common case, take the `set_embed()` path and share only the embedding, keeping their own lm_head by design. 

No new unit test. The change is a pure move with no new identifiers or config, and the existing EAGLE/MTP tests already cover the sharing path; the effect it fixes is a VRAM accounting one that needs a GPU to observe.

Related but a different root cause: #29857 / #30092, where the per-token cell size is inflated by a config attribute fallback.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30234385853](https://github.com/sgl-project/sglang/actions/runs/30234385853)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30234385751](https://github.com/sgl-project/sglang/actions/runs/30234385751)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->