### PR TITLE
perf(openai): keep prompt_ids for text-only requests on multimodal checkpoints

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -158,6 +158,32 @@ def _extract_max_dynamic_patch(request: ChatCompletionRequest):
     return img_max_dynamic_patch, vid_max_dynamic_patch
 
 
+def request_carries_media(processed_messages: MessageProcessingResult) -> bool:
+    """Whether this request actually carries multimodal payload.
+
+    ``model_config.is_multimodal`` only says the checkpoint *can* accept media.
+    Text-only requests served by such a checkpoint do not need the text prompt
+    path, which discards the already-computed ``prompt_ids`` and forces extra
+    full-context tokenization downstream.
+    """
+    return bool(
+        processed_messages.image_data
+        or processed_messages.video_data
+        or processed_messages.audio_data
+    )
+
+
+def has_usable_prompt_ids(processed_messages: MessageProcessingResult) -> bool:
+    """Whether message processing actually produced token ids we can forward.
+
+    The conversation-template path leaves ``prompt_ids`` empty for multimodal
+    models, and some paths carry a raw string there; both must keep using the
+    text prompt.
+    """
+    prompt_ids = processed_messages.prompt_ids
+    return isinstance(prompt_ids, list) and bool(prompt_ids)
+
+
 class OpenAIServingChat(OpenAIServingBase):
     """Handler for /v1/chat/completions requests"""
 
@@ -708,7 +734,10 @@ class OpenAIServingChat(OpenAIServingBase):
         # Handle single vs multiple requests
         if request.input_ids is not None:
             prompt_kwargs = {"input_ids": processed_messages.prompt_ids}
-        elif is_multimodal:
+        elif is_multimodal and (
+            request_carries_media(processed_messages)
+            or not has_usable_prompt_ids(processed_messages)
+        ):
             # Standard VLMs render a text prompt (with placeholder strings) for the MM
             # processor to tokenize. Inkling's custom encoder instead produces pre-rendered
             # input_ids with single placeholders; pass those through so the MM processor

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -65,7 +65,11 @@ from sglang.srt.entrypoints.openai.protocol import (
     Tool,
     UsageInfo,
 )
-from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.srt.entrypoints.openai.serving_chat import (
+    OpenAIServingChat,
+    has_usable_prompt_ids,
+    request_carries_media,
+)
 from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
@@ -484,7 +488,15 @@ class OpenAIServingResponses(OpenAIServingChat):
         is_multimodal = self.tokenizer_manager.model_config.is_multimodal
         processed_messages = self._process_messages(chat_request, is_multimodal)
 
-        if is_multimodal:
+        # A multimodal-capable checkpoint serving a text-only request does not need
+        # the text prompt path: passing text here discards the already-computed
+        # prompt_ids and costs two extra full-context tokenizations downstream (the
+        # max_output_tokens budget below re-encodes the prompt, and TokenizerManager
+        # re-encodes it again). That is O(context) per request and dominates
+        # late-session TTFT on long append-only conversations.
+        if (
+            is_multimodal and request_carries_media(processed_messages)
+        ) or not has_usable_prompt_ids(processed_messages):
             request_prompts = [processed_messages.prompt]
             engine_prompts = [processed_messages.prompt]
         else:


### PR DESCRIPTION
## Motivation

Fixes #32493.

Both `/v1/responses` and `/v1/chat/completions` decide how to hand the prompt to the engine by looking only at `model_config.is_multimodal`, which says the *checkpoint* can accept media — not that *this request* carries any. A text-only request served by a multimodal-capable checkpoint therefore takes the text prompt path, which throws away the `prompt_ids` that `_process_messages` just computed and passes a string instead. Downstream that costs two extra full-context tokenizations per request:

1. `serving_responses` re-encodes the prompt to budget `max_output_tokens` (`prompt_length = len(tokenizer.encode(engine_prompt))`);
2. `TokenizerManager` re-encodes the same text again before scheduling.

Both are O(context), so on long append-only conversations (agent / tool-calling traffic) the cost grows with every turn and shows up as a rising TTFT floor even when only a few hundred new tokens are appended. `py-spy` on the API process under this traffic shows ~80% of CPU in `_encode_plus`.

## Modifications

Gate the text path on whether the request actually carries media, and keep it whenever message processing did not produce usable token ids:

- `request_carries_media()`: true only if the request has image/video/audio payload;
- `has_usable_prompt_ids()`: guards the conversation-template path (which leaves `prompt_ids` empty for multimodal models) and the raw-string corner case.

Requests with media keep the exact previous behaviour, including the Inkling pre-rendered-ids case in `serving_chat`. Text-only requests keep their already-computed token ids.

## Benchmark

Qwen3.5-122B (a multimodal-capable checkpoint) driven by pure-text agent traffic, TP4, late-session warm requests at ~100k context:

| path | before | after |
|---|---:|---:|
| `/v1/responses` | 1.72s | **0.88s (-49%)** |
| `/v1/chat/completions` | 0.49s | **0.27s (-45%)** |

A 20-request in-order replay of a real long session reproduces the same effect (1.73s -> 0.96s average, -45%), with no regression on early short-context requests.

## Test

`test/registered/unit/entrypoints/openai/test_serving_responses.py` + `test_serving_chat.py` with this change: **98 passed, 27 subtests passed** (no failures).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests) (existing unit tests for both entrypoints pass).
- [x] Update documentation / docstrings as needed.
- [x] Provide throughput / latency benchmark results as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30245579273](https://github.com/sgl-project/sglang/actions/runs/30245579273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30245579033](https://github.com/sgl-project/sglang/actions/runs/30245579033)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->