### PR TITLE
[HiCache] Add canary sentinel verification for unified tree MHA/SWA

### DIFF
--- a/python/sglang/srt/kv_canary/pool_patcher/api.py
+++ b/python/sglang/srt/kv_canary/pool_patcher/api.py
@@ -61,6 +61,9 @@ def attach_canary_buffers(
         read_bytes=read_bytes,
         kv_token_id_vs_position_offset=kv_token_id_vs_position_offset,
     )
+    pool.canary_buffer_groups = groups
+    pool.canary_real_kv_hash_mode = config.real_kv_hash_mode
+    pool.canary_real_kv_read_bytes = read_bytes
     logger.info(
         "attach_canary_buffers: pool=%s attacher=%s read_bytes=%d n_groups=%d kinds=%s "
         "kv_token_id_vs_position_offset=%d",

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -62,6 +62,8 @@ class PoolName(str, Enum):
     MAMBA = "mamba"
     SWA = "swa"
     INDEXER = "indexer"
+    CANARY = "canary"
+    CANARY_SWA = "canary_swa"
     # TODO(hzh0425): Current DeepSeek V4 pool naming is verbose; will be normalized to
     # 'COMPRESSED_KV / COMPRESSED_INDEXER / COMPRESSED_STATE' in the next PR.
     DEEPSEEK_V4_C4 = "deepseek_v4_c4"
@@ -357,7 +359,6 @@ class MetadataCache:
 
 
 class HiCacheFile(HiCacheStorage):
-
     def __init__(
         self, storage_config: HiCacheStorageConfig, file_path: str = "/tmp/hicache"
     ):

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+from sglang.kernels.ops.kv_canary.consts import RealKvHashMode
 from sglang.srt.mem_cache.hicache_storage import (
     PoolHitPolicy,
     PoolName,
@@ -32,6 +33,7 @@ from sglang.srt.mem_cache.unified_cache_components import ComponentType
 if TYPE_CHECKING:
     import torch
 
+    from sglang.srt.kv_canary.buffer_group import CanaryBufferGroup
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
     from sglang.srt.mem_cache.hi_mamba_radix_cache import HiMambaRadixCache
     from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
@@ -125,6 +127,59 @@ def build_pool_entry(
     )
 
 
+def _build_canary_entry(
+    *,
+    kv_pool: Any,
+    kv_host_pool: Any,
+    transfer_layer_num: int,
+    canary_group: Optional[CanaryBufferGroup] = None,
+    pool_name: PoolName = PoolName.CANARY,
+) -> Optional[PoolEntry]:
+    """Build a kv-canary sidecar PoolEntry, or None when canary is off."""
+    if canary_group is not None:
+        group = canary_group
+    else:
+        groups = getattr(kv_pool, "canary_buffer_groups", None)
+        if not groups or len(groups) != 1:
+            return None
+        group = groups[0]
+
+    from sglang.srt.environ import envs
+    from sglang.srt.mem_cache.pool_host.canary import CanaryPoolHost
+
+    v_half_enabled = envs.SGLANG_KV_CANARY_ENABLE_MHA_V.get()
+    device_bufs = {"k_head": group.k_head, "k_tail": group.k_tail}
+    if group.v_head is not None and v_half_enabled:
+        device_bufs["v_head"] = group.v_head
+    if group.v_tail is not None and v_half_enabled:
+        device_bufs["v_tail"] = group.v_tail
+    canary_host = CanaryPoolHost(
+        device_num_slots=int(group.k_tail.shape[0]),
+        host_num_slots=kv_host_pool.size,
+        device_bufs=device_bufs,
+        pin_memory=kv_host_pool.pin_memory,
+        can_use_write_back_jit=getattr(kv_host_pool, "can_use_write_back_jit", False),
+        can_use_jit=getattr(kv_host_pool, "can_use_jit", False),
+        host_kv_k_buffer=getattr(kv_host_pool, "k_buffer", None),
+        host_kv_v_buffer=getattr(kv_host_pool, "v_buffer", None),
+        host_kv_layout=getattr(kv_host_pool, "layout", None),
+        host_kv_page_size=getattr(kv_host_pool, "page_size", 1),
+        host_kv_layer_num=getattr(kv_host_pool, "layer_num", 0),
+        real_kv_hash_mode=getattr(
+            kv_pool, "canary_real_kv_hash_mode", RealKvHashMode.NONE
+        ),
+        real_kv_read_bytes=getattr(kv_pool, "canary_real_kv_read_bytes", 0),
+        pool_name=str(pool_name),
+    )
+    return build_pool_entry(
+        name=pool_name,
+        host_pool=canary_host,
+        device_pool=kv_pool,
+        layer_mapping={0: 0},
+        transfer_layer_num=transfer_layer_num,
+    )
+
+
 def build_kv_only_stack(
     *,
     params: CacheInitParams,
@@ -158,6 +213,13 @@ def build_kv_only_stack(
             is_anchor=True,
         )
     ]
+    canary_entry = _build_canary_entry(
+        kv_pool=kv_pool,
+        kv_host_pool=kv_host_pool,
+        transfer_layer_num=transfer_layer_num,
+    )
+    if canary_entry is not None:
+        entries.append(canary_entry)
     host_pool_group = HostPoolGroup(entries)
     cache_controller = HybridCacheController(
         params.token_to_kv_pool_allocator,
@@ -197,6 +259,7 @@ def build_hybrid_swa_stack(
     model_name: Optional[str] = None,
     storage_backend_extra_config: Optional[dict] = None,
     enable_storage_metrics: bool = False,
+    swa_kv_pool_outer: Optional[Any] = None,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = len(full_layer_mapping | swa_layer_mapping)
     kv_host_size = swa_host_size = None
@@ -242,6 +305,27 @@ def build_hybrid_swa_stack(
             device_free_fn=swa_attn_allocator.free,
         ),
     ]
+    if swa_kv_pool_outer is not None:
+        canary_groups = getattr(swa_kv_pool_outer, "canary_buffer_groups", None)
+        if canary_groups and len(canary_groups) == 2:
+            full_canary = _build_canary_entry(
+                kv_pool=swa_kv_pool_outer,
+                kv_host_pool=kv_host_pool,
+                transfer_layer_num=transfer_layer_num,
+                canary_group=canary_groups[0],
+                pool_name=PoolName.CANARY,
+            )
+            if full_canary is not None:
+                entries.append(full_canary)
+            swa_canary = _build_canary_entry(
+                kv_pool=swa_kv_pool_outer,
+                kv_host_pool=swa_host_pool,
+                transfer_layer_num=transfer_layer_num,
+                canary_group=canary_groups[1],
+                pool_name=PoolName.CANARY_SWA,
+            )
+            if swa_canary is not None:
+                entries.append(swa_canary)
     host_pool_group = HostPoolGroup(entries)
     cache_controller = HybridCacheController(
         params.token_to_kv_pool_allocator,
@@ -820,9 +904,7 @@ class StackStrategy:
 
 class _DeepSeekV4Strategy(StackStrategy):
     def matches(self, kvcache, components):
-        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
-            DeepSeekV4TokenToKVPool,
-        )
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 
         return isinstance(kvcache, DeepSeekV4TokenToKVPool) and components == {
             ComponentType.FULL,
@@ -963,9 +1045,7 @@ def _swa_layer_mappings(kvcache) -> tuple[dict[int, int], dict[int, int]]:
 
 class _SwaStrategy(StackStrategy):
     def matches(self, kvcache, components):
-        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
-            DeepSeekV4TokenToKVPool,
-        )
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
         from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 
         return (
@@ -1007,6 +1087,23 @@ class _SwaStrategy(StackStrategy):
             model_name=model_name,
             storage_backend_extra_config=storage_backend_extra_config,
             enable_storage_metrics=enable_storage_metrics,
+            swa_kv_pool_outer=kvcache,
+        )
+        canary_groups = getattr(kvcache, "canary_buffer_groups", None)
+        sidecars = (
+            [
+                SidecarPoolSpec(
+                    pool_name=PoolName.CANARY,
+                    indices_from_pool=PoolName.KV,
+                ),
+                SidecarPoolSpec(
+                    pool_name=PoolName.CANARY_SWA,
+                    indices_from_pool=PoolName.SWA,
+                    hit_policy=PoolHitPolicy.TRAILING_PAGES,
+                ),
+            ]
+            if canary_groups and len(canary_groups) == 2
+            else []
         )
         return StackBuildResult(
             host_pool_group=host_pool_group,
@@ -1015,6 +1112,7 @@ class _SwaStrategy(StackStrategy):
                 ComponentType.FULL: host_pool_group.get_pool(PoolName.KV),
                 ComponentType.SWA: host_pool_group.get_pool(PoolName.SWA),
             },
+            sidecars=sidecars,
             transfer_layer_num=len(full_layer_mapping | swa_layer_mapping),
             pools_desc="KV + SWA",
         )
@@ -1022,9 +1120,7 @@ class _SwaStrategy(StackStrategy):
 
 class _MambaSwaStrategy(StackStrategy):
     def matches(self, kvcache, components):
-        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
-            DeepSeekV4TokenToKVPool,
-        )
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
         from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 
         return (
@@ -1217,9 +1313,7 @@ class _MiniMaxSparseStrategy(StackStrategy):
 
 class _PlainKvStrategy(StackStrategy):
     def matches(self, kvcache, components):
-        from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
-            DeepSeekV4TokenToKVPool,
-        )
+        from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
         from sglang.srt.mem_cache.memory_pool import (
             DSATokenToKVPool,
             HybridLinearKVPool,
@@ -1272,12 +1366,19 @@ class _PlainKvStrategy(StackStrategy):
             storage_backend_extra_config=storage_backend_extra_config,
             enable_storage_metrics=enable_storage_metrics,
         )
+        canary_groups = getattr(full_kv_pool, "canary_buffer_groups", None)
+        sidecars = (
+            [SidecarPoolSpec(pool_name=PoolName.CANARY, indices_from_pool=PoolName.KV)]
+            if canary_groups and len(canary_groups) == 1
+            else []
+        )
         return StackBuildResult(
             host_pool_group=host_pool_group,
             cache_controller=cache_controller,
             component_host_pools={
                 ComponentType.FULL: host_pool_group.get_pool(PoolName.KV),
             },
+            sidecars=sidecars,
             transfer_layer_num=len(full_layer_mapping),
             pools_desc="KV",
         )

--- a/python/sglang/srt/mem_cache/pool_host/canary.py
+++ b/python/sglang/srt/mem_cache/pool_host/canary.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, Optional
+
+import torch
+
+from sglang.kernels.ops.kv_canary.consts import (
+    CANARY_FIELD_REAL_KV_HASH,
+    RealKvHashMode,
+    splitmix64,
+)
+from sglang.kernels.ops.kv_canary.verify import CANARY_SLOT_BYTES
+from sglang.kernels.ops.kv_canary.verify_ref import _splitmix64_fold_bytes_scalar
+
+logger = logging.getLogger(__name__)
+
+
+class CanaryPoolHost:
+    """Host-side sidecar pool for kv-canary sentinels."""
+
+    def __init__(
+        self,
+        *,
+        device_num_slots: int,
+        host_num_slots: int,
+        device_bufs: Dict[str, torch.Tensor],
+        pin_memory: bool = True,
+        can_use_write_back_jit: bool = False,
+        can_use_jit: bool = False,
+        host_kv_k_buffer: Optional[torch.Tensor] = None,
+        host_kv_v_buffer: Optional[torch.Tensor] = None,
+        host_kv_layout: Optional[str] = None,
+        host_kv_page_size: int = 1,
+        host_kv_layer_num: int = 0,
+        real_kv_hash_mode: RealKvHashMode = RealKvHashMode.NONE,
+        real_kv_read_bytes: int = 0,
+        pool_name: str = "",
+    ):
+        if device_num_slots <= 0:
+            raise ValueError(
+                f"device_num_slots must be positive, got {device_num_slots}"
+            )
+        if host_num_slots <= 0:
+            raise ValueError(f"host_num_slots must be positive, got {host_num_slots}")
+        if host_num_slots < device_num_slots:
+            logger.warning(
+                "CanaryPoolHost: host_num_slots (%d) < device_num_slots (%d)",
+                host_num_slots,
+                device_num_slots,
+            )
+        if not device_bufs:
+            raise ValueError("device_bufs must not be empty")
+
+        self.device_num_slots = device_num_slots
+        self.host_num_slots = host_num_slots
+        self.pin_memory = pin_memory
+        self.device_bufs: Dict[str, torch.Tensor] = dict(device_bufs)
+
+        for name, buf in self.device_bufs.items():
+            if buf.dtype != torch.uint8:
+                raise ValueError(
+                    f"device buffer {name!r} must be uint8, got {buf.dtype}"
+                )
+            if tuple(buf.shape) != (device_num_slots, CANARY_SLOT_BYTES):
+                raise ValueError(
+                    f"device buffer {name!r} must have shape "
+                    f"({device_num_slots}, {CANARY_SLOT_BYTES}), got {tuple(buf.shape)}"
+                )
+
+        self.host_bufs: Dict[str, torch.Tensor] = {
+            name: torch.zeros(
+                host_num_slots,
+                CANARY_SLOT_BYTES,
+                dtype=torch.uint8,
+                pin_memory=pin_memory,
+            )
+            for name in self.device_bufs
+        }
+
+        self.can_use_write_back_jit = can_use_write_back_jit
+        self.can_use_jit = can_use_jit
+
+        self._host_kv_k_buffer = host_kv_k_buffer
+        self._host_kv_v_buffer = host_kv_v_buffer
+        self._host_kv_layout = host_kv_layout
+        self._host_kv_page_size = host_kv_page_size
+        self._host_kv_layer_num = host_kv_layer_num
+        self._real_kv_hash_mode = real_kv_hash_mode
+        self._real_kv_read_bytes = real_kv_read_bytes
+        self._pool_name = pool_name or "CANARY"
+        if real_kv_hash_mode == RealKvHashMode.PARTIAL:
+            self._effective_read_bytes = 16
+        elif real_kv_hash_mode == RealKvHashMode.ALL:
+            self._effective_read_bytes = 0
+        else:
+            self._effective_read_bytes = 0
+
+    def backup_from_device_all_layer(
+        self, device_pool, host_indices, device_indices, io_backend
+    ) -> None:
+        """D->H: copy sentinels at device_indices into host slots."""
+        if host_indices.numel() == 0:
+            return
+        if host_indices.numel() != device_indices.numel():
+            raise ValueError("host_indices and device_indices must have equal length")
+
+        for name, dev in self.device_bufs.items():
+            host_buf = self.host_bufs[name]
+            h_idx = host_indices.to(host_buf.device)
+            d_idx = device_indices.to(dev.device)
+            host_buf[h_idx] = dev[d_idx].to(host_buf.device)
+
+        self._verify_backup_real_kv_hash(host_indices=host_indices)
+
+    def load_to_device_per_layer(
+        self, device_pool, host_indices, device_indices, layer_id, io_backend
+    ) -> None:
+        """H->D: copy sentinels from host slots back to device_indices."""
+        if host_indices.numel() == 0:
+            return
+        if host_indices.numel() != device_indices.numel():
+            raise ValueError("host_indices and device_indices must have equal length")
+        for name, dev in self.device_bufs.items():
+            host_buf = self.host_bufs[name]
+            h_idx = host_indices.to(host_buf.device)
+            d_idx = device_indices.to(dev.device)
+            dev[d_idx] = host_buf[h_idx].to(dev.device)
+
+    def _get_slot_kv_bytes(
+        self, buffer: torch.Tensor, slot_idx: int, layer: int = 0
+    ) -> Optional[list[int]]:
+        """Extract raw bytes of a single slot from a host KV buffer."""
+        if buffer is None or self._host_kv_layout is None:
+            return None
+
+        layout = self._host_kv_layout
+        page_size = self._host_kv_page_size
+
+        if layout == "layer_first":
+            slot_data = buffer[layer, slot_idx]
+        elif layout == "page_first":
+            slot_data = buffer[slot_idx, layer]
+        elif layout == "page_first_direct":
+            page_idx = slot_idx // page_size
+            page_off = slot_idx % page_size
+            slot_data = buffer[page_idx, layer, page_off]
+        elif layout == "page_head":
+            page_idx = slot_idx // page_size
+            page_off = slot_idx % page_size
+            slot_data = buffer[page_idx, :, page_off, layer]
+        else:
+            return None
+
+        slot_u8 = slot_data.contiguous().view(torch.uint8).reshape(-1)
+        return slot_u8.tolist()
+
+    def _compute_slot_real_kv_hash(
+        self, buffer: torch.Tensor, slot_idx: int
+    ) -> Optional[int]:
+        """Re-compute real_kv_hash for one slot, matching the GPU-side formula."""
+        raw_bytes = self._get_slot_kv_bytes(buffer, slot_idx, layer=0)
+        if raw_bytes is None or len(raw_bytes) == 0:
+            return None
+
+        if self._real_kv_hash_mode == RealKvHashMode.PARTIAL:
+            effective = min(16, len(raw_bytes))
+        elif self._real_kv_hash_mode == RealKvHashMode.ALL:
+            effective = len(raw_bytes)
+        else:
+            return None
+
+        raw_bytes = raw_bytes[:effective]
+        folded = _splitmix64_fold_bytes_scalar(raw_bytes=raw_bytes)
+        return splitmix64(folded)
+
+    @staticmethod
+    def _read_sentinel_field(
+        host_buf: torch.Tensor, slot_idx: int, field_idx: int
+    ) -> int:
+        """Read a uint64 field from a canary sentinel slot (little-endian)."""
+        byte_off = field_idx * 8
+        field_bytes = host_buf[slot_idx, byte_off : byte_off + 8].tolist()
+        return int.from_bytes(bytes(field_bytes), byteorder="little", signed=False)
+
+    def _verify_backup_real_kv_hash(
+        self,
+        *,
+        host_indices: torch.Tensor,
+    ) -> None:
+        """Verify backed-up sentinel hashes against host KV data."""
+        if self._real_kv_hash_mode == RealKvHashMode.NONE:
+            return
+        if self._host_kv_k_buffer is None:
+            return
+        if not os.environ.get("CANARY_VERIFY_BACKUP"):
+            return
+
+        if self.can_use_write_back_jit:
+            torch.cuda.synchronize()
+        else:
+            torch.cuda.current_stream().synchronize()
+
+        k_tail = self.host_bufs.get("k_tail")
+        v_tail = self.host_bufs.get("v_tail")
+        if k_tail is None:
+            return
+
+        h_indices = host_indices.to(k_tail.device)
+        n_slots = int(h_indices.numel())
+
+        mismatches = 0
+        for i in range(n_slots):
+            h_slot = int(h_indices[i].item())
+            if h_slot < 0 or h_slot >= self.host_num_slots:
+                logger.warning(
+                    "CANARY_VERIFY_BACKUP: slot %d out of range [0, %d), skip",
+                    h_slot,
+                    self.host_num_slots,
+                )
+                continue
+
+            stored_k = self._read_sentinel_field(
+                k_tail, h_slot, CANARY_FIELD_REAL_KV_HASH
+            )
+            computed_k = self._compute_slot_real_kv_hash(self._host_kv_k_buffer, h_slot)
+            if computed_k is not None and stored_k != computed_k:
+                mismatches += 1
+                logger.error(
+                    "CANARY_VERIFY_BACKUP MISMATCH [%s]: k_tail slot=%d "
+                    "stored=0x%016X computed=0x%016X",
+                    self._pool_name,
+                    h_slot,
+                    stored_k,
+                    computed_k,
+                )
+            if v_tail is not None and self._host_kv_v_buffer is not None:
+                stored_v = self._read_sentinel_field(
+                    v_tail, h_slot, CANARY_FIELD_REAL_KV_HASH
+                )
+                computed_v = self._compute_slot_real_kv_hash(
+                    self._host_kv_v_buffer, h_slot
+                )
+                if computed_v is not None and stored_v != computed_v:
+                    mismatches += 1
+                    logger.error(
+                        "CANARY_VERIFY_BACKUP MISMATCH [%s]: v_tail slot=%d "
+                        "stored=0x%016X computed=0x%016X",
+                        self._pool_name,
+                        h_slot,
+                        stored_v,
+                        computed_v,
+                    )
+
+        if mismatches > 0:
+            msg = (
+                f"CANARY_VERIFY_BACKUP: {mismatches} hash mismatch(es) across "
+                f"{n_slots} backed-up slots"
+            )
+            raise RuntimeError(msg)
+
+    def clear(self) -> None:
+        for buf in self.host_bufs.values():
+            buf.zero_()


### PR DESCRIPTION


## Motivation

HiCache enables L1 (GPU) ↔ L2 (Host) KV cache transfers to extend effective cache capacity. However, there is no mechanism to verify that sentinel data is correctly preserved during D→H backup and H→D load operations. Silent corruption in the transfer pipeline (stream races, wrong slot mapping, eviction races) can go undetected, leading to degraded model output quality without any error signal.

This PR introduces `CanaryPoolHost`, a sidecar pool that mirrors KV cache sentinel buffers during HiCache transfers, providing:

- **Backup-time verification**: CPU-side `real_kv_hash` re-computation after D→H copy, comparing stored sentinel hashes against freshly computed ones from host KV data.
- **Load-time verification**: Reuses existing kv-canary infrastructure — sentinel buffer layout, splitmix64 hash algorithm, field constants, and the tail verify mechanism. Since H→D load errors manifest as corrupted sentinels on GPU, the existing verify catches them without additional code.

## Modifications

**New file: `python/sglang/srt/mem_cache/pool_host/canary.py` (+265 lines)**
- `CanaryPoolHost` class with `backup_from_device_all_layer` (D→H + CPU verify) and `load_to_device_per_layer` (H→D, no CPU verify — relies on existing verify)
- `_verify_backup_real_kv_hash`: per-slot hash comparison with three gate conditions (mode ≠ NONE, host KV buffer exists, `CANARY_VERIFY_BACKUP` env var set)
- Conditional stream sync: `can_use_write_back_jit=True` → `cuda.synchronize()` (device-wide, because staged write-back kernel may land on a different stream); `can_use_write_back_jit=False` → `current_stream().synchronize()` (stream-level, preserves overlap pipeline)
- 4 host KV layout adapters: `layer_first`, `page_first`, `page_first_direct`, `page_head` (covers MHA, SWA)
- Reserved parameters (`can_use_jit`, `host_kv_layer_num`, `real_kv_read_bytes`) for future extensions

**Modified: `hybrid_pool_assembler.py` (+113 lines)**
- `_build_canary_entry`: builds sidecar `PoolEntry` from `CanaryBufferGroup`, with v_half gate (env-controlled v_head/v_tail inclusion)
- `build_kv_only_stack`: appends canary sidecar for MHA (1 group → CANARY pool)
- `build_hybrid_swa_stack`: appends dual canary sidecars for SWA (2 groups → CANARY for FULL pool, CANARY_SWA for SWA pool)
- `_SwaStrategy` / `_PlainKvStrategy`: `SidecarPoolSpec` registration with `indices_from_pool` routing

**Modified: `api.py` (+3 lines)**
- Attaches `canary_buffer_groups`, `canary_real_kv_hash_mode`, `canary_real_kv_read_bytes` to pool object for assembler consumption

**Modified: `hicache_storage.py` (+2 lines)**
- `PoolName` enum: `CANARY` and `CANARY_SWA`

## Accuracy Tests

Canary mechanism does not alter model forward path — it only reads/copies sentinel metadata in parallel with normal KV transfers. Accuracy verified on MMLU and GSM8K:

| Model | Benchmark | No-Canary (run 1) | No-Canary (run 2) | With-Canary |
|-------|-----------|-------------------|-------------------|-------------|
| Qwen2.5-7B (MHA) | MMLU | 0.6450 | 0.6450 | 0.6450 |
| Qwen2.5-7B (MHA) | GSM8K | 0.5400 | 0.5450 | 0.5500 |
| gpt-oss-20b (SWA) | MMLU | 0.5600 | 0.5900 | 0.5800 |
| gpt-oss-20b (SWA) | GSM8K | 0.2500 | 0.2450 | 0.2550 |

All accuracy differences fall within the model's own non-determinism range (measured by running no-canary twice). Canary introduces zero additional accuracy impact.

**Fault injection tests:**
- With fault injection (backup_post / load_pre): canary detects all injected corruptions via CPU-side hash mismatch (backup) or verify violation (load). 18/18 scenarios PASS across MHA/SWA × overlap on/off × real_data none/partial/all.
- Without fault injection (baseline): zero false positives — no hash mismatch, no verify violation across all baseline scenarios.

## Speed Tests and Profiling

Canary verification is gated behind `CANARY_VERIFY_BACKUP` env var (default: unset → no overhead). When enabled:
- Backup verify operates on sentinel slots only (CANARY_SLOT_BYTES per slot, typically ~40 bytes), not full KV data
- CPU-side hash computation uses scalar splitmix64 (no GPU kernel launch)
- Stream sync uses `current_stream().synchronize()` (stream-level) when `can_use_write_back_jit=False`, preserving the overlap pipeline. Device-wide `cuda.synchronize()` only when write-back JIT is active

No measurable inference speed impact in default configuration.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30324036352](https://github.com/sgl-project/sglang/actions/runs/30324036352)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30324036185](https://github.com/sgl-project/sglang/actions/runs/30324036185)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->