### PR TITLE
Support GPT-OSS MXFP4 with DeepGEMM and DeepEP

### DIFF
--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -100,6 +100,12 @@ class DeepEPMoE(FusedMoE):
         ):
             self.deprecate_flag = True
         elif (
+            get_moe_runner_backend().is_deep_gemm()
+            and quant_config is not None
+            and quant_config.get_name() == "mxfp4"
+        ):
+            self.deprecate_flag = True
+        elif (
             deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
             and envs.SGLANG_DEEPEP_BF16_DISPATCH.get()
         ):

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -124,6 +124,8 @@ class DeepGemmMoeQuantInfo(MoeQuantInfo):
     use_fp8: bool
     w13_scale: Optional[torch.Tensor] = None
     w2_scale: Optional[torch.Tensor] = None
+    w13_bias: Optional[torch.Tensor] = None
+    w2_bias: Optional[torch.Tensor] = None
     block_shape: Optional[List[int]] = None
     # DSV4 mxfp4 layout flag; selects recipe_a=(1,128)/recipe_b=(1,32) downstream.
     is_fp4_experts: bool = False
@@ -234,7 +236,32 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         dispose_tensor(hidden_states)
         dispose_tensor(hidden_states_scale)
 
-        if envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get():
+        if quant_info.w13_bias is not None:
+            gateup_output.add_(quant_info.w13_bias[m_indices])
+
+        if self.config.gemm1_alpha is not None:
+            from sglang.kernels.ops.quantization.fp8_kernel import (
+                sglang_per_token_group_quant_fp8,
+            )
+            from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import (
+                swiglu_no_interleaved_with_alpha_and_limit,
+            )
+
+            down_input = swiglu_no_interleaved_with_alpha_and_limit(
+                gateup_output,
+                self.config.gemm1_alpha,
+                self.config.gemm1_clamp_limit,
+            )
+            del gateup_output
+            down_input_fp8, down_input_scale = sglang_per_token_group_quant_fp8(
+                down_input,
+                scale_block_size,
+                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+            )
+            del down_input
+        elif envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get():
             swiglu_limit_arg: Optional[float] = self.swiglu_limit
 
             down_input_fp8 = torch.empty(
@@ -317,6 +344,9 @@ class DeepGemmRunnerCore(MoeRunnerCore):
             recipe_a=recipe_a,
             recipe_b=recipe_b,
         )
+
+        if quant_info.w2_bias is not None:
+            down_output.add_(quant_info.w2_bias[m_indices])
 
         return down_output
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -332,6 +332,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
         self.use_flashinfer = get_moe_runner_backend().is_flashinfer_mxfp4()
+        self.use_deep_gemm = get_moe_runner_backend().is_deep_gemm()
         self.use_marlin = get_moe_runner_backend().is_marlin()
         self.flashinfer_mxfp4_moe_precision = (
             get_server_args().flashinfer_mxfp4_moe_precision
@@ -395,6 +396,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     intermediate_size_per_partition, 256
                 )
                 hidden_size = round_up(hidden_size, 256)
+            elif self.use_deep_gemm:
+                self._padded_intermediate = round_up(
+                    intermediate_size_per_partition, 128
+                )
+                self._padded_hidden = round_up(hidden_size, 128)
+                self.hidden_pad = self._padded_hidden - layer.hidden_size
+                self.intermediate_pad = (
+                    self._padded_intermediate
+                    - layer.intermediate_size_per_partition
+                )
             else:
                 intermediate_size_per_partition_after_pad = round_up(
                     intermediate_size_per_partition, triton_kernels_padding_alignment
@@ -436,9 +447,17 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 intermediate_size_per_partition, triton_kernels_padding_alignment
             )
 
-        self.intermediate_size_per_partition = intermediate_size_per_partition_after_pad
-
-        self.hidden_size = hidden_size
+        self.intermediate_size_per_partition = (
+            self._padded_intermediate
+            if self.use_deep_gemm
+            else intermediate_size_per_partition_after_pad
+        )
+        self.hidden_size = self._padded_hidden if self.use_deep_gemm else hidden_size
+        if self.use_deep_gemm:
+            layer.moe_runner_config.hidden_size = self.hidden_size
+            layer.moe_runner_config.intermediate_size_per_partition = (
+                self.intermediate_size_per_partition
+            )
         # Fused gate_up_proj (column parallel)
         w13_weight = torch.nn.Parameter(
             torch.zeros(
@@ -508,6 +527,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer):
+        if self.use_deep_gemm:
+            self._process_weights_for_deep_gemm(layer)
+            return
+
         if self.use_marlin:
             from sglang.srt.layers.quantization.marlin_utils import (
                 check_moe_marlin_supports_layer,
@@ -881,6 +904,98 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight = Parameter(w2_weight.data, requires_grad=False)
         torch.cuda.empty_cache()
 
+    def _process_weights_for_deep_gemm(self, layer):
+        from sglang.srt.layers import deep_gemm_wrapper
+
+        num_experts = layer.num_local_experts
+        intermediate_size = layer.w13_weight.shape[1] // 2
+        hidden_size = layer.w13_weight.shape[2] * 2
+        padded_intermediate = self.intermediate_size_per_partition
+        padded_hidden = self.hidden_size
+        device = layer.w13_weight.device
+
+        def pad_gate_up(
+            x: torch.Tensor, padded_last_dim: int, fill_value: int = 0
+        ) -> torch.Tensor:
+            out = torch.full(
+                (num_experts, 2 * padded_intermediate, padded_last_dim),
+                fill_value,
+                dtype=x.dtype,
+                device=device,
+            )
+            out[:, :intermediate_size, : x.shape[-1]] = x[:, 0::2]
+            out[
+                :,
+                padded_intermediate : padded_intermediate + intermediate_size,
+                : x.shape[-1],
+            ] = x[:, 1::2]
+            return out
+
+        w13_weight = pad_gate_up(
+            layer.w13_weight.data, padded_hidden // 2
+        ).view(torch.int8)
+        w2_weight = torch.zeros(
+            num_experts,
+            padded_hidden,
+            padded_intermediate // 2,
+            dtype=layer.w2_weight.dtype,
+            device=device,
+        )
+        w2_weight[:, :hidden_size, : layer.w2_weight.shape[-1]] = layer.w2_weight.data
+        w2_weight = w2_weight.view(torch.int8)
+
+        w13_scale_raw = pad_gate_up(
+            layer.w13_weight_scale.data, padded_hidden // 32, fill_value=127
+        )
+        w2_scale_raw = torch.full(
+            (num_experts, padded_hidden, padded_intermediate // 32),
+            127,
+            dtype=torch.uint8,
+            device=device,
+        )
+        w2_scale_raw[
+            :, :hidden_size, : layer.w2_weight_scale.shape[-1]
+        ] = layer.w2_weight_scale.data
+
+        w13_bias = pad_gate_up(layer.w13_weight_bias.data.unsqueeze(-1), 1).squeeze(
+            -1
+        )
+        w2_bias = torch.zeros(
+            num_experts,
+            padded_hidden,
+            dtype=layer.w2_weight_bias.dtype,
+            device=device,
+        )
+        w2_bias[:, :hidden_size] = layer.w2_weight_bias.data
+
+        def prepare_scale(scale: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+            scale = torch.exp2(scale.float() - 127)
+            if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+                from deep_gemm import transform_sf_into_required_layout
+
+                num_experts, n, _ = scale.shape
+                scale = transform_sf_into_required_layout(
+                    scale,
+                    mn=n,
+                    k=weight.shape[2] * 2,
+                    recipe=(1, 32),
+                    num_groups=num_experts,
+                    disable_ue8m0_cast=False,
+                )
+            return scale
+
+        layer.w13_weight = Parameter(w13_weight, requires_grad=False)
+        layer.w2_weight = Parameter(w2_weight, requires_grad=False)
+        layer.w13_weight_scale = Parameter(
+            prepare_scale(w13_scale_raw, w13_weight), requires_grad=False
+        )
+        layer.w2_weight_scale = Parameter(
+            prepare_scale(w2_scale_raw, w2_weight), requires_grad=False
+        )
+        layer.w13_weight_bias = Parameter(w13_bias, requires_grad=False)
+        layer.w2_weight_bias = Parameter(w2_bias, requires_grad=False)
+        torch.cuda.empty_cache()
+
     def _process_weights_for_sm90_cutlass(self, layer):
         """De-interleave + pad + halving-swap + byte-interleave MXFP4 weights
         for FlashInfer's SM90 ``cutlass_fused_moe(use_w4_group_scaling=True)``
@@ -1031,6 +1146,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             moe_runner_backend.is_triton_kernels()
             or moe_runner_backend.is_triton()
             or moe_runner_backend.is_marlin()
+            or moe_runner_backend.is_deep_gemm()
         ):
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
         elif (
@@ -1084,7 +1200,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         from sglang.srt.layers.moe.topk import TopKOutputChecker
 
         x = dispatch_output.hidden_states
-        topk_output = dispatch_output.topk_output
+        topk_output = getattr(dispatch_output, "topk_output", None)
         if _is_cpu:
             if use_intel_amx_backend(layer):
                 from sglang.srt.layers.moe.topk import apply_topk_weights_cpu
@@ -1277,6 +1393,29 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             )
 
         backend = self.runner.runner_backend
+        if backend.is_deep_gemm():
+            from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+                DeepGemmMoeQuantInfo,
+            )
+
+            if x.shape[-1] != self.hidden_size:
+                x = torch.nn.functional.pad(
+                    x, (0, self.hidden_pad), mode="constant", value=0.0
+                )
+            quant_info = DeepGemmMoeQuantInfo(
+                w13_weight=layer.w13_weight,
+                w2_weight=layer.w2_weight,
+                use_fp8=True,
+                w13_scale=layer.w13_weight_scale,
+                w2_scale=layer.w2_weight_scale,
+                w13_bias=layer.w13_weight_bias,
+                w2_bias=layer.w2_weight_bias,
+                block_shape=[1, 32],
+                is_fp4_experts=True,
+            )
+            return self.runner.run(
+                dispatch_output._replace(hidden_states=x), quant_info
+            )
         if backend.is_triton_kernels():
             from sglang.srt.layers.moe.moe_runner.triton_kernels import (
                 TritonKernelsQuantInfo,

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -33,6 +33,7 @@ from sglang.srt.distributed import (
 )
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
@@ -263,8 +264,44 @@ class GptOssSparseMoeBlock(nn.Module):
 
         if not get_moe_a2a_backend().is_deepep():
             return self.forward_normal(hidden_states)
+        return self.forward_deepep(hidden_states, forward_batch)
+
+    def forward_deepep(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        if hidden_states.shape[0] > 0:
+            router_logits, _ = self.router(hidden_states)
+            topk_output = self.topk(
+                hidden_states,
+                router_logits,
+                num_token_non_padded=forward_batch.num_token_non_padded,
+                expert_location_dispatch_info=ExpertLocationDispatchInfo.init_new(
+                    layer_id=self.layer_id,
+                ),
+            )
         else:
-            raise NotImplementedError("forward_deepep branch not implemented yet")
+            topk_output = self.topk.empty_topk_output(hidden_states.device)
+
+        expert_hidden_size = getattr(
+            getattr(self.experts, "quant_method", None),
+            "hidden_size",
+            hidden_states.shape[-1],
+        )
+        if expert_hidden_size != hidden_states.shape[-1]:
+            expert_hidden_states = torch.nn.functional.pad(
+                hidden_states,
+                (0, expert_hidden_size - hidden_states.shape[-1]),
+            )
+        else:
+            expert_hidden_states = hidden_states
+
+        final_hidden_states = self.experts(
+            hidden_states=expert_hidden_states,
+            topk_output=topk_output,
+        )
+        return final_hidden_states[..., : hidden_states.shape[-1]].contiguous()
 
     def forward_dwdp(
         self,

--- a/test/registered/unit/models/test_gpt_oss_deepep.py
+++ b/test/registered/unit/models/test_gpt_oss_deepep.py
@@ -1,0 +1,83 @@
+"""Unit tests for GPT-OSS DeepEP routing."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
+from sglang.srt.models.gpt_oss import GptOssSparseMoeBlock
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _DeepEPBackend:
+    def is_deepep(self):
+        return True
+
+
+class _Router(nn.Module):
+    def forward(self, hidden_states):
+        return hidden_states + 1, None
+
+
+class _TopK(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_token_non_padded = None
+
+    def forward(
+        self,
+        hidden_states,
+        router_logits,
+        *,
+        num_token_non_padded,
+        expert_location_dispatch_info,
+    ):
+        self.num_token_non_padded = num_token_non_padded
+        return hidden_states + router_logits
+
+
+class _Experts(nn.Module):
+    def forward(self, hidden_states, topk_output):
+        return hidden_states + topk_output
+
+
+class TestGptOssDeepEPRouting(CustomTestCase):
+    def test_forward_routes_non_padding_token_count_to_deepep_topk(self):
+        block = GptOssSparseMoeBlock.__new__(GptOssSparseMoeBlock)
+        nn.Module.__init__(block)
+        block.layer_id = 3
+        block.router = _Router()
+        block.topk = _TopK()
+        block.experts = _Experts()
+
+        hidden_states = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        forward_batch = SimpleNamespace(num_token_non_padded=1)
+
+        with (
+            patch(
+                "sglang.srt.models.gpt_oss.get_moe_a2a_backend",
+                return_value=_DeepEPBackend(),
+            ),
+            patch(
+                "sglang.srt.models.gpt_oss.get_server_args",
+                return_value=SimpleNamespace(dwdp_size=1),
+            ),
+            patch.object(ExpertLocationDispatchInfo, "init_new", return_value=None),
+        ):
+            output = block(hidden_states, forward_batch)
+
+        self.assertEqual(block.topk.num_token_non_padded, 1)
+        torch.testing.assert_close(
+            output,
+            torch.tensor([[4.0, 7.0], [10.0, 13.0]]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the GPT-OSS DeepEP forward path, including expert-location-aware top-k routing
- support GPT-OSS MXFP4 expert weights and biases in the DeepGEMM MoE runner
- pad and transform GPT-OSS MXFP4 weights/scales into the layouts required by DeepGEMM
- add a focused CPU unit test for the GPT-OSS DeepEP routing path

## Motivation

GPT-OSS-120B MXFP4 could not previously run attention prefill CP together with MoE EP using `--moe-runner-backend deep_gemm --moe-a2a-backend deepep`: the model's DeepEP branch was unimplemented and the MXFP4 quantization path did not prepare DeepGEMM-compatible expert weights, scales, biases, or activation handling.

This enables the intended CP4 + EP4 configuration:

```bash
--tp 4 \
--enable-prefill-cp \
--attn-cp-size 4 \
--cp-strategy zigzag \
--ep 4 \
--moe-runner-backend deep_gemm \
--moe-a2a-backend deepep
```

The default `--deepep-mode auto` should be retained so prefill uses normal dispatch while decode uses low-latency dispatch and remains eligible for CUDA Graph.

## Validation

- `python3 -m pytest -q test/registered/unit/models/test_gpt_oss_deepep.py` — 1 passed
- `git diff --check` — passed
- GPT-OSS-120B GB300 GSM8K smoke with CP4 + EP4 + DeepGEMM + DeepEP — score 0.950

`ruff` was not available in the GB300 devbox environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30330141853](https://github.com/sgl-project/sglang/actions/runs/30330141853)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30330141755](https://github.com/sgl-project/sglang/actions/runs/30330141755)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->