### PR TITLE
feat: expand weight loader v2 PR2 coverage

### DIFF
--- a/python/sglang/srt/model_loader/auto_loader.py
+++ b/python/sglang/srt/model_loader/auto_loader.py
@@ -11,21 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Centralized weight loading utilities for native SGLang models.
-
-This module provides:
-- StackedParamsDispatch: reusable stacked-parameter routing (qkv_proj, gate_up_proj).
-- ExpertParamsDispatch: MoE expert_id + w1/w2/w3 shard routing.
-- filter_pp_weights: generator that drops out-of-range PP layers.
-- RemapRegistry: architecture-specific name remap registration.
-- Re-exports of AutoWeightsLoader and WeightsMapper from models/utils.py.
-
-Load / post-load split (PR1 protocol, see #31051):
-  load_weights(..., run_post_load=True)  -> WeightLoadResult
-  post_load_weights(loaded=result)       -> optional GPU derivations (MLA w_kc/w_vc, etc.)
-
-Migration plan: https://github.com/sgl-project/sglang/issues/31051 (RFC #24703).
-"""
+"""Centralized weight loading utilities for native SGLang models."""
 
 from __future__ import annotations
 
@@ -38,49 +24,29 @@ from torch import nn
 from torch.nn import Parameter
 
 from sglang.srt.layers.utils.common import get_layer_id
+from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.utils import AutoWeightsLoader, WeightsMapper
 
 __all__ = [
     "AutoWeightsLoader",
     "WeightsMapper",
     "StackedParamsDispatch",
+    "ExpertParamsDispatch",
     "STANDARD_QKV_MAPPING",
     "STANDARD_GATE_UP_MAPPING",
     "STANDARD_STACKED_MAPPING",
     "LLAMA_STACKED_MAPPING",
+    "MOE_EXPERT_STACKED_SKIP_SUBSTRS",
+    "try_load_stacked_skip_moe_experts",
+    "load_with_stacked_dispatch",
+    "load_moe_sparse_block_weights",
     "filter_pp_weights",
     "register_weight_remap",
     "get_weight_remap",
 ]
 
 
-# ---------------------------------------------------------------------------
-# Stacked Parameters Dispatch
-# ---------------------------------------------------------------------------
-
-
 class StackedParamsDispatch(msgspec.Struct, frozen=True):
-    """Centralized stacked-parameter loading for fused linear layers.
-
-    Handles the common pattern of mapping checkpoint names
-    (q_proj, k_proj, v_proj, gate_proj, up_proj) to fused runtime parameters
-    (qkv_proj, gate_up_proj) with the correct shard IDs.
-
-    Quantization is handled entirely by ``param.weight_loader`` on the layer —
-    this class only routes the tensor to the correct parameter with the correct
-    shard_id.
-
-    Usage::
-
-        mapping = StackedParamsDispatch([
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-        ])
-        target = mapping.try_load(name, tensor, params_dict)
-    """
-
-    # (fused_param_name, checkpoint_source_name, shard_id).
     mappings: tuple[tuple[str, str, Union[int, str]], ...] = ()
 
     def try_load(
@@ -89,27 +55,25 @@ class StackedParamsDispatch(msgspec.Struct, frozen=True):
         tensor: torch.Tensor,
         params_dict: dict[str, Parameter],
     ) -> str | None:
-        """Try to load a weight via stacked mapping.
-
-        Returns the loaded runtime parameter name if matched and loaded,
-        the target name (for skip tracking) if the target param is missing
-        (e.g. optional bias), or None if no mapping matched.
-        """
+        missing_target: str | None = None
         for fused_name, source_name, shard_id in self.mappings:
             if source_name not in name:
                 continue
             target = name.replace(source_name, fused_name)
             param = params_dict.get(target)
             if param is None:
-                # Parameter doesn't exist — e.g. GPTQ bias.
-                # Return target so caller can track the skip.
-                return target
+                if missing_target is None:
+                    missing_target = target
+                continue
             param.weight_loader(param, tensor, shard_id)
             return target
+        if missing_target is not None:
+            raise ValueError(
+                f"Mapped checkpoint weight {name!r} to missing parameter "
+                f"{missing_target!r}"
+            )
         return None
 
-
-# Pre-built instances for the most common decoder patterns.
 
 STANDARD_QKV_MAPPING = StackedParamsDispatch(
     mappings=(
@@ -136,7 +100,6 @@ STANDARD_STACKED_MAPPING = StackedParamsDispatch(
     )
 )
 
-# Llama-family full-path stacked mapping (dot-prefixed shard names).
 LLAMA_STACKED_MAPPING = StackedParamsDispatch(
     mappings=(
         (".qkv_proj", ".q_proj", "q"),
@@ -147,10 +110,197 @@ LLAMA_STACKED_MAPPING = StackedParamsDispatch(
     )
 )
 
+MOE_EXPERT_STACKED_SKIP_SUBSTRS: tuple[str, ...] = ("mlp.experts", "experts.")
 
-# ---------------------------------------------------------------------------
-# Pipeline Parallel Weight Filter
-# ---------------------------------------------------------------------------
+
+def try_load_stacked_skip_moe_experts(
+    dispatch: StackedParamsDispatch,
+    name: str,
+    tensor: torch.Tensor,
+    params_dict: dict[str, Parameter],
+    *,
+    skip_substrs: tuple[str, ...] = MOE_EXPERT_STACKED_SKIP_SUBSTRS,
+) -> str | None:
+    missing_target: str | None = None
+    for fused_name, source_name, shard_id in dispatch.mappings:
+        if source_name not in name:
+            continue
+        if any(skip in name for skip in skip_substrs):
+            continue
+        target = name.replace(source_name, fused_name)
+        param = params_dict.get(target)
+        if param is None:
+            if missing_target is None:
+                missing_target = target
+            continue
+        param.weight_loader(param, tensor, shard_id)
+        return target
+    if missing_target is not None:
+        raise ValueError(
+            f"Mapped checkpoint weight {name!r} to missing parameter "
+            f"{missing_target!r}"
+        )
+    return None
+
+
+class ExpertParamsDispatch(msgspec.Struct, frozen=True):
+    mappings: tuple[tuple[str, str, int, str], ...] = ()
+
+    @classmethod
+    def from_fused_moe_mapping(
+        cls,
+        expert_params_mapping: list[tuple[str, str, int, str]],
+    ) -> ExpertParamsDispatch:
+        return cls(mappings=tuple(expert_params_mapping))
+
+    @classmethod
+    def from_gate_up_down(
+        cls,
+        *,
+        num_experts: int,
+        ckpt_gate_proj_name: str = "gate_proj",
+        ckpt_down_proj_name: str = "down_proj",
+        ckpt_up_proj_name: str = "up_proj",
+    ) -> ExpertParamsDispatch:
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
+
+        return cls.from_fused_moe_mapping(
+            FusedMoE.make_expert_params_mapping(
+                ckpt_gate_proj_name=ckpt_gate_proj_name,
+                ckpt_down_proj_name=ckpt_down_proj_name,
+                ckpt_up_proj_name=ckpt_up_proj_name,
+                num_experts=num_experts,
+            )
+        )
+
+    def try_load(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        params_dict: dict[str, Parameter],
+    ) -> str | None:
+        missing_target: str | None = None
+        for param_name, weight_name, expert_id, shard_id in self.mappings:
+            if weight_name not in name:
+                continue
+            target = name.replace(weight_name, param_name)
+            param = params_dict.get(target)
+            if param is None:
+                if missing_target is None:
+                    missing_target = target
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(
+                param,
+                tensor,
+                target,
+                shard_id=shard_id,
+                expert_id=expert_id,
+            )
+            return target
+        if missing_target is not None:
+            raise ValueError(
+                f"Mapped checkpoint expert weight {name!r} to missing "
+                f"parameter {missing_target!r}"
+            )
+        return None
+
+
+def load_with_stacked_dispatch(
+    module: nn.Module,
+    weights: Iterable[tuple[str, torch.Tensor]],
+    mapping: StackedParamsDispatch,
+    *,
+    ignore_unexpected_suffixes: tuple[str, ...] = (".bias", ".kv_scale"),
+) -> set[str]:
+    """Load submodule weights via stacked dispatch, then direct param loaders."""
+    loaded: set[str] = set()
+    params_dict = dict(module.named_parameters())
+    for name, tensor in weights:
+        if name.endswith(ignore_unexpected_suffixes):
+            mapped_targets = (
+                name.replace(source_name, fused_name)
+                for fused_name, source_name, _ in mapping.mappings
+                if source_name in name
+            )
+            if name not in params_dict and not any(
+                target in params_dict for target in mapped_targets
+            ):
+                continue
+        target = mapping.try_load(name, tensor, params_dict)
+        if target is not None:
+            if target in params_dict:
+                loaded.add(target)
+            continue
+        if name.endswith("_scale") and name not in params_dict:
+            if abs(tensor.item() - 1.0) >= 1e-6:
+                raise AssertionError(
+                    f"Expected unit scale 1.0, got {tensor.item()} for {name}"
+                )
+            continue
+        if name in params_dict:
+            wl = getattr(params_dict[name], "weight_loader", default_weight_loader)
+            wl(params_dict[name], tensor)
+            loaded.add(name)
+        elif not any(name.endswith(suffix) for suffix in ignore_unexpected_suffixes):
+            raise ValueError(
+                f"No parameter named {name!r} in {module._get_name()}."
+            )
+    return loaded
+
+
+def load_moe_sparse_block_weights(
+    module: nn.Module,
+    weights: Iterable[tuple[str, torch.Tensor]],
+    *,
+    expert_dispatch: ExpertParamsDispatch,
+    dense_stacked: StackedParamsDispatch = STANDARD_GATE_UP_MAPPING,
+    ignore_unexpected_suffixes: tuple[str, ...] = (".bias", "_bias", ".kv_scale"),
+) -> set[str]:
+    loaded: set[str] = set()
+    params_dict = dict(module.named_parameters())
+    for name, tensor in weights:
+        if name.endswith(ignore_unexpected_suffixes):
+            mapped_targets = [
+                name.replace(source_name, fused_name)
+                for fused_name, source_name, _ in dense_stacked.mappings
+                if source_name in name
+            ]
+            mapped_targets.extend(
+                name.replace(weight_name, param_name)
+                for param_name, weight_name, _, _ in expert_dispatch.mappings
+                if weight_name in name
+            )
+            if name not in params_dict and not any(
+                target in params_dict for target in mapped_targets
+            ):
+                continue
+        target = try_load_stacked_skip_moe_experts(
+            dense_stacked, name, tensor, params_dict
+        )
+        if target is not None:
+            if target in params_dict:
+                loaded.add(target)
+            continue
+        target = expert_dispatch.try_load(name, tensor, params_dict)
+        if target is not None:
+            if target in params_dict:
+                loaded.add(target)
+            continue
+        if name.endswith("_scale") and name not in params_dict:
+            if abs(tensor.item() - 1.0) >= 1e-6:
+                raise AssertionError(
+                    f"Expected unit scale 1.0, got {tensor.item()} for {name}"
+                )
+            continue
+        if name not in params_dict:
+            raise ValueError(
+                f"No parameter named {name!r} in {module._get_name()}."
+            )
+        wl = getattr(params_dict[name], "weight_loader", default_weight_loader)
+        wl(params_dict[name], tensor)
+        loaded.add(name)
+    return loaded
 
 
 def filter_pp_weights(
@@ -158,11 +308,6 @@ def filter_pp_weights(
     start_layer: int,
     end_layer: int,
 ) -> Iterable[tuple[str, torch.Tensor]]:
-    """Drop checkpoint entries whose layer index is outside [start_layer, end_layer).
-
-    Weights that don't contain a parseable layer index (embed_tokens, lm_head,
-    layer norms, etc.) are always passed through.
-    """
     for name, tensor in weights:
         layer_id = get_layer_id(name)
         if layer_id is not None and (layer_id < start_layer or layer_id >= end_layer):
@@ -170,29 +315,10 @@ def filter_pp_weights(
         yield name, tensor
 
 
-# ---------------------------------------------------------------------------
-# Weight Remap Registry
-# ---------------------------------------------------------------------------
-
 _REMAP_REGISTRY: dict[str, Callable[[nn.Module], WeightsMapper]] = {}
 
 
 def register_weight_remap(*class_names: str):
-    """Decorator to register an architecture-specific weight remap function.
-
-    The decorated function receives a model instance and returns a
-    ``WeightsMapper``. If no remap is needed for a model, do not register it.
-
-    Example::
-
-        @register_weight_remap("LlamaForCausalLM")
-        def _llama_remap(model) -> WeightsMapper:
-            return WeightsMapper(orig_to_new_suffix={
-                ".activation_scale": ".input_scale",
-                ".weight_scale_inv": ".weight_scale",
-            })
-    """
-
     def decorator(fn: Callable[[nn.Module], WeightsMapper]):
         for cn in class_names:
             _REMAP_REGISTRY[cn] = fn
@@ -202,21 +328,14 @@ def register_weight_remap(*class_names: str):
 
 
 def get_weight_remap(model: nn.Module) -> WeightsMapper | None:
-    """Get the registered weight remap for a model instance, or None."""
     fn = _REMAP_REGISTRY.get(type(model).__name__)
     if fn is None:
         return None
     return fn(model)
 
 
-# ---------------------------------------------------------------------------
-# Architecture-Specific Registrations
-# ---------------------------------------------------------------------------
-
-
 @register_weight_remap("LlamaForCausalLM")
 def _llama_remap(model: nn.Module) -> WeightsMapper:
-    """Llama-family FP8 scale suffix normalization."""
     return WeightsMapper(
         orig_to_new_suffix={
             ".activation_scale": ".input_scale",

--- a/python/sglang/srt/models/afmoe.py
+++ b/python/sglang/srt/models/afmoe.py
@@ -595,6 +595,16 @@ class AfmoeForCausalLM(nn.Module):
         return get_attention_sliding_window_size(self.config)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            self._load_weights_v2(weights)
+            return
+        self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> None:
         stacked_params_mapping = [
             # (param_name, weight_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -643,6 +653,64 @@ class AfmoeForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            STANDARD_GATE_UP_MAPPING,
+            STANDARD_QKV_MAPPING,
+        )
+
+        params_dict = dict(self.named_parameters())
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if "rotary_emb.inv_freq" in name:
+                    continue
+                if ".mlp.router.gate." in name:
+                    name = name.replace(".mlp.router.gate.", ".mlp.gate.")
+                if name.endswith(".bias") and name not in params_dict:
+                    stacked_bias = any(
+                        source_name in name
+                        and name.replace(source_name, fused_name) in params_dict
+                        for dispatch in (
+                            STANDARD_QKV_MAPPING,
+                            STANDARD_GATE_UP_MAPPING,
+                        )
+                        for fused_name, source_name, _ in dispatch.mappings
+                        if not (
+                            ".self_attn." in name
+                            and source_name in {"gate_proj", "up_proj"}
+                        )
+                    )
+                    if not stacked_bias:
+                        continue
+
+                target = STANDARD_QKV_MAPPING.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if ".self_attn." not in name:
+                    target = STANDARD_GATE_UP_MAPPING.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                if name in params_dict:
+                    yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        return loaded | dispatched
 
 
 EntryClass = AfmoeForCausalLM

--- a/python/sglang/srt/models/apertus.py
+++ b/python/sglang/srt/models/apertus.py
@@ -565,6 +565,13 @@ class ApertusForCausalLM(nn.Module):
         return len(params_dict)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             (".qkv_proj", ".q_proj", "q"),
@@ -633,6 +640,69 @@ class ApertusForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import StackedParamsDispatch
+
+        dispatch = StackedParamsDispatch(
+            mappings=(
+                (".qkv_proj", ".q_proj", "q"),
+                (".qkv_proj", ".k_proj", "k"),
+                (".qkv_proj", ".v_proj", "v"),
+            )
+        )
+        params_dict = dict(self.named_parameters())
+        params_dict.update(
+            (name, buffer)
+            for name, buffer in self.named_buffers()
+            if name.endswith((".beta", ".eps"))
+        )
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            layer_id = get_layer_id(name)
+            if (
+                layer_id is not None
+                and hasattr(self.model, "start_layer")
+                and not self.model.start_layer <= layer_id < self.model.end_layer
+            ):
+                continue
+            if (
+                "rotary_emb.inv_freq" in name
+                or "projector" in name
+                or "rotary_emb.cos_cached" in name
+                or "rotary_emb.sin_cached" in name
+                or (name.startswith("model.vision_tower") and name not in params_dict)
+                or (self.config.tie_word_embeddings and "lm_head.weight" in name)
+            ):
+                continue
+            if "scale" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            mapped_target = next(
+                (
+                    name.replace(source_name, fused_name)
+                    for fused_name, source_name, _ in dispatch.mappings
+                    if source_name in name
+                ),
+                None,
+            )
+            if mapped_target is not None and mapped_target not in params_dict:
+                continue
+            target = dispatch.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                loaded.add(target)
+                continue
+            if name.endswith((".bias", ".kv_scale")) and name not in params_dict:
+                continue
+            param = params_dict.get(name)
+            if param is None:
+                logger.warning("Parameter %s not found in params_dict", name)
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/arcee.py
+++ b/python/sglang/srt/models/arcee.py
@@ -474,6 +474,13 @@ class ArceeForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
@@ -522,6 +529,55 @@ class ArceeForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in model.")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import StackedParamsDispatch
+
+        dispatch = StackedParamsDispatch(mappings=tuple(self.stacked_params_mapping))
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            layer_id = get_layer_id(name)
+            if (
+                layer_id is not None
+                and hasattr(self.model, "start_layer")
+                and not self.model.start_layer <= layer_id < self.model.end_layer
+            ):
+                continue
+            if (
+                "rotary_emb.inv_freq" in name
+                or "projector" in name
+                or "rotary_emb.cos_cached" in name
+                or "rotary_emb.sin_cached" in name
+            ):
+                continue
+            if "scale" in name:
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is None:
+                    continue
+            stacked = next(
+                (
+                    (name.replace(source_name, fused_name), shard_id)
+                    for fused_name, source_name, shard_id in dispatch.mappings
+                    if source_name in name
+                    and name.replace(source_name, fused_name) in params_dict
+                ),
+                None,
+            )
+            if stacked is not None:
+                target, shard_id = stacked
+                param = params_dict[target]
+                param.weight_loader(param, loaded_weight, shard_id)
+                loaded.add(target)
+                continue
+            param = params_dict.get(name)
+            if param is None:
+                logger.warning("Parameter %s not found in model.", name)
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         self.model.load_kv_cache_scales(quantization_param_path)

--- a/python/sglang/srt/models/baichuan.py
+++ b/python/sglang/srt/models/baichuan.py
@@ -395,6 +395,13 @@ class BaiChuanBaseForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("gate_up_proj", "gate_proj", 0),
@@ -433,6 +440,44 @@ class BaiChuanBaseForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import StackedParamsDispatch
+
+        dispatch = StackedParamsDispatch(
+            mappings=(
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+            )
+        )
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if name == "lm_head.weight" and self.config.vocab_size == 125696:
+                loaded_weight = torch.nn.functional.normalize(loaded_weight)
+            if name.endswith(".bias") and name not in params_dict:
+                mapped_bias = any(
+                    source_name in name
+                    and name.replace(source_name, fused_name) in params_dict
+                    for fused_name, source_name, _ in dispatch.mappings
+                )
+                if not mapped_bias:
+                    continue
+            target = dispatch.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target not in params_dict:
+                    if target.endswith(".bias"):
+                        continue
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                loaded.add(target)
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 class BaichuanForCausalLM(BaiChuanBaseForCausalLM):

--- a/python/sglang/srt/models/bailing_moe.py
+++ b/python/sglang/srt/models/bailing_moe.py
@@ -880,6 +880,15 @@ class BailingMoEForCausalLM(nn.Module):
             return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]], is_nextn=False):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights, is_nextn=is_nextn)
+        return self._legacy_load_weights(weights, is_nextn=is_nextn)
+
+    def _legacy_load_weights(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], is_nextn=False
+    ):
         if is_nextn:
             if hasattr(self.config, "num_nextn_predict_layers"):
                 num_nextn_layers = self.config.num_nextn_predict_layers
@@ -1013,6 +1022,126 @@ class BailingMoEForCausalLM(nn.Module):
                 if not isinstance(layer, PPMissingLayer)
                 and isinstance(layer.mlp, BailingMoESparseMoeBlock)
             }
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], is_nextn: bool = False
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+            filter_pp_weights,
+        )
+
+        if not is_nextn and hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+
+        if is_nextn:
+            if not hasattr(self.config, "num_nextn_predict_layers"):
+                raise ValueError("num_nextn_predict_layers is not in the config")
+            assert self.config.num_nextn_predict_layers == 1, (
+                "Only 1 nextn layer is supported"
+            )
+            nextn_layer_id = (
+                0
+                if self.config.num_hidden_layers == 1
+                else self.config.num_hidden_layers
+            )
+            nextn_layer_prefix = f"model.layers.{nextn_layer_id}"
+            nextn_spec_weight_names = (
+                "final_layernorm",
+                "eh_proj",
+                "enorm",
+                "hnorm",
+            )
+
+        params_dict = dict(self.named_parameters())
+        stacked_dispatch = StackedParamsDispatch(
+            mappings=(
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+            )
+        )
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_experts
+        )
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if (
+                    "v_head" in name
+                    or "inv_freq" in name
+                    or (self.config.tie_word_embeddings and "lm_head" in name)
+                ):
+                    continue
+                if (
+                    getattr(self.config, "norm_head", False)
+                    and "lm_head.weight" in name
+                ):
+                    loaded_weight = F.normalize(
+                        loaded_weight, dim=0, p=2, eps=1e-7
+                    )
+
+                if is_nextn:
+                    if not name.startswith(nextn_layer_prefix):
+                        continue
+                    if "shared_head.head" in name or "embed_tokens" in name:
+                        continue
+                    if any(
+                        weight_name in name
+                        for weight_name in nextn_spec_weight_names
+                    ):
+                        name = name.replace(nextn_layer_prefix, "model")
+                    else:
+                        name = name.replace(nextn_layer_prefix, "model.decoder")
+
+                if name.endswith(".bias") and name not in params_dict:
+                    stacked_bias = any(
+                        source_name in name
+                        and name.replace(source_name, fused_name) in params_dict
+                        for fused_name, source_name, _ in stacked_dispatch.mappings
+                        if "mlp.experts" not in name
+                    )
+                    expert_bias = any(
+                        weight_name in name
+                        and name.replace(weight_name, param_name) in params_dict
+                        for param_name, weight_name, _, _ in expert_dispatch.mappings
+                    )
+                    if not stacked_bias and not expert_bias:
+                        continue
+
+                if "mlp.experts" not in name:
+                    target = stacked_dispatch.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name in params_dict:
+                    yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        if not is_nextn:
+            self.routed_experts_weights_of_layer = {
+                layer_id: layer.mlp.get_moe_weights()
+                for layer_id, layer in enumerate(self.model.layers)
+                if not isinstance(layer, PPMissingLayer)
+                and isinstance(layer.mlp, BailingMoESparseMoeBlock)
+            }
+        return loaded | dispatched
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/cohere2_moe.py
+++ b/python/sglang/srt/models/cohere2_moe.py
@@ -525,6 +525,13 @@ class Cohere2MoeForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
@@ -613,6 +620,63 @@ class Cohere2MoeForCausalLM(nn.Module):
             loaded_params.add(name)
 
         return loaded_params
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            STANDARD_GATE_UP_MAPPING,
+            STANDARD_QKV_MAPPING,
+        )
+
+        params_dict = dict(self.named_parameters())
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_experts
+        )
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if "rotary_emb.inv_freq" in name or "lm_head.weight" in name:
+                    continue
+                if (name.endswith(".bias") or name.endswith("_bias")) and (
+                    name not in params_dict
+                    and name.replace("q_proj", "qkv_proj") not in params_dict
+                    and name.replace("gate_proj", "gate_up_proj")
+                    not in params_dict
+                ):
+                    continue
+
+                target = STANDARD_QKV_MAPPING.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if "mlp.experts" not in name:
+                    target = STANDARD_GATE_UP_MAPPING.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if name in params_dict:
+                    yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        return loaded | dispatched
 
 
 EntryClass = Cohere2MoeForCausalLM

--- a/python/sglang/srt/models/commandr.py
+++ b/python/sglang/srt/models/commandr.py
@@ -139,6 +139,14 @@ class CohereMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class CohereAttention(nn.Module):
     def __init__(
@@ -253,6 +261,14 @@ class CohereAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class CohereDecoderLayer(nn.Module):
@@ -385,6 +401,13 @@ class CohereForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -424,6 +447,27 @@ class CohereForCausalLM(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        params_dict = dict(self.named_parameters())
+
+        def _prepare(
+            src: Iterable[Tuple[str, torch.Tensor]],
+        ) -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, loaded_weight in src:
+                if "lm_head.weight" in name:
+                    continue
+                name = maybe_remap_kv_scale_name(name, params_dict)
+                if name is not None:
+                    yield name, loaded_weight
+
+        loader = AutoWeightsLoader(
+            self,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(_prepare(weights))
 
 
 class Cohere2ForCausalLM(CohereForCausalLM):

--- a/python/sglang/srt/models/dbrx.py
+++ b/python/sglang/srt/models/dbrx.py
@@ -437,6 +437,13 @@ class DbrxForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         expert_params_mapping = [
             (
                 "ws" if weight_name in ["w1", "v1"] else "w2s",
@@ -463,6 +470,35 @@ class DbrxForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        expert_params_mapping = (
+            ("ws", "experts.mlp.w1"),
+            ("ws", "experts.mlp.v1"),
+            ("w2s", "experts.mlp.w2"),
+        )
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            for param_name, weight_name in expert_params_mapping:
+                if weight_name not in name:
+                    continue
+                target = name.replace(weight_name, param_name)
+                param = params_dict[target]
+                param.weight_loader(param, loaded_weight, weight_name)
+                loaded_params.add(target)
+                break
+            else:
+                target = maybe_remap_kv_scale_name(name, params_dict)
+                if target is None:
+                    continue
+                param = params_dict[target]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded_params.add(target)
+
+        return loaded_params
 
 
 EntryClass = DbrxForCausalLM

--- a/python/sglang/srt/models/deepseek.py
+++ b/python/sglang/srt/models/deepseek.py
@@ -478,6 +478,13 @@ class DeepseekForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -519,6 +526,42 @@ class DeepseekForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import STANDARD_STACKED_MAPPING
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            target = STANDARD_STACKED_MAPPING.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target in params_dict:
+                    loaded_params.add(target)
+                elif (
+                    target.endswith(".bias")
+                    or "mlp.experts." in target
+                    or "mlp.shared_experts." in target
+                ):
+                    continue
+                else:
+                    raise KeyError(target)
+                continue
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            if (
+                "mlp.experts." in name or "mlp.shared_experts." in name
+            ) and name not in params_dict:
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        return loaded_params
 
 
 EntryClass = DeepseekForCausalLM

--- a/python/sglang/srt/models/ernie4.py
+++ b/python/sglang/srt/models/ernie4.py
@@ -340,6 +340,13 @@ class Ernie4_5_ForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
             if self.config.tie_word_embeddings and "lm_head.weight" in name:
@@ -362,12 +369,50 @@ class Ernie4_5_ForCausalLM(nn.Module):
                 else:
                     raise KeyError(f"Parameter '{name}' not found in model.")
 
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            StackedParamsDispatch,
+        )
+
+        stacked_dispatch = StackedParamsDispatch(
+            mappings=tuple(self.stacked_params_mapping)
+        )
+        params_dict = dict(self.named_parameters())
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                    continue
+                target = stacked_dispatch.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target not in params_dict:
+                        raise KeyError(f"Parameter '{target}' not found in model.")
+                    dispatched.add(target)
+                    continue
+                yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        return loaded | dispatched
+
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
 
 class Ernie4_5_MoeForCausalLM(Ernie4_5_ForCausalLM):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         expert_params_mapping = FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
@@ -428,6 +473,60 @@ class Ernie4_5_MoeForCausalLM(Ernie4_5_ForCausalLM):
                         weight_loader(param, loaded_weight)
                     else:
                         raise KeyError(f"Parameter '{name}' not found in model.")
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+        )
+
+        stacked_dispatch = StackedParamsDispatch(
+            mappings=tuple(self.stacked_params_mapping)
+        )
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.moe_num_experts
+        )
+        params_dict = dict(self.named_parameters())
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                    continue
+                if name.startswith("model.mtp_"):
+                    continue
+                if "moe_statics.e_score_correction_bias" in name:
+                    name = name.replace("moe_statics", "gate")
+
+                if not (
+                    "mlp.experts." in name and name not in params_dict
+                ):
+                    target = stacked_dispatch.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target not in params_dict:
+                            raise KeyError(
+                                f"Parameter '{target}' not found in model."
+                            )
+                        dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target not in params_dict:
+                        raise KeyError(
+                            f"Parameter '{target}'(replaced) not found in model."
+                        )
+                    dispatched.add(target)
+                    continue
+                yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        return loaded | dispatched
 
 
 EntryClass = [Ernie4_5_MoeForCausalLM, Ernie4_5_ForCausalLM]

--- a/python/sglang/srt/models/ernie4_eagle.py
+++ b/python/sglang/srt/models/ernie4_eagle.py
@@ -141,6 +141,13 @@ class Ernie4_5_MoeForCausalLMMTP(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         mtp_layer_found = False
         mtp_weight_patterns = [
             f"mtp_block.{self.mtp_layer_id}",
@@ -184,6 +191,53 @@ class Ernie4_5_MoeForCausalLMMTP(nn.Module):
             raise KeyError(
                 f"MTP layers 'mtp_*.{self.mtp_layer_id}.*' not found in weights."
             )
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            StackedParamsDispatch,
+        )
+
+        mtp_weight_patterns = (
+            f"mtp_block.{self.mtp_layer_id}",
+            f"mtp_emb_norm.{self.mtp_layer_id}",
+            f"mtp_hidden_norm.{self.mtp_layer_id}",
+            f"mtp_linear_proj.{self.mtp_layer_id}",
+        )
+        stacked_dispatch = StackedParamsDispatch(
+            mappings=tuple(Ernie4_5_ForCausalLM.stacked_params_mapping)
+        )
+        params_dict = dict(self.named_parameters())
+        dispatched: set[str] = set()
+        mtp_layer_found = False
+
+        def remaining_weights():
+            nonlocal mtp_layer_found
+            for name, loaded_weight in weights:
+                if not any(pattern in name for pattern in mtp_weight_patterns):
+                    continue
+                mtp_layer_found = True
+                name = name.replace(f".{self.mtp_layer_id}.", ".")
+                target = stacked_dispatch.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target not in params_dict:
+                        raise KeyError(
+                            f"Parameter '{target}' not found in MTP model."
+                        )
+                    dispatched.add(target)
+                    continue
+                yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        if not mtp_layer_found:
+            raise KeyError(
+                f"MTP layers 'mtp_*.{self.mtp_layer_id}.*' not found in weights."
+            )
+        return loaded | dispatched
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/exaone.py
+++ b/python/sglang/srt/models/exaone.py
@@ -333,6 +333,13 @@ class ExaoneForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -372,6 +379,52 @@ class ExaoneForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import StackedParamsDispatch
+
+        dispatch = StackedParamsDispatch(
+            mappings=(
+                ("qkv_proj", "q_proj", "q"),
+                ("qkv_proj", "k_proj", "k"),
+                ("qkv_proj", "v_proj", "v"),
+                ("gate_up_proj", "c_fc_0", 0),
+                ("gate_up_proj", "c_fc_1", 1),
+            )
+        )
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if (
+                "rotary_emb.inv_freq" in name
+                or "projector" in name
+                or "rotary_emb.cos_cached" in name
+                or "rotary_emb.sin_cached" in name
+                or (name.startswith("model.vision_tower") and name not in params_dict)
+            ):
+                continue
+            name = name.replace("attn.attention", "self_attn")
+            if name.endswith(".bias") and name not in params_dict:
+                mapped_bias = any(
+                    source_name in name
+                    and name.replace(source_name, fused_name) in params_dict
+                    for fused_name, source_name, _ in dispatch.mappings
+                )
+                if not mapped_bias:
+                    continue
+            target = dispatch.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target not in params_dict:
+                    if target.endswith(".bias"):
+                        continue
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                loaded.add(target)
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 EntryClass = ExaoneForCausalLM

--- a/python/sglang/srt/models/exaone4.py
+++ b/python/sglang/srt/models/exaone4.py
@@ -80,6 +80,14 @@ class Exaone4GatedMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class Exaone4Attention(nn.Module):
     def __init__(
@@ -210,6 +218,14 @@ class Exaone4Attention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class Exaone4DecoderLayer(nn.Module):
@@ -540,6 +556,13 @@ class Exaone4ForCausalLM(nn.Module):
         return get_attention_sliding_window_size(self.config)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             (".qkv_proj", ".q_proj", "q"),
@@ -606,6 +629,38 @@ class Exaone4ForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        params_dict = dict(self.named_parameters())
+
+        def _prepare(
+            src: Iterable[Tuple[str, torch.Tensor]],
+        ) -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, loaded_weight in src:
+                if "scale" in name:
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+                yield name, loaded_weight
+
+        weights = filter_pp_weights(
+            _prepare(weights), self.model.start_layer, self.model.end_layer
+        )
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=["projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
     def get_weights_by_name(
         self, name: str, truncate_size: int = 100, tp_size: int = 1

--- a/python/sglang/srt/models/exaone_moe.py
+++ b/python/sglang/srt/models/exaone_moe.py
@@ -756,6 +756,15 @@ class ExaoneMoEForCausalLM(nn.Module):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
     ):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights, is_mtp=is_mtp)
+        return self._legacy_load_weights(weights, is_mtp=is_mtp)
+
+    def _legacy_load_weights(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
+    ):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -847,6 +856,103 @@ class ExaoneMoEForCausalLM(nn.Module):
                         weight_loader(param, loaded_weight)
                     else:
                         logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            STANDARD_GATE_UP_MAPPING,
+            STANDARD_QKV_MAPPING,
+            filter_pp_weights,
+        )
+
+        if not is_mtp and hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+
+        params_dict = dict(self.named_parameters())
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_experts
+        )
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if is_mtp:
+                    if "mtp" not in name:
+                        continue
+                    if name in (
+                        "mtp.fc.weight",
+                        "mtp.pre_fc_norm_embedding.weight",
+                        "mtp.pre_fc_norm_hidden.weight",
+                    ):
+                        name = name.replace("mtp.", "")
+                    else:
+                        name = name.replace("mtp", "model")
+                elif "mtp" in name:
+                    continue
+
+                if (
+                    "rotary_emb.inv_freq" in name
+                    or "projector" in name
+                    or "rotary_emb.cos_cached" in name
+                    or "rotary_emb.sin_cached" in name
+                ):
+                    continue
+                if name.startswith("model.vision_tower") and name not in params_dict:
+                    continue
+                if name.endswith(".bias") and name not in params_dict:
+                    stacked_bias = any(
+                        source_name in name
+                        and name.replace(source_name, fused_name) in params_dict
+                        for dispatch in (
+                            STANDARD_QKV_MAPPING,
+                            STANDARD_GATE_UP_MAPPING,
+                        )
+                        for fused_name, source_name, _ in dispatch.mappings
+                        if "mlp.experts" not in name
+                    )
+                    expert_bias = any(
+                        weight_name in name
+                        and name.replace(weight_name, param_name) in params_dict
+                        for param_name, weight_name, _, _ in expert_dispatch.mappings
+                    )
+                    if not stacked_bias and not expert_bias:
+                        continue
+
+                target = STANDARD_QKV_MAPPING.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if "mlp.experts" not in name:
+                    target = STANDARD_GATE_UP_MAPPING.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name in params_dict:
+                    yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        return loaded | dispatched
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/exaone_moe_mtp.py
+++ b/python/sglang/srt/models/exaone_moe_mtp.py
@@ -100,7 +100,9 @@ class ExaoneMoEForCausalLMMTP(ExaoneMoEForCausalLM):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
     ):
-        super().load_weights(weights, is_mtp=True)
+        # Keep the wrapper paired with the parent loader so both legacy and
+        # SGLANG_ENABLE_WEIGHT_LOADER_V2 paths apply the MTP name remaps.
+        return super().load_weights(weights, is_mtp=True)
 
 
 EntryClass = ExaoneMoEForCausalLMMTP

--- a/python/sglang/srt/models/gemma.py
+++ b/python/sglang/srt/models/gemma.py
@@ -74,6 +74,14 @@ class GemmaMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class GemmaAttention(nn.Module):
     def __init__(
@@ -156,6 +164,14 @@ class GemmaAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class GemmaDecoderLayer(nn.Module):
@@ -370,6 +386,13 @@ class GemmaForCausalLM(nn.Module):
         return result
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -408,6 +431,25 @@ class GemmaForCausalLM(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        def _prepare(
+            src: Iterable[Tuple[str, torch.Tensor]],
+        ) -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, loaded_weight in src:
+                if "lm_head.weight" in name:
+                    continue
+                if "norm.weight" in name:
+                    loaded_weight = loaded_weight + 1.0
+                yield name, loaded_weight
+
+        loader = AutoWeightsLoader(
+            self,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(_prepare(weights))
 
 
 EntryClass = GemmaForCausalLM

--- a/python/sglang/srt/models/gemma2.py
+++ b/python/sglang/srt/models/gemma2.py
@@ -92,6 +92,14 @@ class Gemma2MLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class Gemma2Attention(nn.Module):
     def __init__(
@@ -199,6 +207,14 @@ class Gemma2Attention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class Gemma2DecoderLayer(nn.Module):
@@ -458,6 +474,13 @@ class Gemma2ForCausalLM(nn.Module):
         return get_attention_sliding_window_size(self.config)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -497,6 +520,27 @@ class Gemma2ForCausalLM(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        params_dict = dict(self.named_parameters())
+
+        def _prepare(
+            src: Iterable[Tuple[str, torch.Tensor]],
+        ) -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, loaded_weight in src:
+                remapped = maybe_remap_kv_scale_name(name, params_dict)
+                if remapped is None:
+                    continue
+                yield remapped, loaded_weight
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["lm_head."],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(_prepare(weights))
 
 
 EntryClass = Gemma2ForCausalLM

--- a/python/sglang/srt/models/gemma2_reward.py
+++ b/python/sglang/srt/models/gemma2_reward.py
@@ -53,9 +53,9 @@ class Gemma2ForSequenceClassification(nn.Module):
         input_embeds: torch.Tensor = None,
         get_embedding: bool = True,
     ) -> EmbeddingPoolerOutput:
-        assert (
-            get_embedding
-        ), "Gemma2ForSequenceClassification is only used for embedding"
+        assert get_embedding, (
+            "Gemma2ForSequenceClassification is only used for embedding"
+        )
 
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
         last_token_hidden = self.pooler(hidden_states, forward_batch).embeddings
@@ -69,7 +69,11 @@ class Gemma2ForSequenceClassification(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        Gemma2ForCausalLM.load_weights(self, weights)
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return Gemma2ForCausalLM._load_weights_v2(self, weights)
+        Gemma2ForCausalLM._legacy_load_weights(self, weights)
 
 
 EntryClass = [Gemma2ForSequenceClassification]

--- a/python/sglang/srt/models/gpt_bigcode.py
+++ b/python/sglang/srt/models/gpt_bigcode.py
@@ -285,6 +285,13 @@ class GPTBigCodeForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         for name, loaded_weight in weights:
             if "lm_head.weight" in name:
@@ -302,6 +309,22 @@ class GPTBigCodeForCausalLM(nn.Module):
                 weight_loader(param, loaded_weight, "v")
             else:
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if "lm_head.weight" in name or ".attn.bias" in name:
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            if "c_attn.input_scale" in name or "c_attn.weight_scale" in name:
+                for shard_id in ("q", "k", "v"):
+                    weight_loader(param, loaded_weight, shard_id)
+            else:
+                weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 EntryClass = GPTBigCodeForCausalLM

--- a/python/sglang/srt/models/gpt_j.py
+++ b/python/sglang/srt/models/gpt_j.py
@@ -280,6 +280,13 @@ class GPTJForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -324,6 +331,50 @@ class GPTJForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import STANDARD_QKV_MAPPING
+
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if "attn.bias" in name or "attn.masked_bias" in name:
+                continue
+            if self.quant_config is not None and (
+                scale_name := self.quant_config.get_cache_scale(name)
+            ):
+                param = params_dict[scale_name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                loaded_weight = (
+                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                )
+                weight_loader(param, loaded_weight)
+                loaded.add(scale_name)
+                continue
+            if name.endswith(".bias") and name not in params_dict:
+                mapped_bias = any(
+                    source_name in name
+                    and name.replace(source_name, fused_name) in params_dict
+                    for fused_name, source_name, _ in STANDARD_QKV_MAPPING.mappings
+                )
+                if not mapped_bias:
+                    continue
+            target = STANDARD_QKV_MAPPING.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target not in params_dict:
+                    if target.endswith(".bias"):
+                        continue
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                loaded.add(target)
+                continue
+            name = maybe_remap_kv_scale_name(name, params_dict)
+            if name is None:
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 EntryClass = GPTJForCausalLM

--- a/python/sglang/srt/models/granite.py
+++ b/python/sglang/srt/models/granite.py
@@ -88,6 +88,14 @@ class GraniteMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class GraniteAttention(nn.Module):
     def __init__(
@@ -177,6 +185,14 @@ class GraniteAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class GraniteDecoderLayer(nn.Module):
@@ -380,6 +396,13 @@ class GraniteForCausalLM(nn.Module):
         return len(params_dict)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             (".qkv_proj", ".q_proj", "q"),
@@ -430,6 +453,33 @@ class GraniteForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=["projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        loaded = loader.load_weights(weights)
+
+        if self.config.tie_word_embeddings:
+            params_dict = dict(self.named_parameters())
+            if "lm_head.weight" in params_dict:
+                embed = dict(self.model.named_parameters()).get("embed_tokens.weight")
+                if embed is not None:
+                    lm_head = params_dict["lm_head.weight"]
+                    wl = getattr(lm_head, "weight_loader", default_weight_loader)
+                    wl(lm_head, embed.data)
+                    loaded.add("lm_head.weight")
+
+        return loaded
 
     def get_weights_by_name(
         self, name: str, truncate_size: int = 100, tp_size: int = 1

--- a/python/sglang/srt/models/granitemoe.py
+++ b/python/sglang/srt/models/granitemoe.py
@@ -51,6 +51,7 @@ class GraniteMoeMoE(nn.Module):
     ):
         super().__init__()
         self.hidden_size = hidden_size
+        self._ckpt_num_experts = num_experts
 
         # Gate always runs at half / full precision for now.
         self.gate = ReplicatedLinear(
@@ -88,9 +89,28 @@ class GraniteMoeMoE(nn.Module):
         final_hidden_states = self.experts(hidden_states, topk_output)
         return final_hidden_states.view(orig_shape)
 
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+            load_moe_sparse_block_weights,
+        )
+
+        expert = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self._ckpt_num_experts,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+        )
+        return load_moe_sparse_block_weights(
+            self,
+            weights,
+            expert_dispatch=expert,
+            dense_stacked=StackedParamsDispatch(),
+        )
+
 
 class GraniteMoeAttention(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
@@ -175,9 +195,16 @@ class GraniteMoeAttention(nn.Module):
         output, _ = self.o_proj(attn_output)
         return output
 
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
+
 
 class GraniteMoeDecoderLayer(nn.Module):
-
     def __init__(
         self,
         config: GraniteConfig,
@@ -240,7 +267,6 @@ class GraniteMoeDecoderLayer(nn.Module):
 
 
 class GraniteMoeModel(nn.Module):
-
     def __init__(
         self,
         config: GraniteConfig,
@@ -296,7 +322,6 @@ class GraniteMoeModel(nn.Module):
 
 
 class GraniteMoeForCausalLM(nn.Module):
-
     def __init__(
         self,
         config: GraniteConfig,
@@ -381,7 +406,24 @@ class GraniteMoeForCausalLM(nn.Module):
                 new_weights[gate_name] = p
             else:
                 new_weights[n] = p
-        mixtral.MixtralForCausalLM.load_weights(self, new_weights.items())
+
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(new_weights.items())
+        return mixtral.MixtralForCausalLM._legacy_load_weights(
+            self, new_weights.items()
+        )
+
+    def _load_weights_v2(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["rotary_emb.inv_freq"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = [GraniteMoeForCausalLM]

--- a/python/sglang/srt/models/hrm_text.py
+++ b/python/sglang/srt/models/hrm_text.py
@@ -460,6 +460,13 @@ class HrmTextForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         # Disk keys use `.attn.`; rename to our `.self_attn.`. The per-step
         # RadixAttention modules hold no params, and disk tensors are already
         # fused so no stacked_params_mapping is needed.
@@ -472,6 +479,20 @@ class HrmTextForCausalLM(nn.Module):
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if ".attn." in name:
+                name = name.replace(".attn.", ".self_attn.", 1)
+            param = params_dict.get(name)
+            if param is None:
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 EntryClass = HrmTextForCausalLM

--- a/python/sglang/srt/models/hunyuan.py
+++ b/python/sglang/srt/models/hunyuan.py
@@ -629,6 +629,13 @@ class HunYuanMoEV1ForCausalLM(nn.Module):
         # return qkv.reshape((num_kv_heads, num_key_value_groups+2 , attention_head_dim, hidden_size)).permute((1,0,2,3)).reshape((-1, hidden_size)),
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         cla_factor = _get_cla_factor(self.config)
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
@@ -770,6 +777,128 @@ class HunYuanMoEV1ForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import ExpertParamsDispatch
+
+        cla_factor = _get_cla_factor(self.config)
+        stacked_params_mapping = (
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        )
+        num_attention_heads = self.config.num_attention_heads
+        num_kv_heads = getattr(
+            self.config, "num_key_value_heads", self.config.num_attention_heads
+        )
+        split_params_mapping = (
+            (".gate_up_proj", ".gate_and_up_proj", 2, ((1, 1), (0, 1)), None),
+            (
+                ".qkv_proj",
+                ".qkv_proj",
+                num_attention_heads + num_kv_heads * 2,
+                (("q", num_attention_heads), ("k", num_kv_heads), ("v", num_kv_heads)),
+                self._split_qkv_weight,
+            ),
+        )
+        expert_dispatch = (
+            ExpertParamsDispatch.from_gate_up_down(
+                num_experts=self.config.num_experts,
+            )
+            if _is_moe(self.config)
+            else None
+        )
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if "gate_proj_bias" in name:
+                name = name.replace("gate_proj_bias", "gate_proj.bias")
+            if "up_proj_bias" in name:
+                name = name.replace("up_proj_bias", "up_proj.bias")
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                continue
+            if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                continue
+
+            loaded_target = None
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name or "mlp.experts" in name:
+                    continue
+                if weight_name == ".q_proj":
+                    match = re.search(r"layers\.\d+", name)
+                    if match:
+                        layer_id = int(match.group(0).split(".")[-1])
+                        if cla_factor > 1 and layer_id % cla_factor != 0:
+                            continue
+                target = name.replace(weight_name, param_name)
+                if target.endswith(".bias") and target not in params_dict:
+                    loaded_target = target
+                    break
+                param = params_dict[target]
+                param.weight_loader(param, loaded_weight, shard_id)
+                loaded_target = target
+                loaded_params.add(target)
+                break
+            if loaded_target is not None:
+                continue
+
+            for (
+                param_name,
+                weight_name,
+                denominator,
+                split_params,
+                transform,
+            ) in split_params_mapping:
+                if weight_name not in name:
+                    continue
+                target = name.replace(weight_name, param_name)
+                if target.endswith(".bias") and target not in params_dict:
+                    loaded_target = target
+                    break
+                if loaded_weight.shape[0] % denominator != 0:
+                    raise ValueError(
+                        f"Cannot split {name}: dimension 0 is not divisible by "
+                        f"{denominator}"
+                    )
+                units = loaded_weight.shape[0] // denominator
+                source = transform(loaded_weight) if transform else loaded_weight
+                param = params_dict[target]
+                offset = 0
+                for shard_id, count in split_params:
+                    new_offset = offset + count * units
+                    param.weight_loader(param, source[offset:new_offset], shard_id)
+                    offset = new_offset
+                loaded_target = target
+                loaded_params.add(target)
+                break
+            if loaded_target is not None:
+                continue
+
+            if expert_dispatch is not None:
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        loaded_params.add(target)
+                    continue
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            target = maybe_remap_kv_scale_name(name, params_dict)
+            if target is None:
+                continue
+            if "mlp.gate.wg." in target:
+                target = target.replace("wg.", "")
+            param = params_dict[target]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(target)
+
+        return loaded_params
 
     # If this function is called, it should always initialize KV cache scale
     # factors (or else raise an exception). Thus, handled exceptions should

--- a/python/sglang/srt/models/hunyuan_v3.py
+++ b/python/sglang/srt/models/hunyuan_v3.py
@@ -564,6 +564,13 @@ class HYV3ForCausalLM(nn.Module):
         torch.cuda.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
@@ -645,6 +652,89 @@ class HYV3ForCausalLM(nn.Module):
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            STANDARD_GATE_UP_MAPPING,
+            STANDARD_QKV_MAPPING,
+        )
+
+        params_dict = dict(self.named_parameters())
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_experts
+        )
+        num_nextn_layers = getattr(self.config, "num_nextn_predict_layers", 0)
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if (
+                    "lm_head.weight" in name
+                    and getattr(self.config, "tie_word_embeddings", False)
+                ):
+                    continue
+                if "rotary_emb.inv_freq" in name:
+                    continue
+                if num_nextn_layers > 0 and name.startswith("model.layers."):
+                    parts = name.split(".")
+                    if (
+                        len(parts) >= 3
+                        and int(parts[2]) >= self.config.num_hidden_layers
+                    ):
+                        continue
+                if name.endswith(".bias") and name not in params_dict:
+                    stacked_bias = any(
+                        source_name in name
+                        and name.replace(source_name, fused_name) in params_dict
+                        for dispatch in (
+                            STANDARD_QKV_MAPPING,
+                            STANDARD_GATE_UP_MAPPING,
+                        )
+                        for fused_name, source_name, _ in dispatch.mappings
+                        if "mlp.experts" not in name
+                    )
+                    expert_bias = any(
+                        weight_name in name
+                        and name.replace(weight_name, param_name) in params_dict
+                        for param_name, weight_name, _, _ in expert_dispatch.mappings
+                    )
+                    if not stacked_bias and not expert_bias:
+                        continue
+
+                target = STANDARD_QKV_MAPPING.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if "mlp.experts" not in name:
+                    target = STANDARD_GATE_UP_MAPPING.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if "router.gate." in name:
+                    name = name.replace("router.", "")
+                if name in params_dict:
+                    yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        return loaded | dispatched
 
 
 EntryClass = [HYV3ForCausalLM]

--- a/python/sglang/srt/models/hunyuan_v3_nextn.py
+++ b/python/sglang/srt/models/hunyuan_v3_nextn.py
@@ -160,6 +160,13 @@ class HYV3ForCausalLMNextN(nn.Module):
         torch.cuda.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         nextn_layer_id = self.config.num_hidden_layers
         nextn_prefix = f"model.layers.{nextn_layer_id}."
         spec_weight_names = ("enorm", "hnorm", "eh_proj")
@@ -253,6 +260,94 @@ class HYV3ForCausalLMNextN(nn.Module):
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            STANDARD_GATE_UP_MAPPING,
+            STANDARD_QKV_MAPPING,
+        )
+
+        nextn_prefix = f"model.layers.{self.config.num_hidden_layers}."
+        spec_weight_names = ("enorm", "hnorm", "eh_proj")
+        params_dict = dict(self.named_parameters())
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_experts
+        )
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if name.startswith(nextn_prefix):
+                    subname = name[len(nextn_prefix) :]
+                    if any(subname.startswith(s) for s in spec_weight_names):
+                        name = f"model.{subname}"
+                    elif subname.startswith("final_layernorm"):
+                        name = "model.shared_head.norm.weight"
+                    else:
+                        name = f"model.decoder.{subname}"
+                elif name != "model.shared_head.norm.weight":
+                    if (
+                        "embed_tokens" in name
+                        or "shared_head.head" in name
+                        or "lm_head" in name
+                    ):
+                        continue
+                    continue
+
+                if "rotary_emb.inv_freq" in name:
+                    continue
+                if "router.gate." in name:
+                    name = name.replace("router.", "")
+                if name.endswith(".bias") and name not in params_dict:
+                    stacked_bias = any(
+                        source_name in name
+                        and name.replace(source_name, fused_name) in params_dict
+                        for dispatch in (
+                            STANDARD_QKV_MAPPING,
+                            STANDARD_GATE_UP_MAPPING,
+                        )
+                        for fused_name, source_name, _ in dispatch.mappings
+                        if "mlp.experts" not in name
+                    )
+                    expert_bias = any(
+                        weight_name in name
+                        and name.replace(weight_name, param_name) in params_dict
+                        for param_name, weight_name, _, _ in expert_dispatch.mappings
+                    )
+                    if not stacked_bias and not expert_bias:
+                        continue
+
+                target = STANDARD_QKV_MAPPING.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if "mlp.experts" not in name:
+                    target = STANDARD_GATE_UP_MAPPING.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+                if name in params_dict:
+                    yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        return loaded | dispatched
 
 
 EntryClass = [HYV3ForCausalLMNextN]

--- a/python/sglang/srt/models/internlm2.py
+++ b/python/sglang/srt/models/internlm2.py
@@ -81,10 +81,25 @@ class InternLM2MLP(nn.Module):
         x, _ = self.w2(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            StackedParamsDispatch,
+            load_with_stacked_dispatch,
+        )
+
+        mapping = StackedParamsDispatch(
+            mappings=(
+                ("gate_up_proj", "w1", 0),
+                ("gate_up_proj", "w3", 1),
+            )
+        )
+        return load_with_stacked_dispatch(self, weights, mapping)
+
 
 class InternLM2Attention(nn.Module):
     def __init__(
         self,
+        config: PretrainedConfig,
         hidden_size: int,
         num_heads: int,
         num_kv_heads: int,
@@ -96,6 +111,7 @@ class InternLM2Attention(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
+        self.config = config
         self.hidden_size = hidden_size
         tp_size = get_parallel().tp_size
         self.total_num_heads = num_heads
@@ -165,6 +181,34 @@ class InternLM2Attention(nn.Module):
         output, _ = self.wo(attn_output)
         return output
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        loaded: set[str] = set()
+        params_dict = dict(self.named_parameters())
+        config = self.config
+        for name, tensor in weights:
+            if "wqkv" in name and name in params_dict:
+                param = params_dict[name]
+                kv_groups = config.num_attention_heads // config.num_key_value_heads
+                head_dim = config.hidden_size // config.num_attention_heads
+                loaded_weight = tensor.view(
+                    -1, 2 + kv_groups, head_dim, tensor.shape[-1]
+                )
+                wq, wk, wv = torch.split(loaded_weight, [kv_groups, 1, 1], dim=1)
+                wq = wq.reshape(-1, wq.shape[-1])
+                wk = wk.reshape(-1, wk.shape[-1])
+                wv = wv.reshape(-1, wv.shape[-1])
+                weight_loader = param.weight_loader
+                weight_loader(param, wq, "q")
+                weight_loader(param, wk, "k")
+                weight_loader(param, wv, "v")
+                loaded.add(name)
+                continue
+            if name in params_dict:
+                wl = getattr(params_dict[name], "weight_loader", default_weight_loader)
+                wl(params_dict[name], tensor)
+                loaded.add(name)
+        return loaded
+
 
 class InternLMDecoderLayer(nn.Module):
     def __init__(
@@ -180,6 +224,7 @@ class InternLMDecoderLayer(nn.Module):
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
         self.attention = InternLM2Attention(
+            config=config,
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             num_kv_heads=config.num_key_value_heads,
@@ -310,6 +355,13 @@ class InternLM2ForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("gate_up_proj", "w1", 0),
@@ -355,6 +407,15 @@ class InternLM2ForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        loader = AutoWeightsLoader(
+            self,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = InternLM2ForCausalLM

--- a/python/sglang/srt/models/internlm2_reward.py
+++ b/python/sglang/srt/models/internlm2_reward.py
@@ -63,7 +63,11 @@ class InternLM2ForRewardModel(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        return InternLM2ForCausalLM.load_weights(self, weights)
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return InternLM2ForCausalLM._load_weights_v2(self, weights)
+        return InternLM2ForCausalLM._legacy_load_weights(self, weights)
 
 
 EntryClass = InternLM2ForRewardModel

--- a/python/sglang/srt/models/iquest_loopcoder.py
+++ b/python/sglang/srt/models/iquest_loopcoder.py
@@ -439,6 +439,13 @@ class IQuestLoopCoderForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
@@ -492,6 +499,54 @@ class IQuestLoopCoderForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import STANDARD_STACKED_MAPPING
+
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if name.startswith("gate_projections."):
+                if name.endswith(".weight"):
+                    target = name.replace(".weight", ".gate_proj.weight")
+                elif name.endswith(".bias"):
+                    target = name.replace(".bias", ".gate_proj.bias")
+                else:
+                    continue
+                param = params_dict.get(target)
+                if param is None:
+                    continue
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded.add(target)
+                continue
+            stacked_match = next(
+                (
+                    name.replace(source_name, fused_name)
+                    for fused_name, source_name, _ in STANDARD_STACKED_MAPPING.mappings
+                    if source_name in name
+                ),
+                None,
+            )
+            if stacked_match is not None and stacked_match not in params_dict:
+                continue
+            target = STANDARD_STACKED_MAPPING.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target not in params_dict:
+                    if target.endswith(".bias"):
+                        continue
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                loaded.add(target)
+                continue
+            param = params_dict.get(name)
+            if param is None:
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 # Entry class for model registration

--- a/python/sglang/srt/models/jet_nemotron.py
+++ b/python/sglang/srt/models/jet_nemotron.py
@@ -548,6 +548,13 @@ class JetNemotronForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         stacked_params_mapping: list[tuple[str, str, str | int]] = [
             # (param_name, shard_weight_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -593,6 +600,42 @@ class JetNemotronForCausalLM(nn.Module):
                 param = params_dict[param_name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping: tuple[tuple[str, str, str | int], ...] = (
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+            ("qkvabz_proj", "q_proj", 0),
+            ("qkvabz_proj", "k_proj", 1),
+            ("qkvabz_proj", "v_proj", 2),
+            ("qkvabz_proj", "a_proj", 3),
+            ("qkvabz_proj", "b_proj", 4),
+            ("qkvabz_proj", "g_proj", 5),
+        )
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            parts = name.split(".")
+            for fused_name, source_name, shard_id in stacked_params_mapping:
+                if source_name not in parts:
+                    continue
+                target = name.replace(source_name, fused_name)
+                param = params_dict.get(target)
+                if param is None:
+                    continue
+                weight_loader = getattr(param, "weight_loader")
+                weight_loader(param, loaded_weight, shard_id)
+                loaded.add(target)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded.add(name)
+        return loaded
 
 
 EntryClass = JetNemotronForCausalLM

--- a/python/sglang/srt/models/laguna.py
+++ b/python/sglang/srt/models/laguna.py
@@ -697,6 +697,13 @@ class LagunaForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
@@ -818,6 +825,131 @@ class LagunaForCausalLM(nn.Module):
                 f"(sample: {sample}). Expected {len(expected)} (layers={moe_layer_ids}, "
                 f"num_experts={self.config.num_experts}, shards=3)."
             )
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            STANDARD_GATE_UP_MAPPING,
+            STANDARD_QKV_MAPPING,
+        )
+
+        params_dict = dict(self.named_parameters())
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_experts
+        )
+        dispatched: set[str] = set()
+        loaded_expert_shards: set[Tuple[int, int, str]] = set()
+        moe_layer_ids = [
+            layer_id
+            for layer_id, mlp_type in enumerate(self.config.mlp_layer_types)
+            if mlp_type == "sparse"
+            and self.start_layer <= layer_id < self.end_layer
+        ]
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                layer_id = get_layer_id(name)
+                if layer_id is not None and (
+                    layer_id < self.start_layer or layer_id >= self.end_layer
+                ):
+                    continue
+                if "rotary_emb.inv_freq" in name:
+                    continue
+                if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                    continue
+                if name.endswith("mlp.experts.e_score_correction_bias"):
+                    name = name.replace(
+                        "mlp.experts.e_score_correction_bias",
+                        "mlp.gate.e_score_correction_bias",
+                    )
+                if name.endswith(".bias") and name not in params_dict:
+                    stacked_bias = any(
+                        source_name in name
+                        and name.replace(source_name, fused_name) in params_dict
+                        for dispatch in (
+                            STANDARD_QKV_MAPPING,
+                            STANDARD_GATE_UP_MAPPING,
+                        )
+                        for fused_name, source_name, _ in dispatch.mappings
+                        if "mlp.experts." not in name
+                    )
+                    expert_bias = any(
+                        weight_name in name
+                        and name.replace(weight_name, param_name) in params_dict
+                        for param_name, weight_name, _, _ in expert_dispatch.mappings
+                    )
+                    if not stacked_bias and not expert_bias:
+                        continue
+
+                target = STANDARD_QKV_MAPPING.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if "mlp.experts." not in name:
+                    target = STANDARD_GATE_UP_MAPPING.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                        if layer_id is not None:
+                            for (
+                                _,
+                                weight_name,
+                                expert_id,
+                                shard_id,
+                            ) in expert_dispatch.mappings:
+                                if weight_name in name:
+                                    loaded_expert_shards.add(
+                                        (layer_id, expert_id, shard_id)
+                                    )
+                                    break
+                    continue
+
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    if ".g_proj." in name:
+                        raise RuntimeError(
+                            f"Checkpoint provides gate weight {name!r} but the model "
+                            "built no g_proj (gating is disabled in the config). Set "
+                            'gating to True, "per-head", or "per-element" to load '
+                            "this checkpoint."
+                        )
+                    logger.warning("Parameter %s not found in params_dict", name)
+                    continue
+                yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        expected = {
+            (layer_id, expert_id, shard_id)
+            for layer_id in moe_layer_ids
+            for expert_id in range(self.config.num_experts)
+            for shard_id in ("w1", "w2", "w3")
+        }
+        missing = expected - loaded_expert_shards
+        if missing:
+            sample = sorted(missing)[:5]
+            raise RuntimeError(
+                f"{len(missing)} routed-expert tensors were not loaded "
+                f"(sample: {sample}). Expected {len(expected)} "
+                f"(layers={moe_layer_ids}, num_experts={self.config.num_experts}, "
+                "shards=3)."
+            )
+        return loaded | dispatched
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/llama_classification.py
+++ b/python/sglang/srt/models/llama_classification.py
@@ -59,9 +59,9 @@ class LlamaForClassification(nn.Module):
         input_embeds: torch.Tensor = None,
         get_embedding: bool = True,
     ) -> EmbeddingPoolerOutput:
-        assert (
-            get_embedding
-        ), "LlamaForClassification is only used for embedding. Please add --is-embedding when you launch the server."
+        assert get_embedding, (
+            "LlamaForClassification is only used for embedding. Please add --is-embedding when you launch the server."
+        )
 
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
         return score_and_pool(
@@ -73,6 +73,13 @@ class LlamaForClassification(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
 
         for name, loaded_weight in weights:
@@ -84,6 +91,26 @@ class LlamaForClassification(nn.Module):
                 continue
             else:
                 LlamaForCausalLM._legacy_load_weights(self, [(name, loaded_weight)])
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            WeightsMapper,
+        )
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["lm_head."],
+            skip_substrs=["projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        mapper = WeightsMapper(
+            orig_to_new_suffix={
+                ".activation_scale": ".input_scale",
+                ".weight_scale_inv": ".weight_scale",
+            }
+        )
+        return loader.load_weights(weights, mapper=mapper)
 
 
 EntryClass = LlamaForClassification

--- a/python/sglang/srt/models/llama_eagle.py
+++ b/python/sglang/srt/models/llama_eagle.py
@@ -140,10 +140,28 @@ class LlamaForCausalLMEagle(LlamaForCausalLM):
         self.capture_aux_hidden_states = False
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        for name, loaded_weight in weights:
-            if "lm_head" not in name:
-                name = "model." + name
-                super().load_weights([(name, loaded_weight)])
+        from sglang.srt.environ import envs
+
+        if not envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            for name, loaded_weight in weights:
+                if "lm_head" not in name:
+                    name = "model." + name
+                    LlamaForCausalLM._legacy_load_weights(
+                        self, [(name, loaded_weight)]
+                    )
+            return
+
+        def prepare_weights():
+            for name, loaded_weight in weights:
+                if "lm_head" not in name:
+                    name = "model." + name
+                    if name.endswith(".activation_scale"):
+                        name = name.replace(".activation_scale", ".input_scale")
+                    elif name.endswith(".weight_scale_inv"):
+                        name = name.replace(".weight_scale_inv", ".weight_scale")
+                    yield name, loaded_weight
+
+        return LlamaForCausalLM._load_weights_v2(self, prepare_weights())
 
 
 EntryClass = [LlamaForCausalLMEagle]

--- a/python/sglang/srt/models/llama_eagle3.py
+++ b/python/sglang/srt/models/llama_eagle3.py
@@ -85,7 +85,6 @@ class LlamaDecoderLayer(LlamaDecoderLayer):
         forward_batch: ForwardBatch,
         residual: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-
         if self.is_input_layer:
             # Input layer consumes target hidden states; no carried residual to fuse.
             residual = hidden_states
@@ -295,6 +294,13 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
         self.hot_token_id = None
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
         params_dict = dict(self.named_parameters())
         # Define the parameter mapping for stacked parameters
         stacked_params_mapping = [
@@ -348,6 +354,44 @@ class LlamaForCausalLMEagle3(LlamaForCausalLM):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        params_dict = dict(self.named_parameters())
+        legacy_name_map = {
+            "midlayer": "layers.0",
+            "aux_norm_low": "fc_norm.0",
+            "aux_norm_mid": "fc_norm.1",
+            "aux_norm_high": "fc_norm.2",
+        }
+
+        def prepare_weights():
+            for name, loaded_weight in weights:
+                for legacy, new in legacy_name_map.items():
+                    if legacy in name:
+                        name = name.replace(legacy, new)
+                if "d2t" in name:
+                    self.hot_token_id = loaded_weight + torch.arange(
+                        loaded_weight.shape[0]
+                    )
+                    continue
+                if "t2d" in name:
+                    continue
+                if name.endswith(".activation_scale"):
+                    name = name.replace(".activation_scale", ".input_scale")
+                elif name.endswith(".weight_scale_inv"):
+                    name = name.replace(".weight_scale_inv", ".weight_scale")
+                if name not in params_dict:
+                    name = f"model.{name}"
+                yield name, loaded_weight
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["rotary_emb.inv_freq"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(prepare_weights())
 
     def get_hot_token_id(self):
         return self.hot_token_id

--- a/python/sglang/srt/models/llama_embedding.py
+++ b/python/sglang/srt/models/llama_embedding.py
@@ -33,13 +33,20 @@ class LlamaEmbeddingModel(nn.Module):
         input_embeds: torch.Tensor = None,
         get_embedding: bool = True,
     ) -> EmbeddingPoolerOutput:
-        assert (
-            get_embedding
-        ), "LlamaEmbeddingModel / MistralModel is only used for embedding"
+        assert get_embedding, (
+            "LlamaEmbeddingModel / MistralModel is only used for embedding"
+        )
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
         return self.pooler(hidden_states, forward_batch)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -78,6 +85,27 @@ class LlamaEmbeddingModel(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        def normalize_names():
+            for name, loaded_weight in weights:
+                if name.endswith(".activation_scale"):
+                    name = name.replace(".activation_scale", ".input_scale")
+                elif name.endswith(".weight_scale_inv"):
+                    name = name.replace(".weight_scale_inv", ".weight_scale")
+                if not name.startswith("model."):
+                    name = add_prefix(name, "model")
+                yield name, loaded_weight
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["lm_head."],
+            skip_substrs=["rotary_emb.inv_freq", "projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(normalize_names())
 
 
 class MistralModel(LlamaEmbeddingModel):

--- a/python/sglang/srt/models/llama_reward.py
+++ b/python/sglang/srt/models/llama_reward.py
@@ -58,9 +58,9 @@ class LlamaForSequenceClassification(nn.Module):
         input_embeds: torch.Tensor = None,
         get_embedding: bool = True,
     ) -> EmbeddingPoolerOutput:
-        assert (
-            get_embedding
-        ), "LlamaForSequenceClassification is only used for embedding"
+        assert get_embedding, (
+            "LlamaForSequenceClassification is only used for embedding"
+        )
 
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
         last_token_hidden = self.pooler(hidden_states, forward_batch).embeddings
@@ -74,6 +74,19 @@ class LlamaForSequenceClassification(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+
+            def normalize_fp8_suffixes():
+                for name, loaded_weight in weights:
+                    if name.endswith(".activation_scale"):
+                        name = name.replace(".activation_scale", ".input_scale")
+                    elif name.endswith(".weight_scale_inv"):
+                        name = name.replace(".weight_scale_inv", ".weight_scale")
+                    yield name, loaded_weight
+
+            return LlamaForCausalLM._load_weights_v2(self, normalize_fp8_suffixes())
         return LlamaForCausalLM._legacy_load_weights(self, weights)
 
 
@@ -110,9 +123,9 @@ class LlamaForSequenceClassificationWithNormal_Weights(LlamaForSequenceClassific
         input_embeds: torch.Tensor = None,
         get_embedding: bool = True,
     ) -> EmbeddingPoolerOutput:
-        assert (
-            get_embedding
-        ), "LlamaForSequenceClassification is only used for embedding"
+        assert get_embedding, (
+            "LlamaForSequenceClassification is only used for embedding"
+        )
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
         logits = self.score(hidden_states)
         weights = self.weights(hidden_states)

--- a/python/sglang/srt/models/mimo.py
+++ b/python/sglang/srt/models/mimo.py
@@ -97,6 +97,13 @@ class MiMoForCausalLM(nn.Module):
             return self.pooler(hidden_states, forward_batch)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -141,6 +148,21 @@ class MiMoForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=["projector", "mtp_layers", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/mimo_mtp.py
+++ b/python/sglang/srt/models/mimo_mtp.py
@@ -119,6 +119,13 @@ class MiMoMTP(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -171,6 +178,39 @@ class MiMoMTP(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        allowed_substrs = (
+            "mtp_block",
+            "embed_tokens",
+            "lm_head",
+            "token_layernorm",
+            "hidden_layernorm",
+            "input_proj",
+            "final_layernorm",
+        )
+
+        def _prepare(
+            src: Iterable[Tuple[str, torch.Tensor]],
+        ) -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, loaded_weight in src:
+                name = self.map_model_name_to_mtp_param_name(name)
+                if any(sub in name for sub in allowed_substrs):
+                    yield name, loaded_weight
+
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=["projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(_prepare(weights))
 
     def map_model_name_to_mtp_param_name(self, name: str) -> str:
         import re

--- a/python/sglang/srt/models/minicpm.py
+++ b/python/sglang/srt/models/minicpm.py
@@ -334,6 +334,13 @@ class MiniCPMForCausalLM(nn.Module):
         return self.logits_processor(input_ids, hidden_states, lm_head, forward_batch)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -394,6 +401,63 @@ class MiniCPMForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import STANDARD_STACKED_MAPPING
+
+        expert_mapping = [
+            (
+                "ws" if weight_name in ("w1", "w3") else "w2s",
+                f"experts.{expert_id}.{weight_name}.weight",
+                expert_id,
+            )
+            for expert_id in range(self.num_experts)
+            for weight_name in ("w1", "w2", "w3")
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if (
+                "rotary_emb.inv_freq" in name
+                or "rotary_emb.cos_cached" in name
+                or "rotary_emb.sin_cached" in name
+                or (self.config.tie_word_embeddings and "lm_head.weight" in name)
+            ):
+                continue
+            if name.endswith(".bias") and name not in params_dict:
+                mapped_bias = any(
+                    source_name in name
+                    and name.replace(source_name, fused_name) in params_dict
+                    for fused_name, source_name, _ in STANDARD_STACKED_MAPPING.mappings
+                )
+                if not mapped_bias:
+                    continue
+            target = STANDARD_STACKED_MAPPING.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target not in params_dict:
+                    if target.endswith(".bias"):
+                        continue
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                loaded.add(target)
+                continue
+            for param_name, weight_name, expert_id in expert_mapping:
+                if weight_name not in name:
+                    continue
+                target = name.replace(weight_name, param_name)
+                param = params_dict.get(target)
+                if param is None:
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                param.weight_loader(
+                    param, loaded_weight, weight_name, expert_id=expert_id
+                )
+                loaded.add(target)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded.add(name)
+        return loaded
 
 
 EntryClass = MiniCPMForCausalLM

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -1293,7 +1293,13 @@ class MiniMaxM2ForCausalLM(nn.Module):
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """Load model weights with proper mapping for MiniMax architecture."""
+        from sglang.srt.environ import envs
 
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -1402,6 +1408,69 @@ class MiniMaxM2ForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
+        return loaded_params
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            STANDARD_STACKED_MAPPING,
+            try_load_stacked_skip_moe_experts,
+        )
+
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_local_experts,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+        )
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            layer_id = get_layer_id(name)
+            if layer_id is not None and (
+                layer_id < self.model.start_layer or layer_id >= self.model.end_layer
+            ):
+                continue
+            if get_spec_layer_idx_from_weight_name(self.config, name) is not None:
+                continue
+
+            # KV-cache scales must retain their checkpoint projection name so
+            # maybe_remap_kv_scale_name can map them to the attention scale.
+            is_kv_scale = name.endswith(".k_scale") or name.endswith(".v_scale")
+            target = (
+                None
+                if is_kv_scale
+                else try_load_stacked_skip_moe_experts(
+                    STANDARD_STACKED_MAPPING,
+                    name,
+                    loaded_weight,
+                    params_dict,
+                )
+            )
+            if target is not None:
+                if target in params_dict:
+                    loaded_params.add(target)
+                continue
+
+            target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target in params_dict:
+                    loaded_params.add(target)
+                continue
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            target = maybe_remap_kv_scale_name(name, params_dict)
+            if target is None or target not in params_dict:
+                continue
+            param = params_dict[target]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(target)
+
         return loaded_params
 
     @classmethod

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -1542,7 +1542,11 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """Load model weights with proper mapping for MiniMax architecture."""
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
 
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # Leading "." on ".qkv_proj" prevents it from falsely matching the sparse
             # index_q/k/v_proj weights (remapped separately below).
@@ -1663,6 +1667,92 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
 
         # Run before the loader's process pass: the raw fp8 weight + uint8 scale are
         # final here (mxfp8 post-process only derives the packed scale, not these).
+        build_minimax_fused_qkv_index(self)
+        return loaded_params
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+            try_load_stacked_skip_moe_experts,
+        )
+
+        stacked_mapping = StackedParamsDispatch(
+            mappings=(
+                (".qkv_proj", ".q_proj", "q"),
+                (".qkv_proj", ".k_proj", "k"),
+                (".qkv_proj", ".v_proj", "v"),
+                (".gate_up_proj", ".gate_proj", 0),
+                (".gate_up_proj", ".up_proj", 1),
+                (".index_qkv_proj", ".index_q_proj", "q"),
+                (".index_qkv_proj", ".index_k_proj", "k"),
+                (".index_qkv_proj", ".index_v_proj", "v"),
+            )
+        )
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_local_experts + self.num_fused_shared_experts,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+        )
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            layer_id = get_layer_id(name)
+            if layer_id is not None and (
+                layer_id < self.model.start_layer or layer_id >= self.model.end_layer
+            ):
+                continue
+
+            name = name.replace(".block_sparse_moe", ".mlp")
+            if self.num_fused_shared_experts > 0 and "mlp.shared_experts" in name:
+                name = name.replace(
+                    "mlp.shared_experts",
+                    f"mlp.experts.{self.config.num_local_experts}",
+                )
+                name = name.replace("gate_proj", "w1")
+                name = name.replace("down_proj", "w2")
+                name = name.replace("up_proj", "w3")
+
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if get_spec_layer_idx_from_weight_name(self.config, name) is not None:
+                continue
+
+            target = try_load_stacked_skip_moe_experts(
+                stacked_mapping,
+                name,
+                loaded_weight,
+                params_dict,
+                skip_substrs=("mlp.experts.",),
+            )
+            if target is not None:
+                if target in params_dict:
+                    loaded_params.add(target)
+                elif not target.endswith(".bias"):
+                    raise KeyError(target)
+                continue
+
+            target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target in params_dict:
+                    loaded_params.add(target)
+                continue
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            target = maybe_remap_kv_scale_name(name, params_dict)
+            if target is None:
+                continue
+            if target not in params_dict:
+                raise KeyError(target)
+            param = params_dict[target]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(target)
+
+        # Build only after all v2 dispatch and strict name checks have succeeded.
         build_minimax_fused_qkv_index(self)
         return loaded_params
 

--- a/python/sglang/srt/models/mistral.py
+++ b/python/sglang/srt/models/mistral.py
@@ -57,7 +57,21 @@ class MistralForCausalLMMistralFormat(MistralForCausalLM):
     # fmt: on
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-        return super().load_weights(self._remap_mistral_to_llama(weights))
+        from sglang.srt.environ import envs
+
+        weights = self._remap_mistral_to_llama(weights)
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+
+            def normalize_fp8_suffixes():
+                for name, loaded_weight in weights:
+                    if name.endswith(".activation_scale"):
+                        name = name.replace(".activation_scale", ".input_scale")
+                    elif name.endswith(".weight_scale_inv"):
+                        name = name.replace(".weight_scale_inv", ".weight_scale")
+                    yield name, loaded_weight
+
+            return LlamaForCausalLM._load_weights_v2(self, normalize_fp8_suffixes())
+        return LlamaForCausalLM._legacy_load_weights(self, weights)
 
     def _remap_mistral_to_llama(
         self, weights: Iterable[tuple[str, torch.Tensor]]

--- a/python/sglang/srt/models/mistral_eagle.py
+++ b/python/sglang/srt/models/mistral_eagle.py
@@ -65,9 +65,9 @@ class MistralEagleModel(nn.Module):
         super().__init__()
         self.config = config
         self.vocab_size = config.vocab_size
-        assert (
-            get_pp_group().world_size == 1
-        ), "MistralForCausalLMEagle currently does not support pipeline parallelism"
+        assert get_pp_group().world_size == 1, (
+            "MistralForCausalLMEagle currently does not support pipeline parallelism"
+        )
         self.pp_group = get_pp_group()
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
@@ -177,11 +177,23 @@ class MistralForCausalLMEagle(LlamaForCausalLMEagle):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
         # Bypass LlamaForCausalLMEagle.load_weights' "prepend model." behaviour
         # because our remap already emits fully-qualified target names.
-        return LlamaForCausalLM.load_weights(
-            self, self._remap_mistral_to_llama(weights)
-        )
+        weights = self._remap_mistral_to_llama(weights)
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+
+            def normalize_fp8_suffixes():
+                for name, loaded_weight in weights:
+                    if name.endswith(".activation_scale"):
+                        name = name.replace(".activation_scale", ".input_scale")
+                    elif name.endswith(".weight_scale_inv"):
+                        name = name.replace(".weight_scale_inv", ".weight_scale")
+                    yield name, loaded_weight
+
+            return LlamaForCausalLM._load_weights_v2(self, normalize_fp8_suffixes())
+        return LlamaForCausalLM._legacy_load_weights(self, weights)
 
     def _remap_mistral_to_llama(
         self, weights: Iterable[Tuple[str, torch.Tensor]]

--- a/python/sglang/srt/models/mixtral.py
+++ b/python/sglang/srt/models/mixtral.py
@@ -78,6 +78,7 @@ class MixtralMoE(nn.Module):
         super().__init__()
         self.tp_size = get_parallel().tp_size
         self.hidden_size = hidden_size
+        self._ckpt_num_experts = num_experts
 
         # Gate always runs at half / full precision for now.
         self.gate = ReplicatedLinear(
@@ -116,6 +117,26 @@ class MixtralMoE(nn.Module):
         if self.tp_size > 1:
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
         return final_hidden_states.view(orig_shape)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+            load_moe_sparse_block_weights,
+        )
+
+        expert = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self._ckpt_num_experts,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+        )
+        return load_moe_sparse_block_weights(
+            self,
+            weights,
+            expert_dispatch=expert,
+            dense_stacked=StackedParamsDispatch(),
+        )
 
 
 class MixtralAttention(nn.Module):
@@ -197,6 +218,14 @@ class MixtralAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class MixtralDecoderLayer(nn.Module):
@@ -388,6 +417,13 @@ class MixtralForCausalLM(nn.Module):
         return self.model.end_layer
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -475,6 +511,24 @@ class MixtralForCausalLM(nn.Module):
                         weight_loader(param, loaded_weight)
                     else:
                         logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        if hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["rotary_emb.inv_freq"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = MixtralForCausalLM

--- a/python/sglang/srt/models/mixtral_quant.py
+++ b/python/sglang/srt/models/mixtral_quant.py
@@ -390,6 +390,13 @@ class QuantMixtralForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -426,6 +433,38 @@ class QuantMixtralForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import STANDARD_QKV_MAPPING
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            target = STANDARD_QKV_MAPPING.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target in params_dict:
+                    loaded_params.add(target)
+                elif target.endswith(".bias"):
+                    continue
+                else:
+                    raise KeyError(target)
+                continue
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            if "block_sparse_moe.experts." in name and name not in params_dict:
+                continue
+            if name not in params_dict:
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        return loaded_params
 
 
 EntryClass = QuantMixtralForCausalLM

--- a/python/sglang/srt/models/nemotron_nas.py
+++ b/python/sglang/srt/models/nemotron_nas.py
@@ -372,6 +372,15 @@ class DeciLMForCausalLM(nn.Module):
             return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> None:
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             (".qkv_proj", ".q_proj", "q"),
@@ -433,6 +442,45 @@ class DeciLMForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        params_dict = dict(self.named_parameters())
+
+        def _prepare(
+            src: Iterable[Tuple[str, torch.Tensor]],
+        ) -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, loaded_weight in src:
+                if self.model.quant_config is not None and (
+                    scale_name := self.model.quant_config.get_cache_scale(name)
+                ):
+                    loaded_weight = (
+                        loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
+                    )
+                    yield scale_name, loaded_weight
+                    continue
+                if "scale" in name:
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+                yield name, loaded_weight
+
+        weights = filter_pp_weights(
+            _prepare(weights), self.model.start_layer, self.model.end_layer
+        )
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = [DeciLMForCausalLM]

--- a/python/sglang/srt/models/olmo.py
+++ b/python/sglang/srt/models/olmo.py
@@ -124,6 +124,14 @@ class OlmoAttention(nn.Module):
         output, _ = self.o_proj(attn_output)
         return output
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
+
 
 class OlmoMLP(nn.Module):
     """
@@ -172,6 +180,14 @@ class OlmoMLP(nn.Module):
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
 
 
 class OlmoDecoderLayer(nn.Module):
@@ -341,6 +357,13 @@ class OlmoForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -377,6 +400,32 @@ class OlmoForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        loaded = loader.load_weights(weights)
+
+        if self.config.tie_word_embeddings:
+            params_dict = dict(self.named_parameters(remove_duplicate=False))
+            if "lm_head.weight" in params_dict:
+                embed = dict(self.model.named_parameters()).get("embed_tokens.weight")
+                if embed is not None:
+                    lm_head = params_dict["lm_head.weight"]
+                    wl = getattr(lm_head, "weight_loader", default_weight_loader)
+                    wl(lm_head, embed.data)
+                    loaded.add("lm_head.weight")
+
+        return loaded
 
 
 EntryClass = OlmoForCausalLM

--- a/python/sglang/srt/models/olmo2.py
+++ b/python/sglang/srt/models/olmo2.py
@@ -211,6 +211,14 @@ class Olmo2Attention(nn.Module):
         output, _ = self.o_proj(attn_output)
         return output
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
+
 
 class Olmo2MLP(nn.Module):
     """
@@ -259,6 +267,14 @@ class Olmo2MLP(nn.Module):
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
 
 
 class Olmo2DecoderLayer(nn.Module):
@@ -441,6 +457,13 @@ class Olmo2ForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -480,6 +503,32 @@ class Olmo2ForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        loaded = loader.load_weights(weights)
+
+        if self.config.tie_word_embeddings:
+            params_dict = dict(self.named_parameters(remove_duplicate=False))
+            if "lm_head.weight" in params_dict:
+                embed = dict(self.model.named_parameters()).get("embed_tokens.weight")
+                if embed is not None:
+                    lm_head = params_dict["lm_head.weight"]
+                    wl = getattr(lm_head, "weight_loader", default_weight_loader)
+                    wl(lm_head, embed.data)
+                    loaded.add("lm_head.weight")
+
+        return loaded
 
 
 EntryClass = Olmo2ForCausalLM

--- a/python/sglang/srt/models/olmoe.py
+++ b/python/sglang/srt/models/olmoe.py
@@ -70,6 +70,7 @@ class OlmoeMoE(nn.Module):
     ):
         super().__init__()
         self.hidden_size = hidden_size
+        self._ckpt_num_experts = num_experts
 
         # Gate always runs at half / full precision for now.
         self.gate = ReplicatedLinear(
@@ -104,6 +105,23 @@ class OlmoeMoE(nn.Module):
         topk_output = self.topk(hidden_states, router_logits)
         final_hidden_states = self.experts(hidden_states, topk_output)
         return final_hidden_states.view(orig_shape)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+            load_moe_sparse_block_weights,
+        )
+
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self._ckpt_num_experts,
+        )
+        return load_moe_sparse_block_weights(
+            self,
+            weights,
+            expert_dispatch=expert_dispatch,
+            dense_stacked=StackedParamsDispatch(),
+        )
 
 
 class OlmoeAttention(nn.Module):
@@ -193,6 +211,26 @@ class OlmoeAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        params_dict = dict(self.named_parameters())
+
+        def remapped_weights():
+            for name, weight in weights:
+                if name.endswith("kv_scale"):
+                    remapped_name = name.replace("kv_scale", "attn.kv_scale")
+                    if remapped_name in params_dict:
+                        name = remapped_name
+                yield name, weight
+
+        return load_with_stacked_dispatch(
+            self, remapped_weights(), STANDARD_QKV_MAPPING
+        )
 
 
 class OlmoeDecoderLayer(nn.Module):
@@ -347,6 +385,13 @@ class OlmoeForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -434,6 +479,23 @@ class OlmoeForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        if hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["rotary_emb.inv_freq"],
+            ignore_unexpected_suffixes=[".bias", "_bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = OlmoeForCausalLM

--- a/python/sglang/srt/models/orion.py
+++ b/python/sglang/srt/models/orion.py
@@ -75,6 +75,14 @@ class OrionMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class OrionAttention(nn.Module):
     def __init__(
@@ -154,6 +162,14 @@ class OrionAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch=forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class OrionDecoderLayer(nn.Module):
@@ -326,6 +342,13 @@ class OrionForCausalLM(nn.Module):
         return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -365,6 +388,28 @@ class OrionForCausalLM(nn.Module):
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        weights = filter_pp_weights(
+            weights, self.model.start_layer, self.model.end_layer
+        )
+        skip_prefixes = []
+        if (
+            self.config.tie_word_embeddings
+            and self.lm_head is self.model.embed_tokens
+        ):
+            skip_prefixes.append("lm_head.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = OrionForCausalLM

--- a/python/sglang/srt/models/phi3_small.py
+++ b/python/sglang/srt/models/phi3_small.py
@@ -459,7 +459,13 @@ class Phi3SmallForCausalLM(nn.Module):
             return self.pooler(hidden_states, forward_batch)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
 
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
@@ -475,6 +481,19 @@ class Phi3SmallForCausalLM(nn.Module):
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        skip_prefixes = (
+            ["lm_head."] if getattr(self.config, "tie_word_embeddings", True) else []
+        )
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            ignore_unexpected_suffixes=[".bias"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = Phi3SmallForCausalLM

--- a/python/sglang/srt/models/phimoe.py
+++ b/python/sglang/srt/models/phimoe.py
@@ -190,6 +190,7 @@ class PhiMoE(nn.Module):
         super().__init__()
         self.hidden_size = hidden_size
         self.tp_size = get_parallel().tp_size
+        self._ckpt_num_experts = num_experts
 
         # Gate always runs at half / full precision for now.
         self.gate = ReplicatedLinear(
@@ -226,6 +227,26 @@ class PhiMoE(nn.Module):
         topk_output = self.topk(hidden_states, router_logits)
         final_hidden_states = self.experts(hidden_states, topk_output)
         return final_hidden_states.view(orig_shape)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+            load_moe_sparse_block_weights,
+        )
+
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self._ckpt_num_experts,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+        )
+        return load_moe_sparse_block_weights(
+            self,
+            weights,
+            expert_dispatch=expert_dispatch,
+            dense_stacked=StackedParamsDispatch(),
+        )
 
 
 class PhiMoEAttention(nn.Module):
@@ -322,6 +343,34 @@ class PhiMoEAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        params_dict = dict(self.named_parameters())
+
+        def remapped_weights():
+            for name, weight in weights:
+                if name.endswith("kv_scale"):
+                    remapped_name = name.replace("kv_scale", "attn.k_scale")
+                    if remapped_name in params_dict:
+                        name = remapped_name
+                elif name.endswith("k_proj.k_scale"):
+                    remapped_name = name.replace("k_proj.k_scale", "attn.k_scale")
+                    if remapped_name in params_dict:
+                        name = remapped_name
+                elif name.endswith("v_proj.v_scale"):
+                    remapped_name = name.replace("v_proj.v_scale", "attn.v_scale")
+                    if remapped_name in params_dict:
+                        name = remapped_name
+                yield name, weight
+
+        return load_with_stacked_dispatch(
+            self, remapped_weights(), STANDARD_QKV_MAPPING
+        )
 
 
 class PhiMoEDecoderLayer(nn.Module):
@@ -498,6 +547,13 @@ class PhiMoEForCausalLM(nn.Module):
             return self.pooler(hidden_states, forward_batch)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -553,6 +609,23 @@ class PhiMoEForCausalLM(nn.Module):
                         param, "weight_loader", default_weight_loader
                     )
                     weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        if hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["rotary_emb.inv_freq"],
+            ignore_unexpected_suffixes=[".bias", "_bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = PhiMoEForCausalLM

--- a/python/sglang/srt/models/qwen.py
+++ b/python/sglang/srt/models/qwen.py
@@ -325,6 +325,13 @@ class QWenLMHeadModel(nn.Module):
         return result
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("gate_up_proj", "w2", 0),
@@ -352,6 +359,42 @@ class QWenLMHeadModel(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import StackedParamsDispatch
+
+        dispatch = StackedParamsDispatch(
+            mappings=(
+                ("gate_up_proj", "w2", 0),
+                ("gate_up_proj", "w1", 1),
+            )
+        )
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if name.endswith(".bias") and name not in params_dict:
+                mapped_bias = any(
+                    source_name in name
+                    and name.replace(source_name, fused_name) in params_dict
+                    for fused_name, source_name, _ in dispatch.mappings
+                )
+                if not mapped_bias:
+                    continue
+            target = dispatch.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target not in params_dict:
+                    if target.endswith(".bias"):
+                        continue
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                loaded.add(target)
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 EntryClass = QWenLMHeadModel

--- a/python/sglang/srt/models/qwen2_classification.py
+++ b/python/sglang/srt/models/qwen2_classification.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2023-2024 SGLang Team
+# Copyright 2023-2024 SGLang Team
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -57,9 +57,9 @@ class Qwen2ForSequenceClassification(nn.Module):
         input_embeds: torch.Tensor = None,
         get_embedding: bool = True,
     ) -> EmbeddingPoolerOutput:
-        assert (
-            get_embedding
-        ), "Qwen2ForSequenceClassification is only used for embedding"
+        assert get_embedding, (
+            "Qwen2ForSequenceClassification is only used for embedding"
+        )
 
         hidden_states = self.model(input_ids, positions, forward_batch, input_embeds)
         return score_and_pool(
@@ -67,10 +67,14 @@ class Qwen2ForSequenceClassification(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
         # Filter out lm_head weights of Qwen2ForCausalLM
         filtered_weights = [
             (name, w) for name, w in weights if not name.startswith("lm_head")
         ]
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return Qwen2ForCausalLM._load_weights_v2(self, filtered_weights)
         return Qwen2ForCausalLM._legacy_load_weights(self, filtered_weights)
 
 

--- a/python/sglang/srt/models/qwen2_eagle.py
+++ b/python/sglang/srt/models/qwen2_eagle.py
@@ -138,10 +138,23 @@ class Qwen2ForCausalLMEagle(Qwen2ForCausalLM):
         self.capture_aux_hidden_states = False
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        for name, loaded_weight in weights:
-            if "lm_head" not in name:
-                name = "model." + name
-                super().load_weights([(name, loaded_weight)])
+        from sglang.srt.environ import envs
+
+        if not envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            for name, loaded_weight in weights:
+                if "lm_head" not in name:
+                    name = "model." + name
+                    Qwen2ForCausalLM._legacy_load_weights(
+                        self, [(name, loaded_weight)]
+                    )
+            return
+
+        def prepare_weights():
+            for name, loaded_weight in weights:
+                if "lm_head" not in name:
+                    yield "model." + name, loaded_weight
+
+        return Qwen2ForCausalLM._load_weights_v2(self, prepare_weights())
 
 
 EntryClass = [Qwen2ForCausalLMEagle]

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -216,6 +216,14 @@ class Qwen2MoeMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class Qwen2MoeSparseMoeBlock(nn.Module):
     def __init__(
@@ -239,6 +247,7 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 f"the number of experts {config.num_experts}."
             )
         self.num_experts = config.num_experts
+        self._ckpt_num_experts = config.num_experts
         self.num_shared_experts = get_num_shared_experts(config)
         self.num_fused_shared_experts = 0
 
@@ -609,6 +618,60 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
 
         return final_hidden_states.view(num_tokens, hidden_dim)
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            StackedParamsDispatch,
+            load_moe_sparse_block_weights,
+        )
+
+        expert_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self._ckpt_num_experts,
+        )
+        if self.enable_shared_expert_fusion:
+            shared_expert_id = self._ckpt_num_experts
+            expert_mapping.extend(
+                [
+                    (
+                        "experts.w13_weight",
+                        "shared_expert.gate_proj.",
+                        shared_expert_id,
+                        "w1",
+                    ),
+                    (
+                        "experts.w2_weight",
+                        "shared_expert.down_proj.",
+                        shared_expert_id,
+                        "w2",
+                    ),
+                    (
+                        "experts.w13_weight",
+                        "shared_expert.up_proj.",
+                        shared_expert_id,
+                        "w3",
+                    ),
+                ]
+            )
+        expert = ExpertParamsDispatch.from_fused_moe_mapping(expert_mapping)
+        dense_stacked = (
+            StackedParamsDispatch()
+            if self.enable_shared_expert_fusion
+            else None
+        )
+        if dense_stacked is None:
+            return load_moe_sparse_block_weights(
+                self, weights, expert_dispatch=expert
+            )
+        return load_moe_sparse_block_weights(
+            self,
+            weights,
+            expert_dispatch=expert,
+            dense_stacked=dense_stacked,
+        )
+
 
 class Qwen2MoeAttention(nn.Module):
     def __init__(
@@ -704,6 +767,14 @@ class Qwen2MoeAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class Qwen2MoeDecoderLayer(nn.Module):
@@ -1107,6 +1178,13 @@ class Qwen2MoeForCausalLM(nn.Module):
         return self.model.end_layer
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -1191,6 +1269,24 @@ class Qwen2MoeForCausalLM(nn.Module):
                         weight_loader(param, loaded_weight)
                     else:
                         logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        if hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["rotary_emb.inv_freq"],
+            ignore_unexpected_suffixes=[".bias"],
+        )
+        return loader.load_weights(weights)
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/qwen2_rm.py
+++ b/python/sglang/srt/models/qwen2_rm.py
@@ -80,10 +80,14 @@ class Qwen2ForRewardModel(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
         # Filter out lm_head weights of Qwen2ForCausalLM
         filtered_weights = [
             (name, w) for name, w in weights if not name.startswith("lm_head")
         ]
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return Qwen2ForCausalLM._load_weights_v2(self, filtered_weights)
         return Qwen2ForCausalLM._legacy_load_weights(self, filtered_weights)
 
 

--- a/python/sglang/srt/models/qwen3.py
+++ b/python/sglang/srt/models/qwen3.py
@@ -306,6 +306,32 @@ class Qwen3Attention(nn.Module):
         output, _ = self.o_proj(attn_output)
         return output
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
+
+
+def _prepare_qwen3_checkpoint_weights(
+    weights: Iterable[Tuple[str, torch.Tensor]],
+    params_dict: dict[str, torch.nn.Parameter],
+) -> Iterable[Tuple[str, torch.Tensor]]:
+    for name, loaded_weight in weights:
+        if not name.startswith("model.") and (
+            name.startswith("layers.")
+            or name.startswith("embed_tokens.")
+            or name.startswith("norm.")
+        ):
+            name = add_prefix(name, "model")
+        if "scale" in name:
+            name = maybe_remap_kv_scale_name(name, params_dict)
+            if name is None:
+                continue
+        yield name, loaded_weight
+
 
 class Qwen3DecoderLayer(nn.Module):
     def __init__(
@@ -594,6 +620,13 @@ class Qwen3ForCausalLM(nn.Module):
         return self.model.end_layer
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -668,6 +701,43 @@ class Qwen3ForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        params_dict = dict(self.named_parameters())
+        weights = _prepare_qwen3_checkpoint_weights(weights, params_dict)
+
+        if hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=["projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        loaded = loader.load_weights(weights)
+
+        if self.config.tie_word_embeddings and self.pp_group.is_last_rank:
+            if "lm_head.weight" in params_dict:
+                embed = dict(self.model.named_parameters()).get("embed_tokens.weight")
+                if embed is not None:
+                    lm_head = params_dict["lm_head.weight"]
+                    wl = getattr(lm_head, "weight_loader", default_weight_loader)
+                    wl(lm_head, embed.data)
+                    loaded.add("lm_head.weight")
+
+        return loaded
 
     def get_embed_and_head(self):
         return self.model.embed_tokens.weight, self.lm_head.weight

--- a/python/sglang/srt/models/qwen3_classification.py
+++ b/python/sglang/srt/models/qwen3_classification.py
@@ -28,7 +28,7 @@ from sglang.srt.layers.pooler import (
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.models.qwen3 import Qwen3Model
+from sglang.srt.models.qwen3 import Qwen3Model, _prepare_qwen3_checkpoint_weights
 from sglang.srt.utils import add_prefix
 
 logger = logging.getLogger(__name__)
@@ -75,6 +75,13 @@ class Qwen3ForPooledOutput(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -123,6 +130,20 @@ class Qwen3ForPooledOutput(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        params_dict = dict(self.named_parameters())
+        weights = _prepare_qwen3_checkpoint_weights(weights, params_dict)
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["lm_head."],
+            skip_substrs=["projector"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 class Qwen3ForSequenceClassification(Qwen3ForPooledOutput):

--- a/python/sglang/srt/models/qwen3_embedding.py
+++ b/python/sglang/srt/models/qwen3_embedding.py
@@ -11,7 +11,10 @@ from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
-from sglang.srt.models.qwen3 import Qwen3Model as Qwen3TransformerModel
+from sglang.srt.models.qwen3 import (
+    Qwen3Model as Qwen3TransformerModel,
+    _prepare_qwen3_checkpoint_weights,
+)
 from sglang.srt.utils import add_prefix
 
 logger = logging.getLogger(__name__)
@@ -60,6 +63,13 @@ class Qwen3Model(nn.Module):
         return self.pooler(hidden_states, forward_batch)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -119,6 +129,19 @@ class Qwen3Model(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        params_dict = dict(self.named_parameters())
+        weights = _prepare_qwen3_checkpoint_weights(weights, params_dict)
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["lm_head."],
+            skip_substrs=["projector"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = Qwen3Model

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -247,6 +247,8 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
                 f"the number of experts {config.num_experts}."
             )
 
+        self._ckpt_num_experts = config.num_experts
+
         from sglang.srt.layers.quantization.gguf import GGUFConfig
 
         norm_topk_prob = getattr(config, "norm_topk_prob", True)
@@ -424,6 +426,17 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
 
     def op_output(self, state):
         state.hidden_states_mlp_output = state.pop("hidden_states_after_combine")
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            ExpertParamsDispatch,
+            load_moe_sparse_block_weights,
+        )
+
+        expert = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self._ckpt_num_experts,
+        )
+        return load_moe_sparse_block_weights(self, weights, expert_dispatch=expert)
 
 
 class Qwen3MoeAttention(nn.Module):
@@ -701,6 +714,14 @@ class Qwen3MoeAttention(nn.Module):
             forward_batch=forward_batch,
         )
         return self.forward_core(s)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class Qwen3MoeDecoderLayer(nn.Module):
@@ -1097,6 +1118,15 @@ class Qwen3MoeForCausalLM(nn.Module):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
     ):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get() and not is_mtp:
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights, is_mtp=is_mtp)
+
+    def _legacy_load_weights(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
+    ):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -1225,6 +1255,35 @@ class Qwen3MoeForCausalLM(nn.Module):
                     )
                 }
             )
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            filter_pp_weights,
+        )
+
+        if hasattr(self.model, "start_layer"):
+            weights = filter_pp_weights(
+                weights, self.model.start_layer, self.model.end_layer
+            )
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["rotary_emb.inv_freq", "mtp"],
+            ignore_unexpected_suffixes=[".bias"],
+        )
+        loaded = loader.load_weights(weights)
+        if not hasattr(self, "routed_experts_weights_of_layer"):
+            self.routed_experts_weights_of_layer = LazyValue(
+                lambda: {
+                    layer_id: self.model.layers[layer_id].mlp.get_moe_weights()
+                    for layer_id in range(self.start_layer, self.end_layer)
+                    if isinstance(
+                        self.model.layers[layer_id].mlp, Qwen3MoeSparseMoeBlock
+                    )
+                }
+            )
+        return loaded
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/qwen3_moe_mtp.py
+++ b/python/sglang/srt/models/qwen3_moe_mtp.py
@@ -125,7 +125,26 @@ class Qwen3MoeForCausalLMMTP(Qwen3MoeForCausalLM):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
     ):
-        return super().load_weights(weights, is_mtp=True)
+        from sglang.srt.environ import envs
+
+        if not envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return Qwen3MoeForCausalLM._legacy_load_weights(self, weights, is_mtp=True)
+
+        def prepare_mtp_weights():
+            for name, loaded_weight in weights:
+                if "mtp" not in name:
+                    continue
+                if name in {
+                    "mtp.fc.weight",
+                    "mtp.pre_fc_norm_embedding.weight",
+                    "mtp.pre_fc_norm_hidden.weight",
+                }:
+                    name = name.removeprefix("mtp.")
+                else:
+                    name = name.replace("mtp", "model")
+                yield name, loaded_weight
+
+        return Qwen3MoeForCausalLM._load_weights_v2(self, prepare_mtp_weights())
 
 
 EntryClass = [Qwen3MoeForCausalLMMTP]

--- a/python/sglang/srt/models/sdar.py
+++ b/python/sglang/srt/models/sdar.py
@@ -85,6 +85,14 @@ class SDARMLP(nn.Module):
         hidden_states, _ = self.down_proj(hidden_states)
         return hidden_states
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class SDARAttention(nn.Module):
     def __init__(
@@ -248,6 +256,14 @@ class SDARAttention(nn.Module):
         )
         out, _ = self.o_proj(context_layer)
         return out
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class SDARBlock(nn.Module):
@@ -514,6 +530,13 @@ class SDARForCausalLM(nn.Module):
             return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -586,6 +609,57 @@ class SDARForCausalLM(nn.Module):
                     weight_loader(param, loaded_weight)
                 else:
                     logger.warning(f"Parameter {name} not found in params_dict")
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            WeightsMapper,
+            filter_pp_weights,
+        )
+
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+
+        def _prepare(
+            src: Iterable[Tuple[str, torch.Tensor]],
+        ) -> Iterable[Tuple[str, torch.Tensor]]:
+            for name, loaded_weight in src:
+                if "scale" in name:
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+                yield name, loaded_weight
+
+        weights = filter_pp_weights(
+            _prepare(weights), self.model.start_layer, self.model.end_layer
+        )
+        mapper = WeightsMapper(
+            orig_to_new_prefix={
+                "layers.": "model.layers.",
+                "embed_tokens.": "model.embed_tokens.",
+                "norm.": "model.norm.",
+            }
+        )
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            skip_prefixes.append("lm_head.")
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=["projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        loaded = loader.load_weights(weights, mapper=mapper)
+
+        if self.config.tie_word_embeddings and self.pp_group.is_last_rank:
+            embed = dict(self.model.named_parameters()).get("embed_tokens.weight")
+            lm_head = params_dict.get("lm_head.weight")
+            if embed is not None and lm_head is not None:
+                weight_loader = getattr(
+                    lm_head, "weight_loader", default_weight_loader
+                )
+                weight_loader(lm_head, embed.data)
+                loaded.add("lm_head.weight")
+        return loaded
 
 
 EntryClass = SDARForCausalLM

--- a/python/sglang/srt/models/sdar_moe.py
+++ b/python/sglang/srt/models/sdar_moe.py
@@ -600,6 +600,13 @@ class SDARMoeForCausalLM(nn.Module):
         return hidden_states
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             ("qkv_proj", "q_proj", "q"),
             ("qkv_proj", "k_proj", "k"),
@@ -723,6 +730,117 @@ class SDARMoeForCausalLM(nn.Module):
                     if isinstance(self.model.layers[lid].mlp, SDARMoeSparseMoeBlock)
                 }
             )
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            AutoWeightsLoader,
+            ExpertParamsDispatch,
+            STANDARD_GATE_UP_MAPPING,
+            STANDARD_QKV_MAPPING,
+        )
+
+        params_dict = dict(self.named_parameters())
+        expert_dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=self.config.num_experts
+        )
+        dispatched: set[str] = set()
+
+        def remaining_weights():
+            for name, loaded_weight in weights:
+                if not name.startswith("model.") and name.startswith(
+                    ("layers.", "embed_tokens.", "norm.")
+                ):
+                    name = add_prefix(name, "model")
+
+                if (
+                    name == "model.embed_tokens.weight"
+                    and self.pp_group.is_last_rank
+                    and getattr(self.config, "tie_word_embeddings", False)
+                    and "lm_head.weight" in params_dict
+                ):
+                    param = params_dict["lm_head.weight"]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    dispatched.add("lm_head.weight")
+
+                layer_id = get_layer_id(name)
+                if layer_id is not None and (
+                    layer_id < self.model.start_layer
+                    or layer_id >= self.model.end_layer
+                ):
+                    continue
+                if (
+                    "rotary_emb.inv_freq" in name
+                    or "projector" in name
+                    or "rotary_emb.cos_cached" in name
+                    or "rotary_emb.sin_cached" in name
+                ):
+                    continue
+                if "scale" in name:
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+                if name.endswith(".bias") and name not in params_dict:
+                    stacked_bias = any(
+                        source_name in name
+                        and name.replace(source_name, fused_name) in params_dict
+                        for dispatch in (
+                            STANDARD_QKV_MAPPING,
+                            STANDARD_GATE_UP_MAPPING,
+                        )
+                        for fused_name, source_name, _ in dispatch.mappings
+                        if "mlp.experts" not in name
+                    )
+                    expert_bias = any(
+                        weight_name in name
+                        and name.replace(weight_name, param_name) in params_dict
+                        for param_name, weight_name, _, _ in expert_dispatch.mappings
+                    )
+                    if not stacked_bias and not expert_bias:
+                        continue
+
+                target = STANDARD_QKV_MAPPING.try_load(
+                    name, loaded_weight, params_dict
+                )
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if "mlp.experts" not in name:
+                    target = STANDARD_GATE_UP_MAPPING.try_load(
+                        name, loaded_weight, params_dict
+                    )
+                    if target is not None:
+                        if target in params_dict:
+                            dispatched.add(target)
+                        continue
+
+                target = expert_dispatch.try_load(name, loaded_weight, params_dict)
+                if target is not None:
+                    if target in params_dict:
+                        dispatched.add(target)
+                    continue
+
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name in params_dict:
+                    yield name, loaded_weight
+
+        loaded = AutoWeightsLoader(self).load_weights(remaining_weights())
+        if not hasattr(self, "routed_experts_weights_of_layer"):
+            self.routed_experts_weights_of_layer = LazyValue(
+                lambda: {
+                    lid: self.model.layers[lid].mlp.get_moe_weights()
+                    for lid in range(self.start_layer, self.end_layer)
+                    if isinstance(self.model.layers[lid].mlp, SDARMoeSparseMoeBlock)
+                }
+            )
+        return loaded | dispatched
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/models/solar.py
+++ b/python/sglang/srt/models/solar.py
@@ -472,7 +472,13 @@ class SolarForCausalLM(nn.Module):
         return hidden_states
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
 
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
 
@@ -501,6 +507,43 @@ class SolarForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import filter_pp_weights
+
+        weights = filter_pp_weights(
+            weights, self.model.start_layer, self.model.end_layer
+        )
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            packed = False
+            for packed_name, sources in self.packed_modules_mapping.items():
+                for source_name, shard_id in sources:
+                    if source_name not in name:
+                        continue
+                    target = name.replace(source_name, packed_name)
+                    param = params_dict.get(target)
+                    if param is None:
+                        continue
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight, shard_id)
+                    loaded.add(target)
+                    packed = True
+                    break
+                if packed:
+                    break
+            if packed:
+                continue
+            param = params_dict.get(name)
+            if param is None:
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 EntryClass = SolarForCausalLM

--- a/python/sglang/srt/models/stablelm.py
+++ b/python/sglang/srt/models/stablelm.py
@@ -83,6 +83,14 @@ class StablelmMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class StablelmAttention(nn.Module):
     def __init__(
@@ -184,6 +192,14 @@ class StablelmAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class StablelmDecoderLayer(nn.Module):
@@ -311,6 +327,13 @@ class StableLmForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -345,6 +368,15 @@ class StableLmForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        loader = AutoWeightsLoader(
+            self,
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = StableLmForCausalLM

--- a/python/sglang/srt/models/starcoder2.py
+++ b/python/sglang/srt/models/starcoder2.py
@@ -322,6 +322,13 @@ class Starcoder2ForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -354,6 +361,28 @@ class Starcoder2ForCausalLM(nn.Module):
 
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import STANDARD_QKV_MAPPING
+
+        params_dict = dict(self.named_parameters())
+        loaded: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freqs" in name:
+                continue
+            target = STANDARD_QKV_MAPPING.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target not in params_dict:
+                    raise ValueError(f"Mapped parameter {target!r} not found")
+                loaded.add(target)
+                continue
+            param = params_dict.get(name)
+            if param is None:
+                continue
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded.add(name)
+        return loaded
 
 
 EntryClass = Starcoder2ForCausalLM

--- a/python/sglang/srt/models/xverse.py
+++ b/python/sglang/srt/models/xverse.py
@@ -83,6 +83,14 @@ class XverseMLP(nn.Module):
         x, _ = self.down_proj(x)
         return x
 
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_GATE_UP_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_GATE_UP_MAPPING)
+
 
 class XverseAttention(nn.Module):
     def __init__(
@@ -172,6 +180,14 @@ class XverseAttention(nn.Module):
         attn_output = self.attn(q, k, v, forward_batch)
         output, _ = self.o_proj(attn_output)
         return output
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import (
+            STANDARD_QKV_MAPPING,
+            load_with_stacked_dispatch,
+        )
+
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
 
 
 class XverseDecoderLayer(nn.Module):
@@ -334,6 +350,17 @@ class XverseForCausalLM(nn.Module):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], name=None, loaded_weight=None
     ):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights, name=name, loaded_weight=loaded_weight)
+        return self._legacy_load_weights(
+            weights, name=name, loaded_weight=loaded_weight
+        )
+
+    def _legacy_load_weights(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], name=None, loaded_weight=None
+    ):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -379,6 +406,20 @@ class XverseForCausalLM(nn.Module):
                 load_weights_per_param(name, loaded_weight)
         else:
             load_weights_per_param(name, loaded_weight)
+
+    def _load_weights_v2(
+        self, weights: Iterable[Tuple[str, torch.Tensor]], name=None, loaded_weight=None
+    ) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import AutoWeightsLoader
+
+        if name is not None and loaded_weight is not None:
+            weights = [(name, loaded_weight)]
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["projector", "model.vision_tower"],
+            ignore_unexpected_suffixes=[".bias", ".kv_scale"],
+        )
+        return loader.load_weights(weights)
 
 
 EntryClass = XverseForCausalLM

--- a/python/sglang/srt/models/xverse_moe.py
+++ b/python/sglang/srt/models/xverse_moe.py
@@ -435,6 +435,13 @@ class XverseMoeForCausalLM(nn.Module):
         )
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        from sglang.srt.environ import envs
+
+        if envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.get():
+            return self._load_weights_v2(weights)
+        return self._legacy_load_weights(weights)
+
+    def _legacy_load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),
@@ -476,6 +483,42 @@ class XverseMoeForCausalLM(nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+
+    def _load_weights_v2(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        from sglang.srt.model_loader.auto_loader import STANDARD_STACKED_MAPPING
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            target = STANDARD_STACKED_MAPPING.try_load(name, loaded_weight, params_dict)
+            if target is not None:
+                if target in params_dict:
+                    loaded_params.add(target)
+                elif (
+                    target.endswith(".bias")
+                    or "mlp.experts." in target
+                    or "mlp.shared_experts." in target
+                ):
+                    continue
+                else:
+                    raise KeyError(target)
+                continue
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            if (
+                "mlp.experts." in name or "mlp.shared_experts." in name
+            ) and name not in params_dict:
+                continue
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        return loaded_params
 
 
 EntryClass = XverseMoeForCausalLM

--- a/test/manual/test_weight_loader_v2_equiv.py
+++ b/test/manual/test_weight_loader_v2_equiv.py
@@ -11,21 +11,69 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-# Manual verification for weight loader v2 (Qwen2 native path).
+# Manual state-dict verification for representative weight-loader-v2 paths.
 #
 # Run:
-#   CUDA_VISIBLE_DEVICES=0 python test/manual/test_weight_loader_v2_equiv.py
+#   CUDA_VISIBLE_DEVICES=0 pytest -v test/manual/test_weight_loader_v2_equiv.py
 #
-# Engine-level e2e (Qwen2 + transformers backend) lives in:
+# Only checkpoints already present in the Hugging Face cache are used. Override
+# any model with SGLANG_WEIGHT_LOADER_V2_<CATEGORY>_MODEL=/path/to/checkpoint.
+# Engine-level e2e coverage lives in:
 #   test/registered/model_loading/test_weight_loader_v2_e2e.py
 
-import unittest
+import os
+from dataclasses import dataclass
+from pathlib import Path
 
+import pytest
 import torch
 
 from sglang.srt.environ import envs
 
-MODEL = "Qwen/Qwen2-0.5B"
+
+@dataclass(frozen=True)
+class ModelCase:
+    category: str
+    default_model: str
+    architecture: str
+    model_type: str = "generation"
+
+    @property
+    def model(self) -> str:
+        env_name = f"SGLANG_WEIGHT_LOADER_V2_{self.category.upper()}_MODEL"
+        return os.environ.get(env_name, self.default_model)
+
+
+# These public fixtures are intentionally small. Their architecture strings map
+# directly to SGLang native loaders (rather than the transformers fallback).
+MODEL_CASES = [
+    ModelCase(
+        "standard_dense",
+        "hf-internal-testing/tiny-random-Gemma2ForCausalLM",
+        "Gemma2ForCausalLM",
+    ),
+    ModelCase(
+        "packed_dense",
+        "hf-internal-testing/tiny-random-GPTBigCodeForCausalLM",
+        "GPTBigCodeForCausalLM",
+    ),
+    ModelCase(
+        "standard_moe",
+        "peft-internal-testing/tiny-random-qwen-1.5-MoE",
+        "Qwen2MoeForCausalLM",
+    ),
+    ModelCase(
+        "shared_special_moe",
+        "hf-internal-testing/tiny-random-MixtralForCausalLM",
+        "MixtralForCausalLM",
+    ),
+    ModelCase(
+        "wrapper",
+        "trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+        "Qwen2ForSequenceClassification",
+        model_type="embedding",
+    ),
+]
 
 
 def _init_model_parallel() -> None:
@@ -49,7 +97,9 @@ def _init_model_parallel() -> None:
         pass
 
 
-def _load_qwen2_native(v2: bool) -> torch.nn.Module:
+def _load_native_model(
+    model_path: str, v2: bool, model_type: str
+) -> torch.nn.Module:
     from sglang.srt.configs.device_config import DeviceConfig
     from sglang.srt.configs.load_config import LoadConfig
     from sglang.srt.configs.model_config import ModelConfig
@@ -58,8 +108,9 @@ def _load_qwen2_native(v2: bool) -> torch.nn.Module:
     from sglang.srt.utils import get_device
 
     server_args = ServerArgs(
-        model_path=MODEL,
+        model_path=model_path,
         dtype=torch.float16,
+        model_type=model_type,
         trust_remote_code=True,
     )
     set_global_server_args_for_scheduler(server_args)
@@ -79,33 +130,76 @@ def _state_dict_cpu(model: torch.nn.Module) -> dict[str, torch.Tensor]:
     }
 
 
-class TestWeightLoaderV2Equiv(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        _init_model_parallel()
+def _require_cached_checkpoint(case: ModelCase) -> str:
+    model = case.model
+    path = Path(model).expanduser()
+    if path.is_dir():
+        cached_path = path
+    else:
+        try:
+            from huggingface_hub import snapshot_download
 
-    @unittest.skipIf(not torch.cuda.is_available(), "needs GPU")
-    def test_qwen2_v1_v2_state_dict_identical(self):
-        model_v1 = _load_qwen2_native(v2=False)
-        state_v1 = _state_dict_cpu(model_v1)
-        del model_v1
-        torch.cuda.empty_cache()
-
-        model_v2 = _load_qwen2_native(v2=True)
-        state_v2 = _state_dict_cpu(model_v2)
-        del model_v2
-        torch.cuda.empty_cache()
-
-        self.assertEqual(set(state_v1.keys()), set(state_v2.keys()))
-        for name in sorted(state_v1.keys()):
-            torch.testing.assert_close(
-                state_v1[name],
-                state_v2[name],
-                rtol=0,
-                atol=0,
-                msg=name,
+            cached_path = Path(snapshot_download(model, local_files_only=True))
+        except Exception as exc:
+            pytest.skip(
+                f"{case.category}: {model!r} is not cached locally ({exc})"
             )
+
+    weight_files = [
+        *cached_path.glob("*.safetensors"),
+        *cached_path.glob("*.bin"),
+    ]
+    if not weight_files:
+        pytest.skip(
+            f"{case.category}: cached checkpoint {str(cached_path)!r} has no weights"
+        )
+
+    try:
+        from transformers import AutoConfig
+
+        config = AutoConfig.from_pretrained(
+            cached_path, local_files_only=True, trust_remote_code=True
+        )
+    except Exception as exc:
+        pytest.skip(
+            f"{case.category}: cached config for {model!r} is unavailable ({exc})"
+        )
+
+    architectures = getattr(config, "architectures", None) or []
+    if case.architecture not in architectures:
+        pytest.skip(
+            f"{case.category}: expected architecture {case.architecture!r}, "
+            f"but {model!r} declares {architectures!r}"
+        )
+    return str(cached_path)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs GPU")
+@pytest.mark.parametrize("case", MODEL_CASES, ids=lambda case: case.category)
+def test_v1_v2_state_dict_identical(case: ModelCase):
+    model_path = _require_cached_checkpoint(case)
+    _init_model_parallel()
+
+    model_v1 = _load_native_model(model_path, v2=False, model_type=case.model_type)
+    state_v1 = _state_dict_cpu(model_v1)
+    del model_v1
+    torch.cuda.empty_cache()
+
+    model_v2 = _load_native_model(model_path, v2=True, model_type=case.model_type)
+    state_v2 = _state_dict_cpu(model_v2)
+    del model_v2
+    torch.cuda.empty_cache()
+
+    assert set(state_v1) == set(state_v2)
+    for name in sorted(state_v1):
+        torch.testing.assert_close(
+            state_v1[name],
+            state_v2[name],
+            rtol=0,
+            atol=0,
+            msg=name,
+        )
 
 
 if __name__ == "__main__":
-    unittest.main()
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/model_loading/test_weight_loader_v2_e2e.py
+++ b/test/registered/model_loading/test_weight_loader_v2_e2e.py
@@ -12,20 +12,96 @@
 # limitations under the License.
 # ==============================================================================
 
-from sglang.test.ci.ci_register import register_cuda_ci
-
-register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
-
 import multiprocessing as mp
+import os
+from dataclasses import dataclass
+from functools import lru_cache
 
 import torch
 
 from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.runners import SRTRunner, check_close_model_outputs
 from sglang.test.test_utils import CustomTestCase
 
-MODEL = "Qwen/Qwen2-0.5B"
-SHORT_PROMPT = "The capital of the United Kingdom is"
+register_cuda_ci(est_time=600, stage="base-b", runner_config="1-gpu-small")
+
+SHORT_PROMPT = "Hello"
+
+
+@dataclass(frozen=True)
+class ModelCase:
+    category: str
+    default_model: str
+    architecture: str
+    model_type: str = "generation"
+
+    @property
+    def model(self) -> str:
+        env_name = f"SGLANG_WEIGHT_LOADER_V2_{self.category.upper()}_MODEL"
+        return os.environ.get(env_name, self.default_model)
+
+
+# Public tiny-random checkpoints, each tied to the exact native SGLang loader
+# named by architecture. Individual cases skip if the fixture cannot be
+# resolved, so a transient Hub outage does not fail unrelated base CI coverage.
+STANDARD_DENSE = ModelCase(
+    "standard_dense",
+    "hf-internal-testing/tiny-random-Gemma2ForCausalLM",
+    "Gemma2ForCausalLM",
+)
+PACKED_DENSE = ModelCase(
+    "packed_dense",
+    "hf-internal-testing/tiny-random-GPTBigCodeForCausalLM",
+    "GPTBigCodeForCausalLM",
+)
+STANDARD_MOE = ModelCase(
+    "standard_moe",
+    "peft-internal-testing/tiny-random-qwen-1.5-MoE",
+    "Qwen2MoeForCausalLM",
+)
+SHARED_SPECIAL_MOE = ModelCase(
+    "shared_special_moe",
+    "hf-internal-testing/tiny-random-MixtralForCausalLM",
+    "MixtralForCausalLM",
+)
+WRAPPER = ModelCase(
+    "wrapper",
+    "trl-internal-testing/tiny-Qwen2ForSequenceClassification-2.5",
+    "Qwen2ForSequenceClassification",
+    model_type="embedding",
+)
+
+
+@lru_cache(maxsize=None)
+def _resolve_model(case: ModelCase) -> tuple[str | None, str | None]:
+    try:
+        from huggingface_hub import snapshot_download
+        from transformers import AutoConfig
+
+        if os.path.isdir(case.model):
+            model_path = case.model
+        else:
+            model_path = snapshot_download(case.model)
+        config = AutoConfig.from_pretrained(
+            model_path, local_files_only=True, trust_remote_code=True
+        )
+    except Exception as exc:
+        reason = (
+            f"{case.category}: cannot resolve checkpoint/config for {case.model!r}; "
+            f"override SGLANG_WEIGHT_LOADER_V2_{case.category.upper()}_MODEL "
+            f"with an available checkpoint ({exc})"
+        )
+        return None, reason
+
+    architectures = getattr(config, "architectures", None) or []
+    if case.architecture not in architectures:
+        reason = (
+            f"{case.category}: {case.model!r} declares {architectures!r}, "
+            f"not the required native SGLang architecture {case.architecture!r}"
+        )
+        return None, reason
+    return model_path, None
 
 
 class TestWeightLoaderV2E2E(CustomTestCase):
@@ -33,27 +109,35 @@ class TestWeightLoaderV2E2E(CustomTestCase):
     def setUpClass(cls):
         mp.set_start_method("spawn", force=True)
 
-    def _runner_kwargs(self):
+    def _require_model(self, case: ModelCase) -> str:
+        model_path, reason = _resolve_model(case)
+        if reason:
+            self.skipTest(reason)
+        assert model_path is not None
+        return model_path
+
+    def _runner_kwargs(self, case: ModelCase):
         return dict(
             torch_dtype=torch.float16,
-            model_type="generation",
+            model_type=case.model_type,
             disable_cuda_graph=True,
             disable_radix_cache=True,
             trust_remote_code=True,
-            max_total_tokens=2048,
+            max_total_tokens=512,
         )
 
-    def test_qwen2_native_v1_v2_generation_match(self):
+    def _assert_generation_equivalent(self, case: ModelCase):
+        model_path = self._require_model(case)
         prompts = [SHORT_PROMPT]
-        max_new_tokens = 32
-        kwargs = self._runner_kwargs()
+        max_new_tokens = 8
+        kwargs = self._runner_kwargs(case)
 
         with envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.override(False):
-            with SRTRunner(MODEL, **kwargs) as runner_v1:
+            with SRTRunner(model_path, **kwargs) as runner_v1:
                 out_v1 = runner_v1.forward(prompts, max_new_tokens=max_new_tokens)
 
         with envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.override(True):
-            with SRTRunner(MODEL, **kwargs) as runner_v2:
+            with SRTRunner(model_path, **kwargs) as runner_v2:
                 out_v2 = runner_v2.forward(prompts, max_new_tokens=max_new_tokens)
 
         check_close_model_outputs(
@@ -62,22 +146,44 @@ class TestWeightLoaderV2E2E(CustomTestCase):
             prefill_tolerance=1e-6,
             decode_tolerance=1e-6,
             rouge_l_tolerance=1.0,
-            debug_text="qwen2 native v1 vs v2 weight loader",
+            debug_text=f"{case.category} native v1 vs v2 weight loader",
         )
 
-    def test_transformers_impl_loads_and_generates(self):
+    def _assert_embedding_wrapper_equivalent(self, case: ModelCase):
+        model_path = self._require_model(case)
         prompts = [SHORT_PROMPT]
-        max_new_tokens = 16
+        kwargs = self._runner_kwargs(case)
 
-        with SRTRunner(
-            MODEL,
-            model_impl="transformers",
-            **self._runner_kwargs(),
-        ) as runner:
-            outputs = runner.forward(prompts, max_new_tokens=max_new_tokens)
+        with envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.override(False):
+            with SRTRunner(model_path, **kwargs) as runner_v1:
+                out_v1 = runner_v1.forward(prompts)
 
-        self.assertEqual(len(outputs.output_strs), 1)
-        self.assertGreater(len(outputs.output_strs[0]), 0)
+        with envs.SGLANG_ENABLE_WEIGHT_LOADER_V2.override(True):
+            with SRTRunner(model_path, **kwargs) as runner_v2:
+                out_v2 = runner_v2.forward(prompts)
+
+        self.assertEqual(len(out_v1.embed_logits), len(out_v2.embed_logits))
+        torch.testing.assert_close(
+            torch.tensor(out_v1.embed_logits),
+            torch.tensor(out_v2.embed_logits),
+            rtol=0,
+            atol=0,
+        )
+
+    def test_standard_dense_gemma2_v1_v2_generation_match(self):
+        self._assert_generation_equivalent(STANDARD_DENSE)
+
+    def test_packed_dense_gpt_bigcode_v1_v2_generation_match(self):
+        self._assert_generation_equivalent(PACKED_DENSE)
+
+    def test_standard_moe_qwen2_v1_v2_generation_match(self):
+        self._assert_generation_equivalent(STANDARD_MOE)
+
+    def test_shared_special_moe_mixtral_v1_v2_generation_match(self):
+        self._assert_generation_equivalent(SHARED_SPECIAL_MOE)
+
+    def test_wrapper_qwen2_sequence_classification_v1_v2_embedding_match(self):
+        self._assert_embedding_wrapper_equivalent(WRAPPER)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_loader/test_pr2_model_local_v2.py
+++ b/test/registered/unit/model_loader/test_pr2_model_local_v2.py
@@ -1,0 +1,305 @@
+"""CPU-only checks for model-local weight-loader-v2 special cases."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch import nn
+
+
+# Model imports transitively import optional kernel extension namespaces.  Stub
+# them before importing any model so this module remains a lightweight CPU test.
+sys.modules["sgl_kernel"] = MagicMock()
+for _submodule in (
+    "elementwise",
+    "flash_attn",
+    "flash_mla",
+    "kvcacheio",
+    "mamba",
+    "quantization",
+    "scalar_type",
+    "sparse_flash_attn",
+    "speculative",
+    "utils",
+):
+    sys.modules[f"sgl_kernel.{_submodule}"] = MagicMock()
+
+from sglang.srt.models.gpt_bigcode import GPTBigCodeForCausalLM  # noqa: E402
+from sglang.srt.models.hunyuan import HunYuanMoEV1ForCausalLM  # noqa: E402
+from sglang.srt.models.internlm2 import (  # noqa: E402
+    InternLM2Attention,
+    InternLM2ForCausalLM,
+)
+from sglang.srt.models.jet_nemotron import JetNemotronForCausalLM  # noqa: E402
+from sglang.srt.models.laguna import LagunaForCausalLM  # noqa: E402
+from sglang.srt.models import minimax_m3  # noqa: E402
+from sglang.srt.models.minimax_m3 import MiniMaxM3SparseForCausalLM  # noqa: E402
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+
+register_cpu_ci(est_time=15, suite="base-b-test-cpu")
+
+
+def _bare(cls):
+    obj = cls.__new__(cls)
+    nn.Module.__init__(obj)
+    return obj
+
+
+def _install_param(root, name, loader):
+    module = root
+    parts = name.split(".")
+    for part in parts[:-1]:
+        if part not in module._modules:
+            module.add_module(part, nn.Module())
+        module = module._modules[part]
+    param = nn.Parameter(torch.zeros(1), requires_grad=False)
+    param.weight_loader = loader
+    module.register_parameter(parts[-1], param)
+    return param
+
+
+def _shard_recorder(calls):
+    def load(_param, tensor, shard_id):
+        calls.append((shard_id, tensor.clone()))
+
+    return load
+
+
+def _expert_recorder(calls):
+    def load(_param, tensor, name, *, shard_id, expert_id):
+        calls.append((name, shard_id, expert_id, tensor.clone()))
+
+    return load
+
+
+def test_internlm2_v2_reorders_packed_wqkv():
+    model = _bare(InternLM2ForCausalLM)
+    model.model = nn.Module()
+    model.model.layers = nn.ModuleList([nn.Module()])
+    attention = _bare(InternLM2Attention)
+    attention.config = SimpleNamespace(
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_size=8,
+    )
+    calls = []
+    param = nn.Parameter(torch.zeros(1), requires_grad=False)
+    param.weight_loader = _shard_recorder(calls)
+    attention.register_parameter("wqkv", param)
+    model.model.layers[0].attention = attention
+    packed = torch.arange(16 * 3).reshape(16, 3)
+
+    loaded = model._load_weights_v2(
+        [("model.layers.0.attention.wqkv", packed)]
+    )
+
+    assert loaded == {"model.layers.0.attention.wqkv"}
+    assert [shard for shard, _ in calls] == ["q", "k", "v"]
+    viewed = packed.view(2, 4, 2, 3)
+    expected = torch.split(viewed, [2, 1, 1], dim=1)
+    for (_, actual), shard in zip(calls, expected):
+        torch.testing.assert_close(actual, shard.reshape(-1, 3))
+
+
+def test_jet_nemotron_v2_fans_six_shards_into_qkvabz():
+    model = _bare(JetNemotronForCausalLM)
+    calls = []
+    target = "model.layers.0.self_attn.qkvabz_proj.weight"
+    _install_param(model, target, _shard_recorder(calls))
+    sources = ("q_proj", "k_proj", "v_proj", "a_proj", "b_proj", "g_proj")
+    weights = [
+        (target.replace("qkvabz_proj", source), torch.tensor([index]))
+        for index, source in enumerate(sources)
+    ]
+
+    loaded = model._load_weights_v2(weights)
+
+    assert loaded == {target}
+    assert [shard for shard, _ in calls] == list(range(6))
+    assert [tensor.item() for _, tensor in calls] == list(range(6))
+
+
+@pytest.mark.parametrize("scale_name", ["input_scale", "weight_scale"])
+def test_gpt_bigcode_v2_fans_attention_scales_to_qkv(scale_name):
+    model = _bare(GPTBigCodeForCausalLM)
+    calls = []
+    name = f"transformer.h.0.attn.c_attn.{scale_name}"
+    _install_param(model, name, _shard_recorder(calls))
+    tensor = torch.tensor([2.5])
+
+    loaded = model._load_weights_v2(
+        [
+            ("lm_head.weight", torch.ones(1)),
+            ("transformer.h.0.attn.bias", torch.ones(1)),
+            (name, tensor),
+        ]
+    )
+
+    assert loaded == {name}
+    assert [shard for shard, _ in calls] == ["q", "k", "v"]
+    assert all(value.item() == tensor.item() for _, value in calls)
+
+
+def test_hunyuan_v2_splits_gate_up_and_packed_qkv():
+    model = _bare(HunYuanMoEV1ForCausalLM)
+    model.config = SimpleNamespace(
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_experts=1,
+        tie_word_embeddings=False,
+        use_cla=False,
+    )
+    model.head_dim = 2
+    model.hidden_size = 4
+    gate_calls, qkv_calls = [], []
+    gate_target = "model.layers.0.mlp.gate_up_proj.weight"
+    qkv_target = "model.layers.0.self_attn.qkv_proj.weight"
+    _install_param(model, gate_target, _shard_recorder(gate_calls))
+    _install_param(model, qkv_target, _shard_recorder(qkv_calls))
+    gate_up = torch.arange(16).reshape(4, 4)
+    packed_qkv = torch.arange(32).reshape(8, 4)
+
+    loaded = model._load_weights_v2(
+        [
+            (gate_target.replace("gate_up_proj", "gate_and_up_proj"), gate_up),
+            (qkv_target, packed_qkv),
+        ]
+    )
+
+    assert loaded == {gate_target, qkv_target}
+    assert [shard for shard, _ in gate_calls] == [1, 0]
+    torch.testing.assert_close(gate_calls[0][1], gate_up[:2])
+    torch.testing.assert_close(gate_calls[1][1], gate_up[2:])
+    assert [shard for shard, _ in qkv_calls] == ["q", "k", "v"]
+    reordered = model._split_qkv_weight(packed_qkv)
+    for (_, actual), expected in zip(qkv_calls, reordered.split([4, 2, 2])):
+        torch.testing.assert_close(actual, expected)
+
+
+def _laguna_model():
+    model = _bare(LagunaForCausalLM)
+    model.config = SimpleNamespace(
+        num_experts=1,
+        mlp_layer_types=["sparse"],
+        tie_word_embeddings=True,
+    )
+    model.model = nn.Module()
+    model.model.start_layer = 0
+    model.model.end_layer = 1
+    return model
+
+
+def test_laguna_v2_maps_shared_and_experts_with_pp_and_tied_skips():
+    model = _laguna_model()
+    shared_calls, expert_calls = [], []
+    shared = "model.layers.0.mlp.shared_expert.gate_up_proj.weight"
+    w13 = "model.layers.0.mlp.experts.w13_weight"
+    w2 = "model.layers.0.mlp.experts.w2_weight"
+    _install_param(model, shared, _shard_recorder(shared_calls))
+    _install_param(model, w13, _expert_recorder(expert_calls))
+    _install_param(model, w2, _expert_recorder(expert_calls))
+    prefix = "model.layers.0.mlp.experts.0"
+    weights = [
+        (shared.replace("gate_up_proj", "gate_proj"), torch.tensor([10])),
+        (f"{prefix}.gate_proj.weight", torch.tensor([1])),
+        (f"{prefix}.down_proj.weight", torch.tensor([2])),
+        (f"{prefix}.up_proj.weight", torch.tensor([3])),
+        ("lm_head.weight", torch.tensor([99])),
+        ("model.layers.1.mlp.experts.0.gate_proj.weight", torch.tensor([99])),
+    ]
+
+    loaded = model._load_weights_v2(weights)
+
+    assert loaded == {shared, w13, w2}
+    assert [shard for shard, _ in shared_calls] == [0]
+    assert [(shard, expert) for _, shard, expert, _ in expert_calls] == [
+        ("w1", 0),
+        ("w2", 0),
+        ("w3", 0),
+    ]
+
+
+def test_laguna_v2_rejects_incomplete_expert_checkpoint():
+    model = _laguna_model()
+    calls = []
+    _install_param(
+        model, "model.layers.0.mlp.experts.w13_weight", _expert_recorder(calls)
+    )
+    _install_param(
+        model, "model.layers.0.mlp.experts.w2_weight", _expert_recorder(calls)
+    )
+
+    with pytest.raises(RuntimeError, match="1 routed-expert tensors were not loaded"):
+        model._load_weights_v2(
+            [
+                (
+                    "model.layers.0.mlp.experts.0.gate_proj.weight",
+                    torch.ones(1),
+                ),
+                (
+                    "model.layers.0.mlp.experts.0.down_proj.weight",
+                    torch.ones(1),
+                ),
+            ]
+        )
+
+
+def test_minimax_m3_v2_shared_index_qkv_alias_and_postload_once(monkeypatch):
+    model = _bare(MiniMaxM3SparseForCausalLM)
+    model.config = SimpleNamespace(
+        num_local_experts=1,
+        sparse_attention_config={},
+        num_mtp_modules=0,
+    )
+    model.num_fused_shared_experts = 1
+    model.model = nn.Module()
+    model.model.start_layer = 0
+    model.model.end_layer = 1
+    index_calls, expert_calls, scale_calls, post_calls = [], [], [], []
+    index = "model.layers.0.self_attn.index_qkv_proj.weight"
+    _install_param(model, index, _shard_recorder(index_calls))
+    _install_param(
+        model, "model.layers.0.mlp.experts.w13_weight", _expert_recorder(expert_calls)
+    )
+    _install_param(
+        model, "model.layers.0.mlp.experts.w2_weight", _expert_recorder(expert_calls)
+    )
+    scale = "model.layers.0.self_attn.attn.k_scale"
+    _install_param(model, scale, lambda _param, tensor: scale_calls.append(tensor))
+    monkeypatch.setattr(
+        minimax_m3,
+        "build_minimax_fused_qkv_index",
+        lambda loaded_model: post_calls.append(loaded_model),
+    )
+    shared = "model.layers.0.mlp.shared_experts"
+
+    loaded = model._load_weights_v2(
+        [
+            (
+                index.replace("index_qkv_proj", "index_q_proj"),
+                torch.tensor([7]),
+            ),
+            (f"{shared}.gate_proj.weight", torch.tensor([1])),
+            (f"{shared}.down_proj.weight", torch.tensor([2])),
+            (f"{shared}.up_proj.weight", torch.tensor([3])),
+            ("model.layers.0.self_attn.k_scale", torch.tensor([4.0])),
+            (
+                "model.layers.1.self_attn.index_q_proj.weight",
+                torch.tensor([99]),
+            ),
+        ]
+    )
+
+    assert index in loaded
+    assert scale in loaded
+    assert [shard for shard, _ in index_calls] == ["q"]
+    assert [(shard, expert) for _, shard, expert, _ in expert_calls] == [
+        ("w1", 1),
+        ("w2", 1),
+        ("w3", 1),
+    ]
+    assert scale_calls[0].item() == 4.0
+    assert post_calls == [model]

--- a/test/registered/unit/model_loader/test_stacked_params_dispatch.py
+++ b/test/registered/unit/model_loader/test_stacked_params_dispatch.py
@@ -1,0 +1,224 @@
+# Copyright 2023-2025 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+from torch import nn
+
+sys.modules["sgl_kernel"] = MagicMock()
+sys.modules["sgl_kernel.quantization"] = MagicMock()
+
+from sglang.srt.model_loader.auto_loader import (  # noqa: E402
+    AutoWeightsLoader,
+    STANDARD_GATE_UP_MAPPING,
+    STANDARD_QKV_MAPPING,
+    StackedParamsDispatch,
+    load_with_stacked_dispatch,
+)
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=6, suite="base-b-test-cpu")
+
+
+class _ParamWithLoader(nn.Parameter):
+    def __new__(cls, data, weight_loader=None):
+        param = super().__new__(cls, data)
+        param.weight_loader = weight_loader or (lambda p, t, *a: p.copy_(t))
+        return param
+
+
+class _StackedChild(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.qkv_proj = nn.Linear(2, 6, bias=False)
+        self.qkv_proj.weight.weight_loader = MagicMock()
+
+    def load_weights(self, weights):
+        return load_with_stacked_dispatch(self, weights, STANDARD_QKV_MAPPING)
+
+
+class TestStackedParamsDispatch(unittest.TestCase):
+    def test_try_load_qkv_shard(self):
+        qkv = _ParamWithLoader(torch.zeros(6, 4))
+        params = {"qkv_proj.weight": qkv}
+        calls = []
+
+        def wl(param, tensor, shard_id):
+            calls.append(shard_id)
+
+        qkv.weight_loader = wl
+
+        target = STANDARD_QKV_MAPPING.try_load(
+            "q_proj.weight", torch.ones(2, 4), params
+        )
+        self.assertEqual(target, "qkv_proj.weight")
+        self.assertEqual(calls, ["q"])
+
+    def test_try_load_rejects_missing_mapped_param(self):
+        with self.assertRaisesRegex(ValueError, "qkv_proj.weight"):
+            STANDARD_QKV_MAPPING.try_load(
+                "q_proj.weight", torch.ones(2, 4), {}
+            )
+
+    def test_try_load_uses_first_existing_mapped_target(self):
+        dispatch = StackedParamsDispatch(
+            mappings=(
+                ("missing_proj", "q_proj", "missing"),
+                ("qkv_proj", "q_proj", "q"),
+            )
+        )
+        qkv = _ParamWithLoader(torch.zeros(6, 4))
+        calls = []
+        qkv.weight_loader = lambda param, tensor, shard_id: calls.append(shard_id)
+
+        target = dispatch.try_load(
+            "q_proj.weight",
+            torch.ones(2, 4),
+            {"qkv_proj.weight": qkv},
+        )
+
+        self.assertEqual(target, "qkv_proj.weight")
+        self.assertEqual(calls, ["q"])
+
+    def test_try_load_stops_after_first_successful_mapping(self):
+        dispatch = StackedParamsDispatch(
+            mappings=(
+                ("qkv_proj", "q_proj", "q"),
+                ("qkv_proj", "q_proj", "duplicate"),
+            )
+        )
+        qkv = _ParamWithLoader(torch.zeros(6, 4))
+        calls = []
+        qkv.weight_loader = lambda param, tensor, shard_id: calls.append(shard_id)
+
+        dispatch.try_load(
+            "q_proj.weight",
+            torch.ones(2, 4),
+            {"qkv_proj.weight": qkv},
+        )
+
+        self.assertEqual(calls, ["q"])
+
+    def test_try_load_propagates_loader_exception(self):
+        qkv = _ParamWithLoader(torch.zeros(6, 4))
+
+        def fail(param, tensor, shard_id):
+            raise RuntimeError("loader failed")
+
+        qkv.weight_loader = fail
+        with self.assertRaisesRegex(RuntimeError, "loader failed"):
+            STANDARD_QKV_MAPPING.try_load(
+                "q_proj.weight",
+                torch.ones(2, 4),
+                {"qkv_proj.weight": qkv},
+            )
+
+    def test_try_load_no_match(self):
+        self.assertIsNone(
+            STANDARD_QKV_MAPPING.try_load("o_proj.weight", torch.ones(2, 4), {})
+        )
+
+    def test_gate_up_mapping(self):
+        gate_up = _ParamWithLoader(torch.zeros(8, 4))
+        params = {"gate_up_proj.weight": gate_up}
+        shard_ids = []
+
+        def wl(param, tensor, shard_id):
+            shard_ids.append(shard_id)
+
+        gate_up.weight_loader = wl
+
+        target = STANDARD_GATE_UP_MAPPING.try_load(
+            "up_proj.weight", torch.ones(4, 4), params
+        )
+        self.assertEqual(target, "gate_up_proj.weight")
+        self.assertEqual(shard_ids, [1])
+
+    def test_load_with_stacked_dispatch_direct_param(self):
+        linear = nn.Linear(3, 2, bias=False)
+        linear.weight = nn.Parameter(torch.zeros(3, 2), requires_grad=False)
+        linear.weight.weight_loader = lambda p, t: p.data.copy_(t)
+        module = nn.Module()
+        module.down_proj = linear
+
+        loaded = load_with_stacked_dispatch(
+            module,
+            [("down_proj.weight", torch.ones(3, 2))],
+            StackedParamsDispatch(mappings=()),
+        )
+        self.assertIn("down_proj.weight", loaded)
+        self.assertTrue(torch.allclose(linear.weight.data, torch.ones(3, 2)))
+
+    def test_load_with_stacked_dispatch_stacked_then_direct(self):
+        qkv_linear = nn.Linear(2, 6, bias=False)
+        o_linear = nn.Linear(2, 3, bias=False)
+        qkv_linear.weight = nn.Parameter(torch.zeros(6, 2), requires_grad=False)
+        o_linear.weight = nn.Parameter(torch.zeros(3, 2), requires_grad=False)
+        qkv_calls = []
+
+        def qkv_wl(param, tensor, shard_id):
+            qkv_calls.append(shard_id)
+
+        qkv_linear.weight.weight_loader = qkv_wl
+        o_linear.weight.weight_loader = lambda p, t: p.data.copy_(t)
+
+        module = nn.Module()
+        module.qkv_proj = qkv_linear
+        module.o_proj = o_linear
+
+        loaded = load_with_stacked_dispatch(
+            module,
+            [
+                ("q_proj.weight", torch.ones(2, 2)),
+                ("o_proj.weight", torch.full((3, 2), 2.0)),
+            ],
+            STANDARD_QKV_MAPPING,
+        )
+        self.assertEqual(loaded, {"qkv_proj.weight", "o_proj.weight"})
+        self.assertEqual(qkv_calls, ["q"])
+
+    def test_auto_weights_loader_qualifies_child_dispatch_result(self):
+        module = nn.Module()
+        module.child = _StackedChild()
+
+        loaded = AutoWeightsLoader(module).load_weights(
+            [("child.q_proj.weight", torch.ones(2, 2))]
+        )
+
+        self.assertEqual(loaded, {"child.qkv_proj.weight"})
+        module.child.qkv_proj.weight.weight_loader.assert_called_once()
+
+    def test_load_with_stacked_dispatch_rejects_unexpected_weight(self):
+        module = nn.Module()
+        with self.assertRaisesRegex(ValueError, "unexpected.weight"):
+            load_with_stacked_dispatch(
+                module,
+                [("unexpected.weight", torch.ones(1))],
+                StackedParamsDispatch(),
+            )
+
+    def test_load_with_stacked_dispatch_has_named_bias_skip(self):
+        loaded = load_with_stacked_dispatch(
+            nn.Module(),
+            [("q_proj.bias", torch.ones(1))],
+            STANDARD_QKV_MAPPING,
+        )
+        self.assertEqual(loaded, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_loader/test_weight_loader_v2_model_contracts.py
+++ b/test/registered/unit/model_loader/test_weight_loader_v2_model_contracts.py
@@ -1,0 +1,347 @@
+"""Exhaustive, import-free contracts for the PR2 model loader migration."""
+
+import ast
+import builtins
+import copy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=8, suite="base-b-test-cpu")
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODEL_ROOT = REPO_ROOT / "python/sglang/srt/models"
+
+# Keep this explicit: adding or removing a migrated production file must be reviewed
+# together with these contracts. These are the 69 model files in the PR2 change.
+CHANGED_MODEL_FILES = (
+    "afmoe.py",
+    "apertus.py",
+    "arcee.py",
+    "baichuan.py",
+    "bailing_moe.py",
+    "cohere2_moe.py",
+    "commandr.py",
+    "dbrx.py",
+    "deepseek.py",
+    "ernie4.py",
+    "ernie4_eagle.py",
+    "exaone.py",
+    "exaone4.py",
+    "exaone_moe.py",
+    "exaone_moe_mtp.py",
+    "gemma.py",
+    "gemma2.py",
+    "gemma2_reward.py",
+    "gpt_bigcode.py",
+    "gpt_j.py",
+    "granite.py",
+    "granitemoe.py",
+    "hrm_text.py",
+    "hunyuan.py",
+    "hunyuan_v3.py",
+    "hunyuan_v3_nextn.py",
+    "internlm2.py",
+    "internlm2_reward.py",
+    "iquest_loopcoder.py",
+    "jet_nemotron.py",
+    "laguna.py",
+    "llama_classification.py",
+    "llama_eagle.py",
+    "llama_eagle3.py",
+    "llama_embedding.py",
+    "llama_reward.py",
+    "mimo.py",
+    "mimo_mtp.py",
+    "minicpm.py",
+    "minimax_m2.py",
+    "minimax_m3.py",
+    "mistral.py",
+    "mistral_eagle.py",
+    "mixtral.py",
+    "mixtral_quant.py",
+    "nemotron_nas.py",
+    "olmo.py",
+    "olmo2.py",
+    "olmoe.py",
+    "orion.py",
+    "phi3_small.py",
+    "phimoe.py",
+    "qwen.py",
+    "qwen2_classification.py",
+    "qwen2_eagle.py",
+    "qwen2_moe.py",
+    "qwen2_rm.py",
+    "qwen3.py",
+    "qwen3_classification.py",
+    "qwen3_embedding.py",
+    "qwen3_moe.py",
+    "qwen3_moe_mtp.py",
+    "sdar.py",
+    "sdar_moe.py",
+    "solar.py",
+    "stablelm.py",
+    "starcoder2.py",
+    "xverse.py",
+    "xverse_moe.py",
+)
+
+PROTECTED_MODEL_PREFIXES = (
+    "chatglm",
+    "glm",
+    "qwen3_5",
+    "qwen3_next",
+    # The production MLA loaders are intentionally outside this migration.
+    "deepseek_v2",
+    "deepseek_nextn",
+    "deepseek_v4",
+)
+
+# Root MoE v2 methods either dispatch fused expert checkpoint names themselves,
+# delegate to a model-local child loader, or load model-local expert parameters.
+MOE_V2_PATHS = (
+    ("afmoe.py", "AfmoeForCausalLM", "local"),
+    ("bailing_moe.py", "BailingMoEForCausalLM", "dispatch"),
+    ("cohere2_moe.py", "Cohere2MoeForCausalLM", "dispatch"),
+    ("dbrx.py", "DbrxForCausalLM", "local"),
+    ("deepseek.py", "DeepseekForCausalLM", "local"),
+    ("ernie4.py", "Ernie4_5_MoeForCausalLM", "dispatch"),
+    ("exaone_moe.py", "ExaoneMoEForCausalLM", "dispatch"),
+    ("granitemoe.py", "GraniteMoeForCausalLM", "delegated"),
+    ("hunyuan.py", "HunYuanMoEV1ForCausalLM", "dispatch"),
+    ("hunyuan_v3.py", "HYV3ForCausalLM", "dispatch"),
+    ("hunyuan_v3_nextn.py", "HYV3ForCausalLMNextN", "dispatch"),
+    ("laguna.py", "LagunaForCausalLM", "dispatch"),
+    ("minicpm.py", "MiniCPMForCausalLM", "local"),
+    ("minimax_m2.py", "MiniMaxM2ForCausalLM", "dispatch"),
+    ("minimax_m3.py", "MiniMaxM3SparseForCausalLM", "dispatch"),
+    ("mixtral.py", "MixtralForCausalLM", "delegated"),
+    ("mixtral_quant.py", "QuantMixtralForCausalLM", "local"),
+    ("olmoe.py", "OlmoeForCausalLM", "delegated"),
+    ("phimoe.py", "PhiMoEForCausalLM", "delegated"),
+    ("qwen2_moe.py", "Qwen2MoeForCausalLM", "delegated"),
+    ("qwen3_moe.py", "Qwen3MoeForCausalLM", "delegated"),
+    ("sdar_moe.py", "SDARMoeForCausalLM", "dispatch"),
+    ("xverse_moe.py", "XverseMoeForCausalLM", "local"),
+)
+
+
+def _tree(filename: str) -> ast.Module:
+    path = MODEL_ROOT / filename
+    return ast.parse(path.read_text(), filename=str(path))
+
+
+def _classes(filename: str) -> dict[str, ast.ClassDef]:
+    return {
+        node.name: node
+        for node in _tree(filename).body
+        if isinstance(node, ast.ClassDef)
+    }
+
+
+def _methods(class_node: ast.ClassDef) -> dict[str, ast.FunctionDef]:
+    return {
+        node.name: node
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _source(filename: str, node: ast.AST) -> str:
+    return ast.get_source_segment((MODEL_ROOT / filename).read_text(), node) or ""
+
+
+def _loader_cases() -> tuple[tuple[str, str], ...]:
+    cases = []
+    for filename in CHANGED_MODEL_FILES:
+        for class_name, class_node in _classes(filename).items():
+            methods = _methods(class_node)
+            if {"_legacy_load_weights", "_load_weights_v2"} <= methods.keys():
+                cases.append((filename, class_name))
+    return tuple(cases)
+
+
+LOADER_CASES = _loader_cases()
+
+
+class _DropImports(ast.NodeTransformer):
+    def visit_Import(self, node):
+        return None
+
+    def visit_ImportFrom(self, node):
+        return None
+
+
+def _compile_gate(filename: str, class_name: str):
+    method = copy.deepcopy(_methods(_classes(filename)[class_name])["load_weights"])
+    method.decorator_list = []
+    method = _DropImports().visit(method)
+    ast.fix_missing_locations(method)
+    synthetic_class = ast.ClassDef(
+        name="_SyntheticLoader",
+        bases=[],
+        keywords=[],
+        body=[method],
+        decorator_list=[],
+    )
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__", names=[ast.alias("annotations")], level=0
+            ),
+            synthetic_class,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, filename, "exec"), namespace)
+    return namespace["_SyntheticLoader"].load_weights
+
+
+def _run_gate(filename: str, class_name: str, enabled: bool):
+    calls = []
+
+    def record(kind):
+        def helper(*args, **kwargs):
+            calls.append((kind, args, kwargs))
+            return kind
+
+        return helper
+
+    instance = SimpleNamespace(
+        _legacy_load_weights=record("legacy"),
+        _load_weights_v2=record("v2"),
+    )
+    method = _compile_gate(filename, class_name)
+    method.__globals__["envs"] = SimpleNamespace(
+        SGLANG_ENABLE_WEIGHT_LOADER_V2=SimpleNamespace(get=lambda: enabled)
+    )
+    method(instance, iter(()))
+    return calls
+
+
+def _called_name_helpers(function: ast.FunctionDef) -> set[str]:
+    return {
+        call.func.id
+        for call in ast.walk(function)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+
+
+def _bound_names(module: ast.Module, function: ast.FunctionDef) -> set[str]:
+    bound = set(dir(builtins))
+    for node in module.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                bound.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            bound.update(
+                child.id
+                for target in targets
+                for child in ast.walk(target)
+                if isinstance(child, ast.Name)
+            )
+    bound.update(arg.arg for arg in function.args.args)
+    bound.update(arg.arg for arg in function.args.kwonlyargs)
+    if function.args.vararg:
+        bound.add(function.args.vararg.arg)
+    if function.args.kwarg:
+        bound.add(function.args.kwarg.arg)
+    for node in ast.walk(function):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                bound.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            bound.add(node.name)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            bound.add(node.id)
+    return bound
+
+
+def test_pr2_scope_is_exact_and_excludes_protected_model_families():
+    assert len(CHANGED_MODEL_FILES) == len(set(CHANGED_MODEL_FILES)) == 69
+    assert all((MODEL_ROOT / filename).is_file() for filename in CHANGED_MODEL_FILES)
+    assert not {
+        filename
+        for filename in CHANGED_MODEL_FILES
+        if filename.startswith(PROTECTED_MODEL_PREFIXES)
+    }
+
+
+def test_removed_standard_moe_root_helper_has_no_production_references():
+    references = [
+        path.relative_to(REPO_ROOT)
+        for path in (REPO_ROOT / "python/sglang").rglob("*.py")
+        if "load_standard_moe_root_weights_v2" in path.read_text()
+    ]
+    assert references == []
+
+
+def test_all_changed_parent_loaders_are_discovered():
+    assert len(LOADER_CASES) == 58
+
+
+@pytest.mark.parametrize(
+    ("filename", "class_name"),
+    LOADER_CASES,
+    ids=lambda value: value.removesuffix(".py"),
+)
+def test_parent_loader_has_structural_v2_gate(filename, class_name):
+    methods = _methods(_classes(filename)[class_name])
+    gate = methods["load_weights"]
+    attributes = {
+        node.attr for node in ast.walk(gate) if isinstance(node, ast.Attribute)
+    }
+    source = _source(filename, gate)
+
+    assert "SGLANG_ENABLE_WEIGHT_LOADER_V2" in source
+    assert {"_legacy_load_weights", "_load_weights_v2"} <= attributes
+
+
+@pytest.mark.parametrize(
+    ("filename", "class_name"),
+    LOADER_CASES,
+    ids=lambda value: value.removesuffix(".py"),
+)
+@pytest.mark.parametrize("enabled", [False, True], ids=["legacy", "v2"])
+def test_parent_loader_runtime_gate_selects_one_path(filename, class_name, enabled):
+    calls = _run_gate(filename, class_name, enabled)
+    assert [kind for kind, _, _ in calls] == ["v2" if enabled else "legacy"]
+
+
+@pytest.mark.parametrize(
+    ("filename", "class_name", "strategy"),
+    MOE_V2_PATHS,
+    ids=lambda value: value.removesuffix(".py"),
+)
+def test_moe_v2_path_uses_dispatch_or_model_local_loader(
+    filename, class_name, strategy
+):
+    module = _tree(filename)
+    methods = _methods(_classes(filename)[class_name])
+    v2_source = _source(filename, methods["_load_weights_v2"])
+    file_source = (MODEL_ROOT / filename).read_text()
+
+    if strategy == "dispatch":
+        assert "ExpertParamsDispatch" in v2_source
+    elif strategy == "delegated":
+        assert "AutoWeightsLoader" in v2_source
+        assert "ExpertParamsDispatch" in file_source
+    else:
+        assert (
+            "AutoWeightsLoader" in v2_source
+            or "weight_loader" in v2_source
+            or "expert_mapping" in v2_source
+        )
+
+    undefined_helpers = _called_name_helpers(
+        methods["_load_weights_v2"]
+    ) - _bound_names(module, methods["_load_weights_v2"])
+    assert undefined_helpers == set()

--- a/test/registered/unit/model_loader/test_wrapper_base_dispatch.py
+++ b/test/registered/unit/model_loader/test_wrapper_base_dispatch.py
@@ -1,0 +1,385 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+sys.modules["sgl_kernel"] = MagicMock()
+for _submodule in (
+    "elementwise",
+    "flash_attn",
+    "flash_mla",
+    "kvcacheio",
+    "mamba",
+    "quantization",
+    "scalar_type",
+    "sparse_flash_attn",
+    "speculative",
+    "utils",
+):
+    sys.modules[f"sgl_kernel.{_submodule}"] = MagicMock()
+
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=12, suite="base-b-test-cpu")
+
+from sglang.srt.environ import envs  # noqa: E402
+from sglang.srt.models import granitemoe  # noqa: E402
+from sglang.srt.models.gemma2 import Gemma2ForCausalLM  # noqa: E402
+from sglang.srt.models.gemma2_reward import (  # noqa: E402
+    Gemma2ForSequenceClassification,
+)
+from sglang.srt.models.internlm2 import InternLM2ForCausalLM  # noqa: E402
+from sglang.srt.models.internlm2_reward import InternLM2ForRewardModel  # noqa: E402
+from sglang.srt.models.llama import LlamaForCausalLM  # noqa: E402
+from sglang.srt.models.llama_classification import LlamaForClassification  # noqa: E402
+from sglang.srt.models.llama_eagle import LlamaForCausalLMEagle  # noqa: E402
+from sglang.srt.models.llama_eagle3 import LlamaForCausalLMEagle3  # noqa: E402
+from sglang.srt.models.llama_embedding import LlamaEmbeddingModel  # noqa: E402
+from sglang.srt.models.llama_reward import (  # noqa: E402
+    LlamaForSequenceClassification,
+)
+from sglang.srt.models.mistral import MistralForCausalLMMistralFormat  # noqa: E402
+from sglang.srt.models.mistral_eagle import MistralForCausalLMEagle  # noqa: E402
+from sglang.srt.models.mixtral import MixtralForCausalLM  # noqa: E402
+from sglang.srt.models.qwen2 import Qwen2ForCausalLM  # noqa: E402
+from sglang.srt.models.qwen2_classification import (  # noqa: E402
+    Qwen2ForSequenceClassification,
+)
+from sglang.srt.models.qwen2_eagle import Qwen2ForCausalLMEagle  # noqa: E402
+from sglang.srt.models.qwen2_rm import Qwen2ForRewardModel  # noqa: E402
+from sglang.srt.models.qwen3_classification import (  # noqa: E402
+    Qwen3ForSequenceClassification,
+)
+from sglang.srt.models.qwen3_embedding import Qwen3Model  # noqa: E402
+from sglang.srt.models.qwen3_moe import Qwen3MoeForCausalLM  # noqa: E402
+from sglang.srt.models.qwen3_moe_mtp import Qwen3MoeForCausalLMMTP  # noqa: E402
+
+
+def _bare_module(cls):
+    module = cls.__new__(cls)
+    torch.nn.Module.__init__(module)
+    return module
+
+
+def _set_v2(monkeypatch, enabled):
+    monkeypatch.setattr(
+        envs,
+        "SGLANG_ENABLE_WEIGHT_LOADER_V2",
+        SimpleNamespace(get=lambda: enabled),
+    )
+
+
+@pytest.mark.parametrize(
+    ("wrapper_class", "base_class", "weights", "expected_names"),
+    [
+        (
+            Gemma2ForSequenceClassification,
+            Gemma2ForCausalLM,
+            [("model.weight", torch.ones(1))],
+            ["model.weight"],
+        ),
+        (
+            InternLM2ForRewardModel,
+            InternLM2ForCausalLM,
+            [("model.weight", torch.ones(1))],
+            ["model.weight"],
+        ),
+        (
+            LlamaForSequenceClassification,
+            LlamaForCausalLM,
+            [("model.weight", torch.ones(1))],
+            ["model.weight"],
+        ),
+        (
+            Qwen2ForSequenceClassification,
+            Qwen2ForCausalLM,
+            [("model.weight", torch.ones(1)), ("lm_head.weight", torch.ones(1))],
+            ["model.weight"],
+        ),
+        (
+            Qwen2ForRewardModel,
+            Qwen2ForCausalLM,
+            [("model.weight", torch.ones(1)), ("lm_head.weight", torch.ones(1))],
+            ["model.weight"],
+        ),
+        (
+            LlamaForCausalLMEagle,
+            LlamaForCausalLM,
+            [
+                ("layers.0.weight", torch.ones(1)),
+                ("norm.weight", torch.ones(1)),
+                ("lm_head.weight", torch.ones(1)),
+            ],
+            ["model.layers.0.weight", "model.norm.weight"],
+        ),
+        (
+            Qwen2ForCausalLMEagle,
+            Qwen2ForCausalLM,
+            [
+                ("layers.0.weight", torch.ones(1)),
+                ("norm.weight", torch.ones(1)),
+                ("lm_head.weight", torch.ones(1)),
+            ],
+            ["model.layers.0.weight", "model.norm.weight"],
+        ),
+        (
+            MistralForCausalLMMistralFormat,
+            LlamaForCausalLM,
+            [("norm.weight", torch.ones(1))],
+            ["model.norm.weight"],
+        ),
+        (
+            MistralForCausalLMEagle,
+            LlamaForCausalLM,
+            [("norm.weight", torch.ones(1))],
+            ["model.norm.weight"],
+        ),
+    ],
+)
+@pytest.mark.parametrize("enabled", [False, True])
+def test_wrappers_select_direct_base_helper_once(
+    monkeypatch, wrapper_class, base_class, weights, expected_names, enabled
+):
+    calls = []
+
+    def capture(kind):
+        def inner(module, incoming):
+            calls.append((kind, module, list(incoming)))
+            return {kind}
+
+        return inner
+
+    monkeypatch.setattr(base_class, "_legacy_load_weights", capture("legacy"))
+    monkeypatch.setattr(base_class, "_load_weights_v2", capture("v2"))
+    monkeypatch.setattr(
+        base_class,
+        "load_weights",
+        lambda *_args, **_kwargs: pytest.fail("unbound dispatcher was called"),
+    )
+    _set_v2(monkeypatch, enabled)
+    wrapper = _bare_module(wrapper_class)
+
+    result = wrapper.load_weights(iter(weights))
+
+    if enabled:
+        assert result == {"v2"}
+        assert len(calls) == 1
+        kind, module, prepared = calls[0]
+        assert kind == "v2"
+        assert module is wrapper
+        assert [name for name, _ in prepared] == expected_names
+    elif wrapper_class in (LlamaForCausalLMEagle, Qwen2ForCausalLMEagle):
+        assert result is None
+        assert [
+            (kind, module, [name for name, _ in prepared])
+            for kind, module, prepared in calls
+        ] == [
+            ("legacy", wrapper, [expected_name])
+            for expected_name in expected_names
+        ]
+    else:
+        expected_result = (
+            None if wrapper_class is Gemma2ForSequenceClassification else {"legacy"}
+        )
+        assert result == expected_result
+        assert len(calls) == 1
+        kind, module, prepared = calls[0]
+        assert kind == "legacy"
+        assert module is wrapper
+        assert [name for name, _ in prepared] == expected_names
+
+
+@pytest.mark.parametrize(
+    "wrapper_class",
+    [
+        Qwen3ForSequenceClassification,
+        Qwen3Model,
+        LlamaForClassification,
+        LlamaEmbeddingModel,
+        LlamaForCausalLMEagle3,
+    ],
+)
+@pytest.mark.parametrize("enabled", [False, True])
+def test_model_local_wrappers_select_local_helper_once(
+    monkeypatch, wrapper_class, enabled
+):
+    calls = []
+
+    def capture(kind):
+        def inner(module, incoming):
+            calls.append((kind, module, list(incoming)))
+            return {kind}
+
+        return inner
+
+    monkeypatch.setattr(wrapper_class, "_legacy_load_weights", capture("legacy"))
+    monkeypatch.setattr(wrapper_class, "_load_weights_v2", capture("v2"))
+    _set_v2(monkeypatch, enabled)
+    wrapper = _bare_module(wrapper_class)
+    weights = [("model.weight", torch.ones(1))]
+
+    result = wrapper.load_weights(iter(weights))
+
+    expected_kind = "v2" if enabled else "legacy"
+    assert result == {expected_kind}
+    assert calls == [(expected_kind, wrapper, weights)]
+
+
+def test_llama_classification_legacy_preserves_per_weight_parent_fanout(
+    monkeypatch,
+):
+    calls = []
+
+    def capture_legacy(module, incoming):
+        calls.append((module, list(incoming)))
+
+    monkeypatch.setattr(LlamaForCausalLM, "_legacy_load_weights", capture_legacy)
+    wrapper = _bare_module(LlamaForClassification)
+    weights = [
+        ("model.layers.0.weight", torch.ones(1)),
+        ("model.layers.1.weight", torch.ones(1)),
+        ("lm_head.weight", torch.ones(1)),
+    ]
+
+    result = wrapper._legacy_load_weights(iter(weights))
+
+    assert result is None
+    assert calls == [
+        (wrapper, [weights[0]]),
+        (wrapper, [weights[1]]),
+    ]
+
+
+def test_llama_embedding_legacy_preserves_early_return():
+    wrapper = _bare_module(LlamaEmbeddingModel)
+    wrapper.model = torch.nn.Linear(1, 1, bias=False)
+    wrapper.model.weight.data.zero_()
+
+    result = wrapper._legacy_load_weights(
+        iter(
+            [
+                ("projector.weight", torch.ones(1)),
+                ("weight", torch.ones_like(wrapper.model.weight)),
+            ]
+        )
+    )
+
+    assert result is None
+    torch.testing.assert_close(
+        wrapper.model.weight, torch.zeros_like(wrapper.model.weight)
+    )
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_qwen3_mtp_selects_helper_and_preserves_mtp_remap(monkeypatch, enabled):
+    calls = []
+
+    def capture_legacy(module, incoming, *, is_mtp):
+        calls.append(("legacy", module, list(incoming), is_mtp))
+        return {"legacy"}
+
+    def capture_v2(module, incoming):
+        calls.append(("v2", module, list(incoming)))
+        return {"v2"}
+
+    monkeypatch.setattr(Qwen3MoeForCausalLM, "_legacy_load_weights", capture_legacy)
+    monkeypatch.setattr(Qwen3MoeForCausalLM, "_load_weights_v2", capture_v2)
+    monkeypatch.setattr(
+        Qwen3MoeForCausalLM,
+        "load_weights",
+        lambda *_args, **_kwargs: pytest.fail("parent dispatcher was called"),
+    )
+    _set_v2(monkeypatch, enabled)
+    wrapper = _bare_module(Qwen3MoeForCausalLMMTP)
+    weights = [
+        ("mtp.fc.weight", torch.ones(1)),
+        ("mtp.layers.0.weight", torch.ones(1)),
+        ("model.layers.1.weight", torch.ones(1)),
+    ]
+
+    result = wrapper.load_weights(iter(weights))
+
+    if enabled:
+        assert result == {"v2"}
+        assert [name for name, _ in calls[0][2]] == [
+            "fc.weight",
+            "model.layers.0.weight",
+        ]
+    else:
+        assert result == {"legacy"}
+        assert calls == [("legacy", wrapper, weights, True)]
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_granitemoe_preserves_expert_fanout_before_selected_loader(
+    monkeypatch, enabled
+):
+    calls = []
+
+    def capture_legacy(module, incoming):
+        calls.append(("legacy", module, dict(incoming)))
+        return {"legacy"}
+
+    def capture_v2(module, incoming):
+        calls.append(("v2", module, dict(incoming)))
+        return {"v2"}
+
+    monkeypatch.setattr(MixtralForCausalLM, "_legacy_load_weights", capture_legacy)
+    monkeypatch.setattr(
+        granitemoe.GraniteMoeForCausalLM, "_load_weights_v2", capture_v2
+    )
+    monkeypatch.setattr(
+        MixtralForCausalLM,
+        "load_weights",
+        lambda *_args, **_kwargs: pytest.fail("unbound dispatcher was called"),
+    )
+    _set_v2(monkeypatch, enabled)
+    wrapper = _bare_module(granitemoe.GraniteMoeForCausalLM)
+    input_weight = torch.arange(16).reshape(2, 4, 2)
+    output_weight = torch.arange(8).reshape(2, 2, 2)
+    router_weight = torch.ones(2, 2)
+    prefix = "model.layers.0.block_sparse_moe"
+
+    result = wrapper.load_weights(
+        iter(
+            [
+                (f"{prefix}.input_linear.weight", input_weight),
+                (f"{prefix}.output_linear.weight", output_weight),
+                (f"{prefix}.router.layer.weight", router_weight),
+            ]
+        )
+    )
+
+    expected_kind = "v2" if enabled else "legacy"
+    assert result == {expected_kind}
+    assert len(calls) == 1
+    kind, module, remapped = calls[0]
+    assert kind == expected_kind
+    assert module is wrapper
+    for expert_id in range(2):
+        expected_w1, expected_w3 = input_weight[expert_id].chunk(2, dim=0)
+        torch.testing.assert_close(
+            remapped[f"{prefix}.experts.{expert_id}.w1.weight"], expected_w1
+        )
+        torch.testing.assert_close(
+            remapped[f"{prefix}.experts.{expert_id}.w3.weight"], expected_w3
+        )
+        torch.testing.assert_close(
+            remapped[f"{prefix}.experts.{expert_id}.w2.weight"],
+            output_weight[expert_id],
+        )
+    torch.testing.assert_close(remapped[f"{prefix}.gate.weight"], router_weight)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    ["qwen3_rm", "mellum", "teleflm", "llama4", "ministral3"],
+)
+def test_adjacent_model_import_smoke(module_name):
+    try:
+        importlib.import_module(f"sglang.srt.models.{module_name}")
+    except ImportError as exc:
+        pytest.skip(f"optional import unavailable: {exc}")

--- a/test/registered/unit/model_loading/test_expert_params_dispatch.py
+++ b/test/registered/unit/model_loading/test_expert_params_dispatch.py
@@ -1,0 +1,161 @@
+import sys
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+import torch
+from torch import nn
+
+sys.modules["sgl_kernel"] = MagicMock()
+sys.modules["sgl_kernel.quantization"] = MagicMock()
+sys.modules["sgl_kernel.scalar_type"] = MagicMock()
+
+from sglang.srt.layers.moe.fused_moe_triton import FusedMoE  # noqa: E402
+from sglang.srt.model_loader.auto_loader import (  # noqa: E402
+    MOE_EXPERT_STACKED_SKIP_SUBSTRS,
+    STANDARD_GATE_UP_MAPPING,
+    ExpertParamsDispatch,
+    load_moe_sparse_block_weights,
+    try_load_stacked_skip_moe_experts,
+)
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=8, suite="base-b-test-cpu")
+
+
+class _RecordingLoader:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    def __call__(self, param, tensor, name, *, shard_id, expert_id):
+        self.calls.append((name, shard_id, expert_id, tuple(tensor.shape)))
+
+
+class TestExpertParamsDispatch(unittest.TestCase):
+    def test_expert_routing_gate_proj(self):
+        mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=2,
+        )
+        dispatch = ExpertParamsDispatch.from_fused_moe_mapping(mapping)
+        loader = _RecordingLoader()
+        param = mock.Mock()
+        param.weight_loader = loader
+        params = {"model.layers.0.mlp.experts.w13_weight": param}
+        tensor = torch.zeros(4, 4)
+        ckpt_name = "model.layers.0.mlp.experts.1.gate_proj.weight"
+        target = dispatch.try_load(ckpt_name, tensor, params)
+        self.assertEqual(target, "model.layers.0.mlp.experts.w13_weight")
+        self.assertEqual(len(loader.calls), 1)
+        self.assertEqual(loader.calls[0][1], "w1")
+        self.assertEqual(loader.calls[0][2], 1)
+
+    def test_from_gate_up_down_mixtral_names(self):
+        dispatch = ExpertParamsDispatch.from_gate_up_down(
+            num_experts=1,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+        )
+        self.assertTrue(
+            any(
+                "experts.0.w1." in weight_name
+                for _, weight_name, _, _ in dispatch.mappings
+            )
+        )
+
+    def test_stacked_skip_moe_experts_before_rename(self):
+        gate_up = mock.Mock()
+        gate_up.weight_loader = mock.Mock()
+        params = {"mlp.experts.0.gate_up_proj.weight": gate_up}
+        tensor = torch.zeros(2, 2)
+        name = "mlp.experts.0.gate_proj.weight"
+        result = try_load_stacked_skip_moe_experts(
+            STANDARD_GATE_UP_MAPPING, name, tensor, params
+        )
+        self.assertIsNone(result)
+        gate_up.weight_loader.assert_not_called()
+
+    def test_stacked_applies_to_shared_expert_path(self):
+        gate_up = mock.Mock()
+        gate_up.weight_loader = mock.Mock()
+        params = {"mlp.shared_expert.gate_up_proj.weight": gate_up}
+        tensor = torch.zeros(2, 2)
+        name = "mlp.shared_expert.gate_proj.weight"
+        result = try_load_stacked_skip_moe_experts(
+            STANDARD_GATE_UP_MAPPING, name, tensor, params
+        )
+        self.assertEqual(result, "mlp.shared_expert.gate_up_proj.weight")
+        gate_up.weight_loader.assert_called_once()
+
+    def test_moe_expert_skip_substrs_cover_experts_prefix(self):
+        self.assertIn("mlp.experts", MOE_EXPERT_STACKED_SKIP_SUBSTRS)
+        self.assertIn("experts.", MOE_EXPERT_STACKED_SKIP_SUBSTRS)
+
+    def test_missing_mapped_expert_target_is_rejected(self):
+        dispatch = ExpertParamsDispatch.from_gate_up_down(num_experts=1)
+        with self.assertRaisesRegex(ValueError, "experts.w13_weight"):
+            dispatch.try_load(
+                "experts.0.gate_proj.weight",
+                torch.zeros(2, 2),
+                {},
+            )
+
+    def test_first_existing_expert_target_wins(self):
+        dispatch = ExpertParamsDispatch.from_fused_moe_mapping(
+            [
+                ("experts.missing_", "experts.0.gate_proj.", 0, "missing"),
+                ("experts.w13_", "experts.0.gate_proj.", 0, "w1"),
+                ("experts.w13_", "experts.0.gate_proj.", 0, "duplicate"),
+            ]
+        )
+        loader = _RecordingLoader()
+        param = mock.Mock()
+        param.weight_loader = loader
+
+        target = dispatch.try_load(
+            "experts.0.gate_proj.weight",
+            torch.zeros(2, 2),
+            {"experts.w13_weight": param},
+        )
+
+        self.assertEqual(target, "experts.w13_weight")
+        self.assertEqual(len(loader.calls), 1)
+        self.assertEqual(loader.calls[0][1], "w1")
+
+    def test_real_loader_type_error_propagates(self):
+        dispatch = ExpertParamsDispatch.from_gate_up_down(num_experts=1)
+        param = mock.Mock()
+        param.weight_loader = mock.Mock(
+            side_effect=TypeError("loader implementation failed")
+        )
+        with self.assertRaisesRegex(TypeError, "loader implementation failed"):
+            dispatch.try_load(
+                "experts.0.gate_proj.weight",
+                torch.zeros(2, 2),
+                {"experts.w13_weight": param},
+            )
+        param.weight_loader.assert_called_once()
+
+    def test_moe_helper_rejects_unexpected_weight(self):
+        with self.assertRaisesRegex(ValueError, "unexpected.weight"):
+            load_moe_sparse_block_weights(
+                nn.Module(),
+                [("unexpected.weight", torch.ones(1))],
+                expert_dispatch=ExpertParamsDispatch(),
+            )
+
+    def test_moe_helper_has_named_expert_bias_skip(self):
+        dispatch = ExpertParamsDispatch.from_gate_up_down(num_experts=1)
+        loaded = load_moe_sparse_block_weights(
+            nn.Module(),
+            [("experts.0.gate_proj.bias", torch.ones(1))],
+            expert_dispatch=dispatch,
+        )
+        self.assertEqual(loaded, set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Implement Weight Loader v2 PR2 from #31051.

## Modifications

- Add strict stacked/expert dispatch.
- Migrate 69 dense, MoE, and wrapper loaders behind the v2 gate.
- Add mapping, gate, completeness, wrapper, and equivalence coverage.

## Accuracy Tests

- 269 CPU tests passed.
- Added five-category GPU equivalence coverage; local execution is blocked by the `sgl_kernel`/PyTorch ABI.

## Speed Tests and Profiling

N/A; loading-only changes behind an environment gate.

## Checklist

- [x] Formatted and linted.
- [x] Added unit tests.
- [x] Followed SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30297442315](https://github.com/sgl-project/sglang/actions/runs/30297442315)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30297441379](https://github.com/sgl-project/sglang/actions/runs/30297441379)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->