### PR TITLE
[Nemotron] Fix decode track-save reading the stale tail of the CUDA-graph track buffer

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -566,12 +566,15 @@ class MambaAttnBackendBase(AttentionBackend):
             self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
         # Refresh the static track-dest buffer in-place (translated); the captured
         # track-save reads it, leaving the handed-in InputBuffer slot read-only.
+        # Hand out only the refreshed [:bs] prefix — Mamba2's track-save slices
+        # [-num_decodes:], which on the full max_bs buffer binds the stale tail.
         track_buf = None
         if mamba_track_indices is not None:
-            track_buf = self.mamba_track_indices_buf
-            track_buf[: len(mamba_track_indices)].copy_(
-                self._translate_mamba_indices(mamba_track_indices)
-            )
+            assert (
+                len(mamba_track_indices) >= bs
+            ), f"{len(mamba_track_indices)=} < {bs=}"
+            track_buf = self.mamba_track_indices_buf[:bs]
+            track_buf.copy_(self._translate_mamba_indices(mamba_track_indices[:bs]))
         # Refresh the static write cursor in-place (mirrors the eager
         # snapshot-then-advance). Skip the advance during capture: dummy slots
         # would corrupt real ring positions.

--- a/test/registered/radix_cache/test_mamba2_extra_buffer_kl.py
+++ b/test/registered/radix_cache/test_mamba2_extra_buffer_kl.py
@@ -1,0 +1,63 @@
+"""Regression test: Mamba2 (NemotronH) ``extra_buffer`` state tracking stays
+consistent under CUDA-graph decode.
+
+The decode-cache-hit KL check guards the graph-replay track-save path: a decode
+that crosses ``--mamba-track-interval`` donates its tracked state to the mamba
+radix tree, the second turn hits that decode-seeded prefix, and its logprobs
+must match a cold recompute. Before the ``[:bs]`` track-buffer fix in
+``MambaAttnBackendBase._replay_metadata``, the captured track-save kernel bound
+the stale tail of the static track buffer and scattered the state to the wrong
+slot, so the tree cached an unwritten slot and this check fails with KL ~1.5
+(vs ~1e-3 healthy).
+
+The existing ``extra_buffer`` KL coverage (test_unified_radix_cache_kl_mamba,
+the int8 checkpoint e2e) runs GDN models (Qwen3-Next), whose decode track-save
+indexes the track buffer from the front and never hit the bug; NemotronH
+(Mamba2) slices it from the tail (``[-num_decodes:]``), so it needs its own
+registered coverage.
+
+Usage:
+    python3 -m unittest test_mamba2_extra_buffer_kl
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.kl_divergence_kit import KLDivergenceMixin
+from sglang.test.server_fixtures.default_fixture import DefaultServerBase
+
+register_cuda_ci(est_time=600, stage="extra-a", runner_config="1-gpu-large")
+
+
+class TestMamba2ExtraBufferKL(KLDivergenceMixin, DefaultServerBase):
+    """NemotronH (Mamba2) + extra_buffer: cache-hit logprobs match cold recompute."""
+
+    model = "nvidia/NVIDIA-Nemotron-Nano-9B-v2"
+
+    # Decode-seeded reuse is the regression trigger (the graphed decode
+    # track-save); the broken path fails at KL ~1.5, so 0.005 discriminates
+    # cleanly while absorbing bf16 reuse noise. Prefill reuse (chunk-aligned
+    # intermediate h states) is inherently looser; threshold matches the manual
+    # TestNvidiaNemotronNanoV2BF16ExtraBuffer calibration.
+    kl_div_thres = 0.005
+    kl_div_thres_prefill = 0.01
+    kl_div_max_samples = 16
+
+    other_args = [
+        "--max-mamba-cache-size",
+        "256",
+        "--mem-fraction-static",
+        "0.8",
+        "--mamba-scheduler-strategy",
+        "extra_buffer",
+        # The 512-token decode turns must cross a track boundary for the tree
+        # to hold decode-seeded states; halve the default interval (must stay
+        # >= the model's mamba chunk size, 128) so nearly every sample donates
+        # one even when it stops early.
+        "--mamba-track-interval",
+        "128",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With the `extra_buffer` mamba radix cache strategy, prefix hits on decode-seeded mamba entries return corrupted logits whenever decode runs under CUDA graphs. Repro shape (deterministic): serve a Mamba2-arch hybrid model (e.g. NemotronH / Nemotron-3-Super-120B) with CUDA graphs on, greedy-decode past a `mamba_track_interval` boundary so the finished request donates a tracked state to the radix tree, then rescore the same tokens with `return_logprob`. The cache-hit rescore diverges from a cold prefill by KL ≈ 1.55 (mean logprob diff ≈ 0.61); with `--disable-cuda-graph` the same check gives KL ≈ 0.002. No crash, no assert — silent corruption.

Related but distinct from #31833: that issue tracks a multi-request prefill offset defect in `_init_track_ssm_indices`; this bug corrupts single-request graphed decode.

## Modifications

Root cause: under decode CUDA graphs, `MambaAttnBackendBase._replay_metadata` refills the static track-destination buffer `mamba_track_indices_buf` at the **front** (`[:bs]`) each replay, but handed the **full max_bs buffer** to `ForwardMetadata`. `Mamba2AttnBackend.forward` slices the track destinations as `[-num_decodes:]`, so the captured track-save kernel bound the buffer's never-refreshed **tail** (zeros):

- On every `mamba_track_interval` boundary crossed during graphed decode, the conv/SSM state snapshot is scattered to physical mamba slot 0 (or a stale slot left by a larger batch) instead of the request's ping-pong track slot.
- The request's ping-pong slot stays unwritten, and `cache_finished_req` inserts that unwritten slot into the mamba radix tree; later prefix hits restore garbage state.
- Side effect: whichever live request owns slot 0 has its recurrent state clobbered mid-decode.

GDN/KDA backends (`_track_mamba_state_decode`) index the same buffer from the front and are unaffected — only Mamba2 archs hit this. The eager path builds bs-length metadata and is also correct: `[-num_decodes:]` is right for eager mixed batches (decode rows sit at the batch tail). So the fix hands the graph path a `[:bs]` view of the static buffer instead of changing the slice: in `_replay_metadata`, return only the refilled `[:bs]` prefix of `mamba_track_indices_buf`, plus an assert that the incoming (padded) track indices cover the batch.

## Regression test

`test/registered/radix_cache/test_mamba2_extra_buffer_kl.py` — a 1-GPU NemotronH (Nemotron-Nano-9B-v2) server test with `--mamba-scheduler-strategy extra_buffer`, using `KLDivergenceMixin`. Its decode-cache-hit check (second turn hits the decode-seeded mamba prefix, logprobs compared against a cold recompute) fails at KL ~1.5 without this fix and passes at ~1e-3 with it. Existing `extra_buffer` KL coverage (`test_unified_radix_cache_kl_mamba.py`, the int8 checkpoint e2e) runs GDN models, which index the track buffer from the front and never hit this bug; the NemotronH KL class in `test/manual/` is not run by CI.

## Accuracy Tests

Cached-vs-cold logprob rescore over a decode-seeded 256-token prefix (NemotronH Super-120B BF16, TP4, `extra_buffer`, CUDA graphs on):

| build | cached-vs-cold KL | mean diff |
| --- | --- | --- |
| before fix | 1.554 | 0.614 |
| before fix, `--disable-cuda-graph` | 0.0020 | 0.010 |
| after fix, graphs on | 0.0025 | 0.014 |

After the fix, the graphed path matches eager within noise.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30470076770](https://github.com/sgl-project/sglang/actions/runs/30470076770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30470076301](https://github.com/sgl-project/sglang/actions/runs/30470076301)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
