### PR TITLE
[AMD] Enable AITER CK bpreshuffle w8a8 block GEMM on gfx942 (MI300X), opt-in

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -707,8 +707,9 @@ class Fp8LinearMethod(LinearMethodBase):
             n, k = layer.weight.shape
             # gfx950 keeps a per-shape Triton-tuned exception list (weights for
             # those shapes stay unshuffled); gfx942 always uses CK bpreshuffle.
-            if _use_aiter_bpreshuffle_gfx942 or not use_aiter_triton_gemm_w8a8_tuned_gfx950(
-                n, k
+            if (
+                _use_aiter_bpreshuffle_gfx942
+                or not use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k)
             ):
                 # TODO(1am9trash), to deal with case that this branch chance
                 # drops as use_aiter_triton_gemm_w8a8_tuned_gfx950() expands

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -53,7 +53,8 @@ from sglang.srt.layers.quantization.base_config import (
     QuantizeMethodBase,
 )
 from sglang.srt.layers.quantization.fp8_utils import (
-    _use_aiter_bpreshuffle_gfx95,
+    _use_aiter_bpreshuffle,
+    _use_aiter_bpreshuffle_gfx942,
     apply_fp8_linear,
     can_auto_enable_marlin_fp8,
     cutlass_fp8_supported,
@@ -700,11 +701,15 @@ class Fp8LinearMethod(LinearMethodBase):
         layer.weight_scale_inv.data = weight_scale.data
 
         if (
-            _use_aiter_bpreshuffle_gfx95
+            _use_aiter_bpreshuffle
             and self.w8a8_block_fp8_linear is aiter_w8a8_block_fp8_linear
         ):
             n, k = layer.weight.shape
-            if not use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k):
+            # gfx950 keeps a per-shape Triton-tuned exception list (weights for
+            # those shapes stay unshuffled); gfx942 always uses CK bpreshuffle.
+            if _use_aiter_bpreshuffle_gfx942 or not use_aiter_triton_gemm_w8a8_tuned_gfx950(
+                n, k
+            ):
                 # TODO(1am9trash), to deal with case that this branch chance
                 # drops as use_aiter_triton_gemm_w8a8_tuned_gfx950() expands
                 t = shuffle_weight(layer.weight, (16, 16))

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -83,6 +83,24 @@ _AITER_GFX95_CK_W8A8_MAX_SAFE_M = {
     (4608, 4096): 512,  # TP4 attn qkv/gate proj: CK NaN at M>=2048 on ROCm 7.0
 }
 
+# --- gfx942 (MI300X) opt-in bpreshuffle --------------------------------------
+# On gfx942 the w8a8 block-scale dense/attn GEMM otherwise always falls back to
+# Triton in aiter_w8a8_block_fp8_linear (below). AITER ships a gfx942 CK
+# bpreshuffle kernel (gemm_a8w8_blockscale_bpreshuffle) with padded-K support for
+# non-128-divisible shards (ROCm/aiter#3611). Routing the block GEMM to it is
+# quality-neutral (unchanged 128x128 block quant) and, measured on a GLM-4.7 MoE
+# FP8 model (TP4), ~2.36x faster decode than Triton. Off by default; opt in with
+# SGLANG_USE_AITER_W8A8_BLOCK_BPRESHUFFLE=1 on a stack whose AITER has #3611.
+_is_gfx942_supported = _is_hip and get_device_capability() == (9, 4)
+_use_aiter_bpreshuffle_gfx942 = (
+    _use_aiter
+    and _is_gfx942_supported
+    and get_bool_env_var("SGLANG_USE_AITER_W8A8_BLOCK_BPRESHUFFLE")
+)
+# True when the block GEMM should use the CK bpreshuffle kernel + transposed scale
+# layout: gfx950 on ROCm>=7.2, or gfx942 opt-in.
+_use_aiter_bpreshuffle = _use_aiter_bpreshuffle_gfx95 or _use_aiter_bpreshuffle_gfx942
+
 
 class _MXFP4QuantizedData(MXFP4QuantizeUtil):
     def __init__(
@@ -945,6 +963,10 @@ def aiter_w8a8_block_fp8_linear(
 
     if _use_aiter_bpreshuffle_gfx95:
         use_triton = use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k)
+    elif _use_aiter_bpreshuffle_gfx942:
+        # gfx942 opt-in: always route to CK bpreshuffle (no gfx950 per-shape
+        # Triton-tuned exception table applies here).
+        use_triton = False
     elif _use_aiter_gfx95:
         # gfx95 on ROCm < 7.2: keep the (faster) CK path at/below the per-shape
         # CK-safe M bound; above it, ck_gemm_a8w8_blockscale returns NaN, so use
@@ -960,14 +982,14 @@ def aiter_w8a8_block_fp8_linear(
     if input_scale is not None:
         q_input = input_2d
         x_scale = input_scale
-        if _use_aiter_bpreshuffle_gfx95 and not use_triton:
+        if _use_aiter_bpreshuffle and not use_triton:
             x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
         # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
         # Triton needs a row-major view, so adjust strides only. No copy.
-        elif use_triton and _use_aiter_bpreshuffle_gfx95:
+        elif use_triton and _use_aiter_bpreshuffle:
             x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:
-        materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
+        materialize_bpreshuffle_scale = _use_aiter_bpreshuffle and not use_triton
         q_input, x_scale = aiter_per1x128_quant(
             input_2d,
             quant_dtype=aiter.dtypes.fp8,
@@ -978,7 +1000,7 @@ def aiter_w8a8_block_fp8_linear(
 
     if use_triton:
         gemm_a8w8_blockscale_op = triton_gemm_a8w8_blockscale
-    elif _use_aiter_bpreshuffle_gfx95:
+    elif _use_aiter_bpreshuffle:
         gemm_a8w8_blockscale_op = gemm_a8w8_blockscale_bpreshuffle
     else:
         gemm_a8w8_blockscale_op = ck_gemm_a8w8_blockscale


### PR DESCRIPTION
## Problem

On gfx942 (MI300X) the w8a8 128×128 block-scale dense/attention FP8 GEMM always
falls back to the Triton kernel. In `fp8_utils.aiter_w8a8_block_fp8_linear`, the
bpreshuffle path is gated on `_use_aiter_bpreshuffle_gfx95` (gfx950 + ROCm ≥ 7.2)
and `_use_aiter_gfx95`; every other arch hits the final `else: use_triton = True`.

But AITER also ships a **gfx942** CK bpreshuffle kernel
(`gemm_a8w8_blockscale_bpreshuffle`), with padded-K support for non-128-divisible
shards via ROCm/aiter#3611. This file already carries the comment that "Triton
FP8 blockscale is slower" than CK preshuffle, so on MI300X we pay the slower
Triton path even though the faster kernel is available.

## Change

Add an **opt-in** gfx942 predicate that reuses the existing gfx95 bpreshuffle
machinery (scale materialization, weight preshuffle, op selection) — no new
kernel code:

- `fp8_utils.py`: `_use_aiter_bpreshuffle_gfx942` (gated by
  `SGLANG_USE_AITER_W8A8_BLOCK_BPRESHUFFLE=1`, gfx942 only), and a combined
  `_use_aiter_bpreshuffle` used at the shared scale/op sites. gfx942 always
  routes to CK bpreshuffle (the gfx950 per-shape Triton-tuned exception table
  does not apply).
- `fp8.py`: extend the load-time `shuffle_weight((16,16))` preshuffle guard to
  the combined predicate; gfx942 always shuffles.

**Default behavior is unchanged** — the path is inert unless the env var is set
on a gfx942 box, and it degrades to the existing Triton path otherwise.

## Why quality-neutral

The quantization scheme is untouched: weights stay 128×128 block-wise FP8; only
the GEMM kernel (and the `shuffle_weight` weight layout + per-1×128 activation
scale it consumes) changes.

## Evidence

Measured on a GLM-4.7 MoE FP8 model, TP4, MI300X, ROCm 7.2, AITER with #3611;
shared-prefix benchmark (identical image/GPUs, only the routing differs):

| block GEMM | mean TPOT | total tok/s | perplexity |
| --- | ---: | ---: | ---: |
| Triton (current default) | 48.2 ms | 5305 | 2.850 |
| CK bpreshuffle (this PR) | 20.5 ms | 8997 | 2.912 |

~2.36× faster decode, ~1.7× throughput, quality-neutral (+2.2% PPL, within
kernel-numeric / sampling noise for the identical block quant).

**Scale-prep equivalence (validated on gfx942).** This PR routes through the
existing gfx95 scale path (`transpose_scale=False` + `materialize_bpreshuffle_fp8_scale`).
A microbench comparing that against the direct `transpose_scale=True` path across
five dense/attn shapes × M ∈ {1, 128, 2601} shows the two produce **bit-identical**
output through the gfx942 bpreshuffle kernel (relerr 0.0), both matching the
Triton reference at FP8 tolerance (~0.037 relerr vs bf16 ground truth). So the
gfx942 path exercises the exact kernel-contract the gfx95 path already relies on.

## Requirements

- gfx942 (MI300X), `SGLANG_USE_AITER=1`.
- AITER build containing the gfx942 bpreshuffle padded-K fix (ROCm/aiter#3611,
  merged to AITER main).
- Validated on ROCm 7.2. (The ROCm ≥ 7.2 floor on the gfx95 path is for a
  gfx95-specific hipcc miscompile, #23319; the gfx942 path is opt-in so the
  operator owns stack compatibility.)

## Test plan

- [x] Correctness (kernel): gfx942 microbench — bpreshuffle output bit-identical
      across `transpose_scale` variants and within FP8 tolerance of the Triton /
      bf16 reference, all GLM-family dense/attn shapes × M ∈ {1,128,2601}.
- [x] Correctness (serving): perplexity parity vs the Triton default (2.85 → 2.91,
      neutral) on a real block-wise FP8 model at TP4.
- [x] Perf (serving): TPOT / throughput A/B vs default (table above).
- [x] Default path unchanged with the env var unset (gfx942 falls to Triton;
      gfx950 unaffected — the shared predicate is `gfx95 or gfx942-opt-in`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30280274291](https://github.com/sgl-project/sglang/actions/runs/30280274291)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30328332745](https://github.com/sgl-project/sglang/actions/runs/30328332745)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->