### PR TITLE
[Kimi-K3] Clone branch source in Docker images

### DIFF
--- a/docker/kimi_k3/kimi_k3_cu12.Dockerfile
+++ b/docker/kimi_k3/kimi_k3_cu12.Dockerfile
@@ -57,10 +57,12 @@ RUN set -eu; \
     done
 
 # --- 1. Kimi-K3 SGLang code (replaces the base's stock sglang, editable) ---
-COPY . /sgl-workspace/sglang
 # Keep the installed extension modules, but discard Rust and pip build
 # artifacts that are not used at runtime.
-RUN cd /sgl-workspace/sglang && \
+RUN rm -rf /sgl-workspace/sglang && \
+    git clone --branch kimi-k3 \
+      https://github.com/sgl-project/sglang.git /sgl-workspace/sglang && \
+    cd /sgl-workspace/sglang && \
     rm -rf .git && \
     test ! -e .git && \
     pip install -e python --no-deps && \

--- a/docker/kimi_k3/kimi_k3_cu13.Dockerfile
+++ b/docker/kimi_k3/kimi_k3_cu13.Dockerfile
@@ -48,10 +48,12 @@ RUN apt-get update && \
 ARG TORCH_CUDA_ARCH_LIST="9.0;10.0a;10.3a"
 
 # --- 1. Kimi-K3 SGLang code (replaces the base's stock sglang, editable) ---
-COPY . /sgl-workspace/sglang
 # Keep the installed extension modules, but discard Rust and pip build
 # artifacts that are not used at runtime.
-RUN cd /sgl-workspace/sglang && \
+RUN rm -rf /sgl-workspace/sglang && \
+    git clone --branch kimi-k3 \
+      https://github.com/sgl-project/sglang.git /sgl-workspace/sglang && \
+    cd /sgl-workspace/sglang && \
     rm -rf .git && \
     test ! -e .git && \
     pip install -e python --no-deps && \


### PR DESCRIPTION
## Motivation

The Kimi-K3 CUDA 12 and CUDA 13 Dockerfiles currently copy the local Docker build context into `/sgl-workspace/sglang`. These images should instead build from the official SGLang `kimi-k3` branch so their source is independent of local checkout contents.

## Modifications

- Remove the stock `/sgl-workspace/sglang` directory inherited from each base image.
- Clone `https://github.com/sgl-project/sglang.git` with `--branch kimi-k3` in both Kimi-K3 Dockerfiles.
- Preserve the existing editable install and build-artifact cleanup.

## Accuracy Tests

Not applicable. This change only selects the SGLang source checkout used while building the Kimi-K3 images.

## Speed Tests and Profiling

Not applicable. No inference code or runtime configuration changes.

## Validation

- Ran a red-green structural check across both Dockerfiles for the clone URL, branch, destination, removal of `COPY .`, and preservation of the editable install.
- Ran `git diff --check origin/kimi-k3...HEAD`.
- All commit-time pre-commit hooks passed.

## Checklist

- [x] Format checks passed through pre-commit.
- [x] Added task-specific structural validation for both Dockerfiles.
- [x] Documentation is unaffected.
- [x] Accuracy and speed benchmarks are not applicable to this source-checkout-only change.
- [x] Followed the existing Dockerfile style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30280800200](https://github.com/sgl-project/sglang/actions/runs/30280800200)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30280799142](https://github.com/sgl-project/sglang/actions/runs/30280799142)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->