### PR TITLE
[MLX] Fix MlxModelRunnerStub crash on --max-running-requests (missing dp_size)

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -236,6 +236,12 @@ class MlxModelRunnerStub(ModelRunner):
             self.max_total_num_tokens = self._mlx_pool_size
         else:
             self.max_total_num_tokens = self.model_config.context_len
+        # The base ModelRunner only ever sets `dcp_size`, never `dp_size`, and
+        # this lightweight override skips base.initialize() -- so derive it from
+        # server_args here. _resolve_max_running_requests splits the requested
+        # concurrency across dp workers, mirroring how the CUDA-side runners
+        # read `server_args.dp_size` (e.g. base_runner.py / cpu_graph_runner.py).
+        self.dp_size = self.server_args.dp_size
         self.max_running_requests = self._resolve_max_running_requests()
         self.is_hybrid_swa = False
 

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
@@ -75,6 +75,49 @@ class TestMlxRunnerPoolContract(unittest.TestCase):
                 f"optional MemoryPoolConfig argument: {exc}"
             )
 
+    def test_initialize_sets_dp_size_for_max_running_requests(self):
+        """Regression: serving with ``--max-running-requests`` crashed with
+        ``AttributeError: 'MlxModelRunnerStub' object has no attribute
+        'dp_size'``.
+
+        ``_resolve_max_running_requests`` splits the requested concurrency
+        across dp workers via ``self.dp_size``, but the base ``ModelRunner``
+        only ever sets ``dcp_size`` (never ``dp_size``) and the stub overrides
+        ``initialize()`` without calling ``super().initialize()``, so
+        ``initialize`` must derive ``dp_size`` from ``server_args`` itself.
+        Every MLX e2e correctness test passes ``--max-running-requests 1``,
+        so without this the whole MLX serving lane is broken.
+        """
+        import inspect
+        from unittest.mock import MagicMock, patch
+
+        import sglang.srt.configs.hybrid_arch as hybrid_arch
+
+        init_src = inspect.getsource(MlxModelRunnerStub.initialize)
+        self.assertIn(
+            "self.dp_size = self.server_args.dp_size",
+            init_src,
+            msg=(
+                "MlxModelRunnerStub.initialize must set self.dp_size from "
+                "server_args before _resolve_max_running_requests runs. The "
+                "base ModelRunner never sets dp_size (only dcp_size) and "
+                "this override skips super().initialize()."
+            ),
+        )
+
+        # The split must divide the requested cap across dp workers without
+        # touching the missing attribute.
+        stub = MlxModelRunnerStub.__new__(MlxModelRunnerStub)
+        stub.max_total_num_tokens = 10000
+        stub.dp_size = 2
+        stub.server_args = MagicMock(
+            max_running_requests=4, dp_size=2, max_mamba_cache_size=None
+        )
+        stub.model_config = MagicMock()
+        with patch.object(hybrid_arch, "mambaish_config", return_value=None):
+            # 4 // dp_size(2) = 2; capacity_cap = 10000 // 2 = 5000; -> 2
+            self.assertEqual(stub._resolve_max_running_requests(), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`MlxModelRunnerStub._resolve_max_running_requests` splits the requested concurrency across dp workers via `self.dp_size`. But the base `ModelRunner` only ever sets `dcp_size` (never `dp_size`), and the MLX stub overrides `initialize()` without calling `super().initialize()`, so `self.dp_size` is never assigned. Serving with `--max-running-requests` therefore crashes at startup:

```
File ".../hardware_backend/mlx/model_runner_stub.py", line 173, in _resolve_max_running_requests
    requested_per_worker = requested // self.dp_size
AttributeError: 'MlxModelRunnerStub' object has no attribute 'dp_size'. Did you mean: 'dcp_size'?
```

This breaks **every** MLX e2e correctness test (`test_qwen2_moe_mlx_correctness`, `test_qwen3_moe_mlx_correctness`, the `test_mlx_reference_correctness` suite) since they all pass `--max-running-requests 1`. It went unnoticed because the macOS MLX CI lane is gated behind `workflow_dispatch` (roadmap #19137, "CI → self-hosted macOS runners" is still pending).

Discovered while wiring up Hunyuan correctness coverage for #19137.

## Modifications

`python/sglang/srt/hardware_backend/mlx/model_runner_stub.py`: set `self.dp_size = self.server_args.dp_size` in `initialize()` before `_resolve_max_running_requests()` runs. This mirrors how the CUDA-side runners derive the value (`base_runner.py:200`, `cpu_graph_runner.py:588`, `prefill_cuda_graph_runner.py:254` all read `server_args.dp_size`). The base `ModelRunner` never sets `dp_size`, so the stub — which skips `super().initialize()` — must set it itself.

No behavior change for the `--max-running-requests`-unset path.

## Test

- Added `test_initialize_sets_dp_size_for_max_running_requests` to `test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py`: asserts `initialize()` sets `dp_size` from `server_args`, and `_resolve_max_running_requests` divides the requested cap across dp workers (`4 // dp_size 2 == 2`) instead of raising `AttributeError`. Full file: 4/4 pass on Apple Silicon.
- End-to-end on M2 Max (mlx 0.32.0, mlx-lm 0.31.3): serving `mlx-community/Hunyuan-7B-Instruct-4bit` previously crashed in `Scheduler.init_tp_model_worker` with the `AttributeError` above before model load completed; with the fix the stub initializes cleanly:
  ```
  MLX stub: initialized minimal pools (max_total_num_tokens=45439, max_running_requests=1, ...)
  ```

## Out of scope (follow-up)

Hunyuan's `auto_map` (`modeling_hunyuan.py`) still fails during `kv_cache_builder.build_kv_cache` → `resolve_transformers_arch` on the MLX path, so Hunyuan cannot yet be served end-to-end. I will file a separate issue; the Hunyuan MLX correctness test waits on that.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [ ] Update documentation (N/A — bug fix)
- [x] Accuracy/speed benchmarks (N/A — startup crash fix, no perf-path change)
- [x] Follow SGLang code style guidance

cc @yeahdongcn @jonahbernard @jlee5814

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30261702797](https://github.com/sgl-project/sglang/actions/runs/30261702797)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30261702604](https://github.com/sgl-project/sglang/actions/runs/30261702604)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->