### PR TITLE
[Apple Silicon] [MLX] Reject --enable-mixed-chunk, which segfaults the scheduler

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4119,6 +4119,11 @@ class ServerArgs:
         if self.device == "mps":
             if not use_mlx():
                 self.disable_overlap_schedule = True
+            elif self.enable_mixed_chunk:
+                logger.warning(
+                    "Mixed chunk is not supported by the MLX overlap scheduler and is disabled."
+                )
+                self.enable_mixed_chunk = False
 
     def _handle_xpu_backends(self):
         if self.device == "xpu":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1835,5 +1835,42 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestMlxMixedChunkGuard(CustomTestCase):
+    """The MLX overlap scheduler never publishes decode tokens into
+    future_map.output_tokens_buf, so a mixed batch (prefill arriving while
+    another request decodes) reads a buffer the MLX loop never writes,
+    crashing the scheduler. --enable-mixed-chunk is therefore force-disabled
+    on this backend, mirroring the dual-chunk-flash-attn and diffusion-LLM
+    guards.
+
+    dummy-model short-circuits __post_init__, so the guard handler is invoked
+    directly (same pattern as TestWaterfillArgs)."""
+
+    def _args(self, **overrides):
+        args = ServerArgs(model_path="dummy")
+        args.enable_mixed_chunk = True
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_mlx_disables_mixed_chunk(self):
+        args = self._args(device="mps")
+        with patch("sglang.srt.server_args.use_mlx", return_value=True):
+            args._handle_mps_backends()
+        self.assertFalse(args.enable_mixed_chunk)
+
+    def test_non_mlx_mps_leaves_mixed_chunk_untouched(self):
+        args = self._args(device="mps")
+        with patch("sglang.srt.server_args.use_mlx", return_value=False):
+            args._handle_mps_backends()
+        self.assertTrue(args.enable_mixed_chunk)
+
+    def test_non_mps_device_leaves_mixed_chunk_untouched(self):
+        args = self._args(device="cuda")
+        with patch("sglang.srt.server_args.use_mlx", return_value=True):
+            args._handle_mps_backends()
+        self.assertTrue(args.enable_mixed_chunk)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

On the MLX backend, `--enable-mixed-chunk` with an explicit `--chunked-prefill-size` segfaults the scheduler when a prefill request arrives while another request is decoding. The subprocess dies with exit code -11. The trace lands in `torch.cat` on MPS during batch preparation, before the prefill batch line is logged.

Repro: `mlx-community/Qwen3-0.6B-4bit`, `--device mps`, `--chunked-prefill-size 512`, `--enable-mixed-chunk`, a long generation in flight, then an oversized prompt (larger than the chunk size) arriving while it is still decoding.

```
Fatal Python error: Segmentation fault
...
File "python/sglang/srt/managers/overlap_utils.py", line 100 in resolve_forward_inputs
File "python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py", line 165 in _launch_fresh
...
in at::native::structured_cat_out_mps::impl(...)
in at::(anonymous namespace)::wrapper_MPS_cat(...)
Subprocess scheduler_0 crashed with exit code -11.
```

`resolve_forward_inputs` (`overlap_utils.py:90-100`) takes its staging branch whenever `prefill_input_ids_cpu` is set, which `prepare_for_extend` (`schedule_batch.py:2178`) does for every extend batch on every backend. On a mixed batch it reads `future_map.output_tokens_buf[batch.mix_running_indices]` for the decode lane. Only `run_batch`'s CUDA branch and spec decode disaggregation write the buffer. The MLX overlap loop never does, and outside CI, the buffer is allocated with `torch.empty`, so the decode lane gathers uninitialized memory into a `torch.cat` and MPS segfaults.

Two runs with both flags crashed, at 6.07 GB and 8.90 GB free. Two runs of the identical workload without `--enable-mixed-chunk` completed cleanly. The combination is untested on this backend.

The same divergence left three per step fields unwritten on the MLX path. #32447 restored `launch_ts` and `forward_iter`; `future_map.output_tokens_buf` is the third, and this PR closes the flag combination that reads it.

## Modifications

Force disable `enable_mixed_chunk` under MLX in `_handle_mps_backends`, mirroring the existing dual chunk flash attention and diffusion LLM guards in `server_args.py`: a condition, a warning naming the backend and the reason, and the assignment.

```python
def _handle_mps_backends(self):
    if self.device == "mps":
        if not use_mlx():
            self.disable_overlap_schedule = True
        elif self.enable_mixed_chunk:
            logger.warning(
                "Mixed chunk is not supported by the MLX overlap scheduler and is disabled."
            )
            self.enable_mixed_chunk = False
```

The guard fires on `enable_mixed_chunk` alone. `is_mixed_chunk` (`scheduler.py:1066`) requires both the flag and a set `chunked_prefill_size`, so disabling the flag keeps the crashing path unreachable. Tracking one input is also simpler to reason about than two.

This is a guard, not a fix. Making the mixed path work would require the MLX overlap loop to publish decode tokens into `future_map.output_tokens_buf`, a relay it does not otherwise use, on a path with no known user. Disabling the flag is the smallest change that removes the crash.

## Accuracy Tests

This PR changes argument post processing, not model outputs.

**Unit:** `TestMlxMixedChunkGuard` in `test/registered/unit/server_args/test_server_args.py` asserts `enable_mixed_chunk` comes back `False` after `_handle_mps_backends()` under MLX and stays `True` on mps without MLX and on non-mps devices, so the guard does not overreach.

**Hardware:** `mlx-community/Qwen3-0.6B-4bit` on Apple Silicon, launched with `--enable-mixed-chunk --chunked-prefill-size 512` under `SGLANG_USE_MLX=1`. The warning logs at startup and the workload that previously crashed the scheduler now completes: a long generation in flight, an oversized prompt arriving mid decode, both requests served. Re-verified on current main after #32447 merged: the crash still reproduces unguarded, at `scheduler_mixin.py:165`.

The MLX unit suite passes at the base commit's rate. `test_metal_profiler.py` fails on the base commit as well.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations). N/A. This adds no flag and changes no documented behavior; the existing `--enable-mixed-chunk` flag is simply unsupported on this backend.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the [SGLang code style guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.ai/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

## AI Usage

The investigation and hardware verification are mine. An agent assisted with tracing the crash path and drafting this PR description. I verified every claim in this description myself.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30417032279](https://github.com/sgl-project/sglang/actions/runs/30417032279)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30417032162](https://github.com/sgl-project/sglang/actions/runs/30417032162)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->