### PR TITLE
[NPU] Day0 Support Kimi-K3 on 910C

### DIFF
--- a/python/sglang/srt/configs/kimi_k3.py
+++ b/python/sglang/srt/configs/kimi_k3.py
@@ -1,0 +1,172 @@
+from transformers.configuration_utils import PretrainedConfig
+
+from sglang.srt.configs.kimi_linear import KimiLinearConfig
+
+
+class KimiK3VisionConfig(PretrainedConfig):
+    model_type = "kimi_k3_vision"
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        init_pos_emb_height: int = 64,
+        init_pos_emb_width: int = 64,
+        init_pos_emb_time: int = 4,
+        pos_emb_type: str = "divided_fixed",
+        vt_num_attention_heads: int = 12,
+        vt_num_hidden_layers: int = 27,
+        vt_hidden_size: int = 1024,
+        vt_intermediate_size: int = 4096,
+        merge_kernel_size: tuple[int, int] = (2, 2),
+        video_attn_type: str = "spatial_temporal",
+        merge_type: str = "sd2_tpool",
+        _attn_implementation: str = "flash_attention_2",
+        mm_projector_type: str = "patchmergerv2",
+        mm_hidden_size: int | None = None,
+        projector_hidden_act: str = "gelu",
+        projector_ln_eps: float = 1e-5,
+        qkv_hidden_size: int = 1536,
+        norm_type: str = "rmsnorm",
+        attn_bias: bool = False,
+        patch_embed_proj_bias: bool = False,
+        mlp_type: str = "mlp2",
+        linear_bias: bool = False,
+        activation_func: str = "gelu_pytorch_tanh",
+        pos_emb_interpolation_mode: str = "bilinear",
+        text_hidden_size: int = 2304,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.patch_size = patch_size
+        self.init_pos_emb_height = init_pos_emb_height
+        self.init_pos_emb_width = init_pos_emb_width
+        self.init_pos_emb_time = init_pos_emb_time
+        self.pos_emb_type = pos_emb_type
+        self.vt_num_attention_heads = vt_num_attention_heads
+        self.vt_num_hidden_layers = vt_num_hidden_layers
+        self.vt_hidden_size = vt_hidden_size
+        self.vt_intermediate_size = vt_intermediate_size
+        self.merge_kernel_size = tuple(merge_kernel_size)
+        self.video_attn_type = video_attn_type
+        self.merge_type = merge_type
+        self._attn_implementation = _attn_implementation
+
+        self.mm_projector_type = mm_projector_type
+        self.mm_hidden_size = (
+            mm_hidden_size if mm_hidden_size is not None else vt_hidden_size
+        )
+        self.projector_hidden_act = projector_hidden_act
+        self.projector_ln_eps = projector_ln_eps
+        self.text_hidden_size = text_hidden_size
+
+        self.qkv_hidden_size = qkv_hidden_size
+        self.norm_type = norm_type
+        self.attn_bias = attn_bias
+        self.patch_embed_proj_bias = patch_embed_proj_bias
+        self.mlp_type = mlp_type
+        self.linear_bias = linear_bias
+        self.activation_func = activation_func
+        self.pos_emb_interpolation_mode = pos_emb_interpolation_mode
+
+        # Aliases consumed by the K2.5 vision implementation.
+        self.num_attention_heads = vt_num_attention_heads
+        self.num_hidden_layers = vt_num_hidden_layers
+        self.hidden_size = vt_hidden_size
+        self.intermediate_size = vt_intermediate_size
+
+
+class KimiK3Config(PretrainedConfig):
+    model_type = "kimi_k3"
+
+    def __init__(
+        self,
+        text_config: dict | KimiLinearConfig | None = None,
+        vision_config: dict | KimiK3VisionConfig | None = None,
+        ignore_index: int = -100,
+        media_placeholder_token_id: int = 163605,
+        pad_token_id: int = 0,
+        image_placeholder: str = "<|kimi_image_placeholder|>",
+        **kwargs,
+    ):
+        if text_config is None:
+            self.text_config = KimiLinearConfig()
+        elif isinstance(text_config, dict):
+            self.text_config = KimiLinearConfig(**text_config)
+        else:
+            self.text_config = text_config
+
+        if vision_config is None:
+            self.vision_config = KimiK3VisionConfig()
+        elif isinstance(vision_config, dict):
+            self.vision_config = KimiK3VisionConfig(**vision_config)
+        else:
+            self.vision_config = vision_config
+
+        if self.vision_config.text_hidden_size != self.text_config.hidden_size:
+            self.vision_config.text_hidden_size = self.text_config.hidden_size
+
+        self.ignore_index = ignore_index
+        self.media_placeholder_token_id = media_placeholder_token_id
+        self.image_placeholder = image_placeholder
+
+        if getattr(self.text_config, "quantization_config", None) is not None:
+            self.quantization_config = self.text_config.quantization_config
+
+        super().__init__(pad_token_id=pad_token_id, **kwargs)
+
+    @property
+    def num_hidden_layers(self) -> int:
+        return self.text_config.num_hidden_layers
+
+    @num_hidden_layers.setter
+    def num_hidden_layers(self, value: int):
+        self.text_config.num_hidden_layers = value
+
+    @property
+    def num_experts(self):
+        return self.text_config.num_experts
+
+    @num_experts.setter
+    def num_experts(self, value):
+        self.text_config.num_experts = value
+
+    @property
+    def n_routed_experts(self):
+        return self.text_config.n_routed_experts
+
+    @n_routed_experts.setter
+    def n_routed_experts(self, value):
+        self.text_config.n_routed_experts = value
+
+    @property
+    def num_shared_experts(self):
+        return self.text_config.num_shared_experts
+
+    @num_shared_experts.setter
+    def num_shared_experts(self, value):
+        self.text_config.num_shared_experts = value
+
+    @property
+    def quantization_config(self):
+        return getattr(self.text_config, "quantization_config", None)
+
+    @quantization_config.setter
+    def quantization_config(self, value):
+        self.text_config.quantization_config = value
+
+    @property
+    def first_k_dense_replace(self):
+        return self.text_config.first_k_dense_replace
+
+    @first_k_dense_replace.setter
+    def first_k_dense_replace(self, value):
+        self.text_config.first_k_dense_replace = value
+
+    @property
+    def hidden_size(self) -> int:
+        return self.text_config.hidden_size
+
+    @property
+    def vocab_size(self) -> int:
+        return self.text_config.vocab_size

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -50,17 +50,12 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.platforms.device_mixin import _DEVICE_TO_DISTRIBUTED_BACKEND
-from sglang.srt.runtime_context import (
-    get_global_dwdp_manager,
-    set_global_dwdp_manager,
-)
 from sglang.srt.utils import (
     get_current_device_stream_fast,
     get_int_env_var,
     is_cpu,
     is_cuda,
     is_cuda_alike,
-    is_gfx95_supported,
     is_hip,
     is_musa,
     is_npu,
@@ -275,8 +270,6 @@ class GroupCoordinator:
         group_name: Optional[str] = None,
         gloo_timeout: timedelta = timedelta(seconds=120 * 60),
         recovered_rank: bool = False,
-        rank_offset: int = 0,
-        max_world_size: Optional[int] = None,
     ):
         # Set group info
         group_name = group_name or "anonymous"
@@ -285,9 +278,6 @@ class GroupCoordinator:
 
         # Set rank info
         self.rank = torch.distributed.get_rank()
-        # Joiner group ranks are local; shift them into global rank space.
-        if rank_offset > 0:
-            group_ranks = [[r + rank_offset for r in ranks] for ranks in group_ranks]
         self.local_rank = local_rank
         self.device_group = None
         self.cpu_group = None
@@ -309,57 +299,25 @@ class GroupCoordinator:
         self.device_module = torch.get_device_module(self.device)
 
         for ranks in group_ranks:
+            active_ranks = torch.ones(len(ranks), dtype=torch.int32, device=self.device)
+            active_ranks_cpu = torch.ones(len(ranks), dtype=torch.int32)
             subgroup_timeout = _MODEL_PARALLEL_GROUP_TIMEOUT
             if "mooncake" in torch_distributed_backend:
                 from mooncake.ep import MooncakeBackendOptions
 
-                pg_active_size = len(ranks)
-                if not recovered_rank and max_world_size is not None:
-                    assert max_world_size >= len(ranks), (
-                        f"max_world_size ({max_world_size}) must be >= "
-                        f"group size ({len(ranks)})"
-                    )
-                    pg_active_size = max_world_size
-
-                pg_active_ranks = torch.zeros(
-                    pg_active_size, dtype=torch.int32, device=self.device
-                )
-                pg_active_ranks[: len(ranks)] = 1
-                pg_active_ranks_cpu = torch.zeros(pg_active_size, dtype=torch.int32)
-                pg_active_ranks_cpu[: len(ranks)] = 1
-
-                if not recovered_rank and max_world_size is not None:
-                    dev_opts = MooncakeBackendOptions(
-                        pg_active_ranks, recovered_rank, max_world_size
-                    )
-                    cpu_opts = MooncakeBackendOptions(
-                        pg_active_ranks_cpu, recovered_rank, max_world_size
-                    )
-                else:
-                    dev_opts = MooncakeBackendOptions(pg_active_ranks, recovered_rank)
-                    cpu_opts = MooncakeBackendOptions(
-                        pg_active_ranks_cpu, recovered_rank
-                    )
-
-                active_ranks = pg_active_ranks[: len(ranks)]
-                active_ranks_cpu = pg_active_ranks_cpu[: len(ranks)]
                 device_group = torch.distributed.new_group(
                     ranks,
                     backend="mooncake",
-                    pg_options=dev_opts,
+                    pg_options=MooncakeBackendOptions(active_ranks, recovered_rank),
                     timeout=subgroup_timeout,
                 )
                 cpu_group = torch.distributed.new_group(
                     ranks,
                     backend="mooncake-cpu",
-                    pg_options=cpu_opts,
+                    pg_options=MooncakeBackendOptions(active_ranks_cpu, recovered_rank),
                     timeout=subgroup_timeout,
                 )
             else:
-                active_ranks = torch.ones(
-                    len(ranks), dtype=torch.int32, device=self.device
-                )
-                active_ranks_cpu = torch.ones(len(ranks), dtype=torch.int32)
                 pg_options = get_torch_distributed_pg_options(group_name)
                 device_group = torch.distributed.new_group(
                     ranks,
@@ -631,10 +589,7 @@ class GroupCoordinator:
 
         In addition, PyTorch custom ops do not support mutation or returning
         a new tensor in the same op. So we need to figure out if the op is
-        in-place or out-of-place ahead of time — except under Dynamo tracing,
-        where the method selection would guard on the symbolic shape; there we
-        always emit the out-of-place op with method "auto" and resolve the
-        method at runtime inside the op.
+        in-place or out-of-place ahead of time.
         """
         # Bypass the function if we are using only 1 GPU.
         if self.world_size == 1:
@@ -664,32 +619,6 @@ class GroupCoordinator:
         if self.npu_communicator is not None and not self.npu_communicator.disabled:
             return self.npu_communicator.all_reduce(input_)
 
-        if torch.compiler.is_compiling():
-            # Byte-size thresholds in method selection (e.g. `_pick_algo` or
-            # `should_mscclpp_allreduce`) would guard on the symbolic token dim
-            # and recompile per shape; defer the selection to runtime inside
-            # the opaque custom op. Groups without any accelerated
-            # communicator keep the inplace split op so their collective
-            # stays outside captured graphs. The symmetric-memory in-place
-            # path below is deliberately bypassed under compile: its raw
-            # pynccl call is untraceable (hard error with fullgraph, graph
-            # break otherwise) and its in-place contract does not fit the
-            # outplace custom op.
-            if (
-                self.ca_comm is None
-                and self.qr_comm is None
-                and self.pymscclpp_comm is None
-                and self.torch_symm_mem_comm is None
-                and self.pynccl_comm is None
-            ):
-                inplace_all_reduce(input_, group_name=self.unique_name)
-                return input_
-            return outplace_all_reduce(
-                input_,
-                group_name=self.unique_name,
-                outplace_all_reduce_method="auto",
-            )
-
         should_use_pymscclpp_allreduce = (
             self.pymscclpp_comm is not None
             and self.pymscclpp_comm.should_mscclpp_allreduce(input_)
@@ -704,10 +633,31 @@ class GroupCoordinator:
                 self.pynccl_comm.all_reduce(input_)
                 return input_
 
-        outplace_all_reduce_method = self._resolve_outplace_all_reduce_method(
-            input_=input_,
-            should_use_pymscclpp_allreduce=should_use_pymscclpp_allreduce,
-        )
+        outplace_all_reduce_method = None
+        if (
+            self.ca_comm is not None
+            and not self.ca_comm.disabled
+            and not should_use_pymscclpp_allreduce
+            and self.ca_comm.should_custom_ar(input_)
+        ):
+            outplace_all_reduce_method = "ca"
+        elif (
+            self.qr_comm is not None
+            and not self.qr_comm.disabled
+            and self.qr_comm.should_quick_allreduce(input_)
+        ):
+            outplace_all_reduce_method = "qr"
+        elif self.pymscclpp_comm is not None and should_use_pymscclpp_allreduce:
+            outplace_all_reduce_method = "pymscclpp"
+        elif (
+            self.torch_symm_mem_comm is not None
+            and not self.torch_symm_mem_comm.disabled
+            and self.torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
+        ):
+            outplace_all_reduce_method = "torch_symm_mem"
+        elif is_in_tc_piecewise_cuda_graph() and self.pynccl_comm is not None:
+            # For piecewise cuda graph, we use pynccl outplace allreduce
+            outplace_all_reduce_method = "pynccl"
         if outplace_all_reduce_method is not None:
             return outplace_all_reduce(
                 input_,
@@ -793,134 +743,9 @@ class GroupCoordinator:
         )
         return fused_outputs
 
-    def fused_allreduce_rmsnorm_quant_per_group(
-        self,
-        input_: torch.Tensor,
-        residual_inp_: torch.Tensor,
-        weight_: torch.Tensor,
-        eps: float,
-        group_size: int = 128,
-        emit_bf16: bool = False,
-    ) -> Optional[Tuple[torch.Tensor, ...]]:
-        """Attempt fused all-reduce + RMSNorm + per-group FP8 quant.
-
-        ROCm/aiter/gfx95-only entry point. Returns ``None`` on any other
-        platform or when the aiter custom-all-reduce communicator cannot
-        service the request, letting the caller fall back to the existing
-        ``fused_allreduce_rmsnorm`` + separate per-group quant path.
-
-        When ``emit_bf16=True`` the fused kernel also writes the
-        pre-quantization bf16/fp16 normed output and returns
-        ``(fp8, residual_out, scale, bf16)`` — used by GDN-style layers that
-        need both an FP8 projection and a bf16 gating projection without
-        launching a separate per-group quant kernel.
-        """
-        if not (is_hip() and is_gfx95_supported()):
-            return None
-
-        ca_comm = self.ca_comm
-        if ca_comm is None or getattr(ca_comm, "disabled", True):
-            return None
-        if not hasattr(ca_comm, "custom_fused_ar_rms_per_group_quant"):
-            return None
-
-        # Shape / size eligibility mirrors aiter's internal gate so we fail
-        # fast without entering the HIP kernel dispatch.
-        K = input_.shape[-1]
-        if K % group_size != 0 or K > 16384:
-            return None
-        total_bytes = input_.numel() * input_.element_size()
-        if total_bytes == 0 or total_bytes > 8 * 1024 * 8192:
-            return None
-        if self.world_size == 6:
-            return None
-
-        if envs.SGLANG_USE_1STAGE_ALLREDUCE.is_set():
-            use_1stage_ar = envs.SGLANG_USE_1STAGE_ALLREDUCE.get()
-        else:
-            token_num = input_.numel() // K
-            use_1stage_ar = total_bytes <= 128 * 1024
-            if (
-                # Keep the default 128 KiB cutoff except for the measured TP=8
-                # K=7168 graph-replay crossover. K=4096 remains on the default
-                # rule because token_num=8/16 still favored 1-stage there.
-                self.world_size == 8
-                and 4096 < K <= 7168
-                and token_num >= 8
-                and use_1stage_ar
-            ):
-                use_1stage_ar = False
-
-        try:
-            return ca_comm.custom_fused_ar_rms_per_group_quant(
-                input_,
-                residual_inp_,
-                weight_,
-                eps,
-                group_size,
-                use_1stage_ar,
-                emit_bf16=emit_bf16,
-            )
-        except Exception:
-            return None
-
-    def _resolve_outplace_all_reduce_method(
-        self,
-        input_: torch.Tensor,
-        should_use_pymscclpp_allreduce: Optional[bool] = None,
-    ) -> Optional[str]:
-        if should_use_pymscclpp_allreduce is None:
-            should_use_pymscclpp_allreduce = (
-                self.pymscclpp_comm is not None
-                and self.pymscclpp_comm.should_mscclpp_allreduce(input_)
-            )
-        if (
-            self.ca_comm is not None
-            and not self.ca_comm.disabled
-            and not should_use_pymscclpp_allreduce
-            and self.ca_comm.should_custom_ar(input_)
-        ):
-            return "ca"
-        if (
-            self.qr_comm is not None
-            and not self.qr_comm.disabled
-            and self.qr_comm.should_quick_allreduce(input_)
-        ):
-            return "qr"
-        if self.pymscclpp_comm is not None and should_use_pymscclpp_allreduce:
-            return "pymscclpp"
-        if (
-            self.torch_symm_mem_comm is not None
-            and not self.torch_symm_mem_comm.disabled
-            and self.torch_symm_mem_comm.should_torch_symm_mem_allreduce(input_)
-        ):
-            return "torch_symm_mem"
-        if is_in_tc_piecewise_cuda_graph() and self.pynccl_comm is not None:
-            # For piecewise cuda graph, we use pynccl outplace allreduce
-            return "pynccl"
-        return None
-
     def _all_reduce_out_place(
         self, input_: torch.Tensor, outplace_all_reduce_method: str
     ) -> torch.Tensor:
-        if outplace_all_reduce_method == "auto":
-            outplace_all_reduce_method = self._resolve_outplace_all_reduce_method(
-                input_
-            )
-            if outplace_all_reduce_method == "pymscclpp":
-                # pymscclpp reduces in place and returns its input; feed it a
-                # clone to honor the op's no-mutation contract.
-                input_ = input_.clone()
-            elif outplace_all_reduce_method is None:
-                # Force pynccl over the in-place fallback: it is graph-capture
-                # safe and NCCL is natively out-of-place, avoiding the clone
-                # the in-place fallback needs.
-                if self.pynccl_comm is not None:
-                    outplace_all_reduce_method = "pynccl"
-                else:
-                    out = input_.clone()
-                    self._all_reduce_in_place(out)
-                    return out
         ca_comm = self.ca_comm
         qr_comm = self.qr_comm
         pymscclpp_comm = self.pymscclpp_comm
@@ -1072,12 +897,7 @@ class GroupCoordinator:
         return True
 
     def _all_to_all_single(self, output: torch.Tensor, input: torch.Tensor) -> None:
-        # pynccl path keeps the a2a exchange CUDA-graph-capturable (DCP a2a backend).
-        pynccl_comm = self.pynccl_comm
-        if pynccl_comm is not None and not pynccl_comm.disabled:
-            pynccl_comm.all_to_all_single(output, input)
-        else:
-            torch.distributed.all_to_all_single(output, input, group=self.device_group)
+        torch.distributed.all_to_all_single(output, input, group=self.device_group)
 
     def all_to_all_single(self, output: torch.Tensor, input: torch.Tensor):
         if self.world_size == 1:
@@ -1133,8 +953,7 @@ class GroupCoordinator:
         # 16B alignment, weak-contiguous, supported topology, and per-rank
         # size <= max_size/(world*2).
         # On a hit, writes directly into the caller's pre-allocated `output` via
-        # all_gather_reg during CUDA-graph capture, and all_gather_unreg
-        # under torch_memory_saver and other paths.
+        # all_gather_reg during CUDA-graph capture and all_gather_unreg otherwise.
         ca_comm = self.ca_comm
         if (
             is_hip()
@@ -1147,10 +966,7 @@ class GroupCoordinator:
         ):
             if getattr(ca_comm, "_IS_CAPTURING", False):
                 if torch.cuda.is_current_stream_capturing():
-                    if envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get():
-                        ca_comm.all_gather_unreg(input, out=output, dim=0)
-                    else:
-                        ca_comm.all_gather_reg(input, out=output, dim=0)
+                    ca_comm.all_gather_reg(input, out=output, dim=0)
                 elif is_in_tc_piecewise_cuda_graph():
                     ca_comm.all_gather_unreg(input, out=output, dim=0)
                 else:
@@ -1202,6 +1018,21 @@ class GroupCoordinator:
             # directly causes Dynamo to rewrite it as _c10d_functional.all_gather_into_tensor
             # + wait_tensor, which invokes sycl_event.wait() and breaks XPU graph capture.
             reg_all_gather_into_tensor(output, input, group_name=self.unique_name)
+
+    def cp_all_gather_into_tensor_async(
+        self, output: torch.Tensor, input: torch.Tensor, stream: torch.cuda.Stream
+    ):
+        """
+        Implement an asynchronous `allgather` operation on a specified stream.
+        (the default `torch.distributed.all_gather_into_tensor` will trigger event synchronization),
+        eliminating the CPU-side launch-kernel blocking issue caused by synchronization problems.
+        The specific implementation uses the interface provided by pynccl to remove the synchronization logic of events.
+        """
+        pynccl_comm = self.pynccl_comm
+        if pynccl_comm is None or pynccl_comm.disabled:
+            self.all_gather_into_tensor(output, input)
+        else:
+            pynccl_comm.cp_all_gather_into_tensor(output, input, stream=stream)
 
     def all_gather(
         self,
@@ -1449,7 +1280,6 @@ class GroupCoordinator:
         obj: Any,
         dst: int,
         async_send: bool = False,
-        tag: int = 0,
     ) -> List[P2PWork]:
         """
         Send the input object list to the destination rank.
@@ -1480,7 +1310,6 @@ class GroupCoordinator:
             size_tensor,
             self.ranks[dst],
             group=self.cpu_group,
-            tag=tag,
         )
         if async_send:
             p2p_work.append(P2PWork(size_work, size_tensor))
@@ -1489,7 +1318,6 @@ class GroupCoordinator:
             object_tensor,
             self.ranks[dst],
             group=self.cpu_group,
-            tag=tag,
         )
         if async_send:
             p2p_work.append(P2PWork(object_work, object_tensor))
@@ -1499,7 +1327,6 @@ class GroupCoordinator:
     def recv_object(
         self,
         src: int,
-        tag: int = 0,
     ) -> Any:
         """Receive the input object list from the source rank."""
         """NOTE: `src` is the local rank of the source rank."""
@@ -1514,7 +1341,7 @@ class GroupCoordinator:
         # Receive object size
         # We have to use irecv here to make it work for both isend and send.
         work = torch.distributed.irecv(
-            size_tensor, src=self.ranks[src], group=self.cpu_group, tag=tag
+            size_tensor, src=self.ranks[src], group=self.cpu_group
         )
         work.wait()
 
@@ -1526,7 +1353,7 @@ class GroupCoordinator:
         )
 
         work = torch.distributed.irecv(
-            object_tensor, src=self.ranks[src], group=self.cpu_group, tag=tag
+            object_tensor, src=self.ranks[src], group=self.cpu_group
         )
         work.wait()
 
@@ -1822,8 +1649,6 @@ def init_model_parallel_group(
     use_mscclpp_allreduce: Optional[bool] = None,
     use_torch_symm_mem_allreduce: Optional[bool] = None,
     recovered_rank: bool = False,
-    rank_offset: int = 0,
-    max_world_size: Optional[int] = None,
 ) -> GroupCoordinator:
     if use_custom_allreduce is None:
         use_custom_allreduce = _ENABLE_CUSTOM_ALL_REDUCE
@@ -1849,8 +1674,6 @@ def init_model_parallel_group(
         use_message_queue_broadcaster=use_message_queue_broadcaster,
         group_name=group_name,
         recovered_rank=recovered_rank,
-        rank_offset=rank_offset,
-        max_world_size=max_world_size,
     )
 
 
@@ -1971,7 +1794,7 @@ def graph_capture(stream=None):
     ):
         with contextlib.ExitStack() as stack:
             seen = {id(_TP), id(_PP)}
-            for group in (_DCP, _ATTN_TP, _MOE_EP, _MOE_TP):
+            for group in (_DCP, _MOE_EP, _MOE_TP):
                 if group is not None and id(group) not in seen:
                     seen.add(id(group))
                     stack.enter_context(group.graph_capture(context))
@@ -2011,12 +1834,7 @@ def get_default_distributed_backend(device: str) -> str:
     return _DEVICE_TO_DISTRIBUTED_BACKEND.get(device, "gloo")
 
 
-def _create_global_tcp_store(
-    rank: int,
-    world_size: int,
-    dist_init_addr: Optional[str] = None,
-    allow_dynamic_membership: bool = False,
-) -> None:
+def _create_global_tcp_store(rank: int, world_size: int) -> None:
     """Create a global TCPStore for coordination across ranks.
 
     This function creates a TCPStore that all ranks can use for coordination
@@ -2024,51 +1842,42 @@ def _create_global_tcp_store(
     """
     from torch.distributed import TCPStore
 
-    base_store_port = envs.SGLANG_TCP_STORE_PORT.get()
-
     master_ip = os.environ.get("MASTER_ADDR")
-    if not master_ip and allow_dynamic_membership and dist_init_addr:
-        addr = dist_init_addr
-        if addr.startswith("tcp://"):
-            addr = addr[len("tcp://") :]
-        master_ip = addr.rsplit(":", 1)[0]
+
     if not master_ip:
         logger.warning(
             "Could not determine master IP for global TCPStore. "
             "Broadcasting from rank 0 to all ranks."
         )
+
+    base_store_port = envs.SGLANG_TCP_STORE_PORT.get()
+
+    # Rank 0 gets its local IP and broadcasts it to all ranks
+    # Use broadcast_object_list which works with any backend (handles CPU/GPU automatically)
+    if not master_ip:
         if rank == 0:
             master_ip = get_local_ip_auto()
             ip_list = [master_ip]
         else:
             ip_list = [None]
+
         torch.distributed.broadcast_object_list(ip_list, src=0)
         master_ip = ip_list[0]
 
     try:
-        if allow_dynamic_membership:
-            is_master = rank == 0
-            tcp_store = TCPStore(
-                host_name=master_ip,
-                port=base_store_port,
-                is_master=is_master,
-                wait_for_workers=False,
-            )
-        else:
-            is_master = rank == 0
-            tcp_store = TCPStore(
-                host_name=master_ip,
-                port=base_store_port,
-                world_size=world_size,
-                is_master=is_master,
-            )
+        tcp_store = TCPStore(
+            host_name=master_ip,
+            port=base_store_port,
+            world_size=world_size,
+            is_master=(rank == 0),
+        )
         set_global_tcp_store(tcp_store)
         logger.info(
-            "Created global TCPStore at %s:%d (rank=%d, is_master=%s)",
+            "Created global TCPStore at %s:%d (rank=%d, world_size=%d)",
             master_ip,
             base_store_port,
             rank,
-            is_master,
+            world_size,
         )
     except Exception as e:
         logger.warning(
@@ -2089,7 +1898,6 @@ def init_distributed_environment(
     timeout: Optional[int] = None,
     moe_a2a_backend: Optional[str] = None,
     recovered_rank: bool = False,
-    max_world_size: Optional[int] = None,
 ):
     logger.debug(
         "world_size=%d rank=%d local_rank=%d " "distributed_init_method=%s backend=%s",
@@ -2099,6 +1907,17 @@ def init_distributed_environment(
         distributed_init_method,
         backend,
     )
+    if "mooncake" in backend:
+        try:
+            from mooncake import ep as mooncake_ep
+        except ImportError as e:
+            raise ImportError(
+                "Please install mooncake by following the instructions at "
+                "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
+                "to run SGLang with Mooncake Backend."
+            ) from e
+        mooncake_ep.set_host_ip(get_local_ip_auto())
+
     if not torch.distributed.is_initialized():
         global _MODEL_PARALLEL_GROUP_TIMEOUT
         assert distributed_init_method is not None, (
@@ -2115,16 +1934,9 @@ def init_distributed_environment(
         if backend == "mooncake":
             from mooncake.ep import MooncakeBackendOptions
 
-            use_max_ws = max_world_size and max_world_size > world_size
-            ar_size = max_world_size if use_max_ws else world_size
-            active_ranks = torch.zeros(ar_size, dtype=torch.int32, device="cuda")
-            active_ranks[:world_size] = 1
-            if use_max_ws:
-                pg_options = MooncakeBackendOptions(
-                    active_ranks, recovered_rank, max_world_size
-                )
-            else:
-                pg_options = MooncakeBackendOptions(active_ranks, recovered_rank)
+            # Setting "cuda" as device here is safe, as it is guarded under the mooncake case
+            active_ranks = torch.ones(world_size, dtype=torch.int32, device="cuda")
+            pg_options = MooncakeBackendOptions(active_ranks, recovered_rank)
         else:
             pg_options = get_torch_distributed_pg_options()
 
@@ -2140,15 +1952,7 @@ def init_distributed_environment(
 
         # Create a global TCPStore for coordination (used by NIXL)
         if moe_a2a_backend == "nixl":
-            _create_global_tcp_store(
-                rank,
-                world_size,
-                dist_init_addr=distributed_init_method,
-                allow_dynamic_membership=(
-                    recovered_rank
-                    or (max_world_size is not None and max_world_size > world_size)
-                ),
-            )
+            _create_global_tcp_store(rank, world_size)
 
     # set the local rank
     # local_rank is not available in torch ProcessGroup,
@@ -2184,8 +1988,6 @@ def initialize_model_parallel(
     duplicate_tp_group: bool = False,
     enable_symm_mem: bool = False,
     recovered_rank: bool = False,
-    rank_offset: int = 0,
-    max_world_size: Optional[int] = None,
 ) -> None:
     """
     Initialize model parallel groups.
@@ -2238,14 +2040,8 @@ def initialize_model_parallel(
     """
     # Get world size and rank. Ensure some consistencies.
     assert torch.distributed.is_initialized()
+    world_size: int = torch.distributed.get_world_size()
     backend = backend or torch.distributed.get_backend(get_world_group().device_group)
-
-    # Joiners construct their local TP/PP layout in global rank space.
-    world_size: int = (
-        tensor_model_parallel_size * pipeline_model_parallel_size
-        if recovered_rank
-        else torch.distributed.get_world_size()
-    )
 
     if world_size != tensor_model_parallel_size * pipeline_model_parallel_size:
         raise RuntimeError(
@@ -2292,8 +2088,6 @@ def initialize_model_parallel(
         use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
         group_name="tp",
         recovered_rank=recovered_rank,
-        rank_offset=rank_offset,
-        max_world_size=max_world_size,
     )
 
     if duplicate_tp_group:
@@ -2308,8 +2102,6 @@ def initialize_model_parallel(
             use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
             group_name="pdmux_prefill_tp",
             recovered_rank=recovered_rank,
-            rank_offset=rank_offset,
-            max_world_size=max_world_size,
         )
         if _TP.pynccl_comm:
             _TP.pynccl_comm.disabled = False
@@ -2372,8 +2164,6 @@ def initialize_model_parallel(
             use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
             group_name="attn_cp",
             recovered_rank=recovered_rank,
-            rank_offset=rank_offset,
-            max_world_size=max_world_size,
         )
 
     from sglang.srt.layers.sampler import SYNC_TOKEN_IDS_ACROSS_TP
@@ -2404,13 +2194,12 @@ def initialize_model_parallel(
             get_world_group().local_rank,
             backend,
             use_pynccl=SYNC_TOKEN_IDS_ACROSS_TP or enable_symm_mem,
+            use_mscclpp_allreduce=False,
             use_custom_allreduce=False,
             use_torch_symm_mem_allreduce=False,
             use_message_queue_broadcaster=envs.SGLANG_USE_MESSAGE_QUEUE_BROADCASTER.get(),
             group_name="attention_tp",
             recovered_rank=recovered_rank,
-            rank_offset=rank_offset,
-            max_world_size=max_world_size,
         )
 
     moe_ep_size = expert_model_parallel_size
@@ -2442,14 +2231,11 @@ def initialize_model_parallel(
             backend,
             group_name="moe_dp",
             recovered_rank=recovered_rank,
-            rank_offset=rank_offset,
-            max_world_size=max_world_size,
         )
 
     global _MOE_EP
     assert _MOE_EP is None, "expert model parallel group is already initialized"
-    # NPU requires a standalone group for MOE expert parallelism
-    if moe_ep_size == tensor_model_parallel_size and not _is_npu:
+    if moe_ep_size == tensor_model_parallel_size:
         _MOE_EP = _TP
     else:
         group_ranks = []
@@ -2472,8 +2258,6 @@ def initialize_model_parallel(
             use_custom_allreduce=False,
             group_name="moe_ep",
             recovered_rank=recovered_rank,
-            rank_offset=rank_offset,
-            max_world_size=max_world_size,
         )
 
     global _MOE_TP
@@ -2502,8 +2286,6 @@ def initialize_model_parallel(
             use_custom_allreduce=False,
             group_name="moe_tp",
             recovered_rank=recovered_rank,
-            rank_offset=rank_offset,
-            max_world_size=max_world_size,
         )
 
     # Build the pipeline model-parallel groups.
@@ -2524,8 +2306,6 @@ def initialize_model_parallel(
         use_custom_allreduce=False,
         group_name="pp",
         recovered_rank=recovered_rank,
-        rank_offset=rank_offset,
-        max_world_size=max_world_size,
     )
 
 
@@ -2746,11 +2526,6 @@ def get_moe_tensor_parallel_rank():
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
-    dwdp_mgr = get_global_dwdp_manager()
-    if dwdp_mgr is not None:
-        dwdp_mgr.cleanup()
-        set_global_dwdp_manager(None)
-
     global _TP
     if _TP:
         _TP.destroy()
@@ -2849,9 +2624,7 @@ def in_the_same_node_as(pg: ProcessGroup, source_rank: int = 0) -> List[bool]:
     world_size = torch.distributed.get_world_size(group=pg)
 
     # local tensor in each process to store the result
-    is_in_the_same_node = torch.tensor(
-        [0] * world_size, dtype=torch.int32, device="cpu"
-    )
+    is_in_the_same_node = torch.tensor([0] * world_size, dtype=torch.int32, device="cpu")
 
     # global ranks of the processes in the group
     ranks = torch.distributed.get_process_group_ranks(pg)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_kda_backend.py
@@ -1,0 +1,554 @@
+"""Ascend NPU backend for Kimi-K3 KDA (Key-Delta Attention).
+
+Decode uses the triton fused_recurrent_kda_packed_decode kernel; prefill uses
+the pypto chunk_kda wrapper. Causal conv1d is a torch-native fallback.
+"""
+
+import logging
+from typing import Optional, Tuple, Union
+
+import torch
+
+from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend import (
+    AscendMambaAttnBackendBase,
+)
+from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+
+logger = logging.getLogger(__name__)
+
+
+def _l2norm_fp32(x: torch.Tensor) -> torch.Tensor:
+    """Per-head L2 normalization in fp32; returns the input dtype."""
+    xf = x.float()
+    return (xf * torch.rsqrt(xf.pow(2).sum(-1, keepdim=True) + 1e-6)).to(x.dtype)
+
+
+def _compute_kda_gate(
+    a: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+) -> torch.Tensor:
+    """Per-K log-decay ``gk`` [1, T, H, K] fp32 from raw forget-gate ``a``.
+
+    Matches the in-kernel gate of fused_recurrent_kda_packed_decode / chunk_kda.
+    """
+    _, T, H, K = a.shape
+    x = a.float() + dt_bias.view(H, K).view(1, 1, H, K)
+    alog = A_log.view(1, 1, H, 1).float()
+    if lower_bound is not None:
+        return lower_bound * torch.sigmoid(torch.exp(alog) * x)
+    softplus = torch.where(x <= 20.0, torch.log(1.0 + torch.exp(x)), x)
+    return -torch.exp(alog) * softplus
+
+
+# Causal conv1d torch-native fallback (sgl_kernel_npu has dtype/shape bugs on 910C).
+
+
+def _causal_conv1d_fallback_decode(
+    x: torch.Tensor,  # [batch, dim]
+    conv_state: torch.Tensor,  # [N, K-1, D] (transposed state)
+    weight: torch.Tensor,  # [out_dim, 1, kernel]
+    bias: torch.Tensor | None,  # [out_dim]
+    cache_indices: torch.Tensor,
+    activation: str = "silu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Single-step causal conv1d with state update (decode path)."""
+    batch_size = cache_indices.shape[0]
+    kernel_size = weight.shape[-1]
+    dim = x.shape[-1]
+    out_dim = weight.shape[0]
+
+    # .contiguous() is required: transpose creates a strided view on NPU.
+    state = conv_state[cache_indices].transpose(1, 2).to(x.dtype).contiguous()  # [B, D, K-1]
+
+    w = weight.squeeze(1).to(x.dtype)  # [out_dim, K]
+    b = bias.to(x.dtype) if bias is not None else None
+
+    # Build full K-element window: state (K-1 past) + current input
+    window = torch.cat([state, x.unsqueeze(-1)], dim=-1)  # [B, D, K]
+
+    # Convolve (K=4 is tiny, loop is fine)
+    out = torch.zeros(batch_size, out_dim, dtype=x.dtype, device=x.device)
+    for i in range(kernel_size):
+        wi = w[:, i].view(dim, -1).contiguous()  # [D, out_dim/D]
+        win_i = window[:, :, i].contiguous()  # [B, D]
+        out = out + (win_i.unsqueeze(-1) * wi.unsqueeze(0)).reshape(batch_size, out_dim)
+
+    if bias is not None:
+        out = out + b
+    if activation == "silu":
+        out = torch.nn.functional.silu(out)
+
+    # Store updated state: last K-1 elements of window → [B, K-1, D]
+    conv_state[cache_indices] = window[..., 1:].transpose(1, 2).to(conv_state.dtype)
+    return out, conv_state
+
+
+def _causal_conv1d_fallback_prefill(
+    x: torch.Tensor,  # [dim, total_seq]
+    conv_state: torch.Tensor,  # [batch, K-1, dim] (transposed state)
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor,
+    has_initial_state: torch.Tensor,
+    weight: torch.Tensor,  # [out_dim, 1, kernel]
+    bias: torch.Tensor | None,
+    activation: str = "silu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Multi-step causal conv1d with state update (prefill path)."""
+    w = weight.squeeze(1).to(x.dtype)  # [out_dim, kernel]
+    b = bias.to(x.dtype) if bias is not None else None
+    kernel_size = weight.shape[-1]
+    dim = x.shape[0]
+    out_dim = w.shape[0]
+
+    seqlens = query_start_loc[1:] - query_start_loc[:-1]
+    batch_size = seqlens.shape[0]
+    # states: [B, K-1, dim] → transpose to [B, dim, K-1]
+    states = conv_state[cache_indices].transpose(1, 2).to(x.dtype)  # [B, dim, K-1]
+
+    outputs = []
+    for b in range(batch_size):
+        start = query_start_loc[b].item()
+        end = query_start_loc[b + 1].item()
+        seq_len = end - start
+        x_b = x[:, start:end]  # [dim, seq_len]
+
+        if has_initial_state[b]:
+            prefix = states[b]  # [dim, K-1]
+            full = torch.cat([prefix, x_b], dim=-1)  # [dim, K-1 + seq_len]
+        else:
+            prefix = torch.zeros(dim, kernel_size - 1, dtype=x.dtype, device=x.device)
+            full = torch.cat([prefix, x_b], dim=-1)  # [dim, K-1 + seq_len]
+
+        # Unfold into sliding windows: [dim, T] → [dim, seq_len, K]
+        # .contiguous() is required: unfold creates a strided view on NPU.
+        windows = full.unfold(-1, kernel_size, 1)[:, :seq_len, :].contiguous()  # [dim, seq_len, K]
+
+        # Convolve (K=4 is tiny, loop is fine)
+        out_b = torch.zeros(seq_len, out_dim, dtype=x.dtype, device=x.device)
+        for i in range(kernel_size):
+            wi = w[:, i].view(dim, -1).contiguous()  # [dim, O_per_dim]
+            win_i = windows[:, :, i].t().contiguous()  # [seq_len, dim]
+            out_b = out_b + (win_i.unsqueeze(-1) * wi.unsqueeze(0)).reshape(seq_len, out_dim)
+
+        out_b = out_b.transpose(0, 1).contiguous()  # [out_dim, seq_len]
+
+        if bias is not None:
+            out_b = out_b + b.unsqueeze(1)
+
+        if activation == "silu":
+            out_b = torch.nn.functional.silu(out_b)
+
+        outputs.append(out_b)
+
+        # Update state: last K-1 elements of sequence
+        full_seq = x[:, start:end]  # [dim, seq_len]
+        if seq_len >= kernel_size - 1:
+            states[b] = full_seq[:, -(kernel_size - 1):]
+        else:
+            prev = states[b] if has_initial_state[b] else torch.zeros(dim, kernel_size - 1, dtype=x.dtype, device=x.device)
+            combined = torch.cat([prev, full_seq], dim=-1)
+            states[b] = combined[:, -(kernel_size - 1):]
+
+    # Write back: transpose [B, dim, K-1] → [B, K-1, dim]
+    conv_state[cache_indices] = states.transpose(1, 2).to(conv_state.dtype)
+    out = torch.cat(outputs, dim=-1)  # [out_dim, total_seq]
+    return out, conv_state
+
+
+class AscendKDAAttnBackend(AscendMambaAttnBackendBase):
+    """NPU backend for KDA (Kimi Delta Attention) layers on Ascend 910C."""
+
+    def __init__(self, model_runner: ModelRunner):
+        super().__init__(model_runner)
+        # KDA conv states are stored transposed vs Mamba2 convention; expose the
+        # transposed shape so the track path reads conv_states_shape[-1] as the
+        # conv window length.
+        self.conv_states_shape = torch.Size(
+            (
+                *model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0]
+                .transpose(-1, -2)
+                .shape,
+            )
+        )
+        self.decode_backend = "cann_recurrent"
+        self.prefill_backend = "pto_chunk"
+
+    # metadata
+
+    def _prepare_kda_inputs(
+        self,
+        bs: int,
+        forward_mode: ForwardMode,
+        spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+    ):
+        """Pre-compute per-forward metadata tensors for CANN operators."""
+        cache_indices = self.forward_metadata.mamba_cache_indices
+        self.num_accept_tokens = torch.ones(
+            [bs], dtype=torch.int32, device=cache_indices.device
+        )
+        self.actual_seq_lengths = torch.ones(
+            [bs], dtype=torch.int32, device=cache_indices.device
+        )
+        if forward_mode.is_target_verify():
+            seq_len = spec_info.draft_token_num
+            self.actual_seq_lengths = self.actual_seq_lengths * seq_len
+            self.ssm_state_indices = torch.arange(
+                cache_indices.shape[0] * seq_len,
+                dtype=torch.int32,
+                device=cache_indices.device,
+            )
+        else:
+            self.ssm_state_indices = cache_indices
+
+    def init_forward_metadata_out_graph(
+        self,
+        forward_batch: ForwardBatch,
+        in_capture: bool = False,
+    ):
+        if forward_batch.forward_mode.is_draft_extend_v2():
+            return
+        super().init_forward_metadata_out_graph(forward_batch, in_capture=in_capture)
+        self._prepare_kda_inputs(
+            forward_batch.batch_size,
+            forward_batch.forward_mode,
+            forward_batch.spec_info,
+        )
+        self.graph_mode = True
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        if forward_batch.forward_mode.is_draft_extend_v2():
+            return
+        super().init_forward_metadata(forward_batch)
+        self._prepare_kda_inputs(
+            forward_batch.batch_size,
+            forward_batch.forward_mode,
+            forward_batch.spec_info,
+        )
+        self.graph_mode = False
+
+    # decode
+
+    def forward_decode(
+        self,
+        layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+        a: torch.Tensor,
+        b: torch.Tensor,
+        **kwargs,
+    ):
+        """Decode path: one token per sequence, recurrent update."""
+        layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
+        conv_states = layer_cache.conv[0]  # [N, D, kernel-1]
+        ssm_states = layer_cache.temporal  # [N, heads, Dv, Dk]
+        cache_indices = self.forward_metadata.mamba_cache_indices
+
+        # causal conv1d
+        assert isinstance(mixed_qkv, torch.Tensor)
+        conv_states_tmp = conv_states.transpose(1, 2).clone()  # [N, K-1, D]
+        qkv, conv_states_out = _causal_conv1d_fallback_decode(
+            mixed_qkv,
+            conv_states_tmp,
+            layer.conv_weights,
+            layer.bias,
+            cache_indices,
+            activation="silu",
+        )
+        # conv_states_out is [N, K-1, D] → transpose back
+        conv_states[:] = conv_states_out.transpose(1, 2).to(conv_states.dtype)
+
+        # KDA recurrent decode via the triton fused_recurrent_kda_packed_decode
+        # kernel: computes gk/beta/q-k L2norm/scale in-kernel and reads/writes
+        # the recurrent state at cache_indices in place.
+        from sglang.srt.layers.attention.fla.fused_recurrent import (
+            fused_recurrent_kda_packed_decode,
+        )
+        N = qkv.shape[0]
+        hv = layer.num_v_heads
+        out = qkv.new_empty(N, 1, hv, layer.head_v_dim)
+        a_2d = a if a.dim() == 2 else a.reshape(N, -1)
+        b_2d = b if b.dim() == 2 else b.reshape(N, -1)
+        core_attn_out, _ = fused_recurrent_kda_packed_decode(
+            mixed_qkv=qkv.contiguous(),
+            a=a_2d.contiguous(),
+            b=b_2d.contiguous(),
+            A_log=layer.A_log.reshape(-1).contiguous(),
+            dt_bias=layer.dt_bias.reshape(-1).contiguous(),
+            scale=layer.head_k_dim ** -0.5,
+            initial_state=ssm_states,
+            out=out,
+            ssm_state_indices=cache_indices,
+            use_qk_l2norm_in_kernel=True,
+            lower_bound=layer.lower_bound,
+        )
+        # out [N, 1, HV, V] → [1, N, HV, V] (model does .squeeze(0)).
+        core_attn_out = core_attn_out.transpose(0, 1)
+
+        self._track_mamba_state_decode(
+            forward_batch, conv_states, ssm_states, cache_indices
+        )
+        return core_attn_out
+
+    def _cann_recurrent_decode(
+        self,
+        mix_qkv_packed: torch.Tensor,
+        batch_size: int,
+        num_heads: int,
+        num_value_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+        recurrent_state: torch.Tensor,
+        beta: torch.Tensor,
+        g: torch.Tensor,
+        gk: torch.Tensor,
+        scale: float,
+        cache_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Wrap CANN aclnnRecurrentGatedDeltaRule via torch.ops.npu."""
+        beta = beta.to(torch.bfloat16)
+
+        if self.graph_mode:
+            num_accept_tokens = torch.full(
+                [batch_size], 1, dtype=torch.int32, device=cache_indices.device
+            )
+            actual_seq_lengths = torch.full(
+                [batch_size], 1, dtype=torch.int32, device=cache_indices.device
+            )
+            ssm_state_indices = self.forward_metadata.mamba_cache_indices
+        else:
+            num_accept_tokens = self.num_accept_tokens
+            actual_seq_lengths = self.actual_seq_lengths
+            ssm_state_indices = self.ssm_state_indices
+
+        # CANN aclnnRecurrentGatedDeltaRule requires an EVEN head count: an odd
+        # num_heads leaves a dangling half-block and raises ADDR_MISALIGN. Pad
+        # the head dim up to the next even number, run the op, then slice back.
+        # The padded head carries zeroed Q/K/V; state slot indexing is remapped
+        # onto a gathered copy of the touched slots.
+        nv = num_value_heads
+        head_pad = nv & 1  # 1 when odd -> pad to even
+        nk_pad = num_heads + head_pad
+        nv_pad = nv + head_pad
+        ssm_state_indices = ssm_state_indices.view(batch_size, -1)
+        if head_pad == 0:
+            attn_core_out = torch.ops.npu.recurrent_gated_delta_rule(
+                mix_qkv_packed.contiguous(),
+                recurrent_state.contiguous(),
+                beta=beta.contiguous(),
+                scale=scale,
+                actual_seq_lengths=actual_seq_lengths,
+                ssm_state_indices=ssm_state_indices.contiguous(),
+                nk=num_heads,
+                nv=nv,
+                intermediate_state=None,
+                cache_indices=cache_indices,
+                num_accepted_tokens=num_accept_tokens,
+                g=g.contiguous(),
+                gk=gk.contiguous(),
+            )
+            return attn_core_out.contiguous()
+
+        # --- odd-head path: pad head dim, gather touched state slots, remap ---
+        N = mix_qkv_packed.shape[1]
+        N = mix_qkv_packed.shape[1]
+        qk_dim = num_heads * head_k_dim
+        v_dim = nv * head_v_dim
+        qk_part = mix_qkv_packed[..., : 2 * qk_dim].view(1, N, 2, num_heads, head_k_dim)
+        v_part = mix_qkv_packed[..., 2 * qk_dim :].view(1, N, nv, head_v_dim)
+        qk_pad = torch.nn.functional.pad(qk_part, (0, 0, 0, head_pad))  # [1,N,2,nk_pad,hk]
+        v_pad = torch.nn.functional.pad(v_part, (0, 0, 0, head_pad))  # [1,N,nv_pad,hv]
+        mix_qkv_pad = torch.cat(
+            [qk_pad.reshape(1, N, 2 * nk_pad * head_k_dim), v_pad.reshape(1, N, nv_pad * head_v_dim)],
+            dim=-1,
+        ).contiguous()
+
+        beta_pad = torch.nn.functional.pad(beta, (0, head_pad))  # pad nv -> nv_pad on last dim
+        g_pad = torch.nn.functional.pad(g, (0, head_pad))
+        # gk is [T, nv, Dk]; pad the head (nv) axis, leave Dk unchanged.
+        gk_pad = torch.nn.functional.pad(gk, (0, 0, 0, head_pad))
+
+        # Gather the touched state slots, pad head dim, remap indices via searchsorted.
+        all_idx = torch.cat([ssm_state_indices.reshape(-1), cache_indices.reshape(-1)])
+        unique_idx = torch.unique(all_idx)  # sorted ascending
+        state_local = recurrent_state[unique_idx]  # [U, nv, hk, hv]
+        state_pad = torch.nn.functional.pad(state_local, (0, 0, 0, 0, 0, head_pad))  # [U, nv_pad, hk, hv]
+        local_ssm = torch.searchsorted(unique_idx, ssm_state_indices.reshape(-1)).reshape(ssm_state_indices.shape).to(torch.int32)
+        local_cache = torch.searchsorted(unique_idx, cache_indices.reshape(-1)).reshape(cache_indices.shape).to(torch.int32)
+
+        attn_core_out = torch.ops.npu.recurrent_gated_delta_rule(
+            mix_qkv_pad,
+            state_pad,
+            beta=beta_pad.contiguous(),
+            scale=scale,
+            actual_seq_lengths=actual_seq_lengths,
+            ssm_state_indices=local_ssm.contiguous(),
+            nk=nk_pad,
+            nv=nv_pad,
+            intermediate_state=None,
+            cache_indices=local_cache,
+            num_accepted_tokens=num_accept_tokens,
+            g=g_pad.contiguous(),
+            gk=gk_pad.contiguous(),
+        )
+        # Slice real heads back; scatter updated slots to the global cache.
+        attn_core_out = attn_core_out[..., :nv, :].contiguous()
+        recurrent_state[unique_idx] = state_pad[:, :nv]
+        return attn_core_out
+
+    # prefill (extend)
+
+    def forward_extend(
+        self,
+        layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
+        a: torch.Tensor,
+        b: torch.Tensor,
+        **kwargs,
+    ):
+        """Prefill path: multi-token chunked KDA."""
+        assert isinstance(mixed_qkv, torch.Tensor)
+        seq_len = mixed_qkv.shape[0]
+        is_target_verify = forward_batch.forward_mode.is_target_verify()
+        forward_metadata = self.forward_metadata
+
+        query_start_loc = forward_metadata.query_start_loc
+        cache_indices = forward_metadata.mamba_cache_indices
+
+        mamba_cache_params = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
+        conv_states = mamba_cache_params.conv[0]
+        ssm_states = mamba_cache_params.temporal
+
+        has_initial_states = forward_batch.extend_prefix_lens > 0
+
+        # causal conv1d (prefill / chunked)
+        mixed_qkv_t = mixed_qkv.transpose(0, 1)  # [dim, seq_len]
+        kernel_size = layer.conv_weights.shape[-1]
+        conv_states_tmp = conv_states.transpose(1, 2).contiguous()  # [N, K-1, D]
+
+        mixed_qkv_t, conv_states_tmp = _causal_conv1d_fallback_prefill(
+            mixed_qkv_t,
+            conv_states_tmp,
+            query_start_loc,
+            cache_indices,
+            has_initial_states,
+            layer.conv_weights,
+            layer.bias,
+            activation="silu",
+        )
+        mixed_qkv_t = mixed_qkv_t.transpose(0, 1)[:seq_len]
+
+        conv_states[:] = conv_states_tmp.transpose(1, 2).contiguous().to(conv_states.dtype)
+
+        # Zero ssm state for new sequences (no prefix): reused slots are not
+        # zeroed by the allocator and would leak the previous request's state.
+        if not bool(has_initial_states.all()):
+            new_indices = cache_indices[~has_initial_states]
+            if new_indices.numel() > 0:
+                ssm_states[new_indices] = 0
+
+        # KDA chunked prefill via the pypto chunk_kda wrapper (1 launch, chunked).
+        # Same KDA recurrence / state ABI / gate / L2norm / scale as forward_decode,
+        # so the state it writes is exactly what decode reads. chunk_kda takes
+        # pre-activated g=gk and sigmoid'd beta; it returns a fresh s_out (not
+        # inplace), so scatter it back to ssm_states. Imported lazily.
+        from sglang.srt.hardware_backend.npu.attention.pto.kda_flash.chunk_kda.chunk_kda_impl import (
+            chunk_kda_wrapper,
+        )
+        hv = layer.num_v_heads
+        kd = layer.head_k_dim
+        vv = layer.head_v_dim
+        A_log = layer.A_log.reshape(-1).contiguous()
+        dt_bias = layer.dt_bias.reshape(-1).contiguous()
+        scale = layer.head_k_dim ** -0.5
+
+        # mixed_qkv_t: [seq_len, packed_dim] (post-conv, Q|K|V), bf16 -> [1,T,H,K/V]
+        qk_dim = hv * kd
+        q = mixed_qkv_t[:, :qk_dim].reshape(1, seq_len, hv, kd).contiguous()
+        k = mixed_qkv_t[:, qk_dim : 2 * qk_dim].reshape(1, seq_len, hv, kd).contiguous()
+        v = mixed_qkv_t[:, 2 * qk_dim :].reshape(1, seq_len, hv, vv).contiguous()
+        g = _compute_kda_gate(a.reshape(1, seq_len, hv, kd), A_log, dt_bias, layer.lower_bound)
+        beta = b.reshape(1, seq_len, hv).float()
+
+        init_state = ssm_states[cache_indices].contiguous()  # [N, hv, vv, kd]
+        core_attn_out, s_out = chunk_kda_wrapper(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=init_state,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=query_start_loc,
+        )  # core_attn_out [1, T, hv, vv]; s_out [N, hv, vv, kd]
+        ssm_states[cache_indices] = s_out
+
+        return core_attn_out
+
+    def _recurrent_prefill_fallback(
+        self,
+        Q, K, V, beta, g, gk, scale,
+        ssm_states, cache_indices, seq_len, batch_size,
+    ) -> torch.Tensor:
+        """Prefill fallback: call recurrent_gated_delta_rule one token at a time."""
+        CHUNK_SIZE = 1  # 1 token/op-call: no race, no OOB, correct handoff
+        # Save mutable state to restore after this fallback
+        saved_num_accept = self.num_accept_tokens
+        saved_seq_lengths = self.actual_seq_lengths
+        saved_ssm_indices = self.ssm_state_indices
+        device = cache_indices.device
+
+        outputs = []
+        for start in range(0, seq_len, CHUNK_SIZE):
+            end = min(start + CHUNK_SIZE, seq_len)
+            chunk_size = end - start
+
+            chunk_qkv = torch.cat([
+                Q[:, start:end].squeeze(0).reshape(-1, Q.shape[-2] * Q.shape[-1]),
+                K[:, start:end].squeeze(0).reshape(-1, K.shape[-2] * K.shape[-1]),
+                V[:, start:end].squeeze(0).reshape(-1, V.shape[-2] * V.shape[-1]),
+            ], dim=-1).unsqueeze(0)  # [1, chunk, 3*D]
+
+            chunk_beta = beta[:, start:end] if beta.dim() == 3 else beta[start:end]
+            chunk_g = g[start:end]
+            chunk_gk = gk[start:end]
+
+            # Per-chunk: update state for _cann_recurrent_decode
+            self.num_accept_tokens = torch.full(
+                [batch_size], chunk_size, dtype=torch.int32, device=device,
+            )
+            self.actual_seq_lengths = self.num_accept_tokens
+            # CHUNK_SIZE=1: ssm_state_indices = cache_indices; state chains across calls.
+            self.ssm_state_indices = cache_indices.repeat_interleave(
+                chunk_size
+            ).to(torch.int32)
+
+            out = self._cann_recurrent_decode(
+                mix_qkv_packed=chunk_qkv,
+                batch_size=batch_size,
+                num_heads=Q.shape[-2],
+                num_value_heads=V.shape[-2],
+                head_k_dim=Q.shape[-1],
+                head_v_dim=V.shape[-1],
+                recurrent_state=ssm_states,
+                beta=chunk_beta.view(batch_size, -1, V.shape[-2]).contiguous(),
+                g=chunk_g.reshape(-1, V.shape[-2]),
+                gk=chunk_gk.reshape(-1, V.shape[-2], Q.shape[-1]).contiguous(),
+                scale=scale,
+                cache_indices=cache_indices,
+            )
+            outputs.append(out)
+
+        # Restore state
+        self.num_accept_tokens = saved_num_accept
+        self.actual_seq_lengths = saved_seq_lengths
+        self.ssm_state_indices = saved_ssm_indices
+
+        return torch.cat(outputs, dim=1)  # concat along seq_len for chunks [1, s1, D] + [1, s2, D]

--- a/python/sglang/srt/hardware_backend/npu/attention/pto/__init__.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/pto/__init__.py
@@ -1,0 +1,6 @@
+"""PTO (Parallel Tile Operation) operators vendored from pypto-gym for Ascend NPU.
+
+These wrap Hisilicon's pypto-gym kernels (commit 5405139) for use inside sglang's
+NPU attention backends. They require the `pypto` package (JIT tile compiler) to be
+installed — see scripts/install_pto_k3.sh for the standard install.
+"""

--- a/python/sglang/srt/hardware_backend/npu/attention/pto/kda_flash/__init__.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/pto/kda_flash/__init__.py
@@ -1,0 +1,1 @@
+"""KDA (Kimi Delta Attention) PTO kernels."""

--- a/python/sglang/srt/hardware_backend/npu/attention/pto/kda_flash/chunk_kda/__init__.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/pto/kda_flash/chunk_kda/__init__.py
@@ -1,0 +1,6 @@
+"""Chunked KDA prefill kernel (pypto-gym commit 5405139, unmodified).
+
+``chunk_kda_wrapper`` is imported lazily from ``chunk_kda_impl`` by callers (not here)
+so that ``import pypto`` only happens on first use, keeping sglang startup free of the
+pypto dependency on non-NPU / fresh environments.
+"""

--- a/python/sglang/srt/hardware_backend/npu/attention/pto/kda_flash/chunk_kda/chunk_kda_impl.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/pto/kda_flash/chunk_kda/chunk_kda_impl.py
@@ -1,0 +1,374 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# =============================================================================
+# chunk_kda_impl.py — Kimi Delta Attention (chunked gated delta-rule linear
+# attention, forward only). A single @pypto.frontend.jit TND-varlen kernel plus a
+# host wrapper; fixed-length (BSND) input folds into the varlen path via synthesized
+# cu_seqlens. See Chunk_KDA.md for the math, public ABI, and constraints.
+# =============================================================================
+
+import pypto
+import torch
+import torch_npu  # noqa: F401  required for NPU device init
+
+_BT = 128   # chunk length (static)
+_MIN = 16   # block-inverse leaf size: BT/8 = 16
+_SCALE = 128 ** -0.5    # K=128 query scale, folded in fp32 in-kernel
+_L2_EPS = 1e-6          # q/k L2-norm eps
+_BC = 64                # intra-chunk decay sub-block (one local pivot per block)
+_NC = _BT // _BC        # sub-blocks per 128-row chunk
+_DECAY_CAP = 80.0       # clamp col-factor exponent below fp32 exp overflow (~88.7)
+
+
+# =============================================================================
+# 8x16 block matrix inverse. Inverts (I + A) where A is strict-lower: feed neg-A so
+# the unit-lower forward-substitution returns (I-(-A))^-1 = (I+A)^-1. Hierarchical
+# merge: 8 leaf 16x16 -> 32 -> 64 -> 128.
+# =============================================================================
+def _inv_min_length(attn_dim1, eye, row_num, col_num):
+    # 8 stacked diag 16x16 blocks [16,128] -> their inverses [16,128] via fwd-subst.
+    size = col_num // row_num                                   # 8
+    pypto.set_vec_tile_shapes(128, 128)
+    cur = attn_dim1[:2, :]                                      # [2,128] rows 0,1
+    for i in range(2, row_num, 1):                             # 2..15
+        cur = cur + 0.0                                        # land in UB
+        row = attn_dim1.view([1, col_num], [i, 0])            # [1,128] row i across blocks
+        row_exp = row.reshape([size, row_num]).view([size, i], [0, 0]).transpose(1, 0).reshape([size * i, 1])
+        cur_r = cur.reshape([size * i, row_num])              # [8i,16]
+        prod_mul = (row_exp * cur_r).reshape([i, col_num])    # [i,128]
+        prod = pypto.sum(prod_mul, dim=0, keepdim=True)       # [1,128]
+        cur = pypto.concat([cur, row + prod], dim=0)         # grow [i+1,128]
+    return cur + eye                                          # [16,128] add diag I
+
+
+def _inv_merge(attn, inv11, inv22, x_ofs, y_ofs, m_len, zero_t):
+    pypto.set_cube_tile_shapes([128, 128], [128, 128], [128, 128])
+    a21 = attn.view([m_len, m_len], [x_ofs + m_len, y_ofs])   # [m,m] lower-left
+    a21_inv = pypto.matmul(pypto.matmul(inv22, a21, pypto.DT_FP32), inv11, pypto.DT_FP32)  # D_inv C A_inv
+    # assemble the [2m,2m] block matrix [[inv11, 0], [a21_inv, inv22]] via concat;
+    # zero_t supplies the [m,m] upper-right zero block
+    pypto.set_vec_tile_shapes(128, 128)
+    top = pypto.concat([inv11, zero_t], dim=1)                # [m,2m] upper: inv11 | 0
+    bot = pypto.concat([a21_inv, inv22], dim=1)               # [m,2m] lower: a21_inv | inv22
+    return pypto.concat([top, bot], dim=0)                    # [2m,2m]
+
+
+def _inverse8(neg_a, eye_stack, z8, z16, z32):
+    pypto.set_vec_tile_shapes(128, 128)
+    diag = [neg_a.view([_MIN, _MIN], [_MIN * i, _MIN * i]) + 0.0 for i in range(8)]  # 8x[16,16]
+    diag_inv = _inv_min_length(pypto.concat(diag, dim=1), eye_stack, _MIN, _BT)      # [16,128]
+    li = [diag_inv[:, _MIN * i:_MIN * (i + 1)] + 0.0 for i in range(8)]              # 8x[16,16]
+    l4 = [_inv_merge(neg_a, li[2 * i], li[2 * i + 1], _MIN * 2 * i, _MIN * 2 * i, _MIN, z8) for i in range(4)]
+    l2 = [_inv_merge(neg_a, l4[2 * i], l4[2 * i + 1], _MIN * 4 * i, _MIN * 4 * i, _MIN * 2, z16) for i in range(2)]
+    return _inv_merge(neg_a, l2[0], l2[1], 0, 0, _MIN * 4, z32)                      # [128,128]
+
+
+# =============================================================================
+# Intra-chunk decay A (k-side) / A_qk (q-side). Splits the [128,128] causal matrix
+# into _NC row-blocks of _BC rows, each with a LOCAL pivot gp = gcum at the block-start
+# row: the row factor exp(gcum_row-gp) has exponent <=0 and the col factor
+# exp(gp-gcum_col) is clamped by _DECAY_CAP, so the reconstructed decay stays finite.
+# Returns both UNMASKED; _chunk_compute applies the tril masks.
+# =============================================================================
+def _intra_chunk_a(q_s, k_s, gcum):
+    pypto.set_vec_tile_shapes(_BC, 128)                       # row [BC,K] & col [128,K] elementwise
+    pypto.set_cube_tile_shapes([_BC, _BC], [128, 128], [_BT, _BT])  # [BC,K]@[K,128]->[BC,128] band matmul
+    af_bands = []
+    a2_bands = []
+    for a in range(_NC):                                      # _NC row-blocks of _BC rows (static loop)
+        r0 = a * _BC
+        gp = gcum[r0:r0 + 1, :]                               # [1,K] pivot = gcum at block-start row
+        g_band = gcum[r0:r0 + _BC, :]                         # [BC,K]
+        row_dec = pypto.exp(g_band - gp)                      # [BC,K] exponent <=0 (rows >= pivot)
+        # A / A_qk matmuls stay fp32 (extreme decay dynamic range would round in bf16)
+        kg_a = k_s[r0:r0 + _BC, :] * row_dec                  # [BC,K] k-side row factor (fp32)
+        qg_a = q_s[r0:r0 + _BC, :] * row_dec                  # [BC,K] q-side row factor (fp32)
+        col_dec = pypto.exp(pypto.minimum(gp - gcum, _DECAY_CAP))  # [128,K] clamp -> no +inf in future region
+        ki_a = k_s * col_dec                                  # [128,K] shared col factor (fp32, feeds both matmuls)
+        af_bands.append(pypto.matmul(kg_a, ki_a, pypto.DT_FP32, b_trans=True))  # [BC,128] fp32 (extreme decay range)
+        a2_bands.append(pypto.matmul(qg_a, ki_a, pypto.DT_FP32, b_trans=True))  # [BC,128] fp32 (extreme decay range)
+    a_full = pypto.concat(af_bands, dim=0)                    # [128,128] (k-side, unmasked)
+    a2 = pypto.concat(a2_bands, dim=0)                        # [128,128] (q-side, unmasked)
+    return a_full, a2
+
+
+# =============================================================================
+# Per-chunk M1+M2+M3 compute. Plain helper (no pypto.is_loop_end); takes the
+# non-tensor bool use_qk_l2norm_in_kernel so it is NOT @pypto.frontend.function-
+# decorated. Called from both is_loop_end branches. Sets its own cube+vec tiles.
+# Returns (oc, s_new); caller writes s_carry[:] = s_new.
+# =============================================================================
+def _chunk_compute(qc, kc, vc, gc, bc, s_carry, tril_incl, tril_strict, eye_stack,
+                   use_qk_l2norm_in_kernel, scale, z8, z16, z32):
+    K = qc.shape[1]                                       # 128 (static); for glast row-(_BT-1) view
+    pypto.set_cube_tile_shapes([64, 128], [128, 128], [128, 128])   # M1/M2 cube (self-contained)
+    pypto.set_vec_tile_shapes(128, 128)                            # M1 vec
+    q_f = pypto.cast(qc, pypto.DT_FP32)                   # [128,K] fp32, pre-scale
+    k_f = pypto.cast(kc, pypto.DT_FP32)                   # [128,K] fp32
+    # --- in-kernel q/k L2-norm over K, applied BEFORE scale (trace-time `if`) ---
+    if use_qk_l2norm_in_kernel:
+        q_f = q_f * pypto.rsqrt(pypto.sum(q_f * q_f, dim=1, keepdim=True) + _L2_EPS)  # [128,K] per-token over K
+        k_f = k_f * pypto.rsqrt(pypto.sum(k_f * k_f, dim=1, keepdim=True) + _L2_EPS)  # [128,K] per-token over K
+    q_s = q_f * scale                                     # [128,K] q*scale (fp32, after l2norm; scale is a trace-time const)
+    k_s = k_f                                             # [128,K] k (unscaled, l2normed)
+    # M1: per-channel gated cumsum
+    gcum = pypto.matmul(tril_incl, gc, pypto.DT_FP32)     # [128,K]
+    eg = pypto.exp(gcum)                                  # [128,K] exp(gcum) shared by kg (M2 w/u) and qg (M3 o)
+    kg = k_s * eg                                         # [128,K] (cross-chunk state term w/u; NOT intra A)
+    # M2: intra-chunk A (k-side) and A_qk (q-side), returned unmasked; masks applied here
+    a_full, a2_raw = _intra_chunk_a(q_s, k_s, gcum)       # [128,128], [128,128] (stable, unmasked)
+    pypto.set_vec_tile_shapes(128, 128)                  # restore caller vec tile (_intra_chunk_a set its own)
+    b_row = bc.transpose(0, 1)                            # [128,1] (bc already fp32)
+    a = a_full * b_row * tril_strict                      # [128,128]
+    neg_a = pypto.neg(a)
+    a_inv = _inverse8(neg_a, eye_stack, z8, z16, z32)     # [128,128]
+    a_inv = a_inv * bc
+    pypto.set_vec_tile_shapes(128, 128)
+    pypto.set_cube_tile_shapes([64, 128], [128, 128], [128, 128])
+    # --- bf16 matmul inputs (Cube fast path), fp32 accumulation ---
+    a_inv_bf = pypto.cast(a_inv, pypto.DT_BF16)          # [128,128] feeds w & u matmuls
+    kg_bf = pypto.cast(kg, pypto.DT_BF16)                # [128,K] kg=k_s*exp(gcum): fp32 then bf16
+    w = pypto.matmul(a_inv_bf, kg_bf, pypto.DT_FP32)     # [128,K] bf16 in, fp32 accum
+    u = pypto.matmul(a_inv_bf, vc, pypto.DT_FP32)        # [128,V] bf16 in (vc already bf16), fp32 accum
+    # M3: cross-chunk recurrence (state S carried over the chunk loop)
+    qg = q_s * eg                                         # [128,K] reuse exp(gcum) from M1 (fp32; cast bf16 below)
+    a2 = a2_raw * tril_incl                               # [128,128] (stable q-side A, inclusive-lower)
+    s_carry_bf = pypto.cast(s_carry, pypto.DT_BF16)      # [K,V] feeds w@s_carry & qg@s_carry; fp32 s_carry kept for s_new
+    w_bf = pypto.cast(w, pypto.DT_BF16)                  # [128,K] w=a_inv@kg: fp32 then bf16
+    vi = u - pypto.matmul(w_bf, s_carry_bf, pypto.DT_FP32)   # [128,V] fp32 (u & matmul both fp32)
+    qg_bf = pypto.cast(qg, pypto.DT_BF16)                # [128,K] qg=q_s*exp(gcum): fp32 then bf16
+    a2_bf = pypto.cast(a2, pypto.DT_BF16)                # [128,128] fp32 -> bf16
+    vi_bf = pypto.cast(vi, pypto.DT_BF16)               # [128,V] feeds a2@vi & kdec@vi -> cast once
+    oc = pypto.matmul(qg_bf, s_carry_bf, pypto.DT_FP32) + pypto.matmul(a2_bf, vi_bf, pypto.DT_FP32)  # [128,V] fp32 accum
+    glast = pypto.view(gcum, [1, K], [_BT - 1, 0])       # [1,K] row _BT-1 == gcum[actual_l-1] (g pad=0 -> flat)
+    kdec = k_s * pypto.exp(glast - gcum)                  # [128,K] (fp32; cast to bf16 below)
+    kdec_bf = pypto.cast(kdec, pypto.DT_BF16)            # [128,K] kdec=k_s*exp(glast-gcum): fp32 then bf16
+    s_new = s_carry * pypto.exp(glast).transpose(0, 1) + pypto.matmul(kdec_bf, vi_bf, pypto.DT_FP32, a_trans=True)  # [K,V] fp32
+    return oc, s_new
+
+
+# =============================================================================
+# JIT entry — the single module-level @pypto.frontend.jit (TND varlen; fixed-len
+# BSND folds in via cu synthesis in the host). K==V==128 baked. Tensors first, then
+# the trace-time bool. The whole loop nest is inlined here so pypto.is_loop_end lives
+# directly in the @jit body.
+# =============================================================================
+@pypto.frontend.jit(
+        runtime_options={"run_mode": pypto.RunMode.NPU, "launch_sched_aicpu_num": 3},
+        pass_options={
+            "vec_nbuffer_setting": {-2: 1, -1: 64},
+            "cube_l1_reuse_setting": {-1: 4},
+            "cube_nbuffer_setting": {-1: 4}
+            },
+        debug_options={
+            "runtime_debug_mode": 0
+        })
+def chunk_kda_varlen_kernel(
+    q:      pypto.Tensor([1, pypto.DYNAMIC, pypto.DYNAMIC, 128], pypto.DT_BF16),  # [1,T,H,K] packed  # SNAP:SIG_JIT
+    k:      pypto.Tensor([1, pypto.DYNAMIC, pypto.DYNAMIC, 128], pypto.DT_BF16),  # [1,T,H,K]
+    v:      pypto.Tensor([1, pypto.DYNAMIC, pypto.DYNAMIC, 128], pypto.DT_BF16),  # [1,T,H,V]
+    g:      pypto.Tensor([1, pypto.DYNAMIC, pypto.DYNAMIC, 128], pypto.DT_FP32),  # [1,T,H,K] fp32
+    beta:   pypto.Tensor([1, pypto.DYNAMIC, pypto.DYNAMIC],      pypto.DT_FP32),  # [1,T,H] fp32
+    cu:     pypto.Tensor([pypto.DYNAMIC], pypto.DT_INT32),  # [N+1] segment boundaries (indexed in-kernel)
+    tril:   pypto.Tensor([128, 128], pypto.DT_FP32),  # cumsum incl
+    trils:  pypto.Tensor([128, 128], pypto.DT_FP32),  # strict-lower mask
+    eyestk: pypto.Tensor([16, 128],  pypto.DT_FP32),  # block-inv diag I
+    state0: pypto.Tensor([pypto.DYNAMIC, pypto.DYNAMIC, 128, 128], pypto.DT_FP32),  # [N,H,V,K] upstream ABI (transpose in-kernel)
+    o_out:  pypto.Tensor([1, pypto.DYNAMIC, pypto.DYNAMIC, 128], pypto.DT_BF16),  # [1,T,H,V]
+    s_out:  pypto.Tensor([pypto.DYNAMIC, pypto.DYNAMIC, 128, 128], pypto.DT_FP32),  # [N,H,V,K] upstream ABI (transpose in-kernel)
+    use_qk_l2norm_in_kernel: bool = False,  # non-tensor param (after all tensors); trace-time switch
+    scale: float = _SCALE,  # non-tensor param; trace-time query-scale constant (folded in fp32 in-kernel)
+):
+    # H/N are derived in-kernel from tensor dims (not int params) so all (H,N) shapes
+    # reuse one compile; use_qk_l2norm_in_kernel and scale are the only trace-time
+    # (non-tensor) params -> they key the compile cache (scale is realistically constant).
+    pypto.experimental.set_operation_options(combine_axis=True)  # inline brcb for tail-1 beta broadcasts
+    K = q.shape[3]                                        # K == 128
+    V = v.shape[3]                                        # V == 128
+    H = q.shape[2]                                        # head count, derived from tensor dim (q [1,T,H,K])
+    N = state0.shape[0]                                   # seq count,  derived from tensor dim (state0 [N,H,V,K])
+    # z8/z16/z32: the _inv_merge upper-right zero quadrants ([16,16]/[32,32]/[64,64]),
+    # loop-invariant so built once per launch and threaded into _chunk_compute/_inverse8.
+    pypto.set_vec_tile_shapes(16, 64)
+    z8 = pypto.full(size=[_MIN, _MIN], fill_value=0.0, dtype=pypto.DT_FP32)
+    z16 = pypto.full(size=[_MIN * 2, _MIN * 2], fill_value=0.0, dtype=pypto.DT_FP32)
+    z32 = pypto.full(size=[_MIN * 4, _MIN * 4], fill_value=0.0, dtype=pypto.DT_FP32)
+    # SNAP:before_nt_loop
+    for h in pypto.loop(0, H, 1, name="LH"):        # head loop
+        for n in pypto.loop(0, N, 1, name="LN"):    # sequence loop
+            bos = cu[n]                                   # seq start token (indexed from device cu tensor)
+            eos = cu[n + 1]                               # seq end token (exclusive)
+            L = eos - bos                                 # seq length (SymbolicScalar; may be %128 != 0)
+            pypto.set_cube_tile_shapes([128, 128], [128, 128], [128, 128])
+            pypto.set_vec_tile_shapes(1, 1, 128, 128)       # rank-4 for state0[N,H,V,K] view (upstream ABI)
+            s_seed_vk = pypto.reshape(pypto.view(state0, [1, 1, V, K], [n, h, 0, 0]), [V, K])  # [V,K] upstream ABI slice
+            pypto.set_vec_tile_shapes(128, 128)             # rank-2 [V,K]->[K,V] transpose (V==K==128)
+            s_carry = s_seed_vk.transpose(0, 1) + 0.0       # [V,K] -> [K,V] internal seed (transpose in-kernel)
+            pypto.set_vec_tile_shapes(128, 128)             # back to rank-2
+            # dynamic-bound static-step chunk loop (step _BT); last iteration is the
+            # possibly-partial tail
+            for s_idx in pypto.loop(0, L, _BT, name="LNT", submit_before_loop=False, unroll_list=[4]):
+                # SNAP:inside_nt_loop
+                off = bos + s_idx                          # absolute token offset of this chunk
+                actual_l = (L - s_idx).min(_BT)            # valid rows in THIS chunk (<= _BT); tail may be < _BT
+                # ---- rank-4 strided head-slice views; valid_shape marks the actual rows.
+                #      Cube tile for the M1/M2 matmuls is set inside _chunk_compute. ----
+                pypto.set_vec_tile_shapes(1, 128, 1, 128)     # rank-4 q/k/v/g chunk views
+                q4 = pypto.view(q, [1, _BT, 1, K], [0, off, h, 0], valid_shape=[1, actual_l, 1, K])
+                k4 = pypto.view(k, [1, _BT, 1, K], [0, off, h, 0], valid_shape=[1, actual_l, 1, K])
+                v4 = pypto.view(v, [1, _BT, 1, V], [0, off, h, 0], valid_shape=[1, actual_l, 1, V])
+                g4 = pypto.view(g, [1, _BT, 1, K], [0, off, h, 0], valid_shape=[1, actual_l, 1, K])
+                q2 = pypto.reshape(q4, [_BT, K], valid_shape=[actual_l, K])   # [128,K], rows>=actual_l are pad
+                k2 = pypto.reshape(k4, [_BT, K], valid_shape=[actual_l, K])
+                v2 = pypto.reshape(v4, [_BT, V], valid_shape=[actual_l, V])
+                g2 = pypto.reshape(g4, [_BT, K], valid_shape=[actual_l, K])
+                pypto.set_vec_tile_shapes(1, 128)             # rank-2 beta view/reshape
+                b3 = pypto.view(beta, [1, _BT, 1], [0, off, h], valid_shape=[1, actual_l, 1])
+                b2 = pypto.reshape(b3, [1, _BT], valid_shape=[1, actual_l])   # [1,128], cols>=actual_l are pad
+                # ---- tail branch: fillpad zeros the pad region of the last, possibly-
+                #      partial chunk; full chunks (actual_l==_BT) skip fillpad. ----
+                if pypto.is_loop_end(s_idx):
+                    pypto.set_vec_tile_shapes(128, 128)                      # q2/k2/v2/g2 are [128,128]
+                    qc = pypto.fillpad(q2, "constant", 0.0)                  # rows [actual_l:_BT] -> 0.0
+                    kc = pypto.fillpad(k2, "constant", 0.0)
+                    vc = pypto.fillpad(v2, "constant", 0.0)
+                    gc = pypto.fillpad(g2, "constant", 0.0)                  # KEY: g pad=0 -> gcum flat (glast valid)
+                    pypto.set_vec_tile_shapes(1, 128)                       # b2 is [1,128]
+                    bc = pypto.fillpad(b2, "constant", 0.0)                  # cols [actual_l:_BT] -> 0.0
+                    oc, s_new = _chunk_compute(qc, kc, vc, gc, bc, s_carry, tril, trils, eyestk,
+                                               use_qk_l2norm_in_kernel, scale, z8, z16, z32)
+                    s_carry[:] = s_new                                       # carry state across chunks
+                    pypto.set_vec_tile_shapes(1, 128, 1, 128)               # rank-4 o reshape+assemble
+                    o_chunk = pypto.reshape(pypto.cast(oc, pypto.DT_BF16), [1, _BT, 1, V],
+                                            valid_shape=[1, actual_l, 1, V])  # only actual_l rows valid
+                    pypto.assemble(o_chunk, [0, off, h, 0], o_out)          # writes o_out[0, off:off+actual_l, h, :]
+                else:
+                    oc, s_new = _chunk_compute(q2, k2, v2, g2, b2, s_carry, tril, trils, eyestk,
+                                               use_qk_l2norm_in_kernel, scale, z8, z16, z32)
+                    s_carry[:] = s_new
+                    pypto.set_vec_tile_shapes(1, 128, 1, 128)               # rank-4 o reshape+assemble
+                    o_chunk = pypto.reshape(pypto.cast(oc, pypto.DT_BF16), [1, _BT, 1, V])  # full 128 rows
+                    pypto.assemble(o_chunk, [0, off, h, 0], o_out)          # non-tail chunk is always full
+                pypto.set_vec_tile_shapes(128, 128)
+            pypto.set_vec_tile_shapes(128, 128)                             # rank-2 [K,V]->[V,K] transpose
+            s_carry_vk = s_carry.transpose(0, 1)                            # [K,V] -> [V,K] upstream ABI (transpose IN-KERNEL)
+            pypto.set_vec_tile_shapes(1, 1, 128, 128)                       # rank-4 reshape+assemble
+            s_chunk = pypto.reshape(s_carry_vk, [1, 1, V, K])               # [N,H,V,K] upstream ABI
+            pypto.assemble(s_chunk, [n, h, 0, 0], s_out)
+    # SNAP:after_nt_loop
+
+
+# =============================================================================
+# Host wrapper — layout/alloc only, one jit call. cu_seqlens=None -> synthesize N==B
+# segments of length T and pack [B,T,H,*]->[1,B*T,H,*] (state [B,H,V,K]); cu_seqlens
+# given -> TND pass-through, cu kept on-device and indexed in-kernel (state [N,H,V,K]).
+# No host padding: the partial last chunk is zero-filled in-kernel by fillpad.
+# initial_state is passed directly in upstream ABI [N,H,V,K] (the [V,K]<->[K,V]
+# transpose is done in-kernel). _validate_inputs does introspection-only validation.
+# =============================================================================
+def _validate_inputs(q, k, v, g, beta, scale, initial_state, output_final_state,
+                     use_qk_l2norm_in_kernel, cu_seqlens):
+    """Introspection-only host validation. Rejects malformed inputs early; derives dims
+    internally for shape checks. Returns nothing (wrapper re-derives dims)."""
+    # Introspection only (.dim()/.shape/.dtype/.device/.numel()); no tensor arithmetic
+    # and no cu_seqlens.cpu()/.tolist() (cu is a device tensor indexed in-kernel, so its
+    # values are not validated here).
+    assert q.dim() == 4, f"q must be 4-D [B,T,H,K]; got dim {q.dim()}"
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    dev = q.device
+    assert k.dim() == 4 and g.dim() == 4, \
+        f"k/g must be 4-D [B,T,H,K]; got dims {k.dim()}/{g.dim()}"
+    assert v.dim() == 4, f"v must be 4-D [B,T,H,V]; got dim {v.dim()}"
+    assert beta.dim() == 3, f"beta must be 3-D [B,T,H]; got dim {beta.dim()}"
+    assert tuple(k.shape) == tuple(q.shape) and tuple(g.shape) == tuple(q.shape), \
+        f"k/g shape must equal q[B,T,H,K]; got k{tuple(k.shape)} g{tuple(g.shape)} vs q{tuple(q.shape)}"
+    assert tuple(v.shape[:3]) == (B, T, H), \
+        f"v.shape[:3] must be (B,T,H)=({B},{T},{H}); got {tuple(v.shape[:3])}"
+    assert tuple(beta.shape) == (B, T, H), \
+        f"beta.shape must be (B,T,H)=({B},{T},{H}); got {tuple(beta.shape)}"
+    # Exact kernel-ABI dtypes (wrapper no longer casts — caller guarantees types).
+    assert q.dtype == torch.bfloat16 and k.dtype == torch.bfloat16 and v.dtype == torch.bfloat16, \
+        f"q/k/v must be bfloat16 (kernel ABI); got {q.dtype}/{k.dtype}/{v.dtype}"
+    assert g.dtype == torch.float32, f"g must be float32 (kernel ABI); got {g.dtype}"
+    assert beta.dtype == torch.float32, f"beta must be float32 (kernel ABI); got {beta.dtype}"
+    assert k.device == dev and v.device == dev and g.device == dev and beta.device == dev, \
+        f"q/k/v/g/beta must share one device; got q{dev} k{k.device} v{v.device} g{g.device} beta{beta.device}"
+    assert scale is None or (isinstance(scale, (int, float)) and not isinstance(scale, bool) and scale > 0), \
+        f"scale must be a positive number or None; got {scale!r}"
+    assert isinstance(output_final_state, (bool, int)), \
+        f"output_final_state must be bool; got {type(output_final_state).__name__}"
+    if initial_state is not None:
+        assert initial_state.dim() == 4, \
+            f"initial_state must be 4-D [N,H,V,K]; got dim {initial_state.dim()}"
+        _N0 = B if cu_seqlens is None else (cu_seqlens.numel() - 1)
+        assert tuple(initial_state.shape) == (_N0, H, V, K), \
+            f"initial_state must be (N,H,V,K)=({_N0},{H},{V},{K}); got {tuple(initial_state.shape)}"
+        assert initial_state.dtype == torch.float32, \
+            f"initial_state must be float32 (kernel ABI); got {initial_state.dtype}"
+    if cu_seqlens is not None:
+        assert cu_seqlens.dim() == 1, f"cu_seqlens must be 1-D [N+1]; got dim {cu_seqlens.dim()}"
+        assert cu_seqlens.dtype == torch.int32, \
+            f"cu_seqlens must be int32 (kernel ABI); got {cu_seqlens.dtype}"
+        assert cu_seqlens.numel() >= 2, f"cu_seqlens must have >=2 entries; got {cu_seqlens.numel()}"
+    assert K == 128 and V == 128, "chunk_kda P0: only K==V==128 supported"
+
+
+def chunk_kda_wrapper(q, k, v, g, beta, scale=None, initial_state=None,
+                      output_final_state=False, use_qk_l2norm_in_kernel=False,
+                      cu_seqlens=None, **kwargs):
+    # Explicit forward ABI (upstream chunk_kda parity); chunk_size is fixed at _BT=128,
+    # so a stray prebuilt_meta / chunk_size in **kwargs is silently ignored.
+    use_qk_l2norm_in_kernel = bool(use_qk_l2norm_in_kernel)
+    _validate_inputs(q, k, v, g, beta, scale, initial_state, output_final_state,
+                     use_qk_l2norm_in_kernel, cu_seqlens)
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+    dev = q.device
+    if scale is None:
+        scale = K ** -0.5
+    scale = float(scale)   # threaded into the JIT as a trace-time constant (folded in fp32 in-kernel)
+    Ttot = B * T
+    # ---- segment boundaries: cu stays a device int32 tensor, indexed in-kernel.
+    #      Fixed-len -> synthesize N==B segments of length T; varlen -> pass through. ----
+    if cu_seqlens is None:
+        assert T % _BT == 0, "T must be a multiple of chunk_size when cu_seqlens=None"
+        N = B
+        cu = torch.arange(0, (B + 1) * T, T, dtype=torch.int32, device=dev)   # [0,T,2T,...,B*T]
+    else:
+        assert B == 1, "varlen (cu_seqlens) requires packed batch size 1"
+        cu = cu_seqlens                                                       # PASS-THROUGH device int32 tensor (validated, no cast)
+        N = cu_seqlens.numel() - 1                                            # python int (introspection)
+    # pack [B,T,H,*] -> [1,Ttot,H,*], reshape only (no dtype cast, no host padding)
+    qk = q.reshape(1, Ttot, H, K)                                      # [1,Ttot,H,K] bf16
+    kk = k.reshape(1, Ttot, H, K)
+    vk = v.reshape(1, Ttot, H, V)
+    gk = g.reshape(1, Ttot, H, K)                                      # [1,Ttot,H,K] fp32
+    bk = beta.reshape(1, Ttot, H)                                      # [1,Ttot,H] fp32
+    # in-kernel constants (arange masks + [16,128] block-diag I)
+    idx = torch.arange(_BT, device=dev)
+    tril = (idx.reshape(_BT, 1) >= idx.reshape(1, _BT)).float()        # inclusive lower-tri (cumsum)
+    trils = (idx.reshape(_BT, 1) > idx.reshape(1, _BT)).float()        # strict lower-tri (A mask)
+    eyestk = torch.eye(_MIN, device=dev, dtype=torch.float32).repeat(1, 8)  # [16,128] block-diag I
+    # pass initial_state directly in upstream ABI [N,H,V,K] (the [V,K]->[K,V] transpose
+    # is done in-kernel); None -> a zeros seed in [N,H,V,K].
+    if initial_state is not None:
+        state_in = initial_state.contiguous()                          # [N,H,V,K] fp32 (validated; contiguity only, no cast)
+    else:
+        state_in = torch.zeros(N, H, V, K, dtype=torch.float32, device=dev)  # [N,H,V,K] zero seed
+    # HOST_WRAPPER_INSPECT_ALLOC
+    o_out = torch.zeros(1, Ttot, H, V, dtype=torch.bfloat16, device=dev)   # [1,Ttot,H,V] (no pad; Tp==Ttot)
+    s_out = torch.zeros(N, H, V, K, dtype=torch.float32, device=dev)       # [N,H,V,K] upstream ABI (transpose in-kernel)
+    # HOST_WRAPPER_INSPECT_PASS — single statically-reachable module-level JIT
+    chunk_kda_varlen_kernel(qk, kk, vk, gk, bk, cu, tril, trils, eyestk, state_in, o_out, s_out,
+                            use_qk_l2norm_in_kernel, scale)
+    o = o_out.reshape(B, T, H, V)          # [1,Ttot,H,V] -> [B,T,H,V] (host view)
+    # final_state already in upstream ABI [N,H,V,K] (internal [K,V]->[V,K] transpose done in-kernel)
+    S = s_out if output_final_state else None
+    return o, S

--- a/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py
@@ -18,6 +18,37 @@ from sglang.srt.layers.attention.dsa.utils import (
 from sglang.srt.layers.communicator import ScatterMode, get_attn_tp_context
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 
+
+def _lazy_init_w_vc(m):
+    """Split kv_b_proj weight into w_kc and w_vc on first use.
+
+    With --load-format dummy, process_weights_after_loading may not run,
+    so w_vc/w_kc are still None. Split the weight manually.
+    """
+    return _ensure_kv_b_proj_split(m)[1]
+
+
+def _ensure_kv_b_proj_split(m):
+    """Ensure both w_kc and w_vc are split from kv_b_proj.
+
+    Returns (w_kc, w_vc).
+    """
+    if m.w_kc is not None and m.w_vc is not None:
+        return m.w_kc, m.w_vc
+
+    total_dim = m.num_local_heads * (m.qk_nope_head_dim + m.v_head_dim)
+    kc_dim = m.num_local_heads * m.qk_nope_head_dim
+    weight = m.kv_b_proj.weight  # [total_dim, kv_lora_rank]
+    if m.w_kc is None:
+        # w_kc shape: [num_heads, qk_nope_head_dim, kv_lora_rank] for bmm(q_nope, w_kc)
+        m.w_kc = weight[:kc_dim].view(m.num_local_heads, m.qk_nope_head_dim, m.kv_lora_rank).contiguous()
+    if m.w_vc is None:
+        # w_vc shape: [num_heads, kv_lora_rank, v_head_dim] for batch_matmul_transpose
+        # batch_matmul_transpose does out = a @ b^T, with b having its last dim as kv_lora_rank
+        m.w_vc = weight[kc_dim:total_dim].view(m.num_local_heads, m.v_head_dim, m.kv_lora_rank).transpose(1, 2).contiguous()
+    return m.w_kc, m.w_vc
+
+
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
     from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
@@ -241,11 +272,17 @@ def forward_mla_prepare_npu(
 
         q_nope, q_pe = q.split([m.qk_nope_head_dim, m.qk_rope_head_dim], dim=-1)
 
-        q_nope_out = torch.bmm(q_nope.transpose(0, 1), m.w_kc)
+        # Lazy-init w_kc/w_vc from kv_b_proj (may be skipped with --load-format dummy)
+        _ensure_kv_b_proj_split(m)
 
-        q_nope_out = q_nope_out.transpose(0, 1)
+        if m.w_kc is not None:
+            q_nope_out = torch.bmm(q_nope.transpose(0, 1), m.w_kc)
+            q_nope_out = q_nope_out.transpose(0, 1)
+        else:
+            q_nope_out = q_nope
 
-        q_pe, k_pe = m.rotary_emb(positions, q_pe, k_pe)
+        if m.rotary_emb is not None:
+            q_pe, k_pe = m.rotary_emb(positions, q_pe, k_pe)
 
         if dsa_use_prefill_cp(forward_batch):
             # support allgather+rerrange
@@ -304,7 +341,13 @@ def forward_mla_core_npu(
     )
 
     attn_output = attn_output.contiguous()
-    torch.ops.npu.batch_matmul_transpose(attn_output, m.w_vc, attn_bmm_output)
+    # Lazily init w_vc if not set (e.g. dummy weights skip process_weights_after_loading)
+    w_vc = m.w_vc
+    if w_vc is None:
+        w_vc = _lazy_init_w_vc(m)
+    if w_vc.dtype != attn_output.dtype:
+        w_vc = w_vc.to(attn_output.dtype)
+    torch.ops.npu.batch_matmul_transpose(attn_output, w_vc, attn_bmm_output)
 
     attn_bmm_output = attn_bmm_output.reshape(-1, m.num_local_heads * m.v_head_dim)
     output, _ = m.o_proj(attn_bmm_output)
@@ -408,16 +451,22 @@ def forward_dsa_prepare_npu(
 
         q_nope, q_pe = q.split([m.qk_nope_head_dim, m.qk_rope_head_dim], dim=-1)
 
-        q_nope_out = torch.bmm(q_nope.transpose(0, 1), m.w_kc)
+        # Lazy-init w_kc/w_vc from kv_b_proj (may be skipped with --load-format dummy)
+        _ensure_kv_b_proj_split(m)
 
-        q_nope_out = q_nope_out.transpose(0, 1)
+        if m.w_kc is not None:
+            q_nope_out = torch.bmm(q_nope.transpose(0, 1), m.w_kc)
+            q_nope_out = q_nope_out.transpose(0, 1)
+        else:
+            q_nope_out = q_nope
 
         if m.layer_id == 0:
             m.rotary_emb.sin_cos_cache = m.rotary_emb.cos_sin_cache.index_select(
                 0, positions
             )
 
-        q_pe, k_pe = m.rotary_emb(positions, q_pe, k_pe)
+        if m.rotary_emb is not None:
+            q_pe, k_pe = m.rotary_emb(positions, q_pe, k_pe)
 
         if dsa_use_prefill_cp(forward_batch):
             # support allgather+rerrange
@@ -485,16 +534,26 @@ def forward_dsa_core_npu(
         and not forward_batch.forward_mode.is_target_verify()
     ):
         attn_output = attn_output.transpose(0, 1)
+        w_vc = m.w_vc
+        if w_vc is None:
+            w_vc = _lazy_init_w_vc(m)
+        if w_vc.dtype != attn_output.dtype:
+            w_vc = w_vc.to(attn_output.dtype)
         torch.bmm(
             attn_output,
-            m.w_vc,
+            w_vc,
             out=attn_bmm_output.view(-1, m.num_local_heads, m.v_head_dim).transpose(
                 0, 1
             ),
         )
     else:
         attn_output = attn_output.contiguous()
-        torch.ops.npu.batch_matmul_transpose(attn_output, m.w_vc, attn_bmm_output)
+        w_vc = m.w_vc
+        if w_vc is None:
+            w_vc = _lazy_init_w_vc(m)
+        if w_vc.dtype != attn_output.dtype:
+            w_vc = w_vc.to(attn_output.dtype)
+        torch.ops.npu.batch_matmul_transpose(attn_output, w_vc, attn_bmm_output)
 
     attn_bmm_output = attn_bmm_output.reshape(-1, m.num_local_heads * m.v_head_dim)
 

--- a/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/fused_moe_method_npu.py
@@ -1,0 +1,1282 @@
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+import torch
+
+from sglang.srt.hardware_backend.npu.utils import npu_format_cast
+from sglang.srt.layers.quantization.base_config import FusedMoEMethodBase
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher import (
+        CombineInput,
+        DeepEPLLDispatchOutput,
+        DeepEPNormalDispatchOutput,
+        DispatchOutput,
+    )
+    from sglang.srt.layers.quantization.base_config import QuantizationConfig
+
+
+def npu_fused_experts_w4a4(
+    hidden_states: torch.Tensor,
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+):
+    original_shape = hidden_states.shape
+    original_dtype = hidden_states.dtype
+    scale_dtype = original_dtype if original_dtype == torch.bfloat16 else torch.float32
+    if len(original_shape) == 3:
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    num_tokens = hidden_states.shape[0]
+    num_experts = w13.shape[0]
+
+    hidden_states, expanded_row_idx, expert_tokens, _ = (
+        torch.ops.npu.npu_moe_init_routing_v2(
+            hidden_states,
+            topk_ids,
+            active_num=num_tokens * top_k,
+            expert_num=num_experts,
+            expert_tokens_num_type=1,
+            expert_tokens_num_flag=True,
+            active_expert_range=[0, num_experts],
+            quant_mode=-1,
+        )
+    )
+    expert_tokens = expert_tokens.to(torch.int64)
+
+    # gmm1: gate_up_proj
+    hidden_states, pertoken_scale = torch.ops.npu.npu_dynamic_quant(
+        hidden_states, dst_type=torch.quint4x2
+    )
+    scale_args13 = {
+        "scale": [w13_scale],
+        "per_token_scale": [pertoken_scale],
+    }
+
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w13],
+        **scale_args13,
+        split_item=2,
+        group_list_type=1,
+        group_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )[0]
+    # act_fn: swiglu
+    hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+    hidden_states, pertoken_scale = torch.ops.npu.npu_dynamic_quant(hidden_states)
+
+    scale_args2 = {
+        "scale": [w2_scale.to(scale_dtype)],
+        "per_token_scale": [pertoken_scale],
+    }
+    # gmm2: down_proj
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w2],
+        **scale_args2,
+        split_item=2,
+        group_list_type=1,
+        group_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )[0]
+
+    final_hidden_states = torch.ops.npu.npu_moe_finalize_routing(
+        hidden_states,
+        skip1=None,
+        skip2=None,
+        bias=None,
+        scales=topk_weights,
+        expanded_src_to_dst_row=expanded_row_idx,
+        export_for_source_row=topk_ids,
+        drop_pad_mode=2,
+    )
+    if len(original_shape) == 3:
+        final_hidden_states = final_hidden_states.view(original_shape)
+    return final_hidden_states
+
+
+def npu_fused_experts(
+    hidden_states: torch.Tensor,
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+    **kwargs,
+):
+    w13_offset = kwargs.get("w13_offset", None)
+    w2_offset = kwargs.get("w2_offset", None)
+    use_wna16 = kwargs.get("use_wna16", False)
+
+    original_shape = hidden_states.shape
+    original_dtype = hidden_states.dtype
+    scale_dtype = original_dtype if original_dtype == torch.bfloat16 else torch.float32
+    if len(original_shape) == 3:
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    num_tokens = hidden_states.shape[0]
+    num_experts = w13.shape[0]
+    row_idx_len = num_tokens * top_k
+    row_idx = (
+        torch.arange(0, row_idx_len, dtype=torch.int32, device=topk_weights.device)
+        .view(top_k, -1)
+        .permute(1, 0)
+        .contiguous()
+    )
+    hidden_states, expanded_row_idx, expanded_expert_idx = (
+        torch.ops.npu.npu_moe_init_routing(
+            hidden_states, row_idx=row_idx, expert_idx=topk_ids, active_num=num_tokens
+        )
+    )
+    expert_tokens = torch.ops.npu.npu_moe_compute_expert_tokens(
+        expanded_expert_idx, num_experts
+    )
+    expert_tokens = expert_tokens.to(torch.int64)
+    # gmm1: gate_up_proj
+    if not use_wna16:
+        hidden_states, pertoken_scale = torch.ops.npu.npu_dynamic_quant(hidden_states)
+        scale_args13 = {
+            "scale": [w13_scale.to(scale_dtype)],
+            "per_token_scale": [pertoken_scale],
+        }
+    else:
+        scale_args13 = {
+            "antiquant_scale": [w13_scale],
+            "antiquant_offset": [w13_offset],
+        }
+
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w13],
+        **scale_args13,
+        split_item=2,
+        group_list_type=0,
+        group_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )[0]
+    # act_fn: swiglu
+    if not use_wna16:
+        hidden_states, pertoken_scale = torch.ops.npu.npu_dequant_swiglu_quant(
+            hidden_states,
+            activate_left=True,
+            quant_mode=1,
+        )
+
+        scale_args2 = {
+            "scale": [w2_scale.to(scale_dtype)],
+            "per_token_scale": [pertoken_scale],
+        }
+    else:
+        hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+        scale_args2 = {"antiquant_scale": [w2_scale], "antiquant_offset": [w2_offset]}
+    # gmm2: down_proj
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w2],
+        **scale_args2,
+        split_item=2,
+        group_list_type=0,
+        group_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )[0]
+
+    final_hidden_states = torch.ops.npu.npu_moe_finalize_routing(
+        hidden_states,
+        skip1=None,
+        skip2=None,
+        bias=None,
+        scales=topk_weights,
+        expanded_src_to_dst_row=expanded_row_idx,
+        export_for_source_row=topk_ids,
+    )
+    if len(original_shape) == 3:
+        final_hidden_states = final_hidden_states.view(original_shape)
+    return final_hidden_states
+
+
+def npu_fused_experts_w8a8_decode(
+    hidden_states: torch.Tensor,
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    top_k: int,
+    **kwargs,
+):
+    num_tokens = hidden_states.shape[:-1].numel()
+    first_expert_idx = 0
+    last_expert_idx = w13.shape[0]
+    global_num_experts = w13.shape[0]
+    original_shape = hidden_states.shape
+    group_list_type = 1
+
+    sorted_hidden_states, expanded_row_idx, expert_tokens, pertoken_scale = (
+        torch.ops.npu.npu_moe_init_routing_v2(
+            hidden_states,
+            topk_ids,
+            active_num=num_tokens * top_k,
+            expert_num=global_num_experts,
+            expert_tokens_num_type=group_list_type,
+            expert_tokens_num_flag=True,
+            active_expert_range=[first_expert_idx, last_expert_idx],
+            quant_mode=1,
+        )
+    )
+
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[sorted_hidden_states],
+        weight=[w13],
+        scale=[w13_scale],
+        per_token_scale=[pertoken_scale],
+        group_list=expert_tokens,
+        split_item=2,
+        group_type=0,
+        group_list_type=group_list_type,
+        output_dtype=torch.bfloat16,
+    )[0]
+
+    # act_fn: swiglu
+    hidden_states, swiglu_out_scale = torch.ops.npu.npu_dequant_swiglu_quant(
+        hidden_states, quant_mode=1, activate_left=True
+    )
+
+    output = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w2],
+        scale=[w2_scale],
+        per_token_scale=[swiglu_out_scale],
+        group_list=expert_tokens,
+        split_item=2,
+        group_type=0,
+        group_list_type=group_list_type,
+        output_dtype=torch.bfloat16,
+    )[0]
+
+    assert original_shape is not None
+    final_hidden_states = torch.ops.npu.npu_moe_token_unpermute(
+        permuted_tokens=output,
+        sorted_indices=torch.abs(expanded_row_idx),
+        probs=topk_weights,
+    )
+    if len(original_shape) == 3:
+        final_hidden_states = final_hidden_states.view(original_shape)
+
+    return final_hidden_states
+
+
+def npu_fused_moe_without_routing_weights_bf16(
+    layer, hidden_states, group_list_type, group_list, output_dtype
+):
+    from sgl_kernel_npu.activation.swiglu_quant import swiglu_quant
+
+    # gmm1: gate_up_proj
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[layer.w13_weight.transpose(1, 2)],
+        split_item=2,
+        group_list_type=group_list_type,
+        group_type=0,
+        group_list=group_list,
+        output_dtype=output_dtype,
+    )[0]
+    hidden_states, _ = swiglu_quant(
+        hidden_states, group_list, group_list_type, need_quant=False
+    )
+    # gmm2: down_proj
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[layer.w2_weight.transpose(1, 2)],
+        split_item=2,
+        group_list_type=group_list_type,
+        group_type=0,
+        group_list=group_list,
+        output_dtype=output_dtype,
+    )[0]
+    return hidden_states
+
+
+def fused_moe_npu(
+    x,
+    w1,
+    w2,
+    topk_output,
+    moe_runner_config,
+):
+    # TODO: reuse the codes of UnquantizedFusedMoEMethod-forward_npu
+    topk_weights, topk_ids, _ = topk_output
+    original_dtype = x.dtype
+    num_tokens = x.shape[0]
+    topk_weights = topk_weights.to(x.dtype)
+    topk_ids = topk_ids.to(torch.int32)
+    num_experts = w1.shape[0]
+    top_k = topk_weights.shape[-1]
+    row_idx_len = num_tokens * top_k
+    row_idx = (
+        torch.arange(0, row_idx_len, dtype=torch.int32, device=topk_weights.device)
+        .view(top_k, -1)
+        .permute(1, 0)
+        .contiguous()
+    )
+
+    hidden_states, expanded_row_idx, expanded_expert_idx = (
+        torch.ops.npu.npu_moe_init_routing(
+            x, row_idx=row_idx, expert_idx=topk_ids, active_num=num_tokens
+        )
+    )
+
+    expert_tokens = torch.ops.npu.npu_moe_compute_expert_tokens(
+        expanded_expert_idx, num_experts
+    )
+
+    expert_tokens = expert_tokens.to(torch.int64)
+
+    # gmm1: gate_up_proj
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w1.permute(0, 2, 1)],
+        bias=None,
+        split_item=2,
+        group_list_type=0,
+        group_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )[0]
+
+    # act_fn:
+    if moe_runner_config.activation == "silu":
+        hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+    else:
+        from sglang.srt.layers.activation import GeluAndMul
+
+        hidden_states = GeluAndMul()(hidden_states)
+
+    # gmm2: down_proj
+    hidden_states = torch.ops.npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=[w2.permute(0, 2, 1)],
+        bias=None,
+        split_item=2,
+        group_list_type=0,
+        group_type=0,
+        group_list=expert_tokens,
+        output_dtype=original_dtype,
+    )[0]
+
+    final_hidden_states = torch.ops.npu.npu_moe_finalize_routing(
+        hidden_states,
+        skip1=None,
+        skip2=None,
+        bias=None,
+        scales=topk_weights,
+        expanded_src_to_dst_row=expanded_row_idx,
+        export_for_source_row=topk_ids,
+    )
+    return final_hidden_states
+
+
+def maybe_apply_deepep_npu(
+    quant_method,
+    layer: torch.nn.Module,
+    dispatch_output: "DispatchOutput",
+) -> Optional["CombineInput"]:
+    """Route DeepEP dispatch outputs through the NPU compute path.
+
+    Replaces the deprecated DeepEPMoE.forward_npu wrapper: detects DeepEP
+    normal/LL formats, calls ``quant_method.apply_without_routing_weights``,
+    and wraps the result in the matching CombineInput. Returns None for
+    non-DeepEP formats so the caller falls through to its standard path.
+    """
+    from sglang.srt.layers.moe.token_dispatcher import (
+        DeepEPLLCombineInput,
+        DeepEPNormalCombineInput,
+    )
+    from sglang.srt.layers.moe.token_dispatcher.base import DispatchOutputChecker
+
+    if not dispatch_output.format.is_deepep():
+        return None
+
+    # NOTE: Ascend's Dispatch & Combine does not support FP16
+    output_dtype = torch.bfloat16
+    group_list_type = 1
+
+    if DispatchOutputChecker.format_is_deepep_normal(dispatch_output):
+        if TYPE_CHECKING:
+            assert isinstance(dispatch_output, DeepEPNormalDispatchOutput)
+        (
+            hidden_states,
+            hidden_states_scale,
+            _,
+            _,
+            num_recv_tokens_per_expert,
+        ) = dispatch_output
+        group_list = torch.tensor(
+            num_recv_tokens_per_expert,
+            dtype=torch.int64,
+            device=hidden_states.device,
+        )
+        combine_cls = DeepEPNormalCombineInput
+    else:
+        if TYPE_CHECKING:
+            assert isinstance(dispatch_output, DeepEPLLDispatchOutput)
+        (
+            hidden_states,
+            hidden_states_scale,
+            _,
+            _,
+            group_list,
+            _,
+        ) = dispatch_output
+        group_list = group_list.to(torch.int64)
+        combine_cls = DeepEPLLCombineInput
+
+    hidden_states = quant_method.apply_without_routing_weights(
+        layer,
+        hidden_states,
+        hidden_states_scale,
+        group_list_type,
+        group_list,
+        output_dtype,
+    )
+
+    return combine_cls(
+        hidden_states=hidden_states,
+        topk_ids=dispatch_output.topk_ids,
+        topk_weights=dispatch_output.topk_weights,
+    )
+
+
+def maybe_apply_fuseep_weights(layer: torch.nn.Module) -> bool:
+    """Apply the FuseEP weight layout if --moe-a2a-backend is ascend_fuseep.
+
+    Returns True when the FuseEP layout was applied and the caller should
+    skip its own ``process_weights_after_loading`` body.
+    """
+    from sglang.srt.layers.moe import get_moe_a2a_backend
+
+    if not get_moe_a2a_backend().is_ascend_fuseep():
+        return False
+    from sglang.srt.hardware_backend.npu.moe.fuseep import process_fuseep_weights
+
+    process_fuseep_weights(layer)
+    return True
+
+
+class _NPUFusedMoEMethodBase(FusedMoEMethodBase):
+
+    def __init__(
+        self,
+        quant_config: Optional["QuantizationConfig"] = None,
+    ):
+        self.quant_config = quant_config
+
+    def _maybe_apply_deepep(
+        self,
+        layer: torch.nn.Module,
+        dispatch_output: "DispatchOutput",
+    ) -> Optional["CombineInput"]:
+        return maybe_apply_deepep_npu(self, layer, dispatch_output)
+
+    @staticmethod
+    def _maybe_apply_fuseep_weights(layer: torch.nn.Module) -> bool:
+        return maybe_apply_fuseep_weights(layer)
+
+
+class NPUW4A4Int4DynamicMoEMethod(_NPUFusedMoEMethodBase):
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.w13_weight.data = npu_format_cast(
+            layer.w13_weight.data.transpose(1, 2).contiguous()
+        )
+        layer.w13_weight.data = self._pack_to_int32(
+            layer.w13_weight.data.to(torch.int32)
+        )
+
+        layer.w2_weight.data = npu_format_cast(
+            layer.w2_weight.data.transpose(1, 2).contiguous()
+        )
+
+        scale_np = layer.w13_weight_scale.data.cpu().numpy()
+        scale_np.dtype = np.uint32
+        scale_uint64_tensor = torch.from_numpy(scale_np.astype(np.int64)).npu()
+
+        layer.w13_weight_scale = torch.nn.Parameter(
+            scale_uint64_tensor.squeeze(-1), requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(
+            layer.w2_weight_scale.data.squeeze(-1), requires_grad=False
+        )
+
+        # Compressed-tensors format doesn't have this field
+        if hasattr(layer, "w13_weight_offset"):
+            layer.w13_weight_offset = torch.nn.Parameter(
+                layer.w13_weight_offset.data.squeeze(-1),
+                requires_grad=False,
+            )
+        if hasattr(layer, "w2_weight_offset"):
+            layer.w2_weight_offset = torch.nn.Parameter(
+                layer.w2_weight_offset.data.squeeze(-1),
+                requires_grad=False,
+            )
+
+        # Quantizes in int4 separately from the dispatcher
+        # since deep_ep does not support quantization in int4
+        # dispatching works in bf16
+        if hasattr(layer, "dispatcher"):
+            layer.dispatcher.set_quant_config({"dispatcher_output_dtype": "bf16"})
+
+    def _pack_to_int32(self, weight: torch.Tensor):
+        # pack 8 int4 to int32, we use a int32 to represent a int4
+        assert (
+            weight.shape[-1] % 8 == 0
+        ), "the last dim of weight needs to be divided by 8"
+        new_weight = torch.ops.npu.npu_convert_weight_to_int4pack(weight.flatten(0, 1))
+        new_weight = new_weight.view(weight.shape[0], weight.shape[1], -1)
+        return new_weight
+
+    def apply(
+        self,
+        layer,
+        dispatch_output: "DispatchOutput",
+    ) -> "CombineInput":
+        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        combine_input = self._maybe_apply_deepep(layer, dispatch_output)
+        if combine_input is not None:
+            return combine_input
+
+        x = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+
+        topk_weights, topk_ids, _ = topk_output
+        topk_ids = topk_ids.to(torch.int32)
+        topk_weights = topk_weights.to(x.dtype)
+        output = npu_fused_experts_w4a4(
+            hidden_states=x,
+            w13=layer.w13_weight,
+            w13_scale=layer.w13_weight_scale,
+            w2=layer.w2_weight,
+            w2_scale=layer.w2_weight_scale,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            top_k=topk_ids.shape[1],
+        )
+        return StandardCombineInput(hidden_states=output)
+
+    def apply_without_routing_weights(
+        self,
+        layer,
+        hidden_states,
+        hidden_states_scale,
+        group_list_type,
+        group_list,
+        output_dtype,
+    ):
+        hidden_states, hidden_states_scale = torch.ops.npu.npu_dynamic_quant(
+            hidden_states, dst_type=torch.quint4x2
+        )
+        # gmm1: up_gate_proj
+        hidden_states = torch.ops.npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[layer.w13_weight],
+            scale=[layer.w13_weight_scale],
+            per_token_scale=[hidden_states_scale],
+            split_item=2,
+            group_list_type=group_list_type,
+            group_type=0,
+            group_list=group_list,
+            output_dtype=output_dtype,
+        )[0]
+        # act_fn: swiglu
+        hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+        hidden_states, pertoken_scale = torch.ops.npu.npu_dynamic_quant(hidden_states)
+
+        # gmm2: down_proj
+        hidden_states = torch.ops.npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[layer.w2_weight],
+            scale=[layer.w2_weight_scale.to(output_dtype)],
+            per_token_scale=[pertoken_scale],
+            split_item=2,
+            group_list_type=group_list_type,
+            group_type=0,
+            group_list=group_list,
+            output_dtype=output_dtype,
+        )[0]
+        return hidden_states
+
+
+class NPUW8A8Int8DynamicMoEMethod(_NPUFusedMoEMethodBase):
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self._maybe_apply_fuseep_weights(layer):
+            return
+        layer.w13_weight.data = npu_format_cast(
+            layer.w13_weight.data.transpose(1, 2).contiguous()
+        )
+        layer.w2_weight.data = npu_format_cast(
+            layer.w2_weight.data.transpose(1, 2).contiguous()
+        )
+        layer.w13_weight_scale = torch.nn.Parameter(
+            layer.w13_weight_scale.data.squeeze(-1), requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(
+            layer.w2_weight_scale.data.squeeze(-1), requires_grad=False
+        )
+        layer.w13_weight_scale_bf16 = torch.nn.Parameter(
+            layer.w13_weight_scale.data.to(dtype=torch.bfloat16), requires_grad=False
+        )
+        layer.w2_weight_scale_bf16 = torch.nn.Parameter(
+            layer.w2_weight_scale.data.to(dtype=torch.bfloat16), requires_grad=False
+        )
+        # Compressed-tensors format doesn't have this field
+        if hasattr(layer, "w13_weight_offset"):
+            layer.w13_weight_offset = torch.nn.Parameter(
+                layer.w13_weight_offset.data.squeeze(-1),
+                requires_grad=False,
+            )
+        if hasattr(layer, "w2_weight_offset"):
+            layer.w2_weight_offset = torch.nn.Parameter(
+                layer.w2_weight_offset.data.squeeze(-1),
+                requires_grad=False,
+            )
+
+        if hasattr(layer, "dispatcher"):
+            layer.dispatcher.set_quant_config({"dispatcher_output_dtype": "int8"})
+
+    def apply(
+        self,
+        layer,
+        dispatch_output: "DispatchOutput",
+    ) -> "CombineInput":
+        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        combine_input = self._maybe_apply_deepep(layer, dispatch_output)
+        if combine_input is not None:
+            return combine_input
+
+        # release fp32 scale to save memory
+        layer.w13_weight_scale = None
+        layer.w2_weight_scale = None
+
+        hidden_states = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+
+        topk_weights, topk_ids, _ = topk_output
+        topk_ids = topk_ids.to(torch.int32)
+        topk_weights = topk_weights.to(hidden_states.dtype)
+
+        # prefill
+        if not torch.npu.is_current_stream_capturing():
+            output = npu_fused_experts(
+                hidden_states=hidden_states,
+                w13=layer.w13_weight,
+                w13_scale=layer.w13_weight_scale_bf16,
+                w2=layer.w2_weight,
+                w2_scale=layer.w2_weight_scale_bf16,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                top_k=topk_ids.shape[1],
+            )
+        # decode
+        else:
+            output = npu_fused_experts_w8a8_decode(
+                hidden_states=hidden_states,
+                w13=layer.w13_weight,
+                w13_scale=layer.w13_weight_scale_bf16,
+                w2=layer.w2_weight,
+                w2_scale=layer.w2_weight_scale_bf16,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                top_k=topk_ids.shape[1],
+            )
+
+        return StandardCombineInput(hidden_states=output)
+
+    def apply_without_routing_weights(
+        self,
+        layer,
+        hidden_states,
+        hidden_states_scale,
+        group_list_type,
+        group_list,
+        output_dtype,
+    ):
+        # gmm1: gate_up_proj
+        hidden_states = torch.ops.npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[layer.w13_weight],
+            split_item=2,
+            group_list_type=group_list_type,
+            group_type=0,
+            group_list=group_list,
+            output_dtype=torch.int32,
+        )[0]
+
+        # act_fn: swiglu
+        hidden_states, swiglu_out_scale = torch.ops.npu.npu_dequant_swiglu_quant(
+            x=hidden_states,
+            weight_scale=layer.w13_weight_scale,
+            activation_scale=hidden_states_scale,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=group_list,
+            activate_left=True,
+            quant_mode=1,
+        )
+
+        # gmm2: down_proj
+        hidden_states = torch.ops.npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[layer.w2_weight],
+            scale=[layer.w2_weight_scale_bf16],
+            per_token_scale=[swiglu_out_scale],
+            split_item=2,
+            group_list_type=group_list_type,
+            group_type=0,
+            group_list=group_list,
+            output_dtype=output_dtype,
+        )[0]
+        return hidden_states
+
+
+class NPUW4A8Int8DynamicMoEMethod(_NPUFusedMoEMethodBase):
+
+    def _process_scale(
+        self, weight: torch.Tensor, scale, per_group_scale, is_per_channel_weight
+    ):
+        scale = scale.transpose(1, 2).contiguous()
+
+        if is_per_channel_weight:
+            scale_np = scale.cpu().numpy()
+            scale_np.dtype = np.uint32
+            scale_uint64_tensor = torch.from_numpy(scale_np.astype(np.int64)).npu()
+            return scale_uint64_tensor, None
+
+        per_group_scale = per_group_scale.transpose(1, 2).contiguous()
+        group_num, k, n = weight.shape
+        # the weight of the new version is reduced by half by pack n, so it needs to be restored
+        n = n * 2
+        per_group_scale = per_group_scale.reshape(group_num, -1, n)
+        group_num, quantgroup_num, n = per_group_scale.shape
+        bias = None
+
+        scale_fp32 = (scale * per_group_scale).to(torch.float16).to(torch.float32)
+        scale_fp32_np = scale_fp32.cpu().numpy()
+        scale_fp32_np.dtype = np.uint32
+        sscale_uint64 = np.zeros((group_num, quantgroup_num, n * 2), dtype=np.uint32)
+
+        sscale_uint64[..., ::2] = scale_fp32_np
+
+        sscale_uint64_buffer = np.frombuffer(
+            sscale_uint64.tobytes(), dtype=np.int64
+        ).copy()
+        sscale_uint64_tensor = torch.from_numpy(sscale_uint64_buffer).reshape(
+            group_num, quantgroup_num, n
+        )
+        sscale_uint64_tensor = sscale_uint64_tensor.npu()
+        return sscale_uint64_tensor, bias
+
+    def _update_bias(self, layer, w13_bias, w2_bias):
+        layer.w13_scale_bias.data = (
+            layer.w13_scale_bias.data.transpose(1, 2).contiguous().sum(axis=1)
+        )
+        layer.w2_scale_bias.data = (
+            layer.w2_scale_bias.data.transpose(1, 2).contiguous().sum(axis=1)
+        )
+
+    def _pack_to_int32(self, weight: torch.Tensor):
+        # pack 4 int8(int4*2) to int32, because in pytorch, we need to use int32 to represent int4
+        assert (
+            weight.shape[-1] % 4 == 0
+        ), "the last dim of weight needs to be divided by 4"
+        return weight.view(torch.int32).contiguous()
+
+    def process_weights_after_loading(
+        self, layer: torch.nn.Module, is_per_channel_weight, activation_use_clip
+    ) -> None:
+        if not activation_use_clip:
+            self._process_weights_without_clip(layer, is_per_channel_weight)
+        else:
+            self._process_weights_with_clip(layer)
+
+        layer.w13_weight = torch.nn.Parameter(
+            layer.w13_weight.data.transpose(1, 2).contiguous(), requires_grad=False
+        )
+        layer.w2_weight = torch.nn.Parameter(
+            layer.w2_weight.data.transpose(1, 2).contiguous(), requires_grad=False
+        )
+
+        layer.w13_weight.data = npu_format_cast(layer.w13_weight.data)
+        layer.w2_weight.data = npu_format_cast(layer.w2_weight.data)
+
+        layer.w13_weight.data = self._pack_to_int32(layer.w13_weight.data)
+        layer.w2_weight.data = self._pack_to_int32(layer.w2_weight.data)
+
+        if hasattr(layer, "dispatcher"):
+            layer.dispatcher.set_quant_config({"dispatcher_output_dtype": "int8"})
+
+    def _process_weights_without_clip(
+        self, layer: torch.nn.Module, is_per_channel_weight
+    ) -> None:
+        w13_weight_scale_second = (
+            layer.w13_weight_scale_second.data
+            if hasattr(layer, "w13_weight_scale_second")
+            else None
+        )
+        w2_weight_scale_second = (
+            layer.w2_weight_scale_second.data
+            if hasattr(layer, "w2_weight_scale_second")
+            else None
+        )
+        layer.w13_weight_scale.data, w13_bias = self._process_scale(
+            layer.w13_weight,
+            layer.w13_weight_scale.data,
+            w13_weight_scale_second,
+            is_per_channel_weight,
+        )
+        layer.w2_weight_scale.data, w2_bias = self._process_scale(
+            layer.w2_weight,
+            layer.w2_weight_scale.data,
+            w2_weight_scale_second,
+            is_per_channel_weight,
+        )
+        if hasattr(layer, "w13_weight_scale_second"):
+            # scale_second is no longer used, release this part of the memory
+            del layer.w13_weight_scale_second
+            del layer.w2_weight_scale_second
+            del layer.w13_weight_offset_second
+            del layer.w2_weight_offset_second
+
+        self._update_bias(layer, w13_bias, w2_bias)
+
+    def _process_weights_with_clip(self, layer: torch.nn.Module) -> None:
+        w13_weight_scale = (
+            layer.w13_weight_scale.data.squeeze(-1).contiguous().unsqueeze(1)
+        )
+        w2_weight_scale = (
+            layer.w2_weight_scale.data.squeeze(-1).contiguous().unsqueeze(1)
+        )
+        layer.w13_weight_scale = torch.nn.Parameter(
+            w13_weight_scale, requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(w2_weight_scale, requires_grad=False)
+        layer.w13_scale_bias = layer.w13_bias
+        layer.w2_scale_bias = layer.w2_bias
+
+    def apply(
+        self,
+        layer,
+        dispatch_output: "DispatchOutput",
+    ) -> "CombineInput":
+        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        combine_input = self._maybe_apply_deepep(layer, dispatch_output)
+        if combine_input is not None:
+            return combine_input
+
+        hidden_states = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+
+        topk_weights, topk_ids, _ = topk_output
+        top_k = topk_ids.shape[1]
+        group_list_type = 1
+        original_shape = hidden_states.shape
+        topk_weights = topk_weights
+
+        num_tokens = hidden_states.shape[:-1].numel()
+
+        first_expert_idx = 0
+        last_expert_idx = layer.num_experts
+        global_num_experts = layer.num_experts
+
+        sorted_hidden_states, expanded_row_idx, expert_tokens, pertoken_scale = (
+            torch.ops.npu.npu_moe_init_routing_v2(
+                hidden_states,
+                topk_ids,
+                active_num=num_tokens * top_k,
+                expert_num=global_num_experts,
+                expert_tokens_num_type=1,
+                expert_tokens_num_flag=True,
+                active_expert_range=[first_expert_idx, last_expert_idx],
+                quant_mode=1,
+            )
+        )
+
+        expert_tokens = expert_tokens.to(torch.int64)
+
+        bias1 = [layer.w13_scale_bias]
+        bias2 = [layer.w2_scale_bias]
+        w1_scale = [layer.w13_weight_scale]
+        w2_scale = [layer.w2_weight_scale]
+        _output_dtype = torch.bfloat16
+
+        hidden_states = torch.ops.npu.npu_grouped_matmul(
+            x=[sorted_hidden_states],
+            weight=[layer.w13_weight],
+            scale=w1_scale,
+            bias=bias1,
+            per_token_scale=[pertoken_scale],
+            group_list=expert_tokens,
+            split_item=2,
+            group_type=0,
+            group_list_type=group_list_type,
+            output_dtype=_output_dtype,
+        )[0]
+
+        # act_fn: swiglu
+        hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+        hidden_states, swiglu_out_scale = torch.ops.npu.npu_dynamic_quant(hidden_states)
+
+        output = torch.ops.npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[layer.w2_weight],
+            scale=w2_scale,
+            bias=bias2,
+            per_token_scale=[swiglu_out_scale],
+            group_list=expert_tokens,
+            split_item=2,
+            group_type=0,
+            group_list_type=group_list_type,
+            output_dtype=_output_dtype,
+        )[0]
+
+        assert original_shape is not None
+        final_hidden_states = torch.ops.npu.npu_moe_token_unpermute(
+            permuted_tokens=output,
+            sorted_indices=torch.abs(expanded_row_idx),
+            probs=topk_weights,
+        )
+        if len(original_shape) == 3:
+            final_hidden_states = final_hidden_states.view(original_shape)
+
+        return StandardCombineInput(hidden_states=final_hidden_states)
+
+    def apply_without_routing_weights(
+        self,
+        layer,
+        hidden_states,
+        hidden_states_scale,
+        group_list_type,
+        group_list,
+        output_dtype,
+    ):
+        from sgl_kernel_npu.activation.swiglu_quant import swiglu_quant
+
+        hidden_states = torch.ops.npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[layer.w13_weight],
+            scale=[layer.w13_weight_scale],
+            bias=[layer.w13_scale_bias],
+            per_token_scale=[hidden_states_scale],
+            group_list=group_list,
+            split_item=2,
+            group_type=0,
+            group_list_type=group_list_type,
+            output_dtype=output_dtype,
+        )[0]
+
+        hidden_states, swiglu_out_scale = swiglu_quant(
+            hidden_states, group_list, group_list_type
+        )
+
+        hidden_states = torch.ops.npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[layer.w2_weight],
+            scale=[layer.w2_weight_scale],
+            bias=[layer.w2_scale_bias],
+            per_token_scale=[swiglu_out_scale],
+            group_list=group_list,
+            split_item=2,
+            group_type=0,
+            group_list_type=group_list_type,
+            output_dtype=output_dtype,
+        )[0]
+
+        return hidden_states
+
+
+class NPUW4A16Int4DynamicMoEMethod(_NPUFusedMoEMethodBase):
+
+    def _pack_to_int32(self, weight: torch.Tensor):
+        assert weight.dim() == 3
+        if weight.dtype == torch.int32:
+            # pack 8 int4 to int32, we use a int32 to represent a int4
+            assert (
+                weight.shape[-1] % 8 == 0
+            ), "the last dim of weight needs to be divided by 8"
+            new_weight = torch.ops.npu.npu_convert_weight_to_int4pack(
+                weight.flatten(0, 1)
+            )
+            new_weight = new_weight.view(weight.shape[0], weight.shape[1], -1)
+        elif weight.dtype == torch.int8:
+            # pack 4 int8(int4*2) to int32, because in pytorch, we need to use int32 to represent int4
+            assert (
+                weight.shape[-1] % 4 == 0
+            ), "the last dim of weight needs to be divided by 4"
+            new_weight = weight.view(torch.int32).contiguous()
+        else:
+            raise ValueError(f"{weight.dtype=} is not supported !")
+        return new_weight
+
+    def _unpack_from_int32(
+        self,
+        value: torch.Tensor,
+        num_bits: int,
+        shape: torch.Size = None,
+        packed_dim=1,
+    ) -> torch.Tensor:
+        """
+        Unpacks a tensor of packed int32 weights into individual int8s, maintaining the
+        original bit range.
+
+        Return tensors in int8
+
+        :param value: tensor to unpack
+        :param num_bits: number of bits to unpack each data point into
+        :param shape: shape to unpack into, used to remove padding
+        :returns: unpacked int8 tensor
+        """
+        if value.dtype is not torch.int32:
+            raise ValueError(
+                f"Expected {torch.int32} but got {value.dtype}, Aborting unpack."
+            )
+
+        if num_bits > 8:
+            raise ValueError("Unpacking is only supported for less than 8 bits")
+
+        pack_factor = 32 // num_bits
+
+        # unpack
+        mask = (1 << num_bits) - 1
+
+        if packed_dim == 1:
+            unpacked = torch.zeros(
+                (value.shape[0], value.shape[1] * pack_factor),
+                device=value.device,
+                dtype=torch.int32,
+            )
+            for i in range(pack_factor):
+                unpacked[:, i::pack_factor] = (value >> (num_bits * i)) & mask
+
+            # remove padding
+            if shape is not None:
+                original_row_size = int(shape[1])
+                unpacked = unpacked[:, :original_row_size]
+        else:
+            unpacked = torch.zeros(
+                (value.shape[0] * pack_factor, value.shape[1]),
+                device=value.device,
+                dtype=torch.int32,
+            )
+            for i in range(pack_factor):
+                unpacked[i::pack_factor, :] = (value >> (num_bits * i)) & mask
+
+            # remove padding
+            original_row_size = int(shape[0])
+            unpacked = unpacked[:original_row_size, :]
+
+        # bits are packed in unsigned format, reformat to signed
+        # update the value range from unsigned to signed
+        offset = pow(2, num_bits) // 2
+        unpacked = (unpacked - offset).to(torch.int8)
+
+        return unpacked
+
+    def _prepack_cache_paths(self, layer, cache_dir):
+        import os
+
+        try:
+            from sglang.srt.distributed.parallel_state import get_tp_group
+
+            rank = get_tp_group().rank_in_group
+        except Exception:
+            rank = 0
+        tag = f"L{layer.layer_id}_R{rank}"
+        return {
+            k: os.path.join(cache_dir, f"{tag}_{k}.pt")
+            for k in ("w13", "w13s", "w13o", "w2", "w2s", "w2o")
+        }
+
+    def _try_load_prepack_cache(self, layer, cache_dir) -> bool:
+        import os
+
+        paths = self._prepack_cache_paths(layer, cache_dir)
+        if not all(os.path.exists(p) for p in paths.values()):
+            return False
+        dev = layer.w13_weight.device
+        layer.w13_weight = torch.nn.Parameter(
+            torch.load(paths["w13"], map_location=dev), requires_grad=False
+        )
+        layer.w13_weight_scale = torch.nn.Parameter(
+            torch.load(paths["w13s"], map_location=dev), requires_grad=False
+        )
+        layer.w13_weight_offset = torch.nn.Parameter(
+            torch.load(paths["w13o"], map_location=dev), requires_grad=False
+        )
+        layer.w2_weight = torch.nn.Parameter(
+            torch.load(paths["w2"], map_location=dev), requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(
+            torch.load(paths["w2s"], map_location=dev), requires_grad=False
+        )
+        layer.w2_weight_offset = torch.nn.Parameter(
+            torch.load(paths["w2o"], map_location=dev), requires_grad=False
+        )
+        if hasattr(layer, "dispatcher"):
+            layer.dispatcher.set_quant_config({"dispatcher_output_dtype": "bf16"})
+        return True
+
+    def _save_prepack_cache(self, layer, cache_dir) -> None:
+        import os
+
+        os.makedirs(cache_dir, exist_ok=True)
+        paths = self._prepack_cache_paths(layer, cache_dir)
+        torch.save(layer.w13_weight.data.cpu(), paths["w13"])
+        torch.save(layer.w13_weight_scale.data.cpu(), paths["w13s"])
+        torch.save(layer.w13_weight_offset.data.cpu(), paths["w13o"])
+        torch.save(layer.w2_weight.data.cpu(), paths["w2"])
+        torch.save(layer.w2_weight_scale.data.cpu(), paths["w2s"])
+        torch.save(layer.w2_weight_offset.data.cpu(), paths["w2o"])
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        import os
+
+        cache_dir = os.environ.get("SGLANG_K3_PREPACKED_DIR")
+        if cache_dir and self._try_load_prepack_cache(layer, cache_dir):
+            return  # skip online npu_convert_weight_to_int4pack (use pre-packed)
+
+        w13_weight_scale = layer.w13_weight_scale.data.transpose(-1, -2).contiguous()
+        w2_weight_scale = layer.w2_weight_scale.data.transpose(-1, -2).contiguous()
+        layer.w13_weight_scale = torch.nn.Parameter(
+            w13_weight_scale, requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(w2_weight_scale, requires_grad=False)
+
+        layer.w13_weight_offset = torch.nn.Parameter(
+            layer.w13_weight_offset.data.transpose(-1, -2).contiguous(),
+            requires_grad=False,
+        )
+        layer.w2_weight_offset = torch.nn.Parameter(
+            layer.w2_weight_offset.data.transpose(-1, -2).contiguous(),
+            requires_grad=False,
+        )
+
+        # w = [n, k // 8]  --> [k, n // 8]
+        # w13_weight = layer.w13_weight.data.transpose(1, 2).contiguous()
+        # w2_weight = layer.w2_weight.data.transpose(1, 2).contiguous()
+        unpacked_w13_weight = (
+            self._unpack_from_int32(layer.w13_weight.data.flatten(0, 1), 4)
+            .view(layer.w13_weight.data.shape[0], layer.w13_weight.data.shape[1], -1)
+            .transpose(1, 2)
+            .contiguous()
+            .int()
+        )
+        unpacked_w2_weight = (
+            self._unpack_from_int32(layer.w2_weight.data.flatten(0, 1), 4)
+            .view(layer.w2_weight.data.shape[0], layer.w2_weight.data.shape[1], -1)
+            .transpose(1, 2)
+            .contiguous()
+            .int()
+        )
+
+        w13_weight = self._pack_to_int32(unpacked_w13_weight)
+        w2_weight = self._pack_to_int32(unpacked_w2_weight)
+
+        layer.w13_weight = torch.nn.Parameter(w13_weight, requires_grad=False)
+        layer.w2_weight = torch.nn.Parameter(w2_weight, requires_grad=False)
+
+        if hasattr(layer, "dispatcher"):
+            layer.dispatcher.set_quant_config({"dispatcher_output_dtype": "bf16"})
+
+        if cache_dir:
+            self._save_prepack_cache(layer, cache_dir)
+
+    def apply(
+        self,
+        layer,
+        dispatch_output: "DispatchOutput",
+    ) -> "CombineInput":
+        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
+
+        combine_input = self._maybe_apply_deepep(layer, dispatch_output)
+        if combine_input is not None:
+            return combine_input
+
+        x = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
+
+        topk_weights, topk_ids, _ = topk_output
+        topk_ids = topk_ids.to(torch.int32)
+        topk_weights = topk_weights.to(x.dtype)
+        output = npu_fused_experts(
+            hidden_states=x,
+            w13=layer.w13_weight,
+            w13_scale=layer.w13_weight_scale,
+            w13_offset=layer.w13_weight_offset,
+            w2=layer.w2_weight,
+            w2_scale=layer.w2_weight_scale,
+            w2_offset=layer.w2_weight_offset,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            top_k=topk_ids.shape[1],
+            use_wna16=True,
+        )
+        return StandardCombineInput(hidden_states=output)
+
+    def apply_without_routing_weights(
+        self,
+        layer,
+        hidden_states,
+        hidden_states_scale,
+        group_list_type,
+        group_list,
+        output_dtype,
+    ):
+        if hidden_states_scale is None:
+            # gmm1: gate_up_proj
+            hidden_states = torch.ops.npu.npu_grouped_matmul(
+                x=[hidden_states],
+                weight=[layer.w13_weight],
+                antiquant_scale=[layer.w13_weight_scale],
+                antiquant_offset=[layer.w13_weight_offset],
+                split_item=2,
+                group_list_type=group_list_type,
+                group_type=0,
+                group_list=group_list,
+                output_dtype=output_dtype,
+            )[0]
+
+            # act_fn: swiglu
+            hidden_states = torch.ops.npu.npu_swiglu(hidden_states)
+
+            # gmm2: down_proj
+            out_hidden = torch.ops.npu.npu_grouped_matmul(
+                x=[hidden_states],
+                weight=[layer.w2_weight],
+                antiquant_scale=[layer.w2_weight_scale],
+                antiquant_offset=[layer.w2_weight_offset],
+                split_item=2,
+                group_list_type=group_list_type,
+                group_type=0,
+                group_list=group_list,
+                output_dtype=output_dtype,
+            )[0]
+        else:
+            raise ValueError(
+                "when weight is int4, hidden_states only supports non-quant dtype!"
+            )
+
+        return out_hidden

--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -33,7 +33,8 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
@@ -57,53 +58,12 @@ _is_xpu = is_xpu()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_cuda:
-    from sgl_kernel import gelu_and_mul as _sgl_gelu_and_mul
-    from sgl_kernel import gelu_tanh_and_mul as _sgl_gelu_tanh_and_mul
-    from sgl_kernel import silu_and_mul as _sgl_silu_and_mul
-
-    from sglang.kernels.ops.activation.activation import (
-        gelu_and_mul as _jit_gelu_and_mul,
-    )
-    from sglang.kernels.ops.activation.activation import (
-        gelu_tanh_and_mul as _jit_gelu_tanh_and_mul,
-    )
-    from sglang.kernels.ops.activation.activation import (
+    from sglang.jit_kernel.activation import (
+        gelu_and_mul,
+        gelu_tanh_and_mul,
         relu2,
+        silu_and_mul,
     )
-    from sglang.kernels.ops.activation.activation import (
-        silu_and_mul as _jit_silu_and_mul,
-    )
-
-    # The jit act-and-mul kernel requires the per-rank hidden size to be a
-    # multiple of the vector width (kMaxVecBytes/dtype: 32B on SM100+, else 16B --
-    # RuntimeCheck "hidden size must be divisible by vector size" in
-    # kernels/jit/csrc/elementwise/activation.cuh). Route unaligned shapes to the
-    # sgl_kernel implementation (e.g. DeepSeek-V2-Lite dense 10944/8 = 1368 at
-    # tp8, 1368 % 16 != 0).
-    _jit_act_max_vec_bytes: Optional[int] = None
-
-    def _jit_act_supported(out: torch.Tensor) -> bool:
-        global _jit_act_max_vec_bytes
-        if _jit_act_max_vec_bytes is None:
-            major, _ = torch.cuda.get_device_capability()
-            _jit_act_max_vec_bytes = 32 if major >= 10 else 16
-        return out.shape[-1] % (_jit_act_max_vec_bytes // out.dtype.itemsize) == 0
-
-    def _act_and_mul(jit_fn, sgl_fn, input: torch.Tensor, out=None) -> torch.Tensor:
-        if out is None:
-            out = input.new_empty(*input.shape[:-1], input.shape[-1] // 2)
-        (jit_fn if _jit_act_supported(out) else sgl_fn)(input, out)
-        return out
-
-    def silu_and_mul(input: torch.Tensor, out=None) -> torch.Tensor:
-        return _act_and_mul(_jit_silu_and_mul, _sgl_silu_and_mul, input, out)
-
-    def gelu_and_mul(input: torch.Tensor, out=None) -> torch.Tensor:
-        return _act_and_mul(_jit_gelu_and_mul, _sgl_gelu_and_mul, input, out)
-
-    def gelu_tanh_and_mul(input: torch.Tensor, out=None) -> torch.Tensor:
-        return _act_and_mul(_jit_gelu_tanh_and_mul, _sgl_gelu_tanh_and_mul, input, out)
-
 elif _is_xpu:
     from sgl_kernel import gelu_and_mul, gelu_tanh_and_mul, silu_and_mul
 elif _is_hip:
@@ -130,7 +90,7 @@ logger = logging.getLogger(__name__)
 class SiluAndMul(MultiPlatformOp):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if get_server_args().rl_on_policy_target is not None:
+        if get_global_server_args().rl_on_policy_target is not None:
             self._forward_method = self.forward_native
         elif _use_aiter and envs.SGLANG_OPT_USE_AITER_SILU_MUL.get():
             self._forward_method = self.forward_aiter
@@ -179,6 +139,38 @@ class SiluAndMul(MultiPlatformOp):
             # XXX (MUSA): nn.SwishGLU seems to have better performance than silu_and_mul on MUSA, we can switch to it for now. We can consider implementing a silu_and_mul kernel for MUSA in the future if needed.
             self._musa_swish_glu = nn.SwishGLU()
         return self._musa_swish_glu(x)
+
+
+class SituAndMul(MultiPlatformOp):
+    """SituGLU activation used by Kimi K3.
+
+    Computes beta * tanh(gate / beta) * sigmoid(gate) * up.
+    When linear_beta is set, up is softly clipped:
+        up = linear_beta * tanh(up / linear_beta).
+    """
+
+    def __init__(self, beta: float = 1.0, linear_beta: float | None = None):
+        super().__init__()
+        self.beta = float(beta)
+        self.linear_beta = None if linear_beta is None else float(linear_beta)
+
+    def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1] // 2
+        # NPU: ensure contiguous strides for downstream ops.
+        gate = x[..., :d].float().contiguous()
+        up = x[..., d:].float().contiguous()
+        gate = self.beta * torch.tanh(gate / self.beta) * torch.sigmoid(gate)
+        if self.linear_beta is not None:
+            up = self.linear_beta * torch.tanh(up / self.linear_beta)
+        return (gate * up).to(x.dtype)
+
+    def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+        from sglang.jit_kernel.kimi_k3.activation import situ_and_mul
+
+        return situ_and_mul(x, None, self.beta, self.linear_beta)
+
+    def forward_cpu(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward_native(x)
 
 
 class GeluAndMul(MultiPlatformOp):

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -2,13 +2,6 @@ import logging
 import warnings
 from typing import TYPE_CHECKING
 
-from sglang.srt.configs.hybrid_arch import (
-    hybrid_gdn_config,
-    hybrid_lightning_config,
-    kimi_linear_config,
-    mamba2_config,
-    mambaish_config,
-)
 from sglang.srt.configs.linear_attn_model_registry import (
     get_linear_attn_config,
     import_backend_class,
@@ -43,9 +36,7 @@ def create_flashinfer_backend(runner):
     import torch
 
     if not runner.use_mla_backend:
-        from sglang.srt.layers.attention.flashinfer_backend import (
-            FlashInferAttnBackend,
-        )
+        from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
 
         # Init streams
         if runner.server_args.speculative_algorithm == "EAGLE":
@@ -221,9 +212,7 @@ def create_flashattention_v3_backend(runner):
 
 @register_attention_backend("fa4")
 def create_flashattention_v4_backend(runner):
-    from sglang.srt.layers.attention.flashattention_backend import (
-        FlashAttentionBackend,
-    )
+    from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
 
     return FlashAttentionBackend(runner, fa_impl_ver=4)
 
@@ -242,23 +231,6 @@ def create_trtllm_mha_backend(runner):
     from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
 
     return TRTLLMHAAttnBackend(runner)
-
-
-@register_attention_backend("hpc_ops")
-def create_hpc_ops_backend(runner):
-    if runner.use_mla_backend:
-        raise ValueError("hpc_ops backend can only be used with non-MLA models.")
-    if runner.model_config.is_encoder_decoder:
-        raise ValueError(
-            "Cross attention is not supported in the hpc_ops attention backend."
-        )
-    if runner.server_args.speculative_algorithm is not None:
-        raise ValueError(
-            "hpc_ops backend does not support speculative decoding for now."
-        )
-    from sglang.srt.layers.attention.hpc_ops_backend import HPCOpsAttnBackend
-
-    return HPCOpsAttnBackend(runner)
 
 
 @register_attention_backend("intel_amx")
@@ -283,31 +255,11 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
     need to change the code of the original attention backend.
     """
     assert not (
-        hybrid_gdn_config(runner.model_config) is not None and runner.use_mla_backend
+        runner.hybrid_gdn_config is not None and runner.use_mla_backend
     ), "hybrid_gdn can only be used with non-MLA models."
 
-    from sglang.srt.configs.model_config import is_minimax_sparse
-
-    if is_minimax_sparse(runner.model_config.hf_config):
-        from sglang.srt.layers.attention.minimax_sparse_backend import (
-            MiniMaxHybridAttnBackend,
-            MiniMaxSparseAttnBackend,
-        )
-
-        sparse_backend = MiniMaxSparseAttnBackend(runner)
-        return MiniMaxHybridAttnBackend(
-            full_attn_backend, sparse_backend, sparse_backend.sparse_layer_ids
-        )
-
-    if cfg := mambaish_config(runner.model_config):
-        from sglang.srt.configs.inkling import InklingMMConfig, InklingModelConfig
-
-        if isinstance(
-            runner.model_config.hf_config, (InklingModelConfig, InklingMMConfig)
-        ):
-            return full_attn_backend
-
-        from sglang.kernels.ops.attention.fla.utils import check_environments
+    if cfg := runner.mambaish_config:
+        from sglang.srt.layers.attention.fla.utils import check_environments
         from sglang.srt.layers.attention.linear.kda_backend import KDAAttnBackend
         from sglang.srt.layers.attention.linear.lightning_backend import (
             LightningAttentionBackend,
@@ -315,21 +267,14 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
         from sglang.srt.layers.attention.linear.utils import (
             initialize_linear_attn_config,
         )
-        from sglang.srt.utils import (
-            is_blackwell,
-            is_npu,
-            is_sm120_supported,
-        )
+        from sglang.srt.utils import is_blackwell, is_npu
 
         if not is_npu():
             from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
                 HybridLinearAttnBackend,
                 Mamba2AttnBackend,
             )
-            from sglang.srt.layers.attention.linear.gdn_backend import (
-                GDNAttnBackend,
-                maybe_set_default_flashinfer_gdn_prefill,
-            )
+            from sglang.srt.layers.attention.linear.gdn_backend import GDNAttnBackend
         else:
             from sglang.srt.hardware_backend.npu.attention.ascend_gdn_backend import (
                 AscendGDNAttnBackend as GDNAttnBackend,
@@ -342,37 +287,23 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
             )
 
         check_environments()
-        if hybrid_gdn_config(runner.model_config) is not None and not is_npu():
-            maybe_set_default_flashinfer_gdn_prefill(runner)
         initialize_linear_attn_config(runner.server_args)
         hybrid_backend_cls = HybridLinearAttnBackend
-        if hybrid_gdn_config(runner.model_config) is not None:
+        if runner.hybrid_gdn_config is not None:
             if is_blackwell():
-                if is_sm120_supported():
-                    allowed = {"triton", "trtllm_mha", "flashinfer"}
-                else:
-                    allowed = {"triton", "trtllm_mha", "fa4"}
-                attn_be = runner.server_args.attention_backend
-                prefill_be = runner.server_args.prefill_attention_backend
-                decode_be = runner.server_args.decode_attention_backend
-                # When using split prefill/decode backends, check each individually
-                if prefill_be and decode_be:
-                    assert prefill_be in allowed and decode_be in allowed, (
-                        f"Only {allowed} backends are supported on Blackwell GPUs for hybrid GDN models. "
-                        f"Got prefill={prefill_be}, decode={decode_be}."
-                    )
-                else:
-                    assert attn_be in allowed, (
-                        f"Only {allowed} backends are supported on Blackwell GPUs for hybrid GDN models. "
-                        f"Got attention_backend={attn_be}."
-                    )
-            elif is_npu():
+                assert (
+                    runner.server_args.attention_backend == "triton"
+                    or runner.server_args.attention_backend == "trtllm_mha"
+                    or runner.server_args.attention_backend == "fa4"
+                    or runner.server_args.attention_backend == "flashinfer"
+                ), "triton, trtllm_mha, fa4, or flashinfer backend are the only supported backends on Blackwell GPUs for hybrid GDN models, use --attention-backend to specify the backend."
+            if is_npu():
                 assert (
                     runner.server_args.attention_backend == "ascend"
                 ), "ascend backend is the only supported backend on NPU for hybrid GDN models, use --attention-backend ascend to specify the backend."
             logger.info(f"Using hybrid linear attention backend for hybrid GDN models.")
             linear_attn_backend = GDNAttnBackend(runner)
-        elif mamba2_config(runner.model_config) is not None:
+        elif runner.mamba2_config is not None:
             from sglang.srt.configs.lfm2 import Lfm2Config
             from sglang.srt.configs.lfm2_moe import Lfm2MoeConfig
             from sglang.srt.configs.lfm2_vl import Lfm2VlConfig
@@ -388,7 +319,7 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                 Lfm2MoeConfig,
                 Lfm2VlConfig,
             )
-            if isinstance(mamba2_config(runner.model_config), short_conv_cfgs):
+            if isinstance(runner.mamba2_config, short_conv_cfgs):
                 if is_npu():
                     # The model conv layers call
                     # get_attn_backend().conv_state_metadata() unconditionally,
@@ -413,9 +344,16 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                 hybrid_backend_cls = ShortConvHybridAttnBackend
             else:
                 linear_attn_backend = Mamba2AttnBackend(runner)
-        elif kimi_linear_config(runner.model_config) is not None:
-            linear_attn_backend = KDAAttnBackend(runner)
-        elif hybrid_lightning_config(runner.model_config) is not None:
+        elif runner.kimi_linear_config is not None:
+            if is_npu():
+                from sglang.srt.hardware_backend.npu.attention.ascend_kda_backend import (
+                    AscendKDAAttnBackend,
+                )
+
+                linear_attn_backend = AscendKDAAttnBackend(runner)
+            else:
+                linear_attn_backend = KDAAttnBackend(runner)
+        elif runner.hybrid_lightning_config is not None:
             linear_attn_backend = LightningAttentionBackend(runner)
         else:
             spec_result = get_linear_attn_config(runner.model_config.hf_config)

--- a/python/sglang/srt/layers/attention/fla/fused_norm_gate.py
+++ b/python/sglang/srt/layers/attention/fla/fused_norm_gate.py
@@ -1,0 +1,410 @@
+# Adapt from https://github.com/fla-org/flash-linear-attention/blob/main/fla/modules/fused_norm_gate.py
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+
+import torch
+import torch.nn as nn
+import triton
+import triton.language as tl
+
+from sglang.srt.utils import (
+    cdiv,
+    cpu_has_amx_support,
+    is_cpu,
+    is_npu,
+    next_power_of_2,
+)
+
+_is_npu = is_npu()
+_use_cpu = is_cpu() and cpu_has_amx_support()
+
+# Maximum rows per Triton block for layernorm gated kernel
+MAX_ROWS_PER_BLOCK = 4
+
+
+@triton.jit
+def layer_norm_gated_fwd_kernel(
+    x,  # pointer to the input
+    g,  # pointer to the gate
+    y,  # pointer to the output
+    w,  # pointer to the weights
+    b,  # pointer to the biases
+    residual,  # pointer to the residual
+    residual_out,  # pointer to the residual
+    mean,  # pointer to the mean
+    rstd,  # pointer to the 1/std
+    eps,  # epsilon to avoid division by zero
+    T,  # number of rows in x
+    D: tl.constexpr,  # number of columns in x
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+
+    o_d = tl.arange(0, BD)
+    m_d = o_d < D
+
+    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_RESIDUAL:
+        p_res = tl.make_block_ptr(
+            residual, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0)
+        )
+        b_x += tl.load(p_res, boundary_check=(0, 1)).to(tl.float32)
+    if STORE_RESIDUAL_OUT:
+        p_res_out = tl.make_block_ptr(
+            residual_out, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0)
+        )
+        tl.store(p_res_out, b_x.to(p_res_out.dtype.element_ty), boundary_check=(0, 1))
+    if not IS_RMS_NORM:
+        b_mean = tl.sum(b_x, axis=1) / D
+        p_mean = tl.make_block_ptr(mean, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        tl.store(p_mean, b_mean.to(p_mean.dtype.element_ty), boundary_check=(0,))
+        b_xbar = tl.where(m_d[None, :], b_x - b_mean[:, None], 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
+    else:
+        b_xbar = tl.where(m_d[None, :], b_x, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+
+    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=m_d).to(tl.float32)
+    b_x_hat = (
+        (b_x - b_mean[:, None]) * b_rstd[:, None]
+        if not IS_RMS_NORM
+        else b_x * b_rstd[:, None]
+    )
+    b_y = b_x_hat * b_w[None, :] if HAS_WEIGHT else b_x_hat
+    if HAS_BIAS:
+        b_y = b_y + b_b[None, :]
+
+    # swish/sigmoid output gate
+    p_g = tl.make_block_ptr(g, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    if ACTIVATION == "swish" or ACTIVATION == "silu":
+        b_y = b_y * b_g * tl.sigmoid(b_g)
+    elif ACTIVATION == "sigmoid":
+        b_y = b_y * tl.sigmoid(b_g)
+
+    # Write output
+    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit
+def layer_norm_gated_fwd_kernel1(
+    x,  # pointer to the input
+    g,  # pointer to the gate
+    y,  # pointer to the output
+    w,  # pointer to the weights
+    b,  # pointer to the biases
+    residual,  # pointer to the residual
+    residual_out,  # pointer to the residual
+    mean,  # pointer to the mean
+    rstd,  # pointer to the 1/std
+    eps,  # epsilon to avoid division by zero
+    D: tl.constexpr,  # number of columns in x
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    x += i_t * D
+    y += i_t * D
+    g += i_t * D
+    if HAS_RESIDUAL:
+        residual += i_t * D
+    if STORE_RESIDUAL_OUT:
+        residual_out += i_t * D
+
+    o_d = tl.arange(0, BD)
+    m_d = o_d < D
+    b_x = tl.load(x + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if HAS_RESIDUAL:
+        b_x += tl.load(residual + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if STORE_RESIDUAL_OUT:
+        tl.store(residual_out + o_d, b_x, mask=m_d)
+    if not IS_RMS_NORM:
+        b_mean = tl.sum(b_x, axis=0) / D
+        tl.store(mean + i_t, b_mean)
+        b_xbar = tl.where(m_d, b_x - b_mean, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    else:
+        b_xbar = tl.where(m_d, b_x, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+    tl.store(rstd + i_t, b_rstd)
+
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=m_d).to(tl.float32)
+    b_x_hat = (b_x - b_mean) * b_rstd if not IS_RMS_NORM else b_x * b_rstd
+    b_y = b_x_hat * b_w if HAS_WEIGHT else b_x_hat
+    if HAS_BIAS:
+        b_y = b_y + b_b
+
+    # swish/sigmoid output gate
+    b_g = tl.load(g + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if ACTIVATION == "swish" or ACTIVATION == "silu":
+        b_y = b_y * b_g * tl.sigmoid(b_g)
+    elif ACTIVATION == "sigmoid":
+        b_y = b_y * tl.sigmoid(b_g)
+
+    # Write output
+    tl.store(y + o_d, b_y, mask=m_d)
+
+
+def layer_norm_gated_fwd(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    activation: str = "swish",
+    eps: float = 1e-5,
+    residual: torch.Tensor = None,
+    out_dtype: torch.dtype = None,
+    residual_dtype: torch.dtype = None,
+    is_rms_norm: bool = False,
+):
+    if residual is not None:
+        residual_dtype = residual.dtype
+    T, D = x.shape
+    if residual is not None:
+        assert residual.shape == (T, D)
+    if weight is not None:
+        assert weight.shape == (D,)
+    if bias is not None:
+        assert bias.shape == (D,)
+    # allocate output
+    y = x if out_dtype is None else torch.empty_like(x, dtype=out_dtype)
+    if residual is not None or (
+        residual_dtype is not None and residual_dtype != x.dtype
+    ):
+        residual_out = torch.empty(T, D, device=x.device, dtype=residual_dtype)
+    else:
+        residual_out = None
+    mean = (
+        torch.empty((T,), dtype=torch.float, device=x.device)
+        if not is_rms_norm
+        else None
+    )
+    rstd = torch.empty((T,), dtype=torch.float, device=x.device)
+    # Less than 64KB per feature: enqueue fused kernel
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+    # heuristics for number of warps
+
+    if D <= 512:
+        BT = 32
+        layer_norm_gated_fwd_kernel[(cdiv(T, BT),)](
+            x=x,
+            g=g,
+            y=y,
+            w=weight,
+            b=bias,
+            residual=residual,
+            residual_out=residual_out,
+            mean=mean,
+            rstd=rstd,
+            eps=eps,
+            T=T,
+            D=D,
+            BD=BD,
+            BT=BT,
+            ACTIVATION=activation,
+            IS_RMS_NORM=is_rms_norm,
+            STORE_RESIDUAL_OUT=residual_out is not None,
+            HAS_RESIDUAL=residual is not None,
+            HAS_WEIGHT=weight is not None,
+            HAS_BIAS=bias is not None,
+            num_warps=4,
+        )
+    else:
+        layer_norm_gated_fwd_kernel1[(T,)](
+            x=x,
+            g=g,
+            y=y,
+            w=weight,
+            b=bias,
+            residual=residual,
+            residual_out=residual_out,
+            mean=mean,
+            rstd=rstd,
+            eps=eps,
+            D=D,
+            BD=BD,
+            ACTIVATION=activation,
+            IS_RMS_NORM=is_rms_norm,
+            STORE_RESIDUAL_OUT=residual_out is not None,
+            HAS_RESIDUAL=residual is not None,
+            HAS_WEIGHT=weight is not None,
+            HAS_BIAS=bias is not None,
+            num_warps=4,
+        )
+    # residual_out is None if residual is None and residual_dtype == input_dtype
+    return y, mean, rstd, residual_out if residual_out is not None else x
+
+
+class LayerNormGatedFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        g: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor,
+        activation: str,
+        residual: torch.Tensor | None = None,
+        eps: float = 1e-6,
+        prenorm: bool = False,
+        residual_in_fp32: bool = False,
+        is_rms_norm: bool = False,
+    ):
+        x_shape_og = x.shape
+        g_shape_og = g.shape
+        # reshape input data into 2D tensor
+        x = x.reshape(-1, x.shape[-1])
+        g = g.reshape(-1, g.shape[-1])
+        if residual is not None:
+            assert residual.shape == x_shape_og
+            residual = residual.reshape(-1, residual.shape[-1])
+        residual_dtype = (
+            residual.dtype
+            if residual is not None
+            else (torch.float if residual_in_fp32 else None)
+        )
+        y, mean, rstd, residual_out = layer_norm_gated_fwd(
+            x=x,
+            g=g,
+            weight=weight,
+            bias=bias,
+            activation=activation,
+            eps=eps,
+            residual=residual,
+            residual_dtype=residual_dtype,
+            is_rms_norm=is_rms_norm,
+        )
+        ctx.save_for_backward(residual_out, g, weight, bias, mean, rstd)
+        ctx.x_shape_og = x_shape_og
+        ctx.g_shape_og = g_shape_og
+        ctx.activation = activation
+        ctx.eps = eps
+        ctx.is_rms_norm = is_rms_norm
+        ctx.has_residual = residual is not None
+        ctx.prenorm = prenorm
+        ctx.x_dtype = x.dtype
+        y = y.reshape(x_shape_og)
+        return y if not prenorm else (y, residual_out.reshape(x_shape_og))
+
+
+def rms_norm_gated(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    activation: str = "swish",
+    residual: torch.Tensor | None = None,
+    prenorm: bool = False,
+    residual_in_fp32: bool = False,
+    eps: float = 1e-6,
+):
+    return LayerNormGatedFunction.apply(
+        x,
+        g,
+        weight,
+        bias,
+        activation,
+        residual,
+        eps,
+        prenorm,
+        residual_in_fp32,
+        True,
+    )
+
+
+class FusedRMSNormGated(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        elementwise_affine: bool = True,
+        eps: float = 1e-5,
+        activation: str = "swish",
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.elementwise_affine = elementwise_affine
+        self.eps = eps
+        self.activation = activation
+
+        if self.activation not in ["swish", "silu", "sigmoid"]:
+            raise ValueError(f"Unsupported activation: {self.activation}")
+
+        if elementwise_affine:
+            self.weight = nn.Parameter(torch.empty(hidden_size, **factory_kwargs))
+        else:
+            self.register_parameter("weight", None)
+        self.register_parameter("bias", None)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        g: torch.Tensor,
+        residual: torch.Tensor | None = None,
+        prenorm: bool = False,
+        residual_in_fp32: bool = False,
+    ) -> torch.Tensor:
+        if _use_cpu:
+            assert (
+                self.activation == "silu"
+            ), "CPU rmsnorm_gated currently only supports activation silu"
+            return torch.ops.sgl_kernel.fused_rmsnorm_gated_cpu(
+                x, self.weight, g, self.eps
+            )
+        if _is_npu:
+            # NPU: Triton kernels unavailable; pure-PyTorch path.
+            # RMSNorm(x) → ⊙ activation(g)
+            rstd = torch.rsqrt(
+                x.float().pow(2).mean(-1, keepdim=True) + self.eps
+            )
+            out = (x.float() * rstd).to(x.dtype)
+            if self.weight is not None:
+                out = out * self.weight
+            if self.activation in ("swish", "silu"):
+                out = out * g * torch.sigmoid(g)
+            else:
+                out = out * torch.sigmoid(g)
+            return out
+        else:
+            return rms_norm_gated(
+                x,
+                g,
+                self.weight,
+                self.bias,
+                self.activation,
+                residual=residual,
+                eps=self.eps,
+                prenorm=prenorm,
+                residual_in_fp32=residual_in_fp32,
+            )

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -24,11 +24,10 @@ from sglang.srt.distributed import (
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
-from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import (
+    get_attention_tp_group,
     is_allocation_symmetric,
 )
-from sglang.srt.layers.moe.utils import should_skip_mlp_all_reduce
 from sglang.srt.layers.parameter import (
     BasevLLMParameter,
     BlockQuantScaleParameter,
@@ -39,7 +38,8 @@ from sglang.srt.layers.parameter import (
     _ColumnvLLMParameter,
 )
 from sglang.srt.layers.utils import pad_or_narrow_weight
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import get_bool_env_var, is_cpu, is_hip, is_npu, set_weight_attrs
 
 if TYPE_CHECKING:
@@ -66,6 +66,7 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "GPTQMarlin24LinearMethod",
     "TPUInt8LinearMethod",
     "GPTQLinearMethod",
+    "FBGEMMFp8LinearMethod",
     "GPTQLinearAscendMethod",
     "GPTQLinearIntelAMXMethod",
     "GPTQMoEAscendMethod",
@@ -75,8 +76,6 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "IPEXAWQLinearMethod",
     "PetitNvFp4LinearMethod",
     "QuarkInt4Fp8LinearMethod",
-    "HummingLinearMethod",
-    "QuarkLinearMethod",
 ]
 
 _is_cpu = is_cpu()
@@ -227,7 +226,6 @@ class ReplicatedLinear(LinearBase):
 
         # All the linear layer supports quant method.
         assert self.quant_method is not None
-        self.with_bias = bias
         self.quant_method.create_weights(
             self,
             self.input_size,
@@ -334,7 +332,6 @@ class ColumnParallelLinear(LinearBase):
             input_size, output_size, skip_bias_add, params_dtype, quant_config, prefix
         )
 
-        self.with_bias = bias
         self.gather_output = gather_output
         self.use_presharded_weights = use_presharded_weights
 
@@ -526,7 +523,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         tp_size: Optional[int] = None,
         use_presharded_weights: bool = False,
     ):
-        self.with_bias = bias
         self.output_sizes = output_sizes
         if tp_rank is None:
             tp_rank = get_parallel().tp_rank
@@ -593,7 +589,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         needs_scalar_to_array = getattr(param, "needs_scalar_to_array", False)
 
         if loaded_shard_id is None:
-            # Loaded weight is already fused-in-checkpoint (qkv/mlp).
+            # Loaded weight is already fused on disk (qkv/mlp).
             if output_dim is None:
                 if needs_scalar_to_array:
                     param_data, loaded_weight = adjust_scalar_to_fused_array(
@@ -626,8 +622,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 # If quantized, we need to adjust the offset and size to account
                 # for the packing.
                 if packed_dim == output_dim:
-                    shard_size = round(shard_size // param.pack_factor)
-                    shard_offset = round(shard_offset // param.pack_factor)
+                    shard_size = shard_size // param.pack_factor
+                    shard_offset = shard_offset // param.pack_factor
                     # Special case for Marlin.
                     shard_size, shard_offset = adjust_marlin_shard(
                         param, shard_size, shard_offset
@@ -659,8 +655,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             # for the packing.
             packed_dim = getattr(param, "packed_dim", None)
             if packed_dim == output_dim:
-                shard_size = round(shard_size // param.pack_factor)
-                shard_offset = round(shard_offset // param.pack_factor)
+                shard_size = shard_size // param.pack_factor
+                shard_offset = shard_offset // param.pack_factor
                 # Special case for Marlin.
                 shard_size, shard_offset = adjust_marlin_shard(
                     param, shard_size, shard_offset
@@ -670,14 +666,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             if use_bitsandbytes_4bit:
                 shard_size = loaded_weight.shape[output_dim]
                 shard_offset = loaded_weight.shape[output_dim] * loaded_shard_id
-
-            # Needed for experimental ModelSlim W4A4 int4x2 packing support
-            # TODO: remove env variable once new packing is fully released
-            if envs.SGLANG_NPU_W4A4_NEW_PACKING.get():
-                pack_factor = getattr(param, "pack_factor", None)
-                if pack_factor is not None:
-                    shard_size = shard_size // pack_factor
-                    shard_offset = shard_offset // pack_factor
 
             param_data = param_data.narrow(output_dim, shard_offset, shard_size)
             start_idx = self.tp_rank * shard_size
@@ -744,8 +732,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
     ):
         """
         Handle special case for models where MLP layers are already
-        fused-in-checkpoint. In this case, we have no shard id. This function
-        determines the shard id by splitting these layers and then calls
+        fused on disk. In this case, we have no shard id. This function
+        determmines the shard id by splitting these layers and then calls
         the weight loader using the shard id.
 
         An example of a model with these fused layers:
@@ -845,28 +833,12 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
     ):
         if loaded_shard_id is None or isinstance(loaded_shard_id, tuple):
             if isinstance(param, PerTensorScaleParameter):
-                if loaded_weight.numel() != 1:
-                    raise ValueError(
-                        "Expected scalar scale for fused-in-checkpoint "
-                        "merged-column checkpoint load, got shape "
-                        f"{tuple(loaded_weight.shape)}"
-                    )
-                if loaded_shard_id is None:
-                    # The checkpoint tensor is already fused-in-checkpoint, so a
-                    # scalar scale applies to the entire merged matrix. Fill
-                    # every logical slot so later reductions only see valid
-                    # scale values.
-                    shard_ids = range(param.data.shape[0])
-                else:
-                    shard_ids = loaded_shard_id
-
-                for shard_id in shard_ids:
-                    param.load_merged_column_weight(
-                        loaded_weight=loaded_weight,
-                        shard_id=shard_id,
-                        tp_rank=self.tp_rank,
-                        tp_size=self.tp_size,
-                    )
+                param.load_merged_column_weight(
+                    loaded_weight=loaded_weight,
+                    shard_id=0,
+                    tp_rank=self.tp_rank,
+                    tp_size=self.tp_size,
+                )
                 return
             elif isinstance(param, BlockQuantScaleParameter):
                 self._load_merged_block_scale(param, loaded_weight)
@@ -961,7 +933,6 @@ class QKVParallelLinear(ColumnParallelLinear):
         v_head_size: Optional[int] = None,
         skip_block_quant_check: bool = False,
     ):
-        self.with_bias = bias
         self.hidden_size = hidden_size
         self.head_size = head_size
         self.v_head_size = v_head_size if v_head_size is not None else head_size
@@ -1037,8 +1008,8 @@ class QKVParallelLinear(ColumnParallelLinear):
     ):
         """
         Handle special case for models where QKV layers are already
-        fused-in-checkpoint. In this case, we have no shard id. This function
-        determines the shard id by splitting these layers and then calls
+        fused on disk. In this case, we have no shard id. This function
+        determmines the shard id by splitting these layers and then calls
         the weight loader using the shard id.
 
         An example of a model with these fused layers:
@@ -1114,19 +1085,7 @@ class QKVParallelLinear(ColumnParallelLinear):
     ):
         if loaded_shard_id is None:  # special case for certain models
             if isinstance(param, PerTensorScaleParameter):
-                # The checkpoint tensor is already fused-in-checkpoint, so a scalar
-                # scale applies to the entire QKV matrix. Fill every logical
-                # slot so later reductions only see valid scale values.
-                if loaded_weight.numel() != 1:
-                    raise ValueError(
-                        "Expected scalar scale for fused-in-checkpoint QKV "
-                        "checkpoint load when loaded_shard_id is None, got "
-                        f"shape {tuple(loaded_weight.shape)}"
-                    )
-                for shard_id in param.qkv_idxs:
-                    param.load_qkv_weight(
-                        loaded_weight=loaded_weight, shard_id=shard_id
-                    )
+                param.load_qkv_weight(loaded_weight=loaded_weight, shard_id=0)
                 return
             elif type(param) in (RowvLLMParameter, BasevLLMParameter):
                 param.load_qkv_weight(loaded_weight=loaded_weight)
@@ -1198,7 +1157,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         needs_scalar_to_array = getattr(param, "needs_scalar_to_array", False)
 
         if loaded_shard_id is None:
-            # Loaded weight is already fused-in-checkpoint (qkv/mlp).
+            # Loaded weight is already fused on disk (qkv/mlp).
             if output_dim is None:
                 if needs_scalar_to_array:
                     param_data, loaded_weight = adjust_scalar_to_fused_array(
@@ -1235,8 +1194,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                 # If quantized, we need to adjust the offset and size to account
                 # for the packing.
                 if packed_dim == output_dim:
-                    shard_size = round(shard_size // param.pack_factor)
-                    shard_offset = round(shard_offset // param.pack_factor)
+                    shard_size = shard_size // param.pack_factor
+                    shard_offset = shard_offset // param.pack_factor
 
                     # Special case for Marlin.
                     shard_size, shard_offset = adjust_marlin_shard(
@@ -1292,8 +1251,8 @@ class QKVParallelLinear(ColumnParallelLinear):
             # for the packing.
             packed_dim = getattr(param, "packed_dim", None)
             if packed_dim == output_dim:
-                shard_size = round(shard_size // param.pack_factor)
-                shard_offset = round(shard_offset // param.pack_factor)
+                shard_size = shard_size // param.pack_factor
+                shard_offset = shard_offset // param.pack_factor
 
                 # Special case for Marlin.
                 shard_size, shard_offset = adjust_marlin_shard(
@@ -1424,7 +1383,6 @@ class RowParallelLinear(LinearBase):
             input_size, output_size, skip_bias_add, params_dtype, quant_config, prefix
         )
 
-        self.with_bias = bias
         self.input_is_parallel = input_is_parallel
         self.reduce_results = reduce_results
         self.use_dp_attention_reduce = use_dp_attention_reduce
@@ -1438,8 +1396,6 @@ class RowParallelLinear(LinearBase):
         self.input_size_per_partition = divide(input_size, self.tp_size)
         assert self.quant_method is not None
         self.use_presharded_weights = use_presharded_weights
-        # Flag set by CpDecodeAttnTpContext to enable all_reduce during decode.
-        self.use_decode_attn_tp: bool = False
 
         self.quant_method.create_weights(
             layer=self,
@@ -1575,7 +1531,7 @@ class RowParallelLinear(LinearBase):
         # bias will not get added more than once in TP>1 case)
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
         if self.use_dp_attention_reduce:
-            symm_ctx = use_symmetric_memory(get_parallel().attn_tp_group)
+            symm_ctx = use_symmetric_memory(get_attention_tp_group())
         else:
             symm_ctx = use_symmetric_memory(
                 get_tp_group(), disabled=not is_allocation_symmetric()
@@ -1583,21 +1539,17 @@ class RowParallelLinear(LinearBase):
         with symm_ctx:
             output_parallel = self.quant_method.apply(self, input_parallel, bias=bias_)
 
-        # skip_all_reduce: explicit call-site override. Also honor
-        # ForwardFlags (fuse_mlp_allreduce / mlp_reduce_scatter) published by
-        # the decoder — callers should not thread those flags into modules.
-        if (
-            ((self.reduce_results and self.tp_size > 1) or self.use_decode_attn_tp)
-            and not skip_all_reduce
-            and not should_skip_mlp_all_reduce()
-        ):
+        if self.reduce_results and self.tp_size > 1 and not skip_all_reduce:
+            # NPU: ensure contiguous strides before HCCL all_reduce.
+            if not output_parallel.is_contiguous():
+                output_parallel = output_parallel.contiguous()
             if self.use_dp_attention_reduce:
-                output = get_parallel().attn_tp_group.all_reduce(output_parallel)
+                output = get_attention_tp_group().all_reduce(output_parallel)
             else:
                 quantize_communications = (
                     (
                         not forward_batch.forward_mode.is_decode_or_idle()
-                        and get_server_args().enable_quant_communications
+                        and get_global_server_args().enable_quant_communications
                     )
                     if forward_batch is not None
                     else False

--- a/python/sglang/srt/layers/vocab_parallel_embedding.py
+++ b/python/sglang/srt/layers/vocab_parallel_embedding.py
@@ -9,9 +9,6 @@ from typing import List, Optional, Sequence, Tuple
 import torch
 from torch.nn.parameter import Parameter, UninitializedParameter
 
-from sglang.kernels.ops.embeddings.vocab_parallel_embedding import (
-    vocab_parallel_embedding as fused_vocab_parallel_embedding,
-)
 from sglang.srt.distributed import (
     divide,
     get_tp_group,
@@ -260,7 +257,7 @@ class VocabParallelEmbedding(torch.nn.Module):
 
         # Support the case where the vocab size is not divisible by the TP size.
         if (
-            _is_cpu
+            (_is_cpu or _is_npu)
             and pad_vocab_size(self.org_vocab_size, padding_size) % self.tp_size != 0
         ):
             padding_size *= self.tp_size
@@ -501,77 +498,40 @@ class VocabParallelEmbedding(torch.nn.Module):
         param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
         param[loaded_weight.shape[0] :].data.fill_(0)
 
-    def _use_triton_embedding(self, input_: torch.Tensor) -> bool:
-        """Whether the fused Triton kernel can replace the mask+gather+fill unit."""
-        if _is_npu:
-            return False
-        if self.tp_size == 1:
-            return False
-        if not isinstance(self.quant_method, UnquantizedEmbeddingMethod):
-            return False
-        if not input_.is_cuda or not input_.is_contiguous():
-            return False
-        if input_.dtype not in (torch.int32, torch.int64):
-            return False
-        return (
-            self.weight.is_cuda
-            and self.weight.ndim == 2
-            and self.weight.stride(1) == 1
-            and self.weight.dtype in (torch.float16, torch.bfloat16, torch.float32)
-        )
-
-    def _embed_local_shard(self, input_: torch.Tensor) -> torch.Tensor:
-        """Embed against the local vocab shard; out-of-shard rows are zero
-        (identity when tp_size == 1).
-
-        The output must be allocated inside the symmetric-memory context so
-        the caller's all-reduce can use it; the mask temporaries and the
-        in-place fill deliberately stay outside the pool.
-        """
-        symm_alloc = use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        )
-        if self.tp_size == 1:
-            with symm_alloc:
-                return self.quant_method.embedding(self, input_.long())
-        if self._use_triton_embedding(input_):
-            with symm_alloc:
-                return fused_vocab_parallel_embedding(
-                    input_,
-                    self.weight,
-                    self.shard_indices.org_vocab_start_index,
-                    self.shard_indices.org_vocab_end_index,
-                    self.shard_indices.num_org_vocab_padding,
-                    self.shard_indices.added_vocab_start_index,
-                    self.shard_indices.added_vocab_end_index,
-                )
-        # Map out-of-shard ids to index 0, gather, then zero those rows.
-        masked_input, input_mask = get_masked_input_and_mask(
-            input_,
-            self.shard_indices.org_vocab_start_index,
-            self.shard_indices.org_vocab_end_index,
-            self.shard_indices.num_org_vocab_padding,
-            self.shard_indices.added_vocab_start_index,
-            self.shard_indices.added_vocab_end_index,
-        )
-        with symm_alloc:
-            output_parallel = self.quant_method.embedding(self, masked_input.long())
-        output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
-        return output_parallel
-
     def forward(self, input_):
         # Surface a bad token id (>= vocab_size, or a negative / unmasked sentinel) as a
         # located async assert instead of a silent OOB embedding gather (tp=1 does not mask).
         maybe_detect_oob(
             input_, 0, self.num_embeddings, "VocabParallelEmbedding input id"
         )
-        output_parallel = self._embed_local_shard(input_)
-        if self.tp_size > 1 and not get_attn_tp_context().input_scattered:
-            if self.use_attn_tp_group:
-                output_parallel = attn_tp_all_reduce(output_parallel)
-            else:
-                # Reduce across all the model parallel GPUs.
-                output_parallel = tensor_model_parallel_all_reduce(output_parallel)
+        if self.tp_size > 1:
+            # Build the mask.
+            masked_input, input_mask = get_masked_input_and_mask(
+                input_,
+                self.shard_indices.org_vocab_start_index,
+                self.shard_indices.org_vocab_end_index,
+                self.shard_indices.num_org_vocab_padding,
+                self.shard_indices.added_vocab_start_index,
+                self.shard_indices.added_vocab_end_index,
+            )
+        else:
+            masked_input = input_
+
+        # Get the embeddings.
+        with use_symmetric_memory(
+            get_tp_group(), disabled=not is_allocation_symmetric()
+        ):
+            output_parallel = self.quant_method.embedding(self, masked_input.long())
+
+        if self.tp_size > 1:
+            # Mask the output embedding.
+            output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
+            if not get_attn_tp_context().input_scattered:
+                if self.use_attn_tp_group:
+                    output_parallel = attn_tp_all_reduce(output_parallel)
+                else:
+                    # Reduce across all the model parallel GPUs.
+                    output_parallel = tensor_model_parallel_all_reduce(output_parallel)
         return output_parallel
 
     def extra_repr(self) -> str:
@@ -611,7 +571,6 @@ class ParallelLMHead(VocabParallelEmbedding):
         padding_size: int = DEFAULT_VOCAB_PADDING_SIZE,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
-        enable_tp: bool = True,
         use_attn_tp_group: bool = False,
         use_presharded_weights: bool = False,
     ):
@@ -623,7 +582,6 @@ class ParallelLMHead(VocabParallelEmbedding):
             padding_size=padding_size,
             quant_config=quant_config,
             prefix=prefix,
-            enable_tp=enable_tp,
             use_attn_tp_group=use_attn_tp_group,
             use_presharded_weights=use_presharded_weights,
         )

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -31,7 +31,10 @@ def _async_d2h(t: torch.Tensor) -> torch.Tensor:
         return t.to("cpu", non_blocking=True)
     cpu_t = torch.empty(t.shape, dtype=t.dtype, pin_memory=True)
     cpu_t.copy_(t, non_blocking=True)
-    t.record_stream(torch.cuda.current_stream(t.device))
+    if hasattr(torch, t.device.type) and hasattr(getattr(torch, t.device.type), "current_stream"):
+        t.record_stream(getattr(torch, t.device.type).current_stream(t.device))
+    else:
+        t.record_stream(torch.cuda.current_stream(t.device))
     return cpu_t
 
 
@@ -39,16 +42,9 @@ def _async_d2h(t: torch.Tensor) -> torch.Tensor:
 class GenerationBatchResult:
     logits_output: Optional[LogitsProcessorOutput] = None
     pp_hidden_states_proxy_tensors: Optional[PPProxyTensors] = None
-    next_token_ids: Optional[
-        Union[torch.Tensor, List[torch.Tensor], List[List[int]]]
-    ] = None
+    next_token_ids: Optional[Union[torch.Tensor, List[torch.Tensor]]] = None
     num_correct_drafts: int = 0  # no bonus included
     num_correct_drafts_per_req_cpu: Optional[List[int]] = None
-    num_block_accept_tokens: int = 0
-    num_cap_tokens: int = 0
-    # FDFO dLLM batching: per-request accepted block length and carried algo state.
-    accept_length_per_req_cpu: Optional[List[int]] = None
-    dllm_algo_state: Optional[List[Any]] = None
     can_run_cuda_graph: bool = False
 
     # PP skip output comm: True when output send/recv was skipped and
@@ -66,20 +62,9 @@ class GenerationBatchResult:
     future_indices: Optional[torch.Tensor] = None
     speculative_num_draft_tokens: Optional[int] = None
 
-    # Grammar FSM advance memoization (spec-v2 overlap). advance_grammar_fsm sets
-    # these once — eagerly via the scheduler's grammar barrier inside verify(), or
-    # lazily in _resolve_spec_v2_tokens — and the latter consumes
-    # grammar_retained_tokens instead of re-advancing the FSM.
-    grammar_advanced: bool = False
-    grammar_retained_tokens: Optional[list] = None
-
     # FIXME(lsyin): maybe move to a better place?
     # sync path: forward stream -> output processor
     accept_lens: Optional[torch.Tensor] = None
-
-    block_accept_lens: Optional[torch.Tensor] = None
-
-    cap_lens: Optional[torch.Tensor] = None
 
     # Next-iter seq_lens; published via on_publish.
     new_seq_lens: Optional[torch.Tensor] = None
@@ -147,12 +132,6 @@ class GenerationBatchResult:
 
         if self.accept_lens is not None:
             self.accept_lens = _async_d2h(self.accept_lens)
-
-        if self.block_accept_lens is not None:
-            self.block_accept_lens = _async_d2h(self.block_accept_lens)
-
-        if self.cap_lens is not None:
-            self.cap_lens = _async_d2h(self.cap_lens)
 
         # Sub-objects only declare their device fields; the single copy+safety
         # primitive (_async_d2h: pinned D2H + record_stream) is injected here so
@@ -231,8 +210,6 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
         "next_token_top_logprobs_idx": result.logits_output.next_token_top_logprobs_idx,
         "next_token_token_ids_logprobs_val": result.logits_output.next_token_token_ids_logprobs_val,
         "next_token_token_ids_logprobs_idx": result.logits_output.next_token_token_ids_logprobs_idx,
-        "next_token_sampling_mask_idx": result.logits_output.next_token_sampling_mask_idx,
-        "next_token_sampling_logprobs": result.logits_output.next_token_sampling_logprobs,
         "input_token_logprobs": result.logits_output.input_token_logprobs,
         "input_top_logprobs_val": result.logits_output.input_top_logprobs_val,
         "input_top_logprobs_idx": result.logits_output.input_top_logprobs_idx,
@@ -257,8 +234,6 @@ def get_logprob_from_pp_outputs(
         next_token_token_ids_logprobs_idx=next_pp_outputs[
             "next_token_token_ids_logprobs_idx"
         ],
-        next_token_sampling_mask_idx=next_pp_outputs["next_token_sampling_mask_idx"],
-        next_token_sampling_logprobs=next_pp_outputs["next_token_sampling_logprobs"],
         input_token_logprobs=next_pp_outputs["input_token_logprobs"],
         input_top_logprobs_val=next_pp_outputs["input_top_logprobs_val"],
         input_top_logprobs_idx=next_pp_outputs["input_top_logprobs_idx"],
@@ -288,7 +263,10 @@ class EmbeddingBatchResult:
     embeddings: torch.Tensor
     pooled_hidden_states: Optional[torch.Tensor] = None
     copy_done: Optional[torch.cuda.Event] = None
-    can_run_cuda_graph: bool = False
+
+    @property
+    def can_run_cuda_graph(self) -> bool:
+        return False
 
     @torch.profiler.record_function("copy_embedding_to_cpu")
     def copy_to_cpu(self):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -23,14 +23,10 @@ KVCache actually holds the physical kv cache.
 from __future__ import annotations
 
 import abc
-import copy
 import dataclasses
 import logging
-import math
-import os
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, fields
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import numpy as np
@@ -38,33 +34,34 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.kernels.ops.attention.dsa import index_buf_accessor
-from sglang.kernels.ops.attention.dsa.quant_k_cache import (
-    quantize_k_cache,
-    quantize_k_cache_separate,
-)
-from sglang.kernels.ops.kvcache.cache_move import (
-    copy_all_layer_kv_cache_func,
-    set_kv_buffer_prefix_valid_tiled,
-    store_cache_4d,
-)
-from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache, store_cache
-from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
+from sglang.jit_kernel.kvcache import can_use_store_cache, store_cache
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
-from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
-from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
-    UnquantizedKVCacheMethod,
+from sglang.srt.layers.attention.dsa import index_buf_accessor
+from sglang.srt.layers.attention.dsa.quant_k_cache import (
+    quantize_k_cache,
+    quantize_k_cache_separate,
 )
+from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
+from sglang.srt.layers.dcp import (
+    dcp_enabled,
+    get_attention_dcp_rank,
+    get_attention_dcp_world_size,
+)
+from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.allocator.mamba import MambaSlotAllocator
-from sglang.srt.mem_cache.kv_vmm_backing import KvVmmBufferOwner
 from sglang.srt.mem_cache.layout.page_major import (
     build_page_major_mamba_views,
     build_page_major_mha_views,
     mamba_entry_bytes,
     mha_entry_bytes,
+)
+from sglang.srt.mem_cache.triton_ops.cache_move import (
+    copy_all_layer_kv_cache_tiled,
+    set_kv_buffer_prefix_valid_tiled,
+    store_cache_4d,
 )
 from sglang.srt.mem_cache.utils import (
     get_mla_kv_buffer_triton,
@@ -74,12 +71,10 @@ from sglang.srt.mem_cache.utils import (
     set_mla_kv_scale_buffer_triton,
 )
 from sglang.srt.platforms import current_platform
-from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
-    is_float4_e2m1fn_x2,
     is_hip,
     is_npu,
     next_power_of_2,
@@ -93,12 +88,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-# Debug-only invariant in the Mamba slot-donation path calls tensor.item(), which
-# forces a per-request cudaStreamSynchronize on the scheduler thread and can stall
-# the scheduler under load. Off by default; set SGLANG_MAMBA_DEBUG_ASSERTS=1 to
-# re-enable for debugging.
-_MAMBA_DEBUG_ASSERTS = os.environ.get("SGLANG_MAMBA_DEBUG_ASSERTS", "0") == "1"
 
 GB = 1024 * 1024 * 1024
 _is_cuda = is_cuda()
@@ -115,19 +104,21 @@ _use_aiter = bool(envs.SGLANG_USE_AITER.get()) and _is_hip
 
 
 def conv_window_dedup_enabled(
-    is_npu: bool, is_cpu: bool, speculative_eagle_topk: Optional[int], is_kda: bool
+    is_npu: bool, is_cpu: bool, speculative_eagle_topk: Optional[int]
 ) -> bool:
     """Whether the deduplicated sliding-window conv-intermediate layout is safe.
 
-    It is safe for CUDA linear draft chains whose kernels consume the window raw.
-    Tree verify, NPU/CPU, and KDA keep dense windows: tree ancestors need independent
-    windows, platform kernels expect contiguous steps, and KDA transposes the window
-    before conv so the overlapping ``as_strided`` layout would corrupt stores.
+    It is only correct for a *linear* draft chain (``speculative_eagle_topk <= 1``,
+    i.e. NEXTN / MTP): consecutive draft tokens then form a true sliding window, so
+    the overlapping physical columns hold identical values. Under EAGLE *tree*
+    verify (``topk > 1``) the conv kernel walks per-token tree ancestors, so aliased
+    columns can need different values from different parent chains -> fall back to
+    the dense layout. NPU/CPU also keep the dense layout (their kernels assume
+    contiguous per-step windows). See ``MambaPool.__init__``.
     """
     return (
         not is_npu
         and not is_cpu
-        and not is_kda
         and (speculative_eagle_topk is None or speculative_eagle_topk <= 1)
     )
 
@@ -275,7 +266,6 @@ class ReqToTokenPool:
                 (self._alloc_size, max_context_len), dtype=torch.int32, device=device
             )
         self.free_slots = list(range(1, self._alloc_size))
-        self.req_generation = torch.zeros(self._alloc_size, dtype=torch.int64)
 
     def write(self, indices, values):
         self.req_to_token[indices] = values
@@ -307,7 +297,6 @@ class ReqToTokenPool:
         for r in reqs:
             if r.req_pool_idx is None:
                 r.req_pool_idx = select_index[offset]
-                self.req_generation[r.req_pool_idx] += 1
                 offset += 1
         return [r.req_pool_idx for r in reqs]
 
@@ -318,14 +307,9 @@ class ReqToTokenPool:
 
     def clear(self):
         self.free_slots = list(range(1, self._alloc_size))
-        self.req_generation.zero_()
 
 
 class MambaPool:
-    # Axis of each two-dimensional conv state that represents the sliding window.
-    # Upstream states use (dim, K-1); subclasses may preserve another layout.
-    conv_window_axis = -1
-
     @dataclass(frozen=True, kw_only=True)
     class State:
         conv: List[torch.Tensor]
@@ -336,20 +320,9 @@ class MambaPool:
         #   replayssm_d: [num_layers, num_slots, HV, L, V]
         #   replayssm_k: [num_layers, num_slots, H,  L, K]
         #   replayssm_g: [num_layers, num_slots, HV, L]  (fp32)
-        #   replayssm_rawv: [num_layers, num_slots, HV, L, V]  (conv/activation dtype)
-        #   replayssm_rawk: [num_layers, num_slots, H,  L, K]  (conv/activation dtype)
-        #   replayssm_beta: [num_layers, num_slots, HV, L]     (fp32)
-        # The raw rings + beta exist only under --enable-gdn-replayssm-spec: the
-        # closed-loop exact fold sequentially replays them through the recurrent
-        # update at flush -- bit-identical to the recurrent baseline -- instead
-        # of folding the chunked `d` records open-loop (which accumulates error
-        # across flushes). See fla/gdn_replayssm_spec_decode.py.
         replayssm_d: Optional[torch.Tensor] = None
         replayssm_k: Optional[torch.Tensor] = None
         replayssm_g: Optional[torch.Tensor] = None
-        replayssm_rawv: Optional[torch.Tensor] = None
-        replayssm_rawk: Optional[torch.Tensor] = None
-        replayssm_beta: Optional[torch.Tensor] = None
 
         def at_layer_idx(self, layer: int):
             kwargs = {}
@@ -375,79 +348,8 @@ class MambaPool:
 
     @dataclass(frozen=True, kw_only=True)
     class SpeculativeState(State):
-        # None under --enable-gdn-replayssm-spec: the spec ring owns rollback
-        # (verify writes ring records, commit moves cursors), so the per-draft
-        # full-state snapshots are never produced or consumed.
-        intermediate_ssm: Optional[torch.Tensor]
+        intermediate_ssm: torch.Tensor
         intermediate_conv_window: List[torch.Tensor]
-
-    def _detect_conv_window_axis(
-        self, conv_state_shape: List[Tuple[int, int]], win_len: int
-    ) -> int:
-        """Prefer GDN's trailing axis when both match; mixed layer layouts cannot
-        share one overlapping conv-window buffer.
-        """
-        axis = None
-        for conv_shape in conv_state_shape:
-            if conv_shape[-1] == win_len:
-                shape_axis = len(conv_shape) - 1
-            elif conv_shape[0] == win_len:
-                shape_axis = 0
-            else:
-                raise ValueError(
-                    f"conv_state shape {conv_shape} has no axis of length "
-                    f"conv_kernel-1={win_len}; cannot build the deduplicated "
-                    "sliding-window conv-intermediate view."
-                )
-            if axis is None:
-                axis = shape_axis
-            elif axis != shape_axis:
-                raise ValueError(
-                    "inconsistent conv-window axis across conv shapes "
-                    f"{conv_state_shape}; a single conv_window_axis cannot serve "
-                    "mixed layouts."
-                )
-        return axis
-
-    def _allocate_deduplicated_conv_window(
-        self,
-        *,
-        conv_shape: Tuple[int, int],
-        num_mamba_layers: int,
-        spec_state_size: int,
-        speculative_num_draft_tokens: int,
-        conv_dtype: torch.dtype,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        window_axis = self.conv_window_axis % len(conv_shape)
-        win = conv_shape[window_axis]
-        physical_conv_shape = list(conv_shape)
-        physical_conv_shape[window_axis] = speculative_num_draft_tokens + win - 1
-        phys = torch.zeros(
-            (
-                num_mamba_layers,
-                spec_state_size + 1,
-                *physical_conv_shape,
-            ),
-            dtype=conv_dtype,
-            device="cuda",
-        )
-        physical_conv_strides = phys.stride()[2:]
-        window_stride = physical_conv_strides[window_axis]
-        view = phys.as_strided(
-            (
-                phys.shape[0],
-                phys.shape[1],
-                speculative_num_draft_tokens,
-                *conv_shape,
-            ),
-            (
-                phys.stride(0),
-                phys.stride(1),
-                window_stride,
-                *physical_conv_strides,
-            ),
-        )
-        return phys, view
 
     def __init__(
         self,
@@ -463,7 +365,6 @@ class MambaPool:
         enable_linear_replayssm: bool = False,
         linear_replayssm_cache_len: int = 16,
         envelope_layout: bool = False,
-        enable_gdn_replayssm_spec: bool = False,
     ):
         conv_state_shape = cache_params.shape.conv
         temporal_state_shape = cache_params.shape.temporal
@@ -473,20 +374,11 @@ class MambaPool:
             enable=enable_memory_saver
         )
         num_mamba_layers = len(mamba_layer_ids)
-        self.mamba_layer_ids = list(mamba_layer_ids)
 
         self.size = size
         self.device = device
-        self.debug_memory_pool = envs.SGLANG_DEBUG_MEMORY_POOL.get()
         self.enable_linear_replayssm = enable_linear_replayssm
         self.linear_replayssm_cache_len = linear_replayssm_cache_len
-        # ReplaySSM spec-verify (Part B of #28511) REUSES the linear_replayssm ring
-        # (replayssm_d/k/g + write_pos) and ADDS two per-slot cursors
-        # (replayssm_cache_base + replayssm_is_flush). Enabling the spec-verify path
-        # therefore implies the ring, so the d/k/g + write_pos allocation gates on
-        # `_replayssm_on` (either flag). GDN-only is enforced upstream + below.
-        self.enable_gdn_replayssm_spec = enable_gdn_replayssm_spec
-        _replayssm_on = enable_linear_replayssm or enable_gdn_replayssm_spec
 
         # for disagg with nvlink
         self.enable_custom_mem_pool, self.custom_mem_pool, _ = (
@@ -562,34 +454,22 @@ class MambaPool:
 
             # GDN ReplaySSM ring buffers (slice 1a). Allocated only when the
             # flag is on; otherwise left as None so the legacy State is
-            # byte-identical. temporal_state_shape == (HV, V, K). Either the decode
-            # ring (--enable-linear-replayssm) or the spec-verify ring
-            # (--enable-gdn-replayssm-spec) shares this allocation.
+            # byte-identical. temporal_state_shape == (HV, V, K).
             replayssm_d = replayssm_k = replayssm_g = None
-            replayssm_rawv = replayssm_rawk = replayssm_beta = None
-            if _replayssm_on:
+            if enable_linear_replayssm:
                 hv, v_dim, k_dim = temporal_state_shape
                 h_k = getattr(cache_params.shape, "num_k_heads_per_tp", hv)
                 L = linear_replayssm_cache_len
                 num_slots = size + 1
-                # Ring dtype. DECODE ring (--enable-linear-replayssm): records
-                # follow the SSM dtype -- its flush folds `d` directly into the
-                # state. SPEC-verify ring (--enable-gdn-replayssm-spec): d/k feed
-                # ONLY the one-shot output reconstruction (the closed-loop exact
-                # fold replays the raw rings for state instead), so their
-                # quantization noise stays below the bf16 output cast; keep them
-                # in the conv/activation dtype instead of the (fp32-enforced)
-                # SSM dtype to halve the ring traffic. g stays fp32 everywhere
-                # (exact-fold input). The two flags are mutually exclusive.
-                ring_dtype = conv_dtype if enable_gdn_replayssm_spec else ssm_dtype
+                # Ring records live in the SSM dtype (bf16/fp32) except g (fp32).
                 replayssm_d = torch.zeros(
                     size=(num_mamba_layers, num_slots, hv, L, v_dim),
-                    dtype=ring_dtype,
+                    dtype=ssm_dtype,
                     device=device,
                 )
                 replayssm_k = torch.zeros(
                     size=(num_mamba_layers, num_slots, h_k, L, k_dim),
-                    dtype=ring_dtype,
+                    dtype=ssm_dtype,
                     device=device,
                 )
                 # The log-decay gate ring (fp32): per-head SCALAR for the GDN
@@ -605,42 +485,6 @@ class MambaPool:
                     dtype=torch.float32,
                     device=device,
                 )
-                # Closed-loop exact-fold rings (spec-verify only). Raw v / raw
-                # pre-norm k live in the conv (activation) dtype -- they are born
-                # there, so storage round-trips losslessly -- beta in fp32. The
-                # flush replays these through the recurrent update sequentially
-                # (bit-identical to the recurrent baseline) instead of folding
-                # the chunked `d` records open-loop.
-                if enable_gdn_replayssm_spec:
-                    # Backstop for the spec-verify ring invariants; this pool
-                    # is sized with the final adaptive-aware draft maximum.
-                    if L & (L - 1) != 0:
-                        raise ValueError(
-                            f"spec-verify ring length must be a power of two, got {L}"
-                        )
-                    if (
-                        speculative_num_draft_tokens is not None
-                        and L < 2 * speculative_num_draft_tokens
-                    ):
-                        raise ValueError(
-                            f"spec-verify ring too small: {L} < "
-                            f"2 * {speculative_num_draft_tokens} (early-flush margin)"
-                        )
-                    replayssm_rawv = torch.zeros(
-                        size=(num_mamba_layers, num_slots, hv, L, v_dim),
-                        dtype=conv_dtype,
-                        device=device,
-                    )
-                    replayssm_rawk = torch.zeros(
-                        size=(num_mamba_layers, num_slots, h_k, L, k_dim),
-                        dtype=conv_dtype,
-                        device=device,
-                    )
-                    replayssm_beta = torch.zeros(
-                        size=(num_mamba_layers, num_slots, hv, L),
-                        dtype=torch.float32,
-                        device=device,
-                    )
 
             if speculative_num_draft_tokens is not None:
                 if _is_npu:
@@ -652,30 +496,18 @@ class MambaPool:
                     )
                 # Cache intermediate SSM states per draft token during target verify
                 # Shape: [num_layers, size + 1, speculative_num_draft_tokens, HV, K, V]
-                #
-                # ReplaySSM spec-verify owns rollback via the ring + cursors (the
-                # verify kernel never writes per-draft snapshots; the commit never
-                # reads them), so this buffer -- the dominant spec scratch, ~46x
-                # the conv state -- is dead weight there and is skipped. The conv
-                # intermediate windows below STAY (conv rollback consumes them).
-                # The recurrent-verify fallback cannot be reached under the flag
-                # (GDN + linear chain + triton enforced in server_args; the
-                # backend asserts loudly if it ever is).
-                if enable_gdn_replayssm_spec:
-                    intermediate_ssm_state_cache = None
-                else:
-                    intermediate_ssm_state_cache = torch.zeros(
-                        size=(
-                            num_mamba_layers,
-                            spec_state_size + 1,
-                            speculative_num_draft_tokens,
-                            temporal_state_shape[0],
-                            temporal_state_shape[1],
-                            temporal_state_shape[2],
-                        ),
-                        dtype=ssm_dtype,
-                        device="cuda",
-                    )
+                intermediate_ssm_state_cache = torch.zeros(
+                    size=(
+                        num_mamba_layers,
+                        spec_state_size + 1,
+                        speculative_num_draft_tokens,
+                        temporal_state_shape[0],
+                        temporal_state_shape[1],
+                        temporal_state_shape[2],
+                    ),
+                    dtype=ssm_dtype,
+                    device="cuda",
+                )
                 # Cache intermediate conv windows (last K-1 inputs) per draft token
                 # during target verify.
                 #
@@ -697,26 +529,43 @@ class MambaPool:
                 # `conv_window_dedup_enabled` for the full rationale. The
                 # `fused_conv_window_scatter_with_mask` scatter is layout-agnostic,
                 # so the dense fallback reads correctly through the same code path.
-                dedup_conv_window = (
-                    not cache_params.shape.disable_conv_window_dedup
-                    and conv_window_dedup_enabled(
-                        _is_npu, _is_cpu, speculative_eagle_topk, cache_params.is_kda
-                    )
+                dedup_conv_window = conv_window_dedup_enabled(
+                    _is_npu, _is_cpu, speculative_eagle_topk
                 )
                 self._intermediate_conv_window_phys = []
                 if dedup_conv_window:
-                    win_len = cache_params.shape.conv_kernel - 1
-                    self.conv_window_axis = self._detect_conv_window_axis(
-                        conv_state_shape, win_len
-                    )
                     intermediate_conv_window_cache = []
                     for conv_shape in conv_state_shape:
-                        phys, view = self._allocate_deduplicated_conv_window(
-                            conv_shape=conv_shape,
-                            num_mamba_layers=num_mamba_layers,
-                            spec_state_size=spec_state_size,
-                            speculative_num_draft_tokens=speculative_num_draft_tokens,
-                            conv_dtype=conv_dtype,
+                        conv_dim, win = conv_shape  # win == conv_kernel - 1 == K-1
+                        shared_win = (
+                            speculative_num_draft_tokens + win - 1
+                        )  # D + (K-1) - 1
+                        phys = torch.zeros(
+                            size=(
+                                num_mamba_layers,
+                                spec_state_size + 1,
+                                conv_dim,
+                                shared_win,
+                            ),
+                            dtype=conv_dtype,
+                            device="cuda",
+                        )
+                        # view[l, s, step, d, w] = phys[l, s, d, step + w]
+                        view = phys.as_strided(
+                            (
+                                phys.shape[0],
+                                phys.shape[1],
+                                speculative_num_draft_tokens,
+                                conv_dim,
+                                win,
+                            ),
+                            (
+                                phys.stride(0),
+                                phys.stride(1),
+                                phys.stride(3),  # step -> shared-win axis (stride 1)
+                                phys.stride(2),  # dim
+                                phys.stride(3),  # win -> shared-win axis (stride 1)
+                            ),
                         )
                         self._intermediate_conv_window_phys.append(phys)
                         intermediate_conv_window_cache.append(view)
@@ -747,21 +596,13 @@ class MambaPool:
                     replayssm_d=replayssm_d,
                     replayssm_k=replayssm_k,
                     replayssm_g=replayssm_g,
-                    replayssm_rawv=replayssm_rawv,
-                    replayssm_rawk=replayssm_rawk,
-                    replayssm_beta=replayssm_beta,
-                )
-                intermediate_ssm_gb = (
-                    get_tensor_size_bytes(intermediate_ssm_state_cache) / GB
-                    if intermediate_ssm_state_cache is not None
-                    else 0.0
                 )
                 logger.info(
                     f"Mamba Cache is allocated. "
                     f"max_mamba_cache_size: {size}, "
                     f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
                     f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
-                    f"intermediate_ssm_state_cache size: {intermediate_ssm_gb:.2f}GB "
+                    f"intermediate_ssm_state_cache size: {get_tensor_size_bytes(intermediate_ssm_state_cache) / GB:.2f}GB "
                     # Report the deduplicated PHYSICAL conv-window buffers (the view
                     # over-reports its logical, un-deduplicated size).
                     f"intermediate_conv_window_cache size: {get_tensor_size_bytes(self._intermediate_conv_window_phys) / GB:.2f}GB "
@@ -773,9 +614,6 @@ class MambaPool:
                     replayssm_d=replayssm_d,
                     replayssm_k=replayssm_k,
                     replayssm_g=replayssm_g,
-                    replayssm_rawv=replayssm_rawv,
-                    replayssm_rawk=replayssm_rawk,
-                    replayssm_beta=replayssm_beta,
                 )
                 logger.info(
                     f"Mamba Cache is allocated. "
@@ -783,48 +621,26 @@ class MambaPool:
                     f"conv_state size: {get_tensor_size_bytes(conv_state) / GB:.2f}GB, "
                     f"ssm_state size: {get_tensor_size_bytes(temporal_state) / GB:.2f}GB "
                 )
-            if _replayssm_on:
+            if enable_linear_replayssm:
                 logger.info(
                     f"GDN ReplaySSM ring buffers allocated (L="
                     f"{linear_replayssm_cache_len}): "
                     f"d={get_tensor_size_bytes(replayssm_d) / GB:.3f}GB, "
                     f"k={get_tensor_size_bytes(replayssm_k) / GB:.3f}GB, "
                     f"g={get_tensor_size_bytes(replayssm_g) / GB:.3f}GB "
-                    + (
-                        f"rawv={get_tensor_size_bytes(replayssm_rawv) / GB:.3f}GB, "
-                        f"rawk={get_tensor_size_bytes(replayssm_rawk) / GB:.3f}GB, "
-                        f"beta={get_tensor_size_bytes(replayssm_beta) / GB:.3f}GB "
-                        if enable_gdn_replayssm_spec
-                        else ""
-                    )
                 )
             # Gate granularity of the linear-attn layers (drives the kernel's
             # IS_KDA path + the g_cache layout). Read by the backend metadata to
             # decide the per-K (KDA) vs scalar (GDN) flush/advance handling.
-            self.replayssm_is_kda = bool(_replayssm_on and cache_params.is_kda)
+            self.replayssm_is_kda = bool(
+                enable_linear_replayssm and cache_params.is_kda
+            )
             # Persistent per-slot decode-position cursor for ReplaySSM. Shared
             # across all linear-attn layers; advanced once per decode forward by
-            # the backend metadata build (decode ring) or once per verify step by
-            # the worker (spec-verify ring). Index 0..size; reset on slot (re)alloc.
+            # the backend metadata build. Index 0..size; reset on slot (re)alloc.
             self.replayssm_write_pos = (
                 torch.zeros((size + 1,), dtype=torch.int32, device=device)
-                if _replayssm_on
-                else None
-            )
-            # ReplaySSM spec-verify (Part B of #28511) extra per-slot cursors. The
-            # circular ring's rolling origin (cache_base) + the per-slot flush flag
-            # (is_flush). Block-keyed (indexed by the physical mamba slot), shared by
-            # all GDN layers of one verify step; advanced by commit_gdn_replayssm_spec.
-            # Only allocated for the spec-verify ring (the decode ring does not use
-            # a circular buffer); None otherwise.
-            self.replayssm_cache_base = (
-                torch.zeros((size + 1,), dtype=torch.int32, device=device)
-                if enable_gdn_replayssm_spec
-                else None
-            )
-            self.replayssm_is_flush = (
-                torch.zeros((size + 1,), dtype=torch.int8, device=device)
-                if enable_gdn_replayssm_spec
+                if enable_linear_replayssm
                 else None
             )
             mem_usage_bytes = self.mamba_cache.mem_usage_bytes()
@@ -841,64 +657,16 @@ class MambaPool:
                 )
             self.mem_usage = mem_usage_bytes / GB
             self.num_mamba_layers = num_mamba_layers
-        # Full (unsharded) conv sub-block dims for PD transfer across different
-        # attn_tp_size (GDN: [key_dim, key_dim, value_dim]); None otherwise.
-        self.conv_shard_groups = getattr(cache_params.shape, "conv_shard_groups", None)
-        self.conv_slice_axis = getattr(cache_params.shape, "conv_slice_axis", 0)
 
     def get_speculative_mamba2_params_all_layers(self) -> SpeculativeState:
         assert isinstance(self.mamba_cache, self.SpeculativeState)
         return self.mamba_cache
 
     def mamba2_layer_cache(self, layer_id: int):
-        # The per-layer views are pool-stable (mamba_cache is only bound at
-        # construction), so each layer's State is built once.
-        cached = self._layer_cache_by_id.get(layer_id)
-        if cached is None:
-            cached = self.mamba_cache.at_layer_idx(layer_id)
-            self._layer_cache_by_id[layer_id] = cached
-        return cached
-
-    # These properties are pool-stable (conv tensors don't move after allocation)
-    # so they're cached per instance on first use. Defined as cached_property
-    # rather than set in __init__ because UnifiedMambaPool skips super().__init__.
-    @cached_property
-    def _layer_cache_by_id(self) -> dict:
-        return {}
-
-    @cached_property
-    def _conv_fuse_ok(self) -> bool:
-        """Whether clear/copy may use the fused kernel: CUDA bf16 contiguous conv.
-        Strided (page-major / unified envelope) or non-bf16 conv fall back to the
-        per-tensor Python loop."""
-        convs = self.mamba_cache.conv
-        return (
-            not _is_npu
-            and len(convs) > 0
-            and convs[0].shape[0] > 0
-            and convs[0].is_cuda
-            and all(c.dtype == torch.bfloat16 and c.is_contiguous() for c in convs)
-        )
-
-    @cached_property
-    def _conv_slot_desc(self):
-        from sglang.srt.mem_cache.mamba_slot_fused import build_conv_slot_descriptor
-
-        return build_conv_slot_descriptor(self.mamba_cache.conv)
-
-    def _should_fuse_slot_ops(self) -> bool:
-        return self._conv_fuse_ok and not envs.SGLANG_DISABLE_FUSED_MAMBA_SLOT_OPS.get()
+        return self.mamba_cache.at_layer_idx(layer_id)
 
     def clear_slots(self, indices: torch.Tensor):
         """Zero out mamba state at the given pool indices. Must run on forward stream."""
-        if self._should_fuse_slot_ops():
-            from sglang.srt.mem_cache.mamba_slot_fused import fused_clear_conv_slots
-
-            fused_clear_conv_slots(self._conv_slot_desc, indices)
-            temporal = self.mamba_cache.temporal
-            if temporal.numel() > 0:
-                temporal[:, indices] = 0
-            return
         if not _is_npu:
             need_size = len(indices)
             for i in range(len(self.mamba_cache.conv)):
@@ -930,7 +698,7 @@ class MambaPool:
         caps the donate to the last flush boundary. The dst cursor is reset to 0
         (the copied checkpoint has no pending ring entries).
         """
-        if self.replayssm_write_pos is not None and self.debug_memory_pool:
+        if self.replayssm_write_pos is not None and envs.SGLANG_DEBUG_MEMORY_POOL.get():
             # Debug-only (syncs): catch any copy of an active, un-flushed slot.
             src_wp = self.replayssm_write_pos[src_indices]
             assert bool((src_wp == 0).all().item()), (
@@ -938,35 +706,15 @@ class MambaPool:
                 f"(write_pos==0), got {src_wp.tolist()} for src "
                 f"{src_indices.tolist()}"
             )
-        if self._should_fuse_slot_ops():
-            from sglang.srt.mem_cache.mamba_slot_fused import fused_copy_conv_slots
-
-            if envs.SGLANG_DEBUG_MEMORY_POOL.get():
-                overlap = set(src_indices.tolist()) & set(dst_indices.tolist())
-                assert not overlap, (
-                    "fused copy_from requires disjoint src/dst slots; "
-                    f"overlap={sorted(overlap)}"
-                )
-            fused_copy_conv_slots(self._conv_slot_desc, src_indices, dst_indices)
-            temporal = self.mamba_cache.temporal
-            if temporal.numel() > 0:
-                temporal[:, dst_indices] = temporal[:, src_indices]
-        else:
-            for i in range(len(self.mamba_cache.conv)):
-                self.mamba_cache.conv[i][:, dst_indices] = self.mamba_cache.conv[i][
-                    :, src_indices
-                ]
-            self.mamba_cache.temporal[:, dst_indices] = self.mamba_cache.temporal[
+        for i in range(len(self.mamba_cache.conv)):
+            self.mamba_cache.conv[i][:, dst_indices] = self.mamba_cache.conv[i][
                 :, src_indices
             ]
+        self.mamba_cache.temporal[:, dst_indices] = self.mamba_cache.temporal[
+            :, src_indices
+        ]
         if self.replayssm_write_pos is not None:
             self.replayssm_write_pos[dst_indices] = 0
-        # ReplaySSM spec-verify ring: a copied checkpoint has no pending ring
-        # entries, so its rolling origin + flush flag reset alongside write_pos.
-        if self.replayssm_cache_base is not None:
-            self.replayssm_cache_base[dst_indices] = 0
-        if self.replayssm_is_flush is not None:
-            self.replayssm_is_flush[dst_indices] = 0
 
     def get_cpu_copy(self, indices):
         current_platform.synchronize()
@@ -977,76 +725,45 @@ class MambaPool:
         temporal_cpu = self.mamba_cache.temporal[:, indices].to(
             "cpu", non_blocking=True
         )
-        # ReplaySSM spec-verify ring: round-trip the per-slot cursors with the
-        # checkpoint so a restored slot reconstructs exactly. Only the spec ring
-        # adds the 3rd tuple element; every other config keeps the legacy 2-tuple
-        # so those paths stay byte-identical.
-        if self.replayssm_cache_base is not None:
-            cursors_cpu = (
-                self.replayssm_write_pos[indices].to("cpu", non_blocking=True),
-                self.replayssm_cache_base[indices].to("cpu", non_blocking=True),
-                self.replayssm_is_flush[indices].to("cpu", non_blocking=True),
-            )
-            current_platform.synchronize()
-            return conv_cpu, temporal_cpu, cursors_cpu
         current_platform.synchronize()
         return conv_cpu, temporal_cpu
 
     def load_cpu_copy(self, mamba_cache_cpu, indices):
-        # Accept both the legacy 2-tuple (conv, temporal) and the 3-tuple that also
-        # carries the ReplaySSM spec-verify cursors.
-        if len(mamba_cache_cpu) == 3:
-            conv_cpu, temporal_cpu, cursors_cpu = mamba_cache_cpu
-        else:
-            conv_cpu, temporal_cpu = mamba_cache_cpu
-            cursors_cpu = None
+        conv_cpu, temporal_cpu = mamba_cache_cpu
         current_platform.synchronize()
         for i, conv in enumerate(self.mamba_cache.conv):
             conv[:, indices] = conv_cpu[i].to(conv.device, non_blocking=True)
         self.mamba_cache.temporal[:, indices] = temporal_cpu.to(
             self.mamba_cache.temporal.device, non_blocking=True
         )
-        if cursors_cpu is not None and self.replayssm_cache_base is not None:
-            wp_cpu, cb_cpu, fl_cpu = cursors_cpu
-            self.replayssm_write_pos[indices] = wp_cpu.to(
-                self.replayssm_write_pos.device, non_blocking=True
-            )
-            self.replayssm_cache_base[indices] = cb_cpu.to(
-                self.replayssm_cache_base.device, non_blocking=True
-            )
-            self.replayssm_is_flush[indices] = fl_cpu.to(
-                self.replayssm_is_flush.device, non_blocking=True
-            )
         current_platform.synchronize()
 
-    _NON_TRANSFER_STATE_FIELDS = frozenset(
-        {
-            "intermediate_ssm",
-            "intermediate_conv_window",
-            "replayssm_d",
-            "replayssm_k",
-            "replayssm_g",
-            "replayssm_rawv",
-            "replayssm_rawk",
-            "replayssm_beta",
-        }
-    )
-
-    def _iter_transfer_state_tensors(self):
-        """Yield transferable state tensors with their per-slot slice axis."""
-        for field, value in vars(self.mamba_cache).items():
-            if field in self._NON_TRANSFER_STATE_FIELDS or value is None:
-                continue
-            tensors = value if isinstance(value, list) else [value]
-            slice_axis = self.conv_slice_axis if field == "conv" else 0
-            for state_tensor in tensors:
-                yield field, state_tensor, slice_axis
-
     def get_contiguous_buf_infos(self):
-        """Get transferable state buffer information for RDMA registration."""
+        """
+        Get buffer info for RDMA registration.
+        Only returns conv and temporal state buffers, excluding intermediate buffers
+        used for speculative decoding (intermediate_ssm, intermediate_conv_window).
+        """
+        state_tensors = []
+        for field in vars(self.mamba_cache):
+            # Skip intermediate buffers used only for speculative decoding
+            # These buffers have different size (spec_state_size + 1) and should not be transferred
+            if field in ("intermediate_ssm", "intermediate_conv_window"):
+                continue
+            # Skip GDN ReplaySSM ring buffers: they are derived/transient decode
+            # scratch, not part of the persistent transferable state.
+            if field in ("replayssm_d", "replayssm_k", "replayssm_g"):
+                continue
+            value = getattr(self.mamba_cache, field)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                state_tensors.extend(value)
+            else:
+                state_tensors.append(value)
         data_ptrs, data_lens, item_lens = [], [], []
 
-        for _, state_tensor, _ in self._iter_transfer_state_tensors():
+        for _, state_tensor in enumerate(state_tensors):
             data_ptrs += [
                 state_tensor[i].data_ptr() for i in range(self.num_mamba_layers)
             ]
@@ -1059,64 +776,45 @@ class MambaPool:
     def get_state_dim_per_tensor(self):
         """Get the sliceable dimension size for each state tensor.
 
-        The slice axis is tensor-specific: normally the first per-slot axis,
-        while Kimi conv state uses the second per-slot axis.
+        For mamba state, the layout is:
+        - conv_state: [num_layers, size+1, conv_dim/tp, conv_kernel-1]
+        - temporal_state: [num_layers, size+1, num_heads/tp, head_dim, state_size]
+
+        The 3rd dimension (index 2) is the one that gets sliced by TP.
+        Returns the size of this dimension for each tensor (repeated for each layer).
         """
+        state_tensors = []
+        for field in vars(self.mamba_cache):
+            # Mirror the exclusions in get_contiguous_buf_infos so the returned
+            # dims line up element-wise with the RDMA buffer list.
+            if field in (
+                "intermediate_ssm",
+                "intermediate_conv_window",
+                "replayssm_d",
+                "replayssm_k",
+                "replayssm_g",
+            ):
+                continue
+            value = getattr(self.mamba_cache, field)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                state_tensors.extend(value)
+            else:
+                state_tensors.append(value)
+
         dim_per_tensor = []
-        for _, state_tensor, slice_axis in self._iter_transfer_state_tensors():
+        for state_tensor in state_tensors:
             # state_tensor shape: [num_layers, size+1, sliceable_dim, ...]
-            # Kimi conv state transposes the two per-slot axes to [K-1, dim].
-            axis = 2 + slice_axis
-            sliceable_dim = state_tensor.shape[axis]
+            # The sliceable dimension is at index 2 (after num_layers and size)
+            sliceable_dim = state_tensor.shape[2]
             # Repeat for each layer since we have per-layer data_ptrs
             dim_per_tensor += [sliceable_dim] * self.num_mamba_layers
         return dim_per_tensor
 
-    def get_state_layer_ids(self):
-        """Global model-layer id for each RDMA state entry.
-
-        Aligned element-wise with get_contiguous_buf_infos(), which flattens
-        the state list tensor-major x layer. Lets PD transfer match entries
-        by layer id when prefill (PP stage) holds a subset of the mamba layers.
-        """
-        state_tensor_count = sum(1 for _ in self._iter_transfer_state_tensors())
-        return list(self.mamba_layer_ids) * state_tensor_count
-
-    def get_state_slice_outer_counts(self):
-        """Get the number of rows preceding each tensor's TP slice axis."""
-        outer_counts = []
-        for _, state_tensor, slice_axis in self._iter_transfer_state_tensors():
-            outer_count = math.prod(state_tensor.shape[2 : 2 + slice_axis])
-            outer_counts += [outer_count] * self.num_mamba_layers
-        return outer_counts
-
-    def get_state_conv_shard_groups(self):
-        """Per-tensor conv sub-block dims, aligned element-wise with
-        get_state_dim_per_tensor().
-
-        For GDN, conv_state's sliceable axis is cat([query, key, value]) with
-        each sub-block head-sharded independently across attn-TP; the full
-        (unsharded) sub-block dims are returned so PD transfer across different
-        attn_tp_size can slice each sub-block. Returns None for temporal_state
-        (single head-sharded axis) and whenever no descriptor is available, so
-        those tensors keep the single contiguous slice.
-        """
-        subdims_per_tensor = []
-        for field, _, _ in self._iter_transfer_state_tensors():
-            # Only conv_state carries a q/k/v decomposition.
-            subdims = (
-                list(self.conv_shard_groups)
-                if field == "conv" and self.conv_shard_groups is not None
-                else None
-            )
-            subdims_per_tensor += [subdims] * self.num_mamba_layers
-        return subdims_per_tensor
-
 
 class HybridReqToTokenPool(ReqToTokenPool):
     """A memory pool that maps a request to its token locations."""
-
-    mamba_pool_cls = MambaPool
 
     def __init__(
         self,
@@ -1138,7 +836,6 @@ class HybridReqToTokenPool(ReqToTokenPool):
         enable_linear_replayssm: bool = False,
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
-        enable_gdn_replayssm_spec: bool = False,
     ):
         super().__init__(
             size=size,
@@ -1165,7 +862,6 @@ class HybridReqToTokenPool(ReqToTokenPool):
             enable_linear_replayssm=enable_linear_replayssm,
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             mamba_envelope_layout=mamba_envelope_layout,
-            enable_gdn_replayssm_spec=enable_gdn_replayssm_spec,
         )
 
     def _init_mamba_pool(
@@ -1181,9 +877,8 @@ class HybridReqToTokenPool(ReqToTokenPool):
         enable_linear_replayssm: bool = False,
         linear_replayssm_cache_len: int = 16,
         mamba_envelope_layout: bool = False,
-        enable_gdn_replayssm_spec: bool = False,
     ):
-        self.mamba_pool = self.mamba_pool_cls(
+        self.mamba_pool = MambaPool(
             size=mamba_size,
             spec_state_size=mamba_spec_state_size,
             cache_params=cache_params,
@@ -1195,7 +890,6 @@ class HybridReqToTokenPool(ReqToTokenPool):
             enable_linear_replayssm=enable_linear_replayssm,
             linear_replayssm_cache_len=linear_replayssm_cache_len,
             envelope_layout=mamba_envelope_layout,
-            enable_gdn_replayssm_spec=enable_gdn_replayssm_spec,
         )
         self.mamba_allocator = MambaSlotAllocator(
             size=mamba_size,
@@ -1231,41 +925,6 @@ class HybridReqToTokenPool(ReqToTokenPool):
                 )
             )
 
-    def clone_with_new_mamba(
-        self,
-        *,
-        mamba_size: int,
-        mamba_spec_state_size: int,
-        cache_params: BaseLinearStateParams,
-        device: str,
-        enable_mamba_extra_buffer: bool,
-        draft_model_idx: int,
-        speculative_num_draft_tokens: int = None,
-        speculative_eagle_topk: Optional[int] = None,
-    ) -> HybridReqToTokenPool:
-        """Shallow copy that shares the req_to_token mapping but owns a fresh mamba
-        pool keyed on a single draft layer. Used by multi-layer EAGLE draft workers:
-        each draft head shares the target's request-to-token mapping but needs its
-        own sconv/mamba cache at layer_id=draft_model_idx.
-        """
-        clone = copy.copy(self)
-        clone._init_mamba_pool(
-            mamba_size=mamba_size,
-            mamba_spec_state_size=mamba_spec_state_size,
-            cache_params=cache_params,
-            mamba_layer_ids=[draft_model_idx],
-            device=device,
-            enable_mamba_extra_buffer=enable_mamba_extra_buffer,
-            speculative_num_draft_tokens=speculative_num_draft_tokens,
-            speculative_eagle_topk=speculative_eagle_topk,
-        )
-        clone.req_index_to_mamba_index_mapping = self.req_index_to_mamba_index_mapping
-        if enable_mamba_extra_buffer:
-            clone.req_index_to_mamba_ping_pong_track_buffer_mapping = (
-                self.req_index_to_mamba_ping_pong_track_buffer_mapping
-            )
-        return clone
-
     def register_layer_transfer_counter(self, layer_transfer_counter: LayerDoneCounter):
         self.layer_transfer_counter = layer_transfer_counter
 
@@ -1294,12 +953,6 @@ class HybridReqToTokenPool(ReqToTokenPool):
                 # (the post-prefill state that prefill wrote into this slot).
                 if self.mamba_pool.replayssm_write_pos is not None:
                     self.mamba_pool.replayssm_write_pos[req.mamba_pool_idx] = 0
-                # ReplaySSM spec-verify ring: an empty ring also resets the
-                # circular origin + flush flag so the first verify step on this
-                # freshly-prefilled slot reconstructs from the checkpoint alone.
-                if self.mamba_pool.replayssm_cache_base is not None:
-                    self.mamba_pool.replayssm_cache_base[req.mamba_pool_idx] = 0
-                    self.mamba_pool.replayssm_is_flush[req.mamba_pool_idx] = 0
             mamba_indices.append(req.mamba_pool_idx)
             if self.enable_mamba_extra_buffer:
                 if req.mamba_ping_pong_track_buffer is None:
@@ -1346,12 +999,6 @@ class HybridReqToTokenPool(ReqToTokenPool):
 
     def get_state_dim_per_tensor(self):
         return self.mamba_pool.get_state_dim_per_tensor()
-
-    def get_state_slice_outer_counts(self):
-        return self.mamba_pool.get_state_slice_outer_counts()
-
-    def get_state_conv_shard_groups(self):
-        return self.mamba_pool.get_state_conv_shard_groups()
 
     def get_mamba_ping_pong_other_idx(self, mamba_next_track_idx: int) -> int:
         if self.mamba_ping_pong_track_buffer_size == 2:
@@ -1421,14 +1068,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
         mamba_value_donated = (
             req.mamba_ping_pong_track_buffer[donate_idx].unsqueeze(-1).clone()
         )
-        if _MAMBA_DEBUG_ASSERTS:
-            # .item() forces a cudaStreamSynchronize; only pay it when debugging.
-            assert mamba_value_donated.item() != -1, (
-                f"Donated mamba slot is -1: donate_idx={donate_idx}, "
-                f"buf={req.mamba_ping_pong_track_buffer.tolist()}, "
-                f"next_track_idx={req.mamba_next_track_idx}, "
-                f"rid={req.rid}"
-            )
+        assert mamba_value_donated.item() != -1, (
+            f"Donated mamba slot is -1: donate_idx={donate_idx}, "
+            f"buf={req.mamba_ping_pong_track_buffer.tolist()}, "
+            f"next_track_idx={req.mamba_next_track_idx}, "
+            f"rid={req.rid}"
+        )
         self.set_mamba_ping_pong_slot(req, donate_idx, new_slot[0])
         return mamba_value_donated
 
@@ -1543,45 +1188,7 @@ def unwrap_write_loc(loc_info):
     return loc_info, None, None
 
 
-class KvBufferDesc:
-    """Byte-span math for one KV buffer laid out as rows of ``row_bytes`` holding
-    ``tokens_per_row`` tokens each (a row = one token slot, or one whole page)."""
-
-    __slots__ = ("name", "shape", "row_bytes", "tokens_per_row")
-
-    def __init__(self, name: str, shape: tuple, *, row_bytes: int, tokens_per_row: int):
-        self.name = name
-        self.shape = tuple(shape)
-        self.row_bytes = int(row_bytes)
-        self.tokens_per_row = int(tokens_per_row)
-
-    def _rows(self, num_tokens: int) -> int:
-        n = max(int(num_tokens), 0)
-        return (n + self.tokens_per_row - 1) // self.tokens_per_row
-
-    def reserved_span_bytes(self, itemsize: int) -> int:
-        """Full upper-bound byte size of the buffer (its whole tensor)."""
-        return math.prod(self.shape) * itemsize
-
-    def prefix_span_bytes(self, num_tokens: int, page_size: int) -> int:
-        """Bytes to back to make the first ``num_tokens`` tokens usable."""
-        return self._rows(num_tokens) * self.row_bytes
-
-    def final_span_bytes(self, num_tokens: int, page_size: int) -> int:
-        """Bytes of the final advertised span (adds the padded page). CEIL, not floor:
-        an unaligned count must still cover its partial last page (e.g. n=17, page=16
-        -> 3 pages, not 2)."""
-        return self._rows(max(int(num_tokens), 0) + page_size) * self.row_bytes
-
-    def item_len_bytes(self, page_size: int) -> int:
-        """Per-page transfer chunk (one page's worth of this buffer)."""
-        return (page_size // self.tokens_per_row) * self.row_bytes
-
-
 class KVCache(abc.ABC):
-    layer_shard_enabled: bool = False
-    post_capture_active: bool = False
-
     @abc.abstractmethod
     def __init__(
         self,
@@ -1642,10 +1249,6 @@ class KVCache(abc.ABC):
             )
             self.mem_usage = kv_size_GB
 
-    def get_kv_buffer_shape(self) -> Tuple[torch.Size, torch.Size]:
-        k_buffer, v_buffer = self.get_kv_buffer(self.start_layer)
-        return k_buffer.shape, v_buffer.shape
-
     @abc.abstractmethod
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
         raise NotImplementedError()
@@ -1677,24 +1280,6 @@ class KVCache(abc.ABC):
     def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
         raise NotImplementedError()
 
-    def get_kv_cache_quant_method(self) -> Any:
-        """Return the concrete KV quant method, unwrapping composite KV pools."""
-        fallback = None
-        for pool in (
-            self,
-            getattr(self, "full_kv_pool", None),
-            getattr(self, "swa_kv_pool", None),
-        ):
-            if pool is None:
-                continue
-            quant_method = getattr(pool, "quant_method", None)
-            if quant_method is None:
-                continue
-            if getattr(quant_method, "name", None) != "unquantized":
-                return quant_method
-            fallback = quant_method
-        return fallback
-
     def maybe_get_custom_mem_pool(self):
         return self.custom_mem_pool
 
@@ -1719,13 +1304,7 @@ class MHATokenToKVPool(KVCache):
         enable_alt_stream: bool = True,
         enable_kv_cache_copy: bool = False,
         kv_cache_layout: Optional[str] = None,
-        quant_method=None,
-        post_capture_active: bool = False,
     ):
-        if post_capture_active:
-            # Reserved upper bound only (unbacked VA): page-align UP so
-            # (size + page_size) % page_size == 0 holds for paged layouts.
-            size = (size + page_size - 1) // page_size * page_size
         super().__init__(
             size,
             page_size,
@@ -1736,8 +1315,6 @@ class MHATokenToKVPool(KVCache):
             start_layer,
             end_layer,
         )
-        self.post_capture_active = post_capture_active
-        self._post_capture_owner = None
         self.head_num = swa_head_num if swa_head_num is not None else head_num
         self.head_dim = swa_head_dim if swa_head_dim is not None else head_dim
         self.v_head_dim = (
@@ -1753,7 +1330,6 @@ class MHATokenToKVPool(KVCache):
         #   X = 16 / dtype_bytes — AITER-only (ignored elsewhere, no consumer kernel).
         # HND and vectorized_5d are mutually exclusive; HND takes precedence.
         self.use_hnd = envs.SGLANG_USE_HND_KVCACHE.get()
-        self.use_native_move_kv_cache = envs.SGLANG_NATIVE_MOVE_KV_CACHE.get()
         if kv_cache_layout is not None:
             # Explicit physical-layout selector wins over the platform default.
             # This is a label only; layouts that change buffer identity (e.g. the
@@ -1790,10 +1366,6 @@ class MHATokenToKVPool(KVCache):
                     )
                     assert self.head_dim % self._kv_vector_x == 0
                     assert self.v_head_dim % self._kv_vector_x == 0
-
-        self.quant_method = (
-            quant_method if quant_method is not None else UnquantizedKVCacheMethod()
-        )
 
         self._create_buffers()
 
@@ -1857,148 +1429,21 @@ class MHATokenToKVPool(KVCache):
         }
 
         dummy_loc = torch.zeros(chunk_upper, dtype=torch.int64, device=self.device)
-        copy_all_layer_kv_cache_func(
+        grid = (self.data_ptrs.numel(), self._kv_copy_config["byte_tiles"])
+
+        copy_all_layer_kv_cache_tiled[grid](
             self.data_ptrs,
             self.data_strides,
             dummy_loc,
             dummy_loc,
             1,
             chunk_upper,
-            self._kv_copy_config,
+            BYTES_PER_TILE=self._kv_copy_config["bytes_per_tile"],
+            num_warps=self._kv_copy_config["num_warps"],
+            num_stages=2,
         )
-
-    @property
-    def is_quantized_kv_cache(self) -> bool:
-        return not isinstance(self.quant_method, UnquantizedKVCacheMethod)
 
     def _create_buffers(self):
-        if self.is_quantized_kv_cache:
-            if self.post_capture_active:
-                raise NotImplementedError(
-                    "Post-capture KV backing is not supported for quantized KV cache."
-                )
-            self._create_quantized_buffers()
-        else:
-            self.k_scale_buffer = None
-            self.v_scale_buffer = None
-            self.dq_k_buffer = None
-            self.dq_v_buffer = None
-            if self.post_capture_active:
-                self._alloc_post_capture_buffers()
-            else:
-                self._create_buffers_normal()
-        self._kv_buffer_descs = self._build_kv_buffer_descs()
-        self._init_data_ptrs_and_strides()
-
-    def _create_quantized_buffers(self):
-        # Quantized recipes own packed-data, scale, and workspace shapes.
-        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
-            with (
-                torch.cuda.use_mem_pool(self.custom_mem_pool)
-                if self.enable_custom_mem_pool
-                else nullcontext()
-            ):
-                buf = self.quant_method.create_buffers(
-                    self.size + self.page_size,
-                    self.head_num,
-                    self.head_dim,
-                    self.layer_num,
-                    self.device,
-                )
-        self.k_buffer = buf["k_buffer"]
-        self.v_buffer = buf["v_buffer"]
-        self.k_scale_buffer = buf.get("k_scale_buffer")
-        self.v_scale_buffer = buf.get("v_scale_buffer")
-        self.dq_k_buffer = buf.get("dq_k_buffer")
-        self.dq_v_buffer = buf.get("dq_v_buffer")
-        self.store_dtype = buf.get("store_dtype", torch.uint8)
-        self._check_quantized_buffer_access_requirements()
-
-    def _check_quantized_buffer_access_requirements(self):
-        expected_workspace_dtype = self.quant_method.dequant_workspace_dtype()
-        has_k_workspace = self.dq_k_buffer is not None
-        has_v_workspace = self.dq_v_buffer is not None
-        if has_k_workspace != has_v_workspace:
-            raise RuntimeError(
-                f"KV cache method {self.quant_method.name!r} created only one "
-                "dequant workspace buffer."
-            )
-
-        if expected_workspace_dtype is None:
-            if has_k_workspace:
-                raise RuntimeError(
-                    f"KV cache method {self.quant_method.name!r} does not declare "
-                    "DEQUANT_WORKSPACE access but created dequant buffers."
-                )
-            return
-
-        if not has_k_workspace:
-            raise RuntimeError(
-                f"KV cache method {self.quant_method.name!r} declares "
-                "DEQUANT_WORKSPACE access but did not create dequant buffers."
-            )
-
-        if (
-            self.dq_k_buffer.dtype != expected_workspace_dtype
-            or self.dq_v_buffer.dtype != expected_workspace_dtype
-        ):
-            raise RuntimeError(
-                f"KV cache method {self.quant_method.name!r} declares dequant "
-                f"workspace dtype {expected_workspace_dtype}, but created "
-                f"{self.dq_k_buffer.dtype}/{self.dq_v_buffer.dtype}."
-            )
-
-    def _slot_move_pointer_buffers(self):
-        """Buffers whose pointers/strides are used when KV slots are remapped.
-
-        FP4 KV cache stores data and per-block scales separately, so slot moves
-        must update both. This list feeds data_ptrs/data_strides; it does not
-        copy tensor contents by itself.
-        """
-        buffers = [*self.k_buffer, *self.v_buffer]
-        if getattr(self, "k_scale_buffer", None) is not None:
-            buffers.extend([*self.k_scale_buffer, *self.v_scale_buffer])
-        return buffers
-
-    def _init_data_ptrs_and_strides(self):
-        self.k_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.k_buffer],
-            dtype=torch.uint64,
-            device=self.device,
-        )
-        self.v_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.v_buffer],
-            dtype=torch.uint64,
-            device=self.device,
-        )
-        slot_move_pointer_buffers = self._slot_move_pointer_buffers()
-        self.data_ptrs = torch.tensor(
-            [x.data_ptr() for x in slot_move_pointer_buffers],
-            dtype=torch.uint64,
-            device=self.device,
-        )
-        self.data_strides = torch.tensor(
-            [
-                np.prod(x.shape[1:]) * x.dtype.itemsize
-                for x in slot_move_pointer_buffers
-            ],
-            device=self.device,
-        )
-
-    def _kv_buffer_shapes(self):
-        """(k_shape, v_shape)"""
-        if self.use_hnd:
-            return (
-                (self.num_pages, self.head_num, self.page_size, self.head_dim),
-                (self.num_pages, self.head_num, self.page_size, self.v_head_dim),
-            )
-        rows = self.size + self.page_size
-        return (
-            (rows, self.head_num, self.head_dim),
-            (rows, self.head_num, self.v_head_dim),
-        )
-
-    def _create_buffers_normal(self):
         with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
             with (
                 torch.cuda.use_mem_pool(self.custom_mem_pool)
@@ -2006,7 +1451,28 @@ class MHATokenToKVPool(KVCache):
                 else nullcontext()
             ):
                 # The padded page (slot 0's page) absorbs dummy padded-token writes.
-                if self.kv_cache_layout == "vectorized_5d":
+                if self.use_hnd:
+                    k_shape = (
+                        self.num_pages,
+                        self.head_num,
+                        self.page_size,
+                        self.head_dim,
+                    )
+                    v_shape = (
+                        self.num_pages,
+                        self.head_num,
+                        self.page_size,
+                        self.v_head_dim,
+                    )
+                    self.k_buffer = [
+                        torch.zeros(k_shape, dtype=self.store_dtype, device=self.device)
+                        for _ in range(self.layer_num)
+                    ]
+                    self.v_buffer = [
+                        torch.zeros(v_shape, dtype=self.store_dtype, device=self.device)
+                        for _ in range(self.layer_num)
+                    ]
+                elif self.kv_cache_layout == "vectorized_5d":
                     total_slots = self.size + self.page_size
                     num_blocks = total_slots // self.page_size
                     x = self._kv_vector_x
@@ -2041,133 +1507,93 @@ class MHATokenToKVPool(KVCache):
                         for _ in range(self.layer_num)
                     ]
                 else:
-                    k_shape, v_shape = self._kv_buffer_shapes()
+                    # [size, head_num, head_dim] for each layer
+                    # The padded slot 0 is used for writing dummy outputs from padded tokens.
                     self.k_buffer = [
-                        torch.zeros(k_shape, dtype=self.store_dtype, device=self.device)
+                        torch.zeros(
+                            (self.size + self.page_size, self.head_num, self.head_dim),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
                         for _ in range(self.layer_num)
                     ]
                     self.v_buffer = [
-                        torch.zeros(v_shape, dtype=self.store_dtype, device=self.device)
+                        torch.zeros(
+                            (
+                                self.size + self.page_size,
+                                self.head_num,
+                                self.v_head_dim,
+                            ),
+                            dtype=self.store_dtype,
+                            device=self.device,
+                        )
                         for _ in range(self.layer_num)
                     ]
 
-    # -- post-capture VA backing (opt-in; overridable per layout) --------------
-
-    def _build_kv_buffer_descs(self):
-        """Per-buffer layout descriptors, k0..k(L-1) then v0..v(L-1). Drives both the
-        CUDA-VMM post-capture backing and PD-transfer registration
-        (get_contiguous_buf_infos). Override per layout."""
-        itemsize = self.store_dtype.itemsize
-        # Derive from the real buffers when they exist (covers arbitrary layouts,
-        # e.g. vectorized_5d); fall back to _kv_buffer_shapes for the pre-allocation
-        # post-capture call, which only runs for NHD/HND.
-        if getattr(self, "k_buffer", None) and getattr(self, "v_buffer", None):
-            k_shape = tuple(self.k_buffer[0].shape)
-            v_shape = tuple(self.v_buffer[0].shape)
-        else:
-            k_shape, v_shape = self._kv_buffer_shapes()
-        # A row is a whole page when the leading dim is pages (hnd, vectorized_5d),
-        # a single token slot for the plain NHD [slots, ...] layout.
-        num_slots = self.size + self.page_size
-        tokens_per_row = (
-            self.page_size if k_shape[0] * self.page_size == num_slots else 1
-        )
-        descs = []
-        for prefix, shape in (("k", k_shape), ("v", v_shape)):
-            row_bytes = int(np.prod(shape[1:])) * itemsize
-            for layer in range(self.layer_num):
-                descs.append(
-                    KvBufferDesc(
-                        f"{prefix}{layer}",
-                        shape,
-                        row_bytes=row_bytes,
-                        tokens_per_row=tokens_per_row,
-                    )
-                )
-        return descs
-
-    def _assign_post_capture_tensors(self, tensors):
-        """Map owner tensors (in ``_build_kv_buffer_descs`` order) to k/v_buffer."""
-        self.k_buffer = tensors[: self.layer_num]
-        self.v_buffer = tensors[self.layer_num :]
-
-    def _alloc_post_capture_buffers(self):
-        dev = torch.device(self.device)
-        device_id = dev.index if dev.index is not None else torch.cuda.current_device()
-        self._post_capture_owner = KvVmmBufferOwner(
+        self.k_data_ptrs = torch.tensor(
+            [x.data_ptr() for x in self.k_buffer],
+            dtype=torch.uint64,
             device=self.device,
-            device_id=device_id,
-            store_dtype=self.store_dtype,
-            page_size=self.page_size,
-            reserved_num_tokens=self.size,
-            buffer_descs=self._build_kv_buffer_descs(),
         )
-        self._assign_post_capture_tensors(self._post_capture_owner.tensors)
-
-    def finalize_backing(self, config) -> None:
-        """After capture+sizing: back the final span and set serving capacity.
-        ``config`` is a MemoryPoolConfig (duck-typed); each pool family reads the
-        fields it needs, so the finalizer stays pool-agnostic."""
-        self._finalize_backing_tokens(config.max_total_num_tokens)
-
-    def _finalize_backing_tokens(self, final_num_tokens: int) -> None:
-        """Token-count primitive shared by composite pools (e.g. SWA sub-pools)."""
-        self._post_capture_owner.finalize(final_num_tokens)
-        self.size = int(final_num_tokens)
-
-    @property
-    def post_capture_backed_bytes(self) -> int:
-        return self._post_capture_owner.backed_bytes if self._post_capture_owner else 0
+        self.v_data_ptrs = torch.tensor(
+            [x.data_ptr() for x in self.v_buffer],
+            dtype=torch.uint64,
+            device=self.device,
+        )
+        self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
+        self.data_strides = torch.tensor(
+            [
+                np.prod(x.shape[1:]) * x.dtype.itemsize
+                for x in self.k_buffer + self.v_buffer
+            ],
+            device=self.device,
+        )
 
     def _clear_buffers(self):
         del self.k_buffer
         del self.v_buffer
-        if hasattr(self, "k_scale_buffer") and self.k_scale_buffer is not None:
-            del self.k_scale_buffer
-        if hasattr(self, "v_scale_buffer") and self.v_scale_buffer is not None:
-            del self.v_scale_buffer
-        if hasattr(self, "dq_k_buffer") and self.dq_k_buffer is not None:
-            del self.dq_k_buffer
-        if hasattr(self, "dq_v_buffer") and self.dq_v_buffer is not None:
-            del self.dq_v_buffer
-        if self._post_capture_owner is not None:
-            self._post_capture_owner.close()
-            self._post_capture_owner = None
 
     def get_kv_size_bytes(self):
         assert hasattr(self, "k_buffer")
         assert hasattr(self, "v_buffer")
-        k_size_bytes = get_tensor_size_bytes(self.k_buffer)
-        v_size_bytes = get_tensor_size_bytes(self.v_buffer)
-        if getattr(self, "k_scale_buffer", None) is not None:
-            k_size_bytes += get_tensor_size_bytes(self.k_scale_buffer)
-            v_size_bytes += get_tensor_size_bytes(self.v_scale_buffer)
-        if getattr(self, "dq_k_buffer", None) is not None:
-            k_size_bytes += get_tensor_size_bytes(self.dq_k_buffer)
-            v_size_bytes += get_tensor_size_bytes(self.dq_v_buffer)
+        k_size_bytes = 0
+        for k_cache in self.k_buffer:
+            k_size_bytes += get_tensor_size_bytes(k_cache)
+        v_size_bytes = 0
+        for v_cache in self.v_buffer:
+            v_size_bytes += get_tensor_size_bytes(v_cache)
         return k_size_bytes, v_size_bytes
 
     # for disagg
-    def _pd_registerable_tensors(self):
-        """Buffers to register for PD KV transfer, in ``_kv_buffer_descs`` order.
-        Override when the registerable storage differs from k/v_buffer."""
-        return self.k_buffer + self.v_buffer
-
     def get_contiguous_buf_infos(self):
-        """(ptrs, lens, item_lens) for PD KV transfer, derived from the descriptors.
-        ``lens`` is the final span at the CURRENT serving size -- for a post-capture
-        pool that is the physically-backed span, not the reserved VA upper bound."""
         assert not self.use_hnd, (
             "PD-disaggregation KV transfer assumes NHD slot-row layout; "
             "HND KV cache (SGLANG_USE_HND_KVCACHE) is not supported with disagg yet."
         )
-        tensors = self._pd_registerable_tensors()
-        ptrs = [t.data_ptr() for t in tensors]
-        lens = [
-            d.final_span_bytes(self.size, self.page_size) for d in self._kv_buffer_descs
+        # layer_num x [seq_len, head_num, head_dim]
+        # layer_num x [page_num, page_size, head_num, head_dim]
+        kv_data_ptrs = [
+            self._get_key_buffer(i).data_ptr()
+            for i in range(self.start_layer, self.start_layer + self.layer_num)
+        ] + [
+            self._get_value_buffer(i).data_ptr()
+            for i in range(self.start_layer, self.start_layer + self.layer_num)
         ]
-        item_lens = [d.item_len_bytes(self.page_size) for d in self._kv_buffer_descs]
-        return ptrs, lens, item_lens
+        kv_data_lens = [
+            self._get_key_buffer(i).nbytes
+            for i in range(self.start_layer, self.start_layer + self.layer_num)
+        ] + [
+            self._get_value_buffer(i).nbytes
+            for i in range(self.start_layer, self.start_layer + self.layer_num)
+        ]
+        kv_item_lens = [
+            self._get_key_buffer(i)[0].nbytes * self.page_size
+            for i in range(self.start_layer, self.start_layer + self.layer_num)
+        ] + [
+            self._get_value_buffer(i)[0].nbytes * self.page_size
+            for i in range(self.start_layer, self.start_layer + self.layer_num)
+        ]
+        return kv_data_ptrs, kv_data_lens, kv_item_lens
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         assert not self.use_hnd, (
@@ -2214,19 +1640,9 @@ class MHATokenToKVPool(KVCache):
 
     def _get_key_buffer(self, layer_id: int):
         # for internal use of referencing
-        local_layer_id = layer_id - self.start_layer
-        if (
-            self.is_quantized_kv_cache
-            and self.quant_method.needs_plain_kv_dequant_read()
-        ):
-            return self.quant_method.dequantize_kv_tensor(
-                self.k_buffer[local_layer_id],
-                self.k_scale_buffer[local_layer_id],
-                layer_id,
-            )
         if self.store_dtype != self.dtype:
-            return self.k_buffer[local_layer_id].view(self.dtype)
-        return self.k_buffer[local_layer_id]
+            return self.k_buffer[layer_id - self.start_layer].view(self.dtype)
+        return self.k_buffer[layer_id - self.start_layer]
 
     def get_key_buffer(self, layer_id: int):
         # note: get_key_buffer is hooked with synchronization for layer-wise KV cache loading
@@ -2238,19 +1654,9 @@ class MHATokenToKVPool(KVCache):
 
     def _get_value_buffer(self, layer_id: int):
         # for internal use of referencing
-        local_layer_id = layer_id - self.start_layer
-        if (
-            self.is_quantized_kv_cache
-            and self.quant_method.needs_plain_kv_dequant_read()
-        ):
-            return self.quant_method.dequantize_kv_tensor(
-                self.v_buffer[local_layer_id],
-                self.v_scale_buffer[local_layer_id],
-                layer_id,
-            )
         if self.store_dtype != self.dtype:
-            return self.v_buffer[local_layer_id].view(self.dtype)
-        return self.v_buffer[local_layer_id]
+            return self.v_buffer[layer_id - self.start_layer].view(self.dtype)
+        return self.v_buffer[layer_id - self.start_layer]
 
     def get_value_buffer(self, layer_id: int):
         if self.layer_transfer_counter is not None:
@@ -2275,25 +1681,10 @@ class MHATokenToKVPool(KVCache):
         # Catch stale slot ids here instead of as illegal-addr / silent KV
         # corruption in the store_kvcache write (gated on SGLANG_ENABLE_ASYNC_ASSERT).
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MHA)")
-        layer_id = (
-            layer_id_override if layer_id_override is not None else layer.layer_id
-        )
-        global_layer_id = layer.layer_id if layer is not None else layer_id
-
-        if self.is_quantized_kv_cache:
-            if dcp_kv_mask is not None:
-                raise RuntimeError("dcp_kv_mask is not supported for FP4 KV cache.")
-            self._set_quantized_kv_buffer(
-                layer_id,
-                global_layer_id,
-                loc,
-                cache_k,
-                cache_v,
-                k_scale,
-                v_scale,
-            )
-            return
-
+        if layer_id_override is not None:
+            layer_id = layer_id_override
+        else:
+            layer_id = layer.layer_id
         if cache_k.dtype != self.dtype:
             if k_scale is not None:
                 cache_k.div_(k_scale)
@@ -2351,7 +1742,7 @@ class MHATokenToKVPool(KVCache):
         # and viewed as ``store_dtype`` by ``set_kv_buffer``.
         if self.kv_cache_layout == "vectorized_5d":
             # Late-import to keep the NHD path import-clean.
-            from sglang.kernels.ops.attention.utils import (
+            from sglang.srt.layers.attention.utils import (
                 launch_reshape_and_cache_shuffle_5d,
             )
 
@@ -2386,255 +1777,6 @@ class MHATokenToKVPool(KVCache):
             alt_stream=self.alt_stream,
             same_kv_dim=self.same_kv_dim,
         )
-
-    def _quantized_scales(self, global_layer_id: int, k_scale, v_scale):
-        if k_scale is None and hasattr(self.quant_method, "k_scales_gpu"):
-            k_scale = self.quant_method.k_scales_gpu[
-                global_layer_id : global_layer_id + 1
-            ]
-            v_scale = self.quant_method.v_scales_gpu[
-                global_layer_id : global_layer_id + 1
-            ]
-        return k_scale, v_scale
-
-    def _set_quantized_kv_buffer(
-        self,
-        layer_id: int,
-        global_layer_id: int,
-        loc_info,
-        cache_k: torch.Tensor,
-        cache_v: torch.Tensor,
-        k_scale=None,
-        v_scale=None,
-    ) -> None:
-        loc, _, _ = unwrap_write_loc(loc_info)
-        local_layer_id = layer_id - self.start_layer
-        k_scale, v_scale = self._quantized_scales(global_layer_id, k_scale, v_scale)
-        self.quant_method.quantize_and_store(
-            self.k_buffer[local_layer_id],
-            self.v_buffer[local_layer_id],
-            (
-                self.k_scale_buffer[local_layer_id]
-                if self.k_scale_buffer is not None
-                else None
-            ),
-            (
-                self.v_scale_buffer[local_layer_id]
-                if self.v_scale_buffer is not None
-                else None
-            ),
-            loc,
-            cache_k,
-            cache_v,
-            k_scale,
-            v_scale,
-        )
-
-    def get_raw_kv_buffer(
-        self, layer_id: int
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        local_layer_id = layer_id - self.start_layer
-        if self.k_scale_buffer is None or self.v_scale_buffer is None:
-            raise RuntimeError("Raw FP4 KV cache requested from a non-FP4 KV pool.")
-        k_scale = self.k_scale_buffer[local_layer_id]
-        v_scale = self.v_scale_buffer[local_layer_id]
-        scale_view_dtype = self.quant_method.scale_buffer_view_dtype()
-        if scale_view_dtype is not None:
-            k_scale = k_scale.view(scale_view_dtype)
-            v_scale = v_scale.view(scale_view_dtype)
-        return (
-            self.k_buffer[local_layer_id],
-            self.v_buffer[local_layer_id],
-            k_scale,
-            v_scale,
-        )
-
-    def get_dequant_workspace(self) -> tuple[torch.Tensor, torch.Tensor]:
-        if self.dq_k_buffer is None or self.dq_v_buffer is None:
-            raise RuntimeError(
-                "Dequant workspace requested from a KV pool without FP4 dequant buffers."
-            )
-        return self.dq_k_buffer, self.dq_v_buffer
-
-    def get_flashinfer_dequant_workspace_kv_buffer(
-        self,
-        layer: RadixAttention,
-        req_to_token: torch.Tensor,
-        req_pool_indices_cpu,
-        extend_prefix_lens_cpu,
-        extend_seq_lens_cpu,
-        page_size: int,
-        *,
-        prepare_workspace: bool,
-        use_ragged: bool,
-        k_cur: Optional[torch.Tensor] = None,
-        v_cur: Optional[torch.Tensor] = None,
-        layer_id_override: Optional[int] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return the FlashInfer FP8 KV view for a quantized KV cache.
-
-        FlashInfer prefill consumes FP8 KV. Quantized pools store packed FP4 plus
-        per-block scales, so the pool owns the dequant workspace and returns the
-        view shape expected by FlashInfer.
-        """
-        if not self.is_quantized_kv_cache:
-            raise RuntimeError(
-                "FlashInfer quantized KV buffer requested from a non-quantized KV pool."
-            )
-
-        if prepare_workspace:
-            transfer_cur_kv = not use_ragged
-            k_cur_fp8 = (
-                k_cur.to(torch.float8_e4m3fn)
-                if k_cur is not None and transfer_cur_kv
-                else None
-            )
-            v_cur_fp8 = (
-                v_cur.to(torch.float8_e4m3fn)
-                if v_cur is not None and transfer_cur_kv
-                else None
-            )
-            self._prepare_dequant_extend_workspace(
-                layer.layer_id if layer_id_override is None else layer_id_override,
-                layer.layer_id,
-                req_to_token,
-                req_pool_indices_cpu,
-                extend_prefix_lens_cpu,
-                extend_seq_lens_cpu,
-                page_size,
-                k_cur_fp8=k_cur_fp8,
-                v_cur_fp8=v_cur_fp8,
-            )
-
-        k_buffer_dq, v_buffer_dq = self.get_dequant_workspace()
-        return (
-            k_buffer_dq.view(-1, layer.tp_k_head_num, layer.head_dim),
-            v_buffer_dq.view(-1, layer.tp_v_head_num, layer.head_dim),
-        )
-
-    def get_flashinfer_decode_dequant_workspace_kv_buffer(
-        self,
-        layer: RadixAttention,
-        req_to_token: torch.Tensor,
-        req_pool_indices,
-        seq_lens,
-        *,
-        layer_id_override: Optional[int] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        if not self.is_quantized_kv_cache:
-            raise RuntimeError(
-                "FlashInfer dequant workspace requested from a non-quantized KV pool."
-            )
-
-        self._prepare_dequant_decode_workspace(
-            layer.layer_id if layer_id_override is None else layer_id_override,
-            layer.layer_id,
-            req_to_token,
-            req_pool_indices,
-            seq_lens,
-        )
-        k_buffer_dq, v_buffer_dq = self.get_dequant_workspace()
-        return (
-            k_buffer_dq.view(-1, layer.tp_k_head_num, layer.head_dim),
-            v_buffer_dq.view(-1, layer.tp_v_head_num, layer.head_dim),
-        )
-
-    @staticmethod
-    def _to_cpu_int_list(values) -> list[int]:
-        if isinstance(values, list):
-            return [int(value) for value in values]
-        if isinstance(values, torch.Tensor):
-            return [int(value) for value in values.cpu().tolist()]
-        return [int(value) for value in values]
-
-    def _prepare_dequant_extend_workspace(
-        self,
-        layer_id: int,
-        global_layer_id: int,
-        req_to_token: torch.Tensor,
-        req_pool_indices_cpu,
-        extend_prefix_lens_cpu,
-        extend_seq_lens_cpu,
-        page_size: int,
-        k_cur_fp8: Optional[torch.Tensor] = None,
-        v_cur_fp8: Optional[torch.Tensor] = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Build the shared FP8 workspace used by FlashInfer extend attention.
-
-        Cached prefix tokens are stored as packed FP4 plus per-block scales, so
-        paged prefill dequantizes those prefix tokens into the FP8 workspace.
-        The current extend chunk can already be FP8 and is copied into the same
-        workspace after the prefix region.
-        """
-        k_fp4, v_fp4, k_scales, v_scales = self.get_raw_kv_buffer(layer_id)
-        dq_k, dq_v = self.get_dequant_workspace()
-
-        cur_batch_start_loc_cpu = 0
-        cur_token_idx_dq = page_size
-
-        for i in range(len(req_pool_indices_cpu)):
-            req_idx = int(req_pool_indices_cpu[i])
-            prev_len = int(extend_prefix_lens_cpu[i])
-            extend_len = int(extend_seq_lens_cpu[i])
-
-            if prev_len > 0:
-                prev_indices = req_to_token[req_idx, :prev_len]
-                k_prev_fp8, v_prev_fp8 = self.quant_method.dequantize_prev_kv(
-                    k_fp4[prev_indices],
-                    k_scales[prev_indices],
-                    v_fp4[prev_indices],
-                    v_scales[prev_indices],
-                    global_layer_id,
-                )
-                dq_k[cur_token_idx_dq : cur_token_idx_dq + prev_len] = k_prev_fp8
-                dq_v[cur_token_idx_dq : cur_token_idx_dq + prev_len] = v_prev_fp8
-
-            if k_cur_fp8 is not None:
-                cur_end = cur_batch_start_loc_cpu + extend_len
-                dst_start = cur_token_idx_dq + prev_len
-                dst_end = dst_start + extend_len
-                dq_k[dst_start:dst_end] = k_cur_fp8[cur_batch_start_loc_cpu:cur_end]
-                dq_v[dst_start:dst_end] = v_cur_fp8[cur_batch_start_loc_cpu:cur_end]
-                cur_batch_start_loc_cpu = cur_end
-
-            workspace_len = prev_len + (extend_len if k_cur_fp8 is not None else 0)
-            cur_token_idx_dq = (
-                (cur_token_idx_dq + workspace_len + page_size - 1)
-                // page_size
-                * page_size
-            )
-
-        return dq_k, dq_v
-
-    def _prepare_dequant_decode_workspace(
-        self,
-        layer_id: int,
-        global_layer_id: int,
-        req_to_token: torch.Tensor,
-        req_pool_indices,
-        seq_lens,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        k_fp4, v_fp4, k_scales, v_scales = self.get_raw_kv_buffer(layer_id)
-        dq_k, dq_v = self.get_dequant_workspace()
-
-        req_pool_indices_cpu = self._to_cpu_int_list(req_pool_indices)
-        seq_lens_cpu = self._to_cpu_int_list(seq_lens)
-
-        for req_idx, seq_len in zip(req_pool_indices_cpu, seq_lens_cpu):
-            if seq_len <= 0:
-                continue
-            kv_indices = req_to_token[req_idx, :seq_len]
-            k_prev_fp8, v_prev_fp8 = self.quant_method.dequantize_prev_kv(
-                k_fp4[kv_indices],
-                k_scales[kv_indices],
-                v_fp4[kv_indices],
-                v_scales[kv_indices],
-                global_layer_id,
-            )
-            dq_k[kv_indices] = k_prev_fp8
-            dq_v[kv_indices] = v_prev_fp8
-
-        return dq_k, dq_v
 
     def set_kv_buffer_prefix_valid(
         self,
@@ -2745,12 +1887,8 @@ class MHATokenToKVPool(KVCache):
         # Physical move strategy. Override for layouts that change buffer identity
         # (e.g. PageMajorMHATokenToKVPool always uses the native move). The 3-D
         # per-layer buffers here ignore page_size in move_kv_cache_native.
-        if self.use_native_move_kv_cache:
+        if envs.SGLANG_NATIVE_MOVE_KV_CACHE.get():
             move_kv_cache_native(self.k_buffer, self.v_buffer, tgt_loc, src_loc)
-            if getattr(self, "k_scale_buffer", None) is not None:
-                move_kv_cache_native(
-                    self.k_scale_buffer, self.v_scale_buffer, tgt_loc, src_loc
-                )
             return
 
         N = tgt_loc.numel()
@@ -2763,16 +1901,20 @@ class MHATokenToKVPool(KVCache):
 
         cfg = self._kv_copy_config
         cap = int(cfg.get("num_locs_upper", 256))
+        grid = (self.data_ptrs.numel(), cfg["byte_tiles"])
 
         if N <= cap:
-            copy_all_layer_kv_cache_func(
+            upper = next_power_of_2(N)
+            copy_all_layer_kv_cache_tiled[grid](
                 self.data_ptrs,
                 self.data_strides,
                 tgt_loc,
                 src_loc,
                 N,
-                next_power_of_2(N),
-                cfg,
+                upper,
+                BYTES_PER_TILE=cfg["bytes_per_tile"],
+                num_warps=cfg["num_warps"],
+                num_stages=2,
             )
             return
 
@@ -2780,14 +1922,17 @@ class MHATokenToKVPool(KVCache):
         for start in range(0, N, cap):
             end = min(start + cap, N)
             chunk_len = end - start
-            copy_all_layer_kv_cache_func(
+            upper = next_power_of_2(chunk_len)
+            copy_all_layer_kv_cache_tiled[grid](
                 self.data_ptrs,
                 self.data_strides,
                 tgt_loc[start:end],
                 src_loc[start:end],
                 chunk_len,
-                next_power_of_2(chunk_len),
-                cfg,
+                upper,
+                BYTES_PER_TILE=cfg["bytes_per_tile"],
+                num_warps=cfg["num_warps"],
+                num_stages=2,
             )
 
 
@@ -2970,10 +2115,10 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
             cache_k_nope_fp4_sf = self.k_scale_buffer[layer_id - self.start_layer]
 
             from sglang.srt.layers.quantization.kvfp4_tensor import (
-                FP4MXBlock16KVQuantizeUtil,
+                BlockFP4KVQuantizeUtil,
             )
 
-            cache_k_nope_fp4_dequant = FP4MXBlock16KVQuantizeUtil.batched_dequantize(
+            cache_k_nope_fp4_dequant = BlockFP4KVQuantizeUtil.batched_dequantize(
                 cache_k_nope_fp4, cache_k_nope_fp4_sf
             )
             return cache_k_nope_fp4_dequant
@@ -2988,10 +2133,10 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
             cache_v_nope_fp4_sf = self.v_scale_buffer[layer_id - self.start_layer]
 
             from sglang.srt.layers.quantization.kvfp4_tensor import (
-                FP4MXBlock16KVQuantizeUtil,
+                BlockFP4KVQuantizeUtil,
             )
 
-            cache_v_nope_fp4_dequant = FP4MXBlock16KVQuantizeUtil.batched_dequantize(
+            cache_v_nope_fp4_dequant = BlockFP4KVQuantizeUtil.batched_dequantize(
                 cache_v_nope_fp4, cache_v_nope_fp4_sf
             )
             return cache_v_nope_fp4_dequant
@@ -3022,15 +2167,11 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
                 cache_v.div_(v_scale)
 
             from sglang.srt.layers.quantization.kvfp4_tensor import (
-                FP4MXBlock16KVQuantizeUtil,
+                BlockFP4KVQuantizeUtil,
             )
 
-            cache_k, cache_k_fp4_sf = FP4MXBlock16KVQuantizeUtil.batched_quantize(
-                cache_k
-            )
-            cache_v, cache_v_fp4_sf = FP4MXBlock16KVQuantizeUtil.batched_quantize(
-                cache_v
-            )
+            cache_k, cache_k_fp4_sf = BlockFP4KVQuantizeUtil.batched_quantize(cache_k)
+            cache_v, cache_v_fp4_sf = BlockFP4KVQuantizeUtil.batched_quantize(cache_v)
 
         if self.store_dtype != self.dtype:
             cache_k = cache_k.view(self.store_dtype)
@@ -3213,294 +2354,6 @@ class PageMajorMHATokenToKVPool(MHATokenToKVPool):
         )
 
 
-class MHATokenToKVPoolMXFP8(MHATokenToKVPool):
-    """MHA KV cache pool for MXFP8 block-scaled FP8.
-
-    K/V data is stored as FP8 E4M3. Per-32-element UE8M0 scale factors are
-    stored beside it and passed to the FA4 MXFP8 kernel.
-    """
-
-    MXFP8_SCALE_BLOCK_SIZE = 32
-
-    def _create_buffers(self):
-        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
-            with (
-                torch.cuda.use_mem_pool(self.custom_mem_pool)
-                if self.enable_custom_mem_pool
-                else nullcontext()
-            ):
-                m = self.size + self.page_size
-                n = self.head_num
-                k = self.head_dim
-                v = self.v_head_dim
-
-                if k % self.MXFP8_SCALE_BLOCK_SIZE != 0:
-                    raise ValueError(
-                        f"MXFP8 KV cache requires head_dim divisible by "
-                        f"{self.MXFP8_SCALE_BLOCK_SIZE}, got {k}."
-                    )
-                if v % self.MXFP8_SCALE_BLOCK_SIZE != 0:
-                    raise ValueError(
-                        f"MXFP8 KV cache requires v_head_dim divisible by "
-                        f"{self.MXFP8_SCALE_BLOCK_SIZE}, got {v}."
-                    )
-                if not hasattr(torch, "float8_e8m0fnu"):
-                    raise RuntimeError(
-                        "MXFP8 KV cache requires torch.float8_e8m0fnu support."
-                    )
-                if self.use_hnd:
-                    # Buffers are NHD; the inherited HND move_kv_cache branch
-                    # would silently relocate wrong bytes.
-                    raise ValueError(
-                        "MXFP8 KV cache does not support SGLANG_USE_HND_KVCACHE."
-                    )
-
-                self.store_dtype = torch.float8_e4m3fn
-                self.k_buffer = [
-                    torch.zeros((m, n, k), dtype=self.store_dtype, device=self.device)
-                    for _ in range(self.layer_num)
-                ]
-                self.v_buffer = [
-                    torch.zeros((m, n, v), dtype=self.store_dtype, device=self.device)
-                    for _ in range(self.layer_num)
-                ]
-
-                # UE8M0 scales, one per 32-element block. For the production
-                # page_size==128 path they are stored interleaved in the FA4
-                # BlockScaledBasicChunk atom layout
-                # (num_pages, head, 32, page_size//32, sf_dim) and written by
-                # the store_sf_interleaved kernel; otherwise flat per slot. Must
-                # be zero-initialized (garbage 0xFF is e8m0 NaN).
-                k_sf_dim = k // self.MXFP8_SCALE_BLOCK_SIZE
-                v_sf_dim = v // self.MXFP8_SCALE_BLOCK_SIZE
-                self.mxfp8_sf_interleaved = self.page_size == 128
-                if self.mxfp8_sf_interleaved:
-                    assert m % self.page_size == 0
-                    num_pages = m // self.page_size
-                    chunk = self.page_size // self.MXFP8_SCALE_BLOCK_SIZE
-                    k_sf_shape = (
-                        num_pages,
-                        n,
-                        self.MXFP8_SCALE_BLOCK_SIZE,
-                        chunk,
-                        k_sf_dim,
-                    )
-                    v_sf_shape = (
-                        num_pages,
-                        n,
-                        self.MXFP8_SCALE_BLOCK_SIZE,
-                        chunk,
-                        v_sf_dim,
-                    )
-                else:
-                    k_sf_shape = (m, n, k_sf_dim)
-                    v_sf_shape = (m, n, v_sf_dim)
-                self.k_scale_buffer = [
-                    torch.zeros(
-                        k_sf_shape, dtype=torch.float8_e8m0fnu, device=self.device
-                    )
-                    for _ in range(self.layer_num)
-                ]
-                self.v_scale_buffer = [
-                    torch.zeros(
-                        v_sf_shape, dtype=torch.float8_e8m0fnu, device=self.device
-                    )
-                    for _ in range(self.layer_num)
-                ]
-
-        self.k_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.k_buffer],
-            dtype=torch.uint64,
-            device=self.device,
-        )
-        self.v_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.v_buffer],
-            dtype=torch.uint64,
-            device=self.device,
-        )
-        self.data_ptrs = torch.cat([self.k_data_ptrs, self.v_data_ptrs], dim=0)
-        self.data_strides = torch.tensor(
-            [
-                np.prod(x.shape[1:]) * x.dtype.itemsize
-                for x in self.k_buffer + self.v_buffer
-            ],
-            device=self.device,
-        )
-
-    def _clear_buffers(self):
-        del self.k_buffer
-        del self.v_buffer
-        del self.k_scale_buffer
-        del self.v_scale_buffer
-
-    def _get_key_buffer(self, layer_id: int):
-        return self.k_buffer[layer_id - self.start_layer]
-
-    def _get_value_buffer(self, layer_id: int):
-        return self.v_buffer[layer_id - self.start_layer]
-
-    def get_kv_scale_buffer(self, layer_id: int) -> Tuple[torch.Tensor, torch.Tensor]:
-        idx = layer_id - self.start_layer
-        return self.k_scale_buffer[idx], self.v_scale_buffer[idx]
-
-    def set_kv_buffer(
-        self,
-        layer: RadixAttention,
-        loc_info,
-        cache_k: torch.Tensor,
-        cache_v: torch.Tensor,
-        k_scale: Optional[torch.Tensor] = None,
-        v_scale: Optional[torch.Tensor] = None,
-        layer_id_override: Optional[int] = None,
-        dcp_kv_mask: Optional[torch.Tensor] = None,
-    ):
-        if dcp_kv_mask is not None:
-            raise NotImplementedError("MXFP8 KV cache does not support DCP KV masks.")
-        loc, _, _ = unwrap_write_loc(loc_info)
-        maybe_detect_oob(
-            loc, 0, self.size + self.page_size, "set_kv_buffer (MHA-MXFP8)"
-        )
-        layer_id = (
-            layer_id_override if layer_id_override is not None else layer.layer_id
-        )
-        idx = layer_id - self.start_layer
-
-        if k_scale is None or v_scale is None:
-            # Fused path (SGLANG_OPT_INKLING_MXFP8_FUSED_QUANT_STORE): the layer
-            # hands us bf16 K/V and one kernel quantizes + scatters the fp8
-            # payload and the interleaved UE8M0 scales.
-            if not self.mxfp8_sf_interleaved or cache_k.dtype == self.store_dtype:
-                raise ValueError("MXFP8 KV cache requires K and V scale tensors.")
-            from sglang.kernels.ops.quantization.mxfp8_quant import quant_store_kv_mxfp8
-
-            quant_store_kv_mxfp8(
-                cache_k,
-                cache_v,
-                loc,
-                self.k_buffer[idx],
-                self.v_buffer[idx],
-                self.k_scale_buffer[idx],
-                self.v_scale_buffer[idx],
-                page_size=self.page_size,
-            )
-            return
-
-        from sglang.srt.model_executor.runner import get_is_capture_mode
-
-        if get_is_capture_mode() and self.alt_stream is not None:
-            current_stream = self.device_module.current_stream()
-            self.alt_stream.wait_stream(current_stream)
-            self.k_buffer[idx][loc] = cache_k
-            self._write_scales(idx, loc, k_scale, v_scale)
-            with self.device_module.stream(self.alt_stream):
-                self.v_buffer[idx][loc] = cache_v
-            current_stream.wait_stream(self.alt_stream)
-        else:
-            self.k_buffer[idx][loc] = cache_k
-            self.v_buffer[idx][loc] = cache_v
-            self._write_scales(idx, loc, k_scale, v_scale)
-
-    def _write_scales(self, idx, loc, k_scale, v_scale):
-        """Write per-token UE8M0 K/V scales — interleaved into the FA4
-        BlockScaledBasicChunk layout for page_size==128, flat otherwise."""
-        if self.mxfp8_sf_interleaved:
-            from sglang.kernels.ops.quantization.mxfp8_interleave_sf import (
-                store_sf_interleaved,
-            )
-
-            store_sf_interleaved(
-                k_scale, self.k_scale_buffer[idx], loc, page_size=self.page_size
-            )
-            store_sf_interleaved(
-                v_scale, self.v_scale_buffer[idx], loc, page_size=self.page_size
-            )
-        else:
-            self.k_scale_buffer[idx][loc] = k_scale
-            self.v_scale_buffer[idx][loc] = v_scale
-
-    def _read_sf_interleaved(self, sf_buf: torch.Tensor, loc: torch.Tensor):
-        """Inverse of store_sf_interleaved: gather per-slot (T, head, sf_dim)
-        UE8M0 scales out of the interleaved BlockScaledBasicChunk buffer."""
-        num_pages, n = sf_buf.shape[0], sf_buf.shape[1]
-        sf_dim = sf_buf.shape[-1]
-        # (num_pages, n, page_size) as u32: 4 packed scales per u32.
-        buf_u32 = sf_buf.reshape(num_pages, n, -1).view(torch.int32)
-        off = loc % self.page_size
-        page = (loc // self.page_size).long()
-        chunk = self.page_size // self.MXFP8_SCALE_BLOCK_SIZE
-        ipos = (
-            (off % self.MXFP8_SCALE_BLOCK_SIZE) * chunk
-            + (off // self.MXFP8_SCALE_BLOCK_SIZE)
-        ).long()
-        heads = torch.arange(n, device=loc.device)
-        gathered = buf_u32[page[:, None], heads[None, :], ipos[:, None]]  # (T, n) int32
-        return (
-            gathered.reshape(loc.shape[0], n, 1)
-            .view(torch.uint8)
-            .reshape(loc.shape[0], n, sf_dim)
-            .view(torch.float8_e8m0fnu)
-        )
-
-    def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
-        # The mamba extra_buffer allocator relocates KV rows during serving;
-        # scale rows must travel with their fp8 payload or dequant reads
-        # mismatched exponents.
-        if self.mxfp8_sf_interleaved:
-            from sglang.kernels.ops.quantization.mxfp8_interleave_sf import (
-                store_sf_interleaved,
-            )
-
-            for idx in range(self.layer_num):
-                self.k_buffer[idx][tgt_loc] = self.k_buffer[idx][src_loc]
-                self.v_buffer[idx][tgt_loc] = self.v_buffer[idx][src_loc]
-                k_sf = self._read_sf_interleaved(self.k_scale_buffer[idx], src_loc)
-                v_sf = self._read_sf_interleaved(self.v_scale_buffer[idx], src_loc)
-                store_sf_interleaved(
-                    k_sf, self.k_scale_buffer[idx], tgt_loc, page_size=self.page_size
-                )
-                store_sf_interleaved(
-                    v_sf, self.v_scale_buffer[idx], tgt_loc, page_size=self.page_size
-                )
-        else:
-            super().move_kv_cache(tgt_loc, src_loc)
-            for idx in range(self.layer_num):
-                self.k_scale_buffer[idx][tgt_loc] = self.k_scale_buffer[idx][src_loc]
-                self.v_scale_buffer[idx][tgt_loc] = self.v_scale_buffer[idx][src_loc]
-
-    # These paths copy k/v buffers without the scale buffers; fail loudly
-    # instead of silently corrupting dequantization.
-    def get_cpu_copy(self, indices, mamba_indices=None):
-        raise NotImplementedError("CPU offloading is unsupported for MXFP8 KV cache.")
-
-    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
-        raise NotImplementedError("CPU offloading is unsupported for MXFP8 KV cache.")
-
-    def get_contiguous_buf_infos(self):
-        raise NotImplementedError(
-            "KV transfer / disaggregation is unsupported for MXFP8 KV cache "
-            "(scale buffers are not exposed)."
-        )
-
-    def set_kv_buffer_prefix_valid(self, *args, **kwargs):
-        raise NotImplementedError(
-            "prefix-valid commit is unsupported for MXFP8 KV cache "
-            "(it does not carry the scale buffers)."
-        )
-
-    def get_kv_size_bytes(self):
-        k_size_bytes = 0
-        v_size_bytes = 0
-        for k_cache in self.k_buffer:
-            k_size_bytes += get_tensor_size_bytes(k_cache)
-        for k_scale in self.k_scale_buffer:
-            k_size_bytes += get_tensor_size_bytes(k_scale)
-        for v_cache in self.v_buffer:
-            v_size_bytes += get_tensor_size_bytes(v_cache)
-        for v_scale in self.v_scale_buffer:
-            v_size_bytes += get_tensor_size_bytes(v_scale)
-        return k_size_bytes, v_size_bytes
-
-
 class HybridLinearKVPool(KVCache):
     """KV cache with separate pools for full and linear attention layers."""
 
@@ -3520,13 +2373,12 @@ class HybridLinearKVPool(KVCache):
         use_mla: bool = False,
         kv_lora_rank: int = None,
         qk_rope_head_dim: int = None,
+        index_head_dim: int = None,
         start_layer: Optional[int] = None,
         full_kv_pool_class: Optional[type] = None,
-        quant_method=None,
         # When provided (shared-KV-pool path), use this pool for the
         # full-attention layers instead of constructing one internally.
         full_kv_pool: Optional[KVCache] = None,
-        post_capture_active: bool = False,
     ):
         self.size = size
         self.dtype = dtype
@@ -3548,32 +2400,21 @@ class HybridLinearKVPool(KVCache):
             self.full_kv_pool = full_kv_pool
         elif not use_mla:
             TokenToKVPoolClass = MHATokenToKVPool
-            quant_method_kwarg = {"quant_method": quant_method}
 
             if current_platform.is_out_of_tree():
                 TokenToKVPoolClass = current_platform.get_mha_kv_pool_cls()
-                quant_method_kwarg = {}
             elif _is_npu:
-                assert not is_float4_e2m1fn_x2(
-                    dtype
-                ), "FP4 is not supported on NPU yet."
                 from sglang.srt.hardware_backend.npu.memory_pool_npu import (
                     NPUMHATokenToKVPool,
                 )
 
                 TokenToKVPoolClass = NPUMHATokenToKVPool
-                quant_method_kwarg = {}
             elif full_kv_pool_class is not None:
                 # Caller-selected MHA layout variant (e.g. the page-major
                 # PageMajorMHATokenToKVPool). NPU / out-of-tree classes keep
                 # priority since they don't understand alternate layouts.
                 TokenToKVPoolClass = full_kv_pool_class
-            else:
-                TokenToKVPoolClass = MHATokenToKVPool
 
-            post_capture_kwargs = (
-                {"post_capture_active": True} if post_capture_active else {}
-            )
             self.full_kv_pool = TokenToKVPoolClass(
                 size=size,
                 page_size=self.page_size,
@@ -3584,8 +2425,6 @@ class HybridLinearKVPool(KVCache):
                 device=device,
                 enable_memory_saver=enable_memory_saver,
                 enable_kv_cache_copy=enable_kv_cache_copy,
-                **quant_method_kwarg,
-                **post_capture_kwargs,
             )
         else:
             TokenToKVPoolClass = MLATokenToKVPool
@@ -3607,6 +2446,7 @@ class HybridLinearKVPool(KVCache):
                 device=device,
                 kv_lora_rank=kv_lora_rank,
                 qk_rope_head_dim=qk_rope_head_dim,
+                index_head_dim=index_head_dim,
                 enable_memory_saver=enable_memory_saver,
             )
         self.full_attention_layer_id_mapping = {
@@ -3618,29 +2458,11 @@ class HybridLinearKVPool(KVCache):
             k_size, v_size = self.get_kv_size_bytes()
             self.mem_usage = (k_size + v_size) / GB
 
-    @property
-    def post_capture_active(self) -> bool:
-        return getattr(self.full_kv_pool, "post_capture_active", False)
-
-    @property
-    def post_capture_backed_bytes(self) -> int:
-        return getattr(self.full_kv_pool, "post_capture_backed_bytes", 0)
-
-    def finalize_backing(self, config) -> None:
-        # Only the attention KV is resized; the mamba state cache is fixed pre-capture.
-        self.full_kv_pool._finalize_backing_tokens(config.max_total_num_tokens)
-        self.size = int(config.max_total_num_tokens)
-
     def get_kv_size_bytes(self):
         return self.full_kv_pool.get_kv_size_bytes()
 
     def get_contiguous_buf_infos(self):
         return self.full_kv_pool.get_contiguous_buf_infos()
-
-    def get_kv_layer_ids(self):
-        """Global layer ids aligned with the full-attention KV buffers."""
-        layer_ids = list(self.full_attention_layer_id_mapping)
-        return layer_ids if self.use_mla else layer_ids * 2
 
     def get_state_buf_infos(self):
         mamba_data_ptrs, mamba_data_lens, mamba_item_lens = (
@@ -3651,18 +2473,6 @@ class HybridLinearKVPool(KVCache):
     def get_state_dim_per_tensor(self):
         """Get the sliceable dimension size for each mamba state tensor."""
         return self.mamba_pool.get_state_dim_per_tensor()
-
-    def get_state_layer_ids(self):
-        """Global layer id per mamba state entry, aligned with get_state_buf_infos()."""
-        return self.mamba_pool.get_state_layer_ids()
-
-    def get_state_slice_outer_counts(self):
-        """Get the row count preceding each mamba state slice axis."""
-        return self.mamba_pool.get_state_slice_outer_counts()
-
-    def get_state_conv_shard_groups(self):
-        """Per-tensor conv sub-block dims (GDN) aligned with the state list."""
-        return self.mamba_pool.get_state_conv_shard_groups()
 
     def maybe_get_custom_mem_pool(self):
         return self.full_kv_pool.maybe_get_custom_mem_pool()
@@ -3684,54 +2494,20 @@ class HybridLinearKVPool(KVCache):
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id - self.start_layer)
 
-    def get_key_buffer(self, layer_id: int, scale: Optional[float] = None):
+    def get_key_buffer(self, layer_id: int):
         self._wait_for_layer(layer_id)
         layer_id = self._transfer_full_attention_id(layer_id)
-        if scale is not None:
-            return self.full_kv_pool.get_key_buffer(layer_id, scale)
         return self.full_kv_pool.get_key_buffer(layer_id)
 
-    def get_value_buffer(self, layer_id: int, scale: Optional[float] = None):
+    def get_value_buffer(self, layer_id: int):
         self._wait_for_layer(layer_id)
         layer_id = self._transfer_full_attention_id(layer_id)
-        if scale is not None:
-            return self.full_kv_pool.get_value_buffer(layer_id, scale)
         return self.full_kv_pool.get_value_buffer(layer_id)
 
     def get_kv_buffer(self, layer_id: int):
         self._wait_for_layer(layer_id)
         layer_id = self._transfer_full_attention_id(layer_id)
         return self.full_kv_pool.get_kv_buffer(layer_id)
-
-    def get_raw_kv_buffer(
-        self, layer_id: int
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        self._wait_for_layer(layer_id)
-        layer_id = self._transfer_full_attention_id(layer_id)
-        return self.full_kv_pool.get_raw_kv_buffer(layer_id)
-
-    def get_dequant_workspace(self) -> tuple[torch.Tensor, torch.Tensor]:
-        return self.full_kv_pool.get_dequant_workspace()
-
-    def get_flashinfer_dequant_workspace_kv_buffer(self, layer, *args, **kwargs):
-        self._wait_for_layer(layer.layer_id)
-        local_layer_id = self._transfer_full_attention_id(layer.layer_id)
-        return self.full_kv_pool.get_flashinfer_dequant_workspace_kv_buffer(
-            layer, *args, layer_id_override=local_layer_id, **kwargs
-        )
-
-    def get_flashinfer_decode_dequant_workspace_kv_buffer(self, layer, *args, **kwargs):
-        self._wait_for_layer(layer.layer_id)
-        local_layer_id = self._transfer_full_attention_id(layer.layer_id)
-        return self.full_kv_pool.get_flashinfer_decode_dequant_workspace_kv_buffer(
-            layer, *args, layer_id_override=local_layer_id, **kwargs
-        )
-
-    def get_kv_scale_buffer(self, layer_id: int):
-        # MXFP8 full_kv_pool exposes per-32 UE8M0 K/V scale buffers.
-        self._wait_for_layer(layer_id)
-        layer_id = self._transfer_full_attention_id(layer_id)
-        return self.full_kv_pool.get_kv_scale_buffer(layer_id)
 
     @contextmanager
     def _transfer_id_context(self, layer: RadixAttention):
@@ -3765,7 +2541,7 @@ class HybridLinearKVPool(KVCache):
         if not self.use_mla:
             write_loc = full_loc if full_loc is not None else loc
             self.full_kv_pool.set_kv_buffer(
-                layer,
+                None,
                 write_loc,
                 cache_k,
                 cache_v,
@@ -3953,12 +2729,14 @@ class MLATokenToKVPool(KVCache):
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MLA)")
         layer_id = layer.layer_id
         assert not self.dsa_kv_cache_store_fp8
-        parallel = get_parallel()
-        if parallel.dcp_enabled:
-            valid_mask = loc % parallel.attn_dcp_size == parallel.attn_dcp_rank
+        if dcp_enabled():
+            valid_mask = (
+                loc % get_attention_dcp_world_size() == get_attention_dcp_rank()
+            )
             if not valid_mask.all():
                 loc = loc[valid_mask]
                 cache_k = cache_k[valid_mask]
+
         if cache_k.dtype != self.dtype:
             cache_k = cache_k.to(self.dtype)
 
@@ -3969,18 +2747,21 @@ class MLATokenToKVPool(KVCache):
         else:
             self.kv_buffer[layer_id - self.start_layer][loc] = cache_k
 
-    def _write_mla_kv_buffer(
+    def set_mla_kv_buffer(
         self,
-        dst_buffer: torch.Tensor,
+        layer: RadixAttention,
         loc: torch.Tensor,
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
-    ) -> None:
+    ):
+        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_mla_kv_buffer (MLA)")
+        layer_id = layer.layer_id
+
         if _is_hip and self.use_dsa and self.dtype == fp8_dtype:
             # HIP FP8 path uses raw MLA KV layout (nope + rope) without per-block scales.
             # Fuse BF16/FP16 -> FP8 cast with paged KV write.
             set_mla_kv_buffer_triton_fp8_quant(
-                dst_buffer,
+                self.kv_buffer[layer_id - self.start_layer],
                 loc,
                 cache_k_nope,
                 cache_k_rope,
@@ -3998,7 +2779,7 @@ class MLATokenToKVPool(KVCache):
             # cache_k_nope_fp8: (num_tokens, 1, 528) uint8 [nope_fp8(512) | scales(16)]
             # cache_k_rope_fp8: (num_tokens, 1, 128) uint8 [rope_bf16_bytes(128)]
             set_mla_kv_buffer_triton(
-                dst_buffer,
+                self.kv_buffer[layer_id - self.start_layer],
                 loc,
                 cache_k_nope_fp8,
                 cache_k_rope_fp8,
@@ -4012,27 +2793,11 @@ class MLATokenToKVPool(KVCache):
                 cache_k_rope = cache_k_rope.view(self.store_dtype)
 
             set_mla_kv_buffer_triton(
-                dst_buffer,
+                self.kv_buffer[layer_id - self.start_layer],
                 loc,
                 cache_k_nope,
                 cache_k_rope,
             )
-
-    def set_mla_kv_buffer(
-        self,
-        layer: RadixAttention,
-        loc: torch.Tensor,
-        cache_k_nope: torch.Tensor,
-        cache_k_rope: torch.Tensor,
-    ):
-        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_mla_kv_buffer (MLA)")
-        layer_id = layer.layer_id
-        self._write_mla_kv_buffer(
-            self.kv_buffer[layer_id - self.start_layer],
-            loc,
-            cache_k_nope,
-            cache_k_rope,
-        )
 
     def get_mla_kv_buffer(
         self,
@@ -4148,10 +2913,10 @@ class MLATokenToKVPoolFP4(MLATokenToKVPool):
             cache_k_nope_fp4_sf = self.kv_scale_buffer[layer_id - self.start_layer]
 
             from sglang.srt.layers.quantization.kvfp4_tensor import (
-                FP4MXBlock16KVQuantizeUtil,
+                BlockFP4KVQuantizeUtil,
             )
 
-            cache_k_nope_fp4_dequant = FP4MXBlock16KVQuantizeUtil.batched_dequantize(
+            cache_k_nope_fp4_dequant = BlockFP4KVQuantizeUtil.batched_dequantize(
                 cache_k_nope_fp4, cache_k_nope_fp4_sf
             )
             return cache_k_nope_fp4_dequant
@@ -4172,10 +2937,10 @@ class MLATokenToKVPoolFP4(MLATokenToKVPool):
         assert not self.dsa_kv_cache_store_fp8
         if cache_k.dtype != self.dtype:
             from sglang.srt.layers.quantization.kvfp4_tensor import (
-                FP4MXBlock16KVQuantizeUtil,
+                BlockFP4KVQuantizeUtil,
             )
 
-            cache_k_fp4, cache_k_fp4_sf = FP4MXBlock16KVQuantizeUtil.batched_quantize(
+            cache_k_fp4, cache_k_fp4_sf = BlockFP4KVQuantizeUtil.batched_quantize(
                 cache_k
             )
 
@@ -4211,14 +2976,14 @@ class MLATokenToKVPoolFP4(MLATokenToKVPool):
         else:
             if cache_k_nope.dtype != self.dtype:
                 from sglang.srt.layers.quantization.kvfp4_tensor import (
-                    FP4MXBlock16KVQuantizeUtil,
+                    BlockFP4KVQuantizeUtil,
                 )
 
                 cache_k_nope_fp4, cache_k_nope_fp4_sf = (
-                    FP4MXBlock16KVQuantizeUtil.batched_quantize(cache_k_nope)
+                    BlockFP4KVQuantizeUtil.batched_quantize(cache_k_nope)
                 )
                 cache_k_rope_fp4, cache_k_rope_fp4_sf = (
-                    FP4MXBlock16KVQuantizeUtil.batched_quantize(cache_k_rope)
+                    BlockFP4KVQuantizeUtil.batched_quantize(cache_k_rope)
                 )
 
             if self.store_dtype != self.dtype:
@@ -4283,7 +3048,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
         self.index_head_dim = index_head_dim
         if index_buf_size is None:
             index_buf_size = size
-        self.index_buf_size = index_buf_size
         # num head == 1 and head dim == 128 for index_k in DSA
         assert index_head_dim == 128
 
@@ -4298,18 +3062,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
                 ), f"HIP legacy DSA path requires page_size == 1, got {self.page_size}"
         else:
             assert self.page_size == 64
-        self._create_index_buffers()
-        self._finalize_allocation_log(size)
-
-    def _index_buffer_shape(self, num_pages: int) -> tuple[int, int]:
-        return (
-            num_pages,
-            self.page_size
-            * (self.index_head_dim + self.index_head_dim // self.quant_block_size * 4),
-        )
-
-    def _create_index_buffers(self):
-        num_pages = (self.index_buf_size + self.page_size + 1) // self.page_size
         with (
             torch.cuda.use_mem_pool(self.custom_mem_pool)
             if self.custom_mem_pool
@@ -4323,15 +3075,22 @@ class DSATokenToKVPool(MLATokenToKVPool):
                     #     data: for page i,
                     #         * buf[i, :page_size * head_dim] for fp8 data
                     #         * buf[i, page_size * head_dim:].view(float32) for scale
-                    self._index_buffer_shape(num_pages),
+                    (
+                        (index_buf_size + page_size + 1) // self.page_size,
+                        self.page_size
+                        * (
+                            index_head_dim + index_head_dim // self.quant_block_size * 4
+                        ),
+                    ),
                     dtype=self.index_k_with_scale_buffer_dtype,
-                    device=self.device,
+                    device=device,
                 )
-                for _ in range(self.layer_num)
+                for _ in range(layer_num)
             ]
+        self._finalize_allocation_log(size)
 
     def _clear_buffers(self):
-        super()._clear_buffers()
+        del self.kv_buffer
         del self.index_k_with_scale_buffer
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
@@ -4678,9 +3437,6 @@ class MiniMaxSparseKVPool(KVCache):
         self.page_size = page_size
         self.dtype = dtype
         self.device = device
-        self.use_minimax_fused_kv_index_store = (
-            envs.SGLANG_OPT_USE_MINIMAX_FUSED_KV_INDEX_STORE.get()
-        )
 
         local_dense_layer_ids = [
             lid for lid in dense_layer_ids if start_layer <= lid < end_layer
@@ -4893,7 +3649,7 @@ class MiniMaxSparseKVPool(KVCache):
         head byte size shared by main and index caches."""
         main = self.main_pool
         return (
-            self.use_minimax_fused_kv_index_store
+            envs.SGLANG_OPT_USE_MINIMAX_FUSED_KV_INDEX_STORE.get()
             and _is_cuda
             # No dtype conversion / fp8 scaling on either side (the fused kernel
             # is a raw byte copy, it does not quantize).
@@ -4925,7 +3681,7 @@ class MiniMaxSparseKVPool(KVCache):
         if index_pool is not None and self._can_fuse_kv_index_store(
             index_pool, cache_k, cache_idx_k
         ):
-            from sglang.kernels.ops.kvcache.minimax_store_kv_index import store_kv_index
+            from sglang.jit_kernel.minimax_store_kv_index import store_kv_index
 
             main = self.main_pool
             head_bytes = main.head_dim * main.dtype.itemsize

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -16,39 +16,78 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
+import gc
 import inspect
 import logging
+import os
+import socket
+import threading
 import time
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.distributed as dist
+from torch import nn
 
-from sglang.srt.configs.load_config import LoadConfig
+from sglang.jit_kernel.ngram_embedding import update_token_table_decode
+from sglang.srt.configs import (
+    BailingHybridConfig,
+    FalconH1Config,
+    GraniteMoeHybridConfig,
+    InternS2PreviewConfig,
+    JetNemotronConfig,
+    JetVLMConfig,
+    KimiLinearConfig,
+    Lfm2Config,
+    Lfm2MoeConfig,
+    Lfm2VlConfig,
+    NemotronH_Nano_VL_V2_Config,
+    NemotronHConfig,
+    Qwen3_5Config,
+    Qwen3_5MoeConfig,
+    Qwen3NextConfig,
+    ZayaConfig,
+)
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.linear_attn_model_registry import get_linear_attn_config
+from sglang.srt.configs.load_config import LoadConfig, LoadFormat
 from sglang.srt.configs.model_config import (
     AttentionArch,
     ModelConfig,
     ModelImpl,
+    dsa_layer_skips_topk,
+    get_num_indexer_layers,
+    is_deepseek_dsa,
 )
 from sglang.srt.configs.update_config import adjust_config_with_unaligned_cpu_tp
+from sglang.srt.constants import GPU_MEMORY_TYPE_WEIGHTS
 from sglang.srt.debug_utils.dumper import dumper
-from sglang.srt.distributed import bootstrap
-from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import (
-    maybe_init_shared_mooncake_transfer_engine,
+from sglang.srt.debug_utils.tensor_dump_forward_hook import (
+    register_forward_hook_for_model,
 )
-from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.distributed import (
+    get_default_distributed_backend,
+    get_pp_group,
+    get_tp_group,
+    get_world_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+    set_custom_all_reduce,
+    set_mscclpp_all_reduce,
+    set_torch_symm_mem_all_reduce,
+)
+from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    use_symmetric_memory,
+)
+from sglang.srt.distributed.parallel_state import monkey_patch_vllm_parallel_state
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.elastic_ep.elastic_ep import (
     ElasticEPStateManager,
-    get_healthy_expert_location_src_rank,
-    get_scale_cohort_target,
     join_process_groups,
-    join_scale_process_group,
-    maybe_rebalance_after_rank_fault,
-    maybe_recover_ep_ranks,
-    register_scale_cohort,
-    try_admit_scale_ranks,
+    try_recover_ranks,
 )
 from sglang.srt.elastic_ep.expert_backup_client import ExpertBackupClient
 from sglang.srt.environ import envs
@@ -61,40 +100,59 @@ from sglang.srt.eplb.expert_distribution import (
 )
 from sglang.srt.eplb.expert_location import (
     ExpertLocationMetadata,
-    append_trivial_expert_slots,
     broadcast_global_expert_location_metadata,
     compute_initial_expert_location_metadata,
-    format_expert_location_layout,
     get_global_expert_location_metadata,
     set_global_expert_location_metadata,
 )
 from sglang.srt.eplb.expert_location_updater import ExpertLocationUpdater
+from sglang.srt.eplb.lplb_solver import (
+    LPLBSolver,
+    assert_lplb_supported_model,
+    clear_global_lplb_solvers,
+    set_global_lplb_solver,
+)
+from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import NPUGraphRunner
+from sglang.srt.hardware_backend.xpu.graph_runner.xpu_graph_runner import XPUGraphRunner
 from sglang.srt.kv_canary.api import install_canary
 from sglang.srt.kv_canary.runner.canary_manager import context_tuple
 from sglang.srt.kv_canary.token_oracle.install import install_token_oracle_from_env
-from sglang.srt.layers import deep_gemm_wrapper, model_parallel
+from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.attention.attention_registry import (
+    ATTENTION_BACKENDS,
+    attn_backend_wrapper,
+)
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
+from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.cp.utils import (
     get_cp_strategy,
 )
+from sglang.srt.layers.dp_attention import (
+    get_attention_tp_group,
+    initialize_dp_attention,
+)
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.moe.hash_topk import HashTopK
+from sglang.srt.layers.moe.topk import TopK
+from sglang.srt.layers.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.layers.sampler import create_sampler
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
 from sglang.srt.layers.utils.cp_utils import is_mla_prefill_cp_enabled
-from sglang.srt.lora.lora_manager import LoRAManager, init_lora_cuda_graph_moe_buffers
+from sglang.srt.lora.lora_manager import LoRAManager
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
-from sglang.srt.mem_cache import kv_cache_dtype
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.kv_cache_configurator import (
-    KVCacheConfigurator,
-)
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
+from sglang.srt.model_executor.cpu_graph_runner import CPUGraphRunner
 from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    Phase,
+    check_cuda_graph_backend,
     cuda_graph_fully_disabled,
 )
 from sglang.srt.model_executor.forward_batch_info import (
     ForwardBatch,
+    ForwardMode,
     PPProxyTensors,
 )
 from sglang.srt.model_executor.forward_context import (
@@ -102,81 +160,34 @@ from sglang.srt.model_executor.forward_context import (
     forward_context,
     has_forward_context,
 )
-from sglang.srt.model_executor.model_runner_components import misc_utils
-from sglang.srt.model_executor.model_runner_components.attention_backend_setup import (
-    build_attention_backends,
-    configure_aux_hidden_state_capture,
-    get_attention_backend,
-)
-from sglang.srt.model_executor.model_runner_components.cuda_graph_setup import (
-    capture_cuda_graphs,
-    capture_decode_graph,
-    capture_prefill_graph,
-)
-from sglang.srt.model_executor.model_runner_components.kv_pool_runtime import (
-    compute_post_capture_kv_resize,
-    is_post_capture_kv_active,
-)
-from sglang.srt.model_executor.model_runner_components.layer_setup import (
-    ModelLayerInfo,
-    adjust_hybrid_swa_layer_ids,
-    resolve_layer_indices,
-)
-from sglang.srt.model_executor.model_runner_components.load_model_utils import (
-    build_load_config,
-    dist_barrier_after_load,
-    load_kv_cache_scales,
-    load_model_with_memory_saver,
-    maybe_downgrade_dtype_for_legacy_gpu,
-    maybe_enable_ipc_weight_cache,
-    maybe_register_debug_tensor_dump_hook,
-    maybe_trigger_remote_instance_nccl_send_group,
-    report_online_quantization,
-    resolve_sliding_window_size,
-)
-from sglang.srt.model_executor.model_runner_components.moe_ep_setup import (
-    check_quantized_moe_compatibility,
-    init_lplb_solvers,
-    prepare_moe_topk,
-)
-from sglang.srt.model_executor.model_runner_components.ngram_embedding_manager import (
-    NgramEmbeddingManager,
-)
-from sglang.srt.model_executor.model_runner_components.remote_instance_weight_transporter import (
-    RemoteInstanceWeightTransporter,
-)
-from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state import (
-    SpecAuxHiddenStateConfig,
-    resolve_spec_aux_hidden_state_config,
-)
-from sglang.srt.model_executor.model_runner_components.weight_exporter import (
-    WeightExporter,
-)
-from sglang.srt.model_executor.model_runner_components.weight_updater import (
-    WeightUpdater,
+from sglang.srt.model_executor.graph_shared_output import GraphSharedOutput
+from sglang.srt.model_executor.hook_manager import register_forward_hooks
+from sglang.srt.model_executor.model_runner_kv_cache_mixin import (
+    ModelRunnerKVCacheMixin,
 )
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.model_executor.runner import (
     EagerRunner,
+    PrefillCudaGraphRunner,
     get_batch_sizes_to_capture,
 )
-from sglang.srt.platforms import current_platform
-from sglang.srt.runtime_context import (
-    get_global_dwdp_manager,
-    get_parallel,
-    get_server_args,
-    set_global_dwdp_manager,
+from sglang.srt.model_loader.loader import DefaultModelLoader, get_model_loader
+from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
+    RemoteInstanceWeightLoaderBackend,
+    register_memory_region,
+    trigger_init_weights_send_group_for_remote_instance_request,
 )
+from sglang.srt.model_loader.utils import set_default_torch_dtype
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.platforms import current_platform
+from sglang.srt.runtime_context import get_flags
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
-from sglang.srt.server_args import (  # noqa: F401  (re-export)
-    CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS,
+from sglang.srt.server_args import (
     ServerArgs,
-    add_chunked_prefix_cache_attention_backend,
     get_global_server_args,
     set_global_server_args_for_scheduler,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 from sglang.srt.state_capturer.indexer_topk import (
     create_indexer_capturer,
@@ -190,17 +201,26 @@ from sglang.srt.state_capturer.routed_experts import (
     set_global_experts_capturer,
 )
 from sglang.srt.utils import (
+    MultiprocessingSerializer,
+    broadcast_pyobj,
     cpu_has_amx_support,
+    dynamic_import,
     enable_show_time_cost,
     get_available_gpu_memory,
+    get_bool_env_var,
+    get_cpu_ids_by_node,
+    init_custom_process_group,
+    is_hip,
     is_host_cpu_arm64,
     is_npu,
-    numa_utils,
+    log_info_on_rank0,
+    monkey_patch_p2p_access_check,
     require_gathered_buffer,
     reserve_rope_cache_for_long_sequences,
     set_cuda_arch,
     slow_rank_detector,
 )
+from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.nvtx_utils import profile_range
 from sglang.srt.utils.offloader import (
@@ -208,13 +228,22 @@ from sglang.srt.utils.offloader import (
     get_offloader,
     set_offloader,
 )
-from sglang.srt.utils.profile_utils import build_step_span_name
+from sglang.srt.utils.patch_torch import (
+    monkey_patch_torch_reductions,
+    register_sgl_tp_rank,
+)
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.srt.utils.weight_checker import WeightChecker
+from sglang.srt.weight_sync.tensor_bucket import (
+    FlattenedTensorBucket,
+    FlattenedTensorMetadata,
+)
 
+_is_hip = is_hip()
 _is_npu = is_npu()
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu_arm64 = is_host_cpu_arm64()
+_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 if _is_npu:
     from sglang.srt.hardware_backend.npu.utils import init_npu_backend
@@ -223,10 +252,87 @@ if _is_npu:
 elif current_platform.is_out_of_tree():
     current_platform.init_backend()
 
+MLA_ATTENTION_BACKENDS = [
+    "aiter",
+    "flashinfer",
+    "fa3",
+    "fa4",
+    "triton",
+    "flashmla",
+    "cutedsl_mla",
+    "cutlass_mla",
+    "trtllm_mla",
+    "tokenspeed_mla",
+    "ascend",
+    "dsa",
+    "nsa",  # Deprecated alias for "dsa"
+    "intel_xpu",
+]
+
+CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS = [
+    "flashinfer",
+    "fa3",
+    "fa4",
+    "flashmla",
+    "cutedsl_mla",
+    "cutlass_mla",
+    "trtllm_mla",
+    "tokenspeed_mla",
+]
+
+TORCH_DTYPE_TO_KV_CACHE_STR = {
+    torch.float8_e4m3fn: "fp8_e4m3",
+    torch.float8_e4m3fnuz: "fp8_e4m3",
+    torch.float8_e5m2: "fp8_e5m2",
+    torch.bfloat16: "bf16",
+}
+
+
+def add_mla_attention_backend(backend_name):
+    if backend_name not in MLA_ATTENTION_BACKENDS:
+        MLA_ATTENTION_BACKENDS.append(backend_name)
+        logger.info(f"Added {backend_name} to MLA_ATTENTION_BACKENDS.")
+
+
+def add_chunked_prefix_cache_attention_backend(backend_name):
+    if backend_name not in CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS:
+        CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS.append(backend_name)
+        logger.info(
+            f"Added {backend_name} to CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS."
+        )
+
+
 # Detect stragger ranks in model loading
+UNBALANCED_MODEL_LOADING_TIMEOUT_S = 2400  # leave more time for post data processing
 
 
 logger = logging.getLogger(__name__)
+
+_UNSET: Any = object()
+
+
+def resolve_language_model(model: nn.Module) -> nn.Module:
+    model_cls_name = model.__class__.__name__
+    if model_cls_name == "Qwen3OmniMoeForConditionalGeneration":
+        return model.thinker.model
+    if hasattr(model, "model"):
+        return model.model
+    if hasattr(model, "language_model"):
+        return model.language_model
+    return model.model
+
+
+class RankZeroFilter(logging.Filter):
+    """Filter that only allows INFO level logs from rank 0, but allows all other levels from any rank."""
+
+    def __init__(self, is_rank_zero):
+        super().__init__()
+        self.is_rank_zero = is_rank_zero
+
+    def filter(self, record):
+        if record.levelno == logging.INFO:
+            return self.is_rank_zero
+        return True
 
 
 @dataclass
@@ -238,7 +344,7 @@ class ModelRunnerOutput:
     indexer_topk_output: Optional[TopkCaptureOutput] = None
 
 
-class ModelRunner:
+class ModelRunner(ModelRunnerKVCacheMixin):
     """ModelRunner runs the forward passes of the models."""
 
     def __init__(
@@ -246,9 +352,17 @@ class ModelRunner:
         model_config: ModelConfig,
         mem_fraction_static: float,
         gpu_id: int,
-        ps: ParallelState,
+        tp_rank: int,
+        tp_size: int,
+        moe_ep_rank: int,
+        moe_ep_size: int,
+        pp_rank: int,
+        pp_size: int,
         nccl_port: int,
         server_args: ServerArgs,
+        dp_rank: Optional[int] = None,
+        attn_cp_rank: Optional[int] = None,
+        moe_dp_rank: Optional[int] = None,
         is_draft_worker: bool = False,
         req_to_token_pool: Optional[ReqToTokenPool] = None,
         token_to_kv_pool_allocator: Optional[BaseTokenToKVPoolAllocator] = None,
@@ -263,9 +377,20 @@ class ModelRunner:
         self.memory_pool_config = memory_pool_config
         self.device = server_args.device
         self.gpu_id = gpu_id
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
         self.dcp_size = server_args.dcp_size
-        self.dcp_rank = ps.tp_rank % self.dcp_size
-        self.ps = ps
+        self.dcp_rank = self.tp_rank % self.dcp_size
+        self.moe_ep_rank = moe_ep_rank
+        self.moe_ep_size = moe_ep_size
+        self.dp_rank = dp_rank
+        self.dp_size = server_args.dp_size if server_args.enable_dp_attention else 1
+        self.pp_rank = pp_rank
+        self.pp_size = pp_size
+        self.attn_cp_rank = attn_cp_rank
+        self.attn_cp_size = server_args.attn_cp_size
+        self.moe_dp_rank = moe_dp_rank
+        self.moe_dp_size = server_args.moe_dp_size
         self.model_config = model_config
         self.dist_port = nccl_port
         self.server_args = server_args
@@ -279,37 +404,130 @@ class ModelRunner:
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-        self.capture_tail_hooks = []
         self.page_size = server_args.page_size
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.is_hybrid_swa = model_config.is_hybrid_swa
-        self.is_hybrid_swa_compress = model_config.is_hybrid_swa_compress
+        self.is_hybrid_swa_compress = getattr(
+            model_config, "is_hybrid_swa_compress", False
+        )
         self.use_mla_backend = self.model_config.attention_arch == AttentionArch.MLA
         self.attention_chunk_size = model_config.attention_chunk_size
+        rope_scaling = getattr(
+            model_config.hf_text_config, "rope_parameters", None
+        ) or getattr(model_config.hf_text_config, "rope_scaling", {})
+        self.model_is_mrope = (
+            rope_scaling is not None and "mrope_section" in rope_scaling
+        )
         self.enable_elastic_ep = server_args.elastic_ep_backend is not None
         self.forward_pass_id = 0
-        self._pending_elastic_scale_update = None
         self.init_new_workspace = False
         self.draft_model_idx = draft_model_idx
         self.enable_hisparse = server_args.enable_hisparse
 
-        self.init_remote_instance_weight_transporter()
+        self.remote_instance_transfer_engine = None
+        self.remote_instance_transfer_engine_session_id = ""
+        self.remote_instance_transfer_engine_weight_info = None
 
-        self.init_msprobe()
+        self.msprobe_debugger = None
+        if server_args.msprobe_dump_config is not None:
+            self.init_msprobe()
 
         # auxiliary hidden capture mode. TODO: expose this to server args?
-        self.init_spec_aux_hidden_state()
+        self.eagle_use_aux_hidden_state = False
+        self.eagle_draft_num_layers = None
+        self.dflash_use_aux_hidden_state = False
+        self.dflash_target_layer_ids = None
+        self.dflash_draft_num_layers = None
+        if (
+            (self.spec_algorithm.is_eagle() or self.spec_algorithm.is_standalone())
+            and not self.is_draft_worker
+            and server_args.speculative_draft_model_path
+        ):
+            # Load draft config to get layer count for KV cache sizing
+            draft_model_config = self._build_model_config(
+                server_args,
+                model_path=server_args.speculative_draft_model_path,
+                model_revision=server_args.speculative_draft_model_revision,
+                is_draft_model=True,
+            )
+            num_nextn_predict_layers = draft_model_config.num_nextn_predict_layers
+            if num_nextn_predict_layers is not None:
+                self.eagle_draft_num_layers = int(num_nextn_predict_layers)
+            else:
+                self.eagle_draft_num_layers = int(
+                    max(
+                        draft_model_config.num_hidden_layers,
+                        draft_model_config.num_attention_layers,
+                    )
+                )
+
+            if self.spec_algorithm.is_eagle3():
+                self.eagle_use_aux_hidden_state = True
+                try:
+                    eagle_config = getattr(
+                        draft_model_config.hf_config, "eagle_config", None
+                    )
+                    self.eagle_use_aux_hidden_state = eagle_config.get(
+                        "use_aux_hidden_state", True
+                    )
+                    self.eagle_aux_hidden_state_layer_ids = eagle_config[
+                        "eagle_aux_hidden_state_layer_ids"
+                    ]
+                except:
+                    # if there is no aux layer, set to None
+                    self.eagle_aux_hidden_state_layer_ids = None
+
+        if self.spec_algorithm.is_dflash() and not self.is_draft_worker:
+            from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
+
+            # Select target layers to capture for building DFlash context features.
+            draft_model_config = self._build_model_config(
+                server_args,
+                model_path=(server_args.speculative_draft_model_path),
+                model_revision=server_args.speculative_draft_model_revision,
+                is_draft_model=True,
+            )
+            dflash_draft_config = parse_dflash_draft_config(
+                draft_hf_config=draft_model_config.hf_config
+            )
+            draft_num_layers = dflash_draft_config.require_num_layers()
+            trained_target_layers = dflash_draft_config.num_target_layers
+
+            target_num_layers = getattr(
+                self.model_config.hf_text_config, "num_hidden_layers", None
+            )
+            if target_num_layers is None:
+                raise ValueError(
+                    "DFLASH requires target num_hidden_layers in config. "
+                    f"Got target={target_num_layers}."
+                )
+            target_num_layers = int(target_num_layers)
+
+            if (
+                trained_target_layers is not None
+                and trained_target_layers != target_num_layers
+            ):
+                logger.warning(
+                    "DFLASH draft config num_target_layers=%s differs from runtime target num_hidden_layers=%s; "
+                    "selecting capture layers based on the runtime target model.",
+                    trained_target_layers,
+                    target_num_layers,
+                )
+
+            self.dflash_use_aux_hidden_state = True
+            self.dflash_draft_num_layers = int(draft_num_layers)
+            self.dflash_target_layer_ids = dflash_draft_config.resolve_target_layer_ids(
+                target_num_layers=int(target_num_layers),
+                draft_num_layers=int(draft_num_layers),
+            )
 
         # Apply the rank zero filter to logger
         if server_args.show_time_cost:
             enable_show_time_cost()
 
-        misc_utils.maybe_disable_chunked_prefix_cache(
-            server_args=server_args,
-            use_mla_backend=self.use_mla_backend,
-            is_draft_worker=self.is_draft_worker,
-        )
+        # Model-specific adjustment
+        self.model_specific_adjustment()
 
         # Set the global server_args in the scheduler process (target worker
         # only, so a draft init cannot clobber target-derived global state).
@@ -321,29 +539,15 @@ class ModelRunner:
             self.init_threads_binding()
 
         # Set float32 matmul precision
-        if get_server_args().enable_tf32_matmul:
+        if get_flags().enable_tf32_matmul:
             torch.set_float32_matmul_precision("high")
-
-        # Set device early so that TransferEngine init (e.g. Ascend NPU)
-        # can access the device context.
-        try:
-            torch.get_device_module(self.device).set_device(ps.gpu_id)
-        except Exception:
-            import os
-
-            logger.warning(
-                f"Context: {self.device=} {ps.gpu_id=} {os.environ.get('CUDA_VISIBLE_DEVICES')=} {ps.tp_rank=} {ps.tp_size=}"
-            )
-            raise
-
-        # Initialize MooncakeTransferEngine BEFORE init_torch_distributed so
-        # that the shared TE can be passed to the Mooncake PG backend (avoids
-        # creating duplicate TransferEngines).
-        self.init_shared_mooncake_transfer_engine()
 
         # Get available memory before model loading.
         # Stored for later use by alloc_memory_pool().
-        self.init_torch_distributed()
+        self.pre_model_load_memory = self.init_torch_distributed()
+
+        # Initialize MooncakeTransferEngine
+        self.init_shared_mooncake_transfer_engine()
 
         # Init forward stream for overlap schedule
         self.forward_stream = torch.get_device_module(self.device).Stream()
@@ -354,11 +558,9 @@ class ModelRunner:
         self.war_fastpath_read_done_event: Optional[torch.cuda.Event] = None
 
         # CPU offload
-        set_offloader(
-            create_offloader_from_server_args(server_args, dp_rank=self.ps.dp_rank)
-        )
+        set_offloader(create_offloader_from_server_args(server_args, dp_rank=dp_rank))
 
-        self._weight_checker = WeightChecker(get_model=lambda: self.model, ps=self.ps)
+        self._weight_checker = WeightChecker(model_runner=self)
 
         if envs.SGLANG_DETECT_SLOW_RANK.get():
             slow_rank_detector.execute()
@@ -373,11 +575,23 @@ class ModelRunner:
         # For hisparse (must be set before initialize() so CUDA graph capture can see it)
         self.hisparse_coordinator = None
 
+        self._linear_attn_registry_cache: Any = _UNSET
+
         # Load model weights and configure
         self.initialize()
         self.check_quantized_moe_compatibility()
 
-        self._initialize_elastic_ep_joiner()
+        if (
+            self.server_args.elastic_ep_backend is not None
+            and self.server_args.elastic_ep_rejoin
+        ):
+            join_process_groups()
+            broadcast_global_expert_location_metadata(
+                src_rank=self._get_healthy_expert_location_src_rank(
+                    invoked_in_elastic_ep_rejoin_path=True
+                )
+            )
+            ElasticEPStateManager.instance().reset()
 
         if self.is_multimodal:
             sanity_check_mm_pad_shift_value(self.model_config.vocab_size)
@@ -387,161 +601,38 @@ class ModelRunner:
             "pp_proxy_tensors" in inspect.signature(self.model.forward).parameters
         )
 
-        if self.ps.pp_size > 1:
+        if self.pp_size > 1:
             assert (
                 self.support_pp
             ), "Pipeline Parallel is not compatible with this model."
 
         # For weight updates
-        self.init_weight_updater()
-        self.init_weight_exporter()
+        self._model_update_group = {}
+        self._weights_send_group = {}
 
-    def _initialize_elastic_ep_joiner(self) -> None:
-        if not (
-            self.server_args.elastic_ep_backend is not None
-            and self.server_args.is_ep_scale_joiner
-        ):
-            return
-
-        join_effective_ep_size = self.server_args.ep_join_rank_offset + self.ps.tp_size
-        dist.barrier(group=self.tp_group.cpu_group)
-        if self.ps.tp_rank == 0:
-            register_scale_cohort(
-                self.server_args.ep_join_rank_offset,
-                join_effective_ep_size,
-            )
-        join_scale_process_group()
-        self.server_args.override(
-            "elastic_ep.scale_join", ep_size=join_effective_ep_size
+    def _build_model_config(
+        self, server_args, model_path=None, model_revision=None, is_draft_model=False
+    ):
+        return ModelConfig.from_server_args(
+            server_args,
+            model_path=model_path,
+            model_revision=model_revision,
+            is_draft_model=is_draft_model,
         )
-
-        global_ep_rank = self.ps.tp_rank + self.server_args.ep_join_rank_offset
-        broadcast_global_expert_location_metadata(
-            model_config=self.model_config,
-            moe_ep_rank=global_ep_rank,
-            src_rank=0,
-        )
-        set_global_expert_distribution_recorder(
-            ExpertDistributionRecorder.init_new(
-                self.server_args,
-                get_global_expert_location_metadata(),
-                rank=global_ep_rank,
-            )
-        )
-
-        from sglang.srt.layers.dp_attention import (
-            enable_joiner_all_gather,
-            update_dp_attention_post_scale,
-        )
-
-        enable_joiner_all_gather()
-        update_dp_attention_post_scale(
-            new_dp_size=join_effective_ep_size,
-            new_dp_rank=global_ep_rank,
-        )
-        self.server_args.override(
-            "elastic_ep.scale_join", dp_size=join_effective_ep_size
-        )
-        if self.eplb_manager is not None:
-            self.eplb_manager.disable_rebalance(
-                "EPLB rebalance is disabled after elastic EP scale-up"
-            )
-
-        state = ElasticEPStateManager.instance()
-        if state is not None:
-            state.active_ranks.zero_()
-            state.active_ranks[:join_effective_ep_size] = 1
-            state.snapshot_active_to_last()
-            state.sync_active_to_cpu()
-            state.scale_phase = "syncing_new_world"
-        self._elastic_scale_ready_barrier(
-            target_size=join_effective_ep_size,
-            log_tag="JOINER",
-        )
-        if state is not None:
-            state.scale_phase = "serving_expanded"
 
     def init_msprobe(self):
-        self.msprobe_debugger = misc_utils.create_msprobe_debugger(self.server_args)
-
-    def init_weight_updater(self):
-        self.weight_updater = WeightUpdater(
-            tp_rank=self.ps.tp_rank,
-            device=self.device,
-            gpu_id=self.gpu_id,
-            model_config=self.model_config,
-            custom_weight_loaders=self.server_args.custom_weight_loader,
-            get_model=lambda: self.model,
-            update_model_fields=self.update_model_fields,
-            recapture_cuda_graph=self.init_decode_cuda_graph,
-            get_model_runner=lambda: self,
-        )
-
-    def init_spec_aux_hidden_state(self):
-        self.spec_aux_config: SpecAuxHiddenStateConfig = (
-            resolve_spec_aux_hidden_state_config(
-                server_args=self.server_args,
-                model_config=self.model_config,
-                spec_algorithm=self.spec_algorithm,
-                is_draft_worker=self.is_draft_worker,
+        # Init the msprobe
+        try:
+            from msprobe.pytorch import PrecisionDebugger, seed_all
+        except ImportError:
+            logger.warning(
+                "Please install msprobe for tensor data dump: pip install mindstudio-probe --pre, "
+                "see https://gitcode.com/Ascend/msprobe for details."
             )
-        )
-
-    def init_weight_exporter(self):
-        self.weight_exporter = WeightExporter(
-            tp_rank=self.ps.tp_rank,
-            tp_size=self.ps.tp_size,
-            gpu_id=self.gpu_id,
-            get_model_path=lambda: self.model_config.model_path,
-            get_model=lambda: self.model,
-        )
-
-    def init_remote_instance_weight_transporter(self):
-        self.remote_instance_weight_transporter = RemoteInstanceWeightTransporter(
-            server_args=self.server_args,
-            get_model=lambda: self.model,
-            tp_rank=self.ps.tp_rank,
-            gpu_id=self.gpu_id,
-        )
-
-    def init_ngram_embedding_manager(self):
-        self.ngram_embedding_manager = NgramEmbeddingManager.from_model(
-            model=self.model,
-            model_config=self.model_config,
-            req_to_token_pool=self.req_to_token_pool,
-            server_args=self.server_args,
-            max_running_requests=self.max_running_requests,
-            device=self.device,
-        )
-
-    def init_kv_cache_configurator(self):
-        self.kv_cache_configurator = KVCacheConfigurator(
-            device=self.device,
-            gpu_id=self.gpu_id,
-            ps=self.ps,
-            pp_group=self.pp_group,
-            model=self.model,
-            model_config=self.model_config,
-            server_args=self.server_args,
-            kv_cache_dtype=self.kv_cache_dtype,
-            model_dtype=self.dtype,
-            page_size=self.page_size,
-            sliding_window_size=self.sliding_window_size,
-            spec_algorithm=self.spec_algorithm,
-            is_draft_worker=self.is_draft_worker,
-            post_capture_kv_active=is_post_capture_kv_active(
-                server_args=self.server_args, is_draft_worker=self.is_draft_worker
-            ),
-            spec_aux_config=self.spec_aux_config,
-            is_hybrid_swa=self.is_hybrid_swa,
-            is_hybrid_swa_compress=self.is_hybrid_swa_compress,
-            use_mla_backend=self.use_mla_backend,
-            layer_info=self.layer_info,
-            forward_stream=self.forward_stream,
-            req_to_token_pool=self.req_to_token_pool,
-            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-            memory_pool_config=self.memory_pool_config,
-            draft_model_idx=self.draft_model_idx,
+            return
+        seed_all(mode=True)
+        self.msprobe_debugger = PrecisionDebugger(
+            config_path=self.server_args.msprobe_dump_config
         )
 
     def init_mindspore_runner(self):
@@ -551,132 +642,74 @@ class ModelRunner:
             from sglang.srt.model_executor.mindspore_runner import init_ms_distributed
 
             init_ms_distributed(
-                world_size=self.ps.tp_size * self.ps.pp_size,
-                rank=self.ps.tp_size * self.ps.pp_rank + self.ps.tp_rank,
+                world_size=self.tp_size * self.pp_size,
+                rank=self.tp_size * self.pp_rank + self.tp_rank,
                 local_rank=self.gpu_id,
                 server_args=self.server_args,
                 port=self.dist_port,
             )
 
     def initialize(self):
-        self.init_memory_saver_adapter()
-        self.maybe_init_remote_instance_transfer_engine()
-        self.maybe_init_expert_location_metadata()
-        self.maybe_init_lplb_solvers()
-        self.maybe_init_eplb_manager()
-        self.expert_location_updater = ExpertLocationUpdater()
-        self.maybe_init_elastic_ep()
-        self.init_token_oracle()
-        self.sampler = create_sampler()
-        self.load_model()
-        prepare_moe_topk(
-            model=self.model,
-            model_config=self.model_config,
-            server_args=self.server_args,
-            moe_ep_size=self.ps.moe_ep_size,
-            moe_ep_rank=self.ps.moe_ep_rank,
+        server_args = self.server_args
+
+        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
+            enable=self.server_args.enable_memory_saver
         )
 
-        self.maybe_init_dwdp()
+        if self.server_args.remote_instance_weight_loader_use_transfer_engine():
+            self.remote_instance_init_transfer_engine()
+
+        if not self.is_draft_worker:
+            set_global_expert_location_metadata(
+                compute_initial_expert_location_metadata(
+                    server_args=server_args,
+                    model_config=self.model_config,
+                    moe_ep_rank=self.moe_ep_rank,
+                )
+            )
+            if self.tp_rank == 0 and envs.SGLANG_LOG_EXPERT_LOCATION_METADATA.get():
+                logger.info(
+                    f"Initial expert_location_metadata: {get_global_expert_location_metadata()}"
+                )
+
+            set_global_expert_distribution_recorder(
+                ExpertDistributionRecorder.init_new(
+                    server_args,
+                    get_global_expert_location_metadata(),
+                    rank=self.tp_rank,
+                )
+            )
+
+        if self.server_args.ep_dispatch_algorithm == "lp" and not self.is_draft_worker:
+            self._init_lplb_solvers()
+
+        # Expert parallelism
+        self.eplb_manager = (
+            EPLBManager(self)
+            if self.server_args.enable_eplb and (not self.is_draft_worker)
+            else None
+        )
+        self.expert_location_updater = ExpertLocationUpdater()
+
+        if self.server_args.elastic_ep_backend:
+            ElasticEPStateManager.init(self.server_args)
+        self._token_oracle_manager = install_token_oracle_from_env(
+            server_args=server_args,
+            vocab_size=self.model_config.vocab_size,
+        )
+        # Load the model
+        self.sampler = create_sampler()
+        self.load_model()
+        self._prepare_moe_topk()
 
         # Must run before backend/graph init so no draft graph records a
         # routed-experts capture-write kernel.
         if self.is_draft_worker:
             disable_routed_experts_capture_for_draft(self.model)
-        self.maybe_init_expert_backup_client()
-        self.remote_instance_weight_transporter.maybe_register_and_publish_weight_info()
-        self.layer_info: ModelLayerInfo = resolve_layer_indices(
-            model=self.model,
-            model_config=self.model_config,
-            is_draft_worker=self.is_draft_worker,
-            spec_algorithm=self.spec_algorithm,
-        )
-        adjust_hybrid_swa_layer_ids(
-            model_config=self.model_config,
-            start_layer=self.layer_info.start_layer,
-            end_layer=self.layer_info.end_layer,
-            is_hybrid_swa=self.is_hybrid_swa,
-        )
-        self.maybe_apply_post_load_model_transforms()
-        self.maybe_init_lora_manager()
-        self.maybe_enable_batch_invariant_mode()
-        self.configure_kv_cache_dtype()
 
-    def init_memory_saver_adapter(self):
-        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
-            enable=self.server_args.enable_memory_saver
-        )
-
-    def maybe_init_remote_instance_transfer_engine(self):
-        if self.server_args.remote_instance_weight_loader_use_transfer_engine():
-            self.remote_instance_weight_transporter.init_engine()
-
-    def maybe_init_expert_location_metadata(self):
-        if self.is_draft_worker:
-            return
-        expert_rank = self.ps.moe_ep_rank + (
-            self.server_args.ep_join_rank_offset
-            if self.server_args.is_ep_scale_joiner
-            else 0
-        )
-        set_global_expert_location_metadata(
-            compute_initial_expert_location_metadata(
-                server_args=self.server_args,
-                model_config=self.model_config,
-                moe_ep_rank=expert_rank,
-            )
-        )
-        if self.ps.tp_rank == 0 and envs.SGLANG_LOG_EXPERT_LOCATION_METADATA.get():
-            logger.info(
-                "Initial expert_location_metadata:\n%s",
-                format_expert_location_layout(get_global_expert_location_metadata()),
-            )
-        set_global_expert_distribution_recorder(
-            ExpertDistributionRecorder.init_new(
-                self.server_args,
-                get_global_expert_location_metadata(),
-                rank=expert_rank,
-            )
-        )
-
-    def maybe_init_lplb_solvers(self):
-        if self.server_args.ep_dispatch_algorithm == "lp" and not self.is_draft_worker:
-            init_lplb_solvers(model_config=self.model_config)
-
-    def maybe_init_eplb_manager(self):
-        self.eplb_manager = (
-            EPLBManager(
-                server_args=self.server_args,
-                model_config=self.model_config,
-                ps=self.ps,
-                get_model=lambda: self.model,
-                get_expert_location_updater=lambda: self.expert_location_updater,
-                get_expert_backup_client=lambda: self.expert_backup_client,
-                get_weight_updater=lambda: self.weight_updater,
-            )
-            if self.server_args.enable_eplb and (not self.is_draft_worker)
-            else None
-        )
-
-    def maybe_init_elastic_ep(self):
-        if self.server_args.elastic_ep_backend:
-            ElasticEPStateManager.init(self.server_args)
-
-    def init_token_oracle(self):
-        self._token_oracle_manager = install_token_oracle_from_env(
-            server_args=self.server_args,
-            vocab_size=self.model_config.vocab_size,
-        )
-
-    def maybe_init_expert_backup_client(self):
+        # Load the expert backup client
         self.expert_backup_client = (
-            ExpertBackupClient(
-                server_args=self.server_args,
-                model_config=self.model_config,
-                moe_ep_size=self.ps.moe_ep_size,
-                moe_ep_rank=self.ps.moe_ep_rank,
-                get_model=lambda: self.model,
-            )
+            ExpertBackupClient(self.server_args, self)
             if (
                 self.server_args.enable_elastic_expert_backup
                 and self.server_args.elastic_ep_backend is not None
@@ -684,80 +717,134 @@ class ModelRunner:
             else None
         )
 
-    def maybe_apply_post_load_model_transforms(self):
-        # In layered loading, torchao may have been applied
+        if (
+            self.server_args.remote_instance_weight_loader_use_transfer_engine()
+            # ModelExpress owns TransferEngine memory registration and metadata
+            # publishing for backend=modelexpress. Re-registering here would
+            # overlap the same weight buffers.
+            and self.server_args.remote_instance_weight_loader_backend
+            != RemoteInstanceWeightLoaderBackend.MODELEXPRESS
+            and self.remote_instance_transfer_engine is not None
+            and self.remote_instance_transfer_engine_weight_info is None
+        ):
+            # Register memory and upstream the transfer engine info to the bootstrap server
+            self.remote_instance_transfer_engine_weight_info = register_memory_region(
+                self.model, self.remote_instance_transfer_engine
+            )
+            self._register_to_engine_info_bootstrap()
+
+        # For MTP models like DeepSeek-V3 or GLM-4.5, the MTP layer(s) are used separately as draft
+        # models for speculative decoding. In those cases, `num_nextn_predict_layers` is used to
+        # determine the number of layers.
+        # Some EAGLE3 drafts (e.g. nvidia/Kimi-K2.5-Thinking-Eagle3) carry the full DeepSeek-V3
+        # config schema and explicitly set `num_nextn_predict_layers: 0`. Treat that the same as
+        # the field being absent — otherwise the draft worker takes the MTP branch below with
+        # model_num_layers=0, sizing the draft KV pool to zero and producing an IndexError on
+        # the first forward (`set_mla_kv_buffer` -> `self.kv_buffer[layer_id - self.start_layer]`).
+        _nnpl = self.model_config.num_nextn_predict_layers
+        model_has_mtp_layers = _nnpl is not None and _nnpl > 0
+        model_num_layers = (
+            self.model_config.num_nextn_predict_layers
+            if self.is_draft_worker and model_has_mtp_layers
+            else max(
+                self.model_config.num_hidden_layers,
+                self.model_config.num_attention_layers,
+            )
+        )
+        if self.model_config.hf_config.architectures[0] == "MiMoV2MTP":
+            model_num_layers = 1
+        elif self.model_config.hf_config.architectures[0] == "Step3p5MTP":
+            model_num_layers = 1
+        self.start_layer = getattr(self.model, "start_layer", 0)
+        self.end_layer = getattr(self.model, "end_layer", model_num_layers)
+        self.num_effective_layers = self.end_layer - self.start_layer
+
+        self.adjust_hybrid_swa_layers_for_pp()
+
+        # For LoopCoder models, each loop has its own layer_id, so we need to multiply by loop_num
+        loop_num = getattr(self.model_config.hf_config, "loop_num", 1)
+        if loop_num > 1:
+            self.num_effective_layers = self.num_effective_layers * loop_num
+
+        assert (
+            (not model_has_mtp_layers)
+            or (self.spec_algorithm.is_none())
+            or (
+                (not self.spec_algorithm.is_none())
+                and (self.num_effective_layers == model_num_layers)
+            )
+        ), "PP is not compatible with MTP models."
+
+        # Apply torchao quantization
         torchao_applied = getattr(self.model, "torchao_applied", False)
+        # In layered loading, torchao may have been applied
         if not torchao_applied:
-            apply_torchao_config_to_model(self.model, get_server_args().torchao_config)
+            apply_torchao_config_to_model(
+                self.model, get_global_server_args().torchao_config
+            )
+
+        # Apply torch TP if the model supports it
         supports_torch_tp = getattr(self.model, "supports_torch_tp", False)
-        if self.ps.tp_size > 1 and supports_torch_tp:
+        if self.tp_size > 1 and supports_torch_tp:
             self.apply_torch_tp()
 
-    def maybe_init_lora_manager(self):
-        if self.server_args.enable_lora:
+        # Init lora
+        if server_args.enable_lora:
             self.init_lora_manager()
+            if not cuda_graph_fully_disabled():
+                # Phase 1 of LoRA CUDA graph init: pre-allocate large MoE
+                # intermediate buffers before init_memory_pool() so memory
+                # profiling accounts for them. The buffers are reused by
+                # any captured graph (decode today; widen here so any
+                # future prefill capture path also picks them up).
+                self._init_lora_cuda_graph_moe_buffers()
 
-    def maybe_enable_batch_invariant_mode(self):
-        if self.server_args.enable_deterministic_inference:
+        # Enable batch invariant mode
+        if server_args.enable_deterministic_inference:
             from sglang.srt.batch_invariant_ops import enable_batch_invariant_mode
 
             enable_batch_invariant_mode()
 
-    def get_pp_proxy_topk_size(self) -> Optional[int]:
-        return misc_utils.resolve_pp_proxy_topk_size(
-            model_config=self.model_config,
-            pp_size=self.ps.pp_size,
-            pp_rank=self.ps.pp_rank,
-            start_layer=self.layer_info.start_layer,
-        )
+        # Deduce KV cache dtype
+        self.configure_kv_cache_dtype()
 
-    def decode_num_tokens_per_req(
+    def get_pp_proxy_topk_size(self) -> Optional[int]:
+        hf_config = self.model_config.hf_text_config
+        if (
+            self.pp_size <= 1
+            or self.pp_rank == 0
+            or not is_deepseek_dsa(hf_config)
+            or not dsa_layer_skips_topk(hf_config, self.start_layer)
+        ):
+            return None
+        return getattr(hf_config, "index_topk", None)
+
+    def decode_num_tokens_per_bs(
         self, *, num_draft_tokens: Optional[int] = None
     ) -> int:
         """Logits rows per decode batch slot."""
         if self.spec_algorithm.is_speculative():
-            return resolve_num_tokens_per_req(
-                phase="target_verify",
-                server_args=self.server_args,
-                spec_algorithm=self.spec_algorithm,
-                is_draft_worker=self.is_draft_worker,
-                num_draft_tokens=num_draft_tokens,
+            if num_draft_tokens is None:
+                num_draft_tokens = self.server_args.speculative_num_draft_tokens
+            return self.spec_algorithm.get_num_tokens_per_bs_for_target_verify(
+                num_draft_tokens, self.is_draft_worker
             )
         dllm_config = DllmConfig.from_server_args(self.server_args)
         return dllm_config.block_size if dllm_config is not None else 1
 
     def max_decode_logits_rows(self) -> int:
         """Rows the shared logits buffer needs."""
-        num_tokens_per_req = self.decode_num_tokens_per_req()
-        capture_bs, _ = get_batch_sizes_to_capture(self, num_tokens_per_req)
-        return max(capture_bs) * num_tokens_per_req
+        num_tokens_per_bs = self.decode_num_tokens_per_bs()
+        capture_bs, _ = get_batch_sizes_to_capture(self, num_tokens_per_bs)
+        return max(capture_bs) * num_tokens_per_bs
 
     def alloc_memory_pool(self, memory_pool_config: Optional[MemoryPoolConfig] = None):
         """Allocate KV cache memory pools only (no backends or cuda graphs)."""
         if memory_pool_config is not None:
             self.memory_pool_config = memory_pool_config
 
-        self.init_kv_cache_configurator()
-        result = self.kv_cache_configurator.configure(
-            pre_model_load_memory=self.pre_model_load_memory
-        )
-        self.max_total_num_tokens = result.max_total_num_tokens
-        self.max_running_requests = result.max_running_requests
-        self.req_to_token_pool = result.req_to_token_pool
-        self.token_to_kv_pool = result.token_to_kv_pool
-        self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
-        self.memory_pool_config = result.memory_pool_config
-        if self.is_hybrid_swa:
-            self.full_max_total_num_tokens = result.full_max_total_num_tokens
-            self.swa_max_total_num_tokens = result.swa_max_total_num_tokens
-        # Keep a reference so the shared byte buffer is not GC'd.
-        self._unified_memory_pool = result.unified_memory_pool
+        self.init_memory_pool(self.pre_model_load_memory)
 
-        self._init_post_memory_pool_components()
-
-    def _init_post_memory_pool_components(self):
-        """Post-pool component wiring, split out of alloc_memory_pool so forks
-        that build bespoke memory pools can reuse it after allocating them."""
         # Must be called AFTER init_memory_pool so the pool object exists for
         # canary to monkey-patch, and BEFORE init_decode_cuda_graph so warmup
         # forwards captured into the graph see the patched pool methods.
@@ -768,152 +855,140 @@ class ModelRunner:
         )
 
         # Init ngram embedding token table
-        self.init_ngram_embedding_manager()
+        self.maybe_init_ngram_embedding()
 
-        self.maybe_init_hisparse_coordinator()
+        if self.enable_hisparse:
+            from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+            from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+            hisparse_cfg = parse_hisparse_config(self.server_args)
+            hisparse_top_k = getattr(
+                self.model_config.hf_text_config, "index_topk", hisparse_cfg.top_k
+            )
+            self.hisparse_coordinator = HiSparseCoordinator(
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                top_k=hisparse_top_k,
+                device_buffer_size=hisparse_cfg.device_buffer_size,
+                device=self.device,
+                tp_group=(
+                    self.attention_tp_group.cpu_group
+                    if self.server_args.enable_dp_attention
+                    else self.tp_group.cpu_group
+                ),
+                host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
+                swap_in_block_size=hisparse_cfg.swap_in_block_size,
+            )
 
         self.init_routed_experts_capturer()
         self.init_indexer_capturer()
 
+        self.attn_backend = None
+        self.decode_attn_backend = None
+        self.decode_attn_backend_group = []
+        self.decode_cuda_graph_runner = None
+        self.graph_mem_usage = 0
+        self.prefill_cuda_graph_runner = None
         self.graph_shared_output = None
-
-    def maybe_init_hisparse_coordinator(self):
-        if not self.enable_hisparse:
-            return
-        from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
-        from sglang.srt.mem_cache.sparsity import parse_hisparse_config
-
-        hisparse_cfg = parse_hisparse_config(self.server_args)
-        hisparse_top_k = getattr(
-            self.model_config.hf_text_config, "index_topk", hisparse_cfg.top_k
-        )
-        self.hisparse_coordinator = HiSparseCoordinator(
-            req_to_token_pool=self.req_to_token_pool,
-            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-            top_k=hisparse_top_k,
-            device_buffer_size=hisparse_cfg.device_buffer_size,
-            device=self.device,
-            tp_group=(
-                self.attention_tp_group.cpu_group
-                if self.server_args.enable_dp_attention
-                else self.tp_group.cpu_group
-            ),
-            host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
-            swap_in_block_size=hisparse_cfg.swap_in_block_size,
-        )
-
-    def post_capture_resize_kv_pool(self):
-        resize = compute_post_capture_kv_resize(self)
-        self.max_total_num_tokens = resize.max_total_num_tokens
-        if self.is_hybrid_swa:
-            self.full_max_total_num_tokens = resize.full_max_total_num_tokens
-            self.swa_max_total_num_tokens = resize.swa_max_total_num_tokens
-        if self.memory_pool_config is not None:
-            self.memory_pool_config.max_total_num_tokens = resize.max_total_num_tokens
-            self.memory_pool_config.full_max_total_num_tokens = (
-                resize.full_max_total_num_tokens
-            )
-            self.memory_pool_config.swa_max_total_num_tokens = (
-                resize.swa_max_total_num_tokens
-            )
-        if resize.capped_max_running_requests is not None:
-            self.max_running_requests = resize.capped_max_running_requests
-            if self.memory_pool_config is not None:
-                self.memory_pool_config.max_running_requests = (
-                    resize.capped_max_running_requests
-                )
-
-    def post_capture_elastic_ep_recover(self):
-        join_process_groups()
-
-        global_ep_rank = self.ps.tp_rank + self.server_args.ep_join_rank_offset
-        broadcast_global_expert_location_metadata(
-            model_config=self.model_config,
-            moe_ep_rank=global_ep_rank,
-            src_rank=get_healthy_expert_location_src_rank(
-                invoked_in_elastic_ep_rejoin_path=True
-            ),
-        )
-        set_global_expert_distribution_recorder(
-            ExpertDistributionRecorder.init_new(
-                self.server_args,
-                get_global_expert_location_metadata(),
-                rank=global_ep_rank,
-            )
-        )
-
-        ElasticEPStateManager.instance().reset()
 
     def init_attention_backends(self):
         """Initialize attention backends only (no cuda graph capture)."""
+        # TODO: Refactor device-specific init branches into platform interface (separate PR).
         # Must be called BEFORE init_decode_cuda_graph() so CUDA graph capture
         # runs with aux hidden state capture enabled.
-        configure_aux_hidden_state_capture(
-            model=self.model,
-            eagle_use_aux_hidden_state=self.spec_aux_config.eagle_use_aux_hidden_state,
-            eagle_aux_hidden_state_layer_ids=self.spec_aux_config.eagle_aux_hidden_state_layer_ids,
-            dflash_use_aux_hidden_state=self.spec_aux_config.dflash_use_aux_hidden_state,
-            dflash_target_layer_ids=self.spec_aux_config.dflash_target_layer_ids,
-            is_dspark=self.spec_algorithm.is_dspark(),
-        )
-        backends = build_attention_backends(model_runner=self)
-        self.attn_backend = backends.attn_backend
-        self.decode_attn_backend = backends.decode_attn_backend
-        self.decode_attn_backend_group = backends.decode_attn_backend_group
-        self.prefill_attention_backend_str = backends.prefill_attention_backend_str
-        self.decode_attention_backend_str = backends.decode_attention_backend_str
+        self.init_aux_hidden_state_capture()
 
-        if self.server_args.dcp_size > 1 and self.server_args.dcp_replicate_q_proj:
-            self._prepare_replicated_q_proj()
+        if self.device == "cuda" or self.device == "musa":
+            self.init_cublas()
+            self.init_attention_backend()
+        elif self.device in ["cpu", "xpu"]:
+            self.init_attention_backend()
+        elif self.device == "npu":
+            self.init_attention_backend()
+            # lazy init for zbal with mix mode (before graph capture when enable_cuda_graph)
+            if envs.SGLANG_ZBAL_LOCAL_MEM_SIZE.get() > 0 and not self.is_draft_worker:
+                from sglang.srt.hardware_backend.npu.utils import lazy_init_zbal_gva_mem
 
-    def _prepare_replicated_q_proj(self) -> None:
-        # --dcp-replicate-q-proj: gather each rank's attn_tp head-shard of
-        # q_b_proj / w_kc into full-head buffers once here (pre-capture) so the
-        # MLA decode path can skip the per-layer Q all-gather. bf16/fp16 only.
-        from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
-        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
-
-        dcp_group = get_parallel().dcp_group
-        if dcp_group.world_size <= 1:
-            return
-        n_prepared = 0
-        for m in self.model.modules():
-            if not isinstance(m, DeepseekV2AttentionMLA):
-                continue
-            if m.w_kc is None:
-                continue
-            qp = m.q_b_proj if m.has_q_b_proj else m.q_proj
-            # q-replicate only supports the unquantized bf16/fp16 absorb path;
-            # quantized q-proj (packed weights) and non-16-bit w_kc keep the
-            # per-layer Q all-gather.
-            if (
-                m.w_kc.dtype not in (torch.bfloat16, torch.float16)
-                or not isinstance(qp.quant_method, UnquantizedLinearMethod)
-                or qp.weight.dtype not in (torch.bfloat16, torch.float16)
-            ):
-                logger.warning(
-                    "dcp_replicate_q_proj: skipping quantized q-proj/w_kc "
-                    "(bf16/fp16 only); this layer keeps the Q all-gather."
+                lazy_init_zbal_gva_mem(
+                    self.device,
+                    self.gpu_id,
+                    get_world_group().rank_in_group,
+                    get_world_group().world_size,
+                    get_world_group().cpu_group,
                 )
-                continue
-            m.w_kc_qrep = dcp_group.all_gather(m.w_kc.contiguous(), dim=0)
-            m.q_b_proj_qrep_weight = dcp_group.all_gather(
-                qp.weight.data.contiguous(), dim=0
-            )
-            n_prepared += 1
-        logger.info(
-            "dcp_replicate_q_proj: prepared full-head Q weights for %d MLA layers",
-            n_prepared,
-        )
+        else:
+            self.init_attention_backend()
 
     def init_cuda_graphs(self, capture_decode_cuda_graph: bool = True):
-        capture = capture_cuda_graphs(
-            model_runner=self, capture_decode_cuda_graph=capture_decode_cuda_graph
-        )
-        self.eager_runner = capture.eager_runner
-        self.prefill_cuda_graph_runner = capture.prefill_runner
-        self.decode_cuda_graph_runner = capture.decode.runner
-        self.graph_mem_usage = capture.decode.graph_mem_usage
+        """Capture cuda graphs. Requires init_attention_backends() to have run.
+
+        Spec draft runners pass capture_decode_cuda_graph=False
+        because they capture their own decode-style graphs separately.
+        """
+
+        self.graph_shared_output = GraphSharedOutput.create_for_model_runner(self)
+
+        # The eager (no-cuda-graph) phase runner, built AFTER the attention
+        # backend so its __init__ can warm up kernels (run-once) and allocate the
+        # fixed-max static buffer — both before the cuda-graph runners, so that
+        # buffer is canonical in the shared pool and the cg runners coalesce onto
+        # it. Always built: it serves both the fully-disabled case (decode/prefill
+        # runners point at it) and the eager fallback when a cg runner can't run a
+        # batch.
+        self.eager_runner = EagerRunner(self)
+
+        # cuda-graph capture: prefill before decode, so both coalesce onto the
+        # eager buffer allocated above. (init_prefill_cuda_graph routes prefill
+        # to the eager runner when the prefill graph is disabled.)
+        self.init_prefill_cuda_graph()
+
+        self.decode_cuda_graph_runner = None
+        self.graph_mem_usage = 0
+
+        if capture_decode_cuda_graph:
+            if self.device in ("cuda", "musa", "cpu", "npu", "xpu"):
+                self.init_decode_cuda_graph()
+            elif (
+                current_platform.is_out_of_tree()
+                and current_platform.support_cuda_graph()
+            ):
+                self.init_decode_cuda_graph()
+        else:
+            self.decode_cuda_graph_runner = self.eager_runner
+
+        # Register forward hooks AFTER cuda-graph capture so their tensor ops are
+        # not traced into any captured graph — capture stays hook-free and hooks
+        # fire only on the eager forward path (capture replay never runs Python
+        # hooks anyway).
+        if self.server_args.forward_hooks:
+            register_forward_hooks(self.model, self.server_args.forward_hooks)
+
+        self.prealloc_symmetric_memory_pool()
+
+        if self.canary_manager is not None and not self.is_draft_worker:
+            self.canary_manager.mark_init_finished()
+
+    def adjust_hybrid_swa_layers_for_pp(self):
+        if not self.is_hybrid_swa:
+            return
+
+        if self.model_config.is_deepseek_v4_arch:
+            return
+
+        full_attention_layer_ids = [
+            layer_idx
+            for layer_idx in range(self.start_layer, self.end_layer + 1)
+            if hasattr(self.model_config, "full_attention_layer_ids")
+            and layer_idx in self.model_config.full_attention_layer_ids
+        ]
+        swa_attention_layer_ids = [
+            layer_idx
+            for layer_idx in range(self.start_layer, self.end_layer + 1)
+            if hasattr(self.model_config, "swa_attention_layer_ids")
+            and layer_idx in self.model_config.swa_attention_layer_ids
+        ]
+        self.model_config.swa_attention_layer_ids = swa_attention_layer_ids
+        self.model_config.full_attention_layer_ids = full_attention_layer_ids
 
     def init_routed_experts_capturer(self):
         if self.is_draft_worker:
@@ -922,10 +997,18 @@ class ModelRunner:
             # would overwrite the target's process-global one.
             return
 
+        if not self.server_args.disable_shared_experts_fusion and hasattr(
+            self.model, "num_fused_shared_experts"
+        ):
+            num_fused_shared_experts = self.model.num_fused_shared_experts
+        else:
+            num_fused_shared_experts = 0
+
         set_global_experts_capturer(
             RoutedExpertsCapturer.create(
-                model=self.model,
+                enable=get_global_server_args().enable_return_routed_experts,
                 model_config=self.model_config,
+                num_fused_shared_experts=num_fused_shared_experts,
                 num_tokens=self.max_total_num_tokens + self.page_size,
                 max_running_requests=self.max_running_requests,
                 device=self.device,
@@ -933,42 +1016,408 @@ class ModelRunner:
         )
 
     def init_indexer_capturer(self):
+        enable = get_global_server_args().enable_return_indexer_topk
+        # Producer wiring is CUDA-only (Indexer.forward_cuda + MLA skip_topk
+        # path); other backends would create a capturer but never feed it.
+        if enable and self.device != "cuda":
+            logger.warning(
+                "indexer-topk capture is CUDA-only; %s backend not yet wired. "
+                "Disabling capturer.",
+                self.device,
+            )
+            set_global_indexer_capturer(None)
+            return
+
+        hf_text_config = self.model_config.hf_text_config
+        num_indexer_layers = get_num_indexer_layers(hf_text_config)
+        index_topk = getattr(hf_text_config, "index_topk", 0)
         set_global_indexer_capturer(
             create_indexer_capturer(
-                model_config=self.model_config,
+                enable=enable,
+                num_indexer_layers=num_indexer_layers,
+                index_topk=index_topk,
                 num_tokens=self.max_total_num_tokens + self.page_size,
                 max_running_requests=self.max_running_requests,
                 device=self.device,
             )
         )
 
-    def check_quantized_moe_compatibility(self):
-        check_quantized_moe_compatibility(
-            model_config=self.model_config,
-            tp_size=self.ps.tp_size,
-            moe_ep_size=self.ps.moe_ep_size,
-            moe_dp_size=self.ps.moe_dp_size,
+    def init_aux_hidden_state_capture(self):
+        """Configure auxiliary hidden state capture for speculative decoding.
+
+        Must be called before CUDA graph capture so the captured graphs
+        include aux hidden state output paths.
+        """
+        if self.eagle_use_aux_hidden_state:
+            self.model.set_eagle3_layers_to_capture(
+                self.eagle_aux_hidden_state_layer_ids
+            )
+        if self.dflash_use_aux_hidden_state:
+            if not hasattr(self.model, "set_dflash_layers_to_capture"):
+                raise ValueError(
+                    f"Model {self.model.__class__.__name__} does not implement "
+                    "set_dflash_layers_to_capture, which is required for DFLASH."
+                )
+            self.model.set_dflash_layers_to_capture(self.dflash_target_layer_ids)
+
+    def remote_instance_init_transfer_engine(self):
+        try:
+            from mooncake.engine import TransferEngine
+        except ImportError:
+            logger.warning(
+                "Please install mooncake for using remote instance transfer engine: pip install mooncake-transfer-engine"
+            )
+            return
+        self.remote_instance_transfer_engine = TransferEngine()
+        local_ip = get_local_ip_auto()
+        self.remote_instance_transfer_engine.initialize(
+            local_ip,
+            "P2PHANDSHAKE",
+            envs.MOONCAKE_PROTOCOL.get(),
+            envs.MOONCAKE_DEVICE.get(),
         )
+        self.remote_instance_transfer_engine_session_id = NetworkAddress(
+            local_ip, self.remote_instance_transfer_engine.get_rpc_port()
+        ).to_host_port_str()
+
+    def _register_to_engine_info_bootstrap(self):
+        """Register transfer engine info with the EngineInfoBootstrapServer via HTTP PUT.
+
+        The bootstrap server runs on node_rank==0. For multi-node setups, the
+        host is derived from dist_init_addr. For single-node, use 127.0.0.1.
+        """
+        import requests as http_requests
+
+        if self.server_args.dist_init_addr:
+            # Multi-node: bootstrap server is on the head node (node_rank==0).
+            # Derive host from dist_init_addr (shared across all nodes).
+            bootstrap_host = (
+                NetworkAddress.parse(self.server_args.dist_init_addr).resolved().host
+            )
+        else:
+            bootstrap_host = "127.0.0.1"
+
+        bootstrap_port = self.server_args.engine_info_bootstrap_port
+        bootstrap_na = NetworkAddress(bootstrap_host, bootstrap_port)
+        url = f"{bootstrap_na.to_url()}/register_transfer_engine_info"
+
+        payload = {
+            "tp_rank": self.tp_rank,
+            "transfer_engine_info": {
+                "session_id": self.remote_instance_transfer_engine_session_id,
+                "weights_info_dict": self.remote_instance_transfer_engine_weight_info,
+            },
+        }
+
+        try:
+            resp = http_requests.put(url, json=payload, timeout=5)
+            if resp.status_code == 200:
+                logger.info(
+                    f"Registered transfer engine info for tp_rank={self.tp_rank} "
+                    f"with bootstrap server at {bootstrap_na}"
+                )
+            else:
+                logger.error(
+                    f"Failed to register transfer engine info for tp_rank={self.tp_rank}: "
+                    f"{resp.status_code}, {resp.text}"
+                )
+        except Exception as e:
+            logger.error(
+                f"Failed to register transfer engine info for tp_rank={self.tp_rank}: {e}"
+            )
+
+    def model_specific_adjustment(self):
+        if self.is_draft_worker:
+            return
+
+        server_args = self.server_args
+
+        # HRM-Text needs bidirectional prompt attention (prefill), which only the
+        # Triton backend honors and only with cuda graph / chunked prefill off
+        # (TritonAttnBackend.allow_bidirectional_attention_in_extend). Radix cache
+        # is also unsafe: the recurrent forward writes direction-dependent KV
+        # across many slots.
+        hf_config = self.model_config.hf_config
+        is_hrm_text = getattr(
+            hf_config, "model_type", None
+        ) == "hrm_text" or "HrmTextForCausalLM" in getattr(
+            hf_config, "architectures", []
+        )
+        # prefix_lm defaults to True upstream; defaulting False would skip the
+        # bidirectional-attention forcing and silently produce junk output.
+        is_prefix_lm_recurrent = is_hrm_text and getattr(hf_config, "prefix_lm", True)
+        if is_prefix_lm_recurrent:
+            if server_args.attention_backend not in (None, "triton"):
+                logger.warning(
+                    f"Overriding --attention-backend "
+                    f"{server_args.attention_backend!r} -> 'triton': only the "
+                    "Triton backend supports HRM-Text's bidirectional prefix "
+                    "attention."
+                )
+            server_args.attention_backend = "triton"
+            server_args.chunked_prefill_size = -1
+            server_args.disable_radix_cache = True
+            server_args.disable_cuda_graph = True
+            logger.warning(
+                "HRM-Text (prefix_lm) detected: forcing --attention-backend "
+                "triton, --chunked-prefill-size -1, --disable-radix-cache, and "
+                "--disable-cuda-graph for correctness of the bidirectional "
+                "prompt attention."
+            )
+
+        if self.is_multimodal:
+            if not self.is_multimodal_chunked_prefill_supported:
+                server_args.chunked_prefill_size = -1
+                logger.info(
+                    f"Automatically turn off --chunked-prefill-size as it is not supported for "
+                    f"{self.model_config.hf_config.model_type}"
+                )
+
+        if (
+            not self.use_mla_backend
+            or server_args.attention_backend
+            not in CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS
+        ):
+            server_args.disable_chunked_prefix_cache = True
+
+        if not server_args.disable_chunked_prefix_cache:
+            log_info_on_rank0(logger, "Chunked prefix cache is turned on.")
+
+        # The imperative adjustments above may overwrite fields the resolution passes
+        # already declared (HRM-Text forces attention_backend); redeclare the
+        # adjusted values so publish parity holds.
+        from sglang.srt.arg_groups.overrides import refresh_declared_fields
+
+        refresh_declared_fields(server_args, ("attention_backend",))
+
+    def check_quantized_moe_compatibility(self):
+        if (
+            quantization_config := getattr(
+                self.model_config.hf_config, "quantization_config", None
+            )
+        ) is not None and (
+            weight_block_size := quantization_config.get("weight_block_size", None)
+        ) is not None:
+            weight_block_size_n = weight_block_size[0]
+
+            if self.tp_size % self.moe_ep_size != 0:
+                raise ValueError(
+                    f"tp_size {self.tp_size} must be divisible by ep_size {self.moe_ep_size}"
+                )
+            moe_tp_size = self.tp_size // self.moe_ep_size // self.moe_dp_size
+
+            moe_intermediate_size = getattr(
+                self.model_config.hf_text_config, "moe_intermediate_size", None
+            )
+            if moe_intermediate_size is None:
+                return
+
+            if moe_intermediate_size % moe_tp_size != 0:
+                raise ValueError(
+                    f"moe_intermediate_size {moe_intermediate_size} must be divisible by moe_tp_size ({moe_tp_size}) which is tp_size ({self.tp_size}) divided by moe_ep_size ({self.moe_ep_size})."
+                )
+
+            if (
+                not envs.SGLANG_SHARED_EXPERT_TP1.get()
+                and (moe_intermediate_size // moe_tp_size) % weight_block_size_n != 0
+                and not _use_aiter
+            ):
+                raise ValueError(
+                    f"For quantized MoE models, please make sure ({moe_intermediate_size=} / {moe_tp_size=}) % {weight_block_size_n=} == 0 "
+                    f"where moe_tp_size is equal to tp_size ({self.tp_size}) divided by ep_size ({self.moe_ep_size}). "
+                    f"You can fix this by setting arguments `--tp` and `--ep` correctly."
+                )
 
     def init_torch_distributed(self):
-        result = bootstrap.init_torch_distributed(
-            server_args=self.server_args,
-            model_config=self.model_config,
-            device=self.device,
-            ps=self.ps,
-            dist_port=self.dist_port,
-            is_draft_worker=self.is_draft_worker,
-            local_omp_cpuid=self.local_omp_cpuid if self.device == "cpu" else None,
+        tic = time.perf_counter()
+        logger.info("Init torch distributed begin.")
+
+        try:
+            torch.get_device_module(self.device).set_device(self.gpu_id)
+        except Exception:
+            logger.warning(
+                f"Context: {self.device=} {self.gpu_id=} {os.environ.get('CUDA_VISIBLE_DEVICES')=} {self.tp_rank=} {self.tp_size=}"
+            )
+            raise
+
+        backend = get_default_distributed_backend(self.device)
+        if self.device == "cuda" and self.server_args.elastic_ep_backend == "mooncake":
+            backend = "mooncake"
+            if self.server_args.mooncake_ib_device:
+                from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import (
+                    get_ib_devices_for_gpu,
+                )
+
+                ib_device_for_gpu = get_ib_devices_for_gpu(
+                    self.server_args.mooncake_ib_device, self.gpu_id
+                )
+                mooncake_ib_device = (
+                    ib_device_for_gpu.split(",") if ib_device_for_gpu else []
+                )
+                try:
+                    from mooncake import ep as mooncake_ep
+
+                    mooncake_ep.set_device_filter(mooncake_ib_device)
+                except:
+                    pass  # A warning will be raised in `init_distributed_environment`
+
+        before_avail_memory = get_available_gpu_memory(self.device, self.gpu_id)
+        if not self.server_args.enable_p2p_check:
+            monkey_patch_p2p_access_check()
+
+        # Allow external orchestrators (e.g. trainpi) to override the distributed
+        # init method.  When set to "env://", torch uses MASTER_ADDR/MASTER_PORT
+        # env-vars and an externally-created TCPStore, completely avoiding port
+        # conflicts with intra-host collocation.
+        dist_init_method_override = envs.SGLANG_DISTRIBUTED_INIT_METHOD_OVERRIDE.get()
+        if dist_init_method_override:
+            dist_init_method = dist_init_method_override
+        elif self.server_args.dist_init_addr:
+            na = NetworkAddress.parse(self.server_args.dist_init_addr)
+            dist_init_method = na.to_tcp()
+        else:
+            dist_init_method = NetworkAddress(
+                self.server_args.host or "127.0.0.1", self.dist_port
+            ).to_tcp()
+        set_custom_all_reduce(not self.server_args.disable_custom_all_reduce)
+        set_mscclpp_all_reduce(self.server_args.enable_mscclpp)
+        set_torch_symm_mem_all_reduce(self.server_args.enable_torch_symm_mem)
+
+        if not self.is_draft_worker:
+            if self.device == "cpu":
+                if _is_cpu_amx_available or _is_cpu_arm64:
+                    # Bind OpenMP threads to CPU cores
+                    torch.ops.sgl_kernel.init_cpu_threads_env(self.local_omp_cpuid)
+
+                    # Set local size to hint SGLang to use shared memory based AllReduce
+                    os.environ["LOCAL_SIZE"] = str(self.tp_size)
+                    torch.ops.sgl_kernel.initialize(self.tp_size, self.tp_rank)
+
+                else:
+                    logger.warning(
+                        "init_cpu_threads_env and shared memory based AllReduce is disabled, only intel amx backend and arm64 are supported"
+                    )
+
+            # Only initialize the distributed environment on the target model worker.
+            init_distributed_environment(
+                backend=backend,
+                world_size=self.tp_size * self.pp_size,
+                rank=self.tp_size * self.pp_rank + self.tp_rank,
+                local_rank=self.gpu_id,
+                distributed_init_method=dist_init_method,
+                timeout=self.server_args.dist_timeout,
+                moe_a2a_backend=self.server_args.moe_a2a_backend,
+                recovered_rank=self.server_args.elastic_ep_rejoin,
+            )
+            initialize_model_parallel(
+                tensor_model_parallel_size=self.tp_size,
+                attention_data_parallel_size=self.dp_size,
+                pipeline_model_parallel_size=self.pp_size,
+                expert_model_parallel_size=self.moe_ep_size,
+                attention_context_model_parallel_size=self.attn_cp_size,
+                moe_data_model_parallel_size=self.moe_dp_size,
+                decode_context_parallel_size=self.dcp_size,
+                duplicate_tp_group=self.server_args.enable_pdmux,
+                enable_symm_mem=self.server_args.enable_symm_mem,
+                recovered_rank=self.server_args.elastic_ep_rejoin,
+            )
+            initialize_dp_attention(
+                server_args=self.server_args,
+                model_config=self.model_config,
+            )
+            if is_npu():
+                register_sgl_tp_rank(self.gpu_id)
+
+            # Pre-warm NCCL/RCCL to eliminate cold-start latency in first request
+            # Controlled by --pre-warm-nccl flag (default: enabled on AMD GPUs)
+            if self.server_args.pre_warm_nccl and (
+                self.tp_size > 1 or self.pp_size > 1 or self.moe_ep_size > 1
+            ):
+                warmup_start = time.perf_counter()
+                tp_group_handle = get_tp_group().device_group
+
+                # Single warmup all_reduce to initialize NCCL/RCCL communicator
+                warmup_tensor = torch.zeros(1, device=torch.cuda.current_device())
+                dist.all_reduce(warmup_tensor, group=tp_group_handle)
+                current_platform.synchronize()
+
+                warmup_elapsed = time.perf_counter() - warmup_start
+                logger.info(
+                    f"NCCL/RCCL warmup completed in {warmup_elapsed:.3f}s "
+                    f"(tp_size={self.tp_size}, pp_size={self.pp_size}, ep_size={self.moe_ep_size})"
+                )
+
+        pre_model_load_memory = get_available_gpu_memory(
+            self.device,
+            self.gpu_id,
+            distributed=get_world_group().world_size > 1,
+            cpu_group=get_world_group().cpu_group,
         )
-        self.tp_group = result.tp_group
-        self.pp_group = result.pp_group
-        self.attention_tp_group = result.attention_tp_group
-        self.pre_model_load_memory = result.pre_model_load_memory
+        self.tp_group = get_tp_group()
+        self.pp_group = get_pp_group()
+        self.attention_tp_group = get_attention_tp_group()
+
+        # Check memory for tensor parallelism
+        local_gpu_memory = get_available_gpu_memory(self.device, self.gpu_id)
+        if self.tp_size > 1 and not self.is_draft_worker:
+            if pre_model_load_memory < local_gpu_memory * 0.9:
+                msg = "The memory capacity is unbalanced. Some GPUs may be occupied by other processes. "
+                msg += f"{pre_model_load_memory=}, {local_gpu_memory=}, {local_gpu_memory * 0.9=}"
+                if envs.SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK.get():
+                    raise RuntimeError(msg)
+                else:
+                    logger.warning(msg)
+
+        logger.info(
+            f"Init torch distributed ends. elapsed={time.perf_counter() - tic:.2f} s, "
+            f"mem usage={(before_avail_memory - local_gpu_memory):.2f} GB"
+        )
+        return pre_model_load_memory
 
     def init_shared_mooncake_transfer_engine(self):
-        maybe_init_shared_mooncake_transfer_engine(
-            server_args=self.server_args, gpu_id=self.gpu_id
+        """
+        Need MooncakeTransferEngine when:
+        1) PD disaggregation uses mooncake for KV transfer (prefill/decode)
+        2) HiCache uses mooncake storage backend
+        3) Encoder disaggregation uses mooncake
+        """
+        use_mooncake_te = (
+            (
+                self.server_args.disaggregation_mode != "null"
+                and self.server_args.disaggregation_transfer_backend == "mooncake"
+            )
+            or (
+                self.server_args.enable_hierarchical_cache
+                and self.server_args.hicache_storage_backend == "mooncake"
+                and envs.SGLANG_HICACHE_MOONCAKE_REUSE_TE.get()
+            )
+            or (
+                self.server_args.encoder_only
+                and self.server_args.encoder_transfer_backend == "mooncake"
+            )
+            or (
+                self.server_args.language_only
+                and self.server_args.encoder_transfer_backend == "mooncake"
+            )
+            or (
+                self.server_args.enable_elastic_expert_backup
+                and self.server_args.elastic_ep_backend is not None
+            )
         )
+
+        if use_mooncake_te:
+            from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import (
+                init_mooncake_transfer_engine,
+            )
+
+            init_mooncake_transfer_engine(
+                hostname=get_local_ip_auto(),
+                gpu_id=self.gpu_id,
+                ib_device=(
+                    self.server_args.disaggregation_ib_device
+                    or self.server_args.mooncake_ib_device
+                ),
+            )
 
     def load_model(self):
         tic_total = time.perf_counter()
@@ -981,55 +1430,96 @@ class ModelRunner:
         if self.device != "cpu":
             torch.set_num_threads(1)
         if self.device == "cuda":
-            maybe_downgrade_dtype_for_legacy_gpu(
-                server_args=self.server_args, model_config=self.model_config
-            )
+            if torch.cuda.get_device_capability()[0] < 8:
+                logger.info(
+                    "Compute capability below sm80. Use float16 due to lack of bfloat16 support."
+                )
+                self.server_args.dtype = "float16"
+                self.model_config.dtype = torch.float16
+                if torch.cuda.get_device_capability()[1] < 5:
+                    raise RuntimeError("SGLang only supports sm75 and above.")
 
         set_cuda_arch()
 
-        self.load_config = build_load_config(
-            server_args=self.server_args,
-            tp_rank=self.ps.tp_rank,
-            remote_instance_weight_transporter_engine=self.remote_instance_weight_transporter.engine,
-            remote_instance_weight_transporter_session_id=self.remote_instance_weight_transporter.session_id,
-            draft_model_idx=self.draft_model_idx,
-            weight_cache_mode=self.server_args.weight_cache_mode,
-            weight_cache_socket=self.server_args.weight_cache_socket,
+        # Prepare the model config
+        from sglang.srt.configs.modelopt_config import ModelOptConfig
+
+        modelopt_config = ModelOptConfig(
+            quant=self.server_args.modelopt_quant,
+            checkpoint_restore_path=self.server_args.modelopt_checkpoint_restore_path,
+            checkpoint_save_path=self.server_args.modelopt_checkpoint_save_path,
+            export_path=self.server_args.modelopt_export_path,
+            quantize_and_serve=self.server_args.quantize_and_serve,
         )
 
-        # If the weight cache is enabled, override the load format to IPC_CACHE
-        # and derive the per-rank daemon socket. Idempotent across reloads.
-        maybe_enable_ipc_weight_cache(
-            load_config=self.load_config,
-            server_args=self.server_args,
-            tp_size=self.ps.tp_size,
-            pp_rank=self.ps.pp_rank,
-            tp_rank=self.ps.tp_rank,
+        self.load_config = LoadConfig(
+            load_format=self.server_args.load_format,
+            download_dir=self.server_args.download_dir,
+            model_loader_extra_config=self.server_args.model_loader_extra_config,
+            tp_rank=self.tp_rank,
+            remote_instance_weight_loader_seed_instance_ip=self.server_args.remote_instance_weight_loader_seed_instance_ip,
+            remote_instance_weight_loader_seed_instance_service_port=self.server_args.remote_instance_weight_loader_seed_instance_service_port,
+            remote_instance_weight_loader_send_weights_group_ports=self.server_args.remote_instance_weight_loader_send_weights_group_ports,
+            remote_instance_weight_loader_backend=self.server_args.remote_instance_weight_loader_backend,
+            remote_instance_weight_loader_transfer_engine=self.remote_instance_transfer_engine,
+            remote_instance_weight_loader_transfer_engine_session_id=self.remote_instance_transfer_engine_session_id,
+            modelexpress_url=self.server_args.modelexpress_url,
+            modelexpress_transport=self.server_args.modelexpress_transport,
+            modelopt_config=modelopt_config,
+            rl_quant_profile=self.server_args.rl_quant_profile,
+            draft_model_idx=self.draft_model_idx,
         )
         if self.device == "cpu":
             self.model_config = adjust_config_with_unaligned_cpu_tp(
-                self.model_config, self.load_config, self.ps.tp_size
+                self.model_config, self.load_config, self.tp_size
             )
 
-        maybe_trigger_remote_instance_nccl_send_group(
-            server_args=self.server_args, tp_rank=self.ps.tp_rank
-        )
+        if (
+            self.server_args.load_format == LoadFormat.REMOTE_INSTANCE
+            and self.server_args.remote_instance_weight_loader_backend
+            == RemoteInstanceWeightLoaderBackend.NCCL
+        ):
+            if self.tp_rank == 0:
+                instance_ip = NetworkAddress.resolve_host(socket.gethostname())
+                t = threading.Thread(
+                    target=trigger_init_weights_send_group_for_remote_instance_request,
+                    args=(
+                        self.server_args.remote_instance_weight_loader_seed_instance_ip,
+                        self.server_args.remote_instance_weight_loader_seed_instance_service_port,
+                        self.server_args.remote_instance_weight_loader_send_weights_group_ports,
+                        instance_ip,
+                    ),
+                )
+                t.start()
 
-        loaded = load_model_with_memory_saver(
-            server_args=self.server_args,
-            model_config=self.model_config,
-            load_config=self.load_config,
-            device=self.device,
-            gpu_id=self.gpu_id,
-            memory_saver_adapter=self.memory_saver_adapter,
-            is_draft_worker=self.is_draft_worker,
+        # Load the model
+        # Remove monkey_patch when linear.py quant remove dependencies with vllm
+        monkey_patch_vllm_parallel_state()
+
+        enable_cpu_backup = self.server_args.enable_weights_cpu_backup or (
+            self.is_draft_worker and self.server_args.enable_draft_weights_cpu_backup
         )
-        self.loader = loaded.loader
-        self.model = loaded.model
-        if loaded.remote_instance_weight_info is not None:
-            self.remote_instance_weight_transporter.weight_info = (
-                loaded.remote_instance_weight_info
+        with self.memory_saver_adapter.region(
+            GPU_MEMORY_TYPE_WEIGHTS,
+            enable_cpu_backup=enable_cpu_backup,
+        ):
+            self.loader = get_model_loader(
+                load_config=self.load_config,
+                model_config=self.model_config,
             )
+            self.model = self.loader.load_model(
+                model_config=self.model_config,
+                device_config=DeviceConfig(self.device, self.gpu_id),
+            )
+            if hasattr(self.loader, "remote_instance_transfer_engine_weight_info"):
+                self.remote_instance_transfer_engine_weight_info = (
+                    self.loader.remote_instance_transfer_engine_weight_info
+                )
+        # Cache needs to be cleared after loading model weights (in the self.loader.load_model function).
+        # To avoid conflict with memory_saver_adapter.region, empty_cache operation is now moved here.
+        if _is_npu:
+            torch.npu.empty_cache()
+        monkey_patch_vllm_parallel_state(reverse=True)
 
         if not self.is_draft_worker:
             get_offloader().post_init()
@@ -1039,11 +1529,44 @@ class ModelRunner:
             pyt_hooks = PytHooks()
             pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        load_kv_cache_scales(model=self.model, server_args=self.server_args)
+        if self.server_args.kv_cache_dtype == "fp8_e4m3":
+            if self.server_args.quantization_param_path is not None:
+                if callable(getattr(self.model, "load_kv_cache_scales", None)):
+                    self.model.load_kv_cache_scales(
+                        self.server_args.quantization_param_path
+                    )
+                    logger.info(
+                        "Loaded KV cache scaling factors from %s",
+                        self.server_args.quantization_param_path,
+                    )
+                else:
+                    raise RuntimeError(
+                        "Using FP8 KV cache and scaling factors provided but "
+                        "model %s does not support loading scaling factors.",
+                        self.model.__class__,
+                    )
+            else:
+                logger.warning(
+                    "Using FP8 KV cache but no scaling factors "
+                    "provided. Defaulting to scaling factors of 1.0. "
+                    "This may lead to less accurate results!"
+                )
 
-        self.sliding_window_size = resolve_sliding_window_size(
-            self.model, self.model_config
-        )
+        # Parse other args
+        self.sliding_window_size = None
+        if hasattr(self.model, "get_attention_sliding_window_size"):
+            self.sliding_window_size = self.model.get_attention_sliding_window_size()
+        elif (
+            self.model_config.is_hybrid_swa
+            and self.model_config.sliding_window_size is not None
+        ):
+            # sliding window field in model config may have different meaning for different kinds of models (e.g., dllm), here we only consider the sliding window in SWA model
+            self.sliding_window_size = self.model_config.sliding_window_size
+        elif self.model_config.attention_chunk_size is not None:
+            self.sliding_window_size = self.model_config.attention_chunk_size
+            logger.info(
+                f"Setting sliding_window_size to be attention_chunk_size: {self.sliding_window_size}"
+            )
 
         self.prefill_aware_swa = (
             hasattr(self.model, "is_prefill_aware_swa")
@@ -1067,17 +1590,34 @@ class ModelRunner:
             f"mem usage={self.weight_load_mem_usage:.2f} GB."
         )
 
-        report_online_quantization(model=self.model, server_args=self.server_args)
-
-        maybe_register_debug_tensor_dump_hook(
-            model=self.model,
-            server_args=self.server_args,
-            spec_algorithm=self.spec_algorithm,
-            is_draft_worker=self.is_draft_worker,
-            tp_size=self.ps.tp_size,
-            tp_rank=self.ps.tp_rank,
-            pp_rank=self.ps.pp_rank,
+        # TODO: Make sure all models have `quant_config` attribute, and all online quantization methods register which layers they actually quantize.
+        # TODO: Move this online-quantization reporting out of ModelRunner.
+        quantized_layers = getattr(
+            getattr(self.model, "quant_config", None), "quantized_layers", None
         )
+        if (
+            self.server_args.quantization is not None
+            and isinstance(quantized_layers, tuple)
+            and len(quantized_layers) == 2
+        ):
+            layer_types, quantized_layers_count = quantized_layers
+            logger.info(
+                f"Online {self.server_args.quantization} quantization: quantized {quantized_layers_count} layers of types: {layer_types}"
+            )
+
+        if self.server_args.debug_tensor_dump_output_folder is not None:
+            dump_folder = self.server_args.debug_tensor_dump_output_folder
+            if self.spec_algorithm.is_eagle():
+                role = "draft" if self.is_draft_worker else "target"
+                dump_folder = os.path.join(dump_folder, role)
+            register_forward_hook_for_model(
+                self.model,
+                dump_folder,
+                self.server_args.debug_tensor_dump_layers,
+                self.tp_size,
+                self.tp_rank,
+                self.pp_rank,
+            )
 
         if dumper.may_enable:
             dumper.apply_source_patches()
@@ -1091,22 +1631,609 @@ class ModelRunner:
             logger,
         )
 
-        dist_barrier_after_load(
-            elastic_ep_backend=self.server_args.elastic_ep_backend,
-            tp_rank=self.ps.tp_rank,
-            is_ep_joiner=self.server_args.is_ep_joiner,
+        if self.server_args.elastic_ep_backend == "mooncake":
+            # Mooncake does not support `monitored_barrier`
+            dist.barrier(group=get_tp_group().cpu_group)
+        else:
+            # Handle the case where some ranks do not finish loading.
+            try:
+                dist.monitored_barrier(
+                    group=get_tp_group().cpu_group,
+                    timeout=datetime.timedelta(
+                        seconds=UNBALANCED_MODEL_LOADING_TIMEOUT_S
+                    ),
+                    wait_all_ranks=True,
+                )
+            except RuntimeError:
+                raise ValueError(
+                    f"TP rank {self.tp_rank} could finish the model loading, but there are other ranks that didn't finish loading. It is likely due to unexpected failures (e.g., OOM) or a slow node."
+                ) from None
+
+    def _prepare_moe_topk(self):
+        balancer_cls = None
+        num_prepared = 0
+        num_routed_experts = None
+        for module in self.model.modules():
+            if not isinstance(module, (TopK, HashTopK)):
+                continue
+            if (
+                not module.enable_deepep_waterfill
+                or module.deepep_waterfill_balancer is not None
+            ):
+                continue
+            if num_routed_experts is None:
+                num_routed_experts = getattr(
+                    self.model_config.hf_config, "n_routed_experts", None
+                )
+                if num_routed_experts is None:
+                    raise ValueError(
+                        "DeepEP waterfill requires model config n_routed_experts."
+                    )
+            if balancer_cls is None:
+                from sglang.srt.layers.moe.deepep_waterfill import (
+                    DeepEPWaterfillBalancer,
+                )
+
+                balancer_cls = DeepEPWaterfillBalancer
+            # Static EPLB remaps TopK ids to physical expert ids before Waterfill.
+            # Redundant experts therefore need to be included in the per-rank
+            # expert count used for Waterfill's shared-expert slot remapping.
+            num_physical_routed_experts = (
+                num_routed_experts + self.server_args.ep_num_redundant_experts
+            )
+            if isinstance(module, TopK):
+                routed_scaling_factor = module.topk_config.routed_scaling_factor
+            else:
+                routed_scaling_factor = module.routed_scaling_factor
+            module.deepep_waterfill_balancer = balancer_cls(
+                num_routed_experts=num_physical_routed_experts,
+                world_size=self.moe_ep_size,
+                rank=self.moe_ep_rank,
+                layer_id=module.layer_id,
+                routed_scaling_factor=(
+                    routed_scaling_factor if routed_scaling_factor is not None else 1.0
+                ),
+            )
+            num_prepared += 1
+        if num_prepared:
+            log_info_on_rank0(
+                logger, f"Prepared {num_prepared} DeepEP waterfill TopK modules."
+            )
+
+    def _init_lplb_solvers(self):
+        """Initialize per-layer LPLB solvers from current expert location metadata."""
+        from sglang.srt.distributed import get_moe_ep_group
+
+        # Gate: refuse LP for non-DeepSeek MoE families whose empty-token paths
+        # don't participate in the EP all-reduce (would deadlock under DP-
+        # attention). Failure here happens before any forward pass.
+        architectures = getattr(self.model_config.hf_config, "architectures", None)
+        if architectures:
+            assert_lplb_supported_model(architectures[0])
+
+        metadata = get_global_expert_location_metadata()
+        if metadata is None:
+            return
+        clear_global_lplb_solvers()
+        ep_group = get_moe_ep_group()
+        for lid in range(metadata.num_layers):
+            solver = LPLBSolver(
+                phy2log=metadata.physical_to_logical_map[lid],
+                log2phy=metadata.logical_to_all_physical_map[lid],
+                num_gpus=metadata.ep_size,
+                ep_group=ep_group,
+                logical_to_all_physical_map_num_valid=(
+                    metadata.logical_to_all_physical_map_num_valid[lid]
+                ),
+            )
+            set_global_lplb_solver(lid, solver)
+        logger.info(f"Initialized LPLB solvers for {metadata.num_layers} layers")
+
+    def update_expert_location(
+        self,
+        new_expert_location_metadata: ExpertLocationMetadata,
+        update_layer_ids: List[int],
+    ):
+        p2p_missing_logical_experts = self.expert_location_updater.update(
+            self.model.routed_experts_weights_of_layer,
+            new_expert_location_metadata,
+            update_layer_ids=update_layer_ids,
+            nnodes=self.server_args.nnodes,
+            rank=self.tp_rank,
         )
 
-    def maybe_init_dwdp(self):
-        if self.is_draft_worker:
-            return
-        if self.server_args.dwdp_size <= 1:
-            return
-        from sglang.srt.layers.moe.dwdp import DwdpManager
+        if len(p2p_missing_logical_experts) > 0:
+            # Load the missing expert weights from disk
+            if callable(getattr(self.model, "generate_weight_name_filter", None)):
+                # Filter and load only missing expert weights
+                weight_name_filter = self.model.generate_weight_name_filter(
+                    p2p_missing_logical_experts
+                )
+            else:
+                # Do a full reload from disk/DRAM
+                logger.info(
+                    "[Elastic EP] Model does not implement generate_weight_name_filter. "
+                    "Performing full weight reload."
+                )
+                weight_name_filter = None
 
-        manager = DwdpManager(self.server_args)
-        set_global_dwdp_manager(manager)
-        manager.setup(self.model)
+            if (
+                self.expert_backup_client is not None
+                and self.expert_backup_client.use_backup
+            ):
+                # Load the missing weights from the DRAM backup
+                self.expert_backup_client.update_weights(weight_name_filter)
+            else:
+                # Load the missing weights from disk
+                self.update_weights_from_disk(
+                    get_global_server_args().model_path,
+                    get_global_server_args().load_format,
+                    weight_name_filter=weight_name_filter,
+                )
+
+        # Re-init LPLB solvers after expert location update
+        if self.server_args.ep_dispatch_algorithm == "lp":
+            self._init_lplb_solvers()
+
+    def maybe_recover_ep_ranks(self):
+        # TODO(perf): `active_ranks.all()` on a CUDA tensor triggers host-device
+        # synchronization, and this function is on the forward-path.
+        # This check only runs when `--elastic-ep-backend` is enabled, so the
+        # synchronization overhead does not propagate to other configs.
+        # Leave for future optimization of the elastic EP path.
+        if self.tp_group.active_ranks.all() and self.tp_group.active_ranks_cpu.all():
+            return
+
+        tp_active_ranks = self.tp_group.active_ranks.detach().cpu().numpy()
+        tp_active_ranks_cpu = self.tp_group.active_ranks_cpu.detach().numpy()
+        tp_active_ranks &= tp_active_ranks_cpu
+        # NOTE: `ranks_to_recover` uses indices in `tp_group`. For the current
+        # Mooncake elastic EP implementation we assume `--pp-size=1`, so the
+        # tp-group index is the same as the global rank index.
+        ranks_to_recover = [
+            i for i in range(len(tp_active_ranks)) if not tp_active_ranks[i]
+        ]
+
+        # try_recover_ranks polls peer state via Mooncake EP backend.
+        # Mooncake's internal semantics guarantee that all ranks observe
+        # consistent peer readiness state, so collective operations below
+        # are safe even though polling appears local.
+        if ranks_to_recover and try_recover_ranks(ranks_to_recover):
+            self.forward_pass_id = 0
+            self.eplb_manager.reset_generator()
+            broadcast_global_expert_location_metadata(
+                src_rank=self._get_healthy_expert_location_src_rank(
+                    invoked_in_elastic_ep_rejoin_path=False
+                )
+            )
+            ElasticEPStateManager.instance().reset()
+
+            broadcast_pyobj(
+                [self.server_args.random_seed],
+                get_world_group().rank,
+                get_world_group().cpu_group,
+                src=get_world_group().ranks[0],
+            )
+            logger.info(f"recover ranks {ranks_to_recover} done")
+
+    def _get_healthy_expert_location_src_rank(
+        self, invoked_in_elastic_ep_rejoin_path: bool
+    ) -> int:
+        world_group = get_world_group()
+        # NOTE: do not key off `self.server_args.elastic_ep_rejoin` here.
+        # A rank that was started as a rejoin rank may later act as a healthy
+        # rank in a subsequent recovery cycle.
+        local_rejoin_flag = bool(invoked_in_elastic_ep_rejoin_path)
+        gathered_rejoin_flags = world_group.all_gather_object(local_rejoin_flag)
+
+        for rank_in_group, is_rejoin_rank in enumerate(gathered_rejoin_flags):
+            if not is_rejoin_rank:
+                return world_group.ranks[rank_in_group]
+
+        raise RuntimeError(
+            "No healthy rank found for broadcasting expert location metadata. "
+            "All ranks are marked as elastic_ep_rejoin."
+        )
+
+    def update_weights_from_disk(
+        self,
+        model_path: str,
+        load_format: str,
+        weight_name_filter: Optional[Callable[[str], bool]] = None,
+        recapture_cuda_graph: bool = False,
+    ) -> tuple[bool, str]:
+        """Update engine weights in-place from the disk."""
+        logger.info(
+            f"Update engine weights online from disk begin. "
+            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id, empty_cache=False):.2f} GB"
+        )
+
+        target_device = torch.device(self.device)
+        self.model_config.model_path = model_path
+        load_config = LoadConfig(load_format=load_format)
+
+        # Only support DefaultModelLoader for now
+        loader = get_model_loader(load_config, self.model_config)
+        if not isinstance(loader, DefaultModelLoader):
+            message = f"Failed to get model loader: {loader}."
+            return False, message
+
+        def get_weight_iter(config):
+            iter = loader._get_weights_iterator(
+                DefaultModelLoader.Source.init_new(config, self.model)
+            )
+            if weight_name_filter is not None:
+                iter = (
+                    (name, weight) for name, weight in iter if weight_name_filter(name)
+                )
+
+            return iter
+
+        def model_load_weights(model, iter):
+            loader.load_weights_and_postprocess(model, iter, target_device)
+            return model
+
+        with set_default_torch_dtype(self.model_config.dtype):
+            try:
+                iter = get_weight_iter(self.model_config)
+            except Exception as e:
+                message = f"Failed to get weights iterator: {e}."
+                return False, message
+            try:
+                model = model_load_weights(self.model, iter)
+            except Exception as e:
+                message = (
+                    f"Failed to update weights: {e}.\nRolling back to original weights."
+                )
+                del iter
+                gc.collect()
+                iter = get_weight_iter(self.model_config)
+                self.model = model_load_weights(self.model, iter)
+                return False, message
+
+        self.model = model
+        self.server_args.model_path = model_path
+        self.server_args.load_format = load_format
+        self.load_config = load_config
+
+        if recapture_cuda_graph and (
+            self.device == "cuda"
+            or self.device == "musa"
+            or (
+                current_platform.is_out_of_tree()
+                and current_platform.support_cuda_graph()
+            )
+        ):
+            self.init_decode_cuda_graph()
+
+        logger.info("Update weights end.")
+        return True, "Succeeded to update model weights."
+
+    def init_weights_send_group_for_remote_instance(
+        self,
+        master_address,
+        ports,
+        group_rank,
+        world_size,
+        group_name,
+        backend="nccl",
+    ):
+        assert (
+            torch.distributed.is_initialized()
+        ), "Default torch process group must be initialized"
+        assert group_name != "", "Group name cannot be empty"
+
+        ports_list = ports.split(",")
+        assert (
+            len(ports_list) == self.tp_size
+        ), f"Expected {self.tp_size} ports, but got {len(ports_list)} ports."
+        group_port = ports_list[self.tp_rank]
+        group_name = f"{group_name}_{group_port}_{self.tp_rank}"
+
+        logger.info(
+            f"init custom process group: tp_rank={self.tp_rank}, gpu_id={self.gpu_id}, master_address={master_address}, master_port={group_port}, "
+            f"group_rank={group_rank}, world_size={world_size}, group_name={group_name}, backend={backend}"
+        )
+
+        current_platform.empty_cache()
+        success = False
+        message = ""
+        try:
+            na = NetworkAddress(master_address, group_port)
+            self._weights_send_group[group_name] = init_custom_process_group(
+                backend=backend,
+                init_method=na.to_tcp(),
+                world_size=world_size,
+                rank=group_rank,
+                group_name=group_name,
+                device_id=torch.device("cuda", self.gpu_id),
+            )
+            dist.barrier(group=self._weights_send_group[group_name])
+            success = True
+            message = f"Succeeded to init group through {na.to_host_port_str()} group."
+        except Exception as e:
+            message = f"Failed to init group: {e}."
+            logger.error(message)
+
+        current_platform.empty_cache()
+        return success, message
+
+    def send_weights_to_remote_instance(
+        self,
+        master_address,
+        ports,
+        group_name,
+    ):
+        assert (
+            torch.distributed.is_initialized()
+        ), "Default torch process group must be initialized"
+        assert group_name != "", "Group name cannot be empty"
+
+        ports_list = ports.split(",")
+        assert (
+            len(ports_list) == self.tp_size
+        ), f"Expected {self.tp_size} ports, but got {len(ports_list)} ports."
+        group_port = ports_list[self.tp_rank]
+        group_name = f"{group_name}_{group_port}_{self.tp_rank}"
+
+        if self._weights_send_group[group_name] is not None:
+            send_group = self._weights_send_group[group_name]
+        else:
+            message = f"Group {group_name} not in _weights_send_group list. Please call `init_weights_send_group_for_remote_instance` first."
+            logger.error(message)
+            return False, message
+
+        current_platform.empty_cache()
+        success = False
+        na = NetworkAddress(master_address, group_port)
+        message = ""
+        try:
+            for _, weights in self.model.named_parameters():
+                torch.distributed.broadcast(
+                    weights,
+                    src=0,
+                    group=send_group,
+                )
+            success = True
+            message = f"Succeeded to send weights through {na.to_host_port_str()} {group_name}."
+        except Exception as e:
+            message = f"Failed to send weights: {e}."
+            logger.error(message)
+
+        # destroy the process group after sending weights
+        del self._weights_send_group[group_name]
+        torch.distributed.distributed_c10d.destroy_process_group(send_group)
+        current_platform.empty_cache()
+        return success, message
+
+    def init_weights_update_group(
+        self,
+        master_address,
+        master_port,
+        rank_offset,
+        world_size,
+        group_name,
+        backend="nccl",
+    ):
+        """Initialize the Torch process group for model parameter updates.
+
+        `_model_update_group` is used in the RLHF workflow, where rank
+        0 is the actor model in the training engine, and the other ranks are
+        the inference engine, which is used for rollout.
+
+        In the RLHF workflow, the training engine updates the model
+        weights/parameters online, and broadcasts them to the inference
+        engine through the `_model_update_group` process group.
+        """
+        assert (
+            torch.distributed.is_initialized()
+        ), "Default torch process group must be initialized"
+        assert group_name != "", "Group name cannot be empty"
+
+        rank = rank_offset + self.tp_rank
+
+        logger.info(
+            f"init custom process group: master_address={master_address}, master_port={master_port}, "
+            f"rank_offset={rank_offset}, rank={rank}, world_size={world_size}, group_name={group_name}, backend={backend}"
+        )
+
+        try:
+            na = NetworkAddress(master_address, master_port)
+            self._model_update_group[group_name] = init_custom_process_group(
+                backend=backend,
+                init_method=na.to_tcp(),
+                world_size=world_size,
+                rank=rank,
+                group_name=group_name,
+            )
+            return True, "Succeeded to initialize custom process group."
+        except Exception as e:
+            message = f"Failed to initialize custom process group: {e}."
+            logger.error(message)
+            return False, message
+
+    def destroy_weights_update_group(self, group_name):
+        try:
+            if group_name in self._model_update_group:
+                pg = self._model_update_group.pop(group_name)
+                torch.distributed.destroy_process_group(pg)
+                return True, "Succeeded to destroy custom process group."
+            else:
+                return False, "The group to be destroyed does not exist."
+        except Exception as e:
+            message = f"Failed to destroy custom process group: {e}."
+            logger.error(message)
+            return False, message
+
+    def update_weights_from_distributed(
+        self,
+        names,
+        dtypes,
+        shapes,
+        group_name,
+        load_format: Optional[str] = None,
+    ):
+        """
+        Update specific parameter in the model weights online
+        through `_model_update_group` process group.
+
+        Args:
+            name: the name of the parameter to be updated.
+            dtype: the data type of the parameter to be updated.
+            shape: the shape of the parameter to be updated.
+        """
+
+        assert group_name in self._model_update_group, (
+            f"Group {group_name} not in {list(self._model_update_group.keys())}. "
+            "Please call `init_weights_update_group` first."
+        )
+
+        if load_format == "flattened_bucket":
+            return self._update_bucketed_weights_from_distributed(
+                names, dtypes, shapes, group_name
+            )
+        try:
+            weights = []
+            handles = []
+            for name, dtype, shape in zip(names, dtypes, shapes):
+                target_dtype = (
+                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+                )
+                weight = torch.empty(shape, dtype=target_dtype, device=self.device)
+                handles.append(
+                    torch.distributed.broadcast(
+                        weight,
+                        src=0,
+                        group=self._model_update_group[group_name],
+                        async_op=True,
+                    )
+                )
+                weights.append((name, weight))
+            for handle in handles:
+                handle.wait()
+
+            self.model.load_weights(weights)
+            return True, "Succeeded to update parameter online."
+
+        except Exception as e:
+            error_msg = (
+                f"Failed to update parameter online: {e}. "
+                f"The full weights of the ModelRunner are partially updated. "
+                f"Please discard the whole weights."
+            )
+            logger.error(error_msg)
+            return False, error_msg
+
+    def _update_bucketed_weights_from_distributed(
+        self, names, dtypes, shapes, group_name
+    ):
+        try:
+            named_tensors = []
+            for name, dtype, shape in zip(names, dtypes, shapes):
+                target_dtype = (
+                    dtype if isinstance(dtype, torch.dtype) else getattr(torch, dtype)
+                )
+                named_tensors.append(
+                    (name, torch.empty(shape, dtype=target_dtype, device=self.device))
+                )
+            bucket = FlattenedTensorBucket(named_tensors=named_tensors)
+            flattened_tensor = bucket.get_flattened_tensor()
+            torch.distributed.broadcast(
+                flattened_tensor,
+                src=0,
+                group=self._model_update_group[group_name],
+            )
+            reconstructed_tensors = bucket.reconstruct_tensors()
+            self.model.load_weights(reconstructed_tensors)
+            return True, f"Succeeded to update parameter online."
+        except Exception as e:
+            error_msg = (
+                f"Failed to update parameter online: {e}. "
+                f"The full weights of the ModelRunner are partially updated. "
+                f"Please discard the whole weights."
+            )
+            logger.error(error_msg)
+            return False, error_msg
+
+    def update_weights_from_tensor(
+        self,
+        named_tensors: List[Tuple[str, Union[torch.Tensor, LocalSerializedTensor]]],
+        load_format: Optional[str] = None,
+    ):
+        monkey_patch_torch_reductions()
+        if load_format == "flattened_bucket":
+            # Handle flattened bucket format
+            return self._update_weights_from_flattened_bucket(
+                flattened_tensor_bucket_dict=named_tensors
+            )
+
+        # We need to get device after patch otherwise the device would be wrong
+        device_module = torch.get_device_module(self.device)
+        infered_device = device_module.current_device()
+
+        named_tensors = [
+            (name, _unwrap_tensor(tensor, tp_rank=self.tp_rank, device=infered_device))
+            for name, tensor in named_tensors
+        ]
+        if load_format == "direct":
+            _model_load_weights_direct(self.model, named_tensors)
+        elif load_format in self.server_args.custom_weight_loader:
+            custom_loader = dynamic_import(load_format)
+            custom_loader(self.model, named_tensors)
+        elif load_format is None:
+            self.model.load_weights(named_tensors)
+        else:
+            raise NotImplementedError(f"Unknown load_format={load_format}")
+        return True, "Success"
+
+    def _update_weights_from_flattened_bucket(
+        self,
+        flattened_tensor_bucket_dict,
+    ):
+        """Handle flattened bucket format for weight updates"""
+        flattened_tensor = flattened_tensor_bucket_dict["flattened_tensor"]
+        metadata = flattened_tensor_bucket_dict["metadata"]
+
+        # Convert metadata dict to our format
+        converted_metadata = []
+        for meta in metadata:
+            converted_meta = FlattenedTensorMetadata(
+                name=meta.name,
+                shape=meta.shape,
+                dtype=meta.dtype,
+                start_idx=meta.start_idx,
+                end_idx=meta.end_idx,
+                numel=meta.numel,
+            )
+            converted_metadata.append(converted_meta)
+
+        # Create bucket and reconstruct tensors
+        bucket = FlattenedTensorBucket(
+            flattened_tensor=flattened_tensor, metadata=converted_metadata
+        )
+        reconstructed_tensors = bucket.reconstruct_tensors()
+
+        # Load the reconstructed tensors using the standard method
+        self.model.load_weights(reconstructed_tensors)
+
+        return True, "Success"
+
+    def get_weights_by_name(
+        self, name: str, truncate_size: int = 100
+    ) -> Optional[torch.Tensor]:
+        """Get the weights of the parameter by its name. Similar to `get_parameter` in Hugging Face.
+
+        Only used for unit test with an unoptimized performance.
+        For optimized performance, please use torch.save and torch.load.
+        """
+        # TODO: (chenyang) Add support for Qwen models.
+        try:
+            return self.model.get_weights_by_name(
+                name, truncate_size, tp_size=self.tp_size
+            )
+        except Exception as e:
+            logger.error(f"Error when getting parameter {name}: {e}")
+            return None
 
     def init_lora_manager(self):
         self.lora_manager = LoRAManager(
@@ -1117,126 +2244,668 @@ class ModelRunner:
             dtype=self.dtype,
             server_args=self.server_args,
             lora_backend=self.server_args.lora_backend,
-            tp_size=self.ps.tp_size,
-            tp_rank=self.ps.tp_rank,
+            tp_size=self.tp_size,
+            tp_rank=self.tp_rank,
             max_lora_rank=self.server_args.max_lora_rank,
             target_modules=self.server_args.lora_target_modules,
             lora_paths=self.server_args.lora_paths,
         )
-        if not cuda_graph_fully_disabled():
-            init_lora_cuda_graph_moe_buffers(
-                server_args=self.server_args,
-                model=self.model,
-                lora_manager=self.lora_manager,
-                dtype=self.dtype,
-            )
+
+    def _init_lora_cuda_graph_moe_buffers(self):
+        """Phase 1 of LoRA CUDA graph init: pre-allocate MoE intermediate buffers.
+
+        Must be called before init_memory_pool() so that memory profiling
+        sees the reduced available memory and sizes KV cache correctly.
+        All MoE LoRA layers share one set of buffers (managed by the
+        lora_backend) since they execute sequentially during forward.
+
+        Phase 2 (dense LoRA batch metadata) is handled later in
+        CudaGraphRunner.__init__() via lora_manager.init_cuda_graph_batch_info(),
+        because it needs capture-time parameters (max_bs, num_tokens_per_bs)
+        that are only available at that stage.
+        """
+        from sglang.srt.lora.layers import FusedMoEWithLoRA
+
+        max_bs = self.server_args.cuda_graph_config.decode.max_bs
+        max_loras = self.server_args.max_loras_per_batch
+        for module in self.model.modules():
+            if isinstance(module, FusedMoEWithLoRA):
+                self.lora_manager.init_cuda_graph_moe_buffers(
+                    max_bs, max_loras, self.dtype, module
+                )
+                logger.info(
+                    f"Pre-allocated shared MoE LoRA CUDA graph buffers "
+                    f"(max_bs={max_bs}, max_loras={max_loras})"
+                )
+                break
 
     def load_lora_adapter(self, lora_ref: LoRARef):
         """Load a new lora adapter from disk or huggingface."""
-        return self.lora_manager.load_lora_adapter(lora_ref)
+
+        logger.info(
+            f"LoRA adapter loading starts: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
+        )
+
+        result = self.lora_manager.load_lora_adapter(lora_ref)
+
+        logger.info(
+            f"LoRA adapter loading completes: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
+        )
+
+        return result
 
     def load_lora_adapter_from_tensors(
         self, lora_ref: LoRARef, tensors, config_dict, added_tokens_config=None
     ):
-        return self.lora_manager.load_lora_adapter_from_tensors(
+        logger.info(f"LoRA adapter loading from tensors starts: {lora_ref}.")
+        result = self.lora_manager.load_lora_adapter_from_tensors(
             lora_ref, tensors, config_dict, added_tokens_config
         )
+        logger.info(f"LoRA adapter loading from tensors completes: {lora_ref}.")
+        return result
 
     def unload_lora_adapter(self, lora_ref: LoRARef):
         """Unload a lora adapter that was previously loaded during initialization or dynamic loading."""
-        return self.lora_manager.unload_lora_adapter(lora_ref)
+
+        logger.info(
+            f"LoRA adapter unloading starts: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
+        )
+
+        result = self.lora_manager.unload_lora_adapter(lora_ref)
+
+        logger.info(
+            f"LoRA adapter unloading completes: {lora_ref}. "
+            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
+        )
+
+        return result
 
     @property
-    def effective_max_total_num_tokens(self):
+    def qwen3_next_config(self):
+        config = self.model_config.hf_config
+        if isinstance(config, Qwen3NextConfig):
+            return config
+        return None
+
+    @property
+    def hybrid_lightning_config(self):
+        config = self.model_config.hf_config
+        if isinstance(config, BailingHybridConfig):
+            return config
+        return None
+
+    @property
+    def hybrid_gdn_config(self):
+        config = self.model_config.hf_config.get_text_config()
+        if isinstance(
+            config,
+            Qwen3NextConfig
+            | Qwen3_5Config
+            | Qwen3_5MoeConfig
+            | InternS2PreviewConfig
+            | JetNemotronConfig
+            | JetVLMConfig,
+        ):
+            return config
+        return None
+
+    @property
+    def mamba2_config(self):
+        config = self.model_config.hf_config
+        if isinstance(config, NemotronHConfig) and self.is_draft_worker:
+            # NemotronH MTP draft models have no Mamba layers (pattern like "*E")
+            # so they shouldn't use HybridLinearAttnBackend
+            pattern = getattr(config, "mtp_hybrid_override_pattern", None)
+            if pattern is not None and "M" not in pattern:
+                return None
+        if isinstance(
+            config,
+            FalconH1Config
+            | NemotronHConfig
+            | Lfm2Config
+            | Lfm2MoeConfig
+            | Lfm2VlConfig
+            | ZayaConfig,
+        ):
+            return config
+        if isinstance(config, NemotronH_Nano_VL_V2_Config):
+            return config.llm_config
+
+        if isinstance(config, GraniteMoeHybridConfig):
+            has_mamba = any(
+                layer_type == "mamba"
+                for layer_type in getattr(config, "layer_types", [])
+            )
+            if not has_mamba:
+                return None
+            else:
+                return config
+
+        return None
+
+    @property
+    def max_token_pool_size(self):
         """Return the max token pool size considering hybrid swa settings."""
         if self.is_hybrid_swa:
             return self.full_max_total_num_tokens or self.swa_max_total_num_tokens
         else:
             return self.max_total_num_tokens
 
+    @property
+    def kimi_linear_config(self):
+        config = self.model_config.hf_config
+        if isinstance(config, KimiLinearConfig):
+            return config
+        text_config = getattr(config, "text_config", None)
+        if isinstance(text_config, KimiLinearConfig):
+            return text_config
+        return None
+
+    def _get_linear_attn_registry_result(self):
+        if self._linear_attn_registry_cache is _UNSET:
+            self._linear_attn_registry_cache = get_linear_attn_config(
+                self.model_config.hf_config
+            )
+        return self._linear_attn_registry_cache
+
+    @property
+    def linear_attn_model_spec(self):
+        result = self._get_linear_attn_registry_result()
+        return result[0] if result else None
+
+    @property
+    def mambaish_config(self):
+        existing = (
+            self.mamba2_config
+            or self.hybrid_gdn_config
+            or self.kimi_linear_config
+            or self.hybrid_lightning_config
+        )
+        if existing:
+            return existing
+        result = self._get_linear_attn_registry_result()
+        return result[1] if result else None
+
     def _record_kv_cache_dtype(self, resolved: str) -> None:
-        # the weight-resolved kv-cache dtype is written to the config
-        # bags via get_context().override, so get_model().kv_cache_dtype readers
-        # see it. server_args stays the pristine RAW record -- configure_kv_cache
-        # _dtype reads it as the resolver INPUT. A draft / mock runner whose
-        # server_args is not the published object keeps the private-bag write.
+        # Load-time resolution transition: the weight-resolved kv-cache dtype
+        # is declared into the flags tier; the dual-apply inside the helper
+        # replaces the legacy in-place write. Mock runners whose server_args
+        # is not the published object keep the plain write.
         from sglang.srt.runtime_context import get_context
 
         if get_context()._server_args is self.server_args:
-            get_context().override(
-                "ModelRunner.configure_kv_cache_dtype", kv_cache_dtype=resolved
+            from sglang.srt.arg_groups.overrides import declare_load_time_override
+
+            declare_load_time_override(
+                "ModelRunner.configure_kv_cache_dtype",
+                {"kv_cache_dtype": resolved},
             )
         else:
-            self.server_args.override(
-                "ModelRunner.configure_kv_cache_dtype", kv_cache_dtype=resolved
-            )
+            self.server_args.kv_cache_dtype = resolved
 
     def configure_kv_cache_dtype(self):
-        spec_algorithm = getattr(self, "spec_algorithm", None)
-        resolved_kv_cache_dtype, self.kv_cache_dtype = (
-            kv_cache_dtype.configure_kv_cache_dtype(
-                # RAW user intent = resolver INPUT; server_args stays pristine
-                # so read it here -- not the resolved get_model() bag.
-                server_args_kv_cache_dtype=self.server_args.kv_cache_dtype,
-                model=getattr(self, "model", None),
-                model_dtype=getattr(self, "dtype", torch.bfloat16),
-                is_draft_worker=getattr(self, "is_draft_worker", False),
-                is_dflash=(
-                    spec_algorithm.is_dflash() if spec_algorithm is not None else False
-                ),
-                speculative_draft_attention_backend=getattr(
-                    self.server_args, "speculative_draft_attention_backend", None
-                ),
+        if self.server_args.kv_cache_dtype == "auto":
+            quant_config = getattr(self.model, "quant_config", None)
+            kv_cache_quant_algo = getattr(quant_config, "kv_cache_quant_algo", None)
+            if (
+                isinstance(kv_cache_quant_algo, str)
+                and kv_cache_quant_algo.upper() == "FP8"
+            ):
+                self.kv_cache_dtype = fp8_dtype if _is_hip else torch.float8_e4m3fn
+                self._record_kv_cache_dtype(
+                    TORCH_DTYPE_TO_KV_CACHE_STR[self.kv_cache_dtype]
+                )
+            else:
+                self.kv_cache_dtype = self.dtype
+        elif self.server_args.kv_cache_dtype == "fp8_e5m2":
+            if _is_hip:  # Using natively supported format
+                self.kv_cache_dtype = fp8_dtype
+            else:
+                self.kv_cache_dtype = torch.float8_e5m2
+        elif self.server_args.kv_cache_dtype == "fp8_e4m3":
+            if _is_hip:  # Using natively supported format
+                self.kv_cache_dtype = fp8_dtype
+            else:
+                self.kv_cache_dtype = torch.float8_e4m3fn
+        elif self.server_args.kv_cache_dtype in ("bf16", "bfloat16"):
+            self.kv_cache_dtype = torch.bfloat16
+        elif self.server_args.kv_cache_dtype == "fp4_e2m1":
+            if hasattr(torch, "float4_e2m1fn_x2"):
+                self.kv_cache_dtype = torch.float4_e2m1fn_x2
+                logger.warning(f"FP4 (E2M1) KV Cache might lead to a accuracy drop!")
+            else:
+                logger.warning(
+                    f"--kv-cache-dtype falls back to 'auto' because this torch version does not support torch.float4_e2m1fn_x2"
+                )
+                self.kv_cache_dtype = self.dtype
+        else:
+            raise ValueError(
+                f"Unsupported kv_cache_dtype: {self.server_args.kv_cache_dtype}."
             )
+
+    def init_cublas(self):
+        """We need to run a small matmul to init cublas. Otherwise, it will raise some errors later."""
+        dtype = torch.float16
+        device = "cuda"
+        a = torch.ones((16, 16), dtype=dtype, device=device)
+        b = torch.ones((16, 16), dtype=dtype, device=device)
+        c = a @ b
+        return c
+
+    def init_attention_backend(self):
+        """Init attention kernel backend."""
+        if self.server_args.enable_pdmux:
+            self.attn_backend = self._get_attention_backend(init_new_workspace=True)
+            self.decode_attn_backend_group = []
+            for _ in range(self.server_args.sm_group_num):
+                self.decode_attn_backend_group.append(self._get_attention_backend())
+            self.decode_attn_backend = self.decode_attn_backend_group[0]
+        elif self.server_args.enable_two_batch_overlap and not self.is_draft_worker:
+            self.attn_backend = TboAttnBackend.init_new(self._get_attention_backend)
+        else:
+            self.attn_backend = self._get_attention_backend()
+
+        # Record resolved per-mode backends on the backend for model dispatch.
+        self.attn_backend.prefill_attention_backend_str = (
+            self.prefill_attention_backend_str
         )
-        # This runner's OWN resolved dtype string (target or draft). Attention
-        # backends read it directly instead of the process-global get_model()
-        # bag: a draft runner does not publish its args, so the bag would carry
-        # the target's dtype and mis-drive the draft's FP8 cast/descale paths.
-        self.kv_cache_dtype_str = (
-            resolved_kv_cache_dtype
-            if resolved_kv_cache_dtype is not None
-            else self.server_args.kv_cache_dtype
+        self.attn_backend.decode_attention_backend_str = (
+            self.decode_attention_backend_str
         )
-        if resolved_kv_cache_dtype is not None:
-            self._record_kv_cache_dtype(resolved_kv_cache_dtype)
 
     def _get_attention_backend(self, init_new_workspace: bool = False):
-        return get_attention_backend(
-            model_runner=self, init_new_workspace=init_new_workspace
+        """Init attention kernel backend."""
+        draft_attn_backend = self.server_args.speculative_draft_attention_backend
+        if self.is_draft_worker and draft_attn_backend:
+            logger.warning(
+                f"Overriding draft attention backend to {draft_attn_backend}."
+            )
+            # Single backend for all draft modes (no prefill/decode split).
+            self.prefill_attention_backend_str = draft_attn_backend
+            self.decode_attention_backend_str = draft_attn_backend
+            return self._get_attention_backend_from_str(
+                draft_attn_backend,
+                init_new_workspace=init_new_workspace,
+            )
+
+        (
+            self.prefill_attention_backend_str,
+            self.decode_attention_backend_str,
+        ) = self.server_args.get_attention_backends()
+
+        if self.decode_attention_backend_str != self.prefill_attention_backend_str:
+            from sglang.srt.layers.attention.hybrid_attn_backend import (
+                HybridAttnBackend,
+            )
+
+            attn_backend = HybridAttnBackend(
+                self,
+                decode_backend=self._get_attention_backend_from_str(
+                    self.decode_attention_backend_str,
+                    init_new_workspace=init_new_workspace,
+                ),
+                prefill_backend=self._get_attention_backend_from_str(
+                    self.prefill_attention_backend_str,
+                    init_new_workspace=init_new_workspace,
+                ),
+            )
+            logger.info(
+                f"Using hybrid attention backend for decode and prefill: "
+                f"decode_backend={self.decode_attention_backend_str}, "
+                f"prefill_backend={self.prefill_attention_backend_str}."
+            )
+            logger.warning(
+                "Warning: Attention backend specified by --attention-backend or default backend might be overridden."
+                "The feature of hybrid attention backend is experimental and unstable. Please raise an issue if you encounter any problem."
+            )
+        else:
+            attn_backend = self._get_attention_backend_from_str(
+                self.server_args.attention_backend,
+                init_new_workspace=init_new_workspace,
+            )
+
+        return attn_backend
+
+    def _get_attention_backend_from_str(
+        self, backend_str: str, init_new_workspace: bool = False
+    ):
+        if backend_str not in ATTENTION_BACKENDS:
+            raise ValueError(f"Invalid attention backend: {backend_str}")
+        self.init_new_workspace = init_new_workspace
+        full_attention_backend = ATTENTION_BACKENDS[backend_str](self)
+        return attn_backend_wrapper(self, full_attention_backend)
+
+    def maybe_init_ngram_embedding(self):
+        self.use_ngram_embedding = self.model_config.use_ngram_embedding
+        if self.use_ngram_embedding:
+            from sglang.srt.layers.n_gram_embedding import NgramEmbedding
+
+            # Sized to mirror req_to_token (indexed by req_pool_idx).
+            self.token_table = torch.empty(
+                self.req_to_token_pool.req_to_token.shape[0],
+                self.model_config.context_len,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            chunked_prefill_size = self.server_args.chunked_prefill_size
+            assert (
+                chunked_prefill_size is not None and chunked_prefill_size > 0
+            ), "Ngram embedding requires chunked prefill to be enabled (chunked_prefill_size > 0)"
+            for module in self.model.modules():
+                if isinstance(module, NgramEmbedding):
+                    module.init_buffers(
+                        self.max_running_requests, chunked_prefill_size, self.device
+                    )
+
+    def maybe_update_ngram_token_table(
+        self,
+        next_token_ids: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ):
+        """Update the ngram embedding token table after sampling."""
+        ngram_embedding_info = forward_batch.ngram_embedding_info
+        if ngram_embedding_info is None:
+            return
+        ngram_embedding_info.out_column_starts[: forward_batch.batch_size] = (
+            forward_batch.seq_lens
+        )
+        ngram_embedding_info.out_req_lens[: forward_batch.batch_size] = 1
+        update_token_table_decode(
+            ne_token_table=ngram_embedding_info.token_table,
+            tokens=next_token_ids.to(torch.int32),
+            row_indices=forward_batch.req_pool_indices,
+            column_starts=ngram_embedding_info.out_column_starts,
         )
 
     def init_decode_cuda_graph(self):
+        """Capture device graphs."""
         self.decode_cuda_graph_runner = None
         self.graph_mem_usage = 0
-        capture = capture_decode_graph(model_runner=self)
-        self.decode_cuda_graph_runner = capture.runner
-        self.graph_mem_usage = capture.graph_mem_usage
+
+        if not self.is_generation:
+            # TODO: Currently, cuda graph only captures decode steps, which only exists for generation models
+            return
+
+        if self.server_args.model_impl.lower() == ModelImpl.MINDSPORE:
+            return
+
+        if self.device != "cpu" and check_cuda_graph_backend(
+            Phase.DECODE, Backend.DISABLED
+        ):
+            return
+
+        if self.device == "cpu" and not get_flags().capture.enable_torch_compile:
+            return
+
+        tic = time.perf_counter()
+        before_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        graph_backend = defaultdict(
+            lambda: f"{current_platform.device_name} graph",
+            {
+                "cuda": "CUDA graph",
+                "musa": "CUDA graph",
+                "cpu": "CPU graph",
+                "npu": "NPU graph",
+                "xpu": "XPU graph",
+            },
+        )
+        role = "draft" if self.is_draft_worker else "target"
+        if self.spec_algorithm.is_speculative():
+            capture_name = f"{role} verify"
+            num_tokens_per_bs = (
+                self.spec_algorithm.get_num_tokens_per_bs_for_target_verify(
+                    self.server_args.speculative_num_draft_tokens,
+                    self.is_draft_worker,
+                )
+            )
+        else:
+            capture_name = f"{role} decode"
+            num_tokens_per_bs = 1
+        capture_bs, _ = get_batch_sizes_to_capture(self, num_tokens_per_bs)
+        decode_backend = self.server_args.cuda_graph_config.decode.backend
+        logger.info(
+            f"Capture {capture_name} {graph_backend[self.device]} begin. "
+            f"backend={decode_backend}, num_tokens_per_bs={num_tokens_per_bs}, "
+            f"bs={capture_bs}, avail mem={before_mem:.2f} GB"
+        )
+
+        if current_platform.is_out_of_tree():
+            GraphRunnerCls = current_platform.get_graph_runner_cls()
+            self.decode_cuda_graph_runner = GraphRunnerCls(self)
+        else:
+            from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+                DecodeCudaGraphRunner,
+            )
+
+            graph_runners = defaultdict(
+                lambda: DecodeCudaGraphRunner,
+                {
+                    "cpu": CPUGraphRunner,
+                    "npu": NPUGraphRunner,
+                    "xpu": XPUGraphRunner,
+                },
+            )
+            self.decode_cuda_graph_runner = graph_runners[self.device](self)
+
+        after_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        self.graph_mem_usage = before_mem - after_mem
+        logger.info(
+            f"Capture {capture_name} {graph_backend[self.device]} end. "
+            f"elapsed={time.perf_counter() - tic:.2f} s, "
+            f"mem usage={self.graph_mem_usage:.2f} GB, avail mem={after_mem:.2f} GB."
+        )
 
     def init_prefill_cuda_graph(self, force_for_draft_worker: bool = False):
+        """Initialize prefill CUDA graph runner."""
         self.prefill_cuda_graph_runner = None
-        self.prefill_cuda_graph_runner = capture_prefill_graph(
-            model_runner=self,
-            eager_runner=self.eager_runner,
-            force_for_draft_worker=force_for_draft_worker,
+
+        if check_cuda_graph_backend(Phase.PREFILL, Backend.DISABLED):
+            logger.info(
+                "Disable prefill CUDA graph because cuda_graph_config "
+                "resolved prefill.backend='disabled' (e.g. via "
+                "--cuda-graph-backend-prefill=disabled or auto-disable rules)."
+            )
+            # Prefill cuda graph disabled: route eager prefill through the
+            # EagerRunner (its can_run_graph returns False, so _forward_raw's
+            # extend branch falls through to the eager path).
+            if not self.is_draft_worker:
+                self.prefill_cuda_graph_runner = self.eager_runner
+            return
+
+        # Draft models skip here during __init__; the eagle worker calls
+        # this method explicitly (force_for_draft_worker=True) after
+        # init_lm_head so graphs capture the final embedding weights.
+        if self.is_draft_worker and not force_for_draft_worker:
+            return
+
+        # Skip prefill CG for EAGLE target on tc_piecewise: that backend
+        # captures CaptureHiddenMode.NULL while runtime requests FULL, so
+        # the captured graph is dead, and capturing it perturbs FP4 /
+        # TRTLLM-MoE state and corrupts decode replay (see #28386). BCG
+        # captures FULL for EAGLE target in PrefillCudaGraphRunner.__init__
+        # (restored from #25795), so it does NOT need this skip.
+        if (
+            self.spec_algorithm.is_eagle()
+            and not self.is_draft_worker
+            and not self.server_args.enable_return_hidden_states
+            and not check_cuda_graph_backend(Phase.PREFILL, Backend.BREAKABLE)
+        ):
+            logger.info(
+                "Disable prefill CUDA graph for EAGLE target on tc_piecewise "
+                "to avoid FP4/MoE decode-replay corruption (#28386)."
+            )
+            self.prefill_cuda_graph_runner = self.eager_runner
+            return
+
+        # Disable prefill CUDA graph for non-language models
+        if not hasattr(self.model, "model"):
+            logger.warning(
+                "Disable prefill CUDA graph because the model is not a language model"
+            )
+            return
+
+        # Disable prefill CUDA graph for non capture size
+        if not self.server_args.cuda_graph_config.prefill.bs:
+            logger.warning(
+                "Disable prefill CUDA graph because the capture size is not set"
+            )
+            return
+
+        # Collect attention layers and moe layers from the model
+        self.model.model = resolve_language_model(self.model)
+        language_model = getattr(self.model, "language_model", self.model)
+
+        # Resolve model with layers: handle CausalLM wrapper (.model.layers) and direct TextModel (.layers)
+        if hasattr(language_model, "model") and hasattr(language_model.model, "layers"):
+            layer_model = language_model.model
+        elif hasattr(language_model, "layers"):
+            layer_model = language_model
+        else:
+            logger.warning(
+                "Disable prefill CUDA graph because the model does not have a 'layers' attribute"
+            )
+            return
+
+        self.attention_layers = []
+        self.moe_layers = []
+        self.moe_fusions = []
+        self.dsa_indexers = []
+        for layer in layer_model.layers:
+            attn_layer = None
+            if hasattr(layer, "self_attn"):
+                if hasattr(layer.self_attn, "attn"):
+                    attn_layer = layer.self_attn.attn
+                elif hasattr(layer.self_attn, "attn_mqa"):
+                    # For DeepSeek model
+                    attn_layer = layer.self_attn.attn_mqa
+                    if _is_hip and hasattr(layer.self_attn, "attn_mha"):
+                        attn_layer._pcg_mha_companion = layer.self_attn.attn_mha
+            # For hybrid model
+            elif hasattr(layer, "attn"):
+                attn_layer = layer.attn
+            elif hasattr(layer, "linear_attn"):
+                if hasattr(layer.linear_attn, "attn"):
+                    attn_layer = layer.linear_attn.attn
+                else:
+                    attn_layer = layer.linear_attn
+            # For InternVL model
+            elif hasattr(layer, "attention"):
+                if hasattr(layer.attention, "attn"):
+                    attn_layer = layer.attention.attn
+            # For NemotronH and similar hybrid models using 'mixer' attribute
+            elif hasattr(layer, "mixer"):
+                if hasattr(layer.mixer, "attn"):
+                    attn_layer = layer.mixer.attn
+                elif hasattr(layer, "_forward_mamba"):
+                    # Mamba layer with split op support - store the layer itself
+                    attn_layer = layer
+
+            if attn_layer is not None:
+                self.attention_layers.append(attn_layer)
+            elif hasattr(layer, "mixer"):
+                self.attention_layers.append(None)
+
+            moe_block = None
+            moe_fusion = None
+            if hasattr(layer, "mlp") and hasattr(layer.mlp, "experts"):
+                moe_block = layer.mlp.experts
+                moe_fusion = layer.mlp
+            if hasattr(layer, "block_sparse_moe") and hasattr(
+                layer.block_sparse_moe, "experts"
+            ):
+                moe_block = layer.block_sparse_moe.experts
+                moe_fusion = layer.block_sparse_moe
+            if hasattr(layer, "moe") and hasattr(layer.moe, "experts"):
+                moe_block = layer.moe.experts
+                moe_fusion = layer.moe
+            # For NemotronH MoE layers using 'mixer' attribute
+            if hasattr(layer, "mixer") and hasattr(layer.mixer, "experts"):
+                moe_block = layer.mixer.experts
+                moe_fusion = layer.mixer
+            self.moe_layers.append(moe_block)
+            self.moe_fusions.append(moe_fusion)
+            # NSA indexers (None for layers without NSA)
+            dsa_indexer = None
+            if hasattr(layer, "self_attn") and hasattr(layer.self_attn, "indexer"):
+                dsa_indexer = layer.self_attn.indexer
+            self.dsa_indexers.append(dsa_indexer)
+
+        if len(self.attention_layers) < self.model_config.num_hidden_layers:
+            # TODO(yuwei): support Non-Standard GQA
+            log_info_on_rank0(
+                logger,
+                "Disable prefill CUDA graph because some layers do not apply Standard GQA",
+            )
+            return
+
+        tic = time.perf_counter()
+        before_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        prefill_backend = self.server_args.cuda_graph_config.prefill.backend
+        role = "draft" if self.is_draft_worker else "target"
+        capture_name = f"{role} prefill"
+        capture_num_tokens = sorted(self.server_args.cuda_graph_config.prefill.bs)
+        logger.info(
+            f"Capture {capture_name} CUDA graph begin. "
+            f"backend={prefill_backend}, num_tokens={capture_num_tokens}, "
+            f"avail mem={before_mem:.2f} GB"
+        )
+
+        self.prefill_cuda_graph_runner = PrefillCudaGraphRunner(self)
+
+        after_mem = get_available_gpu_memory(self.device, self.gpu_id)
+        mem_usage = before_mem - after_mem
+        logger.info(
+            f"Capture {capture_name} CUDA graph end. "
+            f"elapsed={time.perf_counter() - tic:.2f} s, "
+            f"mem usage={mem_usage:.2f} GB, avail mem={after_mem:.2f} GB."
         )
 
     def init_threads_binding(self):
-        self.local_omp_cpuid = numa_utils.init_threads_binding(
-            tp_rank=self.ps.tp_rank, tp_size=self.ps.tp_size
-        )
+        omp_cpuids = os.environ.get("SGLANG_CPU_OMP_THREADS_BIND", "all")
+        cpu_ids_by_node = get_cpu_ids_by_node()
+        n_numa_node = len(cpu_ids_by_node)
+        if omp_cpuids == "all":
+            assert self.tp_size <= n_numa_node, (
+                f"SGLANG_CPU_OMP_THREADS_BIND is not set, in this case, "
+                f"tp_size {self.tp_size} should be smaller than or equal to number of numa node on the machine {n_numa_node}. "
+                f"If you need tp_size to be larger than number of numa node, please set the CPU cores for each tp rank via SGLANG_CPU_OMP_THREADS_BIND explicitly. "
+                f"For example, on a machine with 2 numa nodes, where core 0-31 are on numa node 0 and core 32-63 are on numa node 1, "
+                f"it is suggested to use -tp 2 and bind tp rank 0 to core 0-31 and tp rank 1 to core 32-63. "
+                f"This is the default behavior if SGLANG_CPU_OMP_THREADS_BIND is not set and it is the same as setting SGLANG_CPU_OMP_THREADS_BIND=0-31|32-63. "
+                f"If you do need tp_size to be larger than the number of numa nodes, you could set SGLANG_CPU_OMP_THREADS_BIND explicitly for example SGLANG_CPU_OMP_THREADS_BIND=0-15|16-31|32-47|48-63 and run with -tp 4. "
+                f"If you don't want each tp rank to use all the cores on one numa node, you could set for example SGLANG_CPU_OMP_THREADS_BIND=0-15|32-47 and run with -tp 2."
+            )
+            if self.tp_size < n_numa_node:
+                logger.warning(
+                    f"Detected the current machine has {n_numa_node} numa nodes available, but tp_size is set to {self.tp_size}, so only {self.tp_size} numa nodes are used."
+                )
+            self.local_omp_cpuid = cpu_ids_by_node[self.tp_rank]
+        else:
+            threads_bind_list = omp_cpuids.split("|")
+            assert self.tp_size == len(threads_bind_list), (
+                f"SGLANG_CPU_OMP_THREADS_BIND setting must be aligned with TP size parameter ({self.tp_size}). "
+                f"Please double check your settings."
+            )
+            self.local_omp_cpuid = threads_bind_list[self.tp_rank]
+            if self.tp_size > n_numa_node:
+                logger.warning(
+                    f"TP size ({self.tp_size})is larger than numa node number ({n_numa_node}), "
+                    f"in this case the available memory amount of each rank cannot be determined in prior. "
+                    f"Please set proper `--max-total-tokens` to avoid the out-of-memory error."
+                )
 
     def apply_torch_tp(self):
-        model_parallel.apply_torch_tp(
-            model=self.model, device=self.device, tp_size=self.ps.tp_size
-        )
+        logger.info(f"Enabling torch tensor parallelism on {self.tp_size} devices.")
+        from sglang.srt.layers.model_parallel import tensor_parallel
+
+        device_mesh = torch.distributed.init_device_mesh(self.device, (self.tp_size,))
+        tensor_parallel(self.model, device_mesh)
 
     def update_decode_attn_backend(self, stream_idx: int):
         self.decode_attn_backend = self.decode_attn_backend_group[stream_idx]
-
-    def prepare_dummy_forward_batch(self, forward_batch: ForwardBatch) -> ForwardBatch:
-        """Customize a runner-created dummy batch before attention metadata initialization."""
-        return forward_batch
 
     def _prepare_eager_forward_batch(self, forward_batch: ForwardBatch) -> None:
         """Pad / normalize a batch for the eager (non-cuda-graph) forward.
@@ -1348,14 +3017,12 @@ class ModelRunner:
         # Try msprob debugger
         if self.msprobe_debugger is not None:
             rank_id = (
-                self.gpu_id
-                if self.ps.attn_dp_size is not None and self.ps.attn_dp_size > 1
-                else None
+                self.gpu_id if self.dp_size is not None and self.dp_size > 1 else None
             )
             self.msprobe_debugger.start(model=self.model, rank_id=rank_id)
 
         # Step span
-        step_span_ctx = profile_range(build_step_span_name(forward_batch))
+        step_span_ctx = profile_range(_build_step_span_name(forward_batch))
 
         canary_ctx = (
             context_tuple(
@@ -1424,7 +3091,7 @@ class ModelRunner:
             self.msprobe_debugger.step()
 
         if self.server_args.elastic_ep_backend is not None:
-            self.maybe_join_ep_ranks()
+            self.maybe_recover_ep_ranks()
 
         return output
 
@@ -1527,10 +3194,6 @@ class ModelRunner:
             # dispatch below reads the pool.
             self._maybe_execute_deferred_mamba_cow_and_clear(forward_batch)
 
-            dwdp_mgr = get_global_dwdp_manager()
-            if dwdp_mgr is not None:
-                dwdp_mgr.prefetch_first_layers()
-
             if forward_batch.forward_mode.is_split_prefill():
                 # Layer-split mode; stays on ModelRunner, not the eager runner.
                 ret = self.forward_split_prefill(
@@ -1591,10 +3254,10 @@ class ModelRunner:
 
         # Release the vocab_mask GPU tensor immediately after it has been applied
         # to the logits. In overlap scheduling, the sampling_info (and its
-        # grammar_mask) can be kept alive by the delay_sample_func closure and
+        # vocab_mask) can be kept alive by the delay_sample_func closure and
         # batch_record_buf until the next iteration, causing a steady VRAM leak
         # when structured output (grammar) is used.
-        sampling_info.grammar_mask = None
+        sampling_info.vocab_mask = None
 
     def sample(
         self,
@@ -1626,10 +3289,7 @@ class ModelRunner:
                 else forward_batch.seq_lens - 1
             ),
         )
-        self.ngram_embedding_manager.update_after_decode(
-            next_token_ids=next_token_ids,
-            forward_batch=forward_batch,
-        )
+        self.maybe_update_ngram_token_table(next_token_ids, forward_batch)
         return next_token_ids
 
     def compute_logprobs_only(
@@ -1659,225 +3319,69 @@ class ModelRunner:
         self.sampler.compute_logprobs_only(
             logits_output,
             forward_batch.sampling_info,
+            forward_batch.return_logprob,
             forward_batch.top_logprobs_nums,
             forward_batch.token_ids_logprobs,
         )
+
+    def save_remote_model(self, url: str):
+        from sglang.srt.model_loader.loader import RemoteModelLoader
+
+        logger.info(f"Saving model to {url}")
+        RemoteModelLoader.save_model(self.model, self.model_config.model_path, url)
+
+    def save_sharded_model(
+        self, path: str, pattern: Optional[str] = None, max_size: Optional[int] = None
+    ):
+        from sglang.srt.model_loader.loader import ShardedStateLoader
+
+        logger.info(
+            f"Save sharded model to {path} with pattern {pattern} and max_size {max_size}"
+        )
+        ShardedStateLoader.save_model(self.model, path, pattern, max_size)
 
     def check_weights(self, action: str, allow_quant_error: bool = False):
         return self._weight_checker.handle(
             action=action, allow_quant_error=allow_quant_error
         )
 
-    def _expand_eplb_metadata_for_scale(
-        self,
-        from_ep_size: int,
-        effective_size: int,
-    ) -> None:
-        metadata = get_global_expert_location_metadata()
-        if metadata is None:
+    def update_weights_from_ipc(self, recv_req):
+        """Update weights from IPC for checkpoint-engine integration."""
+        try:
+            from sglang.srt.checkpoint_engine.checkpoint_engine_worker import (
+                SGLangCheckpointEngineWorkerExtensionImpl,
+            )
+
+            # Create a worker extension that integrates with SGLang's model
+            worker = SGLangCheckpointEngineWorkerExtensionImpl(self)
+            worker.update_weights_from_ipc(recv_req.zmq_handles)
+            return True, "IPC weight update completed successfully"
+        except ImportError as e:
+            return False, f"IPC weight update failed: ImportError {e}"
+        except Exception as e:
+            logger.error(f"IPC weight update failed: {e}")
+            return False, str(e)
+
+    def prealloc_symmetric_memory_pool(self):
+        # PyTorch mempools never de-fragment memory in OOM scenarios, so we need to pre-allocate a large chunk of memory to limit fragmentation.
+        if (
+            self.is_draft_worker
+            or not self.server_args.enable_symm_mem
+            or envs.SGLANG_SYMM_MEM_PREALLOC_GB_SIZE.get() <= 0
+        ):
             return
-        old_num_physical = metadata.num_physical_experts
-        num_local = old_num_physical // from_ep_size
-        added = num_local * effective_size - old_num_physical
-        if added <= 0:
-            return
 
-        initial_ep_size = self.server_args.elastic_ep_initial_size
-        assert initial_ep_size is not None
-        self.server_args.override("elastic_ep.scale", ep_size=effective_size)
-
-        expanded_p2l = append_trivial_expert_slots(
-            metadata.physical_to_logical_map,
-            added,
-            metadata.num_logical_experts,
-            start=old_num_physical - num_local * initial_ep_size,
-        )
-        new_metadata = ExpertLocationMetadata.init_by_mapping(
-            self.server_args,
-            self.model_config,
-            physical_to_logical_map=expanded_p2l,
-            moe_ep_rank=self._elastic_global_rank(),
-        )
-        set_global_expert_location_metadata(new_metadata, allow_overwrite=True)
-
-    def _elastic_global_rank(self) -> int:
-        return self.ps.tp_rank + self.server_args.ep_join_rank_offset
-
-    def _report_elastic_scale_failure(self, error: str, effective_size: int) -> None:
-        if self.ps.tp_rank != 0 or self.server_args.is_ep_scale_joiner:
-            return
-        from sglang.srt.managers.io_struct import ElasticScaleUpdateReq
-
-        self._pending_elastic_scale_update = ElasticScaleUpdateReq(
-            success=False,
-            effective_ep_size=effective_size,
-            error=error,
-        )
-
-    def _elastic_scale_ready_barrier(self, target_size: int, log_tag: str) -> None:
-        if self.ps.tp_rank == 0:
-            logger.debug(
-                "[Elastic EP][scale] %s entering post-scale WORLD barrier "
-                "(target_ep_size=%d)",
-                log_tag,
-                target_size,
-            )
-        dist.barrier(group=dist.group.WORLD)
-        if self.ps.tp_rank == 0:
-            logger.debug(
-                "[Elastic EP][scale] %s passed post-scale WORLD barrier "
-                "(target_ep_size=%d)",
-                log_tag,
-                target_size,
-            )
-
-    def _finalize_scale_up(
-        self,
-        ranks_to_join: list[int],
-        target_size: int,
-        effective_size: int,
-    ) -> None:
-        self.forward_pass_id = 0
-        ElasticEPStateManager.mark_configuring_data_plane()
-
-        state = ElasticEPStateManager.instance()
-        for rank in ranks_to_join:
-            state.active_ranks[rank] = 1
-        state.snapshot_active_to_last()
-        state.sync_active_to_cpu()
-        if self.eplb_manager is not None:
-            self.eplb_manager.reset_generator()
-
-        self._expand_eplb_metadata_for_scale(
-            from_ep_size=effective_size,
-            effective_size=target_size,
-        )
-        broadcast_global_expert_location_metadata(
-            model_config=self.model_config,
-            moe_ep_rank=self._elastic_global_rank(),
-            src_rank=0,
-        )
-
-        ElasticEPStateManager.on_scale(effective_size, target_size)
-        set_global_expert_distribution_recorder(
-            ExpertDistributionRecorder.init_new(
-                self.server_args,
-                get_global_expert_location_metadata(),
-                rank=self._elastic_global_rank(),
-            )
-        )
-
-        if self.eplb_manager is not None:
-            self.eplb_manager.disable_rebalance(
-                "EPLB rebalance is disabled after elastic EP scale-up"
-            )
-
-        from sglang.srt.layers.dp_attention import update_dp_attention_post_scale
-
-        update_dp_attention_post_scale(
-            new_dp_size=target_size,
-            new_dp_rank=self._elastic_global_rank(),
-        )
-        self.server_args.override("elastic_ep.scale", dp_size=target_size)
-
-        ElasticEPStateManager.mark_syncing_new_world()
-        self._elastic_scale_ready_barrier(
-            target_size=target_size,
-            log_tag="JOINER" if self.server_args.is_ep_scale_joiner else "PRIMARY",
-        )
-        ElasticEPStateManager.commit_scale()
-
-        if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
-            from sglang.srt.managers.io_struct import ElasticScaleUpdateReq
-
-            self._pending_elastic_scale_update = ElasticScaleUpdateReq(
-                success=True,
-                effective_ep_size=target_size,
-                slot_offset=effective_size,
-                slot_count=target_size - effective_size,
-            )
+        # Memory allocation is tied to a cuda stream, use the forward stream
+        with torch.get_device_module(self.device).stream(self.forward_stream):
             logger.info(
-                "[Elastic EP] Scale completed: old_ep_size=%d "
-                "new_ep_size=%d joined_ranks=%s",
-                effective_size,
-                target_size,
-                ranks_to_join,
+                f"Pre-allocating symmetric memory pool with {envs.SGLANG_SYMM_MEM_PREALLOC_GB_SIZE.get()} GiB"
             )
-
-    def maybe_join_ep_ranks(self) -> None:
-        if not ElasticEPStateManager.is_scaling():
-            return
-
-        state = ElasticEPStateManager.instance()
-        effective_size = ElasticEPStateManager.get_effective_ep_size()
-        pending_size = ElasticEPStateManager.get_pending_ep_size()
-
-        if pending_size is None:
-            if state is not None and state.has_scaled:
-                error = (
-                    "Elastic EP rank recovery is unsupported after runtime scale-up. "
-                    "Restart the expanded deployment."
+            with use_symmetric_memory(get_tp_group()):
+                torch.empty(
+                    (envs.SGLANG_SYMM_MEM_PREALLOC_GB_SIZE.get() * 1024 * 1024 * 1024,),
+                    dtype=torch.uint8,
+                    device=self.device,
                 )
-                ElasticEPStateManager.fail_recovery(error)
-                self._report_elastic_scale_failure(error, effective_size)
-                if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
-                    logger.error("[Elastic EP] %s", error)
-                return
-
-            recovered = maybe_recover_ep_ranks(
-                tp_group=self.tp_group,
-                eplb_manager=self.eplb_manager,
-                model_config=self.model_config,
-                moe_ep_rank=self._elastic_global_rank(),
-            )
-            if recovered:
-                self.forward_pass_id = 0
-            return
-
-        local_timeout = (
-            state.pending_since is not None
-            and time.monotonic() - state.pending_since
-            > self.server_args.elastic_ep_scale_timeout
-        )
-        timeout = state.active_ranks.new_tensor(int(local_timeout))
-        dist.all_reduce(timeout, op=dist.ReduceOp.MAX, group=dist.group.WORLD)
-        if timeout.item():
-            error = f"Timed out waiting for ranks to join target EP size {pending_size}"
-            ElasticEPStateManager.fail_scale(error)
-            self._report_elastic_scale_failure(error, effective_size)
-            if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
-                logger.error("[Elastic EP] %s", error)
-            return
-
-        if state.scale_phase == "waiting_for_cohort":
-            cohort_target = get_scale_cohort_target(effective_size)
-            if cohort_target is None:
-                return
-            if cohort_target != pending_size:
-                error = (
-                    f"Requested target EP size {pending_size} does not match "
-                    f"joining cohort target {cohort_target}"
-                )
-                ElasticEPStateManager.fail_scale(error)
-                self._report_elastic_scale_failure(error, effective_size)
-                if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
-                    logger.error("[Elastic EP] %s", error)
-                return
-            if not ElasticEPStateManager.begin_scale():
-                return
-
-        ranks_to_join = list(range(effective_size, pending_size))
-        if not ranks_to_join:
-            return
-
-        current_platform.synchronize()
-        ElasticEPStateManager.mark_joining()
-        if try_admit_scale_ranks(ranks_to_join):
-            self._finalize_scale_up(
-                ranks_to_join=ranks_to_join,
-                target_size=pending_size,
-                effective_size=effective_size,
-            )
 
     def _maybe_rebalance_after_rank_fault(
         self,
@@ -1887,7 +3391,17 @@ class ModelRunner:
         reinit_attn_backend: bool,
         split_forward_count: int,
     ) -> ModelRunnerOutput:
-        if maybe_rebalance_after_rank_fault(eplb_manager=self.eplb_manager):
+        elastic_ep_state = ElasticEPStateManager.instance()
+        if elastic_ep_state is not None and not elastic_ep_state.is_active_equal_last():
+            elastic_ep_state.snapshot_active_to_last()
+            elastic_ep_state.sync_active_to_cpu()
+            logging.info("EPLB due to rank faults")
+            gen = self.eplb_manager.rebalance()
+            while True:
+                try:
+                    next(gen)
+                except StopIteration:
+                    break
             output = self._forward_raw(
                 forward_batch,
                 pp_proxy_tensors,
@@ -1896,18 +3410,35 @@ class ModelRunner:
             )
         return output
 
-    def update_model_fields(
-        self,
-        new_model: torch.nn.Module,
-        *,
-        model_path: str,
-        load_format: str,
-        load_config: LoadConfig,
-    ) -> None:
-        self.model = new_model
-        self.server_args.override(
-            "model_runner.update_model_fields",
-            model_path=model_path,
-            load_format=load_format,
-        )
-        self.load_config = load_config
+
+def _model_load_weights_direct(model, named_tensors: List[Tuple[str, torch.Tensor]]):
+    params_dict = dict(model.named_parameters())
+    for name, tensor in named_tensors:
+        default_weight_loader(params_dict[name], tensor)
+
+
+def _unwrap_tensor(tensor, tp_rank, device):
+    if isinstance(tensor, LocalSerializedTensor):
+        tensor = tensor.get(tp_rank)
+    return tensor.to(device)
+
+
+def _build_step_span_name(forward_batch: ForwardBatch) -> str:
+    """Build a profile-trace span name for one forward step."""
+    mode = forward_batch.forward_mode
+    bs = forward_batch.batch_size
+    if mode == ForwardMode.EXTEND:
+        ext_toks = forward_batch.extend_num_tokens or 0
+        return f"step[EXTEND bs={bs} toks={ext_toks}]"
+    return f"step[{mode.name} bs={bs}]"
+
+
+@dataclass
+class LocalSerializedTensor:
+    """torch.Tensor that gets serialized by MultiprocessingSerializer (which only serializes a pointer and not the data).
+    The i-th element in the list corresponds to i-th rank's GPU."""
+
+    values: List[bytes]
+
+    def get(self, rank: int):
+        return MultiprocessingSerializer.deserialize(self.values[rank])

--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
@@ -1,0 +1,1339 @@
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.configs.model_config import (
+    get_dsa_index_head_dim,
+    get_minimax_sparse_attention_config,
+    get_minimax_sparse_disable_value_layer_ids,
+    get_minimax_sparse_layer_ids,
+    is_deepseek_dsa,
+    is_deepseek_v4,
+    is_minimax_sparse,
+)
+from sglang.srt.distributed.parallel_state import (
+    get_world_group,
+)
+from sglang.srt.environ import envs
+from sglang.srt.layers.dp_attention import get_attention_tp_size
+from sglang.srt.mem_cache.allocator import (
+    PagedTokenToKVPoolAllocator,
+    TokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.allocator.hisparse import (
+    DeepSeekV4HiSparseTokenToKVPoolAllocator,
+    HiSparseTokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.allocator.swa import (
+    PureSWATokenToKVPoolAllocator,
+    SWATokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.common import get_req_to_token_extra_context_len
+from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
+from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
+from sglang.srt.mem_cache.memory_pool import (
+    DSATokenToKVPool,
+    HybridLinearKVPool,
+    HybridReqToTokenPool,
+    MHATokenToKVPool,
+    MHATokenToKVPoolFP4,
+    MiniMaxSparseKVPool,
+    MLATokenToKVPool,
+    MLATokenToKVPoolFP4,
+    NoOpMHATokenToKVPool,
+    PageMajorMHATokenToKVPool,
+    ReqToTokenPool,
+)
+from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
+from sglang.srt.platforms import current_platform
+from sglang.srt.utils.common import (
+    get_available_gpu_memory,
+    is_float4_e2m1fn_x2,
+    is_hip,
+    is_npu,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+    from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
+
+
+def _should_enable_lazy_compaction() -> bool:
+    """Lazy compaction default — ON unless
+    `SGLANG_DISABLE_LAZY_COMPACTION=1` (escape hatch for A/B / rollback).
+    Centralized here so both unified-memory-pool factory call sites stay in sync.
+    """
+    return not envs.SGLANG_DISABLE_LAZY_COMPACTION.get()
+
+
+# the ratio of mamba cache pool size to max_running_requests
+MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO = 3
+MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP = 2
+MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP_LAZY = 1
+MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP = 1
+
+logger = logging.getLogger(__name__)
+
+
+def _get_dsv4_compress_state_dtypes() -> tuple[torch.dtype, torch.dtype]:
+    dtype_name = envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.get().strip().lower()
+    if dtype_name in ("float32", "fp32"):
+        return torch.float32, torch.float32
+    if dtype_name in ("bfloat16", "bf16"):
+        if envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get():
+            raise ValueError(
+                "SGLANG_DSV4_COMPRESS_STATE_DTYPE=bf16 is not supported when "
+                "SGLANG_OPT_USE_ONLINE_COMPRESS=1; online c128 state must stay float32."
+            )
+        return torch.bfloat16, torch.bfloat16
+    raise ValueError(
+        "Unsupported SGLANG_DSV4_COMPRESS_STATE_DTYPE="
+        f"{dtype_name!r}. Expected one of: float32, fp32, bfloat16, bf16."
+    )
+
+
+_is_npu = is_npu()
+_is_hip = is_hip()
+
+
+class ModelRunnerKVCacheMixin:
+    def _profile_available_bytes(self: ModelRunner, pre_model_load_memory: int) -> int:
+        # KV pool budget = currently-free GPU memory minus the non-static runtime
+        # slack (pre_model_load_memory * (1 - mem_fraction_static)). Whatever is
+        # already resident (model weights, etc.) is thus charged against it.
+        available_gpu_memory = get_available_gpu_memory(
+            self.device,
+            self.gpu_id,
+            distributed=get_world_group().world_size > 1,
+            cpu_group=get_world_group().cpu_group,
+        )
+
+        rest_memory = available_gpu_memory - pre_model_load_memory * (
+            1 - self.mem_fraction_static
+        )
+        if self.mambaish_config is not None:
+            rest_memory = self.handle_max_mamba_cache(rest_memory)
+
+        # Loaded weights (target + draft) can exceed the static budget
+        if rest_memory <= 0:
+            minimum_mem_fraction_static = (
+                1 - available_gpu_memory / pre_model_load_memory
+            )
+            suggested_mem_fraction_static = (
+                math.ceil(minimum_mem_fraction_static * 1000) / 1000
+            )
+            raise ValueError(
+                f"Loaded weights leave no GPU memory for the KV cache under "
+                f"--mem-fraction-static={self.mem_fraction_static}. "
+                f"Raise --mem-fraction-static above "
+                f"{suggested_mem_fraction_static:.3f} "
+                f"(minimum viable = 1 - available/pre = "
+                f"{minimum_mem_fraction_static:.4f}). If using speculative "
+                f"decoding, draft weights are now counted."
+            )
+
+        return int(rest_memory * (1 << 30))  # return in bytes
+
+    def handle_max_mamba_cache(self: ModelRunner, total_rest_memory):
+        config = self.mambaish_config
+        server_args = self.server_args
+        assert config is not None
+
+        has_spec_dec = not self.spec_algorithm.is_none()
+        if has_spec_dec:
+            assert server_args.speculative_num_draft_tokens is not None
+            assert server_args.max_running_requests is not None
+
+        if server_args.max_mamba_cache_size is not None:
+            # Use explicitly set max_mamba_cache_size
+            server_args.max_mamba_cache_size = server_args.max_mamba_cache_size // (
+                server_args.dp_size if server_args.enable_dp_attention else 1
+            )
+            # Reserve intermediate memory based on capped max_num_reqs
+            if has_spec_dec:
+                ratio = self._calculate_mamba_ratio()
+                capped_reqs = min(
+                    server_args.max_running_requests
+                    // (self.dp_size if server_args.enable_dp_attention else 1),
+                    server_args.max_mamba_cache_size // ratio,
+                )
+                intermediate_size = (
+                    config.mamba2_cache_params.mamba_cache_per_req
+                    * capped_reqs
+                    * server_args.speculative_num_draft_tokens
+                )
+                total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
+        elif (
+            server_args.disable_radix_cache
+            and server_args.max_running_requests is not None
+        ):
+            # Use explicitly set max_running_requests when radix cache is disabled
+            server_args.max_mamba_cache_size = server_args.max_running_requests // (
+                server_args.dp_size if server_args.enable_dp_attention else 1
+            )
+            # Reserve intermediate memory based on capped max_num_reqs
+            if has_spec_dec:
+                intermediate_size = (
+                    config.mamba2_cache_params.mamba_cache_per_req
+                    * server_args.max_mamba_cache_size
+                    * server_args.speculative_num_draft_tokens
+                )
+                total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
+        else:
+            # Use ratio-based calculation to auto-fit available memory
+            assert config.mamba2_cache_params.mamba_cache_per_req > 0
+            per_req = config.mamba2_cache_params.mamba_cache_per_req
+
+            # Solve jointly for max_mamba_cache_size accounting for intermediate memory.
+            # The mamba budget (from the ratio split) must cover both:
+            #   1. main mamba state: max_mamba_cache_size * per_req
+            #   2. intermediate states: (max_mamba_cache_size / ratio) * D * per_req
+            # So: max_mamba_cache_size * per_req * (1 + D/ratio) = mamba_budget_bytes
+            mamba_budget = (
+                total_rest_memory
+                * server_args.mamba_full_memory_ratio
+                / (1 + server_args.mamba_full_memory_ratio)
+            )
+            mamba_budget_bytes = mamba_budget * (1 << 30)
+
+            if has_spec_dec:
+                ratio = self._calculate_mamba_ratio()
+                D = server_args.speculative_num_draft_tokens
+                # Joint solve: main_state + intermediate = mamba_budget
+                server_args.max_mamba_cache_size = int(
+                    mamba_budget_bytes // (per_req * (1 + D / ratio))
+                )
+                # Intermediate memory is included in mamba_budget, subtract it
+                # so the return value only has main_state subtracted from total
+                capped_reqs = min(
+                    server_args.max_running_requests
+                    // (self.dp_size if server_args.enable_dp_attention else 1),
+                    server_args.max_mamba_cache_size // ratio,
+                )
+                intermediate_size = per_req * capped_reqs * D
+                total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
+            else:
+                server_args.max_mamba_cache_size = int(mamba_budget_bytes // per_req)
+
+        # Validate: max_mamba_cache_size must be positive after memory allocation.
+        # A non-positive value means GPU memory is insufficient for the requested
+        # configuration. Fail fast with actionable advice instead of silently
+        # producing garbled output at runtime.
+        if server_args.max_mamba_cache_size <= 0:
+            raise RuntimeError(
+                f"Not enough GPU memory for hybrid (mamba/linear-attention) state cache. "
+                f"Computed max_mamba_cache_size={server_args.max_mamba_cache_size} "
+                f"(total_rest_memory={total_rest_memory:.2f} GB, "
+                f"mamba_cache_per_req={config.mamba2_cache_params.mamba_cache_per_req / (1 << 20):.2f} MB). "
+                f"Try: (1) reduce --max-running-requests, "
+                f"(2) increase --mem-fraction-static, "
+                f"(3) reduce --speculative-num-draft-tokens, or "
+                f"(4) use GPUs with more memory."
+            )
+
+        mamba_state_memory = (
+            server_args.max_mamba_cache_size
+            * config.mamba2_cache_params.mamba_cache_per_req
+            / (1 << 30)
+        )
+        return total_rest_memory - mamba_state_memory
+
+    def calculate_mla_kv_cache_dim(self: ModelRunner) -> int:
+        is_dsa_model = is_deepseek_dsa(self.model_config.hf_config)
+        kv_cache_dtype = self.kv_cache_dtype
+        kv_lora_rank = self.model_config.kv_lora_rank
+        qk_rope_head_dim = self.model_config.qk_rope_head_dim
+        kv_cache_dim = kv_lora_rank + qk_rope_head_dim  # default mla kv cache dim
+
+        # For non-DSA models, MLA kv cache dim is simply kv_lora_rank + qk_rope_head_dim
+        if not is_dsa_model:
+            return kv_cache_dim
+
+        # TRTLLM backend does not override kv_cache_dim for MLA kv cache
+        # Assuming dsa prefill and decode backends are the same when using trtllm MLA backend,
+        # since it is not compatible for trtllm and other mla attn backend due to the different
+        # kv cache layout.
+        if (
+            self.server_args.dsa_prefill_backend == "trtllm"
+            or self.server_args.dsa_decode_backend == "trtllm"
+        ):
+            return kv_cache_dim
+
+        # On HIP, TileLang and AITER DSA kernels consume the raw MLA KV layout:
+        # nope(512 fp8) + rope(64 fp8), without extra per-block scales.
+        if _is_hip and (
+            self.server_args.dsa_prefill_backend in ("tilelang", "aiter")
+            or self.server_args.dsa_decode_backend in ("tilelang", "aiter")
+        ):
+            return kv_cache_dim
+
+        quant_block_size = DSATokenToKVPool.quant_block_size
+        rope_storage_dtype = DSATokenToKVPool.rope_storage_dtype
+        # Calculate override_kv_cache_dim for FP8 storage in backends that use scaled KV layout
+        # (excluding TRTLLM and HIP raw-layout kernels).
+        # kv_lora_rank + scale storage (kv_lora_rank // quant_block_size * 4 bytes) + rope dimension storage
+        # Note: rope dimension is stored in original dtype (bf16), not quantized to fp8
+        if kv_cache_dtype == torch.float8_e4m3fn:
+            assert (
+                kv_lora_rank % quant_block_size == 0
+            ), f"kv_lora_rank {kv_lora_rank} must be multiple of quant_block_size {quant_block_size}"
+
+            return (
+                kv_lora_rank
+                + kv_lora_rank // quant_block_size * 4
+                + qk_rope_head_dim * rope_storage_dtype.itemsize
+            )
+
+        return kv_cache_dim
+
+    def _calculate_mamba_ratio(self: ModelRunner) -> int:
+        if self.server_args.disable_radix_cache:
+            return 1
+
+        additional_ratio = 0
+        if self.server_args.enable_mamba_extra_buffer():
+            # ping-pong buffer size is 2 when overlap schedule is on, 1 otherwise.
+            # Lazy mode saves 1 slot (2 → 1) for overlap; non-overlap already uses 1.
+            if not self.server_args.disable_overlap_schedule:
+                if self.server_args.enable_mamba_extra_buffer_lazy():
+                    additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP_LAZY
+                else:
+                    additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP
+            else:
+                assert (
+                    not self.server_args.enable_mamba_extra_buffer_lazy()
+                ), "Lazy extra buffer requires overlap schedule (--disable-overlap-schedule is incompatible)"
+                additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP
+
+        return MAMBA_CACHE_SIZE_MAX_RUNNING_REQUESTS_RATIO + additional_ratio
+
+    def _validate_prefill_only_disable_kv_cache_pool_family(
+        self: ModelRunner,
+        is_dsa_model: bool,
+        is_dsv4_model: bool,
+        current_platform,
+    ):
+        if not self.server_args.prefill_only_disable_kv_cache or self.is_draft_worker:
+            return
+
+        unsupported_pool_family = None
+        if is_dsv4_model:
+            unsupported_pool_family = "DeepSeekV4TokenToKVPool"
+        elif current_platform.is_out_of_tree() and not self.mambaish_config:
+            unsupported_pool_family = "out-of-tree platform KV pool"
+        elif (
+            self.server_args.attention_backend == "ascend" and not self.mambaish_config
+        ):
+            unsupported_pool_family = "NPU/Ascend KV pool"
+        elif self.use_mla_backend and is_dsa_model:
+            unsupported_pool_family = "DSA/MLA KV pool"
+        elif self.use_mla_backend and not self.mambaish_config:
+            unsupported_pool_family = "MLA KV pool"
+        elif self.is_hybrid_swa:
+            unsupported_pool_family = "SWA KV pool"
+        elif self.mambaish_config:
+            unsupported_pool_family = "hybrid linear/Mamba KV pool"
+        elif is_float4_e2m1fn_x2(self.kv_cache_dtype):
+            unsupported_pool_family = "FP4 MHA KV pool"
+
+        if unsupported_pool_family is not None:
+            raise RuntimeError(
+                "--prefill-only-disable-kv-cache is not supported for "
+                f"{unsupported_pool_family}. Supported configurations today: plain MHA "
+                "models on CUDA with the FA (fa3/fa4) prefill backend, --is-embedding, "
+                "--chunked-prefill-size=-1, --disable-radix-cache, no context-parallel "
+                "attention, no HiSparse, and --kv-cache-dtype != fp4_e2m1."
+            )
+
+    def _init_unified_mamba_pools(self: ModelRunner, max_num_reqs: int):
+        """Build the shared-KV-pool stack for a hybrid-Mamba model:
+        one byte buffer split between the full-attn MHA KV pool and the
+        per-request Mamba state pool, with virtual slot ids above the
+        allocator."""
+        from sglang.srt.mem_cache.unified_memory_pool import init_unified_mamba_pools
+
+        config = self.mambaish_config
+        assert config is not None
+        assert (
+            not self.use_mla_backend
+        ), "unified memory pool does not support MLA-hybrid-Mamba yet"
+        # The full sub-pool is page-aware (via `MultiEndedAllocator(page_size=...)`);
+        # the mamba sub-pool stays page=1.
+        assert self.page_size >= 1, f"page_size must be >= 1, got {self.page_size}"
+        # Mirror the non-shared path's extra_max_context_len computation.
+        extra_max_context_len = 4
+        if self.server_args.speculative_num_draft_tokens is not None:
+            extra_max_context_len += self.server_args.speculative_num_draft_tokens
+
+        mamba_layer_ids = [
+            i
+            for i in config.mamba2_cache_params.layers
+            if self.start_layer <= i < self.end_layer
+        ]
+        full_attention_layer_ids = [
+            i
+            for i in config.full_attention_layer_ids
+            if self.start_layer <= i < self.end_layer
+        ]
+
+        bundle = init_unified_mamba_pools(
+            device=self.device,
+            kv_cache_dtype=self.kv_cache_dtype,
+            head_num=self.model_config.get_num_kv_heads(get_attention_tp_size()),
+            head_dim=self.model_config.head_dim,
+            page_size=self.page_size,
+            start_layer=self.start_layer,
+            end_layer=self.end_layer,
+            is_draft_worker=self.is_draft_worker,
+            use_mla_backend=self.use_mla_backend,
+            mamba_layer_ids=mamba_layer_ids,
+            full_attention_layer_ids=full_attention_layer_ids,
+            mamba2_cache_params=config.mamba2_cache_params,
+            model_context_len=self.model_config.context_len,
+            extra_max_context_len=extra_max_context_len,
+            max_total_num_tokens=self.max_total_num_tokens,
+            max_mamba_cache_size=self.server_args.max_mamba_cache_size,
+            max_num_reqs=max_num_reqs,
+            enable_memory_saver=self.server_args.enable_memory_saver,
+            enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+            speculative_num_draft_tokens=self.server_args.speculative_num_draft_tokens,
+            disable_overlap_schedule=self.server_args.disable_overlap_schedule,
+            need_sort=self.server_args.disaggregation_mode in ("decode", "prefill"),
+            mamba_full_memory_ratio=self.server_args.mamba_full_memory_ratio,
+            # Overlap mode: the allocator's `free` drops a wait_stream(forward_stream)
+            # barrier so eager compaction serializes after the in-flight forward's
+            # v2p/KV reads. Near-no-op in normal mode.
+            forward_stream=self.forward_stream,
+            # Lazy compaction: default ON, env-var escape hatch for rollback / A/B.
+            lazy_compaction=_should_enable_lazy_compaction(),
+        )
+        self.req_to_token_pool = bundle.req_to_token_pool
+        self.token_to_kv_pool = bundle.token_to_kv_pool
+        self.token_to_kv_pool_allocator = bundle.token_to_kv_pool_allocator
+        # Keep a reference so the shared byte buffer is not GC'd.
+        self._unified_memory_pool = bundle.unified_memory_pool
+
+    def _init_unified_swa_pools(self: ModelRunner, max_num_reqs: int):
+        """Build the unified-pool stack for a hybrid-SWA model (Triton): one byte
+        buffer split between the full-attention and SWA KV pools."""
+        from sglang.srt.mem_cache.unified_memory_pool import init_unified_swa_pools
+
+        assert self.is_hybrid_swa, "_init_unified_swa_pools called on a non-SWA model"
+        # Both sub-pools are page-aware; the SWA composite runs alloc_extend_kernel
+        # once in virtual space and binds the new pages on both sub-allocators.
+        assert self.page_size >= 1, f"page_size must be >= 1, got {self.page_size}"
+        assert (
+            not self.use_mla_backend
+        ), "unified memory pool does not support MLA-SWA hybrid yet"
+        # Mirror the non-shared path's extra_max_context_len computation.
+        extra_max_context_len = 4
+        if self.server_args.speculative_num_draft_tokens is not None:
+            extra_max_context_len += self.server_args.speculative_num_draft_tokens
+        self.req_to_token_pool = ReqToTokenPool(
+            size=max_num_reqs,
+            max_context_len=self.model_config.context_len + extra_max_context_len,
+            device=self.device,
+            enable_memory_saver=self.server_args.enable_memory_saver,
+        )
+
+        head_num = self.model_config.get_num_kv_heads(get_attention_tp_size())
+        head_dim = self.model_config.head_dim
+        if self.is_hybrid_swa_compress:
+            # Asymmetric head dims between full and SWA (NPU compress path):
+            # pull SWA-specific dims from the hf text config.
+            v_head_dim = self.model_config.hf_text_config.v_head_dim
+            swa_head_num = max(
+                1,
+                self.model_config.hf_text_config.swa_num_key_value_heads
+                // get_attention_tp_size(),
+            )
+            swa_head_dim = self.model_config.hf_text_config.swa_head_dim
+            swa_v_head_dim = self.model_config.hf_text_config.swa_v_head_dim
+        else:
+            v_head_dim = head_dim
+            swa_head_num = head_num
+            swa_head_dim = head_dim
+            swa_v_head_dim = head_dim
+
+        # Filter layer ids to this worker's [start_layer, end_layer) range.
+        swa_attention_layer_ids = [
+            i
+            for i in self.model_config.swa_attention_layer_ids
+            if self.start_layer <= i < self.end_layer
+        ]
+        full_attention_layer_ids = [
+            i
+            for i in self.model_config.full_attention_layer_ids
+            if self.start_layer <= i < self.end_layer
+        ]
+
+        bundle = init_unified_swa_pools(
+            device=self.device,
+            kv_cache_dtype=self.kv_cache_dtype,
+            head_num=head_num,
+            head_dim=head_dim,
+            v_head_dim=v_head_dim,
+            swa_head_num=swa_head_num,
+            swa_head_dim=swa_head_dim,
+            swa_v_head_dim=swa_v_head_dim,
+            page_size=self.page_size,
+            start_layer=self.start_layer,
+            end_layer=self.end_layer,
+            swa_attention_layer_ids=swa_attention_layer_ids,
+            full_attention_layer_ids=full_attention_layer_ids,
+            full_max_total_num_tokens=self.full_max_total_num_tokens,
+            swa_max_total_num_tokens=self.swa_max_total_num_tokens,
+            enable_memory_saver=self.server_args.enable_memory_saver,
+            need_sort=self.server_args.disaggregation_mode in ("decode", "prefill"),
+            # Overlap mode: same wait_stream(forward_stream) rationale as
+            # `_init_unified_mamba_pools`.
+            forward_stream=self.forward_stream,
+            # Lazy compaction: default ON, with env var escape hatch for rollback / A/B.
+            lazy_compaction=_should_enable_lazy_compaction(),
+        )
+        self.token_to_kv_pool = bundle.token_to_kv_pool
+        self.token_to_kv_pool_allocator = bundle.token_to_kv_pool_allocator
+        # Keep a reference so the shared byte buffer is not GC'd.
+        self._unified_memory_pool = bundle.unified_memory_pool
+
+    def _init_pools(self: ModelRunner):
+        """Initialize the memory pools."""
+        max_num_reqs = self.max_running_requests
+
+        # Unified-pool fast path: build req_to_token + token_to_kv pool + allocator
+        # from one byte buffer, then return. Gated to the target worker
+        # (req_to_token_pool is None); supports hybrid Mamba and hybrid SWA (not DSV4).
+        if (
+            self.server_args.enable_unified_memory
+            and self.server_args.disaggregation_mode == "null"
+            and self.req_to_token_pool is None
+        ):
+            if self.mambaish_config is not None:
+                self._init_unified_mamba_pools(max_num_reqs)
+                return
+            if self.is_hybrid_swa and not is_deepseek_v4(self.model_config.hf_config):
+                self._init_unified_swa_pools(max_num_reqs)
+                return
+            # Fail loud, not silently fall through to the normal pools (which would
+            # leave the flag a no-op). The feature replaces the HYBRID pools only.
+            raise ValueError(
+                "--enable-unified-memory only supports hybrid Mamba and "
+                "hybrid sliding-window-attention models (DeepSeek-V4 excluded); "
+                f"the current model ({self.model_config.hf_config.architectures}) "
+                "is neither, so the unified memory pool cannot be built. Drop "
+                "--enable-unified-memory for this model."
+            )
+
+        # Initialize req_to_token_pool
+        if self.req_to_token_pool is None:
+            max_spec_draft_tokens = self.server_args.max_speculative_num_draft_tokens
+            extra_max_context_len = get_req_to_token_extra_context_len(self.server_args)
+
+            if self.server_args.disaggregation_mode == "decode":
+                from sglang.srt.disaggregation.decode import (
+                    DecodeReqToTokenPool,
+                    HybridMambaDecodeReqToTokenPool,
+                )
+
+                # Extra slots for pre-allocated requests
+                pre_alloc_size = self.server_args.disaggregation_decode_extra_slots
+                if config := self.mambaish_config:
+                    self.req_to_token_pool = HybridMambaDecodeReqToTokenPool(
+                        size=max_num_reqs,
+                        max_context_len=self.model_config.context_len
+                        + extra_max_context_len,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        cache_params=config.mamba2_cache_params,
+                        mamba_layer_ids=(
+                            [
+                                i
+                                for i in config.mamba2_cache_params.layers
+                                if self.start_layer <= i < self.end_layer
+                            ]
+                        ),
+                        speculative_num_draft_tokens=max_spec_draft_tokens,
+                        speculative_eagle_topk=self.server_args.speculative_eagle_topk,
+                        enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+                        pre_alloc_size=pre_alloc_size,
+                        enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
+                        mamba_size=self.server_args.max_mamba_cache_size,
+                        start_layer=self.start_layer,
+                    )
+                else:
+                    self.req_to_token_pool = DecodeReqToTokenPool(
+                        size=max_num_reqs,
+                        max_context_len=self.model_config.context_len
+                        + extra_max_context_len,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        pre_alloc_size=pre_alloc_size,
+                    )
+            elif config := self.mambaish_config:
+                self.req_to_token_pool = HybridReqToTokenPool(
+                    size=max_num_reqs,
+                    mamba_size=self.server_args.max_mamba_cache_size,
+                    mamba_spec_state_size=max_num_reqs,
+                    max_context_len=self.model_config.context_len
+                    + extra_max_context_len,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    cache_params=config.mamba2_cache_params,
+                    mamba_layer_ids=(
+                        [
+                            i
+                            for i in config.mamba2_cache_params.layers
+                            if self.start_layer <= i < self.end_layer
+                        ]
+                    ),
+                    enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+                    enable_mamba_extra_buffer_lazy=self.server_args.enable_mamba_extra_buffer_lazy(),
+                    speculative_num_draft_tokens=max_spec_draft_tokens,
+                    speculative_eagle_topk=self.server_args.speculative_eagle_topk,
+                    enable_overlap_schedule=not self.server_args.disable_overlap_schedule,
+                    start_layer=self.start_layer,
+                    enable_linear_replayssm=self.server_args.enable_linear_replayssm,
+                    linear_replayssm_cache_len=self.server_args.linear_replayssm_cache_len,
+                    mamba_envelope_layout=self.server_args.enable_page_major_kv_layout,
+                )
+            else:
+                # DSV4 on NPU needs an extended ReqToTokenPool holding per-req
+                # swa/c4/c128/c{4,128}_state tables; others stay on the stock one.
+                req_to_token_pool_cls = ReqToTokenPool
+                if _is_npu and is_deepseek_v4(self.model_config.hf_config):
+                    from sglang.srt.hardware_backend.npu.dsv4.dsv4_req_to_token_pool import (
+                        DSV4NPUReqToTokenPool,
+                    )
+
+                    req_to_token_pool_cls = DSV4NPUReqToTokenPool
+
+                self.req_to_token_pool = req_to_token_pool_cls(
+                    size=max_num_reqs,
+                    max_context_len=self.model_config.context_len
+                    + extra_max_context_len,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                )
+        else:
+            # Draft worker shares req_to_token_pool with the target worker.
+            assert self.is_draft_worker
+
+        # Initialize token_to_kv_pool
+        is_dsa_model = is_deepseek_dsa(self.model_config.hf_config)
+        is_dsv4_model = is_deepseek_v4(self.model_config.hf_config)
+
+        self._validate_prefill_only_disable_kv_cache_pool_family(
+            is_dsa_model, is_dsv4_model, current_platform
+        )
+
+        # Page-granularity envelope layout for the MHA-shaped (full / SWA) pools,
+        # selected by swapping in the PageMajorMHATokenToKVPool subclass. The
+        # default keeps upstream's per-layer layout. The Mamba state pool is routed
+        # separately via `mamba_envelope_layout` on the req-to-token pool above.
+        enable_page_major = self.server_args.enable_page_major_kv_layout
+        mha_pool_class = (
+            PageMajorMHATokenToKVPool if enable_page_major else MHATokenToKVPool
+        )
+
+        if is_dsv4_model:
+            swa_page_size = self.page_size
+            if not _is_npu:
+                assert swa_page_size == 256, "In paged swa mode, page_size must be 256."
+
+            if self.is_draft_worker:
+                from sglang.srt.models.deepseek_v4_nextn import (
+                    COMPRESS_RATIO_NEXTN_LAYER,
+                )
+
+                compression_ratios = [
+                    COMPRESS_RATIO_NEXTN_LAYER
+                ] * self.num_effective_layers
+            else:
+                compression_ratios = self.model_config.compress_ratios
+
+            # NPU + DSV4 → paged-state subclass: the fused compressor kernel
+            # needs cache_mode=1 (paged); Atlas A3 rejects cache_mode=2 (ring),
+            # so the CUDA ring-buffer state path can't be shared. CUDA keeps
+            # DeepSeekV4TokenToKVPool unchanged; NPU recomputes state sizes below.
+            if _is_npu:
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_memory_pool import (
+                    DSV4NPUTokenToKVPool,
+                    npu_state_pool_size,
+                )
+
+                pool_cls = DSV4NPUTokenToKVPool
+                # Recompute state pool sizes for the NPU paged formula (CUDA's
+                # ring sizes are dropped here). Tail-only allocation keeps the
+                # per-req-budget formula sufficient at any prefill length: long
+                # prompts allocate only ``tail+128`` (c4) / ``tail`` (c128)
+                # slots (tail = seq_len % 128), and decode is drained by
+                # sliding eviction in ``ScheduleBatch._evict_swa``.
+                c4_state_pool_size = npu_state_pool_size(
+                    ratio=4,
+                    page_size=self.page_size,
+                    max_num_reqs=self.max_running_requests,
+                )
+                c128_state_pool_size = npu_state_pool_size(
+                    ratio=128,
+                    page_size=self.page_size,
+                    max_num_reqs=self.max_running_requests,
+                )
+            else:
+                pool_cls = DeepSeekV4TokenToKVPool
+                c4_state_pool_size = self.c4_state_pool_size
+                c128_state_pool_size = self.c128_state_pool_size
+
+            self.token_to_kv_pool = pool_cls(
+                max_num_reqs=self.max_running_requests,
+                # SWA ring is indexed by req_pool_idx; PD decode inflates req_to_token
+                # past max_running_requests (pre-alloc), so size to the real capacity.
+                num_req_slots=self.req_to_token_pool.req_to_token.shape[0],
+                swa_size=self.swa_max_total_num_tokens,
+                c4_size=self.c4_max_total_num_tokens,
+                c128_size=self.c128_max_total_num_tokens,
+                c4_state_pool_size=c4_state_pool_size,
+                c128_state_pool_size=c128_state_pool_size,
+                page_size=self.page_size,
+                swa_page_size=swa_page_size,
+                sliding_window=self.model_config.window_size,
+                dtype=self.kv_cache_dtype,
+                c4_state_dtype=self.c4_state_dtype,
+                c128_state_dtype=self.c128_state_dtype,
+                qk_nope_head_dim=self.model_config.qk_nope_head_dim,
+                qk_rope_head_dim=self.model_config.qk_rope_head_dim,
+                indexer_head_dim=self.model_config.index_head_dim,
+                layer_num=self.num_effective_layers,
+                device=self.device,
+                enable_memory_saver=self.server_args.enable_memory_saver,
+                compression_ratios=compression_ratios,
+                start_layer=self.start_layer,
+                end_layer=self.end_layer,
+                enable_hisparse=self.enable_hisparse,
+                online_mtp_max_draft_tokens=(
+                    self.server_args.max_speculative_num_draft_tokens or 0
+                ),
+            )
+        elif current_platform.is_out_of_tree() and not self.mambaish_config:
+            if self.use_mla_backend and is_dsa_model:
+                PoolCls = current_platform.get_dsa_kv_pool_cls()
+                self.token_to_kv_pool = PoolCls(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    kv_lora_rank=self.model_config.kv_lora_rank,
+                    qk_rope_head_dim=self.model_config.qk_rope_head_dim,
+                    layer_num=self.num_effective_layers,
+                    device=self.device,
+                    kv_cache_dim=self.calculate_mla_kv_cache_dim(),
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                    index_head_dim=get_dsa_index_head_dim(self.model_config.hf_config),
+                )
+            elif self.use_mla_backend:
+                PoolCls = current_platform.get_mla_kv_pool_cls()
+                self.token_to_kv_pool = PoolCls(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    kv_lora_rank=self.model_config.kv_lora_rank,
+                    qk_rope_head_dim=self.model_config.qk_rope_head_dim,
+                    index_head_dim=(
+                        self.model_config.index_head_dim if is_dsa_model else None
+                    ),
+                    layer_num=self.num_effective_layers,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                )
+            else:
+                PoolCls = current_platform.get_mha_kv_pool_cls()
+                self.token_to_kv_pool = PoolCls(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    head_num=self.model_config.get_num_kv_heads(
+                        get_attention_tp_size()
+                    ),
+                    head_dim=self.model_config.head_dim,
+                    layer_num=self.num_effective_layers,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                )
+        elif (
+            self.server_args.attention_backend == "ascend" and not self.mambaish_config
+        ):
+            if self.is_hybrid_swa:
+                from sglang.srt.hardware_backend.npu.memory_pool_npu import (
+                    NPUMHATokenToKVPool,
+                )
+
+                kwargs = {}
+                if self.is_hybrid_swa_compress:
+                    kwargs = {
+                        "swa_head_num": max(
+                            1,
+                            self.model_config.hf_text_config.swa_num_key_value_heads
+                            // get_attention_tp_size(),
+                        ),
+                        "swa_head_dim": self.model_config.swa_head_dim,
+                        "swa_v_head_dim": self.model_config.swa_v_head_dim,
+                        "v_head_dim": self.model_config.v_head_dim,
+                    }
+                self.token_to_kv_pool = SWAKVPool(
+                    size=self.full_max_total_num_tokens,
+                    size_swa=self.swa_max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    head_num=self.model_config.get_num_kv_heads(
+                        get_attention_tp_size()
+                    ),
+                    head_dim=self.model_config.head_dim,
+                    swa_attention_layer_ids=self.model_config.swa_attention_layer_ids,
+                    full_attention_layer_ids=self.model_config.full_attention_layer_ids,
+                    device=self.device,
+                    token_to_kv_pool_class=NPUMHATokenToKVPool,
+                    **kwargs,
+                )
+            elif self.use_mla_backend:
+                from sglang.srt.hardware_backend.npu.memory_pool_npu import (
+                    NPUMLATokenToKVPool,
+                )
+
+                self.token_to_kv_pool = NPUMLATokenToKVPool(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    kv_lora_rank=self.model_config.kv_lora_rank,
+                    qk_rope_head_dim=self.model_config.qk_rope_head_dim,
+                    index_head_dim=(
+                        self.model_config.index_head_dim if is_dsa_model else None
+                    ),
+                    layer_num=self.num_effective_layers,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                )
+            else:
+                from sglang.srt.hardware_backend.npu.memory_pool_npu import (
+                    NPUMHATokenToKVPool,
+                )
+
+                self.token_to_kv_pool = NPUMHATokenToKVPool(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    head_num=self.model_config.get_num_kv_heads(
+                        get_attention_tp_size()
+                    ),
+                    head_dim=self.model_config.head_dim,
+                    layer_num=self.num_effective_layers,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                )
+        elif self.use_mla_backend and is_dsa_model:
+            PoolCls = (
+                HiSparseDSATokenToKVPool if self.enable_hisparse else DSATokenToKVPool
+            )
+            pool_kwargs = {}
+            if self.enable_hisparse:
+                from sglang.srt.mem_cache.sparsity import parse_hisparse_config
+
+                pool_kwargs["host_to_device_ratio"] = parse_hisparse_config(
+                    self.server_args
+                ).host_to_device_ratio
+            self.token_to_kv_pool = PoolCls(
+                self.max_total_num_tokens,
+                page_size=self.page_size,
+                dtype=self.kv_cache_dtype,
+                kv_lora_rank=self.model_config.kv_lora_rank,
+                qk_rope_head_dim=self.model_config.qk_rope_head_dim,
+                layer_num=self.num_effective_layers,
+                device=self.device,
+                kv_cache_dim=self.calculate_mla_kv_cache_dim(),
+                enable_memory_saver=self.server_args.enable_memory_saver,
+                start_layer=self.start_layer,
+                end_layer=self.end_layer,
+                index_head_dim=get_dsa_index_head_dim(self.model_config.hf_config),
+                **pool_kwargs,
+            )
+        elif self.use_mla_backend and not self.mambaish_config:
+            assert not is_dsa_model
+            if is_float4_e2m1fn_x2(self.kv_cache_dtype):
+                self.token_to_kv_pool = MLATokenToKVPoolFP4(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    kv_lora_rank=self.model_config.kv_lora_rank,
+                    qk_rope_head_dim=self.model_config.qk_rope_head_dim,
+                    layer_num=self.num_effective_layers,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                )
+            else:
+                self.token_to_kv_pool = MLATokenToKVPool(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    kv_lora_rank=self.model_config.kv_lora_rank,
+                    qk_rope_head_dim=self.model_config.qk_rope_head_dim,
+                    layer_num=self.num_effective_layers,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                )
+        else:
+            if self.is_hybrid_swa:
+                kwargs = {}
+                if self.is_hybrid_swa_compress:
+                    kwargs = {
+                        "swa_head_num": max(
+                            1,
+                            self.model_config.hf_text_config.swa_num_key_value_heads
+                            // get_attention_tp_size(),
+                        ),
+                        "swa_head_dim": self.model_config.swa_head_dim,
+                        "swa_v_head_dim": self.model_config.swa_v_head_dim,
+                        "v_head_dim": self.model_config.v_head_dim,
+                    }
+                self.token_to_kv_pool = SWAKVPool(
+                    size=self.full_max_total_num_tokens,
+                    size_swa=self.swa_max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    head_num=self.model_config.get_num_kv_heads(
+                        get_attention_tp_size()
+                    ),
+                    head_dim=self.model_config.head_dim,
+                    swa_attention_layer_ids=self.model_config.swa_attention_layer_ids,
+                    full_attention_layer_ids=self.model_config.full_attention_layer_ids,
+                    device=self.device,
+                    enable_kv_cache_copy=(
+                        self.server_args.speculative_algorithm is not None
+                    ),
+                    token_to_kv_pool_class=mha_pool_class,
+                    **kwargs,
+                )
+            elif is_minimax_sparse(self.model_config.hf_config):
+                _hf_config = self.model_config.hf_config
+                sparse_cfg = get_minimax_sparse_attention_config(_hf_config)
+                dense_layer_ids, sparse_layer_ids = get_minimax_sparse_layer_ids(
+                    sparse_cfg
+                )
+                disable_value_sparse_layer_ids = (
+                    get_minimax_sparse_disable_value_layer_ids(sparse_cfg)
+                )
+                self.token_to_kv_pool = MiniMaxSparseKVPool(
+                    size=self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    index_dtype=self.dtype,
+                    head_num=self.model_config.get_num_kv_heads(
+                        get_attention_tp_size()
+                    ),
+                    head_dim=self.model_config.head_dim,
+                    idx_head_dim=sparse_cfg["sparse_index_dim"],
+                    dense_layer_ids=dense_layer_ids,
+                    sparse_layer_ids=sparse_layer_ids,
+                    disable_value_sparse_layer_ids=disable_value_sparse_layer_ids,
+                    device=self.device,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    start_layer=self.start_layer,
+                    end_layer=self.end_layer,
+                )
+            elif config := self.mambaish_config:
+                extra_args = {}
+                if self.use_mla_backend:
+                    extra_args = {
+                        "kv_lora_rank": self.model_config.kv_lora_rank,
+                        "qk_rope_head_dim": self.model_config.qk_rope_head_dim,
+                        "index_head_dim": self.model_config.qk_nope_head_dim,
+                    }
+                self.token_to_kv_pool = HybridLinearKVPool(
+                    page_size=self.page_size,
+                    size=self.max_total_num_tokens,
+                    dtype=self.kv_cache_dtype,
+                    head_num=self.model_config.get_num_kv_heads(
+                        get_attention_tp_size()
+                    ),
+                    head_dim=self.model_config.head_dim,
+                    # if draft worker, we only need 1 attention layer's kv pool
+                    full_attention_layer_ids=(
+                        [0]
+                        if self.is_draft_worker
+                        else [
+                            i
+                            for i in config.full_attention_layer_ids
+                            if self.start_layer <= i < self.end_layer
+                        ]
+                    ),
+                    device=self.device,
+                    mamba_pool=self.req_to_token_pool.mamba_pool,
+                    enable_memory_saver=self.server_args.enable_memory_saver,
+                    enable_kv_cache_copy=(
+                        self.server_args.speculative_algorithm is not None
+                    ),
+                    use_mla=self.use_mla_backend,
+                    start_layer=self.start_layer,
+                    full_kv_pool_class=mha_pool_class,
+                    **extra_args,
+                )
+            else:
+                if is_float4_e2m1fn_x2(self.kv_cache_dtype):
+                    assert (
+                        not enable_page_major
+                    ), "page-major KV layout is not supported with fp4 KV cache"
+                    self.token_to_kv_pool = MHATokenToKVPoolFP4(
+                        self.max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        head_num=self.model_config.get_num_kv_heads(
+                            get_attention_tp_size()
+                        ),
+                        head_dim=self.model_config.head_dim,
+                        v_head_dim=self.model_config.v_head_dim,
+                        layer_num=self.num_effective_layers,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        start_layer=self.start_layer,
+                        end_layer=self.end_layer,
+                        enable_alt_stream=not self.server_args.enable_pdmux,
+                        enable_kv_cache_copy=(
+                            self.server_args.speculative_algorithm is not None
+                        ),
+                    )
+                else:
+                    pool_cls = (
+                        NoOpMHATokenToKVPool
+                        if self.server_args.prefill_only_disable_kv_cache
+                        else mha_pool_class
+                    )
+                    self.token_to_kv_pool = pool_cls(
+                        self.max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        head_num=self.model_config.get_num_kv_heads(
+                            get_attention_tp_size()
+                        ),
+                        head_dim=self.model_config.head_dim,
+                        v_head_dim=self.model_config.v_head_dim,
+                        layer_num=self.num_effective_layers,
+                        device=self.device,
+                        enable_memory_saver=self.server_args.enable_memory_saver,
+                        start_layer=self.start_layer,
+                        end_layer=self.end_layer,
+                        enable_alt_stream=not self.server_args.enable_pdmux,
+                        enable_kv_cache_copy=(
+                            self.server_args.speculative_algorithm is not None
+                        ),
+                    )
+
+        # Initialize token_to_kv_pool_allocator
+        need_sort = self.server_args.disaggregation_mode in ("decode", "prefill")
+        if self.token_to_kv_pool_allocator is None:
+            if current_platform.is_out_of_tree():
+                AllocatorCls = current_platform.get_paged_allocator_cls()
+                self.token_to_kv_pool_allocator = AllocatorCls(
+                    self.max_total_num_tokens,
+                    page_size=self.page_size,
+                    dtype=self.kv_cache_dtype,
+                    device=self.device,
+                    kvcache=self.token_to_kv_pool,
+                    need_sort=need_sort,
+                )
+            elif _is_npu and (
+                self.server_args.attention_backend == "ascend"
+                or is_dsv4_model
+                or self.hybrid_gdn_config is not None
+            ):
+                if self.is_hybrid_swa:
+                    # DSV4 on NPU: SWA allocator subclass that also drives the
+                    # c4/c128 allocators, producing a DSV4OutCacheLoc per alloc.
+                    if is_dsv4_model:
+                        from sglang.srt.hardware_backend.npu.dsv4.dsv4_allocator import (
+                            DSV4NPUTokenToKVPoolAllocator,
+                        )
+
+                        swa_allocator_cls = DSV4NPUTokenToKVPoolAllocator
+                    else:
+                        swa_allocator_cls = SWATokenToKVPoolAllocator
+                    self.token_to_kv_pool_allocator = swa_allocator_cls(
+                        self.full_max_total_num_tokens,
+                        self.swa_max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        device=self.device,
+                        kvcache=self.token_to_kv_pool,
+                        need_sort=need_sort,
+                    )
+                else:
+                    from sglang.srt.hardware_backend.npu.allocator_npu import (
+                        NPUPagedTokenToKVPoolAllocator,
+                    )
+
+                    self.token_to_kv_pool_allocator = NPUPagedTokenToKVPoolAllocator(
+                        self.max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        device=self.device,
+                        kvcache=self.token_to_kv_pool,
+                        need_sort=need_sort,
+                    )
+            else:
+                if self.is_hybrid_swa and self.full_max_total_num_tokens == 0:
+                    self.token_to_kv_pool_allocator = PureSWATokenToKVPoolAllocator(
+                        self.swa_max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        device=self.device,
+                        kvcache=self.token_to_kv_pool,
+                        need_sort=need_sort,
+                    )
+                elif self.is_hybrid_swa:
+                    self.token_to_kv_pool_allocator = SWATokenToKVPoolAllocator(
+                        self.full_max_total_num_tokens,
+                        self.swa_max_total_num_tokens,
+                        page_size=self.page_size,
+                        dtype=self.kv_cache_dtype,
+                        device=self.device,
+                        kvcache=self.token_to_kv_pool,
+                        need_sort=need_sort,
+                    )
+                else:
+                    if self.enable_hisparse:
+                        from sglang.srt.mem_cache.sparsity import (
+                            parse_hisparse_config,
+                        )
+
+                        hisparse_cfg = parse_hisparse_config(self.server_args)
+                        self.token_to_kv_pool_allocator = (
+                            HiSparseTokenToKVPoolAllocator(
+                                self.max_total_num_tokens,
+                                page_size=self.page_size,
+                                dtype=self.kv_cache_dtype,
+                                device=self.device,
+                                kvcache=self.token_to_kv_pool,
+                                need_sort=need_sort,
+                                host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
+                            )
+                        )
+                    elif self.page_size == 1 and self.dcp_size == 1:
+                        self.token_to_kv_pool_allocator = TokenToKVPoolAllocator(
+                            self.max_total_num_tokens,
+                            dtype=self.kv_cache_dtype,
+                            device=self.device,
+                            kvcache=self.token_to_kv_pool,
+                            need_sort=need_sort,
+                        )
+                    else:
+                        self.token_to_kv_pool_allocator = PagedTokenToKVPoolAllocator(
+                            self.max_total_num_tokens * self.dcp_size,
+                            page_size=self.page_size * self.dcp_size,
+                            dtype=self.kv_cache_dtype,
+                            device=self.device,
+                            kvcache=self.token_to_kv_pool,
+                            need_sort=need_sort,
+                        )
+
+            if self.enable_hisparse and is_dsv4_model:
+                assert self.is_hybrid_swa, "DeepSeek V4 HiSparse requires SWA mode."
+                self.token_to_kv_pool_allocator = (
+                    DeepSeekV4HiSparseTokenToKVPoolAllocator(
+                        self.token_to_kv_pool_allocator
+                    )
+                )
+
+            # DSV4-NPU: wire allocator back-ref into req_to_token_pool so its
+            # free(req) can release c4/c128 pool pages alongside the slot.
+            if hasattr(self.req_to_token_pool, "register_dsv4_allocator"):
+                self.req_to_token_pool.register_dsv4_allocator(
+                    self.token_to_kv_pool_allocator
+                )
+
+        else:
+            assert self.is_draft_worker
+            if self.is_hybrid_swa:
+                swa_allocator = getattr(
+                    self.token_to_kv_pool_allocator,
+                    "logical_attn_allocator",
+                    self.token_to_kv_pool_allocator,
+                )
+                assert isinstance(swa_allocator, SWATokenToKVPoolAllocator)
+                self.token_to_kv_pool.register_mapping(
+                    swa_allocator.full_to_swa_index_mapping
+                )
+
+        # Defensive check: the explicit validation above should reject known
+        # unsupported pool families before allocation. Keep this guard here so
+        # future pool-selection refactors fail at boot instead of on first use.
+        if (
+            self.server_args.prefill_only_disable_kv_cache
+            and not self.is_draft_worker
+            and not isinstance(self.token_to_kv_pool, NoOpMHATokenToKVPool)
+        ):
+            raise RuntimeError(
+                "--prefill-only-disable-kv-cache expected NoOpMHATokenToKVPool but the "
+                f"runtime pool is {type(self.token_to_kv_pool).__name__}. This pool "
+                "family is not yet supported by --prefill-only-disable-kv-cache. "
+                "Supported configurations today: plain MHA models on CUDA with the FA "
+                "(fa3/fa4) prefill backend, --is-embedding, --chunked-prefill-size=-1, "
+                "--disable-radix-cache, no context-parallel attention, no HiSparse, "
+                "and --kv-cache-dtype != fp4_e2m1."
+            )
+
+    def _apply_token_constraints(self: ModelRunner, token_capacity: int) -> int:
+        """Apply external constraints to token capacity: user cap, PP sync.
+
+        Page alignment is handled by the configurator, not here.
+        If constraints change the value, the configurator re-runs and re-aligns.
+        """
+        user_limit = self.server_args.max_total_tokens
+
+        # Apply user-specified upper bound
+        if user_limit is not None:
+            if user_limit > token_capacity:
+                logging.warning(
+                    f"max_total_tokens={user_limit} is larger than the profiled value "
+                    f"{token_capacity}. Use the profiled value instead."
+                )
+            token_capacity = min(token_capacity, user_limit)
+
+        # Sync across PP ranks (each may have different layer counts)
+        if self.pp_size > 1:
+            tensor = torch.tensor(token_capacity, dtype=torch.int64)
+            torch.distributed.all_reduce(
+                tensor,
+                op=torch.distributed.ReduceOp.MIN,
+                group=get_world_group().cpu_group,
+            )
+            token_capacity = tensor.item()
+
+        return token_capacity
+
+    def _resolve_max_num_reqs(self: ModelRunner, token_capacity: int) -> int:
+        """Compute max concurrent requests (per dp worker) from the finalized
+        token capacity."""
+        # Estimate pool size (used as upper bound when user specifies max_running_requests)
+        estimated = int(token_capacity / self.model_config.context_len * 512)
+        estimated = max(min(estimated, 4096), 2048)
+
+        max_num_reqs = self.server_args.max_running_requests
+        if max_num_reqs is not None:
+            requested_per_worker = max_num_reqs // self.dp_size
+            max_num_reqs = min(requested_per_worker, token_capacity // 2)
+        else:
+            requested_per_worker = None
+            max_num_reqs = min(estimated, token_capacity // 2)
+
+        if self.mambaish_config is not None:
+            ratio = self._calculate_mamba_ratio()
+            max_num_reqs = min(
+                max_num_reqs, self.server_args.max_mamba_cache_size // ratio
+            )
+
+            if max_num_reqs <= 0:
+                raise RuntimeError(
+                    f"Hybrid (mamba/linear-attention) state cache is too small to serve "
+                    f"any requests. max_mamba_cache_size={self.server_args.max_mamba_cache_size}, "
+                    f"mamba_ratio={ratio}, resulting max_num_reqs={max_num_reqs}. "
+                    f"Try: (1) reduce --max-running-requests, "
+                    f"(2) increase --mem-fraction-static, or "
+                    f"(3) use GPUs with more memory."
+                )
+        if requested_per_worker is not None and max_num_reqs < requested_per_worker:
+            logger.warning(
+                "max_running_requests was reduced from the requested %d to %d "
+                "(per dp worker) due to the available KV cache capacity.",
+                requested_per_worker,
+                max_num_reqs,
+            )
+        return max_num_reqs
+
+    def _apply_memory_pool_config(self: ModelRunner, config: MemoryPoolConfig):
+        """Apply a resolved MemoryPoolConfig and initialize pools."""
+        self.max_total_num_tokens = config.max_total_num_tokens
+        self.max_running_requests = config.max_running_requests
+        if self.is_hybrid_swa:
+            self.full_max_total_num_tokens = config.full_max_total_num_tokens
+            self.swa_max_total_num_tokens = config.swa_max_total_num_tokens
+
+        # DSV4 compressed-attention pool sizes. Draft worker reuses target's
+        # full/swa sizes but does NOT own c4/c128/state pools (those live on
+        # the target rank only); zero them out regardless of what config holds.
+        if self.is_draft_worker:
+            self.c4_max_total_num_tokens = 0
+            self.c128_max_total_num_tokens = 0
+            self.c4_state_pool_size = 0
+            self.c128_state_pool_size = 0
+        else:
+            self.c4_max_total_num_tokens = config.c4_max_total_num_tokens
+            self.c128_max_total_num_tokens = config.c128_max_total_num_tokens
+            self.c4_state_pool_size = config.c4_state_pool_size
+            self.c128_state_pool_size = config.c128_state_pool_size
+
+        # Draft worker does not own the compression-state pools, but keep the
+        # dtype attributes initialized so _init_pools can share one code path.
+        if is_deepseek_v4(self.model_config.hf_config):
+            self.c4_state_dtype, self.c128_state_dtype = (
+                _get_dsv4_compress_state_dtypes()
+            )
+
+        self._init_pools()
+
+    def _resolve_memory_pool_config(
+        self: ModelRunner, pre_model_load_memory: int
+    ) -> MemoryPoolConfig:
+        """Profile GPU memory and resolve all pool parameters into a config."""
+        from sglang.srt.model_executor.pool_configurator import (
+            create_memory_pool_configurator,
+        )
+
+        available_bytes = self._profile_available_bytes(pre_model_load_memory)
+        page_size = self.server_args.page_size
+
+        configurator = create_memory_pool_configurator(self)
+        config = configurator.calculate_pool_sizes(available_bytes, page_size)
+
+        # Apply external constraints (user cap, page alignment, PP sync)
+        constrained = self._apply_token_constraints(config.max_total_num_tokens)
+        if constrained != config.max_total_num_tokens:
+            config = configurator.calculate_pool_sizes_from_max_tokens(
+                constrained, page_size
+            )
+
+        config.max_running_requests = self._resolve_max_num_reqs(
+            config.max_total_num_tokens
+        )
+        config = configurator.finalize_with_max_running_requests(config)
+        config.mem_fraction_static = self.server_args.mem_fraction_static
+        return config
+
+    def init_memory_pool(self: ModelRunner, pre_model_load_memory: int):
+        if not self.spec_algorithm.is_none() and self.is_draft_worker:
+            assert (
+                self.memory_pool_config is not None
+            ), "Draft worker requires memory_pool_config"
+        else:
+            self.memory_pool_config = self._resolve_memory_pool_config(
+                pre_model_load_memory
+            )
+
+        self._apply_memory_pool_config(self.memory_pool_config)
+
+        logger.info(
+            f"Memory pool end. "
+            f"avail mem={get_available_gpu_memory(self.device, self.gpu_id):.2f} GB"
+        )

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -1,0 +1,2409 @@
+# Kimi-K3 multimodal model: KimiLinear text backbone + MoonViT3d vision tower.
+# Based on kimi_linear.py with K3-specific features:
+#   - Attention Residual (attn_res_block_size)
+#   - Latent MoE (routed_expert_hidden_size)
+#   - SiTU activation
+#   - MLA output gate (mla_use_output_gate)
+#   - Full-rank KDA gate (use_full_rank_gate)
+
+import os as _os
+import sys as _sys
+from collections.abc import Iterable
+from typing import List, Optional, Tuple
+
+# NPU detection (before any sglang / triton import).
+_is_npu = False
+try:
+    import torch as _detect_torch
+
+    _is_npu = (
+        hasattr(_detect_torch, "npu")
+        and hasattr(_detect_torch.npu, "is_available")
+        and _detect_torch.npu.is_available()
+    )
+except Exception:
+    pass
+
+# NPU env defaults (must be set before sglang.environ reads).
+if _is_npu:
+    _NPU_ENV_DEFAULTS = {
+        "SGLANG_K3_ATTN_RES_MODE": "torch",
+        "SGLANG_K3_FUSE_MOE_FRONT": "0",
+        "SGLANG_K3_FUSE_KDA_BFA": "0",
+        "SGLANG_K3_DECODE_GEMV": "0",
+        "SGLANG_K3_TAIL_FUSE": "0",
+        "SGLANG_K3_FUSE_O_GATE": "0",
+        "SGLANG_K3_ATTN_RES_FUSED_MIN_T": "999999",
+        "SGLANG_K3_MOE_REDUCE_MODE": "baseline",
+    }
+    for _k, _v in _NPU_ENV_DEFAULTS.items():
+        _os.environ.setdefault(_k, _v)
+
+# Stub CUDA-only modules before they are imported.
+if _is_npu:
+    _STUB_MODULES = {
+        "triton": None,
+        "triton.language": None,
+        "sglang.srt.distributed.device_communicators.pynccl_allocator": None,
+        "sglang.srt.layers.flashinfer_comm_fusion": None,
+        "triton_kernels": None,
+        "triton_kernels.numerics_details": None,
+        "triton_kernels.numerics_details.mxfp": None,
+    }
+    for _mod_name in _STUB_MODULES:
+        if _mod_name not in _sys.modules:
+            try:
+                __import__(_mod_name)
+            except (ImportError, ModuleNotFoundError):
+                _stub = type(_sys)(_mod_name.split(".")[-1])
+                _stub.__spec__ = None  # avoid find_spec ValueError
+                if _mod_name == "triton":
+                    # identity decorator: @triton.jit kernels are defined but not called on NPU.
+                    _stub.jit = lambda fn: fn
+                _sys.modules[_mod_name] = _stub
+
+import torch
+
+# Stub torch.cuda.Stream for NPU.
+if _is_npu:
+
+    class _NoopStream:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    torch.cuda.Stream = _NoopStream  # type: ignore[assignment]
+    torch.cuda.current_stream = lambda *a, **kw: _NoopStream()
+    torch.cuda.default_stream = lambda *a, **kw: _NoopStream()
+
+import triton
+import triton.language as tl
+from torch import nn
+
+from sglang.srt.configs.kimi_k3 import KimiK3Config
+from sglang.srt.configs.kimi_linear import KimiLinearConfig
+from sglang.srt.distributed import (
+    divide,
+    get_pp_group,
+    get_tp_group,
+    tensor_model_parallel_all_reduce,
+)
+if not _is_npu:
+    from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+        use_symmetric_memory,
+    )
+else:
+    use_symmetric_memory = None
+from sglang.srt.environ import envs
+from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
+from sglang.srt.layers.activation import SiluAndMul, SituAndMul
+from sglang.srt.layers.attention.fla.fused_norm_gate import FusedRMSNormGated
+from sglang.srt.layers.dp_attention import is_allocation_symmetric
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import (
+    ColumnParallelBatchedLinear,
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    MergedColumnParallelRepeatedLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.moe import single_token_handoff
+from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.layers.moe.topk import TopK, TopKOutputFormat
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_loader.weight_utils import (
+    default_weight_loader,
+    maybe_remap_kv_scale_name,
+    sharded_weight_loader,
+)
+from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+from sglang.srt.models.kimi_k25 import (
+    K2VLMultiModalProjector,
+    MoonViT3dPretrainedModel,
+    mm_projection_auto,
+)
+from sglang.srt.models.transformers import maybe_prefix
+from sglang.srt.models.utils import WeightsMapper
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.utils import is_npu, make_layers
+from sglang.srt.utils.common import BumpAllocator, add_prefix, set_weight_attrs
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+# Latent MoE TP reduction strategy:
+#   "baseline" - two separate all-reduces (routed latent, then shared)
+#   "concat"   - concat routed latent + shared partials, single all-reduce
+#   "fi_fused" - flashinfer fused allreduce+rmsnorm for the latent reduce
+# A/B on 8xB300 bs=1 decode (2026-07-03): baseline 35.2 tok/s beats
+# concat 33.2 (21.5KB message falls off the one-shot allreduce path into
+# two-shot) and fi_fused 33.0 (lamport-buffer kernel + zero-residual
+# overhead loses to custom one-shot + tiny rmsnorm at 7KB messages).
+# On MULTI-NODE TP the trade flips: single-node custom one-shot is
+# unavailable, both reduces go through NCCL, and one 21.5KB collective
+# beats a 7KB + 14KB pair (2x4 GB300 MNNVL bs=1: 22.05 -> 21.36 ms ITL).
+# Default resolves by topology in KimiK3MoE.__init__; env overrides.
+_K3_MOE_REDUCE_MODE = envs.SGLANG_K3_MOE_REDUCE_MODE.get()
+
+
+def _resolve_moe_reduce_mode() -> str:
+    if _K3_MOE_REDUCE_MODE is not None:
+        return _K3_MOE_REDUCE_MODE
+    try:
+        from sglang.srt.distributed import get_tp_group
+        from sglang.srt.distributed.parallel_state import in_the_same_node_as
+
+        if not all(in_the_same_node_as(get_tp_group().cpu_group, source_rank=0)):
+            return "concat"
+    except Exception:
+        pass
+    return "baseline"
+
+
+# Horizontal fusion of same-input GEMMs (decode is launch/BW bound):
+#   moe_front: shared gate_up + router gate + latent down_proj -> one GEMM
+#   kda_bfa:   KDA b_proj + f_a_proj -> one GEMV
+_K3_FUSE_MOE_FRONT = envs.SGLANG_K3_FUSE_MOE_FRONT.get()
+_K3_FUSE_KDA_BFA = envs.SGLANG_K3_FUSE_KDA_BFA.get()
+# Use the dedicated CUDA decode-GEMV kernel for the skinny KDA projections
+# (b+f_a merged, f_b) instead of cublas gemvx/dot dispatch.
+_K3_DECODE_GEMV = envs.SGLANG_K3_DECODE_GEMV.get()
+# Cross-op tail fusions (decode): residual add fused into the attn_res score
+# kernel, and the MoE tail 3-way add (up + shared + residual) in one kernel.
+_K3_TAIL_FUSE = envs.SGLANG_K3_TAIL_FUSE.get()
+# MLA output gate x * sigmoid(g) in one kernel instead of two elementwise.
+_K3_FUSE_O_GATE = envs.SGLANG_K3_FUSE_O_GATE.get()
+
+
+def _merge_weights_as_views(
+    mods: list, pad_rows_to: int = 1
+) -> tuple[torch.Tensor, list[int]]:
+    """Cat module weights along dim 0; re-point each module's weight to a view
+    of the merged buffer so the original storage is freed (net extra memory ~0).
+
+    With pad_rows_to > 1 the merged buffer gets zero rows appended up to the
+    next multiple, so every row of the fused GEMM output stays 16-byte aligned
+    for vectorized consumers."""
+    ws = [m.weight.data for m in mods]
+    sizes = [w.shape[0] for w in ws]
+    pad = (-sum(sizes)) % pad_rows_to
+    if pad:
+        ws = ws + [ws[0].new_zeros((pad, ws[0].shape[1]))]
+    merged = torch.cat(ws, dim=0).contiguous()
+    off = 0
+    for m, n in zip(mods, sizes):
+        m.weight.data = merged[off : off + n]
+        off += n
+    return merged, sizes
+
+
+# "fused" = new single-kernel aggregation (attn_residual.py)
+# "torch" = pytorch reference (attn_residual.py)
+# "legacy" = existing multi-kernel path (below)
+_K3_ATTN_RES_MODE = envs.SGLANG_K3_ATTN_RES_MODE.get()
+
+_ATTN_RES_MAX_B = 16
+_ATTN_RES_BLOCK_H = 1024
+
+
+@triton.jit
+def _attn_res_scores_kernel(
+    prefix_ptr,  # [T, H]
+    block_ptr,  # [T, NB_total, H]
+    cw_ptr,  # [H] fp32 precombined rmsnorm_weight * proj_weight (set 1)
+    scores_ptr,  # [T, MAX_B] fp32 out (set 1)
+    cw2_ptr,  # [H] fp32 precombined weights (set 2, optional)
+    scores2_ptr,  # [T, MAX_B] fp32 out (set 2, optional)
+    NVB,
+    eps,
+    stride_pm,
+    stride_bm,
+    stride_bb,
+    stride_sm,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    HAS_SECOND: tl.constexpr,
+):
+    """Per-(token, row) score(s): s_j = dot(RMSNorm(v_j), pw). Row NVB is
+    prefix_sum. With HAS_SECOND, also computes the score under a second
+    (norm, proj) weight set in the same pass — the rows are frozen between
+    block writes, so the MLP-side aggregation of the same layer can reuse
+    them without re-reading v (halves pass-1 memory traffic per layer)."""
+    pid_t = tl.program_id(0)
+    j = tl.program_id(1)
+    if j > NVB:
+        return
+    sumsq = 0.0
+    dotv = 0.0
+    dotv2 = 0.0
+    for h0 in tl.static_range(0, H, BLOCK_H):
+        offs_h = h0 + tl.arange(0, BLOCK_H)
+        if j < NVB:
+            v_raw = tl.load(block_ptr + pid_t * stride_bm + j * stride_bb + offs_h)
+        else:
+            v_raw = tl.load(prefix_ptr + pid_t * stride_pm + offs_h)
+        v = v_raw.to(tl.float32)
+        cw = tl.load(cw_ptr + offs_h)
+        sumsq += tl.sum(v * v)
+        dotv += tl.sum(v * cw)
+        if HAS_SECOND:
+            cw2 = tl.load(cw2_ptr + offs_h)
+            dotv2 += tl.sum(v * cw2)
+    rrms = 1.0 / tl.sqrt(sumsq / H + eps)
+    tl.store(scores_ptr + pid_t * stride_sm + j, dotv * rrms)
+    if HAS_SECOND:
+        tl.store(scores2_ptr + pid_t * stride_sm + j, dotv2 * rrms)
+
+
+@triton.jit
+def _attn_res_combine_norm_kernel(
+    prefix_ptr,
+    block_ptr,
+    scores_ptr,  # [T, MAX_B] fp32
+    out_nw_ptr,  # [H] output RMSNorm weight
+    out_ptr,  # [T, H] normed aggregate
+    NVB,
+    out_eps,
+    stride_pm,
+    stride_bm,
+    stride_bb,
+    stride_sm,
+    stride_om,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    MAX_B: tl.constexpr,
+):
+    """out[t] = RMSNorm(sum_j softmax(scores)_j * v_j) * out_nw. One CTA per
+    token, full-H loop (the fused norm needs the full-row sumsq), fusing the
+    input_layernorm / post_attention_layernorm that always follows the
+    aggregation."""
+    pid_t = tl.program_id(0)
+
+    offs_b = tl.arange(0, MAX_B)
+    mask_b = offs_b <= NVB
+    scores = tl.load(
+        scores_ptr + pid_t * stride_sm + offs_b,
+        mask=mask_b,
+        other=float("-inf"),
+    )
+    m = tl.max(scores, axis=0)
+    e = tl.where(mask_b, tl.exp(scores - m), 0.0)
+    p = e / tl.sum(e, axis=0)
+
+    # Pass 1 over H: aggregate + accumulate sumsq for the fused norm.
+    sumsq = 0.0
+    for h0 in tl.static_range(0, H, BLOCK_H):
+        offs_h = h0 + tl.arange(0, BLOCK_H)
+        acc = tl.zeros([BLOCK_H], tl.float32)
+        for j in range(0, NVB + 1):
+            if j < NVB:
+                v_raw = tl.load(block_ptr + pid_t * stride_bm + j * stride_bb + offs_h)
+            else:
+                v_raw = tl.load(prefix_ptr + pid_t * stride_pm + offs_h)
+            p_j = tl.sum(tl.where(offs_b == j, p, 0.0), axis=0)
+            acc += p_j * v_raw.to(tl.float32)
+        sumsq += tl.sum(acc * acc)
+        # Stash the raw aggregate chunk; renormalized in pass 2.
+        tl.store(out_ptr + pid_t * stride_om + offs_h, acc.to(out_ptr.dtype.element_ty))
+    rrms = 1.0 / tl.sqrt(sumsq / H + out_eps)
+    # Pass 2: scale in place with the norm weight.
+    for h0 in tl.static_range(0, H, BLOCK_H):
+        offs_h = h0 + tl.arange(0, BLOCK_H)
+        a = tl.load(out_ptr + pid_t * stride_om + offs_h).to(tl.float32)
+        out_nw = tl.load(out_nw_ptr + offs_h).to(tl.float32)
+        tl.store(
+            out_ptr + pid_t * stride_om + offs_h,
+            (a * rrms * out_nw).to(out_ptr.dtype.element_ty),
+        )
+
+
+def _attn_res_cw(proj: ReplicatedLinear, norm: RMSNorm) -> torch.Tensor:
+    """Cached fp32 product of the (frozen) rmsnorm weight and score-proj
+    weight: dot(RMSNorm(v), pw) == dot(v, nw*pw) / rms(v). fp32 keeps the
+    in-kernel math identical to loading both factors separately."""
+    cw = getattr(proj, "_attn_res_cw", None)
+    if cw is None:
+        cw = (norm.weight.float() * proj.weight.view(-1).float()).contiguous()
+        proj._attn_res_cw = cw
+    return cw
+
+
+def _attn_res_scores(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    proj: ReplicatedLinear,
+    norm: RMSNorm,
+    num_valid_blocks: int,
+    proj2: Optional[ReplicatedLinear] = None,
+    norm2: Optional[RMSNorm] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    T, H = prefix_sum.shape
+    scores = torch.empty(
+        (T, _ATTN_RES_MAX_B), dtype=torch.float32, device=prefix_sum.device
+    )
+    has_second = proj2 is not None
+    scores2 = (
+        torch.empty_like(scores)
+        if has_second
+        else scores  # dummy, unused when HAS_SECOND=False
+    )
+    cw = _attn_res_cw(proj, norm)
+    _attn_res_scores_kernel[(T, num_valid_blocks + 1)](
+        prefix_sum,
+        block_residual,
+        cw,
+        scores,
+        _attn_res_cw(proj2, norm2) if has_second else cw,
+        scores2,
+        num_valid_blocks,
+        norm.variance_epsilon,
+        prefix_sum.stride(0),
+        block_residual.stride(0),
+        block_residual.stride(1),
+        scores.stride(0),
+        H=H,
+        BLOCK_H=_ATTN_RES_BLOCK_H,
+        HAS_SECOND=has_second,
+        num_warps=8,
+    )
+    return scores, (scores2 if has_second else None)
+
+
+def _attn_res_prefix_update(
+    old: Optional[torch.Tensor],
+    delta: torch.Tensor,
+    proj: ReplicatedLinear,
+    norm: RMSNorm,
+    scores: torch.Tensor,
+    idx: int,
+) -> torch.Tensor:
+    """Residual update + score of the updated prefix row into scores[:, idx].
+
+    The add stays a plain (parallel) elementwise op; only the score is a
+    kernel. A fully fused single-CTA-per-token version was measured SLOWER at
+    bs=1 (serial 28KB chain on one SM vs parallel add + tiny score kernel).
+    """
+    new = delta if old is None else old + delta
+    T, H = new.shape
+    # Reuse the scores kernel for a single row: NVB=0 makes row 0 take the
+    # prefix path; aim the output at column `idx` via a pointer offset.
+    scores_at_idx = scores[:, idx:]
+    cw = _attn_res_cw(proj, norm)
+    _attn_res_scores_kernel[(T, 1)](
+        new,
+        new,  # block_ptr unused when NVB == 0
+        cw,
+        scores_at_idx,
+        cw,  # dummy second set (HAS_SECOND=False)
+        scores_at_idx,
+        0,
+        norm.variance_epsilon,
+        new.stride(0),
+        0,
+        0,
+        scores.stride(0),
+        H=H,
+        BLOCK_H=_ATTN_RES_BLOCK_H,
+        HAS_SECOND=False,
+        num_warps=8,
+    )
+    return new
+
+
+@triton.jit
+def _attn_res_combine_kernel(
+    prefix_ptr,
+    block_ptr,
+    scores_ptr,  # [T, MAX_B] fp32
+    out_ptr,  # [T, H]
+    NVB,
+    stride_pm,
+    stride_bm,
+    stride_bb,
+    stride_sm,
+    stride_om,
+    BLOCK_H: tl.constexpr,
+    MAX_B: tl.constexpr,
+):
+    """out[t, chunk] = sum_j softmax(scores)_j * v_j[chunk]. (T, H-chunks)
+    grid: the small-T/decode variant — a fused output norm is impossible here
+    (needs full-row sumsq), but the chunked grid keeps SMs busy at bs=1."""
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    offs_h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+
+    offs_b = tl.arange(0, MAX_B)
+    mask_b = offs_b <= NVB
+    scores = tl.load(
+        scores_ptr + pid_t * stride_sm + offs_b,
+        mask=mask_b,
+        other=float("-inf"),
+    )
+    m = tl.max(scores, axis=0)
+    e = tl.where(mask_b, tl.exp(scores - m), 0.0)
+    p = e / tl.sum(e, axis=0)
+
+    acc = tl.zeros([BLOCK_H], tl.float32)
+    for j in range(0, NVB + 1):
+        if j < NVB:
+            v_raw = tl.load(block_ptr + pid_t * stride_bm + j * stride_bb + offs_h)
+        else:
+            v_raw = tl.load(prefix_ptr + pid_t * stride_pm + offs_h)
+        p_j = tl.sum(tl.where(offs_b == j, p, 0.0), axis=0)
+        acc += p_j * v_raw.to(tl.float32)
+    tl.store(out_ptr + pid_t * stride_om + offs_h, acc.to(out_ptr.dtype.element_ty))
+
+
+# Below this token count, the norm-fused (T,)-grid combine cannot fill the
+# SMs (one CTA per token); use the chunked combine + separate norm instead.
+# Env-overridable for A/B testing.
+# A/B on 8xB300 (2026-07-03): the norm-fused (T,)-grid combine + shared
+# dual-scores path LOSES at every tested size — bs=1 (single-CTA rows) AND
+# bs=64 decode (650 vs 673 tok/s: 64 CTAs underfill 148 SMs), while prefill
+# (T>=1024) shows no measurable difference (attn-res is a tiny fraction of
+# GEMM-dominated prefill). Disabled by default; kernels kept for retuning.
+_ATTN_RES_FUSED_NORM_MIN_T = envs.SGLANG_K3_ATTN_RES_FUSED_MIN_T.get()
+
+
+def _attn_res_combine_norm(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    scores: torch.Tensor,
+    num_valid_blocks: int,
+    out_norm: RMSNorm,
+) -> torch.Tensor:
+    T, H = prefix_sum.shape
+    out = torch.empty_like(prefix_sum)
+    if T < _ATTN_RES_FUSED_NORM_MIN_T:
+        _attn_res_combine_kernel[(T, H // _ATTN_RES_BLOCK_H)](
+            prefix_sum,
+            block_residual,
+            scores,
+            out,
+            num_valid_blocks,
+            prefix_sum.stride(0),
+            block_residual.stride(0),
+            block_residual.stride(1),
+            scores.stride(0),
+            out.stride(0),
+            BLOCK_H=_ATTN_RES_BLOCK_H,
+            MAX_B=_ATTN_RES_MAX_B,
+            num_warps=4,
+        )
+        return out_norm(out)
+    _attn_res_combine_norm_kernel[(T,)](
+        prefix_sum,
+        block_residual,
+        scores,
+        out_norm.weight,
+        out,
+        num_valid_blocks,
+        out_norm.variance_epsilon,
+        prefix_sum.stride(0),
+        block_residual.stride(0),
+        block_residual.stride(1),
+        scores.stride(0),
+        out.stride(0),
+        H=H,
+        BLOCK_H=_ATTN_RES_BLOCK_H,
+        MAX_B=_ATTN_RES_MAX_B,
+        num_warps=8,
+    )
+    return out
+
+
+def _apply_attn_res_fused(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    proj: ReplicatedLinear,
+    norm: RMSNorm,
+    num_valid_blocks: int,
+    out_norm: RMSNorm,
+) -> torch.Tensor:
+    """Aggregation + fused following RMSNorm (every aggregation in K3 is
+    immediately followed by one). num_valid_blocks must be > 0."""
+    scores, _ = _attn_res_scores(
+        prefix_sum, block_residual, proj, norm, num_valid_blocks
+    )
+    return _attn_res_combine_norm(
+        prefix_sum, block_residual, scores, num_valid_blocks, out_norm
+    )
+
+
+def _apply_attn_res_torch(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    proj: ReplicatedLinear,
+    norm: RMSNorm,
+    num_valid_blocks: int,
+) -> torch.Tensor:
+    """Eager reference implementation (kept for testing/fallback)."""
+    if num_valid_blocks <= 0:
+        return prefix_sum
+
+    v = torch.cat(
+        (block_residual[:, :num_valid_blocks, :], prefix_sum.unsqueeze(1)), dim=1
+    )
+    k = norm(v)
+    probs = (k @ proj.weight.squeeze(0)).softmax(-1).unsqueeze(1)
+    hidden_states = torch.matmul(probs, v).squeeze(1)
+    return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# KimiK3MLP — supports both SiLU and SiTU
+# ---------------------------------------------------------------------------
+
+
+class KimiK3MLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: Optional[QuantizationConfig] = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+        activation_situ_beta: float | None = None,
+        activation_situ_linear_beta: float | None = None,
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            reduce_results=reduce_results,
+            prefix=f"{prefix}.down_proj",
+        )
+        if hidden_act == "silu":
+            self.act_fn = SiluAndMul()
+        elif hidden_act == "situ":
+            self.act_fn = SituAndMul(
+                beta=activation_situ_beta or 1.0,
+                linear_beta=activation_situ_linear_beta,
+            )
+        else:
+            raise ValueError(f"Unsupported activation: {hidden_act}")
+
+    def forward(self, x: torch.Tensor, residual: torch.Tensor = None) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(x)
+        # NPU: ensure contiguous strides for downstream ops.
+        if not gate_up.is_contiguous():
+            gate_up = gate_up.contiguous()
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x if residual is None else x + residual
+
+    def forward_from_gate_up(self, gate_up: torch.Tensor) -> torch.Tensor:
+        """Same as forward() but with the gate_up GEMM already computed
+        (e.g. as a slice of a horizontally-fused projection)."""
+        if not gate_up.is_contiguous():
+            gate_up = gate_up.contiguous()
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# KimiK3MoE — with Latent MoE support
+# ---------------------------------------------------------------------------
+
+
+class KimiK3MoE(nn.Module):
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        layer_idx: int = 0,
+        alt_stream: Optional[torch.cuda.Stream] = None,
+    ):
+        super().__init__()
+        hidden_size = config.hidden_size
+        moe_intermediate_size = config.moe_intermediate_size
+        num_experts = config.num_experts
+        moe_renormalize = config.moe_renormalize
+        self.tp_size = get_parallel().tp_size
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.num_shared_experts = config.num_shared_experts
+        self.layer_idx = layer_idx
+        self.alt_stream = alt_stream
+
+        # Latent MoE
+        self.use_latent_moe = config.routed_expert_hidden_size is not None
+        self.moe_reduce_mode = _resolve_moe_reduce_mode()
+        # Merged front weight ([H, gate_up + E + latent]), built after weight
+        # loading by _merge_front_weights().
+        self._front_w: Optional[torch.Tensor] = None
+        self._front_sizes: Optional[List[int]] = None
+        self.moe_hidden_size = (
+            config.routed_expert_hidden_size if self.use_latent_moe else hidden_size
+        )
+
+        # Gate
+        self.gate = ReplicatedLinear(
+            hidden_size,
+            num_experts,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.gate",
+        )
+        self.gate.e_score_correction_bias = nn.Parameter(torch.empty(num_experts))
+
+        # For MXFP4 compressed-tensors, replace quant_config with Mxfp4Config
+        # so FusedMoE's weight_loader uses the MXFP4 fast path
+        moe_quant_config = quant_config
+        if quant_config is not None and getattr(quant_config, "quant_format", None):
+            if "mxfp4" in quant_config.quant_format:
+                from sglang.srt.layers.quantization.mxfp4 import Mxfp4Config
+
+                moe_quant_config = Mxfp4Config(is_checkpoint_mxfp4_serialized=True)
+
+        # Routed experts (operate in moe_hidden_size space)
+        # gate_up_interleaved=False: K3 loads per-expert w1/w3 into non-interleaved layout
+        self.experts = get_moe_impl_class(moe_quant_config)(
+            num_experts=getattr(config, "n_routed_experts", config.num_experts),
+            top_k=config.num_experts_per_token,
+            hidden_size=self.moe_hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            layer_id=self.layer_idx,
+            quant_config=moe_quant_config,
+            routed_scaling_factor=self.routed_scaling_factor,
+            activation=config.hidden_act,
+            gemm1_alpha=config.activation_situ_beta,
+            gemm1_clamp_limit=config.activation_situ_linear_beta,
+            gate_up_interleaved=False,
+            prefix=add_prefix("experts", prefix),
+        )
+
+        self.topk = TopK(
+            top_k=config.num_experts_per_token,
+            renormalize=moe_renormalize,
+            use_grouped_topk=True,
+            num_expert_group=config.num_expert_group,
+            topk_group=config.topk_group,
+            correction_bias=self.gate.e_score_correction_bias,
+            quant_config=quant_config,
+            routed_scaling_factor=self.routed_scaling_factor,
+            apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
+            output_format=TopKOutputFormat.STANDARD if quant_config is None else None,
+        )
+
+        # Shared experts (operate in original hidden_size space)
+        if self.num_shared_experts is not None and self.num_shared_experts > 0:
+            shared_intermediate_size = moe_intermediate_size * self.num_shared_experts
+            self.shared_experts = KimiK3MLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=shared_intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                reduce_results=False,
+                prefix=f"{prefix}.shared_experts",
+                activation_situ_beta=config.activation_situ_beta,
+                activation_situ_linear_beta=config.activation_situ_linear_beta,
+            )
+        else:
+            self.shared_experts = None
+
+        # Latent MoE projections
+        if self.use_latent_moe:
+            self.routed_expert_down_proj = ReplicatedLinear(
+                hidden_size,
+                self.moe_hidden_size,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.routed_expert_down_proj",
+            )
+            self.routed_expert_norm = (
+                RMSNorm(self.moe_hidden_size, eps=config.rms_norm_eps)
+                if config.latent_moe_use_norm
+                else None
+            )
+            self.routed_expert_up_proj = ReplicatedLinear(
+                self.moe_hidden_size,
+                hidden_size,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.routed_expert_up_proj",
+            )
+        else:
+            self.routed_expert_down_proj = None
+            self.routed_expert_norm = None
+            self.routed_expert_up_proj = None
+
+    def _merge_front_weights(self) -> None:
+        """Merge shared gate_up + router gate + latent down_proj weights.
+
+        All three GEMMs consume the same hidden_states; at decode each one is a
+        skinny memory-bound GEMV with its own splitK epilogue. One merged
+        [H, gu+E+latent] GEMM reads the input once and drops 2 GEMM launches
+        plus their splitK-reduce tails per MoE layer.
+
+        Called once from load_weights (after all weights are loaded, before
+        cuda graph capture); only plain bf16/fp16 dense weights are merged —
+        quantized or mixed-dtype checkpoints keep the unfused path.
+        """
+        if not (
+            _K3_FUSE_MOE_FRONT
+            and self.use_latent_moe
+            and self.shared_experts is not None
+        ):
+            return
+        mods = [
+            self.shared_experts.gate_up_proj,
+            self.gate,
+            self.routed_expert_down_proj,
+        ]
+        dtypes = {m.weight.dtype for m in mods}
+        if len(dtypes) != 1 or dtypes.pop() not in (torch.bfloat16, torch.float16):
+            return
+        self._front_w, self._front_sizes = _merge_weights_as_views(mods)
+
+    def _tail_fuse_applicable(
+        self, num_tokens: int, residual: Optional[torch.Tensor]
+    ) -> bool:
+        """Tail-fusion regime (single-token decode on the concat-reduce path):
+        defer the shared down GEMM so it writes its partial sum directly into
+        the concat-AR buffer (no torch.cat), and fold up_out + shared +
+        residual into one moe_tail_add kernel at the end."""
+        return (
+            _K3_TAIL_FUSE
+            and self.use_latent_moe
+            and self.moe_reduce_mode == "concat"
+            and num_tokens == 1
+            and residual is not None
+            and self.tp_size > 1
+            and get_moe_a2a_backend().is_none()
+        )
+
+    def _forward_front(self, hidden_states: torch.Tensor, tail_fuse: bool):
+        """Front section: shared-expert activation, routing, and the latent
+        down-projection.
+
+        The fused regime reads hidden_states once through the merged
+        [H, gate_up + E + latent] weight; otherwise three separate GEMMs.
+        Returns (routed_input, topk_output, shared_output, shared_act);
+        shared_act is non-None when the shared down GEMM is deferred to the
+        concat buffer (tail fusion), with shared_output aliasing it as the
+        usual non-None marker.
+        """
+        use_fused_front = (
+            self._front_w is not None
+            and hidden_states.shape[0] > 0
+            and self._front_w.dtype == hidden_states.dtype
+        )
+        if not use_fused_front:
+            # Shared experts on original hidden_states
+            shared_output = None
+            if self.shared_experts is not None and hidden_states.shape[0] > 0:
+                shared_output = self.shared_experts(hidden_states)
+
+            # Gate + TopK (on original hidden_states for correct token count)
+            router_logits, _ = self.gate(hidden_states)
+            topk_output = self.topk(hidden_states, router_logits)
+
+            # Latent MoE: compress after routing, before experts
+            if self.use_latent_moe:
+                routed_input, _ = self.routed_expert_down_proj(hidden_states)
+            else:
+                routed_input = hidden_states
+            return routed_input, topk_output, shared_output, None
+
+        fused = torch.nn.functional.linear(hidden_states, self._front_w)
+        gate_up, router_logits, routed_input = torch.split(
+            fused, self._front_sizes, dim=-1
+        )
+        if hidden_states.shape[0] > 1:
+            # Downstream kernels want contiguous inputs; free for T==1.
+            gate_up = gate_up.contiguous()
+            router_logits = router_logits.contiguous()
+            routed_input = routed_input.contiguous()
+        shared_act = None
+        if tail_fuse and self.shared_experts.down_proj.weight.dtype == torch.bfloat16:
+            shared_act = self.shared_experts.act_fn(gate_up)
+            shared_output = shared_act  # non-None marker; down GEMM deferred
+        else:
+            shared_output = self.shared_experts.forward_from_gate_up(gate_up)
+        topk_output = self.topk(hidden_states, router_logits)
+        return routed_input, topk_output, shared_output, shared_act
+
+    def _concat_reduce(
+        self,
+        final_hidden_states: torch.Tensor,
+        shared_output: torch.Tensor,
+        shared_act: Optional[torch.Tensor],
+        hidden_size: int,
+        buf: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """One NCCL call instead of two: all-reduce the routed latent (3584)
+        and shared (7168) partial sums as a single [latent | shared] buffer.
+
+        The buffer is allocated in the NCCL symmetric mempool so the
+        all-reduce takes the symmetric-kernel one-shot path instead of
+        falling back to ring (same trick as RowParallelLinear). When the
+        shared down GEMM was deferred (shared_act), it writes its partial sum
+        straight into the buffer slice and the routed latent is one small
+        copy — replacing down-GEMM-then-cat (one fewer 14KB round trip).
+        """
+        if buf is None:
+            with use_symmetric_memory(
+                get_tp_group(), disabled=not is_allocation_symmetric()
+            ):
+                if shared_act is not None:
+                    buf = final_hidden_states.new_empty(
+                        final_hidden_states.shape[0],
+                        self.moe_hidden_size + hidden_size,
+                    )
+                else:
+                    buf = torch.cat((final_hidden_states, shared_output), dim=-1)
+        if shared_act is not None:
+            torch.mm(
+                shared_act,
+                self.shared_experts.down_proj.weight.t(),
+                out=buf[..., self.moe_hidden_size :],
+            )
+            if final_hidden_states.data_ptr() != buf.data_ptr():
+                buf[..., : self.moe_hidden_size].copy_(final_hidden_states)
+        buf = tensor_model_parallel_all_reduce(buf)
+        return (
+            buf[..., : self.moe_hidden_size].contiguous(),
+            buf[..., self.moe_hidden_size :],
+        )
+
+    def forward(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor = None
+    ) -> torch.Tensor:
+        num_tokens, hidden_size = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_size)
+
+        tail_fuse = self._tail_fuse_applicable(num_tokens, residual)
+        routed_input, topk_output, shared_output, shared_act = self._forward_front(
+            hidden_states, tail_fuse
+        )
+
+        # Deferred-tail regime: preallocate the concat-AR buffer and hand its
+        # routed slice to the MoE runner as the final-sum destination, so the
+        # top-k sum writes it directly and _concat_reduce drops its memcpy
+        # (attempt-and-verify: an unconsumed handoff falls back to the copy).
+        buf = None
+        if shared_act is not None:
+            with use_symmetric_memory(
+                get_tp_group(), disabled=not is_allocation_symmetric()
+            ):
+                buf = routed_input.new_empty(1, self.moe_hidden_size + hidden_size)
+            single_token_handoff.stash_output_destination(
+                routed_input, buf[:, : self.moe_hidden_size]
+            )
+
+        # Experts
+        final_hidden_states = self.experts(routed_input, topk_output)
+        if buf is not None:
+            single_token_handoff.clear_output_destination()
+
+        # With an a2a backend (deepep etc.), the combine step already returns
+        # the COMPLETE routed sum; all-reducing again would multiply by tp_size.
+        # Only plain-TP partial sums (a2a=none) need the reduction here.
+        routed_needs_reduce = self.tp_size > 1 and get_moe_a2a_backend().is_none()
+
+        if self.use_latent_moe:
+            # TP-partial routed outputs must be summed in latent space BEFORE
+            # non-linear transforms (RMSNorm): sum(RMSNorm(x_i)) != RMSNorm(sum(x_i)).
+            did_fused_norm = False
+            did_shared_reduce = False
+            if (
+                routed_needs_reduce
+                and shared_output is not None
+                and self.moe_reduce_mode == "concat"
+            ):
+                final_hidden_states, shared_output = self._concat_reduce(
+                    final_hidden_states, shared_output, shared_act, hidden_size, buf
+                )
+                did_shared_reduce = True
+            elif routed_needs_reduce:
+                if (
+                    self.moe_reduce_mode == "fi_fused"
+                    and self.routed_expert_norm is not None
+                ):
+                    # Fuse the latent all-reduce with the RMSNorm epilogue.
+                    from sglang.srt.layers.flashinfer_comm_fusion import (
+                        flashinfer_allreduce_residual_rmsnorm,
+                    )
+
+                    zero_res = torch.zeros_like(final_hidden_states)
+                    norm_out, _ = flashinfer_allreduce_residual_rmsnorm(
+                        final_hidden_states,
+                        zero_res,
+                        self.routed_expert_norm.weight,
+                        eps=self.routed_expert_norm.variance_epsilon,
+                    )
+                    if norm_out is not None:
+                        final_hidden_states = norm_out
+                        did_fused_norm = True
+                if not did_fused_norm:
+                    final_hidden_states = tensor_model_parallel_all_reduce(
+                        final_hidden_states
+                    )
+            if self.routed_expert_norm is not None and not did_fused_norm:
+                final_hidden_states = self.routed_expert_norm(final_hidden_states)
+            # up_proj is replicated, so the routed output is now fully reduced.
+            final_hidden_states, _ = self.routed_expert_up_proj(final_hidden_states)
+            if shared_output is not None:
+                if self.tp_size > 1 and not did_shared_reduce:
+                    shared_output = tensor_model_parallel_all_reduce(shared_output)
+                from sglang.jit_kernel.kimi_k3 import moe_tail_add
+
+                if (
+                    _K3_TAIL_FUSE
+                    and residual is not None
+                    and moe_tail_add.covered(
+                        final_hidden_states,
+                        shared_output,
+                        residual.view(-1, hidden_size),
+                    )
+                ):
+                    # out = bf16(bf16(up + shared) + residual): one kernel, double
+                    # rounding matches the unfused add pair bit-for-bit. Applies
+                    # at any T (prefill included); shared_output may be a
+                    # row-strided slice of the concat-allreduce buffer.
+                    final_hidden_states = moe_tail_add.kimi_k3_moe_tail_add(
+                        final_hidden_states,
+                        shared_output,
+                        residual.view(-1, hidden_size),
+                    )
+                    residual = None  # consumed
+                else:
+                    final_hidden_states = final_hidden_states + shared_output
+        else:
+            if shared_output is not None:
+                final_hidden_states = final_hidden_states + shared_output
+            if self.tp_size > 1:
+                final_hidden_states = tensor_model_parallel_all_reduce(
+                    final_hidden_states
+                )
+        if residual is not None:
+            final_hidden_states = final_hidden_states + residual.view(-1, hidden_size)
+        return final_hidden_states.view(num_tokens, hidden_size)
+
+
+# ---------------------------------------------------------------------------
+# KimiK3DeltaAttention — KDA with full-rank gate option
+# ---------------------------------------------------------------------------
+
+
+class KimiK3DeltaAttention(nn.Module):
+    def __init__(
+        self,
+        layer_idx: int,
+        hidden_size: int,
+        config: KimiLinearConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        rms_norm_eps: float = 1e-5,
+        prefix: str = "",
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        self.tp_size = get_parallel().tp_size
+        # KDA is an attention layer: all head-sharded params must follow the
+        # attention-TP group (= tp under plain TP, = 1 under DP attention),
+        # matching the mamba state cache sizing (KimiLinearCacheParams uses
+        # get_attention_tp_size). Mirrors GLM5-next's head_shard_size pattern.
+        self.attn_tp_size = get_parallel().attn_tp_size
+        self.attn_tp_rank = get_parallel().attn_tp_rank
+        self.hidden_size = hidden_size
+        self.config = config
+        self.head_dim = config.linear_attn_config["head_dim"]
+        self.num_heads = config.linear_attn_config["num_heads"]
+        self.num_k_heads = config.linear_attn_config["num_heads"]
+        self.num_v_heads = config.linear_attn_config["num_heads"]
+        self.head_k_dim = config.linear_attn_config["head_dim"]
+        self.head_v_dim = config.v_head_dim
+        self.layer_idx = layer_idx
+        self.prefix = prefix
+        assert self.num_heads % self.attn_tp_size == 0
+        self.local_num_heads = divide(self.num_heads, self.attn_tp_size)
+
+        projection_size = self.head_dim * self.num_heads
+        self.conv_size = config.linear_attn_config["short_conv_kernel_size"]
+
+        self.use_full_rank_gate = config.linear_attn_config.get(
+            "use_full_rank_gate", False
+        )
+
+        # Decide fusion strategy
+        # The fused path hardcodes tp_size sharding, so require attn_tp == tp.
+        # For the full-rank gate (K3) the checkpoint quantizes only the MoE
+        # experts; attention linears resolve to UnquantizedLinearMethod, so a
+        # non-None quant_config is fine for the merged projection.
+        self.do_fuse_qkvbfg = self.attn_tp_size == self.tp_size and (
+            quant_config is None or self.use_full_rank_gate
+        )
+
+        if self.do_fuse_qkvbfg and self.use_full_rank_gate:
+            # Fuse only the alignment-friendly wide projections [q, k, v, g]
+            # (6144/rank at TP8). Folding b (12/rank) and f_a (128, replicated)
+            # in as well skews the output dim to 6284 and measurably degrades
+            # the GEMM kernel selection; they stay as separate tiny GEMVs.
+            self.fused_qkvg_proj = MergedColumnParallelLinear(
+                self.hidden_size,
+                [
+                    projection_size,
+                    projection_size,
+                    projection_size,
+                    projection_size,
+                ],
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=self.attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                prefix=f"{prefix}.fused_qkvg_proj",
+            )
+            self.split_sizes = [
+                3 * projection_size // self.tp_size,
+                projection_size // self.tp_size,
+            ]
+            self.b_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.num_heads,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=self.attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                prefix=f"{prefix}.b_proj",
+            )
+            self.f_a_proj = ReplicatedLinear(
+                self.hidden_size,
+                self.head_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.f_a_proj",
+            )
+            self.f_b_proj = ColumnParallelLinear(
+                self.head_dim,
+                projection_size,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=self.attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                prefix=f"{prefix}.f_b_proj",
+            )
+            # Merged [f_a | b] weight, built after weight loading by
+            # _merge_bfa_weights().
+            self._bfa_w: Optional[torch.Tensor] = None
+        elif self.do_fuse_qkvbfg:
+            self.qkvb_sizes = [
+                projection_size,
+                projection_size,
+                projection_size,
+                self.num_heads,
+            ]
+            self.fg_sizes = [self.head_dim, self.head_dim]
+
+            self.fused_qkvbfg_a_proj = MergedColumnParallelRepeatedLinear(
+                self.hidden_size,
+                self.qkvb_sizes,
+                self.fg_sizes,
+                quant_config=quant_config,
+                prefix=f"{prefix}.fused_qkvbfg_a_proj",
+            )
+            self.split_sizes = [
+                3 * projection_size // self.tp_size,
+                self.num_heads // self.tp_size,
+                2 * self.head_dim,
+            ]
+            _dtype = config.dtype
+            if isinstance(_dtype, str):
+                _dtype = getattr(torch, _dtype, torch.bfloat16)
+            self.fused_fg_b_proj = ColumnParallelBatchedLinear(
+                2, self.head_dim, projection_size, dtype=_dtype
+            )
+        else:
+            attn_tp_rank = self.attn_tp_rank
+            self.qkv_proj = QKVParallelLinear(
+                self.hidden_size,
+                self.head_dim,
+                self.num_heads,
+                self.num_k_heads,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                v_head_size=self.head_v_dim,
+                prefix=f"{prefix}.qkv_proj",
+            )
+
+            self.f_a_proj = ReplicatedLinear(
+                self.hidden_size,
+                self.head_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.f_a_proj",
+            )
+            self.f_b_proj = ColumnParallelLinear(
+                self.head_dim,
+                projection_size,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                prefix=f"{prefix}.f_b_proj",
+            )
+            self.b_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.num_heads,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                prefix=f"{prefix}.b_proj",
+            )
+
+            if self.use_full_rank_gate:
+                self.g_proj = ColumnParallelLinear(
+                    self.hidden_size,
+                    projection_size,
+                    bias=False,
+                    quant_config=quant_config,
+                    tp_rank=attn_tp_rank,
+                    tp_size=self.attn_tp_size,
+                    prefix=f"{prefix}.g_proj",
+                )
+            else:
+                self.g_a_proj = ReplicatedLinear(
+                    self.hidden_size,
+                    self.head_dim,
+                    bias=False,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.g_a_proj",
+                )
+                self.g_b_proj = ColumnParallelLinear(
+                    self.head_dim,
+                    projection_size,
+                    bias=False,
+                    quant_config=quant_config,
+                    tp_rank=attn_tp_rank,
+                    tp_size=self.attn_tp_size,
+                    prefix=f"{prefix}.g_b_proj",
+                )
+
+        self.dt_bias = nn.Parameter(
+            torch.empty(divide(projection_size, self.attn_tp_size), dtype=torch.float32)
+        )
+        set_weight_attrs(self.dt_bias, {"weight_loader": sharded_weight_loader(0)})
+
+        self.qkv_conv1d = MergedColumnParallelLinear(
+            input_size=self.conv_size,
+            output_sizes=[projection_size, projection_size, projection_size],
+            bias=False,
+            params_dtype=torch.float32,
+            tp_rank=self.attn_tp_rank,
+            tp_size=self.attn_tp_size,
+            prefix=f"{prefix}.qkv_conv1d",
+        )
+        self.qkv_conv1d.weight.data = self.qkv_conv1d.weight.data.unsqueeze(1)
+
+        # K3 checkpoint stores A_log as [head_dim] (128), but the FLA kernel
+        # expects exactly local_num_heads elements.  We define the param as
+        # [1, 1, local_num_heads, 1] (matching the kimi_linear.py convention)
+        # and attach a custom weight_loader that handles both the old 4-D
+        # format and the K3 1-D [head_dim] format by narrowing to the first
+        # num_heads elements then TP-sharding.
+        self.A_log = nn.Parameter(
+            torch.empty(1, 1, self.local_num_heads, 1, dtype=torch.float32)
+        )
+
+        def _a_log_weight_loader(
+            param: torch.Tensor, loaded_weight: torch.Tensor
+        ) -> None:
+            tp_rank = get_parallel().attn_tp_rank
+            shard_size = param.data.shape[2]  # local_num_heads
+            start_idx = tp_rank * shard_size
+
+            # Handle old 4-D checkpoint format: [1, 1, H, 1] -> [H]
+            if loaded_weight.dim() == 4:
+                loaded_weight = loaded_weight.view(loaded_weight.shape[2])
+            # Now loaded_weight is 1-D (either [num_heads] or [head_dim]).
+            # Narrow to the TP shard along the head dimension.
+            loaded_weight = loaded_weight.narrow(0, start_idx, shard_size)
+            # Reshape to match param shape [1, 1, local_num_heads, 1]
+            param.data.copy_(loaded_weight.view(param.data.shape))
+
+        set_weight_attrs(self.A_log, {"weight_loader": _a_log_weight_loader})
+
+        self.o_norm = FusedRMSNormGated(
+            self.head_dim, eps=rms_norm_eps, activation="sigmoid"
+        )
+        self.o_proj = RowParallelLinear(
+            projection_size,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            tp_rank=self.attn_tp_rank,
+            tp_size=self.attn_tp_size,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        conv_weights = self.qkv_conv1d.weight.squeeze(1)
+        bias = self.qkv_conv1d.bias
+
+        self.attn = RadixLinearAttention(
+            layer_id=self.layer_idx,
+            num_q_heads=self.num_k_heads // self.attn_tp_size,
+            num_k_heads=self.num_k_heads // self.attn_tp_size,
+            num_v_heads=self.num_v_heads // self.attn_tp_size,
+            head_q_dim=self.head_k_dim,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+            conv_weights=conv_weights,
+            bias=bias,
+            A_log=self.A_log,
+            dt_bias=self.dt_bias,
+        )
+        # KDA safe gate: checkpoint trained with gate_lower_bound=-5.0
+        self.attn.lower_bound = config.linear_attn_config.get("gate_lower_bound", None)
+
+    def forward_qkvbfg(self, hidden_states: torch.Tensor):
+        qkv, _ = self.qkv_proj(hidden_states)
+        beta = self.b_proj(hidden_states)[0]
+        forget_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
+        if self.use_full_rank_gate:
+            g_proj_states = self.g_proj(hidden_states)[0]
+        else:
+            g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
+        return qkv, beta, forget_gate, g_proj_states
+
+    def _merge_bfa_weights(self) -> None:
+        """Merge f_a_proj (head_dim outputs) + b_proj (heads/tp outputs).
+
+        Both are skinny same-input GEMVs at decode: b lands in a cublas dot
+        kernel pair, f_a in a splitK GEMM. One [H, head_dim + heads/tp (+pad)]
+        GEMV replaces both. f_a leads so its output slice starts at offset 0,
+        and the width is padded to a multiple of 8 so every fused-output row
+        stays 16-byte aligned for vectorized consumers (decode_gemv on f_b).
+
+        Called once from load_weights (after all weights are loaded, before
+        cuda graph capture)."""
+        if not (_K3_FUSE_KDA_BFA and self.use_full_rank_gate):
+            return
+        self._bfa_w, sizes = _merge_weights_as_views(
+            [self.f_a_proj, self.b_proj], pad_rows_to=8
+        )
+        self._bfa_fa_size, self._bfa_b_size = sizes
+
+    def forward_qkvbfg_fused(self, hidden_states: torch.Tensor):
+        if self.use_full_rank_gate:
+            fused_states, _ = self.fused_qkvg_proj(hidden_states)
+            qkv, g_proj_states = torch.split(fused_states, self.split_sizes, dim=-1)
+            if self._bfa_w is not None:
+                w = self._bfa_w
+                n_fa, n_b = self._bfa_fa_size, self._bfa_b_size
+                # decode_gemv re-reads the weight once per token (CTA-per-output),
+                # so its traffic scales linearly with T: measured 2us/launch at
+                # T=1 but 41us at T=64 (5ms/step regression). Break-even vs the
+                # cublas GEMV pair is around T~8.
+                if _K3_DECODE_GEMV and hidden_states.shape[0] <= 8:
+                    from sglang.jit_kernel.kimi_k3.decode_gemv import decode_gemv
+
+                    bfa = decode_gemv(hidden_states, w)
+                    forget_gate = decode_gemv(bfa[..., :n_fa], self.f_b_proj.weight)
+                else:
+                    bfa = torch.nn.functional.linear(hidden_states, w)
+                    forget_gate = self.f_b_proj(bfa[..., :n_fa])[0]
+                beta = bfa[..., n_fa : n_fa + n_b]
+            else:
+                beta = self.b_proj(hidden_states)[0]
+                forget_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
+        else:
+            fused_states = self.fused_qkvbfg_a_proj(hidden_states)
+            qkv, beta, fg_a_states = torch.split(fused_states, self.split_sizes, dim=-1)
+            forget_gate, g_proj_states = self.fused_fg_b_proj(
+                fg_a_states.view(-1, 2, self.head_dim).transpose(0, 1)
+            )
+        return qkv, beta, forget_gate, g_proj_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        zero_allocator: BumpAllocator,
+    ) -> torch.Tensor:
+        if self.do_fuse_qkvbfg:
+            mixed_qkv, beta, forget_gate, g_proj_states = self.forward_qkvbfg_fused(
+                hidden_states
+            )
+        else:
+            mixed_qkv, beta, forget_gate, g_proj_states = self.forward_qkvbfg(
+                hidden_states
+            )
+
+        if not forward_batch.forward_mode.is_decode():
+            forget_gate = forget_gate.unflatten(-1, (-1, self.head_dim))
+            beta = beta.float().sigmoid()
+            forget_gate = forget_gate.unsqueeze(0)
+        beta = beta.unsqueeze(0)
+
+        core_attn_out = self.attn(
+            forward_batch,
+            mixed_qkv=mixed_qkv,
+            a=forget_gate,
+            b=beta,
+        )
+
+        norm_gate = g_proj_states.unflatten(-1, (-1, self.head_dim))
+        core_attn_out = self.o_norm(core_attn_out, norm_gate)
+        core_attn_out = core_attn_out.squeeze(0).flatten(-2)
+
+        return self.o_proj(core_attn_out)[0]
+
+
+# ---------------------------------------------------------------------------
+# KimiK3MLAAttention — MLA with optional output gate
+# ---------------------------------------------------------------------------
+
+
+class KimiK3MLAAttention(DeepseekV2AttentionMLA):
+    """MLA with output gate for K3. Gate is applied in TP-local space before o_proj."""
+
+    def __init__(self, config, layer_idx, quant_config=None, prefix=""):
+        self.use_output_gate = getattr(config, "mla_use_output_gate", False)
+        super().__init__(
+            layer_id=layer_idx,
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            quant_config=quant_config,
+            prefix=prefix,
+            config=config,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            skip_rope=True,
+        )
+        # fused_split_qk_norm expects a .bias attribute on the norms.
+        for _attr, _norm in [("q_a_layernorm", getattr(self, "q_a_layernorm", None)),
+                              ("kv_a_layernorm", getattr(self, "kv_a_layernorm", None))]:
+            if _norm is not None and not hasattr(_norm, "bias"):
+                _norm.bias = None
+
+        if self.use_output_gate:
+            projection_size = config.num_attention_heads * config.v_head_dim
+            # Shard by attn-TP to match the attention output (DSV2 MLA shards
+            # heads across the attention-TP group, not the global TP group).
+            self.g_proj = ColumnParallelLinear(
+                config.hidden_size,
+                projection_size,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=get_parallel().attn_tp_rank,
+                tp_size=get_parallel().attn_tp_size,
+                prefix=f"{prefix}.g_proj",
+            )
+            # Output gate must multiply the TP-local attention output right
+            # before o_proj (vLLM: attn_out * sigmoid(g_proj(hidden_states))).
+            # o_proj is invoked deep inside DeepseekV2AttentionMLA forward
+            # cores, so wrap its forward at the instance level; the module
+            # itself (weights, reduce_results, loading path) is untouched.
+            self._gate_hidden_states = None
+            _orig_o_proj_forward = self.o_proj.forward
+
+            def _gated_o_proj_forward(x, *args, **kwargs):
+                gate_input = self._gate_hidden_states
+                self._gate_hidden_states = None
+                if gate_input is not None and not isinstance(x, tuple):
+                    gate, _ = self.g_proj(gate_input)
+                    from sglang.jit_kernel.kimi_k3 import mla_output_gate
+
+                    if _K3_FUSE_O_GATE and mla_output_gate.covered(x, gate):
+                        # One kernel for x * sigmoid(gate); double rounding
+                        # matches the unfused pair bit-for-bit.
+                        x = mla_output_gate.kimi_k3_mla_output_gate(x, gate)
+                    else:
+                        x = x * torch.sigmoid(gate)
+                return _orig_o_proj_forward(x, *args, **kwargs)
+
+            self.o_proj.forward = _gated_o_proj_forward
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        zero_allocator: BumpAllocator,
+        **kwargs,
+    ):
+        if self.use_output_gate:
+            self._gate_hidden_states = hidden_states
+        return super().forward(
+            positions, hidden_states, forward_batch, zero_allocator, **kwargs
+        )
+
+
+# ---------------------------------------------------------------------------
+# KimiK3DecoderLayer — with Attention Residual
+# ---------------------------------------------------------------------------
+
+
+class KimiK3DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        layer_idx: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.is_moe = config.is_moe
+        self.layer_idx = layer_idx
+
+        # Attention
+        if config.is_kda_layer(layer_idx):
+            self.self_attn = KimiK3DeltaAttention(
+                layer_idx=layer_idx,
+                hidden_size=config.hidden_size,
+                config=config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.self_attn",
+            )
+        else:
+            self.self_attn = KimiK3MLAAttention(
+                config=config,
+                layer_idx=layer_idx,
+                quant_config=quant_config,
+                prefix=f"{prefix}.self_attn",
+            )
+
+        # MLP / MoE
+        if (
+            self.is_moe
+            and config.num_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % config.moe_layer_freq == 0
+        ):
+            self.mlp = KimiK3MoE(
+                config=config,
+                quant_config=quant_config,
+                layer_idx=layer_idx,
+                prefix=f"{prefix}.mlp",
+                alt_stream=alt_stream,
+            )
+        else:
+            self.mlp = KimiK3MLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+                activation_situ_beta=config.activation_situ_beta,
+                activation_situ_linear_beta=config.activation_situ_linear_beta,
+            )
+
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+        # Attention Residual
+        self.use_attn_residuals = config.attn_res_block_size is not None
+        if self.use_attn_residuals:
+            self.attn_res_block_size = config.attn_res_block_size
+            self.is_block_write_layer = layer_idx % self.attn_res_block_size == 0
+            self.block_write_idx = layer_idx // self.attn_res_block_size
+            self.prev_valid_blocks = _cdiv(layer_idx, self.attn_res_block_size)
+            self.self_attention_res_norm = RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.mlp_res_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.self_attention_res_proj = ReplicatedLinear(
+                config.hidden_size,
+                1,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.self_attention_res_proj",
+            )
+            self.mlp_res_proj = ReplicatedLinear(
+                config.hidden_size,
+                1,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.mlp_res_proj",
+            )
+
+    def _run_self_attn(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        zero_allocator: BumpAllocator,
+    ) -> torch.Tensor:
+        # For MLA layers with q_lora_rank, set up communicator attn_inputs
+        # before the forward call (normally done by LayerCommunicator).
+        from sglang.srt.layers.communicator import (
+            AttentionInputs,
+            get_attn_tp_context,
+        )
+
+        qkv_latent_func = getattr(self.self_attn, "prepare_qkv_latent", None)
+        if qkv_latent_func is not None:
+            attn_inputs = AttentionInputs(hidden_states, forward_batch, qkv_latent_func)
+            get_attn_tp_context().set_attn_inputs(attn_inputs)
+
+        result = self.self_attn(
+            hidden_states=hidden_states,
+            positions=positions,
+            forward_batch=forward_batch,
+            zero_allocator=zero_allocator,
+        )
+
+        if qkv_latent_func is not None:
+            get_attn_tp_context().clear_attn_inputs()
+
+        return result
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+        zero_allocator: BumpAllocator,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.use_attn_residuals:
+            assert residual is not None
+            if _K3_ATTN_RES_MODE == "legacy":
+                return self.forward_attn_residual(
+                    positions, hidden_states, residual, forward_batch, zero_allocator
+                )
+            return self._forward_attn_residual_clean(
+                positions, hidden_states, residual, forward_batch, zero_allocator
+            )
+
+        # Standard residual path
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states = self._run_self_attn(
+            hidden_states, positions, forward_batch, zero_allocator
+        )
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+    def _forward_attn_residual_clean(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        block_residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+        zero_allocator: BumpAllocator,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from sglang.srt.layers.attn_residual import (
+            attn_res_aggregate,
+            attn_res_aggregate_fused_add,
+        )
+
+        prefix_sum = hidden_states
+        nvb = self.prev_valid_blocks
+
+        # ---- Aggregation 1: attention side ----
+        if nvb > 0:
+            hidden_states = attn_res_aggregate(
+                prefix_sum,
+                block_residual,
+                nvb,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+                self.input_layernorm,
+            )
+        else:
+            hidden_states = self.input_layernorm(prefix_sum)
+
+        # ---- Write snapshot (before attention, using pre-update prefix) ----
+        if self.is_block_write_layer:
+            block_residual[:, self.block_write_idx, :].copy_(prefix_sum)
+
+        # ---- Attention ----
+        attn_out = self._run_self_attn(
+            hidden_states, positions, forward_batch, zero_allocator
+        )
+        # NPU: ensure contiguous strides for downstream reduce/collective ops.
+        if attn_out is not None and not attn_out.is_contiguous():
+            attn_out = attn_out.contiguous()
+
+        # ---- Residual update + Aggregation 2 (MLP side) ----
+        mlp_nvb = nvb + (1 if self.is_block_write_layer else 0)
+        if self.is_block_write_layer:
+            prefix_sum = attn_out
+            hidden_states = attn_res_aggregate(
+                prefix_sum,
+                block_residual,
+                mlp_nvb,
+                self.mlp_res_proj,
+                self.mlp_res_norm,
+                self.post_attention_layernorm,
+            )
+        elif _K3_TAIL_FUSE:
+            # Residual add fused into the score kernel (bit-identical rounding);
+            # the summed prefix is materialized by the kernel for combine and
+            # for the accumulate below.
+            hidden_states, prefix_sum = attn_res_aggregate_fused_add(
+                prefix_sum,
+                attn_out,
+                block_residual,
+                mlp_nvb,
+                self.mlp_res_proj,
+                self.mlp_res_norm,
+                self.post_attention_layernorm,
+            )
+        else:
+            prefix_sum = prefix_sum + attn_out
+            hidden_states = attn_res_aggregate(
+                prefix_sum,
+                block_residual,
+                mlp_nvb,
+                self.mlp_res_proj,
+                self.mlp_res_norm,
+                self.post_attention_layernorm,
+            )
+
+        # ---- MLP + accumulate ----
+        prefix_sum = self.mlp(hidden_states, residual=prefix_sum)
+        return prefix_sum, block_residual
+
+    def forward_attn_residual(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        block_residual: torch.Tensor,
+        forward_batch: ForwardBatch,
+        zero_allocator: BumpAllocator,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        prefix_sum = hidden_states
+        nvb = self.prev_valid_blocks
+        mlp_valid_blocks = nvb + (1 if self.is_block_write_layer else 0)
+        # The dual-score pass (attention-side + MLP-side frozen-row scores in
+        # one read) and the norm-fused combine are BANDWIDTH optimizations:
+        # at small T (decode) all row-CTAs run in parallel anyway, so sharing
+        # saves no wall clock while the extra cw2 loads and the single-CTA
+        # prefix-score kernel sit on the critical path. Dispatch by T.
+        use_shared_scores = (
+            prefix_sum.shape[0] >= _ATTN_RES_FUSED_NORM_MIN_T and nvb > 0
+        )
+
+        if use_shared_scores:
+            # scores2 row layout matches the MLP-side aggregation:
+            #   - non-write layers: rows 0..nvb-1 frozen blocks; index nvb is
+            #     overwritten below with the updated-prefix score.
+            #   - write layers: the new block IS prefix_sum, whose mlp-score
+            #     landed at index nvb == block_write_idx; the updated
+            #     prefix's score goes to index nvb+1.
+            scores, scores2 = _attn_res_scores(
+                prefix_sum,
+                block_residual,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+                nvb,
+                proj2=self.mlp_res_proj,
+                norm2=self.mlp_res_norm,
+            )
+        elif nvb > 0:
+            scores, _ = _attn_res_scores(
+                prefix_sum,
+                block_residual,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+                nvb,
+            )
+
+        if nvb > 0:
+            hidden_states = _attn_res_combine_norm(
+                prefix_sum, block_residual, scores, nvb, self.input_layernorm
+            )
+        else:
+            # Layer 0: aggregation is a passthrough; just norm.
+            hidden_states = self.input_layernorm(prefix_sum)
+
+        if self.is_block_write_layer:
+            block_residual[:, self.block_write_idx, :].copy_(prefix_sum)
+
+        attn_out = self._run_self_attn(
+            hidden_states, positions, forward_batch, zero_allocator
+        )
+
+        if use_shared_scores:
+            # Residual update + only the updated-prefix score (frozen-row
+            # scores were computed above).
+            prefix_sum = _attn_res_prefix_update(
+                None if self.is_block_write_layer else prefix_sum,
+                attn_out,
+                self.mlp_res_proj,
+                self.mlp_res_norm,
+                scores2,
+                mlp_valid_blocks,
+            )
+        else:
+            if self.is_block_write_layer:
+                prefix_sum = attn_out
+            else:
+                prefix_sum = prefix_sum + attn_out
+            scores2, _ = _attn_res_scores(
+                prefix_sum,
+                block_residual,
+                self.mlp_res_proj,
+                self.mlp_res_norm,
+                mlp_valid_blocks,
+            )
+
+        hidden_states = _attn_res_combine_norm(
+            prefix_sum,
+            block_residual,
+            scores2,
+            mlp_valid_blocks,
+            self.post_attention_layernorm,
+        )
+        hidden_states = self.mlp(hidden_states)
+        prefix_sum = prefix_sum + hidden_states
+        return prefix_sum, block_residual
+
+
+# ---------------------------------------------------------------------------
+# KimiK3LinearModel — language model backbone
+# ---------------------------------------------------------------------------
+
+
+class KimiK3LinearModel(nn.Module):
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.pp_group = get_pp_group()
+
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        self.alt_stream = torch.cuda.Stream()
+
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: KimiK3DecoderLayer(
+                layer_idx=idx,
+                config=config,
+                quant_config=quant_config,
+                prefix=prefix,
+                alt_stream=self.alt_stream,
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=f"{prefix}.layers",
+        )
+
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if config.attn_res_block_size is not None:
+                self.output_attn_res_norm = RMSNorm(
+                    config.hidden_size, eps=config.rms_norm_eps
+                )
+                self.output_attn_res_proj = ReplicatedLinear(
+                    config.hidden_size,
+                    1,
+                    bias=False,
+                    quant_config=None,
+                    prefix=f"{prefix}.output_attn_res_proj",
+                )
+        else:
+            self.norm = PPMissingLayer()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        inputs_embeds: torch.Tensor | None = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_tokens(input_ids)
+            residual = None
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        total_num_layers = self.end_layer - self.start_layer
+        device = hidden_states.device
+        zero_allocator = BumpAllocator(
+            buffer_size=total_num_layers * 2,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        use_attn_res = self.config.attn_res_block_size is not None
+
+        if use_attn_res:
+            attn_res_block_num = _cdiv(self.end_layer, self.config.attn_res_block_size)
+            block_residual = hidden_states.new_empty(
+                hidden_states.size(0), attn_res_block_num, hidden_states.size(1)
+            )
+            if residual is not None:
+                block_residual[:, : residual.size(1), :].copy_(residual)
+            residual = block_residual
+
+        for i in range(self.start_layer, self.end_layer):
+            ctx = get_global_expert_distribution_recorder().with_current_layer(i)
+            with ctx:
+                layer = self.layers[i]
+                hidden_states, residual = layer(
+                    positions=positions,
+                    hidden_states=hidden_states,
+                    forward_batch=forward_batch,
+                    residual=residual,
+                    zero_allocator=zero_allocator,
+                )
+
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        if hidden_states.shape[0] != 0:
+            if use_attn_res:
+                if _K3_ATTN_RES_MODE == "legacy":
+                    hidden_states = _apply_attn_res_fused(
+                        hidden_states,
+                        residual,
+                        self.output_attn_res_proj,
+                        self.output_attn_res_norm,
+                        attn_res_block_num,
+                        out_norm=self.norm,
+                    )
+                else:
+                    from sglang.srt.layers.attn_residual import attn_res_aggregate
+
+                    hidden_states = attn_res_aggregate(
+                        hidden_states,
+                        residual,
+                        attn_res_block_num,
+                        self.output_attn_res_proj,
+                        self.output_attn_res_norm,
+                        self.norm,
+                    )
+            else:
+                if residual is None:
+                    hidden_states = self.norm(hidden_states)
+                else:
+                    hidden_states, _ = self.norm(hidden_states, residual)
+
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# KimiK3LinearForCausalLM — text-only causal LM
+# ---------------------------------------------------------------------------
+
+
+def _coerce_quant_weight_dtype(param: torch.nn.Parameter, loaded_weight: torch.Tensor):
+    """Match a checkpoint weight's dtype to its target parameter's dtype.
+
+    INT4 MoE packed weights are stored as uint8 in the checkpoint but allocated
+    as int32 (8 int4 per int32); view the buffer as int32 to preserve the packed
+    bits. Floating-point scales are cast to the param dtype. No-op otherwise.
+    """
+    if loaded_weight.dtype == param.dtype:
+        return loaded_weight
+    if param.dtype == torch.int32 and loaded_weight.dtype == torch.uint8:
+        return loaded_weight.view(torch.int32)
+    if loaded_weight.dtype.is_floating_point and param.dtype.is_floating_point:
+        return loaded_weight.to(param.dtype)
+    return loaded_weight
+
+
+class KimiK3LinearForCausalLM(nn.Module):
+    def __init__(
+        self,
+        config: KimiLinearConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.quant_config = quant_config
+        self.model = KimiK3LinearModel(
+            config, quant_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.pp_group = get_pp_group()
+        if self.pp_group.is_last_rank:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+        else:
+            self.lm_head = PPMissingLayer()
+        logit_scale = getattr(config, "logit_scale", 1.0)
+        self.logits_processor = LogitsProcessor(config=config, logit_scale=logit_scale)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        embeds = input_embeds if input_embeds is not None else inputs_embeds
+        hidden_states = self.model(
+            input_ids, positions, forward_batch, embeds, pp_proxy_tensors
+        )
+        if self.pp_group.is_last_rank:
+            return self.logits_processor(
+                input_ids, hidden_states, self.lm_head, forward_batch
+            )
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        use_full_rank_gate = bool(
+            (self.config.linear_attn_config or {}).get("use_full_rank_gate", False)
+        )
+        if use_full_rank_gate:
+            # Fused layout (K3): [q, k, v, g] column-parallel; b / f_a / f_b
+            # are standalone modules loaded by name.
+            fused_qkvbfg_mapping = [
+                (".fused_qkvg_proj", ".q_proj", 0),
+                (".fused_qkvg_proj", ".k_proj", 1),
+                (".fused_qkvg_proj", ".v_proj", 2),
+                (".fused_qkvg_proj", ".g_proj", 3),
+            ]
+        else:
+            # Fused layout (low-rank gate): [q, k, v, b] + [f_a, g_a]
+            fused_qkvbfg_mapping = [
+                (".fused_qkvbfg_a_proj", ".q_proj", 0),
+                (".fused_qkvbfg_a_proj", ".k_proj", 1),
+                (".fused_qkvbfg_a_proj", ".v_proj", 2),
+                (".fused_qkvbfg_a_proj", ".b_proj", 3),
+                (".fused_qkvbfg_a_proj", ".f_a_proj", 4),
+                (".fused_qkvbfg_a_proj", ".g_a_proj", 5),
+                (".fused_fg_b_proj", ".f_b_proj", 0),
+                (".fused_fg_b_proj", ".g_b_proj", 1),
+            ]
+
+        stacked_params_mapping = [
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+            *fused_qkvbfg_mapping,
+            # Unfused QKV path
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            # Conv1d fusion
+            (".qkv_conv1d", ".q_conv1d", 0),
+            (".qkv_conv1d", ".k_conv1d", 1),
+            (".qkv_conv1d", ".v_conv1d", 2),
+        ]
+
+        if self.config.is_moe:
+            expert_params_mapping = FusedMoE.make_expert_params_mapping(
+                ckpt_gate_proj_name="w1",
+                ckpt_down_proj_name="w2",
+                ckpt_up_proj_name="w3",
+                num_experts=self.config.num_experts,
+            )
+        else:
+            expert_params_mapping = []
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for args in weights:
+            name, loaded_weight = args[:2]
+            kwargs = args[2] if len(args) > 2 else {}
+
+            # compressed-tensors MXFP4 stores as weight_packed; Mxfp4MoEMethod uses weight
+            if "weight_packed" in name:
+                name = name.replace("weight_packed", "weight")
+
+            # Reduced-layer support: skip weights for layer indices >= num_hidden_layers.
+            if ".layers." in name:
+                _layer_id = name.split(".layers.", 1)[1].split(".", 1)[0]
+                if _layer_id.isdigit() and int(_layer_id) >= self.config.num_hidden_layers:
+                    continue
+
+            # MLA: fuse q_a_proj + kv_a_proj_with_mqa → fused_qkv_a_proj_with_mqa
+            if ".q_a_proj." in name or ".kv_a_proj_with_mqa." in name:
+                fused_name = name.replace(".q_a_proj.", ".fused_qkv_a_proj_with_mqa.")
+                fused_name = fused_name.replace(
+                    ".kv_a_proj_with_mqa.", ".fused_qkv_a_proj_with_mqa."
+                )
+                if fused_name in params_dict:
+                    param = params_dict[fused_name]
+                    if ".q_a_proj." in name:
+                        param.data[: loaded_weight.shape[0]].copy_(loaded_weight)
+                    else:
+                        q_lora_rank = self.config.q_lora_rank or 0
+                        param.data[q_lora_rank:].copy_(loaded_weight)
+                    loaded_params.add(fused_name)
+                    continue
+
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if ("mlp.experts." in name) and name not in params_dict:
+                    continue
+                # Fused projections only apply to KDA layers
+                if param_name in {
+                    ".fused_qkvbfg_a_proj",
+                    ".fused_fg_b_proj",
+                    ".fused_qkvg_proj",
+                }:
+                    layer_id = int(name.split(".")[2])
+                    if not self.config.is_kda_layer(layer_id):
+                        continue
+                    layer = self.model.layers[layer_id].self_attn
+                    if not getattr(layer, "do_fuse_qkvbfg", False):
+                        continue
+                if weight_name in {".q_proj", ".k_proj", ".v_proj"}:
+                    layer_id = int(name.split(".")[2])
+                    if not self.config.is_kda_layer(layer_id):
+                        continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                loaded_weight = _coerce_quant_weight_dtype(param, loaded_weight)
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                for idx, (param_name, weight_name, expert_id, shard_id) in enumerate(
+                    expert_params_mapping
+                ):
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+                    if name not in params_dict:
+                        # Layer reduced: checkpoint has weights for absent layers; skip.
+                        break
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    loaded_weight = _coerce_quant_weight_dtype(param, loaded_weight)
+                    weight_loader(
+                        param,
+                        loaded_weight,
+                        name,
+                        expert_id=expert_id,
+                        shard_id=shard_id,
+                    )
+                    break
+                else:
+                    if (
+                        name.endswith(".bias")
+                        and name not in params_dict
+                        and not self.config.is_linear_attn
+                    ):
+                        continue
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None:
+                        continue
+                    if name not in params_dict:
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    loaded_weight = _coerce_quant_weight_dtype(param, loaded_weight)
+                    weight_loader(param, loaded_weight, **kwargs)
+            loaded_params.add(name)
+
+        # Post-load: absorb kv_b_proj into w_kc and w_vc for MLA layers
+        for layer_id in self.config.full_attention_layer_ids:
+            layer = self.model.layers[layer_id]
+            self_attn = layer.self_attn
+            w_kc, w_vc = self_attn.kv_b_proj.weight.unflatten(
+                0, (-1, self_attn.qk_nope_head_dim + self_attn.v_head_dim)
+            ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
+            self_attn.w_kc = w_kc.transpose(1, 2).contiguous().transpose(1, 2)
+            self_attn.w_vc = w_vc.contiguous().transpose(1, 2)
+            if hasattr(self_attn.kv_b_proj, "weight_scale"):
+                self_attn.w_scale = self_attn.kv_b_proj.weight_scale
+
+        # Post-load: precompute the attn-res combined score weights BEFORE
+        # cuda graph capture (the lazy path inside _attn_res_cw would bake
+        # the multiply into every captured graph replay otherwise).
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            if getattr(layer, "use_attn_residuals", False):
+                _attn_res_cw(
+                    layer.self_attention_res_proj, layer.self_attention_res_norm
+                )
+                _attn_res_cw(layer.mlp_res_proj, layer.mlp_res_norm)
+        if hasattr(self.model, "output_attn_res_proj"):
+            _attn_res_cw(
+                self.model.output_attn_res_proj, self.model.output_attn_res_norm
+            )
+
+        # Post-load: merge the horizontally-fused decode weights. Module
+        # weights are re-pointed to views of the merged buffers (net extra
+        # memory ~0), so this must run after all weights are loaded and
+        # before cuda graph capture.
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            if isinstance(layer.mlp, KimiK3MoE):
+                layer.mlp._merge_front_weights()
+                # The router consumes the correction bias in fp32; convert the
+                # bf16 checkpoint values once (exact) so the per-call
+                # .to(float32) in topk becomes a no-op instead of one upcast
+                # kernel per MoE layer per step.
+                bias = layer.mlp.gate.e_score_correction_bias
+                if bias.dtype != torch.float32:
+                    bias.data = bias.data.to(torch.float32)
+            if isinstance(layer.self_attn, KimiK3DeltaAttention):
+                layer.self_attn._merge_bfa_weights()
+
+
+# ---------------------------------------------------------------------------
+# KimiK3ForConditionalGeneration — multimodal wrapper
+# ---------------------------------------------------------------------------
+
+
+class KimiK3ForConditionalGeneration(nn.Module):
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "language_model.layers.": "language_model.model.layers.",
+            "mm_projector.proj.0": "mm_projector.linear_1",
+            "mm_projector.proj.2": "mm_projector.linear_2",
+        },
+        orig_to_new_substr={
+            "block_sparse_moe": "mlp",
+        },
+    )
+
+    def __init__(
+        self,
+        config: KimiK3Config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.quant_config = quant_config
+
+        # Ensure vision_config has aliases needed by MoonViT3dPretrainedModel.
+        # HF's trust_remote_code config uses vt_* prefixed names; the K25 vision
+        # code expects unprefixed aliases plus video_attn_type.
+        vc = config.vision_config
+        _vc_aliases = {
+            "hidden_size": ("vt_hidden_size", 1024),
+            "num_attention_heads": ("vt_num_attention_heads", 12),
+            "num_hidden_layers": ("vt_num_hidden_layers", 27),
+            "intermediate_size": ("vt_intermediate_size", 4096),
+            "video_attn_type": (None, "spatial_temporal"),
+        }
+        for attr, (src, default) in _vc_aliases.items():
+            if not hasattr(vc, attr):
+                setattr(vc, attr, getattr(vc, src, default) if src else default)
+
+        # K3 vision has 12 heads which may not divide TP size; force DP for encoder
+        self.use_data_parallel = True
+
+        self.vision_tower = MoonViT3dPretrainedModel(
+            config.vision_config,
+            use_data_parallel=self.use_data_parallel,
+            quant_config=None,
+            prefix="vision_tower",
+        )
+        self.mm_projector = K2VLMultiModalProjector(config.vision_config)
+
+        self.language_model = KimiK3LinearForCausalLM(
+            config.text_config,
+            quant_config,
+            prefix="",
+        )
+
+    @property
+    def model(self):
+        return self.language_model
+
+    def __setattr__(self, name, value):
+        if name == "model":
+            return
+        super().__setattr__(name, value)
+
+    def get_input_embeddings(self):
+        return self.language_model.model.embed_tokens
+
+    def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        device = self.vision_tower.device
+        target_dtype = self.vision_tower.patch_embed.proj.weight.dtype
+        pixel_values = torch.cat([item.feature for item in items], dim=0).to(
+            device=device, dtype=target_dtype
+        )
+        image_grid_thws = []
+        for item in items:
+            grid_thw = item.model_specific_data.get("image_grid_thw")
+            if grid_thw is None:
+                grid_thw = item.model_specific_data["grid_thws"]
+            image_grid_thws.append(grid_thw)
+        grid_thws = torch.concat(image_grid_thws, dim=0).to(device)
+
+        if self.use_data_parallel:
+            from sglang.srt.multimodal.mm_utils import run_dp_sharded_mrope_vision_model
+
+            image_embeds = run_dp_sharded_mrope_vision_model(
+                self.vision_tower,
+                pixel_values,
+                grid_thws.tolist(),
+                rope_type="rope_2d",
+            )
+            image_features = self.mm_projector(image_embeds)
+            return image_features
+
+        image_embeds = self.vision_tower(pixel_values, grid_thws)
+        proj_out = mm_projection_auto(self.mm_projector, image_embeds)
+        return torch.cat(proj_out, dim=0)
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        return pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    @property
+    def start_layer(self) -> int:
+        return self.language_model.model.start_layer
+
+    @property
+    def end_layer(self) -> int:
+        return self.language_model.model.end_layer
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        get_embedding: bool = False,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ):
+        hidden_states = general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            data_embedding_funcs={
+                Modality.IMAGE: self.get_image_feature,
+            },
+            positions=positions,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        mapper = getattr(self, "hf_to_sglang_mapper", None)
+        if mapper is not None:
+            weights = mapper.apply(weights)
+
+        vision_params = dict(self.named_parameters(remove_duplicate=False))
+
+        def stream_language_weights():
+            for name, loaded_weight in weights:
+                if "vision_tower" in name or "mm_projector" in name:
+                    vname = (
+                        name.replace(r"wqkv.", r"attn.qkv_proj.")
+                        .replace(r"wo.", r"attn.proj.")
+                        .replace("mm_projector.proj.0", "mm_projector.linear_1")
+                        .replace("mm_projector.proj.2", "mm_projector.linear_2")
+                    )
+                    if vname not in vision_params:
+                        continue
+                    param = vision_params[vname]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    continue
+                yield name.replace("language_model.", ""), loaded_weight
+
+        self.language_model.load_weights(stream_language_weights())
+
+    @property
+    def stacked_params_mapping(self):
+        return getattr(self.language_model, "stacked_params_mapping", [])
+
+    @property
+    def expert_params_mapping(self):
+        return getattr(self.language_model, "expert_params_mapping", [])
+
+
+# Register in the transformers namespace for resolve_transformers_arch.
+import transformers as _transformers
+_transformers.KimiK3ForConditionalGeneration = KimiK3ForConditionalGeneration
+
+EntryClass = [KimiK3ForConditionalGeneration]


### PR DESCRIPTION
### Summary
Day-0 adaptation of Kimi-K3 on Huawei Ascend 910C, built on the Ascend CANN software stack and the forward-looking PyPTO tile DSL

### Test
Run on each node with node-rank 0/1/2.
Cluster: 3× Atlas 800I A3 = 48× Ascend 910C

MODEL_PATH=Kimi-K3-weight
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export HCCL_SOCKET_IFNAME=bond0
export GLOO_SOCKET_IFNAME=bond0
unset ASCEND_LAUNCH_BLOCKING

python3 -m sglang.launch_server \
  --model-path $MODEL_PATH \
  --attention-backend ascend --device npu --tp-size 48 \
  --cuda-graph-bs 1 2 4 \
  --nnodes 3 \
  --node-rank <0|1|2> \
  --dist-init-addr xxx::5000 \
  --dist-timeout 900 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port 30000 \
  --disable-radix-cache --mem-fraction-static 0.85


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30325690077](https://github.com/sgl-project/sglang/actions/runs/30325690077)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30325689947](https://github.com/sgl-project/sglang/actions/runs/30325689947)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->