### PR TITLE
Fix DeepSeek-V4 mixed DP/TP attention gathers with regression coverage

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -65,7 +65,6 @@ from sglang.srt.layers.dp_attention import (
     _tbo_event,
     attn_tp_all_gather,
     attn_tp_all_reduce,
-    dp_gather_partial,
     dp_gather_replicate,
     dp_reduce_scatter_tensor,
     dp_reduce_scatterv_async,
@@ -1810,7 +1809,9 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
             if _do_shared_local and local_hidden_states.shape[0] > 0:
                 _shared_local = self.mlp._forward_shared_experts(local_hidden_states)
-            dp_gather_partial(hidden_states, local_hidden_states, forward_batch)
+            # Attention TP has already reduced these activations, so each rank
+            # holds a replica rather than a partial contribution.
+            dp_gather_replicate(hidden_states, local_hidden_states, forward_batch)
         _a2a_scatter_chunks: Optional[List[torch.Tensor]] = None
         if _use_tp_attn_a2a_scatter:
             s, r = get_parallel().attn_tp_size, get_parallel().attn_tp_rank
@@ -2023,7 +2024,9 @@ class DeepseekV4DecoderLayer(nn.Module):
         compute = torch.cuda.current_stream()
         with torch.cuda.stream(comm):
             comm.wait_stream(compute)
-            dp_gather_partial(global_hidden, local, fb)
+            # TBO receives the same post-attention replicas as the synchronous
+            # path and must preserve their magnitude during the DP gather.
+            dp_gather_replicate(global_hidden, local, fb)
             state.gather_event = _tbo_event(("gather", sub))
             state.gather_event.record(comm)
         state.gather_keepalive = local
@@ -2323,7 +2326,9 @@ class DeepseekV4Model(nn.Module):
             )
             # Token ids are replicated within an attention-TP group. Use replicate
             # gather here to avoid summing duplicated ids when attention_tp_size > 1.
-            dp_gather_replicate(input_ids_global, input_ids[:, None], forward_batch)
+            dp_gather_replicate(
+                input_ids_global, input_ids[:, None].clone(), forward_batch
+            )
             input_ids_global = input_ids_global.squeeze(-1)
         else:
             input_ids_global = input_ids

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -14,7 +14,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_prefill_cp_round_robin_split,
 )
 from sglang.srt.layers.dp_attention import (
-    dp_gather_partial,
+    dp_gather_replicate,
     get_global_dp_buffer_len,
     is_dp_attention_enabled,
 )
@@ -162,7 +162,11 @@ class DeepseekV4ModelNextN(nn.Module):
                 dtype=input_ids.dtype,
                 device=input_ids.device,
             )
-            dp_gather_partial(input_ids_global, input_ids[:, None], forward_batch)
+            # Input ids are replicated across attention TP ranks. Clone the view
+            # because the MAX_LEN gather may clear its local input in place.
+            dp_gather_replicate(
+                input_ids_global, input_ids[:, None].clone(), forward_batch
+            )
             input_ids_global = input_ids_global.squeeze(-1)
         else:
             input_ids_global = input_ids

--- a/test/registered/models_e2e/test_deepseek_v4_flash_fp4_h200.py
+++ b/test/registered/models_e2e/test_deepseek_v4_flash_fp4_h200.py
@@ -99,11 +99,13 @@ class TestDSV4FlashFP4H200FlashInferCutlass(
     GSM8KMixin,
     CustomTestCase,
 ):
-    """FlashInfer SM90 mixed-input cutlass MXFP4 backend (this PR): TP=4 + EAGLE.
+    """FlashInfer MXFP4 with EAGLE and mixed DP/TP attention on eight H200s.
 
     Mirrors :class:`TestDSV4FlashFP4H200` but swaps `--moe-runner-backend marlin`
     for `flashinfer_mxfp4`, exercising the SM90 cutlass path from FlashInfer PR
-    #3084 end-to-end on a real DSv4-Flash checkpoint.
+    #3084 end-to-end on a real DSv4-Flash checkpoint. TP8/DP4 gives attention
+    TP2, covering replicated post-attention gathers in both the base model and
+    the EAGLE NextN path.
     """
 
     gsm8k_accuracy_thres = 0.93
@@ -121,7 +123,11 @@ class TestDSV4FlashFP4H200FlashInferCutlass(
             other_args=[
                 "--trust-remote-code",
                 "--tp",
+                "8",
+                "--dp",
                 "4",
+                "--enable-dp-attention",
+                "--enable-dp-lm-head",
                 "--moe-runner-backend",
                 "flashinfer_mxfp4",
                 "--speculative-algorithm",


### PR DESCRIPTION
## Motivation

DeepSeek-V4 produces numerically corrupted output when DP attention is enabled with both `data_parallel_size > 1` and `attn_tp_size > 1` while the MoE A2A backend is disabled.

After self-attention, hidden states have already been reduced across the attention-TP group and are replicated on its ranks. Treating them as partial contributions in the subsequent DP gather sums identical replicas and scales activations by `attn_tp_size` at every MoE layer.

This was independently reproduced on 8x H20 with DeepSeek-V4-Pro and FlashInfer MXFP4:

- TP8 / DP1: correct
- TP8 / DP2 (attention TP4): corrupted
- TP8 / DP4 (attention TP2): corrupted
- TP8 / DP8 (attention TP1): correct

## Changes

- Gather post-attention hidden states with `dp_gather_replicate` in the synchronous MoE path.
- Apply the same semantics to the two-batch-overlap path.
- Gather replicated NextN input IDs without summing them.
- Clone input-ID views before replicate gathers because the MAX_LEN implementation may mutate its local input.
- Extend the existing 8-GPU H200 FlashInfer MXFP4 + EAGLE E2E test to TP8 / DP4, which exercises attention TP2 in both the base model and NextN path without adding another model-launching test class.

## Validation

Local checks:

- `python3 -m py_compile` on all three changed files
- `git diff --check`

The registered H200 E2E test requires the 8-GPU CI runner. The independent H20 reproduction above establishes the pre-fix failure matrix across flat TP and mixed DP/TP attention configurations.

## Related

- Fixes #31699
- Related: #31700
