### PR TITLE
docs(cookbook): mark every Kimi-K3 cell in-progress; land Playground "Switch base" on the configurator

### DIFF
--- a/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -101,9 +101,9 @@ are scheduled to release by July 27, 2026**. The recipes on this page were valid
 repository (`moonshotai/Kimi-K3`) and a public `lmsysorg/sglang` image with K3 support will be
 available at launch.
 
-Every cell on this page is currently marked **Not Verified**: the recipes run, but none has a
-serving round on the final weights and current code behind it. Re-measure throughput and accuracy
-before you rely on any of them.
+Every cell in the Deploy panel above is currently marked **Final Verification In Progress**: the
+recipe runs, but its serving round on the final weights and current code is still open. Re-measure
+throughput and accuracy before you rely on any of them.
 </Note>
 
 **Recommended generation:** `temperature=1.0`, `top_p=0.95`, `presence_penalty=0`, `frequency_penalty=0` (fixed by the model; informational — do not hardcode in sample code).

--- a/docs_new/src/snippets/_deployment.jsx
+++ b/docs_new/src/snippets/_deployment.jsx
@@ -23,7 +23,8 @@
 //                      `flags` / `env` / `hints` (each a literal array or a function
 //                      of the whole selection), and a row-level `default` / `showWhen`.
 //                      `hints` render as `# ...` lines above the command.
-//   cells              {match, verified?, nnodes?, warn?, redirect?, env, flags}[] — one per
+//   cells              {match, verified?, verificationStatus?, nnodes?, warn?, redirect?,
+//                      env, flags}[] — one per
 //                      (hw × match dims); env/flags are flat literals, only
 //                      {{PLACEHOLDER}} subst applied. `nnodes` supplies the node
 //                      count for configs with no `nodes` dim (default 1). `warn`
@@ -31,6 +32,10 @@
 //                      embed [label](#anchor) links. `redirect: true` renders the
 //                      banner ALONE — no command, header, or copy buttons — for
 //                      cells that only point somewhere else.
+//                      `verified` is the boolean badge baseline.
+//                      `verificationStatus` overrides it with a third state —
+//                      "verified" | "in-progress" | "unverified" — for a recipe
+//                      whose verification round is open rather than absent.
 //   modelNames         HF slug lookup, `hw|variant|quant` then `variant|quant`
 //   placeholders       {{KEY}} → {target: 'command'|'curl', label, default?}
 //   curl               cURL template (uses {{MODEL_NAME}} + placeholders)
@@ -166,18 +171,30 @@ export const Deployment = ({ config, benchmarks }) => {
       color: isDark ? "#fde68a" : "#92400e",
       border: `1px solid ${isDark ? "#92400e" : "#fcd34d"}`,
     },
-    badge: (verified) => ({
+    // Takes either a boolean (legacy `cell.verified`) or a status id — see
+    // VERIFY_LABEL / verifyStatusOf in section 3.
+    badge: (status) => ({
       display: "inline-flex", alignItems: "center", gap: "6px",
       padding: "2px 8px", borderRadius: "10px",
-      background: verified ? (isDark ? "#064e3b" : "#d1fae5")
-                           : (isDark ? "#78350f" : "#fef3c7"),
-      color:      verified ? (isDark ? "#a7f3d0" : "#065f46")
-                           : (isDark ? "#fde68a" : "#92400e"),
-      fontSize: "11px", fontWeight: 600,
+      background: {
+        verified:      isDark ? "#064e3b" : "#d1fae5",
+        "in-progress": isDark ? "#1e3a8a" : "#dbeafe",
+        unverified:    isDark ? "#78350f" : "#fef3c7",
+      }[verifyStatusOf(status)],
+      color: {
+        verified:      isDark ? "#a7f3d0" : "#065f46",
+        "in-progress": isDark ? "#bfdbfe" : "#1e40af",
+        unverified:    isDark ? "#fde68a" : "#92400e",
+      }[verifyStatusOf(status)],
+      // The in-progress label is long; keep the pill on one line and let the
+      // header row wrap around it instead of breaking the text mid-badge.
+      fontSize: "11px", fontWeight: 600, whiteSpace: "nowrap",
     }),
-    badgeDot: (verified) => ({
+    badgeDot: (status) => ({
       width: "8px", height: "8px", borderRadius: "50%",
-      background: verified ? "#10b981" : "#f59e0b",
+      background: { verified: "#10b981", "in-progress": "#3b82f6", unverified: "#f59e0b" }[
+        verifyStatusOf(status)
+      ],
     }),
     iconButton: {
       padding: "4px 10px",
@@ -388,6 +405,25 @@ export const Deployment = ({ config, benchmarks }) => {
   });
 
   // ==== 3. Pure helpers (no React state) ====
+  // Verification badge state. A cell's boolean `verified` is the baseline;
+  // `cell.verificationStatus` overrides it, which is how a recipe whose
+  // verification round is open reports that instead of collapsing into the flat
+  // Verified / Not Verified pair.
+  const VERIFY_LABEL = {
+    verified: "Verified",
+    "in-progress": "Final Verification In Progress",
+    unverified: "Not Verified",
+  };
+  // Booleans keep their historical meaning; an unrecognized status id falls
+  // back to "unverified" rather than to truthiness (a typo must never read as
+  // a green Verified badge).
+  const verifyStatusOf = (v) =>
+    typeof v === "string"
+      ? (VERIFY_LABEL[v] ? v : "unverified")
+      : (v ? "verified" : "unverified");
+  const cellVerifyStatus = (c) =>
+    c ? verifyStatusOf(c.verificationStatus ?? c.verified) : "unverified";
+
   // Two kinds of selector row:
   //   match dims    participate in cell lookup (cell.match[dim] === sel[dim])
   //   overlay dims  never touch cell lookup; the picked option contributes flags
@@ -1122,6 +1158,7 @@ export const Deployment = ({ config, benchmarks }) => {
   // ==== 5. Derived values ====
   const s = makeStyles(isDark);
   const cell = findCell(config.cells, sel);
+  const verifyStatus = cellVerifyStatus(cell);
   // Pin the calculator-computed ratio into the rendered command (before the
   // host/port tail); cells themselves stay ratio-free.
   const cellWithRatio = (() => {
@@ -1337,9 +1374,9 @@ export const Deployment = ({ config, benchmarks }) => {
           ) : (<>
             <div style={s.commandHeader}>
               <div style={s.headerLeft}>
-                <div style={s.badge(Boolean(cell && cell.verified))}>
-                  <span style={s.badgeDot(Boolean(cell && cell.verified))} />
-                  {cell && cell.verified ? "Verified" : "Not Verified"}
+                <div style={s.badge(verifyStatus)}>
+                  <span style={s.badgeDot(verifyStatus)} />
+                  {VERIFY_LABEL[verifyStatus]}
                 </div>
                 <div style={s.runModeWrap} role="tablist" aria-label="Output format">
                   {runModes.map((mode, index) => (

--- a/docs_new/src/snippets/_playground.jsx
+++ b/docs_new/src/snippets/_playground.jsx
@@ -101,6 +101,11 @@ export const Playground = ({ config }) => {
   }) || cell;
   // Shared with `_deployment.jsx` (HOST/PORT/etc. unified across the page).
   const STORAGE_KEY = "sglang-deploy-env";
+  // ==== MIRROR of DEPLOYMENT_COMPONENT_ID in _deployment.jsx — keep identical ====
+  // Snippets cannot import each other. The Deploy panel puts this id on its
+  // root (carrying its own scrollMarginTop), which is what "jump to the base"
+  // should land on.
+  const DEPLOYMENT_COMPONENT_ID = "deployment-configurator";
 
   const pgFeatures = config.playgroundFeatures || {};
   // Single-host PD runs prefill + decode as two engines on one box. Each derives
@@ -2218,12 +2223,16 @@ export const Playground = ({ config }) => {
         <span style={{ fontWeight: 600 }}>Inherited base from Deployment:</span>
         <code style={{ fontFamily: "Menlo, monospace" }}>{baseSummary}</code>
         {/* scrollIntoView (not hash nav) so the base-cell hash survives.
-            Deploy heading slugs to "deployment" or "deploy". */}
+            Target the configurator ITSELF: the "## Deployment" heading sits
+            above the install accordion and a screenful of prose, so landing on
+            the heading leaves the panel you came for off-screen. The heading
+            slugs stay as fallbacks for a page that renders no configurator. */}
         <button
           type="button"
           style={s.switchBaseBtn}
           onClick={() => {
-            const el = document.getElementById("deployment")
+            const el = document.getElementById(DEPLOYMENT_COMPONENT_ID)
+              || document.getElementById("deployment")
               || document.getElementById("deploy");
             if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
           }}

--- a/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -647,11 +647,16 @@ export const config = {
     ],
   },
 
+  // Verification marks: every cell carries "Final Verification In Progress" —
+  // the recipe runs, but its serving round on the final weights and current
+  // code is still open. Flip a cell to `verified: true` (and drop its
+  // `verificationStatus`) once that round lands.
   cells: [
     {
       match: { hw: "b300", pdMode: "unified", strategy: "low-latency" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -670,6 +675,7 @@ export const config = {
       match: { hw: "b300", pdMode: "unified", strategy: "balanced" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -688,6 +694,7 @@ export const config = {
       match: { hw: "b300", pdMode: "unified", strategy: "high-throughput" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       redirect: true,
       warn: "High-Throughput is the large-scale lane: pick a Cluster Size and a Large-Scale Preset in the [Playground](#playground) to compose the DP x EP command on top of this hardware's Balanced recipe.",
       env: [],
@@ -709,6 +716,7 @@ export const config = {
       match: { hw: "b200", pdMode: "unified", strategy: "low-latency" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -729,6 +737,7 @@ export const config = {
       match: { hw: "b200", pdMode: "unified", strategy: "balanced" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -750,6 +759,7 @@ export const config = {
       match: { hw: "b200", pdMode: "unified", strategy: "high-throughput" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       redirect: true,
       warn: "High-Throughput is the large-scale lane: pick a Cluster Size and a Large-Scale Preset in the [Playground](#playground) to compose the DP x EP command on top of this hardware's Balanced recipe.",
       env: [],
@@ -774,6 +784,7 @@ export const config = {
       match: { hw: "b200", pdMode: "unified", strategy: "long-context" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -798,6 +809,7 @@ export const config = {
       match: { hw: "mi350x", pdMode: "unified", strategy: "balanced" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_USE_AITER=1",
         "SGLANG_AITER_K3_OPT=1",
@@ -823,6 +835,7 @@ export const config = {
       match: { hw: "mi355x", pdMode: "unified", strategy: "balanced" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_USE_AITER=1",
         "SGLANG_AITER_K3_OPT=1",
@@ -849,6 +862,7 @@ export const config = {
       match: { hw: "h100", pdMode: "unified", strategy: "low-latency" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_CUMEM_ENABLE=1",
         "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
@@ -880,6 +894,7 @@ export const config = {
       match: { hw: "h100", pdMode: "unified", strategy: "balanced" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_CUMEM_ENABLE=1",
         "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
@@ -911,6 +926,7 @@ export const config = {
       match: { hw: "h100", pdMode: "unified", strategy: "high-throughput" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_CUMEM_ENABLE=1",
         "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
@@ -941,6 +957,7 @@ export const config = {
       match: { hw: "h200", pdMode: "unified", strategy: "low-latency" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_MNNVL_ENABLE=1",
         "NCCL_CUMEM_ENABLE=1",
@@ -966,6 +983,7 @@ export const config = {
       match: { hw: "h200", pdMode: "unified", strategy: "balanced" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_MNNVL_ENABLE=1",
         "NCCL_CUMEM_ENABLE=1",
@@ -991,6 +1009,7 @@ export const config = {
       match: { hw: "h200", pdMode: "unified", strategy: "high-throughput" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_MNNVL_ENABLE=1",
         "NCCL_CUMEM_ENABLE=1",
@@ -1016,6 +1035,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "unified", strategy: "low-latency" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1037,6 +1057,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "unified", strategy: "balanced" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1056,6 +1077,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "unified", strategy: "high-throughput" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       redirect: true,
       warn: "High-Throughput is the large-scale lane: pick a Cluster Size and a Large-Scale Preset in the [Playground](#playground) to compose the DP x EP command on top of this hardware's Balanced recipe.",
       env: [
@@ -1078,6 +1100,7 @@ export const config = {
       match: { hw: "gb200", pdMode: "unified", strategy: "low-latency" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1098,6 +1121,7 @@ export const config = {
       match: { hw: "gb200", pdMode: "unified", strategy: "balanced" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1118,6 +1142,7 @@ export const config = {
       match: { hw: "gb200", pdMode: "unified", strategy: "high-throughput" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       redirect: true,
       warn: "High-Throughput is the large-scale lane: pick a Cluster Size and a Large-Scale Preset in the [Playground](#playground) to compose the DP x EP command on top of this hardware's Balanced recipe.",
       env: [
@@ -1147,6 +1172,7 @@ export const config = {
       match: { hw: "b300", pdMode: "prefill", strategy: "default" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1174,6 +1200,7 @@ export const config = {
       match: { hw: "b300", pdMode: "prefill", strategy: "long-context" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1199,6 +1226,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "prefill", strategy: "default" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1223,6 +1251,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "prefill", strategy: "long-context" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1260,6 +1289,7 @@ export const config = {
       match: { hw: "b300", pdMode: "decode", strategy: "balanced" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1281,6 +1311,7 @@ export const config = {
       match: { hw: "b300", pdMode: "decode", strategy: "low-latency" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1302,6 +1333,7 @@ export const config = {
       match: { hw: "b300", pdMode: "decode", strategy: "high-throughput" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1323,6 +1355,7 @@ export const config = {
       match: { hw: "b200", pdMode: "decode", strategy: "low-latency" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1345,6 +1378,7 @@ export const config = {
       match: { hw: "b200", pdMode: "decode", strategy: "balanced" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1368,6 +1402,7 @@ export const config = {
       match: { hw: "b200", pdMode: "decode", strategy: "high-throughput" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [],
       flags: [
         "--trust-remote-code",
@@ -1391,6 +1426,7 @@ export const config = {
       match: { hw: "mi350x", pdMode: "decode", strategy: "balanced" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_USE_AITER=1",
         "SGLANG_AITER_K3_OPT=1",
@@ -1417,6 +1453,7 @@ export const config = {
       match: { hw: "mi355x", pdMode: "decode", strategy: "balanced" },
       nnodes: 1,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_USE_AITER=1",
         "SGLANG_AITER_K3_OPT=1",
@@ -1443,6 +1480,7 @@ export const config = {
       match: { hw: "h100", pdMode: "decode", strategy: "low-latency" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_CUMEM_ENABLE=1",
         "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
@@ -1474,6 +1512,7 @@ export const config = {
       match: { hw: "h100", pdMode: "decode", strategy: "balanced" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_CUMEM_ENABLE=1",
         "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
@@ -1505,6 +1544,7 @@ export const config = {
       match: { hw: "h100", pdMode: "decode", strategy: "high-throughput" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_CUMEM_ENABLE=1",
         "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True",
@@ -1536,6 +1576,7 @@ export const config = {
       match: { hw: "h200", pdMode: "decode", strategy: "low-latency" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_MNNVL_ENABLE=1",
         "NCCL_CUMEM_ENABLE=1",
@@ -1562,6 +1603,7 @@ export const config = {
       match: { hw: "h200", pdMode: "decode", strategy: "balanced" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_MNNVL_ENABLE=1",
         "NCCL_CUMEM_ENABLE=1",
@@ -1588,6 +1630,7 @@ export const config = {
       match: { hw: "h200", pdMode: "decode", strategy: "high-throughput" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "NCCL_MNNVL_ENABLE=1",
         "NCCL_CUMEM_ENABLE=1",
@@ -1614,6 +1657,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "decode", strategy: "low-latency" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1636,6 +1680,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "decode", strategy: "balanced" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1658,6 +1703,7 @@ export const config = {
       match: { hw: "gb300", pdMode: "decode", strategy: "high-throughput" },
       nnodes: 2,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1680,6 +1726,7 @@ export const config = {
       match: { hw: "gb200", pdMode: "decode", strategy: "low-latency" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1702,6 +1749,7 @@ export const config = {
       match: { hw: "gb200", pdMode: "decode", strategy: "balanced" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
@@ -1724,6 +1772,7 @@ export const config = {
       match: { hw: "gb200", pdMode: "decode", strategy: "high-throughput" },
       nnodes: 4,
       verified: false,
+      verificationStatus: "in-progress",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],


### PR DESCRIPTION
Two independent cookbook fixes, one commit each.

## 1. A third verification state, applied to Kimi-K3

### Motivation

The Kimi-K3 page ([#32542](https://github.com/sgl-project/sglang/pull/32542)) marks every cell `Not Verified`, which reads as *"nobody looked at this"*. But these recipes run — what is open is their serving round on the final weights and current code. Those are different claims, and a two-state badge cannot tell them apart.

**No recipe is upgraded**: not a single `verified` value is flipped (all 45 cells were already `false`), so this only sharpens what the page claims.

### Modifications

**`_deployment.jsx`** — an optional cell field `verificationStatus`, `"verified" | "in-progress" | "unverified"`, overriding the boolean `verified`, plus the blue **Final Verification In Progress** badge it renders.

- **Absent the field, the badge falls back to `verified`** — every other cookbook page renders exactly as before. The `verified` / `unverified` style objects are byte-identical to the previous ones for both `isDark` values; the only added property is `whiteSpace: nowrap`, a no-op for the two short labels and what keeps the longer one from breaking mid-pill.
- **An unrecognized status id resolves to `"unverified"`**, not to string truthiness — a typo such as `"in_progress"` must never render as a green Verified badge.

**`configs/moonshotai/kimi-k3.jsx`** — every cell (unified · prefill · decode, across B300 / GB300 / B200 / GB200 / H200 / H100 / MI350X / MI355X) carries `verificationStatus: "in-progress"`. Pure insertion, no line removed. A comment above `cells[]` records how to retire a mark: flip that cell to `verified: true` and drop its `verificationStatus` once its round lands.

**`Kimi-K3.mdx`** — the page Note names the new state, scoped to the Deploy panel.

## 2. Playground "↑ Switch base" landed on the wrong element

### Motivation

The button scrolled to the `## Deployment` heading, which sits above the install accordion and the whole matrix write-up. Measured gap from that heading down to the panel the reader actually clicked to reach:

| Page | Heading → configurator |
|---|---|
| Kimi-K3 | **10,316 px** |
| Inkling | 2,010 px |
| GLM-5.2 | 1,878 px |

So the jump landed nowhere useful.

### Modifications

The Deploy panel already exposes `id="deployment-configurator"` on its root, carrying its own `scrollMarginTop: 104px` to clear the sticky header — target that, keeping the heading slugs as fallbacks for a page that renders no configurator. Snippets cannot import each other, so the id is mirrored under the same `==== MIRROR ====` convention the file already uses.

## Accuracy

Docs only — no kernel, runtime, or serving-path change.

## Checklist

- [x] `pre-commit run` clean on all changed files — nothing auto-modified
- [x] `mint broken-links --check-anchors --check-redirects` — the lint-CI hard gate — passes
- [x] `mint validate` passes; `docs_new/scripts/check_cookbook_configs.mjs` reports OK
- [x] Rebased on `main`

### Verification

**Every cell.** All 45 resolved through the engine's own `cellVerifyStatus`, lifted verbatim out of `_deployment.jsx` rather than reimplemented — all 45 report `in-progress`. Boolean back-compat re-checked on the same code path: `true → verified`, `false → unverified`, `undefined → unverified`, `"in_progress"` (typo) `→ unverified`.

**Live badges.** In `mint dev`, Deploy badges read *Final Verification In Progress* in blue (`#dbeafe`, dot `#3b82f6`) across unified, prefill and decode roles on B300 / GB300 / MI355X / H100 / B200, each with the resolved selection hash asserted. No console errors.

**Live jump.** `Element.prototype.scrollIntoView` instrumented, then the real button clicked: the scroll target is `#deployment-configurator` on both Kimi-K3 and DeepSeek-V4, with no thrown error and no window `error` events. (The identical target was confirmed for the sibling-match `switch base →` button, which reaches the panel through the Deploy engine's external-hash path and needed no change.)

**No regression elsewhere.** On GLM-5.2 — the page that exercises both boolean branches (27 `verified: true`, 21 `false`) — a 17-step chip sweep reproduces the pre-change badge sequence **byte for byte**, in the original green `#d1fae5` and amber `#fef3c7`, with no `in-progress` leaking in. DeepSeek-V4 badges likewise unchanged.

## Notes for reviewers

Four cells never display a Deploy badge at all: the `Unified · High-Throughput` cells on B300/B200/GB300/GB200 are `redirect: true`, so the engine renders their "pick a Cluster Size and a Large-Scale Preset" banner alone. Pre-existing engine behaviour, untouched here — their mark is set for consistency but is not shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30319696373](https://github.com/sgl-project/sglang/actions/runs/30319696373)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30319696295](https://github.com/sgl-project/sglang/actions/runs/30319696295)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->