### PR TITLE
[LoRA] 1/n Per-rank tensor serialization for load_lora_adapter_from_tensors under dp_size > 1

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1373,10 +1373,11 @@ class Engine(EngineScoreMixin, EngineBase):
             return normalize_serialized_named_tensor_payloads(
                 cast(List[SerializedTensorPayload], tensors)
             )
-        return [
-            MultiprocessingSerializer.serialize(tensors)
-            for _ in range(self.server_args.tp_size)
-        ]
+        else:
+            return [
+                MultiprocessingSerializer.serialize(tensors)
+                for _ in range(self.server_args.tp_size)
+            ]
 
     def load_lora_adapter_from_tensors(
         self,

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1308,15 +1308,9 @@ class Engine(EngineScoreMixin, EngineBase):
     ):
         """Update weights from distributed source. If there are going to be more updates, set `flush_cache` to be false
         to avoid duplicated cache cleaning operation."""
-        if load_format == "flattened_bucket":
-            serialized_named_tensors = normalize_serialized_named_tensor_payloads(
-                cast(List[SerializedTensorPayload], named_tensors)
-            )
-        else:
-            serialized_named_tensors = [
-                MultiprocessingSerializer.serialize(named_tensors)
-                for _ in range(self.server_args.tp_size)
-            ]
+        serialized_named_tensors = self._serialize_tensors_per_rank(
+            named_tensors, load_format
+        )
         obj = UpdateWeightsFromTensorReqInput(
             serialized_named_tensors=serialized_named_tensors,
             load_format=load_format,
@@ -1367,23 +1361,37 @@ class Engine(EngineScoreMixin, EngineBase):
             self.tokenizer_manager.get_weights_by_name(obj, None)
         )
 
+    def _serialize_tensors_per_rank(
+        self,
+        tensors,
+        load_format: Optional[str],
+    ) -> List[bytes]:
+        """One serialized payload per TP rank: each rank deserializes only its
+        own copy, so producer-side CUDA-IPC refcounts drop cleanly after every
+        load. flattened_bucket callers pass pre-serialized per-rank payloads."""
+        if load_format == "flattened_bucket":
+            return normalize_serialized_named_tensor_payloads(
+                cast(List[SerializedTensorPayload], tensors)
+            )
+        return [
+            MultiprocessingSerializer.serialize(tensors)
+            for _ in range(self.server_args.tp_size)
+        ]
+
     def load_lora_adapter_from_tensors(
         self,
         lora_name: str,
-        tensors,
+        tensors: Union[Dict[str, torch.Tensor], List[SerializedTensorPayload]],
         config_dict: Dict,
         load_format: Optional[str] = None,
     ):
-        if load_format == "flattened_bucket":
-            serialized_tensors = tensors
-        else:
-            serialized_tensors = MultiprocessingSerializer.serialize(
-                tensors, output_str=True
-            )
+        serialized_named_tensors = self._serialize_tensors_per_rank(
+            tensors, load_format
+        )
         lora_req = LoadLoRAAdapterFromTensorsReqInput(
             lora_name=lora_name,
             config_dict=config_dict,
-            serialized_tensors=serialized_tensors,
+            serialized_named_tensors=serialized_named_tensors,
             load_format=load_format,
         )
         return self.loop.run_until_complete(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2036,7 +2036,10 @@ class LoadLoRAAdapterFromTensorsReqInput(BaseReq, kw_only=True):
     # The PEFT adapter_config.json, already JSON — a tighter type would only add
     # decode strictness with no benefit.
     config_dict: Dict[str, Any]
-    serialized_tensors: str
+    # One serialized copy of the adapter tensors per TP rank; each rank
+    # deserializes only its own copy. Same normalization conventions as
+    # UpdateWeightsFromTensorReqInput.serialized_named_tensors.
+    serialized_named_tensors: Annotated[List[bytes], Base64Bytes()]
     pinned: bool = False
     added_tokens_config: Optional[Dict[str, int]] = None
     lora_id: Optional[str] = None

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -653,11 +653,15 @@ class TokenizerControlMixin:
                 )
 
             assert (
-                self.server_args.dp_size == 1
-            ), "dp_size must be 1 for dynamic lora loading"
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
             logger.info(
                 "Start load Lora adapter from tensors. Lora name=%s",
                 obj.lora_name,
+            )
+
+            obj.serialized_named_tensors = normalize_serialized_named_tensor_payloads(
+                obj.serialized_named_tensors
             )
 
             async with self.lora_update_lock:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -173,12 +173,19 @@ class BaseTpWorker(ABC):
         )
         return success, message
 
-    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
-
+    def _deserialize_own_rank(self, serialized_named_tensors):
+        """Each rank deserializes only its own payload (index ps.tp_rank);
+        deserializing another rank's copy would break producer-side CUDA-IPC
+        refcounting."""
         monkey_patch_torch_reductions()
+        return MultiprocessingSerializer.deserialize(
+            serialized_named_tensors[self.ps.tp_rank]
+        )
+
+    def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
         success, message = self.model_runner.weight_updater.update_weights_from_tensor(
-            named_tensors=MultiprocessingSerializer.deserialize(
-                recv_req.serialized_named_tensors[self.ps.tp_rank]
+            named_tensors=self._deserialize_own_rank(
+                recv_req.serialized_named_tensors
             ),
             load_format=recv_req.load_format,
         )
@@ -209,18 +216,16 @@ class BaseTpWorker(ABC):
         self, recv_req: LoadLoRAAdapterFromTensorsReqInput
     ):
         # The LoRA code handles TP sharding internally using slice_lora_a_weights
-        # and slice_lora_b_weights methods (see lora/layers.py:46-49, mem_pool.py:437-440).
+        # and slice_lora_b_weights methods (see lora/layers.py and mem_pool.py).
+        data = self._deserialize_own_rank(recv_req.serialized_named_tensors)
         if recv_req.load_format == "flattened_bucket":
-            flattened_data = MultiprocessingSerializer.deserialize(
-                recv_req.serialized_tensors
-            )
             bucket = FlattenedTensorBucket(
-                flattened_tensor=flattened_data["flattened_tensor"],
-                metadata=flattened_data["metadata"],
+                flattened_tensor=data["flattened_tensor"],
+                metadata=data["metadata"],
             )
             tensors = dict(bucket.reconstruct_tensors())
         else:
-            tensors = MultiprocessingSerializer.deserialize(recv_req.serialized_tensors)
+            tensors = data
         if recv_req.expected_checksums is not None:
             import hashlib
 
@@ -245,12 +250,12 @@ class BaseTpWorker(ABC):
             extra = [n for n in tensors if n not in exp]
             if mismatch or missing or extra:
                 raise RuntimeError(
-                    f"[LORA-CHECK] rank{self.tp_rank} adapter sync MISMATCH of {len(exp)} expected: "
+                    f"[LORA-CHECK] rank{self.ps.tp_rank} adapter sync MISMATCH of {len(exp)} expected: "
                     f"{len(mismatch)} value-diff {mismatch[:5]}, {len(missing)} missing {missing[:5]}, "
                     f"{len(extra)} extra {extra[:5]}"
                 )
             logger.info(
-                f"[LORA-CHECK] rank{self.tp_rank} adapter sync OK: {len(exp)}/{len(exp)} tensors match (sha256)"
+                f"[LORA-CHECK] rank{self.ps.tp_rank} adapter sync OK: {len(exp)}/{len(exp)} tensors match (sha256)"
             )
         result = self.model_runner.load_lora_adapter_from_tensors(
             recv_req.to_ref(),

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -184,9 +184,7 @@ class BaseTpWorker(ABC):
 
     def update_weights_from_tensor(self, recv_req: UpdateWeightsFromTensorReqInput):
         success, message = self.model_runner.weight_updater.update_weights_from_tensor(
-            named_tensors=self._deserialize_own_rank(
-                recv_req.serialized_named_tensors
-            ),
+            named_tensors=self._deserialize_own_rank(recv_req.serialized_named_tensors),
             load_format=recv_req.load_format,
         )
         return success, message

--- a/test/registered/rl/test_lora_load_from_tensor.py
+++ b/test/registered/rl/test_lora_load_from_tensor.py
@@ -342,9 +342,11 @@ class TestLoRALoadFromTensor(CustomTestCase):
         }
         serialized = MultiprocessingSerializer.serialize(bucket_dict, output_str=True)
 
+        # flattened_bucket callers pass one serialized copy per TP rank, same
+        # as Engine.update_weights_from_tensor.
         result = self.engine.load_lora_adapter_from_tensors(
             lora_name="self_cognition_Alice_flattened",
-            tensors=serialized,
+            tensors=[serialized],
             config_dict=self.lora_config_dict,
             load_format="flattened_bucket",
         )

--- a/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
+++ b/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
@@ -126,7 +126,7 @@ REGISTRY_TYPE_INSTANCES = {
     "LoadLoRAAdapterFromTensorsReqInput": LoadLoRAAdapterFromTensorsReqInput(
         lora_name="adapter",
         config_dict={"r": 8, "lora_alpha": 16, "target_modules": ["q_proj", "v_proj"]},
-        serialized_tensors="",
+        serialized_named_tensors=[b"tp0-bytes", b"tp1-bytes"],
         added_tokens_config={"<extra>": 32000},
     ),
     "DumperControlReqInput": DumperControlReqInput(method="start", body={"k": "v"}),


### PR DESCRIPTION
## Goal
split https://github.com/sgl-project/sglang/pull/31520 
Support `Engine.load_lora_adapter_from_tensors` (the RL weight-sync flow) with `dp_size > 1` under DP attention.

## Why the current code fails

It serializes the adapter tensors once and ships the same CUDA-IPC payload to every TP rank. Deserializing one payload on multiple ranks breaks producer-side IPC refcounting, and the endpoint asserts `dp_size == 1`.

## How

- One serialized payload per TP rank (`serialized_named_tensors: List[bytes]`), each rank deserializes only its own — the exact `update_weights_from_tensor` contract.
- Shared helpers keep the two flows from drifting: `Engine._serialize_tensors_per_rank()` and `TpWorker._deserialize_own_rank()`.
- Relax the endpoint assert to `dp_size == 1 or enable_dp_attention`.

Breaking: `flattened_bucket` callers now pass a per-rank list instead of a single string.

Depends on #32584 for the DP-attention runtime side; split out of #31520 for review.

## Tests

- `test/registered/unit/managers/test_msgpack_ipc_roundtrip.py`: 7 passed.
- `test/registered/rl/test_lora_load_from_tensor.py`: 4 passed on H200 (covers the per-rank path incl. flattened_bucket).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30322921297](https://github.com/sgl-project/sglang/actions/runs/30322921297)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30322921156](https://github.com/sgl-project/sglang/actions/runs/30322921156)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
