### PR TITLE
FIX:copy-to-gpu-no-ce-arbitrary-n

### DIFF
--- a/python/sglang/kernels/aot/csrc/elementwise/copy.cu
+++ b/python/sglang/kernels/aot/csrc/elementwise/copy.cu
@@ -9,52 +9,35 @@ struct InputArray {
   int values[N];
 };
 
-template <int N>
-__global__ void copy_to_gpu_no_ce_kernel(const InputArray<N> input_array, int* output) {
+// MAX_N ints are passed by value in the kernel launch params (2KB), staying under the 4KB param limit.
+constexpr int kCopyMaxN = 512;
+
+template <int MAX_N>
+__global__ void copy_to_gpu_no_ce_kernel(const InputArray<MAX_N> input_array, int* output, int n) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx < N) {
+  if (idx < n) {
     output[idx] = input_array.values[idx];
   }
 }
 
-template <int N>
-void copy_to_gpu_no_ce_impl(const at::Tensor& input, at::Tensor& output) {
-  TORCH_CHECK(input.dim() == 1, "input must be 1-D");
-  TORCH_CHECK(static_cast<int>(input.numel()) == N, "input numel must equal template N");
-  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
-  TORCH_CHECK(input.dtype() == torch::kInt32, "input dtype must be int32");
-
-  TORCH_CHECK(output.dim() == 1, "output dim");
-  TORCH_CHECK(static_cast<int>(output.numel()) == N, "output size");
-  TORCH_CHECK(output.is_contiguous(), "output contiguous");
-  TORCH_CHECK(output.dtype() == torch::kInt32, "output dtype");
-
+void copy_to_gpu_no_ce(const at::Tensor& input, at::Tensor& output) {
+  int N = static_cast<int>(input.numel());
+  TORCH_CHECK(N <= kCopyMaxN, "copy_to_gpu_no_ce: numel ", N, " exceeds MAX_N ", kCopyMaxN);
+  TORCH_CHECK(input.dim() == 1 && output.dim() == 1, "input/output must be 1-D");
+  TORCH_CHECK(input.numel() == output.numel(), "input/output size mismatch");
+  TORCH_CHECK(input.is_contiguous() && output.is_contiguous(), "input/output must be contiguous");
+  TORCH_CHECK(input.dtype() == torch::kInt32 && output.dtype() == torch::kInt32, "dtype must be int32");
   TORCH_CHECK(input.device().is_cpu(), "input must be a CPU tensor");
   TORCH_CHECK(output.device().is_cuda(), "output must be a CUDA tensor");
 
-  InputArray<N> input_array;
+  InputArray<kCopyMaxN> input_array;
   const int* input_ptr = input.data_ptr<int>();
   for (int i = 0; i < N; ++i)
     input_array.values[i] = input_ptr[i];
 
-  // may use multi thread blocks if performance bottleneck
-  dim3 grid(1);
-  dim3 block(static_cast<int>(input.numel()));
+  dim3 block(256);
+  dim3 grid((N + 255) / 256);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-  copy_to_gpu_no_ce_kernel<<<grid, block, 0, stream>>>(input_array, output.data_ptr<int>());
+  copy_to_gpu_no_ce_kernel<<<grid, block, 0, stream>>>(input_array, output.data_ptr<int>(), N);
   C10_CUDA_KERNEL_LAUNCH_CHECK();
-}
-
-void copy_to_gpu_no_ce(const at::Tensor& input, at::Tensor& output) {
-  int N = static_cast<int>(input.numel());
-  // Can use macro if there are more N needed
-  if (N == 72) {
-    copy_to_gpu_no_ce_impl<72>(input, output);
-  } else if (N == 64) {
-    copy_to_gpu_no_ce_impl<64>(input, output);
-  } else if (N == 32) {
-    copy_to_gpu_no_ce_impl<32>(input, output);
-  } else {
-    TORCH_CHECK(false, "unexpected N");
-  }
 }

--- a/python/sglang/kernels/aot/tests/test_copy.py
+++ b/python/sglang/kernels/aot/tests/test_copy.py
@@ -6,7 +6,7 @@ import torch
 from sgl_kernel.elementwise import copy_to_gpu_no_ce
 
 
-@pytest.mark.parametrize("size", [64, 72])
+@pytest.mark.parametrize("size", [1, 16, 31, 32, 64, 72, 128, 256, 512])
 def test_copy_to_gpu_no_ce(size):
     tensor_cpu = torch.randint(0, 1000000, (size,), dtype=torch.int32, device="cpu")
     tensor_gpu = torch.empty_like(tensor_cpu, device="cuda")


### PR DESCRIPTION

## Motivation
fixes #32507

## Modifications
 replaced the three hard-coded template instantiations + unexpected N dispatch with a single max-size template (kCopyMaxN = 512) that carries the array by value and takes the real count n at runtime


## Accuracy Tests

modified test should be fine

## Speed Tests and Profiling
NA
## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33947654737](https://github.com/sgl-project/sglang/actions/runs/33947654737)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33947654647](https://github.com/sgl-project/sglang/actions/runs/33947654647)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33947654736](https://github.com/sgl-project/sglang/actions/runs/33947654736)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->