### PR TITLE
[MoE] Add SharedEP, a shared-object expert-parallel backend

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
@@ -367,6 +367,7 @@ struct SiluMulQuantContigParams {
   const bf16_t* __restrict__ input;
   fp8_e4m3_t* __restrict__ output;
   float* __restrict__ output_scale;
+  const int32_t* __restrict__ valid_rows;
   float swiglu_limit;  // only read when kApplySwigluLimit=true
   int64_t hidden_dim;
   uint32_t num_tokens;
@@ -386,6 +387,7 @@ __global__ __launch_bounds__(1024, 2) void  // maximize occupancy
   static_assert(!(kTransposed && !kScaleUE8M0), "transposed layout only supports ue8m0");
 
   const auto token_id = blockIdx.x;
+  if (params.valid_rows != nullptr && token_id >= static_cast<uint32_t>(*params.valid_rows)) return;
   const auto work_id = threadIdx.x / kWorkThreads;
 
   const auto input = params.input + token_id * params.hidden_dim * 2;
@@ -473,6 +475,27 @@ struct SiluAndMulContigPostQuantKernel {
       const tvm::ffi::TensorView output_scale,
       const bool transposed,
       const double swiglu_limit) {
+    run_impl(input, output, output_scale, nullptr, transposed, swiglu_limit);
+  }
+
+  static void run_valid(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView output,
+      const tvm::ffi::TensorView output_scale,
+      const tvm::ffi::TensorView valid_rows,
+      const bool transposed,
+      const double swiglu_limit) {
+    run_impl(input, output, output_scale, &valid_rows, transposed, swiglu_limit);
+  }
+
+ private:
+  static void run_impl(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView output,
+      const tvm::ffi::TensorView output_scale,
+      const tvm::ffi::TensorView* valid_rows,
+      const bool transposed,
+      const double swiglu_limit) {
     using namespace host;
 
     auto device = SymbolicDevice{};
@@ -490,6 +513,12 @@ struct SiluAndMulContigPostQuantKernel {
         .with_dtype<fp8_e4m3_t>()
         .with_device(device)
         .verify(output);
+    if (valid_rows != nullptr) {
+      TensorMatcher({1})  //
+          .with_dtype<int32_t>()
+          .with_device(device)
+          .verify(*valid_rows);
+    }
 
     const auto hidden_dim = N.unwrap();
     RuntimeCheck(D.unwrap() == 2 * hidden_dim, "invalid dimension");
@@ -523,6 +552,7 @@ struct SiluAndMulContigPostQuantKernel {
         .input = static_cast<const bf16_t*>(input.data_ptr()),
         .output = static_cast<fp8_e4m3_t*>(output.data_ptr()),
         .output_scale = static_cast<float*>(output_scale.data_ptr()),
+        .valid_rows = valid_rows == nullptr ? nullptr : static_cast<const int32_t*>(valid_rows->data_ptr()),
         .swiglu_limit = static_cast<float>(swiglu_limit),
         .hidden_dim = hidden_dim,
         .num_tokens = num_tokens,

--- a/python/sglang/kernels/jit/csrc/moe/shared_ep_route_prep.cu
+++ b/python/sglang/kernels/jit/csrc/moe/shared_ep_route_prep.cu
@@ -1,0 +1,210 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+namespace {
+
+#if !defined(SHARED_EP_OWNERS) || !defined(SHARED_EP_MAX_TOKENS) || !defined(SHARED_EP_TOP_K) || \
+    !defined(SHARED_EP_LOCAL_EXPERTS) || !defined(SHARED_EP_BLOCK_M) || !defined(SHARED_EP_THREADS)
+#error "SharedEP route-prep specialization is incomplete"
+#endif
+
+constexpr int kOwners = SHARED_EP_OWNERS;
+constexpr int kMaxTokens = SHARED_EP_MAX_TOKENS;
+constexpr int kTopK = SHARED_EP_TOP_K;
+constexpr int kNumel = kOwners * kMaxTokens * kTopK;
+constexpr int kLocalExperts = SHARED_EP_LOCAL_EXPERTS;
+constexpr int kBlockM = SHARED_EP_BLOCK_M;
+constexpr int kThreads = SHARED_EP_THREADS;
+constexpr int kMaxSorted = kNumel + kLocalExperts * (kBlockM - 1);
+constexpr int kMaxBlocks = (kMaxSorted + kBlockM - 1) / kBlockM;
+
+static_assert(kOwners > 0 && kMaxTokens > 0 && kTopK > 0);
+static_assert(kLocalExperts > 0 && kLocalExperts <= kThreads);
+static_assert(kBlockM > 0);
+static_assert(kThreads > 0 && kThreads <= 1024 && kThreads % 32 == 0);
+
+__global__ void shared_ep_route_prep_kernel(
+    const int32_t* __restrict__ global_ids,
+    const float* __restrict__ global_weights,
+    const uint32_t* __restrict__ ready_signals,
+    const int32_t* __restrict__ ready_epoch,
+    int64_t ids_owner_stride,
+    int64_t ids_token_stride,
+    int64_t weights_owner_stride,
+    int64_t weights_token_stride,
+    int32_t* __restrict__ local_ids,
+    float* __restrict__ local_weights,
+    int32_t* __restrict__ sorted_ids,
+    int32_t max_sorted,
+    int32_t* __restrict__ expert_ids,
+    int32_t max_blocks,
+    int32_t* __restrict__ total_padded,
+    int32_t local_expert_start) {
+  __shared__ int32_t counts[kLocalExperts];
+  __shared__ int32_t starts[kLocalExperts + 1];
+  __shared__ int32_t cursors[kLocalExperts];
+
+  const int tid = threadIdx.x;
+  const uint32_t expected_epoch = static_cast<uint32_t>(*ready_epoch);
+  if (tid < kOwners) {
+    uint32_t observed_epoch;
+    do {
+      asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(observed_epoch) : "l"(ready_signals + tid) : "memory");
+    } while (observed_epoch != expected_epoch);
+  }
+  __syncthreads();
+
+  if (tid < kLocalExperts) counts[tid] = 0;
+  __syncthreads();
+
+  for (int index = tid; index < kNumel; index += blockDim.x) {
+    const int owner = index / (kMaxTokens * kTopK);
+    const int owner_route = index - owner * kMaxTokens * kTopK;
+    const int token = owner_route / kTopK;
+    const int slot = owner_route - token * kTopK;
+    const int32_t global_expert = global_ids[owner * ids_owner_stride + token * ids_token_stride + slot];
+    const int32_t local_expert = global_expert - local_expert_start;
+    const bool valid = local_expert >= 0 && local_expert < kLocalExperts;
+    local_ids[index] = valid ? local_expert : -1;
+    local_weights[index] = global_weights[owner * weights_owner_stride + token * weights_token_stride + slot];
+    if (valid) atomicAdd(&counts[local_expert], 1);
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    int32_t cursor = 0;
+    for (int expert = 0; expert < kLocalExperts; ++expert) {
+      starts[expert] = cursor;
+      cursors[expert] = cursor;
+      cursor += ((counts[expert] + kBlockM - 1) / kBlockM) * kBlockM;
+    }
+    starts[kLocalExperts] = cursor;
+    *total_padded = cursor;
+  }
+  __syncthreads();
+
+  const int32_t padded = starts[kLocalExperts];
+  for (int index = tid; index < padded; index += blockDim.x) {
+    sorted_ids[index] = kNumel;
+  }
+  for (int index = tid; index < max_blocks; index += blockDim.x) {
+    expert_ids[index] = -1;
+  }
+  __syncthreads();
+
+  if (tid < kLocalExperts) {
+    for (int offset = starts[tid]; offset < starts[tid + 1]; offset += kBlockM) {
+      expert_ids[offset / kBlockM] = tid;
+    }
+  }
+  __syncthreads();
+
+  for (int index = tid; index < kNumel; index += blockDim.x) {
+    const int32_t expert = local_ids[index];
+    if (expert >= 0) {
+      const int32_t position = atomicAdd(&cursors[expert], 1);
+      sorted_ids[position] = index;
+    }
+  }
+}
+
+struct SharedEpRoutePrepKernel {
+  static void
+  run(tvm::ffi::TensorView global_ids,
+      tvm::ffi::TensorView global_weights,
+      tvm::ffi::TensorView ready_signals,
+      tvm::ffi::TensorView ready_epoch,
+      tvm::ffi::TensorView local_ids,
+      tvm::ffi::TensorView local_weights,
+      tvm::ffi::TensorView sorted_ids,
+      tvm::ffi::TensorView expert_ids,
+      tvm::ffi::TensorView total_padded,
+      int64_t local_expert_start) {
+    using namespace host;
+
+    RuntimeCheck(global_ids.device().device_type == kDLCUDA, "SharedEP route ids must be CUDA");
+    RuntimeCheck(global_weights.device().device_type == kDLCUDA, "SharedEP route weights must be CUDA");
+    RuntimeCheck(ready_signals.device().device_type == kDLCUDA, "SharedEP ready signals must be CUDA");
+    RuntimeCheck(ready_epoch.device().device_type == kDLCUDA, "SharedEP ready epoch must be CUDA");
+    RuntimeCheck(
+        global_ids.device().device_id == global_weights.device().device_id,
+        "SharedEP route ids and weights must use the same CUDA device");
+    RuntimeCheck(is_type<int32_t>(global_ids.dtype()), "SharedEP route ids must be int32");
+    RuntimeCheck(is_type<float>(global_weights.dtype()), "SharedEP route weights must be float32");
+    RuntimeCheck(is_type<uint8_t>(ready_signals.dtype()), "SharedEP ready signals must be uint8 storage");
+    RuntimeCheck(is_type<int32_t>(ready_epoch.dtype()), "SharedEP ready epoch must be int32");
+    RuntimeCheck(is_type<int32_t>(local_ids.dtype()), "SharedEP local route ids must be int32");
+    RuntimeCheck(is_type<float>(local_weights.dtype()), "SharedEP local route weights must be float32");
+    RuntimeCheck(is_type<int32_t>(sorted_ids.dtype()), "SharedEP sorted route ids must be int32");
+    RuntimeCheck(is_type<int32_t>(expert_ids.dtype()), "SharedEP expert ids must be int32");
+    RuntimeCheck(is_type<int32_t>(total_padded.dtype()), "SharedEP padded route count must be int32");
+    const int device_id = global_ids.device().device_id;
+    RuntimeCheck(
+        ready_signals.device().device_id == device_id && ready_epoch.device().device_id == device_id &&
+            local_ids.device().device_type == kDLCUDA && local_weights.device().device_type == kDLCUDA &&
+            sorted_ids.device().device_type == kDLCUDA && expert_ids.device().device_type == kDLCUDA &&
+            total_padded.device().device_type == kDLCUDA && local_ids.device().device_id == device_id &&
+            local_weights.device().device_id == device_id && sorted_ids.device().device_id == device_id &&
+            expert_ids.device().device_id == device_id && total_padded.device().device_id == device_id,
+        "SharedEP route-prep tensors must use the same CUDA device");
+    RuntimeCheck(global_ids.dim() == 3, "SharedEP route ids must be three-dimensional");
+    RuntimeCheck(global_weights.dim() == 3, "SharedEP route weights must be three-dimensional");
+    RuntimeCheck(
+        global_ids.size(0) == kOwners && global_ids.size(1) == kMaxTokens && global_ids.size(2) == kTopK,
+        "SharedEP route id shape does not match the JIT specialization");
+    RuntimeCheck(
+        global_weights.size(0) == kOwners && global_weights.size(1) == kMaxTokens && global_weights.size(2) == kTopK,
+        "SharedEP route weight shape does not match the JIT specialization");
+    RuntimeCheck(global_ids.stride(2) == 1, "SharedEP route id columns must be contiguous");
+    RuntimeCheck(global_weights.stride(2) == 1, "SharedEP route weight columns must be contiguous");
+    RuntimeCheck(
+        local_ids.numel() == kNumel && local_weights.numel() == kNumel, "invalid SharedEP local route output shape");
+    RuntimeCheck(sorted_ids.numel() == kMaxSorted, "invalid SharedEP sorted route output shape");
+    RuntimeCheck(expert_ids.numel() == kMaxBlocks, "invalid SharedEP expert output shape");
+    RuntimeCheck(total_padded.numel() == 1, "total_padded must have one element");
+    RuntimeCheck(ready_signals.numel() >= kOwners * sizeof(uint32_t), "SharedEP ready signal storage is too small");
+    RuntimeCheck(ready_epoch.numel() == 1, "SharedEP ready epoch must have one element");
+
+    auto device = global_ids.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+    LaunchKernel(dim3(1), dim3(kThreads), stream)(
+        shared_ep_route_prep_kernel,
+        static_cast<const int32_t*>(global_ids.data_ptr()),
+        static_cast<const float*>(global_weights.data_ptr()),
+        static_cast<const uint32_t*>(ready_signals.data_ptr()),
+        static_cast<const int32_t*>(ready_epoch.data_ptr()),
+        global_ids.stride(0),
+        global_ids.stride(1),
+        global_weights.stride(0),
+        global_weights.stride(1),
+        static_cast<int32_t*>(local_ids.data_ptr()),
+        static_cast<float*>(local_weights.data_ptr()),
+        static_cast<int32_t*>(sorted_ids.data_ptr()),
+        static_cast<int32_t>(sorted_ids.numel()),
+        static_cast<int32_t*>(expert_ids.data_ptr()),
+        static_cast<int32_t>(expert_ids.numel()),
+        static_cast<int32_t*>(total_padded.data_ptr()),
+        static_cast<int32_t>(local_expert_start));
+  }
+};
+
+}  // namespace

--- a/python/sglang/kernels/ops/attention/dsv4/moe.py
+++ b/python/sglang/kernels/ops/attention/dsv4/moe.py
@@ -88,7 +88,10 @@ def _jit_silu_mul_quant_contig_module(
         make_name("silu_mul_quant_contig"),
         *args,
         cuda_files=["deepseek_v4/silu_and_mul_masked_post_quant.cuh"],
-        cuda_wrappers=[("run", f"SiluAndMulContigPostQuantKernel<{args}>::run")],
+        cuda_wrappers=[
+            ("run", f"SiluAndMulContigPostQuantKernel<{args}>::run"),
+            ("run_valid", f"SiluAndMulContigPostQuantKernel<{args}>::run_valid"),
+        ],
         extra_cuda_cflags=["-use_fast_math"],
     )
 
@@ -223,15 +226,21 @@ def silu_and_mul_contig_post_quant(
     transposed: bool = False,
     swiglu_limit: Optional[float] = None,
     swizzle: bool = False,
+    valid_rows: Optional[torch.Tensor] = None,
 ) -> None:
     apply_swiglu_limit = swiglu_limit is not None
     module = _jit_silu_mul_quant_contig_module(
         quant_group_size, scale_ue8m0, swizzle, apply_swiglu_limit
     )
-    module.run(
-        input,
-        output,
-        output_scale,
-        transposed,
-        float(swiglu_limit) if apply_swiglu_limit else 0.0,
-    )
+    limit = float(swiglu_limit) if apply_swiglu_limit else 0.0
+    if valid_rows is None:
+        module.run(input, output, output_scale, transposed, limit)
+    else:
+        module.run_valid(
+            input,
+            output,
+            output_scale,
+            valid_rows,
+            transposed,
+            limit,
+        )

--- a/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
@@ -745,6 +745,7 @@ def invoke_fused_moe_kernel(
     add_output_mask: Optional[torch.Tensor] = None,
     mask_output: bool = False,
     lora_preserve_base: bool = False,
+    a_is_prequantized: bool = False,
 ) -> None:
     assert topk_weights.stride(1) == 1
     assert sorted_token_ids.stride(0) == 1
@@ -757,7 +758,15 @@ def invoke_fused_moe_kernel(
     padded_size = 0
     if use_fp8_w8a8:
         assert B_scale is not None
-        if block_shape is None:
+        if a_is_prequantized:
+            assert A.dtype == torch.float8_e4m3fn
+            assert A_scale is not None
+            assert block_shape is not None and len(block_shape) == 2
+            block_n, block_k = block_shape
+            assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
+            assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
+            assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
+        elif block_shape is None:
             # activation tensor-wise fp8 quantization, dynamic or static
             padded_size = padding_size
             # activations apply per-token quantization when weights apply per-channel quantization by default
@@ -782,6 +791,7 @@ def invoke_fused_moe_kernel(
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
     elif use_int8_w8a8:
+        assert not a_is_prequantized, "prequantized A currently supports FP8 only"
         assert B_scale is not None
         if block_shape is None:
             # activation channel-wise int8 quantization
@@ -801,9 +811,11 @@ def invoke_fused_moe_kernel(
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
     elif use_int8_w8a16 or use_int4_w4a16:
+        assert not a_is_prequantized, "prequantized A currently supports FP8 only"
         assert B_scale is not None
         assert block_shape is None or block_shape[0] == 0
     else:
+        assert not a_is_prequantized, "prequantized A currently supports FP8 only"
         assert A_scale is None
         assert B_scale is None
 

--- a/python/sglang/kernels/ops/moe/shared_ep_route_prep.py
+++ b/python/sglang/kernels/ops/moe/shared_ep_route_prep.py
@@ -1,0 +1,171 @@
+"""Shape-specialized CUDA route preparation for SharedEP."""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit
+
+_INT32_MAX = 2**31 - 1
+
+
+def _route_specialization_key(
+    shape: tuple[int, ...],
+    *,
+    num_local_experts: int,
+    block_size_m: int,
+    num_threads: int,
+) -> tuple[int, int, int, int, int, int]:
+    """Validate and return every compile-time specialization dimension."""
+    if len(shape) != 3 or any(
+        type(dimension) is not int or dimension <= 0 for dimension in shape
+    ):
+        raise ValueError("SharedEP CUDA route ids require a non-empty 3D tensor")
+    if type(num_local_experts) is not int or type(block_size_m) is not int:
+        raise ValueError("SharedEP route specialization values must be integers")
+    if type(num_threads) is not int:
+        raise ValueError("SharedEP route specialization values must be integers")
+    if not 0 < num_local_experts <= num_threads:
+        raise ValueError("num_local_experts must be within the CUDA thread count")
+    if block_size_m <= 0:
+        raise ValueError("block_size_m must be positive")
+    if num_threads <= 0 or num_threads > 1024 or num_threads % 32 != 0:
+        raise ValueError("num_threads must be a positive warp multiple up to 1024")
+    owners, max_tokens, top_k = shape
+    route_capacity = owners * max_tokens * top_k
+    max_sorted = route_capacity + num_local_experts * (block_size_m - 1)
+    if route_capacity > _INT32_MAX or max_sorted > _INT32_MAX:
+        raise ValueError("SharedEP route specialization exceeds int32 indexing")
+    return (
+        owners,
+        max_tokens,
+        top_k,
+        num_local_experts,
+        block_size_m,
+        num_threads,
+    )
+
+
+@cache_once
+def _jit_shared_ep_route_prep_module(
+    owners: int,
+    max_tokens: int,
+    top_k: int,
+    num_local_experts: int,
+    block_size_m: int,
+    num_threads: int,
+):
+    suffix = (
+        f"o{owners}_m{max_tokens}_k{top_k}_e{num_local_experts}"
+        f"_b{block_size_m}_t{num_threads}"
+    )
+    return load_jit(
+        "shared_ep_route_prep",
+        suffix,
+        cuda_files=["moe/shared_ep_route_prep.cu"],
+        cuda_wrappers=[
+            ("shared_ep_route_prep", "SharedEpRoutePrepKernel::run"),
+        ],
+        extra_cuda_cflags=[
+            f"-DSHARED_EP_OWNERS={owners}",
+            f"-DSHARED_EP_MAX_TOKENS={max_tokens}",
+            f"-DSHARED_EP_TOP_K={top_k}",
+            f"-DSHARED_EP_LOCAL_EXPERTS={num_local_experts}",
+            f"-DSHARED_EP_BLOCK_M={block_size_m}",
+            f"-DSHARED_EP_THREADS={num_threads}",
+        ],
+    )
+
+
+def prepare_routes_cuda(
+    global_ids: torch.Tensor,
+    global_weights: torch.Tensor,
+    ready_signals: torch.Tensor,
+    ready_epoch: torch.Tensor,
+    *,
+    local_expert_start: int,
+    num_local_experts: int,
+    block_size_m: int,
+    num_threads: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Prepare local routes with a cached specialization of one CUDA template."""
+    if type(local_expert_start) is not int or not (
+        -(2**31) <= local_expert_start <= _INT32_MAX
+    ):
+        raise ValueError("local_expert_start must fit int32")
+    specialization = _route_specialization_key(
+        tuple(global_ids.shape),
+        num_local_experts=num_local_experts,
+        block_size_m=block_size_m,
+        num_threads=num_threads,
+    )
+    if global_weights.shape != global_ids.shape:
+        raise ValueError("SharedEP route id and weight shapes must match")
+    if not global_ids.is_cuda or not global_weights.is_cuda:
+        raise ValueError("SharedEP route ids and weights must be CUDA tensors")
+    if not ready_signals.is_cuda or not ready_epoch.is_cuda:
+        raise ValueError("SharedEP ready signals and epoch must be CUDA tensors")
+    if global_weights.device != global_ids.device:
+        raise ValueError("SharedEP route ids and weights must use the same device")
+    if (
+        ready_signals.device != global_ids.device
+        or ready_epoch.device != global_ids.device
+    ):
+        raise ValueError("SharedEP route data and readiness must use the same device")
+    if global_ids.dtype != torch.int32:
+        raise TypeError("SharedEP route ids must use int32")
+    if global_weights.dtype != torch.float32:
+        raise TypeError("SharedEP route weights must use float32")
+    if ready_signals.dtype != torch.uint8:
+        raise TypeError("SharedEP ready signals must use uint8 storage")
+    if ready_epoch.dtype != torch.int32 or ready_epoch.numel() != 1:
+        raise TypeError("SharedEP ready epoch must be one int32 value")
+    if ready_signals.numel() < global_ids.shape[0] * 4:
+        raise ValueError("SharedEP ready signal storage is too small")
+    if global_ids.stride(2) != 1 or global_weights.stride(2) != 1:
+        raise ValueError("SharedEP route columns must be contiguous")
+
+    local_ids = torch.empty_like(
+        global_ids,
+        memory_format=torch.contiguous_format,
+    )
+    local_weights = torch.empty_like(
+        global_weights,
+        memory_format=torch.contiguous_format,
+    )
+    route_capacity = global_ids.numel()
+    max_sorted = route_capacity + num_local_experts * (block_size_m - 1)
+    sorted_token_ids = torch.empty(
+        max_sorted,
+        dtype=torch.int32,
+        device=global_ids.device,
+    )
+    expert_ids = torch.empty(
+        (max_sorted + block_size_m - 1) // block_size_m,
+        dtype=torch.int32,
+        device=global_ids.device,
+    )
+    num_tokens_post_padded = torch.empty(
+        1,
+        dtype=torch.int32,
+        device=global_ids.device,
+    )
+    _jit_shared_ep_route_prep_module(*specialization).shared_ep_route_prep(
+        global_ids,
+        global_weights,
+        ready_signals,
+        ready_epoch,
+        local_ids,
+        local_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        local_expert_start,
+    )
+    return (
+        local_ids,
+        local_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+    )

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2160,6 +2160,7 @@ _A2A_EP_SPANNING_BACKENDS = frozenset(
         "flashinfer",
         "mori",
         "pplx",
+        "shared_ep",
     }
 )
 

--- a/python/sglang/srt/distributed/device_communicators/vmm_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/vmm_utils.py
@@ -114,7 +114,13 @@ def make_rw_access_desc(device_id: int):
 
 def all_ranks_ok(group: ProcessGroup, ok: bool) -> bool:
     """True iff ``ok`` holds on every rank in ``group`` (BAND all-reduce)."""
-    flag = torch.tensor([1 if ok else 0], dtype=torch.int32)
+    backend = dist.get_backend(group)
+    device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if backend == dist.Backend.NCCL
+        else torch.device("cpu")
+    )
+    flag = torch.tensor([1 if ok else 0], dtype=torch.int32, device=device)
     dist.all_reduce(flag, op=dist.ReduceOp.BAND, group=group)
     return flag.item() == 1
 
@@ -258,10 +264,9 @@ def exchange_posix_fds(
     import threading
 
     sock_kind = getattr(socket, "SOCK_SEQPACKET", socket.SOCK_STREAM)
-    sock_dir = tempfile.mkdtemp(prefix="sgl_ar_fd_")
-    sock_path = os.path.join(sock_dir, f"rank_{rank}.sock")
-    server = socket.socket(socket.AF_UNIX, sock_kind)
-    server.settimeout(_FD_SEND_TIMEOUT_S)
+    sock_dir = None
+    sock_path = None
+    server = None
     received_fds = {}
     errors = []
 
@@ -285,13 +290,37 @@ def exchange_posix_fds(
             errors.append(e)
 
     try:
-        server.bind(sock_path)
-        server.listen(world_size)
+        setup_error = None
+        try:
+            sock_dir = tempfile.mkdtemp(prefix="sgl_ar_fd_")
+            sock_path = os.path.join(sock_dir, f"rank_{rank}.sock")
+            server = socket.socket(socket.AF_UNIX, sock_kind)
+            server.settimeout(_FD_SEND_TIMEOUT_S)
+            server.bind(sock_path)
+            server.listen(world_size)
+        except BaseException as e:
+            setup_error = e
+
+        setup_errors = [None] * world_size
+        setup_error_text = (
+            None
+            if setup_error is None
+            else f"{type(setup_error).__name__}: {setup_error}"
+        )
+        dist.all_gather_object(setup_errors, setup_error_text, group=group)
+        for failed_rank, error_text in enumerate(setup_errors):
+            if error_text is not None:
+                raise RuntimeError(
+                    "POSIX fd listener setup failed on "
+                    f"rank {failed_rank}: {error_text}"
+                ) from setup_error
+
         paths = [None] * world_size
         dist.all_gather_object(paths, sock_path, group=group)
 
         thread = threading.Thread(target=recv_loop, daemon=True)
         thread.start()
+        exchange_error = None
         try:
             for peer_rank, peer_path in enumerate(paths):
                 if peer_rank == rank:
@@ -301,13 +330,33 @@ def exchange_posix_fds(
                     sock.connect(peer_path)
                     for base_idx, fd in enumerate(local_fds):
                         _send_fd(sock, fd, rank, base_idx)
+        except BaseException as e:
+            exchange_error = e
         finally:
             thread.join(_FD_SEND_TIMEOUT_S)
 
-        if thread.is_alive():
-            raise RuntimeError("timed out waiting for POSIX fd exchange")
-        if errors:
-            raise RuntimeError("POSIX fd exchange receive failed") from errors[0]
+        if exchange_error is None and thread.is_alive():
+            exchange_error = RuntimeError("timed out waiting for POSIX fd exchange")
+        if exchange_error is None and errors:
+            exchange_error = RuntimeError(
+                f"POSIX fd exchange receive failed: {errors[0]}"
+            )
+
+        exchange_errors = [None] * world_size
+        exchange_error_text = (
+            None
+            if exchange_error is None
+            else f"{type(exchange_error).__name__}: {exchange_error}"
+        )
+        dist.all_gather_object(exchange_errors, exchange_error_text, group=group)
+        for failed_rank, error_text in enumerate(exchange_errors):
+            if error_text is not None:
+                for fd in received_fds.values():
+                    os.close(fd)
+                received_fds.clear()
+                raise RuntimeError(
+                    f"POSIX fd exchange failed on rank {failed_rank}: {error_text}"
+                ) from exchange_error
 
         expected = {
             (src_rank, base_idx)
@@ -326,15 +375,18 @@ def exchange_posix_fds(
             )
         return received_fds
     finally:
-        server.close()
-        try:
-            os.unlink(sock_path)
-        except FileNotFoundError:
-            pass
-        try:
-            os.rmdir(sock_dir)
-        except OSError:
-            pass
+        if server is not None:
+            server.close()
+        if sock_path is not None:
+            try:
+                os.unlink(sock_path)
+            except FileNotFoundError:
+                pass
+        if sock_dir is not None:
+            try:
+                os.rmdir(sock_dir)
+            except OSError:
+                pass
 
 
 def import_peer_handle(fabric_handle, fd, *, use_fabric: bool, peer_rank: int):

--- a/python/sglang/srt/distributed/device_communicators/vmm_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/vmm_utils.py
@@ -366,13 +366,25 @@ def exchange_posix_fds(
         }
         missing = expected.difference(received_fds)
         extra = set(received_fds).difference(expected)
-        if missing or extra:
-            for fd in received_fds.values():
-                os.close(fd)
-            raise RuntimeError(
-                "POSIX fd exchange mismatch: "
-                f"missing={sorted(missing)[:8]}, extra={sorted(extra)[:8]}"
-            )
+        validation_error = (
+            f"missing={sorted(missing)[:8]}, extra={sorted(extra)[:8]}"
+            if missing or extra
+            else None
+        )
+        validation_errors = [None] * world_size
+        dist.all_gather_object(
+            validation_errors,
+            validation_error,
+            group=group,
+        )
+        for failed_rank, error_text in enumerate(validation_errors):
+            if error_text is not None:
+                for fd in received_fds.values():
+                    os.close(fd)
+                received_fds.clear()
+                raise RuntimeError(
+                    f"POSIX fd validation failed on rank {failed_rank}: {error_text}"
+                )
         return received_fds
     finally:
         if server is not None:

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -89,7 +89,9 @@ class DeepEPMoE(FusedMoE):
             and quant_config is not None
             and quant_config.get_name() == "humming"
         )
-        if is_humming:
+        if get_moe_a2a_backend().is_shared_ep():
+            self.deprecate_flag = True
+        elif is_humming:
             self.deprecate_flag = True
         elif _use_aiter:
             self.deprecate_flag = True
@@ -284,6 +286,7 @@ def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
         or get_moe_a2a_backend().is_mooncake()
         or get_moe_a2a_backend().is_nixl()
         or get_moe_a2a_backend().is_pplx()
+        or get_moe_a2a_backend().is_shared_ep()
     ):
         return DeepEPMoE
     return FusedMoE

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -109,7 +109,16 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
     a2a_backend = get_moe_a2a_backend()
     if a2a_backend.is_none() and is_npu():
         return AscendTPDispatcher(moe_runner_config)
-    elif (
+
+    if a2a_backend.is_shared_ep():
+        from sglang.srt.layers.moe.shared_ep import create_shared_ep_dispatcher
+
+        return create_shared_ep_dispatcher(
+            moe_runner_config,
+            group=_get_deepep_comm_group(a2a_backend),
+        )
+
+    if (
         a2a_backend.is_none()
         or a2a_backend.is_megamoe()
         or a2a_backend.is_ascend_fuseep()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -113,10 +113,7 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
     if a2a_backend.is_shared_ep():
         from sglang.srt.layers.moe.shared_ep import create_shared_ep_dispatcher
 
-        return create_shared_ep_dispatcher(
-            moe_runner_config,
-            group=_get_deepep_comm_group(a2a_backend),
-        )
+        return create_shared_ep_dispatcher(moe_runner_config)
 
     if (
         a2a_backend.is_none()

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -114,7 +114,13 @@ class MoeRunner:
 
         # Skip fused func if LoRA is enabled (LoRA requires non-fused path)
         if not lora_enabled:
-            a2a_backend_name = get_moe_a2a_backend().value
+            a2a_backend = get_moe_a2a_backend()
+            if a2a_backend.is_shared_ep():
+                # SharedEP owns a composite dispatch/GEMM/combine path. Import it
+                # before the one-time fused-op lookup in this runner instance.
+                from sglang.srt.layers.moe import shared_ep  # noqa: F401
+
+            a2a_backend_name = a2a_backend.value
             runner_backend_name = runner_backend.value
 
             # TODO(cwan): add a server argument to disable fused func
@@ -139,6 +145,11 @@ class MoeRunner:
                 "SGLANG_CI_DISABLE_MOE_FUSED_FUNC is set to 1, disabling fused func"
             )
             self.fused_func = None
+        if get_moe_a2a_backend().is_shared_ep() and self.fused_func is None:
+            raise RuntimeError(
+                "SharedEP requires its registered fused execution path; "
+                "the generic runner cannot consume SharedEP decode objects."
+            )
 
     def run(
         self, dispatch_output: DispatchOutput, quant_info: MoeQuantInfo, lora_info=None

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -148,7 +148,7 @@ class MoeRunner:
         if get_moe_a2a_backend().is_shared_ep() and self.fused_func is None:
             raise RuntimeError(
                 "SharedEP requires its registered fused execution path; "
-                "the generic runner cannot consume SharedEP decode objects."
+                "the generic runner cannot consume SharedEP objects."
             )
 
     def run(

--- a/python/sglang/srt/layers/moe/shared_ep/__init__.py
+++ b/python/sglang/srt/layers/moe/shared_ep/__init__.py
@@ -1,0 +1,13 @@
+"""Shared-object expert-parallel backend."""
+
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatcher,
+    create_shared_ep_dispatcher,
+    run_shared_ep,
+)
+
+__all__ = [
+    "SharedEpDispatcher",
+    "create_shared_ep_dispatcher",
+    "run_shared_ep",
+]

--- a/python/sglang/srt/layers/moe/shared_ep/admission.py
+++ b/python/sglang/srt/layers/moe/shared_ep/admission.py
@@ -1,0 +1,56 @@
+"""Release admission checks for the SharedEP backend."""
+
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    RELEASE_MAX_TOKENS_PER_RANK,
+)
+from sglang.srt.model_executor.cuda_graph_config import Backend
+
+
+def validate_shared_ep_server_args(server_args) -> None:
+    if server_args.dp_size != 8:
+        raise ValueError(f"SharedEP release requires DP8, got DP{server_args.dp_size}.")
+    if not server_args.enable_dp_attention:
+        raise ValueError("SharedEP release requires --enable-dp-attention.")
+    if server_args.enable_lora or server_args.lora_paths:
+        raise ValueError("SharedEP release does not support LoRA.")
+
+    if server_args.moe_runner_backend == "auto":
+        server_args.override(
+            "validate_shared_ep_server_args",
+            moe_runner_backend="deep_gemm",
+        )
+    elif server_args.moe_runner_backend != "deep_gemm":
+        raise ValueError(
+            "SharedEP requires --moe-runner-backend deep_gemm for its "
+            "composite decode and prefill path."
+        )
+
+    for enabled, option in (
+        (server_args.enable_two_batch_overlap, "--enable-two-batch-overlap"),
+        (server_args.enable_single_batch_overlap, "--enable-single-batch-overlap"),
+    ):
+        if enabled:
+            raise ValueError(
+                f"SharedEP does not support {option}; its single shared "
+                "epoch state is not staged for overlapping batches."
+            )
+
+    if server_args.speculative_algorithm is not None:
+        raise ValueError(
+            "SharedEP initial release does not support speculative decoding."
+        )
+
+    decode = server_args.cuda_graph_config.decode
+    if decode.backend == Backend.DISABLED:
+        return
+    capture_sizes = list(decode.bs or ())
+    if decode.max_bs is not None:
+        capture_sizes.append(decode.max_bs)
+    largest_capture = max(capture_sizes, default=0)
+    if largest_capture > RELEASE_MAX_TOKENS_PER_RANK:
+        raise ValueError(
+            "SharedEP decode CUDA Graph capacity exceeded: "
+            f"{largest_capture} > {RELEASE_MAX_TOKENS_PER_RANK} local "
+            "tokens per rank. Lower --cuda-graph-max-bs-decode and "
+            "--cuda-graph-bs-decode, or disable decode CUDA Graph."
+        )

--- a/python/sglang/srt/layers/moe/shared_ep/admission.py
+++ b/python/sglang/srt/layers/moe/shared_ep/admission.py
@@ -11,6 +11,18 @@ def validate_shared_ep_server_args(server_args) -> None:
         raise ValueError(f"SharedEP release requires DP8, got DP{server_args.dp_size}.")
     if not server_args.enable_dp_attention:
         raise ValueError("SharedEP release requires --enable-dp-attention.")
+    max_running_requests = RELEASE_MAX_TOKENS_PER_RANK * server_args.dp_size
+    if server_args.max_running_requests is None:
+        server_args.override(
+            "validate_shared_ep_server_args",
+            max_running_requests=max_running_requests,
+        )
+    elif server_args.max_running_requests > max_running_requests:
+        raise ValueError(
+            "SharedEP supports --max-running-requests "
+            f"{max_running_requests} or lower, got "
+            f"{server_args.max_running_requests}."
+        )
     if server_args.enable_lora or server_args.lora_paths:
         raise ValueError("SharedEP release does not support LoRA.")
 

--- a/python/sglang/srt/layers/moe/shared_ep/admission.py
+++ b/python/sglang/srt/layers/moe/shared_ep/admission.py
@@ -1,6 +1,7 @@
 """Release admission checks for the SharedEP backend."""
 
 from sglang.srt.layers.moe.shared_ep.profiles import (
+    RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
     RELEASE_MAX_TOKENS_PER_RANK,
 )
 from sglang.srt.model_executor.cuda_graph_config import Backend
@@ -26,16 +27,20 @@ def validate_shared_ep_server_args(server_args) -> None:
     if server_args.enable_lora or server_args.lora_paths:
         raise ValueError("SharedEP release does not support LoRA.")
 
-    if server_args.moe_runner_backend == "auto":
-        server_args.override(
-            "validate_shared_ep_server_args",
-            moe_runner_backend="deep_gemm",
-        )
-    elif server_args.moe_runner_backend != "deep_gemm":
+    prefill_chunk = server_args.chunked_prefill_size
+    if (
+        prefill_chunk is None
+        or prefill_chunk <= 0
+        or prefill_chunk > RELEASE_MAX_PREFILL_TOKENS_PER_RANK
+    ):
         raise ValueError(
-            "SharedEP requires --moe-runner-backend deep_gemm for its "
-            "composite decode and prefill path."
+            "SharedEP requires the DP-adjusted --chunked-prefill-size to be "
+            f"in [1, {RELEASE_MAX_PREFILL_TOKENS_PER_RANK}], got "
+            f"{prefill_chunk}."
         )
+
+    if server_args.moe_runner_backend not in ("auto", "triton"):
+        raise ValueError("SharedEP requires --moe-runner-backend auto or triton.")
 
     for enabled, option in (
         (server_args.enable_two_batch_overlap, "--enable-two-batch-overlap"),
@@ -43,13 +48,19 @@ def validate_shared_ep_server_args(server_args) -> None:
     ):
         if enabled:
             raise ValueError(
-                f"SharedEP does not support {option}; its single shared "
-                "epoch state is not staged for overlapping batches."
+                f"SharedEP does not support {option}; its phase-local epoch "
+                "states are not staged for overlapping batches."
             )
 
     if server_args.speculative_algorithm is not None:
         raise ValueError(
             "SharedEP initial release does not support speculative decoding."
+        )
+
+    if server_args.cuda_graph_config.prefill.backend != Backend.DISABLED:
+        raise ValueError(
+            "SharedEP prefill CUDA Graph is not supported; disable prefill "
+            "CUDA Graph so the pull-cache consumer is selected at runtime."
         )
 
     decode = server_args.cuda_graph_config.decode

--- a/python/sglang/srt/layers/moe/shared_ep/backend.py
+++ b/python/sglang/srt/layers/moe/shared_ep/backend.py
@@ -11,7 +11,10 @@ from sglang.kernels.ops.attention.dsv4 import silu_and_mul_contig_post_quant
 from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
     invoke_fused_moe_kernel,
 )
-from sglang.srt.layers.dp_attention import get_is_extend_in_batch
+from sglang.srt.layers.dp_attention import (
+    get_dp_global_num_tokens,
+    get_is_extend_in_batch,
+)
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeRunnerConfig,
     PermuteMethodPool,
@@ -87,6 +90,23 @@ def decode_intermediate_capacity(profile: SharedEpProfile) -> int:
         num_local_experts=profile.num_local_experts,
         block_size=profile.block_size_m,
     )
+
+
+def _validate_decode_capacity(profile: SharedEpProfile) -> None:
+    global_num_tokens = get_dp_global_num_tokens()
+    if global_num_tokens is None or len(global_num_tokens) != profile.ep_size:
+        raise RuntimeError(
+            "SharedEP requires the complete DP-Attention token-count vector "
+            "before decode publication"
+        )
+    largest = max(global_num_tokens)
+    if largest > profile.max_tokens_per_rank:
+        failed_rank = global_num_tokens.index(largest)
+        raise ValueError(
+            "SharedEP decode capacity exceeded: "
+            f"rank {failed_rank} has {largest} local tokens, "
+            f"capacity is {profile.max_tokens_per_rank}"
+        )
 
 
 def _get_shared_state(
@@ -168,6 +188,7 @@ class SharedEpDispatcher(BaseDispatcher):
 
         state = self.state
         num_tokens = hidden_states.shape[0]
+        _validate_decode_capacity(self.profile)
         if num_tokens > self.profile.max_tokens_per_rank:
             raise ValueError(
                 "SharedEP decode capacity exceeded: "

--- a/python/sglang/srt/layers/moe/shared_ep/backend.py
+++ b/python/sglang/srt/layers/moe/shared_ep/backend.py
@@ -1,8 +1,8 @@
-"""Composite SharedEP decode backend with a DeepEP/DeepGEMM prefill fallback."""
+"""Shared-object EP backend with direct decode and pull-cache prefill consumers."""
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import torch
 import triton.language as tl
@@ -17,22 +17,28 @@ from sglang.srt.layers.dp_attention import (
 )
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeRunnerConfig,
-    PermuteMethodPool,
     register_fused_func,
 )
-from sglang.srt.layers.moe.moe_runner.deep_gemm import (
-    DeepGemmMoeQuantInfo,
-    DeepGemmRunnerCore,
-)
+from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.shared_ep.kernels import (
     prepare_routes,
     quantize_pack_input,
 )
 from sglang.srt.layers.moe.shared_ep.layout import SharedEpLayout
 from sglang.srt.layers.moe.shared_ep.profiles import (
+    RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
     RELEASE_MAX_TOKENS_PER_RANK,
     SharedEpProfile,
+    make_pull_cache_prefill_profile,
+    resolve_prefill_capacity,
     select_profile,
+)
+from sglang.srt.layers.moe.shared_ep.pull_cache_prefill import (
+    PullCache,
+    allocate_pull_cache,
+    invoke_pull_cache_w13,
+    make_pull_cache_prefill_plan,
+    pull_cache_rows,
 )
 from sglang.srt.layers.moe.shared_ep.state import (
     SharedEpState,
@@ -44,11 +50,9 @@ from sglang.srt.layers.moe.token_dispatcher.base import (
     CombineInputChecker,
     DispatchOutputFormat,
 )
-from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPDispatcher
 from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
 from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
-from sglang.srt.layers.moe.utils import get_deepep_mode, get_moe_runner_backend
-from sglang.srt.runtime_context import get_parallel, get_resources
+from sglang.srt.runtime_context import get_parallel, get_resources, get_schedule
 
 
 class SharedEpDispatchOutput(NamedTuple):
@@ -59,6 +63,8 @@ class SharedEpDispatchOutput(NamedTuple):
     profile: SharedEpProfile
     num_tokens: int
     local_expert_start: int
+    phase: Literal["decode", "prefill"]
+    pull_cache: PullCache | None
 
     @property
     def format(self) -> DispatchOutputFormat:
@@ -80,7 +86,7 @@ def compact_intermediate_capacity(
     return valid_routes + experts_with_routes * (block_size - 1)
 
 
-def decode_intermediate_capacity(profile: SharedEpProfile) -> int:
+def intermediate_capacity(profile: SharedEpProfile) -> int:
     """Worst-case EP-local route capacity for uneven owner batches."""
 
     return compact_intermediate_capacity(
@@ -116,7 +122,10 @@ def _get_shared_state(
     """Return the process-lifetime VMM state shared by all MoE layers."""
 
     resources = get_resources().buffers
-    key = f"shared_ep_{profile.name}_ep{profile.ep_size}"
+    key = (
+        f"shared_ep_{profile.name}_ep{profile.ep_size}"
+        f"_capacity{profile.max_tokens_per_rank}"
+    )
     state = resources.get(key)
     if state is None:
         ep_group = get_parallel().moe_ep_group
@@ -148,11 +157,58 @@ def _get_shared_state(
     return state
 
 
+def _get_shared_pull_cache(profile: SharedEpProfile) -> PullCache:
+    resources = get_resources().buffers
+    key = (
+        f"shared_ep_pull_cache_{profile.name}_ep{profile.ep_size}"
+        f"_capacity{profile.max_tokens_per_rank}"
+    )
+    cache = resources.get(key)
+    if cache is None:
+        plan = make_pull_cache_prefill_plan(
+            owners=profile.ep_size,
+            source_tokens_per_owner=profile.max_tokens_per_rank,
+            hidden_size=profile.hidden_size,
+            top_k=profile.top_k,
+            num_local_experts=profile.num_local_experts,
+            expert_alignment=profile.block_size_m,
+        )
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=plan.cache_rows,
+            device=torch.device("cuda", torch.cuda.current_device()),
+        )
+        resources[key] = cache
+    return cache
+
+
+def select_shared_ep_phase(
+    num_tokens: int,
+    *,
+    is_prefill: bool,
+    prefill_capacity: int,
+    supports_pull_cache_prefill: bool,
+) -> Literal["decode", "prefill"]:
+    if num_tokens < 0:
+        raise ValueError(f"num_tokens must be non-negative, got {num_tokens}")
+    if prefill_capacity <= 0:
+        raise ValueError(f"prefill_capacity must be positive, got {prefill_capacity}")
+    if not is_prefill:
+        return "decode"
+    if not supports_pull_cache_prefill:
+        raise ValueError("SharedEP profile does not support prefill")
+    if num_tokens <= prefill_capacity:
+        return "prefill"
+    raise ValueError(
+        "SharedEP prefill capacity exceeded: "
+        f"{num_tokens} > {prefill_capacity} local tokens per rank"
+    )
+
+
 class SharedEpDispatcher(BaseDispatcher):
     def __init__(
         self,
         config: MoeRunnerConfig,
-        fallback_dispatcher: BaseDispatcher | None = None,
     ):
         super().__init__()
         parallel = get_parallel()
@@ -168,38 +224,70 @@ class SharedEpDispatcher(BaseDispatcher):
         )
         self.config = config
         self.state = _get_shared_state(self.config, self.profile)
+        if self.profile.supports_pull_cache_prefill:
+            prefill_capacity = resolve_prefill_capacity(
+                get_schedule().chunked_prefill_size,
+                release_max_tokens=RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
+            )
+            self.prefill_profile = make_pull_cache_prefill_profile(
+                self.profile,
+                prefill_capacity,
+            )
+            if self.prefill_profile is None:
+                raise RuntimeError("SharedEP pull-cache prefill profile is missing")
+            self.prefill_state = _get_shared_state(self.config, self.prefill_profile)
+            self.prefill_cache = _get_shared_pull_cache(self.prefill_profile)
+        else:
+            self.prefill_profile = self.profile
+            self.prefill_state = None
+            self.prefill_cache = None
         self.local_expert_start = parallel.moe_ep_rank * self.profile.num_local_experts
-        self.fallback_dispatcher = fallback_dispatcher
 
     def dispatch(
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
     ):
-        if get_is_extend_in_batch():
-            if self.fallback_dispatcher is None:
-                raise RuntimeError("SharedEP requires a DeepEP prefill fallback")
-            return self.fallback_dispatcher.dispatch(
-                hidden_states=hidden_states,
-                topk_output=topk_output,
+        is_prefill = get_is_extend_in_batch()
+        global_num_tokens = get_dp_global_num_tokens()
+        if global_num_tokens is None or len(global_num_tokens) != self.profile.ep_size:
+            raise RuntimeError(
+                "SharedEP requires the complete DP-Attention token-count vector "
+                "before publication"
             )
+        phase = select_shared_ep_phase(
+            max(global_num_tokens),
+            is_prefill=is_prefill,
+            prefill_capacity=self.prefill_profile.max_tokens_per_rank,
+            supports_pull_cache_prefill=self.profile.supports_pull_cache_prefill,
+        )
         if not TopKOutputChecker.format_is_standard(topk_output):
-            raise TypeError("SharedEP decode requires standard Top-K output")
+            raise TypeError("SharedEP requires standard Top-K output")
 
-        state = self.state
+        if phase == "prefill":
+            if self.prefill_state is None or self.prefill_cache is None:
+                raise RuntimeError("SharedEP prefill consumer was not admitted")
+            profile = self.prefill_profile
+            state = self.prefill_state
+            pull_cache = self.prefill_cache
+        else:
+            profile = self.profile
+            state = self.state
+            pull_cache = None
         num_tokens = hidden_states.shape[0]
-        _validate_decode_capacity(self.profile)
-        if num_tokens > self.profile.max_tokens_per_rank:
+        if phase == "decode":
+            _validate_decode_capacity(profile)
+        if num_tokens > profile.max_tokens_per_rank:
             raise ValueError(
-                "SharedEP decode capacity exceeded: "
-                f"{num_tokens} > {self.profile.max_tokens_per_rank} local tokens"
+                f"SharedEP {phase} capacity exceeded: "
+                f"{num_tokens} > {profile.max_tokens_per_rank} local tokens"
             )
         quantize_pack_input(
             state.local_input,
             source=hidden_states,
             source_ids=topk_output.topk_ids,
             source_weights=topk_output.topk_weights,
-            group_size=self.profile.block_shape[1],
+            group_size=profile.block_shape[1],
         )
         state.input_epoch.publish()
         return SharedEpDispatchOutput(
@@ -207,97 +295,42 @@ class SharedEpDispatcher(BaseDispatcher):
             hidden_states_scale=state.global_input.scales,
             topk_output=topk_output,
             state=state,
-            profile=self.profile,
+            profile=profile,
             num_tokens=num_tokens,
             local_expert_start=self.local_expert_start,
+            phase=phase,
+            pull_cache=pull_cache,
         )
 
     def combine(self, combine_input: CombineInput) -> torch.Tensor:
         if CombineInputChecker.format_is_standard(combine_input):
             return combine_input.hidden_states
-        if self.fallback_dispatcher is None:
-            raise RuntimeError("SharedEP received a fallback output without fallback")
-        return self.fallback_dispatcher.combine(combine_input=combine_input)
-
-    def set_quant_config(self, quant_config: dict) -> None:
-        super().set_quant_config(quant_config)
-        if self.fallback_dispatcher is not None:
-            self.fallback_dispatcher.set_quant_config(quant_config)
+        raise TypeError("SharedEP combine requires StandardCombineInput")
 
 
 def create_shared_ep_dispatcher(
     config: MoeRunnerConfig,
-    *,
-    group,
 ) -> SharedEpDispatcher:
-    """Build the decode backend and its non-overlapped DeepEP prefill fallback."""
+    """Build the standalone SharedEP dispatcher."""
 
-    if not get_moe_runner_backend().is_deep_gemm():
-        raise ValueError(
-            "shared_ep requires --moe-runner-backend deep_gemm "
-            "for its prefill fallback"
-        )
-    fallback_dispatcher = DeepEPDispatcher(
-        group=group,
-        router_topk=config.top_k,
-        permute_fusion=True,
-        num_experts=config.num_experts,
-        num_local_experts=config.num_local_experts,
-        hidden_size=config.hidden_size,
-        params_dtype=config.params_dtype,
-        deepep_mode=get_deepep_mode(),
-        async_finish=True,
-        return_recv_hook=True,
-    )
-    return SharedEpDispatcher(
-        config,
-        fallback_dispatcher=fallback_dispatcher,
-    )
+    return SharedEpDispatcher(config)
 
 
-def _run_deep_gemm_fallback(
-    dispatch_output,
-    quant_info: DeepGemmMoeQuantInfo,
-    runner_config: MoeRunnerConfig,
-):
-    running_state = {}
-    dispatch_format = dispatch_output.format.value
-    pre_permute = PermuteMethodPool.get_pre_permute(
-        dispatch_format,
-        "deep_gemm",
-    )
-    runner_input = pre_permute(
-        dispatch_output,
-        quant_info,
-        runner_config,
-        running_state,
-    )
-    runner_output = DeepGemmRunnerCore(runner_config).run(
-        runner_input,
-        quant_info,
-        running_state,
-    )
-    post_permute = PermuteMethodPool.get_post_permute(
-        "deep_gemm",
-        dispatch_format,
-    )
-    return post_permute(
-        runner_output,
-        quant_info,
-        runner_config,
-        running_state,
-    )
-
-
-def _validate_decode_weights(
+def _validate_weights(
     dispatch_output: SharedEpDispatchOutput,
-    quant_info: DeepGemmMoeQuantInfo,
+    quant_info: TritonMoeQuantInfo,
     runner_config: MoeRunnerConfig,
 ) -> None:
     profile = dispatch_output.profile
-    if not isinstance(quant_info, DeepGemmMoeQuantInfo):
-        raise TypeError("SharedEP requires DeepGemm FP8 weight metadata")
-    if not quant_info.use_fp8 or quant_info.is_fp4_experts or quant_info.use_mxfp8:
+    if not isinstance(quant_info, TritonMoeQuantInfo):
+        raise TypeError("SharedEP requires Triton FP8 weight metadata")
+    if (
+        not quant_info.use_fp8_w8a8
+        or quant_info.use_mxfp8
+        or quant_info.use_int8_w8a8
+        or quant_info.use_int8_w8a16
+        or quant_info.use_int4_w4a16
+    ):
         raise ValueError("SharedEP release supports block-FP8 experts only")
     if tuple(quant_info.block_shape or ()) != profile.block_shape:
         raise ValueError(
@@ -334,19 +367,18 @@ def _validate_decode_weights(
         raise ValueError("SharedEP release does not support gemm1_clamp_limit")
 
 
-@register_fused_func("shared_ep", "deep_gemm")
+@register_fused_func("shared_ep", "triton")
 def run_shared_ep(
     dispatch_output,
-    quant_info: DeepGemmMoeQuantInfo,
+    quant_info: TritonMoeQuantInfo,
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
     if not isinstance(dispatch_output, SharedEpDispatchOutput):
-        return _run_deep_gemm_fallback(
-            dispatch_output,
-            quant_info,
-            runner_config,
+        raise TypeError(
+            "SharedEP fused execution requires SharedEpDispatchOutput, "
+            f"got {type(dispatch_output).__name__}"
         )
-    _validate_decode_weights(dispatch_output, quant_info, runner_config)
+    _validate_weights(dispatch_output, quant_info, runner_config)
 
     profile = dispatch_output.profile
     state = dispatch_output.state
@@ -360,7 +392,7 @@ def run_shared_ep(
     )
     route_ids = routes.local_ids.view(-1, profile.top_k)
     route_weights = routes.local_weights.view(-1, profile.top_k)
-    capacity = decode_intermediate_capacity(profile)
+    capacity = intermediate_capacity(profile)
     gate_up = torch.empty(
         (capacity, profile.intermediate_size * 2),
         dtype=torch.bfloat16,
@@ -374,33 +406,57 @@ def run_shared_ep(
         -1,
         profile.hidden_size // profile.block_shape[1],
     )
-    invoke_fused_moe_kernel(
-        A=shared_activations,
-        B=quant_info.w13_weight,
-        bias=None,
-        C=gate_up,
-        A_scale=shared_scales,
-        B_scale=quant_info.w13_scale,
-        B_zp=None,
-        topk_weights=route_weights,
-        topk_ids=route_ids,
-        sorted_token_ids=routes.sorted_token_ids,
-        expert_ids=routes.expert_ids,
-        num_tokens_post_padded=routes.num_tokens_post_padded,
-        mul_routed_weight=False,
-        top_k=profile.top_k,
-        config=profile.w13_kernel_config(dispatch_output.num_tokens),
-        compute_type=tl.bfloat16,
-        use_fp8_w8a8=True,
-        use_int8_w8a8=False,
-        use_int8_w8a16=False,
-        use_int4_w4a16=False,
-        per_channel_quant=False,
-        block_shape=list(profile.block_shape),
-        filter_expert=True,
-        c_sorted=True,
-        a_is_prequantized=True,
-    )
+    if dispatch_output.phase == "prefill":
+        pull_cache = dispatch_output.pull_cache
+        if pull_cache is None or pull_cache.active_rows != capacity:
+            raise RuntimeError("SharedEP prefill pull-cache capacity mismatch")
+        pull_cache_rows(
+            source_activations=shared_activations,
+            source_scales=shared_scales,
+            sorted_token_ids=routes.sorted_token_ids,
+            num_tokens_post_padded=routes.num_tokens_post_padded,
+            cache=pull_cache,
+            top_k=profile.top_k,
+            source_route_capacity=shared_activations.shape[0] * profile.top_k,
+        )
+        invoke_pull_cache_w13(
+            cache=pull_cache,
+            weight=quant_info.w13_weight,
+            weight_scale=quant_info.w13_scale,
+            output=gate_up,
+            expert_ids=routes.expert_ids,
+            num_tokens_post_padded=routes.num_tokens_post_padded,
+            config=profile.w13_kernel_config(dispatch_output.num_tokens),
+            block_shape=profile.block_shape,
+        )
+    else:
+        invoke_fused_moe_kernel(
+            A=shared_activations,
+            B=quant_info.w13_weight,
+            bias=None,
+            C=gate_up,
+            A_scale=shared_scales,
+            B_scale=quant_info.w13_scale,
+            B_zp=None,
+            topk_weights=route_weights,
+            topk_ids=route_ids,
+            sorted_token_ids=routes.sorted_token_ids,
+            expert_ids=routes.expert_ids,
+            num_tokens_post_padded=routes.num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=profile.top_k,
+            config=profile.w13_kernel_config(dispatch_output.num_tokens),
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=list(profile.block_shape),
+            filter_expert=True,
+            c_sorted=True,
+            a_is_prequantized=True,
+        )
 
     down_fp8 = torch.empty(
         (capacity, profile.intermediate_size),

--- a/python/sglang/srt/layers/moe/shared_ep/backend.py
+++ b/python/sglang/srt/layers/moe/shared_ep/backend.py
@@ -1,0 +1,438 @@
+"""Composite SharedEP decode backend with a DeepEP/DeepGEMM prefill fallback."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+import triton.language as tl
+
+from sglang.kernels.ops.attention.dsv4 import silu_and_mul_contig_post_quant
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.srt.layers.dp_attention import get_is_extend_in_batch
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeRunnerConfig,
+    PermuteMethodPool,
+    register_fused_func,
+)
+from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+    DeepGemmMoeQuantInfo,
+    DeepGemmRunnerCore,
+)
+from sglang.srt.layers.moe.shared_ep.kernels import (
+    prepare_routes,
+    quantize_pack_input,
+)
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpLayout
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    RELEASE_MAX_TOKENS_PER_RANK,
+    SharedEpProfile,
+    select_profile,
+)
+from sglang.srt.layers.moe.shared_ep.state import (
+    SharedEpState,
+    create_shared_ep_state,
+)
+from sglang.srt.layers.moe.token_dispatcher.base import (
+    BaseDispatcher,
+    CombineInput,
+    CombineInputChecker,
+    DispatchOutputFormat,
+)
+from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPDispatcher
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
+from sglang.srt.layers.moe.utils import get_deepep_mode, get_moe_runner_backend
+from sglang.srt.runtime_context import get_parallel, get_resources
+
+
+class SharedEpDispatchOutput(NamedTuple):
+    hidden_states: torch.Tensor
+    hidden_states_scale: torch.Tensor
+    topk_output: TopKOutput
+    state: SharedEpState
+    profile: SharedEpProfile
+    num_tokens: int
+    local_expert_start: int
+
+    @property
+    def format(self) -> DispatchOutputFormat:
+        return DispatchOutputFormat.STANDARD
+
+
+def compact_intermediate_capacity(
+    *,
+    num_tokens: int,
+    world_size: int,
+    top_k: int,
+    num_local_experts: int,
+    block_size: int,
+) -> int:
+    """Graph-static upper bound for this rank's padded local-expert routes."""
+
+    valid_routes = num_tokens * world_size * top_k
+    experts_with_routes = min(valid_routes, num_local_experts)
+    return valid_routes + experts_with_routes * (block_size - 1)
+
+
+def decode_intermediate_capacity(profile: SharedEpProfile) -> int:
+    """Worst-case EP-local route capacity for uneven owner batches."""
+
+    return compact_intermediate_capacity(
+        num_tokens=profile.max_tokens_per_rank,
+        world_size=profile.ep_size,
+        top_k=profile.top_k,
+        num_local_experts=profile.num_local_experts,
+        block_size=profile.block_size_m,
+    )
+
+
+def _get_shared_state(
+    config: MoeRunnerConfig,
+    profile: SharedEpProfile,
+) -> SharedEpState:
+    """Return the process-lifetime VMM state shared by all MoE layers."""
+
+    resources = get_resources().buffers
+    key = f"shared_ep_{profile.name}_ep{profile.ep_size}"
+    state = resources.get(key)
+    if state is None:
+        ep_group = get_parallel().moe_ep_group
+        layout = SharedEpLayout.build(
+            hidden_size=profile.hidden_size,
+            top_k=profile.top_k,
+            max_tokens_per_rank=profile.max_tokens_per_rank,
+        )
+        state = create_shared_ep_state(
+            layout=layout,
+            cpu_group=ep_group.cpu_group,
+            device=torch.device("cuda", torch.cuda.current_device()),
+        )
+        resources[key] = state
+    expected = (
+        config.hidden_size,
+        config.top_k,
+        profile.max_tokens_per_rank,
+    )
+    actual = (
+        state.layout.hidden_size,
+        state.layout.top_k,
+        state.layout.max_tokens_per_rank,
+    )
+    if actual != expected:
+        raise RuntimeError(
+            f"SharedEP process state does not match the layer: {actual=} {expected=}"
+        )
+    return state
+
+
+class SharedEpDispatcher(BaseDispatcher):
+    def __init__(
+        self,
+        config: MoeRunnerConfig,
+        fallback_dispatcher: BaseDispatcher | None = None,
+    ):
+        super().__init__()
+        parallel = get_parallel()
+        if parallel.moe_ep_size != 8:
+            raise ValueError(f"SharedEP requires EP8, got EP{parallel.moe_ep_size}")
+        capability = torch.cuda.get_device_capability()
+        self.profile = select_profile(
+            config,
+            capability=capability,
+            ep_size=parallel.moe_ep_size,
+            block_shape=(128, 128),
+            max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+        )
+        self.config = config
+        self.state = _get_shared_state(self.config, self.profile)
+        self.local_expert_start = parallel.moe_ep_rank * self.profile.num_local_experts
+        self.fallback_dispatcher = fallback_dispatcher
+
+    def dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+    ):
+        if get_is_extend_in_batch():
+            if self.fallback_dispatcher is None:
+                raise RuntimeError("SharedEP requires a DeepEP prefill fallback")
+            return self.fallback_dispatcher.dispatch(
+                hidden_states=hidden_states,
+                topk_output=topk_output,
+            )
+        if not TopKOutputChecker.format_is_standard(topk_output):
+            raise TypeError("SharedEP decode requires standard Top-K output")
+
+        state = self.state
+        num_tokens = hidden_states.shape[0]
+        if num_tokens > self.profile.max_tokens_per_rank:
+            raise ValueError(
+                "SharedEP decode capacity exceeded: "
+                f"{num_tokens} > {self.profile.max_tokens_per_rank} local tokens"
+            )
+        quantize_pack_input(
+            state.local_input,
+            source=hidden_states,
+            source_ids=topk_output.topk_ids,
+            source_weights=topk_output.topk_weights,
+            group_size=self.profile.block_shape[1],
+        )
+        state.input_epoch.publish()
+        return SharedEpDispatchOutput(
+            hidden_states=state.global_input.activations,
+            hidden_states_scale=state.global_input.scales,
+            topk_output=topk_output,
+            state=state,
+            profile=self.profile,
+            num_tokens=num_tokens,
+            local_expert_start=self.local_expert_start,
+        )
+
+    def combine(self, combine_input: CombineInput) -> torch.Tensor:
+        if CombineInputChecker.format_is_standard(combine_input):
+            return combine_input.hidden_states
+        if self.fallback_dispatcher is None:
+            raise RuntimeError("SharedEP received a fallback output without fallback")
+        return self.fallback_dispatcher.combine(combine_input=combine_input)
+
+    def set_quant_config(self, quant_config: dict) -> None:
+        super().set_quant_config(quant_config)
+        if self.fallback_dispatcher is not None:
+            self.fallback_dispatcher.set_quant_config(quant_config)
+
+
+def create_shared_ep_dispatcher(
+    config: MoeRunnerConfig,
+    *,
+    group,
+) -> SharedEpDispatcher:
+    """Build the decode backend and its non-overlapped DeepEP prefill fallback."""
+
+    if not get_moe_runner_backend().is_deep_gemm():
+        raise ValueError(
+            "shared_ep requires --moe-runner-backend deep_gemm "
+            "for its prefill fallback"
+        )
+    fallback_dispatcher = DeepEPDispatcher(
+        group=group,
+        router_topk=config.top_k,
+        permute_fusion=True,
+        num_experts=config.num_experts,
+        num_local_experts=config.num_local_experts,
+        hidden_size=config.hidden_size,
+        params_dtype=config.params_dtype,
+        deepep_mode=get_deepep_mode(),
+        async_finish=True,
+        return_recv_hook=True,
+    )
+    return SharedEpDispatcher(
+        config,
+        fallback_dispatcher=fallback_dispatcher,
+    )
+
+
+def _run_deep_gemm_fallback(
+    dispatch_output,
+    quant_info: DeepGemmMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+):
+    running_state = {}
+    dispatch_format = dispatch_output.format.value
+    pre_permute = PermuteMethodPool.get_pre_permute(
+        dispatch_format,
+        "deep_gemm",
+    )
+    runner_input = pre_permute(
+        dispatch_output,
+        quant_info,
+        runner_config,
+        running_state,
+    )
+    runner_output = DeepGemmRunnerCore(runner_config).run(
+        runner_input,
+        quant_info,
+        running_state,
+    )
+    post_permute = PermuteMethodPool.get_post_permute(
+        "deep_gemm",
+        dispatch_format,
+    )
+    return post_permute(
+        runner_output,
+        quant_info,
+        runner_config,
+        running_state,
+    )
+
+
+def _validate_decode_weights(
+    dispatch_output: SharedEpDispatchOutput,
+    quant_info: DeepGemmMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> None:
+    profile = dispatch_output.profile
+    if not isinstance(quant_info, DeepGemmMoeQuantInfo):
+        raise TypeError("SharedEP requires DeepGemm FP8 weight metadata")
+    if not quant_info.use_fp8 or quant_info.is_fp4_experts or quant_info.use_mxfp8:
+        raise ValueError("SharedEP release supports block-FP8 experts only")
+    if tuple(quant_info.block_shape or ()) != profile.block_shape:
+        raise ValueError(
+            f"SharedEP requires block shape {profile.block_shape}, "
+            f"got {quant_info.block_shape}"
+        )
+    expected_w13 = (
+        profile.num_local_experts,
+        profile.intermediate_size * 2,
+        profile.hidden_size,
+    )
+    expected_w2 = (
+        profile.num_local_experts,
+        profile.hidden_size,
+        profile.intermediate_size,
+    )
+    if tuple(quant_info.w13_weight.shape) != expected_w13:
+        raise ValueError(
+            f"SharedEP W13 shape is {tuple(quant_info.w13_weight.shape)}, "
+            f"expected {expected_w13}"
+        )
+    if tuple(quant_info.w2_weight.shape) != expected_w2:
+        raise ValueError(
+            f"SharedEP W2 shape is {tuple(quant_info.w2_weight.shape)}, "
+            f"expected {expected_w2}"
+        )
+    if quant_info.w13_scale is None or quant_info.w2_scale is None:
+        raise ValueError("SharedEP FP8 weights require W13 and W2 scales")
+    if runner_config.activation != "silu" or not runner_config.is_gated:
+        raise ValueError("SharedEP release supports gated SiLU experts only")
+    if runner_config.gemm1_alpha is not None:
+        raise ValueError("SharedEP release does not support gemm1_alpha")
+    if runner_config.gemm1_clamp_limit is not None:
+        raise ValueError("SharedEP release does not support gemm1_clamp_limit")
+
+
+@register_fused_func("shared_ep", "deep_gemm")
+def run_shared_ep(
+    dispatch_output,
+    quant_info: DeepGemmMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    if not isinstance(dispatch_output, SharedEpDispatchOutput):
+        return _run_deep_gemm_fallback(
+            dispatch_output,
+            quant_info,
+            runner_config,
+        )
+    _validate_decode_weights(dispatch_output, quant_info, runner_config)
+
+    profile = dispatch_output.profile
+    state = dispatch_output.state
+    routes = prepare_routes(
+        profile,
+        state.global_input.topk_ids,
+        state.global_input.topk_weights,
+        state.input_epoch.allocation.local_storage,
+        state.input_epoch.epoch,
+        local_expert_start=dispatch_output.local_expert_start,
+    )
+    route_ids = routes.local_ids.view(-1, profile.top_k)
+    route_weights = routes.local_weights.view(-1, profile.top_k)
+    capacity = decode_intermediate_capacity(profile)
+    gate_up = torch.empty(
+        (capacity, profile.intermediate_size * 2),
+        dtype=torch.bfloat16,
+        device=dispatch_output.hidden_states.device,
+    )
+    shared_activations = dispatch_output.hidden_states.view(
+        -1,
+        profile.hidden_size,
+    )
+    shared_scales = dispatch_output.hidden_states_scale.view(
+        -1,
+        profile.hidden_size // profile.block_shape[1],
+    )
+    invoke_fused_moe_kernel(
+        A=shared_activations,
+        B=quant_info.w13_weight,
+        bias=None,
+        C=gate_up,
+        A_scale=shared_scales,
+        B_scale=quant_info.w13_scale,
+        B_zp=None,
+        topk_weights=route_weights,
+        topk_ids=route_ids,
+        sorted_token_ids=routes.sorted_token_ids,
+        expert_ids=routes.expert_ids,
+        num_tokens_post_padded=routes.num_tokens_post_padded,
+        mul_routed_weight=False,
+        top_k=profile.top_k,
+        config=profile.w13_kernel_config(dispatch_output.num_tokens),
+        compute_type=tl.bfloat16,
+        use_fp8_w8a8=True,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        per_channel_quant=False,
+        block_shape=list(profile.block_shape),
+        filter_expert=True,
+        c_sorted=True,
+        a_is_prequantized=True,
+    )
+
+    down_fp8 = torch.empty(
+        (capacity, profile.intermediate_size),
+        dtype=torch.float8_e4m3fn,
+        device=gate_up.device,
+    )
+    down_scale = torch.empty(
+        (capacity, profile.intermediate_size // profile.block_shape[1]),
+        dtype=torch.float32,
+        device=gate_up.device,
+    )
+    silu_and_mul_contig_post_quant(
+        input=gate_up,
+        output=down_fp8,
+        output_scale=down_scale,
+        quant_group_size=profile.block_shape[1],
+        swiglu_limit=runner_config.swiglu_limit,
+        valid_rows=routes.num_tokens_post_padded,
+    )
+    shared_output = state.global_output.view(-1, profile.hidden_size)
+    invoke_fused_moe_kernel(
+        A=down_fp8,
+        B=quant_info.w2_weight,
+        bias=None,
+        C=shared_output,
+        A_scale=down_scale,
+        B_scale=quant_info.w2_scale,
+        B_zp=None,
+        topk_weights=route_weights,
+        topk_ids=route_ids,
+        sorted_token_ids=routes.sorted_token_ids,
+        expert_ids=routes.expert_ids,
+        num_tokens_post_padded=routes.num_tokens_post_padded,
+        mul_routed_weight=True,
+        top_k=1,
+        config=profile.w2_kernel_config(dispatch_output.num_tokens),
+        compute_type=tl.bfloat16,
+        use_fp8_w8a8=True,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        per_channel_quant=False,
+        block_shape=list(profile.block_shape),
+        filter_expert=True,
+        a_use_tma=True,
+        b_use_tma=True,
+        a_is_prequantized=True,
+    )
+    state.output_epoch.publish()
+    state.output_epoch.wait_all()
+
+    # The next layer cannot reuse this output until every owner has reduced it:
+    # each owner publishes the next input only after this sum, and the next
+    # expert phase waits for all input publications.
+    output = state.local_output[: dispatch_output.num_tokens].sum(dim=1)
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/moe/shared_ep/epoch.py
+++ b/python/sglang/srt/layers/moe/shared_ep/epoch.py
@@ -1,0 +1,130 @@
+"""GPU-only release/acquire epochs for SharedEP VMM objects."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.moe.shared_ep.vmm import (
+    SharedEpVmmAllocation,
+    allocate_rank_major_vmm,
+)
+
+
+@triton.jit
+def _store_release_epoch(addresses, epoch):
+    return tl.inline_asm_elementwise(
+        "atom.global.release.sys.exch.b32 $0, [$1], $2;",
+        "=r,l,r",
+        [addresses, epoch],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _wait_acquire_epoch(addresses, epoch):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 value;
+            .reg .pred pending;
+        wait_epoch:
+            ld.acquire.sys.global.u32 value, [$1];
+            setp.ne.u32 pending, value, $2;
+            @pending bra wait_epoch;
+            mov.u32 $0, value;
+        }
+        """,
+        "=r,l,r",
+        [addresses, epoch],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _publish_epoch_kernel(
+    global_signals,
+    epoch_ptr,
+    rank_stride_words: tl.constexpr,
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    epoch = tl.load(epoch_ptr) + 1
+    tl.store(epoch_ptr, epoch)
+    destinations = tl.arange(0, world_size)
+    signal_words = global_signals.to(tl.pointer_type(tl.uint32))
+    addresses = signal_words + destinations * rank_stride_words + rank
+    _store_release_epoch(addresses, epoch)
+
+
+@triton.jit
+def _wait_epoch_kernel(
+    local_signals,
+    epoch_ptr,
+    world_size: tl.constexpr,
+):
+    epoch = tl.load(epoch_ptr)
+    sources = tl.arange(0, world_size)
+    signal_words = local_signals.to(tl.pointer_type(tl.uint32))
+    _wait_acquire_epoch(signal_words + sources, epoch)
+
+
+class GpuEpoch(msgspec.Struct, kw_only=True):
+    allocation: SharedEpVmmAllocation
+    epoch: torch.Tensor
+    rank: int
+    world_size: int
+    _closed: bool = False
+
+    def publish(self) -> None:
+        _publish_epoch_kernel[(1,)](
+            self.allocation.global_storage,
+            self.epoch,
+            rank_stride_words=self.allocation.mapped_rank_bytes // 4,
+            rank=self.rank,
+            world_size=self.world_size,
+            num_warps=1,
+        )
+
+    def wait_all(self) -> None:
+        _wait_epoch_kernel[(1,)](
+            self.allocation.local_storage,
+            self.epoch,
+            world_size=self.world_size,
+            num_warps=1,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.epoch = torch.empty(0, dtype=torch.int32)
+        self.allocation.close()
+
+
+def create_gpu_epoch(
+    *,
+    cpu_group,
+    device: torch.device,
+    rank: int,
+    world_size: int,
+) -> GpuEpoch:
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, got {world_size}")
+    allocation = allocate_rank_major_vmm(
+        cpu_group=cpu_group,
+        device=device,
+        logical_rank_bytes=world_size * 4,
+    )
+    return GpuEpoch(
+        allocation=allocation,
+        epoch=torch.zeros(1, dtype=torch.int32, device=device),
+        rank=rank,
+        world_size=world_size,
+    )

--- a/python/sglang/srt/layers/moe/shared_ep/kernels.py
+++ b/python/sglang/srt/layers/moe/shared_ep/kernels.py
@@ -102,7 +102,7 @@ def quantize_pack_input(
     source_weights: torch.Tensor,
     group_size: int,
 ) -> None:
-    """Quantize decode activations directly into the shared input object."""
+    """Quantize activations and routes directly into the shared input object."""
 
     if source.ndim != 2:
         raise ValueError("SharedEP activations must be two-dimensional")
@@ -127,9 +127,9 @@ def quantize_pack_input(
     if target.scales.shape[1] != hidden_size // group_size:
         raise ValueError("SharedEP activation scale shape does not match storage")
     if source.dtype != torch.bfloat16:
-        raise TypeError("SharedEP decode activations must use bfloat16")
+        raise TypeError("SharedEP activations must use bfloat16")
     if not source.is_contiguous():
-        raise ValueError("SharedEP decode activations must be contiguous")
+        raise ValueError("SharedEP activations must be contiguous")
     if source_ids.dtype not in (torch.int32, torch.int64):
         raise TypeError("SharedEP route ids must use int32 or int64")
     if source_weights.dtype != torch.float32:

--- a/python/sglang/srt/layers/moe/shared_ep/kernels.py
+++ b/python/sglang/srt/layers/moe/shared_ep/kernels.py
@@ -1,0 +1,221 @@
+"""SharedEP-owned route and compute kernel entry points."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpInputViews
+from sglang.srt.layers.moe.shared_ep.profiles import SharedEpProfile
+
+
+class RoutePreparation(msgspec.Struct, kw_only=True):
+    local_ids: torch.Tensor
+    local_weights: torch.Tensor
+    sorted_token_ids: torch.Tensor
+    expert_ids: torch.Tensor
+    num_tokens_post_padded: torch.Tensor
+
+
+@triton.jit
+def _quantize_pack_input_kernel(
+    source,
+    source_ids,
+    source_weights,
+    target_q,
+    target_scales,
+    target_ids,
+    target_weights,
+    source_q_row_stride: tl.constexpr,
+    source_id_row_stride: tl.constexpr,
+    source_weight_row_stride: tl.constexpr,
+    target_q_row_stride: tl.constexpr,
+    target_scale_row_stride: tl.constexpr,
+    target_id_row_stride: tl.constexpr,
+    target_weight_row_stride: tl.constexpr,
+    quant_programs: tl.constexpr,
+    num_tokens: tl.constexpr,
+    num_groups: tl.constexpr,
+    top_k: tl.constexpr,
+    max_tokens: tl.constexpr,
+    group_size: tl.constexpr,
+    fp8_max: tl.constexpr,
+    eps: tl.constexpr,
+):
+    program = tl.program_id(0)
+    quant_valid = program < quant_programs
+    token = program // num_groups
+    group = program % num_groups
+    columns = group * group_size + tl.arange(0, group_size)
+    value = tl.load(
+        source + token * source_q_row_stride + columns,
+        mask=quant_valid,
+        other=0.0,
+    ).to(tl.float32)
+    absmax = tl.maximum(tl.max(tl.abs(value), axis=0), eps)
+    scale = absmax / fp8_max
+    quantized = tl.clamp(value / scale, -fp8_max, fp8_max).to(tl.float8e4nv)
+    tl.store(
+        target_q + token * target_q_row_stride + columns,
+        quantized,
+        mask=quant_valid,
+    )
+    tl.store(
+        target_scales + token * target_scale_row_stride + group,
+        scale,
+        mask=quant_valid,
+    )
+
+    metadata_row = program
+    metadata_columns = tl.arange(0, group_size)
+    metadata_mask = (metadata_row < max_tokens) & (metadata_columns < top_k)
+    source_mask = metadata_mask & (metadata_row < num_tokens)
+    route_id = tl.load(
+        source_ids + metadata_row * source_id_row_stride + metadata_columns,
+        mask=source_mask,
+        other=-1,
+    )
+    route_weight = tl.load(
+        source_weights + metadata_row * source_weight_row_stride + metadata_columns,
+        mask=source_mask,
+        other=0.0,
+    )
+    tl.store(
+        target_ids + metadata_row * target_id_row_stride + metadata_columns,
+        route_id.to(tl.int32),
+        mask=metadata_mask,
+    )
+    tl.store(
+        target_weights + metadata_row * target_weight_row_stride + metadata_columns,
+        route_weight,
+        mask=metadata_mask,
+    )
+
+
+def quantize_pack_input(
+    target: SharedEpInputViews,
+    *,
+    source: torch.Tensor,
+    source_ids: torch.Tensor,
+    source_weights: torch.Tensor,
+    group_size: int,
+) -> None:
+    """Quantize decode activations directly into the shared input object."""
+
+    if source.ndim != 2:
+        raise ValueError("SharedEP activations must be two-dimensional")
+    if source_ids.ndim != 2 or source_weights.ndim != 2:
+        raise ValueError("SharedEP routes must be two-dimensional")
+    num_tokens, hidden_size = source.shape
+    max_tokens = target.activations.shape[0]
+    if not 0 <= num_tokens <= max_tokens:
+        raise ValueError(
+            f"SharedEP input has {num_tokens} tokens, capacity is {max_tokens}"
+        )
+    if group_size != 128 or hidden_size % group_size != 0:
+        raise ValueError(
+            "SharedEP direct input quantization requires FP8 groups of 128"
+        )
+    if source_ids.shape != source_weights.shape:
+        raise ValueError("SharedEP route id and weight shapes must match")
+    if source_ids.shape != (num_tokens, target.topk_ids.shape[1]):
+        raise ValueError("SharedEP route shape does not match storage")
+    if hidden_size != target.activations.shape[1]:
+        raise ValueError("SharedEP activation hidden size does not match storage")
+    if target.scales.shape[1] != hidden_size // group_size:
+        raise ValueError("SharedEP activation scale shape does not match storage")
+    if source.dtype != torch.bfloat16:
+        raise TypeError("SharedEP decode activations must use bfloat16")
+    if not source.is_contiguous():
+        raise ValueError("SharedEP decode activations must be contiguous")
+    if source_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("SharedEP route ids must use int32 or int64")
+    if source_weights.dtype != torch.float32:
+        raise TypeError("SharedEP route weights must use float32")
+
+    num_groups = hidden_size // group_size
+    quant_programs = num_tokens * num_groups
+    grid = max(quant_programs, max_tokens)
+    _quantize_pack_input_kernel[(grid,)](
+        source,
+        source_ids,
+        source_weights,
+        target.activations,
+        target.scales,
+        target.topk_ids,
+        target.topk_weights,
+        source_q_row_stride=source.stride(0),
+        source_id_row_stride=source_ids.stride(0),
+        source_weight_row_stride=source_weights.stride(0),
+        target_q_row_stride=target.activations.stride(0),
+        target_scale_row_stride=target.scales.stride(0),
+        target_id_row_stride=target.topk_ids.stride(0),
+        target_weight_row_stride=target.topk_weights.stride(0),
+        quant_programs=quant_programs,
+        num_tokens=num_tokens,
+        num_groups=num_groups,
+        top_k=source_ids.shape[1],
+        max_tokens=max_tokens,
+        group_size=group_size,
+        fp8_max=448.0,
+        eps=1e-10,
+        num_warps=4,
+        num_stages=1,
+    )
+
+
+def prepare_routes(
+    profile: SharedEpProfile,
+    global_ids: torch.Tensor,
+    global_weights: torch.Tensor,
+    ready_signals: torch.Tensor,
+    ready_epoch: torch.Tensor,
+    *,
+    local_expert_start: int,
+) -> RoutePreparation:
+    _validate_routes(profile, global_ids, global_weights)
+    from sglang.kernels.ops.moe.shared_ep_route_prep import prepare_routes_cuda
+
+    result = prepare_routes_cuda(
+        global_ids,
+        global_weights,
+        ready_signals,
+        ready_epoch,
+        local_expert_start=local_expert_start,
+        num_local_experts=profile.num_local_experts,
+        block_size_m=profile.block_size_m,
+        num_threads=profile.route_kernel_config["num_threads"],
+    )
+    return RoutePreparation(
+        local_ids=result[0],
+        local_weights=result[1],
+        sorted_token_ids=result[2],
+        expert_ids=result[3],
+        num_tokens_post_padded=result[4],
+    )
+
+
+def _validate_routes(
+    profile: SharedEpProfile,
+    global_ids: torch.Tensor,
+    global_weights: torch.Tensor,
+) -> None:
+    if (
+        global_ids.ndim != 3
+        or not 0 < global_ids.shape[0] <= profile.ep_size
+        or not 0 < global_ids.shape[1] <= profile.max_tokens_per_rank
+        or global_ids.shape[2] != profile.top_k
+    ):
+        raise ValueError(
+            "SharedEP route ids require [owners<=EP, tokens<=capacity, Top-K] "
+            f"within {(profile.ep_size, profile.max_tokens_per_rank, profile.top_k)}, "
+            f"got {tuple(global_ids.shape)}"
+        )
+    if global_weights.shape != global_ids.shape:
+        raise ValueError("SharedEP route id and weight shapes must match")
+    if global_ids.dtype != torch.int32:
+        raise TypeError("SharedEP route ids must use int32")
+    if global_weights.dtype != torch.float32:
+        raise TypeError("SharedEP route weights must use float32")

--- a/python/sglang/srt/layers/moe/shared_ep/layout.py
+++ b/python/sglang/srt/layers/moe/shared_ep/layout.py
@@ -1,0 +1,217 @@
+"""Byte layout and typed tensor views for SharedEP VMM storage."""
+
+from __future__ import annotations
+
+import math
+
+import msgspec
+import torch
+
+
+class SharedEpInputViews(msgspec.Struct, kw_only=True):
+    activations: torch.Tensor
+    scales: torch.Tensor
+    topk_ids: torch.Tensor
+    topk_weights: torch.Tensor
+
+    def owner(self, owner: int) -> SharedEpInputViews:
+        return SharedEpInputViews(
+            activations=self.activations[owner],
+            scales=self.scales[owner],
+            topk_ids=self.topk_ids[owner],
+            topk_weights=self.topk_weights[owner],
+        )
+
+
+class SharedEpLayout(msgspec.Struct, frozen=True, kw_only=True):
+    hidden_size: int
+    top_k: int
+    max_tokens_per_rank: int
+    scale_groups: int
+    input_payload_bytes: int
+    input_row_bytes: int
+    output_payload_bytes: int
+    output_row_bytes: int
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        hidden_size: int,
+        top_k: int,
+        max_tokens_per_rank: int,
+    ) -> SharedEpLayout:
+        for name, value in (
+            ("hidden_size", hidden_size),
+            ("top_k", top_k),
+            ("max_tokens_per_rank", max_tokens_per_rank),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if hidden_size % 128 != 0:
+            raise ValueError(
+                f"hidden_size must be divisible by FP8 group size 128, got {hidden_size}"
+            )
+
+        scale_groups = hidden_size // 128
+        input_payload_bytes = hidden_size + scale_groups * 4 + top_k * 4 * 2
+        output_payload_bytes = hidden_size * 2
+        return cls(
+            hidden_size=hidden_size,
+            top_k=top_k,
+            max_tokens_per_rank=max_tokens_per_rank,
+            scale_groups=scale_groups,
+            input_payload_bytes=input_payload_bytes,
+            input_row_bytes=max(
+                64 * 1024,
+                _next_power_of_two(input_payload_bytes),
+            ),
+            output_payload_bytes=output_payload_bytes,
+            output_row_bytes=max(
+                16 * 1024,
+                _next_power_of_two(output_payload_bytes),
+            ),
+        )
+
+    @property
+    def input_rank_bytes(self) -> int:
+        return self.max_tokens_per_rank * self.input_row_bytes
+
+    @property
+    def output_rows_per_rank(self) -> int:
+        return self.max_tokens_per_rank * self.top_k
+
+    @property
+    def output_rank_bytes(self) -> int:
+        return self.output_rows_per_rank * self.output_row_bytes
+
+    @property
+    def scale_offset(self) -> int:
+        return self.hidden_size
+
+    @property
+    def topk_id_offset(self) -> int:
+        return self.scale_offset + self.scale_groups * 4
+
+    @property
+    def topk_weight_offset(self) -> int:
+        return self.topk_id_offset + self.top_k * 4
+
+    def output_slot_offset(self, token: int, route: int) -> int:
+        if not 0 <= token < self.max_tokens_per_rank:
+            raise IndexError(f"token {token} is outside the owner-local capacity")
+        if not 0 <= route < self.top_k:
+            raise IndexError(f"route {route} is outside Top-K {self.top_k}")
+        return (token * self.top_k + route) * self.output_row_bytes
+
+    def input_views(
+        self,
+        storage: torch.Tensor,
+        *,
+        world_size: int,
+        mapped_rank_bytes: int,
+    ) -> SharedEpInputViews:
+        _validate_storage(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+            logical_rank_bytes=self.input_rank_bytes,
+        )
+        rows = torch.as_strided(
+            storage,
+            size=(world_size, self.max_tokens_per_rank, self.input_row_bytes),
+            stride=(mapped_rank_bytes, self.input_row_bytes, 1),
+        )
+        scale_end = self.scale_offset + self.scale_groups * 4
+        id_end = self.topk_id_offset + self.top_k * 4
+        weight_end = self.topk_weight_offset + self.top_k * 4
+        return SharedEpInputViews(
+            activations=rows[..., : self.hidden_size].view(torch.float8_e4m3fn),
+            scales=rows[..., self.scale_offset : scale_end].view(torch.float32),
+            topk_ids=rows[..., self.topk_id_offset : id_end].view(torch.int32),
+            topk_weights=rows[..., self.topk_weight_offset : weight_end].view(
+                torch.float32
+            ),
+        )
+
+    def output_view(
+        self,
+        storage: torch.Tensor,
+        *,
+        world_size: int,
+        mapped_rank_bytes: int,
+    ) -> torch.Tensor:
+        _validate_storage(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+            logical_rank_bytes=self.output_rank_bytes,
+        )
+        rows = torch.as_strided(
+            storage,
+            size=(world_size, self.output_rows_per_rank, self.output_row_bytes),
+            stride=(mapped_rank_bytes, self.output_row_bytes, 1),
+        )
+        values = rows[..., : self.output_payload_bytes].view(torch.bfloat16)
+        return values.view(
+            world_size,
+            self.max_tokens_per_rank,
+            self.top_k,
+            self.hidden_size,
+        )
+
+
+def _next_power_of_two(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def align_output_layout(
+    layout: SharedEpLayout,
+    *,
+    granularity: int,
+) -> SharedEpLayout:
+    """Choose a fixed row stride so mapped owner segments have no hidden gap."""
+
+    if granularity <= 0:
+        raise ValueError(f"granularity must be positive, got {granularity}")
+    rows = layout.output_rows_per_rank
+    rank_alignment = math.lcm(rows, granularity)
+    required_rank_bytes = rows * layout.output_row_bytes
+    aligned_rank_bytes = (
+        (required_rank_bytes + rank_alignment - 1) // rank_alignment
+    ) * rank_alignment
+    output_row_bytes = aligned_rank_bytes // rows
+    if output_row_bytes == layout.output_row_bytes:
+        return layout
+    return SharedEpLayout(
+        hidden_size=layout.hidden_size,
+        top_k=layout.top_k,
+        max_tokens_per_rank=layout.max_tokens_per_rank,
+        scale_groups=layout.scale_groups,
+        input_payload_bytes=layout.input_payload_bytes,
+        input_row_bytes=layout.input_row_bytes,
+        output_payload_bytes=layout.output_payload_bytes,
+        output_row_bytes=output_row_bytes,
+    )
+
+
+def _validate_storage(
+    storage: torch.Tensor,
+    *,
+    world_size: int,
+    mapped_rank_bytes: int,
+    logical_rank_bytes: int,
+) -> None:
+    if storage.dtype != torch.uint8 or storage.ndim != 1:
+        raise TypeError("SharedEP VMM storage must be a one-dimensional uint8 tensor")
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, got {world_size}")
+    if mapped_rank_bytes < logical_rank_bytes:
+        raise ValueError(
+            "mapped rank bytes cannot be smaller than the logical rank payload"
+        )
+    required_bytes = (world_size - 1) * mapped_rank_bytes + logical_rank_bytes
+    if storage.numel() < required_bytes:
+        raise ValueError(
+            f"SharedEP storage has {storage.numel()} bytes, needs {required_bytes}"
+        )

--- a/python/sglang/srt/layers/moe/shared_ep/profiles.py
+++ b/python/sglang/srt/layers/moe/shared_ep/profiles.py
@@ -36,8 +36,57 @@ _GLM_W2_KERNEL_CONFIG = {
     **_DEFAULT_KERNEL_CONFIG,
     "num_warps": 4,
 }
+_GLM_PREFILL_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "BLOCK_SIZE_M": 64,
+}
+_GLM_PREFILL_W13_KERNEL_CONFIG = {
+    **_GLM_LARGE_W13_KERNEL_CONFIG,
+    "BLOCK_SIZE_M": 64,
+}
+_GLM_PREFILL_W2_KERNEL_CONFIG = {
+    **_GLM_W2_KERNEL_CONFIG,
+    "BLOCK_SIZE_M": 64,
+}
+_DSV4_PREFILL_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "BLOCK_SIZE_M": 64,
+}
+_DSV4_PREFILL_W13_KERNEL_CONFIG = {
+    **_DSV4_LARGE_W13_KERNEL_CONFIG,
+    "BLOCK_SIZE_M": 64,
+}
+_DSV4_PREFILL_W2_KERNEL_CONFIG = {
+    **_DSV4_SMALL_KERNEL_CONFIG,
+    "BLOCK_SIZE_M": 64,
+}
 _ROUTE_KERNEL_CONFIG = {"num_threads": 1024}
 RELEASE_MAX_TOKENS_PER_RANK = 32
+RELEASE_MAX_PREFILL_TOKENS_PER_RANK = 1024
+
+
+def resolve_prefill_capacity(
+    chunked_prefill_size: int | None,
+    *,
+    release_max_tokens: int,
+) -> int:
+    """Validate and return the scheduler's resolved per-rank prefill chunk."""
+
+    if release_max_tokens <= 0:
+        raise ValueError(
+            f"release_max_tokens must be positive, got {release_max_tokens}"
+        )
+    if chunked_prefill_size is None or chunked_prefill_size <= 0:
+        raise ValueError(
+            "SharedEP requires a positive DP-adjusted prefill chunk, got "
+            f"{chunked_prefill_size}"
+        )
+    if chunked_prefill_size > release_max_tokens:
+        raise ValueError(
+            "SharedEP DP-adjusted prefill chunk exceeds release capacity: "
+            f"{chunked_prefill_size} > {release_max_tokens}"
+        )
+    return chunked_prefill_size
 
 
 class SharedEpProfile(msgspec.Struct, frozen=True, kw_only=True):
@@ -55,10 +104,14 @@ class SharedEpProfile(msgspec.Struct, frozen=True, kw_only=True):
     small_kernel_config: dict[str, int] | None
     small_kernel_max_tokens: int
     route_kernel_config: dict[str, int]
+    supports_pull_cache_prefill: bool = False
     default_w13_kernel_config: dict[str, int] | None = None
     default_w2_kernel_config: dict[str, int] | None = None
     small_w13_kernel_config: dict[str, int] | None = None
     small_w2_kernel_config: dict[str, int] | None = None
+    prefill_kernel_config: dict[str, int] | None = None
+    prefill_w13_kernel_config: dict[str, int] | None = None
+    prefill_w2_kernel_config: dict[str, int] | None = None
 
     @property
     def block_size_m(self) -> int:
@@ -140,10 +193,14 @@ GLM52 = SharedEpProfile(
     small_kernel_config=None,
     small_kernel_max_tokens=4,
     route_kernel_config=_ROUTE_KERNEL_CONFIG,
+    supports_pull_cache_prefill=True,
     default_w13_kernel_config=_GLM_LARGE_W13_KERNEL_CONFIG,
     default_w2_kernel_config=_GLM_W2_KERNEL_CONFIG,
     small_w13_kernel_config=_GLM_SMALL_W13_KERNEL_CONFIG,
     small_w2_kernel_config=_GLM_W2_KERNEL_CONFIG,
+    prefill_kernel_config=_GLM_PREFILL_KERNEL_CONFIG,
+    prefill_w13_kernel_config=_GLM_PREFILL_W13_KERNEL_CONFIG,
+    prefill_w2_kernel_config=_GLM_PREFILL_W2_KERNEL_CONFIG,
 )
 
 DSV4_FLASH = SharedEpProfile(
@@ -163,7 +220,46 @@ DSV4_FLASH = SharedEpProfile(
     route_kernel_config=_ROUTE_KERNEL_CONFIG,
     default_w13_kernel_config=_DSV4_LARGE_W13_KERNEL_CONFIG,
     default_w2_kernel_config=_DSV4_SMALL_KERNEL_CONFIG,
+    supports_pull_cache_prefill=True,
+    prefill_kernel_config=_DSV4_PREFILL_KERNEL_CONFIG,
+    prefill_w13_kernel_config=_DSV4_PREFILL_W13_KERNEL_CONFIG,
+    prefill_w2_kernel_config=_DSV4_PREFILL_W2_KERNEL_CONFIG,
 )
+
+
+def make_pull_cache_prefill_profile(
+    profile: SharedEpProfile,
+    max_tokens_per_rank: int,
+) -> SharedEpProfile | None:
+    """Build a pull-cache profile without changing decode admission."""
+
+    if max_tokens_per_rank <= 0:
+        raise ValueError(
+            f"max_tokens_per_rank must be positive, got {max_tokens_per_rank}"
+        )
+    if not profile.supports_pull_cache_prefill:
+        return None
+    if (
+        profile.prefill_kernel_config is None
+        or profile.prefill_w13_kernel_config is None
+        or profile.prefill_w2_kernel_config is None
+    ):
+        raise ValueError(
+            f"SharedEP profile {profile.name} has incomplete prefill kernel configs"
+        )
+    return msgspec.structs.replace(
+        profile,
+        name=f"{profile.name}_prefill_pull",
+        max_tokens_per_rank=max_tokens_per_rank,
+        default_kernel_config=profile.prefill_kernel_config,
+        small_kernel_config=None,
+        small_kernel_max_tokens=0,
+        default_w13_kernel_config=profile.prefill_w13_kernel_config,
+        default_w2_kernel_config=profile.prefill_w2_kernel_config,
+        small_w13_kernel_config=None,
+        small_w2_kernel_config=None,
+    )
+
 
 _PROFILES = (GLM52, DSV4_FLASH)
 

--- a/python/sglang/srt/layers/moe/shared_ep/profiles.py
+++ b/python/sglang/srt/layers/moe/shared_ep/profiles.py
@@ -1,0 +1,197 @@
+"""Internal admission and kernel profiles for SharedEP."""
+
+from __future__ import annotations
+
+import msgspec
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+_DEFAULT_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 3,
+}
+_DSV4_SMALL_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3,
+}
+_DSV4_LARGE_W13_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "num_warps": 4,
+    "num_stages": 4,
+}
+_GLM_SMALL_W13_KERNEL_CONFIG = _DSV4_SMALL_KERNEL_CONFIG
+_GLM_LARGE_W13_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "num_stages": 4,
+}
+_GLM_W2_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "num_warps": 4,
+}
+_ROUTE_KERNEL_CONFIG = {"num_threads": 1024}
+RELEASE_MAX_TOKENS_PER_RANK = 32
+
+
+class SharedEpProfile(msgspec.Struct, frozen=True, kw_only=True):
+    name: str
+    capability: tuple[int, int]
+    hidden_size: int
+    intermediate_size: int
+    top_k: int
+    num_experts: int
+    num_local_experts: int
+    ep_size: int
+    max_tokens_per_rank: int
+    block_shape: tuple[int, int]
+    default_kernel_config: dict[str, int]
+    small_kernel_config: dict[str, int] | None
+    small_kernel_max_tokens: int
+    route_kernel_config: dict[str, int]
+    default_w13_kernel_config: dict[str, int] | None = None
+    default_w2_kernel_config: dict[str, int] | None = None
+    small_w13_kernel_config: dict[str, int] | None = None
+    small_w2_kernel_config: dict[str, int] | None = None
+
+    @property
+    def block_size_m(self) -> int:
+        return self.default_kernel_config["BLOCK_SIZE_M"]
+
+    def kernel_config(self, num_tokens: int) -> dict[str, int]:
+        self._validate_num_tokens(num_tokens)
+        if (
+            self.small_kernel_config is not None
+            and num_tokens <= self.small_kernel_max_tokens
+        ):
+            return self.small_kernel_config
+        return self.default_kernel_config
+
+    def w13_kernel_config(self, num_tokens: int) -> dict[str, int]:
+        return self._stage_kernel_config(
+            num_tokens,
+            default=self.default_w13_kernel_config,
+            small=self.small_w13_kernel_config,
+        )
+
+    def w2_kernel_config(self, num_tokens: int) -> dict[str, int]:
+        return self._stage_kernel_config(
+            num_tokens,
+            default=self.default_w2_kernel_config,
+            small=self.small_w2_kernel_config,
+        )
+
+    def _stage_kernel_config(
+        self,
+        num_tokens: int,
+        *,
+        default: dict[str, int] | None,
+        small: dict[str, int] | None,
+    ) -> dict[str, int]:
+        self._validate_num_tokens(num_tokens)
+        if num_tokens <= self.small_kernel_max_tokens:
+            if small is not None:
+                return small
+            if self.small_kernel_config is not None:
+                return self.small_kernel_config
+        if default is not None:
+            return default
+        return self.kernel_config(num_tokens)
+
+    def _validate_num_tokens(self, num_tokens: int) -> None:
+        if not 0 <= num_tokens <= self.max_tokens_per_rank:
+            raise ValueError(
+                f"local tokens {num_tokens} exceed profile capacity "
+                f"{self.max_tokens_per_rank}"
+            )
+
+    def admission_tuple(self) -> tuple:
+        return (
+            self.capability,
+            self.hidden_size,
+            self.intermediate_size,
+            self.top_k,
+            self.num_experts,
+            self.num_local_experts,
+            self.ep_size,
+            self.max_tokens_per_rank,
+            self.block_shape,
+        )
+
+
+GLM52 = SharedEpProfile(
+    name="glm52",
+    capability=(9, 0),
+    hidden_size=6144,
+    intermediate_size=2048,
+    top_k=8,
+    num_experts=256,
+    num_local_experts=32,
+    ep_size=8,
+    max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+    block_shape=(128, 128),
+    default_kernel_config=_DEFAULT_KERNEL_CONFIG,
+    small_kernel_config=None,
+    small_kernel_max_tokens=4,
+    route_kernel_config=_ROUTE_KERNEL_CONFIG,
+    default_w13_kernel_config=_GLM_LARGE_W13_KERNEL_CONFIG,
+    default_w2_kernel_config=_GLM_W2_KERNEL_CONFIG,
+    small_w13_kernel_config=_GLM_SMALL_W13_KERNEL_CONFIG,
+    small_w2_kernel_config=_GLM_W2_KERNEL_CONFIG,
+)
+
+DSV4_FLASH = SharedEpProfile(
+    name="dsv4_flash",
+    capability=(9, 0),
+    hidden_size=4096,
+    intermediate_size=2048,
+    top_k=6,
+    num_experts=256,
+    num_local_experts=32,
+    ep_size=8,
+    max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+    block_shape=(128, 128),
+    default_kernel_config=_DEFAULT_KERNEL_CONFIG,
+    small_kernel_config=_DSV4_SMALL_KERNEL_CONFIG,
+    small_kernel_max_tokens=4,
+    route_kernel_config=_ROUTE_KERNEL_CONFIG,
+    default_w13_kernel_config=_DSV4_LARGE_W13_KERNEL_CONFIG,
+    default_w2_kernel_config=_DSV4_SMALL_KERNEL_CONFIG,
+)
+
+_PROFILES = (GLM52, DSV4_FLASH)
+
+
+def select_profile(
+    config: MoeRunnerConfig,
+    *,
+    capability: tuple[int, int],
+    ep_size: int,
+    block_shape: tuple[int, int],
+    max_tokens_per_rank: int,
+) -> SharedEpProfile:
+    observed = (
+        capability,
+        config.hidden_size,
+        config.intermediate_size_per_partition,
+        config.top_k,
+        config.num_experts,
+        config.num_local_experts,
+        ep_size,
+        max_tokens_per_rank,
+        tuple(block_shape),
+    )
+    for profile in _PROFILES:
+        if observed == profile.admission_tuple():
+            return profile
+    supported = [profile.admission_tuple() for profile in _PROFILES]
+    raise ValueError(
+        "SharedEP supports only registered release profiles: "
+        f"observed={observed}, supported={supported}"
+    )

--- a/python/sglang/srt/layers/moe/shared_ep/pull_cache_prefill.py
+++ b/python/sglang/srt/layers/moe/shared_ep/pull_cache_prefill.py
@@ -1,0 +1,359 @@
+"""Pull-cache shared-object consumer for SharedEP prefill."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+
+
+class PullCachePrefillPlan(msgspec.Struct, frozen=True, kw_only=True):
+    source_rows: int
+    source_route_capacity: int
+    cache_rows: int
+    hidden_size: int
+    scale_groups: int
+    top_k: int
+    num_local_experts: int
+    expert_alignment: int
+
+    @property
+    def activation_bytes(self) -> int:
+        return self.cache_rows * self.hidden_size
+
+    @property
+    def scale_bytes(self) -> int:
+        return self.cache_rows * self.scale_groups * 4
+
+    @property
+    def total_cache_bytes(self) -> int:
+        return self.activation_bytes + self.scale_bytes
+
+
+class PullCache(msgspec.Struct, kw_only=True):
+    plan: PullCachePrefillPlan
+    active_rows: int
+    activations: torch.Tensor
+    scales: torch.Tensor
+    row_ids: torch.Tensor
+    row_weights: torch.Tensor
+    scale_backing: torch.Tensor
+
+
+def make_pull_cache_prefill_plan(
+    *,
+    owners: int,
+    source_tokens_per_owner: int,
+    hidden_size: int,
+    top_k: int,
+    num_local_experts: int,
+    expert_alignment: int,
+) -> PullCachePrefillPlan:
+    dimensions = {
+        "owners": owners,
+        "source_tokens_per_owner": source_tokens_per_owner,
+        "hidden_size": hidden_size,
+        "top_k": top_k,
+        "num_local_experts": num_local_experts,
+        "expert_alignment": expert_alignment,
+    }
+    for name, value in dimensions.items():
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {value}")
+    if hidden_size % 128 != 0:
+        raise ValueError(f"hidden_size must be divisible by 128, got {hidden_size}")
+    if expert_alignment & (expert_alignment - 1):
+        raise ValueError(
+            f"expert_alignment must be a power of two, got {expert_alignment}"
+        )
+    source_rows = owners * source_tokens_per_owner
+    source_route_capacity = source_rows * top_k
+    cache_rows = source_route_capacity + num_local_experts * (expert_alignment - 1)
+    return PullCachePrefillPlan(
+        source_rows=source_rows,
+        source_route_capacity=source_route_capacity,
+        cache_rows=cache_rows,
+        hidden_size=hidden_size,
+        scale_groups=hidden_size // 128,
+        top_k=top_k,
+        num_local_experts=num_local_experts,
+        expert_alignment=expert_alignment,
+    )
+
+
+def allocate_pull_cache(
+    plan: PullCachePrefillPlan,
+    *,
+    active_rows: int,
+    device: torch.device,
+) -> PullCache:
+    device = torch.device(device)
+    if device.type != "cuda":
+        raise ValueError(f"pull cache requires a CUDA device, got {device}")
+    if not 0 < active_rows <= plan.cache_rows:
+        raise ValueError(
+            f"active_rows must be in [1, {plan.cache_rows}], got {active_rows}"
+        )
+
+    activations = torch.empty(
+        (active_rows, plan.hidden_size),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+    padded_rows = triton.cdiv(active_rows, 4) * 4
+    scale_backing = torch.empty(
+        (plan.scale_groups, padded_rows),
+        dtype=torch.float32,
+        device=device,
+    )
+    scales = scale_backing.t()[:active_rows]
+    row_ids = torch.arange(active_rows, dtype=torch.int32, device=device)
+    row_weights = torch.ones((active_rows, 1), dtype=torch.float32, device=device)
+    return PullCache(
+        plan=plan,
+        active_rows=active_rows,
+        activations=activations,
+        scales=scales,
+        row_ids=row_ids,
+        row_weights=row_weights,
+        scale_backing=scale_backing,
+    )
+
+
+@triton.jit
+def _pull_cache_rows_kernel(
+    source_activations,
+    source_scales,
+    sorted_token_ids,
+    num_tokens_post_padded,
+    cache_activations,
+    cache_scales,
+    source_activation_row_stride: tl.constexpr,
+    source_activation_column_stride: tl.constexpr,
+    source_scale_row_stride: tl.constexpr,
+    source_scale_column_stride: tl.constexpr,
+    cache_activation_row_stride: tl.constexpr,
+    cache_activation_column_stride: tl.constexpr,
+    cache_scale_row_stride: tl.constexpr,
+    cache_scale_column_stride: tl.constexpr,
+    hidden_size: tl.constexpr,
+    scale_groups: tl.constexpr,
+    activation_block: tl.constexpr,
+    scale_block: tl.constexpr,
+    top_k: tl.constexpr,
+    source_route_capacity: tl.constexpr,
+):
+    row = tl.program_id(0)
+    padded_rows = tl.load(num_tokens_post_padded)
+    valid_row = row < padded_rows
+    if valid_row:
+        route_id = tl.load(sorted_token_ids + row)
+        valid_route = (route_id >= 0) & (route_id < source_route_capacity)
+        source_row = route_id // top_k
+
+        for column_start in tl.static_range(0, hidden_size, activation_block):
+            columns = column_start + tl.arange(0, activation_block)
+            column_mask = columns < hidden_size
+            values = tl.load(
+                source_activations
+                + source_row * source_activation_row_stride
+                + columns * source_activation_column_stride,
+                mask=valid_route & column_mask,
+                other=0.0,
+            )
+            tl.store(
+                cache_activations
+                + row * cache_activation_row_stride
+                + columns * cache_activation_column_stride,
+                values,
+                mask=column_mask,
+            )
+
+        scale_columns = tl.arange(0, scale_block)
+        scale_mask = scale_columns < scale_groups
+        scale_values = tl.load(
+            source_scales
+            + source_row * source_scale_row_stride
+            + scale_columns * source_scale_column_stride,
+            mask=valid_route & scale_mask,
+            other=0.0,
+        )
+        tl.store(
+            cache_scales
+            + row * cache_scale_row_stride
+            + scale_columns * cache_scale_column_stride,
+            scale_values,
+            mask=scale_mask,
+        )
+
+
+def pull_cache_rows(
+    *,
+    source_activations: torch.Tensor,
+    source_scales: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    cache: PullCache,
+    top_k: int,
+    source_route_capacity: int,
+) -> None:
+    _validate_pull_inputs(
+        source_activations=source_activations,
+        source_scales=source_scales,
+        sorted_token_ids=sorted_token_ids,
+        num_tokens_post_padded=num_tokens_post_padded,
+        cache=cache,
+        top_k=top_k,
+        source_route_capacity=source_route_capacity,
+    )
+    _pull_cache_rows_kernel[(cache.active_rows,)](
+        source_activations,
+        source_scales,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        cache.activations,
+        cache.scales,
+        source_activation_row_stride=source_activations.stride(0),
+        source_activation_column_stride=source_activations.stride(1),
+        source_scale_row_stride=source_scales.stride(0),
+        source_scale_column_stride=source_scales.stride(1),
+        cache_activation_row_stride=cache.activations.stride(0),
+        cache_activation_column_stride=cache.activations.stride(1),
+        cache_scale_row_stride=cache.scales.stride(0),
+        cache_scale_column_stride=cache.scales.stride(1),
+        hidden_size=cache.plan.hidden_size,
+        scale_groups=cache.plan.scale_groups,
+        activation_block=256,
+        scale_block=triton.next_power_of_2(cache.plan.scale_groups),
+        top_k=top_k,
+        source_route_capacity=source_route_capacity,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+def invoke_pull_cache_w13(
+    *,
+    cache: PullCache,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    config: dict[str, int],
+    block_shape: tuple[int, int],
+) -> None:
+    if output.shape[0] != cache.active_rows:
+        raise ValueError("W13 output rows must match the pull-cache capacity")
+    invoke_fused_moe_kernel(
+        A=cache.activations,
+        B=weight,
+        bias=None,
+        C=output,
+        A_scale=cache.scales,
+        B_scale=weight_scale,
+        B_zp=None,
+        topk_weights=cache.row_weights,
+        topk_ids=cache.row_ids.view(-1, 1),
+        sorted_token_ids=cache.row_ids,
+        expert_ids=expert_ids,
+        num_tokens_post_padded=num_tokens_post_padded,
+        mul_routed_weight=False,
+        top_k=1,
+        config=config,
+        compute_type=tl.bfloat16,
+        use_fp8_w8a8=True,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        per_channel_quant=False,
+        block_shape=list(block_shape),
+        filter_expert=True,
+        c_sorted=True,
+        a_is_prequantized=True,
+    )
+
+
+def _validate_pull_inputs(
+    *,
+    source_activations: torch.Tensor,
+    source_scales: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    cache: PullCache,
+    top_k: int,
+    source_route_capacity: int,
+) -> None:
+    tensors = (
+        source_activations,
+        source_scales,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        cache.activations,
+        cache.scales,
+        cache.row_ids,
+        cache.row_weights,
+    )
+    if any(tensor.device != cache.activations.device for tensor in tensors):
+        raise ValueError("pull-cache tensors must be on the same CUDA device")
+    if source_activations.dtype != torch.float8_e4m3fn:
+        raise TypeError("source activations must use float8_e4m3fn")
+    if source_activations.ndim != 2:
+        raise ValueError("source activations must be two-dimensional")
+    if source_activations.shape[1] != cache.plan.hidden_size:
+        raise ValueError("source activation hidden size does not match the cache plan")
+    if source_scales.dtype != torch.float32:
+        raise TypeError("source scales must use float32")
+    if source_scales.shape != (
+        source_activations.shape[0],
+        cache.plan.scale_groups,
+    ):
+        raise ValueError("source scale shape does not match source activations")
+    for name, tensor in (
+        ("sorted_token_ids", sorted_token_ids),
+        ("num_tokens_post_padded", num_tokens_post_padded),
+    ):
+        if tensor.dtype != torch.int32:
+            raise TypeError(f"{name} must use int32")
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+    if sorted_token_ids.ndim != 1 or sorted_token_ids.numel() < cache.active_rows:
+        raise ValueError("sorted_token_ids must cover every cache row")
+    if num_tokens_post_padded.numel() != 1:
+        raise ValueError("num_tokens_post_padded must contain one device scalar")
+    if top_k != cache.plan.top_k:
+        raise ValueError(f"top_k must match cache plan value {cache.plan.top_k}")
+    max_route_capacity = source_activations.shape[0] * top_k
+    if not 0 < source_route_capacity <= max_route_capacity:
+        raise ValueError(
+            "source_route_capacity must be positive and cannot exceed source rows "
+            f"times Top-K ({max_route_capacity})"
+        )
+    if cache.activations.shape != (
+        cache.active_rows,
+        cache.plan.hidden_size,
+    ):
+        raise ValueError("cache activation shape does not match the cache plan")
+    if not cache.activations.is_contiguous() or cache.activations.stride(1) != 1:
+        raise ValueError("cache activations must be contiguous")
+    if cache.scales.shape != (cache.active_rows, cache.plan.scale_groups):
+        raise ValueError("cache scale shape does not match the cache plan")
+    if cache.scales.stride(0) != 1:
+        raise ValueError("cache scales must use the TMA-aligned column-major layout")
+    if (
+        cache.row_ids.dtype != torch.int32
+        or cache.row_ids.shape != (cache.active_rows,)
+        or not cache.row_ids.is_contiguous()
+    ):
+        raise ValueError("cache row_ids must be contiguous int32 cache indices")
+    if (
+        cache.row_weights.dtype != torch.float32
+        or cache.row_weights.shape != (cache.active_rows, 1)
+        or not cache.row_weights.is_contiguous()
+    ):
+        raise ValueError("cache row_weights must be contiguous float32 column values")

--- a/python/sglang/srt/layers/moe/shared_ep/state.py
+++ b/python/sglang/srt/layers/moe/shared_ep/state.py
@@ -1,0 +1,128 @@
+"""Owning SharedEP VMM state and typed tensor views."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.moe.shared_ep.epoch import GpuEpoch, create_gpu_epoch
+from sglang.srt.layers.moe.shared_ep.layout import (
+    SharedEpInputViews,
+    SharedEpLayout,
+    align_output_layout,
+)
+from sglang.srt.layers.moe.shared_ep.vmm import (
+    SharedEpVmmAllocation,
+    allocate_rank_major_vmm,
+)
+
+
+class SharedEpState(msgspec.Struct, kw_only=True):
+    """Process-lifetime mappings; ``close`` supports partial setup cleanup."""
+
+    layout: SharedEpLayout
+    input_allocation: SharedEpVmmAllocation
+    output_allocation: SharedEpVmmAllocation
+    input_epoch: GpuEpoch
+    output_epoch: GpuEpoch
+    global_input: SharedEpInputViews | None
+    local_input: SharedEpInputViews | None
+    global_output: torch.Tensor | None
+    local_output: torch.Tensor | None
+    _closed: bool = False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.global_input = None
+        self.local_input = None
+        self.global_output = None
+        self.local_output = None
+        self.output_epoch.close()
+        self.input_epoch.close()
+        self.output_allocation.close()
+        self.input_allocation.close()
+
+
+def create_shared_ep_state(
+    *,
+    layout: SharedEpLayout,
+    cpu_group,
+    device: torch.device,
+) -> SharedEpState:
+    rank = dist.get_rank(group=cpu_group)
+    world_size = dist.get_world_size(group=cpu_group)
+    resources = []
+    try:
+        input_allocation = allocate_rank_major_vmm(
+            cpu_group=cpu_group,
+            device=device,
+            logical_rank_bytes=layout.input_rank_bytes,
+        )
+        resources.append(input_allocation)
+        layout = align_output_layout(
+            layout,
+            granularity=input_allocation.granularity,
+        )
+        output_allocation = allocate_rank_major_vmm(
+            cpu_group=cpu_group,
+            device=device,
+            logical_rank_bytes=layout.output_rank_bytes,
+        )
+        resources.append(output_allocation)
+        if output_allocation.mapped_rank_bytes != layout.output_rank_bytes:
+            raise RuntimeError(
+                "SharedEP output rank stride must be exactly representable by rows"
+            )
+        input_epoch = create_gpu_epoch(
+            cpu_group=cpu_group,
+            device=device,
+            rank=rank,
+            world_size=world_size,
+        )
+        resources.append(input_epoch)
+        output_epoch = create_gpu_epoch(
+            cpu_group=cpu_group,
+            device=device,
+            rank=rank,
+            world_size=world_size,
+        )
+        resources.append(output_epoch)
+
+        global_input = layout.input_views(
+            input_allocation.global_storage,
+            world_size=world_size,
+            mapped_rank_bytes=input_allocation.mapped_rank_bytes,
+        )
+        local_input = layout.input_views(
+            input_allocation.local_storage,
+            world_size=1,
+            mapped_rank_bytes=input_allocation.mapped_rank_bytes,
+        ).owner(0)
+        global_output = layout.output_view(
+            output_allocation.global_storage,
+            world_size=world_size,
+            mapped_rank_bytes=output_allocation.mapped_rank_bytes,
+        )
+        local_output = layout.output_view(
+            output_allocation.local_storage,
+            world_size=1,
+            mapped_rank_bytes=output_allocation.mapped_rank_bytes,
+        )[0]
+        return SharedEpState(
+            layout=layout,
+            input_allocation=input_allocation,
+            output_allocation=output_allocation,
+            input_epoch=input_epoch,
+            output_epoch=output_epoch,
+            global_input=global_input,
+            local_input=local_input,
+            global_output=global_output,
+            local_output=local_output,
+        )
+    except BaseException:
+        while resources:
+            resources.pop().close()
+        raise

--- a/python/sglang/srt/layers/moe/shared_ep/vmm.py
+++ b/python/sglang/srt/layers/moe/shared_ep/vmm.py
@@ -1,0 +1,529 @@
+"""Private rank-major byte VMM allocation for SharedEP.
+
+Initialization uses a CPU process group to exchange shareable CUDA allocation
+handles. The resulting tensor views are stable CUDA virtual addresses and do
+not require collectives in the forward path.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+
+import msgspec
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.distributed.device_communicators.vmm_utils import (
+    _get_cuda_driver,
+    all_ranks_ok,
+    check_drv,
+    exchange_posix_fds,
+    export_shareable_handles,
+    import_peer_handle,
+    make_rw_access_desc,
+)
+
+_CLOSED_DLPACK_REFS: list[list[object]] = []
+
+
+def round_up_to_granularity(value: int, granularity: int) -> int:
+    if value <= 0:
+        raise ValueError(f"value must be positive, got {value}")
+    if granularity <= 0:
+        raise ValueError(f"granularity must be positive, got {granularity}")
+    return ((value + granularity - 1) // granularity) * granularity
+
+
+def _synchronize_vmm_stage(
+    cpu_group: ProcessGroup,
+    rank: int,
+    stage: str,
+    local_error: BaseException | None,
+) -> None:
+    errors: list[str | None] = [None] * dist.get_world_size(group=cpu_group)
+    dist.all_gather_object(
+        errors,
+        None if local_error is None else str(local_error),
+        group=cpu_group,
+    )
+    for failed_rank, error in enumerate(errors):
+        if error is not None:
+            message = f"SharedEP VMM {stage} failed on rank {failed_rank}: {error}"
+            if failed_rank == rank:
+                raise RuntimeError(message) from local_error
+            raise RuntimeError(message)
+
+
+def _validate_same_host_group(cpu_group: ProcessGroup) -> None:
+    rank = dist.get_rank(group=cpu_group)
+    hosts: list[str | None] = [None] * dist.get_world_size(group=cpu_group)
+    hostname = None
+    host_error = None
+    try:
+        hostname = os.uname().nodename
+    except BaseException as error:
+        host_error = error
+    _synchronize_vmm_stage(cpu_group, rank, "host query", host_error)
+    dist.all_gather_object(hosts, hostname, group=cpu_group)
+    if len(set(hosts)) != 1:
+        raise ValueError("SharedEP VMM requires every EP rank to be on the same host")
+
+
+def _release_partial_vmm_mapping(
+    driver,
+    *,
+    base_va: int | None,
+    total_bytes: int,
+    mapped_addresses: list[int],
+    segment_bytes: int,
+) -> None:
+    while mapped_addresses:
+        driver.cuMemUnmap(mapped_addresses.pop(), segment_bytes)
+    if base_va is not None:
+        driver.cuMemAddressFree(base_va, total_bytes)
+
+
+def _release_vmm_handles_synchronized(
+    driver,
+    *,
+    retained_handles: list,
+    cpu_group: ProcessGroup,
+    rank: int,
+) -> None:
+    """Release setup handles and publish the result before returning."""
+
+    release_error = None
+    try:
+        while retained_handles:
+            handle = retained_handles[-1]
+            check_drv(
+                driver.cuMemRelease(handle),
+                "cuMemRelease(shared setup handle)",
+            )
+            retained_handles.pop()
+    except BaseException as error:
+        release_error = error
+    _synchronize_vmm_stage(cpu_group, rank, "handle release", release_error)
+
+
+class SharedEpVmmAllocation(msgspec.Struct, kw_only=True):
+    local_storage: torch.Tensor
+    global_storage: torch.Tensor
+    rank: int
+    world_size: int
+    logical_rank_bytes: int
+    mapped_rank_bytes: int
+    granularity: int
+    _base_va: int = 0
+    _total_bytes: int = 0
+    _dlpack_refs: list[object] = msgspec.field(default_factory=list)
+    _closed: bool = False
+
+    def rank_offset(self, rank: int) -> int:
+        if not 0 <= rank < self.world_size:
+            raise IndexError(
+                f"rank {rank} is outside SharedEP world size {self.world_size}"
+            )
+        return rank * self.mapped_rank_bytes
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.local_storage = torch.empty(0, dtype=torch.uint8)
+        self.global_storage = torch.empty(0, dtype=torch.uint8)
+        if self._base_va:
+            torch.cuda.synchronize()
+            driver = _get_cuda_driver()
+            for segment in range(self.world_size):
+                address = self._base_va + segment * self.mapped_rank_bytes
+                check_drv(
+                    driver.cuMemUnmap(address, self.mapped_rank_bytes),
+                    f"cuMemUnmap(segment={segment})",
+                )
+            check_drv(
+                driver.cuMemAddressFree(self._base_va, self._total_bytes),
+                "cuMemAddressFree",
+            )
+            self._base_va = 0
+        if self._dlpack_refs:
+            _CLOSED_DLPACK_REFS.append(self._dlpack_refs)
+            self._dlpack_refs = []
+
+
+def _make_allocation_prop(driver, device_id: int, requested_handle_types):
+    prop = driver.CUmemAllocationProp()
+    prop.requestedHandleTypes = requested_handle_types
+    prop.type = driver.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    prop.location = driver.CUmemLocation()
+    prop.location.type = driver.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    prop.location.id = device_id
+    if hasattr(prop, "allocFlags") and hasattr(prop.allocFlags, "gpuDirectRDMACapable"):
+        prop.allocFlags.gpuDirectRDMACapable = 1
+    return prop
+
+
+def _select_handle_transport(
+    group: ProcessGroup,
+    *,
+    rank: int,
+    world_size: int,
+    local_handle,
+) -> tuple[bool, list[bytes | None], list[int], dict[tuple[int, int], int]]:
+    fabric_handles, local_fds, use_fabric = export_shareable_handles(
+        [local_handle],
+        group,
+        rank,
+    )
+    gathered: list[bytes | None] = [None] * world_size
+    if use_fabric:
+        dist.all_gather_object(gathered, fabric_handles[0], group=group)
+        return True, gathered, [], {}
+    try:
+        peer_fds = exchange_posix_fds(
+            group,
+            rank,
+            world_size,
+            local_fds,
+            [1] * world_size,
+        )
+    except BaseException:
+        for fd in local_fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        raise
+    return False, gathered, local_fds, peer_fds
+
+
+class _DLDevice(ctypes.Structure):
+    _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
+
+
+class _DLDataType(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_uint8),
+        ("bits", ctypes.c_uint8),
+        ("lanes", ctypes.c_uint16),
+    ]
+
+
+class _DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", _DLDevice),
+        ("ndim", ctypes.c_int),
+        ("dtype", _DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class _DLManagedTensor(ctypes.Structure):
+    pass
+
+
+_DELETER_FN = ctypes.CFUNCTYPE(None, ctypes.POINTER(_DLManagedTensor))
+_DLManagedTensor._fields_ = [
+    ("dl_tensor", _DLTensor),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", _DELETER_FN),
+]
+
+
+def _uint8_tensor_from_cuda_ptr(
+    ptr: int,
+    length: int,
+    device_id: int,
+    refs: list[object],
+) -> torch.Tensor:
+    shape = (ctypes.c_int64 * 1)(length)
+    managed = _DLManagedTensor()
+    managed.dl_tensor.data = ctypes.c_void_p(ptr)
+    managed.dl_tensor.device = _DLDevice(2, device_id)
+    managed.dl_tensor.ndim = 1
+    managed.dl_tensor.dtype = _DLDataType(1, 8, 1)
+    managed.dl_tensor.shape = shape
+    managed.dl_tensor.strides = None
+    managed.dl_tensor.byte_offset = 0
+    managed.manager_ctx = None
+
+    @_DELETER_FN
+    def deleter(_):
+        return None
+
+    managed.deleter = deleter
+    refs.extend([managed, shape, deleter])
+    ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+    ctypes.pythonapi.PyCapsule_New.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+        ctypes.c_void_p,
+    ]
+    capsule = ctypes.pythonapi.PyCapsule_New(ctypes.byref(managed), b"dltensor", None)
+    return torch.from_dlpack(capsule)
+
+
+def _construct_rank_major_views(
+    *,
+    cpu_group: ProcessGroup,
+    rank: int,
+    base_va: int,
+    total_bytes: int,
+    mapped_rank_bytes: int,
+    logical_rank_bytes: int,
+    device_id: int,
+    refs: list[object],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Construct both DLPack aliases, then publish one symmetric result."""
+
+    global_storage = None
+    local_storage = None
+    view_error = None
+    try:
+        global_storage = _uint8_tensor_from_cuda_ptr(
+            base_va,
+            total_bytes,
+            device_id,
+            refs,
+        )
+        local_storage = global_storage.narrow(
+            0,
+            rank * mapped_rank_bytes,
+            logical_rank_bytes,
+        )
+    except BaseException as error:
+        view_error = error
+
+    _synchronize_vmm_stage(
+        cpu_group,
+        rank,
+        "tensor view construction",
+        view_error,
+    )
+    assert global_storage is not None and local_storage is not None
+    return global_storage, local_storage
+
+
+def allocate_rank_major_vmm(
+    *,
+    cpu_group: ProcessGroup,
+    device: torch.device,
+    logical_rank_bytes: int,
+) -> SharedEpVmmAllocation:
+    """Allocate one physical byte segment per rank and map them rank-major."""
+
+    if logical_rank_bytes <= 0:
+        raise ValueError(
+            f"logical_rank_bytes must be positive, got {logical_rank_bytes}"
+        )
+    if device.type != "cuda":
+        raise ValueError(f"SharedEP VMM requires a CUDA device, got {device}")
+
+    rank = dist.get_rank(group=cpu_group)
+    world_size = dist.get_world_size(group=cpu_group)
+    _validate_same_host_group(cpu_group)
+
+    driver = None
+    device_id = None
+    posix_type = None
+    prop = None
+    granularity = None
+    mapped_rank_bytes = None
+    preflight_error = None
+    try:
+        driver = _get_cuda_driver()
+        device_id = device.index
+        if device_id is None:
+            device_id = torch.cuda.current_device()
+        handle_types = driver.CUmemAllocationHandleType
+        combined_types = (
+            handle_types.CU_MEM_HANDLE_TYPE_FABRIC
+            | handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+        posix_type = handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        prop = _make_allocation_prop(driver, device_id, combined_types)
+        granularity = int(
+            check_drv(
+                driver.cuMemGetAllocationGranularity(
+                    prop,
+                    driver.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+                ),
+                "cuMemGetAllocationGranularity",
+            )
+        )
+        mapped_rank_bytes = round_up_to_granularity(
+            logical_rank_bytes,
+            granularity,
+        )
+    except BaseException as error:
+        preflight_error = error
+    _synchronize_vmm_stage(
+        cpu_group,
+        rank,
+        "preflight",
+        preflight_error,
+    )
+    assert driver is not None
+    assert device_id is not None
+    assert posix_type is not None
+    assert prop is not None
+    assert granularity is not None
+    assert mapped_rank_bytes is not None
+
+    error, local_handle = driver.cuMemCreate(mapped_rank_bytes, prop, 0)
+    if not all_ranks_ok(cpu_group, error == driver.CUresult.CUDA_SUCCESS):
+        if error == driver.CUresult.CUDA_SUCCESS:
+            driver.cuMemRelease(local_handle)
+        prop = _make_allocation_prop(driver, device_id, posix_type)
+        error, local_handle = driver.cuMemCreate(mapped_rank_bytes, prop, 0)
+        create_error = (
+            None
+            if error == driver.CUresult.CUDA_SUCCESS
+            else RuntimeError(f"cuMemCreate(POSIX_FD): {error}")
+        )
+        try:
+            _synchronize_vmm_stage(
+                cpu_group,
+                rank,
+                "allocation",
+                create_error,
+            )
+        except BaseException:
+            if error == driver.CUresult.CUDA_SUCCESS:
+                driver.cuMemRelease(local_handle)
+            raise
+    elif error != driver.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuMemCreate(FABRIC|POSIX_FD): {error}")
+
+    local_fds: list[int] = []
+    peer_fds: dict[tuple[int, int], int] = {}
+    imported_handles = []
+    retained_handles = []
+    base_va: int | None = None
+    mapped_addresses: list[int] = []
+    total_bytes = mapped_rank_bytes * world_size
+    try:
+        use_fabric, fabric_handles, local_fds, peer_fds = _select_handle_transport(
+            cpu_group,
+            rank=rank,
+            world_size=world_size,
+            local_handle=local_handle,
+        )
+
+        mapping_error = None
+        try:
+            base_va = int(
+                check_drv(
+                    driver.cuMemAddressReserve(total_bytes, granularity, 0, 0),
+                    "cuMemAddressReserve",
+                )
+            )
+            access = make_rw_access_desc(device_id)
+            for peer_rank in range(world_size):
+                handle = local_handle
+                if peer_rank != rank:
+                    handle = import_peer_handle(
+                        fabric_handles[peer_rank],
+                        None if use_fabric else peer_fds[(peer_rank, 0)],
+                        use_fabric=use_fabric,
+                        peer_rank=peer_rank,
+                    )
+                    imported_handles.append(handle)
+                address = base_va + peer_rank * mapped_rank_bytes
+                check_drv(
+                    driver.cuMemMap(
+                        address,
+                        mapped_rank_bytes,
+                        0,
+                        handle,
+                        0,
+                    ),
+                    f"cuMemMap(rank={peer_rank})",
+                )
+                mapped_addresses.append(address)
+                check_drv(
+                    driver.cuMemSetAccess(
+                        address,
+                        mapped_rank_bytes,
+                        [access],
+                        1,
+                    ),
+                    f"cuMemSetAccess(rank={peer_rank})",
+                )
+        except BaseException as error:
+            mapping_error = error
+
+        _synchronize_vmm_stage(
+            cpu_group,
+            rank,
+            "mapping",
+            mapping_error,
+        )
+        assert base_va is not None
+
+        refs: list[object] = []
+        global_storage, local_storage = _construct_rank_major_views(
+            cpu_group=cpu_group,
+            rank=rank,
+            base_va=base_va,
+            total_bytes=total_bytes,
+            mapped_rank_bytes=mapped_rank_bytes,
+            logical_rank_bytes=logical_rank_bytes,
+            device_id=device_id,
+            refs=refs,
+        )
+
+        retained_handles.extend(imported_handles)
+        imported_handles.clear()
+        retained_handles.append(local_handle)
+        local_handle = None
+        _release_vmm_handles_synchronized(
+            driver,
+            retained_handles=retained_handles,
+            cpu_group=cpu_group,
+            rank=rank,
+        )
+        return SharedEpVmmAllocation(
+            local_storage=local_storage,
+            global_storage=global_storage,
+            rank=rank,
+            world_size=world_size,
+            logical_rank_bytes=logical_rank_bytes,
+            mapped_rank_bytes=mapped_rank_bytes,
+            granularity=granularity,
+            _base_va=base_va,
+            _total_bytes=total_bytes,
+            _dlpack_refs=refs,
+        )
+    except BaseException:
+        _release_partial_vmm_mapping(
+            driver,
+            base_va=base_va,
+            total_bytes=total_bytes,
+            mapped_addresses=mapped_addresses,
+            segment_bytes=mapped_rank_bytes,
+        )
+        for handle in imported_handles:
+            driver.cuMemRelease(handle)
+        for handle in retained_handles:
+            driver.cuMemRelease(handle)
+        retained_handles.clear()
+        if local_handle is not None:
+            driver.cuMemRelease(local_handle)
+        raise
+    finally:
+        for fd in local_fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        for fd in peer_fds.values():
+            try:
+                os.close(fd)
+            except OSError:
+                pass

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -287,7 +287,7 @@ class DeepEPBuffer:
     @classmethod
     def clean_buffer(cls):
         state = cls._state()
-        if not state.buffer.low_latency_mode:
+        if state.buffer is None or not state.buffer.low_latency_mode:
             return
         state.buffer.clean_low_latency_buffer(
             state.num_max_dispatch_tokens_per_rank,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -37,6 +37,7 @@ class MoeA2ABackend(Enum):
     FLASHINFER = "flashinfer"
     MEGAMOE = "megamoe"
     PPLX = "pplx"
+    SHARED_EP = "shared_ep"
     CUSTOMIZED = "customized"
 
     @classmethod
@@ -77,6 +78,9 @@ class MoeA2ABackend(Enum):
 
     def is_pplx(self):
         return self == MoeA2ABackend.PPLX
+
+    def is_shared_ep(self):
+        return self == MoeA2ABackend.SHARED_EP
 
     def is_customized(self):
         return self == MoeA2ABackend.CUSTOMIZED
@@ -388,9 +392,15 @@ def is_sbo_enabled() -> bool:
 
 
 def is_deepep_class_backend() -> bool:
-    """Check if the MoE backend is DeepEP-family (DeepEP, Mooncake, Mori, or PPLX)."""
+    """Check whether the backend uses the EP-sharded model contract."""
     b = get_moe_a2a_backend()
-    return b.is_deepep() or b.is_mooncake() or b.is_mori() or b.is_pplx()
+    return (
+        b.is_deepep()
+        or b.is_mooncake()
+        or b.is_mori()
+        or b.is_pplx()
+        or b.is_shared_ep()
+    )
 
 
 def uses_per_rank_fused_shared_slots() -> bool:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -730,6 +730,7 @@ class DeepseekV2MoE(nn.Module):
                 or get_moe_a2a_backend().is_ascend_fuseep()
                 or get_moe_a2a_backend().is_flashinfer()
                 or get_moe_a2a_backend().is_megamoe()
+                or get_moe_a2a_backend().is_shared_ep()
                 or should_use_flashinfer_cutlass_moe_fp4_allgather()
                 or envs.SGLANG_SHARED_EXPERT_TP1.get()
             )
@@ -810,6 +811,7 @@ class DeepseekV2MoE(nn.Module):
             or get_moe_a2a_backend().is_nixl()
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
+            or get_moe_a2a_backend().is_shared_ep()
         ):
             # TODO: we will support tp < ep in the future
             self.ep_size = get_parallel().moe_ep_size
@@ -832,6 +834,7 @@ class DeepseekV2MoE(nn.Module):
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
             or get_moe_a2a_backend().is_flashinfer()
+            or get_moe_a2a_backend().is_shared_ep()
         )
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
         # SGLANG_OPT_MOE_QUANT_ONCE eligibility, resolved lazily on first
@@ -2686,7 +2689,11 @@ class DeepseekV2Model(nn.Module):
                 )
             )
         self.layers_to_capture = []
-        if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mooncake():
+        if (
+            get_moe_a2a_backend().is_deepep()
+            or get_moe_a2a_backend().is_mooncake()
+            or get_moe_a2a_backend().is_shared_ep()
+        ):
             self.enable_a2a_moe = True
         else:
             self.enable_a2a_moe = False

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -478,6 +478,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
                     or get_moe_a2a_backend().is_mori()
                     or get_moe_a2a_backend().is_ascend_fuseep()
                     or get_moe_a2a_backend().is_flashinfer()
+                    or get_moe_a2a_backend().is_shared_ep()
                     or should_use_flashinfer_cutlass_moe_fp4_allgather()
                     else {}
                 ),
@@ -522,6 +523,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
             or get_moe_a2a_backend().is_nixl()
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
+            or get_moe_a2a_backend().is_shared_ep()
         ):
             # TODO: we will support tp < ep in the future
             self.ep_size = get_parallel().moe_ep_size
@@ -544,6 +546,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
             or get_moe_a2a_backend().is_flashinfer()
+            or get_moe_a2a_backend().is_shared_ep()
         )
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
 
@@ -1194,9 +1197,14 @@ class Glm4MoeForCausalLM(nn.Module):
         ):
             disable_reason = "Only GLM-4.5 on AMD-platform with capability >= gfx942(MI30x) can use shared experts fusion optimization under expert parallelism."
         elif disable_reason is None and (
-            get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mori()
+            get_moe_a2a_backend().is_deepep()
+            or get_moe_a2a_backend().is_mori()
+            or get_moe_a2a_backend().is_shared_ep()
         ):
-            disable_reason = "GLM-4.5 cannot use shared experts fusion optimization under deepep expert parallelism."
+            disable_reason = (
+                "GLM-4.5 cannot fuse shared experts with the selected "
+                "expert-parallel A2A backend."
+            )
         elif self.quant_config and self.quant_config.get_name() == "w4afp8":
             disable_reason = "GLM-4.5 W4AFP8 model uses different quant method for routed experts and shared experts."
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -274,6 +274,7 @@ MOE_A2A_BACKEND_CHOICES = [
     "megamoe",
     "pplx",
     "ascend_tp",
+    "shared_ep",
 ]
 
 MXFP8_MOE_RUNNER_BACKEND_CHOICES = [
@@ -2255,9 +2256,14 @@ class ServerArgs:
             "flashinfer",
             "megamoe",
             "pplx",
+            "ascend_tp",
+            "shared_ep",
         ],
         Arg(
-            help="Choose the backend for MoE A2A.",
+            help=(
+                "Choose the backend for MoE A2A. shared_ep is a composite "
+                "backend that uses SharedEP for decode and DeepEP for prefill."
+            ),
             choices=MOE_A2A_BACKEND_CHOICES,
             resolvable=True,
         ),
@@ -8593,6 +8599,12 @@ class ServerArgs:
             )
 
         # Check two batch overlap backend requirement.
+        if self.moe_a2a_backend == "shared_ep":
+            from sglang.srt.layers.moe.shared_ep.admission import (
+                validate_shared_ep_server_args,
+            )
+
+            validate_shared_ep_server_args(self)
         self._check_two_batch_overlap()
 
         # Check communications compression

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2261,8 +2261,9 @@ class ServerArgs:
         ],
         Arg(
             help=(
-                "Choose the backend for MoE A2A. shared_ep is a composite "
-                "backend that uses SharedEP for decode and DeepEP for prefill."
+                "Choose the backend for MoE A2A. shared_ep uses a direct "
+                "shared-object consumer for decode, a pull-cache consumer for "
+                "admitted prefill shapes, and the Triton FusedMoE runner."
             ),
             choices=MOE_A2A_BACKEND_CHOICES,
             resolvable=True,

--- a/test/manual/ep/test_shared_ep_pull_cache_prefill.py
+++ b/test/manual/ep/test_shared_ep_pull_cache_prefill.py
@@ -1,0 +1,482 @@
+import unittest
+
+import torch
+import triton.language as tl
+
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.srt.layers.moe.shared_ep.pull_cache_prefill import (
+    PullCache,
+    allocate_pull_cache,
+    invoke_pull_cache_w13,
+    make_pull_cache_prefill_plan,
+    pull_cache_rows,
+)
+
+
+class TestPullCachePrefillPlan(unittest.TestCase):
+    def test_glm_prefill_plan(self):
+        plan = make_pull_cache_prefill_plan(
+            owners=8,
+            source_tokens_per_owner=1024,
+            hidden_size=6144,
+            top_k=8,
+            num_local_experts=32,
+            expert_alignment=128,
+        )
+
+        self.assertEqual(plan.source_rows, 8192)
+        self.assertEqual(plan.source_route_capacity, 65536)
+        self.assertEqual(plan.cache_rows, 69600)
+        self.assertEqual(plan.scale_groups, 48)
+        self.assertEqual(plan.activation_bytes, 427622400)
+        self.assertEqual(plan.scale_bytes, 13363200)
+        self.assertEqual(plan.total_cache_bytes, 440985600)
+
+    def test_invalid_dimensions_are_rejected(self):
+        valid = {
+            "owners": 8,
+            "source_tokens_per_owner": 1024,
+            "hidden_size": 6144,
+            "top_k": 8,
+            "num_local_experts": 32,
+            "expert_alignment": 128,
+        }
+        for name in valid:
+            with self.subTest(name=name):
+                invalid = {**valid, name: 0}
+                with self.assertRaisesRegex(ValueError, "positive"):
+                    make_pull_cache_prefill_plan(**invalid)
+
+    def test_hidden_size_must_be_divisible_by_scale_group(self):
+        with self.assertRaisesRegex(ValueError, "divisible by 128"):
+            make_pull_cache_prefill_plan(
+                owners=8,
+                source_tokens_per_owner=1024,
+                hidden_size=6145,
+                top_k=8,
+                num_local_experts=32,
+                expert_alignment=128,
+            )
+
+    def test_expert_alignment_must_be_a_power_of_two(self):
+        with self.assertRaisesRegex(ValueError, "power of two"):
+            make_pull_cache_prefill_plan(
+                owners=8,
+                source_tokens_per_owner=1024,
+                hidden_size=6144,
+                top_k=8,
+                num_local_experts=32,
+                expert_alignment=96,
+            )
+
+    def test_plan_is_immutable(self):
+        plan = make_pull_cache_prefill_plan(
+            owners=8,
+            source_tokens_per_owner=1024,
+            hidden_size=6144,
+            top_k=8,
+            num_local_experts=32,
+            expert_alignment=128,
+        )
+        with self.assertRaises(AttributeError):
+            plan.cache_rows = 1
+
+
+class TestPullCachePrefillCuda(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_inactive_capacity_tail_is_not_rewritten(self):
+        plan = make_pull_cache_prefill_plan(
+            owners=1,
+            source_tokens_per_owner=4,
+            hidden_size=256,
+            top_k=2,
+            num_local_experts=2,
+            expert_alignment=8,
+        )
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=16,
+            device=torch.device("cuda"),
+        )
+        cache.activations.fill_(7)
+        cache.scales.fill_(7)
+        sorted_token_ids = torch.full(
+            (16,),
+            plan.source_route_capacity,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        sorted_token_ids[:2] = torch.tensor(
+            [0, 2],
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        pull_cache_rows(
+            source_activations=torch.ones(
+                (plan.source_rows, plan.hidden_size),
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            ),
+            source_scales=torch.ones(
+                (plan.source_rows, plan.scale_groups),
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            sorted_token_ids=sorted_token_ids,
+            num_tokens_post_padded=torch.tensor(
+                [8],
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            cache=cache,
+            top_k=plan.top_k,
+            source_route_capacity=plan.source_route_capacity,
+        )
+
+        self.assertTrue(torch.all(cache.activations[8:] == 7))
+        self.assertTrue(torch.all(cache.scales[8:] == 7))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_permuted_rows_padding_and_reuse(self):
+        plan = make_pull_cache_prefill_plan(
+            owners=3,
+            source_tokens_per_owner=4,
+            hidden_size=256,
+            top_k=2,
+            num_local_experts=2,
+            expert_alignment=8,
+        )
+        active_rows = 24
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=active_rows,
+            device=torch.device("cuda"),
+        )
+        cache.activations.fill_(7)
+        cache.scales.fill_(7)
+        source_values = (
+            torch.arange(plan.source_rows * plan.hidden_size, device="cuda")
+            .view(plan.source_rows, plan.hidden_size)
+            .remainder(31)
+            .sub(15)
+            .to(torch.float8_e4m3fn)
+        )
+        source_scales = (
+            torch.arange(plan.source_rows * plan.scale_groups, device="cuda")
+            .view(plan.source_rows, plan.scale_groups)
+            .to(torch.float32)
+        )
+        route_capacity = source_values.shape[0] * plan.top_k
+        sorted_token_ids = torch.full(
+            (active_rows,),
+            route_capacity,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        sorted_token_ids[:3] = torch.tensor([7, 0, 22], dtype=torch.int32)
+        sorted_token_ids[8:10] = torch.tensor([2, 15], dtype=torch.int32)
+        expert_ids = torch.tensor([1, 0, -1], dtype=torch.int32, device="cuda")
+        num_tokens_post_padded = torch.tensor(
+            [16],
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        def expected():
+            activations = torch.zeros(
+                (active_rows, plan.hidden_size),
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            )
+            scales = torch.zeros(
+                (active_rows, plan.scale_groups),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            activations[16:].fill_(7)
+            scales[16:].fill_(7)
+            for target_row, route in ((0, 7), (1, 0), (2, 22), (8, 2), (9, 15)):
+                source_row = route // plan.top_k
+                activations[target_row].copy_(source_values[source_row])
+                scales[target_row].copy_(source_scales[source_row])
+            return activations, scales
+
+        for delta in (0, 1):
+            if delta:
+                source_values.copy_((source_values.float() + 1).to(source_values.dtype))
+                source_scales.add_(1)
+            pull_cache_rows(
+                source_activations=source_values,
+                source_scales=source_scales,
+                sorted_token_ids=sorted_token_ids,
+                num_tokens_post_padded=num_tokens_post_padded,
+                cache=cache,
+                top_k=plan.top_k,
+                source_route_capacity=route_capacity,
+            )
+            expected_activations, expected_scales = expected()
+            self.assertTrue(torch.equal(cache.activations, expected_activations))
+            self.assertTrue(torch.equal(cache.scales, expected_scales))
+
+        self.assertEqual(cache.scales.stride(0), 1)
+        self.assertGreaterEqual(cache.scales.stride(1), cache.active_rows)
+        self.assertTrue(
+            torch.equal(
+                cache.row_ids,
+                torch.arange(active_rows, dtype=torch.int32, device="cuda"),
+            )
+        )
+        self.assertEqual(cache.row_weights.shape, (active_rows, 1))
+        self.assertTrue(torch.all(cache.row_weights == 1))
+        self.assertTrue(cache.row_weights.is_contiguous())
+        self.assertTrue(cache.activations.is_contiguous())
+
+        config = {
+            "BLOCK_SIZE_M": 8,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 1,
+            "num_warps": 4,
+            "num_stages": 3,
+        }
+        weights = torch.randint(
+            -4,
+            5,
+            (2, 256, 256),
+            dtype=torch.int8,
+            device="cuda",
+        ).to(torch.float8_e4m3fn)
+        weight_scales = torch.ones((2, 2, 2), dtype=torch.float32, device="cuda")
+        actual_w13 = torch.zeros(
+            (active_rows, 256),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        reference_w13 = torch.zeros_like(actual_w13)
+        invoke_pull_cache_w13(
+            cache=cache,
+            weight=weights,
+            weight_scale=weight_scales,
+            output=actual_w13,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            config=config,
+            block_shape=(128, 128),
+        )
+        invoke_fused_moe_kernel(
+            A=source_values,
+            B=weights,
+            bias=None,
+            C=reference_w13,
+            A_scale=source_scales,
+            B_scale=weight_scales,
+            B_zp=None,
+            topk_weights=torch.ones(
+                (plan.source_rows, plan.top_k),
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            topk_ids=torch.zeros(
+                (plan.source_rows, plan.top_k),
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=plan.top_k,
+            config=config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=[128, 128],
+            filter_expert=True,
+            c_sorted=True,
+            a_is_prequantized=True,
+        )
+        valid_positions = sorted_token_ids < route_capacity
+        self.assertTrue(
+            torch.allclose(
+                actual_w13[valid_positions].float(),
+                reference_w13[valid_positions].float(),
+                rtol=1e-2,
+                atol=2e-2,
+            )
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_forged_row_major_scale_cache_is_rejected(self):
+        plan = make_pull_cache_prefill_plan(
+            owners=1,
+            source_tokens_per_owner=2,
+            hidden_size=256,
+            top_k=2,
+            num_local_experts=2,
+            expert_alignment=8,
+        )
+        allocated = allocate_pull_cache(
+            plan,
+            active_rows=8,
+            device=torch.device("cuda"),
+        )
+        forged = PullCache(
+            plan=allocated.plan,
+            active_rows=allocated.active_rows,
+            activations=allocated.activations,
+            scales=torch.empty(
+                (allocated.active_rows, allocated.plan.scale_groups),
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            row_ids=allocated.row_ids,
+            row_weights=allocated.row_weights,
+            scale_backing=allocated.scale_backing,
+        )
+
+        with self.assertRaisesRegex(ValueError, "TMA-aligned"):
+            pull_cache_rows(
+                source_activations=torch.ones(
+                    (2, 256),
+                    dtype=torch.float8_e4m3fn,
+                    device="cuda",
+                ),
+                source_scales=torch.ones(
+                    (2, 2),
+                    dtype=torch.float32,
+                    device="cuda",
+                ),
+                sorted_token_ids=torch.tensor(
+                    [0, 1, 2, 3, 4, 4, 4, 4],
+                    dtype=torch.int32,
+                    device="cuda",
+                ),
+                num_tokens_post_padded=torch.tensor(
+                    [4],
+                    dtype=torch.int32,
+                    device="cuda",
+                ),
+                cache=forged,
+                top_k=2,
+                source_route_capacity=4,
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_empty_expert_set_does_not_touch_reused_cache(self):
+        plan = make_pull_cache_prefill_plan(
+            owners=1,
+            source_tokens_per_owner=2,
+            hidden_size=256,
+            top_k=2,
+            num_local_experts=2,
+            expert_alignment=8,
+        )
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=8,
+            device=torch.device("cuda"),
+        )
+        cache.activations.fill_(1)
+        cache.scales.fill_(1)
+        pull_cache_rows(
+            source_activations=torch.ones(
+                (2, 256),
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            ),
+            source_scales=torch.ones((2, 2), dtype=torch.float32, device="cuda"),
+            sorted_token_ids=torch.full(
+                (8,),
+                4,
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            num_tokens_post_padded=torch.zeros(
+                (1,),
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            cache=cache,
+            top_k=2,
+            source_route_capacity=4,
+        )
+
+        self.assertTrue(torch.all(cache.activations == 1))
+        self.assertTrue(torch.all(cache.scales == 1))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_invalid_pull_contract_is_rejected_before_launch(self):
+        plan = make_pull_cache_prefill_plan(
+            owners=1,
+            source_tokens_per_owner=2,
+            hidden_size=256,
+            top_k=2,
+            num_local_experts=2,
+            expert_alignment=8,
+        )
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=8,
+            device=torch.device("cuda"),
+        )
+        source_activations = torch.zeros(
+            (2, 256),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        source_scales = torch.ones((2, 2), dtype=torch.float32, device="cuda")
+        sorted_token_ids = torch.full(
+            (16,),
+            4,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        padded = torch.tensor([8], dtype=torch.int32, device="cuda")
+        valid = {
+            "source_activations": source_activations,
+            "source_scales": source_scales,
+            "sorted_token_ids": sorted_token_ids,
+            "num_tokens_post_padded": padded,
+            "cache": cache,
+            "top_k": 2,
+            "source_route_capacity": 4,
+        }
+
+        cases = (
+            (
+                {"source_activations": source_activations.float()},
+                TypeError,
+                "float8_e4m3fn",
+            ),
+            (
+                {"source_scales": source_scales.to(torch.bfloat16)},
+                TypeError,
+                "float32",
+            ),
+            (
+                {
+                    "sorted_token_ids": torch.empty(
+                        (16,),
+                        dtype=torch.int32,
+                        device="cuda",
+                    )[::2]
+                },
+                ValueError,
+                "contiguous",
+            ),
+            ({"source_route_capacity": 5}, ValueError, "cannot exceed"),
+        )
+        for mutation, error, message in cases:
+            with self.subTest(mutation=next(iter(mutation))):
+                with self.assertRaisesRegex(error, message):
+                    pull_cache_rows(**{**valid, **mutation})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_dsv4_silu_and_mul_valid_rows.py
+++ b/test/registered/moe/test_dsv4_silu_and_mul_valid_rows.py
@@ -1,0 +1,66 @@
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4 import silu_and_mul_contig_post_quant
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA JIT")
+class TestDsv4SiluAndMulValidRows(unittest.TestCase):
+    def test_device_valid_rows_skip_unused_capacity(self):
+        rows = 32
+        valid = 7
+        intermediate = 256
+        gate_up = torch.randn(
+            (rows, intermediate * 2),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        reference = torch.empty(
+            (rows, intermediate),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        reference_scale = torch.empty(
+            (rows, intermediate // 128),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        silu_and_mul_contig_post_quant(
+            input=gate_up,
+            output=reference,
+            output_scale=reference_scale,
+            quant_group_size=128,
+        )
+
+        output = torch.zeros_like(reference)
+        output_scale = torch.zeros_like(reference_scale)
+        valid_rows = torch.tensor([valid], dtype=torch.int32, device="cuda")
+        silu_and_mul_contig_post_quant(
+            input=gate_up,
+            output=output,
+            output_scale=output_scale,
+            quant_group_size=128,
+            valid_rows=valid_rows,
+        )
+        torch.testing.assert_close(
+            output[:valid].view(torch.uint8),
+            reference[:valid].view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            output_scale[:valid],
+            reference_scale[:valid],
+            rtol=0,
+            atol=0,
+        )
+        self.assertTrue(torch.all(output[valid:].view(torch.uint8) == 0))
+        self.assertTrue(torch.all(output_scale[valid:] == 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_prequantized_fused_moe.py
+++ b/test/registered/moe/test_prequantized_fused_moe.py
@@ -1,0 +1,199 @@
+import unittest
+
+import torch
+import triton.language as tl
+
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+)
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class TestPrequantizedFusedMoe(unittest.TestCase):
+    def test_prequantized_a_matches_internal_quantization(self):
+        """Shared FP8 rows must preserve the default quantize-and-run result."""
+        torch.manual_seed(7)
+        m, n, k, experts, topk = 16, 128, 128, 1, 1
+        block_shape = [128, 128]
+        config = {
+            "BLOCK_SIZE_M": 16,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 3,
+        }
+
+        a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16) * 0.1
+        b = (torch.randn((experts, n, k), device="cuda") * 0.1).to(torch.float8_e4m3fn)
+        b_scale = torch.ones((experts, 1, 1), device="cuda", dtype=torch.float32)
+        topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int64)
+        topk_weights = torch.ones((m, topk), device="cuda", dtype=torch.float32)
+        sorted_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            topk_ids, config["BLOCK_SIZE_M"], experts
+        )
+        expected = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        actual = torch.empty_like(expected)
+
+        common = dict(
+            B=b,
+            bias=None,
+            A_scale=None,
+            B_scale=b_scale,
+            B_zp=None,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=topk,
+            config=config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=block_shape,
+            filter_expert=False,
+        )
+        invoke_fused_moe_kernel(A=a, C=expected, **common)
+
+        a_fp8, a_scale = sglang_per_token_group_quant_fp8(a, block_shape[1])
+        invoke_fused_moe_kernel(
+            A=a_fp8,
+            C=actual,
+            **{**common, "A_scale": a_scale},
+            a_is_prequantized=True,
+        )
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_glm52_and_dsv4_w13_shapes_accept_row_strided_shared_input(self):
+        """One Triton entry must handle both model shapes and shared row strides."""
+        for model_name, hidden_size in (
+            ("glm52", 6144),
+            ("dsv4_flash", 4096),
+        ):
+            with self.subTest(model=model_name):
+                self._assert_row_strided_w13_matches_contiguous(hidden_size)
+
+    def _assert_row_strided_w13_matches_contiguous(self, hidden_size: int):
+        torch.manual_seed(hidden_size)
+        m, n, experts, topk = 16, 4096, 1, 1
+        block_shape = [128, 128]
+        config = {
+            "BLOCK_SIZE_M": 16,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 1,
+            "num_warps": 8,
+            "num_stages": 3,
+        }
+        a = torch.randn(
+            (m, hidden_size),
+            device="cuda",
+            dtype=torch.bfloat16,
+        ).mul_(0.1)
+        b = (
+            torch.randn(
+                (experts, n, hidden_size),
+                device="cuda",
+            )
+            .mul_(0.1)
+            .to(torch.float8_e4m3fn)
+        )
+        b_scale = torch.ones(
+            (
+                experts,
+                n // block_shape[0],
+                hidden_size // block_shape[1],
+            ),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int64)
+        topk_weights = torch.ones(
+            (m, topk),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        sorted_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            topk_ids,
+            config["BLOCK_SIZE_M"],
+            experts,
+        )
+        expected = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        actual = torch.empty_like(expected)
+        common = dict(
+            B=b,
+            bias=None,
+            B_scale=b_scale,
+            B_zp=None,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=topk,
+            config=config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=block_shape,
+            filter_expert=False,
+        )
+        invoke_fused_moe_kernel(
+            A=a,
+            A_scale=None,
+            C=expected,
+            **common,
+        )
+
+        a_fp8, a_scale = sglang_per_token_group_quant_fp8(a, block_shape[1])
+        shared_rows = torch.empty(
+            (m, 64 * 1024),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        shared_scales = torch.empty(
+            (m, 64 * 1024 // torch.float32.itemsize),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        shared_a = shared_rows[:, :hidden_size]
+        shared_a_scale = shared_scales[:, : hidden_size // block_shape[1]]
+        shared_a.copy_(a_fp8)
+        shared_a_scale.copy_(a_scale)
+        self.assertEqual(shared_a.stride(), (64 * 1024, 1))
+        self.assertEqual(
+            shared_a_scale.stride(),
+            (64 * 1024 // torch.float32.itemsize, 1),
+        )
+
+        invoke_fused_moe_kernel(
+            A=shared_a,
+            A_scale=shared_a_scale,
+            C=actual,
+            **common,
+            a_is_prequantized=True,
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_backend.py
+++ b/test/registered/moe/test_shared_ep_backend.py
@@ -1,0 +1,563 @@
+import subprocess
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+)
+from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
+from sglang.srt.layers.moe.fused_moe_triton.layer import create_moe_dispatcher
+from sglang.srt.layers.moe.moe_runner.base import FusedOpPool, MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatcher,
+    _run_deep_gemm_fallback,
+    compact_intermediate_capacity,
+    create_shared_ep_dispatcher,
+    decode_intermediate_capacity,
+)
+from sglang.srt.layers.moe.shared_ep.kernels import (
+    quantize_pack_input,
+)
+from sglang.srt.layers.moe.shared_ep.layout import (
+    SharedEpLayout,
+    align_output_layout,
+)
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.srt.layers.moe.token_dispatcher.base import CombineInputFormat
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.moe.utils import (
+    DeepEPMode,
+    MoeA2ABackend,
+    MoeRunnerBackend,
+    is_deepep_class_backend,
+)
+from sglang.srt.server_args import MOE_A2A_BACKEND_CHOICES
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+
+def _config() -> MoeRunnerConfig:
+    return MoeRunnerConfig(
+        hidden_size=4096,
+        intermediate_size_per_partition=2048,
+        top_k=6,
+        num_experts=256,
+        num_local_experts=32,
+        params_dtype=torch.bfloat16,
+    )
+
+
+def _deepep_kwargs(mode) -> dict:
+    return dict(
+        group="ep_group",
+        router_topk=6,
+        permute_fusion=True,
+        num_experts=256,
+        num_local_experts=32,
+        hidden_size=4096,
+        params_dtype=torch.bfloat16,
+        deepep_mode=mode,
+        async_finish=True,
+        return_recv_hook=True,
+    )
+
+
+class TestSharedEpBackend(unittest.TestCase):
+    def test_runner_bootstraps_shared_fused_func_before_pool_lookup(self):
+        code = """
+import torch
+
+import sglang.srt.layers.moe.moe_runner.runner as runner_module
+from sglang.srt.layers.moe.moe_runner.base import FusedOpPool
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
+
+assert FusedOpPool.get_fused_func("shared_ep", "deep_gemm") is None
+runner_module.get_moe_a2a_backend = lambda: MoeA2ABackend.SHARED_EP
+runner = runner_module.MoeRunner(
+    MoeRunnerBackend.DEEP_GEMM,
+    MoeRunnerConfig(
+        hidden_size=4096,
+        intermediate_size_per_partition=2048,
+        top_k=6,
+        num_experts=256,
+        num_local_experts=32,
+        params_dtype=torch.bfloat16,
+    ),
+)
+assert runner.fused_func is not None
+"""
+        subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_fused_path_cannot_be_disabled(self):
+        code = """
+import os
+
+import torch
+
+os.environ["SGLANG_CI_DISABLE_MOE_FUSED_FUNC"] = "1"
+
+import sglang.srt.layers.moe.moe_runner.runner as runner_module
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
+
+runner_module.get_moe_a2a_backend = lambda: MoeA2ABackend.SHARED_EP
+try:
+    runner_module.MoeRunner(
+        MoeRunnerBackend.DEEP_GEMM,
+        MoeRunnerConfig(
+            hidden_size=4096,
+            intermediate_size_per_partition=2048,
+            top_k=6,
+            num_experts=256,
+            num_local_experts=32,
+            params_dtype=torch.bfloat16,
+        ),
+    )
+except RuntimeError as exc:
+    assert "SharedEP requires its registered fused execution path" in str(exc)
+else:
+    raise AssertionError("SharedEP accepted a disabled fused execution path")
+"""
+        subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_deepep_mode",
+        return_value=DeepEPMode.AUTO,
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_moe_runner_backend",
+        return_value=MoeRunnerBackend.DEEP_GEMM,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend.DeepEPDispatcher")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.SharedEpDispatcher")
+    def test_prefill_factory_builds_direct_deepep_fallback(
+        self,
+        shared_dispatcher,
+        deep_ep_dispatcher,
+        _get_runner_backend,
+        _get_mode,
+    ):
+        fallback = object()
+        result = object()
+        deep_ep_dispatcher.return_value = fallback
+        shared_dispatcher.return_value = result
+
+        self.assertIs(
+            create_shared_ep_dispatcher(_config(), group="ep_group"),
+            result,
+        )
+        deep_ep_dispatcher.assert_called_once_with(**_deepep_kwargs(DeepEPMode.AUTO))
+        shared_dispatcher.assert_called_once_with(
+            _config(),
+            fallback_dispatcher=fallback,
+        )
+
+    def test_shared_backend_identity(self):
+        backend = MoeA2ABackend("shared_ep")
+
+        self.assertEqual(backend, MoeA2ABackend.SHARED_EP)
+        self.assertTrue(backend.is_shared_ep())
+        self.assertIn("shared_ep", MOE_A2A_BACKEND_CHOICES)
+        self.assertIsNotNone(FusedOpPool.get_fused_func("shared_ep", "deep_gemm"))
+        self.assertIsNone(FusedOpPool.get_fused_func("shared_ep", "triton"))
+        with self.assertRaises(ValueError):
+            MoeA2ABackend("shared_moe")
+
+    def test_output_rows_absorb_vmm_granularity_without_owner_gaps(self):
+        dsv4 = SharedEpLayout.build(
+            hidden_size=4096,
+            top_k=6,
+            max_tokens_per_rank=32,
+        )
+        glm = SharedEpLayout.build(
+            hidden_size=6144,
+            top_k=8,
+            max_tokens_per_rank=32,
+        )
+
+        aligned_dsv4 = align_output_layout(dsv4, granularity=2 * 1024 * 1024)
+        aligned_glm = align_output_layout(glm, granularity=2 * 1024 * 1024)
+
+        self.assertEqual(aligned_dsv4.output_row_bytes, 32 * 1024)
+        self.assertEqual(aligned_dsv4.output_rank_bytes, 6 * 1024 * 1024)
+        self.assertEqual(aligned_glm.output_row_bytes, 16 * 1024)
+        self.assertEqual(aligned_glm.output_rank_bytes, 4 * 1024 * 1024)
+
+        storage = torch.zeros(
+            2 * aligned_dsv4.output_rank_bytes,
+            dtype=torch.uint8,
+        )
+        output = aligned_dsv4.output_view(
+            storage,
+            world_size=2,
+            mapped_rank_bytes=aligned_dsv4.output_rank_bytes,
+        )
+        flat_output = output.view(-1, aligned_dsv4.hidden_size)
+        flat_output[aligned_dsv4.output_rows_per_rank + 7, 3] = 9
+        self.assertEqual(output[1].view(-1, aligned_dsv4.hidden_size)[7, 3], 9)
+
+    def test_compact_capacity_covers_routes_and_per_expert_padding(self):
+        self.assertEqual(
+            compact_intermediate_capacity(
+                num_tokens=4,
+                world_size=8,
+                top_k=6,
+                num_local_experts=32,
+                block_size=16,
+            ),
+            672,
+        )
+        self.assertEqual(
+            compact_intermediate_capacity(
+                num_tokens=8,
+                world_size=8,
+                top_k=6,
+                num_local_experts=32,
+                block_size=16,
+            ),
+            864,
+        )
+
+    def test_decode_capacity_is_static_under_uneven_dp_batches(self):
+        dsv4 = select_profile(
+            _config(),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        self.assertEqual(decode_intermediate_capacity(dsv4), 2016)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_quantize_pack_input_matches_reference_layout(self):
+        for hidden_size, top_k in ((4096, 6), (6144, 8)):
+            with self.subTest(hidden_size=hidden_size, top_k=top_k):
+                layout = SharedEpLayout.build(
+                    hidden_size=hidden_size,
+                    top_k=top_k,
+                    max_tokens_per_rank=32,
+                )
+                direct_storage = torch.zeros(
+                    layout.input_rank_bytes,
+                    dtype=torch.uint8,
+                    device="cuda",
+                )
+                direct = layout.input_views(
+                    direct_storage,
+                    world_size=1,
+                    mapped_rank_bytes=layout.input_rank_bytes,
+                ).owner(0)
+                source = torch.linspace(
+                    -2,
+                    2,
+                    4 * hidden_size,
+                    dtype=torch.bfloat16,
+                    device="cuda",
+                ).view(4, hidden_size)
+                source_ids = (
+                    torch.arange(
+                        4 * top_k,
+                        dtype=torch.int32,
+                        device="cuda",
+                    ).view(4, top_k)
+                    * 13
+                ) % 256
+                source_weights = torch.linspace(
+                    0,
+                    1,
+                    4 * top_k,
+                    dtype=torch.float32,
+                    device="cuda",
+                ).view(4, top_k)
+                source_q, source_scales = sglang_per_token_group_quant_fp8(
+                    source,
+                    128,
+                )
+
+                quantize_pack_input(
+                    direct,
+                    source=source,
+                    source_ids=source_ids,
+                    source_weights=source_weights,
+                    group_size=128,
+                )
+
+                torch.testing.assert_close(
+                    direct.scales[:4],
+                    source_scales,
+                    rtol=1e-6,
+                    atol=1e-8,
+                )
+                self.assertTrue(torch.equal(direct.topk_ids[:4], source_ids))
+                self.assertTrue(torch.equal(direct.topk_weights[:4], source_weights))
+                self.assertTrue(torch.all(direct.topk_ids[4:] == -1))
+                self.assertTrue(torch.all(direct.topk_weights[4:] == 0))
+                direct_values = direct.activations[:4].float()
+                direct_values *= direct.scales[:4].repeat_interleave(128, dim=1)
+                reference_values = source_q.float()
+                reference_values *= source_scales.repeat_interleave(128, dim=1)
+                torch.testing.assert_close(
+                    direct_values,
+                    reference_values,
+                    rtol=0.125,
+                    atol=0.25,
+                )
+
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.MaybeTboDeepEPDispatcher",
+        side_effect=AssertionError("SharedEP must not construct the TBO wrapper"),
+    )
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer._get_deepep_comm_group",
+        return_value="ep_group",
+    )
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+        return_value=MoeA2ABackend.SHARED_EP,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.create_shared_ep_dispatcher")
+    def test_shared_backend_delegates_without_tbo_wrapper(
+        self,
+        shared_factory,
+        _get_a2a_backend,
+        _get_group,
+        _tbo_dispatcher,
+    ):
+        result = object()
+        shared_factory.return_value = result
+
+        self.assertIs(create_moe_dispatcher(_config()), result)
+        shared_factory.assert_called_once_with(
+            _config(),
+            group="ep_group",
+        )
+
+    @patch("sglang.srt.layers.moe.fused_moe_triton.layer.StandardDispatcher")
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+        return_value=MoeA2ABackend.NONE,
+    )
+    def test_direct_selection_preserves_standard_dispatcher(
+        self,
+        _get_a2a_backend,
+        standard_dispatcher,
+    ):
+        expected = object()
+        standard_dispatcher.return_value = expected
+
+        self.assertIs(create_moe_dispatcher(_config()), expected)
+        standard_dispatcher.assert_called_once_with(_config())
+
+    @patch("sglang.srt.layers.moe.fused_moe_triton.layer.get_deepep_mode")
+    @patch("sglang.srt.layers.moe.fused_moe_triton.layer.MaybeTboDeepEPDispatcher")
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer._get_deepep_comm_group",
+        return_value="ep_group",
+    )
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+        return_value=MoeA2ABackend.DEEPEP,
+    )
+    def test_direct_selection_preserves_deepep_class_dispatchers(
+        self,
+        get_a2a_backend,
+        _get_group,
+        deepep_dispatcher,
+        get_deepep_mode,
+    ):
+        expected = object()
+        mode = object()
+        deepep_dispatcher.return_value = expected
+        get_deepep_mode.return_value = mode
+
+        for backend in (MoeA2ABackend.DEEPEP, MoeA2ABackend.MOONCAKE):
+            with self.subTest(backend=backend.value):
+                get_a2a_backend.return_value = backend
+                self.assertIs(create_moe_dispatcher(_config()), expected)
+                deepep_dispatcher.assert_called_once_with(**_deepep_kwargs(mode))
+                deepep_dispatcher.reset_mock()
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_parallel",
+        return_value=SimpleNamespace(moe_ep_size=8, moe_ep_rank=0),
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend._get_shared_state")
+    def test_dispatcher_initializes_vmm_before_forward(
+        self,
+        get_shared_state,
+        _get_parallel,
+    ):
+        state = object()
+        get_shared_state.return_value = state
+
+        dispatcher = SharedEpDispatcher(_config())
+
+        self.assertIs(dispatcher.state, state)
+        get_shared_state.assert_called_once_with(dispatcher.config, dispatcher.profile)
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_is_extend_in_batch",
+        return_value=True,
+    )
+    def test_prefill_delegates_dispatch_and_combine(self, _is_extend):
+        fallback = Mock()
+        dispatched = object()
+        combined = torch.ones((33, 4))
+        fallback.dispatch.return_value = dispatched
+        fallback.combine.return_value = combined
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.fallback_dispatcher = fallback
+        hidden_states = torch.zeros((33, 4))
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((33, 1)),
+            topk_ids=torch.zeros((33, 1), dtype=torch.int32),
+            router_logits=None,
+        )
+
+        self.assertIs(dispatcher.dispatch(hidden_states, topk_output), dispatched)
+        fallback.dispatch.assert_called_once_with(
+            hidden_states=hidden_states,
+            topk_output=topk_output,
+        )
+        fallback_input = SimpleNamespace(format=CombineInputFormat.DEEPEP_LL)
+        self.assertIs(dispatcher.combine(fallback_input), combined)
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_is_extend_in_batch",
+        return_value=False,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend.quantize_pack_input")
+    def test_decode_rows_use_direct_path(
+        self,
+        quantize_pack,
+        _is_extend,
+    ):
+        fallback = Mock()
+        profile = SimpleNamespace(
+            max_tokens_per_rank=32,
+            block_shape=(128, 128),
+        )
+        state = SimpleNamespace(
+            local_input=object(),
+            global_input=SimpleNamespace(
+                activations=object(),
+                scales=object(),
+            ),
+            input_epoch=Mock(),
+        )
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.profile = profile
+        dispatcher.state = state
+        dispatcher.local_expert_start = 0
+        dispatcher.fallback_dispatcher = fallback
+        hidden_states = torch.zeros((16, 4))
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((16, 1)),
+            topk_ids=torch.zeros((16, 1), dtype=torch.int32),
+            router_logits=None,
+        )
+
+        output = dispatcher.dispatch(hidden_states, topk_output)
+
+        self.assertEqual(output.num_tokens, 16)
+        self.assertIs(output.state, state)
+        quantize_pack.assert_called_once_with(
+            state.local_input,
+            source=hidden_states,
+            source_ids=topk_output.topk_ids,
+            source_weights=topk_output.topk_weights,
+            group_size=128,
+        )
+        state.input_epoch.publish.assert_called_once_with()
+        state.input_epoch.wait_all.assert_not_called()
+        fallback.dispatch.assert_not_called()
+
+    def test_decode_combine_does_not_depend_on_mutable_dispatch_state(self):
+        fallback = Mock()
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.fallback_dispatcher = fallback
+        hidden_states = torch.ones((32, 4))
+
+        self.assertIs(
+            dispatcher.combine(StandardCombineInput(hidden_states=hidden_states)),
+            hidden_states,
+        )
+        fallback.combine.assert_not_called()
+
+    def test_backend_reuses_ep_sharded_model_contract(self):
+        with patch(
+            "sglang.srt.layers.moe.utils.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.SHARED_EP,
+        ):
+            self.assertTrue(is_deepep_class_backend())
+        with patch(
+            "sglang.srt.layers.moe.ep_moe.layer.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.SHARED_EP,
+        ):
+            self.assertIs(get_moe_impl_class(quant_config=None), DeepEPMoE)
+
+    @patch("sglang.srt.layers.moe.shared_ep.backend.DeepGemmRunnerCore")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.PermuteMethodPool.get_post_permute")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.PermuteMethodPool.get_pre_permute")
+    def test_prefill_runs_existing_deep_gemm_pipeline(
+        self,
+        get_pre_permute,
+        get_post_permute,
+        deep_gemm_runner_core,
+    ):
+        pre_permute = Mock(return_value="runner_input")
+        post_permute = Mock(return_value="combined")
+        runner = deep_gemm_runner_core.return_value
+        runner.run.return_value = "runner_output"
+        get_pre_permute.return_value = pre_permute
+        get_post_permute.return_value = post_permute
+        dispatch_output = SimpleNamespace(format=SimpleNamespace(value="deepep_normal"))
+        quant_info = DeepGemmMoeQuantInfo(
+            w13_weight=torch.empty((1, 2, 3)),
+            w2_weight=torch.empty((1, 3, 1)),
+            use_fp8=True,
+        )
+        config = MoeRunnerConfig()
+
+        result = _run_deep_gemm_fallback(
+            dispatch_output,
+            quant_info,
+            config,
+        )
+
+        self.assertEqual(result, "combined")
+        pre_permute.assert_called_once_with(
+            dispatch_output,
+            quant_info,
+            config,
+            {},
+        )
+        runner.run.assert_called_once_with("runner_input", quant_info, {})
+        post_permute.assert_called_once_with(
+            "runner_output",
+            quant_info,
+            config,
+            {},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_backend.py
+++ b/test/registered/moe/test_shared_ep_backend.py
@@ -12,13 +12,14 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
 from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import create_moe_dispatcher
 from sglang.srt.layers.moe.moe_runner.base import FusedOpPool, MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
+from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.shared_ep.backend import (
     SharedEpDispatcher,
-    _run_deep_gemm_fallback,
+    SharedEpDispatchOutput,
     compact_intermediate_capacity,
     create_shared_ep_dispatcher,
-    decode_intermediate_capacity,
+    intermediate_capacity,
+    run_shared_ep,
 )
 from sglang.srt.layers.moe.shared_ep.kernels import (
     quantize_pack_input,
@@ -27,16 +28,22 @@ from sglang.srt.layers.moe.shared_ep.layout import (
     SharedEpLayout,
     align_output_layout,
 )
-from sglang.srt.layers.moe.shared_ep.profiles import select_profile
-from sglang.srt.layers.moe.token_dispatcher.base import CombineInputFormat
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    GLM52,
+    make_pull_cache_prefill_profile,
+    select_profile,
+)
 from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
 from sglang.srt.layers.moe.topk import StandardTopKOutput
 from sglang.srt.layers.moe.utils import (
-    DeepEPMode,
     MoeA2ABackend,
     MoeRunnerBackend,
     is_deepep_class_backend,
 )
+from sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8_moe import (
+    CompressedTensorsW8A8Fp8MoE,
+)
+from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
 from sglang.srt.server_args import MOE_A2A_BACKEND_CHOICES
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -48,6 +55,17 @@ def _config() -> MoeRunnerConfig:
         hidden_size=4096,
         intermediate_size_per_partition=2048,
         top_k=6,
+        num_experts=256,
+        num_local_experts=32,
+        params_dtype=torch.bfloat16,
+    )
+
+
+def _glm_config() -> MoeRunnerConfig:
+    return MoeRunnerConfig(
+        hidden_size=6144,
+        intermediate_size_per_partition=2048,
+        top_k=8,
         num_experts=256,
         num_local_experts=32,
         params_dtype=torch.bfloat16,
@@ -79,10 +97,10 @@ from sglang.srt.layers.moe.moe_runner.base import FusedOpPool
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
 
-assert FusedOpPool.get_fused_func("shared_ep", "deep_gemm") is None
+assert FusedOpPool.get_fused_func("shared_ep", "triton") is None
 runner_module.get_moe_a2a_backend = lambda: MoeA2ABackend.SHARED_EP
 runner = runner_module.MoeRunner(
-    MoeRunnerBackend.DEEP_GEMM,
+    MoeRunnerBackend.TRITON,
     MoeRunnerConfig(
         hidden_size=4096,
         intermediate_size_per_partition=2048,
@@ -116,7 +134,7 @@ from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
 runner_module.get_moe_a2a_backend = lambda: MoeA2ABackend.SHARED_EP
 try:
     runner_module.MoeRunner(
-        MoeRunnerBackend.DEEP_GEMM,
+        MoeRunnerBackend.TRITON,
         MoeRunnerConfig(
             hidden_size=4096,
             intermediate_size_per_partition=2048,
@@ -138,37 +156,19 @@ else:
             capture_output=True,
         )
 
-    @patch(
-        "sglang.srt.layers.moe.shared_ep.backend.get_deepep_mode",
-        return_value=DeepEPMode.AUTO,
-    )
-    @patch(
-        "sglang.srt.layers.moe.shared_ep.backend.get_moe_runner_backend",
-        return_value=MoeRunnerBackend.DEEP_GEMM,
-    )
-    @patch("sglang.srt.layers.moe.shared_ep.backend.DeepEPDispatcher")
     @patch("sglang.srt.layers.moe.shared_ep.backend.SharedEpDispatcher")
-    def test_prefill_factory_builds_direct_deepep_fallback(
+    def test_factory_builds_standalone_shared_dispatcher(
         self,
         shared_dispatcher,
-        deep_ep_dispatcher,
-        _get_runner_backend,
-        _get_mode,
     ):
-        fallback = object()
         result = object()
-        deep_ep_dispatcher.return_value = fallback
         shared_dispatcher.return_value = result
 
         self.assertIs(
-            create_shared_ep_dispatcher(_config(), group="ep_group"),
+            create_shared_ep_dispatcher(_config()),
             result,
         )
-        deep_ep_dispatcher.assert_called_once_with(**_deepep_kwargs(DeepEPMode.AUTO))
-        shared_dispatcher.assert_called_once_with(
-            _config(),
-            fallback_dispatcher=fallback,
-        )
+        shared_dispatcher.assert_called_once_with(_config())
 
     def test_shared_backend_identity(self):
         backend = MoeA2ABackend("shared_ep")
@@ -176,10 +176,49 @@ else:
         self.assertEqual(backend, MoeA2ABackend.SHARED_EP)
         self.assertTrue(backend.is_shared_ep())
         self.assertIn("shared_ep", MOE_A2A_BACKEND_CHOICES)
-        self.assertIsNotNone(FusedOpPool.get_fused_func("shared_ep", "deep_gemm"))
-        self.assertIsNone(FusedOpPool.get_fused_func("shared_ep", "triton"))
+        self.assertIsNone(FusedOpPool.get_fused_func("shared_ep", "deep_gemm"))
+        self.assertIsNotNone(FusedOpPool.get_fused_func("shared_ep", "triton"))
         with self.assertRaises(ValueError):
             MoeA2ABackend("shared_moe")
+
+    @patch(
+        "sglang.srt.layers.quantization.fp8.get_moe_a2a_backend",
+        return_value=MoeA2ABackend.SHARED_EP,
+    )
+    @patch(
+        "sglang.srt.layers.quantization.fp8.get_moe_runner_backend",
+        return_value=MoeRunnerBackend.AUTO,
+    )
+    @patch("sglang.srt.layers.quantization.fp8.MoeRunner")
+    def test_fp8_auto_runner_resolves_to_triton_for_shared_ep(
+        self,
+        runner,
+        _runner_backend,
+        _a2a_backend,
+    ):
+        method = object.__new__(Fp8MoEMethod)
+
+        method.create_moe_runner(object(), _config())
+
+        runner.assert_called_once_with(MoeRunnerBackend.TRITON, _config())
+
+    @patch(
+        "sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8_moe.get_moe_runner_backend",
+        return_value=MoeRunnerBackend.AUTO,
+    )
+    @patch(
+        "sglang.srt.layers.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8_moe.MoeRunner"
+    )
+    def test_compressed_fp8_auto_runner_resolves_to_triton_for_shared_ep(
+        self,
+        runner,
+        _runner_backend,
+    ):
+        method = object.__new__(CompressedTensorsW8A8Fp8MoE)
+
+        method.create_moe_runner(object(), _config())
+
+        runner.assert_called_once_with(MoeRunnerBackend.TRITON, _config())
 
     def test_output_rows_absorb_vmm_granularity_without_owner_gaps(self):
         dsv4 = SharedEpLayout.build(
@@ -244,7 +283,7 @@ else:
             block_shape=(128, 128),
             max_tokens_per_rank=32,
         )
-        self.assertEqual(decode_intermediate_capacity(dsv4), 2016)
+        self.assertEqual(intermediate_capacity(dsv4), 2016)
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
     def test_quantize_pack_input_matches_reference_layout(self):
@@ -326,10 +365,6 @@ else:
         side_effect=AssertionError("SharedEP must not construct the TBO wrapper"),
     )
     @patch(
-        "sglang.srt.layers.moe.fused_moe_triton.layer._get_deepep_comm_group",
-        return_value="ep_group",
-    )
-    @patch(
         "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
         return_value=MoeA2ABackend.SHARED_EP,
     )
@@ -338,17 +373,13 @@ else:
         self,
         shared_factory,
         _get_a2a_backend,
-        _get_group,
         _tbo_dispatcher,
     ):
         result = object()
         shared_factory.return_value = result
 
         self.assertIs(create_moe_dispatcher(_config()), result)
-        shared_factory.assert_called_once_with(
-            _config(),
-            group="ep_group",
-        )
+        shared_factory.assert_called_once_with(_config())
 
     @patch("sglang.srt.layers.moe.fused_moe_triton.layer.StandardDispatcher")
     @patch(
@@ -399,46 +430,224 @@ else:
         "sglang.srt.layers.moe.shared_ep.backend.get_parallel",
         return_value=SimpleNamespace(moe_ep_size=8, moe_ep_rank=0),
     )
+    @patch("sglang.srt.layers.moe.shared_ep.backend._get_shared_pull_cache")
     @patch("sglang.srt.layers.moe.shared_ep.backend._get_shared_state")
-    def test_dispatcher_initializes_vmm_before_forward(
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_schedule",
+        return_value=SimpleNamespace(chunked_prefill_size=64),
+    )
+    def test_dsv4_dispatcher_initializes_decode_and_prefill_vmm(
         self,
+        _get_schedule,
         get_shared_state,
+        get_shared_pull_cache,
         _get_parallel,
     ):
-        state = object()
-        get_shared_state.return_value = state
+        decode_state = object()
+        prefill_state = object()
+        pull_cache = object()
+        get_shared_state.side_effect = (decode_state, prefill_state)
+        get_shared_pull_cache.return_value = pull_cache
 
         dispatcher = SharedEpDispatcher(_config())
 
-        self.assertIs(dispatcher.state, state)
-        get_shared_state.assert_called_once_with(dispatcher.config, dispatcher.profile)
+        self.assertIs(dispatcher.state, decode_state)
+        self.assertIs(dispatcher.prefill_state, prefill_state)
+        self.assertIs(dispatcher.prefill_cache, pull_cache)
+        self.assertEqual(dispatcher.prefill_profile.max_tokens_per_rank, 64)
+        self.assertEqual(dispatcher.prefill_profile.hidden_size, 4096)
+        self.assertEqual(dispatcher.prefill_profile.top_k, 6)
+        self.assertEqual(get_shared_state.call_count, 2)
+        get_shared_pull_cache.assert_called_once_with(dispatcher.prefill_profile)
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_schedule",
+        return_value=SimpleNamespace(chunked_prefill_size=64),
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_parallel",
+        return_value=SimpleNamespace(moe_ep_size=8, moe_ep_rank=0),
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend._get_shared_pull_cache")
+    @patch("sglang.srt.layers.moe.shared_ep.backend._get_shared_state")
+    def test_glm_dispatcher_initializes_decode_and_prefill_vmm(
+        self,
+        get_shared_state,
+        get_shared_pull_cache,
+        _get_parallel,
+        _get_schedule,
+    ):
+        decode_state = object()
+        prefill_state = object()
+        pull_cache = object()
+        get_shared_state.side_effect = (decode_state, prefill_state)
+        get_shared_pull_cache.return_value = pull_cache
+
+        dispatcher = SharedEpDispatcher(_glm_config())
+
+        self.assertIs(dispatcher.state, decode_state)
+        self.assertIs(dispatcher.prefill_state, prefill_state)
+        self.assertIs(dispatcher.prefill_cache, pull_cache)
+        self.assertEqual(dispatcher.prefill_profile.max_tokens_per_rank, 64)
+        self.assertEqual(dispatcher.prefill_profile.block_size_m, 64)
+        self.assertEqual(
+            dispatcher.prefill_profile.w13_kernel_config(64)["BLOCK_SIZE_M"],
+            64,
+        )
+        self.assertEqual(
+            dispatcher.prefill_profile.w2_kernel_config(64)["BLOCK_SIZE_M"],
+            64,
+        )
+        self.assertEqual(get_shared_state.call_count, 2)
+        get_shared_pull_cache.assert_called_once_with(dispatcher.prefill_profile)
+
+    def test_prefill_route_w13_and_w2_share_one_m_block(self):
+        profile = make_pull_cache_prefill_profile(GLM52, 1024)
+
+        self.assertIsNotNone(profile)
+        self.assertEqual(
+            {
+                profile.block_size_m,
+                profile.w13_kernel_config(1024)["BLOCK_SIZE_M"],
+                profile.w2_kernel_config(1024)["BLOCK_SIZE_M"],
+            },
+            {64},
+        )
+
+    @patch("sglang.srt.layers.moe.shared_ep.backend._validate_weights")
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.intermediate_capacity",
+        return_value=64,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend.prepare_routes")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.silu_and_mul_contig_post_quant")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.pull_cache_rows")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.invoke_pull_cache_w13")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.invoke_fused_moe_kernel")
+    def test_prefill_pulls_w13_rows_while_decode_consumes_directly(
+        self,
+        fused_moe,
+        pull_w13,
+        pull_rows,
+        _silu_and_mul,
+        prepare_routes,
+        _capacity,
+        _validate_weights,
+    ):
+        routes = SimpleNamespace(
+            local_ids=torch.zeros((8, 8), dtype=torch.int32),
+            local_weights=torch.ones((8, 8), dtype=torch.float32),
+            sorted_token_ids=torch.zeros(64, dtype=torch.int32),
+            expert_ids=torch.zeros(1, dtype=torch.int32),
+            num_tokens_post_padded=torch.ones(1, dtype=torch.int32),
+        )
+        prepare_routes.return_value = routes
+        input_epoch = Mock()
+        input_epoch.allocation.local_storage = torch.zeros(1, dtype=torch.uint8)
+        input_epoch.epoch = torch.ones(1, dtype=torch.int32)
+        state = SimpleNamespace(
+            global_input=SimpleNamespace(
+                topk_ids=torch.zeros((8, 1, 8), dtype=torch.int32),
+                topk_weights=torch.ones((8, 1, 8), dtype=torch.float32),
+            ),
+            input_epoch=input_epoch,
+            global_output=torch.empty((64, 6144), dtype=torch.bfloat16),
+            local_output=torch.zeros((8, 8, 6144), dtype=torch.bfloat16),
+            output_epoch=Mock(),
+        )
+        quant_info = SimpleNamespace(
+            w13_weight=torch.empty((1, 1, 1), dtype=torch.float8_e4m3fn),
+            w13_scale=torch.ones((1, 1, 1), dtype=torch.float32),
+            w2_weight=torch.empty((1, 1, 1), dtype=torch.float8_e4m3fn),
+            w2_scale=torch.ones((1, 1, 1), dtype=torch.float32),
+        )
+
+        prefill_profile = make_pull_cache_prefill_profile(GLM52, 1024)
+        self.assertIsNotNone(prefill_profile)
+        pull_cache = SimpleNamespace(active_rows=64)
+        prefill = SharedEpDispatchOutput(
+            hidden_states=torch.empty((8, 6144), dtype=torch.float8_e4m3fn),
+            hidden_states_scale=torch.empty((8, 48), dtype=torch.float32),
+            topk_output=object(),
+            state=state,
+            profile=prefill_profile,
+            num_tokens=8,
+            local_expert_start=0,
+            phase="prefill",
+            pull_cache=pull_cache,
+        )
+
+        run_shared_ep(prefill, quant_info, SimpleNamespace(swiglu_limit=None))
+
+        pull_rows.assert_called_once()
+        pull_w13.assert_called_once()
+        self.assertEqual(fused_moe.call_count, 1)
+
+        pull_rows.reset_mock()
+        pull_w13.reset_mock()
+        fused_moe.reset_mock()
+        decode = SharedEpDispatchOutput(
+            hidden_states=torch.empty((8, 6144), dtype=torch.float8_e4m3fn),
+            hidden_states_scale=torch.empty((8, 48), dtype=torch.float32),
+            topk_output=object(),
+            state=state,
+            profile=GLM52,
+            num_tokens=8,
+            local_expert_start=0,
+            phase="decode",
+            pull_cache=None,
+        )
+
+        run_shared_ep(decode, quant_info, SimpleNamespace(swiglu_limit=None))
+
+        pull_rows.assert_not_called()
+        pull_w13.assert_not_called()
+        self.assertEqual(fused_moe.call_count, 2)
 
     @patch(
         "sglang.srt.layers.moe.shared_ep.backend.get_is_extend_in_batch",
         return_value=True,
     )
-    def test_prefill_delegates_dispatch_and_combine(self, _is_extend):
-        fallback = Mock()
-        dispatched = object()
-        combined = torch.ones((33, 4))
-        fallback.dispatch.return_value = dispatched
-        fallback.combine.return_value = combined
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=[16, 33, 8, 8, 8, 8, 8, 8],
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend.quantize_pack_input")
+    def test_prefill_rejects_peer_capacity_overflow_before_publish(
+        self,
+        quantize_pack,
+        _global_num_tokens,
+        _is_extend,
+    ):
         dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
-        dispatcher.fallback_dispatcher = fallback
-        hidden_states = torch.zeros((33, 4))
+        profile = SimpleNamespace(
+            max_tokens_per_rank=32,
+            ep_size=8,
+            supports_pull_cache_prefill=True,
+        )
+        dispatcher.profile = profile
+        dispatcher.prefill_profile = profile
+        state = SimpleNamespace(
+            local_input=object(),
+            input_epoch=Mock(),
+        )
+        dispatcher.prefill_state = state
+        dispatcher.prefill_cache = object()
+        hidden_states = torch.zeros((16, 4))
         topk_output = StandardTopKOutput(
-            topk_weights=torch.ones((33, 1)),
-            topk_ids=torch.zeros((33, 1), dtype=torch.int32),
+            topk_weights=torch.ones((16, 1)),
+            topk_ids=torch.zeros((16, 1), dtype=torch.int32),
             router_logits=None,
         )
 
-        self.assertIs(dispatcher.dispatch(hidden_states, topk_output), dispatched)
-        fallback.dispatch.assert_called_once_with(
-            hidden_states=hidden_states,
-            topk_output=topk_output,
-        )
-        fallback_input = SimpleNamespace(format=CombineInputFormat.DEEPEP_LL)
-        self.assertIs(dispatcher.combine(fallback_input), combined)
+        with self.assertRaisesRegex(
+            ValueError,
+            "SharedEP prefill capacity exceeded.*33 > 32",
+        ):
+            dispatcher.dispatch(hidden_states, topk_output)
+
+        quantize_pack.assert_not_called()
+        state.input_epoch.publish.assert_not_called()
 
     @patch(
         "sglang.srt.layers.moe.shared_ep.backend.get_is_extend_in_batch",
@@ -459,6 +668,7 @@ else:
             max_tokens_per_rank=32,
             ep_size=8,
             block_shape=(128, 128),
+            supports_pull_cache_prefill=False,
         )
         state = SimpleNamespace(
             local_input=object(),
@@ -470,9 +680,9 @@ else:
         )
         dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
         dispatcher.profile = profile
+        dispatcher.prefill_profile = profile
         dispatcher.state = state
         dispatcher.local_expert_start = 0
-        dispatcher.fallback_dispatcher = Mock()
         hidden_states = torch.zeros((16, 4))
         topk_output = StandardTopKOutput(
             topk_weights=torch.ones((16, 1)),
@@ -504,11 +714,11 @@ else:
         _global_num_tokens,
         _is_extend,
     ):
-        fallback = Mock()
         profile = SimpleNamespace(
             max_tokens_per_rank=32,
             ep_size=8,
             block_shape=(128, 128),
+            supports_pull_cache_prefill=False,
         )
         state = SimpleNamespace(
             local_input=object(),
@@ -520,9 +730,9 @@ else:
         )
         dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
         dispatcher.profile = profile
+        dispatcher.prefill_profile = profile
         dispatcher.state = state
         dispatcher.local_expert_start = 0
-        dispatcher.fallback_dispatcher = fallback
         hidden_states = torch.zeros((16, 4))
         topk_output = StandardTopKOutput(
             topk_weights=torch.ones((16, 1)),
@@ -543,19 +753,15 @@ else:
         )
         state.input_epoch.publish.assert_called_once_with()
         state.input_epoch.wait_all.assert_not_called()
-        fallback.dispatch.assert_not_called()
 
     def test_decode_combine_does_not_depend_on_mutable_dispatch_state(self):
-        fallback = Mock()
         dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
-        dispatcher.fallback_dispatcher = fallback
         hidden_states = torch.ones((32, 4))
 
         self.assertIs(
             dispatcher.combine(StandardCombineInput(hidden_states=hidden_states)),
             hidden_states,
         )
-        fallback.combine.assert_not_called()
 
     def test_backend_reuses_ep_sharded_model_contract(self):
         with patch(
@@ -569,49 +775,14 @@ else:
         ):
             self.assertIs(get_moe_impl_class(quant_config=None), DeepEPMoE)
 
-    @patch("sglang.srt.layers.moe.shared_ep.backend.DeepGemmRunnerCore")
-    @patch("sglang.srt.layers.moe.shared_ep.backend.PermuteMethodPool.get_post_permute")
-    @patch("sglang.srt.layers.moe.shared_ep.backend.PermuteMethodPool.get_pre_permute")
-    def test_prefill_runs_existing_deep_gemm_pipeline(
-        self,
-        get_pre_permute,
-        get_post_permute,
-        deep_gemm_runner_core,
-    ):
-        pre_permute = Mock(return_value="runner_input")
-        post_permute = Mock(return_value="combined")
-        runner = deep_gemm_runner_core.return_value
-        runner.run.return_value = "runner_output"
-        get_pre_permute.return_value = pre_permute
-        get_post_permute.return_value = post_permute
-        dispatch_output = SimpleNamespace(format=SimpleNamespace(value="deepep_normal"))
-        quant_info = DeepGemmMoeQuantInfo(
+    def test_run_rejects_non_shared_dispatch_output_without_fallback(self):
+        quant_info = TritonMoeQuantInfo(
             w13_weight=torch.empty((1, 2, 3)),
             w2_weight=torch.empty((1, 3, 1)),
-            use_fp8=True,
+            use_fp8_w8a8=True,
         )
-        config = MoeRunnerConfig()
-
-        result = _run_deep_gemm_fallback(
-            dispatch_output,
-            quant_info,
-            config,
-        )
-
-        self.assertEqual(result, "combined")
-        pre_permute.assert_called_once_with(
-            dispatch_output,
-            quant_info,
-            config,
-            {},
-        )
-        runner.run.assert_called_once_with("runner_input", quant_info, {})
-        post_permute.assert_called_once_with(
-            "runner_output",
-            quant_info,
-            config,
-            {},
-        )
+        with self.assertRaisesRegex(TypeError, "SharedEpDispatchOutput"):
+            run_shared_ep(object(), quant_info, MoeRunnerConfig())
 
 
 if __name__ == "__main__":

--- a/test/registered/moe/test_shared_ep_backend.py
+++ b/test/registered/moe/test_shared_ep_backend.py
@@ -444,15 +444,70 @@ else:
         "sglang.srt.layers.moe.shared_ep.backend.get_is_extend_in_batch",
         return_value=False,
     )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=[16, 33, 8, 8, 8, 8, 8, 8],
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend.quantize_pack_input")
+    def test_decode_rejects_peer_capacity_overflow_before_publish(
+        self,
+        quantize_pack,
+        _global_num_tokens,
+        _is_extend,
+    ):
+        profile = SimpleNamespace(
+            max_tokens_per_rank=32,
+            ep_size=8,
+            block_shape=(128, 128),
+        )
+        state = SimpleNamespace(
+            local_input=object(),
+            global_input=SimpleNamespace(
+                activations=object(),
+                scales=object(),
+            ),
+            input_epoch=Mock(),
+        )
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.profile = profile
+        dispatcher.state = state
+        dispatcher.local_expert_start = 0
+        dispatcher.fallback_dispatcher = Mock()
+        hidden_states = torch.zeros((16, 4))
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((16, 1)),
+            topk_ids=torch.zeros((16, 1), dtype=torch.int32),
+            router_logits=None,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "rank 1 has 33 local tokens.*capacity is 32",
+        ):
+            dispatcher.dispatch(hidden_states, topk_output)
+
+        quantize_pack.assert_not_called()
+        state.input_epoch.publish.assert_not_called()
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_is_extend_in_batch",
+        return_value=False,
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=[16] * 8,
+    )
     @patch("sglang.srt.layers.moe.shared_ep.backend.quantize_pack_input")
     def test_decode_rows_use_direct_path(
         self,
         quantize_pack,
+        _global_num_tokens,
         _is_extend,
     ):
         fallback = Mock()
         profile = SimpleNamespace(
             max_tokens_per_rank=32,
+            ep_size=8,
             block_shape=(128, 128),
         )
         state = SimpleNamespace(

--- a/test/registered/moe/test_shared_ep_ep8.py
+++ b/test/registered/moe/test_shared_ep_ep8.py
@@ -1,7 +1,8 @@
 import os
-import unittest
 from unittest.mock import patch
 
+import msgspec
+import pytest
 import torch
 import torch.distributed as dist
 import triton.language as tl
@@ -14,7 +15,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
     sglang_per_token_group_quant_fp8,
 )
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
-from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
+from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
     moe_align_block_size,
 )
@@ -24,7 +25,15 @@ from sglang.srt.layers.moe.shared_ep.backend import (
 )
 from sglang.srt.layers.moe.shared_ep.kernels import quantize_pack_input
 from sglang.srt.layers.moe.shared_ep.layout import SharedEpLayout
-from sglang.srt.layers.moe.shared_ep.profiles import SharedEpProfile
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    DSV4_FLASH,
+    SharedEpProfile,
+    make_pull_cache_prefill_profile,
+)
+from sglang.srt.layers.moe.shared_ep.pull_cache_prefill import (
+    allocate_pull_cache,
+    make_pull_cache_prefill_plan,
+)
 from sglang.srt.layers.moe.shared_ep.state import create_shared_ep_state
 from sglang.srt.layers.moe.topk import StandardTopKOutput
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -42,13 +51,13 @@ _KERNEL_CONFIG = {
 }
 
 
-@unittest.skipUnless(
-    torch.cuda.is_available() and int(os.environ.get("WORLD_SIZE", "1")) == 8,
-    "run with torchrun --nproc-per-node=8 on CUDA",
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and int(os.environ.get("WORLD_SIZE", "1")) == 8),
+    reason="run with torchrun --nproc-per-node=8 on CUDA",
 )
-class TestSharedEpEp8(unittest.TestCase):
+class TestSharedEpEp8:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.rank = int(os.environ["RANK"])
         cls.local_rank = int(os.environ["LOCAL_RANK"])
         torch.cuda.set_device(cls.local_rank)
@@ -78,7 +87,7 @@ class TestSharedEpEp8(unittest.TestCase):
         )
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         if dist.is_initialized():
             dist.barrier()
             dist.destroy_process_group()
@@ -94,7 +103,20 @@ class TestSharedEpEp8(unittest.TestCase):
             device=torch.device("cuda", self.local_rank),
         )
         try:
-            self.assertEqual(state.layout.output_row_bytes, 32 * 1024)
+            pull_plan = make_pull_cache_prefill_plan(
+                owners=8,
+                source_tokens_per_owner=32,
+                hidden_size=128,
+                top_k=6,
+                num_local_experts=1,
+                expert_alignment=16,
+            )
+            pull_cache = allocate_pull_cache(
+                pull_plan,
+                active_rows=pull_plan.cache_rows,
+                device=torch.device("cuda", self.local_rank),
+            )
+            assert state.layout.output_row_bytes == 32 * 1024
             tokens = self.rank + 1
             topk_ids = torch.stack(
                 [
@@ -151,10 +173,10 @@ class TestSharedEpEp8(unittest.TestCase):
                 dtype=torch.float32,
                 device="cuda",
             )
-            local_quant = DeepGemmMoeQuantInfo(
+            local_quant = TritonMoeQuantInfo(
                 w13_weight=full_w13[self.rank : self.rank + 1],
                 w2_weight=full_w2[self.rank : self.rank + 1],
-                use_fp8=True,
+                use_fp8_w8a8=True,
                 w13_scale=full_w13_scale[self.rank : self.rank + 1],
                 w2_scale=full_w2_scale[self.rank : self.rank + 1],
                 block_shape=[128, 128],
@@ -185,6 +207,15 @@ class TestSharedEpEp8(unittest.TestCase):
                     skew_output_consumer=generation == 1,
                 )
                 torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                pull_actual = self._run_shared(
+                    state,
+                    hidden,
+                    topk_output,
+                    local_quant,
+                    phase="prefill",
+                    pull_cache=pull_cache,
+                )
+                torch.testing.assert_close(pull_actual, expected, rtol=0, atol=0)
 
             graph_hidden = self._hidden(3, tokens)
             graph_q, graph_scale = sglang_per_token_group_quant_fp8(
@@ -218,12 +249,252 @@ class TestSharedEpEp8(unittest.TestCase):
             dist.barrier()
             state.close()
 
-    def _hidden(self, generation: int, tokens: int) -> torch.Tensor:
+    def test_dsv4_profile_m64_prefill_matches_materialized_ep8(self):
+        profile = make_pull_cache_prefill_profile(
+            DSV4_FLASH,
+            max_tokens_per_rank=1024,
+        )
+        assert profile is not None
+        runner_config = MoeRunnerConfig(
+            num_experts=profile.num_experts,
+            num_local_experts=profile.num_local_experts,
+            hidden_size=profile.hidden_size,
+            intermediate_size_per_partition=profile.intermediate_size,
+            top_k=profile.top_k,
+        )
+        state = create_shared_ep_state(
+            layout=SharedEpLayout.build(
+                hidden_size=profile.hidden_size,
+                top_k=profile.top_k,
+                max_tokens_per_rank=profile.max_tokens_per_rank,
+            ),
+            cpu_group=dist.group.WORLD,
+            device=torch.device("cuda", self.local_rank),
+        )
+        try:
+            pull_plan = make_pull_cache_prefill_plan(
+                owners=profile.ep_size,
+                source_tokens_per_owner=profile.max_tokens_per_rank,
+                hidden_size=profile.hidden_size,
+                top_k=profile.top_k,
+                num_local_experts=profile.num_local_experts,
+                expert_alignment=profile.block_size_m,
+            )
+            pull_cache = allocate_pull_cache(
+                pull_plan,
+                active_rows=pull_plan.cache_rows,
+                device=torch.device("cuda", self.local_rank),
+            )
+            tokens = 1
+            topk_ids = torch.stack(
+                [
+                    (
+                        (
+                            torch.arange(
+                                profile.top_k,
+                                device="cuda",
+                                dtype=torch.int32,
+                            )
+                            + self.rank
+                            + token
+                        )
+                        % profile.ep_size
+                    )
+                    * profile.num_local_experts
+                    + (
+                        (
+                            torch.arange(
+                                profile.top_k,
+                                device="cuda",
+                                dtype=torch.int32,
+                            )
+                            * 5
+                        )
+                        + self.rank * 7
+                        + token * 3
+                    )
+                    % profile.num_local_experts
+                    for token in range(tokens)
+                ]
+            )
+            topk_weights = (
+                torch.arange(
+                    1,
+                    profile.top_k + 1,
+                    device="cuda",
+                    dtype=torch.float32,
+                )
+                .div_(sum(range(1, profile.top_k + 1)))
+                .expand(tokens, -1)
+                .contiguous()
+            )
+            topk_output = StandardTopKOutput(
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                router_logits=None,
+            )
+            reference_topk_output = StandardTopKOutput(
+                topk_weights=topk_weights,
+                topk_ids=torch.arange(
+                    profile.top_k,
+                    device="cuda",
+                    dtype=torch.int32,
+                ).view(1, -1),
+                router_logits=None,
+            )
+            reference_profile = msgspec.structs.replace(
+                DSV4_FLASH,
+                num_experts=profile.top_k,
+                num_local_experts=profile.top_k,
+            )
+
+            local_w13 = torch.empty(
+                (
+                    profile.num_local_experts,
+                    2 * profile.intermediate_size,
+                    profile.hidden_size,
+                ),
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            )
+            local_w2 = torch.empty(
+                (
+                    profile.num_local_experts,
+                    profile.hidden_size,
+                    profile.intermediate_size,
+                ),
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            )
+            local_expert_start = self.rank * profile.num_local_experts
+            for local_expert in range(profile.num_local_experts):
+                value = (local_expert_start + local_expert + 1) / 4096
+                local_w13[local_expert].fill_(value)
+                local_w2[local_expert].fill_(value)
+            local_w13_scale = torch.ones(
+                (
+                    profile.num_local_experts,
+                    2 * profile.intermediate_size // 128,
+                    profile.hidden_size // 128,
+                ),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            local_w2_scale = torch.ones(
+                (
+                    profile.num_local_experts,
+                    profile.hidden_size // 128,
+                    profile.intermediate_size // 128,
+                ),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            reference_w13 = torch.empty(
+                (
+                    profile.top_k,
+                    2 * profile.intermediate_size,
+                    profile.hidden_size,
+                ),
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            )
+            reference_w2 = torch.empty(
+                (
+                    profile.top_k,
+                    profile.hidden_size,
+                    profile.intermediate_size,
+                ),
+                dtype=torch.float8_e4m3fn,
+                device="cuda",
+            )
+            for reference_expert, global_expert in enumerate(topk_ids[0].tolist()):
+                value = (global_expert + 1) / 4096
+                reference_w13[reference_expert].fill_(value)
+                reference_w2[reference_expert].fill_(value)
+            reference_w13_scale = torch.ones(
+                (
+                    profile.top_k,
+                    2 * profile.intermediate_size // 128,
+                    profile.hidden_size // 128,
+                ),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            reference_w2_scale = torch.ones(
+                (
+                    profile.top_k,
+                    profile.hidden_size // 128,
+                    profile.intermediate_size // 128,
+                ),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            local_quant = TritonMoeQuantInfo(
+                w13_weight=local_w13,
+                w2_weight=local_w2,
+                use_fp8_w8a8=True,
+                w13_scale=local_w13_scale,
+                w2_scale=local_w2_scale,
+                block_shape=[128, 128],
+            )
+
+            generation = 1
+            with self.subTest(generation=generation):
+                hidden = self._hidden(
+                    generation,
+                    tokens,
+                    hidden_size=profile.hidden_size,
+                )
+                hidden_fp8, hidden_scale = sglang_per_token_group_quant_fp8(
+                    hidden,
+                    128,
+                )
+                expected = self._run_materialized(
+                    hidden_fp8,
+                    hidden_scale,
+                    reference_topk_output,
+                    reference_w13,
+                    reference_w2,
+                    reference_w13_scale,
+                    reference_w2_scale,
+                    tokens,
+                    profile=reference_profile,
+                )
+                actual = self._run_shared(
+                    state,
+                    hidden,
+                    topk_output,
+                    local_quant,
+                    phase="prefill",
+                    pull_cache=pull_cache,
+                    profile=profile,
+                    runner_config=runner_config,
+                )
+                # Expert-local execution changes the FP8/BF16 reduction order
+                # relative to the materialized all-expert reference.
+                actual_fp32 = actual.float()
+                expected_fp32 = expected.float()
+                difference = (actual_fp32 - expected_fp32).abs()
+                tolerance = 1e-7 + 0.05 * expected_fp32.abs()
+                max_excess = (difference - tolerance).amax().item()
+                max_absolute = difference.amax().item()
+                assert max_excess <= 0, f"{max_absolute=} {max_excess=}"
+        finally:
+            dist.barrier()
+            state.close()
+
+    def _hidden(
+        self,
+        generation: int,
+        tokens: int,
+        *,
+        hidden_size: int = 128,
+    ) -> torch.Tensor:
         values = torch.arange(
-            tokens * 128,
+            tokens * hidden_size,
             dtype=torch.float32,
             device="cuda",
-        ).view(tokens, 128)
+        ).view(tokens, hidden_size)
         values = (values + self.rank * 17 + generation * 29) % 97
         return ((values - 48) / 4096).to(torch.bfloat16)
 
@@ -236,7 +507,13 @@ class TestSharedEpEp8(unittest.TestCase):
         *,
         skew_input_writer=False,
         skew_output_consumer=False,
+        phase="decode",
+        pull_cache=None,
+        profile=None,
+        runner_config=None,
     ) -> torch.Tensor:
+        profile = self.profile if profile is None else profile
+        runner_config = self.runner_config if runner_config is None else runner_config
         if skew_input_writer and self.rank == 0:
             torch.cuda._sleep(250_000_000)
         quantize_pack_input(
@@ -252,15 +529,17 @@ class TestSharedEpEp8(unittest.TestCase):
             hidden_states_scale=state.global_input.scales,
             topk_output=topk_output,
             state=state,
-            profile=self.profile,
+            profile=profile,
             num_tokens=hidden.shape[0],
-            local_expert_start=self.rank,
+            local_expert_start=self.rank * profile.num_local_experts,
+            phase=phase,
+            pull_cache=pull_cache,
         )
         if not skew_output_consumer:
             return run_shared_ep(
                 dispatch_output,
                 quant_info,
-                self.runner_config,
+                runner_config,
             ).hidden_states
 
         output_epoch_type = type(state.output_epoch)
@@ -275,7 +554,7 @@ class TestSharedEpEp8(unittest.TestCase):
             return run_shared_ep(
                 dispatch_output,
                 quant_info,
-                self.runner_config,
+                runner_config,
             ).hidden_states
 
     def _run_materialized(
@@ -288,15 +567,19 @@ class TestSharedEpEp8(unittest.TestCase):
         w13_scale,
         w2_scale,
         num_tokens,
+        *,
+        profile=None,
     ) -> torch.Tensor:
+        profile = self.profile if profile is None else profile
+        kernel_config = profile.kernel_config(num_tokens)
         sorted_ids, expert_ids, padded = moe_align_block_size(
             topk_output.topk_ids,
-            _KERNEL_CONFIG["BLOCK_SIZE_M"],
-            8,
+            kernel_config["BLOCK_SIZE_M"],
+            profile.num_experts,
         )
         route_count = topk_output.topk_ids.numel()
         gate_up = torch.empty(
-            (route_count, 512),
+            (route_count, 2 * profile.intermediate_size),
             dtype=torch.bfloat16,
             device="cuda",
         )
@@ -314,25 +597,25 @@ class TestSharedEpEp8(unittest.TestCase):
             expert_ids=expert_ids,
             num_tokens_post_padded=padded,
             mul_routed_weight=False,
-            top_k=6,
-            config=_KERNEL_CONFIG,
+            top_k=profile.top_k,
+            config=profile.w13_kernel_config(num_tokens),
             compute_type=tl.bfloat16,
             use_fp8_w8a8=True,
             use_int8_w8a8=False,
             use_int8_w8a16=False,
             use_int4_w4a16=False,
             per_channel_quant=False,
-            block_shape=[128, 128],
+            block_shape=list(profile.block_shape),
             filter_expert=False,
             a_is_prequantized=True,
         )
         down_fp8 = torch.empty(
-            (route_count, 256),
+            (route_count, profile.intermediate_size),
             dtype=torch.float8_e4m3fn,
             device="cuda",
         )
         down_scale = torch.empty(
-            (route_count, 2),
+            (route_count, profile.intermediate_size // 128),
             dtype=torch.float32,
             device="cuda",
         )
@@ -343,7 +626,7 @@ class TestSharedEpEp8(unittest.TestCase):
             quant_group_size=128,
         )
         contributions = torch.empty(
-            (route_count, 128),
+            (route_count, profile.hidden_size),
             dtype=torch.bfloat16,
             device="cuda",
         )
@@ -362,18 +645,22 @@ class TestSharedEpEp8(unittest.TestCase):
             num_tokens_post_padded=padded,
             mul_routed_weight=True,
             top_k=1,
-            config=_KERNEL_CONFIG,
+            config=profile.w2_kernel_config(num_tokens),
             compute_type=tl.bfloat16,
             use_fp8_w8a8=True,
             use_int8_w8a8=False,
             use_int8_w8a16=False,
             use_int4_w4a16=False,
             per_channel_quant=False,
-            block_shape=[128, 128],
+            block_shape=list(profile.block_shape),
             filter_expert=False,
             a_is_prequantized=True,
         )
-        return contributions.view(num_tokens, 6, 128).sum(dim=1)
+        return contributions.view(
+            num_tokens,
+            profile.top_k,
+            profile.hidden_size,
+        ).sum(dim=1)
 
 
 if __name__ == "__main__":

--- a/test/registered/moe/test_shared_ep_ep8.py
+++ b/test/registered/moe/test_shared_ep_ep8.py
@@ -1,0 +1,380 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+import triton.language as tl
+
+from sglang.kernels.ops.attention.dsv4 import silu_and_mul_contig_post_quant
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatchOutput,
+    run_shared_ep,
+)
+from sglang.srt.layers.moe.shared_ep.kernels import quantize_pack_input
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpLayout
+from sglang.srt.layers.moe.shared_ep.profiles import SharedEpProfile
+from sglang.srt.layers.moe.shared_ep.state import create_shared_ep_state
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=40, stage="extra-b", runner_config="8-gpu-h200")
+
+_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 3,
+}
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and int(os.environ.get("WORLD_SIZE", "1")) == 8,
+    "run with torchrun --nproc-per-node=8 on CUDA",
+)
+class TestSharedEpEp8(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rank = int(os.environ["RANK"])
+        cls.local_rank = int(os.environ["LOCAL_RANK"])
+        torch.cuda.set_device(cls.local_rank)
+        dist.init_process_group("gloo")
+        cls.profile = SharedEpProfile(
+            name="ep8_test",
+            capability=(9, 0),
+            hidden_size=128,
+            intermediate_size=256,
+            top_k=6,
+            num_experts=8,
+            num_local_experts=1,
+            ep_size=8,
+            max_tokens_per_rank=32,
+            block_shape=(128, 128),
+            default_kernel_config=_KERNEL_CONFIG,
+            small_kernel_config=None,
+            small_kernel_max_tokens=0,
+            route_kernel_config={"num_threads": 1024},
+        )
+        cls.runner_config = MoeRunnerConfig(
+            num_experts=8,
+            num_local_experts=1,
+            hidden_size=128,
+            intermediate_size_per_partition=256,
+            top_k=6,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()
+
+    def test_direct_read_return_reuse_and_graph_match_materialized_ep8(self):
+        state = create_shared_ep_state(
+            layout=SharedEpLayout.build(
+                hidden_size=128,
+                top_k=6,
+                max_tokens_per_rank=32,
+            ),
+            cpu_group=dist.group.WORLD,
+            device=torch.device("cuda", self.local_rank),
+        )
+        try:
+            self.assertEqual(state.layout.output_row_bytes, 32 * 1024)
+            tokens = self.rank + 1
+            topk_ids = torch.stack(
+                [
+                    (
+                        torch.arange(6, device="cuda", dtype=torch.int32)
+                        + self.rank
+                        + token
+                    )
+                    % 8
+                    for token in range(tokens)
+                ]
+            )
+            topk_weights = (
+                torch.arange(1, 7, device="cuda", dtype=torch.float32)
+                .div_(21)
+                .expand(tokens, -1)
+                .contiguous()
+            )
+            topk_output = StandardTopKOutput(
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                router_logits=None,
+            )
+
+            full_w13 = torch.stack(
+                [
+                    torch.full(
+                        (512, 128),
+                        (expert + 1) / 512,
+                        dtype=torch.float8_e4m3fn,
+                        device="cuda",
+                    )
+                    for expert in range(8)
+                ]
+            )
+            full_w2 = torch.stack(
+                [
+                    torch.full(
+                        (128, 256),
+                        (expert + 1) / 512,
+                        dtype=torch.float8_e4m3fn,
+                        device="cuda",
+                    )
+                    for expert in range(8)
+                ]
+            )
+            full_w13_scale = torch.ones(
+                (8, 4, 1),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            full_w2_scale = torch.ones(
+                (8, 1, 2),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            local_quant = DeepGemmMoeQuantInfo(
+                w13_weight=full_w13[self.rank : self.rank + 1],
+                w2_weight=full_w2[self.rank : self.rank + 1],
+                use_fp8=True,
+                w13_scale=full_w13_scale[self.rank : self.rank + 1],
+                w2_scale=full_w2_scale[self.rank : self.rank + 1],
+                block_shape=[128, 128],
+            )
+
+            for generation in (1, 2):
+                hidden = self._hidden(generation, tokens)
+                hidden_fp8, hidden_scale = sglang_per_token_group_quant_fp8(
+                    hidden,
+                    128,
+                )
+                expected = self._run_materialized(
+                    hidden_fp8,
+                    hidden_scale,
+                    topk_output,
+                    full_w13,
+                    full_w2,
+                    full_w13_scale,
+                    full_w2_scale,
+                    tokens,
+                )
+                actual = self._run_shared(
+                    state,
+                    hidden,
+                    topk_output,
+                    local_quant,
+                    skew_input_writer=generation == 2,
+                    skew_output_consumer=generation == 1,
+                )
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+            graph_hidden = self._hidden(3, tokens)
+            graph_q, graph_scale = sglang_per_token_group_quant_fp8(
+                graph_hidden,
+                128,
+            )
+            graph = torch.cuda.CUDAGraph()
+            dist.barrier()
+            with torch.cuda.graph(graph):
+                graph_output = self._run_shared(
+                    state,
+                    graph_hidden,
+                    topk_output,
+                    local_quant,
+                )
+            dist.barrier()
+            graph.replay()
+            torch.cuda.synchronize()
+            expected = self._run_materialized(
+                graph_q,
+                graph_scale,
+                topk_output,
+                full_w13,
+                full_w2,
+                full_w13_scale,
+                full_w2_scale,
+                tokens,
+            )
+            torch.testing.assert_close(graph_output, expected, rtol=0, atol=0)
+        finally:
+            dist.barrier()
+            state.close()
+
+    def _hidden(self, generation: int, tokens: int) -> torch.Tensor:
+        values = torch.arange(
+            tokens * 128,
+            dtype=torch.float32,
+            device="cuda",
+        ).view(tokens, 128)
+        values = (values + self.rank * 17 + generation * 29) % 97
+        return ((values - 48) / 4096).to(torch.bfloat16)
+
+    def _run_shared(
+        self,
+        state,
+        hidden,
+        topk_output,
+        quant_info,
+        *,
+        skew_input_writer=False,
+        skew_output_consumer=False,
+    ) -> torch.Tensor:
+        if skew_input_writer and self.rank == 0:
+            torch.cuda._sleep(250_000_000)
+        quantize_pack_input(
+            state.local_input,
+            source=hidden,
+            source_ids=topk_output.topk_ids,
+            source_weights=topk_output.topk_weights,
+            group_size=128,
+        )
+        state.input_epoch.publish()
+        dispatch_output = SharedEpDispatchOutput(
+            hidden_states=state.global_input.activations,
+            hidden_states_scale=state.global_input.scales,
+            topk_output=topk_output,
+            state=state,
+            profile=self.profile,
+            num_tokens=hidden.shape[0],
+            local_expert_start=self.rank,
+        )
+        if not skew_output_consumer:
+            return run_shared_ep(
+                dispatch_output,
+                quant_info,
+                self.runner_config,
+            ).hidden_states
+
+        output_epoch_type = type(state.output_epoch)
+        original_wait_all = output_epoch_type.wait_all
+
+        def wait_all_with_rank_zero_skew(epoch):
+            original_wait_all(epoch)
+            if epoch is state.output_epoch and self.rank == 0:
+                torch.cuda._sleep(250_000_000)
+
+        with patch.object(output_epoch_type, "wait_all", wait_all_with_rank_zero_skew):
+            return run_shared_ep(
+                dispatch_output,
+                quant_info,
+                self.runner_config,
+            ).hidden_states
+
+    def _run_materialized(
+        self,
+        hidden_fp8,
+        hidden_scale,
+        topk_output,
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        num_tokens,
+    ) -> torch.Tensor:
+        sorted_ids, expert_ids, padded = moe_align_block_size(
+            topk_output.topk_ids,
+            _KERNEL_CONFIG["BLOCK_SIZE_M"],
+            8,
+        )
+        route_count = topk_output.topk_ids.numel()
+        gate_up = torch.empty(
+            (route_count, 512),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        invoke_fused_moe_kernel(
+            A=hidden_fp8,
+            B=w13,
+            bias=None,
+            C=gate_up,
+            A_scale=hidden_scale,
+            B_scale=w13_scale,
+            B_zp=None,
+            topk_weights=topk_output.topk_weights,
+            topk_ids=topk_output.topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=padded,
+            mul_routed_weight=False,
+            top_k=6,
+            config=_KERNEL_CONFIG,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=[128, 128],
+            filter_expert=False,
+            a_is_prequantized=True,
+        )
+        down_fp8 = torch.empty(
+            (route_count, 256),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        down_scale = torch.empty(
+            (route_count, 2),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        silu_and_mul_contig_post_quant(
+            input=gate_up,
+            output=down_fp8,
+            output_scale=down_scale,
+            quant_group_size=128,
+        )
+        contributions = torch.empty(
+            (route_count, 128),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        invoke_fused_moe_kernel(
+            A=down_fp8,
+            B=w2,
+            bias=None,
+            C=contributions,
+            A_scale=down_scale,
+            B_scale=w2_scale,
+            B_zp=None,
+            topk_weights=topk_output.topk_weights,
+            topk_ids=topk_output.topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=padded,
+            mul_routed_weight=True,
+            top_k=1,
+            config=_KERNEL_CONFIG,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=[128, 128],
+            filter_expert=False,
+            a_is_prequantized=True,
+        )
+        return contributions.view(num_tokens, 6, 128).sum(dim=1)
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(8,))

--- a/test/registered/moe/test_shared_ep_epoch.py
+++ b/test/registered/moe/test_shared_ep_epoch.py
@@ -1,0 +1,72 @@
+import inspect
+import unittest
+
+from sglang.srt.layers.moe.shared_ep.epoch import GpuEpoch
+from sglang.srt.layers.moe.shared_ep.state import SharedEpState
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class _Closable:
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def close(self):
+        self.calls.append(self.name)
+
+
+class TestSharedEpEpoch(unittest.TestCase):
+    def test_protocol_uses_system_scope_release_and_acquire(self):
+        """Weakening either PTX scope would permit stale peer activations."""
+        source = inspect.getsource(
+            __import__(
+                "sglang.srt.layers.moe.shared_ep.epoch",
+                fromlist=["GpuEpoch"],
+            )
+        )
+        self.assertIn("atom.global.release.sys.exch.b32", source)
+        self.assertIn("ld.acquire.sys.global", source)
+
+    def test_forward_methods_contain_no_cpu_synchronization(self):
+        """A host collective/readback in publish or wait breaks graph replay."""
+        forbidden = (
+            "dist.barrier",
+            "dist.all_reduce",
+            ".cpu(",
+            ".item(",
+            "torch.cuda.synchronize",
+        )
+        source = inspect.getsource(GpuEpoch.publish) + inspect.getsource(
+            GpuEpoch.wait_all
+        )
+        for expression in forbidden:
+            self.assertNotIn(expression, source)
+
+    def test_state_close_releases_reverse_construction_order_once(self):
+        """Partial-state cleanup must not leak or double-release VMM mappings."""
+        calls = []
+        state = SharedEpState(
+            layout=object(),
+            input_allocation=_Closable("input", calls),
+            output_allocation=_Closable("output", calls),
+            input_epoch=_Closable("input_epoch", calls),
+            output_epoch=_Closable("output_epoch", calls),
+            global_input=object(),
+            local_input=object(),
+            global_output=object(),
+            local_output=object(),
+        )
+
+        state.close()
+        state.close()
+
+        self.assertEqual(
+            calls,
+            ["output_epoch", "input_epoch", "output", "input"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_layout.py
+++ b/test/registered/moe/test_shared_ep_layout.py
@@ -1,0 +1,108 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpLayout
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestSharedEpLayout(unittest.TestCase):
+    def test_registered_model_shapes_have_disjoint_owner_slots(self):
+        """Owner/route address math must never alias a peer contribution."""
+        for hidden_size, top_k in ((6144, 8), (4096, 6)):
+            with self.subTest(hidden_size=hidden_size, top_k=top_k):
+                layout = SharedEpLayout.build(
+                    hidden_size=hidden_size,
+                    top_k=top_k,
+                    max_tokens_per_rank=32,
+                )
+                self.assertEqual(layout.scale_groups, hidden_size // 128)
+                self.assertEqual(layout.input_row_bytes, 64 * 1024)
+                self.assertEqual(layout.output_row_bytes, 16 * 1024)
+
+                intervals = []
+                for token in range(layout.max_tokens_per_rank):
+                    for route in range(layout.top_k):
+                        start = layout.output_slot_offset(token, route)
+                        end = start + layout.output_payload_bytes
+                        self.assertLessEqual(end, layout.output_rank_bytes)
+                        intervals.append((start, end))
+                intervals.sort()
+                for left, right in zip(intervals, intervals[1:]):
+                    self.assertLessEqual(left[1], right[0])
+
+    def test_global_input_views_preserve_vmm_rank_padding(self):
+        """A mapped-rank gap must not shift peer activation or route fields."""
+        layout = SharedEpLayout.build(
+            hidden_size=4096,
+            top_k=6,
+            max_tokens_per_rank=32,
+        )
+        world_size = 2
+        mapped_rank_bytes = layout.input_rank_bytes + 64 * 1024
+        storage = torch.zeros(
+            world_size * mapped_rank_bytes,
+            dtype=torch.uint8,
+        )
+
+        views = layout.input_views(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+        )
+        views.topk_ids[1, 2, 3] = 197
+        views.topk_weights[1, 2, 3] = 0.25
+
+        row_start = mapped_rank_bytes + 2 * layout.input_row_bytes
+        id_start = row_start + layout.topk_id_offset + 3 * 4
+        weight_start = row_start + layout.topk_weight_offset + 3 * 4
+        self.assertEqual(storage[id_start : id_start + 4].view(torch.int32).item(), 197)
+        self.assertEqual(
+            storage[weight_start : weight_start + 4].view(torch.float32).item(),
+            0.25,
+        )
+        self.assertEqual(
+            views.activations.stride(0) * views.activations.element_size(),
+            mapped_rank_bytes,
+        )
+
+    def test_global_output_view_preserves_vmm_rank_padding(self):
+        """Direct W2 stores must address owner slots across a padded rank stride."""
+        layout = SharedEpLayout.build(
+            hidden_size=6144,
+            top_k=8,
+            max_tokens_per_rank=32,
+        )
+        world_size = 2
+        mapped_rank_bytes = layout.output_rank_bytes + 64 * 1024
+        storage = torch.zeros(
+            world_size * mapped_rank_bytes,
+            dtype=torch.uint8,
+        )
+
+        output = layout.output_view(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+        )
+        output[1, 4, 5, 7] = 3.5
+
+        byte_offset = (
+            mapped_rank_bytes
+            + layout.output_slot_offset(4, 5)
+            + 7 * torch.empty((), dtype=torch.bfloat16).element_size()
+        )
+        self.assertEqual(
+            storage[byte_offset : byte_offset + 2].view(torch.bfloat16).item(),
+            3.5,
+        )
+        self.assertEqual(
+            output.stride(0) * output.element_size(),
+            mapped_rank_bytes,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_profiles.py
+++ b/test/registered/moe/test_shared_ep_profiles.py
@@ -3,7 +3,18 @@ import unittest
 import torch
 
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
-from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.srt.layers.moe.shared_ep.backend import (
+    intermediate_capacity,
+    select_shared_ep_phase,
+)
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    DSV4_FLASH,
+    GLM52,
+    RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
+    make_pull_cache_prefill_profile,
+    resolve_prefill_capacity,
+    select_profile,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
@@ -21,6 +32,108 @@ def _config(*, hidden_size, top_k, intermediate_size=2048):
 
 
 class TestSharedEpProfiles(unittest.TestCase):
+    def test_pull_cache_prefill_is_admitted_only_for_validated_profiles(self):
+        self.assertTrue(GLM52.supports_pull_cache_prefill)
+        self.assertTrue(DSV4_FLASH.supports_pull_cache_prefill)
+        self.assertEqual(
+            select_shared_ep_phase(
+                64,
+                is_prefill=True,
+                prefill_capacity=64,
+                supports_pull_cache_prefill=GLM52.supports_pull_cache_prefill,
+            ),
+            "prefill",
+        )
+        self.assertEqual(
+            select_shared_ep_phase(
+                64,
+                is_prefill=True,
+                prefill_capacity=64,
+                supports_pull_cache_prefill=DSV4_FLASH.supports_pull_cache_prefill,
+            ),
+            "prefill",
+        )
+        self.assertEqual(
+            select_shared_ep_phase(
+                8,
+                is_prefill=False,
+                prefill_capacity=64,
+                supports_pull_cache_prefill=DSV4_FLASH.supports_pull_cache_prefill,
+            ),
+            "decode",
+        )
+
+    def test_prefill_capacity_uses_resolved_per_rank_chunk(self):
+        self.assertEqual(
+            resolve_prefill_capacity(
+                64,
+                release_max_tokens=RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
+            ),
+            64,
+        )
+        for invalid in (None, -1, 0, 2048, 8192):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, "prefill"):
+                    resolve_prefill_capacity(
+                        invalid,
+                        release_max_tokens=RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
+                    )
+
+    def test_prefill_capacity_is_phase_local_and_oversize_is_rejected(self):
+        """Adding prefill capacity must not silently enlarge decode."""
+        prefill = make_pull_cache_prefill_profile(
+            GLM52,
+            RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
+        )
+
+        self.assertIsNotNone(prefill)
+        self.assertEqual(GLM52.max_tokens_per_rank, 32)
+        self.assertEqual(GLM52.block_size_m, 16)
+        self.assertEqual(prefill.max_tokens_per_rank, 1024)
+        self.assertEqual(prefill.block_size_m, 64)
+        self.assertEqual(prefill.w13_kernel_config(1024)["BLOCK_SIZE_M"], 64)
+        self.assertEqual(prefill.w2_kernel_config(1024)["BLOCK_SIZE_M"], 64)
+        self.assertEqual(intermediate_capacity(prefill), 67552)
+        self.assertEqual(
+            select_shared_ep_phase(
+                512,
+                is_prefill=True,
+                prefill_capacity=prefill.max_tokens_per_rank,
+                supports_pull_cache_prefill=True,
+            ),
+            "prefill",
+        )
+        with self.assertRaisesRegex(ValueError, "capacity exceeded"):
+            select_shared_ep_phase(
+                1025,
+                is_prefill=True,
+                prefill_capacity=prefill.max_tokens_per_rank,
+                supports_pull_cache_prefill=True,
+            )
+        self.assertEqual(
+            select_shared_ep_phase(
+                8,
+                is_prefill=False,
+                prefill_capacity=prefill.max_tokens_per_rank,
+                supports_pull_cache_prefill=True,
+            ),
+            "decode",
+        )
+
+    def test_pull_cache_prefill_profiles_cover_glm_and_dsv4(self):
+        dsv4 = make_pull_cache_prefill_profile(DSV4_FLASH, 1024)
+
+        self.assertIsNotNone(dsv4)
+        self.assertEqual(dsv4.hidden_size, 4096)
+        self.assertEqual(dsv4.intermediate_size, 2048)
+        self.assertEqual(dsv4.top_k, 6)
+        self.assertEqual(dsv4.num_local_experts, 32)
+        self.assertEqual(dsv4.block_size_m, 64)
+        self.assertEqual(dsv4.w13_kernel_config(1024)["BLOCK_SIZE_M"], 64)
+        self.assertEqual(dsv4.w2_kernel_config(1024)["BLOCK_SIZE_M"], 64)
+        with self.assertRaisesRegex(ValueError, "positive"):
+            make_pull_cache_prefill_profile(GLM52, 0)
+
     def test_exact_glm_and_dsv4_shapes_select_registered_profiles(self):
         """The release registry must cover both promised model contracts."""
         glm = select_profile(

--- a/test/registered/moe/test_shared_ep_profiles.py
+++ b/test/registered/moe/test_shared_ep_profiles.py
@@ -1,0 +1,133 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+def _config(*, hidden_size, top_k, intermediate_size=2048):
+    return MoeRunnerConfig(
+        hidden_size=hidden_size,
+        intermediate_size_per_partition=intermediate_size,
+        top_k=top_k,
+        num_experts=256,
+        num_local_experts=32,
+        params_dtype=torch.bfloat16,
+    )
+
+
+class TestSharedEpProfiles(unittest.TestCase):
+    def test_exact_glm_and_dsv4_shapes_select_registered_profiles(self):
+        """The release registry must cover both promised model contracts."""
+        glm = select_profile(
+            _config(hidden_size=6144, top_k=8),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        dsv4 = select_profile(
+            _config(hidden_size=4096, top_k=6),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+
+        self.assertEqual(glm.name, "glm52")
+        self.assertEqual(dsv4.name, "dsv4_flash")
+        self.assertEqual(glm.route_kernel_config, {"num_threads": 1024})
+        self.assertEqual(dsv4.route_kernel_config, {"num_threads": 1024})
+        self.assertEqual(dsv4.kernel_config(4)["BLOCK_SIZE_N"], 64)
+        self.assertEqual(dsv4.kernel_config(8)["BLOCK_SIZE_N"], 128)
+
+    def test_w13_and_w2_profiles_are_selected_independently(self):
+        """Measured stage profiles must not be collapsed into one compromise."""
+        glm = select_profile(
+            _config(hidden_size=6144, top_k=8),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        dsv4 = select_profile(
+            _config(hidden_size=4096, top_k=6),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+
+        expected = {
+            ("dsv4", 0): ((64, 4, 3), (64, 4, 3)),
+            ("dsv4", 4): ((64, 4, 3), (64, 4, 3)),
+            ("dsv4", 8): ((128, 4, 4), (64, 4, 3)),
+            ("dsv4", 32): ((128, 4, 4), (64, 4, 3)),
+            ("glm", 0): ((64, 4, 3), (128, 4, 3)),
+            ("glm", 4): ((64, 4, 3), (128, 4, 3)),
+            ("glm", 8): ((128, 8, 4), (128, 4, 3)),
+            ("glm", 32): ((128, 8, 4), (128, 4, 3)),
+        }
+        for model, profile in (("dsv4", dsv4), ("glm", glm)):
+            for tokens in (0, 4, 8, 32):
+                with self.subTest(model=model, tokens=tokens):
+                    w13 = profile.w13_kernel_config(tokens)
+                    w2 = profile.w2_kernel_config(tokens)
+                    self.assertEqual(
+                        (
+                            w13["BLOCK_SIZE_N"],
+                            w13["num_warps"],
+                            w13["num_stages"],
+                        ),
+                        expected[(model, tokens)][0],
+                    )
+                    self.assertEqual(
+                        (
+                            w2["BLOCK_SIZE_N"],
+                            w2["num_warps"],
+                            w2["num_stages"],
+                        ),
+                        expected[(model, tokens)][1],
+                    )
+
+        for profile in (dsv4, glm):
+            for tokens in (-1, 33):
+                with self.subTest(profile=profile.name, tokens=tokens):
+                    with self.assertRaisesRegex(ValueError, "profile capacity"):
+                        profile.w13_kernel_config(tokens)
+                    with self.assertRaisesRegex(ValueError, "profile capacity"):
+                        profile.w2_kernel_config(tokens)
+
+    def test_every_unsupported_admission_dimension_is_rejected(self):
+        """A near-match must fail before graph capture instead of misdispatching."""
+        base = dict(
+            config=_config(hidden_size=4096, top_k=6),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        mutations = (
+            {"capability": (10, 0)},
+            {"ep_size": 4},
+            {"block_shape": (64, 128)},
+            {"max_tokens_per_rank": 64},
+            {"config": _config(hidden_size=4096, top_k=8)},
+            {"config": _config(hidden_size=4096, top_k=6, intermediate_size=2560)},
+        )
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                observed = {**base, **mutation}
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "observed=.*supported=",
+                ):
+                    select_profile(**observed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_routes.py
+++ b/test/registered/moe/test_shared_ep_routes.py
@@ -1,0 +1,198 @@
+import unittest
+
+import torch
+
+from sglang.kernels.ops.moe.shared_ep_route_prep import (
+    _route_specialization_key,
+    prepare_routes_cuda,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.shared_ep.kernels import prepare_routes
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+
+def _profile(hidden_size, top_k):
+    return select_profile(
+        MoeRunnerConfig(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=2048,
+            top_k=top_k,
+            num_experts=256,
+            num_local_experts=32,
+        ),
+        capability=(9, 0),
+        ep_size=8,
+        block_shape=(128, 128),
+        max_tokens_per_rank=32,
+    )
+
+
+def _ready(owner_count: int) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        torch.zeros(owner_count * 4, dtype=torch.uint8, device="cuda"),
+        torch.zeros(1, dtype=torch.int32, device="cuda"),
+    )
+
+
+class TestSharedEpRoutes(unittest.TestCase):
+    def test_route_specialization_key_is_shape_based(self):
+        """JIT variants must be selected by kernel shape, never model name."""
+        glm_key = _route_specialization_key(
+            (8, 32, 8),
+            num_local_experts=32,
+            block_size_m=16,
+            num_threads=1024,
+        )
+        dsv4_key = _route_specialization_key(
+            (8, 32, 6),
+            num_local_experts=32,
+            block_size_m=16,
+            num_threads=1024,
+        )
+
+        self.assertEqual(glm_key, (8, 32, 8, 32, 16, 1024))
+        self.assertEqual(dsv4_key, (8, 32, 6, 32, 16, 1024))
+        self.assertNotEqual(glm_key, dsv4_key)
+
+    def test_route_specialization_rejects_invalid_configs(self):
+        invalid_configs = (
+            ((8, 32), 32, 16, 1024),
+            ((8, 0, 6), 32, 16, 1024),
+            ((8, 32, 6), 0, 16, 1024),
+            ((8, 32, 6), 32, 0, 1024),
+            ((8, 32, 6), 32, 16, 1000),
+            ((8, 32, 6), 32, 16, 1056),
+            ((8, 32, 6), 32.0, 16, 1024),
+            ((8, 32, 6), 32, 16, 1024.0),
+        )
+        for shape, num_local_experts, block_size_m, num_threads in invalid_configs:
+            with self.subTest(
+                shape=shape,
+                num_local_experts=num_local_experts,
+                block_size_m=block_size_m,
+                num_threads=num_threads,
+            ):
+                with self.assertRaises(ValueError):
+                    _route_specialization_key(
+                        shape,
+                        num_local_experts=num_local_experts,
+                        block_size_m=block_size_m,
+                        num_threads=num_threads,
+                    )
+
+    def test_cuda_route_prep_rejects_cpu_tensors_before_jit(self):
+        ids = torch.zeros((8, 32, 6), dtype=torch.int32)
+        weights = torch.zeros_like(ids, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "CUDA tensors"):
+            prepare_routes_cuda(
+                ids,
+                weights,
+                torch.zeros(8 * 4, dtype=torch.uint8),
+                torch.zeros(1, dtype=torch.int32),
+                local_expert_start=0,
+                num_local_experts=32,
+                block_size_m=16,
+                num_threads=1024,
+            )
+
+    def test_production_route_prep_rejects_cpu_tensors(self):
+        ids = torch.zeros((8, 32, 6), dtype=torch.int32)
+        weights = torch.zeros_like(ids, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "CUDA tensors"):
+            prepare_routes(
+                _profile(4096, 6),
+                ids,
+                weights,
+                torch.zeros(8 * 4, dtype=torch.uint8),
+                torch.zeros(1, dtype=torch.int32),
+                local_expert_start=0,
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA JIT")
+    def test_route_multiset_and_padding_for_glm_and_dsv4(self):
+        """Every local route must be consumed once by its selected expert."""
+        fixtures = (
+            (_profile(6144, 8), 8),
+            (_profile(4096, 6), 6),
+        )
+        for profile, top_k in fixtures:
+            with self.subTest(profile=profile.name):
+                ids = torch.arange(2 * 3 * top_k, dtype=torch.int32).view(
+                    2,
+                    3,
+                    top_k,
+                )
+                ids = (ids * 13) % 256
+                ids[0, 0, 0] = -1
+                weights = torch.arange(ids.numel(), dtype=torch.float32).view_as(ids)
+                ready_signals, ready_epoch = _ready(ids.shape[0])
+                result = prepare_routes(
+                    profile,
+                    ids.cuda(),
+                    weights.cuda(),
+                    ready_signals,
+                    ready_epoch,
+                    local_expert_start=64,
+                )
+
+                expected_local = ids - 64
+                expected_local = torch.where(
+                    (expected_local >= 0) & (expected_local < 32),
+                    expected_local,
+                    -1,
+                )
+                self.assertTrue(torch.equal(result.local_ids.cpu(), expected_local))
+                self.assertTrue(torch.equal(result.local_weights.cpu(), weights))
+
+                flat_local = result.local_ids.flatten()
+                padded = int(result.num_tokens_post_padded.item())
+                self.assertEqual(padded % profile.block_size_m, 0)
+                for block_start in range(0, padded, profile.block_size_m):
+                    block = result.sorted_token_ids[
+                        block_start : block_start + profile.block_size_m
+                    ]
+                    expert = int(result.expert_ids[block_start // profile.block_size_m])
+                    valid = block[block < flat_local.numel()]
+                    self.assertTrue(torch.all(flat_local[valid] == expert))
+
+                consumed = result.sorted_token_ids[:padded]
+                consumed = consumed[consumed < flat_local.numel()]
+                expected = torch.nonzero(flat_local >= 0).flatten()
+                self.assertEqual(
+                    sorted(consumed.tolist()),
+                    sorted(expected.tolist()),
+                )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA JIT")
+    def test_skew_and_empty_experts_do_not_create_fake_routes(self):
+        """Invalid and non-local routes must not be encoded as a dummy expert."""
+        profile = _profile(4096, 6)
+        ids = torch.full((1, 32, 6), 255, dtype=torch.int32)
+        ids[0, :7, 0] = 96
+        ids[0, :3, 1] = 127
+        weights = torch.ones_like(ids, dtype=torch.float32)
+        ready_signals, ready_epoch = _ready(ids.shape[0])
+
+        result = prepare_routes(
+            profile,
+            ids.cuda(),
+            weights.cuda(),
+            ready_signals,
+            ready_epoch,
+            local_expert_start=96,
+        )
+
+        padded = int(result.num_tokens_post_padded.item())
+        self.assertEqual(padded, 32)
+        self.assertEqual(result.expert_ids[:2].tolist(), [0, 31])
+        self.assertTrue(torch.all(result.expert_ids[2:] == -1))
+        consumed = result.sorted_token_ids[:padded]
+        valid = consumed[consumed < ids.numel()]
+        self.assertEqual(valid.numel(), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_vmm.py
+++ b/test/registered/moe/test_shared_ep_vmm.py
@@ -203,6 +203,63 @@ class TestSharedEpVmmHelpers(unittest.TestCase):
             [None, "/tmp/shared_ep_fd_test/rank_0.sock", "OSError: connect failed"],
         )
 
+    def test_posix_descriptor_mismatch_is_published_before_mapping(self):
+        group = object()
+        server = MagicMock()
+        incoming = MagicMock()
+        incoming.__enter__.return_value = incoming
+        server.accept.return_value = (incoming, None)
+        outgoing = MagicMock()
+        outgoing.__enter__.return_value = outgoing
+        published = []
+
+        def fake_all_gather(output, value, *, group):
+            published.append(value)
+            if len(published) == 1:
+                output[:] = [None, None]
+            elif len(published) == 2:
+                output[:] = [
+                    "/tmp/shared_ep_fd_test/rank_0.sock",
+                    "/tmp/shared_ep_fd_test/rank_1.sock",
+                ]
+            else:
+                output[:] = [value, None]
+
+        with (
+            patch("socket.socket", side_effect=[server, outgoing]),
+            patch("tempfile.mkdtemp", return_value="/tmp/shared_ep_fd_test"),
+            patch.object(vmm_utils, "_recv_fd", return_value=None),
+            patch.object(vmm_utils, "_send_fd"),
+            patch.object(vmm_utils.os, "unlink"),
+            patch.object(vmm_utils.os, "rmdir"),
+            patch.object(
+                vmm_utils.dist,
+                "all_gather_object",
+                side_effect=fake_all_gather,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"POSIX fd validation failed on rank 0.*missing=\[\(1, 0\)\]",
+            ),
+        ):
+            vmm_utils.exchange_posix_fds(
+                group=group,
+                rank=0,
+                world_size=2,
+                local_fds=[10],
+                peer_base_counts=[1, 1],
+            )
+
+        self.assertEqual(
+            published,
+            [
+                None,
+                "/tmp/shared_ep_fd_test/rank_0.sock",
+                None,
+                "missing=[(1, 0)], extra=[]",
+            ],
+        )
+
     def test_preflight_failure_is_synchronized_before_first_allocation(self):
         local_error = RuntimeError("cuMemGetAllocationGranularity failed")
 

--- a/test/registered/moe/test_shared_ep_vmm.py
+++ b/test/registered/moe/test_shared_ep_vmm.py
@@ -1,0 +1,403 @@
+import unittest
+from unittest.mock import MagicMock, Mock, call, patch
+
+import torch
+
+from sglang.srt.distributed.device_communicators import vmm_utils
+from sglang.srt.layers.moe.shared_ep import vmm
+from sglang.srt.layers.moe.shared_ep.state import SharedEpState
+from sglang.srt.layers.moe.shared_ep.vmm import (
+    SharedEpVmmAllocation,
+    _construct_rank_major_views,
+    _release_partial_vmm_mapping,
+    _release_vmm_handles_synchronized,
+    _synchronize_vmm_stage,
+    _validate_same_host_group,
+    allocate_rank_major_vmm,
+    round_up_to_granularity,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestSharedEpStateLifecycle(unittest.TestCase):
+    def test_close_invalidates_views_before_unmap(self):
+        input_epoch = Mock()
+        output_epoch = Mock()
+        input_allocation = Mock()
+        output_allocation = Mock()
+        state = SharedEpState(
+            layout=Mock(),
+            input_allocation=input_allocation,
+            output_allocation=output_allocation,
+            input_epoch=input_epoch,
+            output_epoch=output_epoch,
+            global_input=object(),
+            local_input=object(),
+            global_output=object(),
+            local_output=object(),
+        )
+
+        def assert_views_invalidated():
+            self.assertIsNone(state.global_input)
+            self.assertIsNone(state.local_input)
+            self.assertIsNone(state.global_output)
+            self.assertIsNone(state.local_output)
+
+        output_allocation.close.side_effect = assert_views_invalidated
+        input_allocation.close.side_effect = assert_views_invalidated
+
+        state.close()
+        state.close()
+
+        input_epoch.close.assert_called_once_with()
+        output_epoch.close.assert_called_once_with()
+        input_allocation.close.assert_called_once_with()
+        output_allocation.close.assert_called_once_with()
+
+
+class TestSharedEpVmmHelpers(unittest.TestCase):
+    def test_round_up_to_granularity(self):
+        with self.assertRaisesRegex(ValueError, "positive"):
+            round_up_to_granularity(1, 0)
+        self.assertEqual(round_up_to_granularity(1, 65536), 65536)
+        self.assertEqual(round_up_to_granularity(65536, 65536), 65536)
+        self.assertEqual(round_up_to_granularity(65537, 65536), 131072)
+
+    def test_allocator_rejects_empty_rank_segment_before_cuda_setup(self):
+        with self.assertRaisesRegex(ValueError, "logical_rank_bytes"):
+            allocate_rank_major_vmm(
+                cpu_group=object(),
+                device=torch.device("cpu"),
+                logical_rank_bytes=0,
+            )
+
+    def test_rank_major_offsets_use_mapped_stride(self):
+        storage = torch.empty(0, dtype=torch.uint8)
+        allocation = SharedEpVmmAllocation(
+            local_storage=storage,
+            global_storage=storage,
+            rank=3,
+            world_size=8,
+            logical_rank_bytes=50000,
+            mapped_rank_bytes=65536,
+            granularity=65536,
+        )
+
+        self.assertEqual(allocation.rank_offset(0), 0)
+        self.assertEqual(allocation.rank_offset(3), 3 * 65536)
+        self.assertEqual(allocation.rank_offset(7), 7 * 65536)
+        with self.assertRaisesRegex(IndexError, "rank 8"):
+            allocation.rank_offset(8)
+
+    def test_all_ranks_ok_uses_collective_backend_device(self):
+        cases = (
+            ("gloo", torch.device("cpu")),
+            ("nccl", torch.device("cuda", torch.cuda.current_device())),
+        )
+        for backend, expected_device in cases:
+            with self.subTest(backend=backend):
+                seen = {}
+                group = object()
+
+                def fake_all_reduce(flag, *, op, group):
+                    seen.update(device=flag.device, op=op, group=group)
+
+                with (
+                    patch.object(vmm_utils.dist, "get_backend", return_value=backend),
+                    patch.object(
+                        vmm_utils.dist,
+                        "all_reduce",
+                        side_effect=fake_all_reduce,
+                    ),
+                    torch.device("cuda:3"),
+                ):
+                    self.assertTrue(vmm_utils.all_ranks_ok(group, True))
+
+                self.assertEqual(seen["device"], expected_device)
+                self.assertEqual(seen["op"], torch.distributed.ReduceOp.BAND)
+                self.assertIs(seen["group"], group)
+
+    def test_posix_listener_failure_is_published_before_path_exchange(self):
+        group = object()
+        server = MagicMock()
+        server.bind.side_effect = OSError("bind failed")
+        published = []
+
+        def fake_all_gather(output, value, *, group):
+            published.append(value)
+            output[:] = [value, None]
+
+        with (
+            patch("socket.socket", return_value=server),
+            patch("tempfile.mkdtemp", return_value="/tmp/shared_ep_fd_test"),
+            patch.object(vmm_utils.os, "unlink"),
+            patch.object(vmm_utils.os, "rmdir"),
+            patch.object(
+                vmm_utils.dist,
+                "all_gather_object",
+                side_effect=fake_all_gather,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "POSIX fd listener setup failed on rank 0.*bind failed",
+            ),
+        ):
+            vmm_utils.exchange_posix_fds(
+                group=group,
+                rank=0,
+                world_size=2,
+                local_fds=[10],
+                peer_base_counts=[1, 1],
+            )
+
+        self.assertEqual(published, ["OSError: bind failed"])
+
+    def test_posix_send_failure_is_published_after_exchange_attempt(self):
+        group = object()
+        server = MagicMock()
+        server.accept.side_effect = OSError("accept stopped")
+        outgoing = MagicMock()
+        outgoing.__enter__.return_value = outgoing
+        outgoing.connect.side_effect = OSError("connect failed")
+        published = []
+
+        def fake_all_gather(output, value, *, group):
+            published.append(value)
+            if len(published) == 1:
+                output[:] = [None, None]
+            elif len(published) == 2:
+                output[:] = [
+                    "/tmp/shared_ep_fd_test/rank_0.sock",
+                    "/tmp/shared_ep_fd_test/rank_1.sock",
+                ]
+            else:
+                output[:] = [value, None]
+
+        with (
+            patch("socket.socket", side_effect=[server, outgoing]),
+            patch("tempfile.mkdtemp", return_value="/tmp/shared_ep_fd_test"),
+            patch.object(vmm_utils.os, "unlink"),
+            patch.object(vmm_utils.os, "rmdir"),
+            patch.object(
+                vmm_utils.dist,
+                "all_gather_object",
+                side_effect=fake_all_gather,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "POSIX fd exchange failed on rank 0.*connect failed",
+            ),
+        ):
+            vmm_utils.exchange_posix_fds(
+                group=group,
+                rank=0,
+                world_size=2,
+                local_fds=[10],
+                peer_base_counts=[1, 1],
+            )
+
+        self.assertEqual(
+            published,
+            [None, "/tmp/shared_ep_fd_test/rank_0.sock", "OSError: connect failed"],
+        )
+
+    def test_preflight_failure_is_synchronized_before_first_allocation(self):
+        local_error = RuntimeError("cuMemGetAllocationGranularity failed")
+
+        with (
+            patch.object(vmm, "_validate_same_host_group"),
+            patch.object(vmm.dist, "get_rank", return_value=1),
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(vmm, "_get_cuda_driver", side_effect=local_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric preflight failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric preflight failure"),
+        ):
+            allocate_rank_major_vmm(
+                cpu_group="group",
+                device=torch.device("cuda:1"),
+                logical_rank_bytes=4096,
+            )
+
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "preflight",
+            local_error,
+        )
+
+    def test_same_host_query_failure_is_synchronized(self):
+        local_error = RuntimeError("hostname unavailable")
+
+        with (
+            patch.object(vmm.dist, "get_rank", return_value=1),
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(vmm.os, "uname", side_effect=local_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric host-query failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric host-query failure"),
+        ):
+            _validate_same_host_group("group")
+
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "host query",
+            local_error,
+        )
+
+    def test_stage_failure_reports_local_rank_and_preserves_cause(self):
+        local_error = RuntimeError("cuMemCreate: CUDA_ERROR_OUT_OF_MEMORY")
+
+        with (
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(
+                vmm.dist,
+                "all_gather_object",
+                side_effect=lambda output, value, group: output.__setitem__(0, value),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "SharedEP VMM allocation failed on rank 0.*OUT_OF_MEMORY",
+            ) as raised,
+        ):
+            _synchronize_vmm_stage("group", 0, "allocation", local_error)
+
+        self.assertIs(raised.exception.__cause__, local_error)
+
+    def test_stage_failure_reports_remote_rank(self):
+        gathered_errors = [None, "cuMemMap(rank=0): CUDA_ERROR_INVALID_VALUE"]
+
+        with (
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(
+                vmm.dist,
+                "all_gather_object",
+                side_effect=lambda output, _value, group: output.__setitem__(
+                    slice(None), gathered_errors
+                ),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "SharedEP VMM mapping failed on rank 1.*cuMemMap",
+            ),
+        ):
+            _synchronize_vmm_stage("group", 0, "mapping", None)
+
+    def test_partial_mapping_cleanup_is_reverse_order(self):
+        driver = MagicMock()
+        mapped_addresses = [0x1000, 0x3000]
+
+        _release_partial_vmm_mapping(
+            driver,
+            base_va=0x1000,
+            total_bytes=0x4000,
+            mapped_addresses=mapped_addresses,
+            segment_bytes=0x1000,
+        )
+
+        self.assertEqual(
+            driver.cuMemUnmap.call_args_list,
+            [call(0x3000, 0x1000), call(0x1000, 0x1000)],
+        )
+        driver.cuMemAddressFree.assert_called_once_with(0x1000, 0x4000)
+        self.assertEqual(mapped_addresses, [])
+
+    def test_local_handle_release_failure_is_synchronized_and_retained(self):
+        driver = MagicMock()
+        retained_handles = [11, 22]
+        release_error = RuntimeError("cuMemRelease: CUDA_ERROR_INVALID_HANDLE")
+
+        with (
+            patch.object(vmm, "check_drv", side_effect=release_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric handle-release failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric handle-release failure"),
+        ):
+            _release_vmm_handles_synchronized(
+                driver,
+                retained_handles=retained_handles,
+                cpu_group="group",
+                rank=1,
+            )
+
+        self.assertEqual(retained_handles, [11, 22])
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "handle release",
+            release_error,
+        )
+
+    def test_remote_handle_release_failure_arrives_after_local_release(self):
+        driver = MagicMock()
+        retained_handles = [11, 22]
+
+        with (
+            patch.object(vmm, "check_drv"),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("handle release failed on rank 0"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "failed on rank 0"),
+        ):
+            _release_vmm_handles_synchronized(
+                driver,
+                retained_handles=retained_handles,
+                cpu_group="group",
+                rank=1,
+            )
+
+        self.assertEqual(retained_handles, [])
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "handle release",
+            None,
+        )
+
+    def test_tensor_view_failure_is_synchronized(self):
+        view_error = RuntimeError("torch.from_dlpack rejected CUDA pointer")
+
+        with (
+            patch.object(vmm, "_uint8_tensor_from_cuda_ptr", side_effect=view_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric tensor-view failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric tensor-view failure"),
+        ):
+            _construct_rank_major_views(
+                cpu_group="group",
+                rank=1,
+                base_va=0x1000,
+                total_bytes=0x4000,
+                mapped_rank_bytes=0x2000,
+                logical_rank_bytes=0x1000,
+                device_id=1,
+                refs=[],
+            )
+
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "tensor view construction",
+            view_error,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_vmm_ep8.py
+++ b/test/registered/moe/test_shared_ep_vmm_ep8.py
@@ -1,0 +1,117 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.moe.shared_ep.epoch import create_gpu_epoch
+from sglang.srt.layers.moe.shared_ep.vmm import allocate_rank_major_vmm
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=40, stage="extra-b", runner_config="8-gpu-h200")
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and "RANK" in os.environ,
+    "run with torchrun on a CUDA node",
+)
+class TestSharedEpVmmEp8(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rank = int(os.environ["RANK"])
+        cls.world_size = int(os.environ["WORLD_SIZE"])
+        cls.local_rank = int(os.environ["LOCAL_RANK"])
+        if cls.world_size != 8:
+            raise AssertionError(f"expected EP8, got world size {cls.world_size}")
+        torch.cuda.set_device(cls.local_rank)
+        dist.init_process_group("gloo")
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()
+
+    def test_every_rank_reads_every_owner_segment(self):
+        allocation = None
+        try:
+            logical_rank_bytes = 4096
+            allocation = allocate_rank_major_vmm(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                logical_rank_bytes=logical_rank_bytes,
+            )
+            allocation.local_storage.fill_(self.rank + 1)
+            torch.cuda.synchronize()
+            dist.barrier()
+
+            for owner in range(self.world_size):
+                segment = allocation.global_storage.narrow(
+                    0,
+                    allocation.rank_offset(owner),
+                    logical_rank_bytes,
+                )
+                self.assertTrue(
+                    torch.all(segment == owner + 1).item(),
+                    f"rank {self.rank} observed wrong data for owner {owner}",
+                )
+            dist.barrier()
+        finally:
+            if allocation is not None:
+                allocation.close()
+
+    def test_gpu_epoch_publishes_two_generations_without_host_barrier(self):
+        """Release/acquire epochs must order peer payloads and safe reuse."""
+        allocation = None
+        input_epoch = None
+        completion_epoch = None
+        try:
+            logical_rank_bytes = 4096
+            allocation = allocate_rank_major_vmm(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                logical_rank_bytes=logical_rank_bytes,
+            )
+            input_epoch = create_gpu_epoch(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+            completion_epoch = create_gpu_epoch(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+
+            for generation in (1, 2):
+                allocation.local_storage.fill_(generation * 16 + self.rank)
+                input_epoch.publish()
+                input_epoch.wait_all()
+                for owner in range(self.world_size):
+                    segment = allocation.global_storage.narrow(
+                        0,
+                        allocation.rank_offset(owner),
+                        logical_rank_bytes,
+                    )
+                    self.assertTrue(
+                        torch.all(segment == generation * 16 + owner).item(),
+                        f"rank {self.rank} expected {generation * 16 + owner} for "
+                        f"owner {owner}, observed {torch.unique(segment).tolist()}",
+                    )
+                completion_epoch.publish()
+                completion_epoch.wait_all()
+            dist.barrier()
+        finally:
+            if completion_epoch is not None:
+                completion_epoch.close()
+            if input_epoch is not None:
+                input_epoch.close()
+            if allocation is not None:
+                allocation.close()
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(8,))

--- a/test/registered/moe/test_shared_ep_vmm_ep8.py
+++ b/test/registered/moe/test_shared_ep_vmm_ep8.py
@@ -1,6 +1,6 @@
 import os
-import unittest
 
+import pytest
 import torch
 import torch.distributed as dist
 
@@ -12,13 +12,13 @@ from sglang.test.kernels.utils import multigpu_pytest_main
 register_cuda_ci(est_time=40, stage="extra-b", runner_config="8-gpu-h200")
 
 
-@unittest.skipUnless(
-    torch.cuda.is_available() and "RANK" in os.environ,
-    "run with torchrun on a CUDA node",
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and "RANK" in os.environ),
+    reason="run with torchrun on a CUDA node",
 )
-class TestSharedEpVmmEp8(unittest.TestCase):
+class TestSharedEpVmmEp8:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.rank = int(os.environ["RANK"])
         cls.world_size = int(os.environ["WORLD_SIZE"])
         cls.local_rank = int(os.environ["LOCAL_RANK"])
@@ -28,7 +28,7 @@ class TestSharedEpVmmEp8(unittest.TestCase):
         dist.init_process_group("gloo")
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         if dist.is_initialized():
             dist.barrier()
             dist.destroy_process_group()
@@ -52,10 +52,9 @@ class TestSharedEpVmmEp8(unittest.TestCase):
                     allocation.rank_offset(owner),
                     logical_rank_bytes,
                 )
-                self.assertTrue(
-                    torch.all(segment == owner + 1).item(),
-                    f"rank {self.rank} observed wrong data for owner {owner}",
-                )
+                assert torch.all(
+                    segment == owner + 1
+                ).item(), f"rank {self.rank} observed wrong data for owner {owner}"
             dist.barrier()
         finally:
             if allocation is not None:
@@ -96,10 +95,9 @@ class TestSharedEpVmmEp8(unittest.TestCase):
                         allocation.rank_offset(owner),
                         logical_rank_bytes,
                     )
-                    self.assertTrue(
-                        torch.all(segment == generation * 16 + owner).item(),
+                    assert torch.all(segment == generation * 16 + owner).item(), (
                         f"rank {self.rank} expected {generation * 16 + owner} for "
-                        f"owner {owner}, observed {torch.unique(segment).tolist()}",
+                        f"owner {owner}, observed {torch.unique(segment).tolist()}"
                     )
                 completion_epoch.publish()
                 completion_epoch.wait_all()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -18,6 +18,9 @@ from sglang.srt.entrypoints.sidecar import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
+from sglang.srt.layers.moe.shared_ep.admission import (
+    validate_shared_ep_server_args,
+)
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     CudaGraphConfig,
@@ -1857,6 +1860,110 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         # require dp-attention there.
         args = self._args(moe_a2a_backend="deepep", enable_dp_attention=False)
         args._check_two_batch_overlap()
+
+
+class TestSharedEpConstraints(CustomTestCase):
+    def _args(self, **overrides):
+        args = ServerArgs(model_path="dummy")
+        args.moe_a2a_backend = "shared_ep"
+        args.moe_runner_backend = "deep_gemm"
+        args.tp_size = 8
+        args.dp_size = 8
+        args.enable_dp_attention = True
+        args.enable_lora = False
+        args.lora_paths = None
+        args.enable_two_batch_overlap = False
+        args.enable_single_batch_overlap = False
+        args.speculative_algorithm = None
+        args.speculative_moe_a2a_backend = None
+        args.speculative_moe_runner_backend = None
+        args.speculative_num_steps = None
+        args.speculative_eagle_topk = None
+        args.speculative_num_draft_tokens = None
+        args.cuda_graph_config = CudaGraphConfig(
+            decode=PhaseConfig(
+                backend=Backend.FULL, max_bs=32, bs=[1, 2, 4, 8, 16, 32]
+            ),
+            prefill=PhaseConfig(backend=Backend.DISABLED),
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_release_decode_capacity_is_admitted(self):
+        validate_shared_ep_server_args(self._args())
+
+    def test_release_requires_dp8_with_dp_attention(self):
+        for overrides, pattern in (
+            ({"dp_size": 4}, "DP8"),
+            ({"enable_dp_attention": False}, "enable-dp-attention"),
+        ):
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, pattern):
+                    validate_shared_ep_server_args(self._args(**overrides))
+
+    def test_release_rejects_lora(self):
+        for overrides in (
+            {"enable_lora": True},
+            {"lora_paths": ["adapter"]},
+        ):
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, "LoRA"):
+                    validate_shared_ep_server_args(self._args(**overrides))
+
+    def test_auto_target_runner_resolves_to_deep_gemm(self):
+        args = self._args(moe_runner_backend="auto")
+
+        validate_shared_ep_server_args(args)
+
+        self.assertEqual(args.moe_runner_backend, "deep_gemm")
+
+    def test_conflicting_target_runner_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "moe-runner-backend deep_gemm"):
+            validate_shared_ep_server_args(self._args(moe_runner_backend="triton"))
+
+    def test_overlap_is_rejected(self):
+        for field in ("enable_two_batch_overlap", "enable_single_batch_overlap"):
+            with self.subTest(field=field):
+                with self.assertRaisesRegex(ValueError, field.replace("_", "-")):
+                    validate_shared_ep_server_args(self._args(**{field: True}))
+
+    def test_speculative_decoding_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "does not support speculative"):
+            validate_shared_ep_server_args(
+                self._args(
+                    speculative_algorithm="EAGLE",
+                )
+            )
+
+    def test_oversized_decode_cuda_graph_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "32"):
+            validate_shared_ep_server_args(
+                self._args(
+                    cuda_graph_config=CudaGraphConfig(
+                        decode=PhaseConfig(
+                            backend=Backend.FULL,
+                            max_bs=64,
+                            bs=[1, 32, 64],
+                        ),
+                        prefill=PhaseConfig(backend=Backend.DISABLED),
+                    )
+                )
+            )
+
+    def test_disabled_decode_cuda_graph_ignores_capture_size(self):
+        validate_shared_ep_server_args(
+            self._args(
+                cuda_graph_config=CudaGraphConfig(
+                    decode=PhaseConfig(
+                        backend=Backend.DISABLED,
+                        max_bs=64,
+                        bs=[64],
+                    ),
+                    prefill=PhaseConfig(backend=Backend.DISABLED),
+                )
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1893,6 +1893,20 @@ class TestSharedEpConstraints(CustomTestCase):
     def test_release_decode_capacity_is_admitted(self):
         validate_shared_ep_server_args(self._args())
 
+    def test_release_defaults_global_request_limit_to_dp_capacity(self):
+        args = self._args(max_running_requests=None)
+
+        validate_shared_ep_server_args(args)
+
+        self.assertEqual(args.max_running_requests, 32 * 8)
+
+    def test_release_rejects_global_request_limit_above_dp_capacity(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "max-running-requests 256",
+        ):
+            validate_shared_ep_server_args(self._args(max_running_requests=257))
+
     def test_release_requires_dp8_with_dp_attention(self):
         for overrides, pattern in (
             ({"dp_size": 4}, "DP8"),

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1866,7 +1866,7 @@ class TestSharedEpConstraints(CustomTestCase):
     def _args(self, **overrides):
         args = ServerArgs(model_path="dummy")
         args.moe_a2a_backend = "shared_ep"
-        args.moe_runner_backend = "deep_gemm"
+        args.moe_runner_backend = "auto"
         args.tp_size = 8
         args.dp_size = 8
         args.enable_dp_attention = True
@@ -1880,6 +1880,7 @@ class TestSharedEpConstraints(CustomTestCase):
         args.speculative_num_steps = None
         args.speculative_eagle_topk = None
         args.speculative_num_draft_tokens = None
+        args.chunked_prefill_size = 1024
         args.cuda_graph_config = CudaGraphConfig(
             decode=PhaseConfig(
                 backend=Backend.FULL, max_bs=32, bs=[1, 2, 4, 8, 16, 32]
@@ -1925,16 +1926,27 @@ class TestSharedEpConstraints(CustomTestCase):
                 with self.assertRaisesRegex(ValueError, "LoRA"):
                     validate_shared_ep_server_args(self._args(**overrides))
 
-    def test_auto_target_runner_resolves_to_deep_gemm(self):
+    def test_auto_target_runner_remains_auto(self):
         args = self._args(moe_runner_backend="auto")
 
         validate_shared_ep_server_args(args)
 
-        self.assertEqual(args.moe_runner_backend, "deep_gemm")
+        self.assertEqual(args.moe_runner_backend, "auto")
 
-    def test_conflicting_target_runner_is_rejected(self):
-        with self.assertRaisesRegex(ValueError, "moe-runner-backend deep_gemm"):
-            validate_shared_ep_server_args(self._args(moe_runner_backend="triton"))
+    def test_explicit_triton_target_runner_is_admitted(self):
+        validate_shared_ep_server_args(self._args(moe_runner_backend="triton"))
+
+    def test_explicit_deep_gemm_target_runner_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "auto or triton"):
+            validate_shared_ep_server_args(self._args(moe_runner_backend="deep_gemm"))
+
+    def test_prefill_chunk_must_fit_standalone_capacity(self):
+        for chunked_prefill_size in (None, -1, 0, 1025):
+            with self.subTest(chunked_prefill_size=chunked_prefill_size):
+                with self.assertRaisesRegex(ValueError, "chunked-prefill-size"):
+                    validate_shared_ep_server_args(
+                        self._args(chunked_prefill_size=chunked_prefill_size)
+                    )
 
     def test_overlap_is_rejected(self):
         for field in ("enable_two_batch_overlap", "enable_single_batch_overlap"):
@@ -1961,6 +1973,25 @@ class TestSharedEpConstraints(CustomTestCase):
                             bs=[1, 32, 64],
                         ),
                         prefill=PhaseConfig(backend=Backend.DISABLED),
+                    )
+                )
+            )
+
+    def test_prefill_cuda_graph_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "prefill CUDA Graph"):
+            validate_shared_ep_server_args(
+                self._args(
+                    cuda_graph_config=CudaGraphConfig(
+                        decode=PhaseConfig(
+                            backend=Backend.FULL,
+                            max_bs=32,
+                            bs=[1, 2, 4, 8, 16, 32],
+                        ),
+                        prefill=PhaseConfig(
+                            backend=Backend.FULL,
+                            max_bs=32,
+                            bs=[1, 2, 4, 8, 16, 32],
+                        ),
                     )
                 )
             )

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1913,6 +1913,12 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             ),
             {},
         )
+        self.assertEqual(
+            _a2a_ep_size(
+                ResolvedView(SimpleNamespace(moe_a2a_backend="shared_ep", tp_size=8))
+            ),
+            {"ep_size": 8},
+        )
 
     def test_deepseek_family_order_safe_declarations(self):
         from sglang.srt.arg_groups.overrides import _deepseek_family_overrides

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -664,6 +664,26 @@ class TestEpBufferState(_IsolatedServerArgs):
         reset_context()
         self.assertIsNone(DeepEPBuffer._state().buffer)
 
+    def test_deepep_mode_transition_before_lazy_buffer_allocation(self):
+        try:
+            from sglang.srt.layers.moe.token_dispatcher.deepep import (
+                DeepEPBuffer,
+                DeepEPDispatchMode,
+            )
+        except ImportError:
+            self.skipTest("deep_ep not installed")
+
+        reset_context()
+        DeepEPBuffer.set_dispatch_mode_as_normal()
+
+        # CUDA Graph adapters publish the phase before the dispatcher's first
+        # lazy buffer allocation. NORMAL -> LOW_LATENCY has nothing to clean.
+        DeepEPBuffer.set_dispatch_mode_as_low_latency()
+
+        state = DeepEPBuffer._state()
+        self.assertIsNone(state.buffer)
+        self.assertEqual(state.dispatch_mode, DeepEPDispatchMode.LOW_LATENCY)
+
 
 class TestForwardFlags(_IsolatedServerArgs):
     """ctx.forward: contextvar-backed per-forward flags; scoped() restores,


### PR DESCRIPTION
## Summary

This PR introduces a **shared-object programming model** for expert parallelism inside one directly addressable NVLink domain. Instead of exposing packed communication payloads to the framework, each rank publishes model-semantic activation and routing objects in a canonical rank-major VMM view. Expert computation consumes those objects by index and returns contributions directly to canonical owner slots.

> **Publish object → Consume by index → Return contribution → Reuse**

Decode and Prefill share one object schema and return protocol, with a consumer policy selected for each phase:

- **Decode — Zero-Copy Direct:** indexed W13 consumes local or remote activation rows directly, and W2 returns contributions directly to owner slots.
- **Prefill — Pull Cache:** each expert rank pulls its active rows into a compact local cache for grouped W13; W2 still returns directly to owner slots.

Remote access still moves bytes over NVLink; SharedEP removes framework-level payload materialization, not communication cost.

## Shared-object execution

```mermaid
flowchart LR
  O["Canonical owner activation + route objects"] --> P["GPU publish epoch"]
  P --> C{"Phase consumer"}
  C -->|"Decode"| D["Zero-copy direct indexed remote/local consume"]
  C -->|"Prefill"| F["Pull active rows into local execution cache"]
  D --> W["Expert W13 + activation + W2"]
  F --> W
  W --> R["Direct return to canonical owner slots"]
  R --> E["GPU completion epoch"]
  E --> S["Owner Top-K reduction and safe reuse"]
```

The phase dataflows are shown separately below.

### DeepEP + DeepGEMM

```mermaid
flowchart LR
  B0["Router Top-K"] --> B1["Pack activation + route payload"]
  B1 --> B2["DeepEP dispatch"]
  B2 --> B3["Local grouped W13 + W2"]
  B3 --> B4["DeepEP combine"]
  B4 --> B5["Owner Top-K reduction"]
```

### SharedEP Decode — Zero-Copy Direct

```mermaid
flowchart LR
  D0["Router Top-K"] --> D1["Publish canonical activation + route objects"]
  D1 --> D2["GPU publish epoch"]
  D2 --> D3["Zero-copy indexed W13 consume<br/>direct local / remote reads"]
  D3 --> D4["Zero-copy W2 direct return<br/>to canonical owner slots"]
  D4 --> D5["GPU completion epoch"]
  D5 --> D6["Owner Top-K reduction"]
```

### SharedEP Prefill — Pull Cache

```mermaid
flowchart LR
  P0["Router Top-K"] --> P1["Publish canonical activation + route objects"]
  P1 --> P2["GPU publish epoch"]
  P2 --> P3["Pull active rows into local execution cache"]
  P3 --> P4["Local grouped W13"]
  P4 --> P5["W2 direct return to canonical owner slots"]
  P5 --> P6["GPU completion epoch"]
  P6 --> P7["Owner Top-K reduction"]
```

## Configuration and scope

Enable SharedEP with one option:

```bash
--moe-a2a-backend shared_ep
```

SharedEP is a standalone Triton-backed A2A backend. It reuses SGLang's Triton FusedMoE kernels and adds shared-object routing plus the Prefill row gather. No separate runner option is required.

The validated scope is EP8 block-FP8 on SM90 GPUs inside one directly addressable NVLink domain. GLM-5.2 and DeepSeek-V4-Flash cover both Zero-Copy Direct Decode and Pull Cache Prefill. Model differences are expressed as shape, capacity, and launch profiles rather than copied GEMM implementations.

## Correctness

- GPU epochs order object publication, expert returns, owner reduction, and storage reuse.
- Unit, EP8, CUDA Graph, fixed-input accuracy, and serving E2E tests cover both phases and their transition. DSV4 coverage uses its production 256-expert / 32-local-expert topology and M64 Pull profile.

## Performance validation (DeepEP vs MegaMoe vs SharedEP)

The serving comparison uses GLM-5.2 FP8 on one 8x H20 NVLink node with DP8 + DP-Attention + EP8, CUDA Graph Decode, 8K input, 1K output, scheduler chunk 8K (resolved to 1K per rank), zero cache hits, and global batch 64. The chart reports the stable warmed point and shows absolute latency plus change relative to DeepEP + DeepGEMM.

<img width="4000" height="1550" alt="image" src="https://github.com/user-attachments/assets/322db8f2-606e-41d2-ad4b-fc62e3613ccd" />
<details>
<summary>Reproduce Batch 64</summary>

Select one backend:

```bash
# SharedEP
MOE_ARGS=(--moe-a2a-backend shared_ep)

# DeepEP + DeepGEMM
# MOE_ARGS=(--moe-a2a-backend deepep --moe-runner-backend deep_gemm \
#   --deepep-mode auto \
#   --deepep-config '{"normal_dispatch":{"num_sms":20},"normal_combine":{"num_sms":20}}')

# MegaMoE
# export SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK=1024
# MOE_ARGS=(--moe-a2a-backend megamoe --moe-runner-backend deep_gemm)
```

Start the server:

```bash
export MODEL_PATH=/path/to/GLM-5.2-FP8
SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 python -m sglang.launch_server \
  --model-path "$MODEL_PATH" \
  --tokenizer-path "$MODEL_PATH" \
  --trust-remote-code \
  --json-model-override-args '{"qk_rope_head_dim":64}' \
  --kv-cache-dtype bfloat16 \
  --mem-fraction-static 0.85 \
  --max-running-requests 256 \
  --chunked-prefill-size 8192 \
  --max-prefill-tokens 16384 \
  --schedule-policy fcfs \
  --schedule-conservativeness 0.3 \
  --page-size 64 \
  --swa-full-tokens-ratio 0.8 \
  --tp-size 8 \
  --dp-size 8 \
  --enable-dp-attention \
  --ep-size 8 \
  --attention-backend dsa \
  --dsa-prefill-backend flashmla_sparse \
  --dsa-decode-backend fa3 \
  --cuda-graph-max-bs-decode 32 \
  --cuda-graph-bs-decode 1 2 4 8 12 16 20 24 28 32 \
  --random-seed 20260730 \
  --host 127.0.0.1 \
  --port 30000 \
  --skip-server-warmup \
  "${MOE_ARGS[@]}"
```

Run the warmed serving benchmark:

```bash
python -m sglang.bench_serving \
  --backend sglang \
  --host 127.0.0.1 \
  --port 30000 \
  --dataset-name random-ids \
  --model "$MODEL_PATH" \
  --tokenizer "$MODEL_PATH" \
  --num-prompts 64 \
  --random-input-len 8192 \
  --random-output-len 1024 \
  --random-range-ratio 1.0 \
  --request-rate inf \
  --max-concurrency 64 \
  --output-file result-b64.jsonl \
  --output-details \
  --disable-tqdm \
  --temperature 0 \
  --seed 20260730 \
  --flush-cache \
  --warmup-requests 1 \
  --tokenize-prompt \
  --cache-report
```

</details>

## Follow-up directions

- Extract a reusable shared-object runtime for SharedEP and SharedKV.
- Add more model, quantization, scheduling, and Prefill consumer profiles.
- Extend the VMM substrate to larger directly addressable NVLink supernodes.

This follows the shared-object programming direction introduced by [GLM-5.2 SharedKV #31435](https://github.com/sgl-project/sglang/pull/31435).

Co-authored with [@foraxe](https://github.com/foraxe).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30599576354](https://github.com/sgl-project/sglang/actions/runs/30599576354)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30599576240](https://github.com/sgl-project/sglang/actions/runs/30599576240)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->