### PR TITLE
[Model] Support ZAYA1 native transformers checkpoint format

### DIFF
--- a/python/sglang/srt/configs/zaya.py
+++ b/python/sglang/srt/configs/zaya.py
@@ -47,12 +47,12 @@ class ZayaConfig(PretrainedConfig):
         lm_head_bias: bool = False,
         vocab_size: int = 262272,
         hidden_size: int = 2048,
-        ffn_hidden_size: int = 4096,
+        ffn_hidden_size: Optional[int] = None,
         num_hidden_layers: int = 80,
         num_experts: int = 16,
         num_attention_heads: int = 8,
         head_dim: int = 128,
-        activation_func: str = "swiglu",
+        activation_func: Optional[str] = None,
         max_position_embeddings: int = 32768,
         norm_epsilon: float = 1e-5,
         pad_token_id: int = 0,
@@ -93,6 +93,75 @@ class ZayaConfig(PretrainedConfig):
         _attn_implementation: str = "eager",
         **kwargs,
     ):
+        # --- Checkpoint-schema detection (legacy vs transformers-native) ---
+        # Zyphra ships ZAYA1 in two config schemas. The legacy Megatron-style
+        # exports (ZAYA1-base, ZAYA1-8B-legacy) carry ``activation_func`` /
+        # ``ffn_hidden_size`` / ``zaya_layers``; the transformers-native
+        # (>= v5.13) schema (ZAYA1-8B, ZAYA1-74B-preview) instead describes L
+        # folded hybrid layers (attention + MoE each) via ``layer_types`` /
+        # ``moe_intermediate_size`` plus per-layer-type nested rope
+        # parameters. SGLang's internal module tree is legacy-shaped (2L
+        # interleaved layers), so native fields are translated to the legacy
+        # surface here and the rest of the constructor runs unchanged. Legacy
+        # markers win on conflict (e.g. hand-merged configs).
+        # The native per-layer types are stored as ``zaya_layer_types`` rather
+        # than ``layer_types``: the ``PretrainedConfig`` validator checks
+        # ``layer_types`` entries against a global whitelist that only gains
+        # "hybrid_sliding" together with the upstream zaya port (transformers
+        # v5.13), so the pinned older transformers would reject the 74B
+        # schedule outright.
+        layer_types = list(kwargs.pop("layer_types", None) or []) or None
+        native_keys_present = (
+            layer_types is not None or "moe_intermediate_size" in kwargs
+        )
+        legacy_markers_present = (
+            activation_func is not None
+            or ffn_hidden_size is not None
+            or bool(zaya_layers)
+        )
+        self.checkpoint_format = (
+            "native" if native_keys_present and not legacy_markers_present else "legacy"
+        )
+        if self.checkpoint_format == "native":
+            # Each native hybrid layer folds onto one attention + one MoE
+            # internal layer, so the internal layer count doubles and the
+            # even/odd interleaving rule below applies unchanged.
+            num_native_layers = len(layer_types) if layer_types else num_hidden_layers
+            num_hidden_layers = 2 * num_native_layers
+            # Expand per-layer types to the internal layout (native layer k
+            # covers internal layers 2k and 2k+1) so the list length stays
+            # consistent with the internal ``num_hidden_layers``.
+            self.zaya_layer_types = (
+                [t for t in layer_types for _ in range(2)] if layer_types else None
+            )
+            # ``moe_intermediate_size`` is the per-expert intermediate size I;
+            # the legacy ``ffn_hidden_size`` is the gate+up concatenation 2I.
+            ffn_hidden_size = 2 * int(kwargs.get("moe_intermediate_size", 2048))
+            activation_func = "swiglu"
+            num_query_groups = num_key_value_heads
+            norm_epsilon = float(kwargs.get("rms_norm_eps", norm_epsilon))
+            zaya_mlp_expansion = int(
+                kwargs.get("router_hidden_size", zaya_mlp_expansion)
+            )
+            moe_router_topk = int(kwargs.get("num_experts_per_tok", moe_router_topk))
+            # Native rope parameters are nested per layer type; full-attention
+            # ("hybrid") layers are the only ones the model serves today, and
+            # their entry becomes the flat rope surface.
+            if isinstance(rope_parameters, dict) and "hybrid" in rope_parameters:
+                rope_parameters = dict(rope_parameters["hybrid"])
+            else:
+                rope_parameters = None
+            rope_theta = float((rope_parameters or {}).get("rope_theta", 5_000_000.0))
+            partial_rotary_factor = float(
+                (rope_parameters or {}).get(
+                    "partial_rotary_factor", partial_rotary_factor
+                )
+            )
+        else:
+            self.zaya_layer_types = None
+            activation_func = "swiglu" if activation_func is None else activation_func
+            ffn_hidden_size = 4096 if ffn_hidden_size is None else ffn_hidden_size
+
         self.cca = cca
         self.use_cache = use_cache
         self.attention_bias = attention_bias

--- a/python/sglang/srt/models/zaya.py
+++ b/python/sglang/srt/models/zaya.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import List, Optional, Tuple
 
 import torch
@@ -1479,6 +1479,124 @@ class ZayaModel(nn.Module):
         return hidden_states
 
 
+# --------------- native (transformers >= v5.13) checkpoint keys ---------------
+#
+# Native checkpoints fold each attention + MoE pair into one hybrid layer
+# ``model.layers.k`` and fuse expert weights into 3D tensors, while the module
+# tree above mirrors the legacy layout: 2L interleaved internal layers (even =
+# attention, odd = MoE) with per-expert tensors. Native layer ``k`` maps onto
+# internal layers ``(2k, 2k + 1)``.
+#
+# Residual-scaling blocks associate exit-style in native checkpoints
+# (``post_attention_*`` / ``post_mlp_*`` on the layer they follow) but
+# entry-style internally (``res_scale`` on the layer they precede), which
+# shifts every block one position later: the model-input scale lands on
+# internal layer 0, layer ``k``'s post-attention scale on internal layer
+# ``2k + 1``, layer ``k``'s post-MLP scale on internal layer ``2k + 2``, and
+# the last layer's post-MLP scale on the model-level ``res_scale``.
+
+_NATIVE_TOP_LEVEL_KEYS = {
+    "model.embed_tokens.weight": "model.embed_tokens.weight",
+    "model.norm.weight": "model.final_norm.weight",
+    "model.input_hidden_states_scale": "model.layers.0.res_scale.hidden_states_scale",
+    "model.input_hidden_states_bias": "model.layers.0.res_scale.hidden_states_bias",
+}
+
+# Attention-side suffixes: native layer k -> internal layer 2k.
+_NATIVE_ATTN_SUFFIXES = {
+    "input_layernorm.weight": "input_norm.weight",
+    "self_attn.qkv_proj.q_proj.weight": "self_attn.qkv.linear_q.weight",
+    "self_attn.qkv_proj.k_proj.weight": "self_attn.qkv.linear_k.weight",
+    "self_attn.qkv_proj.v_proj_current.weight": "self_attn.qkv.val_proj1.weight",
+    "self_attn.qkv_proj.v_proj_delayed.weight": "self_attn.qkv.val_proj2.weight",
+    "self_attn.qkv_proj.conv_qk_depthwise.weight": "self_attn.qkv.conv_qk.0.weight",
+    "self_attn.qkv_proj.conv_qk_depthwise.bias": "self_attn.qkv.conv_qk.0.bias",
+    "self_attn.qkv_proj.conv_qk_grouped.weight": "self_attn.qkv.conv_qk.1.weight",
+    "self_attn.qkv_proj.conv_qk_grouped.bias": "self_attn.qkv.conv_qk.1.bias",
+    "self_attn.qk_norm.temp": "self_attn.qkv.temp",
+    "self_attn.o_proj.weight": "self_attn.o_proj.weight",
+}
+
+# MoE-side suffixes: native layer k -> internal layer 2k + 1. The fused
+# ``mlp.experts.{gate_up_proj,down_proj}`` tensors are handled separately in
+# ``_native_weights_to_legacy`` because they expand into per-expert entries.
+_NATIVE_MOE_SUFFIXES = {
+    "post_attention_layernorm.weight": "input_norm.weight",
+    "mlp.gate.down_proj.weight": "zaya_block.router.down_proj.weight",
+    "mlp.gate.down_proj.bias": "zaya_block.router.down_proj.bias",
+    "mlp.gate.router_states_scale": "zaya_block.router.router_states_scale",
+    "mlp.gate.router_mlp.norm.weight": "zaya_block.router.rmsnorm_eda.weight",
+    "mlp.gate.router_mlp.fc1.weight": "zaya_block.router.router_mlp.0.weight",
+    "mlp.gate.router_mlp.fc1.bias": "zaya_block.router.router_mlp.0.bias",
+    "mlp.gate.router_mlp.fc2.weight": "zaya_block.router.router_mlp.2.weight",
+    "mlp.gate.router_mlp.fc2.bias": "zaya_block.router.router_mlp.2.bias",
+    "mlp.gate.router_mlp.out_proj.weight": "zaya_block.router.router_mlp.4.weight",
+    "mlp.gate.balancing_biases": "zaya_block.router.balancing_biases",
+}
+
+_NATIVE_LAYER_RE = re.compile(r"^model\.layers\.(\d+)\.(.+)$")
+_NATIVE_FUSED_EXPERT_RE = re.compile(
+    r"^model\.layers\.(\d+)\.mlp\.experts\.(gate_up_proj|down_proj)$"
+)
+
+
+def _native_to_legacy_key(name: str, num_native_layers: int) -> str:
+    """Translate one native checkpoint key to its internal (legacy-shaped)
+    parameter name. Keys that match no known native pattern are returned
+    unchanged so the caller's regular unknown-key handling applies."""
+    if name in _NATIVE_TOP_LEVEL_KEYS:
+        return _NATIVE_TOP_LEVEL_KEYS[name]
+    match = _NATIVE_LAYER_RE.match(name)
+    if match is None:
+        return name
+    k = int(match.group(1))
+    suffix = match.group(2)
+    if suffix in _NATIVE_ATTN_SUFFIXES:
+        return f"model.layers.{2 * k}.{_NATIVE_ATTN_SUFFIXES[suffix]}"
+    if suffix in _NATIVE_MOE_SUFFIXES:
+        return f"model.layers.{2 * k + 1}.{_NATIVE_MOE_SUFFIXES[suffix]}"
+    for native_block, internal_layer in (
+        ("post_attention_residual_scale", 2 * k + 1),
+        ("post_mlp_residual_scale", 2 * k + 2),
+    ):
+        prefix = f"{native_block}."
+        if suffix.startswith(prefix):
+            field = suffix[len(prefix) :]
+            if internal_layer == 2 * num_native_layers:
+                # The last layer's post-MLP scale precedes the final norm and
+                # lives on the model itself.
+                return f"model.res_scale.{field}"
+            return f"model.layers.{internal_layer}.res_scale.{field}"
+    return name
+
+
+def _native_weights_to_legacy(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    num_native_layers: int,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Rewrite a native checkpoint stream into the legacy key space consumed
+    by ``ZayaForCausalLM.load_weights``.
+
+    Fused expert tensors are expanded per expert: ``gate_up_proj`` has shape
+    ``[num_experts, 2 * I, hidden]`` with the gate rows first, matching the
+    legacy ``linear_fc1`` half-split order, and ``down_proj`` has shape
+    ``[num_experts, hidden, I]``, matching ``linear_fc2``.
+    """
+    for name, tensor in weights:
+        match = _NATIVE_FUSED_EXPERT_RE.match(name)
+        if match is not None:
+            k = int(match.group(1))
+            kind = "linear_fc1" if match.group(2) == "gate_up_proj" else "linear_fc2"
+            prefix = f"model.layers.{2 * k + 1}.zaya_block.experts"
+            for expert_id in range(tensor.shape[0]):
+                yield (
+                    f"{prefix}.local_experts.{expert_id}.{kind}.weight",
+                    tensor[expert_id],
+                )
+            continue
+        yield _native_to_legacy_key(name, num_native_layers), tensor
+
+
 class ZayaForCausalLM(nn.Module):
     def __init__(
         self,
@@ -1490,6 +1608,17 @@ class ZayaForCausalLM(nn.Module):
         self.config = config
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
+
+        if config.zaya_layer_types is not None:
+            unsupported = sorted({t for t in config.zaya_layer_types if t != "hybrid"})
+            if unsupported:
+                # ZAYA1-74B-preview mixes "hybrid_sliding" layers in; serving
+                # them without the sliding window would be silently wrong.
+                raise NotImplementedError(
+                    f"ZAYA1 native layer_types {unsupported} are not supported "
+                    'yet; only all-"hybrid" native checkpoints (e.g. '
+                    "Zyphra/ZAYA1-8B) can be served."
+                )
 
         self.model = ZayaModel(
             config=config,
@@ -1554,7 +1683,17 @@ class ZayaForCausalLM(nn.Module):
            and up projections concatenated along dim 0) is split and routed
            to FusedMoE shards ``w1`` (first half) and ``w3`` (second half);
            ``linear_fc2.weight`` becomes the FusedMoE ``w2`` shard.
+
+        Native-format checkpoints (``config.checkpoint_format == "native"``)
+        are first rewritten into this legacy key space by
+        ``_native_weights_to_legacy``; see the mapping tables above.
         """
+        if self.config.checkpoint_format == "native":
+            weights = _native_weights_to_legacy(
+                weights,
+                num_native_layers=self.config.num_hidden_layers // 2,
+            )
+
         params_dict = dict(self.named_parameters())
         buffers_dict = dict(self.named_buffers())
         # ``balancing_biases`` is a persistent buffer; FusedMoE may also expose

--- a/test/registered/unit/configs/test_zaya_config.py
+++ b/test/registered/unit/configs/test_zaya_config.py
@@ -11,6 +11,103 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
+# Field set copied verbatim (layer list compressed) from Zyphra/ZAYA1-8B
+# config.json at pinned revision 67d34da515b30409ee8daa67c3605c4402d03f6f —
+# the transformers-native (>= v5.13) ZAYA schema.
+_NATIVE_8B_CONFIG = {
+    "architectures": ["ZayaForCausalLM"],
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "bos_token_id": 2,
+    "cca_time0": 2,
+    "cca_time1": 2,
+    "dtype": "bfloat16",
+    "eos_token_id": 106,
+    "head_dim": 128,
+    "hidden_act": "silu",
+    "hidden_size": 2048,
+    "initializer_range": 0.02,
+    "layer_types": ["hybrid"] * 40,
+    "lm_head_bias": False,
+    "max_position_embeddings": 131072,
+    "model_type": "zaya",
+    "moe_intermediate_size": 2048,
+    "num_attention_heads": 8,
+    "num_experts": 16,
+    "num_experts_per_tok": 1,
+    "num_hidden_layers": 40,
+    "num_key_value_heads": 2,
+    "output_router_logits": False,
+    "pad_token_id": 0,
+    "partial_rotary_factor": 0.5,
+    "rms_norm_eps": 1e-05,
+    "rope_parameters": {
+        "hybrid": {
+            "partial_rotary_factor": 0.5,
+            "rope_theta": 5000000,
+            "rope_type": "default",
+        },
+        "hybrid_sliding": {
+            "partial_rotary_factor": 0.5,
+            "rope_theta": 10000.0,
+            "rope_type": "default",
+        },
+        "rope_type": "default",
+    },
+    "router_hidden_size": 256,
+    "sliding_window": None,
+    "tie_word_embeddings": True,
+    "use_cache": True,
+    "vocab_size": 262272,
+}
+
+# Field set copied verbatim from Zyphra/ZAYA1-8B-legacy config.json at pinned
+# revision 1bef1fb587fc4bcb78f318f49ff2ef2b2510f073 — the legacy
+# Megatron-style schema SGLang already understands.
+_LEGACY_8B_CONFIG = {
+    "activation_func": "swiglu",
+    "activation_func_fp8_input_store": False,
+    "add_bias_linear": False,
+    "architectures": ["ZayaForCausalLM"],
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "bias_activation_fusion": True,
+    "bos_token_id": 2,
+    "cca": True,
+    "dtype": "bfloat16",
+    "eos_token_id": 106,
+    "ffn_hidden_size": 4096,
+    "gated_linear_unit": True,
+    "hidden_size": 2048,
+    "head_dim": 128,
+    "kv_channels": 128,
+    "lm_head_bias": False,
+    "mamba_cache_dtype": "float32",
+    "max_position_embeddings": 131072,
+    "model_type": "zaya",
+    "moe_router_topk": 1,
+    "norm_epsilon": 1e-05,
+    "normalization": "RMSNorm",
+    "num_attention_heads": 8,
+    "num_experts": 16,
+    "num_hidden_layers": 80,
+    "num_key_value_heads": 2,
+    "num_query_groups": 2,
+    "pad_token_id": 0,
+    "partial_rotary_factor": 0.5,
+    "residual_in_fp32": True,
+    "rope_scaling": False,
+    "rope_theta": 5000000,
+    "scale_residual_merge": True,
+    "sliding_window": None,
+    "use_cache": True,
+    "vocab_size": 262272,
+    "zaya_mlp_expansion": 256,
+    "zaya_use_eda": True,
+    "zaya_use_mod": True,
+}
+
+
 class TestZayaConfig(CustomTestCase):
     def test_default_fields_match_zaya1_base(self):
         """Defaults reflect Zyphra/ZAYA1-base reference checkpoint."""
@@ -95,6 +192,66 @@ class TestZayaConfig(CustomTestCase):
         # ``AutoConfig.for_model`` now resolves to ``ZayaConfig``.
         cfg = AutoConfig.for_model("zaya")
         self.assertIsInstance(cfg, ZayaConfig)
+
+
+class TestZayaNativeConfigTranslation(CustomTestCase):
+    """Translation of the transformers-native (>= v5.13) ZAYA config schema.
+
+    Zyphra's native checkpoints (ZAYA1-8B, ZAYA1-74B-preview) describe L
+    hybrid layers (attention + MoE folded per layer) with native field
+    names, while SGLang's internal zaya model is legacy-shaped: 2L
+    interleaved layers with Megatron-style field names. Feeding a native
+    config into ``ZayaConfig`` today silently keeps the legacy defaults
+    (e.g. ``num_hidden_layers`` stays at the native 40 while the default
+    4096 ``ffn_hidden_size`` no longer corresponds to it), so the model is
+    built with the wrong geometry and cannot load the checkpoint.
+    """
+
+    def test_native_8b_translates_to_internal_geometry(self):
+        cfg = ZayaConfig(**_NATIVE_8B_CONFIG)
+        self.assertEqual(cfg.checkpoint_format, "native")
+        # L native hybrid layers -> 2L interleaved internal layers.
+        self.assertEqual(cfg.num_hidden_layers, 80)
+        self.assertEqual(cfg.full_attention_layer_ids, list(range(0, 80, 2)))
+        # moe_intermediate_size I -> gated ffn_hidden_size 2I.
+        self.assertEqual(cfg.ffn_hidden_size, 4096)
+        self.assertEqual(cfg.activation_func, "swiglu")
+        self.assertTrue(cfg.gated_linear_unit)
+        # Nested per-layer-type rope -> flat full-attention rope.
+        self.assertEqual(cfg.rope_theta, 5_000_000.0)
+        self.assertEqual(cfg.partial_rotary_factor, 0.5)
+        self.assertEqual(cfg.rope_parameters["rope_theta"], 5_000_000.0)
+        # Field renames.
+        self.assertEqual(cfg.num_query_groups, 2)
+        self.assertEqual(cfg.norm_epsilon, 1e-5)
+        self.assertEqual(cfg.zaya_mlp_expansion, 256)
+        self.assertEqual(cfg.moe_router_topk, 1)
+        # Architecture features that are always on in the native schema.
+        self.assertTrue(cfg.zaya_use_eda)
+        self.assertTrue(cfg.zaya_use_mod)
+        self.assertTrue(cfg.scale_residual_merge)
+        # Unchanged pass-through.
+        self.assertEqual(cfg.vocab_size, 262272)
+        self.assertEqual(cfg.hidden_size, 2048)
+        self.assertEqual(cfg.head_dim, 128)
+        self.assertEqual(cfg.num_experts, 16)
+
+    def test_legacy_8b_stays_legacy(self):
+        cfg = ZayaConfig(**_LEGACY_8B_CONFIG)
+        self.assertEqual(cfg.checkpoint_format, "legacy")
+        self.assertEqual(cfg.num_hidden_layers, 80)
+        self.assertEqual(cfg.ffn_hidden_size, 4096)
+        self.assertEqual(cfg.rope_theta, 5_000_000.0)
+        self.assertEqual(cfg.zaya_mlp_expansion, 256)
+
+    def test_mixed_markers_resolve_as_legacy(self):
+        """A config carrying legacy markers must not be re-translated even if
+        native-only keys are also present (e.g. a hand-converted config that
+        kept both field sets): translating it would double the layer count."""
+        cfg = ZayaConfig(**{**_LEGACY_8B_CONFIG, "moe_intermediate_size": 2048})
+        self.assertEqual(cfg.checkpoint_format, "legacy")
+        self.assertEqual(cfg.num_hidden_layers, 80)
+        self.assertEqual(cfg.ffn_hidden_size, 4096)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_zaya_native_checkpoint.py
+++ b/test/registered/unit/models/test_zaya_native_checkpoint.py
@@ -1,0 +1,408 @@
+"""Loading tests for the transformers-native (>=5.13) ZAYA1 checkpoint format.
+
+Zyphra ships ZAYA1 in two checkpoint layouts. The legacy Megatron-style
+export (ZAYA1-base, ZAYA1-8B-legacy) matches SGLang's internal module tree
+one-to-one: 2L interleaved decoder layers (even = attention, odd = MoE) and
+per-expert ``local_experts.<i>.linear_fc{1,2}`` tensors. The native layout
+(ZAYA1-8B, ZAYA1-74B-preview, defined by ``transformers`` >= v5.13) folds
+each attention + MoE pair into one hybrid layer ``model.layers.k`` and fuses
+expert weights into 3D ``mlp.experts.{gate_up_proj,down_proj}`` tensors, so
+native layer ``k`` must be split onto internal layers ``(2k, 2k + 1)`` at
+load time.
+
+Bug mechanism guarded here (black box): feeding a native-format config and
+checkpoint into SGLang today constructs a model with the wrong geometry and
+then skips every native tensor with "no matching parameter", producing an
+unusable model instead of a correct load or a fast failure.
+
+The residual-scaling association is the trickiest derived property: native
+checkpoints attach scaling blocks exit-style (``post_attention_*`` /
+``post_mlp_*`` on the layer they follow) while SGLang attaches them
+entry-style (``res_scale`` on the layer they precede), so every block shifts
+one position later: the model-input scale lands on internal layer 0, layer
+``k``'s post-attention scale on internal layer ``2k + 1``, layer ``k``'s
+post-MLP scale on internal layer ``2k + 2``, and the last layer's post-MLP
+scale on the model-level ``res_scale``.
+"""
+
+import os
+import unittest
+
+import torch
+
+from sglang.srt.configs.zaya import ZayaConfig
+from sglang.srt.models.zaya import ZayaForCausalLM
+from sglang.srt.runtime_context import get_context, reset_context
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+def _ensure_dist_initialized() -> None:
+    """Minimal single-rank gloo distributed environment plus the SGLang
+    model-parallel groups (TP=1, PP=1, EP=1), required before constructing
+    any parallel linear layer or ``ZayaForCausalLM`` itself."""
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29636")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+        model_parallel_is_initialized,
+    )
+
+    if not torch.distributed.is_initialized():
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            backend="gloo",
+        )
+
+    if not model_parallel_is_initialized():
+        initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            backend="gloo",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tiny two-layer geometry, expressed once in each checkpoint schema
+# ---------------------------------------------------------------------------
+
+_L_NATIVE = 2  # native hybrid layers -> 2 * _L_NATIVE internal layers
+_HIDDEN = 16
+_HEADS = 4
+_KV_HEADS = 2
+_HEAD_DIM = 8
+_MOE_I = 16  # native moe_intermediate_size -> legacy ffn_hidden_size = 2 * I
+_EXPERTS = 2
+_ROUTER_HIDDEN = 8
+_VOCAB = 64
+
+# Native schema (transformers >= v5.13), field set mirroring the pinned
+# Zyphra/ZAYA1-8B config.json shrunk to the tiny geometry above.
+_NATIVE_TINY = {
+    "model_type": "zaya",
+    "vocab_size": _VOCAB,
+    "hidden_size": _HIDDEN,
+    "num_hidden_layers": _L_NATIVE,
+    "num_attention_heads": _HEADS,
+    "num_key_value_heads": _KV_HEADS,
+    "head_dim": _HEAD_DIM,
+    "hidden_act": "silu",
+    "moe_intermediate_size": _MOE_I,
+    "num_experts": _EXPERTS,
+    "num_experts_per_tok": 1,
+    "router_hidden_size": _ROUTER_HIDDEN,
+    "cca_time0": 2,
+    "cca_time1": 2,
+    "rms_norm_eps": 1e-5,
+    "max_position_embeddings": 64,
+    "layer_types": ["hybrid"] * _L_NATIVE,
+    "rope_parameters": {
+        "hybrid": {
+            "rope_type": "default",
+            "rope_theta": 5_000_000.0,
+            "partial_rotary_factor": 0.5,
+        },
+        "hybrid_sliding": {
+            "rope_type": "default",
+            "rope_theta": 10_000.0,
+            "partial_rotary_factor": 0.5,
+        },
+    },
+    "sliding_window": None,
+    "attention_bias": False,
+    "lm_head_bias": False,
+    "tie_word_embeddings": True,
+    "pad_token_id": 0,
+    "bos_token_id": 2,
+    "eos_token_id": 106,
+}
+
+# The same tiny model in the legacy schema SGLang already understands. Used
+# to build the reference internal module tree (names and shapes).
+_LEGACY_TINY = {
+    "model_type": "zaya",
+    "vocab_size": _VOCAB,
+    "hidden_size": _HIDDEN,
+    "ffn_hidden_size": 2 * _MOE_I,
+    "num_hidden_layers": 2 * _L_NATIVE,
+    "num_experts": _EXPERTS,
+    "num_attention_heads": _HEADS,
+    "num_query_groups": _KV_HEADS,
+    "num_key_value_heads": _KV_HEADS,
+    "head_dim": _HEAD_DIM,
+    "cca_time0": 2,
+    "cca_time1": 2,
+    "max_position_embeddings": 64,
+    "moe_router_topk": 1,
+    "zaya_mlp_expansion": _ROUTER_HIDDEN,
+    "rope_theta": 5_000_000.0,
+    "attention_bias": False,
+    "tie_word_embeddings": True,
+}
+
+# The first MoE layer has no previous router state, so neither checkpoint
+# format ships an EDA ``router_states_scale`` for it (verified against the
+# pinned ZAYA1-8B and ZAYA1-8B-legacy safetensors indexes).
+_FIRST_MOE_ROUTER_SCALE = "model.layers.1.zaya_block.router.router_states_scale"
+
+
+def _expected_native_to_internal_map(num_native_layers: int) -> dict:
+    """The mapping contract under test: every non-expert native checkpoint
+    key -> the internal parameter/buffer it must load into."""
+    mapping = {
+        "model.embed_tokens.weight": "model.embed_tokens.weight",
+        "model.norm.weight": "model.final_norm.weight",
+        "model.input_hidden_states_scale": "model.layers.0.res_scale.hidden_states_scale",
+        "model.input_hidden_states_bias": "model.layers.0.res_scale.hidden_states_bias",
+    }
+    attn = {
+        "input_layernorm.weight": "input_norm.weight",
+        "self_attn.qkv_proj.q_proj.weight": "self_attn.qkv.linear_q.weight",
+        "self_attn.qkv_proj.k_proj.weight": "self_attn.qkv.linear_k.weight",
+        "self_attn.qkv_proj.v_proj_current.weight": "self_attn.qkv.val_proj1.weight",
+        "self_attn.qkv_proj.v_proj_delayed.weight": "self_attn.qkv.val_proj2.weight",
+        "self_attn.qkv_proj.conv_qk_depthwise.weight": "self_attn.qkv.conv_qk.0.weight",
+        "self_attn.qkv_proj.conv_qk_depthwise.bias": "self_attn.qkv.conv_qk.0.bias",
+        "self_attn.qkv_proj.conv_qk_grouped.weight": "self_attn.qkv.conv_qk.1.weight",
+        "self_attn.qkv_proj.conv_qk_grouped.bias": "self_attn.qkv.conv_qk.1.bias",
+        "self_attn.qk_norm.temp": "self_attn.qkv.temp",
+        "self_attn.o_proj.weight": "self_attn.o_proj.weight",
+    }
+    moe = {
+        "post_attention_layernorm.weight": "input_norm.weight",
+        "mlp.gate.down_proj.weight": "zaya_block.router.down_proj.weight",
+        "mlp.gate.down_proj.bias": "zaya_block.router.down_proj.bias",
+        "mlp.gate.router_mlp.norm.weight": "zaya_block.router.rmsnorm_eda.weight",
+        "mlp.gate.router_mlp.fc1.weight": "zaya_block.router.router_mlp.0.weight",
+        "mlp.gate.router_mlp.fc1.bias": "zaya_block.router.router_mlp.0.bias",
+        "mlp.gate.router_mlp.fc2.weight": "zaya_block.router.router_mlp.2.weight",
+        "mlp.gate.router_mlp.fc2.bias": "zaya_block.router.router_mlp.2.bias",
+        "mlp.gate.router_mlp.out_proj.weight": "zaya_block.router.router_mlp.4.weight",
+        "mlp.gate.balancing_biases": "zaya_block.router.balancing_biases",
+    }
+    res_fields = (
+        "hidden_states_scale",
+        "hidden_states_bias",
+        "residual_scale",
+        "residual_bias",
+    )
+    for k in range(num_native_layers):
+        for suffix, target in attn.items():
+            mapping[f"model.layers.{k}.{suffix}"] = f"model.layers.{2 * k}.{target}"
+        for suffix, target in moe.items():
+            mapping[f"model.layers.{k}.{suffix}"] = f"model.layers.{2 * k + 1}.{target}"
+        if k != 0:
+            mapping[f"model.layers.{k}.mlp.gate.router_states_scale"] = (
+                f"model.layers.{2 * k + 1}.zaya_block.router.router_states_scale"
+            )
+        for field in res_fields:
+            mapping[f"model.layers.{k}.post_attention_residual_scale.{field}"] = (
+                f"model.layers.{2 * k + 1}.res_scale.{field}"
+            )
+            if k < num_native_layers - 1:
+                mapping[f"model.layers.{k}.post_mlp_residual_scale.{field}"] = (
+                    f"model.layers.{2 * k + 2}.res_scale.{field}"
+                )
+            else:
+                mapping[f"model.layers.{k}.post_mlp_residual_scale.{field}"] = (
+                    f"model.res_scale.{field}"
+                )
+    return mapping
+
+
+def _expert_marker(layer: int, expert: int, part: str) -> float:
+    part_offset = {"gate": 1.0, "up": 2.0, "down": 3.0}[part]
+    return 1000.0 + 100.0 * layer + 10.0 * expert + part_offset
+
+
+def _state_of(model: torch.nn.Module) -> dict:
+    state = dict(model.named_parameters())
+    state.update(dict(model.named_buffers()))
+    return state
+
+
+def _loadable_targets(ref_state: dict) -> set:
+    """Every internal name a full checkpoint load must populate: all params
+    and persistent buffers except rotary caches (computed, never loaded) and
+    the first MoE layer's EDA scale (absent from both checkpoint formats)."""
+    return {
+        name
+        for name in ref_state
+        if "rotary_emb" not in name and name != _FIRST_MOE_ROUTER_SCALE
+    }
+
+
+def _make_native_checkpoint(ref_state: dict, keymap: dict):
+    """Synthetic native checkpoint stream. Every non-expert tensor is filled
+    with a distinct constant so each test can verify exactly where it landed;
+    fused expert tensors carry per-(layer, expert, part) markers."""
+    entries = []
+    markers = {}
+    for i, (native_key, internal_key) in enumerate(sorted(keymap.items())):
+        marker = float(i + 1)
+        entries.append((native_key, torch.full_like(ref_state[internal_key], marker)))
+        markers[native_key] = marker
+    for k in range(_L_NATIVE):
+        gate_up = torch.empty(_EXPERTS, 2 * _MOE_I, _HIDDEN)
+        down = torch.empty(_EXPERTS, _HIDDEN, _MOE_I)
+        for e in range(_EXPERTS):
+            gate_up[e, :_MOE_I] = _expert_marker(k, e, "gate")
+            gate_up[e, _MOE_I:] = _expert_marker(k, e, "up")
+            down[e] = _expert_marker(k, e, "down")
+        entries.append((f"model.layers.{k}.mlp.experts.gate_up_proj", gate_up))
+        entries.append((f"model.layers.{k}.mlp.experts.down_proj", down))
+    return entries, markers
+
+
+def _make_legacy_checkpoint(ref_state: dict):
+    """Synthetic legacy checkpoint stream mirroring the pinned
+    ZAYA1-8B-legacy key set for the tiny geometry."""
+    entries = []
+    for name in sorted(_loadable_targets(ref_state)):
+        if ".zaya_block.experts." in name:
+            continue  # replaced by per-expert linear_fc keys below
+        entries.append((name, torch.zeros_like(ref_state[name])))
+    for internal_layer in range(1, 2 * _L_NATIVE, 2):
+        prefix = f"model.layers.{internal_layer}.zaya_block.experts"
+        for e in range(_EXPERTS):
+            entries.append(
+                (
+                    f"{prefix}.local_experts.{e}.linear_fc1.weight",
+                    torch.zeros(2 * _MOE_I, _HIDDEN),
+                )
+            )
+            entries.append(
+                (
+                    f"{prefix}.local_experts.{e}.linear_fc2.weight",
+                    torch.zeros(_HIDDEN, _MOE_I),
+                )
+            )
+    return entries
+
+
+class _ZayaCpuModelTestBase(CustomTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _ensure_dist_initialized()
+        cls._saved_server_args = get_context()._server_args
+        get_context().set_server_args(ServerArgs(model_path="dummy"))
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if getattr(cls, "_saved_server_args", None) is None:
+            reset_context()
+        else:
+            get_context().set_server_args(cls._saved_server_args)
+
+
+class TestZayaNativeCheckpointLoading(_ZayaCpuModelTestBase):
+    def _reference_state(self) -> dict:
+        return _state_of(ZayaForCausalLM(config=ZayaConfig(**_LEGACY_TINY)))
+
+    def _load_native(self):
+        """Build the model from the native config and load the synthetic
+        native checkpoint into it, returning everything tests inspect."""
+        ref_state = self._reference_state()
+        keymap = _expected_native_to_internal_map(_L_NATIVE)
+        entries, markers = _make_native_checkpoint(ref_state, keymap)
+        model = ZayaForCausalLM(config=ZayaConfig(**_NATIVE_TINY))
+        loaded = model.load_weights(iter(entries))
+        return model, ref_state, keymap, markers, loaded
+
+    def test_native_checkpoint_loads_completely(self):
+        """Every tensor of a native checkpoint must load, and together they
+        must populate every loadable internal parameter and buffer."""
+        model, ref_state, keymap, _, loaded = self._load_native()
+
+        expected = set(keymap.values())
+        for internal_layer in range(1, 2 * _L_NATIVE, 2):
+            prefix = f"model.layers.{internal_layer}.zaya_block.experts"
+            expected.add(f"{prefix}.w13_weight")
+            expected.add(f"{prefix}.w2_weight")
+
+        # Fixture self-consistency: the expected key map covers exactly the
+        # loadable surface of the internal module tree.
+        self.assertEqual(expected, _loadable_targets(ref_state))
+
+        self.assertEqual(loaded, expected)
+
+    def test_native_weights_land_on_mapped_parameters(self):
+        """Marker sweep over every non-expert native key: the constant put
+        into a native tensor must reappear in exactly the mapped internal
+        parameter (this pins the 2:1 layer folding and the one-position
+        residual-scale shift described in the module docstring)."""
+        model, _, keymap, markers, _ = self._load_native()
+        state = _state_of(model)
+        for native_key, internal_key in keymap.items():
+            param = state[internal_key]
+            self.assertTrue(
+                bool(torch.all(param == markers[native_key])),
+                msg=(
+                    f"{native_key} -> {internal_key}: expected constant "
+                    f"{markers[native_key]}, got {param.flatten()[:4].tolist()}"
+                ),
+            )
+
+    def test_native_fused_experts_split_gate_first(self):
+        """Native ``gate_up_proj[e]`` rows ``[:I]`` are the gate (w1) and rows
+        ``[I:]`` the up projection (w3), matching the legacy ``linear_fc1``
+        half-split order; ``down_proj[e]`` is w2."""
+        model, _, _, _, _ = self._load_native()
+        state = _state_of(model)
+        for k in range(_L_NATIVE):
+            prefix = f"model.layers.{2 * k + 1}.zaya_block.experts"
+            w13 = state[f"{prefix}.w13_weight"]
+            w2 = state[f"{prefix}.w2_weight"]
+            for e in range(_EXPERTS):
+                self.assertTrue(
+                    bool(torch.all(w13[e, :_MOE_I] == _expert_marker(k, e, "gate"))),
+                    msg=f"layer {k} expert {e}: gate half mismatch",
+                )
+                self.assertTrue(
+                    bool(torch.all(w13[e, _MOE_I:] == _expert_marker(k, e, "up"))),
+                    msg=f"layer {k} expert {e}: up half mismatch",
+                )
+                self.assertTrue(
+                    bool(torch.all(w2[e] == _expert_marker(k, e, "down"))),
+                    msg=f"layer {k} expert {e}: down projection mismatch",
+                )
+
+    def test_legacy_checkpoint_still_loads_completely(self):
+        """Regression guard: the legacy per-expert key set keeps loading the
+        full parameter surface after the native-format support lands."""
+        ref_state = self._reference_state()
+        model = ZayaForCausalLM(config=ZayaConfig(**_LEGACY_TINY))
+        loaded = model.load_weights(iter(_make_legacy_checkpoint(ref_state)))
+        self.assertEqual(loaded, _loadable_targets(ref_state))
+
+    def test_native_hybrid_sliding_fails_fast(self):
+        """`hybrid_sliding` layers (ZAYA1-74B-preview) are not wired up yet;
+        the config must still translate, but building the model must fail
+        fast instead of silently serving without the sliding window."""
+        cfg = ZayaConfig(
+            **{
+                **_NATIVE_TINY,
+                "layer_types": ["hybrid", "hybrid_sliding"],
+                "sliding_window": 8,
+            }
+        )
+        self.assertEqual(cfg.checkpoint_format, "native")
+        # Full-attention layers keep the "hybrid" rope theta.
+        self.assertEqual(cfg.rope_theta, 5_000_000.0)
+        with self.assertRaises(NotImplementedError):
+            ZayaForCausalLM(config=cfg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The initial ZAYA1 support (#26347) loads the legacy Megatron-style checkpoints (`Zyphra/ZAYA1-base`, `Zyphra/ZAYA1-8B-legacy`). The checkpoints Zyphra publishes for `transformers` >= v5.13 (`Zyphra/ZAYA1-8B`, `Zyphra/ZAYA1-74B-preview`) use the native schema instead: the config describes L folded hybrid layers (`layer_types`, `moe_intermediate_size`, nested per-layer-type `rope_parameters`), and the weights fold each attention + MoE pair into one `model.layers.k` with fused 3D expert tensors and exit-style residual-scaling blocks.

Serving such a checkpoint today silently builds a model with the wrong geometry (the native 40-layer count is used as the internal interleaved layer count, while defaults mask the remaining fields) and then fails to match the native weight keys — an unusable model rather than a correct load or a fast failure.

## Modifications

- `ZayaConfig` detects the checkpoint schema (native-only keys present and legacy markers absent; legacy wins on conflict, e.g. hand-merged configs) and records it as `checkpoint_format`. Native fields are translated to the internal legacy-shaped surface: L → 2L interleaved layers, `moe_intermediate_size` I → gated `ffn_hidden_size` 2I, `num_key_value_heads` → `num_query_groups`, `rms_norm_eps` → `norm_epsilon`, `router_hidden_size` → `zaya_mlp_expansion`, `num_experts_per_tok` → `moe_router_topk`, and `rope_parameters["hybrid"]` flattened to the flat rope surface.
- `ZayaForCausalLM.load_weights` rewrites native checkpoint streams into the legacy key space via pure module-level mapping tables: attention suffixes → internal layer 2k, MoE suffixes → layer 2k+1, exit-style residual-scale blocks shifted one position to the entry-style `res_scale` modules, and fused `mlp.experts.{gate_up_proj,down_proj}` tensors expanded per expert onto the existing FusedMoE shard path (gate rows first, matching the legacy `linear_fc1` half-split order).
- Native `layer_types` are stored as `zaya_layer_types` (the pinned transformers' `PretrainedConfig` validator rejects `"hybrid_sliding"`, which only enters the whitelist together with the v5.13 zaya port). Model build fails fast with `NotImplementedError` when `hybrid_sliding` layers are present (ZAYA1-74B-preview) instead of silently serving without the sliding window; full SWA wiring is follow-up scope.

Legacy checkpoints are unaffected: the translation only engages for `checkpoint_format == "native"`, and the legacy load path is regression-tested.

## Accuracy Tests

CPU unit tests (registered in `base-a-test-cpu`):

- `test/registered/unit/configs/test_zaya_config.py`: native/legacy/mixed-marker translation cases with field sets copied verbatim from the pinned official config.json revisions (ZAYA1-8B `67d34da515b3`, ZAYA1-8B-legacy `1bef1fb587fc`).
- `test/registered/unit/models/test_zaya_native_checkpoint.py`: builds the real `ZayaForCausalLM` on CPU (gloo, TP=1) and verifies (a) a native checkpoint loads completely onto exactly the loadable parameter surface, (b) a marker sweep pins every native key to its mapped internal parameter incl. the residual-scale shift, (c) the fused expert gate/up split order, (d) the legacy key set still loads completely, and (e) the `hybrid_sliding` fail-fast.

Additionally validated against the full pinned safetensors indexes of the real checkpoints at real layer count (L=40 → 80 internal, shrunk dims): the mapping covers exactly the 1283 keys of `Zyphra/ZAYA1-8B` and reproduces exactly the 2483 keys of `Zyphra/ZAYA1-8B-legacy`, with complete loads in both formats.

The existing E2E test needs no changes: `ZAYA_MODEL_PATH=Zyphra/ZAYA1-8B RUN_ZAYA_E2E=1 python test/registered/models/test_zaya.py` exercises the native path once this lands (`Zyphra/ZAYA1-base` remains the default and stays green).

## Speed Tests and Profiling

Not applicable: load-time key translation only; no forward-path change. Legacy loading is byte-identical in behavior.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30259866091](https://github.com/sgl-project/sglang/actions/runs/30259866091)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30259866060](https://github.com/sgl-project/sglang/actions/runs/30259866060)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->