### PR TITLE
[KDA] Fuse prefill QKV causal convolution and layout

### DIFF
--- a/benchmark/bench_linear_attention/bench_kda_prefill_qkv.py
+++ b/benchmark/bench_linear_attention/bench_kda_prefill_qkv.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 
 import torch
+
 from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
     fused_qkv_split_gdn_prefill,
 )

--- a/benchmark/bench_linear_attention/bench_kda_prefill_qkv.py
+++ b/benchmark/bench_linear_attention/bench_kda_prefill_qkv.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import argparse
+
+import torch
+from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+    fused_qkv_split_gdn_prefill,
+)
+from sglang.kernels.ops.mamba.causal_conv1d_triton import causal_conv1d_fn
+
+DTYPES = {
+    "bf16": torch.bfloat16,
+    "fp16": torch.float16,
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark KDA prefill three-way QKV preprocessing against fusion."
+    )
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--total-tokens", "--seq-len", type=int, default=8192)
+    parser.add_argument(
+        "--seq-lens",
+        type=str,
+        help="Comma-separated variable sequence lengths; overrides batch/total tokens.",
+    )
+    parser.add_argument("--num-heads", type=int, default=4)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--conv-width", type=int, default=4)
+    parser.add_argument("--dtype", choices=DTYPES, default="bf16")
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=200)
+    return parser.parse_args()
+
+
+def make_inputs(args):
+    if args.seq_lens:
+        seq_lens_cpu = [int(seq_len) for seq_len in args.seq_lens.split(",")]
+        if not seq_lens_cpu or any(seq_len <= 0 for seq_len in seq_lens_cpu):
+            raise ValueError("--seq-lens must contain positive integers")
+        batch_size = len(seq_lens_cpu)
+        total_tokens = sum(seq_lens_cpu)
+    else:
+        if args.total_tokens % args.batch_size != 0:
+            raise ValueError("--total-tokens must be divisible by --batch-size")
+        batch_size = args.batch_size
+        total_tokens = args.total_tokens
+        seq_lens_cpu = [total_tokens // batch_size] * batch_size
+
+    torch.manual_seed(42)
+    dtype = DTYPES[args.dtype]
+    channel_dim = args.num_heads * args.head_dim
+    qkv_dim = 3 * channel_dim
+    query_start_loc = torch.tensor(
+        [0, *torch.tensor(seq_lens_cpu).cumsum(0).tolist()],
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    return {
+        "mixed_qkv": torch.randn(total_tokens, qkv_dim, device="cuda", dtype=dtype),
+        "conv_weights": torch.randn(
+            qkv_dim, args.conv_width, device="cuda", dtype=dtype
+        ),
+        "conv_states": torch.randn(
+            batch_size,
+            qkv_dim,
+            args.conv_width - 1,
+            device="cuda",
+            dtype=dtype,
+        ),
+        "cache_indices": torch.arange(batch_size, device="cuda", dtype=torch.int32),
+        "has_initial_state": torch.ones(batch_size, device="cuda", dtype=torch.bool),
+        "query_start_loc": query_start_loc,
+        "seq_lens_cpu": seq_lens_cpu,
+        "batch_size": batch_size,
+        "total_tokens": total_tokens,
+        "channel_dim": channel_dim,
+    }
+
+
+def run_baseline_conv(inputs, conv_states):
+    outputs = []
+    for qkv, weight, state in zip(
+        inputs["mixed_qkv"].transpose(0, 1).split(inputs["channel_dim"], dim=0),
+        inputs["conv_weights"].split(inputs["channel_dim"], dim=0),
+        conv_states.split(inputs["channel_dim"], dim=1),
+    ):
+        output = causal_conv1d_fn(
+            qkv,
+            weight,
+            None,
+            activation="silu",
+            conv_states=state,
+            has_initial_state=inputs["has_initial_state"],
+            cache_indices=inputs["cache_indices"],
+            query_start_loc=inputs["query_start_loc"],
+            seq_lens_cpu=inputs["seq_lens_cpu"],
+        ).transpose(0, 1)
+        outputs.append(output)
+    return outputs
+
+
+def run_baseline(inputs, args, conv_states):
+    return [
+        output.view(
+            1, inputs["total_tokens"], args.num_heads, args.head_dim
+        ).contiguous()
+        for output in run_baseline_conv(inputs, conv_states)
+    ]
+
+
+def run_packed_conv(inputs, conv_states):
+    mixed_qkv = causal_conv1d_fn(
+        inputs["mixed_qkv"].transpose(0, 1),
+        inputs["conv_weights"],
+        None,
+        activation="silu",
+        conv_states=conv_states,
+        has_initial_state=inputs["has_initial_state"],
+        cache_indices=inputs["cache_indices"],
+        query_start_loc=inputs["query_start_loc"],
+        seq_lens_cpu=inputs["seq_lens_cpu"],
+    ).transpose(0, 1)
+    return mixed_qkv
+
+
+def run_packed_aten(inputs, args, conv_states):
+    mixed_qkv = run_packed_conv(inputs, conv_states)
+    return tuple(
+        tensor.view(
+            1, inputs["total_tokens"], args.num_heads, args.head_dim
+        ).contiguous()
+        for tensor in mixed_qkv.split(inputs["channel_dim"], dim=-1)
+    )
+
+
+def run_fused(inputs, args, conv_states):
+    mixed_qkv = run_packed_conv(inputs, conv_states)
+    return fused_qkv_split_gdn_prefill(
+        mixed_qkv,
+        args.num_heads,
+        args.num_heads,
+        args.num_heads,
+        args.head_dim,
+        args.head_dim,
+        args.head_dim,
+    )
+
+
+def benchmark(fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) * 1000 / iters
+
+
+def main():
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA or ROCm is required")
+
+    inputs = make_inputs(args)
+    baseline_states = inputs["conv_states"].clone()
+    fused_states = inputs["conv_states"].clone()
+    expected = run_baseline(inputs, args, baseline_states)
+    packed_aten_states = inputs["conv_states"].clone()
+    packed_aten = run_packed_aten(inputs, args, packed_aten_states)
+    actual = run_fused(inputs, args, fused_states)
+    for actual_tensor, expected_tensor in zip(packed_aten, expected):
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)
+    for actual_tensor, expected_tensor in zip(actual, expected):
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=0, atol=0)
+    torch.testing.assert_close(packed_aten_states, baseline_states, rtol=0, atol=0)
+    torch.testing.assert_close(fused_states, baseline_states, rtol=0, atol=0)
+
+    baseline_us = benchmark(
+        lambda: run_baseline(inputs, args, inputs["conv_states"]),
+        args.warmup,
+        args.iters,
+    )
+    baseline_conv_us = benchmark(
+        lambda: run_baseline_conv(inputs, inputs["conv_states"]),
+        args.warmup,
+        args.iters,
+    )
+    packed_conv_us = benchmark(
+        lambda: run_packed_conv(inputs, inputs["conv_states"]),
+        args.warmup,
+        args.iters,
+    )
+    packed_aten_us = benchmark(
+        lambda: run_packed_aten(inputs, args, inputs["conv_states"]),
+        args.warmup,
+        args.iters,
+    )
+    fused_us = benchmark(
+        lambda: run_fused(inputs, args, inputs["conv_states"]),
+        args.warmup,
+        args.iters,
+    )
+
+    print(
+        f"device={torch.cuda.get_device_name()} dtype={args.dtype} "
+        f"batch={inputs['batch_size']} tokens={inputs['total_tokens']} "
+        f"seq_lens={inputs['seq_lens_cpu']} "
+        f"heads={args.num_heads} head_dim={args.head_dim} width={args.conv_width}"
+    )
+    print(f"baseline_us={baseline_us:.2f}")
+    print(f"baseline_conv_us={baseline_conv_us:.2f}")
+    print(f"packed_conv_us={packed_conv_us:.2f}")
+    print(f"packed_aten_us={packed_aten_us:.2f}")
+    print(f"packed_triton_us={fused_us:.2f}")
+    print(f"packed_aten_speedup={baseline_us / packed_aten_us:.2f}x")
+    print(f"packed_triton_speedup={baseline_us / fused_us:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -1,6 +1,7 @@
 from typing import Optional, Tuple, Union
 
 import torch
+
 from sglang.kernels.ops.mamba.causal_conv1d_triton import (
     causal_conv1d_fn,
     causal_conv1d_update,

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -1,7 +1,6 @@
 from typing import Optional, Tuple, Union
 
 import torch
-
 from sglang.kernels.ops.mamba.causal_conv1d_triton import (
     causal_conv1d_fn,
     causal_conv1d_update,
@@ -14,8 +13,27 @@ from sglang.srt.layers.attention.linear.utils import (
     get_linear_attn_prefill_backend,
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
-from sglang.srt.utils import is_cpu, is_cuda, is_npu
+from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_npu
 from sglang.srt.utils.common import rank0_log
+
+if is_cuda() or is_hip():
+    from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+        fused_qkv_split_gdn_prefill,
+    )
+
+MAX_FUSED_QKV_SPLIT_DIM = 8192
+MAX_FUSED_QKV_BYTES = 32 * 1024 * 1024
+
+
+def _can_fuse_kda_prefill_qkv(
+    qkv_dim: int, qkv_numel: int, qkv_element_size: int
+) -> bool:
+    return (
+        (is_cuda() or is_hip())
+        and qkv_dim <= MAX_FUSED_QKV_SPLIT_DIM
+        and qkv_numel * qkv_element_size <= MAX_FUSED_QKV_BYTES
+    )
+
 
 # KDA always uses the triton causal_conv1d_fn (no CUDA override).
 # Only causal_conv1d_update needs platform-specific overrides for decode.
@@ -415,54 +433,82 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 self.forward_metadata.conv_states_mask_indices
             ] = mixed_qkv[self.forward_metadata.track_conv_indices]
 
-        splits = [layer.q_dim, layer.k_dim, layer.v_dim]
-        q, k, v = mixed_qkv.transpose(0, 1).split(splits, dim=0)
-        q_conv_weight, k_conv_weight, v_conv_weight = layer.conv_weights.split(
-            splits, dim=0
+        qkv_dim = layer.q_dim + layer.k_dim + layer.v_dim
+        use_fused_qkv = _can_fuse_kda_prefill_qkv(
+            qkv_dim,
+            mixed_qkv.numel(),
+            mixed_qkv.element_size(),
         )
-        q_conv_state, k_conv_state, v_conv_state = conv_states.split(splits, dim=-2)
-        if layer.bias is not None:
-            q_bias, k_bias, v_bias = layer.bias.split(splits, dim=0)
+        if use_fused_qkv:
+            mixed_qkv = causal_conv1d_fn(
+                mixed_qkv.transpose(0, 1),
+                layer.conv_weights,
+                layer.bias,
+                activation="silu",
+                conv_states=conv_states,
+                has_initial_state=has_initial_state,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            ).transpose(0, 1)
+            q, k, v = fused_qkv_split_gdn_prefill(
+                mixed_qkv,
+                layer.num_q_heads,
+                layer.num_k_heads,
+                layer.num_v_heads,
+                layer.head_q_dim,
+                layer.head_k_dim,
+                layer.head_v_dim,
+            )
         else:
-            q_bias, k_bias, v_bias = None, None, None
+            splits = [layer.q_dim, layer.k_dim, layer.v_dim]
+            q, k, v = mixed_qkv.transpose(0, 1).split(splits, dim=0)
+            q_conv_weight, k_conv_weight, v_conv_weight = layer.conv_weights.split(
+                splits, dim=0
+            )
+            q_conv_state, k_conv_state, v_conv_state = conv_states.split(splits, dim=-2)
+            if layer.bias is not None:
+                q_bias, k_bias, v_bias = layer.bias.split(splits, dim=0)
+            else:
+                q_bias, k_bias, v_bias = None, None, None
 
-        q = causal_conv1d_fn(
-            q,
-            q_conv_weight,
-            q_bias,
-            activation="silu",
-            conv_states=q_conv_state,
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        ).transpose(0, 1)
-        k = causal_conv1d_fn(
-            k,
-            k_conv_weight,
-            k_bias,
-            activation="silu",
-            conv_states=k_conv_state,
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        ).transpose(0, 1)
-        v = causal_conv1d_fn(
-            v,
-            v_conv_weight,
-            v_bias,
-            activation="silu",
-            conv_states=v_conv_state,
-            has_initial_state=has_initial_state,
-            cache_indices=cache_indices,
-            query_start_loc=query_start_loc,
-            seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
-        ).transpose(0, 1)
+            q = causal_conv1d_fn(
+                q,
+                q_conv_weight,
+                q_bias,
+                activation="silu",
+                conv_states=q_conv_state,
+                has_initial_state=has_initial_state,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            ).transpose(0, 1)
+            k = causal_conv1d_fn(
+                k,
+                k_conv_weight,
+                k_bias,
+                activation="silu",
+                conv_states=k_conv_state,
+                has_initial_state=has_initial_state,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            ).transpose(0, 1)
+            v = causal_conv1d_fn(
+                v,
+                v_conv_weight,
+                v_bias,
+                activation="silu",
+                conv_states=v_conv_state,
+                has_initial_state=has_initial_state,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                seq_lens_cpu=forward_batch.extend_seq_lens_cpu,
+            ).transpose(0, 1)
 
-        q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
-        k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
-        v = v.unflatten(-1, (-1, layer.head_v_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
+            q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)
+            k = k.unflatten(-1, (-1, layer.head_k_dim)).unsqueeze(0)
+            v = v.unflatten(-1, (-1, layer.head_v_dim)).unsqueeze(0)
 
         track_ssm = self.forward_metadata.has_mamba_track_mask
         core_attn_out = self.kernel_dispatcher.extend(

--- a/test/registered/attention/test_kda_prefill_qkv.py
+++ b/test/registered/attention/test_kda_prefill_qkv.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import torch
+
 from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
     fused_qkv_split_gdn_prefill,
 )

--- a/test/registered/attention/test_kda_prefill_qkv.py
+++ b/test/registered/attention/test_kda_prefill_qkv.py
@@ -1,0 +1,314 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+    fused_qkv_split_gdn_prefill,
+)
+from sglang.kernels.ops.mamba.causal_conv1d_triton import causal_conv1d_fn
+from sglang.srt.layers.attention.linear import kda_backend
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=12, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=12, stage="stage-b", runner_config="1-gpu-large-amd")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA or ROCm")
+class TestKDAPrefillQKV(unittest.TestCase):
+    def setUp(self):
+        self._configure_case(
+            dtype=torch.bfloat16,
+            conv_width=4,
+            head_counts=(4, 4, 4),
+            head_dims=(128, 128, 128),
+            initial_state_mask=(True, False, True),
+            use_bias=True,
+        )
+
+    def _configure_case(
+        self,
+        *,
+        dtype,
+        conv_width,
+        head_counts,
+        head_dims,
+        initial_state_mask,
+        use_bias,
+    ):
+        torch.manual_seed(42)
+        self.batch_size = 3
+        self.seq_lens_cpu = [67, 128, 35]
+        self.total_tokens = sum(self.seq_lens_cpu)
+        self.head_counts = head_counts
+        self.head_dims = head_dims
+        self.channel_dims = tuple(
+            head_count * head_dim
+            for head_count, head_dim in zip(head_counts, head_dims)
+        )
+        self.qkv_dim = sum(self.channel_dims)
+        self.conv_width = conv_width
+        self.pool_size = 8
+        self.device = "cuda"
+        self.dtype = dtype
+
+        self.mixed_qkv = torch.randn(
+            self.total_tokens,
+            self.qkv_dim,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        self.conv_weights = torch.randn(
+            self.qkv_dim,
+            self.conv_width,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        self.conv_bias = (
+            torch.randn(self.qkv_dim, device=self.device, dtype=self.dtype)
+            if use_bias
+            else None
+        )
+        self.initial_states = torch.randn(
+            self.pool_size,
+            self.qkv_dim,
+            self.conv_width - 1,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        self.cache_indices = torch.tensor(
+            [1, 6, 3], device=self.device, dtype=torch.int32
+        )
+        self.has_initial_state = torch.tensor(
+            initial_state_mask, device=self.device, dtype=torch.bool
+        )
+        self.query_start_loc = torch.tensor(
+            [0, 67, 195, 230], device=self.device, dtype=torch.int32
+        )
+
+    def _run_baseline(self):
+        conv_states = self.initial_states.clone()
+        outputs = []
+        biases = (
+            self.conv_bias.split(self.channel_dims, dim=0)
+            if self.conv_bias is not None
+            else (None, None, None)
+        )
+        for qkv, weight, bias, state, head_count, head_dim in zip(
+            self.mixed_qkv.transpose(0, 1).split(self.channel_dims, dim=0),
+            self.conv_weights.split(self.channel_dims, dim=0),
+            biases,
+            conv_states.split(self.channel_dims, dim=1),
+            self.head_counts,
+            self.head_dims,
+        ):
+            output = causal_conv1d_fn(
+                qkv,
+                weight,
+                bias,
+                activation="silu",
+                conv_states=state,
+                has_initial_state=self.has_initial_state,
+                cache_indices=self.cache_indices,
+                query_start_loc=self.query_start_loc,
+                seq_lens_cpu=self.seq_lens_cpu,
+            ).transpose(0, 1)
+            outputs.append(
+                output.view(1, self.total_tokens, head_count, head_dim).contiguous()
+            )
+        return outputs, conv_states
+
+    def _run_fused(self):
+        conv_states = self.initial_states.clone()
+        mixed_qkv = causal_conv1d_fn(
+            self.mixed_qkv.transpose(0, 1),
+            self.conv_weights,
+            self.conv_bias,
+            activation="silu",
+            conv_states=conv_states,
+            has_initial_state=self.has_initial_state,
+            cache_indices=self.cache_indices,
+            query_start_loc=self.query_start_loc,
+            seq_lens_cpu=self.seq_lens_cpu,
+        ).transpose(0, 1)
+        outputs = fused_qkv_split_gdn_prefill(
+            mixed_qkv,
+            *self.head_counts,
+            *self.head_dims,
+        )
+        return outputs, conv_states
+
+    def test_fused_matches_three_convolutions(self):
+        expected_outputs, expected_states = self._run_baseline()
+        actual_outputs, actual_states = self._run_fused()
+
+        for actual, expected in zip(actual_outputs, expected_outputs):
+            self.assertTrue(actual.is_contiguous())
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        torch.testing.assert_close(actual_states, expected_states, rtol=0, atol=0)
+
+    def test_dtype_width_layout_and_state_variants(self):
+        cases = (
+            {
+                "dtype": torch.float16,
+                "conv_width": 3,
+                "head_counts": (4, 2, 3),
+                "head_dims": (64, 64, 32),
+                "initial_state_mask": (False, False, False),
+                "use_bias": False,
+            },
+            {
+                "dtype": torch.bfloat16,
+                "conv_width": 4,
+                "head_counts": (2, 2, 4),
+                "head_dims": (64, 64, 32),
+                "initial_state_mask": (True, True, True),
+                "use_bias": True,
+            },
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                self._configure_case(**case)
+                expected_outputs, expected_states = self._run_baseline()
+                actual_outputs, actual_states = self._run_fused()
+                for actual, expected in zip(actual_outputs, expected_outputs):
+                    self.assertTrue(actual.is_contiguous())
+                    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                torch.testing.assert_close(
+                    actual_states, expected_states, rtol=0, atol=0
+                )
+
+    def test_fused_dispatch_limits(self):
+        element_size = torch.empty((), dtype=torch.bfloat16).element_size()
+        self.assertTrue(
+            kda_backend._can_fuse_kda_prefill_qkv(
+                kda_backend.MAX_FUSED_QKV_SPLIT_DIM,
+                kda_backend.MAX_FUSED_QKV_BYTES // element_size,
+                element_size,
+            )
+        )
+        self.assertFalse(
+            kda_backend._can_fuse_kda_prefill_qkv(
+                kda_backend.MAX_FUSED_QKV_SPLIT_DIM + 1,
+                1,
+                element_size,
+            )
+        )
+        self.assertFalse(
+            kda_backend._can_fuse_kda_prefill_qkv(
+                kda_backend.MAX_FUSED_QKV_SPLIT_DIM,
+                kda_backend.MAX_FUSED_QKV_BYTES // element_size + 1,
+                element_size,
+            )
+        )
+
+    def test_forward_extend_dispatches_one_or_three_convolutions(self):
+        qkv_dim = 3 * self.channel_dims[0]
+        total_tokens = 8
+        mixed_qkv = torch.randn(
+            total_tokens, qkv_dim, device=self.device, dtype=self.dtype
+        )
+        cache = SimpleNamespace(
+            conv=[
+                torch.zeros(
+                    2,
+                    self.conv_width - 1,
+                    qkv_dim,
+                    device=self.device,
+                    dtype=self.dtype,
+                )
+            ],
+            temporal=torch.empty(0, device=self.device),
+        )
+        dispatcher = SimpleNamespace(extend=Mock(return_value="core-attn-output"))
+        backend = object.__new__(kda_backend.KDAAttnBackend)
+        backend.req_to_token_pool = SimpleNamespace(
+            mamba2_layer_cache=lambda layer_id: cache
+        )
+        backend.forward_metadata = SimpleNamespace(
+            query_start_loc=torch.tensor(
+                [0, total_tokens], device=self.device, dtype=torch.int32
+            ),
+            mamba_cache_indices=torch.tensor(
+                [0], device=self.device, dtype=torch.int32
+            ),
+            has_mamba_track_mask=False,
+        )
+        backend.kernel_dispatcher = dispatcher
+        layer = SimpleNamespace(
+            layer_id=0,
+            q_dim=self.channel_dims[0],
+            k_dim=self.channel_dims[0],
+            v_dim=self.channel_dims[0],
+            num_q_heads=self.head_counts[0],
+            num_k_heads=self.head_counts[0],
+            num_v_heads=self.head_counts[0],
+            head_q_dim=self.head_dims[0],
+            head_k_dim=self.head_dims[0],
+            head_v_dim=self.head_dims[0],
+            conv_weights=torch.empty(
+                qkv_dim,
+                self.conv_width,
+                device=self.device,
+                dtype=self.dtype,
+            ),
+            bias=None,
+            A_log=None,
+            dt_bias=None,
+        )
+        forward_batch = SimpleNamespace(
+            forward_mode=SimpleNamespace(
+                is_target_verify=lambda: False,
+                is_draft_extend_v2=lambda: False,
+            ),
+            extend_prefix_lens=torch.tensor([0], device=self.device),
+            extend_seq_lens_cpu=[total_tokens],
+        )
+        fused_outputs = tuple(
+            torch.empty(
+                1,
+                total_tokens,
+                self.head_counts[0],
+                self.head_dims[0],
+                device=self.device,
+                dtype=self.dtype,
+            )
+            for _ in range(3)
+        )
+
+        for use_fused, expected_conv_calls in ((True, 1), (False, 3)):
+            with self.subTest(use_fused=use_fused):
+                dispatcher.extend.reset_mock()
+                with (
+                    patch.object(
+                        kda_backend,
+                        "_can_fuse_kda_prefill_qkv",
+                        return_value=use_fused,
+                    ),
+                    patch.object(
+                        kda_backend,
+                        "causal_conv1d_fn",
+                        side_effect=lambda tensor, *args, **kwargs: tensor,
+                    ) as conv_mock,
+                    patch.object(
+                        kda_backend,
+                        "fused_qkv_split_gdn_prefill",
+                        return_value=fused_outputs,
+                    ) as split_mock,
+                ):
+                    output = backend.forward_extend(
+                        layer,
+                        forward_batch,
+                        mixed_qkv,
+                        torch.empty(0, device=self.device),
+                        torch.empty(0, device=self.device),
+                    )
+
+                self.assertEqual(output, "core-attn-output")
+                self.assertEqual(conv_mock.call_count, expected_conv_calls)
+                self.assertEqual(split_mock.call_count, int(use_fused))
+                dispatcher.extend.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

KDA prefill currently launches the same varlen `causal_conv1d_fn` kernel independently for Q, K, and V. For common chunked-prefill working sets, processing the packed QKV channels removes two kernel launches while preserving the same per-channel convolution and state update.

This PR optimizes that preprocessing boundary without changing KDA recurrence, radix-cache semantics, model loading, or backend APIs. It does not depend on unreleased model weights.

## Modifications

- Run one packed QKV `causal_conv1d_fn` call instead of three independent calls when the fused path is eligible.
- Reuse the existing `fused_qkv_split_gdn_prefill` kernel to materialize contiguous `[1, T, H, D]` Q/K/V tensors.
- Limit fusion to CUDA/ROCm inputs with QKV dimension at most 8192 and packed activation size at most 32 MiB.
- Retain the original three-convolution implementation for unsupported devices, larger dimensions, and larger working sets.
- Add registered correctness and dispatch tests.
- Add a standalone benchmark covering equal-length and explicit varlen batches.

The 32 MiB guard is intentional: A100 measurements show that large packed activations lose the locality advantage of processing Q, K, and V separately. The guard avoids the observed large-input regression while scaling with dtype, tensor-parallel head count, and token count.

## Accuracy Tests

The focused test compares the packed and three-call implementations with zero tolerance for both output tensors and the mutated convolution state. Coverage includes bf16/fp16, convolution widths 3/4, equal and asymmetric head layouts, varlen batches, non-contiguous cache slots, mixed/all/none initial-state masks, bias/no-bias paths, output contiguity, dispatch boundaries, and actual `KDAAttnBackend.forward_extend` one-call/three-call routing.

```text
test/registered/attention/test_kda_prefill_qkv.py
4 passed, 4 subtests passed

test/registered/attention/test_kda_kernels.py
14 passed, 3 subtests passed

projected KDA attention + split-op extend backend cases
2 passed, 12 subtests passed
```

Commands:

```bash
PYTHONPATH=python python -m pytest -q test/registered/attention/test_kda_prefill_qkv.py
PYTHONPATH=python python -m pytest -q test/registered/attention/test_kda_kernels.py
PYTHONPATH=python python -m pytest -q \
  test/registered/attention/unittests/kda/test_triton.py::TestTritonKDABackendCorrectness::test_projected_kda_attention_cases \
  test/registered/attention/unittests/kda/test_triton.py::TestTritonKDABackendCorrectness::test_runner_mode_split_op_extend_cases
```

A GPU-hidden import smoke test also confirms that the CPU path resolves the fused dispatch predicate to false and does not access the conditionally imported fused kernel.

## Speed Tests and Profiling

Hardware: NVIDIA A100-SXM4-80GB. Configuration: bf16, four Q/K/V heads, head dimension 128, convolution width 4, 20 warmup iterations, and 200 measured iterations.

| Batch | Total tokens | Baseline (us) | Packed + Triton layout (us) | Raw speedup | Runtime selection |
| ---: | ---: | ---: | ---: | ---: | --- |
| 1 | 512 | 182.27 | 89.16 | 2.04x | packed |
| 4 | 2,048 | 181.07 | 89.30 | 2.03x | packed |
| 4 | 8,192 | 179.77 | 88.14 | 2.04x | packed |
| 4 | 16,384 | 185.90 | 167.09 | 1.11x | baseline fallback |
| 4 | 32,768 | 219.70 | 296.64 | 0.74x | baseline fallback |

Varlen `[512, 1024, 1536, 5120]`, 8,192 total tokens:

```text
baseline_us=184.74
packed_triton_us=90.01
packed_triton_speedup=2.05x
```

Reproduction commands:

```bash
PYTHONPATH=python python benchmark/bench_linear_attention/bench_kda_prefill_qkv.py \
  --batch-size 4 --total-tokens 8192 --warmup 20 --iters 200

PYTHONPATH=python python benchmark/bench_linear_attention/bench_kda_prefill_qkv.py \
  --seq-lens 512,1024,1536,5120 --warmup 20 --iters 200
```

ROCm, SM90, and SM100 performance measurements are follow-up work. The operator correctness test is registered for both CUDA and AMD CI, and the fused splitter already supports the CUDA/ROCm path used by GDN.

## Checklist

- [x] Format the code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). Ruff lint/format and `git diff --check` pass for all touched Python files.
- [x] Add unit tests according to the [unit-test guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to the [documentation guide](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing API or configuration changes require product documentation; the benchmark and test coverage are included in this PR.
- [x] Provide accuracy and speed benchmark results according to the [accuracy guide](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [speed guide](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang [code-style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30239725108](https://github.com/sgl-project/sglang/actions/runs/30239725108)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30239725063](https://github.com/sgl-project/sglang/actions/runs/30239725063)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->