### PR TITLE
docs(cookbook): fix broken PD disaggregation anchor on Kimi-K3

### DIFF
--- a/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -36,7 +36,7 @@ If you do not want to use a Docker image, reproduce the dependency installation 
 
 Pick your hardware, then the deployment shape and operating point. Node count follows the hardware recipe (B200 2×8, GB200 4×4, H100 4×8, B300 1×8, H200 2×8, GB300 2×4, MI350X/MI355X 1×8), so it is not a separate choice.
 
-**PD Mode** — `Unified` serves prefill and decode together. `Prefill` / `Decode` split them into dedicated pools (see [PD disaggregation](#pd-disaggregation)); `Prefill` ships two strategies on the TP8 platforms, both chunked at 16k: `Default` (TP8) and `Long-Context` (`--pp-size 8 --tp-size 1`, see [Deep PP](#deep-pp-for-long-context-prefill)).
+**PD Mode** — `Unified` serves prefill and decode together. `Prefill` / `Decode` split them into dedicated pools (see [PD disaggregation](#3-4-pd-disaggregation)); `Prefill` ships two strategies on the TP8 platforms, both chunked at 16k: `Default` (TP8) and `Long-Context` (`--pp-size 8 --tp-size 1`, see [Deep PP](#deep-pp-for-long-context-prefill)).
 
 **Strategy** — the operating point within that shape:
 


### PR DESCRIPTION
## Motivation

The `lint` job is currently failing on `main`. #32542 merged with a red `lint`, and its hard gate `mint broken-links --check-anchors` reports:

```
found 1 broken links in 1 files

cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
 ⎿  #pd-disaggregation
```

The in-page link on line 39 targets `#pd-disaggregation`, but the section it points at is `### 3.4 PD Disaggregation`, whose Mintlify slug is `3-4-pd-disaggregation` — the numbering dot becomes a hyphen. So the anchor resolves to nothing and readers clicking "PD disaggregation" go nowhere.

## Modifications

One-line fix in `docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx`: point the link at the real slug.

This matches the convention already used across `docs_new/` for numbered sections — `#3-1-basic-configuration`, `#4-3-thinking-mode`, `#5-1-speed-benchmark`. The sibling link in the same sentence (`#deep-pp-for-long-context-prefill`, an unnumbered `####` heading) was already correct and is untouched.

## Accuracy Test

Docs-only change; no runtime code touched.

Verified with the exact version CI pins (`mint@4.2.559` — the workflow notes heading-slug rules are version-sensitive, so this was checked against the pinned version rather than inferred):

| Check | Result |
|---|---|
| `mint broken-links --check-anchors --check-redirects` | `success no broken links found` |
| `mint validate` | `success build validation passed` |
| `node docs_new/scripts/check_cookbook_configs.mjs` | `cookbook config check: OK` |
| pre-commit (`--all-files` scope for the changed file) | passed |

## Benchmarking and Profiling

N/A — documentation link fix.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci) — N/A, covered by the existing `lint` gate that this fix turns green.
- [x] Update documentation as needed, including docstrings or example tutorials.

cc @hnyls2002

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30281299243](https://github.com/sgl-project/sglang/actions/runs/30281299243)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30281297781](https://github.com/sgl-project/sglang/actions/runs/30281297781)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->