### PR TITLE
[WIP][Spec] Enable Two-Batch Overlap in Draft Models

### DIFF
--- a/python/sglang/srt/batch_overlap/operations_strategy.py
+++ b/python/sglang/srt/batch_overlap/operations_strategy.py
@@ -96,8 +96,33 @@ def _compute_moe_deepseek_layer_operations_strategy_tbo(
         forward_mode == ForwardMode.DECODE or forward_mode == ForwardMode.TARGET_VERIFY
     ):
         return _compute_moe_deepseek_blog_decode(layer)
+    elif forward_mode == ForwardMode.DRAFT_EXTEND_V2:
+        return _compute_moe_deepseek_draft_extend(layer)
     else:
         raise NotImplementedError(f"Unsupported {forward_mode=}")
+
+
+def _compute_moe_deepseek_draft_extend(layer):
+    """Draft-extend (#7892): the decode op order plus the DSA seed-topk channel.
+
+    The plain decode strategy discards the topk that forward_core returns
+    (target TBO never relays it), but NextN's draft-extend must publish it as
+    the next draft loop's seed. Swap in the topk-keeping attn core and capture
+    the seed right after it, in the same stage, so the state key is consumed
+    before op_comm_postprocess_layer's state.clear.
+    """
+    from sglang.srt.batch_overlap.two_batch_overlap import op_capture_dsa_seed_topk
+
+    base = _compute_moe_deepseek_blog_decode(layer)
+    ops = list[Operation](base.operations)
+    core_index = ops.index(layer.self_attn.op_core)
+    ops[core_index] = layer.self_attn.op_core_with_topk
+    ops.insert(core_index + 1, op_capture_dsa_seed_topk)
+    return OperationsStrategy(
+        deep_gemm_num_sms=base.deep_gemm_num_sms,
+        tbo_delta_stages=base.tbo_delta_stages,
+        operations=ops,
+    )
 
 
 def _compute_moe_deepseek_blog_prefill(layer):

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -46,7 +46,10 @@ from sglang.srt.utils import BumpAllocator, empty_context, get_bool_env_var, is_
 if TYPE_CHECKING:
     from sglang.srt.batch_overlap.single_batch_overlap import CombineOverlapArgs
     from sglang.srt.layers.moe.token_dispatcher import DispatchOutput
-    from sglang.srt.speculative.eagle_info import EagleVerifyInput
+    from sglang.srt.speculative.eagle_info import (
+        EagleDraftExtendInput,
+        EagleVerifyInput,
+    )
 
 _is_hip = is_hip()
 
@@ -64,6 +67,8 @@ def get_token_num_per_seq(
 ):
     if forward_mode.is_target_verify():
         return spec_info.draft_token_num
+    elif forward_mode.is_draft_extend_v2():
+        return spec_info.num_tokens_per_req
     elif forward_mode.is_decode():
         return 1
     elif forward_mode.is_idle():
@@ -83,7 +88,11 @@ def compute_split_seq_index(
     if forward_mode == ForwardMode.EXTEND or forward_mode == ForwardMode.MIXED:
         assert extend_lens is not None
         return _split_extend_seqs(extend_lens)
-    elif forward_mode.is_target_verify() or forward_mode.is_decode():
+    elif (
+        forward_mode.is_target_verify()
+        or forward_mode.is_decode()
+        or forward_mode.is_draft_extend_v2()
+    ):
         assert token_num_per_seq is not None
         return (num_tokens // token_num_per_seq) // 2
     elif forward_mode.is_idle() or forward_mode.is_prebuilt():
@@ -209,7 +218,7 @@ def _compute_mask_offset(seq_index: int, spec_info: Optional[EagleVerifyInput]) 
 
 
 def split_spec_info(
-    spec_info: Optional[EagleVerifyInput],
+    spec_info: EagleVerifyInput | EagleDraftExtendInput | None,
     start_seq_index: int,
     end_seq_index: int,
     start_token_index: int,
@@ -217,6 +226,18 @@ def split_spec_info(
 ):
     if spec_info is None:
         return None
+
+    from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+
+    if isinstance(spec_info, EagleDraftExtendInput):
+        return _split_draft_extend_spec_info(
+            spec_info=spec_info,
+            start_seq_index=start_seq_index,
+            end_seq_index=end_seq_index,
+            start_token_index=start_token_index,
+            end_token_index=end_token_index,
+        )
+
     if spec_info.draft_token is not None:
         draft_token = spec_info.draft_token[start_token_index:end_token_index]
     else:
@@ -282,6 +303,112 @@ def split_spec_info(
     return output_spec_info
 
 
+# EagleDraftExtendInput split taxonomy (fixed-width draft-extend). Every
+# declared or instance-attached field must appear in exactly one bucket here
+# or in the special-cased set inside _split_draft_extend_spec_info — unlisted
+# fields fail loudly there, forcing new fields to pick a split rule.
+_DRAFT_EXTEND_TOKEN_FIELDS = ("input_ids", "positions", "hidden_states")
+_DRAFT_EXTEND_SEQ_FIELDS = (
+    "num_correct_drafts",
+    "num_accept_tokens",
+    "seq_lens",
+    "seq_lens_cpu",
+    "req_pool_indices",
+    "bonus_tokens",
+)
+_DRAFT_EXTEND_SCALAR_FIELDS = (
+    "num_front_tokens",
+    "capture_hidden_mode",
+    "num_tokens_per_req",
+    "num_tokens_for_logprob_per_req",
+)
+_DRAFT_EXTEND_SPECIAL_FIELDS = (
+    "num_accept_tokens_cpu",
+    "kv_indptr",
+    "select_index",
+    "dsa_seed_topk_select",
+    "dsa_seed_topk_capture",
+)
+
+
+def _split_draft_extend_spec_info(
+    spec_info: "EagleDraftExtendInput",
+    start_seq_index: int,
+    end_seq_index: int,
+    start_token_index: int,
+    end_token_index: int,
+):
+    width = spec_info.num_tokens_per_req
+    assert width > 0, f"draft-extend split needs a positive width, got {width=}"
+    # Widening (num_front_tokens > 0) makes the real per-req row count
+    # num_draft_tokens + front — a different width than num_tokens_per_req —
+    # so this fixed-width split would silently mis-slice. No TBO-wrapped
+    # worker widens today (only the multi-layer worker does, without the
+    # wrap); fail loudly so a future multi-layer enablement implements
+    # widening-aware slicing first instead of corrupting requests.
+    assert spec_info.num_front_tokens == 0, f"{spec_info.num_front_tokens=}"
+    # Fixed width: the request-ruler cut and the token-ruler cut must be the
+    # same knife position, or token and request fields would desynchronize.
+    # The parent's END may exceed batch_size * width by a sub-request tail:
+    # attn-tp alignment can pad input_ids (e.g. width=3, 15 tokens -> 16)
+    # with rows that belong to no request, and prepare_mlp_sync_batch floors
+    # batch_size to padded_len // width — so the excess is always < width.
+    # Child B absorbs those rows (token slices clamp to real tensor lengths).
+    assert start_token_index == start_seq_index * width and (
+        0 <= end_token_index - end_seq_index * width < width
+    ), f"{start_seq_index=} {end_seq_index=} {start_token_index=} {end_token_index=} {width=}"
+
+    # Fail loudly on any field without a split rule: silently dropping or
+    # mis-slicing one corrupts requests instead of crashing.
+    handled = (
+        set(_DRAFT_EXTEND_TOKEN_FIELDS)
+        | set(_DRAFT_EXTEND_SEQ_FIELDS)
+        | set(_DRAFT_EXTEND_SCALAR_FIELDS)
+        | set(_DRAFT_EXTEND_SPECIAL_FIELDS)
+    )
+    declared = {field.name for field in dataclasses.fields(spec_info)}
+    unhandled = (declared | set(vars(spec_info))) - handled - {"spec_input_type"}
+    assert not unhandled, f"unclassified EagleDraftExtendInput fields: {unhandled}"
+
+    updates = {}
+    for name in _DRAFT_EXTEND_TOKEN_FIELDS:
+        value = getattr(spec_info, name)
+        if value is not None:
+            updates[name] = value[start_token_index:end_token_index]
+    for name in _DRAFT_EXTEND_SEQ_FIELDS:
+        value = getattr(spec_info, name)
+        if value is not None:
+            updates[name] = value[start_seq_index:end_seq_index]
+    # Scalars (_DRAFT_EXTEND_SCALAR_FIELDS) carry over via replace() unchanged.
+
+    if spec_info.num_accept_tokens_cpu is not None:
+        updates["num_accept_tokens_cpu"] = spec_info.num_accept_tokens_cpu[
+            start_seq_index:end_seq_index
+        ]
+    if spec_info.kv_indptr is not None:
+        # Cumulative array: take bs+1 entries and rebase to the child's origin.
+        kv_indptr = spec_info.kv_indptr[start_seq_index : end_seq_index + 1]
+        updates["kv_indptr"] = kv_indptr - kv_indptr[0]
+    # Per-request values that point at flat token rows: slice by request,
+    # then shift into the child's token coordinate system.
+    if spec_info.select_index is not None:
+        updates["select_index"] = (
+            spec_info.select_index[start_seq_index:end_seq_index] - start_token_index
+        )
+    if spec_info.dsa_seed_topk_select is not None:
+        updates["dsa_seed_topk_select"] = (
+            spec_info.dsa_seed_topk_select[start_seq_index:end_seq_index]
+            - start_token_index
+        )
+    if spec_info.dsa_seed_topk_capture is not None:
+        # Output buffer: keep it a VIEW so child writes land in the parent.
+        updates["dsa_seed_topk_capture"] = spec_info.dsa_seed_topk_capture[
+            start_token_index:end_token_index
+        ]
+
+    return replace(spec_info, **updates)
+
+
 def compute_split_token_index(
     split_seq_index: int,
     forward_mode: ForwardMode,
@@ -293,7 +420,11 @@ def compute_split_token_index(
         if _is_two_chunk_split_enabled(extend_seq_lens):
             return sum(extend_seq_lens) // 2
         return sum(extend_seq_lens[:split_seq_index])
-    elif forward_mode.is_target_verify() or forward_mode.is_decode():
+    elif (
+        forward_mode.is_target_verify()
+        or forward_mode.is_decode()
+        or forward_mode.is_draft_extend_v2()
+    ):
         assert token_num_per_seq is not None
         return split_seq_index * token_num_per_seq
     elif forward_mode.is_idle():
@@ -502,7 +633,14 @@ class TboDPAttentionPreparer:
 class TboForwardBatchPreparer:
     @classmethod
     def prepare(cls, batch: ForwardBatch, is_draft_worker: bool = False):
-        if batch.tbo_split_seq_index is None or is_draft_worker:
+        if batch.tbo_split_seq_index is None:
+            return
+        if is_draft_worker and not cls._should_prepare_draft_extend_children(
+            forward_mode=batch.forward_mode,
+            global_forward_mode=batch.global_forward_mode,
+            spec_info=batch.spec_info,
+            attn_backend=get_attn_backend(),
+        ):
             return
 
         tbo_children_num_token_non_padded = (
@@ -510,6 +648,45 @@ class TboForwardBatchPreparer:
         )
         cls.prepare_raw(
             batch, tbo_children_num_token_non_padded=tbo_children_num_token_non_padded
+        )
+
+    @staticmethod
+    def _should_prepare_draft_extend_children(
+        *,
+        forward_mode: ForwardMode,
+        global_forward_mode: Optional[ForwardMode],
+        spec_info: Optional[SpecInput],
+        attn_backend,
+    ) -> bool:
+        """Draft-worker gate for TBO children (#7892).
+
+        Only fixed-width draft-extend batches split; draft multi-step decode
+        forwards (mode DECODE, EagleDraftInput spec_info) stay monolithic. The
+        worker opts in by wrapping its draft-extend backend in TboAttnBackend,
+        so the backend type doubles as the configuration-static capability
+        signal (model arch, TBO flag, and the draft-extend-graph env are all
+        decided at that wrap site); prepare_raw asserts on that backend type,
+        so gating on it also keeps the assert unreachable while closed.
+        Idle draft-extend ranks must also split ([0, 0] children) so every DP
+        rank runs the same two dispatch/combine collectives (P0-3) — but only
+        under a global DECODE ticket. During a prefill step the active draft
+        ranks run draft-extend as plain EXTEND (monolithic, one dispatch), so
+        an idle rank splitting there would run two collectives against their
+        one and hang the EP group.
+        """
+        from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
+        from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+
+        if not isinstance(attn_backend, TboAttnBackend):
+            return False
+        if not isinstance(spec_info, EagleDraftExtendInput):
+            return False
+        if forward_mode.is_draft_extend_v2():
+            return True
+        return (
+            forward_mode.is_idle()
+            and global_forward_mode is not None
+            and global_forward_mode.is_decode()
         )
 
     @classmethod
@@ -557,10 +734,20 @@ class TboForwardBatchPreparer:
             ),
             out_num_token_non_padded=out_num_token_non_padded_a,
         )
+        if batch.forward_mode.is_draft_extend_v2():
+            # Draft-extend's spec tensors are sized to the real bs * width
+            # rows, while input_ids may carry an attn-TP padding tail. The
+            # padded tail must not leak into child_b's slice — children carry
+            # only real rows and re-pad for themselves.
+            end_token_index_b = batch.batch_size * get_token_num_per_seq(
+                forward_mode=batch.forward_mode, spec_info=batch.spec_info
+            )
+        else:
+            end_token_index_b = batch.input_ids.shape[0]
         child_b = cls.filter_batch(
             batch,
             start_token_index=tbo_split_token_index,
-            end_token_index=batch.input_ids.shape[0],
+            end_token_index=end_token_index_b,
             start_seq_index=batch.tbo_split_seq_index,
             end_seq_index=batch.batch_size,
             out_num_token_non_padded=out_num_token_non_padded_b,
@@ -701,6 +888,25 @@ class TboForwardBatchPreparer:
             ):
                 output_dict[key] = None
                 continue
+            elif key == "extend_start_loc" and batch.forward_mode.is_draft_extend_v2():
+                # Fixed-width draft-extend: rebuild the child's flat-token
+                # offsets (arange * width) rather than slicing the parent's.
+                # The parent copy holds PARENT coordinates, and DP MAX_LEN
+                # padding can grow batch_size without extending per-seq
+                # metadata like this one — a slice would then be short or
+                # stale, while the rebuild is exact for any child size.
+                width = get_token_num_per_seq(
+                    forward_mode=batch.forward_mode, spec_info=batch.spec_info
+                )
+                output_dict[key] = (
+                    torch.arange(
+                        end_seq_index - start_seq_index,
+                        dtype=old_value.dtype,
+                        device=old_value.device,
+                    )
+                    * width
+                )
+                continue
             elif key == "rids" and len(old_value) != num_seqs:
                 output_dict[key] = old_value[
                     start_seq_index : min(end_seq_index, len(old_value))
@@ -746,7 +952,13 @@ class TboForwardBatchPreparer:
         else:
             output_dict["mrope_positions"] = None
 
-        if not batch.forward_mode.is_target_verify():
+        # Uniform-width spec parents (target-verify, draft-extend) may carry an
+        # attn-TP padding tail in input_ids that extend_num_tokens excludes,
+        # so the row-count identity only holds for the other modes.
+        if not (
+            batch.forward_mode.is_target_verify()
+            or batch.forward_mode.is_draft_extend_v2()
+        ):
             assert (
                 _compute_extend_num_tokens(batch.input_ids, batch.forward_mode)
                 == batch.extend_num_tokens
@@ -857,12 +1069,43 @@ def _compute_extend_num_tokens(input_ids, forward_mode: ForwardMode):
         or forward_mode.is_target_verify()
     ):
         return None
-    elif forward_mode.is_extend():
+    elif forward_mode.is_extend(include_draft_extend_v2=True):
+        # Draft-extend children mirror the parent's extend_num_tokens
+        # (= bs * num_tokens_per_req) with their own slice's token count.
         return input_ids.shape[0]
     raise NotImplementedError
 
 
 # -------------------------------- Execution ---------------------------------------
+
+
+def op_capture_dsa_seed_topk(state):
+    """Draft-extend TBO op: publish the DSA seed topk through spec_info.
+
+    Mirrors the tail of ``DeepseekModelNextN.forward``. Under TBO each child's
+    ``spec_info`` holds a *view* slice of the parent's capture buffer (and a
+    rebased ``dsa_seed_topk_select``), so writing through the child lands in
+    the parent rows exactly like the monolithic write. No-op when the batch
+    did not request a seed capture (non-DSA, or the graph path owns the
+    buffer).
+    """
+    topk_indices = state.pop("topk_indices_after_attn")
+    spec_info = state.forward_batch.spec_info
+    seed_buf = spec_info.dsa_seed_topk_capture if spec_info is not None else None
+    if seed_buf is None or topk_indices is None:
+        return
+    # The reuse channel belongs to the draft multi-step decode loop
+    # (eagle_worker_v2 toggles it around that loop only); a draft-extend
+    # forward never sets it, so this op does not implement that write-back.
+    assert not state.forward_batch.reuse_dsa_topk_indices
+    # Decode-path draft-extend leaves select None (the worker gathers rows
+    # post-forward via select_index) and sizes the buffer per token, which is
+    # what makes the per-child view write equal the monolithic write. A
+    # non-None select implies the prefill capture layout ((bs, k) buffer),
+    # whose write targets the TBO split does not preserve — fail loud.
+    assert spec_info.dsa_seed_topk_select is None
+    src = topk_indices[: seed_buf.shape[0]]
+    seed_buf[: src.shape[0]].copy_(src)
 
 
 def model_forward_maybe_tbo(
@@ -874,6 +1117,8 @@ def model_forward_maybe_tbo(
     input_data_scatter_mode: ScatterMode,
     residual: Optional[torch.Tensor],
     zero_allocator: Optional[BumpAllocator] = None,
+    *,
+    strategy_forward_mode: Optional[ForwardMode] = None,
 ):
     inputs = dict(
         positions=positions,
@@ -883,8 +1128,14 @@ def model_forward_maybe_tbo(
         zero_allocator=zero_allocator,
     )
     layer_input_scatter_mode = layers[0].layer_scatter_modes.layer_input_mode
+    if strategy_forward_mode is None:
+        # Cross-rank agreed mode from the DP vote. Idle ranks must build the
+        # same op list as active ranks, hence global rather than local mode.
+        # Call sites whose phase the vote cannot express (draft-extend runs
+        # under a DECODE ticket) pass their mode explicitly.
+        strategy_forward_mode = forward_batch.global_forward_mode
     operations_strategy = OperationsStrategy.init_new_tbo(
-        layers, forward_batch.global_forward_mode
+        layers=layers, forward_mode=strategy_forward_mode
     )
     if enable_tbo:
         return _model_forward_tbo(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1402,6 +1402,20 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     model_runner, child.tbo_padded_len, child.batch_size
                 )
 
+        self._plan_tbo_children_if_preplanned(model_runner.attn_backend)
+
+    def _plan_tbo_children_if_preplanned(self, attn_backend) -> None:
+        if not (self.tbo_children and self.forward_metadata_ready):
+            return
+        from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
+
+        assert isinstance(attn_backend, TboAttnBackend)
+        for child_backend, child in zip(
+            attn_backend.children, self.tbo_children, strict=True
+        ):
+            if child.batch_size > 0:
+                child_backend.init_forward_metadata(forward_batch=child)
+
     def _pad_inputs_to_size(self, model_runner: ModelRunner, num_tokens, bs):
         # padding
         self._original_num_tokens = self.positions.shape[0]

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -25,6 +25,7 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from sglang.kernels.ops.layernorm.fused_eh_norm import fused_eh_norm
+from sglang.srt.batch_overlap.two_batch_overlap import model_forward_maybe_tbo
 from sglang.srt.configs.model_config import is_deepseek_dsa
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.environ import envs
@@ -55,7 +56,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding,
     get_embedding_tp_kwargs,
 )
-from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.models.deepseek_common.utils import enable_nextn_moe_bf16_cast_to_fp8
 from sglang.srt.models.deepseek_v2 import DeepseekV2DecoderLayer, DeepseekV3ForCausalLM
 from sglang.srt.models.utils import WeightsMapper
@@ -190,6 +191,55 @@ class DeepseekModelNextN(nn.Module):
         self.shared_head = nn.Module()
         self.shared_head.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
+    def _forward_decoder(
+        self,
+        *,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+        zero_allocator: BumpAllocator,
+        use_cp_v1: bool,
+    ):
+        """Run the single decoder layer, TBO-split or monolithic.
+
+        Returns (hidden_states, residual, topk_indices). On the TBO path
+        topk_indices is None: the DSA seed is published inside
+        op_capture_dsa_seed_topk (each child writes its view slice of the
+        parent capture buffer), so nothing flows back to forward()'s tail.
+        """
+        if forward_batch.tbo_children is not None:
+            # Draft-extend TBO (#7892): run the two micro-batches interleaved
+            # through the op pipeline.
+            assert not use_cp_v1
+            assert not forward_batch.reuse_dsa_topk_indices
+            hidden_states, residual = model_forward_maybe_tbo(
+                layers=[self.decoder],
+                enable_tbo=True,
+                positions=positions,
+                forward_batch=forward_batch,
+                hidden_states=hidden_states,
+                input_data_scatter_mode=(
+                    self.decoder.layer_scatter_modes.layer_input_mode
+                ),
+                residual=residual,
+                zero_allocator=zero_allocator,
+                strategy_forward_mode=ForwardMode.DRAFT_EXTEND_V2,
+            )
+            return hidden_states, residual, None
+        return self.decoder(
+            positions,
+            hidden_states,
+            forward_batch,
+            residual,
+            zero_allocator,
+            prev_topk_indices=(
+                forward_batch.spec_info.dsa_topk_indices
+                if forward_batch.reuse_dsa_topk_indices
+                else None
+            ),
+        )
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -211,7 +261,10 @@ class DeepseekModelNextN(nn.Module):
 
         try:
             zero_allocator = BumpAllocator(
-                buffer_size=2,
+                # 2 per layer per micro-batch; under TBO both children draw
+                # from this allocator (same formula as DeepseekV2Model.forward
+                # with total_num_layers=1).
+                buffer_size=2 * (2 if forward_batch.can_run_tbo else 1),
                 dtype=torch.float32,
                 device=(
                     input_embeds.device
@@ -270,17 +323,13 @@ class DeepseekModelNextN(nn.Module):
                 forward_batch.reuse_dsa_topk_indices or seed_buf is not None
             )
             with get_global_expert_distribution_recorder().disable_this_region():
-                hidden_states, residual, topk_indices = self.decoder(
-                    positions,
-                    hidden_states,
-                    forward_batch,
-                    residual,
-                    zero_allocator,
-                    prev_topk_indices=(
-                        forward_batch.spec_info.dsa_topk_indices
-                        if forward_batch.reuse_dsa_topk_indices
-                        else None
-                    ),
+                hidden_states, residual, topk_indices = self._forward_decoder(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    forward_batch=forward_batch,
+                    residual=residual,
+                    zero_allocator=zero_allocator,
+                    use_cp_v1=use_cp_v1,
                 )
             if not forward_batch.forward_mode.is_idle():
                 if residual is not None:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1879,6 +1879,18 @@ class DeepseekV2AttentionMLA(
         else:
             state.hidden_states_after_attn = result
 
+    def op_core_with_topk(self, state):
+        # op_core variant for the draft-extend TBO strategy: keep the DSA seed
+        # topk for op_capture_dsa_seed_topk (which pops the key) instead of
+        # discarding it. NextN publishes it into spec_info's capture buffer;
+        # there is no next layer, so no cross-layer relay is involved.
+        result = self.forward_core(state.pop("attn_intermediate_state"))
+        if isinstance(result, tuple):
+            state.hidden_states_after_attn, state.topk_indices_after_attn = result
+        else:
+            state.hidden_states_after_attn = result
+            state.topk_indices_after_attn = None
+
     def forward(
         self,
         positions: torch.Tensor,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -366,6 +366,51 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             draft_backend_factory.create_draft_extend_backend()
         )
 
+        # Draft-extend TBO (#7892): split fixed-width draft-extend batches into
+        # two micro-batches so each deepep dispatch stays under the per-rank
+        # token cap. Gated on the draft-extend cuda graph being disabled (the
+        # graph runner cannot consume tbo_children yet), so default-config
+        # behavior is unchanged. The wrapped backend type is what opens
+        # TboForwardBatchPreparer's draft gate.
+        from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
+        from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
+        from sglang.srt.layers.moe.utils import (
+            get_speculative_moe_a2a_backend,
+            is_tbo_enabled,
+        )
+        from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
+        from sglang.srt.models.deepseek_nextn import DeepseekV3ForCausalLMNextN
+
+        self.enable_draft_extend_tbo = (
+            is_tbo_enabled()
+            and envs.SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH.get()
+            and self.draft_extend_attn_backend is not None
+            and isinstance(self.draft_runner.model, DeepseekV3ForCausalLMNextN)
+            # The decode op list runs op_dispatch_a/b; the draft MoE must own
+            # a segmented-A2A dispatcher. speculative_moe_a2a_backend may
+            # resolve to "none" (StandardDispatcher) even when the target
+            # runs deepep — TBO cannot drive that draft MoE.
+            and not get_speculative_moe_a2a_backend().is_none()
+            # Prefill-CP flips model_input_output() to SCATTERED, which would
+            # route the TBO splitter's residual=None through an unproven
+            # gather path; the split assumes the TP_ATTN_FULL regime.
+            and not is_dsa_enable_prefill_cp()
+            and not is_mla_prefill_cp_enabled()
+        )
+        if self.enable_draft_extend_tbo:
+            self.draft_extend_attn_backend = TboAttnBackend(
+                primary=self.draft_extend_attn_backend,
+                children=[
+                    draft_backend_factory.create_draft_extend_backend()
+                    for _ in range(2)
+                ],
+            )
+            log_info_on_rank0(
+                logger,
+                "Draft-extend TBO enabled: draft-extend attn backend wrapped in "
+                "TboAttnBackend",
+            )
+
         self.draft_runner.draft_attn_backend = self.draft_attn_backend
         if self.draft_extend_attn_backend is not None:
             self.draft_runner.attn_backend = self.draft_extend_attn_backend

--- a/test/registered/ep/test_deepep_mtp_draft_extend_tbo.py
+++ b/test/registered/ep/test_deepep_mtp_draft_extend_tbo.py
@@ -1,0 +1,278 @@
+"""Two-batch overlap on the *draft-extend* forward (issue #7892), end to end.
+
+`TestMTPWithTBO` in `test_deepep_small.py` already covers MTP + TBO with the
+draft-extend forward running **monolithic** -- only the target's prefill and
+target-verify forwards split. This file runs the same model, parallelism and
+speculative config with `SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH=1`, which is
+what opens the draft worker's TBO gate and makes the NextN draft-extend forward
+split into two micro-batches as well. The two files are an A/B pair over one env
+var, and `TestMTPWithTBO` is the baseline -- which is why no second server is
+launched here.
+
+WHAT THIS FILE PROVES, AND HOW
+------------------------------
+Coverage is not asserted by prose, it is **measured**: `SGLANG_TBO_DEBUG=1`
+makes `TboForwardBatchPreparer.prepare_raw` -- the function reached only after
+both TBO gates pass -- log one line per split batch carrying its forward mode.
+`test_tbo_split_forward_mode_census` parses every one of those lines, prints the
+full census, and requires the modes this feature spans. So a run either shows
+you which phases really split, or fails; it never silently degrades into
+testing the monolithic path.
+
+WHAT THIS FILE DOES *NOT* COVER (measure these elsewhere)
+--------------------------------------------------------
+1. **The DSA seed-topk channel** (`op_capture_dsa_seed_topk`,
+   `dsa_seed_topk_capture` / `dsa_seed_topk_select` slicing). `is_deepseek_dsa`
+   additionally requires `index_topk` in the HF config, which plain DeepSeek-V3
+   does not have. On a non-DSA model the seed buffer is None and that op is a
+   no-op. Only the CPU unit tests exercise it, on synthetic tensors.
+2. **The attn-TP padding tail** (the `end_token_index_b` clamp and the relaxed
+   `extend_num_tokens` identity). Here `attn_tp_size = tp_size // dp_size = 1`,
+   so `input_ids` never carries a padding tail.
+3. **The idle-rank arm of the gate.** It needs a DP rank to actually go idle
+   while others run draft-extend; steady traffic does not guarantee that. The
+   gate's positive and negative branches are pinned deterministically by
+   `test/registered/unit/batch_overlap/test_tbo_draft_extend_split.py`
+   (`TestDraftExtendChildrenGate`) instead.
+
+Admission notes (`.claude/rules/unit-test-admission.md`): the census case is a
+**completeness contract** -- the gate is a six-term AND over configuration-static
+facts, and if any term degrades (e.g. `speculative_moe_a2a_backend` stops
+inheriting the target's `deepep` default) the feature turns off while gsm8k
+still passes, because monolithic draft-extend is exactly what main does today.
+The accept-length floor is the **derived property**: mis-slice `hidden_states`,
+`select_index` or `kv_indptr` and the target still verifies correctly -- accuracy
+survives -- while draft quality collapses and accept length falls toward 1.0.
+Accuracy alone cannot see that; the accept-length floor is the guard for the
+split math.
+"""
+
+import os
+import re
+import unittest
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_MODEL_NAME_FOR_TEST_MLA,
+    DEFAULT_MODEL_NAME_FOR_TEST_MLA_NEXTN,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=420, stage="base-c", runner_config="deepep-4-gpu-h100")
+
+STDOUT_FILENAME = "stdout_deepep_mtp_draft_extend_tbo.txt"
+STDERR_FILENAME = "stderr_deepep_mtp_draft_extend_tbo.txt"
+
+# Emitted once per launch by EagleDraftWorker.__init__ when the gate opens.
+GATE_BANNER = "Draft-extend TBO enabled"
+
+# One line per *split* batch, logged from inside prepare_raw. ForwardMode is an
+# IntEnum, so the f-string renders the value, not the name -- map it back through
+# the enum rather than hardcoding numbers, so a renumbering cannot turn this into
+# a silent match against the wrong mode.
+_SPLIT_LOG_RE = re.compile(r"TboForwardBatchPreparer\.prepare\b.*?forward_mode=(\d+)")
+
+# The phases this feature spans, and why each must appear:
+#   TARGET_VERIFY   -- the target's decode-phase forward. Proves TBO is live
+#                      end-to-end under speculative decoding (baseline behavior).
+#   DRAFT_EXTEND_V2 -- the forward #7892 adds. Proves the draft worker's gate
+#                      opened AND a draft-extend batch reached prepare_raw.
+# The draft multi-step decode loop must NOT appear: it carries EagleDraftInput,
+# not EagleDraftExtendInput, so the gate closes on it. That negative branch is
+# not assertable from logs (a draft DECODE and a target DECODE render the same
+# integer), so it is pinned by TestDraftExtendChildrenGate on CPU instead; here
+# the DECODE count is only reported.
+REQUIRED_SPLIT_MODES = (ForwardMode.TARGET_VERIFY, ForwardMode.DRAFT_EXTEND_V2)
+
+
+class TestMTPDraftExtendTBO(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stdout = open(STDOUT_FILENAME, "w")
+        cls.stderr = open(STDERR_FILENAME, "w")
+
+        cls.model = DEFAULT_MODEL_NAME_FOR_TEST_MLA
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "4",
+                "--enable-dp-attention",
+                "--dp-size",
+                "4",
+                "--enable-two-batch-overlap",
+                "--moe-a2a-backend",
+                "deepep",
+                "--trust-remote-code",
+                "--speculative-algorithm",
+                "EAGLE",
+                "--speculative-num-steps",
+                "2",
+                "--speculative-eagle-topk",
+                "3",
+                "--speculative-num-draft-tokens",
+                "3",
+                "--speculative-draft-model-path",
+                DEFAULT_MODEL_NAME_FOR_TEST_MLA_NEXTN,
+                "--chunked-prefill-size",
+                "256",
+                "--cuda-graph-max-bs-decode",
+                "32",
+                "--max-running-requests",
+                "128",
+            ],
+            env={
+                **os.environ,
+                "SGLANG_TBO_DEBUG": "1",
+                # The draft-extend cuda graph runner cannot consume tbo_children,
+                # so the gate requires the graph to be off. This is the single
+                # env var that separates this test from TestMTPWithTBO.
+                "SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH": "1",
+            },
+            return_stdout_stderr=(cls.stdout, cls.stderr),
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "process", None):
+            kill_process_tree(cls.process.pid)
+        for handle in (getattr(cls, "stdout", None), getattr(cls, "stderr", None)):
+            if handle:
+                handle.close()
+
+    @staticmethod
+    def _read_server_logs() -> str:
+        """Both streams: the banner and the TBO debug lines are logger output,
+        whose stream depends on the logging config, so never assume one file."""
+        chunks = []
+        for name in (STDOUT_FILENAME, STDERR_FILENAME):
+            if os.path.exists(name):
+                with open(name, errors="replace") as f:
+                    chunks.append(f.read())
+        return "\n".join(chunks)
+
+    @classmethod
+    def _split_mode_census(cls) -> Counter:
+        """How many batches of each forward mode actually got TBO-split."""
+        census = Counter()
+        for raw in _SPLIT_LOG_RE.findall(cls._read_server_logs()):
+            try:
+                census[ForwardMode(int(raw))] += 1
+            except ValueError:
+                census[f"unknown({raw})"] += 1
+        return census
+
+    def _drive_decode_traffic(self, num_requests: int = 32) -> None:
+        """Generate decode rounds with a batch big enough to actually split.
+
+        The split index is `bs // 2` *per DP rank*, so with dp_size=4 a handful
+        of requests can leave a rank with bs=1 and an empty child A. 32 in
+        flight keeps every rank above that.
+        """
+
+        def _one(i: int):
+            response = requests.post(
+                self.base_url + "/generate",
+                json={
+                    "text": f"Question {i}: describe the water cycle step by step.",
+                    "sampling_params": {"max_new_tokens": 64, "temperature": 0},
+                },
+                timeout=180,
+            )
+            self.assertEqual(response.status_code, 200)
+
+        with ThreadPoolExecutor(max_workers=num_requests) as pool:
+            list(pool.map(_one, range(num_requests)))
+
+    def test_draft_extend_tbo_gate_opened(self):
+        """The six-term gate in EagleDraftWorker.__init__ actually opened.
+
+        Needs no traffic -- the banner is emitted at worker init. Kept separate
+        from the census so a closed gate is distinguishable from a gate that
+        opened but never saw a draft-extend batch.
+        """
+        self.assertIn(
+            GATE_BANNER,
+            self._read_server_logs(),
+            "draft-extend TBO never engaged: the gate stayed closed at worker "
+            "init, so this run is exercising the monolithic path. Check the TBO "
+            "flag, SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH, the NextN draft model "
+            "class, and that speculative_moe_a2a_backend still inherits the "
+            "target's deepep default.",
+        )
+
+    def test_tbo_split_forward_mode_census(self):
+        """Measure which forward modes really produced two micro-batches.
+
+        This is the coverage proof for the whole file. `prepare_raw` is reached
+        only after `tbo_split_seq_index` is non-None *and* (for the draft worker)
+        the draft-extend gate opens, so one debug line per mode is direct
+        evidence that phase split -- not an inference from accuracy holding up.
+        """
+        self._drive_decode_traffic()
+
+        census = self._split_mode_census()
+        print("\n###TBO split census (forward mode -> number of split batches):")
+        for mode, count in sorted(census.items(), key=lambda kv: str(kv[0])):
+            name = mode.name if isinstance(mode, ForwardMode) else str(mode)
+            print(f"    {name:<16} {count}")
+        print(
+            f"    (DECODE reported only; the draft decode loop must stay "
+            f"monolithic, which TestDraftExtendChildrenGate pins on CPU)\n"
+        )
+
+        missing = [m.name for m in REQUIRED_SPLIT_MODES if census[m] == 0]
+        self.assertFalse(
+            missing,
+            f"these forward modes never split: {missing}. Modes seen: "
+            f"{ {getattr(m, 'name', m): c for m, c in census.items()} }. "
+            f"DRAFT_EXTEND_V2 missing means #7892's path did not run; "
+            f"TARGET_VERIFY missing means TBO itself is not engaging and the "
+            f"whole comparison against TestMTPWithTBO is void.",
+        )
+
+    def test_gsm8k_accuracy_and_accept_length(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(metrics)
+
+        server_info = requests.get(self.base_url + "/server_info")
+        avg_spec_accept_length = server_info.json()["internal_states"][0][
+            "avg_spec_accept_length"
+        ]
+        print(
+            f"###test_gsm8k (deepseek-v3 mtp + dp + tbo + draft-extend tbo):\n"
+            f"accuracy={metrics['score']:.3f}\n"
+            f"{avg_spec_accept_length=:.3f}\n"
+        )
+
+        # Same thresholds as TestMTPWithTBO: splitting draft-extend must be
+        # output-equivalent, so neither number is allowed to move.
+        self.assertGreater(metrics["score"], 0.60)
+        self.assertGreater(avg_spec_accept_length, 2.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/batch_overlap/test_tbo_draft_extend_split.py
+++ b/test/registered/unit/batch_overlap/test_tbo_draft_extend_split.py
@@ -1,0 +1,484 @@
+"""Two-batch-overlap split math for the draft-extend forward mode (issue #7892).
+
+Draft-extend (`DRAFT_EXTEND_V2`) fills a uniform `num_tokens_per_req` slots per
+req, so it splits on a clean seq boundary at `bs // 2` exactly like
+`TARGET_VERIFY` -- not like variable-length `EXTEND`. That uniform-width shape is
+what lets the split stay well-defined at cuda-graph replay time (where
+`extend_lens` is unavailable). CPU-only.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.batch_overlap import operations
+from sglang.srt.batch_overlap.operations_strategy import (
+    _compute_moe_deepseek_blog_decode,
+    _compute_moe_deepseek_draft_extend,
+)
+from sglang.srt.batch_overlap.two_batch_overlap import (
+    TboForwardBatchPreparer,
+    compute_split_indices_for_cuda_graph_replay,
+    compute_split_seq_index,
+    compute_split_token_index,
+    get_token_num_per_seq,
+    op_capture_dsa_seed_topk,
+    split_spec_info,
+)
+from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _draft_extend_spec(num_tokens_per_req: int) -> SimpleNamespace:
+    # get_token_num_per_seq only reads `.num_tokens_per_req` off the spec info.
+    return SimpleNamespace(num_tokens_per_req=num_tokens_per_req)
+
+
+# (batch_size, num_draft_tokens) pairs covering odd/even bs and topk-1/tree width.
+_CASES = [(1, 1), (2, 4), (4, 8), (6, 8), (7, 2), (8, 3), (31, 4), (64, 8)]
+
+
+class TestTboDraftExtendSplit(CustomTestCase):
+    def test_get_token_num_per_seq_reads_num_tokens_per_req(self):
+        for _, width in _CASES:
+            spec = _draft_extend_spec(width)
+            self.assertEqual(
+                get_token_num_per_seq(ForwardMode.DRAFT_EXTEND_V2, spec), width
+            )
+
+    def test_split_seq_index_is_half_the_batch(self):
+        # Uniform width => split on a seq boundary at bs // 2, independent of width.
+        for bs, width in _CASES:
+            num_tokens = bs * width
+            got = compute_split_seq_index(
+                ForwardMode.DRAFT_EXTEND_V2,
+                num_tokens=num_tokens,
+                extend_lens=None,
+                token_num_per_seq=width,
+            )
+            self.assertEqual(got, bs // 2, msg=f"{bs=} {width=}")
+
+    def test_split_token_index_matches_seq_boundary(self):
+        # The token cut must land exactly on child_a's seq boundary so the two
+        # micro-batches partition the flat token buffer with no overlap/gap.
+        for bs, width in _CASES:
+            num_tokens = bs * width
+            ssi = compute_split_seq_index(
+                ForwardMode.DRAFT_EXTEND_V2,
+                num_tokens=num_tokens,
+                extend_lens=None,
+                token_num_per_seq=width,
+            )
+            sti = compute_split_token_index(
+                ssi,
+                ForwardMode.DRAFT_EXTEND_V2,
+                extend_seq_lens=None,
+                token_num_per_seq=width,
+            )
+            self.assertEqual(sti, ssi * width, msg=f"{bs=} {width=}")
+            # child_a = [0, sti), child_b = [sti, num_tokens): a clean partition.
+            self.assertGreaterEqual(sti, 0)
+            self.assertLessEqual(sti, num_tokens)
+
+    def test_parity_with_target_verify(self):
+        # Design invariant: draft-extend and target-verify share the uniform-width
+        # split. Same (bs, width) must yield identical seq/token cuts.
+        for bs, width in _CASES:
+            num_tokens = bs * width
+            de_seq = compute_split_seq_index(
+                ForwardMode.DRAFT_EXTEND_V2,
+                num_tokens=num_tokens,
+                extend_lens=None,
+                token_num_per_seq=width,
+            )
+            tv_seq = compute_split_seq_index(
+                ForwardMode.TARGET_VERIFY,
+                num_tokens=num_tokens,
+                extend_lens=None,
+                token_num_per_seq=width,
+            )
+            self.assertEqual(de_seq, tv_seq, msg=f"{bs=} {width=}")
+
+    def test_cuda_graph_replay_indices_without_extend_lens(self):
+        # The replay path passes extend_lens=None and relies solely on
+        # token_num_per_seq; draft-extend must resolve to concrete indices there.
+        for bs, width in _CASES:
+            spec = _draft_extend_spec(width)
+            ssi, sti = compute_split_indices_for_cuda_graph_replay(
+                forward_mode=ForwardMode.DRAFT_EXTEND_V2,
+                cuda_graph_num_tokens=bs * width,
+                spec_info=spec,
+            )
+            self.assertEqual(ssi, bs // 2, msg=f"{bs=} {width=}")
+            self.assertEqual(sti, (bs // 2) * width, msg=f"{bs=} {width=}")
+
+
+def _make_draft_extend_spec_info() -> EagleDraftExtendInput:
+    # bs=5, width=4 -> 20 flat token rows. Values are all distinct so a
+    # mis-slice cannot accidentally reproduce the parent.
+    return EagleDraftExtendInput(
+        hidden_states=torch.arange(60, dtype=torch.float32).reshape(20, 3),
+        num_correct_drafts=torch.tensor([0, 1, 2, 3, 0]),
+        num_accept_tokens=torch.tensor([1, 2, 3, 4, 1]),
+        num_accept_tokens_cpu=[1, 2, 3, 4, 1],
+        input_ids=torch.arange(20),
+        seq_lens=torch.tensor([10, 20, 30, 40, 50]),
+        seq_lens_cpu=torch.tensor([10, 20, 30, 40, 50]),
+        req_pool_indices=torch.tensor([7, 8, 9, 10, 11]),
+        positions=torch.arange(100, 120),
+        bonus_tokens=torch.tensor([5, 6, 7, 8, 9]),
+        capture_hidden_mode=CaptureHiddenMode.LAST,
+        num_tokens_per_req=4,
+        num_tokens_for_logprob_per_req=4,
+        dsa_seed_topk_capture=torch.zeros(20, 2, dtype=torch.int64),
+        dsa_seed_topk_select=torch.tensor([3, 7, 11, 15, 19]),
+        select_index=torch.tensor([0, 5, 10, 15, 16]),
+        kv_indptr=torch.tensor([0, 3, 7, 12, 18, 25]),
+    )
+
+
+def _split_in_two(spec: EagleDraftExtendInput, ssi: int, width: int):
+    bs = spec.num_accept_tokens.shape[0]
+    child_a = split_spec_info(spec, 0, ssi, 0, ssi * width)
+    child_b = split_spec_info(spec, ssi, bs, ssi * width, bs * width)
+    return child_a, child_b
+
+
+class TestDraftExtendSpecInfoSplit(CustomTestCase):
+    """Round-trip contract of the EagleDraftExtendInput splitter (P0-1).
+
+    Derived property: the two children must partition the parent losslessly
+    (concat(childA, childB) == parent), with flat-row pointers rebased into
+    each child's token coordinates. A "looks equivalent" rewrite that slices
+    one field on the wrong ruler silently corrupts requests; these cases are
+    the only guard.
+    """
+
+    def test_roundtrip_partitions_every_field(self):
+        parent = _make_draft_extend_spec_info()
+        child_a, child_b = _split_in_two(parent, ssi=2, width=4)
+
+        for name in ("input_ids", "positions", "hidden_states"):
+            merged = torch.cat([getattr(child_a, name), getattr(child_b, name)])
+            self.assertTrue(torch.equal(merged, getattr(parent, name)), name)
+        for name in (
+            "num_correct_drafts",
+            "num_accept_tokens",
+            "seq_lens",
+            "seq_lens_cpu",
+            "req_pool_indices",
+            "bonus_tokens",
+        ):
+            merged = torch.cat([getattr(child_a, name), getattr(child_b, name)])
+            self.assertTrue(torch.equal(merged, getattr(parent, name)), name)
+        self.assertEqual(
+            child_a.num_accept_tokens_cpu + child_b.num_accept_tokens_cpu,
+            parent.num_accept_tokens_cpu,
+        )
+        # Scalars carry over; the child is a first-class spec input.
+        for child in (child_a, child_b):
+            self.assertEqual(child.num_tokens_per_req, 4)
+            self.assertEqual(child.capture_hidden_mode, CaptureHiddenMode.LAST)
+            self.assertEqual(child.spec_input_type, parent.spec_input_type)
+
+    def test_flat_row_pointers_rebase_to_child_origin(self):
+        parent = _make_draft_extend_spec_info()
+        child_a, child_b = _split_in_two(parent, ssi=2, width=4)
+
+        # kv_indptr: bs+1 cumulative entries, child origin rebased to zero.
+        self.assertTrue(torch.equal(child_a.kv_indptr, torch.tensor([0, 3, 7])))
+        self.assertTrue(torch.equal(child_b.kv_indptr, torch.tensor([0, 5, 11, 18])))
+        # select_index / dsa_seed_topk_select: per-req flat-row pointers must
+        # shift by the child's token offset (8), or child B reads child A rows.
+        self.assertTrue(torch.equal(child_a.select_index, torch.tensor([0, 5])))
+        self.assertTrue(torch.equal(child_b.select_index, torch.tensor([2, 7, 8])))
+        self.assertTrue(torch.equal(child_a.dsa_seed_topk_select, torch.tensor([3, 7])))
+        self.assertTrue(
+            torch.equal(child_b.dsa_seed_topk_select, torch.tensor([3, 7, 11]))
+        )
+
+    def test_capture_buffer_stays_a_view_of_parent(self):
+        # The DSA seed capture buffer is an OUTPUT: children must write into
+        # the parent's rows. If a rewrite turns the slice into a copy, seeds
+        # silently stop reaching the next draft loop (no crash, wrong decode).
+        parent = _make_draft_extend_spec_info()
+        child_a, child_b = _split_in_two(parent, ssi=2, width=4)
+        child_b.dsa_seed_topk_capture.fill_(7)
+        self.assertTrue(torch.all(parent.dsa_seed_topk_capture[8:] == 7))
+        self.assertTrue(torch.all(parent.dsa_seed_topk_capture[:8] == 0))
+        child_a.dsa_seed_topk_capture.fill_(3)
+        self.assertTrue(torch.all(parent.dsa_seed_topk_capture[:8] == 3))
+
+    def test_rejects_token_cut_off_the_seq_boundary(self):
+        # Fixed width means the token knife and the request knife are the same
+        # knife. A drifted caller (e.g. a ragged token cut) must fail loudly.
+        parent = _make_draft_extend_spec_info()
+        with self.assertRaises(AssertionError):
+            split_spec_info(parent, 0, 2, 0, 7)
+
+    def test_rejects_unset_width(self):
+        # width=-1 (prefill-flavored or default-constructed spec) has no
+        # defined split; slicing with it would corrupt instead of crash.
+        with self.assertRaises(AssertionError):
+            split_spec_info(EagleDraftExtendInput(), 0, 0, 0, 0)
+
+    def test_rejects_widened_spec(self):
+        # Widening (num_front_tokens > 0) changes the real per-req row count
+        # away from num_tokens_per_req; fixed-width slicing would silently
+        # mis-slice, so the splitter must refuse until it is widening-aware.
+        parent = _make_draft_extend_spec_info()
+        parent.num_front_tokens = 2
+        with self.assertRaises(AssertionError):
+            _split_in_two(parent, ssi=2, width=4)
+
+    def test_unclassified_field_fails_loudly(self):
+        # Bookkeeping guard: adding a field to EagleDraftExtendInput without
+        # assigning it a split rule must crash the split, not silently drop
+        # or mis-slice the new field.
+        parent = _make_draft_extend_spec_info()
+        parent.mystery_field = torch.zeros(2)
+        with self.assertRaises(AssertionError) as ctx:
+            _split_in_two(parent, ssi=2, width=4)
+        self.assertIn("unclassified", str(ctx.exception))
+
+
+class TestDraftExtendChildrenGate(CustomTestCase):
+    """Draft-worker TBO gate (#7892).
+
+    The gate decides which draft forwards split into two micro-batches. Its
+    negative branches are load-bearing: a gate that degrades to always-true
+    splits the draft decode loop (or the prefill-side draft-extend) and
+    desynchronizes the per-rank EP collective schedule.
+    """
+
+    @staticmethod
+    def _gate(forward_mode, spec_info, attn_backend, global_forward_mode):
+        return TboForwardBatchPreparer._should_prepare_draft_extend_children(
+            forward_mode=forward_mode,
+            global_forward_mode=global_forward_mode,
+            spec_info=spec_info,
+            attn_backend=attn_backend,
+        )
+
+    def setUp(self):
+        self.tbo_backend = MagicMock(spec=TboAttnBackend)
+        self.extend_input = MagicMock(spec=EagleDraftExtendInput)
+
+    def test_opens_for_decode_step_draft_extend(self):
+        self.assertTrue(
+            self._gate(
+                ForwardMode.DRAFT_EXTEND_V2,
+                self.extend_input,
+                self.tbo_backend,
+                ForwardMode.DECODE,
+            )
+        )
+
+    def test_opens_for_decode_step_idle_rank(self):
+        # P0-3: the idle rank must split ([0, 0] children) so every DP rank
+        # runs the same two dispatch/combine collectives as active ranks.
+        self.assertTrue(
+            self._gate(
+                ForwardMode.IDLE,
+                self.extend_input,
+                self.tbo_backend,
+                ForwardMode.DECODE,
+            )
+        )
+
+    def test_closed_without_tbo_backend(self):
+        self.assertFalse(
+            self._gate(
+                ForwardMode.DRAFT_EXTEND_V2,
+                self.extend_input,
+                MagicMock(),
+                ForwardMode.DECODE,
+            )
+        )
+
+    def test_closed_for_draft_decode_loop(self):
+        # The draft multi-step decode loop (mode DECODE) and non-draft-extend
+        # spec inputs must stay monolithic even though the same TboAttnBackend
+        # is installed for the whole draft runner.
+        self.assertFalse(
+            self._gate(
+                ForwardMode.DECODE,
+                self.extend_input,
+                self.tbo_backend,
+                ForwardMode.DECODE,
+            )
+        )
+        self.assertFalse(
+            self._gate(
+                ForwardMode.DRAFT_EXTEND_V2,
+                MagicMock(),
+                self.tbo_backend,
+                ForwardMode.DECODE,
+            )
+        )
+        self.assertFalse(
+            self._gate(
+                ForwardMode.DRAFT_EXTEND_V2, None, self.tbo_backend, ForwardMode.DECODE
+            )
+        )
+
+    def test_closed_for_prefill_step_idle_rank(self):
+        """Bug regression (#7892 review finding F2).
+
+        Prefill step with target TBO active: active ranks run the prefill-side
+        draft-extend under mode EXTEND (gate closed, ONE collective schedule),
+        while an idle DP rank's batch arrives as mode IDLE with the same
+        EagleDraftExtendInput spec, the same wrapped backend, and a
+        tbo_split_seq_index inherited from the target prefill vote. If the
+        idle arm opens outside the decode phase, the idle rank executes TWO
+        dispatch/combine rounds against the active ranks' one, and the EP
+        all-to-all deadlocks.
+
+        Contract pinned here: the idle arm opens only under a voted DECODE
+        ticket — never for another phase's ticket, and never when the vote
+        produced no ticket at all. Verified red against the pre-fix gate
+        (which could not receive the phase signal).
+        """
+        self.assertFalse(
+            self._gate(
+                ForwardMode.IDLE,
+                self.extend_input,
+                self.tbo_backend,
+                ForwardMode.EXTEND,
+            )
+        )
+        self.assertFalse(
+            self._gate(ForwardMode.IDLE, self.extend_input, self.tbo_backend, None)
+        )
+
+
+class TestDraftExtendOperationsStrategy(CustomTestCase):
+    """Op-sequence invariants of the draft-extend strategy (P0-2).
+
+    The capture op must sit in the same stage as the attn core (its state key
+    is consumed before op_comm_postprocess_layer's state.clear), and building
+    the draft strategy must not corrupt the shared decode strategy.
+    """
+
+    def test_swaps_core_and_inserts_capture_in_same_stage(self):
+        layer = MagicMock()
+        base = _compute_moe_deepseek_blog_decode(layer)
+        draft = _compute_moe_deepseek_draft_extend(layer)
+
+        idx = base.operations.index(layer.self_attn.op_core)
+        self.assertIs(draft.operations[idx], layer.self_attn.op_core_with_topk)
+        self.assertIs(draft.operations[idx + 1], op_capture_dsa_seed_topk)
+        self.assertNotIn(layer.self_attn.op_core, draft.operations)
+
+        # Everything around the swap point is untouched, so the capture op is
+        # adjacent to the core (same stage) and stage boundaries are preserved.
+        # YieldOperation instances are fresh per builder call, so compare them
+        # by type rather than identity.
+        def _normalize(ops):
+            return [
+                (
+                    operations.YieldOperation
+                    if isinstance(op, operations.YieldOperation)
+                    else op
+                )
+                for op in ops
+            ]
+
+        self.assertEqual(
+            _normalize(draft.operations[:idx]), _normalize(base.operations[:idx])
+        )
+        self.assertEqual(
+            _normalize(draft.operations[idx + 2 :]),
+            _normalize(base.operations[idx + 1 :]),
+        )
+        self.assertEqual(
+            sum(isinstance(op, operations.YieldOperation) for op in draft.operations),
+            sum(isinstance(op, operations.YieldOperation) for op in base.operations),
+        )
+        self.assertEqual(draft.tbo_delta_stages, base.tbo_delta_stages)
+        self.assertEqual(draft.deep_gemm_num_sms, base.deep_gemm_num_sms)
+
+    def test_does_not_mutate_the_decode_strategy(self):
+        # The draft builder derives from the decode op list; an in-place
+        # insert would poison every later decode/target-verify strategy.
+        layer = MagicMock()
+        base = _compute_moe_deepseek_blog_decode(layer)
+        ops_before = list(base.operations)
+        _compute_moe_deepseek_draft_extend(layer)
+        self.assertEqual(base.operations, ops_before)
+
+
+class _FakeOpState(dict):
+    """Minimal operations-state stand-in: dict pop + forward_batch attr."""
+
+    forward_batch = None
+
+
+class TestCaptureDsaSeedTopkOp(CustomTestCase):
+    """op_capture_dsa_seed_topk mirrors the monolithic NextN tail write."""
+
+    @staticmethod
+    def _state(topk_indices, spec_info, reuse=False):
+        state = _FakeOpState(topk_indices_after_attn=topk_indices)
+        state.forward_batch = SimpleNamespace(
+            spec_info=spec_info, reuse_dsa_topk_indices=reuse
+        )
+        return state
+
+    def test_writes_rows_into_the_per_token_buffer(self):
+        # Decode-path contract: select is None, the buffer is per-token sized,
+        # and the write is a plain row copy — which is exactly what makes a
+        # per-child view write land like the monolithic write.
+        topk = torch.arange(12).reshape(4, 3)
+        buf = torch.zeros(8, 3, dtype=torch.int64)
+        spec = SimpleNamespace(dsa_seed_topk_capture=buf, dsa_seed_topk_select=None)
+        op_capture_dsa_seed_topk(self._state(topk, spec))
+        self.assertTrue(torch.equal(buf[:4], topk))
+        self.assertTrue(torch.all(buf[4:] == 0))
+
+    def test_prefill_select_layout_is_refused(self):
+        # A non-None select implies the prefill (bs, k) capture layout, whose
+        # write targets a TBO split does not preserve — the op must fail
+        # loudly instead of scattering seeds to wrong rows.
+        topk = torch.arange(12).reshape(4, 3)
+        spec = SimpleNamespace(
+            dsa_seed_topk_capture=torch.zeros(8, 3, dtype=torch.int64),
+            dsa_seed_topk_select=torch.tensor([1, 3]),
+        )
+        with self.assertRaises(AssertionError):
+            op_capture_dsa_seed_topk(self._state(topk, spec))
+
+    def test_noop_without_capture_request(self):
+        # Non-DSA batches (no seed buffer) and topk-less cores must both be
+        # silent no-ops; the state key is still consumed either way.
+        topk = torch.arange(12).reshape(4, 3)
+        state = self._state(topk, SimpleNamespace(dsa_seed_topk_capture=None))
+        op_capture_dsa_seed_topk(state)
+        self.assertNotIn("topk_indices_after_attn", state)
+        op_capture_dsa_seed_topk(
+            self._state(None, SimpleNamespace(dsa_seed_topk_capture=torch.zeros(2, 2)))
+        )
+        op_capture_dsa_seed_topk(self._state(topk, None))
+
+    def test_reuse_channel_is_refused(self):
+        # The op deliberately does not implement the dsa_topk_indices
+        # write-back; a batch arriving with the reuse flag set means a caller
+        # wired the wrong phase through it and must fail loudly.
+        topk = torch.arange(12).reshape(4, 3)
+        spec = SimpleNamespace(
+            dsa_seed_topk_capture=torch.zeros(4, 3, dtype=torch.int64),
+            dsa_seed_topk_select=None,
+        )
+        with self.assertRaises(AssertionError):
+            op_capture_dsa_seed_topk(self._state(topk, spec, reuse=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Draft / WIP** — opening early for visibility. Not yet validated on GPU.

Closes #7892.

## Motivation

Enable two-batch overlap on the **draft model**. Today only the target model's
forwards split into two micro-batches; the NextN draft-extend forward stays
monolithic, so its deepep dispatch carries the whole batch in one shot.

## Modifications

TBD

## Accuracy Tests

TBD — still writing tests.

## Speed Tests and Profiling

TBD

## Known issues

- The draft-worker gate reads `get_attn_backend()` from `ForwardBatch.init_new`,
  which runs outside any forward context, so it asserts. Fix in progress
  (pass `model_runner.attn_backend` in explicitly, like the adjacent
  `_plan_tbo_children_if_preplanned` already does).

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30268264423](https://github.com/sgl-project/sglang/actions/runs/30268264423)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30268264159](https://github.com/sgl-project/sglang/actions/runs/30268264159)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->