### PR TITLE
[JIT] Restore the previous division behavior in per-token group quantization

### DIFF
--- a/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
@@ -305,7 +305,7 @@ struct QuantTrait {
     } else {
       // fp32 scale: multiply in fp32 (hmul2 brings too much precision loss)
       scale_inv = raw_scale;
-      const float quant_scale = kMaxValue * __frcp_rn(amax);
+      const float quant_scale = kMaxValue / amax;
       const float2 quant_scale2 = {quant_scale, quant_scale};
 #pragma unroll
       for (uint32_t i = 0; i < kVecSize / 2; ++i) {


### PR DESCRIPTION
 ## Motivation

  #30924 changed the FP32-scale quantization multiplier from direct division to an explicit reciprocal multiplication. This introduces small FP8 rounding differences on Hopper.

  The exact mechanism is still unclear, and this change may not fully resolve the GLM-5.2 decode regression reported in #32582.

  ## Modifications

  Restore `kMaxValue / amax` in the shared per-token-group quantization path, matching the previous v2 kernel behavior.


  ## Accuracy Tests
  - FP32-scale CUDA tests on H20: 8 passed.
  - Bitwise comparison with the previous v2 kernel: zero FP8 code and scale mismatches.
  - With #30393, the DeepSeek-V3.2 MTP L3 replay accept length recovered from `2.462` to `3.368`, compared with a cold-run accept length of `3.459`.

CC @BBuf @whybeyoung @DarkSharpness

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30331073644](https://github.com/sgl-project/sglang/actions/runs/30331073644)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #30331960865](https://github.com/sgl-project/sglang/actions/runs/30331960865)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->