### PR TITLE
fix(hicache): report recomputed GPU blocks

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1854,6 +1854,9 @@ class HiRadixCache(RadixCache):
                     self._update_host_leaf_status(node)
                     # update parent status as a new leaf is added into device
                     self._update_leaf_status(node.parent)
+                    # Re-materialized on device via recomputation: emit
+                    # store(GPU) so downstream indexers see it device-local again.
+                    self._record_store_event(node, medium=StorageMedium.GPU)
                 else:
                     self._inc_hit_count(node, chunked)
                     total_prefix_length += prefix_len
@@ -1869,6 +1872,9 @@ class HiRadixCache(RadixCache):
                     self._update_host_leaf_status(new_node)
                     # update parent status as a new leaf is added into device
                     self._update_leaf_status(new_node.parent)
+                    # Re-materialized on device via recomputation: emit
+                    # store(GPU) so downstream indexers see it device-local again.
+                    self._record_store_event(new_node, medium=StorageMedium.GPU)
                 else:
                     self._inc_hit_count(new_node, chunked)
                     total_prefix_length += prefix_len

--- a/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
@@ -96,6 +96,25 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
             if isinstance(e, BlockStored) and e.medium == StorageMedium.CPU
         ]
 
+    def _stored_gpu_events(self, cache):
+        return [
+            e
+            for e in cache.take_events()
+            if isinstance(e, BlockStored) and e.medium == StorageMedium.GPU
+        ]
+
+    def _backup_and_evict(self, cache, tokens):
+        node = self._leaf_for(cache, tokens)
+        backed_up = cache.write_backup(node, write_back=True)
+        self.assertGreater(backed_up, 0)
+        cache.writing_check(write_back=True)
+        cache.take_events()
+        self.assertGreater(cache._evict_backuped(node), 0)
+        cache.take_events()
+        self.assertTrue(node.evicted)
+        self.assertTrue(node.backuped)
+        return node
+
     def test_split_pending_write_through_publishes_fragments(self):
         cache, allocator = self._build_cache()
         cache.take_events()
@@ -119,6 +138,49 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
         )
         self.assertIsNone(stored_cpu[0].parent_block_hash)
         self.assertEqual(stored_cpu[1].parent_block_hash, stored_cpu[0].block_hashes[0])
+
+    def test_exact_recomputation_publishes_gpu_store(self):
+        cache, allocator = self._build_cache()
+        cache.take_events()
+
+        self._insert(cache, allocator, [1, 2, 3, 4])
+        self._backup_and_evict(cache, [1, 2, 3, 4])
+
+        self._insert(cache, allocator, [1, 2, 3, 4])
+        stored_gpu = self._stored_gpu_events(cache)
+        self.assertEqual(
+            [list(e.token_ids) for e in stored_gpu],
+            [[1, 2], [3, 4]],
+        )
+        self.assertIsNone(stored_gpu[0].parent_block_hash)
+        self.assertEqual(stored_gpu[1].parent_block_hash, stored_gpu[0].block_hashes[0])
+
+    def test_partial_recomputation_publishes_only_materialized_gpu_blocks(self):
+        cache, allocator = self._build_cache()
+        cache.take_events()
+
+        self._insert(cache, allocator, [1, 2, 3, 4])
+        self._backup_and_evict(cache, [1, 2, 3, 4])
+
+        self._insert(cache, allocator, [1, 2, 5, 6])
+        stored_gpu = self._stored_gpu_events(cache)
+        self.assertEqual(
+            [list(e.token_ids) for e in stored_gpu],
+            [[1, 2], [5, 6]],
+        )
+        self.assertNotIn([3, 4], [list(e.token_ids) for e in stored_gpu])
+        self.assertIsNone(stored_gpu[0].parent_block_hash)
+        self.assertEqual(stored_gpu[1].parent_block_hash, stored_gpu[0].block_hashes[0])
+
+    def test_existing_device_node_does_not_publish_duplicate_gpu_store(self):
+        cache, allocator = self._build_cache()
+        cache.take_events()
+
+        self._insert(cache, allocator, [1, 2, 3, 4])
+        cache.take_events()
+        self._insert(cache, allocator, [1, 2, 3, 4])
+
+        self.assertEqual(self._stored_gpu_events(cache), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`HiRadixCache.insert()` has a KV-recomputation path: when a node's device KV was evicted but the node is still backed up on the host, a later insert of the same tokens re-materializes it on GPU by restoring `node.value` instead of allocating fresh pages.

That path never emitted a `BlockStored` event for the GPU medium. Consumers of the KV event stream that track tier placement (e.g. an external KV indexer) therefore keep stale information: the last events they saw for those blocks were the host store and the GPU removal at eviction time, so the blocks look host-only even though they are device-resident again. Any placement or routing decision derived from the stream is wrong until the node happens to be re-inserted through a path that does emit an event.

## Modifications

`python/sglang/srt/mem_cache/hiradix_cache.py`

Emit `_record_store_event(..., medium=StorageMedium.GPU)` in the two `insert()` paths that re-materialize an evicted node on device:

- the exact-match path, inside `if node.evicted:`
- the partial-match path, inside `if new_node.evicted:` after `_split_node()`

Only the `evicted` branches are touched, so a node that is already resident on device still goes through `_inc_hit_count()` and produces no extra event.

`test/registered/unit/mem_cache/test_hiradix_cache_unit.py`

Three cases added to the existing `TestHiRadixCacheKVEvents`, plus two helpers (`_backup_and_evict`, `_stored_gpu_events`):

- `test_exact_recomputation_publishes_gpu_store` — exact recomputation publishes one store(GPU) per page with intact `parent_block_hash` parentage.
- `test_partial_recomputation_publishes_only_materialized_gpu_blocks` — after a split, only the re-materialized pages are published; the still-evicted tail is not reported.
- `test_existing_device_node_does_not_publish_duplicate_gpu_store` — a node already on device publishes nothing, guarding against over-emission.

Note on behaviour: this changes default behaviour when `enable_kv_cache_events` is on, since additional `BlockStored(GPU)` events are now emitted on recomputation. It is deliberately not gated behind a flag — the event stream was simply missing these residency transitions, and consumers already handle store events for this medium.

## Accuracy Tests

Not applicable. The change only records cache events; it does not touch kernels, model forward, or any allocation/eviction decision.

## Speed Tests and Profiling

Not applicable. The added work is one event record per re-materialized page, and only when KV cache events are enabled.

Test results, on 1x AMD Instinct MI300X (ROCm 7.2, torch 2.9.1+rocm7.2.0):

- `test/registered/unit/mem_cache/test_hiradix_cache_unit.py` — 4 passed in ~18s.
- Negative control: reverting only the 6 production lines and re-running makes `test_exact_recomputation_publishes_gpu_store` and `test_partial_recomputation_publishes_only_materialized_gpu_blocks` fail, confirming the new tests actually pin the fix rather than passing vacuously.
- Wider regression, `test/registered/unit/mem_cache/` plus `test/registered/unit/disaggregation/test_kv_events.py` — 499 passed, 126 subtests passed, 8 failed. The same 8 fail on unmodified `main` in this environment, so they are pre-existing and unrelated: 7 in `test_store_cache_4d.py` from a Triton AMD backend compiler assertion while building `store_cache_4d_kernel`, and 1 in `test_unified_radix_cache_bench.py::TestBench_FULL_SWA_ps128::test_bench_cache_finished`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — not applicable, no user-facing surface changes.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — not applicable, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30271344269](https://github.com/sgl-project/sglang/actions/runs/30271344269)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30271343827](https://github.com/sgl-project/sglang/actions/runs/30271343827)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->