### PR TITLE
[Bugfix] Thread LTX-2 linear prefixes for ModelOpt NVFP4

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -710,6 +710,7 @@ class LTX2Attention(nn.Module):
             bias=True,
             gather_output=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.to_q" if prefix else "to_q",
         )
         self.to_k = ColumnParallelLinear(
             self.context_dim,
@@ -717,6 +718,7 @@ class LTX2Attention(nn.Module):
             bias=True,
             gather_output=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.to_k" if prefix else "to_k",
         )
         self.to_v = ColumnParallelLinear(
             self.context_dim,
@@ -724,6 +726,7 @@ class LTX2Attention(nn.Module):
             bias=True,
             gather_output=False,
             quant_config=quant_config,
+            prefix=f"{prefix}.to_v" if prefix else "to_v",
         )
         self.to_gate_logits: ColumnParallelLinear | None = None
         if self.apply_gated_attention:
@@ -733,6 +736,7 @@ class LTX2Attention(nn.Module):
                 bias=True,
                 gather_output=False,
                 quant_config=quant_config,
+                prefix=f"{prefix}.to_gate_logits" if prefix else "to_gate_logits",
             )
 
         self.q_norm: nn.Module | None = None
@@ -760,6 +764,7 @@ class LTX2Attention(nn.Module):
                 bias=True,
                 input_is_parallel=True,
                 quant_config=quant_config,
+                prefix=f"{prefix}.to_out.0" if prefix else "to_out.0",
             ),
             nn.Identity(),
         )
@@ -976,6 +981,7 @@ class LTX2FeedForward(nn.Module):
         dim_out: int | None = None,
         mult: int = 4,
         quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         if dim_out is None:
@@ -983,7 +989,12 @@ class LTX2FeedForward(nn.Module):
         inner_dim = int(dim * mult)
 
         self.proj_in = ColumnParallelLinear(
-            dim, inner_dim, bias=True, gather_output=False, quant_config=quant_config
+            dim,
+            inner_dim,
+            bias=True,
+            gather_output=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj_in" if prefix else "proj_in",
         )
         self.act = nn.GELU(approximate="tanh")
         self.proj_out = RowParallelLinear(
@@ -992,6 +1003,7 @@ class LTX2FeedForward(nn.Module):
             bias=True,
             input_is_parallel=True,
             quant_config=quant_config,
+            prefix=f"{prefix}.proj_out" if prefix else "proj_out",
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -1123,9 +1135,14 @@ class LTX2TransformerBlock(nn.Module):
         )
 
         # 4. Feedforward layers
-        self.ff = LTX2FeedForward(dim, dim_out=dim, quant_config=quant_config)
+        self.ff = LTX2FeedForward(
+            dim, dim_out=dim, quant_config=quant_config, prefix=f"{prefix}.ff"
+        )
         self.audio_ff = LTX2FeedForward(
-            audio_dim, dim_out=audio_dim, quant_config=quant_config
+            audio_dim,
+            dim_out=audio_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.audio_ff",
         )
 
         # 5. Modulation Parameters
@@ -1567,6 +1584,7 @@ class LTX2VideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             bias=True,
             gather_output=True,
             quant_config=quant_config,
+            prefix="patchify_proj",
         )
         self.audio_patchify_proj = ColumnParallelLinear(
             arch.audio_in_channels,
@@ -1574,6 +1592,7 @@ class LTX2VideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             bias=True,
             gather_output=True,
             quant_config=quant_config,
+            prefix="audio_patchify_proj",
         )
 
         # 2. Prompt embeddings
@@ -1760,7 +1779,7 @@ class LTX2VideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
                     ),
                     enable_packed_qkv_input_a2a=arch.enable_packed_qkv_input_a2a,
                     supported_attention_backends=self._supported_attention_backends,
-                    prefix=config.prefix,
+                    prefix=f"transformer_blocks.{idx}",
                     quant_config=quant_config,
                 )
                 for idx in range(arch.num_layers)
@@ -1777,6 +1796,7 @@ class LTX2VideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             bias=True,
             gather_output=True,
             quant_config=quant_config,
+            prefix="proj_out",
         )
 
         self.audio_norm_out = nn.LayerNorm(
@@ -1788,6 +1808,7 @@ class LTX2VideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             bias=True,
             gather_output=True,
             quant_config=quant_config,
+            prefix="audio_proj_out",
         )
 
         self.out_channels_raw = arch.out_channels // (

--- a/python/sglang/multimodal_gen/test/unit/test_ltx2_quantized_linear_prefixes.py
+++ b/python/sglang/multimodal_gen/test/unit/test_ltx2_quantized_linear_prefixes.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import torch.nn as nn
+
+from sglang.multimodal_gen.configs.models.dits.ltx_2 import (
+    LTX2ArchConfig,
+    LTX2Config,
+)
+from sglang.multimodal_gen.runtime.models.dits import ltx_2
+
+
+class _FakeParallelLinear(nn.Module):
+    def __init__(
+        self,
+        *_args,
+        quant_config=None,
+        prefix: str = "",
+        **_kwargs,
+    ) -> None:
+        super().__init__()
+        self.quant_config = quant_config
+        self.prefix = prefix
+
+
+class _FakeAttention(nn.Module):
+    def __init__(self, *_args, prefix: str = "", **_kwargs) -> None:
+        super().__init__()
+        self.prefix = prefix
+
+
+def _tiny_ltx2_config() -> LTX2Config:
+    return LTX2Config(
+        arch_config=LTX2ArchConfig(
+            num_attention_heads=1,
+            attention_head_dim=4,
+            in_channels=4,
+            out_channels=4,
+            num_layers=2,
+            cross_attention_dim=4,
+            caption_channels=4,
+            positional_embedding_max_pos=[2, 8, 8],
+            audio_num_attention_heads=1,
+            audio_attention_head_dim=4,
+            audio_in_channels=4,
+            audio_out_channels=4,
+            audio_cross_attention_dim=4,
+            audio_positional_embedding_max_pos=[2],
+            connector_num_attention_heads=1,
+            audio_connector_num_attention_heads=1,
+            apply_gated_attention=True,
+        )
+    )
+
+
+def test_ltx2_quantized_linears_use_checkpoint_module_paths():
+    quant_config = object()
+
+    with (
+        patch.object(ltx_2, "get_tp_world_size", return_value=1),
+        patch.object(ltx_2, "ColumnParallelLinear", _FakeParallelLinear),
+        patch.object(ltx_2, "RowParallelLinear", _FakeParallelLinear),
+        patch.object(ltx_2, "USPAttention", _FakeAttention),
+        patch.object(ltx_2, "LocalAttention", _FakeAttention),
+    ):
+        model = ltx_2.LTX2VideoTransformer3DModel(
+            _tiny_ltx2_config(),
+            {
+                "patch_size": 1,
+                "patch_size_t": 1,
+                "audio_patch_size": 1,
+                "audio_patch_size_t": 1,
+            },
+            quant_config=quant_config,
+        )
+
+    quantized_prefixes = {
+        name: module.prefix
+        for name, module in model.named_modules()
+        if isinstance(module, _FakeParallelLinear)
+        and module.quant_config is quant_config
+    }
+
+    assert len(quantized_prefixes) == 72
+    assert quantized_prefixes == {name: name for name in quantized_prefixes}


### PR DESCRIPTION
## Motivation

Current SGLang main contains the ModelOpt NVFP4 scale-layout conversion for
non-packed-QKV DiTs, but LTX-2 does not propagate checkpoint-compatible layer
prefixes into its quantizable parallel-linear modules.

This breaks two coupled contracts:

1. `ModelOptQuantConfig.is_layer_excluded()` cannot match checkpoint exclusion
   patterns such as `transformer_blocks.0.*`.
2. `uses_flux1_scale_layout` cannot recognize the affected LTX-2 layers because
   it requires a prefix beginning with `transformer_blocks.` or
   `single_transformer_blocks.`.

The resulting load-time packed-versus-dense shape assertion can look like a
checkpoint architecture mismatch, but the serialized `(2048, 1024)` FP4
weight is the packed representation of a logical `(2048, 2048)` matrix.

Sibling DiTs including Flux, Flux2, GLM-Image, Qwen-Image, and the SANA-WM
refiner already construct their blocks with `transformer_blocks.<index>`.

## Modifications

- Construct each LTX-2 block with `transformer_blocks.<index>`.
- Propagate prefixes through attention `to_q`, `to_k`, `to_v`,
  `to_gate_logits`, and `to_out.0`.
- Propagate prefixes through feed-forward `proj_in` and `proj_out` and the
  block `ff` and `audio_ff` paths.
- Add stable prefixes to `patchify_proj`, `audio_patchify_proj`, `proj_out`,
  and `audio_proj_out`.
- Add a CPU-only regression test that constructs a tiny two-block LTX-2 model
  and verifies every quantized parallel linear receives its exact checkpoint
  module path.

The patch changes `ltx_2.py` and one focused unit-test file. It does not modify
checkpoint bytes, quantization math, or backend selection.

## Accuracy Tests

Validated on upstream main
`61057bda6c4b8cda1117d74f100d0735645c0cfb` at commit
`3528d293bda89c748da7fe559f97430b4c238ef2`.

Static checks:

```bash
uvx --from pre-commit pre-commit run --files \
  python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py \
  python/sglang/multimodal_gen/test/unit/test_ltx2_quantized_linear_prefixes.py
python -m py_compile <both changed Python files>
git diff --check origin/main...HEAD
```

All applicable hooks passed.

Focused regression and the exact diffusion unit-suite entry point:

```bash
python -m pytest -q \
  python/sglang/multimodal_gen/test/unit/test_ltx2_quantized_linear_prefixes.py

cd python
SGLANG_DIFFUSION_CONSISTENCY_PLATFORM=h100 \
  python3 sglang/multimodal_gen/test/run_suite.py --suite unit
```

- Focused regression: `1 passed`.
- Diffusion unit suite: `797 passed, 4 skipped, 50 subtests passed`.
- The regression verifies 72 quantized parallel-linear instances across a
  two-block gated-attention configuration, including both block indices and
  the four top-level projections.

Full end-to-end workload:

- `LTX2TwoStagePipeline`
- felt-birds prompt, seed 10, guidance 3
- 768x1280, 241 frames, 24 fps, 30 steps, audio
- Cache-DiT and SageAttention2
- one fresh request per mode, serialized on one SM120 GPU

| Mode | Result | Inference | Reported peak memory |
| --- | --- | ---: | ---: |
| BF16 | valid coherent H.264 + AAC | 60.090 s | 77,756 MB |
| W4A4 NVFP4 | valid coherent H.264 + AAC | 48.011 s | 55,494 MB |

The current native loader reported:

```text
group_size=16
excluded modules=1010
packed_qkv=False
scale_layout=linear
swap_nibbles=False
```

Five-frame inspection at frames 0/60/120/180/240 found coherent felt birds,
a cardboard/twine birdhouse, stable motion, and no visual collapse in W4A4.
Different BF16 and W4A4 compositions are expected trajectory drift and are
not treated as a pixel-parity failure.

### Visual evidence

BF16 is on the left and W4A4 NVFP4 is on the right. Columns show frames
0/60/120/180/240.

<!--
Before submitting, drag this file into the GitHub PR editor on the next line:
/root/ltx23-nvfp4-artifacts/exp_20260726_sglang_latest_prefix_validation/pr_material/contact_sheet_full.png
Keep the generated github.com/user-attachments image Markdown here.
-->

<details>
<summary>Full 10-second BF16 versus W4A4 side-by-side video</summary>

<!--
Before submitting, drag this file into this details block in the GitHub PR editor:
/root/felt_birds_latest_main_bf16_vs_w4a4_prefix_fixed.mp4
Keep the generated github.com/user-attachments video URL here.
-->

</details>

Both processes released the GPU to 0 MiB with volatile ECC 0/0.

## Speed Tests and Profiling

No averaged speed claim is made. The table reports one fresh full request per
mode for validation context.

The W4A4 run explicitly used the CUTLASS FlashInfer backend because current
diffusion backend selection defaults to TRTLLM, which the recorded FlashInfer
build rejects on SM120. Backend selection is a separate issue and is outside
this prefix-only change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - All hooks applicable to the two changed Python files passed.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - Added `test_ltx2_quantized_linear_prefixes.py`; the complete diffusion unit
    suite passed with the new test collected.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - Not applicable: this restores internal module-name propagation and does
    not change a user-facing interface.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - Full-resolution BF16 and W4A4 results are above. Timings are disclosed as
    single fresh requests; this PR makes no speed claim.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

## AI assistance disclosure

AI tooling assisted with investigation, implementation review, experiment
orchestration, testing, and drafting. The patch and PR are reviewed and
submitted by @Qyx5-5.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31019611162](https://github.com/sgl-project/sglang/actions/runs/31019611162)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31019611225](https://github.com/sgl-project/sglang/actions/runs/31019611225)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->