### PR TITLE
[XPU][Deps] Fix sgl-kernel-xpu package rename in pyproject_xpu.toml

### DIFF
--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -54,7 +54,7 @@ dependencies = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
+  "sglang-kernel-xpu @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",  # distribution renamed from `sgl-kernel` in sgl-kernel-xpu#322
   "smg-grpc-servicer>=0.5.0",
   "soundfile==0.13.1",
   "tiktoken",


### PR DESCRIPTION
## Summary

Rename the `sgl-kernel-xpu` requirement in `python/pyproject_xpu.toml` from `sgl-kernel` to `sglang-kernel-xpu` to match the upstream distribution name.

## Why

[sgl-project/sgl-kernel-xpu#322](https://github.com/sgl-project/sgl-kernel-xpu/pull/322) ("Updates for first release", merged 2026-07-27 03:19 UTC) renamed the built distribution from `sgl-kernel` to `sglang-kernel-xpu`. Because our git-URL requirement was unpinned, pip fetched the new metadata and rejected the install:

```
WARNING: Generating metadata for package sgl-kernel produced metadata
         for project name sglang-kernel-xpu. Fix your #egg=sgl-kernel fragments.
Discarding git+https://github.com/sgl-project/sgl-kernel-xpu.git:
  Requested sglang-kernel-xpu from ... has inconsistent name:
  expected 'sgl-kernel', but metadata has 'sglang-kernel-xpu'
ERROR: No matching distribution found for sgl-kernel (unavailable)
```

Every `pr-test-xpu` run after 03:19 UTC on 2026-07-27 fails at stage-a "Install Dependency" for this reason (example: [run 30235064082](https://github.com/sgl-project/sglang/actions/runs/30235064082/job/89881258481)).

## Test plan

- [ ] `pr-test-xpu` stage-a "Install Dependency" completes and `sglang-kernel-xpu` installs from the git URL
- [ ] Downstream `import sgl_kernel` still resolves (import name is unchanged upstream)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30236230613](https://github.com/sgl-project/sglang/actions/runs/30236230613)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30236230513](https://github.com/sgl-project/sglang/actions/runs/30236230513)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->