### PR TITLE
[Model Loader] Select RunAI shards for MTP draft models

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -135,6 +135,107 @@ _is_npu = is_npu()
 logger = logging.getLogger(__name__)
 
 
+def _is_draft_weight_name(weight_name: str, draft_model_idx: int) -> bool:
+    """Whether an index entry belongs to the requested MTP draft layer.
+
+    Checkpoints in the wild use both ``mtp.<idx>.`` (DeepSeek native format)
+    and ``model.mtp.layers.<idx>.`` (HF-style format). Other tensors below
+    ``mtp`` are draft-wide parameters, such as the shared norm, and must be
+    kept for every layer.
+    """
+    hf_layer_prefix = "model.mtp.layers."
+    if weight_name.startswith(hf_layer_prefix):
+        layer = weight_name[len(hf_layer_prefix) :].split(".", 1)[0]
+        return layer.isdigit() and int(layer) == draft_model_idx
+
+    native_prefix = "mtp."
+    if weight_name.startswith(native_prefix):
+        layer_or_name = weight_name[len(native_prefix) :].split(".", 1)[0]
+        return not layer_or_name.isdigit() or int(layer_or_name) == draft_model_idx
+
+    return weight_name.startswith("model.mtp.")
+
+
+def _select_runai_draft_weight_files(
+    model_name_or_path: str,
+    hf_folder: str,
+    hf_weights_files: List[str],
+    draft_model_idx: int,
+) -> Optional[List[str]]:
+    """Select shards containing the requested MTP draft weights.
+
+    Object-storage metadata is downloaded before workers are launched, so its
+    index is read from ObjectStorageModel's local cache. Returning ``None``
+    tells the caller to stream every shard when the index is unavailable or
+    the checkpoint layout is not recognized.
+    """
+    from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
+
+    index_folder = (
+        ObjectStorageModel.get_path(model_name_or_path)
+        if is_runai_obj_uri(model_name_or_path)
+        else hf_folder
+    )
+    index_path = os.path.join(index_folder, SAFE_WEIGHTS_INDEX_NAME)
+
+    try:
+        with open(index_path, encoding="utf-8") as index_file:
+            index = json.load(index_file)
+        weight_map = index.get("weight_map", {})
+        if not isinstance(weight_map, dict):
+            raise TypeError("weight_map must be an object")
+    except (AttributeError, OSError, ValueError, TypeError) as exc:
+        logger.warning(
+            "Unable to read safetensors index for RunAI draft shard selection "
+            "from %s (%s); streaming all %d shards",
+            index_path,
+            exc,
+            len(hf_weights_files),
+        )
+        return None
+
+    wanted_shards = {
+        shard
+        for weight_name, shard in weight_map.items()
+        if _is_draft_weight_name(weight_name, draft_model_idx)
+    }
+    if not wanted_shards:
+        logger.info(
+            "No MTP draft weights for layer %d found in %s; streaming all %d shards",
+            draft_model_idx,
+            index_path,
+            len(hf_weights_files),
+        )
+        return None
+
+    normalized_shards = {str(shard).replace("\\", "/") for shard in wanted_shards}
+    selected = [
+        weight_file
+        for weight_file in hf_weights_files
+        if any(
+            str(weight_file).replace("\\", "/") == shard
+            or str(weight_file).replace("\\", "/").endswith("/" + shard)
+            for shard in normalized_shards
+        )
+    ]
+    if not selected:
+        logger.warning(
+            "Safetensors index identified %d RunAI draft shards, but none "
+            "matched the listed weight files; streaming all %d shards",
+            len(wanted_shards),
+            len(hf_weights_files),
+        )
+        return None
+
+    logger.info(
+        "RunAI draft layer %d selected %d of %d safetensors shards",
+        draft_model_idx,
+        len(selected),
+        len(hf_weights_files),
+    )
+    return selected
+
+
 @contextmanager
 def device_loading_context(module: torch.nn.Module, target_device: torch.device):
     if target_device.type == "cpu":
@@ -3973,6 +4074,34 @@ class RunaiModelStreamerLoader(BaseModelLoader):
                 "model.safetensors.index.json",
                 source.model_config.hf_config,
             )
+
+        draft_architectures = (
+            getattr(source.model_config.hf_config, "architectures", ())
+            if source.model_config is not None
+            else ()
+        )
+        is_mtp_draft = (
+            source.model_config is not None
+            and getattr(source.model_config, "is_draft_model", False)
+            and (
+                self.load_config.draft_model_idx is not None
+                or any(
+                    "MTP" in architecture.upper() or "NEXTN" in architecture.upper()
+                    for architecture in draft_architectures
+                    if isinstance(architecture, str)
+                )
+            )
+        )
+        if is_mtp_draft:
+            draft_model_idx = self.load_config.draft_model_idx or 0
+            selected_files = _select_runai_draft_weight_files(
+                source.model_or_path,
+                hf_folder,
+                hf_weights_files,
+                draft_model_idx,
+            )
+            if selected_files is not None:
+                hf_weights_files = selected_files
 
         weights_iterator = runai_safetensors_weights_iterator(
             hf_weights_files, self._is_distributed, self.target_device_str

--- a/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
+++ b/test/registered/unit/model_loader/test_runai_model_streamer_loader.py
@@ -1,4 +1,7 @@
+import json
+import os
 import sys
+import tempfile
 import unittest
 from types import SimpleNamespace
 from typing import cast
@@ -24,6 +27,155 @@ class _FakeModel:
 
 
 class TestRunaiModelStreamerLoader(CustomTestCase):
+    def _write_index(self, folder, weight_map):
+        with open(
+            os.path.join(folder, "model.safetensors.index.json"),
+            "w",
+            encoding="utf-8",
+        ) as index_file:
+            json.dump({"weight_map": weight_map}, index_file)
+
+    def test_selects_only_requested_native_mtp_layer_shards(self):
+        with tempfile.TemporaryDirectory() as folder:
+            self._write_index(
+                folder,
+                {
+                    "model.layers.0.weight": "model-00001.safetensors",
+                    "mtp.0.decoder.weight": "mtp-00000.safetensors",
+                    "mtp.1.decoder.weight": "mtp-00001.safetensors",
+                    "mtp.shared_norm.weight": "mtp-shared.safetensors",
+                },
+            )
+            files = [
+                os.path.join(folder, filename)
+                for filename in (
+                    "model-00001.safetensors",
+                    "mtp-00000.safetensors",
+                    "mtp-00001.safetensors",
+                    "mtp-shared.safetensors",
+                )
+            ]
+
+            selected = loader_mod._select_runai_draft_weight_files(
+                folder, folder, files, draft_model_idx=1
+            )
+
+        self.assertEqual(selected, [files[2], files[3]])
+
+    def test_selects_hf_mtp_layer_and_common_mtp_shards(self):
+        with tempfile.TemporaryDirectory() as folder:
+            self._write_index(
+                folder,
+                {
+                    "model.mtp.layers.0.decoder.weight": "mtp-0.safetensors",
+                    "model.mtp.layers.1.decoder.weight": "mtp-1.safetensors",
+                    "model.mtp.norm.weight": "mtp-common.safetensors",
+                },
+            )
+            files = [
+                os.path.join(folder, filename)
+                for filename in (
+                    "mtp-0.safetensors",
+                    "mtp-1.safetensors",
+                    "mtp-common.safetensors",
+                )
+            ]
+
+            selected = loader_mod._select_runai_draft_weight_files(
+                folder, folder, files, draft_model_idx=0
+            )
+
+        self.assertEqual(selected, [files[0], files[2]])
+
+    def test_reads_object_storage_index_from_metadata_cache(self):
+        with tempfile.TemporaryDirectory() as metadata_folder:
+            self._write_index(
+                metadata_folder,
+                {"mtp.0.decoder.weight": "mtp.safetensors"},
+            )
+            files = [
+                "s3://bucket/model/model.safetensors",
+                "s3://bucket/model/mtp.safetensors",
+            ]
+
+            with patch(
+                "sglang.srt.utils.runai_utils.ObjectStorageModel.get_path",
+                return_value=metadata_folder,
+            ):
+                selected = loader_mod._select_runai_draft_weight_files(
+                    "s3://bucket/model",
+                    "s3://bucket/model",
+                    files,
+                    draft_model_idx=0,
+                )
+
+        self.assertEqual(selected, [files[1]])
+
+    def test_falls_back_to_all_shards_for_unrecognized_checkpoint(self):
+        with tempfile.TemporaryDirectory() as folder:
+            self._write_index(
+                folder,
+                {"model.layers.0.weight": "model.safetensors"},
+            )
+
+            selected = loader_mod._select_runai_draft_weight_files(
+                folder,
+                folder,
+                [os.path.join(folder, "model.safetensors")],
+                draft_model_idx=0,
+            )
+
+        self.assertIsNone(selected)
+
+    def test_get_weights_iterator_passes_only_draft_shards_to_runai(self):
+        runai_loader = loader_mod.RunaiModelStreamerLoader(
+            LoadConfig(
+                load_format=LoadFormat.RUNAI_STREAMER,
+                model_loader_extra_config={},
+                draft_model_idx=0,
+            )
+        )
+        runai_loader.target_device_str = "cpu"
+        runai_loader._is_distributed = False
+
+        with tempfile.TemporaryDirectory() as folder:
+            self._write_index(
+                folder,
+                {
+                    "model.layers.0.weight": "model.safetensors",
+                    "mtp.0.decoder.weight": "mtp.safetensors",
+                },
+            )
+            files = [
+                os.path.join(folder, "model.safetensors"),
+                os.path.join(folder, "mtp.safetensors"),
+            ]
+            source = loader_mod.RunaiModelStreamerLoader.Source(
+                model_or_path=folder,
+                revision=None,
+                model_config=cast(
+                    ModelConfig,
+                    SimpleNamespace(
+                        is_draft_model=True,
+                        hf_config=SimpleNamespace(architectures=[None]),
+                    ),
+                ),
+            )
+
+            with (
+                patch.object(
+                    runai_loader, "_prepare_weights", return_value=(folder, files)
+                ),
+                patch.object(
+                    weight_utils,
+                    "runai_safetensors_weights_iterator",
+                    return_value=iter([("mtp.0.decoder.weight", torch.tensor([1]))]),
+                ) as mock_iterator,
+            ):
+                list(runai_loader._get_weights_iterator(source))
+
+        mock_iterator.assert_called_once_with([files[1]], False, "cpu")
+
     def test_passes_quant_config_to_model_init(self):
         quant_config = object()
         fake_model = _FakeModel()


### PR DESCRIPTION
## Motivation

RunAI currently receives every safetensors shard before speculative draft tensors are filtered. For large checkpoints with bundled MTP/NextN weights, this makes the draft worker open and scan target-model shards it cannot use, increasing startup I/O and file-descriptor pressure, especially with object storage.

Fixes #32485.

## Modifications

- Read the local safetensors index metadata to identify shards for the requested MTP draft layer.
- Support native `mtp.<index>.*`, Hugging Face-style `model.mtp.layers.<index>.*`, and draft-wide MTP parameters.
- Pass only selected draft shards to the RunAI iterator.
- Fall back to all shards when the index is unavailable, malformed, unrecognized, or cannot be matched to listed files.

## Accuracy Tests

Not applicable. Tensor filtering and model computation are unchanged.

## Speed Tests and Profiling

Not included. This PR narrows the shard set before RunAI streaming.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add unit tests.
- [x] Documentation is not required for this loader optimization.
- [x] Accuracy and speed benchmarks are not included.
- [x] Follow the SGLang code style guidance.

## Testing

Added unit tests for native and Hugging Face MTP layouts, shared draft parameters, object-storage metadata-cache indexes, safe fallback for unrecognized checkpoints, and the RunAI iterator receiving only selected draft shards.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30244137031](https://github.com/sgl-project/sglang/actions/runs/30244137031)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30244136967](https://github.com/sgl-project/sglang/actions/runs/30244136967)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->