### PR TITLE
[MLX] Fix SchedulerProfilerManager MPS capture mocks

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
+++ b/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
@@ -204,7 +204,7 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
         return mgr
 
     def test_start_profile_failure_does_not_crash(self):
-        import mlx.core as mx
+        import torch
 
         from sglang.srt.hardware_backend.mlx.profiler import (
             apply_metal_profiler_patches,
@@ -214,10 +214,16 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             mgr = self._make_manager(tmp)
-            with patch.object(
-                mx.metal,
-                "start_capture",
-                side_effect=RuntimeError("Capture layer is not inserted"),
+            with (
+                patch(
+                    "sglang.srt.hardware_backend.mlx.profiler.use_mlx",
+                    return_value=False,
+                ),
+                patch.object(
+                    torch.mps.profiler,
+                    "metal_capture",
+                    side_effect=RuntimeError("Capture layer is not inserted"),
+                ),
             ):
                 result = mgr._start_profile()
 
@@ -226,9 +232,7 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
         self.assertIsNone(mgr.torch_profiler)
 
     def test_start_profile_success_with_mock_capture(self):
-        from unittest.mock import patch as mock_patch
-
-        import mlx.core as mx
+        import torch
 
         from sglang.srt.hardware_backend.mlx.profiler import (
             apply_metal_profiler_patches,
@@ -238,14 +242,25 @@ class TestSchedulerProfilerManagerMPS(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             mgr = self._make_manager(tmp)
-            with mock_patch.object(mx.metal, "start_capture"), mock_patch.object(
-                mx.metal, "stop_capture"
-            ), mock_patch("torch.distributed.barrier"):
+            mock_ctx = MagicMock()
+            with (
+                patch(
+                    "sglang.srt.hardware_backend.mlx.profiler.use_mlx",
+                    return_value=False,
+                ),
+                patch.object(
+                    torch.mps.profiler, "metal_capture", return_value=mock_ctx
+                ),
+                patch("torch.distributed.barrier"),
+            ):
                 result = mgr._start_profile()
                 self.assertTrue(result.success)
                 self.assertTrue(mgr.profile_in_progress)
                 mgr._stop_profile()
                 self.assertFalse(mgr.profile_in_progress)
+
+            mock_ctx.__enter__.assert_called_once_with()
+            mock_ctx.__exit__.assert_called_once_with(None, None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`test_metal_profiler.py::TestSchedulerProfilerManagerMPS::test_start_profile_success_with_mock_capture` fails on unmodified main on Apple Silicon (`AssertionError: False is not true`), reported in #30550.

`SchedulerProfilerManager._start_profile` (`profiler_manager.py:166`) maps the default `activities=["CPU","GPU"]` to `[ProfilerActivity.CPU, ProfilerActivity.CUDA]`. With `SGLANG_USE_MLX` unset, `use_mlx()` is `False`, so the patched `torch.profiler.profile` (`profiler.py:163`) takes the MPS branch and constructs `MetalTorchProfiler(start_metal_capture=MetalCaptureProfiler.start_mps)`, which calls `torch.mps.profiler.metal_capture`. The existing tests mocked `mx.metal.start_capture` — the MLX-path object — which is never invoked on this path. The success test therefore started a real Metal capture and failed without `MTL_CAPTURE_ENABLED`, and the failure test passed for the wrong reason.

## Modifications

- Pin `use_mlx` to `False` in both manager tests so they deterministically exercise the MPS path regardless of whether the CI lane exports `SGLANG_USE_MLX`.
- Mock the actual `torch.mps.profiler.metal_capture` call.
- Assert the successful capture context is entered and exited; drive the failure case through the mocked `metal_capture` `RuntimeError`.

## Test

Verified on real Apple Silicon (M2 Max 64GB, macOS, mlx 0.32.0, mlx-lm 0.31.3, torch 2.11.0, transformers 5.12.1):

```
$ python -m pytest test/registered/unit/hardware_backend/mlx/test_metal_profiler.py -v
# Before (unmodified main db9143e): test_start_profile_success_with_mock_capture FAILED (False is not true); other 9 pass
# After (this PR): 10 passed in 4.72s
```

## Notes

This is a rebase onto current main plus a real-hardware verification of #30886 by @zxyasfas, who did the root-cause analysis and the original fix. I opened it to help unblock that PR — it has been idle, and its author noted the test could not be run locally on Apple Silicon. Happy to fold this back into #30886 instead and post the verification there if that is preferred. Fixes #30550.

## Checklist

- [x] Format your code according to the Format code with pre-commit guidance.
- [x] Add or update unit tests according to the unit test guidance.
- [ ] N/A — update documentation
- [ ] N/A — accuracy test (test-only change, no runtime behavior changed)
- [ ] N/A — speed test

cc @zxyasfas @yeahdongcn

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30268392471](https://github.com/sgl-project/sglang/actions/runs/30268392471)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30268392188](https://github.com/sgl-project/sglang/actions/runs/30268392188)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->