### PR TITLE
[Perf] Allow multimem all-gather on cross-node NVLink cliques (MNNVL)

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
+++ b/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
@@ -466,6 +466,7 @@ class MultimemAllGatherer:
             # Lazy import avoids a module-load dependency on the distributed facade.
             from sglang.srt.distributed import get_tp_group
             from sglang.srt.distributed.parallel_state import in_the_same_node_as
+            from sglang.srt.environ import envs
             from sglang.srt.runtime_context import get_server_args
 
             tp_group = get_tp_group()
@@ -475,8 +476,14 @@ class MultimemAllGatherer:
             # paths). On a single node every TP rank is co-located, so skip the
             # in_the_same_node_as() all-reduce, which can segfault under some
             # EP/mooncake setups, and keep multimem enabled.
+            # SGLANG_MULTIMEM_AG_CROSS_NODE keeps multimem enabled on
+            # multi-node deployments whose TP group is one NVLink clique
+            # (MNNVL fabric): torch symmetric memory rendezvous and multicast
+            # work across such nodes, and create_state below still falls back
+            # to NCCL when the multicast pointer is unavailable.
             if (
                 tp_group.world_size > 1
+                and not envs.SGLANG_MULTIMEM_AG_CROSS_NODE.get()
                 and get_server_args().nnodes > 1
                 and not all(in_the_same_node_as(tp_group.cpu_group, source_rank=0))
             ):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1034,6 +1034,12 @@ class Envs:
     SGLANG_FLASHINFER_AUTOTUNE_CACHE = EnvBool(True)
     SGLANG_ENABLE_MOE_DEFERRED_FINALIZE = EnvBool(False)
 
+    # Keep the multimem (symmetric-memory) all-gather enabled when the TP
+    # group spans nodes that form one NVLink clique (MNNVL fabric), where
+    # cross-node multicast works. Default off preserves the conservative
+    # single-node-only behavior.
+    SGLANG_MULTIMEM_AG_CROSS_NODE = EnvBool(False)
+
     # Plugin system
     SGLANG_PLATFORM = EnvStr("")
     SGLANG_PLUGINS = EnvStr("")


### PR DESCRIPTION
## Motivation

`MultimemAllGatherer` (the symmetric-memory multimem all-gather used for vocab-parallel logits) disables itself whenever the TP group spans nodes. On multi-node NVLink cliques (MNNVL fabric, e.g. GB200/GB300 racks) this check mis-fires: torch symmetric-memory rendezvous succeeds across such nodes with a valid multicast pointer, and the multimem kernel works cross-node — the same fabric already serves FlashInfer's MNNVL fused all-reduces in the same CUDA graphs.

With speculative decoding the logits gather is hot: on GLM-5.2 EAGLE 5-1-6 bs=1, every speculative step performs six vocab-parallel logits all-gathers (five draft forwards + the target verify), each costing ~20 µs on NCCL `AllGather_RING_LL` across nodes, ~100% exposed on the critical path.

## Modifications

- `SGLANG_MULTIMEM_AG_CROSS_NODE` (EnvBool, default **off**): when set, `MultimemAllGatherer` skips the spans-nodes disable. `create_state`'s existing multicast-pointer check remains the fail-closed fallback to NCCL, so topologies without cross-node multicast are unaffected.

Default-off: zero behavior change unless the flag is set.

## Validation

Two-node probe (2×4 GB300, MNNVL): symm-mem rendezvous succeeds cross-node with a non-zero multicast pointer; gathers bit-exact vs NCCL at M=1/M=6 (shard 19360 bf16); cross-rank-max medians at or below NCCL.

## Benchmarks

GLM-5.2-FP8, bs=1, EAGLE 5-1-6, TP8 over 2×4 GB300 (MNNVL). Official protocol = serial 3×40 coding prompts, fresh server, mean decode throughput.

| Metric | Before | After |
|---|---:|---:|
| Decode throughput (3×40, bs=1) | 388.45 tok/s | **391.06 tok/s (+0.67%)** |
| Logits all-gather kernel (trace) | NCCL RING_LL, 20 µs ×6/step | multimem `_all_gather_kernel_inner`, 6.6 µs ×6/step |
| NCCL kernels per decode step | 6 | **0** |
| Spec accept length | 3.8623 | 3.8623 |
| Response bytes (120 official records) | — | 120/120 byte-identical |

| Accuracy | Before | After |
|---|---:|---:|
| GSM8K 200q (few-shot 5, greedy) | 0.975 | 0.975 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30283972382](https://github.com/sgl-project/sglang/actions/runs/30283972382)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30283972601](https://github.com/sgl-project/sglang/actions/runs/30283972601)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->