### PR TITLE
Fix partial pinned offload rollback

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/memory_occupation_controller.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/memory_occupation_controller.py
@@ -131,11 +131,11 @@ class MemoryOccupationController:
             for name in names:
                 module = modules[name]
                 src_device_map[name] = _get_module_device(module)
+                moved.append(name)
                 if device.startswith("cpu"):
                     _module_to_pinned_cpu(module)
                 else:
                     module.to(device, non_blocking=True)
-                moved.append(name)
                 _move_unregistered_tensors(module, device)
             torch.cuda.synchronize()
         except Exception as e:

--- a/python/sglang/multimodal_gen/test/unit/test_memory_occupation_controller.py
+++ b/python/sglang/multimodal_gen/test/unit/test_memory_occupation_controller.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.managers.memory_managers import (
+    memory_occupation_controller as memory_controller,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="requires CUDA pinned-memory transfers",
+)
+
+
+class _StridedFp16Module(torch.nn.Module):
+    def __init__(self, device: torch.device) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.arange(6, device=device, dtype=torch.float16).reshape(2, 3).t()
+        )
+        self.bias = torch.nn.Parameter(
+            (torch.arange(6, device=device, dtype=torch.float16) + 10)
+            .reshape(2, 3)
+            .t()
+        )
+        self.register_buffer(
+            "offset",
+            (torch.arange(6, device=device, dtype=torch.float16) + 20)
+            .reshape(2, 3)
+            .t(),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * self.weight + self.bias + self.offset
+
+
+@pytest.mark.parametrize(
+    "failure_at",
+    [1, 2],
+    ids=["first_allocation", "after_partial_move"],
+)
+def test_release_rolls_back_partial_pinned_offload(
+    monkeypatch: pytest.MonkeyPatch, failure_at: int
+) -> None:
+    device = torch.device("cuda", torch.cuda.current_device())
+    module = _StridedFp16Module(device)
+    pipeline = object()
+    controller = memory_controller.MemoryOccupationController(
+        pipeline=pipeline,
+        rank=0,
+        use_fsdp_inference=False,
+    )
+
+    monkeypatch.setattr(
+        memory_controller,
+        "get_updatable_modules",
+        lambda current_pipeline: (
+            {"transformer": module}
+            if current_pipeline is pipeline
+            else pytest.fail("unexpected pipeline")
+        ),
+    )
+    monkeypatch.setattr(
+        memory_controller,
+        "_is_layerwise_offload_managed",
+        lambda _module: False,
+    )
+
+    original_tensors = {
+        name: (
+            tensor.device,
+            tensor.detach().clone(),
+            tensor.stride(),
+        )
+        for name, tensor in (
+            list(module.named_parameters()) + list(module.named_buffers())
+        )
+    }
+    forward_input = torch.full(
+        module.weight.shape,
+        0.5,
+        device=device,
+        dtype=torch.float16,
+    )
+    expected_output = module(forward_input).detach().clone()
+
+    real_empty_strided = torch.empty_strided
+    allocation_count = 0
+    successful_allocations = []
+
+    def faulting_empty_strided(*args, **kwargs):
+        nonlocal allocation_count
+        allocation_count += 1
+        if allocation_count == failure_at:
+            raise RuntimeError("injected pinned allocation failure")
+        pin = real_empty_strided(*args, **kwargs)
+        successful_allocations.append(pin)
+        return pin
+
+    monkeypatch.setattr(torch, "empty_strided", faulting_empty_strided)
+
+    with pytest.raises(RuntimeError, match="injected pinned allocation failure"):
+        controller.release_memory_occupation()
+
+    assert allocation_count == failure_at
+    assert len(successful_allocations) == failure_at - 1
+    assert all(pin.is_pinned() for pin in successful_allocations)
+    assert not controller.is_sleeping()
+    assert controller.resume_memory_occupation() == {
+        "success": True,
+        "sleeping": False,
+        "message": "already awake",
+    }
+
+    current_tensors = dict(module.named_parameters()) | dict(module.named_buffers())
+    assert current_tensors.keys() == original_tensors.keys()
+    for name, tensor in current_tensors.items():
+        original_device, original_value, original_stride = original_tensors[name]
+        assert tensor.device == original_device
+        assert tensor.stride() == original_stride
+        torch.testing.assert_close(tensor, original_value, rtol=0, atol=0)
+
+    torch.testing.assert_close(
+        module(forward_input),
+        expected_output,
+        rtol=0,
+        atol=0,
+    )

--- a/python/sglang/multimodal_gen/test/unit/test_memory_occupation_controller.py
+++ b/python/sglang/multimodal_gen/test/unit/test_memory_occupation_controller.py
@@ -20,9 +20,7 @@ class _StridedFp16Module(torch.nn.Module):
             torch.arange(6, device=device, dtype=torch.float16).reshape(2, 3).t()
         )
         self.bias = torch.nn.Parameter(
-            (torch.arange(6, device=device, dtype=torch.float16) + 10)
-            .reshape(2, 3)
-            .t()
+            (torch.arange(6, device=device, dtype=torch.float16) + 10).reshape(2, 3).t()
         )
         self.register_buffer(
             "offset",


### PR DESCRIPTION
## Motivation

Pinned CPU offload can fail partway through converting a module (for example, while allocating pinned storage for its second tensor). The controller currently records the module as moved only after the conversion finishes, so exception rollback skips that partially modified module. This can leave one module split between CPU and CUDA and make the next forward fail with a device mismatch.

## Modifications

- Record each module in the rollback set before beginning its move.
- Add a focused CUDA regression test that injects failure on both the first pinned allocation and after one successful allocation.
- Verify rollback restores every parameter and buffer's device, value, and stride, keeps controller state awake, and permits a real forward pass.

## Accuracy Tests

Validated on a leased NVIDIA GeForce RTX 2080 Ti (SM75) with FP16 strided parameters and buffers:

- Base: failure on the second pinned allocation leaves mixed CPU/CUDA tensors and the forward fails (expected RED).
- Patch: first-allocation and second-allocation failures both restore exact devices, values, and strides; forward passes (GREEN).
- GPU lease command and release both exited 0; no compute process remained.

Static checks:

- `git diff --check`
- `python -m py_compile` on the changed production and test files

## Speed Tests and Profiling

Not applicable. The change only adjusts exception rollback bookkeeping and does not alter the successful offload path's operations.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change needed for internal rollback behavior.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (GPU correctness evidence above; no performance-path change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30337269863](https://github.com/sgl-project/sglang/actions/runs/30337269863)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30337268133](https://github.com/sgl-project/sglang/actions/runs/30337268133)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->