### PR TITLE
fix: don't replay prefill CUDA graph when mamba tracking is unwired

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -285,6 +285,7 @@ def prepare_mlp_sync_batch_raw(
                     capture_hidden_mode=None,
                     return_logprob=local_batch.return_logprob,
                     lora_ineligible=prefill_graph_runner.enable_lora,
+                    extend_lens=local_batch.extend_lens,
                 )
             )
             and breakable_prefill

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -42,7 +42,7 @@ import inspect
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import torch
 import tqdm
@@ -108,6 +108,7 @@ from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidde
 from sglang.srt.utils import (
     get_available_gpu_memory,
     is_npu,
+    log_info_on_rank0,
     require_attn_tp_gather,
     require_gathered_buffer,
     require_mlp_tp_gather,
@@ -285,6 +286,17 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             self.capture_hidden_mode = self.return_hidden_states_mode
 
         self.mamba_track_enabled = self._is_mamba_track_enabled()
+        self.mamba_cache_chunk_size = model_runner.server_args.mamba_cache_chunk_size
+        if not self.mamba_track_enabled and self._mamba_track_wanted():
+            # Said once here rather than from the replay-eligibility check,
+            # which runs per forward. Without it the eager fallback is
+            # invisible and reads as unexplained loss of graph coverage.
+            log_info_on_rank0(
+                logger,
+                "Mamba state tracking is not wired into the prefill CUDA graph "
+                "buffers under speculative decoding, so prefill batches that "
+                "need a track write will fall back to eager.",
+            )
 
         # --- buffers ---------------------------------------------------
         self.buffers: PrefillInputBuffers = PrefillInputBuffers.create(
@@ -508,12 +520,18 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         self.raw_num_tokens = 0
         self.raw_bs = 0
 
-    def _is_mamba_track_enabled(self) -> bool:
+    def _mamba_track_wanted(self) -> bool:
+        """Whether the config asks for mamba tracking, ignoring whether this
+        runner can honor it. Separates "tracking is off by design" from
+        "tracking is wanted but unwired", which is the case that must not
+        replay."""
         return (
             self.model_runner.server_args.enable_mamba_extra_buffer()
             and not self.model_runner.server_args.disable_radix_cache
-            and self.model_runner.spec_algorithm.is_none()
         )
+
+    def _is_mamba_track_enabled(self) -> bool:
+        return self._mamba_track_wanted() and self.model_runner.spec_algorithm.is_none()
 
     def _cache_loc_dtype(self):
         return torch.int64 if not is_npu() else torch.int32
@@ -1011,6 +1029,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         return_logprob: bool,
         lora_ineligible: bool = False,
         chunked_prefix_uncapturable: bool = False,
+        extend_lens: Optional[List[int]] = None,
     ) -> bool:
         """Rank-local replay eligibility: the single source of truth for
         ``can_run_graph`` (ForwardBatch, forward time) and the dp mlp-sync
@@ -1041,6 +1060,22 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             and any(prefix_lens)
         ):
             return False
+        # Mamba state tracking is only wired into the static buffers when
+        # _is_mamba_track_enabled() holds, which notably excludes speculative
+        # decoding. Replaying without them silently skips the track write while
+        # the scheduler still advances the ping-pong cursor, so the radix cache
+        # commits a never-written slot and a later prefix hit restores a valid
+        # but wrong mamba state. A request is tracked when its extend reaches
+        # mamba_cache_chunk_size (see _mamba_radix_cache_v2_req_prepare_for_extend),
+        # so this reads CPU lengths and never syncs the device-side mask.
+        # extend_lens is None at call sites that cannot supply it; be
+        # conservative there rather than replay into a skipped track write.
+        if not self.mamba_track_enabled and self._mamba_track_wanted():
+            if (
+                extend_lens is None
+                or max(extend_lens, default=0) >= self.mamba_cache_chunk_size
+            ):
+                return False
         # FullCG's chunked-prefix topology covers a bounded prefix. The flag
         # gating it is FULL-backend-only, so this is inert for the breakable
         # vote path.
@@ -1103,6 +1138,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 and self._has_prefix_hit(forward_batch)
                 and self._select_prefix_capture_chunks(forward_batch) is None
             ),
+            extend_lens=forward_batch.extend_seq_lens_cpu,
         ):
             return False
         # Multi-req replay is supported by body-capture backends via the


### PR DESCRIPTION
## Context

This came out of the accuracy regression I reported on #31099. That PR is not
the cause, and the Non-Standard-GQA gate it removes never fires for NemotronH,
so the prefill graph was already enabled there by flags alone. Full write-up is
in [this comment](https://github.com/sgl-project/sglang/pull/31099#issuecomment-5099058077).

@b8zhong had already narrowed it to breakable CUDA graph and speculative
decoding running together, which turns out to be exactly right. The gate below
is conditioned on `spec_algorithm.is_none()`, so speculative decoding is what
switches the tracking buffers off.

## Motivation

When the prefill CUDA graph runs on a hybrid Mamba model that also uses
speculative decoding, mamba state tracking is silently skipped. The radix cache
then serves a valid but wrong mamba state to any later request matching the
affected prefix. Accuracy decays across repeated runs against the same server
while a single cold run still looks healthy.

The gate is in `PrefillCudaGraphRunner._is_mamba_track_enabled()`.

```python
return (
    self.model_runner.server_args.enable_mamba_extra_buffer()
    and not self.model_runner.server_args.disable_radix_cache
    and self.model_runner.spec_algorithm.is_none()   # <-- here
)
```

When this returns False the `mamba_track_*` static buffers are never
registered, so inside the graph `forward_batch.mamba_track_mask` is None and the
track write never runs. The scheduler still advances the ping-pong cursor
(`req.mamba_next_track_idx`), so `get_mamba_ping_pong_keep_idx()` ends up
pointing at a slot that was never written, and
`MambaRadixCache._commit_int8_checkpoint()` commits that slot.

What makes this bite is that nothing complains. Rather than declining to replay
when tracking is required but unsupported, the runner just omits the buffers and
leaves the scheduler and the radix cache believing the tracked state was
written.

## Modifications

`can_run_graph()` now declines the prefill graph for batches that carry a track
mask this runner cannot honor. This mirrors the LoRA guard immediately above it,
which already refuses to replay unless the metadata made it into the static
buffers.

The condition is also logged once at startup, so the eager fallback is visible
rather than reading as an unexplained loss of graph coverage. That follows the
existing notice for the EAGLE-on-tc_piecewise skip in
`ModelRunner.init_prefill_cuda_graph`. It is emitted from `__init__` and not from
`can_run_graph()`, which runs per forward, and only when the config actually asks
for tracking, so a run with no mamba tracking stays quiet.

A follow-up could wire the `mamba_track_*` buffers on the speculative-decoding
path so those prefills keep graph speed. That is a larger change and presumably
why the gate exists, so this PR takes the conservative route.

## Accuracy

Measured on `NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`, 8xH100 (SM90), with
EAGLE (7 steps), `--mamba-radix-cache-strategy extra_buffer`,
`--enable-int8-mamba-checkpoint`, `--mem-fraction-static 0.75`, and the full
8192 prefill bucket set. Three `few_shot_gsm8k --num-questions 200 --parallel 64`
passes back to back against the same server with no restart between them.

| build | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| before | 0.965 | 0.895 | 0.890 |
| **after** | **0.965** | **0.955** | **0.955** |

Five consecutive passes after the fix give 0.965 / 0.955 / 0.955 / 0.945 /
0.955, with no monotonic decay.

Instrumenting `_track_mamba_state_extend` over an identical workload shows the
mechanism directly.

| | track writes | prefill batches eager | prefill batches replayed |
| --- | --- | --- | --- |
| before, graph ON | **0** | | |
| **after**, graph ON | **6,144** | 16 (4.3 %) | 359 |
| graph OFF (reference) | 6,144 | all | 0 |

Tracking is restored exactly, with the same count and the same internal split
(`h_src_n=1` x5760, `h_src_n=2` x384) as the eager reference. The fallback stays
narrow, since 359 of 375 prefill batches still replay through the graph and
prefix reuse is preserved, with latency still falling from 31.9 s to 20.3 s.

Varying one thing at a time from the same base config isolates it.

| arm | run 1, 2, 3 |
| --- | --- |
| prefill graph ON (the bug) | 0.965, 0.895, 0.890 |
| prefill graph OFF | 0.965, 0.950, 0.955 |
| `no_buffer` plus `--disable-overlap-schedule` | 0.965, 0.965, 0.965 |
| `--disable-overlap-schedule` only | 0.960, 0.890, 0.880 |
| int8 checkpoint off | 0.960, 0.945, 0.955 |
| speculative decoding off | 0.980, 0.950, 0.955 |

Both the prefill graph and tracking are required. The overlap scheduler is not
involved. int8 and speculative decoding act as amplifiers, int8 by raising
checkpoint capacity so more cached states get restored, and speculative decoding
by disabling tracking under the graph outright.

Cache read-back is the vector. On one server with no restart, `/flush_cache`
gives 0.965, running again without flushing gives 0.915, and flushing once more
gives 0.975.

## Notes for reviewers

The bytes committed to the cache are a perfectly valid state, which is what
makes this easy to misdiagnose. int8 store and load integrity came back clean
over 648 loads with zero signature mismatches, covering both temporal and conv
state, and quantization is sane with `nonfinite=0` and a worst round-trip
relative error of 0.0039. The state itself is fine. What is wrong is which point
in the sequence it belongs to.

`--mamba-track-interval` is not a workaround. Setting it to the model's
`chunk_size` leaves the track write count at zero and only shifts radix node
boundaries. Accuracy sometimes looks fine by luck, 0.960 / 0.950 / 0.960 in one
set, then regresses to 0.965 / 0.940 in a repeat of the same config.

`--num-questions 1319` cannot observe this bug at all. On the same server and
the same arm it gives 0.942 / 0.941 / 0.945 while n=200 gives 0.965, 0.895,
0.890. The harness takes `lines[:num_questions]`, so n=200 is a strict subset of
n=1319, and the difference is cache residency. At n=200 the working set stays
resident and hits deepen, with latency dropping from 29 s to 20 s, while at
n=1319 it evicts and latency goes from 135 s to 137 s with no speedup. This is
worth knowing when adding regression coverage for hybrid models, since warm
repeated passes over a resident working set are what surface this class of bug.

A residual warm drop of roughly 1 to 1.5 pp survives this fix, and a comparable
2.7 pp residual exists with speculative decoding off, where the gate passes and
tracking does run under the graph. There is likely a second and milder issue in
the tracking-enabled graph path. I have not characterized it and it is out of
scope here.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Provide accuracy results, see above.
- [x] Change is limited to a `can_run_graph()` predicate, with no kernel or capture-path changes.
