### PR TITLE
[Bugfix] Link JIT modules against the pip CUDA runtime

### DIFF
--- a/python/sglang/kernels/jit/utils/compile.py
+++ b/python/sglang/kernels/jit/utils/compile.py
@@ -162,11 +162,94 @@ def _tvm_ffi_version() -> str:
         return "unknown"
 
 
+def _ensure_cuda_home_link(link: pathlib.Path, target: pathlib.Path) -> None:
+    try:
+        link.symlink_to(target)
+    except FileExistsError:
+        if not link.is_symlink() or link.resolve() != target.resolve():
+            raise RuntimeError(
+                f"CUDA compatibility link {link} already exists and does not "
+                f"point to {target}."
+            )
+
+
+def _prepare_cuda_runtime_home(
+    cuda_home: pathlib.Path, cache_dir: pathlib.Path
+) -> Tuple[pathlib.Path | None, str | None]:
+    """Normalize nonstandard CUDA runtime layouts for TVM-FFI's linker."""
+    standard_runtime = cuda_home / "lib64" / "libcudart.so"
+    if standard_runtime.is_file():
+        return None, None
+
+    runtime_dirs = (cuda_home / "lib", cuda_home / "lib64")
+    for runtime_dir in runtime_dirs:
+        runtime_link = runtime_dir / "libcudart.so"
+        if runtime_link.is_file():
+            runtime = runtime_link.resolve()
+            tag = hashlib.sha256(str(runtime).encode()).hexdigest()[:12]
+            break
+    else:
+        # NVIDIA's pip CUDA runtime ships only a versioned shared library under
+        # ``lib/``. TVM-FFI currently searches ``lib64/`` and can silently
+        # resolve a system libcudart from another CUDA major instead.
+        runtimes = {
+            runtime.resolve()
+            for runtime_dir in runtime_dirs
+            for runtime in runtime_dir.glob("libcudart.so.*")
+            if runtime.is_file()
+        }
+        if not runtimes:
+            return None, None
+        if len(runtimes) > 1:
+            raise RuntimeError(
+                f"Found multiple CUDA runtime libraries under {cuda_home}; "
+                "add an unversioned libcudart.so link to select one."
+            )
+
+        runtime = runtimes.pop()
+        tag = hashlib.sha256(str(runtime).encode()).hexdigest()[:12]
+
+    compat_home = cache_dir / "sglang-cuda-home" / tag
+    compat_home.mkdir(parents=True, exist_ok=True)
+    for entry in cuda_home.iterdir():
+        if entry.name != "lib64":
+            _ensure_cuda_home_link(compat_home / entry.name, entry)
+
+    compat_lib64 = compat_home / "lib64"
+    compat_lib64.mkdir(exist_ok=True)
+    source_lib64 = cuda_home / "lib64"
+    if source_lib64.is_dir():
+        for entry in source_lib64.iterdir():
+            if entry.name != "libcudart.so":
+                _ensure_cuda_home_link(compat_lib64 / entry.name, entry)
+    _ensure_cuda_home_link(compat_lib64 / "libcudart.so", runtime)
+    return compat_home, tag
+
+
+def _cuda_runtime_link_config() -> Tuple[pathlib.Path | None, str | None]:
+    if os.name == "nt" or is_hip_runtime():
+        return None, None
+
+    # Keep CUDA_HOME resolution identical to the pinned TVM-FFI compiler that
+    # consumes this configuration.
+    from tvm_ffi.cpp.extension import _find_cuda_home
+
+    cuda_home = pathlib.Path(_find_cuda_home()).expanduser().resolve()
+    cache_dir = pathlib.Path(
+        os.environ.get("TVM_FFI_CACHE_DIR", "~/.cache/tvm-ffi")
+    ).expanduser()
+    return _prepare_cuda_runtime_home(cuda_home, cache_dir)
+
+
 def _jit_build_dir_name(module_name: str) -> str:
     # Key on arch + tvm-ffi ABI too (module_name only hashes sources), so a
     # shared cache volume never reuses a cross-arch/ABI .so.
     arch = get_jit_cuda_arch().target_name
-    return f"{module_name}__arch_{arch}__tvmffi_{_tvm_ffi_version()}"
+    name = f"{module_name}__arch_{arch}__tvmffi_{_tvm_ffi_version()}"
+    _, cuda_runtime_tag = _cuda_runtime_link_config()
+    if cuda_runtime_tag is not None:
+        name += f"__cudart_{cuda_runtime_tag}"
+    return name
 
 
 def load_jit(
@@ -300,13 +383,24 @@ def _jit_compile_context():
     if is_hip_runtime():
         yield  # TODO: support ROCm `TVM_FFI_ROCM_ARCH_LIST` if needed
         return
-    env_key = "TVM_FFI_CUDA_ARCH_LIST"
-    old_value = os.environ.get(env_key, None)
-    os.environ[env_key] = get_jit_cuda_arch().target_name
+    compat_cuda_home, _ = _cuda_runtime_link_config()
+    env_updates = {"TVM_FFI_CUDA_ARCH_LIST": get_jit_cuda_arch().target_name}
+    if compat_cuda_home is not None:
+        env_updates["CUDA_HOME"] = str(compat_cuda_home)
+
+    old_values = {key: os.environ.get(key) for key in env_updates}
+    os.environ.update(env_updates)
+    if compat_cuda_home is not None:
+        from tvm_ffi.cpp.extension import _find_cuda_home
+
+        _find_cuda_home.cache_clear()
     try:
         yield
     finally:
-        if old_value is None:
-            os.environ.pop(env_key, None)
-        else:
-            os.environ[env_key] = old_value
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+        if compat_cuda_home is not None:
+            _find_cuda_home.cache_clear()

--- a/test/registered/unit/compilation/test_jit_cuda_runtime.py
+++ b/test/registered/unit/compilation/test_jit_cuda_runtime.py
@@ -1,0 +1,95 @@
+import os
+import pathlib
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.kernels.jit.utils import compile as jit_compile
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestJitCudaRuntime(CustomTestCase):
+    def test_versioned_cuda_runtime_is_exposed_to_the_linker(self):
+        """A versioned-only pip CUDA runtime must not fall through to a system CUDA."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            cuda_home = root / "cuda"
+            runtime_dir = cuda_home / "lib"
+            runtime_dir.mkdir(parents=True)
+            runtime = runtime_dir / "libcudart.so.13"
+            runtime.write_bytes(b"test runtime")
+            cache_dir = root / "cache"
+
+            with (
+                patch(
+                    "tvm_ffi.cpp.extension._find_cuda_home",
+                    side_effect=lambda: os.environ["CUDA_HOME"],
+                ),
+                patch.object(
+                    jit_compile,
+                    "get_jit_cuda_arch",
+                    return_value=SimpleNamespace(target_name="sm_80"),
+                ),
+                patch.dict(
+                    os.environ,
+                    {
+                        "CUDA_HOME": str(cuda_home),
+                        "LIBRARY_PATH": "/existing/link/path",
+                        "TVM_FFI_CACHE_DIR": str(cache_dir),
+                    },
+                ),
+            ):
+                with jit_compile._jit_compile_context():
+                    compat_home = pathlib.Path(os.environ["CUDA_HOME"])
+                    runtime_link = compat_home / "lib64" / "libcudart.so"
+                    self.assertNotEqual(compat_home, cuda_home)
+                    self.assertEqual(runtime_link.resolve(), runtime.resolve())
+                    self.assertEqual(os.environ["LIBRARY_PATH"], "/existing/link/path")
+
+                self.assertEqual(os.environ["CUDA_HOME"], str(cuda_home))
+                self.assertIn(
+                    "__cudart_", jit_compile._jit_build_dir_name("test_module")
+                )
+
+    def test_standard_cuda_runtime_layout_is_unchanged(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = pathlib.Path(temp_dir)
+            cuda_home = root / "cuda"
+            runtime_dir = cuda_home / "lib64"
+            runtime_dir.mkdir(parents=True)
+            (runtime_dir / "libcudart.so").write_bytes(b"test runtime")
+
+            with (
+                patch(
+                    "tvm_ffi.cpp.extension._find_cuda_home",
+                    side_effect=lambda: os.environ["CUDA_HOME"],
+                ),
+                patch.object(
+                    jit_compile,
+                    "get_jit_cuda_arch",
+                    return_value=SimpleNamespace(target_name="sm_80"),
+                ),
+                patch.dict(
+                    os.environ,
+                    {
+                        "CUDA_HOME": str(cuda_home),
+                        "LIBRARY_PATH": "/existing/link/path",
+                        "TVM_FFI_CACHE_DIR": str(root / "cache"),
+                    },
+                ),
+            ):
+                with jit_compile._jit_compile_context():
+                    self.assertEqual(os.environ["LIBRARY_PATH"], "/existing/link/path")
+                    self.assertEqual(os.environ["CUDA_HOME"], str(cuda_home))
+
+                self.assertNotIn(
+                    "__cudart_", jit_compile._jit_build_dir_name("test_module")
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

SGLang's TVM-FFI JIT path can link against the wrong CUDA runtime when CUDA is provided by NVIDIA's pip packages. In the failing layout, TVM-FFI resolved `CUDA_HOME` to the pip CUDA package, but searched `CUDA_HOME/lib64` while that package exposed only a versioned `libcudart.so.13` under `CUDA_HOME/lib`. The linker then fell through to the system CUDA installation and produced a JIT module with a `libcudart.so.11.0` dependency. Loading that module in a CUDA 13 process caused `CUDA error: invalid resource handle` in the activation kernel.

This issue was discovered independently while validating an unrelated inference report.

## Modifications

- Detect a versioned-only CUDA runtime layout before invoking TVM-FFI.
- Create a cache-local compatibility `CUDA_HOME` that exposes the selected runtime as `lib64/libcudart.so`, without modifying the CUDA installation.
- Add the selected runtime identity to the JIT build-directory key so an existing module linked against another runtime is not reused.
- Preserve standard CUDA layouts and the existing ROCm/Windows behavior.
- Add CPU unit coverage for both the versioned pip layout and the standard `lib64/libcudart.so` layout.

## Accuracy Tests

Validation was run on a node with 2x RTX 3090 (SM 8.6), the pip CUDA 13 runtime, NVCC 13.0.88, PyTorch 2.11.0+cu130, and TVM-FFI 0.1.11.

- `python -m pytest -q test/registered/unit/compilation/test_jit_cuda_runtime.py`: 2 passed.
- `python -m pytest -q test/registered/kernels/ops/activation/test_activation.py`: 487 passed.
- TP=2 Qwen3.5-4B serving completed a 32-token generation request successfully with prefill and decode CUDA graphs enabled.
- `readelf -d` showed that all 3 JIT activation modules built by the serving run depended on `libcudart.so.13` (3/3).
- The relevant pre-commit hooks passed on both changed files.

## Speed Tests and Profiling

No throughput or latency benchmark was run. This changes JIT link-time path selection and cache invalidation, not the generated kernel or steady-state execution path.

## Limitations

- Full upstream CI was not run; it requires maintainer-triggered checks.
- This was not validated with a pip CUDA 12 layout, Clang, or GPU architectures other than SM 8.6.
- The integration follows the CUDA-home resolver in the pinned TVM-FFI version. The durable ownership of this behavior may belong in TVM-FFI, and maintainers may prefer to move the fix upstream.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing documentation change is required.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Correctness tests are above; no speed benchmark was run.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30288341267](https://github.com/sgl-project/sglang/actions/runs/30288341267)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30288341125](https://github.com/sgl-project/sglang/actions/runs/30288341125)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->