### PR TITLE
Update mi35x ROCm image to k3-20260727

### DIFF
--- a/.claude/skills/cookbook-add-model/templates/config.jsx.tmpl
+++ b/.claude/skills/cookbook-add-model/templates/config.jsx.tmpl
@@ -156,8 +156,8 @@ sgl-eval run gsm8k \\
     gb300: "lmsysorg/sglang:dev",
     mi300x: "lmsysorg/sglang:dev-rocm720-mi30x",
     mi325x: "lmsysorg/sglang:dev-rocm720-mi30x",
-    mi350x: "lmsysorg/sglang:dev-rocm720-mi35x",
-    mi355x: "lmsysorg/sglang:dev-rocm720-mi35x",
+    mi350x: "lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727",
+    mi355x: "lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727",
   },
 
   // Prefills the issue template's free-form `model` field on "Submit verified cell".

--- a/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -216,8 +216,8 @@ export const config = {
     gb300:  "lmsysorg/sglang:kimi-k3",
     b200:   "lmsysorg/sglang:kimi-k3",
     gb200:  "lmsysorg/sglang:kimi-k3",
-    mi350x: "lmsysorg/sglang:dev-rocm720-mi35x",
-    mi355x: "lmsysorg/sglang:dev-rocm720-mi35x",
+    mi350x: "lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727",
+    mi355x: "lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727",
   },
   // Pre-selects the issue template's `model` field on "Submit verified cell".
   github: {


### PR DESCRIPTION
Replace `lmsysorg/sglang:dev-rocm720-mi35x` with `lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727` in the mi350x/mi355x config entries.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30290823762](https://github.com/sgl-project/sglang/actions/runs/30290823762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30290822320](https://github.com/sgl-project/sglang/actions/runs/30290822320)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->