### PR TITLE
docker: install one complete multi-arch Dynamo nightly in dev images

### DIFF
--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -61,11 +61,13 @@ jobs:
             echo "checkout_ref=" >> $GITHUB_OUTPUT
           fi
 
-          # Determine extra build args
+          # Determine extra build args. INSTALL_DYNAMO=1 installs the ai-dynamo
+          # nightly here only; release-docker.yml / release-docker-runtime.yml
+          # leave it at the Dockerfile default (0), keeping it out of releases.
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "extra_build_args=--build-arg USE_LATEST_SGLANG=1 --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
+            echo "extra_build_args=--build-arg USE_LATEST_SGLANG=1 --build-arg INSTALL_DYNAMO=1 --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
           else
-            echo "extra_build_args=--build-arg BRANCH_TYPE=local --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
+            echo "extra_build_args=--build-arg BRANCH_TYPE=local --build-arg INSTALL_DYNAMO=1 --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
           fi
 
           # Determine tag suffix

--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -45,6 +45,8 @@ jobs:
       overlay_cudas_json: ${{ steps.config.outputs.overlay_cudas_json }}
       overlay_tags_json: ${{ steps.config.outputs.overlay_tags_json }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Compute build configuration
         id: config
         env:
@@ -61,13 +63,19 @@ jobs:
             echo "checkout_ref=" >> $GITHUB_OUTPUT
           fi
 
-          # Determine extra build args. INSTALL_DYNAMO=1 installs the ai-dynamo
-          # nightly here only; release-docker.yml / release-docker-runtime.yml
-          # leave it at the Dockerfile default (0), keeping it out of releases.
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "extra_build_args=--build-arg USE_LATEST_SGLANG=1 --build-arg INSTALL_DYNAMO=1 --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
+          DYNAMO_VERSION="$(python3 scripts/ci/utils/resolve_dynamo_version.py)"
+          DYNAMO_BUILD_ARG=""
+          if [ -n "$DYNAMO_VERSION" ]; then
+            echo "Using multi-architecture Dynamo nightly ${DYNAMO_VERSION}"
+            DYNAMO_BUILD_ARG="--build-arg DYNAMO_VERSION=${DYNAMO_VERSION}"
           else
-            echo "extra_build_args=--build-arg BRANCH_TYPE=local --build-arg INSTALL_DYNAMO=1 --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
+            echo "::warning title=Dynamo installation skipped::No nightly has ai-dynamo plus x86_64 and aarch64 runtime wheels"
+          fi
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "extra_build_args=--build-arg USE_LATEST_SGLANG=1 ${DYNAMO_BUILD_ARG} --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
+          else
+            echo "extra_build_args=--build-arg BRANCH_TYPE=local ${DYNAMO_BUILD_ARG} --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
           fi
 
           # Determine tag suffix

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -630,8 +630,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
                 *) echo "ERROR: no X.Y.Z.devYYYYMMDD nightly found in the index (format may have changed)"; exit 1 ;; \
             esac; \
         fi; \
-        echo "Installing ai-dynamo==${DYNAMO_VERSION}"; \
-        python3 -m pip install --extra-index-url https://pypi.nvidia.com "ai-dynamo==${DYNAMO_VERSION}"; \
+        runtime_wheel="ai_dynamo_runtime-${DYNAMO_VERSION}-cp310-abi3-manylinux_2_28_$(uname -m).whl"; \
+        if curl -fsSI "https://pypi.nvidia.com/ai-dynamo-runtime/${runtime_wheel}" >/dev/null; then \
+            echo "Installing ai-dynamo==${DYNAMO_VERSION}"; \
+            python3 -m pip install --extra-index-url https://pypi.nvidia.com "ai-dynamo==${DYNAMO_VERSION}"; \
+        else \
+            echo "WARNING: skipping ai-dynamo==${DYNAMO_VERSION}; ${runtime_wheel} is unavailable"; \
+        fi; \
     fi
 
 # Per-CUDA-major package installs. The `nixl` stub package is needed (it owns

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -610,33 +610,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     termplotlib \
     "runai-model-streamer[s3,gcs,azure]>=0.15.7"
 
-# Optional ai-dynamo nightly for Dynamo + SGLang integration testing. Gated by
-# INSTALL_DYNAMO so it lands only in the dev image (release-docker-dev.yml sets
-# it), not the version-tagged release/runtime images. Empty DYNAMO_VERSION
-# resolves the latest (highest-version) nightly, matching `pip install --pre`;
-# set it to pin an exact version for a reproducible build.
-ARG INSTALL_DYNAMO=0
+# Optional ai-dynamo nightly for Dynamo + SGLang integration testing.
+# release-docker-dev.yml resolves one version with wheels for both architectures;
+# version-tagged release/runtime images leave it empty and skip the install.
 ARG DYNAMO_VERSION=
 RUN --mount=type=cache,target=/root/.cache/pip \
-    set -eu; \
-    if [ "$INSTALL_DYNAMO" = "1" ]; then \
-        if [ -z "$DYNAMO_VERSION" ]; then \
-            index="$(curl -fsSL --retry 3 --retry-delay 2 https://pypi.nvidia.com/ai-dynamo/)" \
-                || { echo "ERROR: failed to fetch the ai-dynamo index from pypi.nvidia.com"; exit 1; }; \
-            DYNAMO_VERSION="$(printf '%s\n' "$index" \
-                | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]{8}' | sort -Vu | tail -1)"; \
-            case "$DYNAMO_VERSION" in \
-                *.*.*.dev????????) : ;; \
-                *) echo "ERROR: no X.Y.Z.devYYYYMMDD nightly found in the index (format may have changed)"; exit 1 ;; \
-            esac; \
-        fi; \
-        runtime_wheel="ai_dynamo_runtime-${DYNAMO_VERSION}-cp310-abi3-manylinux_2_28_$(uname -m).whl"; \
-        if curl -fsSI "https://pypi.nvidia.com/ai-dynamo-runtime/${runtime_wheel}" >/dev/null; then \
-            echo "Installing ai-dynamo==${DYNAMO_VERSION}"; \
-            python3 -m pip install --extra-index-url https://pypi.nvidia.com "ai-dynamo==${DYNAMO_VERSION}"; \
-        else \
-            echo "WARNING: skipping ai-dynamo==${DYNAMO_VERSION}; ${runtime_wheel} is unavailable"; \
-        fi; \
+    if [ -n "$DYNAMO_VERSION" ]; then \
+        python3 -m pip install --extra-index-url https://pypi.nvidia.com "ai-dynamo==${DYNAMO_VERSION}"; \
     fi
 
 # Per-CUDA-major package installs. The `nixl` stub package is needed (it owns
@@ -696,7 +676,7 @@ ARG BUILD_TYPE
 ARG CUDA_VERSION
 ARG SGL_VERSION
 ARG USE_LATEST_SGLANG
-ARG INSTALL_DYNAMO=0
+ARG DYNAMO_VERSION=
 
 WORKDIR /sgl-workspace
 
@@ -757,7 +737,7 @@ COPY --from=gateway_builder /build/gateway_wheels /tmp/gateway_wheels
 # --no-deps so it cannot re-resolve and replace Dynamo's shared dependencies.
 # Otherwise resolve the gateway's own dependencies normally.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    if [ "$INSTALL_DYNAMO" = "1" ]; then \
+    if [ -n "$DYNAMO_VERSION" ]; then \
         python3 -m pip install --force-reinstall --no-deps /tmp/gateway_wheels/*.whl; \
     else \
         python3 -m pip install --force-reinstall /tmp/gateway_wheels/*.whl; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -610,6 +610,30 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     termplotlib \
     "runai-model-streamer[s3,gcs,azure]>=0.15.7"
 
+# Optional ai-dynamo nightly for Dynamo + SGLang integration testing. Gated by
+# INSTALL_DYNAMO so it lands only in the dev image (release-docker-dev.yml sets
+# it), not the version-tagged release/runtime images. Empty DYNAMO_VERSION
+# resolves the latest (highest-version) nightly, matching `pip install --pre`;
+# set it to pin an exact version for a reproducible build.
+ARG INSTALL_DYNAMO=0
+ARG DYNAMO_VERSION=
+RUN --mount=type=cache,target=/root/.cache/pip \
+    set -eu; \
+    if [ "$INSTALL_DYNAMO" = "1" ]; then \
+        if [ -z "$DYNAMO_VERSION" ]; then \
+            index="$(curl -fsSL --retry 3 --retry-delay 2 https://pypi.nvidia.com/ai-dynamo/)" \
+                || { echo "ERROR: failed to fetch the ai-dynamo index from pypi.nvidia.com"; exit 1; }; \
+            DYNAMO_VERSION="$(printf '%s\n' "$index" \
+                | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.dev[0-9]{8}' | sort -Vu | tail -1)"; \
+            case "$DYNAMO_VERSION" in \
+                *.*.*.dev????????) : ;; \
+                *) echo "ERROR: no X.Y.Z.devYYYYMMDD nightly found in the index (format may have changed)"; exit 1 ;; \
+            esac; \
+        fi; \
+        echo "Installing ai-dynamo==${DYNAMO_VERSION}"; \
+        python3 -m pip install --extra-index-url https://pypi.nvidia.com "ai-dynamo==${DYNAMO_VERSION}"; \
+    fi
+
 # Per-CUDA-major package installs. The `nixl` stub package is needed (it owns
 # the `nixl` import path) but unconditionally requires nixl-cu12, so we install
 # it with --no-deps and pair it with the matching nixl-cu12 / nixl-cu13 binary
@@ -667,6 +691,7 @@ ARG BUILD_TYPE
 ARG CUDA_VERSION
 ARG SGL_VERSION
 ARG USE_LATEST_SGLANG
+ARG INSTALL_DYNAMO=0
 
 WORKDIR /sgl-workspace
 
@@ -723,8 +748,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Install pre-built gateway artifacts from parallel builder
 COPY --from=gateway_builder /build/sgl-model-gateway-bin /usr/local/bin/sgl-model-gateway
 COPY --from=gateway_builder /build/gateway_wheels /tmp/gateway_wheels
+# When ai-dynamo is installed (dev image), reinstall the gateway wheel with
+# --no-deps so it cannot re-resolve and replace Dynamo's shared dependencies.
+# Otherwise resolve the gateway's own dependencies normally.
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install --force-reinstall /tmp/gateway_wheels/*.whl \
+    if [ "$INSTALL_DYNAMO" = "1" ]; then \
+        python3 -m pip install --force-reinstall --no-deps /tmp/gateway_wheels/*.whl; \
+    else \
+        python3 -m pip install --force-reinstall /tmp/gateway_wheels/*.whl; \
+    fi \
     && rm -rf /tmp/gateway_wheels
 
 # Set workspace directory

--- a/scripts/ci/utils/resolve_dynamo_version.py
+++ b/scripts/ci/utils/resolve_dynamo_version.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import re
+from time import sleep
+from urllib.error import URLError
+from urllib.request import urlopen
+
+INDEX_URL = "https://pypi.nvidia.com"
+VERSION = r"\d+\.\d+\.\d+\.dev\d{8}"
+ARCHES = {"x86_64", "aarch64"}
+
+
+def fetch_index(package):
+    for attempt in range(3):
+        try:
+            with urlopen(f"{INDEX_URL}/{package}/", timeout=30) as response:
+                return response.read().decode()
+        except URLError:
+            if attempt == 2:
+                raise
+            sleep(2)
+
+
+def resolve_version(dynamo_index, runtime_index):
+    dynamo_versions = set(
+        re.findall(rf"ai_dynamo-({VERSION})-py3-none-any\.whl", dynamo_index)
+    )
+    runtime_arches = {}
+    for version, arch in re.findall(
+        rf"ai_dynamo_runtime-({VERSION})-cp310-abi3-manylinux_2_28_(x86_64|aarch64)\.whl",
+        runtime_index,
+    ):
+        runtime_arches.setdefault(version, set()).add(arch)
+
+    complete = dynamo_versions & {
+        version for version, arches in runtime_arches.items() if arches >= ARCHES
+    }
+    return max(
+        complete,
+        key=lambda version: tuple(map(int, re.findall(r"\d+", version))),
+        default="",
+    )
+
+
+if __name__ == "__main__":
+    print(resolve_version(fetch_index("ai-dynamo"), fetch_index("ai-dynamo-runtime")))


### PR DESCRIPTION
Adding this back with an important change. Now we check for existence. If it doesn't exist then it just skips. Right choice for an optional dep

---

The development-image workflow now resolves one complete multi-architecture Dynamo nightly before any Docker build starts. Every CUDA and architecture image receives the same pinned version, while incomplete publishes produce a visible workflow warning and skip Dynamo for the whole build.

### How This Was Implemented
- Add a standard-library resolver that intersects the universal `ai-dynamo` wheels with `x86_64` and `aarch64` runtime wheels.
- Run it once in the existing `prepare` job and pass `DYNAMO_VERSION` to every image build.
- Use an empty `DYNAMO_VERSION` to skip Dynamo; release and runtime images remain unchanged.
- Reinstall the gateway wheel with `--no-deps` only when a Dynamo version was selected.

<details>
<summary>Walkthrough</summary>

The workflow owns version selection. It chooses the newest nightly for which `ai-dynamo`, `ai-dynamo-runtime` for `x86_64`, and `ai-dynamo-runtime` for `aarch64` are all present.

The Dockerfile only installs the pinned version it receives. If no complete nightly exists, the workflow emits a warning and leaves the version empty, so every image consistently skips the optional dependency.

</details>

### Validation
- Synthetic resolver checks for complete and incomplete uploads.
- Current NVIDIA indexes resolved `1.4.0.dev20260726`.
- Ruff passed.
- BuildKit Dockerfile check passed with no warnings.
- A targeted Docker build installed `ai-dynamo==1.4.0.dev20260726` and its matching 50.4 MB runtime wheel.
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30488968004](https://github.com/sgl-project/sglang/actions/runs/30488968004)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30488967907](https://github.com/sgl-project/sglang/actions/runs/30488967907)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
