### PR TITLE
[AMD] add Gemma3RMSNorm.forward_hip to unbreak ROCm

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1087,6 +1087,11 @@ class Gemma3RMSNorm(MultiPlatformOp):
             return gemma_rmsnorm(x, self.weight.data, self.eps)
         return self.forward_native(x)
 
+    def forward_hip(self, x, residual: Optional[torch.Tensor] = None):
+        # sgl_kernel's gemma_rmsnorm/gemma_fused_add_rmsnorm are not available on
+        # ROCm; delegate to the pure-PyTorch implementation.
+        return self.forward_native(x, residual)
+
     def forward_npu(self, x, residual: Optional[torch.Tensor] = None):
         if residual is not None:
             return self.forward_native(x, residual)


### PR DESCRIPTION
## Motivation

Gemma3 is completely broken on ROCm on `main`. Any Gemma3 server launch on an AMD
GPU crashes during the first forward:
```
File "/sglang/python/sglang/srt/layers/layernorm.py", line 1087, in forward_cuda return gemma_rmsnorm(x, self.weight.data, self.eps) NameError: name 'gemma_rmsnorm' is not defined. Did you mean: 'GemmaRMSNorm'?
```
This shows up in AMD CI as `test_triton_sliding_window.py` failing with
`Server process exited with code -9` — the scheduler dies during CUDA graph
capture and the `-9` / retry-exhausted messages are only downstream symptoms.
Root cause: #32383 (`08af5aea57`, *optimize EmbeddingGemma prefill performance*)
changed `Gemma3RMSNorm.forward_cuda` from a plain `return self.forward_native(x)`
into a call to `gemma_fused_add_rmsnorm` / `gemma_rmsnorm`. Those names are bound
at module scope only under:
```python
if _is_cuda or _is_xpu or _is_musa:
    from sgl_kernel import fused_add_rmsnorm, gemma_fused_add_rmsnorm, gemma_rmsnorm, rmsnorm
```

On ROCm is_hip() is true and is_cuda() is false, so neither name exists. Gemma3RMSNorm never defined forward_hip, and MultiPlatformOp.forward_hip defaults to return self.forward_cuda(...), so HIP walks straight into the CUDA-only path. Before #32383 that fallback was harmless because forward_cuda just re-entered forward_native.

GemmaRMSNorm and Gemma4RMSNorm in the same file already guard against this; Gemma3RMSNorm was the only remaining hole.

## Modifications
Add Gemma3RMSNorm.forward_hip, delegating to forward_native (which already handles the optional residual argument and returns the (output, residual) tuple the Gemma3 decoder layer expects). This mirrors the existing Gemma4RMSNorm.forward_hip, which carries the same "sgl_kernel's gemma_rmsnorm is not available on ROCm" rationale.

No CUDA/XPU/MUSA/NPU/CPU behavior changes — the fused kernel path added by #32383 is untouched, so the EmbeddingGemma prefill speedup is preserved on NVIDIA.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30329809681](https://github.com/sgl-project/sglang/actions/runs/30329809681)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30329942318](https://github.com/sgl-project/sglang/actions/runs/30329942318)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->