### PR TITLE
fix(metrics): report kv_*_blocks in pages, not tokens

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1865,6 +1865,7 @@ class Scheduler(
             send_metrics_from_scheduler=self.ipc_channels.send_metrics_from_scheduler,
             max_running_requests=self.max_running_requests,
             max_total_num_tokens=self.max_total_num_tokens,
+            page_size=self.page_size,
             get_stats=lambda: self.metrics_reporter.stats,
         )
 

--- a/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
+++ b/python/sglang/srt/managers/scheduler_components/kv_events_publisher.py
@@ -53,6 +53,7 @@ class SchedulerKvEventsPublisher:
     send_metrics_from_scheduler: Optional[zmq.Socket]
     max_running_requests: int
     max_total_num_tokens: int
+    page_size: int
     get_stats: Callable
     enable_kv_cache_events: bool = False
     kv_event_publisher: Any = None
@@ -80,13 +81,14 @@ class SchedulerKvEventsPublisher:
         if not self.enable_kv_cache_events:
             return
 
+        # These are page counts, not token counts.
+        num_blocks = self.max_total_num_tokens // self.page_size
+
         kv_metrics = KvMetrics()
         kv_metrics.request_active_slots = self.get_stats().num_running_reqs.total
         kv_metrics.request_total_slots = self.max_running_requests
-        kv_metrics.kv_active_blocks = int(
-            self.get_stats().token_usage * self.max_total_num_tokens
-        )
-        kv_metrics.kv_total_blocks = self.max_total_num_tokens
+        kv_metrics.kv_active_blocks = int(self.get_stats().token_usage * num_blocks)
+        kv_metrics.kv_total_blocks = num_blocks
         kv_metrics.num_requests_waiting = self.get_stats().num_queue_reqs.total
         kv_metrics.gpu_cache_usage_perc = self.get_stats().token_usage
         kv_metrics.gpu_prefix_cache_hit_rate = self.get_stats().cache_hit_rate

--- a/test/registered/unit/managers/test_kv_events_publisher.py
+++ b/test/registered/unit/managers/test_kv_events_publisher.py
@@ -1,0 +1,67 @@
+"""Unit tests for KV metric block accounting."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers.scheduler_components import kv_events_publisher
+from sglang.srt.managers.scheduler_components.kv_events_publisher import (
+    SchedulerKvEventsPublisher,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+MAX_TOTAL_NUM_TOKENS = 8192
+TOKEN_USAGE = 0.5
+
+
+def emit_metrics(page_size):
+    stats = SimpleNamespace(
+        num_running_reqs=SimpleNamespace(total=0),
+        num_queue_reqs=SimpleNamespace(total=0),
+        token_usage=TOKEN_USAGE,
+        cache_hit_rate=0.0,
+    )
+    publisher = SchedulerKvEventsPublisher(
+        kv_events_config=None,
+        ps=SimpleNamespace(dp_rank=None),
+        attn_tp_rank=0,
+        attn_cp_rank=0,
+        attn_dp_rank=0,
+        dp_rank=None,
+        tree_cache=SimpleNamespace(),
+        send_metrics_from_scheduler=SimpleNamespace(closed=False),
+        max_running_requests=16,
+        max_total_num_tokens=MAX_TOTAL_NUM_TOKENS,
+        page_size=page_size,
+        get_stats=lambda: stats,
+    )
+    publisher.enable_kv_cache_events = True
+
+    with patch.object(kv_events_publisher, "sock_send") as sock_send:
+        publisher.emit_kv_metrics()
+
+    return sock_send.call_args.args[1]
+
+
+class TestKvMetricsBlockUnits(CustomTestCase):
+    def test_paged_kv_reports_pages_not_tokens(self):
+        metrics = emit_metrics(page_size=16)
+        num_blocks = MAX_TOTAL_NUM_TOKENS // 16
+
+        self.assertEqual(metrics.kv_total_blocks, num_blocks)
+        self.assertEqual(metrics.kv_active_blocks, int(TOKEN_USAGE * num_blocks))
+
+    def test_page_size_one_is_unchanged(self):
+        metrics = emit_metrics(page_size=1)
+
+        self.assertEqual(metrics.kv_total_blocks, MAX_TOTAL_NUM_TOKENS)
+        self.assertEqual(
+            metrics.kv_active_blocks, int(TOKEN_USAGE * MAX_TOTAL_NUM_TOKENS)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #32475.

`kv_total_blocks` and `kv_active_blocks` are named as page counts, but `emit_kv_metrics` fills them straight from `max_total_num_tokens`, which is a token capacity. With `page_size > 1` both values come out roughly `page_size` times too large. Consumers of the KV event stream (KV-aware routers, autoscalers) see inflated capacity and usage. It only looks right when `page_size == 1`.

With `max_total_num_tokens=8192`, `page_size=16`, `token_usage=0.5` we report `8192 / 4096` blocks instead of `512 / 256`.

## Modifications

- Pass `page_size` into `SchedulerKvEventsPublisher` and derive `num_blocks = max_total_num_tokens // page_size`, matching how the scheduler already computes `num_pages`.
- Use that for both `kv_total_blocks` and `kv_active_blocks`.
- Add a CPU unit test for `page_size=16` and keep a `page_size=1` case so the existing numbers stay pinned.

`gpu_cache_usage_perc` is untouched, it is already a ratio.

## Accuracy Tests

Not applicable, metrics only. No sampling or model output path is touched.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30248294070](https://github.com/sgl-project/sglang/actions/runs/30248294070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30248293892](https://github.com/sgl-project/sglang/actions/runs/30248293892)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->