### PR TITLE
[Kimi K3] Support parser auto-detection

### DIFF
--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -600,8 +600,11 @@ def _resolve_architecture_auto_parsers(server_args) -> None:
     )
     architectures = getattr(config, "architectures", None) or []
     arch = architectures[0] if architectures else ""
+    model_type = getattr(config, "model_type", "")
 
-    if "DeepseekV4" in arch:
+    if "KimiK3" in arch or model_type == "kimi_k3":
+        reasoning_parser, tool_call_parser = "kimi_k3", "kimi_k3"
+    elif "DeepseekV4" in arch:
         reasoning_parser, tool_call_parser = "deepseek-v4", "deepseekv4"
     elif "DeepseekV3" in arch:
         reasoning_parser, tool_call_parser = "deepseek-v3", "deepseekv32"

--- a/test/registered/unit/parser/test_template_manager.py
+++ b/test/registered/unit/parser/test_template_manager.py
@@ -15,7 +15,7 @@ from sglang.srt.parser.template_detection import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(2.0, "base-a-test-cpu")
+register_cpu_ci(est_time=2.0, suite="base-a-test-cpu")
 
 
 class _DummyTokenizer:
@@ -737,6 +737,34 @@ class TestResolveAutoParsers(unittest.TestCase):
 
         self.assertEqual(args.reasoning_parser, "deepseek-v4")
         self.assertEqual(args.tool_call_parser, "deepseekv4")
+
+    def test_kimi_k3_arch_without_chat_template_uses_custom_encoder(self):
+        args = self._make_server_args(reasoning_parser="auto", tool_call_parser="auto")
+        tokenizer = _DummyTokenizer([])
+        config = SimpleNamespace(
+            architectures=["KimiK3ForConditionalGeneration"], model_type="kimi_k3"
+        )
+
+        with _patch_hf_transformers_utils(
+            Mock(return_value=tokenizer), Mock(return_value=config)
+        ):
+            resolve_auto_parsers(args)
+
+        self.assertEqual(args.reasoning_parser, "kimi_k3")
+        self.assertEqual(args.tool_call_parser, "kimi_k3")
+
+    def test_kimi_k3_model_type_without_architecture_uses_custom_encoder(self):
+        args = self._make_server_args(reasoning_parser="auto", tool_call_parser="auto")
+        tokenizer = _DummyTokenizer([])
+        config = SimpleNamespace(architectures=None, model_type="kimi_k3")
+
+        with _patch_hf_transformers_utils(
+            Mock(return_value=tokenizer), Mock(return_value=config)
+        ):
+            resolve_auto_parsers(args)
+
+        self.assertEqual(args.reasoning_parser, "kimi_k3")
+        self.assertEqual(args.tool_call_parser, "kimi_k3")
 
     def test_deepseek_arch_fallback_runs_when_tokenizer_load_fails(self):
         args = self._make_server_args(reasoning_parser="auto", tool_call_parser="auto")


### PR DESCRIPTION
## Summary

- resolve `--reasoning-parser=auto` and `--tool-call-parser=auto` to `kimi_k3` for Kimi K3 configs
- support both the architecture name and `model_type="kimi_k3"`
- cover both config forms in the template-detection unit tests

## Why

Kimi K3 uses a custom chat encoder without a Jinja chat template. Parser auto-detection therefore falls back to the model architecture, but the architecture fallback currently only handles DeepSeek models. Both K3 parser settings are consequently disabled when users select `auto`.

This PR extends the existing free-function architecture dispatch rather than adding a separate model-specific detection path.

This is stacked on #32541 and targets its `kimi-k3` branch.

## Validation

- `PYTHONPATH=python python -m pytest -q test/registered/unit/parser/test_template_manager.py`
  - 35 passed, 43 subtests passed
- `pre-commit run --files python/sglang/srt/parser/template_detection.py test/registered/unit/parser/test_template_manager.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30331364440](https://github.com/sgl-project/sglang/actions/runs/30331364440)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30331364248](https://github.com/sgl-project/sglang/actions/runs/30331364248)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->