### PR TITLE
Fix AttributeError when AutoProcessor resolves to an image-only processor

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -47,6 +47,7 @@ from .tokenizer import (
     _TOKENIZERS_BACKEND,
     _fix_added_tokens_encoding,
     _fix_special_tokens_pattern,
+    get_tokenizer,
 )
 
 
@@ -268,13 +269,30 @@ def get_processor(
     ):
         processor = wrap_as_pixtral(processor, config)
 
-    tokenizer = get_tokenizer_from_processor(processor)
+    if not isinstance(processor, PreTrainedTokenizerBase) and not hasattr(
+        processor, "tokenizer"
+    ):
+        # e.g. InternVL2.5's tokenizer ships as separate remote code.
+        logger.warning(
+            "Processor %s for %s has no tokenizer attribute, loading tokenizer "
+            "separately",
+            type(processor).__name__,
+            tokenizer_name,
+        )
+        tokenizer = get_tokenizer(
+            tokenizer_name,
+            tokenizer_mode=tokenizer_mode,
+            trust_remote_code=trust_remote_code,
+            tokenizer_revision=revision,
+            tokenizer_backend=tokenizer_backend,
+        )
+        processor.tokenizer = tokenizer
+    else:
+        tokenizer = get_tokenizer_from_processor(processor)
 
     # AutoProcessor may internally create a TokenizersBackend tokenizer
     # (same issue as get_tokenizer). Replace it with a properly loaded one.
     if type(tokenizer).__name__ == _TOKENIZERS_BACKEND:
-        from .tokenizer import get_tokenizer
-
         logger.warning(
             "Processor tokenizer for %s is TokenizersBackend, "
             "reloading via get_tokenizer",

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -71,6 +71,33 @@ class TestGetProcessor(unittest.TestCase):
             revision=None,
         )
 
+    def test_loads_tokenizer_separately_for_image_only_processor(self):
+        """Regression for #32169: an AutoProcessor with no .tokenizer (e.g. InternVL2.5's image-only processor) must not raise AttributeError."""
+        config = SimpleNamespace(model_type="internvl_chat", auto_map={})
+        image_only_processor = MagicMock(spec=BaseImageProcessor)
+        fake_tokenizer = MagicMock()
+        fake_tokenizer.chat_template = "template"
+
+        auto_config = MagicMock()
+        auto_config.from_pretrained.return_value = config
+        auto_processor = MagicMock()
+        auto_processor.from_pretrained.return_value = image_only_processor
+        get_tokenizer_mock = MagicMock(return_value=fake_tokenizer)
+
+        self.assertFalse(hasattr(image_only_processor, "tokenizer"))
+
+        with patch.multiple(
+            processor_utils,
+            AutoConfig=auto_config,
+            AutoProcessor=auto_processor,
+            get_tokenizer=get_tokenizer_mock,
+        ):
+            processor = processor_utils.get_processor("OpenGVLab/InternVL2_5-2B")
+
+        get_tokenizer_mock.assert_called_once()
+        self.assertIs(processor, image_only_processor)
+        self.assertIs(processor.tokenizer, fake_tokenizer)
+
 
 # ---------------------------------------------------------------------------
 # _patch_image_processor_kwargs


### PR DESCRIPTION
## Motivation

Fixes #32169. Serving `OpenGVLab/InternVL2_5-2B` crashes at startup: `AutoProcessor.from_pretrained` resolves to a bare image processor (e.g. `CLIPImageProcessor`) because InternVL2.5's tokenizer ships as separate remote code rather than being bundled into a combined `AutoProcessor`. `get_processor`'s unguarded `get_tokenizer_from_processor(processor)` call then does `return processor.tokenizer`, raising `AttributeError` and preventing the server from ever becoming ready.

## Modifications

In `get_processor` (`python/sglang/srt/utils/hf_transformers/processor.py`), detect when the resolved `processor` has no `.tokenizer` attribute (and isn't itself a tokenizer). In that case, load the tokenizer independently via the existing `get_tokenizer(...)` helper (using the same `tokenizer_name`/`revision`/`trust_remote_code` already in scope) and attach it via `processor.tokenizer = tokenizer`, so downstream `get_tokenizer_from_processor(processor)` calls (e.g. in `tokenizer_manager.py`) keep working. This mirrors the existing `TOKENIZERS_BACKEND` reload branch immediately below it in the same function, and the equivalent `hasattr(self._processor, "tokenizer")` guard already used in the runtime `InternVLProcessor`.

## Accuracy Tests

Verified end-to-end on a real GPU using `OpenGVLab/InternVL2_5-2B`:
- Server boots past tokenizer/processor init (previously crashed with `AttributeError: 'CLIPImageProcessorPil' object has no attribute 'tokenizer'`) and reports "The server is fired up and ready to roll!".
- A real `/v1/chat/completions` multimodal request against a sample image returns a correct description: *"A man is ironing a shirt on an ironing board attached to the back of a moving yellow taxi in the middle of a city street."*

## Speed Tests and Profiling

N/A — this only affects processor/tokenizer resolution at startup, not the inference path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) — added `TestGetProcessor.test_loads_tokenizer_separately_for_image_only_processor` regression test in `test/registered/unit/utils/test_hf_transformers.py`.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — not applicable, internal bugfix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) — see Accuracy Tests above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30237039524](https://github.com/sgl-project/sglang/actions/runs/30237039524)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30237039405](https://github.com/sgl-project/sglang/actions/runs/30237039405)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->