### PR TITLE
[PD] Support MiniMax-M3 sparse KV CPU copy

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4654,6 +4654,33 @@ class MHATokenToKOnlyPool(KVCache):
         k_size_bytes = sum(get_tensor_size_bytes(k) for k in self.k_buffer)
         return k_size_bytes, 0
 
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        current_platform.synchronize()
+        k_cache_cpu = []
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            k_cache_cpu.append([])
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                k_cpu = self.k_buffer[layer_id][chunk_indices].to(
+                    "cpu", non_blocking=True
+                )
+                k_cache_cpu[-1].append(k_cpu)
+        current_platform.synchronize()
+        return k_cache_cpu
+
+    def load_cpu_copy(self, k_cache_cpu, indices, mamba_indices=None):
+        current_platform.synchronize()
+        chunk_size = self.cpu_offloading_chunk_size
+        for layer_id in range(self.layer_num):
+            for i in range(0, len(indices), chunk_size):
+                chunk_indices = indices[i : i + chunk_size]
+                k_cpu = k_cache_cpu[layer_id][i // chunk_size]
+                assert k_cpu.shape[0] == len(chunk_indices)
+                k_chunk = k_cpu.to(self.k_buffer[layer_id].device, non_blocking=True)
+                self.k_buffer[layer_id][chunk_indices] = k_chunk
+        current_platform.synchronize()
+
 
 class MiniMaxSparseKVPool(KVCache):
     def __init__(
@@ -4961,6 +4988,29 @@ class MiniMaxSparseKVPool(KVCache):
         sub_pools = [self.main_pool, self.index_kv_pool, self.index_k_pool]
         sizes = [p.get_kv_size_bytes() for p in sub_pools if p is not None]
         return sum(k for k, _ in sizes), sum(v for _, v in sizes)
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        return {
+            "main": self.main_pool.get_cpu_copy(indices),
+            "index_kv": (
+                self.index_kv_pool.get_cpu_copy(indices)
+                if self.index_kv_pool is not None
+                else None
+            ),
+            "index_k": (
+                self.index_k_pool.get_cpu_copy(indices)
+                if self.index_k_pool is not None
+                else None
+            ),
+        }
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        """Reload KV previously produced by ``get_cpu_copy`` back onto device."""
+        self.main_pool.load_cpu_copy(kv_cache_cpu["main"], indices)
+        if self.index_kv_pool is not None:
+            self.index_kv_pool.load_cpu_copy(kv_cache_cpu["index_kv"], indices)
+        if self.index_k_pool is not None:
+            self.index_k_pool.load_cpu_copy(kv_cache_cpu["index_k"], indices)
 
     def get_contiguous_buf_infos(self):
         # Main K/V only; index buffers ride the state-buffer channel.

--- a/test/registered/unit/mem_cache/test_minimax_sparse_pool_pd_unit.py
+++ b/test/registered/unit/mem_cache/test_minimax_sparse_pool_pd_unit.py
@@ -2,7 +2,7 @@ import unittest
 
 import torch
 
-from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
+from sglang.srt.mem_cache.memory_pool import MHATokenToKOnlyPool, MiniMaxSparseKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -29,6 +29,23 @@ def _make_k_only_pool(start_layer: int = 0) -> MiniMaxSparseKVPool:
     )
 
 
+def _all_buffers(pool: MiniMaxSparseKVPool):
+    return [
+        *pool.main_pool.k_buffer,
+        *pool.main_pool.v_buffer,
+        *pool.index_k_pool.k_buffer,
+    ]
+
+
+def _fill_and_snapshot(pool: MiniMaxSparseKVPool):
+    snapshots = []
+    for buffer_id, buffer in enumerate(_all_buffers(pool)):
+        values = torch.arange(buffer.numel(), dtype=torch.int64).reshape(buffer.shape)
+        buffer.copy_(((values + 17 * buffer_id) % 251).to(buffer.dtype))
+        snapshots.append(buffer.clone())
+    return snapshots
+
+
 class TestMiniMaxSparsePoolPD(unittest.TestCase):
     def test_contiguous_buf_infos_main_only(self):
         pool = _make_k_only_pool()
@@ -52,6 +69,190 @@ class TestMiniMaxSparsePoolPD(unittest.TestCase):
             self.assertEqual(ptrs[i], buf.data_ptr())
             self.assertEqual(lens[i], buf.nbytes)
             self.assertEqual(item_lens[i], buf[0].nbytes * pool.page_size)
+
+    def test_cpu_copy_round_trip(self):
+        # Released M3 shape: all sparse layers K-only, so index_kv_pool is None
+        # and get/load_cpu_copy must round-trip main K/V + index-K and skip the
+        # absent index_kv sub-pool.
+        pool = _make_k_only_pool()
+        self.assertIsNone(pool.index_kv_pool)
+        self.assertIsNotNone(pool.index_k_pool)
+
+        indices = torch.tensor([7, 1, 5], dtype=torch.long)
+        # Force >1 chunk so the chunked copy path is exercised.
+        pool.main_pool.cpu_offloading_chunk_size = 2
+        pool.index_k_pool.cpu_offloading_chunk_size = 2
+
+        snapshots = _fill_and_snapshot(pool)
+        cpu_copy = pool.get_cpu_copy(indices)
+
+        self.assertEqual(set(cpu_copy), {"main", "index_kv", "index_k"})
+        self.assertIsNone(cpu_copy["index_kv"])
+        self.assertEqual(cpu_copy["main"][0][0][0].device.type, "cpu")
+
+        for buffer in _all_buffers(pool):
+            buffer[indices] = 0
+        pool.load_cpu_copy(cpu_copy, indices)
+
+        for buffer, snapshot in zip(_all_buffers(pool), snapshots):
+            torch.testing.assert_close(buffer, snapshot, rtol=0, atol=0)
+
+
+def _make_extended_pool(
+    sparse_value_mode: str, start_layer: int = 0
+) -> MiniMaxSparseKVPool:
+    dense_layer_ids = [start_layer, start_layer + 1, start_layer + 2]
+    sparse_layer_ids = [start_layer + 3 + i for i in range(4)]
+    end_layer = sparse_layer_ids[-1] + 1
+
+    if sparse_value_mode == "kv_only":
+        disable_value_sparse_layer_ids = []
+    elif sparse_value_mode == "mixed":
+        disable_value_sparse_layer_ids = sparse_layer_ids[::2]
+    else:
+        raise ValueError(f"Unknown sparse value mode: {sparse_value_mode}")
+
+    return MiniMaxSparseKVPool(
+        size=8,
+        page_size=4,
+        dtype=torch.float32,
+        head_num=2,
+        head_dim=8,
+        idx_head_dim=16,
+        dense_layer_ids=dense_layer_ids,
+        sparse_layer_ids=sparse_layer_ids,
+        disable_value_sparse_layer_ids=disable_value_sparse_layer_ids,
+        device="cpu",
+        start_layer=start_layer,
+        end_layer=end_layer,
+    )
+
+
+def _named_extended_buffers(pool: MiniMaxSparseKVPool):
+    buffers = []
+    buffers.extend(
+        (f"main.k[{i}]", buffer) for i, buffer in enumerate(pool.main_pool.k_buffer)
+    )
+    buffers.extend(
+        (f"main.v[{i}]", buffer) for i, buffer in enumerate(pool.main_pool.v_buffer)
+    )
+    if pool.index_kv_pool is not None:
+        buffers.extend(
+            (f"index_kv.k[{i}]", buffer)
+            for i, buffer in enumerate(pool.index_kv_pool.k_buffer)
+        )
+        buffers.extend(
+            (f"index_kv.v[{i}]", buffer)
+            for i, buffer in enumerate(pool.index_kv_pool.v_buffer)
+        )
+    if pool.index_k_pool is not None:
+        buffers.extend(
+            (f"index_k.k[{i}]", buffer)
+            for i, buffer in enumerate(pool.index_k_pool.k_buffer)
+        )
+    return buffers
+
+
+def _fill_extended_buffers(pool: MiniMaxSparseKVPool):
+    snapshots = {}
+    for buffer_id, (name, buffer) in enumerate(_named_extended_buffers(pool)):
+        values = torch.arange(buffer.numel(), dtype=torch.int64).reshape(buffer.shape)
+        buffer.copy_(((values + 17 * buffer_id) % 251).to(buffer.dtype))
+        snapshots[name] = buffer.clone()
+    return snapshots
+
+
+class TestMiniMaxSparsePoolCPUCopies(unittest.TestCase):
+    source_indices = torch.tensor([7, 1, 5], dtype=torch.long)
+    destination_indices = torch.tensor([2, 6, 0], dtype=torch.long)
+
+    def test_k_only_pool_chunked_copy_to_new_indices(self):
+        pool = MHATokenToKOnlyPool(
+            size=8,
+            page_size=4,
+            dtype=torch.float32,
+            head_num=1,
+            head_dim=16,
+            layer_num=2,
+            device="cpu",
+            enable_memory_saver=False,
+        )
+        pool.cpu_offloading_chunk_size = 2
+
+        snapshots = []
+        for layer_id, buffer in enumerate(pool.k_buffer):
+            values = torch.arange(buffer.numel(), dtype=torch.int64).reshape(
+                buffer.shape
+            )
+            buffer.copy_(((values + 17 * layer_id) % 251).to(buffer.dtype))
+            snapshots.append(buffer.clone())
+
+        cpu_copy = pool.get_cpu_copy(self.source_indices)
+
+        self.assertEqual(len(cpu_copy), pool.layer_num)
+        for layer_id, chunks in enumerate(cpu_copy):
+            self.assertEqual([chunk.shape[0] for chunk in chunks], [2, 1])
+            self.assertTrue(all(chunk.device.type == "cpu" for chunk in chunks))
+            torch.testing.assert_close(
+                torch.cat(chunks),
+                snapshots[layer_id][self.source_indices],
+                rtol=0,
+                atol=0,
+            )
+
+        for buffer in pool.k_buffer:
+            buffer[self.source_indices] = 0
+            buffer[self.destination_indices] = 0
+        pool.load_cpu_copy(cpu_copy, self.destination_indices)
+
+        for layer_id, buffer in enumerate(pool.k_buffer):
+            expected = snapshots[layer_id].clone()
+            expected[self.source_indices] = 0
+            expected[self.destination_indices] = snapshots[layer_id][
+                self.source_indices
+            ]
+            torch.testing.assert_close(buffer, expected, rtol=0, atol=0)
+
+    def _assert_composite_round_trip(
+        self,
+        pool: MiniMaxSparseKVPool,
+        *,
+        has_index_kv: bool,
+        has_index_k: bool,
+    ):
+        for sub_pool in (pool.main_pool, pool.index_kv_pool, pool.index_k_pool):
+            if sub_pool is not None:
+                sub_pool.cpu_offloading_chunk_size = 2
+
+        snapshots = _fill_extended_buffers(pool)
+        cpu_copy = pool.get_cpu_copy(self.source_indices)
+
+        self.assertEqual(set(cpu_copy), {"main", "index_kv", "index_k"})
+        self.assertEqual(cpu_copy["index_kv"] is not None, has_index_kv)
+        self.assertEqual(cpu_copy["index_k"] is not None, has_index_k)
+
+        for _, buffer in _named_extended_buffers(pool):
+            buffer[self.source_indices] = 0
+            buffer[self.destination_indices] = 0
+        pool.load_cpu_copy(cpu_copy, self.destination_indices)
+
+        for name, buffer in _named_extended_buffers(pool):
+            expected = snapshots[name].clone()
+            expected[self.source_indices] = 0
+            expected[self.destination_indices] = snapshots[name][self.source_indices]
+            torch.testing.assert_close(buffer, expected, rtol=0, atol=0, msg=name)
+
+    def test_composite_copy_without_index_k_pool(self):
+        pool = _make_extended_pool("kv_only")
+        self.assertIsNotNone(pool.index_kv_pool)
+        self.assertIsNone(pool.index_k_pool)
+        self._assert_composite_round_trip(pool, has_index_kv=True, has_index_k=False)
+
+    def test_composite_copy_with_both_index_pools(self):
+        pool = _make_extended_pool("mixed")
+        self.assertIsNotNone(pool.index_kv_pool)
+        self.assertIsNotNone(pool.index_k_pool)
+        self._assert_composite_round_trip(pool, has_index_kv=True, has_index_k=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

MiniMax-M3 uses a sparse KV cache with three possible storage components: the main K/V pool, an optional index-KV pool, and an optional index-K-only pool.

During PD decode retraction, the KV cache is saved to CPU and restored later. `MHATokenToKOnlyPool` did not implement the CPU save/restore round trip, and `MiniMaxSparseKVPool` did not compose CPU copies for all optional sub-pools. As a result, MiniMax-M3 configurations containing index-K-only state could not safely complete decode KV retraction.

## Changes

- Add chunked CPU save/restore support to `MHATokenToKOnlyPool`.
- Compose CPU copies for the main K/V pool, optional index-KV pool, and optional index-K pool in `MiniMaxSparseKVPool`.
- Preserve the existing per-layer and per-chunk CPU copy structure.
- Support restoring saved KV data into different non-contiguous destination indices.
- Keep the change scoped to MiniMax sparse KV pool behavior.

## Tests

The focused unit test was run directly on the latest upstream-based code in an 8x H20 environment:

```bash
python3 -m pytest -q \
  test/registered/unit/mem_cache/test_minimax_sparse_pool_pd_unit.py
```

Result:

```text
6 passed
```

The test coverage includes:

- direct `MHATokenToKOnlyPool` chunked CPU copy;
- the released MiniMax-M3 K-only configuration;
- KV-only configuration;
- mixed index-KV/index-K configuration;
- non-contiguous source indices `[7, 1, 5]`;
- different destination indices `[2, 6, 0]`;
- exact round-trip validation for all main/index K/V buffers.

## Validation

- Changed-file pre-commit checks pass.
- Python compile checks pass.
- `git diff --check` passes.
- No model forward computation or normal decode path is changed.
- Speed benchmarking is not applicable because this change only handles CPU
  save/restore during decode KV retraction.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30354098949](https://github.com/sgl-project/sglang/actions/runs/30354098949)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30354098704](https://github.com/sgl-project/sglang/actions/runs/30354098704)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->