### PR TITLE
[easy][Cleanup] Drop unused tbo_split_seq_index in TBO replay_prepare

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -373,12 +373,10 @@ class TboCudaGraphRunnerPlugin:
         token_num_per_seq = get_token_num_per_seq(
             forward_mode=forward_mode, spec_info=spec_info
         )
-        tbo_split_seq_index, tbo_split_token_index = (
-            compute_split_indices_for_cuda_graph_replay(
-                forward_mode=forward_mode,
-                cuda_graph_num_tokens=bs * token_num_per_seq,
-                spec_info=spec_info,
-            )
+        _, tbo_split_token_index = compute_split_indices_for_cuda_graph_replay(
+            forward_mode=forward_mode,
+            cuda_graph_num_tokens=bs * token_num_per_seq,
+            spec_info=spec_info,
         )
 
         self._tbo_children_num_token_non_padded[...] = (


### PR DESCRIPTION
`TboCudaGraphRunnerPlugin.replay_prepare` only uses the token index; drop the unused `tbo_split_seq_index` variable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30269907901](https://github.com/sgl-project/sglang/actions/runs/30269907901)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30269907587](https://github.com/sgl-project/sglang/actions/runs/30269907587)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->