### PR TITLE
Defer gfx950 A8W8 quantization to AITER

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -69,6 +69,7 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _use_aiter_gfx95 = _use_aiter and _is_gfx95_supported
 # ROCm 7.0 hipcc miscompiles gemm_a8w8_blockscale_bpreshuffle on gfx95 (#23319).
 _use_aiter_bpreshuffle_gfx95 = _use_aiter_gfx95 and get_hip_version() >= (7, 2, 0)
+_aiter_bpreshuffle_supports_unquantized_input = False
 # gfx95 + ROCm < 7.2: bpreshuffle CK is disabled (above), and the non-bpreshuffle
 # fallback ck_gemm_a8w8_blockscale returns NaN above a per-shape M for some shapes
 # (measured NaN onset: (2560,4096)@M>=4096, (4096,1024)@M>=8192 at TP8; at TP4 the
@@ -158,6 +159,13 @@ if _use_aiter:
     )
 
     aiter_per1x128_quant = get_hip_quant(aiter.QuantType.per_1x128)
+    _aiter_bpreshuffle_supports_unquantized_input = bool(
+        getattr(
+            aiter,
+            "GEMM_A8W8_BPRESHUFFLE_SUPPORTS_UNQUANTIZED_INPUT",
+            False,
+        )
+    )
 
 
 if _is_cuda:
@@ -955,41 +963,59 @@ def aiter_w8a8_block_fp8_linear(
         )
     else:
         use_triton = True
-
-    # if input_scale not None, input is quanted
-    if input_scale is not None:
-        q_input = input_2d
-        x_scale = input_scale
-        if _use_aiter_bpreshuffle_gfx95 and not use_triton:
-            x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
-        # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
-        # Triton needs a row-major view, so adjust strides only. No copy.
-        elif use_triton and _use_aiter_bpreshuffle_gfx95:
-            x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
-    else:
-        materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
-        q_input, x_scale = aiter_per1x128_quant(
-            input_2d,
-            quant_dtype=aiter.dtypes.fp8,
-            transpose_scale=False,
-        )
-        if materialize_bpreshuffle_scale:
-            x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
-
-    if use_triton:
-        gemm_a8w8_blockscale_op = triton_gemm_a8w8_blockscale
-    elif _use_aiter_bpreshuffle_gfx95:
-        gemm_a8w8_blockscale_op = gemm_a8w8_blockscale_bpreshuffle
-    else:
-        gemm_a8w8_blockscale_op = ck_gemm_a8w8_blockscale
-
-    output = gemm_a8w8_blockscale_op(
-        q_input,
-        weight,
-        x_scale,
-        weight_scale,
-        dtype=torch.bfloat16 if input_scale is not None else input.dtype,
+    
+    use_backend_native_quant = (
+        input_scale is None
+        and _use_aiter_bpreshuffle_gfx95
+        and not use_triton
+        and _aiter_bpreshuffle_supports_unquantized_input
     )
+
+    # Let AITER perform backend-native quantization
+    # (e.g. MXFP8 1x32 for FlyDSL) when supported.
+    if use_backend_native_quant:
+        output = gemm_a8w8_blockscale_bpreshuffle(
+            input_2d,
+            weight,
+            None,
+            weight_scale,
+            dtype=input.dtype,
+        )
+    else:
+        # if input_scale not None, input is quanted
+        if input_scale is not None:
+            q_input = input_2d
+            x_scale = input_scale
+            if _use_aiter_bpreshuffle_gfx95 and not use_triton:
+                x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
+            # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
+            # Triton needs a row-major view, so adjust strides only. No copy.
+            elif use_triton and _use_aiter_bpreshuffle_gfx95:
+                x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
+        else:
+            materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
+            q_input, x_scale = aiter_per1x128_quant(
+                input_2d,
+                quant_dtype=aiter.dtypes.fp8,
+                transpose_scale=False,
+            )
+            if materialize_bpreshuffle_scale:
+                x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
+            
+        if use_triton:
+            gemm_a8w8_blockscale_op = triton_gemm_a8w8_blockscale
+        elif _use_aiter_bpreshuffle_gfx95:
+            gemm_a8w8_blockscale_op = gemm_a8w8_blockscale_bpreshuffle
+        else:
+            gemm_a8w8_blockscale_op = ck_gemm_a8w8_blockscale
+
+        output = gemm_a8w8_blockscale_op(
+            q_input,
+            weight,
+            x_scale,
+            weight_scale,
+            dtype=torch.bfloat16 if input_scale is not None else input.dtype,
+        )    
 
     if bias is not None:
         output += bias

--- a/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
+++ b/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest.mock import patch
 
 import torch
 
+from sglang.srt.layers.quantization import fp8_utils
 from sglang.srt.layers.quantization.fp8_utils import (
     materialize_bpreshuffle_fp8_scale,
     materialize_bpreshuffle_fp8_scale_tuple,
@@ -45,6 +47,73 @@ class TestBpreshuffleScaleMaterialization(CustomTestCase):
         self.assertIs(bf16_out, bf16_side)
         self.assertTrue(torch.equal(scale_out, scale))
         self.assertEqual(scale_out.stride(), (1, scale.shape[0]))
+
+    def test_aiter_bpreshuffle_defers_activation_quantization(self):
+        input_tensor = torch.ones((2, 3), dtype=torch.bfloat16)
+        weight = torch.ones((4, 3), dtype=torch.float32)
+        weight_scale = torch.ones((1, 1), dtype=torch.float32)
+        expected = torch.arange(8, dtype=torch.float32).to(torch.bfloat16).view(2, 4)
+        captured = {}
+
+        def fake_bpreshuffle_gemm(
+            passed_input,
+            passed_weight,
+            passed_input_scale,
+            passed_weight_scale,
+            dtype,
+        ):
+            captured.update(
+                input=passed_input,
+                weight=passed_weight,
+                input_scale=passed_input_scale,
+                weight_scale=passed_weight_scale,
+                dtype=dtype,
+            )
+            return expected
+
+        with (
+            patch.object(fp8_utils, "_use_aiter_bpreshuffle_gfx95", True),
+            patch.object(
+                fp8_utils,
+                "_aiter_bpreshuffle_supports_unquantized_input",
+                True,
+            ),
+            patch.object(
+                fp8_utils,
+                "use_aiter_triton_gemm_w8a8_tuned_gfx950",
+                return_value=False,
+            ),
+            patch.object(
+                fp8_utils,
+                "gemm_a8w8_blockscale_bpreshuffle",
+                side_effect=fake_bpreshuffle_gemm,
+                create=True,
+            ),
+            patch.object(
+                fp8_utils,
+                "aiter_per1x128_quant",
+                side_effect=AssertionError("SGLang must defer activation quantization"),
+                create=True,
+            ),
+        ):
+            result = fp8_utils.aiter_w8a8_block_fp8_linear(
+                input_tensor,
+                weight,
+                [128, 128],
+                weight_scale,
+            )
+
+        self.assertTrue(
+            torch.equal(
+                captured["input"],
+                input_tensor.view(-1, input_tensor.shape[-1]),
+            )
+        )
+        self.assertIs(captured["weight"], weight)
+        self.assertIsNone(captured["input_scale"])
+        self.assertIs(captured["weight_scale"], weight_scale)
+        self.assertEqual(captured["dtype"], input_tensor.dtype)
+        self.assertTrue(torch.equal(result, expected))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Defer gfx950 A8W8 blockscale BpreShuffle activation quantization to AITER.

This allows AITER to select the tuned GEMM backend before choosing the activation quantization format (e.g. MXFP8 for FlyDSL or per-1x128 FP8 for legacy CK/CKTile/ASM backends).

Add an AITER capability check for backward compatibility. Older AITER versions continue using the existing SGLang-side per-1x128 activation quantization path.

## Changes

- Update `aiter_w8a8_block_fp8_linear()` to pass unquantized BF16/FP16 activations with `x_scale=None` to AITER when supported.
- Add runtime capability detection via: `GEMM_A8W8_BPRESHUFFLE_SUPPORTS_UNQUANTIZED_INPUT`.
- Let AITER determine the activation quantization format after selecting the tuned backend.
- Preserve existing behavior for:
  - pre-quantized inputs (`input_scale is not None`)
  - Triton paths
  - ROCm < 7.2
  - older AITER versions without unquantized-input support
- Add a CPU unit test covering deferred activation quantization.

## Compatibility

The new path is only enabled when AITER advertises:

```python
GEMM_A8W8_BPRESHUFFLE_SUPPORTS_UNQUANTIZED_INPUT = True
```

## Test Plan

### Unit Tests

```bash
python3 -m pytest -q test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
```

### Result

```bash
....
4 passed
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30249943919](https://github.com/sgl-project/sglang/actions/runs/30249943919)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30249943814](https://github.com/sgl-project/sglang/actions/runs/30249943814)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->