### PR TITLE
[Cleanup] Stop backfilling seq_lens_sum onto ScheduleBatch in init_new

### DIFF
--- a/.claude/rules/forward-batch-init-new-purity.md
+++ b/.claude/rules/forward-batch-init-new-purity.md
@@ -12,6 +12,5 @@ writes (`out_cache_loc`, `seq_lens_*`, ...) before `init_new` are out of scope.
 
 Tolerated exceptions (don't add new ones):
 
-- `seq_lens_sum` backfill — the `seq_lens` family is slated for removal (→ kv-committed lengths).
 - `sampling_info` sub-object writes (grammars, canary ids) — shared object, until the sampling forward-copy op.
 - `_expand_mrope_from_input` memoizing `mrope_position_delta_repeated_cache` — pre-existing.

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -727,10 +727,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         # TODO(seq-lens-removal): the whole ScheduleBatch seq_lens family
         # (incl. seq_lens_sum) is slated for removal in favor of kv-committed
-        # lengths, so this init_new-time backfill onto the ScheduleBatch is
-        # tolerated for now despite the init_new-must-not-mutate-SB rule.
-        if batch.seq_lens_sum is None and seq_lens_cpu is not None:
-            batch.seq_lens_sum = int(seq_lens_cpu.sum())
+        # lengths.
+        seq_lens_sum = batch.seq_lens_sum
+        if seq_lens_sum is None and seq_lens_cpu is not None:
+            seq_lens_sum = int(seq_lens_cpu.sum())
 
         ret = cls(
             # Required core inputs
@@ -740,7 +740,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             req_pool_indices=batch.req_pool_indices,
             seq_lens=batch.seq_lens,
             out_cache_loc=batch.out_cache_loc,
-            seq_lens_sum=batch.seq_lens_sum,
+            seq_lens_sum=seq_lens_sum,
             # Inputs aliased by reference from ScheduleBatch
             seq_lens_cpu=seq_lens_cpu,
             orig_seq_lens=batch.orig_seq_lens,


### PR DESCRIPTION
Compute the lazy `seq_lens_sum` as a local for the ForwardBatch instead of backfilling it onto the ScheduleBatch, and drop the now-stale tolerated exception from the `init_new` purity rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30268422214](https://github.com/sgl-project/sglang/actions/runs/30268422214)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30268421977](https://github.com/sgl-project/sglang/actions/runs/30268421977)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->