### PR TITLE
[AMD][CI] Bound each MI355X disagg benchmark phase

### DIFF
--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -42,6 +42,11 @@
 #   SLURM_EXCLUSIVE    - request whole nodes (default 1); set 0 to disable
 #   TIME_LIMIT         - salloc time limit, default 02:30:00 (covers server
 #                        load + perf sweep + full GSM8K, under the 180m step cap)
+#   BENCH_PHASE_TIMEOUT - per-phase wall-clock budget in seconds for the GSM8K
+#                        gate and each concurrency point, default 600. Observed
+#                        phases run 50-80s, so this is ~8x headroom; it exists
+#                        so one request that never completes fails its phase in
+#                        minutes instead of holding the sweep until TIME_LIMIT.
 
 set -euo pipefail
 set -x
@@ -57,6 +62,7 @@ set -x
 
 SLURM_PARTITION="${SLURM_PARTITION:-amd-sglang}"
 TIME_LIMIT="${TIME_LIMIT:-02:30:00}"
+BENCH_PHASE_TIMEOUT="${BENCH_PHASE_TIMEOUT:-600}"
 MODEL_PATH="${MODEL_PATH:-${MODEL:-}}"
 SGLANG_USE_CHECKOUT_RUNTIME="${SGLANG_USE_CHECKOUT_RUNTIME:-1}"
 case "${SGLANG_USE_CHECKOUT_RUNTIME,,}" in
@@ -828,25 +834,45 @@ $PREFILL_WAIT_ROUTER
       echo "=== GSM8K accuracy gate (num_questions=$ACC_NQ shots=$ACC_SHOTS) ==="
       DP_ARG=""
       [ -s \$CIDIR/gsm8k_test.jsonl ] && DP_ARG="--data-path \$CIDIR/gsm8k_test.jsonl"
+      timeout -k 30 $BENCH_PHASE_TIMEOUT \
       python3 -m sglang.test.few_shot_gsm8k \
         --num-shots $ACC_SHOTS --num-questions $ACC_NQ --parallel $MAXREQ \
         --max-new-tokens 512 --host http://127.0.0.1 --port $LBPORT \
         \$DP_ARG 2>&1 | tee \$CIDIR/gsm8k.log
       ACC=\$(grep -oE "Accuracy: [0-9.]+" \$CIDIR/gsm8k.log | tail -1 | cut -d" " -f2)
-      [ -n "\$ACC" ] || { echo "[gsm8k] could not parse accuracy from harness output"; exit 1; }
+      [ -n "\$ACC" ] || { echo "[gsm8k] no accuracy in harness output -- it crashed or exceeded the ${BENCH_PHASE_TIMEOUT}s phase budget"; exit 1; }
       python3 \$CIDIR/check_acc.py "\$ACC" "$ACC_THR" || { echo "[gsm8k] accuracy below threshold -- failing before sweep"; exit 1; }
     fi
+    # bench_serving waits on each response stream with no per-request deadline,
+    # so a single reply that never terminates parks the sweep here until SLURM
+    # kills the allocation at TIME_LIMIT and every later concurrency point is
+    # lost. Bound each phase instead: a stuck point dies in minutes, the rest of
+    # the sweep still produces numbers, and the leg fails at the end.
+    SWEEP_TIMED_OUT=""
     for C in ${CONCS//,/ }; do
       echo "=== concurrency=\$C ==="
       OUT=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}/raw_conc\${C}.json
       rm -f \$OUT
+      RC=0
+      timeout -k 30 $BENCH_PHASE_TIMEOUT \
       python3 -m sglang.bench_serving --backend sglang \
         --host 127.0.0.1 --port $LBPORT --model $MODEL_PATH \
         --dataset-name random --random-input-len $ISL --random-output-len $OSL \
         --random-range-ratio $RRR --max-concurrency \$C \
         --num-prompts \$((C*$NPF)) --warmup-requests \$C \
-        --output-file \$OUT || true
+        --output-file \$OUT || RC=\$?
+      case \$RC in
+        0) ;;
+        # 124 = timeout sent SIGTERM; 137 = the -k SIGKILL was needed.
+        124|137) echo "[bench] concurrency=\$C exceeded the ${BENCH_PHASE_TIMEOUT}s phase budget -- killed"
+                 SWEEP_TIMED_OUT="\$SWEEP_TIMED_OUT \$C" ;;
+        *) echo "[bench] concurrency=\$C failed (rc=\$RC)" ;;
+      esac
     done
+    if [ -n "\$SWEEP_TIMED_OUT" ]; then
+      echo "[bench] FAILED: phase budget exceeded at concurrency:\$SWEEP_TIMED_OUT"
+      exit 1
+    fi
   '
 EOF
 chmod +x "$WORKDIR"/*.sh

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -42,6 +42,11 @@
 #   SLURM_EXCLUSIVE    - request whole nodes (default 1); set 0 to disable
 #   TIME_LIMIT         - salloc time limit, default 02:30:00 (covers server
 #                        load + perf sweep + full GSM8K, under the 180m step cap)
+#   BENCH_PHASE_TIMEOUT - per-phase wall-clock budget in seconds for the GSM8K
+#                        gate and each concurrency point, default 600. Observed
+#                        phases run 50-80s, so this is ~8x headroom; it exists
+#                        so one request that never completes fails its phase in
+#                        minutes instead of holding the sweep until TIME_LIMIT.
 
 set -euo pipefail
 set -x
@@ -57,6 +62,7 @@ set -x
 
 SLURM_PARTITION="${SLURM_PARTITION:-amd-sglang}"
 TIME_LIMIT="${TIME_LIMIT:-02:30:00}"
+BENCH_PHASE_TIMEOUT="${BENCH_PHASE_TIMEOUT:-600}"
 MODEL_PATH="${MODEL_PATH:-${MODEL:-}}"
 SGLANG_USE_CHECKOUT_RUNTIME="${SGLANG_USE_CHECKOUT_RUNTIME:-1}"
 case "${SGLANG_USE_CHECKOUT_RUNTIME,,}" in
@@ -565,25 +571,45 @@ docker run $DOCKER_COMMON --name mi355x_bench \
       echo "=== GSM8K accuracy gate (num_questions=$ACC_NQ shots=$ACC_SHOTS) ==="
       DP_ARG=""
       [ -s \$CIDIR/gsm8k_test.jsonl ] && DP_ARG="--data-path \$CIDIR/gsm8k_test.jsonl"
+      timeout -k 30 $BENCH_PHASE_TIMEOUT \
       python3 -m sglang.test.few_shot_gsm8k \
         --num-shots $ACC_SHOTS --num-questions $ACC_NQ --parallel $MAXREQ \
         --max-new-tokens 512 --host http://127.0.0.1 --port $LBPORT \
         \$DP_ARG 2>&1 | tee \$CIDIR/gsm8k.log
       ACC=\$(grep -oE "Accuracy: [0-9.]+" \$CIDIR/gsm8k.log | tail -1 | cut -d" " -f2)
-      [ -n "\$ACC" ] || { echo "[gsm8k] could not parse accuracy from harness output"; exit 1; }
+      [ -n "\$ACC" ] || { echo "[gsm8k] no accuracy in harness output -- it crashed or exceeded the ${BENCH_PHASE_TIMEOUT}s phase budget"; exit 1; }
       python3 \$CIDIR/check_acc.py "\$ACC" "$ACC_THR" || { echo "[gsm8k] accuracy below threshold -- failing before sweep"; exit 1; }
     fi
+    # bench_serving waits on each response stream with no per-request deadline,
+    # so a single reply that never terminates parks the sweep here until SLURM
+    # kills the allocation at TIME_LIMIT and every later concurrency point is
+    # lost. Bound each phase instead: a stuck point dies in minutes, the rest of
+    # the sweep still produces numbers, and the leg fails at the end.
+    SWEEP_TIMED_OUT=""
     for C in ${CONCS//,/ }; do
       echo "=== concurrency=\$C ==="
       OUT=/host_home/.mi355x_ci/${MATRIX_CONFIG_NAME}/raw_conc\${C}.json
       rm -f \$OUT
+      RC=0
+      timeout -k 30 $BENCH_PHASE_TIMEOUT \
       python3 -m sglang.bench_serving --backend sglang \
         --host 127.0.0.1 --port $LBPORT --model $MODEL_PATH \
         --dataset-name random --random-input-len $ISL --random-output-len $OSL \
         --random-range-ratio $RRR --max-concurrency \$C \
         --num-prompts \$((C*$NPF)) --warmup-requests \$C \
-        --output-file \$OUT || true
+        --output-file \$OUT || RC=\$?
+      case \$RC in
+        0) ;;
+        # 124 = timeout sent SIGTERM; 137 = the -k SIGKILL was needed.
+        124|137) echo "[bench] concurrency=\$C exceeded the ${BENCH_PHASE_TIMEOUT}s phase budget -- killed"
+                 SWEEP_TIMED_OUT="\$SWEEP_TIMED_OUT \$C" ;;
+        *) echo "[bench] concurrency=\$C failed (rc=\$RC)" ;;
+      esac
     done
+    if [ -n "\$SWEEP_TIMED_OUT" ]; then
+      echo "[bench] FAILED: phase budget exceeded at concurrency:\$SWEEP_TIMED_OUT"
+      exit 1
+    fi
   '
 EOF
 chmod +x "$WORKDIR"/*.sh


### PR DESCRIPTION
## Motivation

`nightly-amd-mi355x-disagg` run [30237209346](https://github.com/sgl-project/sglang/actions/runs/30237209346) (`dsv4flash-fp4-1k1k-1p1d-dp8ep8-mtp`) froze at 1023/1024 requests in the `conc=256` point and produced nothing for the next 2h15m, until SLURM killed the step at the wall clock and every role exited rc=143.

From the run artifacts, both servers were idle and healthy the whole time — the last prefill batch was at 13:21:28, the last decode batch at 13:21:42, decode's final log line shows `#prealloc-req: 0, #transfer-req: 0`, and both answered their `/health` probe every 60s until the kill. The `smg` router started and head-finished all 1280 requests of that phase (256 warmup + 1024). Only the client was still waiting.

That is possible because nothing bounds a single request: `bench_serving` waits on each response stream with no per-request deadline, and the sweep's only guard was `|| true`, which covers a phase that crashes but not one that hangs. One unterminated stream therefore costs the entire allocation, including the concurrency points that had not run yet.

This PR does not diagnose why that one stream never completed; it stops that class of failure from consuming a 2.5h reservation and taking the rest of the sweep with it.

## Modifications

- Run the GSM8K gate and each concurrency point under `timeout -k 30 $BENCH_PHASE_TIMEOUT` (new env knob, default 600s). Measured phase durations on the last green run of this config are 52-76s for the sweep points and ~60s for the gate, so the default is ~8x headroom.
- On a timeout, record the concurrency, keep sweeping so the remaining points still produce numbers, and fail the leg at the end.
- A phase that fails for any other reason keeps its previous behaviour (logged, sweep continues).

The deferred failure is deliberate. The result normalizer already skips a missing `raw_conc<C>.json` with `WARN: missing ...`, and the leg only fails when the bench rc is non-zero or zero results were produced — so simply dropping a timed-out phase would have reported this failure as **green**. Exiting non-zero at the end of the sweep propagates through `bench_exit` -> `drive.sh` -> `salloc` -> `SALLOC_RC` while the partial results are still normalized and uploaded.

## Tests

Shell-only change to a generated script, so it was first verified by expansion, then exercised end to end on the runner (below):

- `bash -n` on the launcher.
- Expanded the `bench.sh` heredoc with realistic variables and `bash -n` on the generated file, then extracted the inner single-quoted `bash -lc` block and `bash -n` on that too (the escaping inside that block is the actual risk). The substitution lands as intended: `timeout -k 30 600` baked in, `$C` / `$RC` / `$OUT` preserved for runtime.
- Simulated the control flow against stub commands: healthy phases exit 0; hung phases are killed per phase, the sweep continues, and the leg exits 1; a crashing phase preserves the pre-existing continue-and-pass behaviour.
- `pre-commit run --files scripts/ci/slurm/launch_mi355x.sh` clean.

## Validated on the MI355X runner

Dispatched this branch at the affected leg (`dsv4flash-fp4-1k1k-1p1d-dp8ep8-mtp`, pinning the image via the `workflow_dispatch` inputs) to confirm the new budget does not perturb a healthy sweep. It did not fire in either run, and both completed all seven concurrency points:

- [Run 30310490611](https://github.com/sgl-project/sglang/actions/runs/30310490611) on `lmsysorg/sglang-rocm:v0.5.16-rocm720-mi35x-20260726`, the image the original hang appeared on: **success**, GSM8K 0.925, `conc=256` 1024/1024 in 64.85s.
- [Run 30310514312](https://github.com/sgl-project/sglang/actions/runs/30310514312) on `lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260724`, the last image this config was green on: GSM8K 0.918, `conc=256` 1024/1024 in 64.67s. This one reads *cancelled* at the workflow level only because I cancelled it as redundant once the first run passed - the benchmark job had already finished every step and uploaded its results.

The last scheduled green run of this config did `conc=256` in 64.96s, so the guard costs nothing on a healthy phase.

Incidentally this also answers the triage question those runs were dispatched for: the hang does not reproduce on the image it first appeared on, so R292 looks like a rare race rather than a regression - which is the case this PR is meant to contain rather than fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31543110660](https://github.com/sgl-project/sglang/actions/runs/31543110660)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31543110390](https://github.com/sgl-project/sglang/actions/runs/31543110390)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
