### PR TITLE
[LoRA] Support LoRA under DP attention: idle-forward guards, attn-TP-local slicing and buffer sharding

### DIFF
--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 import triton
@@ -26,6 +26,10 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
     def __init__(self, max_loras_per_batch: int, device: torch.device):
         self.max_loras_per_batch = max_loras_per_batch
         self.device = device
+        # Set by prepare_lora_batch() before each forward; cleared by
+        # reset_batch_state() on DP-attention idle forwards. None means "no
+        # batch prepared" — the LoRA layers read it to skip LoRA application.
+        self.batch_info: Optional[LoRABatchInfo] = None
         self.init_lm_head_config()
         self._is_moe_lora = False
         # Static metadata read by prefill-CUDA-graph kernels, refreshed in
@@ -34,6 +38,15 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         # Request/token caps for serving a batch from the static metadata.
         self.prefill_cuda_graph_max_bs: int | None = None
         self.prefill_cuda_graph_max_tokens: int | None = None
+
+    def reset_batch_state(self):
+        """Idle-forward counterpart of prepare_lora_batch(): clears all
+        per-batch metadata. batch_info=None is the master "no batch
+        prepared" signal that the layer guards (lora_active) read."""
+        self.batch_info = None
+        self.lm_head_batch_info = None
+        self.lm_head_pass_batch_infos = None
+        self._lm_head_pass_idx = None
 
     def run_lora_a_embedding(
         self,

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -32,6 +32,13 @@ class TritonLoRABackend(BaseLoRABackend):
         **kwargs,
     ):
         super().__init__(max_loras_per_batch, device)
+        # Merged-segment variant of batch_info; set alongside it in
+        # prepare_lora_batch and cleared together in reset_batch_state.
+        self.sgemm_batch_info: Optional[LoRABatchInfo] = None
+
+    def reset_batch_state(self):
+        super().reset_batch_state()
+        self.sgemm_batch_info = None
 
     def run_lora_a_embedding(
         self,
@@ -55,7 +62,12 @@ class TritonLoRABackend(BaseLoRABackend):
         """Return the sgemm batch_info (merged segments when available)."""
         if pruned_batch_info is not None:
             return pruned_batch_info
-        return getattr(self, "sgemm_batch_info", None) or self.batch_info
+        assert self.batch_info is not None, (
+            "LoRA kernel invoked with no prepared batch (DP-attention idle "
+            "forward?). Gate the caller on lora_active, as in "
+            "sglang/srt/lora/layers.py forwards."
+        )
+        return self.sgemm_batch_info or self.batch_info
 
     def run_lora_a_sgemm(
         self,

--- a/python/sglang/srt/lora/deepseek_mla_correction.py
+++ b/python/sglang/srt/lora/deepseek_mla_correction.py
@@ -46,8 +46,6 @@ def _get_state(
     if not hasattr(attn_module.kv_b_proj, "A_buffer"):
         return None
     lora_backend = attn_module.kv_b_proj.lora_backend
-    if not hasattr(lora_backend, "batch_info"):
-        return None
     batch_info = lora_backend.batch_info
     if batch_info is None:
         return None

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -45,9 +45,23 @@ class BaseLayerWithLoRA(nn.Module):
             self.weight = self.base_layer.weight
         if hasattr(self.base_layer, "bias") and self.base_layer.bias is not None:
             self.bias = self.base_layer.bias
+        # Forward reduce_results so model code that inspects it on the module
+        # (e.g. DeepseekV2AttentionMLA's `assert not self.o_proj.reduce_results`
+        # on DP-attention idle forwards) keeps working when the layer is
+        # LoRA-wrapped.
+        if hasattr(self.base_layer, "reduce_results"):
+            self.reduce_results = self.base_layer.reduce_results
 
     def forward(self, x: torch.Tensor):
         return self.base_layer.forward(x)
+
+    @property
+    def lora_active(self) -> bool:
+        """True when this layer has LoRA buffers set AND the current forward
+        has LoRA batch metadata. batch_info is None on DP-attention idle
+        forwards (see LoRAManager.prepare_lora_batch), so idle forwards take
+        the base path."""
+        return self.set_lora and self.lora_backend.batch_info is not None
 
     def set_lora_info(self, *args):
         pass
@@ -211,8 +225,9 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         ):
             base_output = self.extra_token_embedding(input_, base_output)
 
-        # Apply LoRA if configured
-        if self.set_lora:
+        # Apply LoRA if configured; DP-attention idle forwards take the base
+        # path (see lora_active).
+        if self.lora_active:
             # The backend's run_lora_a_embedding now handles both regular
             # and extra tokens efficiently with CUDA graph support
             base_output = self.apply_lora(base_output, input_, batch_info)
@@ -377,8 +392,7 @@ class ParallelLMHeadWithLoRA(BaseLayerWithLoRA):
             hidden_states, self.weight, bias=getattr(self.base_layer, "bias", None)
         )
 
-        # Apply LoRA if set
-        if self.set_lora:
+        if self.lora_active:
             base_output = self.apply_lora(base_output, hidden_states)
 
         return base_output
@@ -467,7 +481,7 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
             self.base_layer, input_, bias
         )
 
-        if self.set_lora:
+        if self.lora_active:
             output_parallel = self.apply_lora(output_parallel, input_)
 
         if self.base_layer.gather_output:
@@ -773,7 +787,8 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
             and not should_skip_mlp_all_reduce()
         )
 
-        if self.set_lora and should_reduce:
+        lora_active = self.lora_active
+        if lora_active and should_reduce:
             lora_a_output = self.lora_backend.run_lora_a_sgemm(
                 input_parallel, self.A_buffer
             )
@@ -787,7 +802,7 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
                 base_output=output_,
             )
         else:
-            if self.set_lora:
+            if lora_active:
                 output_parallel = self.apply_lora(output_parallel, input_parallel)
             if should_reduce:
                 output_ = tensor_model_parallel_all_reduce(output_parallel)
@@ -886,7 +901,7 @@ class ReplicatedLinearWithLoRA(BaseLayerWithLoRA):
     def forward(self, x: torch.Tensor):
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None
         output = self.base_layer.quant_method.apply(self.base_layer, x, bias)
-        if self.set_lora:
+        if self.lora_active:
             output = self.apply_lora(output, x)
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output, output_bias
@@ -1090,6 +1105,9 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         1. After gate_up projection, before activation
         2. After down projection, before final reduction
         """
+        # DP-attention idle forward: no batch_info, run the base MoE path.
+        if self.lora_backend.batch_info is None:
+            return self.base_layer.forward(hidden_states, topk_output, **kwargs)
 
         # Build LoRA info for this batch
         lora_info = self._get_lora_info()

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -66,10 +66,13 @@ class BaseLayerWithLoRA(nn.Module):
     def set_lora_info(self, *args):
         pass
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    # Weight slicing derives the shard rank from the wrapped base layer
+    # (base_layer.tp_rank): under DP attention, attention layers are built
+    # on the attn-TP group, so the outer/global TP rank would overshoot.
+    def slice_lora_a_weights(self, A: torch.Tensor):
         pass
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
         pass
 
 
@@ -234,13 +237,13 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
 
         return base_output
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
         # LoRA A weights (rank, vocab_size) are kept unsharded.
         # Each rank does a full embedding lookup; the result is complete
         # on every rank and added to the already all-reduced base output.
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
         # LoRA B weights (embedding_dim, rank) are kept unsharded.
         # The base embedding output is all-reduced (full embedding_dim),
         # so LoRA B must also produce full embedding_dim.
@@ -414,12 +417,12 @@ class ParallelLMHeadWithLoRA(BaseLayerWithLoRA):
         """Reset the lm_head pass index after all passes are done."""
         self.lora_backend._lm_head_pass_idx = None
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
         # LoRA A weights (rank, hidden_size) are kept unsharded.
         # Each rank receives full hidden_states, so A operates on full input.
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
         # lm_head is column-parallel: each rank produces vocab_size/tp_size (shard_vocab_size)
         # logits.  LoRA B (vocab_size, rank) must be sliced along the vocab
         # dimension to match the sharded base output.
@@ -491,13 +494,14 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output, output_bias
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
+        local_tp_rank = self.base_layer.tp_rank
         shard_size = self.base_layer.output_partition_sizes[0]
-        start_idx = tp_rank * shard_size
-        end_idx = (tp_rank + 1) * shard_size
+        start_idx = local_tp_rank * shard_size
+        end_idx = (local_tp_rank + 1) * shard_size
         B = B[start_idx:end_idx, :]
         return B
 
@@ -587,16 +591,17 @@ class MergedColumnParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
             )
         return lora_output
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
+        local_tp_rank = self.base_layer.tp_rank
         partition_sizes = self.base_layer.output_partition_sizes
         output_sizes = self.base_layer.output_sizes
         slices = []
         offset = 0
         for full_size, part_size in zip(output_sizes, partition_sizes):
-            start_idx = tp_rank * part_size
+            start_idx = local_tp_rank * part_size
             end_idx = start_idx + part_size
             slices.append(B[offset + start_idx : offset + end_idx, :])
             offset += full_size
@@ -613,8 +618,9 @@ class InklingQKVRLinearWithLoRA(MergedColumnParallelLinearWithLoRA):
     are head-partitioned uniformly. LoRA-A stays unsharded (inherited).
     """
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
         bl = self.base_layer
+        tp_rank = bl.tp_rank
         hd, nkv, nh, dr, tp = (
             bl.inkling_head_dim,
             bl.inkling_num_kv_heads,
@@ -692,19 +698,20 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
 
         return lora_output
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int) -> torch.Tensor:
+    def slice_lora_b_weights(self, B: torch.Tensor) -> torch.Tensor:
         base_layer = self.base_layer
         q_proj_shard_size = base_layer.q_proj_shard_size
         kv_proj_shard_size = base_layer.kv_proj_shard_size
         num_kv_head_replicas = base_layer.num_kv_head_replicas
+        local_tp_rank = base_layer.tp_rank
 
-        q_start_idx = q_proj_shard_size * tp_rank
+        q_start_idx = q_proj_shard_size * local_tp_rank
         q_end_idx = q_start_idx + q_proj_shard_size
 
-        kv_shard_id = tp_rank // num_kv_head_replicas
+        kv_shard_id = local_tp_rank // num_kv_head_replicas
         kv_start_idx = kv_proj_shard_size * kv_shard_id
         kv_end_idx = kv_start_idx + kv_proj_shard_size
 
@@ -787,13 +794,21 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
             and not should_skip_mlp_all_reduce()
         )
 
+        # Match the base layer's reduce group: layers built with
+        # use_dp_attention_reduce are sharded over the attn-TP group, so
+        # reducing over the global TP group would mix tokens across DP groups.
+        if self.base_layer.use_dp_attention_reduce:
+            all_reduce = get_parallel().attn_tp_group.all_reduce
+        else:
+            all_reduce = tensor_model_parallel_all_reduce
+
         lora_active = self.lora_active
         if lora_active and should_reduce:
             lora_a_output = self.lora_backend.run_lora_a_sgemm(
                 input_parallel, self.A_buffer
             )
-            output_ = tensor_model_parallel_all_reduce(output_parallel)
-            lora_a_output = tensor_model_parallel_all_reduce(lora_a_output)
+            output_ = all_reduce(output_parallel)
+            lora_a_output = all_reduce(lora_a_output)
             output_ = self.lora_backend.run_lora_b_sgemm(
                 x=lora_a_output,
                 weights=self.B_buffer,
@@ -805,21 +820,22 @@ class RowParallelLinearWithLoRA(BaseLayerWithLoRA):
             if lora_active:
                 output_parallel = self.apply_lora(output_parallel, input_parallel)
             if should_reduce:
-                output_ = tensor_model_parallel_all_reduce(output_parallel)
+                output_ = all_reduce(output_parallel)
             else:
                 output_ = output_parallel
 
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output_, output_bias
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
+        local_tp_rank = self.base_layer.tp_rank
         shard_size = self.base_layer.input_size_per_partition
-        start_idx = tp_rank * shard_size
-        end_idx = (tp_rank + 1) * shard_size
+        start_idx = local_tp_rank * shard_size
+        end_idx = (local_tp_rank + 1) * shard_size
         A = A[:, start_idx:end_idx].contiguous()
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
         return B
 
 
@@ -906,10 +922,10 @@ class ReplicatedLinearWithLoRA(BaseLayerWithLoRA):
         output_bias = self.base_layer.bias if self.base_layer.skip_bias_add else None
         return output, output_bias
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
         return B
 
 
@@ -1166,10 +1182,10 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
 
         return final_hidden_states
 
-    def slice_lora_a_weights(self, A: torch.Tensor, tp_rank: int):
+    def slice_lora_a_weights(self, A: torch.Tensor):
         return A
 
-    def slice_lora_b_weights(self, B: torch.Tensor, tp_rank: int):
+    def slice_lora_b_weights(self, B: torch.Tensor):
         return B
 
     def slice_moe_lora_a_weights(

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -46,6 +46,7 @@ from sglang.srt.lora.utils import (
 )
 from sglang.srt.managers.io_struct import LoRAUpdateOutput
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_available_gpu_memory, replace_submodule
 from sglang.srt.utils.hf_transformers_utils import AutoConfig
@@ -82,6 +83,9 @@ class LoRAManager:
         self.device: torch.device = next(self.base_model.parameters()).device
         self.tp_size: int = tp_size
         self.tp_rank: int = tp_rank
+        # Attention projections shard on the attn-TP group; extracted once
+        # here (parallel groups are frozen after init_torch_distributed).
+        self.attn_tp_size: int = get_parallel().attn_tp_size
         self.lora_added_tokens_size: Optional[int] = None
         self.enable_lora_overlap_loading: Optional[bool] = (
             server_args.enable_lora_overlap_loading
@@ -853,6 +857,7 @@ class LoRAManager:
             dtype=self.dtype,
             tp_size=self.tp_size,
             tp_rank=self.tp_rank,
+            attn_tp_size=self.attn_tp_size,
             max_lora_rank=self.max_lora_rank,
             target_modules=self.target_modules,
             base_model=self.base_model,

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -418,14 +418,14 @@ class LoRAManager:
                 if callable(notify):
                     notify(slot_ids)
 
-    def prepare_lora_batch(self, forward_batch: ForwardBatch):
-        if forward_batch.forward_mode.is_idle():
-            # DP-attention idle forward: zero local tokens; clear per-batch
-            # state so the LoRA layers take the base path instead of reading
-            # the previous batch's stale metadata.
-            self.lora_backend.reset_batch_state()
-            return
+    def reset_lora_batch(self):
+        """Clear per-batch LoRA state. Called instead of prepare_lora_batch()
+        on DP-attention idle forwards (zero local tokens), so the LoRA layers
+        take the base path instead of reading the previous batch's stale
+        metadata."""
+        self.lora_backend.reset_batch_state()
 
+    def prepare_lora_batch(self, forward_batch: ForwardBatch):
         # set up batch info shared by all lora modules
         bs = forward_batch.batch_size
 

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -415,6 +415,13 @@ class LoRAManager:
                     notify(slot_ids)
 
     def prepare_lora_batch(self, forward_batch: ForwardBatch):
+        if forward_batch.forward_mode.is_idle():
+            # DP-attention idle forward: zero local tokens; clear per-batch
+            # state so the LoRA layers take the base path instead of reading
+            # the previous batch's stale metadata.
+            self.lora_backend.reset_batch_state()
+            return
+
         # set up batch info shared by all lora modules
         bs = forward_batch.batch_size
 

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -27,12 +27,13 @@ from sglang.srt.lora.lora_config import LoRAConfig
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.lora.utils import (
     EMBEDDING_NAMES,
-    REPLICATED_LINEAR_LORA_NAMES,
-    ROW_PARALLELISM_LINEAR_LORA_NAMES,
+    LoRAParallelism,
+    LoRAShardGroup,
     LoRAType,
     copy_weight_into_buffer,
     get_hidden_dim,
     get_lm_head_lora_b_shard_size,
+    get_lora_shard_spec,
     get_normalized_target_modules,
     get_stacked_multiply,
     get_target_module_name,
@@ -137,6 +138,7 @@ class LoRAMemoryPool:
         dtype: torch.dtype,
         tp_size: int,
         tp_rank: int,
+        attn_tp_size: int,
         max_lora_rank: int,
         target_modules: Set[str],
         base_model: torch.nn.Module,
@@ -182,9 +184,14 @@ class LoRAMemoryPool:
         # here would yield a 4x-narrower inner dim than the adapter weight
         # (which MoE LoRA modules correctly skip-slice when
         # `moe_tp_size <= 1`), producing a shape-mismatch
-        # assert during weight load. Non-MoE modules still shard by
-        # `tp_size` because attention TP is unchanged.
+        # assert during weight load.
         self.moe_tp_size, self.moe_tp_rank = _get_moe_tp_context()
+
+        # Attention projections shard along the attention TP group, which
+        # under `--enable-dp-attention` is `attn_tp_size = tp_size // dp_size`.
+        # The corresponding LoRA wrappers slice weights by the base layer's
+        # attn_tp-local rank, so the buffer shapes must match that shard.
+        self.attn_tp_size: int = attn_tp_size
 
         # Initialize eviction policy
         self.eviction_policy = get_eviction_policy(eviction_policy)
@@ -254,6 +261,19 @@ class LoRAMemoryPool:
     def is_moe_module(self, module_name: str) -> bool:
         """Check if module is part of MoE experts."""
         return "moe" in module_name
+
+    def _effective_tp_size(self, module_name: str) -> int:
+        """TP width the module's weights are actually sharded along: routed
+        MoE experts shard by `moe_tp_size` (shared experts by the outer
+        `tp_size` at EP=1), attention projections by `attn_tp_size` (smaller
+        than the outer `tp_size` under `--enable-dp-attention`), everything
+        else by the outer `tp_size`."""
+        _, shard_group = get_lora_shard_spec(module_name)
+        if shard_group is LoRAShardGroup.MOE_TP:
+            return self.moe_tp_size
+        if shard_group is LoRAShardGroup.ATTN_TP:
+            return self.attn_tp_size
+        return self.tp_size
 
     @staticmethod
     def is_shared_moe_module(module_name: str) -> bool:
@@ -354,22 +374,6 @@ class LoRAMemoryPool:
             f"Expected dict or 3D torch.Tensor, got {type(weights).__name__}."
         )
 
-    def _get_standard_shape(
-        self,
-        module_name: str,
-        base_model: torch.nn.Module,
-        max_lora_dim: int,
-        layer_idx: int,
-    ) -> Tuple[int]:
-        """Get 3D shape for standard (non-MoE) modules."""
-        input_dim, _ = get_hidden_dim(
-            module_name, self.base_hf_config, base_model, layer_idx
-        )
-        c = get_stacked_multiply(module_name, base_model)
-        if self.tp_size > 1 and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES:
-            input_dim = divide(input_dim, self.tp_size)
-        return (self.max_loras_per_batch, max_lora_dim * c, input_dim)
-
     def get_lora_A_shape(
         self,
         module_name: str,
@@ -388,18 +392,9 @@ class LoRAMemoryPool:
             module_name, self.base_hf_config, base_model, layer_idx
         )
         c = get_stacked_multiply(module_name, base_model)
-        # Routed MoE shards along moe_tp_size; shared MoE shards over full TP at EP=1.
-        effective_tp_size = (
-            self.tp_size
-            if not self.is_moe_module(module_name)
-            or self.is_shared_moe_module(module_name)
-            else self.moe_tp_size
-        )
-        if (
-            effective_tp_size > 1
-            and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES
-            and module_name not in REPLICATED_LINEAR_LORA_NAMES
-        ):
+        effective_tp_size = self._effective_tp_size(module_name)
+        parallelism, _ = get_lora_shard_spec(module_name)
+        if effective_tp_size > 1 and parallelism is LoRAParallelism.ROW:
             input_dim = divide(input_dim, effective_tp_size)
 
         if self.is_moe_module(module_name):
@@ -491,18 +486,9 @@ class LoRAMemoryPool:
         _, output_dim = get_hidden_dim(
             module_name, self.base_hf_config, base_model, layer_idx
         )
-        # Same TP-vs-moe-TP sharding rule as get_lora_A_shape above.
-        effective_tp_size = (
-            self.tp_size
-            if not self.is_moe_module(module_name)
-            or self.is_shared_moe_module(module_name)
-            else self.moe_tp_size
-        )
-        if (
-            effective_tp_size > 1
-            and module_name not in ROW_PARALLELISM_LINEAR_LORA_NAMES
-            and module_name not in REPLICATED_LINEAR_LORA_NAMES
-        ):
+        effective_tp_size = self._effective_tp_size(module_name)
+        parallelism, _ = get_lora_shard_spec(module_name)
+        if effective_tp_size > 1 and parallelism is LoRAParallelism.COLUMN:
             output_dim = self._column_parallel_lora_b_per_rank_dim(
                 module_name, output_dim, effective_tp_size
             )
@@ -1067,7 +1053,7 @@ class LoRAMemoryPool:
 
                 # Handle standard modules
                 temp_A_buffer[target_module] = module.slice_lora_a_weights(
-                    temp_A_buffer[target_module], self.tp_rank
+                    temp_A_buffer[target_module]
                 )
                 cache_keys = temp_A_cache_keys[target_module]
                 assert cache_keys is not None
@@ -1077,7 +1063,7 @@ class LoRAMemoryPool:
                 )
 
                 temp_B_buffer[target_module] = module.slice_lora_b_weights(
-                    temp_B_buffer[target_module], self.tp_rank
+                    temp_B_buffer[target_module]
                 )
                 cache_keys = temp_B_cache_keys[target_module]
                 assert cache_keys is not None
@@ -1413,7 +1399,7 @@ class LoRAMemoryPool:
                     # Slice B along vocab dimension for this TP rank
                     if self.tp_size > 1:
                         lora_b_weights = lora_lm_head_module.slice_lora_b_weights(
-                            lora_b_weights, self.tp_rank
+                            lora_b_weights
                         )
                         cache_key = append_cache_key_suffix(name, f"tp{self.tp_rank}")
                     else:

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -26,14 +26,14 @@ from sglang.srt.lora.lora import LoRAAdapter
 from sglang.srt.lora.lora_config import LoRAConfig
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.lora.utils import (
+    ATTN_TP_LORA_MODULE_NAMES,
     EMBEDDING_NAMES,
-    LoRAParallelism,
-    LoRAShardGroup,
+    REPLICATED_LINEAR_LORA_NAMES,
+    ROW_PARALLELISM_LINEAR_LORA_NAMES,
     LoRAType,
     copy_weight_into_buffer,
     get_hidden_dim,
     get_lm_head_lora_b_shard_size,
-    get_lora_shard_spec,
     get_normalized_target_modules,
     get_stacked_multiply,
     get_target_module_name,
@@ -262,23 +262,24 @@ class LoRAMemoryPool:
         """Check if module is part of MoE experts."""
         return "moe" in module_name
 
+    @staticmethod
+    def is_shared_moe_module(module_name: str) -> bool:
+        """Whether this buffer belongs to the shared-expert MoE namespace."""
+        return module_name.endswith("_shared_moe")
+
     def _effective_tp_size(self, module_name: str) -> int:
         """TP width the module's weights are actually sharded along: routed
         MoE experts shard by `moe_tp_size` (shared experts by the outer
         `tp_size` at EP=1), attention projections by `attn_tp_size` (smaller
         than the outer `tp_size` under `--enable-dp-attention`), everything
         else by the outer `tp_size`."""
-        _, shard_group = get_lora_shard_spec(module_name)
-        if shard_group is LoRAShardGroup.MOE_TP:
+        if self.is_moe_module(module_name) and not self.is_shared_moe_module(
+            module_name
+        ):
             return self.moe_tp_size
-        if shard_group is LoRAShardGroup.ATTN_TP:
+        if module_name in ATTN_TP_LORA_MODULE_NAMES:
             return self.attn_tp_size
         return self.tp_size
-
-    @staticmethod
-    def is_shared_moe_module(module_name: str) -> bool:
-        """Whether this buffer belongs to the shared-expert MoE namespace."""
-        return module_name.endswith("_shared_moe")
 
     @staticmethod
     def _get_num_experts(base_model: torch.nn.Module) -> int:
@@ -374,6 +375,22 @@ class LoRAMemoryPool:
             f"Expected dict or 3D torch.Tensor, got {type(weights).__name__}."
         )
 
+    def _get_standard_shape(
+        self,
+        module_name: str,
+        base_model: torch.nn.Module,
+        max_lora_dim: int,
+        layer_idx: int,
+    ) -> Tuple[int]:
+        """Get 3D shape for standard (non-MoE) modules."""
+        input_dim, _ = get_hidden_dim(
+            module_name, self.base_hf_config, base_model, layer_idx
+        )
+        c = get_stacked_multiply(module_name, base_model)
+        if self.tp_size > 1 and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES:
+            input_dim = divide(input_dim, self.tp_size)
+        return (self.max_loras_per_batch, max_lora_dim * c, input_dim)
+
     def get_lora_A_shape(
         self,
         module_name: str,
@@ -393,8 +410,11 @@ class LoRAMemoryPool:
         )
         c = get_stacked_multiply(module_name, base_model)
         effective_tp_size = self._effective_tp_size(module_name)
-        parallelism, _ = get_lora_shard_spec(module_name)
-        if effective_tp_size > 1 and parallelism is LoRAParallelism.ROW:
+        if (
+            effective_tp_size > 1
+            and module_name in ROW_PARALLELISM_LINEAR_LORA_NAMES
+            and module_name not in REPLICATED_LINEAR_LORA_NAMES
+        ):
             input_dim = divide(input_dim, effective_tp_size)
 
         if self.is_moe_module(module_name):
@@ -486,9 +506,13 @@ class LoRAMemoryPool:
         _, output_dim = get_hidden_dim(
             module_name, self.base_hf_config, base_model, layer_idx
         )
+        # Same sharding rule as get_lora_A_shape above.
         effective_tp_size = self._effective_tp_size(module_name)
-        parallelism, _ = get_lora_shard_spec(module_name)
-        if effective_tp_size > 1 and parallelism is LoRAParallelism.COLUMN:
+        if (
+            effective_tp_size > 1
+            and module_name not in ROW_PARALLELISM_LINEAR_LORA_NAMES
+            and module_name not in REPLICATED_LINEAR_LORA_NAMES
+        ):
             output_dim = self._column_parallel_lora_b_per_rank_dim(
                 module_name, output_dim, effective_tp_size
             )

--- a/python/sglang/srt/lora/trtllm_lora_temp/attention.py
+++ b/python/sglang/srt/lora/trtllm_lora_temp/attention.py
@@ -36,7 +36,7 @@ def qkv_proj_lora_forward(self, input_: torch.Tensor):
     AND base_output, so it runs after the rejoin on the main stream.
     """
     if (
-        not self.set_lora
+        not self.lora_active
         or not is_two_stream_active(input_)
         or not supports_two_stream_dense_lora(self.A_buffer_qkv, self.B_buffer_qkv)
     ):
@@ -104,7 +104,7 @@ def row_parallel_lora_forward(
         input_parallel = splitted_input[tp_rank].contiguous()
 
     if (
-        not self.set_lora
+        not self.lora_active
         or not is_two_stream_active(input_parallel)
         or not supports_two_stream_dense_lora(self.A_buffer, self.B_buffer)
     ):
@@ -176,7 +176,7 @@ def column_parallel_lora_forward(self, input_: torch.Tensor):
     for non-decode batches or when LoRA isn't set on this layer.
     """
     if (
-        not self.set_lora
+        not self.lora_active
         or not is_two_stream_active(input_)
         or not supports_two_stream_dense_lora(self.A_buffer, self.B_buffer)
     ):
@@ -231,7 +231,7 @@ def replicated_lora_forward(self, x: torch.Tensor):
     the main after the rejoin. Falls back to the saved-original otherwise.
     """
     if (
-        not self.set_lora
+        not self.lora_active
         or not is_two_stream_active(x)
         or not supports_two_stream_dense_lora(self.A_buffer, self.B_buffer)
     ):

--- a/python/sglang/srt/lora/trtllm_lora_temp/merged_column.py
+++ b/python/sglang/srt/lora/trtllm_lora_temp/merged_column.py
@@ -31,7 +31,7 @@ from sglang.srt.lora.trtllm_lora_temp import (
 def merged_column_lora_forward(self, input_: torch.Tensor):
     """O9 — side-stream LoRA-A shrink ‖ base merged-column GEMM."""
     if (
-        not self.set_lora
+        not self.lora_active
         or not is_two_stream_active(input_)
         or not supports_two_stream_dense_lora(self.A_buffer, self.B_buffer)
     ):

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -323,23 +323,72 @@ def get_target_module_name(full_module_name: str, target_modules: Set[str]) -> s
 
 
 EMBEDDING_NAMES = ["embed_tokens", "lm_head"]
-ROW_PARALLELISM_LINEAR_LORA_NAMES = [
-    "o_proj",
-    "out_proj",
-    "down_proj",
-    "down_proj_moe",
-    "down_proj_shared_moe",
-    "wo_ud",
-]
 DSA_INDEXER_LORA_NAMES = frozenset(
     {"indexer.wq_b", "indexer.wk", "indexer.weights_proj"}
 )
-REPLICATED_LINEAR_LORA_NAMES = [
-    "fused_qkv_a_proj_with_mqa",
-    "fc1_latent_proj",
-    "fc2_latent_proj",
-    *DSA_INDEXER_LORA_NAMES,
-]
+
+
+class LoRAParallelism(Enum):
+    COLUMN = "column"
+    ROW = "row"
+    REPLICATED = "replicated"
+
+
+class LoRAShardGroup(Enum):
+    """Which TP group shards a module's weights. Under
+    `--enable-dp-attention`, ATTN_TP means `attn_tp_size = tp_size // dp_size`
+    rather than the outer `tp_size`; MOE_TP is the routed-expert TP width."""
+
+    GLOBAL_TP = "global_tp"
+    ATTN_TP = "attn_tp"
+    MOE_TP = "moe_tp"
+
+
+# One row per linear LoRA module name: (parallelism, shard group). A module's
+# buffer shapes and slicing both follow this table, so adding a module states
+# both sharding decisions in one place instead of across parallel name lists.
+LORA_LINEAR_SHARD_SPECS: dict[str, Tuple[LoRAParallelism, LoRAShardGroup]] = {
+    # Attention projections: sharded on the attention TP group.
+    "qkv_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
+    "qkvr": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
+    "q_b_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
+    "kv_b_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
+    "o_proj": (LoRAParallelism.ROW, LoRAShardGroup.ATTN_TP),
+    "out_proj": (LoRAParallelism.ROW, LoRAShardGroup.ATTN_TP),
+    "wo_ud": (LoRAParallelism.ROW, LoRAShardGroup.ATTN_TP),
+    # Linear-attention input projections: their layers switch to the attn-TP
+    # group under `--enable-dp-attention` (mamba.py sets tp_size/tp_rank from
+    # attn_tp when dp-attention is enabled; qwen3_5.py builds in_proj_qkvz
+    # with tp_rank=attn_tp_rank), so their LoRA buffers must too.
+    "in_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
+    "in_proj_qkvz": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
+    # Dense MLP: sharded on the outer TP group.
+    "up_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP),
+    "gate_up_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP),
+    "down_proj": (LoRAParallelism.ROW, LoRAShardGroup.GLOBAL_TP),
+    # Routed MoE experts shard by moe_tp; shared experts by the outer TP.
+    "gate_up_proj_moe": (LoRAParallelism.COLUMN, LoRAShardGroup.MOE_TP),
+    "down_proj_moe": (LoRAParallelism.ROW, LoRAShardGroup.MOE_TP),
+    "gate_up_proj_shared_moe": (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP),
+    "down_proj_shared_moe": (LoRAParallelism.ROW, LoRAShardGroup.GLOBAL_TP),
+    # Replicated projections: never sharded.
+    "fused_qkv_a_proj_with_mqa": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
+    "fc1_latent_proj": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
+    "fc2_latent_proj": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
+    "indexer.wq_b": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
+    "indexer.wk": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
+    "indexer.weights_proj": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
+}
+
+
+def get_lora_shard_spec(module_name: str) -> Tuple[LoRAParallelism, LoRAShardGroup]:
+    """Sharding spec for a linear LoRA module. Non-linear modules (embedding,
+    lm_head) default to column / outer-TP, matching the legacy list-based
+    membership checks."""
+    return LORA_LINEAR_SHARD_SPECS.get(
+        module_name, (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP)
+    )
+
 
 # Normalized module names that the LoRA system fully supports
 # (i.e. get_hidden_dim, init_buffers, and init_lora_modules can handle them).

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -323,72 +323,41 @@ def get_target_module_name(full_module_name: str, target_modules: Set[str]) -> s
 
 
 EMBEDDING_NAMES = ["embed_tokens", "lm_head"]
+ROW_PARALLELISM_LINEAR_LORA_NAMES = [
+    "o_proj",
+    "out_proj",
+    "down_proj",
+    "down_proj_moe",
+    "down_proj_shared_moe",
+    "wo_ud",
+]
 DSA_INDEXER_LORA_NAMES = frozenset(
     {"indexer.wq_b", "indexer.wk", "indexer.weights_proj"}
 )
-
-
-class LoRAParallelism(Enum):
-    COLUMN = "column"
-    ROW = "row"
-    REPLICATED = "replicated"
-
-
-class LoRAShardGroup(Enum):
-    """Which TP group shards a module's weights. Under
-    `--enable-dp-attention`, ATTN_TP means `attn_tp_size = tp_size // dp_size`
-    rather than the outer `tp_size`; MOE_TP is the routed-expert TP width."""
-
-    GLOBAL_TP = "global_tp"
-    ATTN_TP = "attn_tp"
-    MOE_TP = "moe_tp"
-
-
-# One row per linear LoRA module name: (parallelism, shard group). A module's
-# buffer shapes and slicing both follow this table, so adding a module states
-# both sharding decisions in one place instead of across parallel name lists.
-LORA_LINEAR_SHARD_SPECS: dict[str, Tuple[LoRAParallelism, LoRAShardGroup]] = {
-    # Attention projections: sharded on the attention TP group.
-    "qkv_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
-    "qkvr": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
-    "q_b_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
-    "kv_b_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
-    "o_proj": (LoRAParallelism.ROW, LoRAShardGroup.ATTN_TP),
-    "out_proj": (LoRAParallelism.ROW, LoRAShardGroup.ATTN_TP),
-    "wo_ud": (LoRAParallelism.ROW, LoRAShardGroup.ATTN_TP),
-    # Linear-attention input projections: their layers switch to the attn-TP
-    # group under `--enable-dp-attention` (mamba.py sets tp_size/tp_rank from
-    # attn_tp when dp-attention is enabled; qwen3_5.py builds in_proj_qkvz
-    # with tp_rank=attn_tp_rank), so their LoRA buffers must too.
-    "in_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
-    "in_proj_qkvz": (LoRAParallelism.COLUMN, LoRAShardGroup.ATTN_TP),
-    # Dense MLP: sharded on the outer TP group.
-    "up_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP),
-    "gate_up_proj": (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP),
-    "down_proj": (LoRAParallelism.ROW, LoRAShardGroup.GLOBAL_TP),
-    # Routed MoE experts shard by moe_tp; shared experts by the outer TP.
-    "gate_up_proj_moe": (LoRAParallelism.COLUMN, LoRAShardGroup.MOE_TP),
-    "down_proj_moe": (LoRAParallelism.ROW, LoRAShardGroup.MOE_TP),
-    "gate_up_proj_shared_moe": (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP),
-    "down_proj_shared_moe": (LoRAParallelism.ROW, LoRAShardGroup.GLOBAL_TP),
-    # Replicated projections: never sharded.
-    "fused_qkv_a_proj_with_mqa": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
-    "fc1_latent_proj": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
-    "fc2_latent_proj": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
-    "indexer.wq_b": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
-    "indexer.wk": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
-    "indexer.weights_proj": (LoRAParallelism.REPLICATED, LoRAShardGroup.GLOBAL_TP),
-}
-
-
-def get_lora_shard_spec(module_name: str) -> Tuple[LoRAParallelism, LoRAShardGroup]:
-    """Sharding spec for a linear LoRA module. Non-linear modules (embedding,
-    lm_head) default to column / outer-TP, matching the legacy list-based
-    membership checks."""
-    return LORA_LINEAR_SHARD_SPECS.get(
-        module_name, (LoRAParallelism.COLUMN, LoRAShardGroup.GLOBAL_TP)
-    )
-
+REPLICATED_LINEAR_LORA_NAMES = [
+    "fused_qkv_a_proj_with_mqa",
+    "fc1_latent_proj",
+    "fc2_latent_proj",
+    *DSA_INDEXER_LORA_NAMES,
+]
+# Attention-projection LoRA modules shard on the attention-TP group, which
+# under `--enable-dp-attention` is `attn_tp_size = tp_size // dp_size` rather
+# than the outer TP size. in_proj / in_proj_qkvz (linear-attention hybrids)
+# belong here too: their layers are built on the attn-TP group (mamba.py and
+# qwen3_5.py take tp_size/tp_rank from attn_tp when dp attention is enabled).
+ATTN_TP_LORA_MODULE_NAMES = frozenset(
+    {
+        "qkv_proj",
+        "qkvr",
+        "q_b_proj",
+        "kv_b_proj",
+        "o_proj",
+        "out_proj",
+        "wo_ud",
+        "in_proj",
+        "in_proj_qkvz",
+    }
+)
 
 # Normalized module names that the LoRA system fully supports
 # (i.e. get_hidden_dim, init_buffers, and init_lora_modules can handle them).

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -574,11 +574,9 @@ class TokenizerControlMixin:
                     "LoRA is not enabled. Please set `--enable-lora` to enable LoRA."
                 )
 
-            # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
-            # with dp_size > 1.
             assert (
-                self.server_args.dp_size == 1
-            ), "dp_size must be 1 for dynamic lora loading"
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
             logger.info(
                 "Start load Lora adapter. Lora name=%s, path=%s",
                 obj.lora_name,
@@ -730,11 +728,9 @@ class TokenizerControlMixin:
                 obj.lora_name is not None
             ), "lora_name must be provided to unload LoRA adapter"
 
-            # TODO (lifuhuang): Remove this after we verify that dynamic lora loading works
-            # with dp_size > 1.
             assert (
-                self.server_args.dp_size == 1
-            ), "dp_size must be 1 for dynamic lora loading"
+                self.server_args.dp_size == 1 or self.server_args.enable_dp_attention
+            ), "dp_size must be 1 or dp attention must be enabled for dynamic lora loading"
             logger.info(
                 "Start unload Lora adapter. Lora name=%s",
                 obj.lora_name,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -850,7 +850,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         if ret.forward_mode.is_idle():
             ret.positions = torch.empty((0,), dtype=torch.int64, device=device)
             if model_runner.server_args.enable_lora:
-                model_runner.lora_manager.prepare_lora_batch(ret)
+                model_runner.lora_manager.reset_lora_batch()
             return ret
 
         # Override the positions with diffusion LLM or spec_info

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -849,6 +849,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         if ret.forward_mode.is_idle():
             ret.positions = torch.empty((0,), dtype=torch.int64, device=device)
+            if model_runner.server_args.enable_lora:
+                model_runner.lora_manager.prepare_lora_batch(ret)
             return ret
 
         # Override the positions with diffusion LLM or spec_info

--- a/test/registered/unit/lora/test_mem_pool_ep_unit.py
+++ b/test/registered/unit/lora/test_mem_pool_ep_unit.py
@@ -101,10 +101,10 @@ class _FakeRoutedMoeLayer(_FakeFusedMoEWithLoRA, _IdentityMoeSlices):
 
 
 class _FakeDenseLayer:
-    def slice_lora_a_weights(self, weights, _rank):
+    def slice_lora_a_weights(self, weights):
         return weights
 
-    def slice_lora_b_weights(self, weights, _rank):
+    def slice_lora_b_weights(self, weights):
         return weights
 
 
@@ -994,6 +994,7 @@ class TestPoolInitPicksUpEpContext(unittest.TestCase):
                 dtype=torch.bfloat16,
                 tp_size=tp_size,
                 tp_rank=tp_rank,
+                attn_tp_size=tp_size,
                 max_lora_rank=8,
                 target_modules={"qkv_proj"},
                 base_model=base_model,
@@ -1089,6 +1090,9 @@ def _fake_base_model_with_hidden_dim(num_experts: int) -> torch.nn.Module:
                 return cfg.hidden_size, cfg.moe_intermediate_size * 2
             if module_name == "down_proj_moe":
                 return cfg.moe_intermediate_size, cfg.hidden_size
+            if module_name == "in_proj_qkvz":
+                # linear-attention qkvz input projection (column-parallel)
+                return cfg.hidden_size, 4 * cfg.hidden_size
             raise NotImplementedError(module_name)
 
     return _Model()
@@ -1119,6 +1123,9 @@ class TestMoeBufferShardsByMoeTp(unittest.TestCase):
         pool.max_loras_per_batch = 2
         pool.tp_size = tp_size
         pool.tp_rank = 0
+        # Without --enable-dp-attention the attention TP group equals the
+        # outer TP group.
+        pool.attn_tp_size = tp_size
         pool.moe_ep_size = ep_size
         pool.moe_ep_rank = ep_rank
         pool.moe_tp_size = moe_tp_size
@@ -1216,6 +1223,76 @@ class TestMoeBufferShardsByMoeTp(unittest.TestCase):
         q_b = pool.get_lora_B_shape("qkv_proj", model, 8, 0)
         # head_dim * (heads + 2*kv_heads) / tp_size = 8 * 24 / 4 = 48.
         self.assertEqual(q_b, (2, 48, 8))
+
+
+class TestAttnModulesShardByAttnTp(unittest.TestCase):
+    """Regression: attention-module LoRA buffers must shard by `attn_tp_size`,
+    not the outer `tp_size`.
+
+    Under `--enable-dp-attention` attention layers are built on the attn_tp
+    group (`attn_tp_size = tp_size // dp_size`), so e.g. MLA `o_proj` holds an
+    attn_tp-local input shard. Sizing the LoRA buffer by the outer `tp_size`
+    would make it narrower than the slice produced by
+    `RowParallelLinearWithLoRA.slice_lora_a_weights` (which slices by the base
+    layer's attn_tp-local rank), failing the shape-match assert at load time.
+    """
+
+    def _pool(self, *, tp_size: int, attn_tp_size: int) -> LoRAMemoryPool:
+        pool = LoRAMemoryPool.__new__(LoRAMemoryPool)
+        pool.max_loras_per_batch = 2
+        pool.tp_size = tp_size
+        pool.tp_rank = 0
+        pool.attn_tp_size = attn_tp_size
+        pool.moe_ep_size = 1
+        pool.moe_ep_rank = 0
+        pool.moe_tp_size = tp_size
+        pool.moe_tp_rank = 0
+        pool.moe_use_local_expert_ids = False
+        pool._num_experts_local = 1
+        pool.experts_shared_outer_loras = False
+        pool.base_hf_config = types.SimpleNamespace(
+            hidden_size=64,
+            num_attention_heads=8,
+            num_key_value_heads=8,
+            head_dim=8,
+            intermediate_size=256,
+            moe_intermediate_size=192,
+        )
+        return pool
+
+    def test_attn_tp_1_keeps_attention_buffers_full_width(self):
+        """tp=4 with attn_tp=1 (dp-attention, dp=4): attention weights are
+        replicated across ranks, so the LoRA buffers must be full-width.
+        """
+        pool = self._pool(tp_size=4, attn_tp_size=1)
+        model = _fake_base_model_with_hidden_dim(num_experts=1)
+        # o_proj is row-parallel: A input_dim = head_dim*num_heads = 64,
+        # undivided under attn_tp=1 (pre-fix: 16).
+        self.assertEqual(pool.get_lora_A_shape("o_proj", model, 8, 0), (2, 8, 64))
+        # qkv_proj is column-parallel: B output_dim = 8 * 24 = 192,
+        # undivided under attn_tp=1 (pre-fix: 48).
+        self.assertEqual(pool.get_lora_B_shape("qkv_proj", model, 8, 0), (2, 192, 8))
+
+    def test_attn_tp_gt1_still_shards_attention_buffers(self):
+        """tp=4 with attn_tp=2 (dp=2): attention weights are sharded 2-way."""
+        pool = self._pool(tp_size=4, attn_tp_size=2)
+        model = _fake_base_model_with_hidden_dim(num_experts=1)
+        self.assertEqual(pool.get_lora_A_shape("o_proj", model, 8, 0), (2, 8, 32))
+        self.assertEqual(pool.get_lora_B_shape("qkv_proj", model, 8, 0), (2, 96, 8))
+
+    def test_linear_attention_in_proj_shards_by_attn_tp(self):
+        """Regression: in_proj_qkvz is built on the attn-TP group under
+        dp-attention (qwen3_5.py passes tp_rank=attn_tp_rank), but it was
+        classified as outer-TP, so with tp=4 / attn_tp=1 its LoRA B buffer
+        came out 4x narrower than the wrapper's attn_tp-local slice and
+        adapter load failed on the shape assert."""
+        pool = self._pool(tp_size=4, attn_tp_size=1)
+        model = _fake_base_model_with_hidden_dim(num_experts=1)
+        # column-parallel: B output_dim = 4*64 = 256, undivided under
+        # attn_tp=1 (pre-fix: divided by the outer tp=4 -> 64).
+        self.assertEqual(
+            pool.get_lora_B_shape("in_proj_qkvz", model, 8, 0), (2, 256, 8)
+        )
 
 
 class TestLoadBufferPassesMoeTpRankToSlice(unittest.TestCase):


### PR DESCRIPTION
LoRA fails under `--enable-dp-attention`. Three causes, three fixes:

1. **Idle DP forwards crash** — they skip `prepare_lora_batch()`, so LoRA kernels read stale batch metadata. Idle forwards now call `reset_lora_batch()` to clear the backend batch state; LoRA layers gate on `lora_active` and take the base path when no batch is prepared.
2. **Wrong TP rank** — attention layers shard on attn-TP (`tp_size / dp_size`), not the global rank, so adapter loads hit shape-mismatch asserts. Weights are now sliced by the wrapped layer's own `base_layer.tp_rank`, buffers sized by `attn_tp_size` for the modules in `ATTN_TP_LORA_MODULE_NAMES` (equal to `tp_size` without dp attention, so existing setups are unchanged), and RowParallel LoRA all-reduces over the same group as its base layer. Also classifies linear-attention `in_proj` / `in_proj_qkvz` as attn-TP, with a regression test.
3. **Blocked endpoints** — dynamic-LoRA load/unload asserted `dp_size == 1`. Allow `enable_dp_attention`.

Split (2/2) of #31520; the tensor-loading path was #32580 (merged). Two standalone fixes found along the way moved to their own PRs: #32703 (full-prefill-CG LoRA gating), #32704 (MoE LoRA buffer sizing).

**Tests**: 8x H200, DeepSeek-V2-Lite, `--tp 8 --dp 8 --enable-dp-attention`: load / generate (7/8 ranks idle) / unload pass, adapter effect verified in logprobs; the same launch on main crashes. `--tp 8 --dp 2` (attn_tp=4) passes. `test_mem_pool_ep_unit.py`: 39 passed, including the new attn-TP buffer-sharding regression tests.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30414288560](https://github.com/sgl-project/sglang/actions/runs/30414288560)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30414288437](https://github.com/sgl-project/sglang/actions/runs/30414288437)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->


