### PR TITLE
test(mimo-v2): add HiCache kernel/page_first write-back regression guard

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -1051,19 +1051,6 @@ class AsymmetricMHATokenToKVPoolHost(MHATokenToKVPoolHost):
         )
         return (k_buffer, v_buffer)
 
-    def _init_write_back_staging_buffers(self):
-        # Asymmetric K/V (head_dim != v_head_dim) has no JIT staged write-back
-        # path: jit_transfer_hicache_all_layer_staged_lf_pf assumes a single
-        # combined buffer with one shared stride, but K and V here live in two
-        # buffers with different strides. Disable the JIT flag so the controller
-        # moves host_indices to GPU (via move_hybrid_indices) and the non-JIT
-        # transfer_kv_all_layer_mla_lf_pf kernel receives CUDA dst_indices.
-        self.staging_page_capacity = 0
-        self.staging_token_capacity = 0
-        self.staging_k_buffer = None
-        self.staging_v_buffer = None
-        self.can_use_write_back_jit = False
-
     def _k_token_stride_size(self) -> int:
         return self.head_num * self.head_dim * self.dtype.itemsize
 

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -1051,6 +1051,19 @@ class AsymmetricMHATokenToKVPoolHost(MHATokenToKVPoolHost):
         )
         return (k_buffer, v_buffer)
 
+    def _init_write_back_staging_buffers(self):
+        # Asymmetric K/V (head_dim != v_head_dim) has no JIT staged write-back
+        # path: jit_transfer_hicache_all_layer_staged_lf_pf assumes a single
+        # combined buffer with one shared stride, but K and V here live in two
+        # buffers with different strides. Disable the JIT flag so the controller
+        # moves host_indices to GPU (via move_hybrid_indices) and the non-JIT
+        # transfer_kv_all_layer_mla_lf_pf kernel receives CUDA dst_indices.
+        self.staging_page_capacity = 0
+        self.staging_token_capacity = 0
+        self.staging_k_buffer = None
+        self.staging_v_buffer = None
+        self.can_use_write_back_jit = False
+
     def _k_token_stride_size(self) -> int:
         return self.head_num * self.head_dim * self.dtype.itemsize
 

--- a/test/registered/models_e2e/test_mimo_v2_flash.py
+++ b/test/registered/models_e2e/test_mimo_v2_flash.py
@@ -1,52 +1,75 @@
 import unittest
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import is_blackwell
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.spec_decoding_kit import SpecDecodingMixin
 from sglang.test.server_fixtures.default_fixture import DefaultServerBase
 
-register_cuda_ci(est_time=350, stage="base-c", runner_config="8-gpu-h200")
+register_cuda_ci(est_time=650, stage="base-c", runner_config="8-gpu-h200")
+
+_COMMON_ARGS = [
+    "--tp",
+    "4",
+    "--dp",
+    "2",
+    "--enable-dp-attention",
+    "--trust-remote-code",
+    "--attention-backend",
+    "fa3",
+    "--max-running-requests",
+    "128",
+    "--cuda-graph-max-bs-decode",
+    "64",
+    "--page-size",
+    "64",
+    "--mem-fraction-static",
+    "0.75",
+    "--model-loader-extra-config",
+    '{"enable_multithread_load": true,"num_threads": 64}',
+    "--enable-hierarchical-cache",
+    "--hicache-ratio",
+    "1.5",
+]
+
+_SPEC_ARGS = [
+    "--speculative-algorithm",
+    "EAGLE",
+    "--speculative-num-steps",
+    "3",
+    "--speculative-eagle-topk",
+    "1",
+    "--speculative-num-draft-tokens",
+    "4",
+    "--enable-multi-layer-eagle",
+]
 
 
-class TestMiMoV2Flash(GSM8KMixin, SpecDecodingMixin, DefaultServerBase):
+class MiMoV2FlashBase(GSM8KMixin, DefaultServerBase):
+    """Shared MiMo-V2-Flash fixture; subclasses set ``hicache_args`` /
+    ``extra_args`` per parameter combination. Named without a ``Test`` prefix
+    so unittest does not collect the base (it has no concrete config).
+    """
+
+    model = "XiaomiMiMo/MiMo-V2-Flash"
     gsm8k_accuracy_thres = 0.75
+
+    hicache_args: list[str] = []
+    extra_args: list[str] = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.other_args = _COMMON_ARGS + cls.extra_args + cls.hicache_args
+        with envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.override(True):
+            super().setUpClass()
+
+
+class TestMiMoV2Flash(SpecDecodingMixin, MiMoV2FlashBase):
     gsm8k_num_questions = 1319
     gsm8k_num_threads = 1319
-    model = "XiaomiMiMo/MiMo-V2-Flash"
 
-    other_args = [
-        "--tp",
-        "4",
-        "--dp",
-        "2",
-        "--enable-dp-attention",
-        "--trust-remote-code",
-        "--attention-backend",
-        "fa4" if is_blackwell() else "fa3",
-        "--max-running-requests",
-        "128",
-        "--cuda-graph-max-bs-decode",
-        "64",
-        "--page-size",
-        "64",
-        "--mem-fraction-static",
-        "0.75",
-        "--speculative-algorithm",
-        "EAGLE",
-        "--speculative-num-steps",
-        "3",
-        "--speculative-eagle-topk",
-        "1",
-        "--speculative-num-draft-tokens",
-        "4",
-        "--enable-multi-layer-eagle",
-        "--model-loader-extra-config",
-        '{"enable_multithread_load": true,"num_threads": 64}',
-        "--enable-hierarchical-cache",
-        "--hicache-ratio",
-        "1.5",
+    extra_args = _SPEC_ARGS
+    hicache_args = [
         "--hicache-mem-layout",
         "page_first_direct",
         "--hicache-io-backend",
@@ -56,10 +79,24 @@ class TestMiMoV2Flash(GSM8KMixin, SpecDecodingMixin, DefaultServerBase):
     bs_1_speed_thres = 170
     accept_length_thres = 3.2
 
-    @classmethod
-    def setUpClass(cls):
-        with envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.override(True):
-            super().setUpClass()
+
+class TestMiMoV2FlashHicacheKernelWriteBack(MiMoV2FlashBase):
+    """Regression guard: MiMo-V2 has head_dim != v_head_dim (asymmetric KV
+    host pool). With --hicache-io-backend kernel and --hicache-mem-layout
+    page_first, unified-radix write-back used to crash at startup with
+    "Destination indices must be a CUDA tensor". This config exercises that
+    exact write-back path; the direct-io sibling above does not.
+    """
+
+    gsm8k_num_questions = 200
+    gsm8k_num_threads = 200
+
+    hicache_args = [
+        "--hicache-mem-layout",
+        "page_first",
+        "--hicache-io-backend",
+        "kernel",
+    ]
 
 
 if __name__ == "__main__":

--- a/test/registered/models_e2e/test_mimo_v2_flash.py
+++ b/test/registered/models_e2e/test_mimo_v2_flash.py
@@ -1,6 +1,7 @@
 import unittest
 
 from sglang.srt.environ import envs
+from sglang.srt.utils import is_blackwell
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.kits.spec_decoding_kit import SpecDecodingMixin
@@ -16,7 +17,7 @@ _COMMON_ARGS = [
     "--enable-dp-attention",
     "--trust-remote-code",
     "--attention-backend",
-    "fa3",
+    "fa4" if is_blackwell() else "fa3",
     "--max-running-requests",
     "128",
     "--cuda-graph-max-bs-decode",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
test/registered/models_e2e/test_mimo_v2_flash.py only exercised HiCache with --hicache-io-backend direct / --hicache-mem-layout page_first_direct. It did not cover the kernel / page_first combination, which routes through a different write-back path (transfer_kv_all_layer_mla_lf_pf) for asymmetric-KV models (head_dim != v_head_dim, e.g. MiMo-V2). A recently-fixed startup crash (RuntimeError: Destination indices must be a CUDA tensor) lived precisely on that uncovered path, so nothing guards against its regression.

## Modifications

<!-- Detail the changes made in this pull request. -->

- Add TestMiMoV2FlashHicacheKernelWriteBack — a regression guard running MiMo-V2 with --hicache-io-backend kernel --hicache-mem-layout page_first (the previously-crashing config), with a smaller 200-question GSM8K since it only needs to exercise startup + write-back.

- Refactor into a shared MiMoV2FlashBase holding common server args (_COMMON_ARGS), the unified-radix-tree setUpClass, model, and GSM8K threshold. Config-specific args are composed via extra_args + hicache_args, letting multiple parameter combinations live in one file under a single CI registration.

- TestMiMoV2Flash keeps the original direct / page_first_direct config plus EAGLE speculative decoding (_SPEC_ARGS).

- Bumped est_time from 350 → 650 to reflect the second server launch.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30270481900](https://github.com/sgl-project/sglang/actions/runs/30270481900)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30270481490](https://github.com/sgl-project/sglang/actions/runs/30270481490)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->