### PR TITLE
fix(dsa): correct packed FlashInfer top-k and backend selection semantics

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -340,6 +340,8 @@ def _build_flashinfer_paged_args(
         else None
     )
 
+    # Both dynamic mappings contain one entry per logit row. Supplying the known
+    # size avoids synchronizing CUDA to infer the sum of the repeat counts.
     if (
         row_to_batch is not None
         and cu_seqlens_q_topk is not None
@@ -348,7 +350,9 @@ def _build_flashinfer_paged_args(
         q_lens = (cu_seqlens_q_topk[1:] - cu_seqlens_q_topk[:-1]).to(
             dtype=torch.int32, device=device
         )
-        row_to_batch = torch.repeat_interleave(row_to_batch, q_lens)
+        row_to_batch = torch.repeat_interleave(
+            row_to_batch, q_lens, output_size=num_rows
+        )
 
     if row_to_batch is None and cu_seqlens_q_topk is not None:
         # Decode-like case (one query row per batch) does not need an explicit mapping.
@@ -361,6 +365,7 @@ def _build_flashinfer_paged_args(
             row_to_batch = torch.repeat_interleave(
                 torch.arange(q_lens.shape[0], dtype=torch.int32, device=device),
                 q_lens,
+                output_size=num_rows,
             )
 
     if row_starts is not None and row_to_batch is None:

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -154,6 +154,26 @@ class DSATopKBackend(Enum):
             import flashinfer
 
             if topk_transform_method == TopkTransformMethod.PAGED:
+                if row_starts is not None:
+                    # Packed PAGED extend uses batch-global score offsets with
+                    # request-local page tables. FlashInfer applies row_starts
+                    # to both, so reuse the SGL transform.
+                    from sgl_kernel import fast_topk_transform_fused
+
+                    page_table_size_1 = (
+                        attn_metadata.page_table_1[batch_idx_list]
+                        if batch_idx_list is not None
+                        else attn_metadata.page_table_1
+                    )
+                    return fast_topk_transform_fused(
+                        score=logits,
+                        lengths=lengths,
+                        page_table_size_1=page_table_size_1,
+                        cu_seqlens_q=cu_seqlens_q_topk,
+                        topk=topk,
+                        row_starts=row_starts,
+                    )
+
                 row_to_batch, local_row_starts = _build_flashinfer_paged_args(
                     attn_metadata=attn_metadata,
                     row_starts=row_starts,

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -34,6 +34,9 @@ class DSATopKBackend(Enum):
     def is_flashinfer(self) -> bool:
         return self == DSATopKBackend.FLASHINFER
 
+    def should_use_topk_v2(self) -> bool:
+        return self.is_sgl_kernel() and envs.SGLANG_OPT_USE_TOPK_V2.get()
+
     def topk_func(
         self,
         score: torch.Tensor,
@@ -88,18 +91,19 @@ class DSATopKBackend(Enum):
         if not envs.SGLANG_DSA_FUSE_TOPK.get() or force_unfused_topk:
             return self.topk_func(logits, lengths, topk, row_starts=row_starts)
 
-        # Decode-shaped PAGED top-k (plain decode AND spec verify / draft-extend,
-        # whose expanded rows match the same shape) routes to the DeepSeek-V4 top-k
-        # v2 JIT kernel, which fuses top-k selection and the page-table transform in
-        # one launch and consumes the indexer's own page_size>=1 table directly, so
-        # no page_size=1 table is materialized. Shared by DeepSeek-V3.2 and GLM DSA.
+        # Decode-shaped PAGED top-k for the SGL backend (plain decode AND spec
+        # verify / draft-extend, whose expanded rows match the same shape) routes
+        # to the DeepSeek-V4 top-k v2 JIT kernel. It fuses top-k selection and the
+        # page-table transform in one launch and consumes the indexer's own
+        # page_size>=1 table directly, so no page_size=1 table is materialized.
+        # Shared by DeepSeek-V3.2 and GLM DSA.
         # This is a deterministic dispatch on the work shape, not a best-effort
         # attempt: the fused-decode CUDA graph drops the page_size=1 table for
         # exactly this case (see dsa_drop_wide_page_table), so once the shape
         # matches we commit to v2 and never silently fall back to the legacy
         # page_size=1 path from here.
         if (
-            envs.SGLANG_OPT_USE_TOPK_V2.get()
+            self.should_use_topk_v2()
             and topk_transform_method == TopkTransformMethod.PAGED
             and row_starts is None
             and batch_idx_list is None
@@ -288,7 +292,6 @@ def _topk_transform_v2_paged(
     ``seqlens_expand_kernel``); 0 takes the trivial all-(-1) output path.
     """
     from sglang.kernels.ops.attention.dsv4.topk import topk_transform_512_v2
-    from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 
     num_rows = logits.shape[0]
 
@@ -317,7 +320,7 @@ def _topk_transform_v2_paged(
         plan is not None and plan.shape[0] == num_rows + 1
     ), "topk_v2_plan must be preprocessed per forward (see DSAMetadata.topk_v2_plan)"
 
-    page_size = get_token_to_kv_pool().page_size
+    page_size = attn_metadata.page_size
     out = logits.new_full((num_rows, topk), -1, dtype=torch.int32)
     topk_transform_512_v2(logits, lengths_i32, page_table, out, page_size, plan)
     return out

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -208,7 +208,7 @@ class DSAMetadata:
     paged_mqa_ctx_lens_2d: Optional[torch.Tensor] = None
     # Precomputed once per forward batch and reused across layers: the
     # DeepSeek-V4 top-k v2 plan (cluster-threshold metadata) for the folded
-    # decode top-k transform. None unless SGLANG_OPT_USE_TOPK_V2 and decode.
+    # decode top-k transform. None unless the SGL top-k v2 path is enabled.
     topk_v2_plan: Optional[torch.Tensor] = None
     # The sum of sequence lengths for key, prefill only
     seq_lens_sum: Optional[int] = None
@@ -722,8 +722,8 @@ class DeepseekSparseAttnBackend(
         # that dispatches to `_topk_transform_v2_paged` -- decode AND MTP
         # target-verify / draft-extend, whose expanded row count is exactly what v2
         # sees -- otherwise the helper's plan-present assertion fires. None only
-        # when the fold is disabled; such metadata is never dispatched to v2.
-        if not envs.SGLANG_OPT_USE_TOPK_V2.get():
+        # when the SGL v2 path is disabled; such metadata is never dispatched to v2.
+        if not self.dsa_topk_backend.should_use_topk_v2():
             return None
         from sglang.kernels.ops.attention.dsv4.topk import plan_topk_v2
 
@@ -1182,12 +1182,12 @@ class DeepseekSparseAttnBackend(
         # page_size=1 table. This MUST match the exact condition under which
         # `DSATopKBackend.topk_transform` dispatches decode PAGED to
         # `_topk_transform_v2_paged` -- otherwise the legacy transform would read a
-        # dropped (None) table. Hence: fused top-k AND v2 enabled AND index_topk in
-        # the kernel's supported range, on CUDA with page_size>1. Excludes HIP (its
-        # indexer reads page_table_1), hisparse (needs page_size=1 loc translation),
-        # and spec decoding (MTP precompute fast-path + target-verify/draft-extend
-        # still consume the wide table). Computed once from stable config; the graph
-        # is captured once per process.
+        # dropped (None) table. Hence: SGL top-k backend AND fused top-k AND v2
+        # enabled AND index_topk in the kernel's supported range, on CUDA with
+        # page_size>1. Excludes HIP (its indexer reads page_table_1), hisparse
+        # (needs page_size=1 loc translation), and spec decoding (MTP precompute
+        # fast-path + target-verify/draft-extend still consume the wide table).
+        # Computed once from stable config; the graph is captured once per process.
         self.dsa_drop_wide_page_table = (
             is_cuda()
             and not _is_hip
@@ -1195,9 +1195,9 @@ class DeepseekSparseAttnBackend(
             and self.hisparse_coordinator is None
             and not self.speculative_num_draft_tokens
             and self.use_fused_topk
-            and envs.SGLANG_OPT_USE_TOPK_V2.get()
+            and self.dsa_topk_backend.should_use_topk_v2()
             and self.dsa_index_topk is not None
-            and self.dsa_index_topk <= 2048
+            and 0 < self.dsa_index_topk <= 2048
         )
 
         max_ctx_len = self.req_to_token.shape[1]

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -308,6 +308,8 @@ class DSAIndexerMetadata(BaseIndexerMetadata):
             cu_topk_indices_offset = torch.repeat_interleave(
                 cu_seqlens_q_topk[:-1],
                 cu_seqlens_q,
+                # Avoid reading sum(cu_seqlens_q) back to the host.
+                output_size=logits.shape[0],
             )
         else:
             cu_seqlens_q_topk = self.attn_metadata.cu_seqlens_q

--- a/test/registered/kernels/ops/attention/test_dsa_indexer.py
+++ b/test/registered/kernels/ops/attention/test_dsa_indexer.py
@@ -678,10 +678,7 @@ class TestDSAIndexer(CustomTestCase):
             topk_backend=DSATopKBackend.FLASHINFER,
         )
 
-        with (
-            envs.SGLANG_DSA_FUSE_TOPK.override(True),
-            envs.SGLANG_OPT_USE_TOPK_V2.override(False),
-        ):
+        with envs.SGLANG_DSA_FUSE_TOPK.override(True):
             out_sgl = metadata_sgl.topk_transform(
                 logits,
                 topk,
@@ -1004,6 +1001,56 @@ class TestDSAIndexer(CustomTestCase):
                         with_row_starts=True,
                         query_lens=[1, 2, 3, 1, 2, 1, 3, 2],
                     )
+
+    def test_topk_v2_respects_topk_backend(self):
+        seq_lens = torch.tensor([2048, 4096], dtype=torch.int32, device=self.device)
+        expected_plan = torch.empty(3, dtype=torch.int32, device=self.device)
+
+        for topk_backend, should_use_topk_v2 in [
+            (DSATopKBackend.SGL_KERNEL, True),
+            (DSATopKBackend.FLASHINFER, False),
+        ]:
+            with self.subTest(topk_backend=topk_backend.value):
+                backend = object.__new__(DeepseekSparseAttnBackend)
+                backend.device = self.device
+                backend.real_page_size = 64
+                backend.hisparse_coordinator = None
+                backend.speculative_num_draft_tokens = 0
+                backend.use_fused_topk = True
+                backend.dsa_topk_backend = topk_backend
+                backend.dsa_index_topk = 2048
+                backend.dsa_decode_impl = "fa3"
+                backend.req_to_token = torch.empty(
+                    2, 4096, dtype=torch.int32, device=self.device
+                )
+
+                with (
+                    envs.SGLANG_OPT_USE_TOPK_V2.override(True),
+                    patch(
+                        "sglang.kernels.ops.attention.dsv4.topk.plan_topk_v2",
+                        return_value=expected_plan,
+                    ) as mock_plan_topk_v2,
+                ):
+                    self.assertEqual(
+                        topk_backend.should_use_topk_v2(), should_use_topk_v2
+                    )
+                    actual_plan = backend._build_topk_v2_plan(seq_lens)
+                    backend.init_cuda_graph_state(max_bs=2, max_num_tokens=2)
+
+                if should_use_topk_v2:
+                    self.assertIs(actual_plan, expected_plan)
+                    mock_plan_topk_v2.assert_called_once_with(seq_lens)
+                else:
+                    self.assertIsNone(actual_plan)
+                    mock_plan_topk_v2.assert_not_called()
+                self.assertEqual(
+                    backend.dsa_drop_wide_page_table,
+                    should_use_topk_v2,
+                )
+                self.assertEqual(
+                    backend.decode_cuda_graph_metadata["page_table"] is None,
+                    should_use_topk_v2,
+                )
 
     # TODO: enable this test after indexer accuracy aligned
     # @patch("sglang.srt.layers.attention.dsa.dsa_indexer.deep_gemm")

--- a/test/registered/kernels/ops/attention/test_dsa_indexer.py
+++ b/test/registered/kernels/ops/attention/test_dsa_indexer.py
@@ -678,7 +678,10 @@ class TestDSAIndexer(CustomTestCase):
             topk_backend=DSATopKBackend.FLASHINFER,
         )
 
-        with envs.SGLANG_DSA_FUSE_TOPK.override(True):
+        with (
+            envs.SGLANG_DSA_FUSE_TOPK.override(True),
+            envs.SGLANG_OPT_USE_TOPK_V2.override(False),
+        ):
             out_sgl = metadata_sgl.topk_transform(
                 logits,
                 topk,
@@ -956,13 +959,6 @@ class TestDSAIndexer(CustomTestCase):
                 TopkTransformMethod.RAGGED,
             ]:
                 for with_row_starts in [False, True]:
-                    if (
-                        topk_transform_method == TopkTransformMethod.PAGED
-                        and with_row_starts
-                    ):
-                        # The synthetic paged fixture uses the decode-like row mapping.
-                        # Ragged fused and unfused cases cover shifted row windows.
-                        continue
                     with self.subTest(
                         tie_break=tie_break,
                         topk_transform_method=topk_transform_method.name,
@@ -991,6 +987,21 @@ class TestDSAIndexer(CustomTestCase):
                         topk=topk,
                         topk_transform_method=TopkTransformMethod.PAGED,
                         with_row_starts=False,
+                        query_lens=[1, 2, 3, 1, 2, 1, 3, 2],
+                    )
+            with self.subTest(
+                tie_break=tie_break,
+                topk_transform_method=TopkTransformMethod.PAGED.name,
+                with_row_starts=True,
+                query_lens="multi",
+            ):
+                with envs.SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK.override(tie_break):
+                    self._run_fused_topk_backend_equivalence_test(
+                        batch_size=batch_size,
+                        max_score_len=max_score_len,
+                        topk=topk,
+                        topk_transform_method=TopkTransformMethod.PAGED,
+                        with_row_starts=True,
                         query_lens=[1, 2, 3, 1, 2, 1, 3, 2],
                     )
 

--- a/test/registered/kernels/ops/attention/test_dsa_indexer.py
+++ b/test/registered/kernels/ops/attention/test_dsa_indexer.py
@@ -678,7 +678,14 @@ class TestDSAIndexer(CustomTestCase):
             topk_backend=DSATopKBackend.FLASHINFER,
         )
 
-        with envs.SGLANG_DSA_FUSE_TOPK.override(True):
+        repeat_interleave = torch.repeat_interleave
+        with (
+            envs.SGLANG_DSA_FUSE_TOPK.override(True),
+            patch(
+                "sglang.srt.layers.attention.dsa_backend.torch.repeat_interleave",
+                wraps=repeat_interleave,
+            ) as mock_repeat_interleave,
+        ):
             out_sgl = metadata_sgl.topk_transform(
                 logits,
                 topk,
@@ -692,6 +699,15 @@ class TestDSAIndexer(CustomTestCase):
                 ks=row_starts,
                 cu_seqlens_q=q_lens,
                 batch_idx_list=batch_idx_list,
+            )
+
+        if query_lens is not None:
+            self.assertTrue(mock_repeat_interleave.call_args_list)
+            self.assertTrue(
+                all(
+                    call.kwargs.get("output_size") == num_rows
+                    for call in mock_repeat_interleave.call_args_list
+                )
             )
 
         self.assertEqual(out_sgl.shape, out_flashinfer.shape)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
@humansand

[PR #22851](https://github.com/sgl-project/sglang/pull/22851) introduced `--dsa-topk-backend` and integrated FlashInfer and PyTorch top-k into the fused and unfused DSA paths. This PR follows up on that integration with three focused fixes:

1. **FlashInfer packed PAGED correctness:** packed extend uses batch-global offsets for score rows while its page tables remain request-local. FlashInfer's PAGED transform applies its single `row_starts` argument to both score selection and page-table lookup, so it cannot represent this layout.
2. **Backend-selection semantics:** `SGLANG_OPT_USE_TOPK_V2` is an `sgl-kernel` implementation optimization and should not override an explicit `--dsa-topk-backend` choice. Previously, eligible decode calls could enter the SGL top-k v2 path even when another backend, such as `flashinfer` or `torch`, was selected. CUDA graph metadata construction made the same assumption when deciding whether to build the v2 plan and retain the page-size-1 table.
3. **Avoidable top-k host synchronization:** dynamic `torch.repeat_interleave` calls without `output_size` infer their output size by reading repeat counts back from CUDA. Each affected mapping is already known to produce one entry per logit row, so supplying that row count avoids the host synchronization without changing mapping semantics.

The accompanying page-size lookup change does not introduce new paging behavior. `_topk_transform_v2_paged` already consumes `DSAMetadata.real_page_table`, and both eager and CUDA graph metadata associate that table with `DSAMetadata.page_size` from the backend's `real_page_size`. Reading the table and its page size from the same metadata removes an ambient forward-context dependency while preserving the existing value.

## Modifications

- Use `sgl_kernel.fast_topk_transform_fused` as a correctness fallback for the unsupported FlashInfer PAGED case where `row_starts` is present. Unshifted PAGED and RAGGED calls continue to use FlashInfer.
- Make `SGLANG_OPT_USE_TOPK_V2` subordinate to `--dsa-topk-backend`: top-k v2 is eligible only when `sgl-kernel` is selected. Apply this policy consistently to dispatch, plan construction, and CUDA graph wide-page-table elision.
- Read the v2 transform's page size from the same `DSAMetadata` that supplies `real_page_table`, rather than consulting global forward context.
- Pass the known logit row count as `output_size` to dynamic repeat-interleave calls in FlashInfer PAGED row mapping and top-k offset construction.
- Expand backend equivalence coverage to shifted PAGED rows, including multiple query rows per request, and add a centralized regression for top-k v2 backend selection and metadata handling.

## Known Limitation

The packed PAGED fallback in this PR is numerically correct, but it is not a complete FlashInfer fused top-k path: when `row_starts` is present, the FlashInfer branch invokes `sgl_kernel.fast_topk_transform_fused`.

A fully semantically correct FlashInfer fused top-k implementation for this case requires [flashinfer-ai/flashinfer#4169](https://github.com/flashinfer-ai/flashinfer/pull/4169). That PR adds a separate `page_table_row_starts` argument so FlashInfer can use the score-window and page-table starts independently. Until SGLang adopts a FlashInfer version containing that API, `--dsa-topk-backend flashinfer` will continue to use the SGL fallback for packed PAGED rows, and the FlashInfer deterministic and tie-break settings will not apply to that shape.

The backend-selection fix in this PR is independent of that dependency: it prevents the SGL-only top-k v2 optimization from overriding an explicitly selected non-SGL backend on paths the selected backend supports.

## Accuracy Tests

Focused tests were run on an NVIDIA B200 with CUDA 13.0, FlashInfer 0.6.15.post1, and `sglang-kernel` 0.4.5:

```bash
python3 -m pytest -q --tb=short \
  test/registered/kernels/ops/attention/test_dsa_indexer.py::TestDSAIndexer::test_topk_unfused_backends_valid_selection \
  test/registered/kernels/ops/attention/test_dsa_indexer.py::TestDSAIndexer::test_topk_fused_backends_equivalence \
  test/registered/kernels/ops/attention/test_dsa_indexer.py::TestDSAIndexer::test_topk_v2_respects_topk_backend
```

Result: `3 passed, 30 subtests passed in 11.58s`.

The tests compare exact selected index sets using tie-free logits across PAGED and RAGGED layouts, shifted and unshifted rows, and multi-query batches. The multi-query fused cases also assert that every dynamic top-k repeat supplies `output_size=num_rows`, the PyTorch API contract that avoids reading `sum(repeats)` back to the host. FlashInfer tie-break modes `None`, `small`, and `large` are exercised on paths that invoke FlashInfer. Shifted PAGED cases validate the SGL fallback against the SGL backend and therefore do not exercise FlashInfer tie-breaking. No model-level accuracy benchmark was run.

`pre-commit run --all-files` also passed.

## Speed Tests and Profiling

No standalone performance benchmark was run for the repeat-interleave change. Supplying the already-known `output_size` removes PyTorch's implicit host read without changing mapping values. The packed PAGED change is a correctness fix, while the top-k v2 change restores the expected backend-selection semantics. FlashInfer remains unchanged for layouts its API can represent; only packed PAGED rows with separate score/page-table coordinate systems use the existing SGL fused transform.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API change.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30403592750](https://github.com/sgl-project/sglang/actions/runs/30403592750)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30403592267](https://github.com/sgl-project/sglang/actions/runs/30403592267)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
