### PR TITLE
[test] Add regression test for validate_deepseek_v4_cp hook ordering (#32553; fix landed via #33532)

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -167,6 +167,8 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
         )
 
     server_args.enable_dsa_prefill_context_parallel = True
+    # Clear the generic legacy alias the pre-model-arch legacy-CP mirror may have set.
+    server_args.enable_prefill_context_parallel = False
     server_args.dsa_prefill_cp_mode = "round-robin-split"
     server_args.enable_dp_attention = True
     server_args.moe_dense_tp_size = 1

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -900,6 +900,32 @@ class TestContextParallelServerArgs(CustomTestCase):
         self.assertTrue(is_cp_enabled())
         self.assertTrue(is_interleave())
 
+    def test_canonical_cp_survives_deepseek_v4_hook_ordering(self):
+        """Regression for #32553: canonical CP flags crashed on DeepSeek V4."""
+        from sglang.srt.arg_groups.deepseek_v4_hook import validate_deepseek_v4_cp
+
+        server_args = self._new_cp_args(
+            enable_prefill_cp=True,
+            cp_strategy="interleave",
+            tp_size=8,
+            enable_dp_attention=False,
+            moe_dense_tp_size=None,
+            moe_a2a_backend="none",
+        )
+
+        try:
+            # Same handler ordering as __post_init__.
+            server_args._handle_legacy_cp_arguments()
+            validate_deepseek_v4_cp(server_args)
+            server_args._handle_legacy_cp_arguments()
+            server_args._handle_context_parallelism()
+        finally:
+            envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.clear()
+
+        self.assertTrue(server_args.enable_dsa_prefill_context_parallel)
+        self.assertFalse(server_args.enable_prefill_context_parallel)
+        self.assertEqual(server_args.dsa_prefill_cp_mode, "round-robin-split")
+
     def test_registered_cp_legacy_args_map_to_unified_strategy(self):
         cases = [
             (

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -532,6 +532,32 @@ class TestContextParallelServerArgs(CustomTestCase):
         self.assertTrue(is_cp_enabled())
         self.assertTrue(is_interleave())
 
+    def test_canonical_cp_survives_deepseek_v4_hook_ordering(self):
+        """Regression for #32553: canonical CP flags crashed on DeepSeek V4."""
+        from sglang.srt.arg_groups.deepseek_v4_hook import validate_deepseek_v4_cp
+
+        server_args = self._new_cp_args(
+            enable_prefill_cp=True,
+            cp_strategy="interleave",
+            tp_size=8,
+            enable_dp_attention=False,
+            moe_dense_tp_size=None,
+            moe_a2a_backend="none",
+        )
+
+        try:
+            # Same handler ordering as __post_init__.
+            server_args._handle_legacy_cp_arguments()
+            validate_deepseek_v4_cp(server_args)
+            server_args._handle_legacy_cp_arguments()
+            server_args._handle_context_parallelism()
+        finally:
+            envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.clear()
+
+        self.assertTrue(server_args.enable_dsa_prefill_context_parallel)
+        self.assertFalse(server_args.enable_prefill_context_parallel)
+        self.assertEqual(server_args.dsa_prefill_cp_mode, "round-robin-split")
+
     def test_registered_cp_legacy_args_map_to_unified_strategy(self):
         cases = [
             (


### PR DESCRIPTION
## Motivation

Relevant to #32553 — the crash was fixed on main by #33532; this PR adds the regression coverage that fix landed without.

`--enable-prefill-cp --cp-strategy interleave` crashed at startup on DeepSeek-V4-Flash. Root cause was ordering in `ServerArgs.__post_init__`: the first `_handle_legacy_cp_arguments()` pass runs before model-specific defaults and mirrors the canonical flags to the generic legacy alias, `validate_deepseek_v4_cp` then set the DSA alias without clearing the generic one, and `_handle_context_parallelism()` raised the mutual-exclusion `ValueError`. This PR originally carried the same fix; after #33532 merged I rebased and dropped it, so the diff is now test-only.

## Modifications

`test/registered/unit/server_args/test_server_args.py` (+26/-0): adds `test_canonical_cp_survives_deepseek_v4_hook_ordering`, which replays the `__post_init__` handler ordering through `validate_deepseek_v4_cp` and asserts the canonical CP flags survive. The existing CP tests cover the alias mirroring but never exercise the DSV4 hook path.

Verified on the rebased head: `pytest test/registered/unit/server_args/test_server_args.py -k canonical_cp` → 1 passed against current main, and fails with the issue's `ValueError` if #33532's hook change is reverted.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31552763963](https://github.com/sgl-project/sglang/actions/runs/31552763963)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31552763913](https://github.com/sgl-project/sglang/actions/runs/31552763913)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->