### PR TITLE
[WIP] feat(router): add engine-pressure-aware scheduling

### DIFF
--- a/experimental/sgl-router/src/policies/load_based.rs
+++ b/experimental/sgl-router/src/policies/load_based.rs
@@ -1,14 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::policies::{Policy, SelectionContext};
+use crate::policies::load_scoring::EngineLoadScorer;
+use crate::policies::{Policy, PolicyCandidate, SelectionContext};
 use crate::workers::Worker;
+use rand::Rng;
 use std::sync::Arc;
 
-/// Deterministic load-based policy.
+/// Engine-pressure-weighted routing policy.
 ///
-/// Chooses the candidate with the lowest current `Worker::active_load`.
-/// Ties follow the candidate slice order, which is registry-dependent.
+/// A candidate's routing weight is `1 - pressure`, where pressure combines
+/// request saturation, uncached-token queue delay, throughput, and hottest-rank
+/// KV usage. Higher-pressure engines therefore receive proportionally fewer new
+/// requests instead of losing every decision because of one small load delta.
 #[derive(Debug, Default)]
 pub struct LoadBasedPolicy;
 
@@ -17,17 +21,68 @@ impl LoadBasedPolicy {
         Self
     }
 
-    pub fn pick_min_load(workers: &[Arc<Worker>]) -> Option<Arc<Worker>> {
-        workers
+    /// Selects a candidate proportionally to its engine-pressure weight.
+    ///
+    /// Candidates without an Engine report retain the legacy least-active
+    /// behavior. Production LoadMonitor snapshots are all-reported or filtered,
+    /// but this fallback also keeps direct policy callers backward compatible.
+    pub fn pick_weighted(candidates: &[PolicyCandidate]) -> Option<Arc<Worker>> {
+        if candidates.iter().all(|candidate| candidate.load.is_none()) {
+            return candidates
+                .iter()
+                .min_by_key(|candidate| candidate.worker.active_load())
+                .map(|candidate| Arc::clone(&candidate.worker));
+        }
+        Self::pick_weighted_with(candidates, &mut rand::thread_rng())
+    }
+
+    fn pick_weighted_with<R: Rng + ?Sized>(
+        candidates: &[PolicyCandidate],
+        rng: &mut R,
+    ) -> Option<Arc<Worker>> {
+        let total_weight: f64 = candidates
             .iter()
-            .min_by_key(|w| w.active_load())
-            .map(Arc::clone)
+            .map(candidate_weight)
+            .filter(|weight| weight.is_finite() && *weight > 0.0)
+            .sum();
+        if !total_weight.is_finite() || total_weight <= f64::EPSILON {
+            return None;
+        }
+
+        let mut draw = rng.gen_range(0.0..total_weight);
+        let mut last_positive = None;
+        for candidate in candidates {
+            let weight = candidate_weight(candidate);
+            if !weight.is_finite() || weight <= 0.0 {
+                continue;
+            }
+            last_positive = Some(candidate);
+            if draw < weight {
+                return Some(Arc::clone(&candidate.worker));
+            }
+            draw -= weight;
+        }
+
+        // Floating-point subtraction can leave `draw` a few ulps above zero.
+        last_positive.map(|candidate| Arc::clone(&candidate.worker))
     }
 }
 
+fn candidate_weight(candidate: &PolicyCandidate) -> f64 {
+    candidate
+        .load
+        .as_ref()
+        .map(EngineLoadScorer::routing_weight)
+        .unwrap_or(1.0)
+}
+
 impl Policy for LoadBasedPolicy {
-    fn select(&self, workers: &[Arc<Worker>], _ctx: &SelectionContext<'_>) -> Option<Arc<Worker>> {
-        Self::pick_min_load(workers)
+    fn select(
+        &self,
+        candidates: &[PolicyCandidate],
+        _ctx: &SelectionContext<'_>,
+    ) -> Option<Arc<Worker>> {
+        Self::pick_weighted(candidates)
     }
 }
 
@@ -35,6 +90,9 @@ impl Policy for LoadBasedPolicy {
 mod tests {
     use super::*;
     use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
+    use crate::load_monitor::AggregateLoad;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
 
     fn worker(id: &str) -> Arc<Worker> {
         Arc::new(Worker::new(WorkerSpec {
@@ -46,6 +104,18 @@ mod tests {
         }))
     }
 
+    fn candidate(worker: Arc<Worker>, pressure: Option<f64>) -> PolicyCandidate {
+        PolicyCandidate {
+            worker,
+            load: pressure.map(|max_rank_token_usage| AggregateLoad {
+                max_running_requests: 100,
+                available_slots: 100,
+                max_rank_token_usage,
+                ..AggregateLoad::default()
+            }),
+        }
+    }
+
     #[test]
     fn empty_returns_none() {
         let policy = LoadBasedPolicy::new();
@@ -55,16 +125,63 @@ mod tests {
     }
 
     #[test]
-    fn picks_lowest_active_load() {
-        let policy = LoadBasedPolicy::new();
-        let model = ModelId("tiny".into());
-        let ctx = SelectionContext::new(&model, None);
-        let w0 = worker("w0");
-        let w1 = worker("w1");
-        let _g0 = w0.load_guard();
+    fn missing_metrics_preserve_least_active_routing() {
+        let busy = worker("busy");
+        let idle = worker("idle");
+        let _busy_guard = busy.load_guard();
+        let candidates = vec![candidate(busy, None), candidate(Arc::clone(&idle), None)];
+
         assert_eq!(
-            policy.select(&[w0, Arc::clone(&w1)], &ctx).unwrap().id,
-            w1.id
+            LoadBasedPolicy::pick_weighted(&candidates).unwrap().id,
+            idle.id
         );
+    }
+
+    #[test]
+    fn pressure_reduces_observed_selection_frequency() {
+        let cool = worker("cool");
+        let hot = worker("hot");
+        let candidates = vec![
+            candidate(Arc::clone(&cool), Some(0.1)),
+            candidate(Arc::clone(&hot), Some(0.9)),
+        ];
+        let mut rng = StdRng::seed_from_u64(7);
+        let mut cool_count = 0;
+        let mut hot_count = 0;
+        for _ in 0..10_000 {
+            match LoadBasedPolicy::pick_weighted_with(&candidates, &mut rng)
+                .unwrap()
+                .id
+                .0
+                .as_str()
+            {
+                "cool" => cool_count += 1,
+                "hot" => hot_count += 1,
+                other => panic!("unexpected worker {other}"),
+            }
+        }
+        assert!(
+            cool_count > hot_count * 7,
+            "cool={cool_count}, hot={hot_count}"
+        );
+    }
+
+    #[test]
+    fn fully_pressured_candidate_is_never_selected() {
+        let full = worker("full");
+        let available = worker("available");
+        let candidates = vec![
+            candidate(full, Some(1.0)),
+            candidate(Arc::clone(&available), Some(0.0)),
+        ];
+        let mut rng = StdRng::seed_from_u64(11);
+        for _ in 0..100 {
+            assert_eq!(
+                LoadBasedPolicy::pick_weighted_with(&candidates, &mut rng)
+                    .unwrap()
+                    .id,
+                available.id
+            );
+        }
     }
 }

--- a/experimental/sgl-router/src/policies/load_scoring.rs
+++ b/experimental/sgl-router/src/policies/load_scoring.rs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::load_monitor::AggregateLoad;
+
+/// Scores one fresh Engine load aggregate for routing and admission.
+///
+/// This scorer is intentionally independent of routing and request admission
+/// execution so its inputs, normalization, and outputs can be reviewed in
+/// isolation.
+#[derive(Debug, Default)]
+pub struct EngineLoadScorer;
+
+impl EngineLoadScorer {
+    /// Returns normalized pressure in `[0, 1]`.
+    ///
+    /// The input signals are normalized as follows:
+    ///
+    /// ```text
+    /// request_pressure = clamp(total_requests / max_running_requests, 0, 1)
+    ///
+    /// throughput = max(prefill_throughput, gen_throughput)
+    /// queue_delay = waiting_uncached_tokens / throughput
+    /// queue_pressure = queue_delay / (1 + queue_delay)
+    ///
+    /// pressure = clamp(
+    ///     max(request_pressure, queue_pressure, max_rank_token_usage),
+    ///     0,
+    ///     1,
+    /// )
+    /// ```
+    ///
+    /// `queue_delay / (1 + queue_delay)` maps a non-negative delay to
+    /// `[0, 1)` without introducing a tuning threshold. Queued work with zero
+    /// throughput is treated as full pressure. Taking the maximum prevents a
+    /// saturated request, queue, or KV-cache dimension from being hidden by
+    /// healthier dimensions.
+    pub fn pressure(load: &AggregateLoad) -> f64 {
+        let request_pressure = ratio(load.total_requests, load.max_running_requests);
+        let queue_pressure = if load.num_waiting_uncached_tokens == 0 {
+            0.0
+        } else {
+            let throughput = load.prefill_throughput.max(load.gen_throughput);
+            if throughput > 0.0 {
+                let delay = load.num_waiting_uncached_tokens as f64 / throughput;
+                delay / (1.0 + delay)
+            } else {
+                1.0
+            }
+        };
+        load.max_rank_token_usage
+            .max(request_pressure)
+            .max(queue_pressure)
+            .clamp(0.0, 1.0)
+    }
+
+    /// Relative probability available to a pressure-aware routing policy.
+    pub fn routing_weight(load: &AggregateLoad) -> f64 {
+        1.0 - Self::pressure(load)
+    }
+
+    /// Router-side concurrent requests allowed beyond the captured Engine
+    /// state. This is a policy output only; it does not mutate worker state.
+    pub fn admission_quota(load: &AggregateLoad) -> usize {
+        let weight = Self::routing_weight(load);
+        if load.available_slots == 0 || weight <= f64::EPSILON {
+            return 0;
+        }
+        let quota = (load.available_slots as f64 * weight).floor() as u64;
+        usize::try_from(quota.max(1)).unwrap_or(usize::MAX)
+    }
+}
+
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 {
+        f64::from(numerator > 0)
+    } else {
+        (numerator as f64 / denominator as f64).clamp(0.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pressure_uses_queue_kv_and_throughput() {
+        let load = AggregateLoad {
+            total_requests: 20,
+            max_running_requests: 100,
+            num_waiting_uncached_tokens: 100,
+            prefill_throughput: 100.0,
+            max_rank_token_usage: 0.4,
+            ..AggregateLoad::default()
+        };
+        assert_eq!(EngineLoadScorer::pressure(&load), 0.5);
+
+        let faster = AggregateLoad {
+            prefill_throughput: 900.0,
+            ..load.clone()
+        };
+        assert_eq!(EngineLoadScorer::pressure(&faster), 0.4);
+    }
+
+    #[test]
+    fn no_throughput_with_queued_work_is_full_pressure() {
+        let load = AggregateLoad {
+            num_waiting_uncached_tokens: 1,
+            max_running_requests: 100,
+            available_slots: 100,
+            ..AggregateLoad::default()
+        };
+        assert_eq!(EngineLoadScorer::pressure(&load), 1.0);
+        assert_eq!(EngineLoadScorer::admission_quota(&load), 0);
+    }
+
+    #[test]
+    fn pressure_reduces_weight_and_quota() {
+        let cool = AggregateLoad {
+            max_running_requests: 100,
+            available_slots: 100,
+            max_rank_token_usage: 0.1,
+            ..AggregateLoad::default()
+        };
+        let hot = AggregateLoad {
+            max_rank_token_usage: 0.9,
+            ..cool.clone()
+        };
+        assert_eq!(EngineLoadScorer::routing_weight(&cool), 0.9);
+        assert!((EngineLoadScorer::routing_weight(&hot) - 0.1).abs() < f64::EPSILON);
+        assert_eq!(EngineLoadScorer::admission_quota(&cool), 90);
+        assert_eq!(EngineLoadScorer::admission_quota(&hot), 9);
+    }
+
+    #[test]
+    fn full_request_pressure_sheds_new_work() {
+        let load = AggregateLoad {
+            total_requests: 100,
+            max_running_requests: 100,
+            available_slots: 10,
+            ..AggregateLoad::default()
+        };
+        assert_eq!(EngineLoadScorer::pressure(&load), 1.0);
+        assert_eq!(EngineLoadScorer::routing_weight(&load), 0.0);
+        assert_eq!(EngineLoadScorer::admission_quota(&load), 0);
+    }
+}

--- a/experimental/sgl-router/src/policies/mod.rs
+++ b/experimental/sgl-router/src/policies/mod.rs
@@ -6,6 +6,7 @@ pub mod cache_aware_zmq;
 pub mod factory;
 pub mod kv_events;
 pub mod load_based;
+pub mod load_scoring;
 pub mod power_of_two;
 pub mod random;
 pub mod registry;


### PR DESCRIPTION
## Motivation

Define Engine pressure-aware scheduling independently so it can be reviewed while the LoadMonitor dependency remains in #32510.

This is a stacked WIP that depends on #32510. No #32510 implementation is included in this PR.

## Modifications

- derive normalized pressure from request saturation, queued uncached tokens, prefill/decode throughput, and hottest-rank KV usage
- route `load_based` candidates using inverse-pressure weights
- assign zero routing weight to fully pressured engines
- preserve least-active routing when Engine metrics are unavailable
- add deterministic scorer and weighted-routing tests

## Accuracy Tests

Not applicable. This change affects Router backend selection, not model execution or output accuracy.

## Speed Tests and Profiling

Pressure scoring is O(1) per candidate and weighted selection is O(n). No request body buffering or model-path synchronization is added.

## Tests

Validated after applying this patch to the exact #32510 head (`5528529ab3`):

- `cargo fmt --all -- --check`
- 4 pressure scorer tests passed
- 4 load-based scheduling tests passed
- `cargo clippy --all-targets -- -D warnings`

The standalone WIP intentionally does not compile until #32510 provides `AggregateLoad` and `PolicyCandidate`.

## Checklist

- [x] Format code
- [x] Add unit tests
- [x] Follow SGLang code style guidance
- [ ] Update documentation if the final user-facing configuration changes
- [ ] Run full benchmarks after the dependency is integrated

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30912391345](https://github.com/sgl-project/sglang/actions/runs/30912391345)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30912390880](https://github.com/sgl-project/sglang/actions/runs/30912390880)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->