### PR TITLE
[Bugfix] Download metadata for object-store draft models

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3681,7 +3681,7 @@ class ServerArgs:
             )
 
     def _handle_model_source_paths(self):
-        """Resolve model/tokenizer paths backed by remote object stores."""
+        """Resolve model, tokenizer, and draft paths backed by object stores."""
         if is_runai_obj_uri(self.model_path):
             ObjectStorageModel.download_and_get_path(self.model_path)
 
@@ -3691,6 +3691,13 @@ class ServerArgs:
             and self.tokenizer_path != self.model_path
         ):
             ObjectStorageModel.download_and_get_path(self.tokenizer_path)
+
+        if (
+            self.speculative_draft_model_path is not None
+            and is_runai_obj_uri(self.speculative_draft_model_path)
+            and self.speculative_draft_model_path != self.model_path
+        ):
+            ObjectStorageModel.download_and_get_path(self.speculative_draft_model_path)
 
     def _handle_pd_disaggregation(self):
         from sglang.srt.arg_groups.pd_disaggregation_hook import (

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1564,6 +1564,56 @@ class TestHandleCrashDumpEnv(CustomTestCase):
             )
 
 
+class TestHandleModelSourcePaths(CustomTestCase):
+    def _run_handler(
+        self,
+        *,
+        model_path="local-model",
+        tokenizer_path=None,
+        speculative_draft_model_path=None,
+    ):
+        server_args = SimpleNamespace(
+            model_path=model_path,
+            tokenizer_path=tokenizer_path,
+            speculative_draft_model_path=speculative_draft_model_path,
+        )
+        with patch.object(
+            server_args_module.ObjectStorageModel,
+            "download_and_get_path",
+        ) as mock_download:
+            ServerArgs._handle_model_source_paths(server_args)
+        return mock_download
+
+    def test_downloads_explicit_draft_object_storage_metadata(self):
+        mock_download = self._run_handler(
+            speculative_draft_model_path="s3://bucket/draft-model"
+        )
+
+        mock_download.assert_called_once_with("s3://bucket/draft-model")
+
+    def test_does_not_redownload_draft_when_it_matches_main_model(self):
+        model_path = "s3://bucket/model"
+        mock_download = self._run_handler(
+            model_path=model_path,
+            speculative_draft_model_path=model_path,
+        )
+
+        mock_download.assert_called_once_with(model_path)
+
+    def test_does_not_download_local_draft_path(self):
+        mock_download = self._run_handler(speculative_draft_model_path="/models/draft")
+
+        mock_download.assert_not_called()
+
+    def test_preserves_tokenizer_object_storage_handling(self):
+        mock_download = self._run_handler(
+            tokenizer_path="s3://bucket/tokenizer",
+            speculative_draft_model_path="/models/draft",
+        )
+
+        mock_download.assert_called_once_with("s3://bucket/tokenizer")
+
+
 class TestGrpcServerArgs(CustomTestCase):
     """Native gRPC is enabled by --grpc-port (or SGLANG_GRPC_PORT) and runs
     alongside HTTP; --smg-grpc-mode (and the deprecated --grpc-mode) select the


### PR DESCRIPTION
## Motivation

Speculative draft models stored at a separate object-storage path need their configuration and safetensors index metadata available before draft worker initialization. The target model and tokenizer paths are currently prepared during `ServerArgs` post-processing, but the explicit draft path is skipped.

Fixes #32486.

This complements #32082, which resolves an explicit draft `auto` format to the appropriate loader. This PR prepares the metadata required after the object-storage loader has been selected.

## Modifications

- Prepare an explicit object-storage draft model path in `_handle_model_source_paths()`.
- Avoid downloading metadata twice when the target and draft use the same path.
- Preserve the existing target model, tokenizer, and local draft path behavior.

## Accuracy Tests

Not applicable. This change only prepares model metadata before worker startup.

## Speed Tests and Profiling

Not applicable. Weight streaming and model execution are unchanged.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add unit tests.
- [x] Documentation is not required for this bug fix.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

## Testing

Added unit tests for downloading distinct object-storage draft metadata, deduplicating identical target and draft paths, preserving local draft paths, and preserving tokenizer metadata handling.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30244134654](https://github.com/sgl-project/sglang/actions/runs/30244134654)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30244134619](https://github.com/sgl-project/sglang/actions/runs/30244134619)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->