### PR TITLE
[AMD] Fix pip setup in AMD Miles nightly builds

### DIFF
--- a/.github/workflows/release-docker-amd-miles-rocm700-nightly.yml
+++ b/.github/workflows/release-docker-amd-miles-rocm700-nightly.yml
@@ -38,7 +38,10 @@ jobs:
         run: echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
 
       - name: Install docker/build.py dependencies
-        run: python3 -m pip install --quiet typer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          python3 -m pip install --break-system-packages --quiet typer
 
       - name: Build image via miles docker/build.py and tag with date
         run: |

--- a/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
@@ -37,7 +37,10 @@ jobs:
         run: echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV
 
       - name: Install docker/build.py dependencies
-        run: python3 -m pip install --quiet typer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          python3 -m pip install --break-system-packages --quiet typer
 
       - name: Build image via miles docker/build.py and tag with date
         run: |


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123

## Summary

Fix the AMD Miles nightly image builds by installing `python3-pip` before installing `typer`.

The runners do not have pip available for the system Python, causing the workflows to fail with:

```text
/usr/bin/python3: No module named pip
```

Also use `--break-system-packages` for the system Python environment.

This applies to both the ROCm 7.0 and ROCm 7.2 nightly workflows.

## Test

The same setup was previously verified in a successful manual ROCm 7.2 image build.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30234663485](https://github.com/sgl-project/sglang/actions/runs/30234663485)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30234663423](https://github.com/sgl-project/sglang/actions/runs/30234663423)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->