### PR TITLE
feat(dsa): drive DSA backend defaulting and validation from a declarative compatibility table

### DIFF
--- a/python/sglang/srt/arg_groups/dsa_compat.py
+++ b/python/sglang/srt/arg_groups/dsa_compat.py
@@ -1,0 +1,286 @@
+"""Declarative DSA backend compatibility table (step 1 of RFC #31774).
+
+Single source for DSA backend defaulting, validation, and the per-cell test.
+Undeclared cells are UNKNOWN: never defaulted, never rejected. Torch-free:
+device facts are passed in by the caller.
+"""
+
+from typing import Dict, List, Optional, Tuple
+
+import msgspec
+
+# sm90 = CUDA below SM100; hip = any ROCm device.
+PLATFORM_SM90 = "sm90"
+PLATFORM_SM100 = "sm100"
+PLATFORM_HIP = "hip"
+PLATFORMS = (PLATFORM_SM90, PLATFORM_SM100, PLATFORM_HIP)
+
+# The resolver only distinguishes fp8_e4m3 from everything else.
+KV_FP8 = "fp8_e4m3"
+KV_BF16 = "bfloat16"
+KV_BUCKETS = (KV_BF16, KV_FP8)
+
+PHASE_PREFILL = "prefill"
+PHASE_DECODE = "decode"
+PHASES = (PHASE_PREFILL, PHASE_DECODE)
+
+STATUS_SUPPORTED = "supported"
+STATUS_UNSUPPORTED = "unsupported"
+STATUS_UNKNOWN = "unknown"
+
+
+class DSACell(msgspec.Struct, frozen=True, kw_only=True):
+    backend: str
+    platform: str
+    kv_dtype: str
+    phase: str
+    status: str
+    # highest supported priority wins defaulting; None = never a default
+    default_priority: Optional[int] = None
+    # unsupported cells: user-facing why
+    reason: str = ""
+    # PR/issue or code reference backing the status
+    evidence: str = ""
+
+
+def _supported(
+    backend: str,
+    platform: str,
+    kv_dtype: str,
+    phase: str,
+    *,
+    priority: Optional[int] = None,
+    evidence: str = "",
+) -> DSACell:
+    return DSACell(
+        backend=backend,
+        platform=platform,
+        kv_dtype=kv_dtype,
+        phase=phase,
+        status=STATUS_SUPPORTED,
+        default_priority=priority,
+        evidence=evidence,
+    )
+
+
+def _unsupported(
+    backend: str,
+    platform: str,
+    kv_dtype: str,
+    phase: str,
+    *,
+    reason: str,
+    evidence: str,
+) -> DSACell:
+    return DSACell(
+        backend=backend,
+        platform=platform,
+        kv_dtype=kv_dtype,
+        phase=phase,
+        status=STATUS_UNSUPPORTED,
+        reason=reason,
+        evidence=evidence,
+    )
+
+
+_TILELANG_FP8_CUDA_REASON = (
+    "the CUDA tilelang sparse kernels hardcode a bfloat16 KV cache; the fp8 "
+    "path exists on ROCm only"
+)
+_Q8_DECODE_REASON = (
+    "flashmla_sparse_q8 is a prefill-only backend; for FP8 decode use "
+    "flashmla_kv (SM90) or trtllm (SM100)"
+)
+
+# fmt: off
+DSA_COMPAT_TABLE: Tuple[DSACell, ...] = (
+    # tilelang: ROCm default; on CUDA bf16 only (#31346)
+    _supported("tilelang", PLATFORM_HIP, KV_BF16, PHASE_PREFILL, priority=100, evidence="ROCm resolver default"),
+    _supported("tilelang", PLATFORM_HIP, KV_BF16, PHASE_DECODE, priority=100, evidence="ROCm resolver default"),
+    _supported("tilelang", PLATFORM_HIP, KV_FP8, PHASE_PREFILL, priority=100, evidence="ROCm fp8 sparse-MLA kernels, see #31346"),
+    _supported("tilelang", PLATFORM_HIP, KV_FP8, PHASE_DECODE, priority=100, evidence="ROCm fp8 sparse-MLA kernels, see #31346"),
+    _supported("tilelang", PLATFORM_SM90, KV_BF16, PHASE_PREFILL, evidence="bf16 CUDA path verified on H100, see #31346"),
+    _supported("tilelang", PLATFORM_SM90, KV_BF16, PHASE_DECODE, evidence="bf16 CUDA path verified on H100, see #31346"),
+    _unsupported("tilelang", PLATFORM_SM90, KV_FP8, PHASE_PREFILL, reason=_TILELANG_FP8_CUDA_REASON, evidence="#31346"),
+    _unsupported("tilelang", PLATFORM_SM90, KV_FP8, PHASE_DECODE, reason=_TILELANG_FP8_CUDA_REASON, evidence="#31346"),
+    _unsupported("tilelang", PLATFORM_SM100, KV_FP8, PHASE_PREFILL, reason=_TILELANG_FP8_CUDA_REASON, evidence="#31346"),
+    _unsupported("tilelang", PLATFORM_SM100, KV_FP8, PHASE_DECODE, reason=_TILELANG_FP8_CUDA_REASON, evidence="#31346"),
+    # flashmla_sparse: bf16 prefill default on CUDA
+    _supported("flashmla_sparse", PLATFORM_SM90, KV_BF16, PHASE_PREFILL, priority=100, evidence="resolver default"),
+    _supported("flashmla_sparse", PLATFORM_SM100, KV_BF16, PHASE_PREFILL, priority=100, evidence="resolver default"),
+    # fa3: bf16 decode default below SM100
+    _supported("fa3", PLATFORM_SM90, KV_BF16, PHASE_DECODE, priority=100, evidence="resolver default"),
+    # trtllm: SM100 defaults
+    _supported("trtllm", PLATFORM_SM100, KV_BF16, PHASE_DECODE, priority=100, evidence="resolver default"),
+    _supported("trtllm", PLATFORM_SM100, KV_FP8, PHASE_PREFILL, priority=100, evidence="resolver default"),
+    _supported("trtllm", PLATFORM_SM100, KV_FP8, PHASE_DECODE, priority=100, evidence="resolver default"),
+    # flashmla_kv: fp8 default below SM100
+    _supported("flashmla_kv", PLATFORM_SM90, KV_FP8, PHASE_PREFILL, priority=100, evidence="resolver default"),
+    _supported("flashmla_kv", PLATFORM_SM90, KV_FP8, PHASE_DECODE, priority=100, evidence="resolver default"),
+    # flashmla_sparse_q8: mirrors the dsa_backend.py construction checks
+    _supported("flashmla_sparse_q8", PLATFORM_SM90, KV_FP8, PHASE_PREFILL, evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_SM90, KV_BF16, PHASE_PREFILL, reason="flashmla_sparse_q8 is native FP8 and requires an fp8_e4m3 KV cache; use flashmla_sparse for the bf16 path", evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_SM100, KV_BF16, PHASE_PREFILL, reason="flashmla_sparse_q8 is SM90-only", evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_SM100, KV_FP8, PHASE_PREFILL, reason="flashmla_sparse_q8 is SM90-only", evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_SM90, KV_BF16, PHASE_DECODE, reason=_Q8_DECODE_REASON, evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_SM90, KV_FP8, PHASE_DECODE, reason=_Q8_DECODE_REASON, evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_SM100, KV_BF16, PHASE_DECODE, reason=_Q8_DECODE_REASON, evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_SM100, KV_FP8, PHASE_DECODE, reason=_Q8_DECODE_REASON, evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_HIP, KV_BF16, PHASE_DECODE, reason=_Q8_DECODE_REASON, evidence="dsa_backend.py construction checks"),
+    _unsupported("flashmla_sparse_q8", PLATFORM_HIP, KV_FP8, PHASE_DECODE, reason=_Q8_DECODE_REASON, evidence="dsa_backend.py construction checks"),
+    # q8 requires fp8 on every platform; q8+HIP+fp8 prefill stays UNKNOWN
+    # because dsa_backend.py's sm-major-9 check passes on gfx9 ROCm.
+    _unsupported("flashmla_sparse_q8", PLATFORM_HIP, KV_BF16, PHASE_PREFILL, reason="flashmla_sparse_q8 is native FP8 and requires an fp8_e4m3 KV cache; use flashmla_sparse for the bf16 path", evidence="dsa_backend.py construction checks"),
+    # aiter: ROCm decode path
+    _supported("aiter", PLATFORM_HIP, KV_BF16, PHASE_DECODE, evidence="aiter mla_decode_fwd path in dsa_backend.py"),
+    _supported("aiter", PLATFORM_HIP, KV_FP8, PHASE_DECODE, evidence="aiter fp8 metadata path in dsa_backend.py"),
+    # flashmla_auto: prefill-only; decode rejection lands separately in #31344
+    _supported("flashmla_auto", PLATFORM_SM90, KV_BF16, PHASE_PREFILL, evidence="auto-select in dsa_backend.py"),
+    _supported("flashmla_auto", PLATFORM_SM90, KV_FP8, PHASE_PREFILL, evidence="auto-select in dsa_backend.py"),
+    _supported("flashmla_auto", PLATFORM_SM100, KV_BF16, PHASE_PREFILL, evidence="auto-select in dsa_backend.py"),
+    _supported("flashmla_auto", PLATFORM_SM100, KV_FP8, PHASE_PREFILL, evidence="auto-select in dsa_backend.py"),
+)
+# fmt: on
+
+_CellKey = Tuple[str, str, str, str]
+
+
+def _build_index() -> Dict[_CellKey, DSACell]:
+    index: Dict[_CellKey, DSACell] = {}
+    for cell in DSA_COMPAT_TABLE:
+        key = (cell.backend, cell.platform, cell.kv_dtype, cell.phase)
+        if key in index:
+            raise AssertionError(f"duplicate DSA compat cell: {key}")
+        index[key] = cell
+    return index
+
+
+_CELL_INDEX: Dict[_CellKey, DSACell] = _build_index()
+
+
+def platform_bucket(sm_major: int, *, hip: bool) -> str:
+    if hip:
+        return PLATFORM_HIP
+    return PLATFORM_SM100 if sm_major >= 10 else PLATFORM_SM90
+
+
+def kv_dtype_bucket(kv_cache_dtype: str) -> str:
+    return KV_FP8 if kv_cache_dtype == KV_FP8 else KV_BF16
+
+
+def lookup_cell(*, backend: str, platform: str, kv_dtype: str, phase: str) -> DSACell:
+    """Declared cell, or an implicit UNKNOWN."""
+    cell = _CELL_INDEX.get((backend, platform, kv_dtype, phase))
+    if cell is not None:
+        return cell
+    return DSACell(
+        backend=backend,
+        platform=platform,
+        kv_dtype=kv_dtype,
+        phase=phase,
+        status=STATUS_UNKNOWN,
+    )
+
+
+def supported_backends(*, platform: str, kv_dtype: str, phase: str) -> List[str]:
+    return [
+        cell.backend
+        for cell in DSA_COMPAT_TABLE
+        if cell.platform == platform
+        and cell.kv_dtype == kv_dtype
+        and cell.phase == phase
+        and cell.status == STATUS_SUPPORTED
+    ]
+
+
+def _default_backend(*, platform: str, kv_dtype: str, phase: str) -> Optional[str]:
+    candidates = [
+        cell
+        for cell in DSA_COMPAT_TABLE
+        if cell.platform == platform
+        and cell.kv_dtype == kv_dtype
+        and cell.phase == phase
+        and cell.status == STATUS_SUPPORTED
+        and cell.default_priority is not None
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda cell: cell.default_priority).backend
+
+
+def resolve_dsa_default_backends(
+    *,
+    sm_major: int,
+    hip: bool,
+    kv_cache_dtype: str,
+    user_set_prefill: bool,
+    user_set_decode: bool,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Table-driven defaults, bit-identical to the historical branches.
+    Quirk preserved: HIP tilelang default needs both sides unset; a
+    partially-set HIP config falls through to the CUDA-bucket defaults."""
+    kv_dtype = kv_dtype_bucket(kv_cache_dtype)
+    if hip and not user_set_prefill and not user_set_decode:
+        platform = PLATFORM_HIP
+    else:
+        platform = platform_bucket(sm_major, hip=False)
+    prefill = None
+    decode = None
+    if not user_set_prefill:
+        prefill = _default_backend(
+            platform=platform, kv_dtype=kv_dtype, phase=PHASE_PREFILL
+        )
+    if not user_set_decode:
+        decode = _default_backend(
+            platform=platform, kv_dtype=kv_dtype, phase=PHASE_DECODE
+        )
+    return prefill, decode
+
+
+def check_dsa_backend_compat(
+    *,
+    kv_cache_dtype: str,
+    prefill_backend: Optional[str],
+    decode_backend: Optional[str],
+    sm_major: int,
+    hip: bool,
+) -> None:
+    """Reject combinations declared unsupported; unknown cells pass."""
+    platform = platform_bucket(sm_major, hip=hip)
+    kv_dtype = kv_dtype_bucket(kv_cache_dtype)
+    for phase, backend in (
+        (PHASE_PREFILL, prefill_backend),
+        (PHASE_DECODE, decode_backend),
+    ):
+        if backend is None:
+            continue
+        cell = lookup_cell(
+            backend=backend, platform=platform, kv_dtype=kv_dtype, phase=phase
+        )
+        if cell.status != STATUS_UNSUPPORTED:
+            continue
+        alternatives = supported_backends(
+            platform=platform, kv_dtype=kv_dtype, phase=phase
+        )
+        # dtypes under which THIS backend is supported here (the #31346 hint:
+        # keep the backend, switch the KV dtype)
+        keep_backend_dtypes = [
+            c.kv_dtype
+            for c in DSA_COMPAT_TABLE
+            if c.backend == backend
+            and c.platform == platform
+            and c.phase == phase
+            and c.status == STATUS_SUPPORTED
+        ]
+        switch_hint = (
+            f" Or keep --dsa-{phase}-backend {backend} and set "
+            f"--kv-cache-dtype {keep_backend_dtypes[0]}."
+            if keep_backend_dtypes
+            else ""
+        )
+        raise ValueError(
+            f"--dsa-{phase}-backend {backend} is not supported with "
+            f"--kv-cache-dtype {kv_cache_dtype} on {platform}: {cell.reason} "
+            f"(see {cell.evidence}). Supported {phase} backends here: "
+            f"{', '.join(alternatives) or 'none declared'}.{switch_hint}"
+        )

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -34,6 +34,10 @@ import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 from sglang.srt.arg_groups.arg_utils import resolvable_fields
+from sglang.srt.arg_groups.dsa_compat import (
+    check_dsa_backend_compat,
+    resolve_dsa_default_backends,
+)
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.utils.common import (
@@ -1248,29 +1252,6 @@ def _dsa_kv_cache_dtype_default(view: Any) -> dict:
     return {}
 
 
-def _check_tilelang_dsa_fp8_kv(
-    kv_cache_dtype: str,
-    prefill_backend: Optional[str],
-    decode_backend: Optional[str],
-    *,
-    hip: bool,
-) -> None:
-    """tilelang's fp8 KV path is ROCm-only; the CUDA kernel hardcodes bfloat16.
-    Reject here instead of crashing at decode CUDA-graph capture."""
-    if (
-        not hip
-        and kv_cache_dtype == "fp8_e4m3"
-        and "tilelang" in {prefill_backend, decode_backend}
-    ):
-        raise ValueError(
-            "The tilelang DSA prefill/decode kernels only support an fp8_e4m3 KV "
-            "cache on ROCm/HIP; on CUDA they require a bfloat16 KV cache. Use "
-            "--kv-cache-dtype bfloat16 with the tilelang backend, or keep "
-            "--kv-cache-dtype fp8_e4m3 and pick an fp8-capable DSA backend "
-            "(flashmla_kv on Hopper, trtllm on Blackwell)."
-        )
-
-
 @register_post_process
 def _dsa_split_backend_resolution(view: Any) -> dict:
     """Slot pass in the DSA arm: default the DSA prefill/decode split
@@ -1310,26 +1291,27 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
         )
         return declared
 
-    if not user_set_prefill and not user_set_decode and is_hip():
-        declared["dsa_prefill_backend"] = "tilelang"
-        declared["dsa_decode_backend"] = "tilelang"
-    elif kv_cache_dtype == "fp8_e4m3":
-        # Blackwell FP8 defaults to trtllm; Hopper FP8 to flashmla_kv.
-        default = "trtllm" if major >= 10 else "flashmla_kv"
-        if not user_set_prefill:
-            declared["dsa_prefill_backend"] = default
-        if not user_set_decode:
-            declared["dsa_decode_backend"] = default
-    else:
-        # Set prefill/decode backends based on hardware architecture.
-        if not user_set_prefill:
-            declared["dsa_prefill_backend"] = "flashmla_sparse"
-        if not user_set_decode:
-            declared["dsa_decode_backend"] = "trtllm" if major >= 10 else "fa3"
+    default_prefill, default_decode = resolve_dsa_default_backends(
+        sm_major=major,
+        hip=is_hip(),
+        kv_cache_dtype=kv_cache_dtype,
+        user_set_prefill=user_set_prefill,
+        user_set_decode=user_set_decode,
+    )
+    if default_prefill is not None:
+        declared["dsa_prefill_backend"] = default_prefill
+    if default_decode is not None:
+        declared["dsa_decode_backend"] = default_decode
 
     prefill = declared.get("dsa_prefill_backend", view.dsa_prefill_backend)
     decode = declared.get("dsa_decode_backend", view.dsa_decode_backend)
-    _check_tilelang_dsa_fp8_kv(kv_cache_dtype, prefill, decode, hip=is_hip())
+    check_dsa_backend_compat(
+        kv_cache_dtype=kv_cache_dtype,
+        prefill_backend=prefill,
+        decode_backend=decode,
+        sm_major=major,
+        hip=is_hip(),
+    )
     logger.warning(
         f"Set DSA backends for {kv_cache_dtype} KV Cache: "
         f"prefill={prefill}, decode={decode}."

--- a/test/registered/unit/test_dsa_compat_table.py
+++ b/test/registered/unit/test_dsa_compat_table.py
@@ -1,0 +1,188 @@
+"""Per-cell contract of the DSA compatibility table (RFC #31774).
+
+Guards: defaults equal the historical if/elif spec over the full input
+product; rejection fires exactly on unsupported cells; the table stays in
+sync with ``DSA_CHOICES``.
+"""
+
+import itertools
+import unittest
+from typing import Optional, Tuple
+
+from sglang.srt.arg_groups.dsa_compat import (
+    DSA_COMPAT_TABLE,
+    KV_BUCKETS,
+    PHASES,
+    PLATFORM_HIP,
+    PLATFORM_SM100,
+    PLATFORMS,
+    STATUS_SUPPORTED,
+    STATUS_UNSUPPORTED,
+    check_dsa_backend_compat,
+    lookup_cell,
+    resolve_dsa_default_backends,
+    supported_backends,
+)
+from sglang.srt.server_args import DSA_CHOICES
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _historical_defaults(
+    sm_major: int,
+    hip: bool,
+    kv_cache_dtype: str,
+    user_set_prefill: bool,
+    user_set_decode: bool,
+) -> Tuple[Optional[str], Optional[str]]:
+    """The pre-table resolver branches, kept verbatim as the spec."""
+    if not user_set_prefill and not user_set_decode and hip:
+        return "tilelang", "tilelang"
+    if kv_cache_dtype == "fp8_e4m3":
+        default = "trtllm" if sm_major >= 10 else "flashmla_kv"
+        return (
+            None if user_set_prefill else default,
+            None if user_set_decode else default,
+        )
+    return (
+        None if user_set_prefill else "flashmla_sparse",
+        None if user_set_decode else ("trtllm" if sm_major >= 10 else "fa3"),
+    )
+
+
+class TestDsaDefaultsMatchHistorical(CustomTestCase):
+
+    def test_full_input_product(self):
+        for (
+            sm_major,
+            hip,
+            kv_cache_dtype,
+            user_set_prefill,
+            user_set_decode,
+        ) in itertools.product(
+            (8, 9, 10, 12),
+            (False, True),
+            ("auto", "bfloat16", "fp8_e5m2", "fp8_e4m3"),
+            (False, True),
+            (False, True),
+        ):
+            expected = _historical_defaults(
+                sm_major, hip, kv_cache_dtype, user_set_prefill, user_set_decode
+            )
+            got = resolve_dsa_default_backends(
+                sm_major=sm_major,
+                hip=hip,
+                kv_cache_dtype=kv_cache_dtype,
+                user_set_prefill=user_set_prefill,
+                user_set_decode=user_set_decode,
+            )
+            self.assertEqual(
+                got,
+                expected,
+                msg=(
+                    f"defaults diverged for sm_major={sm_major} hip={hip} "
+                    f"kv={kv_cache_dtype} user_set_prefill={user_set_prefill} "
+                    f"user_set_decode={user_set_decode}"
+                ),
+            )
+
+
+class TestDsaCompatValidation(CustomTestCase):
+
+    def test_rejects_exactly_the_unsupported_cells(self):
+        for backend, platform, kv_dtype, phase in itertools.product(
+            DSA_CHOICES, PLATFORMS, KV_BUCKETS, PHASES
+        ):
+            cell = lookup_cell(
+                backend=backend, platform=platform, kv_dtype=kv_dtype, phase=phase
+            )
+            kwargs = dict(
+                kv_cache_dtype=kv_dtype,
+                prefill_backend=backend if phase == "prefill" else None,
+                decode_backend=backend if phase == "decode" else None,
+                sm_major=10 if platform == PLATFORM_SM100 else 9,
+                hip=platform == PLATFORM_HIP,
+            )
+            if cell.status == STATUS_UNSUPPORTED:
+                with self.assertRaises(ValueError, msg=f"expected reject: {cell}"):
+                    check_dsa_backend_compat(**kwargs)
+            else:
+                check_dsa_backend_compat(**kwargs)
+
+    def test_error_names_supported_alternatives(self):
+        # the actionable hint from #31346: an fp8-capable backend, plus the
+        # keep-backend-switch-dtype route
+        with self.assertRaises(ValueError) as ctx:
+            check_dsa_backend_compat(
+                kv_cache_dtype="fp8_e4m3",
+                prefill_backend="tilelang",
+                decode_backend=None,
+                sm_major=9,
+                hip=False,
+            )
+        msg = str(ctx.exception)
+        self.assertIn("flashmla_kv", msg)
+        self.assertIn("bfloat16", msg)
+
+
+class TestDsaCompatTableWellFormed(CustomTestCase):
+
+    def test_backends_exist_in_dsa_choices(self):
+        for cell in DSA_COMPAT_TABLE:
+            self.assertIn(cell.backend, DSA_CHOICES)
+
+    def test_axis_values_are_valid(self):
+        for cell in DSA_COMPAT_TABLE:
+            self.assertIn(cell.platform, PLATFORMS)
+            self.assertIn(cell.kv_dtype, KV_BUCKETS)
+            self.assertIn(cell.phase, PHASES)
+
+    def test_unsupported_cells_carry_reason_and_evidence(self):
+        for cell in DSA_COMPAT_TABLE:
+            if cell.status == STATUS_UNSUPPORTED:
+                self.assertTrue(cell.reason, msg=f"missing reason: {cell}")
+                self.assertTrue(cell.evidence, msg=f"missing evidence: {cell}")
+
+    def test_default_is_unambiguous(self):
+        for platform, kv_dtype, phase in itertools.product(
+            PLATFORMS, KV_BUCKETS, PHASES
+        ):
+            priorities = [
+                cell.default_priority
+                for cell in DSA_COMPAT_TABLE
+                if cell.platform == platform
+                and cell.kv_dtype == kv_dtype
+                and cell.phase == phase
+                and cell.status == STATUS_SUPPORTED
+                and cell.default_priority is not None
+            ]
+            if priorities:
+                self.assertEqual(
+                    priorities.count(max(priorities)),
+                    1,
+                    msg=f"ambiguous default for {platform}/{kv_dtype}/{phase}",
+                )
+
+    def test_only_supported_cells_can_default(self):
+        for cell in DSA_COMPAT_TABLE:
+            if cell.default_priority is not None:
+                self.assertEqual(cell.status, STATUS_SUPPORTED, msg=str(cell))
+
+    def test_supported_backends_is_nonempty_where_something_rejects(self):
+        # every rejection must be able to name an alternative
+        rejecting = {
+            (cell.platform, cell.kv_dtype, cell.phase)
+            for cell in DSA_COMPAT_TABLE
+            if cell.status == STATUS_UNSUPPORTED
+        }
+        for platform, kv_dtype, phase in rejecting:
+            self.assertTrue(
+                supported_backends(platform=platform, kv_dtype=kv_dtype, phase=phase),
+                msg=f"no supported alternative for {platform}/{kv_dtype}/{phase}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_dsa_tilelang_fp8_validation.py
+++ b/test/registered/unit/test_dsa_tilelang_fp8_validation.py
@@ -7,7 +7,7 @@ but got float8_e4m3fn``.
 
 import unittest
 
-from sglang.srt.arg_groups.overrides import _check_tilelang_dsa_fp8_kv
+from sglang.srt.arg_groups.dsa_compat import check_dsa_backend_compat
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -18,23 +18,53 @@ class TestDsaTilelangFp8Validation(CustomTestCase):
 
     def test_cuda_fp8_tilelang_decode_rejected(self):
         with self.assertRaises(ValueError):
-            _check_tilelang_dsa_fp8_kv("fp8_e4m3", "flashmla_kv", "tilelang", hip=False)
+            check_dsa_backend_compat(
+                kv_cache_dtype="fp8_e4m3",
+                prefill_backend="flashmla_kv",
+                decode_backend="tilelang",
+                sm_major=9,
+                hip=False,
+            )
 
     def test_cuda_fp8_tilelang_prefill_rejected(self):
         with self.assertRaises(ValueError):
-            _check_tilelang_dsa_fp8_kv("fp8_e4m3", "tilelang", "trtllm", hip=False)
+            check_dsa_backend_compat(
+                kv_cache_dtype="fp8_e4m3",
+                prefill_backend="tilelang",
+                decode_backend="trtllm",
+                sm_major=9,
+                hip=False,
+            )
 
     def test_hip_fp8_tilelang_allowed(self):
         # ROCm has a real fp8 tilelang kernel
-        _check_tilelang_dsa_fp8_kv("fp8_e4m3", "tilelang", "tilelang", hip=True)
+        check_dsa_backend_compat(
+            kv_cache_dtype="fp8_e4m3",
+            prefill_backend="tilelang",
+            decode_backend="tilelang",
+            sm_major=9,
+            hip=True,
+        )
 
     def test_bf16_tilelang_allowed(self):
         # what the CUDA kernel expects
-        _check_tilelang_dsa_fp8_kv("bfloat16", "tilelang", "tilelang", hip=False)
+        check_dsa_backend_compat(
+            kv_cache_dtype="bfloat16",
+            prefill_backend="tilelang",
+            decode_backend="tilelang",
+            sm_major=9,
+            hip=False,
+        )
 
     def test_cuda_fp8_non_tilelang_allowed(self):
         # fp8-capable backends must pass
-        _check_tilelang_dsa_fp8_kv("fp8_e4m3", "flashmla_kv", "trtllm", hip=False)
+        check_dsa_backend_compat(
+            kv_cache_dtype="fp8_e4m3",
+            prefill_backend="flashmla_kv",
+            decode_backend="trtllm",
+            sm_major=9,
+            hip=False,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -978,6 +978,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 _dsa_split_backend_resolution(_view(dsa_prefill_backend="trtllm")),
                 {"dsa_decode_backend": "flashmla_kv"},
             )
+            # tilelang + fp8 KV on CUDA is rejected end-to-end (#31346)
+            with self.assertRaises(ValueError):
+                _dsa_split_backend_resolution(_view(dsa_prefill_backend="tilelang"))
             # hisparse arm takes precedence (CUDA fp8 -> flashmla_kv)
             self.assertEqual(
                 _dsa_split_backend_resolution(_view(enable_hisparse=True)),


### PR DESCRIPTION
## Motivation

First concrete step of RFC #31774, claimed in that thread and listed in the H2 2026 quantization roadmap #31783 under 1.3 and 7. DSA backend compatibility knowledge is currently spread over three places that can drift apart: the shared `DSA_CHOICES` argparse list, the if/elif defaulting plus one hand-written guard in `_dsa_split_backend_resolution`, and the construction-time checks in `dsa_backend.py`. This PR makes the matrix explicit as one declarative table next to the resolver and drives defaulting, validation and tests from it, so they cannot disagree by construction.

## Modifications

`arg_groups/dsa_compat.py` declares per-cell support (backend, platform sm90/sm100/hip, kv dtype bucket, phase) with a status, an optional default priority, and a reason plus evidence for unsupported cells. Undeclared cells are UNKNOWN: never picked as a default, never rejected, so absence of evidence is not a rejection. The resolver now takes its defaults and its validation from the table. Defaults are unchanged: the new unit test keeps the historical branches verbatim as the spec and asserts equality over the full input product, including the preserved quirk that the HIP tilelang default only applies when neither side was set by the user. Rejection changes are limited to combinations already proven unsupported: tilelang with fp8_e4m3 KV on CUDA (#31346), and the flashmla_sparse_q8 misuse cases that `dsa_backend.py` already rejects at construction, which now fail at resolution with an error that lists the supported alternatives generated from the table. The flashmla_auto decode cells stay unknown on purpose, their rejection lands separately in #31344. `dsa_backend.py` itself is untouched here, pointing it at the same table is a follow-up.

## Accuracy Tests

Not applicable: no kernel or model forward changes. Defaults are proven unchanged by `test_dsa_compat_table.py`, which pins the historical resolver branches as the spec and asserts equality over all 128 input combinations.

## Speed Tests and Profiling

Not applicable: the change is resolution-time only, nothing on the inference path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30313894903](https://github.com/sgl-project/sglang/actions/runs/30313894903)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30313894803](https://github.com/sgl-project/sglang/actions/runs/30313894803)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->