### PR TITLE
fix(distributed): use full TP group for fused post-MoE all-reduce

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -24,7 +24,6 @@ from sglang.srt.distributed import (
     attention_tensor_model_parallel_all_reduce,
     attention_tensor_model_parallel_quant_all_reduce,
     get_tp_group,
-    moe_tensor_model_parallel_all_reduce,
     tensor_model_parallel_all_reduce,
 )
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
@@ -608,7 +607,7 @@ class LayerCommunicator:
                             )
                         )
                 else:
-                    hidden_states = moe_tensor_model_parallel_all_reduce(hidden_states)
+                    hidden_states = tensor_model_parallel_all_reduce(hidden_states)
                     hidden_states, residual = self.input_layernorm(
                         hidden_states, residual
                     )

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -8,8 +8,6 @@ from torch.distributed import ProcessGroup
 
 from sglang.srt.distributed import (
     get_attn_tp_group,
-    get_moe_ep_group,
-    get_moe_tp_group,
     get_tp_group,
 )
 from sglang.srt.distributed.parallel_state import in_the_same_node_as
@@ -628,6 +626,13 @@ def _sync_allreduce_unavailable_across_tp():
         logger.debug(f"Failed to sync flashinfer unavailable flag: {e}")
 
 
+def _get_allreduce_group_info(use_attn_tp_group: bool):
+    parallel = get_parallel()
+    if use_attn_tp_group:
+        return parallel.attn_tp_size, parallel.attn_tp_rank, get_attn_tp_group()
+    return parallel.tp_size, parallel.tp_rank, get_tp_group()
+
+
 def ensure_workspace_initialized(
     max_token_num: int = 2048,
     hidden_dim: int = 4096,
@@ -644,19 +649,7 @@ def ensure_workspace_initialized(
     if not is_flashinfer_available() or _flashinfer_comm is None:
         return False
 
-    if use_attn_tp_group:
-        world_size = get_parallel().attn_tp_size
-        rank = get_parallel().attn_tp_rank
-        coordinator = get_attn_tp_group()
-    else:
-        if get_parallel().moe_ep_size > 1:
-            world_size = get_parallel().moe_ep_size
-            rank = get_parallel().moe_ep_rank
-            coordinator = get_moe_ep_group()
-        else:
-            world_size = get_parallel().moe_tp_size
-            rank = get_parallel().moe_tp_rank
-            coordinator = get_moe_tp_group()
+    world_size, rank, coordinator = _get_allreduce_group_info(use_attn_tp_group)
 
     # Always pass the coordinator's groups: flashinfer >=0.6.10 reads the
     # rendezvous group from `group=...` (falling back to WORLD when None),
@@ -753,7 +746,8 @@ def flashinfer_allreduce_residual_rmsnorm(
         use_oneshot: Whether to use oneshot mode
         trigger_completion_at_end: Whether to trigger completion at end
         fp32_acc: Whether to use fp32 precision
-        use_attn_tp_group: If True, use attention TP group; otherwise use MoE TP group
+        use_attn_tp_group: If True, use the attention TP group; otherwise use
+            the full TP group matching the unfused post-MoE all-reduce.
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: (norm_output, residual_output)
@@ -764,13 +758,11 @@ def flashinfer_allreduce_residual_rmsnorm(
         )
         return None, None
 
-    if use_attn_tp_group:
-        world_size = get_parallel().attn_tp_size
-    else:
-        if get_parallel().moe_ep_size > 1:
-            world_size = get_parallel().moe_ep_size
-        else:
-            world_size = get_parallel().moe_tp_size
+    world_size = (
+        get_parallel().attn_tp_size
+        if use_attn_tp_group
+        else get_parallel().tp_size
+    )
 
     if world_size <= 1:
         logger.debug("Single GPU, no need for allreduce fusion")

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -194,10 +194,7 @@ def _forward_with_allreduce_fusion(
         if use_attn_tp_group:
             world_size = get_parallel().attn_tp_size
         else:
-            if get_parallel().moe_ep_size > 1:
-                world_size = get_parallel().moe_ep_size
-            else:
-                world_size = get_parallel().moe_tp_size
+            world_size = get_parallel().tp_size
 
         if world_size > 1:
             if post_residual_addition is not None:

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -7,6 +7,7 @@ import torch
 from sglang.srt.layers import flashinfer_comm_fusion as fusion
 from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=30, stage="base-c", runner_config="4-gpu-h100")
 register_cuda_ci(est_time=30, stage="base-c", runner_config="4-gpu-b200")
@@ -71,7 +72,37 @@ def _torch_allreduce_residual_rmsnorm_baseline(
     return norm_out, residual_out
 
 
-class TestFlashInferCommFusion(unittest.TestCase):
+class TestFlashInferCommFusion(CustomTestCase):
+    def test_post_moe_fusion_uses_full_tp_group(self):
+        tp_group = object()
+        attn_tp_group = object()
+
+        for moe_ep_size, moe_tp_size in ((1, 8), (2, 4), (4, 2), (8, 1)):
+            parallel = types.SimpleNamespace(
+                tp_size=8,
+                tp_rank=3,
+                attn_tp_size=4,
+                attn_tp_rank=1,
+                moe_ep_size=moe_ep_size,
+                moe_ep_rank=0,
+                moe_tp_size=moe_tp_size,
+                moe_tp_rank=min(3, moe_tp_size - 1),
+            )
+            with (
+                self.subTest(moe_ep_size=moe_ep_size, moe_tp_size=moe_tp_size),
+                patch.object(fusion, "get_parallel", return_value=parallel),
+                patch.object(fusion, "get_tp_group", return_value=tp_group),
+                patch.object(fusion, "get_attn_tp_group", return_value=attn_tp_group),
+            ):
+                self.assertEqual(
+                    fusion._get_allreduce_group_info(use_attn_tp_group=False),
+                    (8, 3, tp_group),
+                )
+                self.assertEqual(
+                    fusion._get_allreduce_group_info(use_attn_tp_group=True),
+                    (4, 1, attn_tp_group),
+                )
+
     def test_auto_backend_resolves_by_arch(self):
         single_node = types.SimpleNamespace(
             flashinfer_allreduce_fusion_backend="auto", nnodes=1


### PR DESCRIPTION
## Motivation

With `--flashinfer-allreduce-fusion-backend` enabled, mixed EP × MoE-TP layouts
(e.g. `--tp 8 --ep-size 2`) produce corrupted output: the fused post-MoE
all-reduce only sums a subgroup of the partial results. GSM8K smoke on
TP8/EP2 scores 0/8 before this fix, 8/8 after. Pure layouts (EP1, EP=TP) are
unaffected, which is why this went unnoticed.

## Root cause

When fusion is enabled, the MoE layer skips **both** post-expert reductions —
the EP all-reduce and the MoE-TP all-reduce (`should_skip_post_experts_all_reduce`
returns True for both paths) — deferring the entire reduction to the fused
allreduce+residual+RMSNorm kernel of the next layer. The tensor entering the
fused kernel is therefore partial across *both* axes, so the fused reduction
must span the product of the two groups: the full TP group.

$$
\Sigma_{\mathrm{full\ TP}}
\equiv
\Sigma_{\mathrm{EP}} \circ \Sigma_{\mathrm{MoE\text{-}TP}}
$$

The fusion path instead selected the EP group (`moe_ep_size > 1`) or the
MoE-TP group (otherwise). That subgroup equals the full TP group only at the
endpoint decompositions (EP1 / EP=TP); in mixed layouts the fused RMSNorm
consumed an incomplete sum and corrupted every following layer.

## Modifications

- Build the post-MoE FlashInfer workspace on the full TP group and use full TP
  world size/rank (`_get_allreduce_group_info`).
- Gate the fused-RMSNorm entry on full TP world size (`layernorm.py`).
- Fix the unavailable-fusion fallback: it previously did a MoE-TP-only
  all-reduce, which under-reduces in mixed layouts and is a silent **no-op at
  EP=TP** — now it performs the same full-TP all-reduce as the unfused path.
- Endpoint layouts are numerically unchanged on the fused path (same rank set;
  only the process-group handle changes). A2A backends (DeepEP etc.) are not
  affected: they force `ep_size == tp_size` and run MoE in SCATTERED mode,
  which disables this fusion.
- Add a parameterized TP8 regression test covering EP1/2/4/8 group selection.

## Accuracy Tests

- `test_flashinfer_comm_fusion.py` 4/4.
- E2E on 8×H20, GLM FP8 + EAGLE, fusion auto: GSM8K smoke 8/8 on TP8 ×
  EP{1,2,4,8} (EP2 was 0/8 before the fix); no API errors / OOM.