### PR TITLE
docs(cookbook): update Kimi-K3 GB200 recipes from measured 4x4 runs

### DIFF
--- a/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -1310,6 +1310,39 @@ export const config = {
         "--port {{PORT}}",
       ],
     },
+    {
+      // Same chunked-PP shape as the Default cell, with mem-fraction raised to
+      // 0.90 for KV headroom — the B300/GB300 Long-Context recipes make the same
+      // trade. Keeping TP at 1 is what buys the context length here: with TP > 1
+      // the MLA KV is replicated across the TP ranks, so TP2 x PP8 would hold
+      // roughly half the tokens of TP1 x PP16 for the same memory.
+      // Not yet benchmarked on long-context workloads.
+      match: { hw: "gb200", pdMode: "prefill", strategy: "long-context" },
+      nnodes: 4,
+      verified: false,
+      verificationStatus: "in-progress",
+      env: [
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
+      ],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp-size 1",
+        "--pp-size 16",
+        "--mem-fraction-static 0.90",
+        "--chunked-prefill-size 16384",
+        "--max-prefill-tokens 16384",
+        "--disable-flashinfer-autotune",
+        "--weight-loader-prefetch-checkpoints",
+        "--reasoning-parser kimi_k3",
+        "--tool-call-parser kimi_k3",
+        "--disaggregation-mode prefill",
+        "--disaggregation-transfer-backend nixl",
+        "--disaggregation-bootstrap-port 8998",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
 
     // ----- Decode role: the unified cell for the same hw and strategy, plus
     // the PD role and transport flags, and re-sized KDA state.

--- a/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs_new/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -1275,8 +1275,48 @@ export const config = {
       ],
     },
 
+    {
+      // PP16 x TP1 spans all 16 ranks. Prefill tok/s/GPU at ISL 8192,
+      // concurrency 32: 4550 here vs 3596 (PP8 x TP2), 2407 (TEP16), 1652 (TP16);
+      // flat past 32. Below concurrency ~8 the pipeline cannot fill and TEP16
+      // leads instead (1947 vs 1227) — use `--tp-size 16 --ep-size 16` there.
+      // That four-way comparison was measured aggregated at OSL 1; the shape
+      // itself is as-run in this PD role. Pairs with the Balanced and
+      // High-Throughput decode cells; the Low-Latency decode cell runs pp=2 and
+      // needs a PP2 x TP8 prefill instead.
+      match: { hw: "gb200", pdMode: "prefill", strategy: "default" },
+      nnodes: 4,
+      verified: false,
+      verificationStatus: "in-progress",
+      env: [
+        "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
+      ],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp-size 1",
+        "--pp-size 16",
+        "--mem-fraction-static 0.85",
+        "--chunked-prefill-size 16384",
+        "--max-prefill-tokens 16384",
+        "--disable-flashinfer-autotune",
+        "--weight-loader-prefetch-checkpoints",
+        "--reasoning-parser kimi_k3",
+        "--tool-call-parser kimi_k3",
+        "--disaggregation-mode prefill",
+        "--disaggregation-transfer-backend nixl",
+        "--disaggregation-bootstrap-port 8998",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+
     // ----- Decode role: the unified cell for the same hw and strategy, plus
     // the PD role and transport flags, and re-sized KDA state.
+    //
+    // GB200 decode figures below: ISL 8192 / OSL 1024, 16 GPU decode, behind a
+    // shared PP2 x TP8 prefill. Comparisons hold; absolutes would be higher
+    // behind the PP16 x TP1 prefill cell above.
     //
     // Decode runs the KV cache as a chunk cache, so the unified 5-slots-per-
     // request reservation (1 state + ping-pong copies for radix reuse) drops to
@@ -1723,18 +1763,25 @@ export const config = {
       ],
     },
     {
+      // PP2 x TP8 is the fastest decode shape below concurrency ~100:
+      // 13.3 out tok/s/GPU @ 57.7 out tok/s/user at concurrency 8, against
+      // 9.5 @ 40.7 (TP16), 9.3 @ 39.9 (DCP16) and 9.3 @ 39.7 (DCP16+EP16) —
+      // +40% throughput and +45% interactivity over the best pp=1 shape. It
+      // stays ahead through concurrency 64 and is overtaken by DCP16+EP16 at 128.
+      // Measured without --enable-symm-mem.
       match: { hw: "gb200", pdMode: "decode", strategy: "low-latency" },
       nnodes: 4,
       verified: false,
       verificationStatus: "in-progress",
+      warn: "SGLang requires `decode pp_size == prefill pp_size or 1`, so this cell must be paired with a PP2 x TP8 prefill (`--tp-size 8 --pp-size 2`) rather than the PP16 x TP1 Prefill recipe. That prefill delivers 2919 prefill tok/s/GPU against PP16's 4550, which is the trade for the decode-side latency.",
       env: [
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0",
       ],
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--tp-size 16",
-        "--enable-symm-mem",
+        "--tp-size 8",
+        "--pp-size 2",
         "--mem-fraction-static 0.85",
         "--disaggregation-decode-extra-slots 16",
         "--reasoning-parser kimi_k3",
@@ -1746,6 +1793,9 @@ export const config = {
       ],
     },
     {
+      // EP16 on top of DCP16 is +6% to +10% out tok/s/GPU at every concurrency
+      // measured, at the same batch size: 56.2 vs 52.4 (c64), 92.7 vs 84.5
+      // (c128), 136.1 vs 126.1 (c256), 153.5 vs 144.2 (c512).
       match: { hw: "gb200", pdMode: "decode", strategy: "balanced" },
       nnodes: 4,
       verified: false,
@@ -1758,6 +1808,7 @@ export const config = {
         "--model-path {{MODEL_NAME}}",
         "--tp-size 16",
         "--dcp-size 16",
+        "--ep-size 16",
         "--mem-fraction-static 0.85",
         "--disaggregation-decode-extra-slots 16",
         "--reasoning-parser kimi_k3",
@@ -1769,6 +1820,16 @@ export const config = {
       ],
     },
     {
+      // Grouping DCP as 8 x dp2 rather than a flat DCP16 is what makes MegaMoE
+      // pay off here. out tok/s/GPU @ out tok/s/user, concurrency 256 / 512:
+      //   DCP8 x dp2 + EP16   145.5 @ 25.4   157.5 @ 25.2   <- this cell
+      //   DCP16 + EP16        136.1 @ 20.6   153.5 @ 17.5
+      //   DCP16               126.1 @ 18.7   144.2 @ 16.1
+      //   TP16                 87.4 @ 23.9    90.2 @ 23.9   (batch caps at ~125)
+      // Pair this cell with MegaMoE in the MoE Parallelism card: +8.3% / +10.0% /
+      // +11.0% over FlashInfer MXFP4 at concurrency 64 / 128 / 256, and the
+      // combination validated to concurrency 512. The gain needs dp > 1 — on the
+      // flat DCP16 cell MegaMoE is the slower of the two below concurrency 256.
       match: { hw: "gb200", pdMode: "decode", strategy: "high-throughput" },
       nnodes: 4,
       verified: false,
@@ -1780,8 +1841,11 @@ export const config = {
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
         "--tp-size 16",
-        "--dcp-size 16",
-        "--mem-fraction-static 0.92",
+        "--dcp-size 8",
+        "--dp-size 2",
+        "--enable-dp-attention",
+        "--ep-size 16",
+        "--mem-fraction-static 0.85",
         "--disaggregation-decode-extra-slots 16",
         "--reasoning-parser kimi_k3",
         "--tool-call-parser kimi_k3",
@@ -1802,6 +1866,15 @@ export const config = {
       "  NCCL_SOCKET_IFNAME=<your-nic>   # force NCCL off kube-ipvs0",
       "  SGLANG_HOST_IP=<this-node-ip>",
       "  NCCL_IB_HCA=<hca0,hca1,...>     # RDMA fabrics only",
+    ],
+    gb200: [
+      "Allocate all four nodes within a single NVL72 domain.",
+      "MNNVL is off by default — set on every rank:",
+      "  NCCL_MNNVL_ENABLE=1",
+      "  NCCL_CUMEM_ENABLE=1",
+      "Point the JIT caches at GB200-only paths; GB200 is SM100 and GB300 is SM103,",
+      "so the two architectures need separate caches:",
+      "  TORCH_EXTENSIONS_DIR / TRITON_CACHE_DIR / TVM_FFI_CACHE_DIR",
     ],
     h100: [
       "Set This node IP separately on each node; use the same cross-node NIC name on all four nodes.",


### PR DESCRIPTION
Follow-up to #32542. Updates the GB200 recipes for Kimi-K3.

Work done in collaboration with @leejnau.

The GB200 cells were derived from the GB300 recipe. This replaces the PD-disaggregated ones with measured configurations, and adds two pieces GB200 was missing: a prefill cell and a `multiNodeHints` entry.

## Changes

| Cell | Before | After |
|---|---|---|
| prefill / default | *(none)* | `--tp-size 1 --pp-size 16` |
| prefill / long-context | *(none)* | `--tp-size 1 --pp-size 16`, `mem-fraction 0.90` |
| decode / low-latency | `tp16` | `tp8 pp2` |
| decode / balanced | `tp16 dcp16` | `tp16 dcp16 ep16` |
| decode / high-throughput | `tp16 dcp16`, `mem-fraction 0.92` | `tp16 dcp8 dp2 ep16`, `mem-fraction 0.85` |
| `multiNodeHints.gb200` | *(none)* | MNNVL env, NVL72 domain, JIT cache paths |

The five GB200 PD cells stay `verified: false` / `verificationStatus: "in-progress"`. Unified cells are unchanged.

## Setup

4×4 GB200, 16 GPU per worker. Decode figures: PD-disaggregated, ISL 8192 / OSL 1024, behind a shared PP2 × TP8 prefill. Prefill topology comparison: aggregated, ISL 8192 / OSL 1.

## Prefill — prefill tok/s/GPU, ISL 8192

| Topology | c4 | c16 | c32 | c64 |
|---|---:|---:|---:|---:|
| **PP16 × TP1** | 1227 | **3978** | **4550** | **4552** |
| PP8 × TP2 | 961 | 2967 | 3596 | 3773 |
| TEP16 | **1947** | 2518 | 2407 | 2389 |
| TP16 | 1448 | 1631 | 1652 | 1561 |

PP16 × TP1 leads from concurrency 16 and is flat past 32. Below concurrency ~8 the pipeline does not fill and TEP16 leads instead; the cell comment records both so a reader at a different operating point can choose.

## Decode — out tok/s/GPU @ out tok/s/user, 16 GPU decode

| Decode | MoE | c8 | c64 | c128 | c256 | c512 |
|---|---|---|---|---|---|---|
| **PP2 × TP8** | FlashInfer | **13.3 @ 57.7** | **60.0 @ 33.7** | 91.3 @ 26.2 | 135.1 @ 19.8 | — |
| **DCP8 × dp2 + EP16** | MegaMoE | 8.6 @ 37.1 | 54.5 @ 31.4 | 94.5 @ 28.5 | **145.5 @ 25.4** | **157.5 @ 25.2** |
| DCP16 + EP16 | FlashInfer | 9.3 @ 39.7 | 56.2 @ 32.4 | 92.7 @ 27.4 | 136.1 @ 20.6 | 153.5 @ 17.5 |
| DCP16 | FlashInfer | 9.3 @ 39.9 | 52.4 @ 30.0 | 84.5 @ 24.5 | 126.1 @ 18.7 | 144.2 @ 16.1 |
| TP16 | FlashInfer | 9.5 @ 40.7 | 52.9 @ 29.9 | 84.9 @ 24.5 | 87.4 @ 23.9 | 90.2 @ 23.9 |

The three cells follow the three regimes in that table:

**Below concurrency ~100, PP2 × TP8 leads on both axes** — +40% throughput and +45% interactivity over TP16 at concurrency 8, still ahead at 64, overtaken by DCP16 + EP16 at 128. It is the Low-Latency cell. Because SGLang requires `decode pp_size == prefill pp_size or 1`, the cell carries a `warn` telling the reader to pair it with a PP2 × TP8 prefill.

**DCP raises the achievable batch size.** Concurrent decodes admitted at an offered concurrency of 512: 311 for DCP16, 308 for DCP16 + EP16, 125 for TP16. TP16 stops scaling past concurrency 128, which is why its throughput is flat above. GB300's TP8 does not show the same limit.

**EP16 on top of DCP16 is +6% to +10%** out tok/s/GPU at every concurrency measured, at the same batch size — hence its addition to the Balanced cell.

**MegaMoE's advantage requires dp > 1.** On DCP8 × dp2 + EP16 it is +8.3% / +10.0% / +11.0% over FlashInfer MXFP4 at concurrency 64 / 128 / 256. On the flat DCP16 + EP16 shape it is the slower of the two below concurrency 256. The High-Throughput cell comment states this so MegaMoE is not read as a general recommendation.

## Accuracy

GSM8K on each of the three published prefill/decode pairs, same 4×4 GB200 deployment:

| Cell | Prefill → Decode | GSM8K |
|---|---|---:|
| Low-Latency | PP2 × TP8 → PP2 × TP8 | 0.975 |
| Balanced | PP16 × TP1 → DCP16 + EP16 | 0.974 |
| High-Throughput | PP16 × TP1 → DCP8 × dp2 + EP16 + MegaMoE | 0.976 |

1314 questions, `--api chat` with thinking enabled, temperature 0, `--num-threads 256`. The standard error at that sample size is 0.43%, and the spread across the three is 0.15%, so the parallelism and MoE-backend choices in this PR are accuracy-neutral — including the MegaMoE + DeepGEMM path, which is the only one of the three not on FlashInfer MXFP4.

## Long-context prefill

The Long-Context cell keeps the same chunked-PP shape as Default and raises `mem-fraction-static` to 0.90 for KV headroom, which is the trade the B300 and GB300 Long-Context recipes already make.

TP stays at 1 rather than moving to TP2 × PP8: MLA KV is replicated across TP ranks, so TP2 × PP8 would hold roughly half the tokens of TP1 × PP16 for the same memory, and context length is what this cell is for. Long-context workloads have not been benchmarked on GB200 yet, so the cell is a recipe rather than a measurement — consistent with its `verificationStatus: "in-progress"`.

## Validation

`node docs_new/scripts/check_cookbook_configs.mjs` → `cookbook config check: OK`.

Parallelism invariants checked on all seven GB200 cells: `tp × pp` = node count × 4, `dcp × dp` = `tp`, `ep` = `tp`, and `dp > 1` implies `--enable-dp-attention`.

cc @Po-Han-Huang-NV

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30406605833](https://github.com/sgl-project/sglang/actions/runs/30406605833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30406605716](https://github.com/sgl-project/sglang/actions/runs/30406605716)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
