### PR TITLE
Feat/sgl router segment cache

### DIFF
--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -53,6 +53,13 @@ minijinja-contrib = { version = "2", features = ["pycompat"] }
 # `strftime_now` chat-template helper (some templates inject the current date).
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
+# Segment tokenize-cache (opt-in via --segment-cache): a chat prompt is split at
+# its chat-template marker tokens (turn boundaries) and each segment's token ids
+# are cached, so multi-turn conversations only re-tokenize the newest turn.
+# `moka` is the in-process L1, keyed by the segment bytes themselves (moka
+# compares keys, so lookups are collision-free with no manual hashing).
+moka = { version = "0.12", features = ["sync"] }
+
 # Utilities
 anyhow = "1"
 thiserror = "2"

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -13,7 +13,7 @@ use crate::config::{
     default_cb_cool_down, default_proxy_request_timeout_secs, default_stale_request_timeout_secs,
     resolve_mode, ActiveLoadConfig, CacheAwareConfig, CircuitBreakerConfig, Config,
     DiscoveryBackend, K8sDiscoveryConfig, LogFormat, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
+    ProxyConfig, SegmentCacheConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
 };
 
 /// `sgl-router` — slim KV-aware OpenAI-compatible router for SGLang workers.
@@ -89,6 +89,21 @@ pub struct Cli {
     /// Defaults to 60.
     #[arg(long)]
     pub sticky_eviction_interval_secs: Option<u64>,
+
+    // ---- segment tokenize-cache (opt-in) ----
+    /// Enable the segment tokenize-cache: split chat prompts at their
+    /// chat-template marker tokens and cache each segment's token ids, so a
+    /// multi-turn conversation only re-tokenizes the newest turn. Applies to
+    /// chat requests on a model with a Jinja chat template. Off by default.
+    #[arg(long)]
+    pub segment_cache: bool,
+    /// Max number of cached segments (store cap). Only with `--segment-cache`.
+    #[arg(long)]
+    pub segment_cache_capacity: Option<u64>,
+    /// Prompts shorter than this many bytes skip the cache and encode whole.
+    /// Only with `--segment-cache`.
+    #[arg(long)]
+    pub segment_cache_min_bytes: Option<usize>,
 
     // ---- discovery: static ----
     /// Static worker URLs (space-separated or repeated). Mutually
@@ -226,6 +241,25 @@ impl Cli {
             None
         };
 
+        // Segment tokenize-cache (opt-in). Sub-knobs require the feature flag,
+        // mirroring the cache-aware / sticky mutual-requirement checks above.
+        let tuned_segment_cache =
+            self.segment_cache_capacity.is_some() || self.segment_cache_min_bytes.is_some();
+        if tuned_segment_cache && !self.segment_cache {
+            return Err(anyhow!(
+                "--segment-cache-capacity / --segment-cache-min-bytes require --segment-cache"
+            ));
+        }
+        let segment_cache = if self.segment_cache {
+            let d = SegmentCacheConfig::default();
+            Some(SegmentCacheConfig {
+                capacity: self.segment_cache_capacity.unwrap_or(d.capacity),
+                min_bytes: self.segment_cache_min_bytes.unwrap_or(d.min_bytes),
+            })
+        } else {
+            None
+        };
+
         let circuit_breaker = self.cb_threshold.map(|threshold| CircuitBreakerConfig {
             threshold,
             cool_down_secs: self.cb_cool_down_secs.unwrap_or_else(default_cb_cool_down),
@@ -267,6 +301,7 @@ impl Cli {
                 circuit_breaker,
                 cache_aware,
                 sticky,
+                segment_cache,
             },
             discovery,
             proxy: ProxyConfig {

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -88,6 +88,7 @@ mod tests {
                 circuit_breaker: None,
                 cache_aware: None,
                 sticky: None,
+                segment_cache: None,
             },
             discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
                 urls: urls.iter().map(|s| s.to_string()).collect(),

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -155,6 +155,31 @@ pub struct ModelConfig {
     /// The chat handler reads `sticky.header_name` to populate
     /// [`crate::policies::SelectionContext::routing_key`].
     pub sticky: Option<StickyConfig>,
+    /// Segment tokenize-cache tuning. `Some` when `--segment-cache` is set,
+    /// `None` (default) leaves the chat path re-tokenizing every request as
+    /// before. Applies only to chat requests on a model with a Jinja chat
+    /// template (markers are derived from the template). See
+    /// [`crate::tokenizer::segment`].
+    pub segment_cache: Option<SegmentCacheConfig>,
+}
+
+/// Per-model segment tokenize-cache tuning (opt-in via `--segment-cache`).
+#[derive(Debug, Clone, Copy)]
+pub struct SegmentCacheConfig {
+    /// Max number of cached segments (store entry cap). Default 131072.
+    pub capacity: u64,
+    /// Prompts shorter than this many bytes skip the cache and encode whole —
+    /// below it the per-segment bookkeeping outweighs re-tokenizing. Default 4096.
+    pub min_bytes: usize,
+}
+
+impl Default for SegmentCacheConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 131_072,
+            min_bytes: 4096,
+        }
+    }
 }
 
 /// Per-model cache-aware-ZMQ tuning.

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -300,6 +300,7 @@ mod tests {
                 circuit_breaker: None,
                 cache_aware: None,
                 sticky: None,
+                segment_cache: None,
             },
             discovery: crate::config::DiscoveryBackend::StaticUrls(
                 crate::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -172,6 +172,7 @@ mod tests {
                 circuit_breaker: None,
                 cache_aware: None,
                 sticky: None,
+                segment_cache: None,
             },
             discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
                 urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -112,6 +112,7 @@ impl AppContext {
                     circuit_breaker: None,
                     cache_aware: None,
                     sticky: None,
+                    segment_cache: None,
                 },
                 discovery: crate::config::DiscoveryBackend::StaticUrls(
                     crate::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/src/server/routes/models.rs
+++ b/experimental/sgl-router/src/server/routes/models.rs
@@ -54,6 +54,7 @@ mod tests {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         };
         let app = crate::server::app::build_router(std::sync::Arc::new(ctx));
         let res = app

--- a/experimental/sgl-router/src/server/routes/tokenize.rs
+++ b/experimental/sgl-router/src/server/routes/tokenize.rs
@@ -121,6 +121,7 @@ mod tests {
                 circuit_breaker: None,
                 cache_aware: None,
                 sticky: None,
+                segment_cache: None,
             },
             discovery: crate::config::DiscoveryBackend::StaticUrls(
                 crate::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/src/tokenizer/adapter.rs
+++ b/experimental/sgl-router/src/tokenizer/adapter.rs
@@ -108,6 +108,79 @@ pub fn load_tokenizer_config(source: &str) -> Result<Option<serde_json::Value>> 
     Ok(Some(value))
 }
 
+/// Load the added-token strings from the `tokenizer.json` named by `source`
+/// (the same value passed to [`load`]) — the structural markers the segment
+/// cache splits on (`<|im_start|>`, role headers, `<|vision_start|>`, ...).
+///
+/// These live in tokenizer.json's `added_tokens` array, NOT in
+/// tokenizer_config.json's `special_tokens_map` (which carries only the 7 named
+/// bos/eos/... tokens). An added token is a HuggingFace hard split boundary (the
+/// tokenizer pre-splits input at them before BPE), so splitting a prompt there
+/// is byte-exact — EXCEPT for tokens with `lstrip`/`rstrip`, which absorb
+/// adjacent whitespace across the boundary and so are NOT byte-exact split
+/// points; those are excluded here. (`normalized`/`single_word` tokens are kept
+/// — they don't move the boundary; validated empirically, e.g. DeepSeek-V4's
+/// `normalized` `<｜User｜>`/`<｜Assistant｜>`, with the self-check as backstop.)
+/// [`super::segment`] additionally probe-filters
+/// the survivors to the tokens the chat template actually emits and runs a
+/// startup self-check (which also catches Metaspace/normalizer models where
+/// per-segment encoding diverges — those self-disable, staying correct).
+///
+/// Returns an empty vec — segmentation then disables itself — on any
+/// missing/unreadable/unparsable file, never an error: an absent marker set is
+/// a graceful "don't segment", not a fatal condition.
+pub fn load_added_special_tokens(source: &str) -> Vec<String> {
+    let path = if Path::new(source).is_file() || looks_like_path(source) {
+        std::path::PathBuf::from(source)
+    } else {
+        match download_tokenizer_json(source) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(repo = %source, error = %e,
+                    "could not resolve tokenizer.json for segment markers; segment cache disabled for this model");
+                return Vec::new();
+            }
+        }
+    };
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e,
+                "read tokenizer.json for segment markers failed; segment cache disabled");
+            return Vec::new();
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e,
+                "parse tokenizer.json for segment markers failed; segment cache disabled");
+            return Vec::new();
+        }
+    };
+    value
+        .get("added_tokens")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| {
+                    // Exclude whitespace-absorbing tokens: `lstrip`/`rstrip`
+                    // pull adjacent spaces into the token, so splitting at them
+                    // is not byte-exact (the space crosses the boundary).
+                    let lstrip = t.get("lstrip").and_then(|b| b.as_bool()).unwrap_or(false);
+                    let rstrip = t.get("rstrip").and_then(|b| b.as_bool()).unwrap_or(false);
+                    if lstrip || rstrip {
+                        return None;
+                    }
+                    t.get("content").and_then(|c| c.as_str())
+                })
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub fn encode(t: &Tokenizer, text: &str) -> Result<Vec<u32>> {
     let enc = t.encode(text).context("encode")?;
     Ok(enc.token_ids().to_vec())
@@ -136,4 +209,36 @@ pub fn decode_complete(t: &Tokenizer, ids: &[u32], skip_special: bool) -> Result
             s
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `load_added_special_tokens` keeps clean/normalized markers but excludes
+    /// whitespace-absorbing (`lstrip`/`rstrip`) tokens, which are not byte-exact
+    /// split points, and drops empty content.
+    #[test]
+    fn added_tokens_excludes_lstrip_rstrip() {
+        let markers = load_added_special_tokens("tests/fixtures/added_tokens_flags.json");
+        assert!(markers.contains(&"<|clean|>".to_string()));
+        assert!(
+            markers.contains(&"<|normalized|>".to_string()),
+            "normalized (non-strip) tokens are kept"
+        );
+        for excluded in ["<|lstrip_tok|>", "<|rstrip_tok|>", "<|both_strip|>", ""] {
+            assert!(
+                !markers.contains(&excluded.to_string()),
+                "{excluded:?} must be excluded (lstrip/rstrip/empty)"
+            );
+        }
+        assert_eq!(markers.len(), 2, "only <|clean|> + <|normalized|> survive");
+    }
+
+    /// A missing/unreadable file yields no markers (segmentation self-disables),
+    /// never a panic/error.
+    #[test]
+    fn added_tokens_missing_file_is_empty() {
+        assert!(load_added_special_tokens("tests/fixtures/does_not_exist.json").is_empty());
+    }
 }

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -4,11 +4,13 @@
 pub mod adapter;
 pub mod chat_template;
 pub mod dsv4;
+pub mod segment;
 
 use anyhow::Result;
 use chat_template::ChatTemplate;
 use dashmap::DashMap;
 use dynamo_tokenizers::Tokenizer;
+use segment::{SegmentCache, SegmentEncoder};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -34,14 +36,36 @@ impl ChatEncoder {
     }
 }
 
+/// Per-model bundle implementing the segment cache's [`SegmentEncoder`] contract:
+/// render via the model's chat encoder, tokenize via its tokenizer, markers from
+/// its added tokens. The `chat` encoder is shared (`Arc`) with the registry's
+/// [`ChatEncoderEntry`] so there is exactly one encoder per model.
+struct ModelSegmentEncoder {
+    chat: Arc<ChatEncoder>,
+    tokenizer: Arc<Tokenizer>,
+    added_tokens: Vec<String>,
+}
+
+impl SegmentEncoder for ModelSegmentEncoder {
+    fn render(&self, messages: &serde_json::Value) -> Option<String> {
+        self.chat.render(messages).ok()
+    }
+    fn encode(&self, text: &str) -> Result<Vec<u32>> {
+        adapter::encode(&self.tokenizer, text)
+    }
+    fn marker_candidates(&self) -> &[String] {
+        &self.added_tokens
+    }
+}
+
 /// A model's chat encoder plus its fallback-logging state.
 struct ChatEncoderEntry {
-    encoder: ChatEncoder,
+    encoder: Arc<ChatEncoder>,
     fallback_warned: AtomicBool,
 }
 
 impl ChatEncoderEntry {
-    fn new(encoder: ChatEncoder) -> Self {
+    fn new(encoder: Arc<ChatEncoder>) -> Self {
         Self {
             encoder,
             fallback_warned: AtomicBool::new(false),
@@ -74,6 +98,12 @@ pub struct TokenizerRegistry {
     /// requests the way the engine does; models without one fall back to raw
     /// prompt-text tokenization.
     encoders: DashMap<String, Arc<ChatEncoderEntry>>,
+    /// Per-model segment tokenize-cache, present only when `--segment-cache` is
+    /// set for the model. Its [`SegmentEncoder`] is a [`ModelSegmentEncoder`]
+    /// bundling this model's chat encoder + tokenizer, so it works for any
+    /// encoder (Jinja or the DeepSeek-V4 code encoder). [`Self::encode_chat`]
+    /// routes through it when present. See [`segment`].
+    segment_caches: DashMap<String, Arc<SegmentCache>>,
 }
 
 impl std::fmt::Debug for TokenizerRegistry {
@@ -89,7 +119,7 @@ impl TokenizerRegistry {
         let me = TokenizerRegistry::default();
         let m = &cfg.model;
         let t = adapter::load(&m.tokenizer_path)?;
-        me.inner.insert(m.id.clone(), t);
+        me.inner.insert(m.id.clone(), Arc::clone(&t));
         // Resolve the chat encoder, best-effort: a Jinja template from
         // tokenizer_config.json, else a built-in encoder for a recognized model
         // (DeepSeek-V4), else none (chat traffic routes via raw text). Every
@@ -98,8 +128,24 @@ impl TokenizerRegistry {
         // routing degraded to overlap=0 on chat traffic", so it must never be
         // silent.
         if let Some(encoder) = me.resolve_chat_encoder(&m.id, &m.tokenizer_path) {
+            // One chat encoder per model, shared (Arc) between the render path
+            // (ChatEncoderEntry) and the segment cache's SegmentEncoder.
+            let chat = Arc::new(encoder);
+            // Segment tokenize-cache (opt-in, per-model). The ModelSegmentEncoder
+            // bundles render (chat) + encode (tokenizer) + markers (added tokens),
+            // so segmentation works for any encoder — Jinja or DeepSeek-V4 code.
+            if let Some(sc_cfg) = m.segment_cache.as_ref() {
+                let added = adapter::load_added_special_tokens(&m.tokenizer_path);
+                let seg_encoder: Arc<dyn SegmentEncoder> = Arc::new(ModelSegmentEncoder {
+                    chat: Arc::clone(&chat),
+                    tokenizer: Arc::clone(&t),
+                    added_tokens: added,
+                });
+                let sc = SegmentCache::new(&m.id, seg_encoder, sc_cfg);
+                me.segment_caches.insert(m.id.clone(), Arc::new(sc));
+            }
             me.encoders
-                .insert(m.id.clone(), Arc::new(ChatEncoderEntry::new(encoder)));
+                .insert(m.id.clone(), Arc::new(ChatEncoderEntry::new(chat)));
         }
         Ok(me)
     }
@@ -161,7 +207,14 @@ impl TokenizerRegistry {
                 entry.log_fallback(model_id, &format!("render failed: {e:#}"))
             })
             .ok()?;
-        match adapter::encode(&tokenizer, &rendered) {
+        // Route through the segment cache when one is configured for this model;
+        // it is byte-identical to `adapter::encode(&tokenizer, &rendered)` but
+        // reuses cached per-segment ids across turns. Absent → encode whole.
+        let encoded = match self.segment_caches.get(model_id) {
+            Some(sc) => sc.encode_cached(&rendered),
+            None => adapter::encode(&tokenizer, &rendered),
+        };
+        match encoded {
             Ok(ids) if !ids.is_empty() => Some(ids),
             Ok(_) => {
                 entry.log_fallback(model_id, "rendered prompt tokenized to zero tokens");
@@ -185,7 +238,7 @@ impl TokenizerRegistry {
     pub(crate) fn attach_chat_encoder_for_test(&self, model_id: &str, encoder: ChatEncoder) {
         self.encoders.insert(
             model_id.to_string(),
-            Arc::new(ChatEncoderEntry::new(encoder)),
+            Arc::new(ChatEncoderEntry::new(Arc::new(encoder))),
         );
     }
 
@@ -235,6 +288,7 @@ mod tests {
                 circuit_breaker: None,
                 cache_aware: None,
                 sticky: None,
+                segment_cache: None,
             },
             discovery: crate::config::DiscoveryBackend::StaticUrls(
                 crate::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/src/tokenizer/segment/cache.rs
+++ b/experimental/sgl-router/src/tokenizer/segment/cache.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Storage backend for the segment cache: segment bytes → token ids.
+//!
+//! [`SegmentStore`] is the one storage abstraction [`super::SegmentCache`]
+//! depends on. Today there is a single in-process backend ([`InProcStore`]); a
+//! shared/cross-process tier (e.g. an shm-backed store, or a tiered store
+//! combining the two) can be added later as another `SegmentStore` impl without
+//! changing the cache.
+
+use moka::sync::Cache;
+use std::sync::Arc;
+
+/// A store of segment → token-ids. Implement to add a backend (in-proc today;
+/// shm / tiered / NUMA-sharded later). Must be thread-safe: one instance is
+/// shared across all requests.
+///
+/// **Correctness contract:** a `get` hit MUST return the exact ids previously
+/// `insert`ed for THAT segment — i.e. the store is collision-free. How it
+/// achieves that is the backend's business ([`InProcStore`] keys by the bytes;
+/// a hash-keyed shm store must byte-verify on hit).
+pub trait SegmentStore: Send + Sync {
+    /// Cached ids for `seg`, if present.
+    fn get(&self, seg: &str) -> Option<Arc<[u32]>>;
+
+    /// Store `ids` for `seg`.
+    fn insert(&self, seg: &str, ids: Arc<[u32]>);
+
+    /// Approximate number of cached segments (observability / tests).
+    fn entry_count(&self) -> u64;
+
+    /// Reserved hint for backends with expensive lookups (a future shm store):
+    /// warm the slot for `seg` ahead of a `get`. Default no-op — in-proc stores
+    /// have nothing to prefetch.
+    fn prefetch(&self, _seg: &str) {}
+}
+
+/// In-process [`SegmentStore`]: a bounded `moka` map (LRU/TinyLFU eviction)
+/// keyed by the segment string itself, so lookups are **collision-free** with no
+/// manual hashing — a hit is always the exact segment's ids. Values are
+/// `Arc<[u32]>` so a hit clones a pointer, not the token vector. Thread-safe:
+/// `moka::sync::Cache` supports concurrent get/insert.
+pub struct InProcStore {
+    inner: Cache<Box<str>, Arc<[u32]>>,
+}
+
+impl InProcStore {
+    /// `capacity` is the max number of cached segments.
+    pub fn new(capacity: u64) -> Self {
+        Self {
+            inner: Cache::builder().max_capacity(capacity).build(),
+        }
+    }
+}
+
+impl std::fmt::Debug for InProcStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InProcStore")
+            .field("entry_count", &self.inner.entry_count())
+            .finish()
+    }
+}
+
+impl SegmentStore for InProcStore {
+    fn get(&self, seg: &str) -> Option<Arc<[u32]>> {
+        self.inner.get(seg)
+    }
+
+    fn insert(&self, seg: &str, ids: Arc<[u32]>) {
+        self.inner.insert(seg.into(), ids);
+    }
+
+    fn entry_count(&self) -> u64 {
+        self.inner.run_pending_tasks();
+        self.inner.entry_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_by_exact_segment() {
+        let c = InProcStore::new(16);
+        assert!(c.get("<|im_start|>user\nhi").is_none());
+        c.insert("<|im_start|>user\nhi", Arc::from(vec![1u32, 2, 3]));
+        assert_eq!(
+            c.get("<|im_start|>user\nhi").as_deref(),
+            Some(&[1u32, 2, 3][..])
+        );
+        // a different segment is a distinct key (no hash-collision aliasing).
+        assert!(c.get("<|im_start|>user\nbye").is_none());
+        assert_eq!(c.entry_count(), 1);
+    }
+}

--- a/experimental/sgl-router/src/tokenizer/segment/markers.rs
+++ b/experimental/sgl-router/src/tokenizer/segment/markers.rs
@@ -1,0 +1,242 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Derive segment **markers** by probe-rendering a chat encoder.
+//!
+//! Encoder-agnostic: the caller passes a `render` closure (the model's actual
+//! chat encoder — a Jinja template, DeepSeek-V4's built-in code encoder, etc.),
+//! and we probe-render a conversation whose message contents are unique
+//! sentinels (containing no special tokens). Every special token that appears in
+//! the output must therefore be template *framing* → a marker. Splitting the
+//! rendered prompt at markers yields the cache reuse unit; markers are
+//! `AddedToken`s = HuggingFace hard split boundaries, so splitting there is
+//! byte-exact. [`super::SegmentCache`] then runs a startup self-check
+//! (concat-of-segments == whole) with the real tokenizer before trusting them.
+//!
+//! Role-agnostic: we do NOT categorize turns / tool-calls / roles — a marker is
+//! just any structural special token the encoder emits.
+
+use serde_json::Value;
+
+/// Result of analyzing an encoder.
+pub struct Segmenter {
+    /// Turn-boundary marker strings (special tokens), longest first.
+    pub markers: Vec<String>,
+    /// False if no structural markers were found (caller must not segment).
+    pub segmentable: bool,
+}
+
+/// Derive segment markers: probe-render (via `render`) with sentinel contents,
+/// then keep every special token from `specials` that shows up in the output (it
+/// must be framing, since the sentinels contain none). `render` takes a chat
+/// `messages` array and returns the rendered prompt, or `None` if it can't
+/// render that shape (e.g. a text-only template handed multimodal content — that
+/// probe is simply skipped).
+pub fn derive_markers<F>(render: F, specials: &[String]) -> Result<Segmenter, String>
+where
+    F: Fn(&Value) -> Option<String>,
+{
+    let s = |i: usize| format!("\u{E000}MT{i}\u{E001}");
+    // Probe conversation covering system/user/assistant AND a tool interaction
+    // (assistant tool_calls + a tool-output message) so tool framing special
+    // tokens are emitted and captured as markers. Encoders that ignore tools
+    // simply emit nothing extra.
+    let probe = serde_json::json!([
+        { "role": "system", "content": s(0) },
+        { "role": "user", "content": s(1) },
+        { "role": "assistant", "content": s(2) },
+        { "role": "user", "content": s(3) },
+        { "role": "assistant", "content": "",
+          "tool_calls": [ { "type": "function",
+              "function": { "name": s(4), "arguments": "{}" } } ] },
+        { "role": "tool", "content": s(5) },
+        { "role": "assistant", "content": s(6) },
+    ]);
+    let mut rendered = render(&probe).ok_or_else(|| "probe render failed".to_string())?;
+
+    // Best-effort multimodal probe: a user message whose content is a list of
+    // content-parts (image + text), the common HF multimodal format. Makes the
+    // encoder emit vision/image framing tokens (<|vision_start|>, <|image_pad|>,
+    // ...) so they're captured too. Encoders that don't handle list content
+    // return None here and are skipped, leaving the text markers unaffected.
+    let mm = serde_json::json!([
+        { "role": "user", "content": [
+            { "type": "image" },
+            { "type": "text", "text": s(7) },
+        ] },
+    ]);
+    if let Some(r) = render(&mm) {
+        rendered.push_str(&r);
+    }
+
+    // Validate the plain-content sentinels survived (0..3 always present).
+    for i in 0..4 {
+        if !rendered.contains(&s(i)) {
+            return Err(format!("sentinel {i} missing from probe render"));
+        }
+    }
+
+    let mut markers: Vec<String> = specials
+        .iter()
+        .filter(|t| !t.is_empty() && rendered.contains(t.as_str()))
+        .cloned()
+        .collect();
+    // longest first so split matches the longest marker at a position.
+    markers.sort_by_key(|m| std::cmp::Reverse(m.len()));
+    markers.dedup();
+    let segmentable = !markers.is_empty();
+    Ok(Segmenter {
+        markers,
+        segmentable,
+    })
+}
+
+/// Split `text` at marker boundaries; each segment starts with its leading
+/// marker. Markers must be BPE hard boundaries (special tokens).
+pub fn split_at_markers<'a>(text: &'a str, markers: &[String]) -> Vec<&'a str> {
+    if markers.is_empty() {
+        return if text.is_empty() { vec![] } else { vec![text] };
+    }
+    let b = text.as_bytes();
+    let mut cuts = vec![0usize];
+    let mut i = 0;
+    let mut prev_end = usize::MAX; // byte end of the previously matched marker
+    let mut prev_marker = usize::MAX; // its index in `markers`
+    while i < b.len() {
+        let mut matched = false;
+        for (mi, m) in markers.iter().enumerate() {
+            let mb = m.as_bytes();
+            if !mb.is_empty() && b[i..].starts_with(mb) {
+                // Coalesce a run of the SAME marker (e.g. multimodal placeholders
+                // like <|image_pad|> repeated thousands of times) into ONE
+                // segment: only cut when this occurrence isn't contiguous with an
+                // identical one. Byte-exact (the run still encodes token-per-
+                // token via added-vocab); avoids pathological over-segmentation.
+                let coalesce = i == prev_end && mi == prev_marker;
+                if i != 0 && !coalesce {
+                    cuts.push(i);
+                }
+                i += mb.len();
+                prev_end = i;
+                prev_marker = mi;
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            // advance one UTF-8 char
+            let step = match b[i] {
+                0x00..=0x7F => 1,
+                0xC0..=0xDF => 2,
+                0xE0..=0xEF => 3,
+                _ => 4,
+            };
+            i += step.min(b.len() - i);
+        }
+    }
+    cuts.dedup();
+    let mut out = Vec::with_capacity(cuts.len());
+    for w in cuts.windows(2) {
+        out.push(&text[w[0]..w[1]]);
+    }
+    let last = *cuts.last().unwrap();
+    if last < text.len() {
+        out.push(&text[last..]);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A stand-in Qwen-style encoder: wraps each message in `<|im_start|>` /
+    /// `<|im_end|>` framing. Exercises `derive_markers` without a real template.
+    fn qwen_render(msgs: &Value) -> Option<String> {
+        let mut s = String::new();
+        for m in msgs.as_array()? {
+            let role = m.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+            let c = m.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            s.push_str(&format!("<|im_start|>{role}\n{c}<|im_end|>\n"));
+        }
+        Some(s)
+    }
+
+    #[test]
+    fn derives_only_emitted_markers() {
+        let specials = vec![
+            "<|im_start|>".to_string(),
+            "<|im_end|>".to_string(),
+            "<|endoftext|>".to_string(), // in vocab but never emitted → not a marker
+        ];
+        let seg = derive_markers(qwen_render, &specials).unwrap();
+        assert!(seg.segmentable);
+        assert!(seg.markers.contains(&"<|im_start|>".to_string()));
+        assert!(seg.markers.contains(&"<|im_end|>".to_string()));
+        assert!(!seg.markers.contains(&"<|endoftext|>".to_string()));
+    }
+
+    #[test]
+    fn dsv4_style_markers_derived() {
+        // DeepSeek-V4 code encoder emits these; all are added tokens.
+        fn dsv4_render(msgs: &Value) -> Option<String> {
+            let mut s = String::from("<\u{ff5c}begin\u{2581}of\u{2581}sentence\u{ff5c}>");
+            for m in msgs.as_array()? {
+                let c = m.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                s.push_str("<\u{ff5c}User\u{ff5c}>");
+                s.push_str(c);
+                s.push_str("<\u{ff5c}Assistant\u{ff5c}></think>");
+            }
+            Some(s)
+        }
+        let specials = vec![
+            "<\u{ff5c}User\u{ff5c}>".to_string(),
+            "<\u{ff5c}Assistant\u{ff5c}>".to_string(),
+            "</think>".to_string(),
+        ];
+        let seg = derive_markers(dsv4_render, &specials).unwrap();
+        assert!(seg.segmentable);
+        assert!(seg.markers.contains(&"<\u{ff5c}User\u{ff5c}>".to_string()));
+        assert!(seg.markers.contains(&"</think>".to_string()));
+    }
+
+    #[test]
+    fn no_markers_when_encoder_emits_none() {
+        fn plain(msgs: &Value) -> Option<String> {
+            let mut s = String::new();
+            for m in msgs.as_array()? {
+                s.push_str(m.get("content").and_then(|c| c.as_str()).unwrap_or(""));
+                s.push('\n');
+            }
+            Some(s)
+        }
+        let seg = derive_markers(plain, &["<|im_start|>".to_string()]).unwrap();
+        assert!(!seg.segmentable);
+        assert!(seg.markers.is_empty());
+    }
+
+    #[test]
+    fn split_starts_each_segment_with_its_marker() {
+        let markers = vec!["<|im_start|>".to_string(), "<|im_end|>".to_string()];
+        let text = "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n";
+        let segs = split_at_markers(text, &markers);
+        assert_eq!(segs.concat(), text);
+        assert!(segs[0].starts_with("<|im_start|>"));
+        assert!(segs.iter().skip(1).all(|s| s.starts_with("<|im")));
+    }
+
+    #[test]
+    fn split_no_markers_returns_whole() {
+        assert_eq!(split_at_markers("hello", &[]), vec!["hello"]);
+        assert!(split_at_markers("", &[]).is_empty());
+    }
+
+    #[test]
+    fn split_coalesces_same_marker_run() {
+        let markers = vec!["<|image_pad|>".to_string()];
+        let text = "a<|image_pad|><|image_pad|><|image_pad|>b";
+        let segs = split_at_markers(text, &markers);
+        assert_eq!(segs.concat(), text);
+        assert_eq!(segs, vec!["a", "<|image_pad|><|image_pad|><|image_pad|>b"]);
+    }
+}

--- a/experimental/sgl-router/src/tokenizer/segment/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/segment/mod.rs
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Segment tokenize-cache (opt-in). A chat prompt is split at its chat-template
+//! marker tokens (turn boundaries) and each segment's token ids are cached, so a
+//! multi-turn conversation only re-tokenizes the newest turn. `encode_cached` is
+//! **byte-identical** to encoding the whole rendered prompt in one shot.
+//!
+//! # Programming model
+//!
+//! The cache has two pluggable axes, both trait objects:
+//!   * [`SegmentEncoder`] — a model's chat encoder (render + tokenize + marker
+//!     candidates). Implement it to support a new model template / encoder.
+//!   * [`SegmentStore`] — the storage backend (in-process today; shm / tiered
+//!     later). Implement it to add a backend.
+//!
+//! [`SegmentCache`] owns an `Arc<dyn SegmentEncoder>` and an
+//! `Arc<dyn SegmentStore>`; neither the cache logic nor the other axis changes
+//! when you add one. Usage: the caller renders the prompt via the encoder, then
+//! hands the rendered string to [`SegmentCache::encode_cached`].
+//! [`SegmentCache::new`] uses the default [`InProcStore`];
+//! [`SegmentCache::with_store`] injects a custom backend.
+//!
+//! Correctness rests on three things, none involving hashes:
+//!   1. the encoder's tokenizer is aligned to the engine (operator's resolved
+//!      tokenizer.json) — orthogonal to this layer;
+//!   2. markers are AddedTokens = HuggingFace hard split boundaries, so
+//!      splitting there is byte-exact;
+//!   3. a startup self-check asserts `concat(encode(segment_i)) == encode(whole)`
+//!      and disables segmentation (falls back to whole-prompt encode) on any
+//!      mismatch.
+
+mod cache;
+mod markers;
+
+use markers::{derive_markers, split_at_markers, Segmenter};
+use std::sync::Arc;
+
+pub use crate::config::SegmentCacheConfig;
+pub use cache::{InProcStore, SegmentStore};
+
+/// A model's chat-encoding contract, and the only thing [`SegmentCache`] depends
+/// on. Implement this to add a new model template / encoder — the cache is
+/// untouched. Must be thread-safe: one instance is shared across all requests.
+pub trait SegmentEncoder: Send + Sync {
+    /// Render a chat `messages` array into the prompt string the engine would
+    /// tokenize. `None` if this encoder can't render that shape (the marker
+    /// probe then skips it). Only called at [`SegmentCache::new`] (marker
+    /// derivation); the request path renders once at ingress and passes the
+    /// string to [`SegmentCache::encode_cached`].
+    fn render(&self, messages: &serde_json::Value) -> Option<String>;
+
+    /// Tokenize `text` to ids with `add_special_tokens = false` (specials come
+    /// from the rendered text, not the tokenizer's auto-insertion).
+    fn encode(&self, text: &str) -> anyhow::Result<Vec<u32>>;
+
+    /// Special-token strings that may appear as segment markers (turn / tool /
+    /// vision framing). Typically the tokenizer's `added_tokens`; the probe
+    /// filters these to the ones the encoder actually emits.
+    fn marker_candidates(&self) -> &[String];
+}
+
+/// Per-model segment cache: derived markers + the [`SegmentStore`] + the safety
+/// gate, plus the [`SegmentEncoder`] it was built from (used for encode on a
+/// miss). Both the store and the encoder are pluggable via trait objects.
+pub struct SegmentCache {
+    /// Turn-boundary markers, longest-first (from [`derive_markers`]).
+    markers: Vec<String>,
+    /// Gate: false when there are no markers or the self-check failed. When
+    /// false, `encode_cached` degrades to a plain whole-prompt encode.
+    segmentable: bool,
+    /// Below this many bytes, skip the cache and encode whole: for short prompts
+    /// the per-segment bookkeeping outweighs re-tokenizing.
+    min_bytes: usize,
+    store: Arc<dyn SegmentStore>,
+    encoder: Arc<dyn SegmentEncoder>,
+}
+
+impl std::fmt::Debug for SegmentCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SegmentCache")
+            .field("markers", &self.markers.len())
+            .field("segmentable", &self.segmentable)
+            .field("min_bytes", &self.min_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SegmentCache {
+    /// Build for a model with the default in-process store ([`InProcStore`],
+    /// sized by `cfg.capacity`). Convenience over [`Self::with_store`].
+    pub fn new(model_id: &str, encoder: Arc<dyn SegmentEncoder>, cfg: &SegmentCacheConfig) -> Self {
+        let store: Arc<dyn SegmentStore> = Arc::new(InProcStore::new(cfg.capacity));
+        Self::with_store(model_id, encoder, cfg.min_bytes, store)
+    }
+
+    /// Build with an injected [`SegmentStore`] (e.g. a shared/tiered backend, or
+    /// a test double). Derives markers by probe-rendering `encoder` against its
+    /// marker candidates, then runs the startup self-check with `encoder.encode`.
+    pub fn with_store(
+        model_id: &str,
+        encoder: Arc<dyn SegmentEncoder>,
+        min_bytes: usize,
+        store: Arc<dyn SegmentStore>,
+    ) -> Self {
+        let Segmenter {
+            markers,
+            segmentable,
+        } = derive_markers(|m| encoder.render(m), encoder.marker_candidates()).unwrap_or_else(|e| {
+            tracing::warn!(model = %model_id, error = %e,
+                "segment-cache marker derivation failed; segmentation disabled (whole-prompt encode)");
+            Segmenter {
+                markers: Vec::new(),
+                segmentable: false,
+            }
+        });
+        let mut me = Self {
+            markers,
+            segmentable,
+            min_bytes,
+            store,
+            encoder,
+        };
+        me.self_check(model_id);
+        me
+    }
+
+    /// Whether segmentation is live (markers found AND self-check passed).
+    pub fn is_segmentable(&self) -> bool {
+        self.segmentable
+    }
+
+    /// Startup safety gate — the universal correctness oracle. Synthesize a
+    /// prompt that exercises every boundary shape around each marker, then assert
+    /// `concat(encode(segment_i)) == encode(whole)`. Template-independent: it
+    /// validates BPE-safety of *these markers* with *this tokenizer* directly, so
+    /// it catches ANY tokenizer where per-segment encoding diverges — whitespace-
+    /// absorbing tokens, Metaspace/SentencePiece prefix-space, context-dependent
+    /// normalizers, etc. A proven mismatch disables segmentation (stays correct,
+    /// falls back to whole-prompt encode); an `encode` error leaves it enabled
+    /// (can't disprove the hard-boundary invariant).
+    ///
+    /// The probe deliberately puts each marker in four adjacencies —
+    /// `content <m>` (space before → lstrip), `<m> content` (space after →
+    /// rstrip), `content<m>content` (glued), and `<m0><m1>` (adjacent markers) —
+    /// so a boundary that isn't byte-exact reliably shows up.
+    fn self_check(&mut self, model_id: &str) {
+        if !self.segmentable {
+            return;
+        }
+        let fillers = [
+            "hello world",
+            "the quick brown fox jumps",
+            "你好,世界",
+            "def f(x): return x + 1",
+        ];
+        let mut probe = String::from("preamble text ");
+        for (i, m) in self.markers.iter().enumerate() {
+            let f = fillers[i % fillers.len()];
+            // "<f> <m> <f><m><f> ": space-before, space-after, and glued-both-sides.
+            probe.push_str(f);
+            probe.push(' ');
+            probe.push_str(m);
+            probe.push(' ');
+            probe.push_str(f);
+            probe.push_str(m);
+            probe.push_str(f);
+            probe.push(' ');
+        }
+        // Exercise two adjacent markers (no content between) if we have them.
+        if self.markers.len() >= 2 {
+            probe.push_str(&self.markers[0]);
+            probe.push_str(&self.markers[1]);
+            probe.push_str("tail");
+        }
+
+        let whole = match self.encoder.encode(&probe) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!(model = %model_id, error = %e,
+                    "segment-cache self-check: probe encode failed; leaving segmentation enabled (relying on added-token hard-boundary invariant)");
+                return;
+            }
+        };
+        let mut seg = Vec::with_capacity(whole.len());
+        for s in split_at_markers(&probe, &self.markers) {
+            match self.encoder.encode(s) {
+                Ok(v) => seg.extend(v),
+                Err(e) => {
+                    tracing::debug!(model = %model_id, error = %e,
+                        "segment-cache self-check: segment encode failed; leaving segmentation enabled");
+                    return;
+                }
+            }
+        }
+        if whole != seg {
+            tracing::warn!(model = %model_id, markers = self.markers.len(),
+                "segment-cache self-check FAILED (segmented != whole); disabling segmentation for this model (whole-prompt encode)");
+            self.segmentable = false;
+        } else {
+            tracing::info!(model = %model_id, markers = self.markers.len(),
+                "segment-cache enabled (self-check passed)");
+        }
+    }
+
+    /// Encode a rendered prompt with segment caching. **Byte-identical** to
+    /// `encoder.encode(rendered)`; only faster when segments repeat across
+    /// requests. The caller renders `rendered` via the same encoder at ingress.
+    pub fn encode_cached(&self, rendered: &str) -> anyhow::Result<Vec<u32>> {
+        if !self.segmentable || rendered.len() < self.min_bytes {
+            return self.encoder.encode(rendered);
+        }
+        let mut out: Vec<u32> = Vec::with_capacity(rendered.len() / 3 + 1);
+        for seg in split_at_markers(rendered, &self.markers) {
+            if let Some(ids) = self.store.get(seg) {
+                out.extend_from_slice(&ids);
+            } else {
+                let ids = self.encoder.encode(seg)?;
+                self.store.insert(seg, Arc::from(ids.as_slice()));
+                out.extend_from_slice(&ids);
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Generic test [`SegmentEncoder`] backed by two closures + a marker set.
+    struct TestEncoder<R, E> {
+        render_fn: R,
+        encode_fn: E,
+        markers: Vec<String>,
+    }
+
+    impl<R, E> SegmentEncoder for TestEncoder<R, E>
+    where
+        R: Fn(&Value) -> Option<String> + Send + Sync,
+        E: Fn(&str) -> anyhow::Result<Vec<u32>> + Send + Sync,
+    {
+        fn render(&self, m: &Value) -> Option<String> {
+            (self.render_fn)(m)
+        }
+        fn encode(&self, t: &str) -> anyhow::Result<Vec<u32>> {
+            (self.encode_fn)(t)
+        }
+        fn marker_candidates(&self) -> &[String] {
+            &self.markers
+        }
+    }
+
+    fn enc_arc<R, E>(render_fn: R, encode_fn: E, markers: Vec<String>) -> Arc<dyn SegmentEncoder>
+    where
+        R: Fn(&Value) -> Option<String> + Send + Sync + 'static,
+        E: Fn(&str) -> anyhow::Result<Vec<u32>> + Send + Sync + 'static,
+    {
+        Arc::new(TestEncoder {
+            render_fn,
+            encode_fn,
+            markers,
+        })
+    }
+
+    /// Stand-in Qwen-style chat encoder for tests: wraps each message in
+    /// `<|im_start|>` / `<|im_end|>` framing so both are derived as markers.
+    fn qwen_render(msgs: &Value) -> Option<String> {
+        let mut s = String::new();
+        for m in msgs.as_array()? {
+            let role = m.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+            let c = m.get("content").and_then(|c| c.as_str()).unwrap_or("");
+            s.push_str(&format!("<|im_start|>{role}\n{c}<|im_end|>\n"));
+        }
+        Some(s)
+    }
+
+    /// A deterministic byte-level fake encoder: one id per UTF-8 byte. Trivially
+    /// split-safe (`concat(enc(parts)) == enc(whole)` always), so it exercises the
+    /// cache plumbing / segmentation independent of a real BPE.
+    fn byte_encode(s: &str) -> anyhow::Result<Vec<u32>> {
+        Ok(s.bytes().map(|b| b as u32).collect())
+    }
+
+    fn cfg() -> SegmentCacheConfig {
+        SegmentCacheConfig {
+            capacity: 1024,
+            min_bytes: 0, // exercise the cache path even for tiny prompts in tests
+        }
+    }
+
+    fn added() -> Vec<String> {
+        vec!["<|im_start|>".to_string(), "<|im_end|>".to_string()]
+    }
+
+    fn qwen_cache() -> SegmentCache {
+        SegmentCache::new("m", enc_arc(qwen_render, byte_encode, added()), &cfg())
+    }
+
+    #[test]
+    fn cached_equals_whole_encode() {
+        let sc = qwen_cache();
+        assert!(sc.is_segmentable());
+        let rendered =
+            "<|im_start|>user\nhello there<|im_end|>\n<|im_start|>assistant\nhi<|im_end|>\n";
+        let got = sc.encode_cached(rendered).unwrap();
+        assert_eq!(got, byte_encode(rendered).unwrap());
+    }
+
+    #[test]
+    fn second_call_hits_cache_and_matches() {
+        let sc = qwen_cache();
+        let r1 = "<|im_start|>user\nturn one<|im_end|>\n";
+        let r2 = "<|im_start|>user\nturn one<|im_end|>\n<|im_start|>user\nturn two<|im_end|>\n";
+        assert_eq!(sc.encode_cached(r1).unwrap(), byte_encode(r1).unwrap());
+        // r2 reuses r1's segments from cache; result still byte-identical.
+        assert_eq!(sc.encode_cached(r2).unwrap(), byte_encode(r2).unwrap());
+    }
+
+    #[test]
+    fn empty_and_marker_only_and_no_content() {
+        let sc = qwen_cache();
+        for r in [
+            "",
+            "<|im_start|>",
+            "<|im_start|><|im_end|>",
+            "no markers here",
+        ] {
+            assert_eq!(
+                sc.encode_cached(r).unwrap(),
+                byte_encode(r).unwrap(),
+                "mismatch for {r:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn self_check_disables_on_bad_encoder() {
+        // An encoder whose whole-encode differs from concat-of-parts (drops the
+        // first byte of every call) must trip the self-check → segmentation off.
+        fn lossy(s: &str) -> anyhow::Result<Vec<u32>> {
+            Ok(s.bytes().skip(1).map(|b| b as u32).collect())
+        }
+        let sc = SegmentCache::new("m", enc_arc(qwen_render, lossy, added()), &cfg());
+        assert!(
+            !sc.is_segmentable(),
+            "lossy encoder must disable segmentation"
+        );
+        // encode_cached then just delegates to the (lossy) whole encode.
+        let r = "<|im_start|>user\nhi<|im_end|>\n";
+        assert_eq!(sc.encode_cached(r).unwrap(), lossy(r).unwrap());
+    }
+
+    #[test]
+    fn min_bytes_bypasses_cache() {
+        let big_min = SegmentCacheConfig {
+            capacity: 16,
+            min_bytes: 10_000,
+        };
+        let sc = SegmentCache::new("m", enc_arc(qwen_render, byte_encode, added()), &big_min);
+        let r = "<|im_start|>user\nhi<|im_end|>\n";
+        assert_eq!(sc.encode_cached(r).unwrap(), byte_encode(r).unwrap());
+        // nothing cached because we bypassed the cache path.
+        assert_eq!(sc.store.entry_count(), 0);
+    }
+
+    /// End-to-end differential against the REAL dynamo tokenizer (checked-in tiny
+    /// byte-level BPE fixture): `encode_cached == encode(whole)` for an actual BPE
+    /// with real marker splitting (cold + warm + prefix reuse). The fixture's one
+    /// special added token, `<|endoftext|>`, is the turn marker.
+    #[test]
+    fn real_tokenizer_cached_equals_whole() {
+        use crate::tokenizer::adapter;
+        let tok = adapter::load("tests/fixtures/tiny_tokenizer.json").expect("load tiny fixture");
+        let tok_enc = Arc::clone(&tok);
+        let render = |msgs: &Value| {
+            let mut s = String::new();
+            for m in msgs.as_array().unwrap() {
+                s.push_str("<|endoftext|>");
+                s.push_str(m.get("content").and_then(|c| c.as_str()).unwrap_or(""));
+            }
+            Some(s)
+        };
+        let sc = SegmentCache::new(
+            "tiny",
+            enc_arc(
+                render,
+                move |s: &str| adapter::encode(&tok_enc, s),
+                vec!["<|endoftext|>".to_string()],
+            ),
+            &cfg(),
+        );
+        assert!(
+            sc.is_segmentable(),
+            "marker <|endoftext|> should be derived and self-check should pass"
+        );
+
+        let rendered =
+            "<|endoftext|>hello there friend<|endoftext|>how are you<|endoftext|>goodbye now";
+        let whole = adapter::encode(&tok, rendered).unwrap();
+        assert_eq!(sc.encode_cached(rendered).unwrap(), whole); // cold
+        assert_eq!(sc.encode_cached(rendered).unwrap(), whole); // warm
+
+        let extended = format!("{rendered}<|endoftext|>one more turn here");
+        assert_eq!(
+            sc.encode_cached(&extended).unwrap(),
+            adapter::encode(&tok, &extended).unwrap()
+        );
+    }
+
+    #[test]
+    fn concurrent_encode_matches_reference() {
+        use std::thread;
+        let sc = Arc::new(qwen_cache());
+        let inputs: Vec<String> = (0..32)
+            .map(|i| {
+                format!(
+                    "<|im_start|>user\nmsg {i}<|im_end|>\n<|im_start|>assistant\nok<|im_end|>\n"
+                )
+            })
+            .collect();
+        let expected: Vec<Vec<u32>> = inputs.iter().map(|s| byte_encode(s).unwrap()).collect();
+        let mut handles = Vec::new();
+        for (i, s) in inputs.into_iter().enumerate() {
+            let sc = Arc::clone(&sc);
+            handles.push(thread::spawn(move || (i, sc.encode_cached(&s).unwrap())));
+        }
+        for h in handles {
+            let (i, got) = h.join().unwrap();
+            assert_eq!(got, expected[i], "concurrent mismatch at {i}");
+        }
+    }
+}

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -481,6 +481,7 @@ mod tests {
                 }),
                 cache_aware: None,
                 sticky: None,
+                segment_cache: None,
             },
             discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
                 urls: vec!["http://test:30000".into()],

--- a/experimental/sgl-router/tests/component/discovery/static_urls.rs
+++ b/experimental/sgl-router/tests/component/discovery/static_urls.rs
@@ -133,6 +133,7 @@ async fn static_urls_pd_role_resolved_end_to_end() {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec![url.clone()],

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -72,6 +72,7 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: sgl_router::config::DiscoveryBackend::StaticUrls(
             sgl_router::config::StaticUrlsDiscoveryConfig {

--- a/experimental/sgl-router/tests/fixtures/added_tokens_flags.json
+++ b/experimental/sgl-router/tests/fixtures/added_tokens_flags.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Minimal tokenizer.json-shaped fixture for adapter::load_added_special_tokens. Exercises the lstrip/rstrip exclusion: only <|clean|> and <|normalized|> should survive as segment markers.",
+  "added_tokens": [
+    { "id": 1, "content": "<|clean|>", "lstrip": false, "rstrip": false, "normalized": false, "special": true },
+    { "id": 2, "content": "<|lstrip_tok|>", "lstrip": true, "rstrip": false, "normalized": false, "special": true },
+    { "id": 3, "content": "<|rstrip_tok|>", "lstrip": false, "rstrip": true, "normalized": false, "special": true },
+    { "id": 4, "content": "<|both_strip|>", "lstrip": true, "rstrip": true, "normalized": false, "special": true },
+    { "id": 5, "content": "<|normalized|>", "lstrip": false, "rstrip": false, "normalized": true, "special": true },
+    { "id": 6, "content": "", "lstrip": false, "rstrip": false, "special": true }
+  ]
+}

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -54,6 +54,7 @@ fn config() -> Config {
             circuit_breaker: None,
             cache_aware: Some(CacheAwareConfig::default()),
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -37,6 +37,7 @@ fn config_for(_worker_url: &str) -> Config {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/failover.rs
+++ b/experimental/sgl-router/tests/proxy/failover.rs
@@ -41,6 +41,7 @@ async fn failover_when_one_worker_dies() {
             }),
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec![w1.url.clone(), w2.url.clone(), w3.url.clone()],

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -47,6 +47,7 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -34,6 +34,7 @@ async fn forwards_whitelisted_headers_strips_others() {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -49,6 +49,7 @@ fn config() -> Config {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -48,6 +48,7 @@ fn config() -> Config {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -45,6 +45,7 @@ fn config() -> Config {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -64,6 +64,7 @@ fn config() -> Config {
                 idle_secs: 3600,
                 eviction_interval_secs: 3600,
             }),
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -50,6 +50,7 @@ fn build_sticky_ctx(header_name: &str, worker_urls: &[String]) -> Arc<AppContext
                 idle_secs: 3600,
                 eviction_interval_secs: 3600,
             }),
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -41,6 +41,7 @@ fn config(_worker_url: &str) -> Config {
             circuit_breaker: None,
             cache_aware: None,
             sticky: None,
+            segment_cache: None,
         },
         discovery: DiscoveryBackend::StaticUrls(StaticUrlsDiscoveryConfig {
             urls: vec!["http://placeholder:0".into()],


### PR DESCRIPTION
# [router] Opt-in segment tokenize-cache for multi-turn chat

## Summary
Adds an **opt-in** (`--segment-cache`, default off) **per-model** tokenize-cache to
`sgl-router`. A chat prompt is split at its chat-template marker tokens (turn
boundaries) and each segment's token ids are cached, so a multi-turn conversation
only re-tokenizes the **newest turn** instead of the whole history every request.
`encode_cached` is **byte-identical** to whole-prompt encode; when disabled,
behavior is unchanged.

## Architecture — request path

```mermaid
flowchart TD
    req["chat request /v1/chat/completions (messages[])"]
    req --> enc
    subgraph reg["TokenizerRegistry (per model)"]
      enc["ChatEncoder.render(messages)  —  Jinja template | DeepSeek-V4 code"]
      sc["SegmentCache.encode_cached(rendered)"]
    end
    enc -->|"rendered prompt (string)"| sc

    subgraph inner["inside encode_cached"]
      split["split_at_markers(rendered)"] --> loop{"per segment"}
      loop --> get["SegmentStore.get(seg)"]
      get -->|hit| reuse["reuse cached ids"] --> cat["concat"]
      get -->|miss| encx["SegmentEncoder.encode(seg)"] --> ins["SegmentStore.insert(seg, ids)"] --> cat
    end
    sc --> split

    cat --> ids["token ids Vec u32 (== whole-encode, byte-exact)"]
    ids --> route["cache-aware routing: block-hash ids -> pick worker"]
    ids --> fwd["forward as input_ids to engine"]
```


## Architecture — two pluggable axes (trait objects)

```mermaid
classDiagram
    class SegmentCache {
      markers, segmentable, min_bytes
      +new(encoder, cfg)
      +with_store(encoder, min_bytes, store)
      +encode_cached(rendered)
    }
    class SegmentEncoder {
      <<trait>>
      +render(messages) Option~String~
      +encode(text) Vec~u32~
      +marker_candidates() slice~String~
    }
    class SegmentStore {
      <<trait>>
      +get(seg) Option~Arc~
      +insert(seg, ids)
      +entry_count() u64
      +prefetch(seg)
    }
    SegmentCache --> SegmentEncoder : Arc dyn
    SegmentCache --> SegmentStore : Arc dyn
    SegmentEncoder <|.. ModelSegmentEncoder
    SegmentStore <|.. InProcStore
    ModelSegmentEncoder --> ChatEncoder : Jinja | DeepSeekV4
    ModelSegmentEncoder --> Tokenizer
```

## Correctness

The only guarantee: token ids **identical to a one-shot encode**. Three layers
keep this **universal** (never wrong ids on any tokenizer):

1. **Markers are HuggingFace hard split boundaries** (added tokens), so splitting
   there is byte-exact — with `lstrip`/`rstrip` tokens **excluded** (they absorb
   adjacent whitespace across the boundary, so are not byte-exact split points).
   `normalized`/`single_word` tokens are kept (they don't move the boundary;
   validated, e.g. DeepSeek-V4's `normalized` `<｜User｜>`/`<｜Assistant｜>`).
2. **Startup self-check = universal oracle.** A synthetic probe puts each marker
   in four adjacencies (space-before / space-after / glued / adjacent-marker) and
   asserts `concat(encode(seg_i)) == encode(whole)`. This catches ANY tokenizer
   where per-segment encoding diverges — Metaspace/SentencePiece prefix-space,
   context-dependent normalizers, etc. — which then **self-disable** (fall back to
   whole-prompt encode, staying correct).
3. **Collision-free store**: `InProcStore` keys by the segment bytes, so a hit is
   always the exact segment's ids.

**Verified byte-exact (0 mismatches)** across three real tokenizers / both encoder paths:

| tokenizer | encoder path | grid | result |
|---|---|---|---|
| Qwen3-0.6B | Jinja template | 16k→1M step 8k (127 pts) | ✅ 0 |
| DeepSeek-V4-Pro | code encoder | 16k/65k/262k/524k/1M | ✅ 0 |
| Kimi-K2.6 | im-markers | 16k/65k/262k/524k/1M | ✅ 0 |

Plus **ShareGPT real multi-turn**: 21,456 turns / ~20M tokens, **0 mismatches**
(Qwen & DSV4).

**Universality envelope:** byte-level-BPE-style models (Qwen / DSV4 / Kimi /
Llama-BPE) segment and are byte-exact; Metaspace/SentencePiece (or heavy
lstrip/rstrip/normalizer) models self-disable via the self-check — correct, just
no caching benefit.

## Performance (real tokenizers, median ms)

| tokenizer | 1M whole | 1M cold (single-round) | 1M warm (multi-turn) | warm speedup |
|---|---:|---:|---:|---:|
| Qwen3-0.6B | 471.5 | 415.6 | 13.9 | ~34× |
| DeepSeek-V4-Pro | 927.4 | 775.2 | 18.4 | ~50× |
| Kimi-K2.6 | 517.5 | 407.8 | 12.7 | ~41× |

- Warm (history cached) **~34–55×**, scaling with conversation depth. On real
  ShareGPT (~7-turn avg): **2.5–3.4× end-to-end** (short convos cap the gain).
- Cold single-round **≈ whole** (~10–15% faster) — the cache never hurts latency
  even with zero reuse (splitting avoids some per-call pretokenize overhead).
- `--segment-cache-min-bytes` (default 4096) bypasses the cache for short prompts,
  where the per-segment bookkeeping would outweigh re-tokenizing.

## Scope / design notes
- **Per-model**: `segment_cache` is a `ModelConfig` field (like `cache_aware` /
  `sticky`); the registry holds one `SegmentCache` per model — ready for the router
  serving multiple different-model engines.
- **Backend-agnostic**: the dynamo tokenizer is untouched; a future HF backend
  needs no change to this layer (encode goes through the `SegmentEncoder` closure).
- **No routing changes**: the cache only produces token ids; cache-aware routing's
  block-hashing consumes those ids downstream, unchanged.

## Usage
```bash
sgl-router --model-id qwen3 --tokenizer-path /models/qwen3/tokenizer.json \
           --segment-cache [--segment-cache-capacity N] [--segment-cache-min-bytes B] \
           --worker-urls ...
```

## Testing
`cargo test` covers: byte-exact differential (fake + real dynamo BPE), self-check
disable-on-unsafe, lstrip/rstrip marker exclusion (fixture), concurrent encode,
marker derivation (Jinja + dsv4), split-at-markers edge cases. Offline reproduce:

```bash
cd experimental/sgl-router
cargo test --all-targets
cargo clippy --all-targets -- -D warnings
cargo fmt --check
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30324622543](https://github.com/sgl-project/sglang/actions/runs/30324622543)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30324622535](https://github.com/sgl-project/sglang/actions/runs/30324622535)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->