### PR TITLE
[MLX] Preserve auxiliary state before chained decode lookahead

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/kv_cache/auxiliary_state.py
+++ b/python/sglang/srt/hardware_backend/mlx/kv_cache/auxiliary_state.py
@@ -72,9 +72,6 @@ def _snapshot_cache(cache: Any) -> _CacheSnapshot:
         for name in _CACHE_ATTRS
         if hasattr(cache, name)
     }
-    arrays = _arrays_in_tree((state, meta_state, attrs))
-    if arrays:
-        mx.eval(*arrays)
     return _CacheSnapshot(state=state, meta_state=meta_state, attrs=attrs)
 
 
@@ -165,9 +162,28 @@ class MlxAuxiliaryStatePool:
         cache: list[Any],
         layer_indices: Iterable[int],
     ) -> None:
-        self._snapshots[self._index(index)] = {
+        self.store_snapshot(index, self.capture_cache(cache, layer_indices))
+
+    def capture_cache(
+        self,
+        cache: list[Any],
+        layer_indices: Iterable[int],
+    ) -> dict[int, _CacheSnapshot]:
+        """Clone a cache boundary without synchronizing its lazy MLX graph."""
+        return {
             layer_idx: _snapshot_cache(cache[layer_idx]) for layer_idx in layer_indices
         }
+
+    def store_snapshot(
+        self,
+        index: Any,
+        snapshot: dict[int, _CacheSnapshot],
+    ) -> None:
+        """Materialize and publish a previously captured cache boundary."""
+        arrays = _arrays_in_tree(snapshot)
+        if arrays:
+            mx.eval(*arrays)
+        self._snapshots[self._index(index)] = snapshot
 
     def restore_cache(
         self,

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -102,6 +102,7 @@ class MlxPendingDecode:
     lazy_tokens: mx.array
     req_ids: list[str]
     caches: list[list[Any]]
+    auxiliary_state_snapshots: dict[str, Any] | None = None
 
 
 _MLX_QUANTIZATION_PRESETS: dict[str, tuple[int, int]] = {
@@ -176,6 +177,10 @@ class MlxModelRunner:
         self._req_to_token_pool: ReqToTokenPool | None = None
         self._req_pool_idx: dict[str, int] = {}
         self._req_synced_offset: dict[str, int] = {}
+        # Boundary snapshots captured before an already-launched lookahead
+        # mutates the same native auxiliary caches. They become authoritative
+        # only after the corresponding decode step is finalized.
+        self._finalized_auxiliary_state_snapshots: dict[str, Any] = {}
 
         self._pool_size = self._compute_pool_size(pool_size)
         self._aot_kernels = self._build_aot_kernels()
@@ -264,7 +269,46 @@ class MlxModelRunner:
         cache = self._req_caches.get(req_id)
         if req_pool_idx is None or cache is None:
             return
+        finalized_snapshots = getattr(self, "_finalized_auxiliary_state_snapshots", {})
+        snapshot = finalized_snapshots.pop(req_id, None)
+        if snapshot is not None:
+            pool_index = self._get_auxiliary_state_pool_index(req_pool_idx)
+            pool = self._get_auxiliary_state_pool()
+            if pool_index is not None and callable(
+                getattr(pool, "store_snapshot", None)
+            ):
+                pool.store_snapshot(pool_index, snapshot)
+                return
         self._store_auxiliary_state(req_pool_idx, cache)
+
+    def _capture_pending_auxiliary_state(self, pending: MlxPendingDecode) -> None:
+        """Preserve this decode boundary before lookahead mutates live caches."""
+        if not self._cache_layout.has_auxiliary_state:
+            return
+        pool = self._get_auxiliary_state_pool()
+        capture_cache = getattr(pool, "capture_cache", None)
+        if not callable(capture_cache):
+            return
+        pending.auxiliary_state_snapshots = {
+            req_id: capture_cache(
+                cache,
+                self._cache_layout.auxiliary_layer_indices,
+            )
+            for req_id, cache in zip(pending.req_ids, pending.caches)
+        }
+
+    def _record_finalized_auxiliary_state(self, pending: MlxPendingDecode) -> None:
+        """Make the finalized step's pre-lookahead snapshots available to release."""
+        finalized = getattr(self, "_finalized_auxiliary_state_snapshots", None)
+        if finalized is None:
+            finalized = self._finalized_auxiliary_state_snapshots = {}
+        snapshots = pending.auxiliary_state_snapshots or {}
+        for req_id in pending.req_ids:
+            snapshot = snapshots.get(req_id)
+            if snapshot is None:
+                finalized.pop(req_id, None)
+            else:
+                finalized[req_id] = snapshot
 
     def _select_auxiliary_state_track_len(
         self,
@@ -1204,6 +1248,11 @@ class MlxModelRunner:
           returned pending: state bookkeeping for step N has to happen
           before step N+1's bookkeeping.
         """
+        # The scheduler does not know whether prev produced EOS until after the
+        # lookahead graph is launched. Preserve prev's auxiliary-state boundary
+        # before graph construction advances the shared native cache to N+1.
+        # capture_cache only clones lazy arrays; it does not wait on the GPU.
+        self._capture_pending_auxiliary_state(prev)
         caches = prev.caches
 
         # After prev's graph ran, each attention KV cache offset was
@@ -1248,6 +1297,8 @@ class MlxModelRunner:
         for i, rid in enumerate(pending.req_ids):
             self._req_token_ids[rid].append(next_tokens[i])
 
+        self._record_finalized_auxiliary_state(pending)
+
         self._decode_step_ct += 1
         if self._clear_steps > 0 and self._decode_step_ct % self._clear_steps == 0:
             mx.clear_cache()
@@ -1269,6 +1320,7 @@ class MlxModelRunner:
             self._release_cache(cache)
         self._req_pool_idx.pop(req_id, None)
         self._req_synced_offset.pop(req_id, None)
+        getattr(self, "_finalized_auxiliary_state_snapshots", {}).pop(req_id, None)
 
     def clear(self):
         """Clear all request states."""
@@ -1278,5 +1330,6 @@ class MlxModelRunner:
         self._req_caches.clear()
         self._req_pool_idx.clear()
         self._req_synced_offset.clear()
+        getattr(self, "_finalized_auxiliary_state_snapshots", {}).clear()
         if self._attention_kv_pool is not None:
             self._attention_kv_pool.clear()

--- a/test/registered/unit/hardware_backend/mlx/test_auxiliary_state_lookahead.py
+++ b/test/registered/unit/hardware_backend/mlx/test_auxiliary_state_lookahead.py
@@ -1,0 +1,78 @@
+"""Regression tests for auxiliary-state snapshots across MLX lookahead decode."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+
+
+@unittest.skipUnless(_HAS_MLX, "requires mlx")
+class TestAuxiliaryStateLookahead(CustomTestCase):
+    def test_finished_step_snapshots_before_already_launched_lookahead(self):
+        import mlx.core as mx
+        import torch
+
+        from sglang.srt.hardware_backend.mlx.kv_cache import MlxAuxiliaryStatePool
+        from sglang.srt.hardware_backend.mlx.model_runner import (
+            MlxModelRunner,
+            MlxPendingDecode,
+        )
+
+        pool = MlxAuxiliaryStatePool(size=2, device="cpu")
+
+        class _ReqPool:
+            auxiliary_state_pool = pool
+
+            @staticmethod
+            def get_auxiliary_state_indices(_req_pool_idx):
+                return torch.tensor([1], dtype=torch.int64)
+
+        cache = SimpleNamespace(state=(mx.array([1], dtype=mx.int32),))
+        runner = object.__new__(MlxModelRunner)
+        runner._cache_layout = SimpleNamespace(
+            has_auxiliary_state=True,
+            auxiliary_layer_indices=[0],
+        )
+        runner._req_to_token_pool = _ReqPool()
+        runner._req_pool_idx = {"r0": 0}
+        runner._req_caches = {"r0": [cache]}
+        runner._req_token_ids = {"r0": [7]}
+        runner._decode_step_ct = 0
+        runner._clear_steps = 0
+
+        def launch_lookahead(caches, _input_ids, _req_ids):
+            # Graph construction for token N+1 advances the shared native cache
+            # before token N has gone through scheduler finish detection.
+            caches[0][0].state = (mx.array([2], dtype=mx.int32),)
+            return mx.array([10], dtype=mx.int32)
+
+        runner._decode_with_hybrid_batching = launch_lookahead
+        prev = MlxPendingDecode(
+            lazy_tokens=mx.array([9], dtype=mx.int32),
+            req_ids=["r0"],
+            caches=[[cache]],
+        )
+
+        runner.decode_batch_start_chained(prev)
+        self.assertEqual(cache.state[0].item(), 2)
+
+        # Token 9 is then found to finish the request. The radix snapshot must
+        # describe the committed N boundary (state=1), not discarded N+1.
+        runner.decode_batch_finalize(prev)
+        runner.store_auxiliary_state_for_request("r0")
+
+        restored = SimpleNamespace(state=(mx.array([0], dtype=mx.int32),))
+        self.assertTrue(pool.restore_cache(torch.tensor([1]), [restored], [0]))
+        self.assertEqual(restored.state[0].item(), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The MLX overlap loop queues decode step N+1 before step N is materialized and processed by the scheduler. Hybrid models reuse the same native auxiliary cache objects across both graphs, and building N+1 advances those objects immediately.

If token N is EOS or otherwise finishes the request, N+1 is discarded by scheduler bookkeeping. The finish hook nevertheless snapshots the live auxiliary cache after lookahead has advanced it, so the radix tree stores state for N+1 while its token sequence ends at N. A later prefix hit can therefore restore auxiliary state one token ahead of the matched prefix.

## Modifications

- Split auxiliary snapshot capture from publication:
  - capture_cache clones the current lazy MLX arrays without mx.eval.
  - store_snapshot materializes and publishes a captured boundary only when the scheduler actually caches the request.
- Before decode_batch_start_chained mutates shared caches for N+1, attach the N boundary snapshots to the previous pending decode.
- When N finalizes, make those snapshots authoritative for a subsequent finish-time radix insert.
- Clear stale finalized snapshots when a non-lookahead step becomes authoritative or request state is removed.

This keeps the two-graph overlap intact and adds no early GPU synchronization.

## Tests

Added test_auxiliary_state_lookahead.py, which reproduces the lifecycle directly:

1. step N owns auxiliary state 1;
2. already-launched lookahead advances the shared live cache to state 2;
3. step N finishes;
4. the radix snapshot must restore state 1, not the discarded state 2.

The regression fails on current main with 2 != 1 and passes with this change.

Validation on Apple Silicon:

    SGLANG_USE_MLX=1 PYTHONPATH=python .venv-mlx/bin/python -m pytest -q [tracked MLX unit tests except reference correctness] test_auxiliary_state_lookahead.py
    77 passed, 17 skipped

Focused auxiliary and attention coverage:

    38 passed, 2 subtests passed

Formatting and lint:

    black --check: passed
    ruff check: passed
    git diff --check: passed

## Accuracy Tests

No model weights are changed. The regression verifies that radix reuse restores the cache boundary matching the committed token sequence.

## Speed Tests and Profiling

No blocking operation was added to lookahead launch. Captures clone lazy array handles; evaluation remains deferred until a request actually publishes a radix snapshot.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add a registered MLX unit regression.
- [x] Preserve overlap scheduling without an early synchronization.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30257188588](https://github.com/sgl-project/sglang/actions/runs/30257188588)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30257187233](https://github.com/sgl-project/sglang/actions/runs/30257187233)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->