### PR TITLE
Fix S3 speculative draft loading

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3683,16 +3683,20 @@ class ServerArgs:
             )
 
     def _handle_model_source_paths(self):
-        """Resolve model/tokenizer paths backed by remote object stores."""
-        if is_runai_obj_uri(self.model_path):
-            ObjectStorageModel.download_and_get_path(self.model_path)
-
-        if (
-            self.tokenizer_path is not None
-            and is_runai_obj_uri(self.tokenizer_path)
-            and self.tokenizer_path != self.model_path
+        """Prepare metadata for model paths backed by remote object stores."""
+        seen_paths = set()
+        for model_path in (
+            self.model_path,
+            self.tokenizer_path,
+            self.speculative_draft_model_path,
         ):
-            ObjectStorageModel.download_and_get_path(self.tokenizer_path)
+            if (
+                model_path is not None
+                and model_path not in seen_paths
+                and is_runai_obj_uri(model_path)
+            ):
+                ObjectStorageModel.download_and_get_path(model_path)
+                seen_paths.add(model_path)
 
     def _handle_pd_disaggregation(self):
         from sglang.srt.arg_groups.pd_disaggregation_hook import (
@@ -7075,6 +7079,13 @@ class ServerArgs:
             self.load_format = "runai_streamer"
         elif is_remote_url(self.model_path):
             self.load_format = "remote"
+
+        if (
+            self.speculative_draft_model_path is not None
+            and is_runai_obj_uri(self.speculative_draft_model_path)
+            and self.speculative_draft_load_format is None
+        ):
+            self.speculative_draft_load_format = "runai_streamer"
 
         if self.custom_weight_loader is None:
             self.custom_weight_loader = []

--- a/test/registered/unit/multimodal/test_kimi_k3_gpu_preprocess.py
+++ b/test/registered/unit/multimodal/test_kimi_k3_gpu_preprocess.py
@@ -7,8 +7,8 @@ import pytest
 import torch
 from PIL import Image
 
-from sglang.srt.multimodal.processors.kimi_k25 import _resize_bicubic_if_needed
 from sglang.srt.multimodal.processors.kimi_k3 import _fill_transparent_bg
+from sglang.srt.multimodal.processors.kimi_k25 import _resize_bicubic_if_needed
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -5,7 +5,7 @@ import socket
 import tempfile
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.arg_groups import pd_disaggregation_hook
@@ -39,6 +39,52 @@ register_cpu_ci(est_time=12, suite="base-c-test-cpu")
 # Mock get_device() so all tests run on CPU-only CI runners
 _mock_device = patch("sglang.srt.server_args.get_device", return_value="cuda")
 _mock_device.start()
+
+
+class TestObjectStorageModelSources(CustomTestCase):
+    @patch("sglang.srt.server_args.ObjectStorageModel.download_and_get_path")
+    def test_prepare_unique_model_source_metadata(self, mock_download):
+        model_uri = "s3://bucket/target/"
+        draft_uri = "s3://bucket/draft/"
+        server_args = ServerArgs(
+            model_path="dummy",
+            tokenizer_path=model_uri,
+            speculative_draft_model_path=draft_uri,
+        )
+        server_args.model_path = model_uri
+
+        server_args._handle_model_source_paths()
+
+        self.assertEqual(
+            mock_download.call_args_list,
+            [call(model_uri), call(draft_uri)],
+        )
+
+    def test_remote_draft_uses_runai_streamer(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            speculative_draft_model_path="s3://bucket/draft/",
+        )
+        server_args.model_path = "/models/target"
+        server_args.load_format = "safetensors"
+
+        server_args._handle_load_format()
+
+        self.assertEqual(server_args.load_format, "safetensors")
+        self.assertEqual(server_args.speculative_draft_load_format, "runai_streamer")
+
+    def test_explicit_draft_load_format_is_preserved(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            speculative_draft_model_path="s3://bucket/draft/",
+            speculative_draft_load_format="dummy",
+        )
+        server_args.model_path = "/models/target"
+        server_args.load_format = "safetensors"
+
+        server_args._handle_load_format()
+
+        self.assertEqual(server_args.speculative_draft_load_format, "dummy")
 
 
 class TestPrepareServerArgs(CustomTestCase):


### PR DESCRIPTION
## Why

SGLang prefetches object-storage metadata for the target model, but not the speculative draft. Config parsing therefore fails before S3 draft weights can load.

## Summary

Support S3 speculative draft models with the same metadata and RunAI loading flow as the target model.

## Details

- Prefetch metadata for unique target, tokenizer, and draft object-storage paths.
- Select `runai_streamer` for remote drafts unless explicitly overridden.
- Fix the existing Kimi K3 test import order required by repository-wide lint.

## Test

- Added unit coverage for metadata deduplication and draft load-format selection.
- Passed Ruff, Black, isort, and `pre-commit run isort --all-files`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30297734364](https://github.com/sgl-project/sglang/actions/runs/30297734364)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30297733960](https://github.com/sgl-project/sglang/actions/runs/30297733960)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->