### PR TITLE
[PD][AMD] Release the MoRI transfer worker when a KV transfer trips its SLA

### DIFF
--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1499,7 +1499,6 @@ class MoriKVSender(CommonKVSender):
 
         start = time.perf_counter()
         sla_ms = self.kv_mgr._transfer_timeout_ms
-        sla_tripped = False
 
         while True:
             rc = self.kv_mgr.engine.wait_all(
@@ -1507,13 +1506,14 @@ class MoriKVSender(CommonKVSender):
             )
             if rc != StatusCode.IN_PROGRESS:
                 return rc
-            if (
-                sla_ms > 0
-                and not sla_tripped
-                and (time.perf_counter() - start) * 1000 >= sla_ms
-            ):
-                sla_tripped = True
+            if sla_ms > 0 and (time.perf_counter() - start) * 1000 >= sla_ms:
+                # The room is already concluded Failed and decode has been
+                # notified, so nothing can consume a later completion. Give the
+                # shard worker back instead of spinning on it forever: there are
+                # only SGLANG_MORI_TRANSFER_SHARDS of them, and every thread
+                # parked here is one fewer for the transfers still to come.
                 self._finalize_failure(f"KV transfer exceeded SLA {sla_ms}ms")
+                return rc
 
     def _fail_from_worker(self, reason: str) -> None:
         self._finalize_failure(reason)


### PR DESCRIPTION
## Motivation

`MoriKVSender._wait_chunk` polls `engine.wait_all` in a `while True` loop. When the transfer exceeds `SGLANG_MORI_TRANSFER_TIMEOUT_MS` it marks the request failed via `_finalize_failure`, sets `sla_tripped` so it will not do so again — and then keeps looping. Since the transfer is by definition not completing, the loop never exits and the shard worker thread running it never returns to its queue.

Those threads are a fixed pool: `SGLANG_MORI_TRANSFER_SHARDS` of them (4 by default), started once in `MoriKVManager.__init__` and shared by every request hashed to that shard. So a handful of SLA-tripped transfers permanently wedge all later KV transfers on the rank, and because the SLA path only notifies decode of the failure, there is no error on the prefill side pointing at the cause.

Found while investigating an unrelated PD hang; it is not the cause of that hang.

## Modifications

Return from `_wait_chunk` once the SLA trips.

`_finalize_failure` has already concluded the room `Failed` and notified decode, so no later completion can be consumed by anyone — continuing to wait buys nothing. `_run_chunk` checks `conclude_state` before it looks at the returned rc, so the early return cannot cause a double finalize.

Also drops the now-redundant `sla_tripped` flag.

## Scope

Latent on current defaults: `SGLANG_MORI_TRANSFER_TIMEOUT_MS` is `EnvInt(0)`, and `sla_ms > 0` gates the whole branch, so stock deployments never enter it (they wait forever instead, which is its own discussion). Only deployments that set the deadline are exposed today. This PR does not change that default.

## Tests

`pre-commit run --files python/sglang/srt/disaggregation/mori/conn.py` clean. No behavioural test added: reaching this path needs a real MoRI RDMA transfer that stalls past the SLA, which the existing disaggregation unit tests do not model.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30310452156](https://github.com/sgl-project/sglang/actions/runs/30310452156)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30310451943](https://github.com/sgl-project/sglang/actions/runs/30310451943)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->