### PR TITLE
feat(moe): add ROCm SharedEP backend

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/silu_and_mul_masked_post_quant.cuh
@@ -11,8 +11,26 @@
 #include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
 
 #include <cstdint>
+#ifndef USE_ROCM
 #include <cuda_fp8.h>
+#endif
 #include <type_traits>
+
+#ifdef USE_ROCM
+struct fp8_e4m3_tensor_t {};
+namespace host::details {
+template <>
+struct DLDataTypeTrait<::fp8_e4m3_tensor_t> {
+#if HIP_FP8_TYPE_FNUZ
+  inline static constexpr DLDataType value = {.code = DLDataTypeCode::kDLFloat8_e4m3fnuz, .bits = 8, .lanes = 1};
+#else
+  inline static constexpr DLDataType value = {.code = DLDataTypeCode::kDLFloat8_e4m3fn, .bits = 8, .lanes = 1};
+#endif
+};
+}  // namespace host::details
+#else
+using fp8_e4m3_tensor_t = fp8_e4m3_t;
+#endif
 
 namespace {
 
@@ -31,6 +49,11 @@ struct SiluMulQuantVarlenParams {
 };
 
 constexpr uint32_t kMaxExperts = 256;
+#ifdef USE_ROCM
+constexpr uint32_t kScanThreads = 64;
+#else
+constexpr uint32_t kScanThreads = 32;
+#endif
 
 struct alignas(16) CTAWork {
   uint32_t expert_id;
@@ -39,12 +62,22 @@ struct alignas(16) CTAWork {
 };
 
 SGL_DEVICE uint32_t warp_inclusive_sum(uint32_t lane_id, uint32_t val) {
+#ifndef USE_ROCM
   static_assert(device::kWarpThreads == 32);
 #pragma unroll
   for (uint32_t offset = 1; offset < 32; offset *= 2) {
     uint32_t n = __shfl_up_sync(0xFFFFFFFF, val, offset);
     if (lane_id >= offset) val += n;
   }
+#else
+#pragma unroll
+  for (uint32_t offset = 1; offset < kScanThreads; offset *= 2) {
+    // CDNA executes wave64. Passing width=64 prevents the upper half-wave from
+    // being accidentally treated as a second NVIDIA-style logical warp.
+    uint32_t n = __shfl_up(val, offset, kScanThreads);
+    if (lane_id >= offset) val += n;
+  }
+#endif
   return val;
 }
 
@@ -78,11 +111,12 @@ SGL_DEVICE CTAWork get_work(const SiluMulQuantVarlenParams& params) {
   // 1. blockDim.x >= params.num_experts
   // 2. params.num_experts <= kMaxExperts
   using namespace device;
-  static_assert(kWarpThreads == 32);
 
   static __shared__ uint32_t s_warp_sum[32];
   static __shared__ CTAWork result;
 
+#ifndef USE_ROCM
+  static_assert(kWarpThreads == 32);
   result.valid = false;
 
   const uint32_t tx = threadIdx.x;
@@ -100,6 +134,34 @@ SGL_DEVICE CTAWork get_work(const SiluMulQuantVarlenParams& params) {
   __syncthreads();
   const auto tmp_val = lane_id < warp_id ? s_warp_sum[lane_id] : 0u;
   const auto prefix_exclusive = warp::reduce_sum(tmp_val) + warp_exclusive;
+#else
+  const uint32_t tx = threadIdx.x;
+  const uint32_t lane_id = tx % kScanThreads;
+  const uint32_t warp_id = tx / kScanThreads;
+  if (tx == 0) result.valid = false;
+  __syncthreads();
+
+  const uint32_t val = tx < params.num_experts ? params.masked_m[tx] : 0u;
+
+  // Per-warp inclusive scan of masked_m.
+  const uint32_t warp_inclusive = warp_inclusive_sum(lane_id, val);
+  const uint32_t warp_exclusive = warp_inclusive - val;
+
+  // Write each warp total.
+  if (lane_id == kScanThreads - 1) s_warp_sum[warp_id] = warp_inclusive;
+  __syncthreads();
+  if (tx == 0) {
+    const uint32_t num_warps = blockDim.x / kScanThreads;
+    uint32_t prefix = 0;
+    for (uint32_t warp = 0; warp < num_warps; ++warp) {
+      const uint32_t total = s_warp_sum[warp];
+      s_warp_sum[warp] = prefix;
+      prefix += total;
+    }
+  }
+  __syncthreads();
+  const auto prefix_exclusive = s_warp_sum[warp_id] + warp_exclusive;
+#endif
   const auto bx = blockIdx.x;
   if (prefix_exclusive <= bx && bx < prefix_exclusive + val) {
     result = {tx, bx - prefix_exclusive, true};
@@ -264,14 +326,14 @@ struct SiluAndMulMaskedPostQuantKernel {
     auto D = SymbolicSize{"hidden_dim x 2"};
     auto N = SymbolicSize{"hidden_dim"};
     auto G = SymbolicSize{"num_groups"};
-    device.set_options<kDLCUDA>();
+    device.set_options<kDLGPU>();
 
     TensorMatcher({E, T, D})  // input
         .with_dtype<bf16_t>()
         .with_device(device)
         .verify(input);
     TensorMatcher({E, T, N})  // output
-        .with_dtype<fp8_e4m3_t>()
+        .with_dtype<fp8_e4m3_tensor_t>()
         .with_device(device)
         .verify(output);
     if (!transposed) {
@@ -315,7 +377,7 @@ struct SiluAndMulMaskedPostQuantKernel {
     };
 
     const auto num_threads = hidden_dim / 8;
-    RuntimeCheck(num_threads % device::kWarpThreads == 0);
+    RuntimeCheck(num_threads % kScanThreads == 0);
     RuntimeCheck(num_threads >= num_experts);
     const auto kernel = transposed ? kernel_transposed : kernel_normal;
     LaunchKernel(num_tokens * topk, num_threads, device.unwrap())  //
@@ -334,7 +396,7 @@ struct SiluAndMulClampKernel {
     auto M = SymbolicSize{"num_tokens"};
     auto D = SymbolicSize{"gate_up_dim"};  // 2 * out_dim
     auto H = SymbolicSize{"out_dim"};
-    device.set_options<kDLCUDA>();
+    device.set_options<kDLGPU>();
 
     TensorMatcher({M, D})  // input  (gate || up)
         .with_dtype<DType>()
@@ -367,6 +429,7 @@ struct SiluMulQuantContigParams {
   const bf16_t* __restrict__ input;
   fp8_e4m3_t* __restrict__ output;
   float* __restrict__ output_scale;
+  const int32_t* __restrict__ valid_rows;
   float swiglu_limit;  // only read when kApplySwigluLimit=true
   int64_t hidden_dim;
   uint32_t num_tokens;
@@ -386,6 +449,7 @@ __global__ __launch_bounds__(1024, 2) void  // maximize occupancy
   static_assert(!(kTransposed && !kScaleUE8M0), "transposed layout only supports ue8m0");
 
   const auto token_id = blockIdx.x;
+  if (params.valid_rows != nullptr && token_id >= static_cast<uint32_t>(*params.valid_rows)) return;
   const auto work_id = threadIdx.x / kWorkThreads;
 
   const auto input = params.input + token_id * params.hidden_dim * 2;
@@ -473,6 +537,27 @@ struct SiluAndMulContigPostQuantKernel {
       const tvm::ffi::TensorView output_scale,
       const bool transposed,
       const double swiglu_limit) {
+    run_impl(input, output, output_scale, nullptr, transposed, swiglu_limit);
+  }
+
+  static void run_valid(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView output,
+      const tvm::ffi::TensorView output_scale,
+      const tvm::ffi::TensorView valid_rows,
+      const bool transposed,
+      const double swiglu_limit) {
+    run_impl(input, output, output_scale, &valid_rows, transposed, swiglu_limit);
+  }
+
+ private:
+  static void run_impl(
+      const tvm::ffi::TensorView input,
+      const tvm::ffi::TensorView output,
+      const tvm::ffi::TensorView output_scale,
+      const tvm::ffi::TensorView* valid_rows,
+      const bool transposed,
+      const double swiglu_limit) {
     using namespace host;
 
     auto device = SymbolicDevice{};
@@ -480,16 +565,22 @@ struct SiluAndMulContigPostQuantKernel {
     auto D = SymbolicSize{"hidden_dim x 2"};
     auto N = SymbolicSize{"hidden_dim"};
     auto G = SymbolicSize{"num_groups"};
-    device.set_options<kDLCUDA>();
+    device.set_options<kDLGPU>();
 
     TensorMatcher({M, D})  // input (gate/up, natural or gran=8 interleaved on last dim)
         .with_dtype<bf16_t>()
         .with_device(device)
         .verify(input);
     TensorMatcher({M, N})  // fp8 output
-        .with_dtype<fp8_e4m3_t>()
+        .with_dtype<fp8_e4m3_tensor_t>()
         .with_device(device)
         .verify(output);
+    if (valid_rows != nullptr) {
+      TensorMatcher({1})  //
+          .with_dtype<int32_t>()
+          .with_device(device)
+          .verify(*valid_rows);
+    }
 
     const auto hidden_dim = N.unwrap();
     RuntimeCheck(D.unwrap() == 2 * hidden_dim, "invalid dimension");
@@ -523,6 +614,7 @@ struct SiluAndMulContigPostQuantKernel {
         .input = static_cast<const bf16_t*>(input.data_ptr()),
         .output = static_cast<fp8_e4m3_t*>(output.data_ptr()),
         .output_scale = static_cast<float*>(output_scale.data_ptr()),
+        .valid_rows = valid_rows == nullptr ? nullptr : static_cast<const int32_t*>(valid_rows->data_ptr()),
         .swiglu_limit = static_cast<float>(swiglu_limit),
         .hidden_dim = hidden_dim,
         .num_tokens = num_tokens,
@@ -530,7 +622,11 @@ struct SiluAndMulContigPostQuantKernel {
     };
 
     const auto num_threads = hidden_dim / 8;
+#ifdef USE_ROCM
+    RuntimeCheck(num_threads % 16 == 0);
+#else
     RuntimeCheck(num_threads % device::kWarpThreads == 0);
+#endif
     const auto kernel = transposed ? kernel_transposed : kernel_normal;
     LaunchKernel(num_tokens, num_threads, device.unwrap())  //
         .enable_pdl(kUsePDL)(kernel, params);

--- a/python/sglang/kernels/jit/csrc/moe/shared_ep_route_prep.cu
+++ b/python/sglang/kernels/jit/csrc/moe/shared_ep_route_prep.cu
@@ -1,0 +1,378 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <cstdint>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+namespace {
+
+#if defined(USE_ROCM)
+constexpr auto kSharedEpDeviceType = kDLROCM;
+constexpr int kRouteThreadGroupSize = 64;
+#else
+constexpr auto kSharedEpDeviceType = kDLCUDA;
+constexpr int kRouteThreadGroupSize = 32;
+#endif
+
+SGL_DEVICE uint32_t shared_ep_load_acquire_system(const uint32_t* address) {
+#if defined(USE_ROCM)
+  return __hip_atomic_load(address, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+  uint32_t value;
+  asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(value) : "l"(address) : "memory");
+  return value;
+#endif
+}
+
+#if defined(USE_ROCM)
+SGL_DEVICE void shared_ep_store_release_system(uint32_t* address, uint32_t value) {
+  __hip_atomic_store(address, value, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
+__global__ void shared_ep_publish_epoch_kernel(
+    uint8_t* global_signals, int32_t* epoch_ptr, int64_t rank_stride_words, int32_t rank, int32_t world_size) {
+  __shared__ uint32_t next_epoch;
+  const int32_t tid = static_cast<int32_t>(threadIdx.x);
+  if (tid == 0) {
+    next_epoch = static_cast<uint32_t>(*epoch_ptr) + 1u;
+    *epoch_ptr = static_cast<int32_t>(next_epoch);
+  }
+  __syncthreads();
+  if (tid < world_size) {
+    auto* signal_words = reinterpret_cast<uint32_t*>(global_signals);
+    shared_ep_store_release_system(signal_words + tid * rank_stride_words + rank, next_epoch);
+  }
+}
+
+__global__ void shared_ep_publish_pointer_table_epoch_kernel(
+    const uint64_t* peer_signal_bases, int32_t* epoch_ptr, int32_t rank, int32_t world_size) {
+  __shared__ uint32_t next_epoch;
+  const int32_t tid = static_cast<int32_t>(threadIdx.x);
+  if (tid == 0) {
+    next_epoch = static_cast<uint32_t>(*epoch_ptr) + 1u;
+    *epoch_ptr = static_cast<int32_t>(next_epoch);
+  }
+  __syncthreads();
+  if (tid < world_size) {
+    auto* peer_signals = reinterpret_cast<uint32_t*>(peer_signal_bases[tid]);
+    shared_ep_store_release_system(peer_signals + rank, next_epoch);
+  }
+}
+
+__global__ void
+shared_ep_wait_epoch_kernel(const uint8_t* local_signals, const int32_t* epoch_ptr, int32_t world_size) {
+  __shared__ uint32_t expected_epoch;
+  const int32_t tid = static_cast<int32_t>(threadIdx.x);
+  if (tid == 0) expected_epoch = static_cast<uint32_t>(*epoch_ptr);
+  __syncthreads();
+  if (tid < world_size) {
+    const auto* signal_words = reinterpret_cast<const uint32_t*>(local_signals);
+    while (shared_ep_load_acquire_system(signal_words + tid) != expected_epoch) {
+    }
+  }
+}
+
+struct SharedEpEpochKernel {
+  static void publish(
+      tvm::ffi::TensorView global_signals,
+      tvm::ffi::TensorView epoch,
+      int64_t rank_stride_words,
+      int64_t rank,
+      int64_t world_size) {
+    using namespace host;
+    RuntimeCheck(global_signals.device().device_type == kDLROCM, "SharedEP epoch signals must be ROCm");
+    RuntimeCheck(epoch.device().device_type == kDLROCM, "SharedEP epoch counter must be ROCm");
+    RuntimeCheck(
+        global_signals.device().device_id == epoch.device().device_id,
+        "SharedEP epoch tensors must use the same ROCm device");
+    RuntimeCheck(is_type<uint8_t>(global_signals.dtype()), "SharedEP epoch signals must use uint8 storage");
+    RuntimeCheck(is_type<int32_t>(epoch.dtype()) && epoch.numel() == 1, "SharedEP epoch must be one int32 value");
+    RuntimeCheck(rank_stride_words > 0, "SharedEP epoch rank stride must be positive");
+    RuntimeCheck(world_size > 0 && world_size <= 1024, "SharedEP epoch world size must be in [1, 1024]");
+    RuntimeCheck(rank >= 0 && rank < world_size, "SharedEP epoch rank is outside the world");
+    const int64_t required_words = (world_size - 1) * rank_stride_words + rank + 1;
+    RuntimeCheck(
+        required_words <= global_signals.numel() / static_cast<int64_t>(sizeof(uint32_t)),
+        "SharedEP global epoch storage is too small");
+
+    const auto device = global_signals.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+    LaunchKernel(dim3(1), dim3(static_cast<uint32_t>(world_size)), stream)(
+        shared_ep_publish_epoch_kernel,
+        static_cast<uint8_t*>(global_signals.data_ptr()),
+        static_cast<int32_t*>(epoch.data_ptr()),
+        rank_stride_words,
+        static_cast<int32_t>(rank),
+        static_cast<int32_t>(world_size));
+  }
+
+  static void publish_pointer_table(
+      tvm::ffi::TensorView peer_signal_bases,
+      tvm::ffi::TensorView epoch,
+      int64_t rank,
+      int64_t world_size) {
+    using namespace host;
+    RuntimeCheck(peer_signal_bases.device().device_type == kDLROCM, "SharedEP peer pointer table must be ROCm");
+    RuntimeCheck(epoch.device().device_type == kDLROCM, "SharedEP epoch counter must be ROCm");
+    RuntimeCheck(
+        peer_signal_bases.device().device_id == epoch.device().device_id,
+        "SharedEP peer pointer table and epoch must use the same ROCm device");
+    RuntimeCheck(is_type<uint64_t>(peer_signal_bases.dtype()), "SharedEP peer pointer table must use uint64");
+    RuntimeCheck(is_type<int32_t>(epoch.dtype()) && epoch.numel() == 1, "SharedEP epoch must be one int32 value");
+    RuntimeCheck(world_size > 0 && world_size <= 1024, "SharedEP epoch world size must be in [1, 1024]");
+    RuntimeCheck(rank >= 0 && rank < world_size, "SharedEP epoch rank is outside the world");
+    RuntimeCheck(
+        peer_signal_bases.numel() == world_size, "SharedEP peer pointer table must contain one pointer per rank");
+
+    const auto device = peer_signal_bases.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+    LaunchKernel(dim3(1), dim3(static_cast<uint32_t>(world_size)), stream)(
+        shared_ep_publish_pointer_table_epoch_kernel,
+        static_cast<const uint64_t*>(peer_signal_bases.data_ptr()),
+        static_cast<int32_t*>(epoch.data_ptr()),
+        static_cast<int32_t>(rank),
+        static_cast<int32_t>(world_size));
+  }
+
+  static void wait(tvm::ffi::TensorView local_signals, tvm::ffi::TensorView epoch, int64_t world_size) {
+    using namespace host;
+    RuntimeCheck(local_signals.device().device_type == kDLROCM, "SharedEP epoch signals must be ROCm");
+    RuntimeCheck(epoch.device().device_type == kDLROCM, "SharedEP epoch counter must be ROCm");
+    RuntimeCheck(
+        local_signals.device().device_id == epoch.device().device_id,
+        "SharedEP epoch tensors must use the same ROCm device");
+    RuntimeCheck(is_type<uint8_t>(local_signals.dtype()), "SharedEP epoch signals must use uint8 storage");
+    RuntimeCheck(is_type<int32_t>(epoch.dtype()) && epoch.numel() == 1, "SharedEP epoch must be one int32 value");
+    RuntimeCheck(world_size > 0 && world_size <= 1024, "SharedEP epoch world size must be in [1, 1024]");
+    RuntimeCheck(
+        world_size <= local_signals.numel() / static_cast<int64_t>(sizeof(uint32_t)),
+        "SharedEP local epoch storage is too small");
+
+    const auto device = local_signals.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+    LaunchKernel(dim3(1), dim3(static_cast<uint32_t>(world_size)), stream)(
+        shared_ep_wait_epoch_kernel,
+        static_cast<const uint8_t*>(local_signals.data_ptr()),
+        static_cast<const int32_t*>(epoch.data_ptr()),
+        static_cast<int32_t>(world_size));
+  }
+};
+#endif
+
+#if defined(SHARED_EP_OWNERS) || defined(SHARED_EP_MAX_TOKENS) || defined(SHARED_EP_TOP_K) || \
+    defined(SHARED_EP_LOCAL_EXPERTS) || defined(SHARED_EP_BLOCK_M) || defined(SHARED_EP_THREADS)
+#if !defined(SHARED_EP_OWNERS) || !defined(SHARED_EP_MAX_TOKENS) || !defined(SHARED_EP_TOP_K) || \
+    !defined(SHARED_EP_LOCAL_EXPERTS) || !defined(SHARED_EP_BLOCK_M) || !defined(SHARED_EP_THREADS)
+#error "SharedEP route-prep specialization is incomplete"
+#endif
+
+constexpr int kOwners = SHARED_EP_OWNERS;
+constexpr int kMaxTokens = SHARED_EP_MAX_TOKENS;
+constexpr int kTopK = SHARED_EP_TOP_K;
+constexpr int kNumel = kOwners * kMaxTokens * kTopK;
+constexpr int kLocalExperts = SHARED_EP_LOCAL_EXPERTS;
+constexpr int kBlockM = SHARED_EP_BLOCK_M;
+constexpr int kThreads = SHARED_EP_THREADS;
+constexpr int kMaxSorted = kNumel + kLocalExperts * (kBlockM - 1);
+constexpr int kMaxBlocks = (kMaxSorted + kBlockM - 1) / kBlockM;
+
+static_assert(kOwners > 0 && kMaxTokens > 0 && kTopK > 0);
+static_assert(kLocalExperts > 0 && kLocalExperts <= kThreads);
+static_assert(kBlockM > 0);
+static_assert(kThreads > 0 && kThreads <= 1024 && kThreads % kRouteThreadGroupSize == 0);
+
+__global__ void shared_ep_route_prep_kernel(
+    const int32_t* __restrict__ global_ids,
+    const float* __restrict__ global_weights,
+    const uint32_t* __restrict__ ready_signals,
+    const int32_t* __restrict__ ready_epoch,
+    int64_t ids_owner_stride,
+    int64_t ids_token_stride,
+    int64_t weights_owner_stride,
+    int64_t weights_token_stride,
+    int32_t* __restrict__ local_ids,
+    float* __restrict__ local_weights,
+    int32_t* __restrict__ sorted_ids,
+    int32_t max_sorted,
+    int32_t* __restrict__ expert_ids,
+    int32_t max_blocks,
+    int32_t* __restrict__ total_padded,
+    int32_t local_expert_start) {
+  __shared__ int32_t counts[kLocalExperts];
+  __shared__ int32_t starts[kLocalExperts + 1];
+  __shared__ int32_t cursors[kLocalExperts];
+
+  const int tid = threadIdx.x;
+  const uint32_t expected_epoch = static_cast<uint32_t>(*ready_epoch);
+  if (tid < kOwners) {
+    uint32_t observed_epoch;
+    do {
+      observed_epoch = shared_ep_load_acquire_system(ready_signals + tid);
+    } while (observed_epoch != expected_epoch);
+  }
+  __syncthreads();
+
+  if (tid < kLocalExperts) counts[tid] = 0;
+  __syncthreads();
+
+  for (int index = tid; index < kNumel; index += blockDim.x) {
+    const int owner = index / (kMaxTokens * kTopK);
+    const int owner_route = index - owner * kMaxTokens * kTopK;
+    const int token = owner_route / kTopK;
+    const int slot = owner_route - token * kTopK;
+    const int32_t global_expert = global_ids[owner * ids_owner_stride + token * ids_token_stride + slot];
+    const int32_t local_expert = global_expert - local_expert_start;
+    const bool valid = local_expert >= 0 && local_expert < kLocalExperts;
+    local_ids[index] = valid ? local_expert : -1;
+    local_weights[index] = global_weights[owner * weights_owner_stride + token * weights_token_stride + slot];
+    if (valid) atomicAdd(&counts[local_expert], 1);
+  }
+  __syncthreads();
+
+  if (tid == 0) {
+    int32_t cursor = 0;
+    for (int expert = 0; expert < kLocalExperts; ++expert) {
+      starts[expert] = cursor;
+      cursors[expert] = cursor;
+      cursor += ((counts[expert] + kBlockM - 1) / kBlockM) * kBlockM;
+    }
+    starts[kLocalExperts] = cursor;
+    *total_padded = cursor;
+  }
+  __syncthreads();
+
+  const int32_t padded = starts[kLocalExperts];
+  for (int index = tid; index < padded; index += blockDim.x) {
+    sorted_ids[index] = kNumel;
+  }
+  for (int index = tid; index < max_blocks; index += blockDim.x) {
+    expert_ids[index] = -1;
+  }
+  __syncthreads();
+
+  if (tid < kLocalExperts) {
+    for (int offset = starts[tid]; offset < starts[tid + 1]; offset += kBlockM) {
+      expert_ids[offset / kBlockM] = tid;
+    }
+  }
+  __syncthreads();
+
+  for (int index = tid; index < kNumel; index += blockDim.x) {
+    const int32_t expert = local_ids[index];
+    if (expert >= 0) {
+      const int32_t position = atomicAdd(&cursors[expert], 1);
+      sorted_ids[position] = index;
+    }
+  }
+}
+
+struct SharedEpRoutePrepKernel {
+  static void
+  run(tvm::ffi::TensorView global_ids,
+      tvm::ffi::TensorView global_weights,
+      tvm::ffi::TensorView ready_signals,
+      tvm::ffi::TensorView ready_epoch,
+      tvm::ffi::TensorView local_ids,
+      tvm::ffi::TensorView local_weights,
+      tvm::ffi::TensorView sorted_ids,
+      tvm::ffi::TensorView expert_ids,
+      tvm::ffi::TensorView total_padded,
+      int64_t local_expert_start) {
+    using namespace host;
+
+    RuntimeCheck(
+        global_ids.device().device_type == kSharedEpDeviceType, "SharedEP route ids must use the active GPU platform");
+    RuntimeCheck(
+        global_weights.device().device_type == kSharedEpDeviceType,
+        "SharedEP route weights must use the active GPU platform");
+    RuntimeCheck(
+        ready_signals.device().device_type == kSharedEpDeviceType,
+        "SharedEP ready signals must use the active GPU platform");
+    RuntimeCheck(
+        ready_epoch.device().device_type == kSharedEpDeviceType,
+        "SharedEP ready epoch must use the active GPU platform");
+    RuntimeCheck(
+        global_ids.device().device_id == global_weights.device().device_id,
+        "SharedEP route ids and weights must use the same GPU device");
+    RuntimeCheck(is_type<int32_t>(global_ids.dtype()), "SharedEP route ids must be int32");
+    RuntimeCheck(is_type<float>(global_weights.dtype()), "SharedEP route weights must be float32");
+    RuntimeCheck(is_type<uint8_t>(ready_signals.dtype()), "SharedEP ready signals must be uint8 storage");
+    RuntimeCheck(is_type<int32_t>(ready_epoch.dtype()), "SharedEP ready epoch must be int32");
+    RuntimeCheck(is_type<int32_t>(local_ids.dtype()), "SharedEP local route ids must be int32");
+    RuntimeCheck(is_type<float>(local_weights.dtype()), "SharedEP local route weights must be float32");
+    RuntimeCheck(is_type<int32_t>(sorted_ids.dtype()), "SharedEP sorted route ids must be int32");
+    RuntimeCheck(is_type<int32_t>(expert_ids.dtype()), "SharedEP expert ids must be int32");
+    RuntimeCheck(is_type<int32_t>(total_padded.dtype()), "SharedEP padded route count must be int32");
+    const int device_id = global_ids.device().device_id;
+    RuntimeCheck(
+        ready_signals.device().device_id == device_id && ready_epoch.device().device_id == device_id &&
+            local_ids.device().device_type == kSharedEpDeviceType &&
+            local_weights.device().device_type == kSharedEpDeviceType &&
+            sorted_ids.device().device_type == kSharedEpDeviceType &&
+            expert_ids.device().device_type == kSharedEpDeviceType &&
+            total_padded.device().device_type == kSharedEpDeviceType && local_ids.device().device_id == device_id &&
+            local_weights.device().device_id == device_id && sorted_ids.device().device_id == device_id &&
+            expert_ids.device().device_id == device_id && total_padded.device().device_id == device_id,
+        "SharedEP route-prep tensors must use the same GPU device");
+    RuntimeCheck(global_ids.dim() == 3, "SharedEP route ids must be three-dimensional");
+    RuntimeCheck(global_weights.dim() == 3, "SharedEP route weights must be three-dimensional");
+    RuntimeCheck(
+        global_ids.size(0) == kOwners && global_ids.size(1) == kMaxTokens && global_ids.size(2) == kTopK,
+        "SharedEP route id shape does not match the JIT specialization");
+    RuntimeCheck(
+        global_weights.size(0) == kOwners && global_weights.size(1) == kMaxTokens && global_weights.size(2) == kTopK,
+        "SharedEP route weight shape does not match the JIT specialization");
+    RuntimeCheck(global_ids.stride(2) == 1, "SharedEP route id columns must be contiguous");
+    RuntimeCheck(global_weights.stride(2) == 1, "SharedEP route weight columns must be contiguous");
+    RuntimeCheck(
+        local_ids.numel() == kNumel && local_weights.numel() == kNumel, "invalid SharedEP local route output shape");
+    RuntimeCheck(sorted_ids.numel() == kMaxSorted, "invalid SharedEP sorted route output shape");
+    RuntimeCheck(expert_ids.numel() == kMaxBlocks, "invalid SharedEP expert output shape");
+    RuntimeCheck(total_padded.numel() == 1, "total_padded must have one element");
+    RuntimeCheck(ready_signals.numel() >= kOwners * sizeof(uint32_t), "SharedEP ready signal storage is too small");
+    RuntimeCheck(ready_epoch.numel() == 1, "SharedEP ready epoch must have one element");
+
+    auto device = global_ids.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+    LaunchKernel(dim3(1), dim3(kThreads), stream)(
+        shared_ep_route_prep_kernel,
+        static_cast<const int32_t*>(global_ids.data_ptr()),
+        static_cast<const float*>(global_weights.data_ptr()),
+        static_cast<const uint32_t*>(ready_signals.data_ptr()),
+        static_cast<const int32_t*>(ready_epoch.data_ptr()),
+        global_ids.stride(0),
+        global_ids.stride(1),
+        global_weights.stride(0),
+        global_weights.stride(1),
+        static_cast<int32_t*>(local_ids.data_ptr()),
+        static_cast<float*>(local_weights.data_ptr()),
+        static_cast<int32_t*>(sorted_ids.data_ptr()),
+        static_cast<int32_t>(sorted_ids.numel()),
+        static_cast<int32_t*>(expert_ids.data_ptr()),
+        static_cast<int32_t>(expert_ids.numel()),
+        static_cast<int32_t*>(total_padded.data_ptr()),
+        static_cast<int32_t>(local_expert_start));
+  }
+};
+
+#endif
+
+}  // namespace

--- a/python/sglang/kernels/jit/csrc/moe/shared_ep_route_prep.cu
+++ b/python/sglang/kernels/jit/csrc/moe/shared_ep_route_prep.cu
@@ -16,11 +16,11 @@ limitations under the License.
 #include <sgl_kernel/tensor.h>
 #include <sgl_kernel/utils.h>
 
-#include <cstdint>
-
 #include <sgl_kernel/utils.cuh>
 
 #include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
 
 namespace {
 
@@ -125,10 +125,7 @@ struct SharedEpEpochKernel {
   }
 
   static void publish_pointer_table(
-      tvm::ffi::TensorView peer_signal_bases,
-      tvm::ffi::TensorView epoch,
-      int64_t rank,
-      int64_t world_size) {
+      tvm::ffi::TensorView peer_signal_bases, tvm::ffi::TensorView epoch, int64_t rank, int64_t world_size) {
     using namespace host;
     RuntimeCheck(peer_signal_bases.device().device_type == kDLROCM, "SharedEP peer pointer table must be ROCm");
     RuntimeCheck(epoch.device().device_type == kDLROCM, "SharedEP epoch counter must be ROCm");

--- a/python/sglang/kernels/jit/include/sgl_kernel/warp.cuh
+++ b/python/sglang/kernels/jit/include/sgl_kernel/warp.cuh
@@ -181,7 +181,11 @@ SGL_DEVICE uint32_t inclusive_sum(uint32_t lane_id, uint32_t val) {
   static_assert(kWarpThreads == 32);
 #pragma unroll
   for (uint32_t offset = 1; offset < 32; offset *= 2) {
-    uint32_t n = __shfl_up_sync(0xFFFFFFFF, val, offset);
+#ifndef USE_ROCM
+    uint32_t n = __shfl_up_sync(kFullMask, val, offset);
+#else
+    uint32_t n = __shfl_up(val, offset, 32);
+#endif
     if (lane_id >= offset) val += n;
   }
   return val;

--- a/python/sglang/kernels/ops/attention/dsv4/moe.py
+++ b/python/sglang/kernels/ops/attention/dsv4/moe.py
@@ -88,7 +88,10 @@ def _jit_silu_mul_quant_contig_module(
         make_name("silu_mul_quant_contig"),
         *args,
         cuda_files=["deepseek_v4/silu_and_mul_masked_post_quant.cuh"],
-        cuda_wrappers=[("run", f"SiluAndMulContigPostQuantKernel<{args}>::run")],
+        cuda_wrappers=[
+            ("run", f"SiluAndMulContigPostQuantKernel<{args}>::run"),
+            ("run_valid", f"SiluAndMulContigPostQuantKernel<{args}>::run_valid"),
+        ],
         extra_cuda_cflags=["-use_fast_math"],
     )
 
@@ -223,15 +226,21 @@ def silu_and_mul_contig_post_quant(
     transposed: bool = False,
     swiglu_limit: Optional[float] = None,
     swizzle: bool = False,
+    valid_rows: Optional[torch.Tensor] = None,
 ) -> None:
     apply_swiglu_limit = swiglu_limit is not None
     module = _jit_silu_mul_quant_contig_module(
         quant_group_size, scale_ue8m0, swizzle, apply_swiglu_limit
     )
-    module.run(
-        input,
-        output,
-        output_scale,
-        transposed,
-        float(swiglu_limit) if apply_swiglu_limit else 0.0,
-    )
+    limit = float(swiglu_limit) if apply_swiglu_limit else 0.0
+    if valid_rows is None:
+        module.run(input, output, output_scale, transposed, limit)
+    else:
+        module.run_valid(
+            input,
+            output,
+            output_scale,
+            valid_rows,
+            transposed,
+            limit,
+        )

--- a/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_triton_kernels.py
@@ -376,6 +376,7 @@ def fused_moe_kernel(
     per_channel_quant: tl.constexpr,
     even_Ks: tl.constexpr,
     c_sorted: tl.constexpr,
+    a_sorted: tl.constexpr,
     filter_expert: tl.constexpr,
     swap_ab: tl.constexpr,
     FUSE_ADD_TO_OUTPUT: tl.constexpr,
@@ -461,13 +462,15 @@ def fused_moe_kernel(
 
     offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
     offs_k = tl.arange(0, BLOCK_SIZE_K)
+    if a_sorted:
+        offs_a = offs_token_id
+    else:
+        offs_a = offs_token // top_k
     if a_desc is not None:
         assert use_fp8_w8a8 and group_n > 0 and group_k > 0
         start_offs_m = pid_m * BLOCK_SIZE_M
     else:
-        a_ptrs = a_ptr + (
-            offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
-        )
+        a_ptrs = a_ptr + offs_a[:, None] * stride_am + offs_k[None, :] * stride_ak
 
     if b_desc is not None:
         start_offs_n = pid_n * BLOCK_SIZE_N
@@ -494,7 +497,7 @@ def fused_moe_kernel(
             if a_desc is not None:
                 a_scale_ptrs = a_scale_ptr + offs_token_id * stride_asm
             else:
-                a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+                a_scale_ptrs = a_scale_ptr + offs_a * stride_asm
             if BLOCK_SIZE_N > group_n:
                 offs_bsn = offs_bn // group_n
             else:
@@ -509,7 +512,7 @@ def fused_moe_kernel(
             )
             b_scale = tl.load(b_scale_ptrs)
             # Load per-token scale for activations
-            a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+            a_scale_ptrs = a_scale_ptr + offs_a * stride_asm
             a_scale = tl.load(a_scale_ptrs, mask=token_mask, other=0.0)[:, None]
         # tensor-wise
         else:
@@ -745,9 +748,17 @@ def invoke_fused_moe_kernel(
     add_output_mask: Optional[torch.Tensor] = None,
     mask_output: bool = False,
     lora_preserve_base: bool = False,
+    a_is_prequantized: bool = False,
+    a_sorted: bool = False,
 ) -> None:
     assert topk_weights.stride(1) == 1
     assert sorted_token_ids.stride(0) == 1
+    if _is_hip and (a_use_tma or b_use_tma):
+        raise RuntimeError(
+            "TMA tensor descriptors are unavailable on ROCm; use "
+            "a_use_tma=False and b_use_tma=False, and set a_sorted=True "
+            "when W2 activations use route-sorted rows"
+        )
 
     if use_fp8_w8a8:
         swap_ab = should_enable_swap_ab(config["BLOCK_SIZE_M"], config["BLOCK_SIZE_N"])
@@ -757,7 +768,15 @@ def invoke_fused_moe_kernel(
     padded_size = 0
     if use_fp8_w8a8:
         assert B_scale is not None
-        if block_shape is None:
+        if a_is_prequantized:
+            assert A.dtype == torch.float8_e4m3fn
+            assert A_scale is not None
+            assert block_shape is not None and len(block_shape) == 2
+            block_n, block_k = block_shape
+            assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
+            assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
+            assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
+        elif block_shape is None:
             # activation tensor-wise fp8 quantization, dynamic or static
             padded_size = padding_size
             # activations apply per-token quantization when weights apply per-channel quantization by default
@@ -782,6 +801,7 @@ def invoke_fused_moe_kernel(
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
     elif use_int8_w8a8:
+        assert not a_is_prequantized, "prequantized A currently supports FP8 only"
         assert B_scale is not None
         if block_shape is None:
             # activation channel-wise int8 quantization
@@ -801,9 +821,11 @@ def invoke_fused_moe_kernel(
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
     elif use_int8_w8a16 or use_int4_w4a16:
+        assert not a_is_prequantized, "prequantized A currently supports FP8 only"
         assert B_scale is not None
         assert block_shape is None or block_shape[0] == 0
     else:
+        assert not a_is_prequantized, "prequantized A currently supports FP8 only"
         assert A_scale is None
         assert B_scale is None
 
@@ -845,6 +867,7 @@ def invoke_fused_moe_kernel(
         and block_shape is not None
         and block_shape[1] > 0
     ):
+        assert not a_sorted, "a_sorted is not supported for GPTQ/AWQ kernels"
         assert (
             not fuse_sum_all_reduce
         ), "fuse_sum_all_reduce is not supported for GPTQ/AWQ kernels"
@@ -952,6 +975,7 @@ def invoke_fused_moe_kernel(
             use_int8_w8a16=use_int8_w8a16,
             per_channel_quant=per_channel_quant,
             even_Ks=even_Ks,
+            a_sorted=a_sorted,
             c_sorted=c_sorted,
             filter_expert=filter_expert,
             swap_ab=swap_ab,

--- a/python/sglang/kernels/ops/moe/shared_ep_route_prep.py
+++ b/python/sglang/kernels/ops/moe/shared_ep_route_prep.py
@@ -1,0 +1,180 @@
+"""Shape-specialized CUDA/ROCm route preparation for SharedEP."""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, is_hip_runtime, load_jit
+
+_INT32_MAX = 2**31 - 1
+
+
+def _route_specialization_key(
+    shape: tuple[int, ...],
+    *,
+    num_local_experts: int,
+    block_size_m: int,
+    num_threads: int,
+    thread_group_size: int | None = None,
+) -> tuple[int, int, int, int, int, int]:
+    """Validate and return every compile-time specialization dimension."""
+    if len(shape) != 3 or any(
+        type(dimension) is not int or dimension <= 0 for dimension in shape
+    ):
+        raise ValueError("SharedEP GPU route ids require a non-empty 3D tensor")
+    if type(num_local_experts) is not int or type(block_size_m) is not int:
+        raise ValueError("SharedEP route specialization values must be integers")
+    if type(num_threads) is not int:
+        raise ValueError("SharedEP route specialization values must be integers")
+    if thread_group_size is None:
+        thread_group_size = 64 if is_hip_runtime() else 32
+    if type(thread_group_size) is not int or thread_group_size not in (32, 64):
+        raise ValueError("thread_group_size must be 32 (CUDA) or 64 (ROCm)")
+    if not 0 < num_local_experts <= num_threads:
+        raise ValueError("num_local_experts must be within the GPU thread count")
+    if block_size_m <= 0:
+        raise ValueError("block_size_m must be positive")
+    if num_threads <= 0 or num_threads > 1024 or num_threads % thread_group_size != 0:
+        group_name = "wave" if thread_group_size == 64 else "warp"
+        raise ValueError(
+            f"num_threads must be a positive {thread_group_size}-thread "
+            f"{group_name} multiple up to 1024"
+        )
+    owners, max_tokens, top_k = shape
+    route_capacity = owners * max_tokens * top_k
+    max_sorted = route_capacity + num_local_experts * (block_size_m - 1)
+    if route_capacity > _INT32_MAX or max_sorted > _INT32_MAX:
+        raise ValueError("SharedEP route specialization exceeds int32 indexing")
+    return (
+        owners,
+        max_tokens,
+        top_k,
+        num_local_experts,
+        block_size_m,
+        num_threads,
+    )
+
+
+@cache_once
+def _jit_shared_ep_route_prep_module(
+    owners: int,
+    max_tokens: int,
+    top_k: int,
+    num_local_experts: int,
+    block_size_m: int,
+    num_threads: int,
+):
+    suffix = (
+        f"o{owners}_m{max_tokens}_k{top_k}_e{num_local_experts}"
+        f"_b{block_size_m}_t{num_threads}"
+    )
+    return load_jit(
+        "shared_ep_route_prep",
+        suffix,
+        cuda_files=["moe/shared_ep_route_prep.cu"],
+        cuda_wrappers=[
+            ("shared_ep_route_prep", "SharedEpRoutePrepKernel::run"),
+        ],
+        extra_cuda_cflags=[
+            f"-DSHARED_EP_OWNERS={owners}",
+            f"-DSHARED_EP_MAX_TOKENS={max_tokens}",
+            f"-DSHARED_EP_TOP_K={top_k}",
+            f"-DSHARED_EP_LOCAL_EXPERTS={num_local_experts}",
+            f"-DSHARED_EP_BLOCK_M={block_size_m}",
+            f"-DSHARED_EP_THREADS={num_threads}",
+        ],
+    )
+
+
+def prepare_routes_cuda(
+    global_ids: torch.Tensor,
+    global_weights: torch.Tensor,
+    ready_signals: torch.Tensor,
+    ready_epoch: torch.Tensor,
+    *,
+    local_expert_start: int,
+    num_local_experts: int,
+    block_size_m: int,
+    num_threads: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Prepare local routes with a cached specialization of one GPU template."""
+    if type(local_expert_start) is not int or not (
+        -(2**31) <= local_expert_start <= _INT32_MAX
+    ):
+        raise ValueError("local_expert_start must fit int32")
+    specialization = _route_specialization_key(
+        tuple(global_ids.shape),
+        num_local_experts=num_local_experts,
+        block_size_m=block_size_m,
+        num_threads=num_threads,
+    )
+    if global_weights.shape != global_ids.shape:
+        raise ValueError("SharedEP route id and weight shapes must match")
+    if not global_ids.is_cuda or not global_weights.is_cuda:
+        raise ValueError("SharedEP route ids and weights must be GPU tensors")
+    if not ready_signals.is_cuda or not ready_epoch.is_cuda:
+        raise ValueError("SharedEP ready signals and epoch must be GPU tensors")
+    if global_weights.device != global_ids.device:
+        raise ValueError("SharedEP route ids and weights must use the same device")
+    if (
+        ready_signals.device != global_ids.device
+        or ready_epoch.device != global_ids.device
+    ):
+        raise ValueError("SharedEP route data and readiness must use the same device")
+    if global_ids.dtype != torch.int32:
+        raise TypeError("SharedEP route ids must use int32")
+    if global_weights.dtype != torch.float32:
+        raise TypeError("SharedEP route weights must use float32")
+    if ready_signals.dtype != torch.uint8:
+        raise TypeError("SharedEP ready signals must use uint8 storage")
+    if ready_epoch.dtype != torch.int32 or ready_epoch.numel() != 1:
+        raise TypeError("SharedEP ready epoch must be one int32 value")
+    if ready_signals.numel() < global_ids.shape[0] * 4:
+        raise ValueError("SharedEP ready signal storage is too small")
+    if global_ids.stride(2) != 1 or global_weights.stride(2) != 1:
+        raise ValueError("SharedEP route columns must be contiguous")
+
+    local_ids = torch.empty_like(
+        global_ids,
+        memory_format=torch.contiguous_format,
+    )
+    local_weights = torch.empty_like(
+        global_weights,
+        memory_format=torch.contiguous_format,
+    )
+    route_capacity = global_ids.numel()
+    max_sorted = route_capacity + num_local_experts * (block_size_m - 1)
+    sorted_token_ids = torch.empty(
+        max_sorted,
+        dtype=torch.int32,
+        device=global_ids.device,
+    )
+    expert_ids = torch.empty(
+        (max_sorted + block_size_m - 1) // block_size_m,
+        dtype=torch.int32,
+        device=global_ids.device,
+    )
+    num_tokens_post_padded = torch.empty(
+        1,
+        dtype=torch.int32,
+        device=global_ids.device,
+    )
+    _jit_shared_ep_route_prep_module(*specialization).shared_ep_route_prep(
+        global_ids,
+        global_weights,
+        ready_signals,
+        ready_epoch,
+        local_ids,
+        local_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        local_expert_start,
+    )
+    return (
+        local_ids,
+        local_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+    )

--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -270,12 +270,10 @@ def _per_token_group_quant_8bit_raw(
     ), "the last dimension of `x` cannot be divisible by `group_size`"
     assert x.is_contiguous(), "`x` is not contiguous"
 
-    if _is_hip:
-        if dtype == torch.int8:
-            bit8_max = 127.0
-        else:
-            bit8_max = 224.0
-        bit8_min = -bit8_max  # TODO incorrect for int8
+    if _is_hip and dtype == torch.float8_e4m3fnuz:
+        # gfx94x uses the legacy FNUZ encoding and its established safe range.
+        bit8_max = 224.0
+        bit8_min = -bit8_max
     else:
         if dtype == torch.int8:
             info = torch.iinfo(dtype)
@@ -808,7 +806,24 @@ def sglang_per_token_quant_fp8(
         dtype=torch.float32,
     )
 
-    sgl_per_token_quant_fp8(x, x_q, x_s)
+    if _is_hip:
+        if dtype != fp8_dtype:
+            raise ValueError(
+                f"ROCm per-token FP8 quantization requires {fp8_dtype}, got {dtype}"
+            )
+        if _use_aiter:
+            dynamic_per_token_scaled_quant(x_q, x, x_s)
+        elif _has_vllm:
+            torch.ops._C.dynamic_per_token_scaled_fp8_quant(
+                x_q,
+                x,
+                x_s,
+                None,
+            )
+        else:
+            _native_dynamic_per_token_quant_fp8(x_q, x, x_s)
+    else:
+        sgl_per_token_quant_fp8(x, x_q, x_s)
 
     return x_q, x_s
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -2207,6 +2207,7 @@ _A2A_EP_SPANNING_BACKENDS = frozenset(
         "flashinfer",
         "mori",
         "pplx",
+        "shared_ep",
     }
 )
 
@@ -2229,6 +2230,25 @@ def _a2a_backend_overrides(view: Any) -> dict:
         )
     if moe_a2a_backend != view.moe_a2a_backend:
         return {"moe_a2a_backend": moe_a2a_backend}
+    return {}
+
+
+@register_post_process
+def _shared_ep_runner_resolution(view: Any) -> dict:
+    """Resolve the platform-native prefill runner for composite SharedEP."""
+
+    if view.moe_a2a_backend != "shared_ep":
+        return {}
+    from sglang.srt.layers.moe.utils import get_shared_ep_prefill_backend
+
+    expected = get_shared_ep_prefill_backend().value
+    if view.moe_runner_backend == "auto":
+        return {"moe_runner_backend": expected}
+    if view.moe_runner_backend != expected:
+        raise ValueError(
+            "SharedEP requires --moe-runner-backend "
+            f"{expected} on this platform, got {view.moe_runner_backend}."
+        )
     return {}
 
 

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -736,6 +736,7 @@ class TboForwardBatchPreparer:
             "orig_seq_lens",  # only used by qwen-1m, thus not care
             "return_pooled_hidden_states",
             "reuse_dsa_topk_indices",  # forward-level flag, inherited by both child batches
+            "shared_ep_generation",  # generation lane is orthogonal to TBO subbatch
         ]:
             output_dict[key] = getattr(batch, key)
 

--- a/python/sglang/srt/distributed/device_communicators/hip_vmm.py
+++ b/python/sglang/srt/distributed/device_communicators/hip_vmm.py
@@ -1,0 +1,467 @@
+"""ROCm HIP virtual-memory primitives used by the SharedEP VMM facade.
+
+The HIP runtime has no supported Python bindings in SGLang's ROCm dependency
+set.  These wrappers bind the small, C-compatible VMM surface directly instead
+of adding an unpinned package or requiring a compiler on serving nodes.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+from functools import lru_cache
+
+_HIP_SUCCESS = 0
+_HIP_MEM_ALLOCATION_TYPE_UNCACHED = 0x40000000
+_HIP_MEM_HANDLE_TYPE_POSIX_FD = 0x1
+_HIP_MEM_LOCATION_TYPE_DEVICE = 0x1
+_HIP_MEM_ACCESS_PROT_READ_WRITE = 0x3
+_HIP_MEM_GRANULARITY_MINIMUM = 0x0
+_MIN_UNCACHED_VMM_RUNTIME_VERSION = 7 * 10_000_000 + 2 * 100_000
+
+
+class _HipMemLocation(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("id", ctypes.c_int),
+    ]
+
+
+class _HipMemAllocationFlags(ctypes.Structure):
+    _fields_ = [
+        ("compression_type", ctypes.c_ubyte),
+        ("gpu_direct_rdma_capable", ctypes.c_ubyte),
+        ("usage", ctypes.c_ushort),
+    ]
+
+
+class _HipMemAllocationProp(ctypes.Structure):
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("requested_handle_type", ctypes.c_int),
+        ("location", _HipMemLocation),
+        ("win32_handle_metadata", ctypes.c_void_p),
+        ("alloc_flags", _HipMemAllocationFlags),
+    ]
+
+
+class _HipMemAccessDesc(ctypes.Structure):
+    _fields_ = [
+        ("location", _HipMemLocation),
+        ("flags", ctypes.c_int),
+    ]
+
+
+class HipVmmError(RuntimeError):
+    def __init__(self, label: str, code: int, detail: str):
+        self.label = label
+        self.code = int(code)
+        super().__init__(f"{label}: HIP error {code} ({detail})")
+
+
+class _HipRuntime:
+    """Typed ctypes binding for the HIP VMM ABI."""
+
+    def __init__(self, library: ctypes.CDLL):
+        self._library = library
+        self._bind_functions()
+
+    def _bind(self, name: str, argtypes, restype=ctypes.c_int):
+        try:
+            function = getattr(self._library, name)
+        except AttributeError as error:
+            raise RuntimeError(
+                f"HIP runtime does not export required VMM symbol {name}"
+            ) from error
+        function.argtypes = argtypes
+        function.restype = restype
+        return function
+
+    def _bind_functions(self) -> None:
+        void_p = ctypes.c_void_p
+        size_t = ctypes.c_size_t
+        uint64 = ctypes.c_ulonglong
+        self.hipGetErrorString = self._bind(
+            "hipGetErrorString",
+            [ctypes.c_int],
+            ctypes.c_char_p,
+        )
+        self.hipRuntimeGetVersion = self._bind(
+            "hipRuntimeGetVersion",
+            [ctypes.POINTER(ctypes.c_int)],
+        )
+        self.hipSetDevice = self._bind("hipSetDevice", [ctypes.c_int])
+        self.hipMemGetAllocationGranularity = self._bind(
+            "hipMemGetAllocationGranularity",
+            [
+                ctypes.POINTER(size_t),
+                ctypes.POINTER(_HipMemAllocationProp),
+                ctypes.c_int,
+            ],
+        )
+        self.hipMemCreate = self._bind(
+            "hipMemCreate",
+            [
+                ctypes.POINTER(void_p),
+                size_t,
+                ctypes.POINTER(_HipMemAllocationProp),
+                uint64,
+            ],
+        )
+        self.hipMemExportToShareableHandle = self._bind(
+            "hipMemExportToShareableHandle",
+            [void_p, void_p, ctypes.c_int, uint64],
+        )
+        self.hipMemImportFromShareableHandle = self._bind(
+            "hipMemImportFromShareableHandle",
+            [ctypes.POINTER(void_p), void_p, ctypes.c_int],
+        )
+        self.hipMemAddressReserve = self._bind(
+            "hipMemAddressReserve",
+            [ctypes.POINTER(void_p), size_t, size_t, void_p, uint64],
+        )
+        self.hipMemMap = self._bind(
+            "hipMemMap",
+            [void_p, size_t, size_t, void_p, uint64],
+        )
+        self.hipMemSetAccess = self._bind(
+            "hipMemSetAccess",
+            [
+                void_p,
+                size_t,
+                ctypes.POINTER(_HipMemAccessDesc),
+                size_t,
+            ],
+        )
+        self.hipMemUnmap = self._bind("hipMemUnmap", [void_p, size_t])
+        self.hipMemRelease = self._bind("hipMemRelease", [void_p])
+        self.hipMemAddressFree = self._bind(
+            "hipMemAddressFree",
+            [void_p, size_t],
+        )
+
+    def _error_string(self, code: int) -> str:
+        message = self.hipGetErrorString(int(code))
+        return (
+            message.decode("utf-8", errors="replace")
+            if message is not None
+            else "unknown error"
+        )
+
+    def check(self, code: int, label: str) -> None:
+        if int(code) != _HIP_SUCCESS:
+            raise HipVmmError(label, int(code), self._error_string(int(code)))
+
+    def runtime_version(self) -> int:
+        version = ctypes.c_int()
+        self.check(
+            self.hipRuntimeGetVersion(ctypes.byref(version)),
+            "hipRuntimeGetVersion",
+        )
+        return int(version.value)
+
+    def set_device(self, device_id: int) -> None:
+        self.check(self.hipSetDevice(int(device_id)), "hipSetDevice")
+
+    def allocation_granularity(self, device_id: int) -> int:
+        prop = _allocation_prop(device_id)
+        granularity = ctypes.c_size_t()
+        self.check(
+            self.hipMemGetAllocationGranularity(
+                ctypes.byref(granularity),
+                ctypes.byref(prop),
+                _HIP_MEM_GRANULARITY_MINIMUM,
+            ),
+            "hipMemGetAllocationGranularity",
+        )
+        return int(granularity.value)
+
+    def create(self, size: int, device_id: int) -> int:
+        prop = _allocation_prop(device_id)
+        handle = ctypes.c_void_p()
+        self.check(
+            self.hipMemCreate(
+                ctypes.byref(handle),
+                int(size),
+                ctypes.byref(prop),
+                0,
+            ),
+            "hipMemCreate(Uncached, POSIX_FD)",
+        )
+        if handle.value is None:
+            raise RuntimeError("hipMemCreate returned a null allocation handle")
+        return int(handle.value)
+
+    def export_fd(self, handle: int) -> int:
+        fd = ctypes.c_int(-1)
+        self.check(
+            self.hipMemExportToShareableHandle(
+                ctypes.byref(fd),
+                ctypes.c_void_p(handle),
+                _HIP_MEM_HANDLE_TYPE_POSIX_FD,
+                0,
+            ),
+            "hipMemExportToShareableHandle(POSIX_FD)",
+        )
+        if fd.value < 0:
+            raise RuntimeError(f"HIP exported an invalid POSIX fd {fd.value}")
+        return int(fd.value)
+
+    def import_fd(self, fd: int) -> int:
+        handle = ctypes.c_void_p()
+        # ROCm 7.1+ takes the descriptor value cast to void*, not int*.
+        os_handle = ctypes.c_void_p(int(fd))
+        self.check(
+            self.hipMemImportFromShareableHandle(
+                ctypes.byref(handle),
+                os_handle,
+                _HIP_MEM_HANDLE_TYPE_POSIX_FD,
+            ),
+            "hipMemImportFromShareableHandle(POSIX_FD)",
+        )
+        if handle.value is None:
+            raise RuntimeError(
+                "hipMemImportFromShareableHandle returned a null allocation handle"
+            )
+        return int(handle.value)
+
+    def reserve(self, size: int, alignment: int) -> int:
+        address = ctypes.c_void_p()
+        self.check(
+            self.hipMemAddressReserve(
+                ctypes.byref(address),
+                int(size),
+                int(alignment),
+                None,
+                0,
+            ),
+            "hipMemAddressReserve",
+        )
+        if address.value is None:
+            raise RuntimeError("hipMemAddressReserve returned a null address")
+        return int(address.value)
+
+    def map(self, address: int, size: int, handle: int) -> None:
+        self.check(
+            self.hipMemMap(
+                ctypes.c_void_p(address),
+                int(size),
+                0,
+                ctypes.c_void_p(handle),
+                0,
+            ),
+            "hipMemMap",
+        )
+
+    def set_access(self, address: int, size: int, device_id: int) -> None:
+        access = _HipMemAccessDesc(
+            location=_HipMemLocation(
+                type=_HIP_MEM_LOCATION_TYPE_DEVICE,
+                id=int(device_id),
+            ),
+            flags=_HIP_MEM_ACCESS_PROT_READ_WRITE,
+        )
+        self.check(
+            self.hipMemSetAccess(
+                ctypes.c_void_p(address),
+                int(size),
+                ctypes.byref(access),
+                1,
+            ),
+            "hipMemSetAccess(PROT_READWRITE)",
+        )
+
+    def unmap(self, address: int, size: int) -> None:
+        self.check(
+            self.hipMemUnmap(ctypes.c_void_p(address), int(size)),
+            "hipMemUnmap",
+        )
+
+    def release(self, handle: int) -> None:
+        self.check(
+            self.hipMemRelease(ctypes.c_void_p(handle)),
+            "hipMemRelease",
+        )
+
+    def address_free(self, address: int, size: int) -> None:
+        self.check(
+            self.hipMemAddressFree(ctypes.c_void_p(address), int(size)),
+            "hipMemAddressFree",
+        )
+
+
+def _allocation_prop(device_id: int) -> _HipMemAllocationProp:
+    return _HipMemAllocationProp(
+        type=_HIP_MEM_ALLOCATION_TYPE_UNCACHED,
+        requested_handle_type=_HIP_MEM_HANDLE_TYPE_POSIX_FD,
+        location=_HipMemLocation(
+            type=_HIP_MEM_LOCATION_TYPE_DEVICE,
+            id=int(device_id),
+        ),
+        win32_handle_metadata=None,
+        alloc_flags=_HipMemAllocationFlags(),
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_hip_runtime() -> _HipRuntime:
+    override = os.environ.get("SGLANG_HIP_RUNTIME_LIBRARY")
+    candidates = [
+        override,
+        ctypes.util.find_library("amdhip64"),
+        "libamdhip64.so",
+        "/opt/rocm/lib/libamdhip64.so",
+        "/opt/rocm/lib64/libamdhip64.so",
+    ]
+    errors = []
+    seen = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            return _HipRuntime(ctypes.CDLL(candidate))
+        except OSError as error:
+            errors.append(f"{candidate}: {error}")
+    raise RuntimeError(
+        "Unable to load the ROCm HIP runtime (libamdhip64.so)"
+        + (f": {'; '.join(errors)}" if errors else "")
+    )
+
+
+def _format_hip_version(version: int) -> str:
+    major = version // 10_000_000
+    minor = (version // 100_000) % 100
+    patch = version % 100_000
+    return f"{major}.{minor}.{patch}"
+
+
+class HipVmmBackend:
+    """HIP implementation of SharedEP VMM using uncached POSIX allocations."""
+
+    platform = "rocm"
+    dlpack_device_type = 10  # kDLROCM
+    supports_fabric = False
+
+    @lru_cache(maxsize=None)
+    def ensure_supported(self, device_id: int) -> None:
+        if os.name != "posix":
+            raise RuntimeError("HIP POSIX-fd VMM is supported only on POSIX systems")
+        runtime = _load_hip_runtime()
+        version = runtime.runtime_version()
+        if version < _MIN_UNCACHED_VMM_RUNTIME_VERSION:
+            raise RuntimeError(
+                "uncached HIP VMM requires ROCm 7.2 or newer; "
+                f"found HIP runtime {_format_hip_version(version)}"
+            )
+        runtime.set_device(device_id)
+
+        # Probe the complete local primitive chain. Device attributes alone do
+        # not guarantee that POSIX export is enabled by the driver/kernel stack.
+        local_handle = None
+        imported_handle = None
+        exported_fd = None
+        address = None
+        mapped = False
+        granularity = None
+        probe_error = None
+        try:
+            granularity = self.get_allocation_granularity(
+                device_id,
+                allow_fabric=False,
+            )
+            local_handle = self.create_allocation(
+                granularity,
+                device_id,
+                allow_fabric=False,
+            )
+            exported_fd = self.export_posix_fd(local_handle)
+            imported_handle = self.import_posix_fd(exported_fd)
+            address = self.reserve(granularity, granularity)
+            self.map(address, granularity, imported_handle)
+            mapped = True
+            self.set_access(address, granularity, device_id)
+        except BaseException as error:
+            probe_error = error
+
+        cleanup_errors = []
+        cleanup_actions = []
+        if mapped:
+            cleanup_actions.append(
+                lambda: self.unmap(address, granularity),
+            )
+        if address is not None:
+            cleanup_actions.append(
+                lambda: self.address_free(address, granularity),
+            )
+        if imported_handle is not None:
+            cleanup_actions.append(lambda: self.release(imported_handle))
+        if exported_fd is not None:
+            cleanup_actions.append(lambda: os.close(exported_fd))
+        if local_handle is not None:
+            cleanup_actions.append(lambda: self.release(local_handle))
+        for cleanup in cleanup_actions:
+            try:
+                cleanup()
+            except BaseException as error:
+                cleanup_errors.append(error)
+
+        if probe_error is not None:
+            message = f"HIP VMM capability probe failed: {probe_error}"
+            if cleanup_errors:
+                message += "; cleanup errors: " + "; ".join(
+                    str(error) for error in cleanup_errors
+                )
+            raise RuntimeError(message) from probe_error
+        if cleanup_errors:
+            raise RuntimeError(
+                "HIP VMM capability cleanup failed: "
+                + "; ".join(str(error) for error in cleanup_errors)
+            )
+
+    def get_allocation_granularity(self, device_id: int, *, allow_fabric: bool) -> int:
+        if allow_fabric:
+            raise RuntimeError("HIP VMM does not support CUDA FABRIC handles")
+        return _load_hip_runtime().allocation_granularity(device_id)
+
+    def create_allocation(
+        self, size: int, device_id: int, *, allow_fabric: bool
+    ) -> int:
+        if allow_fabric:
+            raise RuntimeError("HIP VMM does not support CUDA FABRIC handles")
+        return _load_hip_runtime().create(size, device_id)
+
+    def release(self, handle: int) -> None:
+        _load_hip_runtime().release(handle)
+
+    def export_fabric(self, handle: int) -> bytes:
+        raise RuntimeError("FABRIC VMM handles are CUDA-only")
+
+    def export_posix_fd(self, handle: int) -> int:
+        return _load_hip_runtime().export_fd(handle)
+
+    def import_fabric(self, handle: bytes) -> int:
+        raise RuntimeError("FABRIC VMM handles are CUDA-only")
+
+    def import_posix_fd(self, fd: int) -> int:
+        dup_fd = os.dup(fd)
+        try:
+            return _load_hip_runtime().import_fd(dup_fd)
+        finally:
+            os.close(dup_fd)
+
+    def reserve(self, size: int, alignment: int = 0) -> int:
+        return _load_hip_runtime().reserve(size, alignment)
+
+    def map(self, address: int, size: int, handle: int) -> None:
+        _load_hip_runtime().map(address, size, handle)
+
+    def set_access(self, address: int, size: int, device_id: int) -> None:
+        _load_hip_runtime().set_access(address, size, device_id)
+
+    def unmap(self, address: int, size: int) -> None:
+        _load_hip_runtime().unmap(address, size)
+
+    def address_free(self, address: int, size: int) -> None:
+        _load_hip_runtime().address_free(address, size)

--- a/python/sglang/srt/distributed/device_communicators/vmm_utils.py
+++ b/python/sglang/srt/distributed/device_communicators/vmm_utils.py
@@ -2,7 +2,9 @@ import logging
 import os
 import struct
 import time
-from typing import Any, List, Optional
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, List, Optional, Protocol
 
 import torch
 import torch.distributed as dist
@@ -36,6 +38,275 @@ def check_drv(result_tuple, label):
     if err != drv.CUresult.CUDA_SUCCESS:
         raise RuntimeError(f"{label}: {err}")
     return result_tuple[1] if len(result_tuple) > 1 else None
+
+
+class VmmBackend(Protocol):
+    """Platform-neutral operations needed by SharedEP rank-major VMM."""
+
+    platform: str
+    dlpack_device_type: int
+    supports_fabric: bool
+
+    def ensure_supported(self, device_id: int) -> None: ...
+
+    def get_allocation_granularity(
+        self, device_id: int, *, allow_fabric: bool
+    ) -> int: ...
+
+    def create_allocation(self, size: int, device_id: int, *, allow_fabric: bool): ...
+
+    def release(self, handle) -> None: ...
+
+    def export_fabric(self, handle) -> bytes: ...
+
+    def export_posix_fd(self, handle) -> int: ...
+
+    def import_fabric(self, handle: bytes): ...
+
+    def import_posix_fd(self, fd: int): ...
+
+    def reserve(self, size: int, alignment: int = 0) -> int: ...
+
+    def map(self, address: int, size: int, handle) -> None: ...
+
+    def set_access(self, address: int, size: int, device_id: int) -> None: ...
+
+    def unmap(self, address: int, size: int) -> None: ...
+
+    def address_free(self, address: int, size: int) -> None: ...
+
+
+@dataclass(frozen=True)
+class VmmCapability:
+    platform: str
+    device_id: int
+    supported: bool
+    reason: Optional[str] = None
+
+
+def _make_cuda_allocation_prop(device_id: int, *, allow_fabric: bool):
+    drv = _get_cuda_driver()
+    handle_types = drv.CUmemAllocationHandleType
+    requested_handle_types = (
+        handle_types.CU_MEM_HANDLE_TYPE_FABRIC
+        | handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        if allow_fabric
+        else handle_types.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+    )
+    prop = drv.CUmemAllocationProp()
+    prop.requestedHandleTypes = requested_handle_types
+    prop.type = drv.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
+    prop.location = drv.CUmemLocation()
+    prop.location.type = drv.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
+    prop.location.id = device_id
+    if hasattr(prop, "allocFlags") and hasattr(prop.allocFlags, "gpuDirectRDMACapable"):
+        prop.allocFlags.gpuDirectRDMACapable = 1
+    return prop
+
+
+class CudaVmmBackend:
+    """CUDA driver-backed implementation of the SharedEP VMM facade."""
+
+    platform = "cuda"
+    dlpack_device_type = 2  # kDLCUDA
+    supports_fabric = True
+
+    def ensure_supported(self, device_id: int) -> None:
+        drv = _get_cuda_driver()
+        attribute = getattr(
+            drv.CUdevice_attribute,
+            "CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED",
+            None,
+        )
+        if attribute is None:
+            # Older cuda-python bindings do not expose the query. Preserve the
+            # previous behavior and let the first VMM operation report support.
+            return
+        supported = check_drv(
+            drv.cuDeviceGetAttribute(attribute, device_id),
+            "cuDeviceGetAttribute(VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED)",
+        )
+        if not supported:
+            raise RuntimeError(
+                f"CUDA device {device_id} does not support virtual memory management"
+            )
+
+    def get_allocation_granularity(self, device_id: int, *, allow_fabric: bool) -> int:
+        drv = _get_cuda_driver()
+        prop = _make_cuda_allocation_prop(
+            device_id,
+            allow_fabric=allow_fabric,
+        )
+        return int(
+            check_drv(
+                drv.cuMemGetAllocationGranularity(
+                    prop,
+                    drv.CUmemAllocationGranularity_flags.CU_MEM_ALLOC_GRANULARITY_RECOMMENDED,
+                ),
+                "cuMemGetAllocationGranularity",
+            )
+        )
+
+    def create_allocation(self, size: int, device_id: int, *, allow_fabric: bool):
+        drv = _get_cuda_driver()
+        prop = _make_cuda_allocation_prop(
+            device_id,
+            allow_fabric=allow_fabric,
+        )
+        label = (
+            "cuMemCreate(FABRIC|POSIX_FD)" if allow_fabric else "cuMemCreate(POSIX_FD)"
+        )
+        return check_drv(drv.cuMemCreate(size, prop, 0), label)
+
+    def release(self, handle) -> None:
+        check_drv(_get_cuda_driver().cuMemRelease(handle), "cuMemRelease")
+
+    def export_fabric(self, handle) -> bytes:
+        drv = _get_cuda_driver()
+        fabric = drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        exported = check_drv(
+            drv.cuMemExportToShareableHandle(handle, fabric, 0),
+            "cuMemExportToShareableHandle(FABRIC)",
+        )
+        return bytes(exported.data)
+
+    def export_posix_fd(self, handle) -> int:
+        drv = _get_cuda_driver()
+        posix = drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        return int(
+            check_drv(
+                drv.cuMemExportToShareableHandle(handle, posix, 0),
+                "cuMemExportToShareableHandle(POSIX_FD)",
+            )
+        )
+
+    def import_fabric(self, handle: bytes):
+        drv = _get_cuda_driver()
+        fabric = drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        return check_drv(
+            drv.cuMemImportFromShareableHandle(handle, fabric),
+            "cuMemImportFromShareableHandle(FABRIC)",
+        )
+
+    def import_posix_fd(self, fd: int):
+        drv = _get_cuda_driver()
+        posix = drv.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        dup_fd = os.dup(fd)
+        try:
+            return check_drv(
+                drv.cuMemImportFromShareableHandle(dup_fd, posix),
+                "cuMemImportFromShareableHandle(POSIX_FD)",
+            )
+        finally:
+            os.close(dup_fd)
+
+    def reserve(self, size: int, alignment: int = 0) -> int:
+        return int(
+            check_drv(
+                _get_cuda_driver().cuMemAddressReserve(size, alignment, 0, 0),
+                "cuMemAddressReserve",
+            )
+        )
+
+    def map(self, address: int, size: int, handle) -> None:
+        check_drv(
+            _get_cuda_driver().cuMemMap(address, size, 0, handle, 0),
+            "cuMemMap",
+        )
+
+    def set_access(self, address: int, size: int, device_id: int) -> None:
+        drv = _get_cuda_driver()
+        access = make_rw_access_desc(device_id)
+        check_drv(
+            drv.cuMemSetAccess(address, size, [access], 1),
+            "cuMemSetAccess",
+        )
+
+    def unmap(self, address: int, size: int) -> None:
+        check_drv(_get_cuda_driver().cuMemUnmap(address, size), "cuMemUnmap")
+
+    def address_free(self, address: int, size: int) -> None:
+        check_drv(
+            _get_cuda_driver().cuMemAddressFree(address, size),
+            "cuMemAddressFree",
+        )
+
+
+@lru_cache(maxsize=1)
+def get_vmm_backend() -> VmmBackend:
+    """Return the VMM implementation matching the active PyTorch runtime."""
+
+    if torch.version.hip:
+        from sglang.srt.distributed.device_communicators.hip_vmm import (
+            HipVmmBackend,
+        )
+
+        return HipVmmBackend()
+    return CudaVmmBackend()
+
+
+def query_vmm_capability(
+    device: torch.device | str | None = None,
+    *,
+    backend: Optional[VmmBackend] = None,
+) -> VmmCapability:
+    """Probe whether SharedEP's complete VMM primitive set is usable."""
+
+    selected = backend or get_vmm_backend()
+    if device is None:
+        try:
+            device = torch.device("cuda", torch.cuda.current_device())
+        except BaseException as error:
+            return VmmCapability(
+                platform=selected.platform,
+                device_id=-1,
+                supported=False,
+                reason=f"no active CUDA/HIP device: {type(error).__name__}: {error}",
+            )
+    else:
+        device = torch.device(device)
+    if device.type != "cuda":
+        return VmmCapability(
+            platform=selected.platform,
+            device_id=-1,
+            supported=False,
+            reason=f"VMM storage requires a CUDA/HIP device, got {device}",
+        )
+    device_id = device.index
+    if device_id is None:
+        device_id = torch.cuda.current_device()
+    try:
+        selected.ensure_supported(device_id)
+    except BaseException as error:
+        return VmmCapability(
+            platform=selected.platform,
+            device_id=device_id,
+            supported=False,
+            reason=f"{type(error).__name__}: {error}",
+        )
+    return VmmCapability(
+        platform=selected.platform,
+        device_id=device_id,
+        supported=True,
+    )
+
+
+def require_vmm_backend(
+    device: torch.device | str,
+    *,
+    backend: Optional[VmmBackend] = None,
+    purpose: str = "SharedEP VMM",
+) -> VmmBackend:
+    """Return a supported backend or raise an actionable capability error."""
+
+    selected = backend or get_vmm_backend()
+    capability = query_vmm_capability(device, backend=selected)
+    if not capability.supported:
+        raise RuntimeError(
+            f"{purpose} is unavailable on {selected.platform} "
+            f"device {capability.device_id}: {capability.reason}"
+        )
+    return selected
 
 
 def is_vmm_pointer(ptr: int) -> bool:
@@ -114,7 +385,13 @@ def make_rw_access_desc(device_id: int):
 
 def all_ranks_ok(group: ProcessGroup, ok: bool) -> bool:
     """True iff ``ok`` holds on every rank in ``group`` (BAND all-reduce)."""
-    flag = torch.tensor([1 if ok else 0], dtype=torch.int32)
+    backend = dist.get_backend(group)
+    device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if backend == dist.Backend.NCCL
+        else torch.device("cpu")
+    )
+    flag = torch.tensor([1 if ok else 0], dtype=torch.int32, device=device)
     dist.all_reduce(flag, op=dist.ReduceOp.BAND, group=group)
     return flag.item() == 1
 
@@ -258,10 +535,9 @@ def exchange_posix_fds(
     import threading
 
     sock_kind = getattr(socket, "SOCK_SEQPACKET", socket.SOCK_STREAM)
-    sock_dir = tempfile.mkdtemp(prefix="sgl_ar_fd_")
-    sock_path = os.path.join(sock_dir, f"rank_{rank}.sock")
-    server = socket.socket(socket.AF_UNIX, sock_kind)
-    server.settimeout(_FD_SEND_TIMEOUT_S)
+    sock_dir = None
+    sock_path = None
+    server = None
     received_fds = {}
     errors = []
 
@@ -285,13 +561,37 @@ def exchange_posix_fds(
             errors.append(e)
 
     try:
-        server.bind(sock_path)
-        server.listen(world_size)
+        setup_error = None
+        try:
+            sock_dir = tempfile.mkdtemp(prefix="sgl_ar_fd_")
+            sock_path = os.path.join(sock_dir, f"rank_{rank}.sock")
+            server = socket.socket(socket.AF_UNIX, sock_kind)
+            server.settimeout(_FD_SEND_TIMEOUT_S)
+            server.bind(sock_path)
+            server.listen(world_size)
+        except BaseException as e:
+            setup_error = e
+
+        setup_errors = [None] * world_size
+        setup_error_text = (
+            None
+            if setup_error is None
+            else f"{type(setup_error).__name__}: {setup_error}"
+        )
+        dist.all_gather_object(setup_errors, setup_error_text, group=group)
+        for failed_rank, error_text in enumerate(setup_errors):
+            if error_text is not None:
+                raise RuntimeError(
+                    "POSIX fd listener setup failed on "
+                    f"rank {failed_rank}: {error_text}"
+                ) from setup_error
+
         paths = [None] * world_size
         dist.all_gather_object(paths, sock_path, group=group)
 
         thread = threading.Thread(target=recv_loop, daemon=True)
         thread.start()
+        exchange_error = None
         try:
             for peer_rank, peer_path in enumerate(paths):
                 if peer_rank == rank:
@@ -301,13 +601,33 @@ def exchange_posix_fds(
                     sock.connect(peer_path)
                     for base_idx, fd in enumerate(local_fds):
                         _send_fd(sock, fd, rank, base_idx)
+        except BaseException as e:
+            exchange_error = e
         finally:
             thread.join(_FD_SEND_TIMEOUT_S)
 
-        if thread.is_alive():
-            raise RuntimeError("timed out waiting for POSIX fd exchange")
-        if errors:
-            raise RuntimeError("POSIX fd exchange receive failed") from errors[0]
+        if exchange_error is None and thread.is_alive():
+            exchange_error = RuntimeError("timed out waiting for POSIX fd exchange")
+        if exchange_error is None and errors:
+            exchange_error = RuntimeError(
+                f"POSIX fd exchange receive failed: {errors[0]}"
+            )
+
+        exchange_errors = [None] * world_size
+        exchange_error_text = (
+            None
+            if exchange_error is None
+            else f"{type(exchange_error).__name__}: {exchange_error}"
+        )
+        dist.all_gather_object(exchange_errors, exchange_error_text, group=group)
+        for failed_rank, error_text in enumerate(exchange_errors):
+            if error_text is not None:
+                for fd in received_fds.values():
+                    os.close(fd)
+                received_fds.clear()
+                raise RuntimeError(
+                    f"POSIX fd exchange failed on rank {failed_rank}: {error_text}"
+                ) from exchange_error
 
         expected = {
             (src_rank, base_idx)
@@ -317,24 +637,39 @@ def exchange_posix_fds(
         }
         missing = expected.difference(received_fds)
         extra = set(received_fds).difference(expected)
-        if missing or extra:
-            for fd in received_fds.values():
-                os.close(fd)
-            raise RuntimeError(
-                "POSIX fd exchange mismatch: "
-                f"missing={sorted(missing)[:8]}, extra={sorted(extra)[:8]}"
-            )
+        validation_error = (
+            f"missing={sorted(missing)[:8]}, extra={sorted(extra)[:8]}"
+            if missing or extra
+            else None
+        )
+        validation_errors = [None] * world_size
+        dist.all_gather_object(
+            validation_errors,
+            validation_error,
+            group=group,
+        )
+        for failed_rank, error_text in enumerate(validation_errors):
+            if error_text is not None:
+                for fd in received_fds.values():
+                    os.close(fd)
+                received_fds.clear()
+                raise RuntimeError(
+                    f"POSIX fd validation failed on rank {failed_rank}: {error_text}"
+                )
         return received_fds
     finally:
-        server.close()
-        try:
-            os.unlink(sock_path)
-        except FileNotFoundError:
-            pass
-        try:
-            os.rmdir(sock_dir)
-        except OSError:
-            pass
+        if server is not None:
+            server.close()
+        if sock_path is not None:
+            try:
+                os.unlink(sock_path)
+            except FileNotFoundError:
+                pass
+        if sock_dir is not None:
+            try:
+                os.rmdir(sock_dir)
+            except OSError:
+                pass
 
 
 def import_peer_handle(fabric_handle, fd, *, use_fabric: bool, peer_rank: int):

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -103,7 +103,9 @@ class DeepEPMoE(FusedMoE):
             and quant_config is not None
             and quant_config.get_name() == "humming"
         )
-        if is_humming:
+        if get_moe_a2a_backend().is_shared_ep():
+            self.deprecate_flag = True
+        elif is_humming:
             self.deprecate_flag = True
         elif _use_aiter:
             self.deprecate_flag = True
@@ -349,6 +351,7 @@ def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
         or get_moe_a2a_backend().is_mooncake()
         or get_moe_a2a_backend().is_nixl()
         or get_moe_a2a_backend().is_pplx()
+        or get_moe_a2a_backend().is_shared_ep()
     ):
         return DeepEPMoE
     return FusedMoE

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -97,7 +97,7 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 def _get_deepep_comm_group(a2a_backend):
     group = get_tp_group().device_group
 
-    if a2a_backend.is_mori():
+    if a2a_backend.is_mori() or (a2a_backend.is_shared_ep() and _is_hip):
         group = get_tp_group()
 
     elif _is_npu:
@@ -110,7 +110,16 @@ def create_moe_dispatcher(moe_runner_config: MoeRunnerConfig) -> BaseDispatcher:
     a2a_backend = get_moe_a2a_backend()
     if a2a_backend.is_none() and is_npu():
         return AscendTPDispatcher(moe_runner_config)
-    elif (
+
+    if a2a_backend.is_shared_ep():
+        from sglang.srt.layers.moe.shared_ep import create_shared_ep_dispatcher
+
+        return create_shared_ep_dispatcher(
+            moe_runner_config,
+            group=_get_deepep_comm_group(a2a_backend),
+        )
+
+    if (
         a2a_backend.is_none()
         or a2a_backend.is_megamoe()
         or a2a_backend.is_ascend_fuseep()
@@ -228,6 +237,7 @@ class FusedMoE(torch.nn.Module):
         routing_method_type: Optional[RoutingMethodType] = None,
         is_gated: bool = True,
         gate_up_interleaved: bool = True,
+        shared_ep_model_namespace: str = "target",
     ):
         super().__init__()
         if params_dtype is None:
@@ -319,6 +329,7 @@ class FusedMoE(torch.nn.Module):
             top_k=top_k,
             num_fused_shared_experts=num_fused_shared_experts,
             params_dtype=params_dtype,
+            shared_ep_model_namespace=shared_ep_model_namespace,
             activation=activation,
             apply_router_weight_on_input=apply_router_weight_on_input,
             inplace=inplace,

--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -45,6 +45,10 @@ class MoeRunnerConfig:
     num_fused_shared_experts: Optional[int] = None
     params_dtype: Optional[torch.dtype] = None
     routing_method_type: Optional[RoutingMethodType] = None
+    # Rank-identical namespace for process-lifetime SharedEP VMM lanes.
+    # Sequential target layers intentionally share "target"; NEXTN/draft
+    # models must use a distinct namespace.
+    shared_ep_model_namespace: str = "target"
 
     # Runner configuration
     activation: str = "silu"

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -162,14 +162,13 @@ class MoeRunner:
         if self.fused_func is not None and not self.lora_enabled:
             if not self.is_shared_ep or getattr(
                 dispatch_output,
-                "is_shared_ep_decode",
-                False,
+                "uses_shared_ep_fused",
+                getattr(dispatch_output, "is_shared_ep_decode", False),
             ):
                 return self.fused_func(dispatch_output, quant_info, self.config)
 
-            # SharedEP is composite: only decode uses the fused shared-object
-            # path. Prefill returns the platform dispatcher's native object and
-            # continues through this already-constructed runner core.
+            # Unsupported SharedEP phases return the platform dispatcher's
+            # native object and continue through this constructed runner core.
             from sglang.srt.layers.moe.moe_runner.shared_ep import (
                 SharedEpQuantInfo,
             )

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -9,7 +9,6 @@ from sglang.srt.layers.moe.moe_runner.base import (
     MoeRunnerConfig,
     PermuteMethodPool,
 )
-from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmRunnerCore
 from sglang.srt.layers.moe.moe_runner.triton import TritonRunnerCore
 from sglang.srt.layers.moe.moe_runner.triton_kernels import TritonKernelsRunnerCore
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
@@ -61,6 +60,10 @@ class MoeRunner:
         elif runner_backend.is_triton_kernels():
             self.runner_core = TritonKernelsRunnerCore(config)
         elif runner_backend.is_deep_gemm():
+            from sglang.srt.layers.moe.moe_runner.deep_gemm import (
+                DeepGemmRunnerCore,
+            )
+
             self.runner_core = DeepGemmRunnerCore(config)
         elif runner_backend.is_humming():
             from sglang.srt.layers.moe.moe_runner.humming import HummingRunnerCore
@@ -112,9 +115,17 @@ class MoeRunner:
         else:
             raise NotImplementedError(f"Unsupported runner backend: {runner_backend}")
 
+        self.is_shared_ep = get_moe_a2a_backend().is_shared_ep()
+
         # Skip fused func if LoRA is enabled (LoRA requires non-fused path)
         if not lora_enabled:
-            a2a_backend_name = get_moe_a2a_backend().value
+            a2a_backend = get_moe_a2a_backend()
+            if a2a_backend.is_shared_ep():
+                # SharedEP owns a composite dispatch/GEMM/combine path. Import it
+                # before the one-time fused-op lookup in this runner instance.
+                from sglang.srt.layers.moe import shared_ep  # noqa: F401
+
+            a2a_backend_name = a2a_backend.value
             runner_backend_name = runner_backend.value
 
             # TODO(cwan): add a server argument to disable fused func
@@ -139,16 +150,43 @@ class MoeRunner:
                 "SGLANG_CI_DISABLE_MOE_FUSED_FUNC is set to 1, disabling fused func"
             )
             self.fused_func = None
+        if get_moe_a2a_backend().is_shared_ep() and self.fused_func is None:
+            raise RuntimeError(
+                "SharedEP requires its registered fused execution path; "
+                "the generic runner cannot consume SharedEP decode objects."
+            )
 
     def run(
         self, dispatch_output: DispatchOutput, quant_info: MoeQuantInfo, lora_info=None
     ) -> CombineInput:
         if self.fused_func is not None and not self.lora_enabled:
-            return self.fused_func(dispatch_output, quant_info, self.config)
+            if not self.is_shared_ep or getattr(
+                dispatch_output,
+                "is_shared_ep_decode",
+                False,
+            ):
+                return self.fused_func(dispatch_output, quant_info, self.config)
+
+            # SharedEP is composite: only decode uses the fused shared-object
+            # path. Prefill returns the platform dispatcher's native object and
+            # continues through this already-constructed runner core.
+            from sglang.srt.layers.moe.moe_runner.shared_ep import (
+                SharedEpQuantInfo,
+            )
+
+            if not isinstance(quant_info, SharedEpQuantInfo):
+                raise TypeError(
+                    "SharedEP prefill requires SharedEpQuantInfo with "
+                    "backend-specific fallback metadata"
+                )
+            quant_info = quant_info.fallback_for(self.runner_backend)
 
         assert self.runner_core is not None
 
         def _maybe_build_lora_hooks(_runner_input: Any) -> LoRAHooks:
+            if not self.lora_enabled or lora_info is None:
+                return None
+
             from sglang.srt.layers.moe.token_dispatcher.base import DispatchOutput
             from sglang.srt.lora.lora_moe_runners import build_lora_hooks
 
@@ -160,13 +198,11 @@ class MoeRunner:
             else:
                 hidden_states = _runner_input.hidden_states
                 topk_ids = getattr(_runner_input, "topk_ids", None)
-            if self.lora_enabled and lora_info is not None:
-                return build_lora_hooks(
-                    hidden_states,
-                    lora_info,
-                    topk_ids,
-                )
-            return None
+            return build_lora_hooks(
+                hidden_states,
+                lora_info,
+                topk_ids,
+            )
 
         # Runners that handle dispatch_output directly (e.g., MarlinRunnerCore)
         # bypass the pre-permute step and do their own alignment internally.

--- a/python/sglang/srt/layers/moe/moe_runner/shared_ep.py
+++ b/python/sglang/srt/layers/moe/moe_runner/shared_ep.py
@@ -1,0 +1,125 @@
+"""Runner-neutral quantization metadata for SharedEP composite execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeQuantInfo
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+
+class SharedEpQuantCapability(str, Enum):
+    CANONICAL_BLOCK_FP8 = "canonical_block_fp8"
+    CANONICAL_MXFP4 = "canonical_mxfp4"
+
+
+class SharedEpQuantization(str, Enum):
+    BLOCK_FP8 = "block_fp8"
+    MXFP4 = "mxfp4"
+
+
+class SharedEpWeightLayout(str, Enum):
+    CANONICAL = "canonical"
+    AITER_SHUFFLED = "aiter_shuffled"
+
+
+class SharedEpScaleLayout(str, Enum):
+    CANONICAL = "canonical"
+    AITER_SHUFFLED = "aiter_shuffled"
+
+
+@dataclass
+class SharedEpQuantInfo(MoeQuantInfo):
+    """Decode metadata plus backend-specific prefill metadata.
+
+    SharedEP decode consumes canonical tensors. The nested fallback payload may
+    use a backend-private layout such as AITER's shuffled MXFP4 weights/scales
+    and is exposed only to the matching prefill runner. When
+    ``fallback_uses_duplicate_tensors`` is true, that payload is the temporary
+    MoRI+AITER prefill duplicate; it is not the production no-dup layout.
+    """
+
+    w13_weight: torch.Tensor
+    w2_weight: torch.Tensor
+    w13_scale: Optional[torch.Tensor]
+    w2_scale: Optional[torch.Tensor]
+    block_shape: tuple[int, int]
+    fallback_quant_info: MoeQuantInfo
+    fallback_backend: MoeRunnerBackend
+    quantization: SharedEpQuantization = SharedEpQuantization.BLOCK_FP8
+    weight_layout: SharedEpWeightLayout = SharedEpWeightLayout.CANONICAL
+    scale_layout: SharedEpScaleLayout = SharedEpScaleLayout.CANONICAL
+    weight_group_size: Optional[int] = None
+    scale_format: Optional[str] = None
+    capabilities: frozenset[SharedEpQuantCapability] = frozenset(
+        {SharedEpQuantCapability.CANONICAL_BLOCK_FP8}
+    )
+    fallback_weight_layout: SharedEpWeightLayout = SharedEpWeightLayout.CANONICAL
+    fallback_scale_layout: SharedEpScaleLayout = SharedEpScaleLayout.CANONICAL
+    fallback_uses_duplicate_tensors: bool = False
+
+    def require_decode_capability(
+        self,
+        capability: SharedEpQuantCapability,
+    ) -> None:
+        if capability not in self.capabilities:
+            raise TypeError(
+                f"SharedEP quant metadata does not provide {capability.value}"
+            )
+        expected_quantization = {
+            SharedEpQuantCapability.CANONICAL_BLOCK_FP8: SharedEpQuantization.BLOCK_FP8,
+            SharedEpQuantCapability.CANONICAL_MXFP4: SharedEpQuantization.MXFP4,
+        }[capability]
+        if self.quantization is not expected_quantization:
+            raise TypeError(
+                f"SharedEP {capability.value} metadata cannot describe "
+                f"{self.quantization.value} tensors"
+            )
+        if self.weight_layout is not SharedEpWeightLayout.CANONICAL:
+            raise ValueError(
+                "SharedEP decode requires canonical weights, got "
+                f"{self.weight_layout.value}"
+            )
+        if self.scale_layout is not SharedEpScaleLayout.CANONICAL:
+            raise ValueError(
+                "SharedEP decode requires canonical scales, got "
+                f"{self.scale_layout.value}"
+            )
+        if capability is SharedEpQuantCapability.CANONICAL_MXFP4:
+            if self.weight_group_size != 32:
+                raise ValueError(
+                    "SharedEP MXFP4 requires E8M0 weight group size 32, got "
+                    f"{self.weight_group_size}"
+                )
+            if self.scale_format != "e8m0":
+                raise ValueError(
+                    "SharedEP MXFP4 requires canonical E8M0 scales, got "
+                    f"{self.scale_format!r}"
+                )
+        shuffled = [
+            name
+            for name, tensor in (
+                ("w13_weight", self.w13_weight),
+                ("w2_weight", self.w2_weight),
+                ("w13_scale", self.w13_scale),
+                ("w2_scale", self.w2_scale),
+            )
+            if tensor is not None and getattr(tensor, "is_shuffled", False)
+        ]
+        if shuffled:
+            raise ValueError(
+                "SharedEP decode cannot consume AITER-pre-shuffled tensors: "
+                + ", ".join(shuffled)
+            )
+
+    def fallback_for(self, backend: MoeRunnerBackend) -> MoeQuantInfo:
+        if backend is not self.fallback_backend:
+            raise TypeError(
+                "SharedEP prefill quant metadata targets "
+                f"{self.fallback_backend.value}, not {backend.value}"
+            )
+        return self.fallback_quant_info

--- a/python/sglang/srt/layers/moe/shared_ep/__init__.py
+++ b/python/sglang/srt/layers/moe/shared_ep/__init__.py
@@ -1,0 +1,25 @@
+"""Shared-object expert-parallel backend."""
+
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatcher,
+    SharedEpLaneDispatcher,
+    create_shared_ep_dispatcher,
+    run_shared_ep,
+)
+from sglang.srt.layers.moe.shared_ep.runtime import (
+    SharedEpRuntimeCapability,
+    SharedEpRuntimeHooks,
+    get_shared_ep_runtime_hooks,
+    register_shared_ep_runtime,
+)
+
+__all__ = [
+    "SharedEpDispatcher",
+    "SharedEpLaneDispatcher",
+    "SharedEpRuntimeCapability",
+    "SharedEpRuntimeHooks",
+    "create_shared_ep_dispatcher",
+    "get_shared_ep_runtime_hooks",
+    "register_shared_ep_runtime",
+    "run_shared_ep",
+]

--- a/python/sglang/srt/layers/moe/shared_ep/admission.py
+++ b/python/sglang/srt/layers/moe/shared_ep/admission.py
@@ -1,0 +1,190 @@
+"""Release admission checks for the SharedEP backend."""
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.moe.shared_ep.lanes import (
+    SharedEpLaneProtocol,
+    compute_shared_ep_lane_protocol,
+)
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    RELEASE_MAX_TOKENS_PER_RANK,
+)
+from sglang.srt.layers.moe.utils import get_shared_ep_prefill_backend
+from sglang.srt.model_executor.cuda_graph_config import Backend
+
+_SUPPORTED_MODEL_ARCHITECTURES = frozenset(
+    {
+        "DeepseekV4ForCausalLM",
+        "GlmMoeDsaForCausalLM",
+    }
+)
+
+
+def _resolved_server_args(server_args):
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    return resolved_view(server_args)
+
+
+def _validate_model_architecture(server_args) -> str | None:
+    if str(server_args.model_path).lower() in ("dummy", "none"):
+        return None
+    architecture = server_args.get_model_config().hf_config.architectures[0]
+    if architecture not in _SUPPORTED_MODEL_ARCHITECTURES:
+        raise ValueError(
+            "SharedEP initial release supports GLM-5.2 and "
+            "DeepSeek-V4 Flash/Pro only; got "
+            f"{architecture}"
+        )
+    return architecture
+
+
+def _validate_shared_ep_speculative(
+    view,
+    *,
+    prefill_backend,
+) -> None:
+    algorithm = getattr(view, "speculative_algorithm", None)
+    speculative_fields = {
+        "speculative_num_steps": getattr(view, "speculative_num_steps", None),
+        "speculative_eagle_topk": getattr(view, "speculative_eagle_topk", None),
+        "speculative_num_draft_tokens": getattr(
+            view, "speculative_num_draft_tokens", None
+        ),
+        "enable_multi_layer_eagle": getattr(view, "enable_multi_layer_eagle", False),
+    }
+    if algorithm is None:
+        if any(
+            value is not None and value is not False
+            for value in speculative_fields.values()
+        ):
+            raise ValueError(
+                "SharedEP MTP settings require --speculative-algorithm NEXTN: "
+                f"{speculative_fields}."
+            )
+        return
+
+    algorithm = str(algorithm).upper()
+    if algorithm not in ("NEXTN", "EAGLE"):
+        raise ValueError(
+            "SharedEP speculative release supports only linear NEXTN/MTP "
+            f"(resolved algorithm EAGLE), got {algorithm}."
+        )
+    topk = speculative_fields["speculative_eagle_topk"]
+    steps = speculative_fields["speculative_num_steps"]
+    draft_tokens = speculative_fields["speculative_num_draft_tokens"]
+    if topk != 1:
+        raise ValueError(
+            f"SharedEP NEXTN/MTP requires --speculative-eagle-topk 1, got {topk}."
+        )
+    if not isinstance(steps, int) or steps < 1:
+        raise ValueError(
+            "SharedEP NEXTN/MTP requires a positive --speculative-num-steps."
+        )
+    if not isinstance(draft_tokens, int) or draft_tokens != steps + 1:
+        raise ValueError(
+            "SharedEP NEXTN/MTP requires --speculative-num-draft-tokens "
+            f"to equal steps + 1, got steps={steps}, draft_tokens={draft_tokens}."
+        )
+    if speculative_fields["enable_multi_layer_eagle"]:
+        raise ValueError("SharedEP does not support multi-layer EAGLE.")
+    if getattr(view, "speculative_adaptive", False):
+        raise ValueError("SharedEP does not support adaptive speculative decoding.")
+
+    expected_a2a = "mori" if prefill_backend.is_aiter() else "deepep"
+    if getattr(view, "speculative_moe_a2a_backend", None) != expected_a2a:
+        raise ValueError(
+            "SharedEP NEXTN/MTP requires the materialized draft fallback "
+            f"--speculative-moe-a2a-backend {expected_a2a}."
+        )
+    if getattr(view, "speculative_moe_runner_backend", None) != (prefill_backend.value):
+        raise ValueError(
+            "SharedEP NEXTN/MTP requires "
+            f"--speculative-moe-runner-backend {prefill_backend.value}."
+        )
+
+
+def get_shared_ep_lane_protocol(server_args) -> SharedEpLaneProtocol:
+    """Public pure helper used by admission tests and runtime construction."""
+
+    return compute_shared_ep_lane_protocol(_resolved_server_args(server_args))
+
+
+def validate_shared_ep_server_args(server_args) -> None:
+    view = _resolved_server_args(server_args)
+    if view.nnodes != 1:
+        raise ValueError(
+            f"SharedEP initial release is same-host only, got {view.nnodes} nodes."
+        )
+    if view.ep_size != 8:
+        raise ValueError(f"SharedEP release requires EP8, got EP{view.ep_size}.")
+    if view.dp_size != 8:
+        raise ValueError(f"SharedEP release requires DP8, got DP{view.dp_size}.")
+    if not view.enable_dp_attention:
+        raise ValueError("SharedEP release requires --enable-dp-attention.")
+    max_running_requests = RELEASE_MAX_TOKENS_PER_RANK * view.dp_size
+    if view.max_running_requests is None:
+        server_args.override(
+            "validate_shared_ep_server_args",
+            max_running_requests=max_running_requests,
+        )
+    elif view.max_running_requests > max_running_requests:
+        raise ValueError(
+            "SharedEP supports --max-running-requests "
+            f"{max_running_requests} or lower, got "
+            f"{view.max_running_requests}."
+        )
+    if view.enable_lora or view.lora_paths:
+        raise ValueError("SharedEP release does not support LoRA.")
+    if getattr(view, "enable_pdmux", False):
+        raise ValueError(
+            "SharedEP does not support PD-Multiplexing; its concurrent stream "
+            "index is not part of the admitted lane protocol."
+        )
+
+    architecture = _validate_model_architecture(server_args)
+    prefill_backend = get_shared_ep_prefill_backend()
+    if prefill_backend.is_aiter() and not envs.SGLANG_USE_AITER.get():
+        envs.SGLANG_USE_AITER.set(True)
+    if view.moe_runner_backend == "auto":
+        server_args.override(
+            "validate_shared_ep_server_args",
+            moe_runner_backend=prefill_backend.value,
+        )
+    elif view.moe_runner_backend != prefill_backend.value:
+        raise ValueError(
+            "SharedEP requires --moe-runner-backend "
+            f"{prefill_backend.value} for its composite decode and prefill path "
+            "on this platform."
+        )
+
+    if view.enable_single_batch_overlap:
+        raise ValueError(
+            "SharedEP does not support SBO/--enable-single-batch-overlap; "
+            "the lane protocol covers TBO subbatches only."
+        )
+    if (
+        view.enable_two_batch_overlap
+        and architecture is not None
+        and architecture != "DeepseekV4ForCausalLM"
+    ):
+        raise ValueError("SharedEP TBO is currently admitted only for DeepSeek-V4.")
+
+    _validate_shared_ep_speculative(view, prefill_backend=prefill_backend)
+    # Compute after all routing checks. This is also the fixed memory-resource
+    # cap: every admitted lane owns disjoint VMM and epoch objects.
+    compute_shared_ep_lane_protocol(view)
+
+    decode = view.cuda_graph_config.decode
+    if decode.backend == Backend.DISABLED:
+        return
+    capture_sizes = list(decode.bs or ())
+    if decode.max_bs is not None:
+        capture_sizes.append(decode.max_bs)
+    largest_capture = max(capture_sizes, default=0)
+    if largest_capture > RELEASE_MAX_TOKENS_PER_RANK:
+        raise ValueError(
+            "SharedEP decode CUDA Graph capacity exceeded: "
+            f"{largest_capture} > {RELEASE_MAX_TOKENS_PER_RANK} local "
+            "tokens per rank. Lower --cuda-graph-max-bs-decode and "
+            "--cuda-graph-bs-decode, or disable decode CUDA Graph."
+        )

--- a/python/sglang/srt/layers/moe/shared_ep/backend.py
+++ b/python/sglang/srt/layers/moe/shared_ep/backend.py
@@ -1,0 +1,1091 @@
+"""Composite SharedEP decode backend with platform-native prefill fallback."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, NamedTuple
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.dp_attention import (
+    get_dp_global_num_tokens,
+)
+from sglang.srt.layers.moe.moe_runner.base import (
+    MoeRunnerConfig,
+    register_fused_func,
+)
+from sglang.srt.layers.moe.moe_runner.shared_ep import (
+    SharedEpQuantCapability,
+    SharedEpQuantInfo,
+    SharedEpQuantization,
+    SharedEpScaleLayout,
+    SharedEpWeightLayout,
+)
+from sglang.srt.layers.moe.shared_ep.lanes import (
+    SharedEpLaneProtocol,
+    compute_shared_ep_lane_protocol,
+    shared_ep_state_resource_key,
+    validate_shared_ep_model_namespace,
+)
+from sglang.srt.layers.moe.shared_ep.layout import (
+    SharedEpInputFormat,
+    SharedEpLayout,
+)
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    RELEASE_MAX_TOKENS_PER_RANK,
+    SharedEpProfile,
+    select_profile,
+)
+from sglang.srt.layers.moe.shared_ep.runtime import (
+    SharedEpRuntimeHooks,
+    get_shared_ep_runtime_hooks,
+)
+from sglang.srt.layers.moe.token_dispatcher.base import (
+    BaseDispatcher,
+    CombineInput,
+    CombineInputChecker,
+    DispatchOutputFormat,
+)
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+from sglang.srt.layers.moe.topk import TopKOutput, TopKOutputChecker
+from sglang.srt.layers.moe.utils import (
+    DeepEPMode,
+    get_moe_runner_backend,
+    get_shared_ep_prefill_backend,
+)
+from sglang.srt.runtime_context import (
+    get_forward,
+    get_parallel,
+    get_resources,
+    get_server_args,
+)
+from sglang.srt.utils import is_cuda, is_hip
+
+
+class SharedEpDispatchOutput(NamedTuple):
+    hidden_states: torch.Tensor
+    hidden_states_scale: torch.Tensor | None
+    topk_output: TopKOutput
+    state: Any
+    profile: SharedEpProfile
+    num_tokens: int
+    local_expert_start: int
+
+    @property
+    def format(self) -> DispatchOutputFormat:
+        return DispatchOutputFormat.STANDARD
+
+    @property
+    def is_shared_ep_decode(self) -> bool:
+        return True
+
+
+def compact_intermediate_capacity(
+    *,
+    num_tokens: int,
+    world_size: int,
+    top_k: int,
+    num_local_experts: int,
+    block_size: int,
+) -> int:
+    """Graph-static upper bound for this rank's padded local-expert routes."""
+
+    valid_routes = num_tokens * world_size * top_k
+    experts_with_routes = min(valid_routes, num_local_experts)
+    return valid_routes + experts_with_routes * (block_size - 1)
+
+
+def decode_intermediate_capacity(profile: SharedEpProfile) -> int:
+    """Worst-case EP-local route capacity for uneven owner batches."""
+
+    return compact_intermediate_capacity(
+        num_tokens=profile.max_tokens_per_rank,
+        world_size=profile.ep_size,
+        top_k=profile.top_k,
+        num_local_experts=profile.num_local_experts,
+        block_size=profile.block_size_m,
+    )
+
+
+def _validate_decode_capacity(profile: SharedEpProfile) -> None:
+    global_num_tokens = get_dp_global_num_tokens()
+    if global_num_tokens is None:
+        global_num_tokens = get_forward().shared_ep_global_num_tokens
+    if global_num_tokens is None:
+        # Eager DP-attention does not populate the gathered-buffer metadata
+        # when SharedEP bypasses that buffer. Admission caps the global request
+        # count at EP * max_tokens_per_rank and every owner validates its local
+        # row count below, so the fixed-capacity route scan remains safe.
+        return
+    global_num_tokens = tuple(int(value) for value in global_num_tokens)
+    if not global_num_tokens:
+        return
+    largest = max(global_num_tokens)
+    if largest > profile.max_tokens_per_rank:
+        failed_rank = global_num_tokens.index(largest)
+        raise ValueError(
+            "SharedEP decode capacity exceeded: "
+            f"rank {failed_rank} has {largest} local tokens, "
+            f"capacity is {profile.max_tokens_per_rank}"
+        )
+
+
+def _get_device_profile_capability() -> tuple[tuple[int, int], str]:
+    """Validate the release device and map it to the registered profile key."""
+
+    if is_hip():
+        properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+        arch = getattr(properties, "gcnArchName", "").split(":", 1)[0]
+        if arch != "gfx950":
+            raise ValueError(
+                f"ROCm SharedEP initial release requires gfx950, got {arch or 'unknown'}"
+            )
+        return (9, 5), "rocm:gfx950"
+
+    if is_cuda():
+        capability = torch.cuda.get_device_capability()
+        if capability != (9, 0):
+            raise ValueError(
+                "CUDA SharedEP initial release requires SM90, got "
+                f"SM{capability[0]}{capability[1]}"
+            )
+        return capability, "cuda:sm90"
+
+    raise ValueError("SharedEP requires NVIDIA CUDA or AMD ROCm")
+
+
+def _profile_quantization(
+    config: MoeRunnerConfig,
+) -> tuple[SharedEpQuantization, tuple[int, int]]:
+    """Select only the exact DSV4-Pro shape into the MXFP4 profile."""
+
+    dsv4_pro = (
+        config.hidden_size,
+        config.intermediate_size_per_partition,
+        config.top_k,
+        config.num_experts,
+        config.num_local_experts,
+    ) == (7168, 3072, 6, 384, 48)
+    if dsv4_pro:
+        return SharedEpQuantization.MXFP4, (1, 32)
+    return SharedEpQuantization.BLOCK_FP8, (128, 128)
+
+
+def _synchronize_admission_stage(
+    cpu_group,
+    *,
+    stage: str,
+    descriptor: tuple | None,
+    local_error: BaseException | None,
+) -> None:
+    """Publish framework failures before any rank can enter a GPU wait loop."""
+
+    world_size = dist.get_world_size(group=cpu_group)
+    rank = dist.get_rank(group=cpu_group)
+    local_result = (
+        descriptor,
+        None if local_error is None else f"{type(local_error).__name__}: {local_error}",
+    )
+    results: list[tuple[tuple | None, str | None] | None] = [None] * world_size
+    dist.all_gather_object(results, local_result, group=cpu_group)
+
+    for failed_rank, result in enumerate(results):
+        if result is None:
+            error_text = "rank did not publish an admission result"
+        else:
+            _, error_text = result
+        if error_text is not None:
+            message = (
+                f"SharedEP {stage} admission failed on rank {failed_rank}: {error_text}"
+            )
+            if failed_rank == rank:
+                raise RuntimeError(message) from local_error
+            raise RuntimeError(message)
+
+    descriptors = [result[0] for result in results if result is not None]
+    if descriptors and any(value != descriptors[0] for value in descriptors[1:]):
+        raise RuntimeError(
+            f"SharedEP {stage} admission differs across ranks: {descriptors}"
+        )
+
+
+def _admit_shared_ep_framework(
+    config: MoeRunnerConfig,
+    parallel,
+) -> tuple[SharedEpProfile, SharedEpRuntimeHooks, Any]:
+    cpu_group = parallel.moe_ep_group.cpu_group
+    profile = None
+    runtime_hooks = None
+    descriptor = None
+    local_error = None
+    try:
+        if parallel.moe_ep_size != 8:
+            raise ValueError(f"SharedEP requires EP8, got EP{parallel.moe_ep_size}")
+        if parallel.attn_dp_size != 8:
+            raise ValueError(f"SharedEP requires DP8, got DP{parallel.attn_dp_size}")
+        capability, device_name = _get_device_profile_capability()
+        quantization, block_shape = _profile_quantization(config)
+        profile = select_profile(
+            config,
+            capability=capability,
+            ep_size=parallel.moe_ep_size,
+            block_shape=block_shape,
+            max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+            quantization=quantization,
+        )
+        runtime_hooks = get_shared_ep_runtime_hooks()
+        lane_protocol = compute_shared_ep_lane_protocol(get_server_args())
+        model_namespace = validate_shared_ep_model_namespace(
+            config.shared_ep_model_namespace
+        )
+        descriptor = (
+            device_name,
+            runtime_hooks.name,
+            profile.admission_tuple(),
+            model_namespace,
+            lane_protocol.tbo_width,
+            lane_protocol.generation_width,
+        )
+    except BaseException as error:
+        local_error = error
+
+    _synchronize_admission_stage(
+        cpu_group,
+        stage="framework",
+        descriptor=descriptor,
+        local_error=local_error,
+    )
+    assert profile is not None and runtime_hooks is not None
+    return profile, runtime_hooks, cpu_group
+
+
+def _get_shared_state(
+    config: MoeRunnerConfig,
+    profile: SharedEpProfile,
+    runtime_hooks: SharedEpRuntimeHooks,
+    *,
+    model_namespace: str,
+    lane_id: int,
+) -> Any:
+    """Return one process-lifetime VMM lane shared by sequential MoE layers."""
+
+    resources = get_resources().buffers
+    key = shared_ep_state_resource_key(
+        runtime_name=runtime_hooks.name,
+        profile_name=profile.name,
+        ep_size=profile.ep_size,
+        model_namespace=model_namespace,
+        lane_id=lane_id,
+    )
+    state = resources.get(key)
+    if state is None:
+        ep_group = get_parallel().moe_ep_group
+        use_mxfp4 = profile.quantization is SharedEpQuantization.MXFP4
+        layout = SharedEpLayout.build(
+            hidden_size=profile.hidden_size,
+            top_k=profile.top_k,
+            max_tokens_per_rank=profile.max_tokens_per_rank,
+            input_format=(
+                SharedEpInputFormat.BF16 if use_mxfp4 else SharedEpInputFormat.BLOCK_FP8
+            ),
+            direct_output=use_mxfp4,
+        )
+        state = runtime_hooks.create_state(
+            layout=layout,
+            cpu_group=ep_group.cpu_group,
+            device=torch.device("cuda", torch.cuda.current_device()),
+        )
+        resources[key] = state
+    expected = (
+        config.hidden_size,
+        config.top_k,
+        profile.max_tokens_per_rank,
+        (
+            SharedEpInputFormat.BF16
+            if profile.quantization is SharedEpQuantization.MXFP4
+            else SharedEpInputFormat.BLOCK_FP8
+        ),
+        profile.quantization is SharedEpQuantization.MXFP4,
+    )
+    actual = (
+        state.layout.hidden_size,
+        state.layout.top_k,
+        state.layout.max_tokens_per_rank,
+        state.layout.input_format,
+        state.layout.direct_output,
+    )
+    if actual != expected:
+        raise RuntimeError(
+            f"SharedEP process state does not match the layer: {actual=} {expected=}"
+        )
+    return state
+
+
+class SharedEpDispatcher(BaseDispatcher):
+    def __init__(
+        self,
+        config: MoeRunnerConfig,
+        fallback_dispatcher: BaseDispatcher | None = None,
+        *,
+        model_namespace: str | None = None,
+        lane_id: int = 0,
+        admission: tuple[SharedEpProfile, SharedEpRuntimeHooks, Any] | None = None,
+    ):
+        super().__init__()
+        parallel = get_parallel()
+        self.profile, self.runtime_hooks, self.cpu_group = (
+            admission
+            if admission is not None
+            else _admit_shared_ep_framework(config, parallel)
+        )
+        self.config = config
+        configured_namespace = validate_shared_ep_model_namespace(
+            config.shared_ep_model_namespace
+        )
+        if model_namespace is not None and model_namespace != configured_namespace:
+            raise ValueError(
+                "SharedEP dispatcher namespace differs from its admitted model "
+                f"config: {model_namespace!r} != {configured_namespace!r}"
+            )
+        self.model_namespace = configured_namespace
+        self.lane_id = int(lane_id)
+        self.state = _get_shared_state(
+            self.config,
+            self.profile,
+            self.runtime_hooks,
+            model_namespace=self.model_namespace,
+            lane_id=self.lane_id,
+        )
+        self.local_expert_start = parallel.moe_ep_rank * self.profile.num_local_experts
+        self.fallback_dispatcher = fallback_dispatcher
+        self.expert_mask_gpu = getattr(
+            fallback_dispatcher,
+            "expert_mask_gpu",
+            None,
+        )
+        self._decode_quant_admitted = False
+        self._stage = "initial"
+        self._active_uses_shared_ep: bool | None = None
+
+    def set_fallback_dispatcher(self, fallback_dispatcher: BaseDispatcher) -> None:
+        self.fallback_dispatcher = fallback_dispatcher
+        self.expert_mask_gpu = getattr(
+            fallback_dispatcher,
+            "expert_mask_gpu",
+            None,
+        )
+
+    def _require_stage(self, expected: str) -> None:
+        if self._stage != expected:
+            raise RuntimeError(
+                f"SharedEP lane {self.lane_id} is already in stage "
+                f"{self._stage!r}; expected {expected!r}. Concurrent writers "
+                "must select different state lanes."
+            )
+
+    @staticmethod
+    def _use_shared_ep_decode() -> bool:
+        # This flag is set from ForwardBatch.forward_mode before eager execution
+        # and graph capture. Unlike is_extend_in_batch, it remains false for
+        # TARGET_VERIFY even when decode-graph capture normalizes DP metadata.
+        return bool(get_forward().shared_ep_is_decode) or (
+            os.environ.get("SGLANG_SHARED_EP_DIRECT_SMALL_BATCH", "0") == "1"
+        )
+
+    def _require_fallback(self) -> BaseDispatcher:
+        if self.fallback_dispatcher is None:
+            raise RuntimeError(
+                "SharedEP requires a platform materialized fallback outside "
+                "plain decode"
+            )
+        return self.fallback_dispatcher
+
+    def dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+    ):
+        self._require_stage("initial")
+        use_shared_ep = self._use_shared_ep_decode()
+        if use_shared_ep:
+            output = self._dispatch_shared_ep(hidden_states, topk_output)
+        else:
+            output = self._require_fallback().dispatch(
+                hidden_states=hidden_states,
+                topk_output=topk_output,
+            )
+        self._active_uses_shared_ep = use_shared_ep
+        self._stage = "after_dispatch_b"
+        return output
+
+    def _dispatch_shared_ep(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+    ) -> SharedEpDispatchOutput:
+        if not TopKOutputChecker.format_is_standard(topk_output):
+            raise TypeError("SharedEP decode requires standard Top-K output")
+        if not self._decode_quant_admitted:
+            raise RuntimeError(
+                "SharedEP decode quantization was not admitted during weight setup"
+            )
+
+        state = self.state
+        num_tokens = hidden_states.shape[0]
+        _validate_decode_capacity(self.profile)
+        if num_tokens > self.profile.max_tokens_per_rank:
+            raise ValueError(
+                "SharedEP decode capacity exceeded: "
+                f"{num_tokens} > {self.profile.max_tokens_per_rank} local tokens"
+            )
+        if self.profile.quantization is SharedEpQuantization.MXFP4:
+            from sglang.srt.layers.moe.shared_ep.fp4 import (
+                publish_bf16_owner_input,
+            )
+
+            publish_bf16_owner_input(
+                state.local_input,
+                source=hidden_states,
+                source_ids=topk_output.topk_ids,
+                source_weights=topk_output.topk_weights,
+            )
+            # A missing/invalid route must reduce as zero rather than reusing a
+            # contribution from the previous epoch.
+            state.local_output[:num_tokens].zero_()
+        else:
+            from sglang.srt.layers.moe.shared_ep.kernels import quantize_pack_input
+
+            quantize_pack_input(
+                state.local_input,
+                source=hidden_states,
+                source_ids=topk_output.topk_ids,
+                source_weights=topk_output.topk_weights,
+                group_size=self.profile.block_shape[1],
+            )
+        state.input_epoch.publish()
+        return SharedEpDispatchOutput(
+            hidden_states=state.global_input.activations,
+            hidden_states_scale=state.global_input.scales,
+            topk_output=topk_output,
+            state=state,
+            profile=self.profile,
+            num_tokens=num_tokens,
+            local_expert_start=self.local_expert_start,
+        )
+
+    def combine(self, combine_input: CombineInput) -> torch.Tensor:
+        self._require_stage("after_dispatch_b")
+        try:
+            if self._active_uses_shared_ep:
+                if not CombineInputChecker.format_is_standard(combine_input):
+                    raise TypeError(
+                        "SharedEP decode produced a non-standard combine input"
+                    )
+                return combine_input.hidden_states
+            return self._require_fallback().combine(combine_input=combine_input)
+        finally:
+            self._active_uses_shared_ep = None
+            self._stage = "initial"
+
+    def dispatch_a(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+    ) -> None:
+        """Publish/launch dispatch while retaining graph-static lane ownership."""
+
+        self._require_stage("initial")
+        use_shared_ep = self._use_shared_ep_decode()
+        if use_shared_ep:
+            self._staged_dispatch_output = self._dispatch_shared_ep(
+                hidden_states,
+                topk_output,
+            )
+        else:
+            self._fallback_num_tokens = hidden_states.shape[0]
+            self._require_fallback().dispatch_a(
+                hidden_states=hidden_states,
+                topk_output=topk_output,
+            )
+        self._active_uses_shared_ep = use_shared_ep
+        self._stage = "after_dispatch_a"
+
+    def dispatch_b(self):
+        self._require_stage("after_dispatch_a")
+        if self._active_uses_shared_ep:
+            output = self._staged_dispatch_output
+            del self._staged_dispatch_output
+        else:
+            output = self._require_fallback().dispatch_b()
+        self._stage = "after_dispatch_b"
+        return output
+
+    def combine_a(self, combine_input: CombineInput) -> None:
+        self._require_stage("after_dispatch_b")
+        if self._active_uses_shared_ep:
+            if not CombineInputChecker.format_is_standard(combine_input):
+                raise TypeError("SharedEP decode produced a non-standard combine input")
+            self._staged_combined_output = combine_input.hidden_states
+        else:
+            self._require_fallback().combine_a(combine_input=combine_input)
+        self._stage = "after_combine_a"
+
+    def combine_b(self) -> torch.Tensor:
+        self._require_stage("after_combine_a")
+        try:
+            if self._active_uses_shared_ep:
+                output = self._staged_combined_output
+                del self._staged_combined_output
+                return output
+            output = self._require_fallback().combine_b()
+            num_tokens = self._fallback_num_tokens
+            del self._fallback_num_tokens
+            return output[:num_tokens]
+        finally:
+            self._active_uses_shared_ep = None
+            self._stage = "initial"
+
+    def set_quant_config(self, quant_config: dict) -> None:
+        descriptor = None
+        local_error = None
+        try:
+            descriptor = self._validate_quant_config(quant_config)
+            if self.fallback_dispatcher is not None:
+                self.fallback_dispatcher.set_quant_config(quant_config)
+        except BaseException as error:
+            local_error = error
+
+        _synchronize_admission_stage(
+            self.cpu_group,
+            stage="quantization",
+            descriptor=descriptor,
+            local_error=local_error,
+        )
+        super().set_quant_config(quant_config)
+        self._decode_quant_admitted = True
+
+    def _validate_quant_config(self, quant_config: dict) -> tuple:
+        profile = self.profile
+        if profile.quantization is SharedEpQuantization.MXFP4:
+            return self._validate_mxfp4_quant_config(quant_config)
+        if quant_config.get("shared_ep_quantization") != "block_fp8":
+            raise ValueError("SharedEP supports block-FP8 expert weights only")
+        if quant_config.get("shared_ep_weight_layout") != (
+            SharedEpWeightLayout.CANONICAL.value
+        ):
+            raise ValueError(
+                "SharedEP decode requires canonical weights; AITER-shuffled "
+                "weights are fallback-only"
+            )
+        block_shape = tuple(quant_config.get("block_shape") or ())
+        if block_shape != profile.block_shape:
+            raise ValueError(
+                f"SharedEP requires block shape {profile.block_shape}, "
+                f"got {block_shape}"
+            )
+
+        weight_dtype = quant_config.get("weight_dtype")
+        fp8_dtypes = {
+            torch.float8_e4m3fn,
+            getattr(torch, "float8_e4m3fnuz", torch.float8_e4m3fn),
+        }
+        if weight_dtype not in fp8_dtypes:
+            raise TypeError(f"SharedEP requires FP8 expert weights, got {weight_dtype}")
+
+        expected_w13 = (
+            profile.num_local_experts,
+            profile.intermediate_size * 2,
+            profile.hidden_size,
+        )
+        expected_w2 = (
+            profile.num_local_experts,
+            profile.hidden_size,
+            profile.intermediate_size,
+        )
+        expected_s13 = (
+            profile.num_local_experts,
+            profile.intermediate_size * 2 // profile.block_shape[0],
+            profile.hidden_size // profile.block_shape[1],
+        )
+        expected_s2 = (
+            profile.num_local_experts,
+            profile.hidden_size // profile.block_shape[0],
+            profile.intermediate_size // profile.block_shape[1],
+        )
+        observed_shapes = (
+            tuple(quant_config.get("w13_shape") or ()),
+            tuple(quant_config.get("w2_shape") or ()),
+            tuple(quant_config.get("w13_scale_shape") or ()),
+            tuple(quant_config.get("w2_scale_shape") or ()),
+        )
+        expected_shapes = (expected_w13, expected_w2, expected_s13, expected_s2)
+        if observed_shapes != expected_shapes:
+            raise ValueError(
+                "SharedEP canonical weight/scale shapes do not match the "
+                f"{profile.name} profile: observed={observed_shapes}, "
+                f"expected={expected_shapes}"
+            )
+        return (
+            "block_fp8",
+            SharedEpWeightLayout.CANONICAL.value,
+            str(weight_dtype),
+            block_shape,
+            observed_shapes,
+        )
+
+    def _validate_mxfp4_quant_config(self, quant_config: dict) -> tuple:
+        profile = self.profile
+        if quant_config.get("shared_ep_quantization") != (
+            SharedEpQuantization.MXFP4.value
+        ):
+            raise ValueError(
+                "The DSV4-Pro SharedEP profile requires canonical MXFP4 experts"
+            )
+        if quant_config.get("shared_ep_weight_layout") != (
+            SharedEpWeightLayout.CANONICAL.value
+        ):
+            raise ValueError(
+                "SharedEP MXFP4 decode requires canonical unswizzled weights"
+            )
+        if quant_config.get("shared_ep_scale_layout") != (
+            SharedEpScaleLayout.CANONICAL.value
+        ):
+            raise ValueError(
+                "SharedEP MXFP4 decode requires canonical unswizzled E8M0 scales"
+            )
+        block_shape = tuple(quant_config.get("block_shape") or ())
+        if block_shape != profile.block_shape:
+            raise ValueError(
+                f"SharedEP MXFP4 requires block shape {profile.block_shape}, "
+                f"got {block_shape}"
+            )
+        if quant_config.get("weight_group_size") != 32:
+            raise ValueError("SharedEP MXFP4 requires weight group size 32")
+        if quant_config.get("scale_format") != "e8m0":
+            raise ValueError("SharedEP MXFP4 requires E8M0 weight scales")
+
+        weight_dtype = quant_config.get("weight_dtype")
+        fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+        valid_weight_dtypes = {torch.uint8}
+        if fp4_dtype is not None:
+            valid_weight_dtypes.add(fp4_dtype)
+        if weight_dtype not in valid_weight_dtypes:
+            raise TypeError(
+                "SharedEP MXFP4 requires packed OCP E2M1 expert weights, "
+                f"got {weight_dtype}"
+            )
+        scale_dtype = quant_config.get("weight_scale_dtype")
+        e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+        valid_scale_dtypes = {torch.uint8}
+        if e8m0_dtype is not None:
+            valid_scale_dtypes.add(e8m0_dtype)
+        if scale_dtype not in valid_scale_dtypes:
+            raise TypeError(
+                f"SharedEP MXFP4 requires E8M0 scale bytes, got {scale_dtype}"
+            )
+
+        expected_shapes = (
+            (
+                profile.num_local_experts,
+                profile.intermediate_size * 2,
+                profile.hidden_size // 2,
+            ),
+            (
+                profile.num_local_experts,
+                profile.hidden_size,
+                profile.intermediate_size // 2,
+            ),
+            (
+                profile.num_local_experts,
+                profile.intermediate_size * 2,
+                profile.hidden_size // 32,
+            ),
+            (
+                profile.num_local_experts,
+                profile.hidden_size,
+                profile.intermediate_size // 32,
+            ),
+        )
+        observed_shapes = (
+            tuple(quant_config.get("w13_shape") or ()),
+            tuple(quant_config.get("w2_shape") or ()),
+            tuple(quant_config.get("w13_scale_shape") or ()),
+            tuple(quant_config.get("w2_scale_shape") or ()),
+        )
+        if observed_shapes != expected_shapes:
+            raise ValueError(
+                "SharedEP canonical MXFP4 weight/scale shapes do not match "
+                f"{profile.name}: observed={observed_shapes}, "
+                f"expected={expected_shapes}"
+            )
+        return (
+            SharedEpQuantization.MXFP4.value,
+            SharedEpWeightLayout.CANONICAL.value,
+            SharedEpScaleLayout.CANONICAL.value,
+            str(weight_dtype),
+            str(scale_dtype),
+            block_shape,
+            observed_shapes,
+            bool(quant_config.get("fallback_uses_duplicate_tensors", False)),
+        )
+
+
+class SharedEpLaneDispatcher(BaseDispatcher):
+    """Graph-static dispatcher facade over disjoint SharedEP state lanes."""
+
+    def __init__(
+        self,
+        inners: list[SharedEpDispatcher],
+        lane_protocol: SharedEpLaneProtocol,
+    ):
+        super().__init__()
+        if len(inners) != lane_protocol.lane_count:
+            raise ValueError(
+                "SharedEP lane dispatcher received the wrong number of inner "
+                f"dispatchers: {len(inners)} != {lane_protocol.lane_count}"
+            )
+        self._inners = tuple(inners)
+        self.lane_protocol = lane_protocol
+
+    @property
+    def expert_mask_gpu(self):
+        return self._inners[0].expert_mask_gpu
+
+    @property
+    def inner_dispatchers(self) -> tuple[SharedEpDispatcher, ...]:
+        return self._inners
+
+    def _inner(
+        self,
+        *,
+        tbo_subbatch_index: int | None = None,
+    ) -> SharedEpDispatcher:
+        lane_id = self.lane_protocol.lane_id(
+            generation_index=int(get_forward().shared_ep_generation),
+            tbo_subbatch_index=tbo_subbatch_index,
+        )
+        return self._inners[lane_id]
+
+    def dispatch(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+    ):
+        return self._inner().dispatch(
+            hidden_states=hidden_states,
+            topk_output=topk_output,
+        )
+
+    def combine(self, combine_input: CombineInput) -> torch.Tensor:
+        return self._inner().combine(combine_input=combine_input)
+
+    def dispatch_a(
+        self,
+        *,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        tbo_subbatch_index: int | None = None,
+    ) -> None:
+        self._inner(tbo_subbatch_index=tbo_subbatch_index).dispatch_a(
+            hidden_states=hidden_states,
+            topk_output=topk_output,
+        )
+
+    def dispatch_b(self, *, tbo_subbatch_index: int | None = None):
+        return self._inner(tbo_subbatch_index=tbo_subbatch_index).dispatch_b()
+
+    def combine_a(
+        self,
+        *,
+        combine_input: CombineInput,
+        tbo_subbatch_index: int | None = None,
+    ) -> None:
+        self._inner(tbo_subbatch_index=tbo_subbatch_index).combine_a(
+            combine_input=combine_input
+        )
+
+    def combine_b(
+        self,
+        *,
+        tbo_subbatch_index: int | None = None,
+    ) -> torch.Tensor:
+        return self._inner(tbo_subbatch_index=tbo_subbatch_index).combine_b()
+
+    def set_quant_config(self, quant_config: dict) -> None:
+        super().set_quant_config(quant_config)
+        for inner in self._inners:
+            inner.set_quant_config(quant_config)
+
+    def set_overlap_args(self, combine_overlap_args, meta_overlap_args: dict) -> None:
+        super().set_overlap_args(combine_overlap_args, meta_overlap_args)
+        for inner in self._inners:
+            inner.set_overlap_args(combine_overlap_args, meta_overlap_args)
+
+    def clear_overlap_args(self) -> None:
+        super().clear_overlap_args()
+        for inner in self._inners:
+            inner.clear_overlap_args()
+
+
+def _create_shared_ep_prefill_dispatcher(
+    config: MoeRunnerConfig,
+    *,
+    group,
+    instance_id: int = 0,
+):
+    fallback_backend = get_shared_ep_prefill_backend()
+    if fallback_backend.is_aiter():
+        from sglang.srt.layers.moe.token_dispatcher.moriep import MoriEPDispatcher
+
+        fallback_cls = MoriEPDispatcher
+        platform_kwargs = {"instance_id": int(instance_id)}
+    else:
+        from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPDispatcher
+
+        fallback_cls = DeepEPDispatcher
+        platform_kwargs = {}
+
+    fallback_dispatcher = fallback_cls(
+        group=group,
+        router_topk=config.top_k,
+        permute_fusion=True,
+        num_experts=config.num_experts,
+        num_local_experts=config.num_local_experts,
+        hidden_size=config.hidden_size,
+        params_dtype=config.params_dtype,
+        # Prefill, TARGET_VERIFY, and DRAFT_EXTEND require the materialized
+        # dispatcher. Do not let decode-graph capture's normalized
+        # is_extend_in_batch=False select the low-latency implementation.
+        deepep_mode=DeepEPMode.NORMAL,
+        async_finish=True,
+        return_recv_hook=True,
+        **platform_kwargs,
+    )
+    return fallback_dispatcher
+
+
+def create_shared_ep_dispatcher(
+    config: MoeRunnerConfig,
+    *,
+    group,
+) -> SharedEpLaneDispatcher:
+    """Build graph-static SharedEP lanes plus materialized platform fallbacks."""
+
+    fallback_backend = get_shared_ep_prefill_backend()
+    if get_moe_runner_backend() is not fallback_backend:
+        raise ValueError(
+            "shared_ep requires --moe-runner-backend "
+            f"{fallback_backend.value} on this platform"
+        )
+
+    lane_protocol = compute_shared_ep_lane_protocol(get_server_args())
+    model_namespace = validate_shared_ep_model_namespace(
+        config.shared_ep_model_namespace
+    )
+    # Admit every rank before constructing communication fallbacks, then create
+    # all VMM/epoch lanes in deterministic lane-ID order on every rank.
+    admission = _admit_shared_ep_framework(config, get_parallel())
+    inners = [
+        SharedEpDispatcher(
+            config,
+            model_namespace=model_namespace,
+            lane_id=lane_id,
+            admission=admission,
+        )
+        for lane_id in range(lane_protocol.lane_count)
+    ]
+    for inner in inners:
+        inner.set_fallback_dispatcher(
+            _create_shared_ep_prefill_dispatcher(
+                config,
+                group=group,
+                instance_id=inner.lane_id,
+            )
+        )
+    return SharedEpLaneDispatcher(inners, lane_protocol)
+
+
+def _validate_decode_weights(
+    dispatch_output: SharedEpDispatchOutput,
+    quant_info: SharedEpQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> None:
+    profile = dispatch_output.profile
+    if not isinstance(quant_info, SharedEpQuantInfo):
+        raise TypeError("SharedEP requires runner-neutral SharedEpQuantInfo")
+    quant_info.require_decode_capability(SharedEpQuantCapability.CANONICAL_BLOCK_FP8)
+    if tuple(quant_info.block_shape or ()) != profile.block_shape:
+        raise ValueError(
+            f"SharedEP requires block shape {profile.block_shape}, "
+            f"got {quant_info.block_shape}"
+        )
+    expected_w13 = (
+        profile.num_local_experts,
+        profile.intermediate_size * 2,
+        profile.hidden_size,
+    )
+    expected_w2 = (
+        profile.num_local_experts,
+        profile.hidden_size,
+        profile.intermediate_size,
+    )
+    if tuple(quant_info.w13_weight.shape) != expected_w13:
+        raise ValueError(
+            f"SharedEP W13 shape is {tuple(quant_info.w13_weight.shape)}, "
+            f"expected {expected_w13}"
+        )
+    if tuple(quant_info.w2_weight.shape) != expected_w2:
+        raise ValueError(
+            f"SharedEP W2 shape is {tuple(quant_info.w2_weight.shape)}, "
+            f"expected {expected_w2}"
+        )
+    if quant_info.w13_scale is None or quant_info.w2_scale is None:
+        raise ValueError("SharedEP FP8 weights require W13 and W2 scales")
+    if runner_config.activation != "silu" or not runner_config.is_gated:
+        raise ValueError("SharedEP release supports gated SiLU experts only")
+    if runner_config.gemm1_alpha is not None:
+        raise ValueError("SharedEP release does not support gemm1_alpha")
+    if runner_config.gemm1_clamp_limit is not None:
+        raise ValueError("SharedEP release does not support gemm1_clamp_limit")
+
+
+@register_fused_func("shared_ep", "aiter")
+@register_fused_func("shared_ep", "deep_gemm")
+def run_shared_ep(
+    dispatch_output,
+    quant_info: SharedEpQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    if not isinstance(dispatch_output, SharedEpDispatchOutput):
+        raise TypeError(
+            "The SharedEP fused path received a prefill dispatch object; "
+            "MoeRunner must route it through the native fallback runner"
+        )
+    if dispatch_output.profile.quantization is SharedEpQuantization.MXFP4:
+        from sglang.srt.layers.moe.shared_ep.fp4 import run_shared_ep_mxfp4
+
+        return run_shared_ep_mxfp4(dispatch_output, quant_info, runner_config)
+    _validate_decode_weights(dispatch_output, quant_info, runner_config)
+
+    import triton.language as tl
+
+    from sglang.kernels.ops.attention.dsv4 import (
+        silu_and_mul_contig_post_quant,
+    )
+    from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+        invoke_fused_moe_kernel,
+    )
+    from sglang.srt.layers.moe.shared_ep.kernels import prepare_routes
+
+    profile = dispatch_output.profile
+    state = dispatch_output.state
+    routes = prepare_routes(
+        profile,
+        state.global_input.topk_ids,
+        state.global_input.topk_weights,
+        state.input_epoch.allocation.local_storage,
+        state.input_epoch.epoch,
+        local_expert_start=dispatch_output.local_expert_start,
+    )
+    route_ids = routes.local_ids.view(-1, profile.top_k)
+    route_weights = routes.local_weights.view(-1, profile.top_k)
+    capacity = decode_intermediate_capacity(profile)
+    gate_up = torch.empty(
+        (capacity, profile.intermediate_size * 2),
+        dtype=torch.bfloat16,
+        device=dispatch_output.hidden_states.device,
+    )
+    shared_activations = dispatch_output.hidden_states.view(
+        -1,
+        profile.hidden_size,
+    )
+    shared_scales = dispatch_output.hidden_states_scale.view(
+        -1,
+        profile.hidden_size // profile.block_shape[1],
+    )
+    invoke_fused_moe_kernel(
+        A=shared_activations,
+        B=quant_info.w13_weight,
+        bias=None,
+        C=gate_up,
+        A_scale=shared_scales,
+        B_scale=quant_info.w13_scale,
+        B_zp=None,
+        topk_weights=route_weights,
+        topk_ids=route_ids,
+        sorted_token_ids=routes.sorted_token_ids,
+        expert_ids=routes.expert_ids,
+        num_tokens_post_padded=routes.num_tokens_post_padded,
+        mul_routed_weight=False,
+        top_k=profile.top_k,
+        config=profile.w13_kernel_config(dispatch_output.num_tokens),
+        compute_type=tl.bfloat16,
+        use_fp8_w8a8=True,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        per_channel_quant=False,
+        block_shape=list(profile.block_shape),
+        filter_expert=True,
+        c_sorted=True,
+        a_is_prequantized=True,
+    )
+
+    down_fp8 = torch.empty(
+        (capacity, profile.intermediate_size),
+        dtype=torch.float8_e4m3fn,
+        device=gate_up.device,
+    )
+    down_scale = torch.empty(
+        (capacity, profile.intermediate_size // profile.block_shape[1]),
+        dtype=torch.float32,
+        device=gate_up.device,
+    )
+    silu_and_mul_contig_post_quant(
+        input=gate_up,
+        output=down_fp8,
+        output_scale=down_scale,
+        quant_group_size=profile.block_shape[1],
+        swiglu_limit=runner_config.swiglu_limit,
+        valid_rows=routes.num_tokens_post_padded,
+    )
+    shared_output = state.global_output.view(-1, profile.hidden_size)
+    use_tma = is_cuda()
+    invoke_fused_moe_kernel(
+        A=down_fp8,
+        B=quant_info.w2_weight,
+        bias=None,
+        C=shared_output,
+        A_scale=down_scale,
+        B_scale=quant_info.w2_scale,
+        B_zp=None,
+        topk_weights=route_weights,
+        topk_ids=route_ids,
+        sorted_token_ids=routes.sorted_token_ids,
+        expert_ids=routes.expert_ids,
+        num_tokens_post_padded=routes.num_tokens_post_padded,
+        mul_routed_weight=True,
+        top_k=1,
+        config=profile.w2_kernel_config(dispatch_output.num_tokens),
+        compute_type=tl.bfloat16,
+        use_fp8_w8a8=True,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        per_channel_quant=False,
+        block_shape=list(profile.block_shape),
+        filter_expert=True,
+        a_use_tma=use_tma,
+        b_use_tma=use_tma,
+        a_sorted=not use_tma,
+        a_is_prequantized=True,
+    )
+    state.output_epoch.publish()
+    state.output_epoch.wait_all()
+
+    # The next layer cannot reuse this output until every owner has reduced it:
+    # each owner publishes the next input only after this sum, and the next
+    # expert phase waits for all input publications.
+    output = state.local_output[: dispatch_output.num_tokens].sum(dim=1)
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/moe/shared_ep/backend.py
+++ b/python/sglang/srt/layers/moe/shared_ep/backend.py
@@ -1,9 +1,9 @@
-"""Composite SharedEP decode backend with platform-native prefill fallback."""
+"""SharedEP direct decode plus ROCm block-FP8 pull-cache prefill."""
 
 from __future__ import annotations
 
-import os
-from typing import Any, NamedTuple
+import logging
+from typing import Any, Literal, NamedTuple
 
 import torch
 import torch.distributed as dist
@@ -33,9 +33,19 @@ from sglang.srt.layers.moe.shared_ep.layout import (
     SharedEpLayout,
 )
 from sglang.srt.layers.moe.shared_ep.profiles import (
+    RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
     RELEASE_MAX_TOKENS_PER_RANK,
     SharedEpProfile,
+    make_pull_cache_prefill_profile,
+    resolve_prefill_capacity,
     select_profile,
+)
+from sglang.srt.layers.moe.shared_ep.pull_cache_prefill import (
+    PullCache,
+    allocate_pull_cache,
+    invoke_pull_cache_w13,
+    make_pull_cache_prefill_plan,
+    pull_cache_rows,
 )
 from sglang.srt.layers.moe.shared_ep.runtime import (
     SharedEpRuntimeHooks,
@@ -54,13 +64,17 @@ from sglang.srt.layers.moe.utils import (
     get_moe_runner_backend,
     get_shared_ep_prefill_backend,
 )
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.runtime_context import (
     get_forward,
     get_parallel,
     get_resources,
+    get_schedule,
     get_server_args,
 )
 from sglang.srt.utils import is_cuda, is_hip
+
+logger = logging.getLogger(__name__)
 
 
 class SharedEpDispatchOutput(NamedTuple):
@@ -71,6 +85,8 @@ class SharedEpDispatchOutput(NamedTuple):
     profile: SharedEpProfile
     num_tokens: int
     local_expert_start: int
+    phase: Literal["decode", "prefill"] = "decode"
+    pull_cache: PullCache | None = None
 
     @property
     def format(self) -> DispatchOutputFormat:
@@ -78,6 +94,10 @@ class SharedEpDispatchOutput(NamedTuple):
 
     @property
     def is_shared_ep_decode(self) -> bool:
+        return self.phase == "decode"
+
+    @property
+    def uses_shared_ep_fused(self) -> bool:
         return True
 
 
@@ -96,8 +116,8 @@ def compact_intermediate_capacity(
     return valid_routes + experts_with_routes * (block_size - 1)
 
 
-def decode_intermediate_capacity(profile: SharedEpProfile) -> int:
-    """Worst-case EP-local route capacity for uneven owner batches."""
+def intermediate_capacity(profile: SharedEpProfile) -> int:
+    """Worst-case EP-local route capacity for the profile's phase."""
 
     return compact_intermediate_capacity(
         num_tokens=profile.max_tokens_per_rank,
@@ -108,27 +128,56 @@ def decode_intermediate_capacity(profile: SharedEpProfile) -> int:
     )
 
 
-def _validate_decode_capacity(profile: SharedEpProfile) -> None:
-    global_num_tokens = get_dp_global_num_tokens()
+def decode_intermediate_capacity(profile: SharedEpProfile) -> int:
+    """Compatibility name for callers that only exercise decode."""
+
+    return intermediate_capacity(profile)
+
+
+def _validate_phase_capacity(
+    profile: SharedEpProfile,
+    *,
+    phase: Literal["decode", "prefill"],
+) -> None:
+    # ForwardBatch carries the scheduler's complete DP vector even when the
+    # legacy gathered-buffer accessor exposes only this rank's local entry.
+    forward = get_forward()
+    global_num_tokens = getattr(
+        forward,
+        "shared_ep_global_num_tokens",
+        None,
+    )
     if global_num_tokens is None:
-        global_num_tokens = get_forward().shared_ep_global_num_tokens
-    if global_num_tokens is None:
-        # Eager DP-attention does not populate the gathered-buffer metadata
-        # when SharedEP bypasses that buffer. Admission caps the global request
-        # count at EP * max_tokens_per_rank and every owner validates its local
-        # row count below, so the fixed-capacity route scan remains safe.
-        return
-    global_num_tokens = tuple(int(value) for value in global_num_tokens)
+        global_num_tokens = get_dp_global_num_tokens()
+    global_num_tokens = (
+        ()
+        if global_num_tokens is None
+        else tuple(int(value) for value in global_num_tokens)
+    )
     if not global_num_tokens:
-        return
+        raise RuntimeError(
+            f"SharedEP {phase} requires the complete DP token-count vector "
+            "before object publication"
+        )
+    if len(global_num_tokens) != profile.ep_size:
+        raise RuntimeError(
+            f"SharedEP {phase} expected {profile.ep_size} DP token counts, "
+            f"got {len(global_num_tokens)}"
+        )
     largest = max(global_num_tokens)
     if largest > profile.max_tokens_per_rank:
         failed_rank = global_num_tokens.index(largest)
         raise ValueError(
-            "SharedEP decode capacity exceeded: "
+            f"SharedEP {phase} capacity exceeded: "
             f"rank {failed_rank} has {largest} local tokens, "
             f"capacity is {profile.max_tokens_per_rank}"
         )
+
+
+def _validate_decode_capacity(profile: SharedEpProfile) -> None:
+    """Compatibility wrapper for decode-only callers."""
+
+    _validate_phase_capacity(profile, phase="decode")
 
 
 def _get_device_profile_capability() -> tuple[tuple[int, int], str]:
@@ -210,12 +259,45 @@ def _synchronize_admission_stage(
         )
 
 
+def _resolve_pull_prefill_profile(
+    profile: SharedEpProfile,
+    lane_protocol: SharedEpLaneProtocol,
+) -> SharedEpProfile | None:
+    """Admit only the initial single-lane ROCm block-FP8 eager path."""
+
+    if (
+        profile.platform != "rocm"
+        or profile.quantization is not SharedEpQuantization.BLOCK_FP8
+        or not profile.supports_pull_cache_prefill
+        or lane_protocol.lane_count != 1
+    ):
+        return None
+    prefill_graph = get_server_args().cuda_graph_config.prefill
+    if prefill_graph.backend != Backend.DISABLED:
+        return None
+    chunked_prefill_size = get_schedule().chunked_prefill_size
+    if (
+        chunked_prefill_size is None
+        or chunked_prefill_size <= 0
+        or chunked_prefill_size > RELEASE_MAX_PREFILL_TOKENS_PER_RANK
+    ):
+        return None
+    capacity = resolve_prefill_capacity(chunked_prefill_size)
+    return make_pull_cache_prefill_profile(profile, capacity)
+
+
 def _admit_shared_ep_framework(
     config: MoeRunnerConfig,
     parallel,
-) -> tuple[SharedEpProfile, SharedEpRuntimeHooks, Any]:
+) -> tuple[
+    SharedEpProfile,
+    SharedEpProfile | None,
+    SharedEpRuntimeHooks,
+    Any,
+]:
     cpu_group = parallel.moe_ep_group.cpu_group
     profile = None
+    prefill_profile = None
     runtime_hooks = None
     descriptor = None
     local_error = None
@@ -236,6 +318,7 @@ def _admit_shared_ep_framework(
         )
         runtime_hooks = get_shared_ep_runtime_hooks()
         lane_protocol = compute_shared_ep_lane_protocol(get_server_args())
+        prefill_profile = _resolve_pull_prefill_profile(profile, lane_protocol)
         model_namespace = validate_shared_ep_model_namespace(
             config.shared_ep_model_namespace
         )
@@ -246,6 +329,7 @@ def _admit_shared_ep_framework(
             model_namespace,
             lane_protocol.tbo_width,
             lane_protocol.generation_width,
+            (None if prefill_profile is None else prefill_profile.admission_tuple()),
         )
     except BaseException as error:
         local_error = error
@@ -257,7 +341,14 @@ def _admit_shared_ep_framework(
         local_error=local_error,
     )
     assert profile is not None and runtime_hooks is not None
-    return profile, runtime_hooks, cpu_group
+    if prefill_profile is not None and dist.get_rank(group=cpu_group) == 0:
+        logger.info_once(
+            "SharedEP ROCm pull-cache prefill admitted: "
+            f"profile={prefill_profile.name}, "
+            f"tokens_per_rank={prefill_profile.max_tokens_per_rank}, "
+            f"block_m={prefill_profile.block_size_m}"
+        )
+    return profile, prefill_profile, runtime_hooks, cpu_group
 
 
 def _get_shared_state(
@@ -322,6 +413,70 @@ def _get_shared_state(
     return state
 
 
+def _get_shared_pull_cache(
+    profile: SharedEpProfile,
+    runtime_hooks: SharedEpRuntimeHooks,
+    *,
+    model_namespace: str,
+    lane_id: int,
+    cpu_group,
+) -> PullCache:
+    resources = get_resources().buffers
+    key = (
+        shared_ep_state_resource_key(
+            runtime_name=runtime_hooks.name,
+            profile_name=profile.name,
+            ep_size=profile.ep_size,
+            model_namespace=model_namespace,
+            lane_id=lane_id,
+        )
+        + ":pull-cache"
+    )
+    cache = resources.get(key)
+    if cache is not None:
+        return cache
+
+    plan = make_pull_cache_prefill_plan(
+        owners=profile.ep_size,
+        source_tokens_per_owner=profile.max_tokens_per_rank,
+        hidden_size=profile.hidden_size,
+        top_k=profile.top_k,
+        num_local_experts=profile.num_local_experts,
+        expert_alignment=profile.block_size_m,
+    )
+    active_rows = intermediate_capacity(profile)
+    if active_rows != plan.cache_rows:
+        raise RuntimeError(
+            "SharedEP pull-cache plan and route capacity disagree: "
+            f"{active_rows} != {plan.cache_rows}"
+        )
+
+    cache = None
+    local_error = None
+    try:
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=active_rows,
+            device=torch.device("cuda", torch.cuda.current_device()),
+        )
+    except Exception as error:
+        local_error = error
+    _synchronize_admission_stage(
+        cpu_group,
+        stage="pull-cache allocation",
+        descriptor=(
+            profile.admission_tuple(),
+            plan.cache_rows,
+            plan.hidden_size,
+            plan.scale_groups,
+        ),
+        local_error=local_error,
+    )
+    assert cache is not None
+    resources[key] = cache
+    return cache
+
+
 class SharedEpDispatcher(BaseDispatcher):
     def __init__(
         self,
@@ -330,11 +485,19 @@ class SharedEpDispatcher(BaseDispatcher):
         *,
         model_namespace: str | None = None,
         lane_id: int = 0,
-        admission: tuple[SharedEpProfile, SharedEpRuntimeHooks, Any] | None = None,
+        admission: (
+            tuple[
+                SharedEpProfile,
+                SharedEpProfile | None,
+                SharedEpRuntimeHooks,
+                Any,
+            ]
+            | None
+        ) = None,
     ):
         super().__init__()
         parallel = get_parallel()
-        self.profile, self.runtime_hooks, self.cpu_group = (
+        self.profile, self.prefill_profile, self.runtime_hooks, self.cpu_group = (
             admission
             if admission is not None
             else _admit_shared_ep_framework(config, parallel)
@@ -357,6 +520,24 @@ class SharedEpDispatcher(BaseDispatcher):
             model_namespace=self.model_namespace,
             lane_id=self.lane_id,
         )
+        if self.prefill_profile is None:
+            self.prefill_state = None
+            self.prefill_cache = None
+        else:
+            self.prefill_state = _get_shared_state(
+                self.config,
+                self.prefill_profile,
+                self.runtime_hooks,
+                model_namespace=self.model_namespace,
+                lane_id=self.lane_id,
+            )
+            self.prefill_cache = _get_shared_pull_cache(
+                self.prefill_profile,
+                self.runtime_hooks,
+                model_namespace=self.model_namespace,
+                lane_id=self.lane_id,
+                cpu_group=self.cpu_group,
+            )
         self.local_expert_start = parallel.moe_ep_rank * self.profile.num_local_experts
         self.fallback_dispatcher = fallback_dispatcher
         self.expert_mask_gpu = getattr(
@@ -389,9 +570,22 @@ class SharedEpDispatcher(BaseDispatcher):
         # This flag is set from ForwardBatch.forward_mode before eager execution
         # and graph capture. Unlike is_extend_in_batch, it remains false for
         # TARGET_VERIFY even when decode-graph capture normalizes DP metadata.
-        return bool(get_forward().shared_ep_is_decode) or (
-            os.environ.get("SGLANG_SHARED_EP_DIRECT_SMALL_BATCH", "0") == "1"
+        return bool(get_forward().shared_ep_is_decode)
+
+    def _use_shared_ep_prefill(self) -> bool:
+        return (
+            getattr(self, "prefill_profile", None) is not None
+            and getattr(self, "prefill_state", None) is not None
+            and getattr(self, "prefill_cache", None) is not None
+            and bool(getattr(get_forward(), "shared_ep_is_prefill", False))
         )
+
+    def _execution_mode(self) -> Literal["decode", "prefill", "fallback"]:
+        if self._use_shared_ep_decode():
+            return "decode"
+        if self._use_shared_ep_prefill():
+            return "prefill"
+        return "fallback"
 
     def _require_fallback(self) -> BaseDispatcher:
         if self.fallback_dispatcher is None:
@@ -407,9 +601,14 @@ class SharedEpDispatcher(BaseDispatcher):
         topk_output: TopKOutput,
     ):
         self._require_stage("initial")
-        use_shared_ep = self._use_shared_ep_decode()
+        mode = self._execution_mode()
+        use_shared_ep = mode != "fallback"
         if use_shared_ep:
-            output = self._dispatch_shared_ep(hidden_states, topk_output)
+            output = self._dispatch_shared_ep(
+                hidden_states,
+                topk_output,
+                phase=mode,
+            )
         else:
             output = self._require_fallback().dispatch(
                 hidden_states=hidden_states,
@@ -423,23 +622,38 @@ class SharedEpDispatcher(BaseDispatcher):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
+        *,
+        phase: Literal["decode", "prefill"] = "decode",
     ) -> SharedEpDispatchOutput:
         if not TopKOutputChecker.format_is_standard(topk_output):
-            raise TypeError("SharedEP decode requires standard Top-K output")
+            raise TypeError(f"SharedEP {phase} requires standard Top-K output")
         if not self._decode_quant_admitted:
             raise RuntimeError(
-                "SharedEP decode quantization was not admitted during weight setup"
+                "SharedEP quantization was not admitted during weight setup"
             )
 
-        state = self.state
+        if phase == "prefill":
+            if self.prefill_profile is None or self.prefill_state is None:
+                raise RuntimeError("SharedEP pull-cache prefill was not admitted")
+            profile = self.prefill_profile
+            state = self.prefill_state
+            pull_cache = self.prefill_cache
+        else:
+            profile = self.profile
+            state = self.state
+            pull_cache = None
         num_tokens = hidden_states.shape[0]
-        _validate_decode_capacity(self.profile)
-        if num_tokens > self.profile.max_tokens_per_rank:
+        _validate_phase_capacity(profile, phase=phase)
+        if num_tokens > profile.max_tokens_per_rank:
             raise ValueError(
-                "SharedEP decode capacity exceeded: "
-                f"{num_tokens} > {self.profile.max_tokens_per_rank} local tokens"
+                f"SharedEP {phase} capacity exceeded: "
+                f"{num_tokens} > {profile.max_tokens_per_rank} local tokens"
             )
-        if self.profile.quantization is SharedEpQuantization.MXFP4:
+        if profile.quantization is SharedEpQuantization.MXFP4:
+            if phase != "decode":
+                raise RuntimeError(
+                    "SharedEP MXFP4 prefill must use the native fallback"
+                )
             from sglang.srt.layers.moe.shared_ep.fp4 import (
                 publish_bf16_owner_input,
             )
@@ -450,9 +664,6 @@ class SharedEpDispatcher(BaseDispatcher):
                 source_ids=topk_output.topk_ids,
                 source_weights=topk_output.topk_weights,
             )
-            # A missing/invalid route must reduce as zero rather than reusing a
-            # contribution from the previous epoch.
-            state.local_output[:num_tokens].zero_()
         else:
             from sglang.srt.layers.moe.shared_ep.kernels import quantize_pack_input
 
@@ -461,17 +672,22 @@ class SharedEpDispatcher(BaseDispatcher):
                 source=hidden_states,
                 source_ids=topk_output.topk_ids,
                 source_weights=topk_output.topk_weights,
-                group_size=self.profile.block_shape[1],
+                group_size=profile.block_shape[1],
             )
+        # Missing/invalid routes reduce as zero instead of reusing a prior
+        # epoch's owner contribution.
+        state.local_output[:num_tokens].zero_()
         state.input_epoch.publish()
         return SharedEpDispatchOutput(
             hidden_states=state.global_input.activations,
             hidden_states_scale=state.global_input.scales,
             topk_output=topk_output,
             state=state,
-            profile=self.profile,
+            profile=profile,
             num_tokens=num_tokens,
             local_expert_start=self.local_expert_start,
+            phase=phase,
+            pull_cache=pull_cache,
         )
 
     def combine(self, combine_input: CombineInput) -> torch.Tensor:
@@ -496,11 +712,13 @@ class SharedEpDispatcher(BaseDispatcher):
         """Publish/launch dispatch while retaining graph-static lane ownership."""
 
         self._require_stage("initial")
-        use_shared_ep = self._use_shared_ep_decode()
+        mode = self._execution_mode()
+        use_shared_ep = mode != "fallback"
         if use_shared_ep:
             self._staged_dispatch_output = self._dispatch_shared_ep(
                 hidden_states,
                 topk_output,
+                phase=mode,
             )
         else:
             self._fallback_num_tokens = hidden_states.shape[0]
@@ -854,9 +1072,8 @@ def _create_shared_ep_prefill_dispatcher(
         num_local_experts=config.num_local_experts,
         hidden_size=config.hidden_size,
         params_dtype=config.params_dtype,
-        # Prefill, TARGET_VERIFY, and DRAFT_EXTEND require the materialized
-        # dispatcher. Do not let decode-graph capture's normalized
-        # is_extend_in_batch=False select the low-latency implementation.
+        # Unsupported prefill profiles, graph/overlap prefill, TARGET_VERIFY,
+        # and DRAFT_EXTEND require this materialized dispatcher.
         deepep_mode=DeepEPMode.NORMAL,
         async_finish=True,
         return_recv_hook=True,
@@ -959,8 +1176,7 @@ def run_shared_ep(
 ) -> StandardCombineInput:
     if not isinstance(dispatch_output, SharedEpDispatchOutput):
         raise TypeError(
-            "The SharedEP fused path received a prefill dispatch object; "
-            "MoeRunner must route it through the native fallback runner"
+            "The SharedEP fused path received a native fallback dispatch object"
         )
     if dispatch_output.profile.quantization is SharedEpQuantization.MXFP4:
         from sglang.srt.layers.moe.shared_ep.fp4 import run_shared_ep_mxfp4
@@ -990,7 +1206,7 @@ def run_shared_ep(
     )
     route_ids = routes.local_ids.view(-1, profile.top_k)
     route_weights = routes.local_weights.view(-1, profile.top_k)
-    capacity = decode_intermediate_capacity(profile)
+    capacity = intermediate_capacity(profile)
     gate_up = torch.empty(
         (capacity, profile.intermediate_size * 2),
         dtype=torch.bfloat16,
@@ -1000,37 +1216,63 @@ def run_shared_ep(
         -1,
         profile.hidden_size,
     )
+    if dispatch_output.hidden_states_scale is None:
+        raise RuntimeError("SharedEP block-FP8 execution requires activation scales")
     shared_scales = dispatch_output.hidden_states_scale.view(
         -1,
         profile.hidden_size // profile.block_shape[1],
     )
-    invoke_fused_moe_kernel(
-        A=shared_activations,
-        B=quant_info.w13_weight,
-        bias=None,
-        C=gate_up,
-        A_scale=shared_scales,
-        B_scale=quant_info.w13_scale,
-        B_zp=None,
-        topk_weights=route_weights,
-        topk_ids=route_ids,
-        sorted_token_ids=routes.sorted_token_ids,
-        expert_ids=routes.expert_ids,
-        num_tokens_post_padded=routes.num_tokens_post_padded,
-        mul_routed_weight=False,
-        top_k=profile.top_k,
-        config=profile.w13_kernel_config(dispatch_output.num_tokens),
-        compute_type=tl.bfloat16,
-        use_fp8_w8a8=True,
-        use_int8_w8a8=False,
-        use_int8_w8a16=False,
-        use_int4_w4a16=False,
-        per_channel_quant=False,
-        block_shape=list(profile.block_shape),
-        filter_expert=True,
-        c_sorted=True,
-        a_is_prequantized=True,
-    )
+    if dispatch_output.phase == "prefill":
+        pull_cache = dispatch_output.pull_cache
+        if pull_cache is None or pull_cache.active_rows != capacity:
+            raise RuntimeError("SharedEP prefill pull-cache capacity mismatch")
+        pull_cache_rows(
+            source_activations=shared_activations,
+            source_scales=shared_scales,
+            sorted_token_ids=routes.sorted_token_ids,
+            num_tokens_post_padded=routes.num_tokens_post_padded,
+            cache=pull_cache,
+            top_k=profile.top_k,
+            source_route_capacity=shared_activations.shape[0] * profile.top_k,
+        )
+        invoke_pull_cache_w13(
+            cache=pull_cache,
+            weight=quant_info.w13_weight,
+            weight_scale=quant_info.w13_scale,
+            output=gate_up,
+            expert_ids=routes.expert_ids,
+            num_tokens_post_padded=routes.num_tokens_post_padded,
+            config=profile.w13_kernel_config(dispatch_output.num_tokens),
+            block_shape=profile.block_shape,
+        )
+    else:
+        invoke_fused_moe_kernel(
+            A=shared_activations,
+            B=quant_info.w13_weight,
+            bias=None,
+            C=gate_up,
+            A_scale=shared_scales,
+            B_scale=quant_info.w13_scale,
+            B_zp=None,
+            topk_weights=route_weights,
+            topk_ids=route_ids,
+            sorted_token_ids=routes.sorted_token_ids,
+            expert_ids=routes.expert_ids,
+            num_tokens_post_padded=routes.num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=profile.top_k,
+            config=profile.w13_kernel_config(dispatch_output.num_tokens),
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=list(profile.block_shape),
+            filter_expert=True,
+            c_sorted=True,
+            a_is_prequantized=True,
+        )
 
     down_fp8 = torch.empty(
         (capacity, profile.intermediate_size),

--- a/python/sglang/srt/layers/moe/shared_ep/epoch.py
+++ b/python/sglang/srt/layers/moe/shared_ep/epoch.py
@@ -1,0 +1,258 @@
+"""GPU-only release/acquire epochs for SharedEP peer-visible objects."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.jit.utils import cache_once, is_hip_runtime, load_jit
+from sglang.srt.layers.moe.shared_ep.vmm import (
+    SharedEpVmmAllocation,
+    allocate_rank_major_vmm,
+)
+
+_IS_HIP = is_hip_runtime()
+
+
+@cache_once
+def _jit_shared_ep_epoch_module():
+    if not _IS_HIP:
+        raise RuntimeError("The native SharedEP epoch module is only used on ROCm")
+    return load_jit(
+        "shared_ep_epoch_rocm",
+        cuda_files=["moe/shared_ep_route_prep.cu"],
+        cuda_wrappers=[
+            ("publish_epoch", "SharedEpEpochKernel::publish"),
+            (
+                "publish_pointer_table_epoch",
+                "SharedEpEpochKernel::publish_pointer_table",
+            ),
+            ("wait_epoch", "SharedEpEpochKernel::wait"),
+        ],
+    )
+
+
+@triton.jit
+def _store_release_epoch(addresses, epoch):
+    return tl.inline_asm_elementwise(
+        "atom.global.release.sys.exch.b32 $0, [$1], $2;",
+        "=r,l,r",
+        [addresses, epoch],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _wait_acquire_epoch(addresses, epoch):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .u32 value;
+            .reg .pred pending;
+        wait_epoch:
+            ld.acquire.sys.global.u32 value, [$1];
+            setp.ne.u32 pending, value, $2;
+            @pending bra wait_epoch;
+            mov.u32 $0, value;
+        }
+        """,
+        "=r,l,r",
+        [addresses, epoch],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _publish_epoch_kernel(
+    global_signals,
+    epoch_ptr,
+    rank_stride_words: tl.constexpr,
+    rank: tl.constexpr,
+    world_size: tl.constexpr,
+):
+    epoch = tl.load(epoch_ptr) + 1
+    tl.store(epoch_ptr, epoch)
+    destinations = tl.arange(0, world_size)
+    signal_words = global_signals.to(tl.pointer_type(tl.uint32))
+    addresses = signal_words + destinations * rank_stride_words + rank
+    _store_release_epoch(addresses, epoch)
+
+
+@triton.jit
+def _wait_epoch_kernel(
+    local_signals,
+    epoch_ptr,
+    world_size: tl.constexpr,
+):
+    epoch = tl.load(epoch_ptr)
+    sources = tl.arange(0, world_size)
+    signal_words = local_signals.to(tl.pointer_type(tl.uint32))
+    _wait_acquire_epoch(signal_words + sources, epoch)
+
+
+class GpuEpoch(msgspec.Struct, kw_only=True):
+    allocation: SharedEpVmmAllocation
+    epoch: torch.Tensor
+    rank: int
+    world_size: int
+    _closed: bool = False
+
+    def publish(self) -> None:
+        if _IS_HIP:
+            _jit_shared_ep_epoch_module().publish_epoch(
+                self.allocation.global_storage,
+                self.epoch,
+                self.allocation.mapped_rank_bytes // 4,
+                self.rank,
+                self.world_size,
+            )
+            return
+        _publish_epoch_kernel[(1,)](
+            self.allocation.global_storage,
+            self.epoch,
+            rank_stride_words=self.allocation.mapped_rank_bytes // 4,
+            rank=self.rank,
+            world_size=self.world_size,
+            num_warps=1,
+        )
+
+    def wait_all(self) -> None:
+        if _IS_HIP:
+            _jit_shared_ep_epoch_module().wait_epoch(
+                self.allocation.local_storage,
+                self.epoch,
+                self.world_size,
+            )
+            return
+        _wait_epoch_kernel[(1,)](
+            self.allocation.local_storage,
+            self.epoch,
+            world_size=self.world_size,
+            num_warps=1,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.epoch = torch.empty(0, dtype=torch.int32)
+        self.allocation.close()
+
+
+class GpuPointerTableEpoch(msgspec.Struct, kw_only=True):
+    """HIP epoch over independently mapped symmetric peer signal objects."""
+
+    peer_signal_bases: torch.Tensor
+    local_signals: torch.Tensor
+    epoch: torch.Tensor
+    rank: int
+    world_size: int
+    _closed: bool = False
+
+    def publish(self) -> None:
+        _jit_shared_ep_epoch_module().publish_pointer_table_epoch(
+            self.peer_signal_bases,
+            self.epoch,
+            self.rank,
+            self.world_size,
+        )
+
+    def wait_all(self) -> None:
+        _jit_shared_ep_epoch_module().wait_epoch(
+            self.local_signals,
+            self.epoch,
+            self.world_size,
+        )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.peer_signal_bases = torch.empty(0, dtype=torch.uint64)
+        self.local_signals = torch.empty(0, dtype=torch.uint8)
+        self.epoch = torch.empty(0, dtype=torch.int32)
+
+
+def create_gpu_epoch(
+    *,
+    cpu_group,
+    device: torch.device,
+    rank: int,
+    world_size: int,
+) -> GpuEpoch:
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, got {world_size}")
+    allocation = allocate_rank_major_vmm(
+        cpu_group=cpu_group,
+        device=device,
+        logical_rank_bytes=world_size * 4,
+    )
+    return GpuEpoch(
+        allocation=allocation,
+        epoch=torch.zeros(1, dtype=torch.int32, device=device),
+        rank=rank,
+        world_size=world_size,
+    )
+
+
+def create_gpu_pointer_table_epoch(
+    *,
+    peer_signals: list[torch.Tensor] | tuple[torch.Tensor, ...],
+    rank: int,
+) -> GpuPointerTableEpoch:
+    """Create a HIP epoch from one directly addressable signal view per peer.
+
+    The caller owns the symmetric signal allocation and must keep every view
+    alive until this epoch is closed.
+    """
+
+    if not _IS_HIP:
+        raise RuntimeError("SharedEP pointer-table epochs require a ROCm runtime")
+    if not isinstance(peer_signals, (list, tuple)) or not peer_signals:
+        raise ValueError("peer_signals must be a non-empty list or tuple")
+    world_size = len(peer_signals)
+    if world_size > 1024:
+        raise ValueError(f"world_size must be at most 1024, got {world_size}")
+    if type(rank) is not int or not 0 <= rank < world_size:
+        raise ValueError(f"rank {rank!r} is outside world size {world_size}")
+
+    local_signals = peer_signals[rank]
+    if not isinstance(local_signals, torch.Tensor) or not local_signals.is_cuda:
+        raise ValueError("peer signal views must be GPU tensors")
+    device = local_signals.device
+    required_bytes = world_size * torch.tensor([], dtype=torch.int32).element_size()
+    pointers: list[int] = []
+    for peer, signals in enumerate(peer_signals):
+        if not isinstance(signals, torch.Tensor) or not signals.is_cuda:
+            raise ValueError(f"peer signal view {peer} is not a GPU tensor")
+        if signals.device != device:
+            raise ValueError("peer signal views must use the same GPU device")
+        if signals.dtype != torch.uint8 or not signals.is_contiguous():
+            raise TypeError("peer signal views must be contiguous uint8 tensors")
+        if signals.numel() < required_bytes:
+            raise ValueError(
+                f"peer signal view {peer} has {signals.numel()} bytes; "
+                f"{required_bytes} required"
+            )
+        pointer = signals.data_ptr()
+        if pointer == 0 or pointer % 4:
+            raise ValueError(f"peer signal view {peer} has an invalid uint32 pointer")
+        pointers.append(pointer)
+
+    return GpuPointerTableEpoch(
+        peer_signal_bases=torch.tensor(
+            pointers,
+            dtype=torch.uint64,
+            device=device,
+        ),
+        local_signals=local_signals,
+        epoch=torch.zeros(1, dtype=torch.int32, device=device),
+        rank=rank,
+        world_size=world_size,
+    )

--- a/python/sglang/srt/layers/moe/shared_ep/fp4.py
+++ b/python/sglang/srt/layers/moe/shared_ep/fp4.py
@@ -1,0 +1,257 @@
+"""Canonical gfx950 MXFP4 decode execution for SharedEP."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.shared_ep import (
+    SharedEpQuantCapability,
+    SharedEpQuantInfo,
+    SharedEpQuantization,
+)
+from sglang.srt.layers.moe.shared_ep.kernels import (
+    prepare_routes,
+    reduce_owner_output,
+)
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpInputViews
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.shared_ep.backend import SharedEpDispatchOutput
+
+
+def publish_bf16_owner_input(
+    target: SharedEpInputViews,
+    *,
+    source: torch.Tensor,
+    source_ids: torch.Tensor,
+    source_weights: torch.Tensor,
+) -> None:
+    """Publish BF16 activations and canonical Top-K metadata into owner storage."""
+
+    if source.ndim != 2 or source.dtype != torch.bfloat16:
+        raise TypeError("SharedEP MXFP4 owner activations must be 2D BF16")
+    if not source.is_contiguous():
+        raise ValueError("SharedEP MXFP4 owner activations must be contiguous")
+    if target.activations.ndim != 2 or target.activations.dtype != torch.bfloat16:
+        raise TypeError("SharedEP MXFP4 target must expose directly addressable BF16")
+    if target.scales is not None:
+        raise ValueError("SharedEP MXFP4 BF16 owner storage must not expose FP8 scales")
+    if source_ids.ndim != 2 or source_weights.ndim != 2:
+        raise ValueError("SharedEP MXFP4 routes must be two-dimensional")
+    if source_ids.shape != source_weights.shape:
+        raise ValueError("SharedEP MXFP4 route id and weight shapes must match")
+    if source_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("SharedEP MXFP4 route ids must use int32 or int64")
+    if source_weights.dtype != torch.float32:
+        raise TypeError("SharedEP MXFP4 route weights must use float32")
+
+    num_tokens, hidden_size = source.shape
+    if not 0 <= num_tokens <= target.activations.shape[0]:
+        raise ValueError(
+            f"SharedEP MXFP4 input has {num_tokens} tokens, "
+            f"capacity is {target.activations.shape[0]}"
+        )
+    if hidden_size != target.activations.shape[1]:
+        raise ValueError("SharedEP MXFP4 activation hidden size does not match storage")
+    if source_ids.shape != (num_tokens, target.topk_ids.shape[1]):
+        raise ValueError("SharedEP MXFP4 route shape does not match owner storage")
+    tensors = (
+        source,
+        source_ids,
+        source_weights,
+        target.activations,
+        target.topk_ids,
+        target.topk_weights,
+    )
+    if any(tensor.device != source.device for tensor in tensors[1:]):
+        raise ValueError("SharedEP MXFP4 owner tensors must use one device")
+
+    target.topk_ids.fill_(-1)
+    target.topk_weights.zero_()
+    if num_tokens:
+        target.activations[:num_tokens].copy_(source)
+        target.topk_ids[:num_tokens].copy_(source_ids)
+        target.topk_weights[:num_tokens].copy_(source_weights)
+
+
+def _valid_fp4_dtype(dtype: torch.dtype) -> bool:
+    fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    return dtype == torch.uint8 or (fp4_dtype is not None and dtype == fp4_dtype)
+
+
+def _valid_e8m0_dtype(dtype: torch.dtype) -> bool:
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    return dtype == torch.uint8 or (e8m0_dtype is not None and dtype == e8m0_dtype)
+
+
+def validate_shared_ep_mxfp4_weights(
+    dispatch_output: SharedEpDispatchOutput,
+    quant_info: SharedEpQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> None:
+    """Validate SGLang's profile and canonical tensor metadata before AITER."""
+
+    profile = dispatch_output.profile
+    if profile.quantization is not SharedEpQuantization.MXFP4:
+        raise TypeError("SharedEP MXFP4 execution requires an MXFP4 profile")
+    if not isinstance(quant_info, SharedEpQuantInfo):
+        raise TypeError("SharedEP MXFP4 requires runner-neutral quant metadata")
+    quant_info.require_decode_capability(SharedEpQuantCapability.CANONICAL_MXFP4)
+    if tuple(quant_info.block_shape) != (1, 32):
+        raise ValueError(
+            f"SharedEP MXFP4 requires canonical (1, 32) groups, "
+            f"got {quant_info.block_shape}"
+        )
+    if quant_info.w13_scale is None or quant_info.w2_scale is None:
+        raise ValueError("SharedEP MXFP4 requires W13 and W2 E8M0 scales")
+
+    expected_shapes = (
+        (
+            profile.num_local_experts,
+            profile.intermediate_size * 2,
+            profile.hidden_size // 2,
+        ),
+        (
+            profile.num_local_experts,
+            profile.hidden_size,
+            profile.intermediate_size // 2,
+        ),
+        (
+            profile.num_local_experts,
+            profile.intermediate_size * 2,
+            profile.hidden_size // 32,
+        ),
+        (
+            profile.num_local_experts,
+            profile.hidden_size,
+            profile.intermediate_size // 32,
+        ),
+    )
+    tensors = (
+        quant_info.w13_weight,
+        quant_info.w2_weight,
+        quant_info.w13_scale,
+        quant_info.w2_scale,
+    )
+    observed_shapes = tuple(tuple(tensor.shape) for tensor in tensors)
+    if observed_shapes != expected_shapes:
+        raise ValueError(
+            "SharedEP canonical MXFP4 tensor shapes do not match the profile: "
+            f"observed={observed_shapes}, expected={expected_shapes}"
+        )
+    for name, weight in (
+        ("w13_weight", quant_info.w13_weight),
+        ("w2_weight", quant_info.w2_weight),
+    ):
+        if not _valid_fp4_dtype(weight.dtype):
+            raise TypeError(f"{name} must contain packed OCP E2M1 values")
+        if not weight.is_contiguous():
+            raise ValueError(f"{name} must use canonical contiguous storage")
+    for name, scale in (
+        ("w13_scale", quant_info.w13_scale),
+        ("w2_scale", quant_info.w2_scale),
+    ):
+        if not _valid_e8m0_dtype(scale.dtype):
+            raise TypeError(f"{name} must contain canonical E8M0 bytes")
+        if not scale.is_contiguous():
+            raise ValueError(f"{name} must use canonical contiguous storage")
+
+    if runner_config.activation != "silu" or not runner_config.is_gated:
+        raise ValueError("SharedEP MXFP4 supports gated SiLU experts only")
+    if runner_config.gemm1_alpha is not None:
+        raise ValueError("SharedEP MXFP4 does not support gemm1_alpha")
+    if runner_config.gemm1_clamp_limit is not None:
+        raise ValueError("SharedEP MXFP4 does not support gemm1_clamp_limit")
+
+
+def _load_aiter_mxfp4_ops() -> tuple[Callable, Callable]:
+    from aiter.ops.triton.moe.shared_ep_mxfp4 import (
+        shared_ep_mxfp4_w2,
+        shared_ep_mxfp4_w13,
+    )
+
+    return shared_ep_mxfp4_w13, shared_ep_mxfp4_w2
+
+
+def run_shared_ep_mxfp4(
+    dispatch_output: SharedEpDispatchOutput,
+    quant_info: SharedEpQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> StandardCombineInput:
+    """Run canonical W13/W2 and write W2 into global owner route slots."""
+
+    validate_shared_ep_mxfp4_weights(dispatch_output, quant_info, runner_config)
+    profile = dispatch_output.profile
+    state = dispatch_output.state
+    routes = prepare_routes(
+        profile,
+        state.global_input.topk_ids,
+        state.global_input.topk_weights,
+        state.input_epoch.allocation.local_storage,
+        state.input_epoch.epoch,
+        local_expert_start=dispatch_output.local_expert_start,
+    )
+
+    owner_activations = dispatch_output.hidden_states
+    owner_rows = owner_activations.numel() // profile.hidden_size
+    route_capacity = owner_rows * profile.top_k
+    route_weights = routes.local_weights.view(owner_rows, profile.top_k)
+    intermediate = torch.empty(
+        (route_capacity, profile.intermediate_size),
+        dtype=torch.bfloat16,
+        device=owner_activations.device,
+    )
+    global_output = state.global_output.view(route_capacity, profile.hidden_size)
+    if not global_output.is_contiguous():
+        raise RuntimeError(
+            "SharedEP MXFP4 direct output requires a dense rank-major HIP VMM "
+            "mapping with no rank or route padding"
+        )
+
+    shared_ep_mxfp4_w13, shared_ep_mxfp4_w2 = _load_aiter_mxfp4_ops()
+    intermediate = shared_ep_mxfp4_w13(
+        owner_activations,
+        quant_info.w13_weight,
+        quant_info.w13_scale,
+        routes.sorted_token_ids,
+        routes.expert_ids,
+        routes.num_tokens_post_padded,
+        top_k=profile.top_k,
+        route_block_size=profile.block_size_m,
+        out=intermediate,
+        weight_layout=quant_info.weight_layout.value,
+        scale_layout=quant_info.scale_layout.value,
+        config=profile.w13_kernel_config(dispatch_output.num_tokens),
+        swiglu_limit=runner_config.swiglu_limit,
+        check_route_values=False,
+    )
+    direct_output = shared_ep_mxfp4_w2(
+        intermediate,
+        quant_info.w2_weight,
+        quant_info.w2_scale,
+        route_weights,
+        routes.sorted_token_ids,
+        routes.expert_ids,
+        routes.num_tokens_post_padded,
+        top_k=profile.top_k,
+        route_block_size=profile.block_size_m,
+        out=global_output,
+        weight_layout=quant_info.weight_layout.value,
+        scale_layout=quant_info.scale_layout.value,
+        config=profile.w2_kernel_config(dispatch_output.num_tokens),
+        check_route_values=False,
+    )
+    if direct_output.data_ptr() != global_output.data_ptr():
+        raise RuntimeError("AITER MXFP4 W2 did not preserve the direct output buffer")
+
+    state.output_epoch.publish()
+    state.output_epoch.wait_all()
+    output = reduce_owner_output(
+        state.local_output,
+        num_tokens=dispatch_output.num_tokens,
+    )
+    return StandardCombineInput(hidden_states=output)

--- a/python/sglang/srt/layers/moe/shared_ep/kernels.py
+++ b/python/sglang/srt/layers/moe/shared_ep/kernels.py
@@ -1,0 +1,315 @@
+"""SharedEP-owned route and compute kernel entry points."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpInputViews
+from sglang.srt.layers.moe.shared_ep.profiles import SharedEpProfile
+
+
+class RoutePreparation(msgspec.Struct, kw_only=True):
+    local_ids: torch.Tensor
+    local_weights: torch.Tensor
+    sorted_token_ids: torch.Tensor
+    expert_ids: torch.Tensor
+    num_tokens_post_padded: torch.Tensor
+
+
+@triton.jit
+def _quantize_pack_input_kernel(
+    source,
+    source_ids,
+    source_weights,
+    target_q,
+    target_scales,
+    target_ids,
+    target_weights,
+    source_q_row_stride: tl.constexpr,
+    source_id_row_stride: tl.constexpr,
+    source_weight_row_stride: tl.constexpr,
+    target_q_row_stride: tl.constexpr,
+    target_scale_row_stride: tl.constexpr,
+    target_id_row_stride: tl.constexpr,
+    target_weight_row_stride: tl.constexpr,
+    quant_programs: tl.constexpr,
+    num_tokens: tl.constexpr,
+    num_groups: tl.constexpr,
+    top_k: tl.constexpr,
+    max_tokens: tl.constexpr,
+    group_size: tl.constexpr,
+    fp8_max: tl.constexpr,
+    eps: tl.constexpr,
+):
+    program = tl.program_id(0)
+    quant_valid = program < quant_programs
+    token = program // num_groups
+    group = program % num_groups
+    columns = group * group_size + tl.arange(0, group_size)
+    value = tl.load(
+        source + token * source_q_row_stride + columns,
+        mask=quant_valid,
+        other=0.0,
+    ).to(tl.float32)
+    absmax = tl.maximum(tl.max(tl.abs(value), axis=0), eps)
+    scale = absmax / fp8_max
+    quantized = tl.clamp(value / scale, -fp8_max, fp8_max).to(tl.float8e4nv)
+    tl.store(
+        target_q + token * target_q_row_stride + columns,
+        quantized,
+        mask=quant_valid,
+    )
+    tl.store(
+        target_scales + token * target_scale_row_stride + group,
+        scale,
+        mask=quant_valid,
+    )
+
+    metadata_row = program
+    metadata_columns = tl.arange(0, group_size)
+    metadata_mask = (metadata_row < max_tokens) & (metadata_columns < top_k)
+    source_mask = metadata_mask & (metadata_row < num_tokens)
+    route_id = tl.load(
+        source_ids + metadata_row * source_id_row_stride + metadata_columns,
+        mask=source_mask,
+        other=-1,
+    )
+    route_weight = tl.load(
+        source_weights + metadata_row * source_weight_row_stride + metadata_columns,
+        mask=source_mask,
+        other=0.0,
+    )
+    tl.store(
+        target_ids + metadata_row * target_id_row_stride + metadata_columns,
+        route_id.to(tl.int32),
+        mask=metadata_mask,
+    )
+    tl.store(
+        target_weights + metadata_row * target_weight_row_stride + metadata_columns,
+        route_weight,
+        mask=metadata_mask,
+    )
+
+
+def quantize_pack_input(
+    target: SharedEpInputViews,
+    *,
+    source: torch.Tensor,
+    source_ids: torch.Tensor,
+    source_weights: torch.Tensor,
+    group_size: int,
+) -> None:
+    """Quantize decode activations directly into the shared input object."""
+
+    if source.ndim != 2:
+        raise ValueError("SharedEP activations must be two-dimensional")
+    if source_ids.ndim != 2 or source_weights.ndim != 2:
+        raise ValueError("SharedEP routes must be two-dimensional")
+    num_tokens, hidden_size = source.shape
+    max_tokens = target.activations.shape[0]
+    if not 0 <= num_tokens <= max_tokens:
+        raise ValueError(
+            f"SharedEP input has {num_tokens} tokens, capacity is {max_tokens}"
+        )
+    if group_size != 128 or hidden_size % group_size != 0:
+        raise ValueError(
+            "SharedEP direct input quantization requires FP8 groups of 128"
+        )
+    if source_ids.shape != source_weights.shape:
+        raise ValueError("SharedEP route id and weight shapes must match")
+    if source_ids.shape != (num_tokens, target.topk_ids.shape[1]):
+        raise ValueError("SharedEP route shape does not match storage")
+    if hidden_size != target.activations.shape[1]:
+        raise ValueError("SharedEP activation hidden size does not match storage")
+    if target.scales.shape[1] != hidden_size // group_size:
+        raise ValueError("SharedEP activation scale shape does not match storage")
+    if source.dtype != torch.bfloat16:
+        raise TypeError("SharedEP decode activations must use bfloat16")
+    if not source.is_contiguous():
+        raise ValueError("SharedEP decode activations must be contiguous")
+    if source_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("SharedEP route ids must use int32 or int64")
+    if source_weights.dtype != torch.float32:
+        raise TypeError("SharedEP route weights must use float32")
+    if target.activations.dtype != torch.float8_e4m3fn:
+        raise TypeError("SharedEP requires OCP FP8 E4M3FN activation storage")
+    if target.scales.dtype != torch.float32:
+        raise TypeError("SharedEP activation scales must use float32")
+    if target.topk_ids.dtype != torch.int32:
+        raise TypeError("SharedEP stored route ids must use int32")
+    if target.topk_weights.dtype != torch.float32:
+        raise TypeError("SharedEP stored route weights must use float32")
+    tensors = (
+        source,
+        source_ids,
+        source_weights,
+        target.activations,
+        target.scales,
+        target.topk_ids,
+        target.topk_weights,
+    )
+    if any(not tensor.is_cuda for tensor in tensors):
+        raise ValueError("SharedEP input quantization requires GPU tensors")
+    if any(tensor.device != source.device for tensor in tensors[1:]):
+        raise ValueError(
+            "SharedEP input quantization tensors must use the same GPU device"
+        )
+
+    num_groups = hidden_size // group_size
+    quant_programs = num_tokens * num_groups
+    grid = max(quant_programs, max_tokens)
+    _quantize_pack_input_kernel[(grid,)](
+        source,
+        source_ids,
+        source_weights,
+        target.activations,
+        target.scales,
+        target.topk_ids,
+        target.topk_weights,
+        source_q_row_stride=source.stride(0),
+        source_id_row_stride=source_ids.stride(0),
+        source_weight_row_stride=source_weights.stride(0),
+        target_q_row_stride=target.activations.stride(0),
+        target_scale_row_stride=target.scales.stride(0),
+        target_id_row_stride=target.topk_ids.stride(0),
+        target_weight_row_stride=target.topk_weights.stride(0),
+        quant_programs=quant_programs,
+        num_tokens=num_tokens,
+        num_groups=num_groups,
+        top_k=source_ids.shape[1],
+        max_tokens=max_tokens,
+        group_size=group_size,
+        fp8_max=448.0,
+        eps=1e-10,
+        num_warps=4,
+        num_stages=1,
+    )
+
+
+@triton.jit
+def _reduce_owner_output_kernel(
+    source,
+    target,
+    source_token_stride,
+    source_route_stride,
+    source_column_stride,
+    target_token_stride,
+    hidden_size: tl.constexpr,
+    top_k: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    token = tl.program_id(0)
+    columns = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    column_mask = columns < hidden_size
+    accumulator = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    for route in tl.static_range(0, top_k):
+        values = tl.load(
+            source
+            + token * source_token_stride
+            + route * source_route_stride
+            + columns * source_column_stride,
+            mask=column_mask,
+            other=0.0,
+        )
+        accumulator += values.to(tl.float32)
+    tl.store(
+        target + token * target_token_stride + columns,
+        accumulator,
+        mask=column_mask,
+    )
+
+
+def reduce_owner_output(source: torch.Tensor, *, num_tokens: int) -> torch.Tensor:
+    """Reduce this owner's strided Top-K contribution rows on the GPU."""
+
+    if source.ndim != 3:
+        raise ValueError("SharedEP owner output must have [tokens, Top-K, hidden]")
+    if source.dtype != torch.bfloat16:
+        raise TypeError("SharedEP owner output must use bfloat16")
+    if not source.is_cuda:
+        raise ValueError("SharedEP owner reduction requires a GPU tensor")
+    if type(num_tokens) is not int or not 0 <= num_tokens <= source.shape[0]:
+        raise ValueError(
+            f"SharedEP owner reduction token count must be in [0, {source.shape[0]}]"
+        )
+
+    output = torch.empty(
+        (num_tokens, source.shape[2]),
+        dtype=source.dtype,
+        device=source.device,
+    )
+    if num_tokens == 0:
+        return output
+    block_size = 256
+    _reduce_owner_output_kernel[(num_tokens, triton.cdiv(source.shape[2], block_size))](
+        source,
+        output,
+        source.stride(0),
+        source.stride(1),
+        source.stride(2),
+        output.stride(0),
+        hidden_size=source.shape[2],
+        top_k=source.shape[1],
+        BLOCK_SIZE=block_size,
+        num_warps=4,
+        num_stages=1,
+    )
+    return output
+
+
+def prepare_routes(
+    profile: SharedEpProfile,
+    global_ids: torch.Tensor,
+    global_weights: torch.Tensor,
+    ready_signals: torch.Tensor,
+    ready_epoch: torch.Tensor,
+    *,
+    local_expert_start: int,
+) -> RoutePreparation:
+    _validate_routes(profile, global_ids, global_weights)
+    from sglang.kernels.ops.moe.shared_ep_route_prep import prepare_routes_cuda
+
+    result = prepare_routes_cuda(
+        global_ids,
+        global_weights,
+        ready_signals,
+        ready_epoch,
+        local_expert_start=local_expert_start,
+        num_local_experts=profile.num_local_experts,
+        block_size_m=profile.block_size_m,
+        num_threads=profile.route_kernel_config["num_threads"],
+    )
+    return RoutePreparation(
+        local_ids=result[0],
+        local_weights=result[1],
+        sorted_token_ids=result[2],
+        expert_ids=result[3],
+        num_tokens_post_padded=result[4],
+    )
+
+
+def _validate_routes(
+    profile: SharedEpProfile,
+    global_ids: torch.Tensor,
+    global_weights: torch.Tensor,
+) -> None:
+    if (
+        global_ids.ndim != 3
+        or not 0 < global_ids.shape[0] <= profile.ep_size
+        or not 0 < global_ids.shape[1] <= profile.max_tokens_per_rank
+        or global_ids.shape[2] != profile.top_k
+    ):
+        raise ValueError(
+            "SharedEP route ids require [owners<=EP, tokens<=capacity, Top-K] "
+            f"within {(profile.ep_size, profile.max_tokens_per_rank, profile.top_k)}, "
+            f"got {tuple(global_ids.shape)}"
+        )
+    if global_weights.shape != global_ids.shape:
+        raise ValueError("SharedEP route id and weight shapes must match")
+    if global_ids.dtype != torch.int32:
+        raise TypeError("SharedEP route ids must use int32")
+    if global_weights.dtype != torch.float32:
+        raise TypeError("SharedEP route weights must use float32")

--- a/python/sglang/srt/layers/moe/shared_ep/lanes.py
+++ b/python/sglang/srt/layers/moe/shared_ep/lanes.py
@@ -1,0 +1,102 @@
+"""Deterministic SharedEP state-lane geometry and resource keys."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Every lane owns two VMM mappings and two system-scope GPU epochs. Keep the
+# initial production envelope small and explicit instead of allowing an
+# unbounded speculative setting to multiply persistent peer mappings.
+SHARED_EP_MAX_STATE_LANES = 8
+
+_MODEL_NAMESPACE_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,63}$")
+
+
+@dataclass(frozen=True)
+class SharedEpLaneProtocol:
+    """Static lane dimensions captured by every MoE layer on every rank."""
+
+    tbo_width: int
+    generation_width: int
+
+    @property
+    def lane_count(self) -> int:
+        return self.tbo_width * self.generation_width
+
+    def lane_id(
+        self,
+        *,
+        generation_index: int = 0,
+        tbo_subbatch_index: int | None = None,
+    ) -> int:
+        subbatch = 0 if tbo_subbatch_index is None else int(tbo_subbatch_index)
+        generation = int(generation_index)
+        if not 0 <= subbatch < self.tbo_width:
+            raise ValueError(
+                "SharedEP TBO subbatch index is outside the admitted lane "
+                f"protocol: {subbatch} not in [0, {self.tbo_width})"
+            )
+        if not 0 <= generation < self.generation_width:
+            raise ValueError(
+                "SharedEP generation index is outside the admitted lane "
+                f"protocol: {generation} not in [0, {self.generation_width})"
+            )
+        return generation * self.tbo_width + subbatch
+
+
+def _max_speculative_draft_tokens(server_args) -> int:
+    if not getattr(server_args, "speculative_algorithm", None):
+        return 1
+    value = getattr(server_args, "max_speculative_num_draft_tokens", None)
+    if value is None:
+        value = getattr(server_args, "speculative_num_draft_tokens", None)
+    return max(1, int(value or 1))
+
+
+def compute_shared_ep_lane_protocol(server_args) -> SharedEpLaneProtocol:
+    """Derive a rank-identical, fixed-size lane protocol from server config."""
+
+    protocol = SharedEpLaneProtocol(
+        tbo_width=2 if getattr(server_args, "enable_two_batch_overlap", False) else 1,
+        generation_width=_max_speculative_draft_tokens(server_args),
+    )
+    if protocol.lane_count > SHARED_EP_MAX_STATE_LANES:
+        raise ValueError(
+            "SharedEP state-lane requirement exceeds the fixed release cap: "
+            f"{protocol.tbo_width} TBO lane(s) * "
+            f"{protocol.generation_width} generation lane(s) = "
+            f"{protocol.lane_count}, cap is {SHARED_EP_MAX_STATE_LANES}. "
+            "Reduce --speculative-num-draft-tokens or disable TBO."
+        )
+    return protocol
+
+
+def validate_shared_ep_model_namespace(model_namespace: str) -> str:
+    namespace = str(model_namespace)
+    if not _MODEL_NAMESPACE_RE.fullmatch(namespace):
+        raise ValueError(
+            "SharedEP model namespace must be a deterministic lowercase "
+            f"identifier, got {namespace!r}"
+        )
+    return namespace
+
+
+def shared_ep_state_resource_key(
+    *,
+    runtime_name: str,
+    profile_name: str,
+    ep_size: int,
+    model_namespace: str,
+    lane_id: int,
+) -> str:
+    """Build the process resource key without rank-local hashes or object IDs."""
+
+    namespace = validate_shared_ep_model_namespace(model_namespace)
+    lane = int(lane_id)
+    if lane < 0:
+        raise ValueError(f"SharedEP lane ID must be non-negative, got {lane}")
+    return (
+        f"shared_ep:{runtime_name}:{profile_name}:ep{int(ep_size)}:"
+        f"model={namespace}:lane={lane}"
+    )

--- a/python/sglang/srt/layers/moe/shared_ep/layout.py
+++ b/python/sglang/srt/layers/moe/shared_ep/layout.py
@@ -1,0 +1,277 @@
+"""Byte layout and typed tensor views for SharedEP VMM storage."""
+
+from __future__ import annotations
+
+import math
+from enum import Enum
+
+import msgspec
+import torch
+
+
+def shared_ep_fp8_dtype() -> torch.dtype:
+    """Return the OCP E4M3 storage dtype used by supported SharedEP devices.
+
+    ROCm's gfx94x devices use the legacy FNUZ encoding, but the ROCm SharedEP
+    admission gate is gfx950-only. CDNA4 uses the OCP E4M3FN encoding, matching
+    the CUDA release profiles.
+    """
+
+    return torch.float8_e4m3fn
+
+
+class SharedEpInputFormat(str, Enum):
+    BLOCK_FP8 = "block_fp8"
+    BF16 = "bf16"
+
+
+class SharedEpInputViews(msgspec.Struct, kw_only=True):
+    activations: torch.Tensor
+    scales: torch.Tensor | None
+    topk_ids: torch.Tensor
+    topk_weights: torch.Tensor
+
+    def owner(self, owner: int) -> SharedEpInputViews:
+        return SharedEpInputViews(
+            activations=self.activations[owner],
+            scales=None if self.scales is None else self.scales[owner],
+            topk_ids=self.topk_ids[owner],
+            topk_weights=self.topk_weights[owner],
+        )
+
+
+class SharedEpLayout(msgspec.Struct, frozen=True, kw_only=True):
+    hidden_size: int
+    top_k: int
+    max_tokens_per_rank: int
+    input_format: SharedEpInputFormat
+    direct_output: bool
+    scale_groups: int
+    input_payload_bytes: int
+    input_row_bytes: int
+    output_payload_bytes: int
+    output_row_bytes: int
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        hidden_size: int,
+        top_k: int,
+        max_tokens_per_rank: int,
+        input_format: SharedEpInputFormat | str = SharedEpInputFormat.BLOCK_FP8,
+        direct_output: bool = False,
+    ) -> SharedEpLayout:
+        for name, value in (
+            ("hidden_size", hidden_size),
+            ("top_k", top_k),
+            ("max_tokens_per_rank", max_tokens_per_rank),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        try:
+            input_format = SharedEpInputFormat(input_format)
+        except ValueError as error:
+            raise ValueError(
+                f"Unsupported SharedEP input format {input_format!r}"
+            ) from error
+        if input_format is SharedEpInputFormat.BLOCK_FP8 and hidden_size % 128 != 0:
+            raise ValueError(
+                f"hidden_size must be divisible by FP8 group size 128, got {hidden_size}"
+            )
+
+        if input_format is SharedEpInputFormat.BLOCK_FP8:
+            activation_bytes = hidden_size
+            scale_groups = hidden_size // 128
+        else:
+            activation_bytes = hidden_size * torch.bfloat16.itemsize
+            scale_groups = 0
+        input_payload_bytes = activation_bytes + scale_groups * 4 + top_k * 4 * 2
+        output_payload_bytes = hidden_size * 2
+        return cls(
+            hidden_size=hidden_size,
+            top_k=top_k,
+            max_tokens_per_rank=max_tokens_per_rank,
+            input_format=input_format,
+            direct_output=direct_output,
+            scale_groups=scale_groups,
+            input_payload_bytes=input_payload_bytes,
+            input_row_bytes=max(
+                64 * 1024,
+                _next_power_of_two(input_payload_bytes),
+            ),
+            output_payload_bytes=output_payload_bytes,
+            output_row_bytes=(
+                output_payload_bytes
+                if direct_output
+                else max(
+                    16 * 1024,
+                    _next_power_of_two(output_payload_bytes),
+                )
+            ),
+        )
+
+    @property
+    def input_rank_bytes(self) -> int:
+        return self.max_tokens_per_rank * self.input_row_bytes
+
+    @property
+    def output_rows_per_rank(self) -> int:
+        return self.max_tokens_per_rank * self.top_k
+
+    @property
+    def output_rank_bytes(self) -> int:
+        return self.output_rows_per_rank * self.output_row_bytes
+
+    @property
+    def scale_offset(self) -> int:
+        element_size = (
+            torch.bfloat16.itemsize
+            if self.input_format is SharedEpInputFormat.BF16
+            else 1
+        )
+        return self.hidden_size * element_size
+
+    @property
+    def topk_id_offset(self) -> int:
+        return self.scale_offset + self.scale_groups * 4
+
+    @property
+    def topk_weight_offset(self) -> int:
+        return self.topk_id_offset + self.top_k * 4
+
+    def output_slot_offset(self, token: int, route: int) -> int:
+        if not 0 <= token < self.max_tokens_per_rank:
+            raise IndexError(f"token {token} is outside the owner-local capacity")
+        if not 0 <= route < self.top_k:
+            raise IndexError(f"route {route} is outside Top-K {self.top_k}")
+        return (token * self.top_k + route) * self.output_row_bytes
+
+    def input_views(
+        self,
+        storage: torch.Tensor,
+        *,
+        world_size: int,
+        mapped_rank_bytes: int,
+    ) -> SharedEpInputViews:
+        _validate_storage(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+            logical_rank_bytes=self.input_rank_bytes,
+        )
+        rows = torch.as_strided(
+            storage,
+            size=(world_size, self.max_tokens_per_rank, self.input_row_bytes),
+            stride=(mapped_rank_bytes, self.input_row_bytes, 1),
+        )
+        scale_end = self.scale_offset + self.scale_groups * 4
+        id_end = self.topk_id_offset + self.top_k * 4
+        weight_end = self.topk_weight_offset + self.top_k * 4
+        activation_bytes = self.scale_offset
+        if self.input_format is SharedEpInputFormat.BF16:
+            activations = rows[..., :activation_bytes].view(torch.bfloat16)
+            scales = None
+        else:
+            activations = rows[..., :activation_bytes].view(shared_ep_fp8_dtype())
+            scales = rows[..., self.scale_offset : scale_end].view(torch.float32)
+        return SharedEpInputViews(
+            activations=activations,
+            scales=scales,
+            topk_ids=rows[..., self.topk_id_offset : id_end].view(torch.int32),
+            topk_weights=rows[..., self.topk_weight_offset : weight_end].view(
+                torch.float32
+            ),
+        )
+
+    def output_view(
+        self,
+        storage: torch.Tensor,
+        *,
+        world_size: int,
+        mapped_rank_bytes: int,
+    ) -> torch.Tensor:
+        _validate_storage(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+            logical_rank_bytes=self.output_rank_bytes,
+        )
+        rows = torch.as_strided(
+            storage,
+            size=(world_size, self.output_rows_per_rank, self.output_row_bytes),
+            stride=(mapped_rank_bytes, self.output_row_bytes, 1),
+        )
+        values = rows[..., : self.output_payload_bytes].view(torch.bfloat16)
+        return values.view(
+            world_size,
+            self.max_tokens_per_rank,
+            self.top_k,
+            self.hidden_size,
+        )
+
+
+def _next_power_of_two(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def align_output_layout(
+    layout: SharedEpLayout,
+    *,
+    granularity: int,
+) -> SharedEpLayout:
+    """Choose a fixed row stride so mapped owner segments have no hidden gap."""
+
+    if granularity <= 0:
+        raise ValueError(f"granularity must be positive, got {granularity}")
+    if layout.direct_output:
+        if layout.output_rank_bytes % granularity:
+            raise RuntimeError(
+                "SharedEP direct-output rows must remain densely contiguous, but "
+                f"rank bytes {layout.output_rank_bytes} are not divisible by VMM "
+                f"granularity {granularity}"
+            )
+        return layout
+    rows = layout.output_rows_per_rank
+    rank_alignment = math.lcm(rows, granularity)
+    required_rank_bytes = rows * layout.output_row_bytes
+    aligned_rank_bytes = (
+        (required_rank_bytes + rank_alignment - 1) // rank_alignment
+    ) * rank_alignment
+    output_row_bytes = aligned_rank_bytes // rows
+    if output_row_bytes == layout.output_row_bytes:
+        return layout
+    return SharedEpLayout(
+        hidden_size=layout.hidden_size,
+        top_k=layout.top_k,
+        max_tokens_per_rank=layout.max_tokens_per_rank,
+        input_format=layout.input_format,
+        direct_output=layout.direct_output,
+        scale_groups=layout.scale_groups,
+        input_payload_bytes=layout.input_payload_bytes,
+        input_row_bytes=layout.input_row_bytes,
+        output_payload_bytes=layout.output_payload_bytes,
+        output_row_bytes=output_row_bytes,
+    )
+
+
+def _validate_storage(
+    storage: torch.Tensor,
+    *,
+    world_size: int,
+    mapped_rank_bytes: int,
+    logical_rank_bytes: int,
+) -> None:
+    if storage.dtype != torch.uint8 or storage.ndim != 1:
+        raise TypeError("SharedEP VMM storage must be a one-dimensional uint8 tensor")
+    if world_size <= 0:
+        raise ValueError(f"world_size must be positive, got {world_size}")
+    if mapped_rank_bytes < logical_rank_bytes:
+        raise ValueError(
+            "mapped rank bytes cannot be smaller than the logical rank payload"
+        )
+    required_bytes = (world_size - 1) * mapped_rank_bytes + logical_rank_bytes
+    if storage.numel() < required_bytes:
+        raise ValueError(
+            f"SharedEP storage has {storage.numel()} bytes, needs {required_bytes}"
+        )

--- a/python/sglang/srt/layers/moe/shared_ep/profiles.py
+++ b/python/sglang/srt/layers/moe/shared_ep/profiles.py
@@ -1,0 +1,324 @@
+"""Internal admission and kernel profiles for SharedEP."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.shared_ep import SharedEpQuantization
+
+_DEFAULT_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 3,
+}
+_DSV4_SMALL_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 3,
+}
+_DSV4_LARGE_W13_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "num_warps": 4,
+    "num_stages": 4,
+}
+_GLM_SMALL_W13_KERNEL_CONFIG = _DSV4_SMALL_KERNEL_CONFIG
+_GLM_LARGE_W13_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "num_stages": 4,
+}
+_GLM_W2_KERNEL_CONFIG = {
+    **_DEFAULT_KERNEL_CONFIG,
+    "num_warps": 4,
+}
+_ROUTE_KERNEL_CONFIG = {"num_threads": 1024}
+_HIP_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+}
+_HIP_SMALL_KERNEL_CONFIG = {
+    **_HIP_KERNEL_CONFIG,
+    "num_warps": 4,
+    "num_stages": 1,
+}
+_HIP_ROUTE_KERNEL_CONFIG = {"num_threads": 256}
+_GFX950_MXFP4_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 4,
+    "num_warps": 8,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 1,
+}
+RELEASE_MAX_TOKENS_PER_RANK = 32
+
+
+class SharedEpProfile(msgspec.Struct, frozen=True, kw_only=True):
+    name: str
+    capability: tuple[int, int]
+    hidden_size: int
+    intermediate_size: int
+    top_k: int
+    num_experts: int
+    num_local_experts: int
+    ep_size: int
+    max_tokens_per_rank: int
+    quantization: SharedEpQuantization
+    block_shape: tuple[int, int]
+    default_kernel_config: dict[str, int]
+    small_kernel_config: dict[str, int] | None
+    small_kernel_max_tokens: int
+    route_kernel_config: dict[str, int]
+    default_w13_kernel_config: dict[str, int] | None = None
+    default_w2_kernel_config: dict[str, int] | None = None
+    small_w13_kernel_config: dict[str, int] | None = None
+    small_w2_kernel_config: dict[str, int] | None = None
+    platform: str = "cuda"
+
+    @property
+    def block_size_m(self) -> int:
+        return self.default_kernel_config["BLOCK_SIZE_M"]
+
+    def kernel_config(self, num_tokens: int) -> dict[str, int]:
+        self._validate_num_tokens(num_tokens)
+        if (
+            self.small_kernel_config is not None
+            and num_tokens <= self.small_kernel_max_tokens
+        ):
+            return self.small_kernel_config
+        return self.default_kernel_config
+
+    def w13_kernel_config(self, num_tokens: int) -> dict[str, int]:
+        return self._stage_kernel_config(
+            num_tokens,
+            default=self.default_w13_kernel_config,
+            small=self.small_w13_kernel_config,
+        )
+
+    def w2_kernel_config(self, num_tokens: int) -> dict[str, int]:
+        return self._stage_kernel_config(
+            num_tokens,
+            default=self.default_w2_kernel_config,
+            small=self.small_w2_kernel_config,
+        )
+
+    def _stage_kernel_config(
+        self,
+        num_tokens: int,
+        *,
+        default: dict[str, int] | None,
+        small: dict[str, int] | None,
+    ) -> dict[str, int]:
+        self._validate_num_tokens(num_tokens)
+        if num_tokens <= self.small_kernel_max_tokens:
+            if small is not None:
+                return small
+            if self.small_kernel_config is not None:
+                return self.small_kernel_config
+        if default is not None:
+            return default
+        return self.kernel_config(num_tokens)
+
+    def _validate_num_tokens(self, num_tokens: int) -> None:
+        if not 0 <= num_tokens <= self.max_tokens_per_rank:
+            raise ValueError(
+                f"local tokens {num_tokens} exceed profile capacity "
+                f"{self.max_tokens_per_rank}"
+            )
+
+    def admission_tuple(self) -> tuple:
+        return (
+            self.platform,
+            self.capability,
+            self.hidden_size,
+            self.intermediate_size,
+            self.top_k,
+            self.num_experts,
+            self.num_local_experts,
+            self.ep_size,
+            self.max_tokens_per_rank,
+            self.quantization,
+            self.block_shape,
+        )
+
+
+GLM52 = SharedEpProfile(
+    name="glm52",
+    capability=(9, 0),
+    hidden_size=6144,
+    intermediate_size=2048,
+    top_k=8,
+    num_experts=256,
+    num_local_experts=32,
+    ep_size=8,
+    max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+    quantization=SharedEpQuantization.BLOCK_FP8,
+    block_shape=(128, 128),
+    default_kernel_config=_DEFAULT_KERNEL_CONFIG,
+    small_kernel_config=None,
+    small_kernel_max_tokens=4,
+    route_kernel_config=_ROUTE_KERNEL_CONFIG,
+    default_w13_kernel_config=_GLM_LARGE_W13_KERNEL_CONFIG,
+    default_w2_kernel_config=_GLM_W2_KERNEL_CONFIG,
+    small_w13_kernel_config=_GLM_SMALL_W13_KERNEL_CONFIG,
+    small_w2_kernel_config=_GLM_W2_KERNEL_CONFIG,
+)
+
+DSV4_FLASH = SharedEpProfile(
+    name="dsv4_flash",
+    capability=(9, 0),
+    hidden_size=4096,
+    intermediate_size=2048,
+    top_k=6,
+    num_experts=256,
+    num_local_experts=32,
+    ep_size=8,
+    max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+    quantization=SharedEpQuantization.BLOCK_FP8,
+    block_shape=(128, 128),
+    default_kernel_config=_DEFAULT_KERNEL_CONFIG,
+    small_kernel_config=_DSV4_SMALL_KERNEL_CONFIG,
+    small_kernel_max_tokens=4,
+    route_kernel_config=_ROUTE_KERNEL_CONFIG,
+    default_w13_kernel_config=_DSV4_LARGE_W13_KERNEL_CONFIG,
+    default_w2_kernel_config=_DSV4_SMALL_KERNEL_CONFIG,
+)
+
+GLM52_GFX950 = SharedEpProfile(
+    name="glm52_gfx950",
+    capability=(9, 5),
+    hidden_size=6144,
+    intermediate_size=2048,
+    top_k=8,
+    num_experts=256,
+    num_local_experts=32,
+    ep_size=8,
+    max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+    quantization=SharedEpQuantization.BLOCK_FP8,
+    block_shape=(128, 128),
+    default_kernel_config=_HIP_KERNEL_CONFIG,
+    small_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    small_kernel_max_tokens=4,
+    route_kernel_config=_HIP_ROUTE_KERNEL_CONFIG,
+    default_w13_kernel_config=_HIP_KERNEL_CONFIG,
+    default_w2_kernel_config=_HIP_KERNEL_CONFIG,
+    small_w13_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    small_w2_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    platform="rocm",
+)
+
+DSV4_FLASH_GFX950 = SharedEpProfile(
+    name="dsv4_flash_gfx950",
+    capability=(9, 5),
+    hidden_size=4096,
+    intermediate_size=2048,
+    top_k=6,
+    num_experts=256,
+    num_local_experts=32,
+    ep_size=8,
+    max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+    quantization=SharedEpQuantization.BLOCK_FP8,
+    block_shape=(128, 128),
+    default_kernel_config=_HIP_KERNEL_CONFIG,
+    small_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    small_kernel_max_tokens=4,
+    route_kernel_config=_HIP_ROUTE_KERNEL_CONFIG,
+    default_w13_kernel_config=_HIP_KERNEL_CONFIG,
+    default_w2_kernel_config=_HIP_KERNEL_CONFIG,
+    small_w13_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    small_w2_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    platform="rocm",
+)
+
+DSV4_PRO_MXFP4_GFX950 = SharedEpProfile(
+    name="dsv4_pro_mxfp4_gfx950",
+    capability=(9, 5),
+    hidden_size=7168,
+    intermediate_size=3072,
+    top_k=6,
+    num_experts=384,
+    num_local_experts=48,
+    ep_size=8,
+    max_tokens_per_rank=RELEASE_MAX_TOKENS_PER_RANK,
+    quantization=SharedEpQuantization.MXFP4,
+    # MXFP4 has one E8M0 scale per output row and 32 logical K values.
+    block_shape=(1, 32),
+    default_kernel_config=_GFX950_MXFP4_KERNEL_CONFIG,
+    small_kernel_config=None,
+    small_kernel_max_tokens=RELEASE_MAX_TOKENS_PER_RANK,
+    route_kernel_config=_HIP_ROUTE_KERNEL_CONFIG,
+    default_w13_kernel_config=_GFX950_MXFP4_KERNEL_CONFIG,
+    default_w2_kernel_config=_GFX950_MXFP4_KERNEL_CONFIG,
+    platform="rocm",
+)
+
+_PROFILES = (
+    GLM52,
+    DSV4_FLASH,
+    GLM52_GFX950,
+    DSV4_FLASH_GFX950,
+    DSV4_PRO_MXFP4_GFX950,
+)
+
+
+def _runtime_platform_key() -> str:
+    return "rocm" if torch.version.hip is not None else "cuda"
+
+
+def select_profile(
+    config: MoeRunnerConfig,
+    *,
+    capability: tuple[int, int],
+    ep_size: int,
+    block_shape: tuple[int, int],
+    max_tokens_per_rank: int,
+    platform: str | None = None,
+    quantization: SharedEpQuantization | str = SharedEpQuantization.BLOCK_FP8,
+) -> SharedEpProfile:
+    if platform is None:
+        platform = _runtime_platform_key()
+    if platform not in ("cuda", "rocm"):
+        raise ValueError(
+            f"SharedEP platform must be 'cuda' or 'rocm', got {platform!r}"
+        )
+    try:
+        quantization = SharedEpQuantization(quantization)
+    except ValueError as error:
+        raise ValueError(
+            f"Unsupported SharedEP expert quantization {quantization!r}"
+        ) from error
+    observed = (
+        platform,
+        capability,
+        config.hidden_size,
+        config.intermediate_size_per_partition,
+        config.top_k,
+        config.num_experts,
+        config.num_local_experts,
+        ep_size,
+        max_tokens_per_rank,
+        quantization,
+        tuple(block_shape),
+    )
+    for profile in _PROFILES:
+        if observed == profile.admission_tuple():
+            return profile
+    supported = [profile.admission_tuple() for profile in _PROFILES]
+    raise ValueError(
+        "SharedEP supports only registered release profiles: "
+        f"observed={observed}, supported={supported}"
+    )

--- a/python/sglang/srt/layers/moe/shared_ep/profiles.py
+++ b/python/sglang/srt/layers/moe/shared_ep/profiles.py
@@ -52,6 +52,10 @@ _HIP_SMALL_KERNEL_CONFIG = {
     "num_warps": 4,
     "num_stages": 1,
 }
+_HIP_PREFILL_KERNEL_CONFIG = {
+    **_HIP_KERNEL_CONFIG,
+    "BLOCK_SIZE_M": 64,
+}
 _HIP_ROUTE_KERNEL_CONFIG = {"num_threads": 256}
 _GFX950_MXFP4_KERNEL_CONFIG = {
     "BLOCK_SIZE_M": 128,
@@ -65,6 +69,31 @@ _GFX950_MXFP4_KERNEL_CONFIG = {
     "kpack": 1,
 }
 RELEASE_MAX_TOKENS_PER_RANK = 32
+RELEASE_MAX_PREFILL_TOKENS_PER_RANK = 1024
+
+
+def resolve_prefill_capacity(
+    chunked_prefill_size: int | None,
+    *,
+    release_max_tokens: int = RELEASE_MAX_PREFILL_TOKENS_PER_RANK,
+) -> int:
+    """Validate the already DP-adjusted local prefill chunk."""
+
+    if release_max_tokens <= 0:
+        raise ValueError(
+            f"release_max_tokens must be positive, got {release_max_tokens}"
+        )
+    if chunked_prefill_size is None or chunked_prefill_size <= 0:
+        raise ValueError(
+            "SharedEP pull-cache prefill requires a positive DP-adjusted "
+            f"chunk, got {chunked_prefill_size}"
+        )
+    if chunked_prefill_size > release_max_tokens:
+        raise ValueError(
+            "SharedEP DP-adjusted prefill chunk exceeds pull-cache capacity: "
+            f"{chunked_prefill_size} > {release_max_tokens}"
+        )
+    return chunked_prefill_size
 
 
 class SharedEpProfile(msgspec.Struct, frozen=True, kw_only=True):
@@ -83,10 +112,14 @@ class SharedEpProfile(msgspec.Struct, frozen=True, kw_only=True):
     small_kernel_config: dict[str, int] | None
     small_kernel_max_tokens: int
     route_kernel_config: dict[str, int]
+    supports_pull_cache_prefill: bool = False
     default_w13_kernel_config: dict[str, int] | None = None
     default_w2_kernel_config: dict[str, int] | None = None
     small_w13_kernel_config: dict[str, int] | None = None
     small_w2_kernel_config: dict[str, int] | None = None
+    prefill_kernel_config: dict[str, int] | None = None
+    prefill_w13_kernel_config: dict[str, int] | None = None
+    prefill_w2_kernel_config: dict[str, int] | None = None
     platform: str = "cuda"
 
     @property
@@ -218,6 +251,10 @@ GLM52_GFX950 = SharedEpProfile(
     default_w2_kernel_config=_HIP_KERNEL_CONFIG,
     small_w13_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
     small_w2_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    supports_pull_cache_prefill=True,
+    prefill_kernel_config=_HIP_PREFILL_KERNEL_CONFIG,
+    prefill_w13_kernel_config=_HIP_PREFILL_KERNEL_CONFIG,
+    prefill_w2_kernel_config=_HIP_PREFILL_KERNEL_CONFIG,
     platform="rocm",
 )
 
@@ -241,6 +278,10 @@ DSV4_FLASH_GFX950 = SharedEpProfile(
     default_w2_kernel_config=_HIP_KERNEL_CONFIG,
     small_w13_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
     small_w2_kernel_config=_HIP_SMALL_KERNEL_CONFIG,
+    supports_pull_cache_prefill=True,
+    prefill_kernel_config=_HIP_PREFILL_KERNEL_CONFIG,
+    prefill_w13_kernel_config=_HIP_PREFILL_KERNEL_CONFIG,
+    prefill_w2_kernel_config=_HIP_PREFILL_KERNEL_CONFIG,
     platform="rocm",
 )
 
@@ -273,6 +314,40 @@ _PROFILES = (
     DSV4_FLASH_GFX950,
     DSV4_PRO_MXFP4_GFX950,
 )
+
+
+def make_pull_cache_prefill_profile(
+    profile: SharedEpProfile,
+    max_tokens_per_rank: int,
+) -> SharedEpProfile | None:
+    """Derive a phase-local profile without changing decode admission."""
+
+    if max_tokens_per_rank <= 0:
+        raise ValueError(
+            f"max_tokens_per_rank must be positive, got {max_tokens_per_rank}"
+        )
+    if not profile.supports_pull_cache_prefill:
+        return None
+    if (
+        profile.prefill_kernel_config is None
+        or profile.prefill_w13_kernel_config is None
+        or profile.prefill_w2_kernel_config is None
+    ):
+        raise ValueError(
+            f"SharedEP profile {profile.name} has incomplete prefill kernel configs"
+        )
+    return msgspec.structs.replace(
+        profile,
+        name=f"{profile.name}_prefill_pull",
+        max_tokens_per_rank=max_tokens_per_rank,
+        default_kernel_config=profile.prefill_kernel_config,
+        small_kernel_config=None,
+        small_kernel_max_tokens=0,
+        default_w13_kernel_config=profile.prefill_w13_kernel_config,
+        default_w2_kernel_config=profile.prefill_w2_kernel_config,
+        small_w13_kernel_config=None,
+        small_w2_kernel_config=None,
+    )
 
 
 def _runtime_platform_key() -> str:

--- a/python/sglang/srt/layers/moe/shared_ep/pull_cache_prefill.py
+++ b/python/sglang/srt/layers/moe/shared_ep/pull_cache_prefill.py
@@ -1,0 +1,361 @@
+"""ROCm pull-cache consumer for block-FP8 SharedEP prefill."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.srt.layers.moe.shared_ep.layout import shared_ep_fp8_dtype
+
+
+class PullCachePrefillPlan(msgspec.Struct, frozen=True, kw_only=True):
+    source_rows: int
+    source_route_capacity: int
+    cache_rows: int
+    hidden_size: int
+    scale_groups: int
+    top_k: int
+    num_local_experts: int
+    expert_alignment: int
+
+    @property
+    def activation_bytes(self) -> int:
+        return self.cache_rows * self.hidden_size
+
+    @property
+    def scale_bytes(self) -> int:
+        return self.cache_rows * self.scale_groups * torch.float32.itemsize
+
+    @property
+    def total_cache_bytes(self) -> int:
+        return self.activation_bytes + self.scale_bytes
+
+
+class PullCache(msgspec.Struct, kw_only=True):
+    plan: PullCachePrefillPlan
+    active_rows: int
+    activations: torch.Tensor
+    scales: torch.Tensor
+    row_ids: torch.Tensor
+    row_weights: torch.Tensor
+
+
+def make_pull_cache_prefill_plan(
+    *,
+    owners: int,
+    source_tokens_per_owner: int,
+    hidden_size: int,
+    top_k: int,
+    num_local_experts: int,
+    expert_alignment: int,
+) -> PullCachePrefillPlan:
+    dimensions = {
+        "owners": owners,
+        "source_tokens_per_owner": source_tokens_per_owner,
+        "hidden_size": hidden_size,
+        "top_k": top_k,
+        "num_local_experts": num_local_experts,
+        "expert_alignment": expert_alignment,
+    }
+    for name, value in dimensions.items():
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {value}")
+    if hidden_size % 128 != 0:
+        raise ValueError(f"hidden_size must be divisible by 128, got {hidden_size}")
+    if expert_alignment & (expert_alignment - 1):
+        raise ValueError(
+            f"expert_alignment must be a power of two, got {expert_alignment}"
+        )
+
+    source_rows = owners * source_tokens_per_owner
+    source_route_capacity = source_rows * top_k
+    experts_with_routes = min(source_route_capacity, num_local_experts)
+    cache_rows = source_route_capacity + experts_with_routes * (expert_alignment - 1)
+    return PullCachePrefillPlan(
+        source_rows=source_rows,
+        source_route_capacity=source_route_capacity,
+        cache_rows=cache_rows,
+        hidden_size=hidden_size,
+        scale_groups=hidden_size // 128,
+        top_k=top_k,
+        num_local_experts=num_local_experts,
+        expert_alignment=expert_alignment,
+    )
+
+
+def allocate_pull_cache(
+    plan: PullCachePrefillPlan,
+    *,
+    active_rows: int,
+    device: torch.device,
+) -> PullCache:
+    device = torch.device(device)
+    if device.type != "cuda":
+        raise ValueError(f"SharedEP pull cache requires a GPU device, got {device}")
+    if not 0 < active_rows <= plan.cache_rows:
+        raise ValueError(
+            f"active_rows must be in [1, {plan.cache_rows}], got {active_rows}"
+        )
+
+    activations = torch.empty(
+        (active_rows, plan.hidden_size),
+        dtype=shared_ep_fp8_dtype(),
+        device=device,
+    )
+    scales = torch.empty(
+        (active_rows, plan.scale_groups),
+        dtype=torch.float32,
+        device=device,
+    )
+    row_ids = torch.arange(active_rows, dtype=torch.int32, device=device)
+    row_weights = torch.ones((active_rows, 1), dtype=torch.float32, device=device)
+    return PullCache(
+        plan=plan,
+        active_rows=active_rows,
+        activations=activations,
+        scales=scales,
+        row_ids=row_ids,
+        row_weights=row_weights,
+    )
+
+
+@triton.jit
+def _pull_cache_rows_kernel(
+    source_activations,
+    source_scales,
+    sorted_token_ids,
+    num_tokens_post_padded,
+    cache_activations,
+    cache_scales,
+    source_activation_row_stride: tl.constexpr,
+    source_activation_column_stride: tl.constexpr,
+    source_scale_row_stride: tl.constexpr,
+    source_scale_column_stride: tl.constexpr,
+    cache_activation_row_stride: tl.constexpr,
+    cache_activation_column_stride: tl.constexpr,
+    cache_scale_row_stride: tl.constexpr,
+    cache_scale_column_stride: tl.constexpr,
+    hidden_size: tl.constexpr,
+    scale_groups: tl.constexpr,
+    activation_block: tl.constexpr,
+    scale_block: tl.constexpr,
+    top_k: tl.constexpr,
+    source_route_capacity: tl.constexpr,
+):
+    row = tl.program_id(0)
+    padded_rows = tl.load(num_tokens_post_padded)
+    if row < padded_rows:
+        route_id = tl.load(sorted_token_ids + row)
+        valid_route = (route_id >= 0) & (route_id < source_route_capacity)
+        source_row = route_id // top_k
+
+        for column_start in tl.static_range(0, hidden_size, activation_block):
+            columns = column_start + tl.arange(0, activation_block)
+            column_mask = columns < hidden_size
+            values = tl.load(
+                source_activations
+                + source_row * source_activation_row_stride
+                + columns * source_activation_column_stride,
+                mask=valid_route & column_mask,
+                other=0.0,
+            )
+            tl.store(
+                cache_activations
+                + row * cache_activation_row_stride
+                + columns * cache_activation_column_stride,
+                values,
+                mask=column_mask,
+            )
+
+        scale_columns = tl.arange(0, scale_block)
+        scale_mask = scale_columns < scale_groups
+        scale_values = tl.load(
+            source_scales
+            + source_row * source_scale_row_stride
+            + scale_columns * source_scale_column_stride,
+            mask=valid_route & scale_mask,
+            other=0.0,
+        )
+        tl.store(
+            cache_scales
+            + row * cache_scale_row_stride
+            + scale_columns * cache_scale_column_stride,
+            scale_values,
+            mask=scale_mask,
+        )
+
+
+def pull_cache_rows(
+    *,
+    source_activations: torch.Tensor,
+    source_scales: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    cache: PullCache,
+    top_k: int,
+    source_route_capacity: int,
+) -> None:
+    _validate_pull_inputs(
+        source_activations=source_activations,
+        source_scales=source_scales,
+        sorted_token_ids=sorted_token_ids,
+        num_tokens_post_padded=num_tokens_post_padded,
+        cache=cache,
+        top_k=top_k,
+        source_route_capacity=source_route_capacity,
+    )
+    _pull_cache_rows_kernel[(cache.active_rows,)](
+        source_activations,
+        source_scales,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        cache.activations,
+        cache.scales,
+        source_activation_row_stride=source_activations.stride(0),
+        source_activation_column_stride=source_activations.stride(1),
+        source_scale_row_stride=source_scales.stride(0),
+        source_scale_column_stride=source_scales.stride(1),
+        cache_activation_row_stride=cache.activations.stride(0),
+        cache_activation_column_stride=cache.activations.stride(1),
+        cache_scale_row_stride=cache.scales.stride(0),
+        cache_scale_column_stride=cache.scales.stride(1),
+        hidden_size=cache.plan.hidden_size,
+        scale_groups=cache.plan.scale_groups,
+        activation_block=256,
+        scale_block=triton.next_power_of_2(cache.plan.scale_groups),
+        top_k=top_k,
+        source_route_capacity=source_route_capacity,
+        num_warps=4,
+        num_stages=1,
+    )
+
+
+def invoke_pull_cache_w13(
+    *,
+    cache: PullCache,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    output: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    config: dict[str, int],
+    block_shape: tuple[int, int],
+) -> None:
+    if output.shape[0] != cache.active_rows:
+        raise ValueError("W13 output rows must match the pull-cache capacity")
+    invoke_fused_moe_kernel(
+        A=cache.activations,
+        B=weight,
+        bias=None,
+        C=output,
+        A_scale=cache.scales,
+        B_scale=weight_scale,
+        B_zp=None,
+        topk_weights=cache.row_weights,
+        topk_ids=cache.row_ids.view(-1, 1),
+        sorted_token_ids=cache.row_ids,
+        expert_ids=expert_ids,
+        num_tokens_post_padded=num_tokens_post_padded,
+        mul_routed_weight=False,
+        top_k=1,
+        config=config,
+        compute_type=tl.bfloat16,
+        use_fp8_w8a8=True,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        per_channel_quant=False,
+        block_shape=list(block_shape),
+        filter_expert=True,
+        c_sorted=True,
+        a_sorted=True,
+        a_is_prequantized=True,
+    )
+
+
+def _validate_pull_inputs(
+    *,
+    source_activations: torch.Tensor,
+    source_scales: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    cache: PullCache,
+    top_k: int,
+    source_route_capacity: int,
+) -> None:
+    tensors = (
+        source_activations,
+        source_scales,
+        sorted_token_ids,
+        num_tokens_post_padded,
+        cache.activations,
+        cache.scales,
+        cache.row_ids,
+        cache.row_weights,
+    )
+    if any(tensor.device != cache.activations.device for tensor in tensors):
+        raise ValueError("pull-cache tensors must be on the same GPU device")
+    if source_activations.dtype != shared_ep_fp8_dtype():
+        raise TypeError(
+            f"source activations must use {shared_ep_fp8_dtype()}, "
+            f"got {source_activations.dtype}"
+        )
+    if source_activations.ndim != 2:
+        raise ValueError("source activations must be two-dimensional")
+    if source_activations.shape[1] != cache.plan.hidden_size:
+        raise ValueError("source activation hidden size does not match the cache plan")
+    if source_scales.dtype != torch.float32:
+        raise TypeError("source scales must use float32")
+    if source_scales.shape != (
+        source_activations.shape[0],
+        cache.plan.scale_groups,
+    ):
+        raise ValueError("source scale shape does not match source activations")
+    for name, tensor in (
+        ("sorted_token_ids", sorted_token_ids),
+        ("num_tokens_post_padded", num_tokens_post_padded),
+    ):
+        if tensor.dtype != torch.int32:
+            raise TypeError(f"{name} must use int32")
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+    if sorted_token_ids.ndim != 1 or sorted_token_ids.numel() < cache.active_rows:
+        raise ValueError("sorted_token_ids must cover every cache row")
+    if num_tokens_post_padded.numel() != 1:
+        raise ValueError("num_tokens_post_padded must contain one device scalar")
+    if top_k != cache.plan.top_k:
+        raise ValueError(f"top_k must match cache plan value {cache.plan.top_k}")
+    max_route_capacity = source_activations.shape[0] * top_k
+    if not 0 < source_route_capacity <= max_route_capacity:
+        raise ValueError(
+            "source_route_capacity must be positive and cannot exceed source rows "
+            f"times Top-K ({max_route_capacity})"
+        )
+    if cache.activations.shape != (
+        cache.active_rows,
+        cache.plan.hidden_size,
+    ):
+        raise ValueError("cache activation shape does not match the cache plan")
+    if not cache.activations.is_contiguous():
+        raise ValueError("cache activations must be contiguous")
+    if cache.scales.shape != (cache.active_rows, cache.plan.scale_groups):
+        raise ValueError("cache scale shape does not match the cache plan")
+    if not cache.scales.is_contiguous():
+        raise ValueError("ROCm pull-cache scales must be contiguous row-major")
+    if (
+        cache.row_ids.dtype != torch.int32
+        or cache.row_ids.shape != (cache.active_rows,)
+        or not cache.row_ids.is_contiguous()
+    ):
+        raise ValueError("cache row_ids must be contiguous int32 cache indices")
+    if (
+        cache.row_weights.dtype != torch.float32
+        or cache.row_weights.shape != (cache.active_rows, 1)
+        or not cache.row_weights.is_contiguous()
+    ):
+        raise ValueError("cache row_weights must be contiguous float32 column values")

--- a/python/sglang/srt/layers/moe/shared_ep/rocm_runtime.py
+++ b/python/sglang/srt/layers/moe/shared_ep/rocm_runtime.py
@@ -1,0 +1,31 @@
+"""ROCm runtime registration for SharedEP's HIP VMM and native epochs."""
+
+from __future__ import annotations
+
+from sglang.srt.layers.moe.shared_ep.runtime import (
+    SharedEpRuntimeCapability,
+    SharedEpRuntimeHooks,
+)
+
+
+def _create_rocm_state(**kwargs):
+    from sglang.srt.layers.moe.shared_ep.state import create_shared_ep_state
+
+    return create_shared_ep_state(**kwargs)
+
+
+_ROCM_RUNTIME = SharedEpRuntimeHooks(
+    name="hip_vmm",
+    platform="rocm",
+    create_state=_create_rocm_state,
+    capabilities=frozenset(
+        {
+            SharedEpRuntimeCapability.RANK_MAJOR_VMM,
+            SharedEpRuntimeCapability.SYSTEM_SCOPE_GPU_EPOCH,
+        }
+    ),
+)
+
+
+def get_shared_ep_runtime_hooks() -> SharedEpRuntimeHooks:
+    return _ROCM_RUNTIME

--- a/python/sglang/srt/layers/moe/shared_ep/runtime.py
+++ b/python/sglang/srt/layers/moe/shared_ep/runtime.py
@@ -1,0 +1,124 @@
+"""Platform runtime hooks for SharedEP state and GPU epochs.
+
+The framework layer deliberately does not import a platform VMM implementation.
+CUDA keeps its existing implementation behind a lazy hook, while ROCm provides
+its VMM/epoch implementation through ``shared_ep.rocm_runtime`` (or explicit
+registration by an out-of-tree backend).
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable
+
+from sglang.srt.utils import is_hip
+
+
+class SharedEpRuntimeCapability(str, Enum):
+    RANK_MAJOR_VMM = "rank_major_vmm"
+    SYSTEM_SCOPE_GPU_EPOCH = "system_scope_gpu_epoch"
+
+
+_REQUIRED_CAPABILITIES = frozenset(
+    {
+        SharedEpRuntimeCapability.RANK_MAJOR_VMM,
+        SharedEpRuntimeCapability.SYSTEM_SCOPE_GPU_EPOCH,
+    }
+)
+
+
+@dataclass(frozen=True)
+class SharedEpRuntimeHooks:
+    """Framework-facing capabilities supplied by a platform runtime."""
+
+    name: str
+    platform: str
+    create_state: Callable[..., Any]
+    capabilities: frozenset[SharedEpRuntimeCapability]
+
+    def validate(self) -> None:
+        if self.platform not in ("cuda", "rocm"):
+            raise ValueError(f"Unsupported SharedEP runtime platform {self.platform!r}")
+        missing = _REQUIRED_CAPABILITIES.difference(self.capabilities)
+        if missing:
+            missing_names = sorted(capability.value for capability in missing)
+            raise RuntimeError(
+                f"SharedEP runtime {self.name!r} is missing capabilities "
+                f"{missing_names}"
+            )
+
+
+_RUNTIME_HOOKS: dict[str, SharedEpRuntimeHooks] = {}
+
+
+def register_shared_ep_runtime(
+    hooks: SharedEpRuntimeHooks,
+    *,
+    replace: bool = False,
+) -> None:
+    """Register one platform implementation without importing the other."""
+
+    hooks.validate()
+    existing = _RUNTIME_HOOKS.get(hooks.platform)
+    if existing is not None and not replace:
+        raise ValueError(
+            f"SharedEP runtime for {hooks.platform!r} is already registered "
+            f"as {existing.name!r}"
+        )
+    _RUNTIME_HOOKS[hooks.platform] = hooks
+
+
+def _create_cuda_state(**kwargs):
+    # Keep CUDA VMM/PTX modules out of ROCm import paths.
+    from sglang.srt.layers.moe.shared_ep.state import create_shared_ep_state
+
+    return create_shared_ep_state(**kwargs)
+
+
+_CUDA_RUNTIME = SharedEpRuntimeHooks(
+    name="cuda_vmm",
+    platform="cuda",
+    create_state=_create_cuda_state,
+    capabilities=_REQUIRED_CAPABILITIES,
+)
+
+
+def _load_rocm_runtime() -> None:
+    module_name = "sglang.srt.layers.moe.shared_ep.rocm_runtime"
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as error:
+        if error.name != module_name:
+            raise
+        return
+
+    if "rocm" in _RUNTIME_HOOKS:
+        return
+    get_hooks = getattr(module, "get_shared_ep_runtime_hooks", None)
+    if get_hooks is not None:
+        register_shared_ep_runtime(get_hooks())
+
+
+def get_shared_ep_runtime_hooks(
+    platform: str | None = None,
+) -> SharedEpRuntimeHooks:
+    """Resolve hooks for the active platform without cross-platform imports."""
+
+    platform = platform or ("rocm" if is_hip() else "cuda")
+    if platform == "cuda":
+        hooks = _RUNTIME_HOOKS.get(platform, _CUDA_RUNTIME)
+    elif platform == "rocm":
+        _load_rocm_runtime()
+        hooks = _RUNTIME_HOOKS.get(platform)
+        if hooks is None:
+            raise RuntimeError(
+                "ROCm SharedEP requires a registered rank-major VMM and "
+                "system-scope GPU epoch runtime"
+            )
+    else:
+        raise ValueError(f"Unsupported SharedEP platform {platform!r}")
+
+    hooks.validate()
+    return hooks

--- a/python/sglang/srt/layers/moe/shared_ep/state.py
+++ b/python/sglang/srt/layers/moe/shared_ep/state.py
@@ -1,0 +1,149 @@
+"""Owning SharedEP VMM state and typed tensor views."""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+import torch.distributed as dist
+
+from sglang.srt.distributed.device_communicators.vmm_utils import (
+    VmmCapability,
+    query_vmm_capability,
+    require_vmm_backend,
+)
+from sglang.srt.layers.moe.shared_ep.epoch import GpuEpoch, create_gpu_epoch
+from sglang.srt.layers.moe.shared_ep.layout import (
+    SharedEpInputViews,
+    SharedEpLayout,
+    align_output_layout,
+)
+from sglang.srt.layers.moe.shared_ep.vmm import (
+    SharedEpVmmAllocation,
+    allocate_rank_major_vmm,
+)
+
+
+def shared_ep_vmm_capability(
+    device: torch.device | str | None = None,
+) -> VmmCapability:
+    """Return an actionable SharedEP VMM capability result."""
+
+    return query_vmm_capability(device)
+
+
+def is_shared_ep_vmm_supported(device: torch.device | str | None = None) -> bool:
+    return shared_ep_vmm_capability(device).supported
+
+
+def require_shared_ep_vmm_support(device: torch.device | str) -> None:
+    require_vmm_backend(device, purpose="SharedEP VMM runtime")
+
+
+class SharedEpState(msgspec.Struct, kw_only=True):
+    """Process-lifetime mappings; ``close`` supports partial setup cleanup."""
+
+    layout: SharedEpLayout
+    input_allocation: SharedEpVmmAllocation
+    output_allocation: SharedEpVmmAllocation
+    input_epoch: GpuEpoch
+    output_epoch: GpuEpoch
+    global_input: SharedEpInputViews | None
+    local_input: SharedEpInputViews | None
+    global_output: torch.Tensor | None
+    local_output: torch.Tensor | None
+    _closed: bool = False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.global_input = None
+        self.local_input = None
+        self.global_output = None
+        self.local_output = None
+        self.output_epoch.close()
+        self.input_epoch.close()
+        self.output_allocation.close()
+        self.input_allocation.close()
+
+
+def create_shared_ep_state(
+    *,
+    layout: SharedEpLayout,
+    cpu_group,
+    device: torch.device,
+) -> SharedEpState:
+    rank = dist.get_rank(group=cpu_group)
+    world_size = dist.get_world_size(group=cpu_group)
+    resources = []
+    try:
+        input_allocation = allocate_rank_major_vmm(
+            cpu_group=cpu_group,
+            device=device,
+            logical_rank_bytes=layout.input_rank_bytes,
+        )
+        resources.append(input_allocation)
+        layout = align_output_layout(
+            layout,
+            granularity=input_allocation.granularity,
+        )
+        output_allocation = allocate_rank_major_vmm(
+            cpu_group=cpu_group,
+            device=device,
+            logical_rank_bytes=layout.output_rank_bytes,
+        )
+        resources.append(output_allocation)
+        if output_allocation.mapped_rank_bytes != layout.output_rank_bytes:
+            raise RuntimeError(
+                "SharedEP output rank stride must be exactly representable by rows"
+            )
+        input_epoch = create_gpu_epoch(
+            cpu_group=cpu_group,
+            device=device,
+            rank=rank,
+            world_size=world_size,
+        )
+        resources.append(input_epoch)
+        output_epoch = create_gpu_epoch(
+            cpu_group=cpu_group,
+            device=device,
+            rank=rank,
+            world_size=world_size,
+        )
+        resources.append(output_epoch)
+
+        global_input = layout.input_views(
+            input_allocation.global_storage,
+            world_size=world_size,
+            mapped_rank_bytes=input_allocation.mapped_rank_bytes,
+        )
+        local_input = layout.input_views(
+            input_allocation.local_storage,
+            world_size=1,
+            mapped_rank_bytes=input_allocation.mapped_rank_bytes,
+        ).owner(0)
+        global_output = layout.output_view(
+            output_allocation.global_storage,
+            world_size=world_size,
+            mapped_rank_bytes=output_allocation.mapped_rank_bytes,
+        )
+        local_output = layout.output_view(
+            output_allocation.local_storage,
+            world_size=1,
+            mapped_rank_bytes=output_allocation.mapped_rank_bytes,
+        )[0]
+        return SharedEpState(
+            layout=layout,
+            input_allocation=input_allocation,
+            output_allocation=output_allocation,
+            input_epoch=input_epoch,
+            output_epoch=output_epoch,
+            global_input=global_input,
+            local_input=local_input,
+            global_output=global_output,
+            local_output=local_output,
+        )
+    except BaseException:
+        while resources:
+            resources.pop().close()
+        raise

--- a/python/sglang/srt/layers/moe/shared_ep/vmm.py
+++ b/python/sglang/srt/layers/moe/shared_ep/vmm.py
@@ -1,0 +1,597 @@
+"""Private rank-major byte VMM allocation for SharedEP.
+
+Initialization uses a CPU process group to exchange platform shareable
+allocation handles. The resulting tensor views are stable GPU virtual addresses
+and do not require collectives in the forward path.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+
+import msgspec
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.distributed.device_communicators.vmm_utils import (
+    VmmBackend,
+    all_ranks_ok,
+    exchange_posix_fds,
+    get_vmm_backend,
+    require_vmm_backend,
+)
+
+
+def round_up_to_granularity(value: int, granularity: int) -> int:
+    if value <= 0:
+        raise ValueError(f"value must be positive, got {value}")
+    if granularity <= 0:
+        raise ValueError(f"granularity must be positive, got {granularity}")
+    return ((value + granularity - 1) // granularity) * granularity
+
+
+def _synchronize_vmm_stage(
+    cpu_group: ProcessGroup,
+    rank: int,
+    stage: str,
+    local_error: BaseException | None,
+) -> None:
+    errors: list[str | None] = [None] * dist.get_world_size(group=cpu_group)
+    dist.all_gather_object(
+        errors,
+        None if local_error is None else str(local_error),
+        group=cpu_group,
+    )
+    for failed_rank, error in enumerate(errors):
+        if error is not None:
+            message = f"SharedEP VMM {stage} failed on rank {failed_rank}: {error}"
+            if failed_rank == rank:
+                raise RuntimeError(message) from local_error
+            raise RuntimeError(message)
+
+
+def _validate_same_host_group(cpu_group: ProcessGroup) -> None:
+    rank = dist.get_rank(group=cpu_group)
+    hosts: list[str | None] = [None] * dist.get_world_size(group=cpu_group)
+    hostname = None
+    host_error = None
+    try:
+        hostname = os.uname().nodename
+    except BaseException as error:
+        host_error = error
+    _synchronize_vmm_stage(cpu_group, rank, "host query", host_error)
+    dist.all_gather_object(hosts, hostname, group=cpu_group)
+    if len(set(hosts)) != 1:
+        raise ValueError("SharedEP VMM requires every EP rank to be on the same host")
+
+
+def _release_partial_vmm_mapping(
+    backend: VmmBackend,
+    *,
+    base_va: int | None,
+    total_bytes: int,
+    mapped_addresses: list[int],
+    segment_bytes: int,
+) -> None:
+    while mapped_addresses:
+        backend.unmap(mapped_addresses.pop(), segment_bytes)
+    if base_va is not None:
+        backend.address_free(base_va, total_bytes)
+
+
+def _release_vmm_handles_synchronized(
+    backend: VmmBackend,
+    *,
+    retained_handles: list,
+    cpu_group: ProcessGroup,
+    rank: int,
+) -> None:
+    """Release setup handles and publish the result before returning."""
+
+    release_error = None
+    try:
+        while retained_handles:
+            handle = retained_handles[-1]
+            backend.release(handle)
+            retained_handles.pop()
+    except BaseException as error:
+        release_error = error
+    _synchronize_vmm_stage(cpu_group, rank, "handle release", release_error)
+
+
+class SharedEpVmmAllocation(msgspec.Struct, kw_only=True):
+    local_storage: torch.Tensor
+    global_storage: torch.Tensor
+    rank: int
+    world_size: int
+    logical_rank_bytes: int
+    mapped_rank_bytes: int
+    granularity: int
+    _base_va: int = 0
+    _total_bytes: int = 0
+    _vmm_backend: object | None = None
+    _closed: bool = False
+
+    def rank_offset(self, rank: int) -> int:
+        if not 0 <= rank < self.world_size:
+            raise IndexError(
+                f"rank {rank} is outside SharedEP world size {self.world_size}"
+            )
+        return rank * self.mapped_rank_bytes
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.local_storage = torch.empty(0, dtype=torch.uint8)
+        self.global_storage = torch.empty(0, dtype=torch.uint8)
+        if self._base_va:
+            torch.cuda.synchronize()
+            backend = self._vmm_backend or get_vmm_backend()
+            for segment in range(self.world_size):
+                address = self._base_va + segment * self.mapped_rank_bytes
+                backend.unmap(address, self.mapped_rank_bytes)
+            backend.address_free(self._base_va, self._total_bytes)
+            self._base_va = 0
+
+
+def _select_handle_transport(
+    group: ProcessGroup,
+    *,
+    backend: VmmBackend,
+    rank: int,
+    world_size: int,
+    local_handle,
+) -> tuple[bool, list[bytes | None], list[int], dict[tuple[int, int], int]]:
+    gathered: list[bytes | None] = [None] * world_size
+    fabric_error = None
+    if backend.supports_fabric:
+        try:
+            local_fabric_handle = backend.export_fabric(local_handle)
+            fabric_ok = True
+        except BaseException as error:
+            local_fabric_handle = None
+            fabric_error = error
+            fabric_ok = False
+        if all_ranks_ok(group, fabric_ok):
+            dist.all_gather_object(gathered, local_fabric_handle, group=group)
+            return True, gathered, [], {}
+
+    local_fds = []
+    posix_error = None
+    try:
+        local_fds.append(backend.export_posix_fd(local_handle))
+        posix_ok = True
+    except BaseException as error:
+        posix_error = error
+        posix_ok = False
+    try:
+        posix_all_ok = all_ranks_ok(group, posix_ok)
+    except BaseException:
+        for fd in local_fds:
+            os.close(fd)
+        raise
+    if not posix_all_ok:
+        for fd in local_fds:
+            os.close(fd)
+        local_detail = posix_error or fabric_error
+        message = "SharedEP VMM POSIX-fd export failed on at least one rank"
+        if local_detail is not None:
+            message += f"; local rank {rank}: {local_detail}"
+        raise RuntimeError(message) from posix_error
+
+    try:
+        peer_fds = exchange_posix_fds(
+            group,
+            rank,
+            world_size,
+            local_fds,
+            [1] * world_size,
+        )
+    except BaseException:
+        for fd in local_fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        raise
+    return False, gathered, local_fds, peer_fds
+
+
+class _DLDevice(ctypes.Structure):
+    _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
+
+
+class _DLDataType(ctypes.Structure):
+    _fields_ = [
+        ("code", ctypes.c_uint8),
+        ("bits", ctypes.c_uint8),
+        ("lanes", ctypes.c_uint16),
+    ]
+
+
+class _DLTensor(ctypes.Structure):
+    _fields_ = [
+        ("data", ctypes.c_void_p),
+        ("device", _DLDevice),
+        ("ndim", ctypes.c_int),
+        ("dtype", _DLDataType),
+        ("shape", ctypes.POINTER(ctypes.c_int64)),
+        ("strides", ctypes.POINTER(ctypes.c_int64)),
+        ("byte_offset", ctypes.c_uint64),
+    ]
+
+
+class _DLManagedTensor(ctypes.Structure):
+    pass
+
+
+_DELETER_FN = ctypes.CFUNCTYPE(None, ctypes.POINTER(_DLManagedTensor))
+_DLManagedTensor._fields_ = [
+    ("dl_tensor", _DLTensor),
+    ("manager_ctx", ctypes.c_void_p),
+    ("deleter", _DELETER_FN),
+]
+
+
+class _DLManagedTensorOwner(ctypes.Structure):
+    _fields_ = [
+        ("managed", _DLManagedTensor),
+        ("shape", ctypes.c_int64 * 1),
+    ]
+
+
+_C_RUNTIME = ctypes.CDLL(None)
+_C_RUNTIME.calloc.argtypes = [ctypes.c_size_t, ctypes.c_size_t]
+_C_RUNTIME.calloc.restype = ctypes.c_void_p
+_C_RUNTIME.free.argtypes = [ctypes.c_void_p]
+_C_RUNTIME.free.restype = None
+
+# The managed tensor is the first field in the calloc-owned wrapper, so the C
+# runtime's native ``free`` is itself a valid DLPack deleter. Keeping teardown
+# native avoids a Python callback during interpreter shutdown.
+_delete_dlmanaged_tensor = ctypes.cast(_C_RUNTIME.free, _DELETER_FN)
+
+
+ctypes.pythonapi.PyCapsule_New.restype = ctypes.py_object
+ctypes.pythonapi.PyCapsule_New.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_char_p,
+    ctypes.c_void_p,
+]
+ctypes.pythonapi.PyCapsule_IsValid.restype = ctypes.c_int
+ctypes.pythonapi.PyCapsule_IsValid.argtypes = [
+    ctypes.py_object,
+    ctypes.c_char_p,
+]
+
+
+def _uint8_tensor_from_cuda_ptr(
+    ptr: int,
+    length: int,
+    device_id: int,
+    refs: list[object],
+    *,
+    dlpack_device_type: int | None = None,
+) -> torch.Tensor:
+    """Wrap a VMM pointer with DLPack-owned metadata.
+
+    PyTorch owns the allocated ``DLManagedTensor`` after consuming the capsule,
+    so its deleter remains valid even if tensor views outlive this function.
+    ``refs`` is retained in the signature for compatibility with the original
+    CUDA helper; metadata lifetime no longer depends on that Python list.
+    """
+
+    del refs
+    if ptr == 0:
+        raise ValueError("cannot wrap a null VMM pointer")
+    if length <= 0:
+        raise ValueError(f"DLPack tensor length must be positive, got {length}")
+    if dlpack_device_type is None:
+        dlpack_device_type = 10 if torch.version.hip else 2
+    if dlpack_device_type not in (2, 10):
+        raise ValueError(f"unsupported DLPack GPU device type {dlpack_device_type}")
+
+    raw_owner = _C_RUNTIME.calloc(1, ctypes.sizeof(_DLManagedTensorOwner))
+    if not raw_owner:
+        raise MemoryError("failed to allocate DLPack tensor metadata")
+    owner = ctypes.cast(raw_owner, ctypes.POINTER(_DLManagedTensorOwner))
+    managed = ctypes.pointer(owner.contents.managed)
+    owner.contents.shape[0] = int(length)
+    managed.contents.dl_tensor.data = ctypes.c_void_p(ptr)
+    managed.contents.dl_tensor.device = _DLDevice(dlpack_device_type, device_id)
+    managed.contents.dl_tensor.ndim = 1
+    managed.contents.dl_tensor.dtype = _DLDataType(1, 8, 1)
+    managed.contents.dl_tensor.shape = ctypes.cast(
+        owner.contents.shape,
+        ctypes.POINTER(ctypes.c_int64),
+    )
+    managed.contents.dl_tensor.strides = None
+    managed.contents.dl_tensor.byte_offset = 0
+    managed.contents.manager_ctx = None
+    managed.contents.deleter = _delete_dlmanaged_tensor
+    capsule = None
+    try:
+        capsule = ctypes.pythonapi.PyCapsule_New(managed, b"dltensor", None)
+        return torch.from_dlpack(capsule)
+    except BaseException:
+        # A consumer that renamed the capsule to ``used_dltensor`` owns the
+        # managed tensor even if it subsequently raised.
+        if capsule is None or ctypes.pythonapi.PyCapsule_IsValid(capsule, b"dltensor"):
+            _delete_dlmanaged_tensor(managed)
+        raise
+
+
+def _construct_rank_major_views(
+    *,
+    cpu_group: ProcessGroup,
+    rank: int,
+    base_va: int,
+    total_bytes: int,
+    mapped_rank_bytes: int,
+    logical_rank_bytes: int,
+    device_id: int,
+    refs: list[object],
+    dlpack_device_type: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Construct both DLPack aliases, then publish one symmetric result."""
+
+    global_storage = None
+    local_storage = None
+    view_error = None
+    try:
+        global_storage = _uint8_tensor_from_cuda_ptr(
+            base_va,
+            total_bytes,
+            device_id,
+            refs,
+            dlpack_device_type=dlpack_device_type,
+        )
+        local_storage = global_storage.narrow(
+            0,
+            rank * mapped_rank_bytes,
+            logical_rank_bytes,
+        )
+    except BaseException as error:
+        view_error = error
+
+    _synchronize_vmm_stage(
+        cpu_group,
+        rank,
+        "tensor view construction",
+        view_error,
+    )
+    assert global_storage is not None and local_storage is not None
+    return global_storage, local_storage
+
+
+def allocate_rank_major_vmm(
+    *,
+    cpu_group: ProcessGroup,
+    device: torch.device,
+    logical_rank_bytes: int,
+) -> SharedEpVmmAllocation:
+    """Allocate one physical byte segment per rank and map them rank-major.
+
+    CUDA prefers FABRIC handles and falls back collectively to POSIX fds. HIP
+    uses uncached POSIX-fd allocations exclusively.
+    """
+
+    if logical_rank_bytes <= 0:
+        raise ValueError(
+            f"logical_rank_bytes must be positive, got {logical_rank_bytes}"
+        )
+    if device.type != "cuda":
+        raise ValueError(f"SharedEP VMM requires a CUDA/HIP device, got {device}")
+
+    rank = dist.get_rank(group=cpu_group)
+    world_size = dist.get_world_size(group=cpu_group)
+    _validate_same_host_group(cpu_group)
+
+    backend = None
+    device_id = None
+    granularity = None
+    mapped_rank_bytes = None
+    preflight_error = None
+    try:
+        backend = require_vmm_backend(device)
+        device_id = device.index
+        if device_id is None:
+            device_id = torch.cuda.current_device()
+        granularity = backend.get_allocation_granularity(
+            device_id,
+            allow_fabric=backend.supports_fabric,
+        )
+        mapped_rank_bytes = round_up_to_granularity(
+            logical_rank_bytes,
+            granularity,
+        )
+    except BaseException as error:
+        preflight_error = error
+    _synchronize_vmm_stage(
+        cpu_group,
+        rank,
+        "preflight",
+        preflight_error,
+    )
+    assert backend is not None
+    assert device_id is not None
+    assert granularity is not None
+    assert mapped_rank_bytes is not None
+
+    local_handle = None
+    create_error = None
+    try:
+        local_handle = backend.create_allocation(
+            mapped_rank_bytes,
+            device_id,
+            allow_fabric=backend.supports_fabric,
+        )
+    except BaseException as error:
+        create_error = error
+
+    if backend.supports_fabric:
+        try:
+            combined_all_ok = all_ranks_ok(cpu_group, create_error is None)
+        except BaseException:
+            if local_handle is not None:
+                backend.release(local_handle)
+                local_handle = None
+            raise
+        if not combined_all_ok:
+            fallback_cleanup_error = None
+            if local_handle is not None:
+                try:
+                    backend.release(local_handle)
+                except BaseException as error:
+                    fallback_cleanup_error = error
+                local_handle = None
+            _synchronize_vmm_stage(
+                cpu_group,
+                rank,
+                "FABRIC allocation fallback cleanup",
+                fallback_cleanup_error,
+            )
+            create_error = None
+            try:
+                local_handle = backend.create_allocation(
+                    mapped_rank_bytes,
+                    device_id,
+                    allow_fabric=False,
+                )
+            except BaseException as error:
+                create_error = error
+            try:
+                _synchronize_vmm_stage(
+                    cpu_group,
+                    rank,
+                    "allocation",
+                    create_error,
+                )
+            except BaseException:
+                if local_handle is not None:
+                    backend.release(local_handle)
+                    local_handle = None
+                raise
+    else:
+        try:
+            _synchronize_vmm_stage(
+                cpu_group,
+                rank,
+                "allocation",
+                create_error,
+            )
+        except BaseException:
+            if local_handle is not None:
+                backend.release(local_handle)
+                local_handle = None
+            raise
+    assert local_handle is not None
+
+    local_fds: list[int] = []
+    peer_fds: dict[tuple[int, int], int] = {}
+    imported_handles = []
+    retained_handles = []
+    base_va: int | None = None
+    mapped_addresses: list[int] = []
+    total_bytes = mapped_rank_bytes * world_size
+    try:
+        use_fabric, fabric_handles, local_fds, peer_fds = _select_handle_transport(
+            cpu_group,
+            backend=backend,
+            rank=rank,
+            world_size=world_size,
+            local_handle=local_handle,
+        )
+
+        mapping_error = None
+        try:
+            base_va = backend.reserve(total_bytes, granularity)
+            for peer_rank in range(world_size):
+                handle = local_handle
+                if peer_rank != rank:
+                    handle = (
+                        backend.import_fabric(fabric_handles[peer_rank])
+                        if use_fabric
+                        else backend.import_posix_fd(peer_fds[(peer_rank, 0)])
+                    )
+                    imported_handles.append(handle)
+                address = base_va + peer_rank * mapped_rank_bytes
+                backend.map(address, mapped_rank_bytes, handle)
+                mapped_addresses.append(address)
+                backend.set_access(address, mapped_rank_bytes, device_id)
+        except BaseException as error:
+            mapping_error = error
+
+        _synchronize_vmm_stage(
+            cpu_group,
+            rank,
+            "mapping",
+            mapping_error,
+        )
+        assert base_va is not None
+
+        refs: list[object] = []
+        global_storage, local_storage = _construct_rank_major_views(
+            cpu_group=cpu_group,
+            rank=rank,
+            base_va=base_va,
+            total_bytes=total_bytes,
+            mapped_rank_bytes=mapped_rank_bytes,
+            logical_rank_bytes=logical_rank_bytes,
+            device_id=device_id,
+            refs=refs,
+            dlpack_device_type=backend.dlpack_device_type,
+        )
+
+        retained_handles.extend(imported_handles)
+        imported_handles.clear()
+        retained_handles.append(local_handle)
+        local_handle = None
+        _release_vmm_handles_synchronized(
+            backend,
+            retained_handles=retained_handles,
+            cpu_group=cpu_group,
+            rank=rank,
+        )
+        return SharedEpVmmAllocation(
+            local_storage=local_storage,
+            global_storage=global_storage,
+            rank=rank,
+            world_size=world_size,
+            logical_rank_bytes=logical_rank_bytes,
+            mapped_rank_bytes=mapped_rank_bytes,
+            granularity=granularity,
+            _base_va=base_va,
+            _total_bytes=total_bytes,
+            _vmm_backend=backend,
+        )
+    except BaseException:
+        _release_partial_vmm_mapping(
+            backend,
+            base_va=base_va,
+            total_bytes=total_bytes,
+            mapped_addresses=mapped_addresses,
+            segment_bytes=mapped_rank_bytes,
+        )
+        for handle in imported_handles:
+            backend.release(handle)
+        for handle in retained_handles:
+            backend.release(handle)
+        retained_handles.clear()
+        if local_handle is not None:
+            backend.release(local_handle)
+        raise
+    finally:
+        for fd in local_fds:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        for fd in peer_fds.values():
+            try:
+                os.close(fd)
+            except OSError:
+                pass

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -287,7 +287,7 @@ class DeepEPBuffer:
     @classmethod
     def clean_buffer(cls):
         state = cls._state()
-        if not state.buffer.low_latency_mode:
+        if state.buffer is None or not state.buffer.low_latency_mode:
             return
         state.buffer.clean_low_latency_buffer(
             state.num_max_dispatch_tokens_per_rank,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -13,7 +13,7 @@ from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
 from sglang.srt.runtime_context import get_exec, get_flags, get_forward, get_parallel
-from sglang.srt.utils import is_cuda, is_npu
+from sglang.srt.utils import is_cuda, is_hip, is_npu
 
 _is_npu = is_npu()
 
@@ -37,6 +37,7 @@ class MoeA2ABackend(Enum):
     FLASHINFER = "flashinfer"
     MEGAMOE = "megamoe"
     PPLX = "pplx"
+    SHARED_EP = "shared_ep"
     CUSTOMIZED = "customized"
 
     @classmethod
@@ -78,6 +79,9 @@ class MoeA2ABackend(Enum):
     def is_pplx(self):
         return self == MoeA2ABackend.PPLX
 
+    def is_shared_ep(self):
+        return self == MoeA2ABackend.SHARED_EP
+
     def is_customized(self):
         return self == MoeA2ABackend.CUSTOMIZED
 
@@ -88,6 +92,7 @@ class MoeA2ABackend(Enum):
             MoeA2ABackend.MOONCAKE,
             MoeA2ABackend.NIXL,
             MoeA2ABackend.MORI,
+            MoeA2ABackend.SHARED_EP,
         )
 
 
@@ -337,6 +342,12 @@ def get_moe_runner_backend() -> MoeRunnerBackend:
     return moe.runner_backend
 
 
+def get_shared_ep_prefill_backend() -> MoeRunnerBackend:
+    """Platform-native runner used by the SharedEP prefill fallback."""
+
+    return MoeRunnerBackend.AITER if is_hip() else MoeRunnerBackend.DEEP_GEMM
+
+
 def get_speculative_moe_runner_backend() -> MoeRunnerBackend:
     moe = get_flags().moe
     if moe.speculative_runner_backend is None:
@@ -388,9 +399,15 @@ def is_sbo_enabled() -> bool:
 
 
 def is_deepep_class_backend() -> bool:
-    """Check if the MoE backend is DeepEP-family (DeepEP, Mooncake, Mori, or PPLX)."""
+    """Check whether the backend uses the EP-sharded model contract."""
     b = get_moe_a2a_backend()
-    return b.is_deepep() or b.is_mooncake() or b.is_mori() or b.is_pplx()
+    return (
+        b.is_deepep()
+        or b.is_mooncake()
+        or b.is_mori()
+        or b.is_pplx()
+        or b.is_shared_ep()
+    )
 
 
 def uses_per_rank_fused_shared_slots() -> bool:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1399,6 +1399,66 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         ):
             self._ensure_cutlass_buffers_initialized(layer)
 
+    @staticmethod
+    def _prepare_shared_ep_aiter_fallback_weights(layer: Module) -> None:
+        """Keep decode canonical and isolate AITER's private shuffled layout."""
+
+        w13_weight = shuffle_weight(layer.w13_weight.contiguous(), (16, 16))
+        w2_weight = shuffle_weight(layer.w2_weight.contiguous(), (16, 16))
+        w13_weight.is_shuffled = True
+        w2_weight.is_shuffled = True
+        layer._shared_ep_aiter_w13_weight = w13_weight
+        layer._shared_ep_aiter_w2_weight = w2_weight
+        layer.w13_weight.is_shuffled = False
+        layer.w2_weight.is_shuffled = False
+
+    @staticmethod
+    def _prepare_shared_ep_aiter_mxfp4_fallback(
+        layer: Module,
+        *,
+        gate_up_interleaved: bool,
+    ) -> None:
+        """Keep canonical MXFP4 tensors plus an explicit MoRI prefill copy."""
+
+        for scale_name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
+            scale = getattr(layer, scale_name)
+            num_experts, num_rows, _ = scale.shape
+            is_w13_scale = scale_name == "w13_weight_scale_inv"
+            shuffled = shuffle_scale(
+                scale.reshape(-1, scale.shape[-1]),
+                num_experts,
+                gate_up_interleaved,
+                is_w13_scale,
+            ).view(num_experts, num_rows, -1)
+            shuffled.is_shuffled = True
+            fallback_name = (
+                "_shared_ep_aiter_w13_scale"
+                if is_w13_scale
+                else "_shared_ep_aiter_w2_scale"
+            )
+            setattr(layer, fallback_name, shuffled)
+            scale.is_shuffled = False
+
+        layer._shared_ep_aiter_w13_weight = shuffle_weight(
+            layer.w13_weight,
+            is_guinterleave=gate_up_interleaved,
+            gate_up=True,
+        )
+        layer._shared_ep_aiter_w2_weight = shuffle_weight(
+            layer.w2_weight,
+            is_guinterleave=gate_up_interleaved,
+            gate_up=False,
+        )
+        layer._shared_ep_aiter_w13_weight.is_shuffled = True
+        layer._shared_ep_aiter_w2_weight.is_shuffled = True
+        layer.w13_weight.is_shuffled = False
+        layer.w2_weight.is_shuffled = False
+        logger.warning_once(
+            "SharedEP DSV4-Pro MXFP4 keeps canonical decode tensors and "
+            "currently allocates an explicit shuffled duplicate for "
+            "MoRI+AITER prefill."
+        )
+
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
         if _use_aiter and self.is_fp4_expert:
@@ -1483,30 +1543,46 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     new_s2, requires_grad=False
                 )
 
-            for scale_name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
-                scale = getattr(layer, scale_name)
-                num_experts, num_rows, _ = scale.shape
-                is_w13_scale = scale_name == "w13_weight_scale_inv"
-                scale_2d = scale.reshape(-1, scale.shape[-1])
-                scale.data = shuffle_scale(scale_2d, num_experts, gu_intv, is_w13_scale)
-
             layer.w13_weight.data = layer.w13_weight.data.view(fp4_weight_dtype)
             layer.w2_weight.data = layer.w2_weight.data.view(fp4_weight_dtype)
 
-            is_shuffled = _is_shuffle_moe_mxfp4
-            if is_shuffled:
-                layer.w13_weight.data = shuffle_weight(
-                    layer.w13_weight,
-                    is_guinterleave=gu_intv,
-                    gate_up=True,
+            if get_moe_a2a_backend().is_shared_ep():
+                if not _is_shuffle_moe_mxfp4:
+                    raise RuntimeError(
+                        "SharedEP MXFP4 requires gfx950 AITER weight shuffling "
+                        "for its temporary prefill fallback"
+                    )
+                self._prepare_shared_ep_aiter_mxfp4_fallback(
+                    layer,
+                    gate_up_interleaved=gu_intv,
                 )
-                layer.w2_weight.data = shuffle_weight(
-                    layer.w2_weight,
-                    is_guinterleave=gu_intv,
-                    gate_up=False,
-                )
-            layer.w13_weight.is_shuffled = is_shuffled
-            layer.w2_weight.is_shuffled = is_shuffled
+            else:
+                for scale_name in ("w13_weight_scale_inv", "w2_weight_scale_inv"):
+                    scale = getattr(layer, scale_name)
+                    num_experts, _, _ = scale.shape
+                    is_w13_scale = scale_name == "w13_weight_scale_inv"
+                    scale_2d = scale.reshape(-1, scale.shape[-1])
+                    scale.data = shuffle_scale(
+                        scale_2d,
+                        num_experts,
+                        gu_intv,
+                        is_w13_scale,
+                    )
+
+                is_shuffled = _is_shuffle_moe_mxfp4
+                if is_shuffled:
+                    layer.w13_weight.data = shuffle_weight(
+                        layer.w13_weight,
+                        is_guinterleave=gu_intv,
+                        gate_up=True,
+                    )
+                    layer.w2_weight.data = shuffle_weight(
+                        layer.w2_weight,
+                        is_guinterleave=gu_intv,
+                        gate_up=False,
+                    )
+                layer.w13_weight.is_shuffled = is_shuffled
+                layer.w2_weight.is_shuffled = is_shuffled
             return
 
         if self.convert_mxfp8_to_block:
@@ -1542,12 +1618,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 and self.runner.runner_backend.is_aiter()
             )
             if _use_aiter and runner_is_aiter:
-                layer.w13_weight.data = shuffle_weight(
-                    layer.w13_weight.contiguous(), (16, 16)
-                )
-                layer.w2_weight.data = shuffle_weight(
-                    layer.w2_weight.contiguous(), (16, 16)
-                )
+                if get_moe_a2a_backend().is_shared_ep():
+                    self._prepare_shared_ep_aiter_fallback_weights(layer)
+                else:
+                    layer.w13_weight.data = shuffle_weight(
+                        layer.w13_weight.contiguous(), (16, 16)
+                    )
+                    layer.w2_weight.data = shuffle_weight(
+                        layer.w2_weight.contiguous(), (16, 16)
+                    )
             return
         elif self.use_mxfp8:
             self._process_mxfp8_moe_weights(
@@ -1580,20 +1659,26 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
             layer.w2_input_scale = None
             if _use_aiter:
-                layer.w13_weight.data = shuffle_weight(
-                    layer.w13_weight.contiguous(), (16, 16)
-                )
-                layer.w2_weight.data = shuffle_weight(
-                    layer.w2_weight.contiguous(), (16, 16)
-                )
+                if get_moe_a2a_backend().is_shared_ep():
+                    self._prepare_shared_ep_aiter_fallback_weights(layer)
+                else:
+                    layer.w13_weight.data = shuffle_weight(
+                        layer.w13_weight.contiguous(), (16, 16)
+                    )
+                    layer.w2_weight.data = shuffle_weight(
+                        layer.w2_weight.contiguous(), (16, 16)
+                    )
         elif _use_aiter:
-            # Pre-shuffle weights
-            t = shuffle_weight(layer.w13_weight, (16, 16))
-            layer.w13_weight.copy_(t)
-            del t
-            t = shuffle_weight(layer.w2_weight, (16, 16))
-            layer.w2_weight.copy_(t)
-            del t
+            if get_moe_a2a_backend().is_shared_ep():
+                self._prepare_shared_ep_aiter_fallback_weights(layer)
+            else:
+                # Pre-shuffle weights
+                t = shuffle_weight(layer.w13_weight, (16, 16))
+                layer.w13_weight.copy_(t)
+                del t
+                t = shuffle_weight(layer.w2_weight, (16, 16))
+                layer.w2_weight.copy_(t)
+                del t
         elif _is_cpu:
             assert (
                 _is_cpu_amx_available
@@ -2119,7 +2204,57 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             self._prepare_hpc_ops_weights(layer)
 
         if hasattr(layer, "dispatcher"):
-            layer.dispatcher.set_quant_config({"weight_dtype": layer.w13_weight.dtype})
+            dispatcher_quant_config = {"weight_dtype": layer.w13_weight.dtype}
+            if get_moe_a2a_backend().is_shared_ep():
+                from sglang.srt.layers.moe.moe_runner.shared_ep import (
+                    SharedEpScaleLayout,
+                    SharedEpWeightLayout,
+                )
+
+                is_canonical = not (
+                    getattr(layer.w13_weight, "is_shuffled", False)
+                    or getattr(layer.w2_weight, "is_shuffled", False)
+                )
+                w13_scale = getattr(layer, "w13_weight_scale_inv", None)
+                w2_scale = getattr(layer, "w2_weight_scale_inv", None)
+                scales_are_canonical = not (
+                    getattr(w13_scale, "is_shuffled", False)
+                    or getattr(w2_scale, "is_shuffled", False)
+                )
+                if self.is_fp4_expert:
+                    shared_ep_quantization = "mxfp4"
+                    block_shape = (1, 32)
+                elif self.block_quant and not self.use_mxfp8:
+                    shared_ep_quantization = "block_fp8"
+                    block_shape = tuple(self.weight_block_size or ())
+                else:
+                    shared_ep_quantization = "unsupported"
+                    block_shape = tuple(self.weight_block_size or ())
+                dispatcher_quant_config.update(
+                    shared_ep_quantization=shared_ep_quantization,
+                    shared_ep_weight_layout=(
+                        SharedEpWeightLayout.CANONICAL.value
+                        if is_canonical
+                        else SharedEpWeightLayout.AITER_SHUFFLED.value
+                    ),
+                    shared_ep_scale_layout=(
+                        SharedEpScaleLayout.CANONICAL.value
+                        if scales_are_canonical
+                        else SharedEpScaleLayout.AITER_SHUFFLED.value
+                    ),
+                    block_shape=block_shape,
+                    weight_group_size=32 if self.is_fp4_expert else None,
+                    scale_format="e8m0" if self.is_fp4_expert else None,
+                    weight_scale_dtype=getattr(w13_scale, "dtype", None),
+                    w13_shape=tuple(layer.w13_weight.shape),
+                    w2_shape=tuple(layer.w2_weight.shape),
+                    w13_scale_shape=tuple(getattr(w13_scale, "shape", ())),
+                    w2_scale_shape=tuple(getattr(w2_scale, "shape", ())),
+                    fallback_uses_duplicate_tensors=hasattr(
+                        layer, "_shared_ep_aiter_w13_weight"
+                    ),
+                )
+            layer.dispatcher.set_quant_config(dispatcher_quant_config)
 
     def _prepare_hpc_ops_weights(self, layer: Module) -> None:
         """Precompute the scale layouts consumed by the HPC-Ops fused MoE kernels.
@@ -2318,6 +2453,63 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             block_shape=self.weight_block_size,
         )
 
+    def _wrap_shared_ep_quant_info(
+        self,
+        layer: torch.nn.Module,
+        fallback_quant_info,
+    ):
+        if not get_moe_a2a_backend().is_shared_ep():
+            return fallback_quant_info
+
+        from sglang.srt.layers.moe.moe_runner.shared_ep import (
+            SharedEpQuantCapability,
+            SharedEpQuantInfo,
+            SharedEpQuantization,
+            SharedEpScaleLayout,
+            SharedEpWeightLayout,
+        )
+
+        is_mxfp4 = self.is_fp4_expert
+        has_fallback_duplicate = hasattr(layer, "_shared_ep_aiter_w13_weight")
+        return SharedEpQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
+            w13_scale=layer.w13_weight_scale_inv,
+            w2_scale=layer.w2_weight_scale_inv,
+            block_shape=(1, 32) if is_mxfp4 else tuple(self.weight_block_size or ()),
+            fallback_quant_info=fallback_quant_info,
+            fallback_backend=self.runner.runner_backend,
+            quantization=(
+                SharedEpQuantization.MXFP4
+                if is_mxfp4
+                else SharedEpQuantization.BLOCK_FP8
+            ),
+            weight_layout=SharedEpWeightLayout.CANONICAL,
+            scale_layout=SharedEpScaleLayout.CANONICAL,
+            weight_group_size=32 if is_mxfp4 else None,
+            scale_format="e8m0" if is_mxfp4 else None,
+            capabilities=frozenset(
+                {
+                    (
+                        SharedEpQuantCapability.CANONICAL_MXFP4
+                        if is_mxfp4
+                        else SharedEpQuantCapability.CANONICAL_BLOCK_FP8
+                    )
+                }
+            ),
+            fallback_weight_layout=(
+                SharedEpWeightLayout.AITER_SHUFFLED
+                if has_fallback_duplicate
+                else SharedEpWeightLayout.CANONICAL
+            ),
+            fallback_scale_layout=(
+                SharedEpScaleLayout.AITER_SHUFFLED
+                if is_mxfp4 and has_fallback_duplicate
+                else SharedEpScaleLayout.CANONICAL
+            ),
+            fallback_uses_duplicate_tensors=has_fallback_duplicate,
+        )
+
     def apply(
         self,
         layer: torch.nn.Module,
@@ -2368,6 +2560,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 moe_runner_config.no_combine,
             )
             if quant_info is not None:
+                quant_info = self._wrap_shared_ep_quant_info(layer, quant_info)
                 return self.runner.run(dispatch_output, quant_info)
 
         if use_intel_xpu_backend():
@@ -2484,6 +2677,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 is_fp4_experts=self.is_fp4_expert,
                 use_mxfp8=self.use_mxfp8,
             )
+            quant_info = self._wrap_shared_ep_quant_info(layer, quant_info)
         elif (
             self.runner.runner_backend.is_flashinfer_trtllm()
             or self.runner.runner_backend.is_flashinfer_trtllm_routed()
@@ -2617,8 +2811,38 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             AiterQuantType,
         )
 
-        w13_weight = layer.w13_weight
-        w2_weight = layer.w2_weight
+        if get_moe_a2a_backend().is_shared_ep():
+            w13_weight = getattr(layer, "_shared_ep_aiter_w13_weight", None)
+            w2_weight = getattr(layer, "_shared_ep_aiter_w2_weight", None)
+            if w13_weight is None or w2_weight is None:
+                raise RuntimeError(
+                    "SharedEP ROCm prefill requires isolated AITER-shuffled "
+                    "weights; canonical decode weights must not be reused"
+                )
+            if self.is_fp4_expert:
+                w13_scale = getattr(layer, "_shared_ep_aiter_w13_scale", None)
+                w2_scale = getattr(layer, "_shared_ep_aiter_w2_scale", None)
+                if w13_scale is None or w2_scale is None:
+                    raise RuntimeError(
+                        "SharedEP ROCm MXFP4 prefill requires isolated "
+                        "AITER-shuffled E8M0 scales"
+                    )
+            else:
+                w13_scale = layer.w13_weight_scale_inv
+                w2_scale = layer.w2_weight_scale_inv
+        else:
+            w13_weight = layer.w13_weight
+            w2_weight = layer.w2_weight
+            w13_scale = (
+                layer.w13_weight_scale_inv
+                if self.block_quant
+                else layer.w13_weight_scale1
+            )
+            w2_scale = (
+                layer.w2_weight_scale_inv
+                if self.block_quant
+                else layer.w2_weight_scale1
+            )
 
         if self.block_quant:
             quant_type = (
@@ -2628,18 +2852,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             )
 
             if self.is_fp4_expert:
+                is_shuffled = getattr(w13_weight, "is_shuffled", False)
                 fp4_weight_dtype = _require_fp4_dtype()
                 w13_weight = w13_weight.view(fp4_weight_dtype)
                 w2_weight = w2_weight.view(fp4_weight_dtype)
-                if getattr(layer.w13_weight, "is_shuffled", False):
+                if is_shuffled:
                     w13_weight.is_shuffled = True
                     w2_weight.is_shuffled = True
-            w13_scale = layer.w13_weight_scale_inv
-            w2_scale = layer.w2_weight_scale_inv
         else:
             quant_type = AiterQuantType.PER_TOKEN
-            w13_scale = layer.w13_weight_scale1
-            w2_scale = layer.w2_weight_scale1
         return AiterMoeQuantInfo(
             w13_weight=w13_weight,
             w2_weight=w2_weight,

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -9,7 +9,10 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
-from sglang.srt.layers.moe.utils import get_moe_weight_sizes
+from sglang.srt.layers.moe.utils import (
+    get_moe_a2a_backend,
+    get_moe_weight_sizes,
+)
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.dequantization import (
     copy_missing_attrs,
@@ -560,6 +563,37 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
 
         layer.w2_weight = torch.nn.Parameter(qw2_weight, requires_grad=False)
 
+    @staticmethod
+    def _prepare_shared_ep_aiter_fallback(layer: torch.nn.Module) -> None:
+        """Keep canonical decode tensors and expose the temporary prefill copy."""
+
+        if not _use_aiter or not _is_shuffle_moe_mxfp4:
+            raise RuntimeError(
+                "SharedEP Quark MXFP4 prefill requires gfx950 AITER shuffling"
+            )
+
+        for name in ("w13_weight_scale", "w2_weight_scale"):
+            scale = getattr(layer, name)
+            experts, rows, _ = scale.shape
+            shuffled = e8m0_shuffle(scale.view(experts * rows, -1))
+            shuffled = shuffled.view(experts, rows, -1)
+            shuffled.is_shuffled = True
+            setattr(layer, f"_shared_ep_aiter_{name}", shuffled)
+            scale.is_shuffled = False
+
+        w13_weight = shuffle_weight(layer.w13_weight.contiguous(), (16, 16))
+        w2_weight = shuffle_weight(layer.w2_weight.contiguous(), (16, 16))
+        w13_weight.is_shuffled = True
+        w2_weight.is_shuffled = True
+        layer._shared_ep_aiter_w13_weight = w13_weight
+        layer._shared_ep_aiter_w2_weight = w2_weight
+        layer.w13_weight.is_shuffled = False
+        layer.w2_weight.is_shuffled = False
+        logger.warning_once(
+            "SharedEP MXFP4 keeps canonical decode weights/scales and currently "
+            "allocates an explicit shuffled duplicate for MoRI+AITER prefill."
+        )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if (
             not self.is_checkpoint_mxfp4_serialized
@@ -574,31 +608,56 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             assert layer.w13_weight_scale.dtype == torch.uint8
             assert layer.w2_weight_scale.dtype == torch.uint8
 
-        # Pre-shuffle weight scales
-        s0, s1, _ = layer.w13_weight_scale.shape
-        w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
-        w13_weight_scale = e8m0_shuffle(w13_weight_scale)
-        layer.w13_weight_scale.data = w13_weight_scale.view(s0, s1, -1)
+        if get_moe_a2a_backend().is_shared_ep():
+            self._prepare_shared_ep_aiter_fallback(layer)
+        else:
+            # Pre-shuffle weight scales
+            s0, s1, _ = layer.w13_weight_scale.shape
+            w13_weight_scale = layer.w13_weight_scale.view(s0 * s1, -1)
+            w13_weight_scale = e8m0_shuffle(w13_weight_scale)
+            layer.w13_weight_scale.data = w13_weight_scale.view(s0, s1, -1)
 
-        s0, s1, _ = layer.w2_weight_scale.shape
-        w2_weight_scale = layer.w2_weight_scale.view(s0 * s1, -1)
-        w2_weight_scale = e8m0_shuffle(w2_weight_scale)
-        layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
+            s0, s1, _ = layer.w2_weight_scale.shape
+            w2_weight_scale = layer.w2_weight_scale.view(s0 * s1, -1)
+            w2_weight_scale = e8m0_shuffle(w2_weight_scale)
+            layer.w2_weight_scale.data = w2_weight_scale.view(s0, s1, -1)
 
-        # Pre-shuffle weight
-        if _is_shuffle_moe_mxfp4:
-            layer.w13_weight.data = shuffle_weight(
-                layer.w13_weight.contiguous(), (16, 16)
-            )
-            layer.w2_weight.data = shuffle_weight(
-                layer.w2_weight.contiguous(), (16, 16)
-            )
-            layer.w13_weight.is_shuffled = True
-            layer.w2_weight.is_shuffled = True
+            # Pre-shuffle weight
+            if _is_shuffle_moe_mxfp4:
+                layer.w13_weight.data = shuffle_weight(
+                    layer.w13_weight.contiguous(), (16, 16)
+                )
+                layer.w2_weight.data = shuffle_weight(
+                    layer.w2_weight.contiguous(), (16, 16)
+                )
+                layer.w13_weight.is_shuffled = True
+                layer.w2_weight.is_shuffled = True
 
         if hasattr(layer, "dispatcher"):
             # Weights are stored as torch.uint8 but semantically MXFP4
-            layer.dispatcher.set_quant_config({"weight_dtype": torch.float4_e2m1fn_x2})
+            fp4_dtype = getattr(torch, "float4_e2m1fn_x2", torch.uint8)
+            quant_config = {"weight_dtype": fp4_dtype}
+            if get_moe_a2a_backend().is_shared_ep():
+                from sglang.srt.layers.moe.moe_runner.shared_ep import (
+                    SharedEpScaleLayout,
+                    SharedEpWeightLayout,
+                )
+
+                quant_config.update(
+                    shared_ep_quantization="mxfp4",
+                    shared_ep_weight_layout=SharedEpWeightLayout.CANONICAL.value,
+                    shared_ep_scale_layout=SharedEpScaleLayout.CANONICAL.value,
+                    block_shape=(1, OCP_MX_BLOCK_SIZE),
+                    weight_group_size=OCP_MX_BLOCK_SIZE,
+                    scale_format="e8m0",
+                    weight_scale_dtype=layer.w13_weight_scale.dtype,
+                    w13_shape=tuple(layer.w13_weight.shape),
+                    w2_shape=tuple(layer.w2_weight.shape),
+                    w13_scale_shape=tuple(layer.w13_weight_scale.shape),
+                    w2_scale_shape=tuple(layer.w2_weight_scale.shape),
+                    fallback_uses_duplicate_tensors=True,
+                )
+            layer.dispatcher.set_quant_config(quant_config)
 
     def create_moe_runner(
         self, layer: torch.nn.Module, moe_runner_config: MoeRunnerConfig
@@ -629,23 +688,76 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             AiterQuantType,
         )
 
-        if hasattr(torch, "float4_e2m1fn_x2"):
-            w13_weight = layer.w13_weight.view(torch.float4_e2m1fn_x2)
-            w2_weight = layer.w2_weight.view(torch.float4_e2m1fn_x2)
+        is_shared_ep = get_moe_a2a_backend().is_shared_ep()
+        if is_shared_ep:
+            required = (
+                "_shared_ep_aiter_w13_weight",
+                "_shared_ep_aiter_w2_weight",
+                "_shared_ep_aiter_w13_weight_scale",
+                "_shared_ep_aiter_w2_weight_scale",
+            )
+            missing = [name for name in required if not hasattr(layer, name)]
+            if missing:
+                raise RuntimeError(
+                    "SharedEP MXFP4 prefill fallback was not materialized: "
+                    + ", ".join(missing)
+                )
+            prefill_w13 = layer._shared_ep_aiter_w13_weight
+            prefill_w2 = layer._shared_ep_aiter_w2_weight
+            prefill_s13 = layer._shared_ep_aiter_w13_weight_scale
+            prefill_s2 = layer._shared_ep_aiter_w2_weight_scale
         else:
-            w13_weight = layer.w13_weight
-            w2_weight = layer.w2_weight
+            prefill_w13 = layer.w13_weight
+            prefill_w2 = layer.w2_weight
+            prefill_s13 = layer.w13_weight_scale
+            prefill_s2 = layer.w2_weight_scale
 
-        if hasattr(layer.w13_weight, "is_shuffled"):
+        if hasattr(torch, "float4_e2m1fn_x2"):
+            w13_weight = prefill_w13.view(torch.float4_e2m1fn_x2)
+            w2_weight = prefill_w2.view(torch.float4_e2m1fn_x2)
+        else:
+            w13_weight = prefill_w13
+            w2_weight = prefill_w2
+
+        if getattr(prefill_w13, "is_shuffled", False):
             w13_weight.is_shuffled = True
             w2_weight.is_shuffled = True
 
-        quant_info = AiterMoeQuantInfo(
+        fallback_quant_info = AiterMoeQuantInfo(
             w13_weight=w13_weight,
             w2_weight=w2_weight,
             quant_type=AiterQuantType.PER_1X32,
+            w13_scale=prefill_s13,
+            w2_scale=prefill_s2,
+            expert_mask=layer.dispatcher.expert_mask_gpu,
+        )
+        if not is_shared_ep:
+            return self.runner.run(dispatch_output, fallback_quant_info)
+
+        from sglang.srt.layers.moe.moe_runner.shared_ep import (
+            SharedEpQuantCapability,
+            SharedEpQuantInfo,
+            SharedEpQuantization,
+            SharedEpScaleLayout,
+            SharedEpWeightLayout,
+        )
+
+        quant_info = SharedEpQuantInfo(
+            w13_weight=layer.w13_weight,
+            w2_weight=layer.w2_weight,
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
-            expert_mask=layer.dispatcher.expert_mask_gpu,
+            block_shape=(1, OCP_MX_BLOCK_SIZE),
+            fallback_quant_info=fallback_quant_info,
+            fallback_backend=self.runner.runner_backend,
+            quantization=SharedEpQuantization.MXFP4,
+            weight_layout=SharedEpWeightLayout.CANONICAL,
+            scale_layout=SharedEpScaleLayout.CANONICAL,
+            weight_group_size=OCP_MX_BLOCK_SIZE,
+            scale_format="e8m0",
+            capabilities=frozenset({SharedEpQuantCapability.CANONICAL_MXFP4}),
+            fallback_weight_layout=SharedEpWeightLayout.AITER_SHUFFLED,
+            fallback_scale_layout=SharedEpScaleLayout.AITER_SHUFFLED,
+            fallback_uses_duplicate_tensors=True,
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -459,6 +459,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     can_run_dp_cuda_graph: bool = False
     can_run_dp_breakable_cuda_graph: bool = False
     global_forward_mode: Optional[ForwardMode] = None
+    # Graph-static SharedEP generation lane. Speculative draft loops assign a
+    # distinct value before each model forward; target/ordinary decode is zero.
+    shared_ep_generation: int = 0
 
     # For two-batch overlap
     tbo_split_seq_index: Optional[int] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -169,6 +169,7 @@ from sglang.srt.runtime_context import (
     get_model,
     get_parallel,
     get_schedule,
+    publish_shared_ep_forward_flags,
     set_global_dwdp_manager,
 )
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
@@ -1460,6 +1461,7 @@ class ModelRunner:
         reinit_attn_backend: bool = False,
         split_forward_count: int = 1,
     ) -> ModelRunnerOutput:
+        publish_shared_ep_forward_flags(forward_batch)
         if has_forward_context():
             ctx_mgr = contextlib.nullcontext()
         else:

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -44,7 +44,11 @@ from sglang.srt.model_executor.runner.flashinfer_autotune import (
     run_flashinfer_autotune_forward,
     should_run_flashinfer_autotune,
 )
-from sglang.srt.runtime_context import get_flags, get_parallel
+from sglang.srt.runtime_context import (
+    get_flags,
+    get_parallel,
+    publish_shared_ep_forward_flags,
+)
 from sglang.srt.speculative.spec_info import create_dummy_verify_input
 from sglang.srt.utils import (
     empty_context,
@@ -586,6 +590,7 @@ class BaseRunner(ABC):
                 global_num_tokens_cpu,
             )
             set_is_extend_in_batch(False)
+            publish_shared_ep_forward_flags(forward_batch)
 
             kwargs = {}
             if (

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -91,7 +91,12 @@ from sglang.srt.model_executor.runner_utils.deepep_adapter import (
     DeepEPCudaGraphRunnerAdapter,
 )
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
-from sglang.srt.runtime_context import get_flags, get_parallel, get_spec
+from sglang.srt.runtime_context import (
+    get_flags,
+    get_parallel,
+    get_spec,
+    publish_shared_ep_forward_flags,
+)
 from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.utils import (
     empty_context,
@@ -962,6 +967,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     forward_batch.global_num_tokens_cpu,
                 )
                 set_is_extend_in_batch(False)
+                publish_shared_ep_forward_flags(forward_batch)
 
                 kwargs = {}
                 if (

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -103,7 +103,11 @@ from sglang.srt.model_executor.runner_utils.buffers import (
     PrefillInputBuffers,
 )
 from sglang.srt.model_loader.utils import resolve_language_model
-from sglang.srt.runtime_context import get_parallel, get_schedule
+from sglang.srt.runtime_context import (
+    get_parallel,
+    get_schedule,
+    publish_shared_ep_forward_flags,
+)
 from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidden_dim
 from sglang.srt.utils import (
     get_available_gpu_memory,
@@ -639,6 +643,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             forward_batch.global_num_tokens_cpu,
         )
         set_is_extend_in_batch(False)
+        publish_shared_ep_forward_flags(forward_batch)
 
         with self._prefill_forward_context(forward_batch):
             if self._uses_eager_prefill_tail():
@@ -710,6 +715,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             fb.global_num_tokens_cpu,
         )
         set_is_extend_in_batch(False)
+        publish_shared_ep_forward_flags(fb)
 
         with (
             forward_context(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -654,6 +654,9 @@ class DeepseekV2MoE(nn.Module):
             ),
             swiglu_limit=getattr(config, "swiglu_limit", None),
             prefix=add_prefix("experts", prefix),
+            shared_ep_model_namespace=(
+                "draft-nextn" if is_nextn else "target"
+            ),
         )
 
         if self.is_hash and not (is_nextn and is_deepseek_v4):
@@ -731,6 +734,7 @@ class DeepseekV2MoE(nn.Module):
                 or get_moe_a2a_backend().is_ascend_fuseep()
                 or get_moe_a2a_backend().is_flashinfer()
                 or get_moe_a2a_backend().is_megamoe()
+                or get_moe_a2a_backend().is_shared_ep()
                 or should_use_flashinfer_cutlass_moe_fp4_allgather()
                 or envs.SGLANG_SHARED_EXPERT_TP1.get()
             )
@@ -811,6 +815,7 @@ class DeepseekV2MoE(nn.Module):
             or get_moe_a2a_backend().is_nixl()
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
+            or get_moe_a2a_backend().is_shared_ep()
         ):
             # TODO: we will support tp < ep in the future
             self.ep_size = get_parallel().moe_ep_size
@@ -833,6 +838,7 @@ class DeepseekV2MoE(nn.Module):
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
             or get_moe_a2a_backend().is_flashinfer()
+            or get_moe_a2a_backend().is_shared_ep()
         )
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
         # SGLANG_OPT_MOE_QUANT_ONCE eligibility, resolved lazily on first
@@ -2695,7 +2701,11 @@ class DeepseekV2Model(nn.Module):
                 )
             )
         self.layers_to_capture = []
-        if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mooncake():
+        if (
+            get_moe_a2a_backend().is_deepep()
+            or get_moe_a2a_backend().is_mooncake()
+            or get_moe_a2a_backend().is_shared_ep()
+        ):
             self.enable_a2a_moe = True
         else:
             self.enable_a2a_moe = False

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -654,9 +654,7 @@ class DeepseekV2MoE(nn.Module):
             ),
             swiglu_limit=getattr(config, "swiglu_limit", None),
             prefix=add_prefix("experts", prefix),
-            shared_ep_model_namespace=(
-                "draft-nextn" if is_nextn else "target"
-            ),
+            shared_ep_model_namespace=("draft-nextn" if is_nextn else "target"),
         )
 
         if self.is_hash and not (is_nextn and is_deepseek_v4):

--- a/python/sglang/srt/models/glm4_moe.py
+++ b/python/sglang/srt/models/glm4_moe.py
@@ -473,6 +473,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
                     or get_moe_a2a_backend().is_mori()
                     or get_moe_a2a_backend().is_ascend_fuseep()
                     or get_moe_a2a_backend().is_flashinfer()
+                    or get_moe_a2a_backend().is_shared_ep()
                     or should_use_flashinfer_cutlass_moe_fp4_allgather()
                     else {}
                 ),
@@ -517,6 +518,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
             or get_moe_a2a_backend().is_nixl()
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
+            or get_moe_a2a_backend().is_shared_ep()
         ):
             # TODO: we will support tp < ep in the future
             self.ep_size = get_parallel().moe_ep_size
@@ -539,6 +541,7 @@ class Glm4MoeSparseMoeBlock(nn.Module):
             or get_moe_a2a_backend().is_mori()
             or get_moe_a2a_backend().is_ascend_fuseep()
             or get_moe_a2a_backend().is_flashinfer()
+            or get_moe_a2a_backend().is_shared_ep()
         )
         self._fuse_shared_experts_inside_sbo = SboFlags.fuse_shared_experts_inside_sbo()
 
@@ -1189,9 +1192,14 @@ class Glm4MoeForCausalLM(nn.Module):
         ):
             disable_reason = "Only GLM-4.5 on AMD-platform with capability >= gfx942(MI30x) can use shared experts fusion optimization under expert parallelism."
         elif disable_reason is None and (
-            get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mori()
+            get_moe_a2a_backend().is_deepep()
+            or get_moe_a2a_backend().is_mori()
+            or get_moe_a2a_backend().is_shared_ep()
         ):
-            disable_reason = "GLM-4.5 cannot use shared experts fusion optimization under deepep expert parallelism."
+            disable_reason = (
+                "GLM-4.5 cannot fuse shared experts with the selected "
+                "expert-parallel A2A backend."
+            )
         elif self.quant_config and self.quant_config.get_name() == "w4afp8":
             disable_reason = "GLM-4.5 W4AFP8 model uses different quant method for routed experts and shared experts."
 

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -479,8 +479,10 @@ class ForwardFlags:
         # must use the materialized fallback. Speculative loops may advance the
         # generation index explicitly; plain target decode stays on lane zero.
         "shared_ep_is_decode": False,
+        "shared_ep_is_prefill": False,
         "shared_ep_generation": 0,
         "shared_ep_global_num_tokens": None,
+        "shared_ep_counts_synchronized": False,
         # Per-layer MLP collective control (set by decoder via scoped()
         # around the MLP / MoE / hybrid mixer call).
         # fuse_mlp_allreduce: next residual+LN absorbs the post-MLP all-reduce.
@@ -501,8 +503,10 @@ class ForwardFlags:
             "attn_inputs",
             "is_extend_in_batch",
             "shared_ep_is_decode",
+            "shared_ep_is_prefill",
             "shared_ep_generation",
             "shared_ep_global_num_tokens",
+            "shared_ep_counts_synchronized",
             "fuse_mlp_allreduce",
             "mlp_reduce_scatter",
             "flashinfer_trtllm_bypass",
@@ -1098,20 +1102,82 @@ def publish_shared_ep_forward_flags(forward_batch: Any) -> None:
     local_mode = forward_batch.forward_mode
     mode = global_mode or local_mode
     forward = get_forward()
-    forward.set("shared_ep_is_decode", mode.is_decode())
     forward.set(
         "shared_ep_generation",
         int(getattr(forward_batch, "shared_ep_generation", 0)),
     )
-    global_num_tokens = getattr(forward_batch, "global_num_tokens_cpu", None)
+    raw_num_tokens = getattr(forward_batch, "global_num_tokens_cpu", None)
+    global_num_tokens = (
+        None
+        if raw_num_tokens is None
+        else tuple(int(value) for value in raw_num_tokens)
+    )
+    counts_synchronized = False
+    try:
+        use_shared_ep = get_exec().moe.moe_a2a_backend == "shared_ep"
+    except (AttributeError, ValueError):
+        use_shared_ep = False
+    if use_shared_ep:
+        import torch.distributed as dist
+
+        parallel = get_parallel()
+        world_size = dist.get_world_size(group=parallel.moe_ep_group.cpu_group)
+        if world_size != parallel.moe_ep_size:
+            raise RuntimeError(
+                "SharedEP token-count group does not match expert parallel size: "
+                f"{world_size} != {parallel.moe_ep_size}"
+            )
+        if global_num_tokens and len(global_num_tokens) == parallel.attn_dp_size:
+            local_num_tokens = global_num_tokens[parallel.attn_dp_rank]
+        elif global_num_tokens:
+            local_num_tokens = sum(global_num_tokens)
+        else:
+            input_ids = getattr(forward_batch, "input_ids", None)
+            if input_ids is None:
+                raise RuntimeError(
+                    "SharedEP requires local input IDs or DP token counts "
+                    "before model forward"
+                )
+            local_num_tokens = int(input_ids.shape[0])
+        gathered_state: list[tuple[int, int] | None] = [None] * world_size
+        dist.all_gather_object(
+            gathered_state,
+            (int(local_num_tokens), int(mode)),
+            group=parallel.moe_ep_group.cpu_group,
+        )
+        if any(value is None for value in gathered_state):
+            raise RuntimeError("SharedEP failed to gather every DP forward state")
+        gathered = [value for value in gathered_state if value is not None]
+        global_num_tokens = tuple(value[0] for value in gathered)
+        mode_type = type(local_mode)
+        gathered_modes = [mode_type(value[1]) for value in gathered]
+        decode_modes = [value for value in gathered_modes if value.is_decode()]
+        prefill_modes = [
+            value for value in gathered_modes if value.is_extend_without_speculative()
+        ]
+        if decode_modes:
+            if not all(value.is_decode_or_idle() for value in gathered_modes):
+                raise RuntimeError(
+                    f"SharedEP ranks disagree on decode phase: {gathered_modes}"
+                )
+            mode = decode_modes[0]
+        elif prefill_modes:
+            if not all(
+                value.is_extend_without_speculative() or value.is_idle()
+                for value in gathered_modes
+            ):
+                raise RuntimeError(
+                    f"SharedEP ranks disagree on prefill phase: {gathered_modes}"
+                )
+            mode = prefill_modes[0]
+        counts_synchronized = True
+    forward.set("shared_ep_is_decode", mode.is_decode())
+    forward.set("shared_ep_is_prefill", mode.is_extend_without_speculative())
     forward.set(
         "shared_ep_global_num_tokens",
-        (
-            tuple(int(value) for value in global_num_tokens)
-            if global_num_tokens is not None
-            else None
-        ),
+        global_num_tokens,
     )
+    forward.set("shared_ep_counts_synchronized", counts_synchronized)
 
 
 # --- Resolved config namespaces -------------------------

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1117,7 +1117,9 @@ def publish_shared_ep_forward_flags(forward_batch: Any) -> None:
         use_shared_ep = get_exec().moe.moe_a2a_backend == "shared_ep"
     except (AttributeError, ValueError):
         use_shared_ep = False
+    force_shared_ep_fallback = False
     if use_shared_ep:
+        import torch
         import torch.distributed as dist
 
         parallel = get_parallel()
@@ -1139,40 +1141,52 @@ def publish_shared_ep_forward_flags(forward_batch: Any) -> None:
                     "before model forward"
                 )
             local_num_tokens = int(input_ids.shape[0])
-        gathered_state: list[tuple[int, int] | None] = [None] * world_size
-        dist.all_gather_object(
+        buffers = get_resources().buffers
+        state_buffers = buffers.get("shared_ep_forward_state_cpu")
+        if state_buffers is None:
+            state_buffers = (
+                torch.empty(2, dtype=torch.int64, device="cpu"),
+                torch.empty(world_size * 2, dtype=torch.int64, device="cpu"),
+            )
+            buffers["shared_ep_forward_state_cpu"] = state_buffers
+        local_state, gathered_state = state_buffers
+        local_state[0] = int(local_num_tokens)
+        local_state[1] = int(mode)
+        dist.all_gather_into_tensor(
             gathered_state,
-            (int(local_num_tokens), int(mode)),
+            local_state,
             group=parallel.moe_ep_group.cpu_group,
         )
-        if any(value is None for value in gathered_state):
-            raise RuntimeError("SharedEP failed to gather every DP forward state")
-        gathered = [value for value in gathered_state if value is not None]
-        global_num_tokens = tuple(value[0] for value in gathered)
+        gathered = gathered_state.view(world_size, 2)
+        global_num_tokens = tuple(int(value) for value in gathered[:, 0])
         mode_type = type(local_mode)
-        gathered_modes = [mode_type(value[1]) for value in gathered]
+        gathered_modes = [mode_type(int(value)) for value in gathered[:, 1]]
         decode_modes = [value for value in gathered_modes if value.is_decode()]
         prefill_modes = [
             value for value in gathered_modes if value.is_extend_without_speculative()
         ]
         if decode_modes:
-            if not all(value.is_decode_or_idle() for value in gathered_modes):
-                raise RuntimeError(
-                    f"SharedEP ranks disagree on decode phase: {gathered_modes}"
-                )
-            mode = decode_modes[0]
+            if all(value.is_decode_or_idle() for value in gathered_modes):
+                mode = decode_modes[0]
+            else:
+                force_shared_ep_fallback = True
         elif prefill_modes:
-            if not all(
+            if all(
                 value.is_extend_without_speculative() or value.is_idle()
                 for value in gathered_modes
             ):
-                raise RuntimeError(
-                    f"SharedEP ranks disagree on prefill phase: {gathered_modes}"
-                )
-            mode = prefill_modes[0]
+                mode = prefill_modes[0]
+            else:
+                force_shared_ep_fallback = True
         counts_synchronized = True
-    forward.set("shared_ep_is_decode", mode.is_decode())
-    forward.set("shared_ep_is_prefill", mode.is_extend_without_speculative())
+    forward.set(
+        "shared_ep_is_decode",
+        mode.is_decode() and not force_shared_ep_fallback,
+    )
+    forward.set(
+        "shared_ep_is_prefill",
+        mode.is_extend_without_speculative() and not force_shared_ep_fallback,
+    )
     forward.set(
         "shared_ep_global_num_tokens",
         global_num_tokens,

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -474,6 +474,13 @@ class ForwardFlags:
         # Sticky across forwards: every ForwardBatch construction writes it;
         # graph runners force False around capture.
         "is_extend_in_batch": False,
+        # SharedEP's graph-static route and generation-lane selector. The
+        # forward mode, not is_extend_in_batch, decides whether TARGET_VERIFY
+        # must use the materialized fallback. Speculative loops may advance the
+        # generation index explicitly; plain target decode stays on lane zero.
+        "shared_ep_is_decode": False,
+        "shared_ep_generation": 0,
+        "shared_ep_global_num_tokens": None,
         # Per-layer MLP collective control (set by decoder via scoped()
         # around the MLP / MoE / hybrid mixer call).
         # fuse_mlp_allreduce: next residual+LN absorbs the post-MLP all-reduce.
@@ -493,6 +500,9 @@ class ForwardFlags:
             "attn_input_scattered",
             "attn_inputs",
             "is_extend_in_batch",
+            "shared_ep_is_decode",
+            "shared_ep_generation",
+            "shared_ep_global_num_tokens",
             "fuse_mlp_allreduce",
             "mlp_reduce_scatter",
             "flashinfer_trtllm_bypass",
@@ -1079,6 +1089,29 @@ def get_resources() -> Resources:
 
 def get_forward() -> ForwardFlags:
     return _CONTEXT.forward
+
+
+def publish_shared_ep_forward_flags(forward_batch: Any) -> None:
+    """Publish the rank-consistent SharedEP route and graph-static lane."""
+
+    global_mode = getattr(forward_batch, "global_forward_mode", None)
+    local_mode = forward_batch.forward_mode
+    mode = global_mode or local_mode
+    forward = get_forward()
+    forward.set("shared_ep_is_decode", mode.is_decode())
+    forward.set(
+        "shared_ep_generation",
+        int(getattr(forward_batch, "shared_ep_generation", 0)),
+    )
+    global_num_tokens = getattr(forward_batch, "global_num_tokens_cpu", None)
+    forward.set(
+        "shared_ep_global_num_tokens",
+        (
+            tuple(int(value) for value in global_num_tokens)
+            if global_num_tokens is not None
+            else None
+        ),
+    )
 
 
 # --- Resolved config namespaces -------------------------

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -275,6 +275,7 @@ MOE_A2A_BACKEND_CHOICES = [
     "megamoe",
     "pplx",
     "ascend_tp",
+    "shared_ep",
 ]
 
 MXFP8_MOE_RUNNER_BACKEND_CHOICES = [
@@ -2256,9 +2257,15 @@ class ServerArgs:
             "flashinfer",
             "megamoe",
             "pplx",
+            "ascend_tp",
+            "shared_ep",
         ],
         Arg(
-            help="Choose the backend for MoE A2A.",
+            help=(
+                "Choose the backend for MoE A2A. shared_ep is a composite "
+                "backend that uses SharedEP for decode, DeepEP + DeepGEMM "
+                "for CUDA prefill, and MoRI + AITER for ROCm prefill."
+            ),
             choices=MOE_A2A_BACKEND_CHOICES,
             resolvable=True,
         ),
@@ -6573,10 +6580,13 @@ class ServerArgs:
             _a2a_backend_overrides,
             _a2a_ep_size,
             _a2a_fusion_adjustments,
+            _shared_ep_runner_resolution,
+            resolved_view,
             run_post_process_pass,
         )
 
         run_post_process_pass(self, _a2a_backend_overrides)
+        run_post_process_pass(self, _shared_ep_runner_resolution)
         run_post_process_pass(self, _a2a_ep_size)
 
         # The a2a-driven shared-experts fusion adjustments moved to the
@@ -8625,6 +8635,12 @@ class ServerArgs:
             )
 
         # Check two batch overlap backend requirement.
+        if self.moe_a2a_backend == "shared_ep":
+            from sglang.srt.layers.moe.shared_ep.admission import (
+                validate_shared_ep_server_args,
+            )
+
+            validate_shared_ep_server_args(self)
         self._check_two_batch_overlap()
 
         # Check communications compression

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2263,8 +2263,9 @@ class ServerArgs:
         Arg(
             help=(
                 "Choose the backend for MoE A2A. shared_ep is a composite "
-                "backend that uses SharedEP for decode, DeepEP + DeepGEMM "
-                "for CUDA prefill, and MoRI + AITER for ROCm prefill."
+                "backend that uses shared objects for decode and admitted "
+                "ROCm block-FP8 eager prefill, with DeepEP + DeepGEMM or "
+                "MoRI + AITER fallbacks for other phases."
             ),
             choices=MOE_A2A_BACKEND_CHOICES,
             resolvable=True,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -615,6 +615,11 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 out_cache_loc = out_cache_loc.contiguous()
             forward_batch.out_cache_loc = out_cache_loc[i]
             spec_info.hidden_states = hidden_states
+            # Keep any graph-static EP state selected by this draft generation
+            # disjoint from the other in-flight generations. SharedEP admission
+            # currently routes NEXTN draft MoE through MoRI, but propagating the
+            # selector here makes the lane contract explicit and graph-visible.
+            forward_batch.shared_ep_generation = i
 
             # Run forward under a per-step ForwardContext so the model layer
             # reads attn_backends[i] for the i-th draft step, plus a canary

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -522,6 +522,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
 
         forward_batch.input_ids = seed_input_ids
         forward_batch.spec_info.hidden_states = seed_prev_hidden
+        forward_batch.shared_ep_generation = 0
         self._set_positions(forward_batch)
 
         with (
@@ -565,6 +566,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
 
             forward_batch.input_ids = input_ids
             forward_batch.spec_info.hidden_states = hidden_states
+            forward_batch.shared_ep_generation = i + 1
             self._set_positions(forward_batch)
 
             with (

--- a/test/manual/ep/benchmark_shared_ep_glm52.py
+++ b/test/manual/ep/benchmark_shared_ep_glm52.py
@@ -34,6 +34,13 @@ def main() -> None:
         "SGLANG_SHARED_EP_BENCHMARK_OUTPUT",
         f"/tmp/glm52-{backend}-batch64.jsonl",
     )
+    num_prompts = os.environ.get("SGLANG_SHARED_EP_NUM_PROMPTS", "64")
+    input_len = os.environ.get("SGLANG_SHARED_EP_INPUT_LEN", "8192")
+    output_len = os.environ.get("SGLANG_SHARED_EP_OUTPUT_LEN", "1024")
+    concurrency = os.environ.get("SGLANG_SHARED_EP_CONCURRENCY", "64")
+    warmup_requests = os.environ.get("SGLANG_SHARED_EP_WARMUP_REQUESTS", "1")
+    profile_enabled = os.environ.get("SGLANG_SHARED_EP_PROFILE", "0") == "1"
+    profile_steps = os.environ.get("SGLANG_SHARED_EP_PROFILE_STEPS", "4")
     os.environ.setdefault("SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "1024")
     os.environ.setdefault("SGLANG_USE_AITER", "1")
 
@@ -130,17 +137,17 @@ def main() -> None:
             "--tokenizer",
             model,
             "--num-prompts",
-            "64",
+            num_prompts,
             "--random-input-len",
-            "8192",
+            input_len,
             "--random-output-len",
-            "1024",
+            output_len,
             "--random-range-ratio",
             "1.0",
             "--request-rate",
             "inf",
             "--max-concurrency",
-            "64",
+            concurrency,
             "--output-file",
             output_file,
             "--output-details",
@@ -151,10 +158,27 @@ def main() -> None:
             "20260730",
             "--flush-cache",
             "--warmup-requests",
-            "1",
+            warmup_requests,
             "--tokenize-prompt",
             "--cache-report",
         ]
+        if profile_enabled:
+            command.extend(
+                [
+                    "--profile",
+                    "--profile-by-stage",
+                    "--profile-num-steps",
+                    profile_steps,
+                    "--profile-stages",
+                    "prefill",
+                    "decode",
+                    "--profile-activities",
+                    "CPU",
+                    "GPU",
+                    "--profile-prefix",
+                    backend,
+                ]
+            )
         print(f"Running aligned GLM-5.2 benchmark: backend={backend}")
         print(" ".join(command))
         subprocess.run(command, check=True, timeout=7200)

--- a/test/manual/ep/benchmark_shared_ep_glm52.py
+++ b/test/manual/ep/benchmark_shared_ep_glm52.py
@@ -1,0 +1,167 @@
+"""Aligned GLM-5.2 batch-64 SharedEP serving benchmark.
+
+The workload mirrors SGLang PR #32482: DP8 + DP-Attention + EP8, 8K input,
+1K output, global batch 64, and a DP-adjusted 1K-token prefill chunk.
+ROCm uses MoRI+AITER as the materialized baseline and TileLang DSA kernels.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_server,
+)
+
+
+def main() -> None:
+    model = os.environ.get(
+        "SGLANG_SHARED_EP_GLM_MODEL",
+        "/models/models--zai-org--GLM-5.2-FP8",
+    )
+    backend = os.environ.get("SGLANG_SHARED_EP_MOE_A2A_BACKEND", "shared_ep")
+    if backend not in ("shared_ep", "mori"):
+        raise ValueError(f"unsupported ROCm benchmark backend: {backend}")
+    base_url = os.environ.get(
+        "SGLANG_SHARED_EP_BENCHMARK_URL",
+        "http://127.0.0.1:30000",
+    )
+    output_file = os.environ.get(
+        "SGLANG_SHARED_EP_BENCHMARK_OUTPUT",
+        f"/tmp/glm52-{backend}-batch64.jsonl",
+    )
+    os.environ.setdefault("SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "1024")
+    os.environ.setdefault("SGLANG_USE_AITER", "1")
+
+    server_args = [
+        "--tokenizer-path",
+        model,
+        "--trust-remote-code",
+        "--json-model-override-args",
+        '{"qk_rope_head_dim":64}',
+        "--kv-cache-dtype",
+        "bfloat16",
+        "--mem-fraction-static",
+        "0.85",
+        "--max-running-requests",
+        "256",
+        "--chunked-prefill-size",
+        "8192",
+        "--max-prefill-tokens",
+        "16384",
+        "--schedule-policy",
+        "fcfs",
+        "--schedule-conservativeness",
+        "0.3",
+        "--page-size",
+        "64",
+        "--swa-full-tokens-ratio",
+        "0.8",
+        "--tp-size",
+        "8",
+        "--dp-size",
+        "8",
+        "--enable-dp-attention",
+        "--ep-size",
+        "8",
+        "--moe-dense-tp-size",
+        "1",
+        "--enable-dp-lm-head",
+        "--moe-a2a-backend",
+        backend,
+        "--moe-runner-backend",
+        "aiter",
+        "--ep-dispatch-algorithm",
+        "fake",
+        "--attention-backend",
+        "dsa",
+        "--dsa-prefill-backend",
+        "tilelang",
+        "--dsa-decode-backend",
+        "tilelang",
+        "--cuda-graph-backend-prefill",
+        "disabled",
+        "--cuda-graph-max-bs-decode",
+        "32",
+        "--cuda-graph-bs-decode",
+        "1",
+        "2",
+        "4",
+        "8",
+        "12",
+        "16",
+        "20",
+        "24",
+        "28",
+        "32",
+        "--random-seed",
+        "20260730",
+        "--host",
+        "127.0.0.1",
+        "--skip-server-warmup",
+    ]
+    process = popen_launch_server(
+        model,
+        base_url,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 12,
+        other_args=server_args,
+        env=dict(os.environ),
+    )
+    try:
+        host, port = base_url.removeprefix("http://").rsplit(":", 1)
+        command = [
+            sys.executable,
+            "-m",
+            "sglang.bench_serving",
+            "--backend",
+            "sglang",
+            "--host",
+            host,
+            "--port",
+            port,
+            "--dataset-name",
+            "random-ids",
+            "--model",
+            model,
+            "--tokenizer",
+            model,
+            "--num-prompts",
+            "64",
+            "--random-input-len",
+            "8192",
+            "--random-output-len",
+            "1024",
+            "--random-range-ratio",
+            "1.0",
+            "--request-rate",
+            "inf",
+            "--max-concurrency",
+            "64",
+            "--output-file",
+            output_file,
+            "--output-details",
+            "--disable-tqdm",
+            "--temperature",
+            "0",
+            "--seed",
+            "20260730",
+            "--flush-cache",
+            "--warmup-requests",
+            "1",
+            "--tokenize-prompt",
+            "--cache-report",
+        ]
+        print(f"Running aligned GLM-5.2 benchmark: backend={backend}")
+        print(" ".join(command))
+        subprocess.run(command, check=True, timeout=7200)
+        print(f"Benchmark result: {output_file}")
+    finally:
+        kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/ep/test_shared_ep_dsv4_pro_smoke.py
+++ b/test/manual/ep/test_shared_ep_dsv4_pro_smoke.py
@@ -1,0 +1,168 @@
+"""Manual 8xMI355X DSV4-Pro SharedEP control/TBO/MTP smoke test."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_server,
+)
+
+
+def main() -> None:
+    model = os.environ.get(
+        "SGLANG_SHARED_EP_DSV4_MODEL",
+        "/models/DeepSeek-V4-Pro",
+    )
+    base_url = os.environ.get(
+        "SGLANG_SHARED_EP_SMOKE_URL",
+        "http://127.0.0.1:30000",
+    )
+    enable_tbo = os.environ.get("SGLANG_SHARED_EP_TBO", "0") == "1"
+    enable_graph = os.environ.get("SGLANG_SHARED_EP_GRAPH", "0") == "1"
+    mtp_steps = int(os.environ.get("SGLANG_SHARED_EP_MTP_STEPS", "0"))
+    rounds = int(os.environ.get("SGLANG_SHARED_EP_SMOKE_ROUNDS", "1"))
+    if rounds < 1:
+        raise ValueError("SGLANG_SHARED_EP_SMOKE_ROUNDS must be positive")
+    mem_fraction_static = "0.87" if mtp_steps else "0.85"
+    os.environ.setdefault("SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "64")
+    os.environ.setdefault("AITER_FLYDSL_FORCE", "1")
+    os.environ.setdefault("SGLANG_SHARED_EP_DIRECT_SMALL_BATCH", "1")
+    args = [
+        "--tp-size",
+        "8",
+        "--ep-size",
+        "8",
+        "--dp-size",
+        "8",
+        "--enable-dp-attention",
+        "--moe-dense-tp-size",
+        "1",
+        "--enable-dp-lm-head",
+        "--moe-a2a-backend",
+        "shared_ep",
+        "--moe-runner-backend",
+        "aiter",
+        "--ep-dispatch-algorithm",
+        "fake",
+        "--attention-backend",
+        "dsv4",
+        "--kv-cache-dtype",
+        "fp8_e4m3",
+        "--page-size",
+        "256",
+        "--swa-full-tokens-ratio",
+        "0.1",
+        "--disable-shared-experts-fusion",
+        "--disable-radix-cache",
+        "--max-running-requests",
+        "64",
+        "--chunked-prefill-size",
+        "4096",
+        "--context-length",
+        "4096",
+        "--max-total-tokens",
+        "8192",
+        "--mem-fraction-static",
+        mem_fraction_static,
+        "--watchdog-timeout",
+        "1800",
+        "--random-seed",
+        "42",
+        "--load-balance-method",
+        "round_robin",
+        "--skip-server-warmup",
+        "--trust-remote-code",
+    ]
+    if enable_graph:
+        args.extend(["--cuda-graph-max-bs-decode", "8"])
+    else:
+        args.append("--disable-cuda-graph")
+    if enable_tbo:
+        args.append("--enable-two-batch-overlap")
+    if mtp_steps:
+        args.extend(
+            [
+                "--speculative-algorithm",
+                "EAGLE",
+                "--speculative-eagle-topk",
+                "1",
+                "--speculative-num-steps",
+                str(mtp_steps),
+                "--speculative-num-draft-tokens",
+                str(mtp_steps + 1),
+                "--speculative-moe-a2a-backend",
+                "mori",
+                "--speculative-moe-runner-backend",
+                "aiter",
+            ]
+        )
+
+    process = popen_launch_server(
+        model,
+        base_url,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 10,
+        other_args=args,
+        env=dict(os.environ),
+    )
+    try:
+
+        def generate(index: int):
+            response = requests.post(
+                f"{base_url}/generate",
+                json={
+                    "text": f"Request {index}: The capital of France is",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 8,
+                    },
+                },
+                timeout=900,
+            )
+            response.raise_for_status()
+            result = response.json()
+            text = result.get("text")
+            if not isinstance(text, str) or not text:
+                raise RuntimeError(f"SharedEP smoke returned no text: {result}")
+            return text
+
+        request_count = 2 if enable_tbo else 1
+        started = time.perf_counter()
+        outputs = []
+        all_outputs = []
+        with ThreadPoolExecutor(max_workers=request_count) as executor:
+            for round_index in range(rounds):
+                offset = round_index * request_count
+                outputs = list(
+                    executor.map(
+                        generate,
+                        range(offset, offset + request_count),
+                    )
+                )
+                all_outputs.extend(outputs)
+        elapsed = time.perf_counter() - started
+        requests_completed = rounds * request_count
+        print(
+            "SharedEP DSV4-Pro smoke: "
+            f"mtp_steps={mtp_steps}, tbo={enable_tbo}, graph={enable_graph}, "
+            f"requests={requests_completed}, elapsed={elapsed:.3f}s, "
+            f"request_rate={requests_completed / elapsed:.3f}/s, "
+            f"last_outputs={outputs!r}"
+        )
+        output_path = os.environ.get("SGLANG_SHARED_EP_OUTPUT_PATH")
+        if output_path:
+            with open(output_path, "w", encoding="utf-8") as stream:
+                json.dump(all_outputs, stream)
+    finally:
+        kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/ep/test_shared_ep_dsv4_pro_smoke.py
+++ b/test/manual/ep/test_shared_ep_dsv4_pro_smoke.py
@@ -31,10 +31,12 @@ def main() -> None:
     rounds = int(os.environ.get("SGLANG_SHARED_EP_SMOKE_ROUNDS", "1"))
     if rounds < 1:
         raise ValueError("SGLANG_SHARED_EP_SMOKE_ROUNDS must be positive")
-    mem_fraction_static = "0.87" if mtp_steps else "0.85"
+    mem_fraction_static = os.environ.get(
+        "SGLANG_SHARED_EP_MEM_FRACTION_STATIC",
+        "0.87" if mtp_steps else "0.84",
+    )
     os.environ.setdefault("SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "64")
     os.environ.setdefault("AITER_FLYDSL_FORCE", "1")
-    os.environ.setdefault("SGLANG_SHARED_EP_DIRECT_SMALL_BATCH", "1")
     args = [
         "--tp-size",
         "8",

--- a/test/manual/ep/test_shared_ep_glm52_smoke.py
+++ b/test/manual/ep/test_shared_ep_glm52_smoke.py
@@ -1,0 +1,115 @@
+"""Manual 8xMI355X GLM-5.2 block-FP8 pull-cache prefill smoke test."""
+
+from __future__ import annotations
+
+import os
+import time
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_server,
+)
+
+
+def main() -> None:
+    model = os.environ.get(
+        "SGLANG_SHARED_EP_GLM_MODEL",
+        "/models/GLM-5.2-FP8",
+    )
+    base_url = os.environ.get(
+        "SGLANG_SHARED_EP_SMOKE_URL",
+        "http://127.0.0.1:30000",
+    )
+    rounds = int(os.environ.get("SGLANG_SHARED_EP_SMOKE_ROUNDS", "1"))
+    if rounds < 1:
+        raise ValueError("SGLANG_SHARED_EP_SMOKE_ROUNDS must be positive")
+    moe_a2a_backend = os.environ.get(
+        "SGLANG_SHARED_EP_MOE_A2A_BACKEND",
+        "shared_ep",
+    )
+    os.environ.setdefault("SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK", "1024")
+    args = [
+        "--tp-size",
+        "8",
+        "--ep-size",
+        "8",
+        "--dp-size",
+        "8",
+        "--enable-dp-attention",
+        "--moe-dense-tp-size",
+        "1",
+        "--enable-dp-lm-head",
+        "--moe-a2a-backend",
+        moe_a2a_backend,
+        "--moe-runner-backend",
+        "aiter",
+        "--ep-dispatch-algorithm",
+        "fake",
+        "--kv-cache-dtype",
+        "fp8_e4m3",
+        "--disable-radix-cache",
+        "--max-running-requests",
+        "64",
+        "--chunked-prefill-size",
+        "8192",
+        "--max-prefill-tokens",
+        "16384",
+        "--context-length",
+        "4096",
+        "--max-total-tokens",
+        "8192",
+        "--mem-fraction-static",
+        os.environ.get("SGLANG_SHARED_EP_MEM_FRACTION_STATIC", "0.84"),
+        "--watchdog-timeout",
+        "1800",
+        "--random-seed",
+        "42",
+        "--skip-server-warmup",
+        "--trust-remote-code",
+        "--disable-cuda-graph",
+    ]
+
+    process = popen_launch_server(
+        model,
+        base_url,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH * 10,
+        other_args=args,
+        env=dict(os.environ),
+    )
+    try:
+        started = time.perf_counter()
+        outputs = []
+        for index in range(rounds):
+            response = requests.post(
+                f"{base_url}/generate",
+                json={
+                    "text": f"Request {index}: The capital of France is",
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 8,
+                    },
+                },
+                timeout=900,
+            )
+            response.raise_for_status()
+            result = response.json()
+            text = result.get("text")
+            if not isinstance(text, str) or not text:
+                raise RuntimeError(f"SharedEP GLM smoke returned no text: {result}")
+            outputs.append(text)
+        elapsed = time.perf_counter() - started
+        print(
+            "SharedEP GLM-5.2 smoke: "
+            f"backend={moe_a2a_backend}, "
+            f"requests={rounds}, elapsed={elapsed:.3f}s, "
+            f"request_rate={rounds / elapsed:.3f}/s, outputs={outputs!r}"
+        )
+    finally:
+        kill_process_tree(process.pid)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/ep/test_shared_ep_vmm_rocm.py
+++ b/test/manual/ep/test_shared_ep_vmm_rocm.py
@@ -1,0 +1,222 @@
+"""Manual eight-process ROCm SharedEP VMM feasibility probe.
+
+Run on one 8-GPU ROCm 7.2 node:
+
+    torchrun --standalone --nproc-per-node=8 \
+      test/manual/ep/test_shared_ep_vmm_rocm.py
+
+This exercises only the VMM runtime; no SGLang server or model is started.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib
+import os
+import sys
+import types
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.distributed.device_communicators import vmm_utils
+
+# Avoid importing SharedEP's compute backend: this probe intentionally exercises
+# only the memory runtime.
+_SHARED_EP_PACKAGE = "sglang.srt.layers.moe.shared_ep"
+if _SHARED_EP_PACKAGE not in sys.modules:
+    package = types.ModuleType(_SHARED_EP_PACKAGE)
+    srt_root = Path(vmm_utils.__file__).resolve().parents[2]
+    package.__path__ = [str(srt_root / "layers" / "moe" / "shared_ep")]
+    sys.modules[_SHARED_EP_PACKAGE] = package
+_vmm = importlib.import_module(f"{_SHARED_EP_PACKAGE}.vmm")
+allocate_rank_major_vmm = _vmm.allocate_rank_major_vmm
+
+
+def _publish_stage_error(stage: str, local_error: BaseException | None) -> None:
+    world_size = dist.get_world_size()
+    errors: list[str | None] = [None] * world_size
+    text = (
+        None if local_error is None else f"{type(local_error).__name__}: {local_error}"
+    )
+    dist.all_gather_object(errors, text)
+    failures = [
+        f"rank {failed_rank}: {error}"
+        for failed_rank, error in enumerate(errors)
+        if error is not None
+    ]
+    if failures:
+        raise RuntimeError(f"{stage} failed; " + "; ".join(failures))
+
+
+def _open_fd_count() -> int:
+    return len(os.listdir("/proc/self/fd"))
+
+
+def _exercise_mapping(logical_bytes: int) -> None:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device("cuda", local_rank)
+
+    capability = vmm_utils.query_vmm_capability(device)
+    capability_error = (
+        None
+        if capability.supported and capability.platform == "rocm"
+        else RuntimeError(f"unexpected SharedEP VMM capability result: {capability}")
+    )
+    _publish_stage_error("ROCm VMM capability probe", capability_error)
+
+    # Warm DLPack and teardown before measuring descriptor cleanup.
+    warmup_error = None
+    try:
+        warmup = allocate_rank_major_vmm(
+            cpu_group=dist.group.WORLD,
+            device=device,
+            logical_rank_bytes=world_size,
+        )
+        warmup.close()
+        del warmup
+        gc.collect()
+        torch.cuda.synchronize()
+    except BaseException as error:
+        warmup_error = error
+    _publish_stage_error("VMM warmup and teardown", warmup_error)
+    dist.barrier()
+    baseline_fds = _open_fd_count()
+
+    allocation = None
+    allocation_error = None
+    try:
+        allocation = allocate_rank_major_vmm(
+            cpu_group=dist.group.WORLD,
+            device=device,
+            logical_rank_bytes=logical_bytes,
+        )
+    except BaseException as error:
+        allocation_error = error
+    _publish_stage_error("rank-major allocation", allocation_error)
+    assert allocation is not None
+
+    publish_error = None
+    try:
+        # Every owner first publishes a distinct local pattern.
+        allocation.local_storage.fill_(rank + 1)
+        torch.cuda.synchronize()
+    except BaseException as error:
+        publish_error = error
+    _publish_stage_error("local pattern publication", publish_error)
+    dist.barrier()
+
+    read_error = None
+    try:
+        for owner in range(world_size):
+            segment = allocation.global_storage.narrow(
+                0,
+                allocation.rank_offset(owner),
+                logical_bytes,
+            )
+            if not torch.all(segment == owner + 1).item():
+                raise AssertionError(
+                    f"rank {rank} read the wrong initial pattern from owner {owner}"
+                )
+        del segment
+    except BaseException as error:
+        read_error = error
+    _publish_stage_error("all-rank initial reads", read_error)
+
+    write_error = None
+    try:
+        # Each writer updates a disjoint byte in every owner's physical segment.
+        remote_offsets = torch.tensor(
+            [allocation.rank_offset(owner) + rank for owner in range(world_size)],
+            dtype=torch.int64,
+            device=device,
+        )
+        allocation.global_storage[remote_offsets] = 128 + rank
+        torch.cuda.synchronize()
+    except BaseException as error:
+        write_error = error
+    _publish_stage_error("all-rank remote writes", write_error)
+    dist.barrier()
+
+    verify_error = None
+    try:
+        expected = torch.arange(
+            128,
+            128 + world_size,
+            dtype=torch.uint8,
+            device=device,
+        )
+        if not torch.equal(allocation.local_storage[:world_size], expected):
+            raise AssertionError(
+                f"owner rank {rank} did not observe every remote writer"
+            )
+        for owner in range(world_size):
+            observed = allocation.global_storage.narrow(
+                0,
+                allocation.rank_offset(owner),
+                world_size,
+            )
+            if not torch.equal(observed, expected):
+                raise AssertionError(
+                    f"rank {rank} read the wrong remote-write vector "
+                    f"from owner {owner}"
+                )
+        del observed, expected, remote_offsets
+        torch.cuda.synchronize()
+    except BaseException as error:
+        verify_error = error
+    _publish_stage_error("remote-write visibility validation", verify_error)
+
+    cleanup_error = None
+    try:
+        assert allocation is not None
+        allocation.close()
+        allocation.close()
+        if allocation._base_va != 0:
+            raise AssertionError("allocation retained its virtual address after close")
+        if allocation.local_storage.numel() or allocation.global_storage.numel():
+            raise AssertionError("allocation retained tensor views after close")
+        del allocation
+        gc.collect()
+        torch.cuda.synchronize()
+    except BaseException as error:
+        cleanup_error = error
+    dist.barrier()
+    final_fds = _open_fd_count()
+    if cleanup_error is None and final_fds != baseline_fds:
+        cleanup_error = RuntimeError(
+            f"POSIX descriptor count changed across allocation cleanup: "
+            f"{baseline_fds} -> {final_fds}"
+        )
+    _publish_stage_error("VMM cleanup", cleanup_error)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--logical-bytes", type=int, default=64 * 1024)
+    args = parser.parse_args()
+    if args.logical_bytes < 8:
+        raise ValueError("--logical-bytes must be at least 8")
+    if torch.version.hip is None:
+        raise RuntimeError("this probe requires a ROCm PyTorch build")
+    if int(os.environ.get("WORLD_SIZE", "1")) != 8:
+        raise RuntimeError("launch this probe with torchrun --nproc-per-node=8")
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("gloo")
+    try:
+        _exercise_mapping(args.logical_bytes)
+        if dist.get_rank() == 0:
+            print("ROCm SharedEP VMM EP8 feasibility probe passed")
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/moe/test_dsv4_silu_and_mul_valid_rows.py
+++ b/test/registered/moe/test_dsv4_silu_and_mul_valid_rows.py
@@ -1,0 +1,92 @@
+import unittest
+from pathlib import Path
+
+import torch
+
+import sglang.kernels.ops.attention.dsv4.moe as dsv4_moe_module
+from sglang.kernels.ops.attention.dsv4 import silu_and_mul_contig_post_quant
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestDsv4SiluAndMulPlatformSource(unittest.TestCase):
+    def test_rocm_path_uses_wave64_and_ocp_fp8_helpers(self):
+        package_root = next(
+            parent
+            for parent in Path(dsv4_moe_module.__file__).resolve().parents
+            if parent.name == "sglang"
+        )
+        source = (
+            package_root
+            / "kernels"
+            / "jit"
+            / "csrc"
+            / "deepseek_v4"
+            / "silu_and_mul_masked_post_quant.cuh"
+        ).read_text()
+        self.assertIn("#ifndef USE_ROCM\n#include <cuda_fp8.h>", source)
+        self.assertIn("constexpr uint32_t kScanThreads = 64", source)
+        self.assertIn("__shfl_up(val, offset, kScanThreads)", source)
+        self.assertIn("device.set_options<kDLGPU>()", source)
+        self.assertIn("fp8_e4m3_tensor_t", source)
+        self.assertIn("math::FP8_E4M3_MAX", source)
+        self.assertIn("pack_fp8(scaled_val0, scaled_val1)", source)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA JIT")
+class TestDsv4SiluAndMulValidRows(unittest.TestCase):
+    def test_device_valid_rows_skip_unused_capacity(self):
+        rows = 32
+        valid = 7
+        intermediate = 256
+        gate_up = torch.randn(
+            (rows, intermediate * 2),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        reference = torch.empty(
+            (rows, intermediate),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        reference_scale = torch.empty(
+            (rows, intermediate // 128),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        silu_and_mul_contig_post_quant(
+            input=gate_up,
+            output=reference,
+            output_scale=reference_scale,
+            quant_group_size=128,
+        )
+
+        output = torch.zeros_like(reference)
+        output_scale = torch.zeros_like(reference_scale)
+        valid_rows = torch.tensor([valid], dtype=torch.int32, device="cuda")
+        silu_and_mul_contig_post_quant(
+            input=gate_up,
+            output=output,
+            output_scale=output_scale,
+            quant_group_size=128,
+            valid_rows=valid_rows,
+        )
+        torch.testing.assert_close(
+            output[:valid].view(torch.uint8),
+            reference[:valid].view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            output_scale[:valid],
+            reference_scale[:valid],
+            rtol=0,
+            atol=0,
+        )
+        self.assertTrue(torch.all(output[valid:].view(torch.uint8) == 0))
+        self.assertTrue(torch.all(output_scale[valid:] == 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_prequantized_fused_moe.py
+++ b/test/registered/moe/test_prequantized_fused_moe.py
@@ -1,0 +1,290 @@
+import unittest
+from pathlib import Path
+
+import torch
+import triton.language as tl
+
+import sglang.kernels.ops.moe.fused_moe_triton_kernels as fused_moe_module
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    per_token_group_quant_fp8,
+)
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestSortedAContract(unittest.TestCase):
+    def test_sorted_a_is_independent_of_tma(self):
+        source = Path(fused_moe_module.__file__).read_text()
+        self.assertIn("a_sorted: tl.constexpr", source)
+        self.assertIn("offs_a = offs_token_id", source)
+        self.assertIn("offs_a = offs_token // top_k", source)
+        self.assertIn("a_ptrs = a_ptr + offs_a[:, None] * stride_am", source)
+        self.assertIn("a_scale_ptrs = a_scale_ptr + offs_a * stride_asm", source)
+        self.assertIn("c_ptr + stride_cm * offs_token[:, None]", source)
+        self.assertIn("TMA tensor descriptors are unavailable on ROCm", source)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class TestPrequantizedFusedMoe(unittest.TestCase):
+    def test_sorted_a_non_tma_matches_indexed_a(self):
+        """ROCm W2 must consume route-sorted rows without a TMA descriptor."""
+        torch.manual_seed(11)
+        m, n, k, experts = 8, 128, 128, 2
+        config = {
+            "BLOCK_SIZE_M": 16,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 1,
+            "num_warps": 4,
+            "num_stages": 2,
+        }
+        block_shape = [128, 128]
+        a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16) * 0.1
+        a_fp8, a_scale = per_token_group_quant_fp8(a, block_shape[1])
+        b = (torch.randn((experts, n, k), device="cuda") * 0.1).to(torch.float8_e4m3fn)
+        b_scale = torch.ones((experts, 1, 1), device="cuda", dtype=torch.float32)
+        topk_ids = (torch.arange(m, device="cuda", dtype=torch.int64) + 1) % experts
+        topk_ids = topk_ids[:, None]
+        topk_weights = torch.ones((m, 1), device="cuda", dtype=torch.float32)
+        sorted_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            topk_ids,
+            config["BLOCK_SIZE_M"],
+            experts,
+        )
+        padded = int(num_tokens_post_padded.item())
+        sorted_a = torch.zeros(
+            (padded, k),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        sorted_scale = torch.zeros((padded, 1), dtype=torch.float32, device="cuda")
+        valid_positions = torch.nonzero(sorted_ids[:padded] < m).flatten()
+        source_rows = sorted_ids[valid_positions].long()
+        sorted_a[valid_positions] = a_fp8[source_rows]
+        sorted_scale[valid_positions] = a_scale[source_rows]
+
+        expected = torch.empty((m, n), dtype=torch.bfloat16, device="cuda")
+        actual = torch.empty_like(expected)
+        common = dict(
+            B=b,
+            bias=None,
+            B_scale=b_scale,
+            B_zp=None,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=1,
+            config=config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=block_shape,
+            filter_expert=False,
+            a_is_prequantized=True,
+        )
+        invoke_fused_moe_kernel(
+            A=a_fp8,
+            A_scale=a_scale,
+            C=expected,
+            **common,
+        )
+        invoke_fused_moe_kernel(
+            A=sorted_a,
+            A_scale=sorted_scale,
+            C=actual,
+            a_sorted=True,
+            **common,
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_prequantized_a_matches_internal_quantization(self):
+        """Shared FP8 rows must preserve the default quantize-and-run result."""
+        torch.manual_seed(7)
+        m, n, k, experts, topk = 16, 128, 128, 1, 1
+        block_shape = [128, 128]
+        config = {
+            "BLOCK_SIZE_M": 16,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 8,
+            "num_warps": 4,
+            "num_stages": 3,
+        }
+
+        a = torch.randn((m, k), device="cuda", dtype=torch.bfloat16) * 0.1
+        b = (torch.randn((experts, n, k), device="cuda") * 0.1).to(torch.float8_e4m3fn)
+        b_scale = torch.ones((experts, 1, 1), device="cuda", dtype=torch.float32)
+        topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int64)
+        topk_weights = torch.ones((m, topk), device="cuda", dtype=torch.float32)
+        sorted_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            topk_ids, config["BLOCK_SIZE_M"], experts
+        )
+        expected = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        actual = torch.empty_like(expected)
+
+        common = dict(
+            B=b,
+            bias=None,
+            A_scale=None,
+            B_scale=b_scale,
+            B_zp=None,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=topk,
+            config=config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=block_shape,
+            filter_expert=False,
+        )
+        invoke_fused_moe_kernel(A=a, C=expected, **common)
+
+        a_fp8, a_scale = per_token_group_quant_fp8(a, block_shape[1])
+        invoke_fused_moe_kernel(
+            A=a_fp8,
+            C=actual,
+            **{**common, "A_scale": a_scale},
+            a_is_prequantized=True,
+        )
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_glm52_and_dsv4_w13_shapes_accept_row_strided_shared_input(self):
+        """One Triton entry must handle both model shapes and shared row strides."""
+        for model_name, hidden_size in (
+            ("glm52", 6144),
+            ("dsv4_flash", 4096),
+        ):
+            with self.subTest(model=model_name):
+                self._assert_row_strided_w13_matches_contiguous(hidden_size)
+
+    def _assert_row_strided_w13_matches_contiguous(self, hidden_size: int):
+        torch.manual_seed(hidden_size)
+        m, n, experts, topk = 16, 4096, 1, 1
+        block_shape = [128, 128]
+        config = {
+            "BLOCK_SIZE_M": 16,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 1,
+            "num_warps": 8,
+            "num_stages": 3,
+        }
+        a = torch.randn(
+            (m, hidden_size),
+            device="cuda",
+            dtype=torch.bfloat16,
+        ).mul_(0.1)
+        b = (
+            torch.randn(
+                (experts, n, hidden_size),
+                device="cuda",
+            )
+            .mul_(0.1)
+            .to(torch.float8_e4m3fn)
+        )
+        b_scale = torch.ones(
+            (
+                experts,
+                n // block_shape[0],
+                hidden_size // block_shape[1],
+            ),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        topk_ids = torch.zeros((m, topk), device="cuda", dtype=torch.int64)
+        topk_weights = torch.ones(
+            (m, topk),
+            device="cuda",
+            dtype=torch.float32,
+        )
+        sorted_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            topk_ids,
+            config["BLOCK_SIZE_M"],
+            experts,
+        )
+        expected = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+        actual = torch.empty_like(expected)
+        common = dict(
+            B=b,
+            bias=None,
+            B_scale=b_scale,
+            B_zp=None,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            mul_routed_weight=False,
+            top_k=topk,
+            config=config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=block_shape,
+            filter_expert=False,
+        )
+        invoke_fused_moe_kernel(
+            A=a,
+            A_scale=None,
+            C=expected,
+            **common,
+        )
+
+        a_fp8, a_scale = per_token_group_quant_fp8(a, block_shape[1])
+        shared_rows = torch.empty(
+            (m, 64 * 1024),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        shared_scales = torch.empty(
+            (m, 64 * 1024 // torch.float32.itemsize),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        shared_a = shared_rows[:, :hidden_size]
+        shared_a_scale = shared_scales[:, : hidden_size // block_shape[1]]
+        shared_a.copy_(a_fp8)
+        shared_a_scale.copy_(a_scale)
+        self.assertEqual(shared_a.stride(), (64 * 1024, 1))
+        self.assertEqual(
+            shared_a_scale.stride(),
+            (64 * 1024 // torch.float32.itemsize, 1),
+        )
+
+        invoke_fused_moe_kernel(
+            A=shared_a,
+            A_scale=shared_a_scale,
+            C=actual,
+            **common,
+            a_is_prequantized=True,
+        )
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_backend.py
+++ b/test/registered/moe/test_shared_ep_backend.py
@@ -28,14 +28,17 @@ from sglang.srt.layers.moe.moe_runner.shared_ep import (
 )
 from sglang.srt.layers.moe.shared_ep.backend import (
     SharedEpDispatcher,
+    SharedEpDispatchOutput,
     SharedEpLaneDispatcher,
     _create_shared_ep_prefill_dispatcher,
     _get_device_profile_capability,
+    _resolve_pull_prefill_profile,
     _synchronize_admission_stage,
     _validate_decode_capacity,
     compact_intermediate_capacity,
     create_shared_ep_dispatcher,
     decode_intermediate_capacity,
+    run_shared_ep,
 )
 from sglang.srt.layers.moe.shared_ep.kernels import (
     quantize_pack_input,
@@ -45,7 +48,10 @@ from sglang.srt.layers.moe.shared_ep.layout import (
     SharedEpLayout,
     align_output_layout,
 )
-from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    make_pull_cache_prefill_profile,
+    select_profile,
+)
 from sglang.srt.layers.moe.shared_ep.runtime import (
     SharedEpRuntimeCapability,
     SharedEpRuntimeHooks,
@@ -60,10 +66,12 @@ from sglang.srt.layers.moe.utils import (
     is_deepep_class_backend,
 )
 from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
+from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.server_args import MOE_A2A_BACKEND_CHOICES
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=20, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _config() -> MoeRunnerConfig:
@@ -169,7 +177,7 @@ else:
         inners = [Mock(), Mock()]
         for lane_id, inner in enumerate(inners):
             inner.lane_id = lane_id
-        admission = (object(), object(), object())
+        admission = (object(), None, object(), object())
         parallel = object()
         with (
             patch(
@@ -390,6 +398,84 @@ else:
     ):
         _validate_decode_capacity(SimpleNamespace(ep_size=8, max_tokens_per_rank=4))
 
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=None,
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_global_num_tokens=None),
+    )
+    def test_decode_capacity_fails_closed_without_global_counts(
+        self,
+        _get_forward,
+        _get_dp_tokens,
+    ):
+        with self.assertRaisesRegex(RuntimeError, "complete DP token-count vector"):
+            _validate_decode_capacity(
+                SimpleNamespace(ep_size=8, max_tokens_per_rank=32)
+            )
+
+    def test_pull_prefill_profile_requires_single_lane_eager_rocm(self):
+        decode = select_profile(
+            _config(),
+            capability=(9, 5),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+            platform="rocm",
+        )
+        eager_args = SimpleNamespace(
+            cuda_graph_config=SimpleNamespace(
+                prefill=SimpleNamespace(backend=Backend.DISABLED)
+            )
+        )
+        with (
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_server_args",
+                return_value=eager_args,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_schedule",
+                return_value=SimpleNamespace(chunked_prefill_size=1024),
+            ),
+        ):
+            prefill = _resolve_pull_prefill_profile(
+                decode,
+                SharedEpLaneProtocol(1, 1),
+            )
+            self.assertIsNotNone(prefill)
+            self.assertEqual(prefill.max_tokens_per_rank, 1024)
+            self.assertEqual(prefill.block_size_m, 64)
+            self.assertIsNone(
+                _resolve_pull_prefill_profile(
+                    decode,
+                    SharedEpLaneProtocol(2, 1),
+                )
+            )
+
+        graph_args = SimpleNamespace(
+            cuda_graph_config=SimpleNamespace(
+                prefill=SimpleNamespace(backend=Backend.FULL)
+            )
+        )
+        with (
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_server_args",
+                return_value=graph_args,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_schedule",
+                return_value=SimpleNamespace(chunked_prefill_size=1024),
+            ),
+        ):
+            self.assertIsNone(
+                _resolve_pull_prefill_profile(
+                    decode,
+                    SharedEpLaneProtocol(1, 1),
+                )
+            )
+
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
     def test_quantize_pack_input_matches_reference_layout(self):
         for hidden_size, top_k in ((4096, 6), (6144, 8)):
@@ -588,7 +674,7 @@ else:
             create_state=Mock(),
             capabilities=frozenset(SharedEpRuntimeCapability),
         )
-        admit_framework.return_value = (profile, runtime, "cpu_group")
+        admit_framework.return_value = (profile, None, runtime, "cpu_group")
         get_shared_state.return_value = state
 
         dispatcher = SharedEpDispatcher(_config())
@@ -655,6 +741,7 @@ else:
         )
         state = SimpleNamespace(
             local_input=object(),
+            local_output=torch.ones((16, 1, 4)),
             global_input=SimpleNamespace(
                 activations=object(),
                 scales=object(),
@@ -710,6 +797,7 @@ else:
         )
         state = SimpleNamespace(
             local_input=object(),
+            local_output=torch.ones((16, 1, 4)),
             global_input=SimpleNamespace(
                 activations=object(),
                 scales=object(),
@@ -745,6 +833,83 @@ else:
         )
         state.input_epoch.publish.assert_called_once_with()
         state.input_epoch.wait_all.assert_not_called()
+        self.assertTrue(torch.all(state.local_output == 0))
+        fallback.dispatch.assert_not_called()
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(
+            shared_ep_is_decode=False,
+            shared_ep_is_prefill=True,
+        ),
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=[16] * 8,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.kernels.quantize_pack_input")
+    def test_admitted_prefill_publishes_pull_cache_object(
+        self,
+        quantize_pack,
+        _global_num_tokens,
+        _get_forward,
+    ):
+        fallback = Mock()
+        decode_profile = SimpleNamespace(
+            max_tokens_per_rank=32,
+            ep_size=8,
+            block_shape=(128, 128),
+            quantization=SharedEpQuantization.BLOCK_FP8,
+        )
+        prefill_profile = SimpleNamespace(
+            max_tokens_per_rank=1024,
+            ep_size=8,
+            block_shape=(128, 128),
+            quantization=SharedEpQuantization.BLOCK_FP8,
+        )
+        prefill_state = SimpleNamespace(
+            local_input=object(),
+            local_output=torch.ones((16, 1, 4)),
+            global_input=SimpleNamespace(
+                activations=object(),
+                scales=object(),
+            ),
+            input_epoch=Mock(),
+        )
+        pull_cache = object()
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.profile = decode_profile
+        dispatcher.prefill_profile = prefill_profile
+        dispatcher.prefill_state = prefill_state
+        dispatcher.prefill_cache = pull_cache
+        dispatcher.lane_id = 0
+        dispatcher._stage = "initial"
+        dispatcher._active_uses_shared_ep = None
+        dispatcher.local_expert_start = 0
+        dispatcher.fallback_dispatcher = fallback
+        dispatcher._decode_quant_admitted = True
+        hidden_states = torch.zeros((16, 4))
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((16, 1)),
+            topk_ids=torch.zeros((16, 1), dtype=torch.int32),
+            router_logits=None,
+        )
+
+        output = dispatcher.dispatch(hidden_states, topk_output)
+
+        self.assertEqual(output.phase, "prefill")
+        self.assertIs(output.profile, prefill_profile)
+        self.assertIs(output.state, prefill_state)
+        self.assertIs(output.pull_cache, pull_cache)
+        quantize_pack.assert_called_once_with(
+            prefill_state.local_input,
+            source=hidden_states,
+            source_ids=topk_output.topk_ids,
+            source_weights=topk_output.topk_weights,
+            group_size=128,
+        )
+        self.assertTrue(torch.all(prefill_state.local_output == 0))
+        prefill_state.input_epoch.publish.assert_called_once_with()
         fallback.dispatch.assert_not_called()
 
     def test_decode_combine_uses_the_admitted_lane_stage(self):
@@ -833,6 +998,95 @@ else:
             config,
             {},
         )
+
+    @patch("sglang.srt.layers.moe.shared_ep.backend._validate_decode_weights")
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.intermediate_capacity",
+        return_value=64,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.kernels.prepare_routes")
+    @patch("sglang.kernels.ops.attention.dsv4.silu_and_mul_contig_post_quant")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.pull_cache_rows")
+    @patch("sglang.srt.layers.moe.shared_ep.backend.invoke_pull_cache_w13")
+    @patch("sglang.kernels.ops.moe.fused_moe_triton_kernels.invoke_fused_moe_kernel")
+    def test_fused_prefill_pulls_w13_and_direct_returns_w2(
+        self,
+        fused_moe,
+        pull_w13,
+        pull_rows,
+        _silu_and_mul,
+        prepare_routes,
+        _capacity,
+        _validate_weights,
+    ):
+        decode_profile = select_profile(
+            _config(),
+            platform="rocm",
+            capability=(9, 5),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        profile = make_pull_cache_prefill_profile(decode_profile, 1024)
+        self.assertIsNotNone(profile)
+        routes = SimpleNamespace(
+            local_ids=torch.zeros((8, 1, profile.top_k), dtype=torch.int32),
+            local_weights=torch.ones((8, 1, profile.top_k), dtype=torch.float32),
+            sorted_token_ids=torch.zeros(64, dtype=torch.int32),
+            expert_ids=torch.zeros(1, dtype=torch.int32),
+            num_tokens_post_padded=torch.ones(1, dtype=torch.int32),
+        )
+        prepare_routes.return_value = routes
+        input_epoch = Mock()
+        input_epoch.allocation.local_storage = torch.zeros(1, dtype=torch.uint8)
+        input_epoch.epoch = torch.ones(1, dtype=torch.int32)
+        state = SimpleNamespace(
+            global_input=SimpleNamespace(
+                topk_ids=torch.zeros((8, 1, profile.top_k), dtype=torch.int32),
+                topk_weights=torch.ones((8, 1, profile.top_k), dtype=torch.float32),
+            ),
+            input_epoch=input_epoch,
+            global_output=torch.empty((64, profile.hidden_size), dtype=torch.bfloat16),
+            local_output=torch.zeros(
+                (1, profile.top_k, profile.hidden_size), dtype=torch.bfloat16
+            ),
+            output_epoch=Mock(),
+        )
+        pull_cache = SimpleNamespace(active_rows=64)
+        dispatch_output = SharedEpDispatchOutput(
+            hidden_states=torch.empty(
+                (8, profile.hidden_size), dtype=torch.float8_e4m3fn
+            ),
+            hidden_states_scale=torch.ones(
+                (8, profile.hidden_size // 128), dtype=torch.float32
+            ),
+            topk_output=object(),
+            state=state,
+            profile=profile,
+            num_tokens=1,
+            local_expert_start=0,
+            phase="prefill",
+            pull_cache=pull_cache,
+        )
+        quant_info = SimpleNamespace(
+            w13_weight=torch.empty((1, 1, 1), dtype=torch.float8_e4m3fn),
+            w13_scale=torch.ones((1, 1, 1), dtype=torch.float32),
+            w2_weight=torch.empty((1, 1, 1), dtype=torch.float8_e4m3fn),
+            w2_scale=torch.ones((1, 1, 1), dtype=torch.float32),
+        )
+
+        output = run_shared_ep(
+            dispatch_output,
+            quant_info,
+            SimpleNamespace(swiglu_limit=None),
+        )
+
+        self.assertEqual(output.hidden_states.shape, (1, profile.hidden_size))
+        pull_rows.assert_called_once()
+        pull_w13.assert_called_once()
+        fused_moe.assert_called_once()
+        state.output_epoch.publish.assert_called_once_with()
+        state.output_epoch.wait_all.assert_called_once_with()
 
     def test_quant_metadata_rejects_aiter_shuffled_decode_weights(self):
         w13 = torch.empty((1, 2, 3))

--- a/test/registered/moe/test_shared_ep_backend.py
+++ b/test/registered/moe/test_shared_ep_backend.py
@@ -1,0 +1,962 @@
+import subprocess
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+import torch
+
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    per_token_group_quant_fp8,
+)
+from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE, get_moe_impl_class
+from sglang.srt.layers.moe.fused_moe_triton.layer import (
+    _get_deepep_comm_group,
+    create_moe_dispatcher,
+)
+from sglang.srt.layers.moe.moe_runner.base import (
+    FusedOpPool,
+    MoeRunnerConfig,
+    PermuteMethodPool,
+)
+from sglang.srt.layers.moe.moe_runner.runner import MoeRunner
+from sglang.srt.layers.moe.moe_runner.shared_ep import (
+    SharedEpQuantCapability,
+    SharedEpQuantInfo,
+    SharedEpQuantization,
+    SharedEpWeightLayout,
+)
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatcher,
+    SharedEpLaneDispatcher,
+    _create_shared_ep_prefill_dispatcher,
+    _get_device_profile_capability,
+    _synchronize_admission_stage,
+    _validate_decode_capacity,
+    compact_intermediate_capacity,
+    create_shared_ep_dispatcher,
+    decode_intermediate_capacity,
+)
+from sglang.srt.layers.moe.shared_ep.kernels import (
+    quantize_pack_input,
+)
+from sglang.srt.layers.moe.shared_ep.lanes import SharedEpLaneProtocol
+from sglang.srt.layers.moe.shared_ep.layout import (
+    SharedEpLayout,
+    align_output_layout,
+)
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.srt.layers.moe.shared_ep.runtime import (
+    SharedEpRuntimeCapability,
+    SharedEpRuntimeHooks,
+)
+from sglang.srt.layers.moe.token_dispatcher.base import CombineInputFormat
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.moe.utils import (
+    DeepEPMode,
+    MoeA2ABackend,
+    MoeRunnerBackend,
+    is_deepep_class_backend,
+)
+from sglang.srt.layers.quantization.fp8 import Fp8MoEMethod
+from sglang.srt.server_args import MOE_A2A_BACKEND_CHOICES
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+
+
+def _config() -> MoeRunnerConfig:
+    return MoeRunnerConfig(
+        hidden_size=4096,
+        intermediate_size_per_partition=2048,
+        top_k=6,
+        num_experts=256,
+        num_local_experts=32,
+        params_dtype=torch.bfloat16,
+    )
+
+
+def _deepep_kwargs(mode) -> dict:
+    return dict(
+        group="ep_group",
+        router_topk=6,
+        permute_fusion=True,
+        num_experts=256,
+        num_local_experts=32,
+        hidden_size=4096,
+        params_dtype=torch.bfloat16,
+        deepep_mode=mode,
+        async_finish=True,
+        return_recv_hook=True,
+    )
+
+
+class TestSharedEpBackend(unittest.TestCase):
+    def test_runner_bootstraps_shared_fused_func_before_pool_lookup(self):
+        code = """
+import sys
+
+import torch
+
+import sglang.srt.layers.moe.moe_runner.runner as runner_module
+from sglang.srt.layers.moe.moe_runner.base import FusedOpPool
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
+
+assert FusedOpPool.get_fused_func("shared_ep", "deep_gemm") is None
+runner_module.get_moe_a2a_backend = lambda: MoeA2ABackend.SHARED_EP
+runner = runner_module.MoeRunner(
+    MoeRunnerBackend.DEEP_GEMM,
+    MoeRunnerConfig(
+        hidden_size=4096,
+        intermediate_size_per_partition=2048,
+        top_k=6,
+        num_experts=256,
+        num_local_experts=32,
+        params_dtype=torch.bfloat16,
+    ),
+)
+assert runner.fused_func is not None
+assert "sglang.srt.layers.moe.shared_ep.state" not in sys.modules
+"""
+        subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_fused_path_cannot_be_disabled(self):
+        code = """
+import os
+
+import torch
+
+os.environ["SGLANG_CI_DISABLE_MOE_FUSED_FUNC"] = "1"
+
+import sglang.srt.layers.moe.moe_runner.runner as runner_module
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
+
+runner_module.get_moe_a2a_backend = lambda: MoeA2ABackend.SHARED_EP
+try:
+    runner_module.MoeRunner(
+        MoeRunnerBackend.DEEP_GEMM,
+        MoeRunnerConfig(
+            hidden_size=4096,
+            intermediate_size_per_partition=2048,
+            top_k=6,
+            num_experts=256,
+            num_local_experts=32,
+            params_dtype=torch.bfloat16,
+        ),
+    )
+except RuntimeError as exc:
+    assert "SharedEP requires its registered fused execution path" in str(exc)
+else:
+    raise AssertionError("SharedEP accepted a disabled fused execution path")
+"""
+        subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_composite_factory_attaches_platform_fallback(self):
+        fallbacks = [object(), object()]
+        inners = [Mock(), Mock()]
+        for lane_id, inner in enumerate(inners):
+            inner.lane_id = lane_id
+        admission = (object(), object(), object())
+        parallel = object()
+        with (
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_shared_ep_prefill_backend",
+                return_value=MoeRunnerBackend.DEEP_GEMM,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_moe_runner_backend",
+                return_value=MoeRunnerBackend.DEEP_GEMM,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.compute_shared_ep_lane_protocol",
+                return_value=SharedEpLaneProtocol(2, 1),
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend._admit_shared_ep_framework",
+                return_value=admission,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_server_args",
+                return_value=object(),
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.get_parallel",
+                return_value=parallel,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.SharedEpDispatcher",
+                side_effect=inners,
+            ) as shared_dispatcher,
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend._create_shared_ep_prefill_dispatcher",
+                side_effect=fallbacks,
+            ) as create_fallback,
+        ):
+            result = create_shared_ep_dispatcher(_config(), group="ep_group")
+
+        self.assertIsInstance(result, SharedEpLaneDispatcher)
+        self.assertEqual(result.inner_dispatchers, tuple(inners))
+        self.assertEqual(
+            shared_dispatcher.call_args_list,
+            [
+                call(
+                    _config(),
+                    model_namespace="target",
+                    lane_id=lane_id,
+                    admission=admission,
+                )
+                for lane_id in range(2)
+            ],
+        )
+        self.assertEqual(
+            create_fallback.call_args_list,
+            [
+                call(
+                    _config(),
+                    group="ep_group",
+                    instance_id=lane_id,
+                )
+                for lane_id in range(2)
+            ],
+        )
+        for inner, fallback in zip(inners, fallbacks):
+            inner.set_fallback_dispatcher.assert_called_once_with(fallback)
+
+    @patch("sglang.srt.layers.moe.token_dispatcher.moriep.MoriEPDispatcher")
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_shared_ep_prefill_backend",
+        return_value=MoeRunnerBackend.AITER,
+    )
+    def test_rocm_prefill_uses_mori_dispatcher(
+        self,
+        _get_prefill_backend,
+        mori_dispatcher,
+    ):
+        expected = object()
+        mori_dispatcher.return_value = expected
+
+        self.assertIs(
+            _create_shared_ep_prefill_dispatcher(_config(), group="ep_group"),
+            expected,
+        )
+        mori_dispatcher.assert_called_once_with(
+            **_deepep_kwargs(DeepEPMode.NORMAL),
+            instance_id=0,
+        )
+
+    @patch("sglang.srt.layers.moe.token_dispatcher.deepep.DeepEPDispatcher")
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_shared_ep_prefill_backend",
+        return_value=MoeRunnerBackend.DEEP_GEMM,
+    )
+    def test_cuda_prefill_preserves_deepep_dispatcher(
+        self,
+        _get_prefill_backend,
+        deepep_dispatcher,
+    ):
+        _create_shared_ep_prefill_dispatcher(_config(), group="ep_group")
+
+        deepep_dispatcher.assert_called_once_with(**_deepep_kwargs(DeepEPMode.NORMAL))
+
+    def test_shared_backend_identity(self):
+        backend = MoeA2ABackend("shared_ep")
+
+        self.assertEqual(backend, MoeA2ABackend.SHARED_EP)
+        self.assertTrue(backend.is_shared_ep())
+        self.assertIn("shared_ep", MOE_A2A_BACKEND_CHOICES)
+        self.assertIsNotNone(FusedOpPool.get_fused_func("shared_ep", "deep_gemm"))
+        self.assertIsNotNone(FusedOpPool.get_fused_func("shared_ep", "aiter"))
+        self.assertIsNone(FusedOpPool.get_fused_func("shared_ep", "triton"))
+        with self.assertRaises(ValueError):
+            MoeA2ABackend("shared_moe")
+
+    @patch("sglang.srt.layers.moe.shared_ep.backend.is_hip", return_value=True)
+    @patch("sglang.srt.layers.moe.shared_ep.backend.torch.cuda.get_device_properties")
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.torch.cuda.current_device",
+        return_value=0,
+    )
+    def test_rocm_device_admission_requires_exact_gfx950(
+        self,
+        _current_device,
+        get_properties,
+        _is_hip,
+    ):
+        get_properties.return_value = SimpleNamespace(
+            gcnArchName="gfx950:sramecc+:xnack-"
+        )
+        self.assertEqual(
+            _get_device_profile_capability(),
+            ((9, 5), "rocm:gfx950"),
+        )
+
+        get_properties.return_value = SimpleNamespace(gcnArchName="gfx942")
+        with self.assertRaisesRegex(ValueError, "requires gfx950"):
+            _get_device_profile_capability()
+
+    def test_output_rows_absorb_vmm_granularity_without_owner_gaps(self):
+        dsv4 = SharedEpLayout.build(
+            hidden_size=4096,
+            top_k=6,
+            max_tokens_per_rank=32,
+        )
+        glm = SharedEpLayout.build(
+            hidden_size=6144,
+            top_k=8,
+            max_tokens_per_rank=32,
+        )
+
+        aligned_dsv4 = align_output_layout(dsv4, granularity=2 * 1024 * 1024)
+        aligned_glm = align_output_layout(glm, granularity=2 * 1024 * 1024)
+
+        self.assertEqual(aligned_dsv4.output_row_bytes, 32 * 1024)
+        self.assertEqual(aligned_dsv4.output_rank_bytes, 6 * 1024 * 1024)
+        self.assertEqual(aligned_glm.output_row_bytes, 16 * 1024)
+        self.assertEqual(aligned_glm.output_rank_bytes, 4 * 1024 * 1024)
+
+        storage = torch.zeros(
+            2 * aligned_dsv4.output_rank_bytes,
+            dtype=torch.uint8,
+        )
+        output = aligned_dsv4.output_view(
+            storage,
+            world_size=2,
+            mapped_rank_bytes=aligned_dsv4.output_rank_bytes,
+        )
+        flat_output = output.view(-1, aligned_dsv4.hidden_size)
+        flat_output[aligned_dsv4.output_rows_per_rank + 7, 3] = 9
+        self.assertEqual(output[1].view(-1, aligned_dsv4.hidden_size)[7, 3], 9)
+
+    def test_compact_capacity_covers_routes_and_per_expert_padding(self):
+        self.assertEqual(
+            compact_intermediate_capacity(
+                num_tokens=4,
+                world_size=8,
+                top_k=6,
+                num_local_experts=32,
+                block_size=16,
+            ),
+            672,
+        )
+        self.assertEqual(
+            compact_intermediate_capacity(
+                num_tokens=8,
+                world_size=8,
+                top_k=6,
+                num_local_experts=32,
+                block_size=16,
+            ),
+            864,
+        )
+
+    def test_decode_capacity_is_static_under_uneven_dp_batches(self):
+        dsv4 = select_profile(
+            _config(),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+            platform="cuda",
+        )
+        self.assertEqual(decode_intermediate_capacity(dsv4), 2016)
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=None,
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(
+            shared_ep_global_num_tokens=(4, 3, 2, 1, 1, 1, 1, 1)
+        ),
+    )
+    def test_decode_capacity_uses_forward_batch_counts(
+        self,
+        _get_forward,
+        _get_dp_tokens,
+    ):
+        _validate_decode_capacity(SimpleNamespace(ep_size=8, max_tokens_per_rank=4))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_quantize_pack_input_matches_reference_layout(self):
+        for hidden_size, top_k in ((4096, 6), (6144, 8)):
+            with self.subTest(hidden_size=hidden_size, top_k=top_k):
+                layout = SharedEpLayout.build(
+                    hidden_size=hidden_size,
+                    top_k=top_k,
+                    max_tokens_per_rank=32,
+                )
+                direct_storage = torch.zeros(
+                    layout.input_rank_bytes,
+                    dtype=torch.uint8,
+                    device="cuda",
+                )
+                direct = layout.input_views(
+                    direct_storage,
+                    world_size=1,
+                    mapped_rank_bytes=layout.input_rank_bytes,
+                ).owner(0)
+                source = torch.linspace(
+                    -2,
+                    2,
+                    4 * hidden_size,
+                    dtype=torch.bfloat16,
+                    device="cuda",
+                ).view(4, hidden_size)
+                source_ids = (
+                    torch.arange(
+                        4 * top_k,
+                        dtype=torch.int32,
+                        device="cuda",
+                    ).view(4, top_k)
+                    * 13
+                ) % 256
+                source_weights = torch.linspace(
+                    0,
+                    1,
+                    4 * top_k,
+                    dtype=torch.float32,
+                    device="cuda",
+                ).view(4, top_k)
+                source_q, source_scales = per_token_group_quant_fp8(
+                    source,
+                    128,
+                )
+
+                quantize_pack_input(
+                    direct,
+                    source=source,
+                    source_ids=source_ids,
+                    source_weights=source_weights,
+                    group_size=128,
+                )
+
+                torch.testing.assert_close(
+                    direct.scales[:4],
+                    source_scales,
+                    rtol=1e-6,
+                    atol=1e-8,
+                )
+                self.assertTrue(torch.equal(direct.topk_ids[:4], source_ids))
+                self.assertTrue(torch.equal(direct.topk_weights[:4], source_weights))
+                self.assertTrue(torch.all(direct.topk_ids[4:] == -1))
+                self.assertTrue(torch.all(direct.topk_weights[4:] == 0))
+                direct_values = direct.activations[:4].float()
+                direct_values *= direct.scales[:4].repeat_interleave(128, dim=1)
+                reference_values = source_q.float()
+                reference_values *= source_scales.repeat_interleave(128, dim=1)
+                torch.testing.assert_close(
+                    direct_values,
+                    reference_values,
+                    rtol=0.125,
+                    atol=0.25,
+                )
+
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.MaybeTboDeepEPDispatcher",
+        side_effect=AssertionError("SharedEP must not construct the TBO wrapper"),
+    )
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer._get_deepep_comm_group",
+        return_value="ep_group",
+    )
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+        return_value=MoeA2ABackend.SHARED_EP,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.create_shared_ep_dispatcher")
+    def test_shared_backend_delegates_without_tbo_wrapper(
+        self,
+        shared_factory,
+        _get_a2a_backend,
+        _get_group,
+        _tbo_dispatcher,
+    ):
+        result = object()
+        shared_factory.return_value = result
+
+        self.assertIs(create_moe_dispatcher(_config()), result)
+        shared_factory.assert_called_once_with(
+            _config(),
+            group="ep_group",
+        )
+
+    @patch("sglang.srt.layers.moe.fused_moe_triton.layer.StandardDispatcher")
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+        return_value=MoeA2ABackend.NONE,
+    )
+    def test_direct_selection_preserves_standard_dispatcher(
+        self,
+        _get_a2a_backend,
+        standard_dispatcher,
+    ):
+        expected = object()
+        standard_dispatcher.return_value = expected
+
+        self.assertIs(create_moe_dispatcher(_config()), expected)
+        standard_dispatcher.assert_called_once_with(_config())
+
+    @patch("sglang.srt.layers.moe.fused_moe_triton.layer.get_tp_group")
+    def test_rocm_shared_ep_passes_mori_process_group(self, get_tp_group):
+        group = SimpleNamespace(device_group=object())
+        get_tp_group.return_value = group
+
+        with patch(
+            "sglang.srt.layers.moe.fused_moe_triton.layer._is_hip",
+            True,
+        ):
+            self.assertIs(
+                _get_deepep_comm_group(MoeA2ABackend.SHARED_EP),
+                group,
+            )
+        with patch(
+            "sglang.srt.layers.moe.fused_moe_triton.layer._is_hip",
+            False,
+        ):
+            self.assertIs(
+                _get_deepep_comm_group(MoeA2ABackend.SHARED_EP),
+                group.device_group,
+            )
+
+    @patch("sglang.srt.layers.moe.fused_moe_triton.layer.get_deepep_mode")
+    @patch("sglang.srt.layers.moe.fused_moe_triton.layer.MaybeTboDeepEPDispatcher")
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer._get_deepep_comm_group",
+        return_value="ep_group",
+    )
+    @patch(
+        "sglang.srt.layers.moe.fused_moe_triton.layer.get_moe_a2a_backend",
+        return_value=MoeA2ABackend.DEEPEP,
+    )
+    def test_direct_selection_preserves_deepep_class_dispatchers(
+        self,
+        get_a2a_backend,
+        _get_group,
+        deepep_dispatcher,
+        get_deepep_mode,
+    ):
+        expected = object()
+        mode = object()
+        deepep_dispatcher.return_value = expected
+        get_deepep_mode.return_value = mode
+
+        for backend in (MoeA2ABackend.DEEPEP, MoeA2ABackend.MOONCAKE):
+            with self.subTest(backend=backend.value):
+                get_a2a_backend.return_value = backend
+                self.assertIs(create_moe_dispatcher(_config()), expected)
+                deepep_dispatcher.assert_called_once_with(**_deepep_kwargs(mode))
+                deepep_dispatcher.reset_mock()
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_parallel",
+        return_value=SimpleNamespace(moe_ep_size=8, moe_ep_rank=0),
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.backend._admit_shared_ep_framework")
+    @patch("sglang.srt.layers.moe.shared_ep.backend._get_shared_state")
+    def test_dispatcher_initializes_vmm_before_forward(
+        self,
+        get_shared_state,
+        admit_framework,
+        _get_parallel,
+    ):
+        state = object()
+        profile = select_profile(
+            _config(),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+            platform="cuda",
+        )
+        runtime = SharedEpRuntimeHooks(
+            name="test",
+            platform="cuda",
+            create_state=Mock(),
+            capabilities=frozenset(SharedEpRuntimeCapability),
+        )
+        admit_framework.return_value = (profile, runtime, "cpu_group")
+        get_shared_state.return_value = state
+
+        dispatcher = SharedEpDispatcher(_config())
+
+        self.assertIs(dispatcher.state, state)
+        get_shared_state.assert_called_once_with(
+            dispatcher.config,
+            dispatcher.profile,
+            runtime,
+            model_namespace="target",
+            lane_id=0,
+        )
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_is_decode=False),
+    )
+    def test_non_decode_phase_delegates_dispatch_and_combine(self, _get_forward):
+        fallback = Mock()
+        dispatched = object()
+        combined = torch.ones((33, 4))
+        fallback.dispatch.return_value = dispatched
+        fallback.combine.return_value = combined
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.lane_id = 0
+        dispatcher._stage = "initial"
+        dispatcher._active_uses_shared_ep = None
+        dispatcher.fallback_dispatcher = fallback
+        hidden_states = torch.zeros((33, 4))
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((33, 1)),
+            topk_ids=torch.zeros((33, 1), dtype=torch.int32),
+            router_logits=None,
+        )
+
+        self.assertIs(dispatcher.dispatch(hidden_states, topk_output), dispatched)
+        fallback.dispatch.assert_called_once_with(
+            hidden_states=hidden_states,
+            topk_output=topk_output,
+        )
+        fallback_input = SimpleNamespace(format=CombineInputFormat.DEEPEP_LL)
+        self.assertIs(dispatcher.combine(fallback_input), combined)
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_is_decode=True),
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=[16, 33, 8, 8, 8, 8, 8, 8],
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.kernels.quantize_pack_input")
+    def test_decode_rejects_peer_capacity_overflow_before_publish(
+        self,
+        quantize_pack,
+        _global_num_tokens,
+        _get_forward,
+    ):
+        profile = SimpleNamespace(
+            max_tokens_per_rank=32,
+            ep_size=8,
+            block_shape=(128, 128),
+            quantization=SharedEpQuantization.BLOCK_FP8,
+        )
+        state = SimpleNamespace(
+            local_input=object(),
+            global_input=SimpleNamespace(
+                activations=object(),
+                scales=object(),
+            ),
+            input_epoch=Mock(),
+        )
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.profile = profile
+        dispatcher.state = state
+        dispatcher.lane_id = 0
+        dispatcher._stage = "initial"
+        dispatcher._active_uses_shared_ep = None
+        dispatcher.local_expert_start = 0
+        dispatcher.fallback_dispatcher = Mock()
+        dispatcher._decode_quant_admitted = True
+        hidden_states = torch.zeros((16, 4))
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((16, 1)),
+            topk_ids=torch.zeros((16, 1), dtype=torch.int32),
+            router_logits=None,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "rank 1 has 33 local tokens.*capacity is 32",
+        ):
+            dispatcher.dispatch(hidden_states, topk_output)
+
+        quantize_pack.assert_not_called()
+        state.input_epoch.publish.assert_not_called()
+
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_is_decode=True),
+    )
+    @patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_dp_global_num_tokens",
+        return_value=[16] * 8,
+    )
+    @patch("sglang.srt.layers.moe.shared_ep.kernels.quantize_pack_input")
+    def test_decode_rows_use_direct_path(
+        self,
+        quantize_pack,
+        _global_num_tokens,
+        _get_forward,
+    ):
+        fallback = Mock()
+        profile = SimpleNamespace(
+            max_tokens_per_rank=32,
+            ep_size=8,
+            block_shape=(128, 128),
+            quantization=SharedEpQuantization.BLOCK_FP8,
+        )
+        state = SimpleNamespace(
+            local_input=object(),
+            global_input=SimpleNamespace(
+                activations=object(),
+                scales=object(),
+            ),
+            input_epoch=Mock(),
+        )
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.profile = profile
+        dispatcher.state = state
+        dispatcher.lane_id = 0
+        dispatcher._stage = "initial"
+        dispatcher._active_uses_shared_ep = None
+        dispatcher.local_expert_start = 0
+        dispatcher.fallback_dispatcher = fallback
+        dispatcher._decode_quant_admitted = True
+        hidden_states = torch.zeros((16, 4))
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((16, 1)),
+            topk_ids=torch.zeros((16, 1), dtype=torch.int32),
+            router_logits=None,
+        )
+
+        output = dispatcher.dispatch(hidden_states, topk_output)
+
+        self.assertEqual(output.num_tokens, 16)
+        self.assertIs(output.state, state)
+        quantize_pack.assert_called_once_with(
+            state.local_input,
+            source=hidden_states,
+            source_ids=topk_output.topk_ids,
+            source_weights=topk_output.topk_weights,
+            group_size=128,
+        )
+        state.input_epoch.publish.assert_called_once_with()
+        state.input_epoch.wait_all.assert_not_called()
+        fallback.dispatch.assert_not_called()
+
+    def test_decode_combine_uses_the_admitted_lane_stage(self):
+        fallback = Mock()
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.lane_id = 0
+        dispatcher._stage = "after_dispatch_b"
+        dispatcher._active_uses_shared_ep = True
+        dispatcher.fallback_dispatcher = fallback
+        hidden_states = torch.ones((32, 4))
+
+        self.assertIs(
+            dispatcher.combine(StandardCombineInput(hidden_states=hidden_states)),
+            hidden_states,
+        )
+        fallback.combine.assert_not_called()
+
+    def test_backend_reuses_ep_sharded_model_contract(self):
+        with patch(
+            "sglang.srt.layers.moe.utils.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.SHARED_EP,
+        ):
+            self.assertTrue(is_deepep_class_backend())
+        with patch(
+            "sglang.srt.layers.moe.ep_moe.layer.get_moe_a2a_backend",
+            return_value=MoeA2ABackend.SHARED_EP,
+        ):
+            self.assertIs(get_moe_impl_class(quant_config=None), DeepEPMoE)
+
+    @patch.object(PermuteMethodPool, "get_post_permute")
+    @patch.object(PermuteMethodPool, "get_pre_permute")
+    def test_prefill_reuses_constructed_native_runner(
+        self,
+        get_pre_permute,
+        get_post_permute,
+    ):
+        pre_permute = Mock(return_value="runner_input")
+        post_permute = Mock(return_value="combined")
+        get_pre_permute.return_value = pre_permute
+        get_post_permute.return_value = post_permute
+        dispatch_output = SimpleNamespace(format=SimpleNamespace(value="deepep_normal"))
+        fallback_quant_info = Mock()
+        quant_info = SharedEpQuantInfo(
+            w13_weight=torch.empty((1, 2, 3)),
+            w2_weight=torch.empty((1, 3, 1)),
+            w13_scale=torch.empty((1, 1, 1)),
+            w2_scale=torch.empty((1, 1, 1)),
+            block_shape=(128, 128),
+            fallback_quant_info=fallback_quant_info,
+            fallback_backend=MoeRunnerBackend.DEEP_GEMM,
+        )
+        config = MoeRunnerConfig()
+        runner_core = SimpleNamespace(
+            runner_backend=MoeRunnerBackend.DEEP_GEMM,
+            run=Mock(return_value="runner_output"),
+        )
+        runner = MoeRunner.__new__(MoeRunner)
+        runner.runner_backend = MoeRunnerBackend.DEEP_GEMM
+        runner.runner_core = runner_core
+        runner.config = config
+        runner.fused_func = Mock()
+        runner.is_shared_ep = True
+        runner.lora_enabled = False
+        runner.down_gemm_overlap_args = None
+        runner.meta_overlap_args = None
+
+        result = runner.run(dispatch_output, quant_info)
+
+        self.assertEqual(result, "combined")
+        runner.fused_func.assert_not_called()
+        pre_permute.assert_called_once_with(
+            dispatch_output,
+            fallback_quant_info,
+            config,
+            {},
+        )
+        runner_core.run.assert_called_once_with(
+            "runner_input",
+            fallback_quant_info,
+            {},
+            hooks=None,
+        )
+        post_permute.assert_called_once_with(
+            "runner_output",
+            fallback_quant_info,
+            config,
+            {},
+        )
+
+    def test_quant_metadata_rejects_aiter_shuffled_decode_weights(self):
+        w13 = torch.empty((1, 2, 3))
+        w2 = torch.empty((1, 3, 1))
+        info = SharedEpQuantInfo(
+            w13_weight=w13,
+            w2_weight=w2,
+            w13_scale=torch.empty((1, 1, 1)),
+            w2_scale=torch.empty((1, 1, 1)),
+            block_shape=(128, 128),
+            fallback_quant_info=Mock(),
+            fallback_backend=MoeRunnerBackend.AITER,
+        )
+        info.require_decode_capability(SharedEpQuantCapability.CANONICAL_BLOCK_FP8)
+
+        w13.is_shuffled = True
+        with self.assertRaisesRegex(ValueError, "AITER-pre-shuffled"):
+            info.require_decode_capability(SharedEpQuantCapability.CANONICAL_BLOCK_FP8)
+
+    def test_aiter_fallback_shuffle_preserves_canonical_decode_weights(self):
+        layer = SimpleNamespace(
+            w13_weight=torch.nn.Parameter(torch.arange(6.0).view(1, 2, 3)),
+            w2_weight=torch.nn.Parameter(torch.arange(3.0).view(1, 3, 1)),
+        )
+        canonical_w13 = layer.w13_weight.detach().clone()
+        canonical_w2 = layer.w2_weight.detach().clone()
+
+        def fake_shuffle(weight, _shape):
+            return weight.detach().clone() + 10
+
+        with patch(
+            "sglang.srt.layers.quantization.fp8.shuffle_weight",
+            side_effect=fake_shuffle,
+            create=True,
+        ):
+            Fp8MoEMethod._prepare_shared_ep_aiter_fallback_weights(layer)
+
+        torch.testing.assert_close(layer.w13_weight, canonical_w13)
+        torch.testing.assert_close(layer.w2_weight, canonical_w2)
+        self.assertTrue(layer._shared_ep_aiter_w13_weight.is_shuffled)
+        self.assertTrue(layer._shared_ep_aiter_w2_weight.is_shuffled)
+        self.assertFalse(layer.w13_weight.is_shuffled)
+        self.assertFalse(layer.w2_weight.is_shuffled)
+
+    @patch("sglang.srt.layers.moe.shared_ep.backend._synchronize_admission_stage")
+    def test_quant_admission_publishes_canonical_shapes(self, synchronize):
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.profile = select_profile(
+            _config(),
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+            platform="cuda",
+        )
+        dispatcher.cpu_group = "cpu_group"
+        dispatcher.fallback_dispatcher = Mock()
+        dispatcher._decode_quant_admitted = False
+        quant_config = {
+            "weight_dtype": torch.float8_e4m3fn,
+            "shared_ep_quantization": "block_fp8",
+            "shared_ep_weight_layout": SharedEpWeightLayout.CANONICAL.value,
+            "block_shape": (128, 128),
+            "w13_shape": (32, 4096, 4096),
+            "w2_shape": (32, 4096, 2048),
+            "w13_scale_shape": (32, 32, 32),
+            "w2_scale_shape": (32, 32, 16),
+        }
+
+        dispatcher.set_quant_config(quant_config)
+
+        self.assertTrue(dispatcher._decode_quant_admitted)
+        dispatcher.fallback_dispatcher.set_quant_config.assert_called_once_with(
+            quant_config
+        )
+        synchronize.assert_called_once()
+        self.assertEqual(
+            synchronize.call_args.kwargs["stage"],
+            "quantization",
+        )
+
+    def test_remote_admission_failure_is_synchronized(self):
+        def fake_all_gather(results, local_result, *, group):
+            results[:] = [
+                local_result,
+                (None, "ValueError: unsupported gfx architecture"),
+            ]
+
+        with (
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.dist.get_world_size",
+                return_value=2,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.dist.get_rank",
+                return_value=0,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.backend.dist.all_gather_object",
+                side_effect=fake_all_gather,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "framework admission failed on rank 1.*unsupported gfx",
+            ),
+        ):
+            _synchronize_admission_stage(
+                "cpu_group",
+                stage="framework",
+                descriptor=("rocm:gfx950", "runtime", ("profile",)),
+                local_error=None,
+            )
+
+    def test_runtime_requires_vmm_and_epoch_capabilities(self):
+        hooks = SharedEpRuntimeHooks(
+            name="incomplete_rocm",
+            platform="rocm",
+            create_state=Mock(),
+            capabilities=frozenset({SharedEpRuntimeCapability.RANK_MAJOR_VMM}),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "system_scope_gpu_epoch"):
+            hooks.validate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_ep8.py
+++ b/test/registered/moe/test_shared_ep_ep8.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 import torch.distributed as dist
@@ -15,7 +15,10 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
 )
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
-from sglang.srt.layers.moe.moe_runner.shared_ep import SharedEpQuantInfo
+from sglang.srt.layers.moe.moe_runner.shared_ep import (
+    SharedEpQuantCapability,
+    SharedEpQuantInfo,
+)
 from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
     moe_align_block_size,
 )
@@ -24,18 +27,29 @@ from sglang.srt.layers.moe.shared_ep.backend import (
     run_shared_ep,
 )
 from sglang.srt.layers.moe.shared_ep.kernels import quantize_pack_input
-from sglang.srt.layers.moe.shared_ep.layout import SharedEpLayout
+from sglang.srt.layers.moe.shared_ep.layout import (
+    SharedEpInputFormat,
+    SharedEpLayout,
+)
 from sglang.srt.layers.moe.shared_ep.profiles import (
+    DSV4_PRO_MXFP4_GFX950,
+    GLM52_GFX950,
     SharedEpProfile,
     SharedEpQuantization,
+    make_pull_cache_prefill_profile,
+)
+from sglang.srt.layers.moe.shared_ep.pull_cache_prefill import (
+    allocate_pull_cache,
+    make_pull_cache_prefill_plan,
 )
 from sglang.srt.layers.moe.shared_ep.state import create_shared_ep_state
 from sglang.srt.layers.moe.topk import StandardTopKOutput
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kernels.utils import multigpu_pytest_main
 
 register_cuda_ci(est_time=40, stage="extra-b", runner_config="8-gpu-h200")
+register_amd_ci(est_time=120, suite="stage-c-test-large-8-gpu-amd-mi35x")
 
 _KERNEL_CONFIG = {
     "BLOCK_SIZE_M": 16,
@@ -102,6 +116,19 @@ class TestSharedEpEp8(unittest.TestCase):
         )
         try:
             self.assertEqual(state.layout.output_row_bytes, 16 * 1024)
+            pull_plan = make_pull_cache_prefill_plan(
+                owners=self.profile.ep_size,
+                source_tokens_per_owner=self.profile.max_tokens_per_rank,
+                hidden_size=self.profile.hidden_size,
+                top_k=self.profile.top_k,
+                num_local_experts=self.profile.num_local_experts,
+                expert_alignment=self.profile.block_size_m,
+            )
+            pull_cache = allocate_pull_cache(
+                pull_plan,
+                active_rows=pull_plan.cache_rows,
+                device=torch.device("cuda", self.local_rank),
+            )
             tokens = self.rank + 1
             topk_ids = torch.stack(
                 [
@@ -205,6 +232,15 @@ class TestSharedEpEp8(unittest.TestCase):
                     skew_output_consumer=generation == 1,
                 )
                 torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+                pull_actual = self._run_shared(
+                    state,
+                    hidden,
+                    topk_output,
+                    local_quant,
+                    phase="prefill",
+                    pull_cache=pull_cache,
+                )
+                torch.testing.assert_close(pull_actual, expected, rtol=0, atol=0)
 
             graph_hidden = self._hidden(3, tokens)
             graph_q, graph_scale = per_token_group_quant_fp8(
@@ -238,6 +274,513 @@ class TestSharedEpEp8(unittest.TestCase):
             dist.barrier()
             state.close()
 
+    @unittest.skipUnless(torch.version.hip is not None, "requires ROCm")
+    def test_glm52_pull_cache_matches_direct_ep8(self):
+        arch = torch.cuda.get_device_properties(self.local_rank).gcnArchName.split(
+            ":",
+            1,
+        )[0]
+        if arch != "gfx950":
+            self.skipTest(f"requires gfx950, got {arch}")
+
+        decode_profile = GLM52_GFX950
+        prefill_profile = make_pull_cache_prefill_profile(decode_profile, 64)
+        self.assertIsNotNone(prefill_profile)
+        runner_config = MoeRunnerConfig(
+            num_experts=decode_profile.num_experts,
+            num_local_experts=decode_profile.num_local_experts,
+            hidden_size=decode_profile.hidden_size,
+            intermediate_size_per_partition=decode_profile.intermediate_size,
+            top_k=decode_profile.top_k,
+        )
+
+        def create_state(profile):
+            return create_shared_ep_state(
+                layout=SharedEpLayout.build(
+                    hidden_size=profile.hidden_size,
+                    top_k=profile.top_k,
+                    max_tokens_per_rank=profile.max_tokens_per_rank,
+                ),
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+            )
+
+        decode_state = create_state(decode_profile)
+        prefill_state = create_state(prefill_profile)
+        pull_plan = make_pull_cache_prefill_plan(
+            owners=prefill_profile.ep_size,
+            source_tokens_per_owner=prefill_profile.max_tokens_per_rank,
+            hidden_size=prefill_profile.hidden_size,
+            top_k=prefill_profile.top_k,
+            num_local_experts=prefill_profile.num_local_experts,
+            expert_alignment=prefill_profile.block_size_m,
+        )
+        pull_cache = allocate_pull_cache(
+            pull_plan,
+            active_rows=pull_plan.cache_rows,
+            device=torch.device("cuda", self.local_rank),
+        )
+        w13 = torch.empty(
+            (
+                decode_profile.num_local_experts,
+                2 * decode_profile.intermediate_size,
+                decode_profile.hidden_size,
+            ),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        w2 = torch.empty(
+            (
+                decode_profile.num_local_experts,
+                decode_profile.hidden_size,
+                decode_profile.intermediate_size,
+            ),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        local_start = self.rank * decode_profile.num_local_experts
+        for local_expert in range(decode_profile.num_local_experts):
+            value = (local_start + local_expert + 1) / 4096
+            w13[local_expert].fill_(value)
+            w2[local_expert].fill_(value)
+        w13_scale = torch.ones(
+            (
+                decode_profile.num_local_experts,
+                2 * decode_profile.intermediate_size // 128,
+                decode_profile.hidden_size // 128,
+            ),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        w2_scale = torch.ones(
+            (
+                decode_profile.num_local_experts,
+                decode_profile.hidden_size // 128,
+                decode_profile.intermediate_size // 128,
+            ),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        quant_info = SharedEpQuantInfo(
+            w13_weight=w13,
+            w2_weight=w2,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
+            block_shape=(128, 128),
+            fallback_quant_info=Mock(),
+            fallback_backend=MoeRunnerBackend.AITER,
+        )
+        hidden = (
+            torch.arange(
+                decode_profile.hidden_size,
+                dtype=torch.float32,
+                device="cuda",
+            )
+            .remainder(97)
+            .sub(48)
+            .div_(4096)
+            .to(torch.bfloat16)
+            .view(1, -1)
+        )
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.full(
+                (1, decode_profile.top_k),
+                1 / decode_profile.top_k,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            topk_ids=torch.tensor(
+                [
+                    [
+                        ((self.rank + slot) % decode_profile.ep_size)
+                        * decode_profile.num_local_experts
+                        + slot
+                        for slot in range(decode_profile.top_k)
+                    ]
+                ],
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            router_logits=None,
+        )
+
+        def run(profile, state, phase, cache=None):
+            quantize_pack_input(
+                state.local_input,
+                source=hidden,
+                source_ids=topk_output.topk_ids,
+                source_weights=topk_output.topk_weights,
+                group_size=128,
+            )
+            state.local_output[:1].zero_()
+            state.input_epoch.publish()
+            return run_shared_ep(
+                SharedEpDispatchOutput(
+                    hidden_states=state.global_input.activations,
+                    hidden_states_scale=state.global_input.scales,
+                    topk_output=topk_output,
+                    state=state,
+                    profile=profile,
+                    num_tokens=1,
+                    local_expert_start=local_start,
+                    phase=phase,
+                    pull_cache=cache,
+                ),
+                quant_info,
+                runner_config,
+            ).hidden_states
+
+        try:
+            direct = run(decode_profile, decode_state, "decode")
+            pulled = run(
+                prefill_profile,
+                prefill_state,
+                "prefill",
+                pull_cache,
+            )
+            torch.testing.assert_close(pulled, direct, rtol=5e-2, atol=2e-2)
+        finally:
+            dist.barrier()
+            prefill_state.close()
+            decode_state.close()
+
+    @unittest.skipUnless(torch.version.hip is not None, "requires ROCm")
+    def test_mxfp4_direct_return_reuses_ep8_epochs(self):
+        arch = torch.cuda.get_device_properties(self.local_rank).gcnArchName.split(
+            ":",
+            1,
+        )[0]
+        if arch != "gfx950":
+            self.skipTest(f"requires gfx950, got {arch}")
+
+        config = {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 1,
+            "num_warps": 4,
+            "num_stages": 2,
+            "waves_per_eu": 0,
+            "matrix_instr_nonkdim": 16,
+            "kpack": 1,
+        }
+        profile = SharedEpProfile(
+            name="ep8_mxfp4_test",
+            capability=(9, 5),
+            hidden_size=128,
+            intermediate_size=128,
+            top_k=2,
+            num_experts=8,
+            num_local_experts=1,
+            ep_size=8,
+            max_tokens_per_rank=128,
+            quantization=SharedEpQuantization.MXFP4,
+            block_shape=(1, 32),
+            default_kernel_config=config,
+            small_kernel_config=None,
+            small_kernel_max_tokens=128,
+            route_kernel_config={"num_threads": 256},
+            default_w13_kernel_config=config,
+            default_w2_kernel_config=config,
+            platform="rocm",
+        )
+        runner_config = MoeRunnerConfig(
+            num_experts=8,
+            num_local_experts=1,
+            hidden_size=128,
+            intermediate_size_per_partition=128,
+            top_k=2,
+        )
+        state = create_shared_ep_state(
+            layout=SharedEpLayout.build(
+                hidden_size=profile.hidden_size,
+                top_k=profile.top_k,
+                max_tokens_per_rank=profile.max_tokens_per_rank,
+                input_format=SharedEpInputFormat.BF16,
+                direct_output=True,
+            ),
+            cpu_group=dist.group.WORLD,
+            device=torch.device("cuda", self.local_rank),
+        )
+        w13 = torch.full(
+            (1, 2 * profile.intermediate_size, profile.hidden_size // 2),
+            0x22,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        w2 = torch.full(
+            (1, profile.hidden_size, profile.intermediate_size // 2),
+            0x22,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        w13_scale = torch.full(
+            (1, 2 * profile.intermediate_size, profile.hidden_size // 32),
+            127,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        w2_scale = torch.full(
+            (1, profile.hidden_size, profile.intermediate_size // 32),
+            127,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        quant_info = SharedEpQuantInfo(
+            w13_weight=w13,
+            w2_weight=w2,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
+            block_shape=(1, 32),
+            fallback_quant_info=Mock(),
+            fallback_backend=MoeRunnerBackend.AITER,
+            quantization=SharedEpQuantization.MXFP4,
+            weight_group_size=32,
+            scale_format="e8m0",
+            capabilities=frozenset({SharedEpQuantCapability.CANONICAL_MXFP4}),
+        )
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.tensor(
+                [[0.6, 0.4]],
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            topk_ids=torch.tensor(
+                [[self.rank, (self.rank + 1) % 8]],
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            router_logits=None,
+        )
+
+        previous = None
+        try:
+            from sglang.srt.layers.moe.shared_ep.fp4 import (
+                publish_bf16_owner_input,
+            )
+
+            for generation in (1, 4):
+                hidden = torch.full(
+                    (1, profile.hidden_size),
+                    (self.rank + 1) * generation / 1024,
+                    dtype=torch.bfloat16,
+                    device="cuda",
+                )
+                publish_bf16_owner_input(
+                    state.local_input,
+                    source=hidden,
+                    source_ids=topk_output.topk_ids,
+                    source_weights=topk_output.topk_weights,
+                )
+                state.local_output[:1].zero_()
+                state.input_epoch.publish()
+                actual = run_shared_ep(
+                    SharedEpDispatchOutput(
+                        hidden_states=state.global_input.activations,
+                        hidden_states_scale=None,
+                        topk_output=topk_output,
+                        state=state,
+                        profile=profile,
+                        num_tokens=1,
+                        local_expert_start=self.rank,
+                    ),
+                    quant_info,
+                    runner_config,
+                ).hidden_states
+                self.assertEqual(tuple(actual.shape), (1, profile.hidden_size))
+                self.assertTrue(torch.isfinite(actual).all().item())
+                self.assertGreater(actual.abs().max().item(), 0)
+                if previous is not None:
+                    self.assertFalse(torch.equal(actual, previous))
+                previous = actual.clone()
+        finally:
+            dist.barrier()
+            state.close()
+
+    @unittest.skipUnless(torch.version.hip is not None, "requires ROCm")
+    def test_dsv4_pro_mxfp4_production_shape_ep8(self):
+        arch = torch.cuda.get_device_properties(self.local_rank).gcnArchName.split(
+            ":",
+            1,
+        )[0]
+        if arch != "gfx950":
+            self.skipTest(f"requires gfx950, got {arch}")
+
+        profile = DSV4_PRO_MXFP4_GFX950
+        runner_config = MoeRunnerConfig(
+            num_experts=profile.num_experts,
+            num_local_experts=profile.num_local_experts,
+            hidden_size=profile.hidden_size,
+            intermediate_size_per_partition=profile.intermediate_size,
+            top_k=profile.top_k,
+        )
+        state = create_shared_ep_state(
+            layout=SharedEpLayout.build(
+                hidden_size=profile.hidden_size,
+                top_k=profile.top_k,
+                max_tokens_per_rank=profile.max_tokens_per_rank,
+                input_format=SharedEpInputFormat.BF16,
+                direct_output=True,
+            ),
+            cpu_group=dist.group.WORLD,
+            device=torch.device("cuda", self.local_rank),
+        )
+        w13 = torch.full(
+            (
+                profile.num_local_experts,
+                2 * profile.intermediate_size,
+                profile.hidden_size // 2,
+            ),
+            0x22,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        w2 = torch.full(
+            (
+                profile.num_local_experts,
+                profile.hidden_size,
+                profile.intermediate_size // 2,
+            ),
+            0x22,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        w13_scale = torch.full(
+            (
+                profile.num_local_experts,
+                2 * profile.intermediate_size,
+                profile.hidden_size // 32,
+            ),
+            127,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        w2_scale = torch.full(
+            (
+                profile.num_local_experts,
+                profile.hidden_size,
+                profile.intermediate_size // 32,
+            ),
+            127,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        quant_info = SharedEpQuantInfo(
+            w13_weight=w13,
+            w2_weight=w2,
+            w13_scale=w13_scale,
+            w2_scale=w2_scale,
+            block_shape=(1, 32),
+            fallback_quant_info=Mock(),
+            fallback_backend=MoeRunnerBackend.AITER,
+            quantization=SharedEpQuantization.MXFP4,
+            weight_group_size=32,
+            scale_format="e8m0",
+            capabilities=frozenset({SharedEpQuantCapability.CANONICAL_MXFP4}),
+        )
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.full(
+                (1, profile.top_k),
+                1 / profile.top_k,
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            topk_ids=torch.tensor(
+                [
+                    [
+                        ((self.rank + slot) % profile.ep_size)
+                        * profile.num_local_experts
+                        for slot in range(profile.top_k)
+                    ]
+                ],
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            router_logits=None,
+        )
+
+        try:
+            from sglang.srt.layers.moe.shared_ep.fp4 import (
+                publish_bf16_owner_input,
+            )
+
+            for generation in range(1, 81):
+                hidden = torch.full(
+                    (1, profile.hidden_size),
+                    (self.rank + 1) * ((generation - 1) % 4 + 1) / 4096,
+                    dtype=torch.bfloat16,
+                    device="cuda",
+                )
+                publish_bf16_owner_input(
+                    state.local_input,
+                    source=hidden,
+                    source_ids=topk_output.topk_ids,
+                    source_weights=topk_output.topk_weights,
+                )
+                state.local_output[:1].zero_()
+                state.input_epoch.publish()
+                actual = run_shared_ep(
+                    SharedEpDispatchOutput(
+                        hidden_states=state.global_input.activations,
+                        hidden_states_scale=None,
+                        topk_output=topk_output,
+                        state=state,
+                        profile=profile,
+                        num_tokens=1,
+                        local_expert_start=self.rank * profile.num_local_experts,
+                    ),
+                    quant_info,
+                    runner_config,
+                ).hidden_states
+                self.assertEqual(tuple(actual.shape), (1, profile.hidden_size))
+                self.assertTrue(torch.isfinite(actual).all().item())
+                self.assertGreater(actual.abs().max().item(), 0)
+
+            idle_tokens = 1 if self.rank == 0 else 0
+            idle_hidden = torch.full(
+                (idle_tokens, profile.hidden_size),
+                1 / 1024,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            idle_ids = topk_output.topk_ids[:idle_tokens]
+            idle_weights = topk_output.topk_weights[:idle_tokens]
+            idle_topk = StandardTopKOutput(
+                topk_weights=idle_weights,
+                topk_ids=idle_ids,
+                router_logits=None,
+            )
+            publish_bf16_owner_input(
+                state.local_input,
+                source=idle_hidden,
+                source_ids=idle_ids,
+                source_weights=idle_weights,
+            )
+            state.local_output[:idle_tokens].zero_()
+            state.input_epoch.publish()
+            idle_output = run_shared_ep(
+                SharedEpDispatchOutput(
+                    hidden_states=state.global_input.activations,
+                    hidden_states_scale=None,
+                    topk_output=idle_topk,
+                    state=state,
+                    profile=profile,
+                    num_tokens=idle_tokens,
+                    local_expert_start=self.rank * profile.num_local_experts,
+                ),
+                quant_info,
+                runner_config,
+            ).hidden_states
+            self.assertEqual(
+                tuple(idle_output.shape),
+                (idle_tokens, profile.hidden_size),
+            )
+            self.assertTrue(torch.isfinite(idle_output).all().item())
+        finally:
+            del quant_info, w13, w2, w13_scale, w2_scale
+            dist.barrier()
+            state.close()
+
     def _hidden(self, generation: int, tokens: int) -> torch.Tensor:
         values = torch.arange(
             tokens * 128,
@@ -256,6 +799,8 @@ class TestSharedEpEp8(unittest.TestCase):
         *,
         skew_input_writer=False,
         skew_output_consumer=False,
+        phase="decode",
+        pull_cache=None,
     ) -> torch.Tensor:
         if skew_input_writer and self.rank == 0:
             torch.cuda._sleep(250_000_000)
@@ -275,6 +820,8 @@ class TestSharedEpEp8(unittest.TestCase):
             profile=self.profile,
             num_tokens=hidden.shape[0],
             local_expert_start=self.rank,
+            phase=phase,
+            pull_cache=pull_cache,
         )
         if not skew_output_consumer:
             return run_shared_ep(
@@ -397,4 +944,7 @@ class TestSharedEpEp8(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    multigpu_pytest_main(__name__, __file__, num_gpus=(8,))
+    if "WORLD_SIZE" in os.environ:
+        unittest.main()
+    else:
+        multigpu_pytest_main(__name__, __file__, num_gpus=(8,))

--- a/test/registered/moe/test_shared_ep_ep8.py
+++ b/test/registered/moe/test_shared_ep_ep8.py
@@ -1,0 +1,400 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.distributed as dist
+import triton.language as tl
+
+from sglang.kernels.ops.attention.dsv4 import silu_and_mul_contig_post_quant
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    per_token_group_quant_fp8,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.deep_gemm import DeepGemmMoeQuantInfo
+from sglang.srt.layers.moe.moe_runner.shared_ep import SharedEpQuantInfo
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size,
+)
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatchOutput,
+    run_shared_ep,
+)
+from sglang.srt.layers.moe.shared_ep.kernels import quantize_pack_input
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpLayout
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    SharedEpProfile,
+    SharedEpQuantization,
+)
+from sglang.srt.layers.moe.shared_ep.state import create_shared_ep_state
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.moe.utils import MoeRunnerBackend
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=40, stage="extra-b", runner_config="8-gpu-h200")
+
+_KERNEL_CONFIG = {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 8,
+    "num_stages": 3,
+}
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and int(os.environ.get("WORLD_SIZE", "1")) == 8,
+    "run with torchrun --nproc-per-node=8 on CUDA",
+)
+class TestSharedEpEp8(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rank = int(os.environ["RANK"])
+        cls.local_rank = int(os.environ["LOCAL_RANK"])
+        torch.cuda.set_device(cls.local_rank)
+        dist.init_process_group("gloo")
+        cls.profile = SharedEpProfile(
+            name="ep8_test",
+            capability=(9, 5) if torch.version.hip else (9, 0),
+            hidden_size=128,
+            intermediate_size=256,
+            top_k=6,
+            num_experts=8,
+            num_local_experts=1,
+            ep_size=8,
+            max_tokens_per_rank=32,
+            block_shape=(128, 128),
+            default_kernel_config=_KERNEL_CONFIG,
+            small_kernel_config=None,
+            small_kernel_max_tokens=0,
+            route_kernel_config={"num_threads": 1024},
+            quantization=SharedEpQuantization.BLOCK_FP8,
+            platform="rocm" if torch.version.hip else "cuda",
+        )
+        cls.runner_config = MoeRunnerConfig(
+            num_experts=8,
+            num_local_experts=1,
+            hidden_size=128,
+            intermediate_size_per_partition=256,
+            top_k=6,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()
+
+    def test_direct_read_return_reuse_and_graph_match_materialized_ep8(self):
+        state = create_shared_ep_state(
+            layout=SharedEpLayout.build(
+                hidden_size=128,
+                top_k=6,
+                max_tokens_per_rank=32,
+            ),
+            cpu_group=dist.group.WORLD,
+            device=torch.device("cuda", self.local_rank),
+        )
+        try:
+            self.assertEqual(state.layout.output_row_bytes, 16 * 1024)
+            tokens = self.rank + 1
+            topk_ids = torch.stack(
+                [
+                    (
+                        torch.arange(6, device="cuda", dtype=torch.int32)
+                        + self.rank
+                        + token
+                    )
+                    % 8
+                    for token in range(tokens)
+                ]
+            )
+            topk_weights = (
+                torch.arange(1, 7, device="cuda", dtype=torch.float32)
+                .div_(21)
+                .expand(tokens, -1)
+                .contiguous()
+            )
+            topk_output = StandardTopKOutput(
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                router_logits=None,
+            )
+
+            full_w13 = torch.stack(
+                [
+                    torch.full(
+                        (512, 128),
+                        (expert + 1) / 512,
+                        dtype=torch.float8_e4m3fn,
+                        device="cuda",
+                    )
+                    for expert in range(8)
+                ]
+            )
+            full_w2 = torch.stack(
+                [
+                    torch.full(
+                        (128, 256),
+                        (expert + 1) / 512,
+                        dtype=torch.float8_e4m3fn,
+                        device="cuda",
+                    )
+                    for expert in range(8)
+                ]
+            )
+            full_w13_scale = torch.ones(
+                (8, 4, 1),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            full_w2_scale = torch.ones(
+                (8, 1, 2),
+                dtype=torch.float32,
+                device="cuda",
+            )
+            local_w13 = full_w13[self.rank : self.rank + 1]
+            local_w2 = full_w2[self.rank : self.rank + 1]
+            local_w13_scale = full_w13_scale[self.rank : self.rank + 1]
+            local_w2_scale = full_w2_scale[self.rank : self.rank + 1]
+            fallback_quant = DeepGemmMoeQuantInfo(
+                w13_weight=local_w13,
+                w2_weight=local_w2,
+                use_fp8=True,
+                w13_scale=local_w13_scale,
+                w2_scale=local_w2_scale,
+                block_shape=[128, 128],
+            )
+            local_quant = SharedEpQuantInfo(
+                w13_weight=local_w13,
+                w2_weight=local_w2,
+                w13_scale=local_w13_scale,
+                w2_scale=local_w2_scale,
+                block_shape=(128, 128),
+                fallback_quant_info=fallback_quant,
+                fallback_backend=MoeRunnerBackend.DEEP_GEMM,
+            )
+
+            for generation in (1, 2):
+                hidden = self._hidden(generation, tokens)
+                hidden_fp8, hidden_scale = per_token_group_quant_fp8(
+                    hidden,
+                    128,
+                )
+                expected = self._run_materialized(
+                    hidden_fp8,
+                    hidden_scale,
+                    topk_output,
+                    full_w13,
+                    full_w2,
+                    full_w13_scale,
+                    full_w2_scale,
+                    tokens,
+                )
+                actual = self._run_shared(
+                    state,
+                    hidden,
+                    topk_output,
+                    local_quant,
+                    skew_input_writer=generation == 2,
+                    skew_output_consumer=generation == 1,
+                )
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+            graph_hidden = self._hidden(3, tokens)
+            graph_q, graph_scale = per_token_group_quant_fp8(
+                graph_hidden,
+                128,
+            )
+            graph = torch.cuda.CUDAGraph()
+            dist.barrier()
+            with torch.cuda.graph(graph):
+                graph_output = self._run_shared(
+                    state,
+                    graph_hidden,
+                    topk_output,
+                    local_quant,
+                )
+            dist.barrier()
+            graph.replay()
+            torch.cuda.synchronize()
+            expected = self._run_materialized(
+                graph_q,
+                graph_scale,
+                topk_output,
+                full_w13,
+                full_w2,
+                full_w13_scale,
+                full_w2_scale,
+                tokens,
+            )
+            torch.testing.assert_close(graph_output, expected, rtol=0, atol=0)
+        finally:
+            dist.barrier()
+            state.close()
+
+    def _hidden(self, generation: int, tokens: int) -> torch.Tensor:
+        values = torch.arange(
+            tokens * 128,
+            dtype=torch.float32,
+            device="cuda",
+        ).view(tokens, 128)
+        values = (values + self.rank * 17 + generation * 29) % 97
+        return ((values - 48) / 4096).to(torch.bfloat16)
+
+    def _run_shared(
+        self,
+        state,
+        hidden,
+        topk_output,
+        quant_info,
+        *,
+        skew_input_writer=False,
+        skew_output_consumer=False,
+    ) -> torch.Tensor:
+        if skew_input_writer and self.rank == 0:
+            torch.cuda._sleep(250_000_000)
+        quantize_pack_input(
+            state.local_input,
+            source=hidden,
+            source_ids=topk_output.topk_ids,
+            source_weights=topk_output.topk_weights,
+            group_size=128,
+        )
+        state.input_epoch.publish()
+        dispatch_output = SharedEpDispatchOutput(
+            hidden_states=state.global_input.activations,
+            hidden_states_scale=state.global_input.scales,
+            topk_output=topk_output,
+            state=state,
+            profile=self.profile,
+            num_tokens=hidden.shape[0],
+            local_expert_start=self.rank,
+        )
+        if not skew_output_consumer:
+            return run_shared_ep(
+                dispatch_output,
+                quant_info,
+                self.runner_config,
+            ).hidden_states
+
+        output_epoch_type = type(state.output_epoch)
+        original_wait_all = output_epoch_type.wait_all
+
+        def wait_all_with_rank_zero_skew(epoch):
+            original_wait_all(epoch)
+            if epoch is state.output_epoch and self.rank == 0:
+                torch.cuda._sleep(250_000_000)
+
+        with patch.object(output_epoch_type, "wait_all", wait_all_with_rank_zero_skew):
+            return run_shared_ep(
+                dispatch_output,
+                quant_info,
+                self.runner_config,
+            ).hidden_states
+
+    def _run_materialized(
+        self,
+        hidden_fp8,
+        hidden_scale,
+        topk_output,
+        w13,
+        w2,
+        w13_scale,
+        w2_scale,
+        num_tokens,
+    ) -> torch.Tensor:
+        sorted_ids, expert_ids, padded = moe_align_block_size(
+            topk_output.topk_ids,
+            _KERNEL_CONFIG["BLOCK_SIZE_M"],
+            8,
+        )
+        route_count = topk_output.topk_ids.numel()
+        gate_up = torch.empty(
+            (route_count, 512),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        invoke_fused_moe_kernel(
+            A=hidden_fp8,
+            B=w13,
+            bias=None,
+            C=gate_up,
+            A_scale=hidden_scale,
+            B_scale=w13_scale,
+            B_zp=None,
+            topk_weights=topk_output.topk_weights,
+            topk_ids=topk_output.topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=padded,
+            mul_routed_weight=False,
+            top_k=6,
+            config=_KERNEL_CONFIG,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=[128, 128],
+            filter_expert=False,
+            a_is_prequantized=True,
+        )
+        down_fp8 = torch.empty(
+            (route_count, 256),
+            dtype=torch.float8_e4m3fn,
+            device="cuda",
+        )
+        down_scale = torch.empty(
+            (route_count, 2),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        silu_and_mul_contig_post_quant(
+            input=gate_up,
+            output=down_fp8,
+            output_scale=down_scale,
+            quant_group_size=128,
+        )
+        contributions = torch.empty(
+            (route_count, 128),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        invoke_fused_moe_kernel(
+            A=down_fp8,
+            B=w2,
+            bias=None,
+            C=contributions,
+            A_scale=down_scale,
+            B_scale=w2_scale,
+            B_zp=None,
+            topk_weights=topk_output.topk_weights,
+            topk_ids=topk_output.topk_ids,
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=padded,
+            mul_routed_weight=True,
+            top_k=1,
+            config=_KERNEL_CONFIG,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=[128, 128],
+            filter_expert=False,
+            a_is_prequantized=True,
+        )
+        return contributions.view(num_tokens, 6, 128).sum(dim=1)
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(8,))

--- a/test/registered/moe/test_shared_ep_epoch.py
+++ b/test/registered/moe/test_shared_ep_epoch.py
@@ -1,0 +1,98 @@
+import inspect
+import unittest
+from pathlib import Path
+
+import sglang.srt.layers.moe.shared_ep.epoch as epoch_module
+from sglang.srt.layers.moe.shared_ep.epoch import GpuEpoch, GpuPointerTableEpoch
+from sglang.srt.layers.moe.shared_ep.state import SharedEpState
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class _Closable:
+    def __init__(self, name, calls):
+        self.name = name
+        self.calls = calls
+
+    def close(self):
+        self.calls.append(self.name)
+
+
+class TestSharedEpEpoch(unittest.TestCase):
+    def test_protocol_uses_system_scope_release_and_acquire(self):
+        """Both platform paths must make peer payload writes visible."""
+        source = inspect.getsource(
+            __import__(
+                "sglang.srt.layers.moe.shared_ep.epoch",
+                fromlist=["GpuEpoch"],
+            )
+        )
+        self.assertIn("atom.global.release.sys.exch.b32", source)
+        self.assertIn("ld.acquire.sys.global", source)
+        package_root = next(
+            parent
+            for parent in Path(epoch_module.__file__).resolve().parents
+            if parent.name == "sglang"
+        )
+        native_source = (
+            package_root
+            / "kernels"
+            / "jit"
+            / "csrc"
+            / "moe"
+            / "shared_ep_route_prep.cu"
+        ).read_text()
+        self.assertIn("__hip_atomic_store", native_source)
+        self.assertIn("__ATOMIC_RELEASE", native_source)
+        self.assertIn("__hip_atomic_load", native_source)
+        self.assertIn("__ATOMIC_ACQUIRE", native_source)
+        self.assertIn("__HIP_MEMORY_SCOPE_SYSTEM", native_source)
+        self.assertIn("shared_ep_publish_pointer_table_epoch_kernel", native_source)
+        self.assertIn("peer_signal_bases", native_source)
+        self.assertIn("kDLROCM", native_source)
+
+    def test_forward_methods_contain_no_cpu_synchronization(self):
+        """A host collective/readback in publish or wait breaks graph replay."""
+        forbidden = (
+            "dist.barrier",
+            "dist.all_reduce",
+            ".cpu(",
+            ".item(",
+            "torch.cuda.synchronize",
+        )
+        source = inspect.getsource(GpuEpoch.publish) + inspect.getsource(
+            GpuEpoch.wait_all
+        )
+        source += inspect.getsource(GpuPointerTableEpoch.publish) + inspect.getsource(
+            GpuPointerTableEpoch.wait_all
+        )
+        for expression in forbidden:
+            self.assertNotIn(expression, source)
+
+    def test_state_close_releases_reverse_construction_order_once(self):
+        """Partial-state cleanup must not leak or double-release VMM mappings."""
+        calls = []
+        state = SharedEpState(
+            layout=object(),
+            input_allocation=_Closable("input", calls),
+            output_allocation=_Closable("output", calls),
+            input_epoch=_Closable("input_epoch", calls),
+            output_epoch=_Closable("output_epoch", calls),
+            global_input=object(),
+            local_input=object(),
+            global_output=object(),
+            local_output=object(),
+        )
+
+        state.close()
+        state.close()
+
+        self.assertEqual(
+            calls,
+            ["output_epoch", "input_epoch", "output", "input"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_fp4.py
+++ b/test/registered/moe/test_shared_ep_fp4.py
@@ -1,0 +1,495 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.shared_ep import (
+    SharedEpQuantCapability,
+    SharedEpQuantInfo,
+    SharedEpQuantization,
+    SharedEpScaleLayout,
+    SharedEpWeightLayout,
+)
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatcher,
+    _profile_quantization,
+)
+from sglang.srt.layers.moe.shared_ep.fp4 import (
+    publish_bf16_owner_input,
+    run_shared_ep_mxfp4,
+)
+from sglang.srt.layers.moe.shared_ep.kernels import RoutePreparation
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpInputViews
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.srt.layers.moe.utils import MoeA2ABackend, MoeRunnerBackend
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=20, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+
+_CONFIG = {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 1,
+    "num_warps": 4,
+    "num_stages": 2,
+    "waves_per_eu": 0,
+    "matrix_instr_nonkdim": 16,
+    "kpack": 1,
+}
+
+
+def _small_profile():
+    return SimpleNamespace(
+        name="test_mxfp4",
+        quantization=SharedEpQuantization.MXFP4,
+        hidden_size=128,
+        intermediate_size=128,
+        top_k=2,
+        num_local_experts=2,
+        block_size_m=64,
+        w13_kernel_config=lambda _tokens: _CONFIG,
+        w2_kernel_config=lambda _tokens: _CONFIG,
+    )
+
+
+def _small_quant_info() -> SharedEpQuantInfo:
+    return SharedEpQuantInfo(
+        w13_weight=torch.zeros((2, 256, 64), dtype=torch.uint8),
+        w2_weight=torch.zeros((2, 128, 64), dtype=torch.uint8),
+        w13_scale=torch.zeros((2, 256, 4), dtype=torch.uint8),
+        w2_scale=torch.zeros((2, 128, 4), dtype=torch.uint8),
+        block_shape=(1, 32),
+        fallback_quant_info=Mock(),
+        fallback_backend=MoeRunnerBackend.AITER,
+        quantization=SharedEpQuantization.MXFP4,
+        weight_layout=SharedEpWeightLayout.CANONICAL,
+        scale_layout=SharedEpScaleLayout.CANONICAL,
+        weight_group_size=32,
+        scale_format="e8m0",
+        capabilities=frozenset({SharedEpQuantCapability.CANONICAL_MXFP4}),
+        fallback_weight_layout=SharedEpWeightLayout.AITER_SHUFFLED,
+        fallback_scale_layout=SharedEpScaleLayout.AITER_SHUFFLED,
+        fallback_uses_duplicate_tensors=True,
+    )
+
+
+class TestSharedEpMXFP4Contracts(unittest.TestCase):
+    def test_bf16_owner_publish_is_direct_and_clears_unused_routes(self):
+        backing = torch.zeros((4, 256), dtype=torch.bfloat16)
+        target = SharedEpInputViews(
+            activations=backing[:, :128],
+            scales=None,
+            topk_ids=torch.full((4, 2), 77, dtype=torch.int32),
+            topk_weights=torch.full((4, 2), 9.0, dtype=torch.float32),
+        )
+        source = torch.arange(2 * 128, dtype=torch.bfloat16).view(2, 128)
+        ids = torch.tensor([[3, 4], [5, 6]], dtype=torch.int64)
+        weights = torch.tensor([[0.1, 0.2], [0.3, 0.4]], dtype=torch.float32)
+
+        publish_bf16_owner_input(
+            target,
+            source=source,
+            source_ids=ids,
+            source_weights=weights,
+        )
+
+        self.assertEqual(target.activations.stride(), (256, 1))
+        torch.testing.assert_close(target.activations[:2], source)
+        self.assertTrue(torch.equal(target.topk_ids[:2], ids.to(torch.int32)))
+        self.assertTrue(torch.equal(target.topk_weights[:2], weights))
+        self.assertTrue(torch.all(target.topk_ids[2:] == -1))
+        self.assertTrue(torch.all(target.topk_weights[2:] == 0))
+
+    def test_mxfp4_metadata_fails_closed_on_shuffled_scales(self):
+        info = _small_quant_info()
+        info.require_decode_capability(SharedEpQuantCapability.CANONICAL_MXFP4)
+        self.assertTrue(info.fallback_uses_duplicate_tensors)
+        self.assertIs(
+            info.fallback_weight_layout,
+            SharedEpWeightLayout.AITER_SHUFFLED,
+        )
+
+        info.w13_scale.is_shuffled = True
+        with self.assertRaisesRegex(ValueError, "pre-shuffled"):
+            info.require_decode_capability(SharedEpQuantCapability.CANONICAL_MXFP4)
+
+    def test_quark_exposes_canonical_decode_and_explicit_prefill_duplicate(self):
+        import sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4_moe as quark_module
+
+        scheme = quark_module.QuarkW4A4MXFp4MoE.__new__(quark_module.QuarkW4A4MXFp4MoE)
+        layer = SimpleNamespace(
+            w13_weight=torch.nn.Parameter(
+                torch.arange(8, dtype=torch.uint8).view(1, 2, 4),
+                requires_grad=False,
+            ),
+            w2_weight=torch.nn.Parameter(
+                torch.arange(8, dtype=torch.uint8).view(1, 2, 4),
+                requires_grad=False,
+            ),
+            w13_weight_scale=torch.nn.Parameter(
+                torch.arange(4, dtype=torch.uint8).view(1, 2, 2),
+                requires_grad=False,
+            ),
+            w2_weight_scale=torch.nn.Parameter(
+                torch.arange(4, dtype=torch.uint8).view(1, 2, 2),
+                requires_grad=False,
+            ),
+        )
+        canonical = tuple(
+            tensor.detach().clone()
+            for tensor in (
+                layer.w13_weight,
+                layer.w2_weight,
+                layer.w13_weight_scale,
+                layer.w2_weight_scale,
+            )
+        )
+
+        with (
+            patch.object(quark_module, "_use_aiter", True),
+            patch.object(quark_module, "_is_shuffle_moe_mxfp4", True),
+            patch.object(
+                quark_module,
+                "shuffle_weight",
+                side_effect=lambda value, _layout: value.detach().clone() + 10,
+                create=True,
+            ),
+            patch.object(
+                quark_module,
+                "e8m0_shuffle",
+                side_effect=lambda value: value.detach().clone() + 20,
+                create=True,
+            ),
+        ):
+            scheme._prepare_shared_ep_aiter_fallback(layer)
+
+        for actual, expected in zip(
+            (
+                layer.w13_weight,
+                layer.w2_weight,
+                layer.w13_weight_scale,
+                layer.w2_weight_scale,
+            ),
+            canonical,
+        ):
+            self.assertTrue(torch.equal(actual, expected))
+            self.assertFalse(actual.is_shuffled)
+        self.assertTrue(layer._shared_ep_aiter_w13_weight.is_shuffled)
+        self.assertTrue(layer._shared_ep_aiter_w13_weight_scale.is_shuffled)
+
+        scheme.runner = SimpleNamespace(
+            runner_backend=MoeRunnerBackend.AITER,
+            run=lambda _dispatch, quant_info: quant_info,
+        )
+        layer.dispatcher = SimpleNamespace(expert_mask_gpu=None)
+        with patch.object(
+            quark_module,
+            "get_moe_a2a_backend",
+            return_value=MoeA2ABackend.SHARED_EP,
+        ):
+            info = scheme.apply_weights(layer, object())
+        self.assertIsInstance(info, SharedEpQuantInfo)
+        self.assertIn(
+            SharedEpQuantCapability.CANONICAL_MXFP4,
+            info.capabilities,
+        )
+        self.assertTrue(info.fallback_uses_duplicate_tensors)
+        self.assertIs(info.w13_weight, layer.w13_weight)
+        self.assertIs(info.w13_scale, layer.w13_weight_scale)
+
+    def test_fp8_fp4_experts_publish_canonical_mxfp4_metadata(self):
+        import sglang.srt.layers.quantization.fp8 as fp8_module
+
+        method = fp8_module.Fp8MoEMethod.__new__(fp8_module.Fp8MoEMethod)
+        method.is_fp4_expert = True
+        method.weight_block_size = [128, 128]
+        method.runner = SimpleNamespace(runner_backend=MoeRunnerBackend.AITER)
+        layer = SimpleNamespace(
+            w13_weight=torch.zeros((2, 256, 64), dtype=torch.uint8),
+            w2_weight=torch.zeros((2, 128, 64), dtype=torch.uint8),
+            w13_weight_scale_inv=torch.zeros((2, 256, 4), dtype=torch.uint8),
+            w2_weight_scale_inv=torch.zeros((2, 128, 4), dtype=torch.uint8),
+            _shared_ep_aiter_w13_weight=torch.ones(
+                (2, 256, 64),
+                dtype=torch.uint8,
+            ),
+            _shared_ep_aiter_w2_weight=torch.ones(
+                (2, 128, 64),
+                dtype=torch.uint8,
+            ),
+        )
+        with patch.object(
+            fp8_module,
+            "get_moe_a2a_backend",
+            return_value=MoeA2ABackend.SHARED_EP,
+        ):
+            info = method._wrap_shared_ep_quant_info(layer, Mock())
+
+        self.assertIs(info.quantization, SharedEpQuantization.MXFP4)
+        self.assertEqual(info.block_shape, (1, 32))
+        self.assertEqual(info.weight_group_size, 32)
+        self.assertIn(
+            SharedEpQuantCapability.CANONICAL_MXFP4,
+            info.capabilities,
+        )
+        self.assertTrue(info.fallback_uses_duplicate_tensors)
+        info.require_decode_capability(SharedEpQuantCapability.CANONICAL_MXFP4)
+
+    def test_cpu_adapter_preserves_canonical_route_ids_and_direct_output(self):
+        profile = _small_profile()
+        global_ids = torch.tensor(
+            [[[0, 1], [1, 0], [0, 1]]],
+            dtype=torch.int32,
+        )
+        global_weights = torch.tensor(
+            [[[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]],
+            dtype=torch.float32,
+        )
+        activations = torch.ones((1, 3, 128), dtype=torch.bfloat16)
+        global_output = torch.zeros((1, 3, 2, 128), dtype=torch.bfloat16)
+        output_epoch = Mock()
+        state = SimpleNamespace(
+            global_input=SimpleNamespace(
+                topk_ids=global_ids,
+                topk_weights=global_weights,
+            ),
+            global_output=global_output,
+            local_output=global_output[0],
+            input_epoch=SimpleNamespace(
+                allocation=SimpleNamespace(local_storage=object()),
+                epoch=object(),
+            ),
+            output_epoch=output_epoch,
+        )
+        dispatch_output = SimpleNamespace(
+            profile=profile,
+            state=state,
+            hidden_states=activations,
+            num_tokens=3,
+            local_expert_start=0,
+        )
+        sorted_routes = torch.full((128,), 6, dtype=torch.int32)
+        sorted_routes[:6] = torch.tensor([5, 0, 3, 2, 4, 1], dtype=torch.int32)
+        routes = RoutePreparation(
+            local_ids=global_ids.clone(),
+            local_weights=global_weights.clone(),
+            sorted_token_ids=sorted_routes,
+            expert_ids=torch.tensor([0, 1], dtype=torch.int32),
+            num_tokens_post_padded=torch.tensor([128], dtype=torch.int32),
+        )
+        seen = {}
+
+        def fake_w13(*args, **kwargs):
+            seen["w13_routes"] = args[3]
+            seen["swiglu_limit"] = kwargs["swiglu_limit"]
+            kwargs["out"].fill_(1)
+            return kwargs["out"]
+
+        def fake_w2(*args, **kwargs):
+            seen["w2_routes"] = args[4]
+            seen["direct_out"] = kwargs["out"]
+            out = kwargs["out"]
+            for route in range(6):
+                out[route].fill_(route + 1)
+            return out
+
+        def fake_reduce(source, *, num_tokens):
+            self.assertIs(source, state.local_output)
+            return source[:num_tokens].float().sum(dim=1).to(torch.bfloat16)
+
+        with (
+            patch(
+                "sglang.srt.layers.moe.shared_ep.fp4.prepare_routes",
+                return_value=routes,
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.fp4._load_aiter_mxfp4_ops",
+                return_value=(fake_w13, fake_w2),
+            ),
+            patch(
+                "sglang.srt.layers.moe.shared_ep.fp4.reduce_owner_output",
+                side_effect=fake_reduce,
+            ),
+        ):
+            result = run_shared_ep_mxfp4(
+                dispatch_output,
+                _small_quant_info(),
+                MoeRunnerConfig(
+                    activation="silu",
+                    is_gated=True,
+                    swiglu_limit=10.0,
+                ),
+            )
+
+        self.assertIs(seen["w13_routes"], sorted_routes)
+        self.assertEqual(seen["swiglu_limit"], 10.0)
+        self.assertIs(seen["w2_routes"], sorted_routes)
+        self.assertEqual(
+            seen["direct_out"].data_ptr(),
+            global_output.data_ptr(),
+        )
+        expected = torch.tensor([3, 7, 11], dtype=torch.bfloat16)[:, None].expand(
+            3, 128
+        )
+        torch.testing.assert_close(result.hidden_states, expected)
+        output_epoch.publish.assert_called_once_with()
+        output_epoch.wait_all.assert_called_once_with()
+
+    def test_dsv4_pro_profile_metadata_matches_packed_shapes(self):
+        config = MoeRunnerConfig(
+            hidden_size=7168,
+            intermediate_size_per_partition=3072,
+            top_k=6,
+            num_experts=384,
+            num_local_experts=48,
+            params_dtype=torch.bfloat16,
+        )
+        profile = select_profile(
+            config,
+            platform="rocm",
+            capability=(9, 5),
+            ep_size=8,
+            quantization=SharedEpQuantization.MXFP4,
+            block_shape=(1, 32),
+            max_tokens_per_rank=32,
+        )
+        self.assertEqual(
+            (
+                profile.num_local_experts,
+                profile.intermediate_size * 2,
+                profile.hidden_size // 2,
+            ),
+            (48, 6144, 3584),
+        )
+        self.assertEqual(
+            (
+                profile.num_local_experts,
+                profile.hidden_size,
+                profile.intermediate_size // 32,
+            ),
+            (48, 7168, 96),
+        )
+        self.assertEqual(
+            _profile_quantization(config),
+            (SharedEpQuantization.MXFP4, (1, 32)),
+        )
+
+        dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+        dispatcher.profile = profile
+        descriptor = dispatcher._validate_mxfp4_quant_config(
+            {
+                "shared_ep_quantization": "mxfp4",
+                "shared_ep_weight_layout": "canonical",
+                "shared_ep_scale_layout": "canonical",
+                "block_shape": (1, 32),
+                "weight_group_size": 32,
+                "scale_format": "e8m0",
+                "weight_dtype": getattr(
+                    torch,
+                    "float4_e2m1fn_x2",
+                    torch.uint8,
+                ),
+                "weight_scale_dtype": getattr(
+                    torch,
+                    "float8_e8m0fnu",
+                    torch.uint8,
+                ),
+                "w13_shape": (48, 6144, 3584),
+                "w2_shape": (48, 7168, 1536),
+                "w13_scale_shape": (48, 6144, 224),
+                "w2_scale_shape": (48, 7168, 96),
+                "fallback_uses_duplicate_tensors": True,
+            }
+        )
+        self.assertEqual(descriptor[0], "mxfp4")
+        self.assertTrue(descriptor[-1])
+
+    def test_gfx950_aiter_route_indexing_and_direct_output(self):
+        if not torch.cuda.is_available() or torch.version.hip is None:
+            self.skipTest("requires a ROCm GPU")
+        arch = torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
+        if arch != "gfx950":
+            self.skipTest(f"requires gfx950, got {arch}")
+        try:
+            from aiter.ops.triton.moe.shared_ep_mxfp4 import (
+                shared_ep_mxfp4_route_rows,
+                shared_ep_mxfp4_w2,
+                shared_ep_mxfp4_w13,
+            )
+        except ImportError as error:
+            self.skipTest(f"requires the SharedEP AITER API: {error}")
+
+        device = torch.device("cuda")
+        route_ids = torch.tensor([5, 0, 3, 2], dtype=torch.int32, device=device)
+        w13_rows, w13_out_rows = shared_ep_mxfp4_route_rows(
+            route_ids,
+            stage="w13",
+            top_k=2,
+        )
+        self.assertTrue(
+            torch.equal(
+                w13_rows.cpu(),
+                torch.tensor([2, 0, 1, 1], dtype=torch.int32),
+            )
+        )
+        self.assertTrue(torch.equal(w13_out_rows, route_ids))
+
+        sorted_routes = torch.full((128,), 6, dtype=torch.int32, device=device)
+        sorted_routes[:3] = torch.tensor([0, 3, 4], dtype=torch.int32, device=device)
+        sorted_routes[64:67] = torch.tensor(
+            [1, 2, 5],
+            dtype=torch.int32,
+            device=device,
+        )
+        experts = torch.tensor([0, 1], dtype=torch.int32, device=device)
+        num_padded = torch.tensor([128], dtype=torch.int32, device=device)
+        activations = torch.full(
+            (3, 128),
+            1 / 64,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        w13 = torch.full((2, 256, 64), 0x22, dtype=torch.uint8, device=device)
+        s13 = torch.full((2, 256, 4), 127, dtype=torch.uint8, device=device)
+        intermediate = shared_ep_mxfp4_w13(
+            activations,
+            w13,
+            s13,
+            sorted_routes,
+            experts,
+            num_padded,
+            top_k=2,
+            route_block_size=64,
+            config=_CONFIG,
+        )
+        w2 = torch.full((2, 128, 64), 0x22, dtype=torch.uint8, device=device)
+        s2 = torch.full((2, 128, 4), 127, dtype=torch.uint8, device=device)
+        route_weights = torch.ones((3, 2), dtype=torch.float32, device=device)
+        owner_slots = torch.empty(
+            (1, 3, 2, 128),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        direct = shared_ep_mxfp4_w2(
+            intermediate,
+            w2,
+            s2,
+            route_weights,
+            sorted_routes,
+            experts,
+            num_padded,
+            top_k=2,
+            route_block_size=64,
+            out=owner_slots.view(6, 128),
+            config=_CONFIG,
+        )
+        self.assertEqual(direct.data_ptr(), owner_slots.data_ptr())
+        self.assertTrue(torch.isfinite(owner_slots).all().item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_lanes.py
+++ b/test/registered/moe/test_shared_ep_lanes.py
@@ -1,0 +1,311 @@
+"""CPU-only coverage for SharedEP lane ownership and staged dispatch."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.shared_ep.backend import (
+    SharedEpDispatcher,
+    SharedEpLaneDispatcher,
+    _get_shared_state,
+)
+from sglang.srt.layers.moe.shared_ep.lanes import (
+    SHARED_EP_MAX_STATE_LANES,
+    SharedEpLaneProtocol,
+    compute_shared_ep_lane_protocol,
+    shared_ep_state_resource_key,
+)
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.srt.layers.moe.shared_ep.runtime import (
+    SharedEpRuntimeCapability,
+    SharedEpRuntimeHooks,
+)
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+
+def _server_args(**overrides):
+    values = dict(
+        enable_two_batch_overlap=False,
+        speculative_algorithm=None,
+        speculative_num_draft_tokens=None,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _config() -> MoeRunnerConfig:
+    return MoeRunnerConfig(
+        hidden_size=4096,
+        intermediate_size_per_partition=2048,
+        top_k=6,
+        num_experts=256,
+        num_local_experts=32,
+        params_dtype=torch.bfloat16,
+        shared_ep_model_namespace="target",
+    )
+
+
+def test_lane_protocol_separates_tbo_and_speculative_generations():
+    assert compute_shared_ep_lane_protocol(_server_args()).lane_count == 1
+
+    protocol = compute_shared_ep_lane_protocol(
+        _server_args(
+            enable_two_batch_overlap=True,
+            speculative_algorithm="EAGLE",
+            speculative_num_draft_tokens=4,
+        )
+    )
+    assert protocol == SharedEpLaneProtocol(tbo_width=2, generation_width=4)
+    assert protocol.lane_count == SHARED_EP_MAX_STATE_LANES
+    assert {
+        protocol.lane_id(generation_index=generation, tbo_subbatch_index=subbatch)
+        for generation in range(4)
+        for subbatch in range(2)
+    } == set(range(8))
+
+    with pytest.raises(ValueError, match="fixed release cap"):
+        compute_shared_ep_lane_protocol(
+            _server_args(
+                enable_two_batch_overlap=True,
+                speculative_algorithm="EAGLE",
+                speculative_num_draft_tokens=5,
+            )
+        )
+
+
+def test_state_resource_keys_are_deterministic_and_namespaced():
+    kwargs = dict(
+        runtime_name="rocm",
+        profile_name="dsv4_pro_mxfp4",
+        ep_size=8,
+        model_namespace="target",
+        lane_id=3,
+    )
+    key = shared_ep_state_resource_key(**kwargs)
+    assert key == shared_ep_state_resource_key(**kwargs)
+    assert "model=target" in key
+    assert "lane=3" in key
+    assert key != shared_ep_state_resource_key(
+        **{**kwargs, "model_namespace": "draft-nextn"}
+    )
+    assert key != shared_ep_state_resource_key(**{**kwargs, "lane_id": 4})
+
+
+def test_state_lookup_reuses_one_lane_but_not_another():
+    profile = select_profile(
+        _config(),
+        capability=(9, 0),
+        ep_size=8,
+        block_shape=(128, 128),
+        max_tokens_per_rank=32,
+        platform="cuda",
+    )
+    resources = SimpleNamespace(buffers={})
+
+    def create_state(**kwargs):
+        return SimpleNamespace(
+            layout=kwargs["layout"],
+            input_allocation=object(),
+            output_allocation=object(),
+            input_epoch=object(),
+            output_epoch=object(),
+        )
+
+    runtime = SharedEpRuntimeHooks(
+        name="test",
+        platform="cuda",
+        create_state=Mock(side_effect=create_state),
+        capabilities=frozenset(SharedEpRuntimeCapability),
+    )
+    parallel = SimpleNamespace(moe_ep_group=SimpleNamespace(cpu_group="cpu"))
+
+    with (
+        patch(
+            "sglang.srt.layers.moe.shared_ep.backend.get_resources",
+            return_value=resources,
+        ),
+        patch(
+            "sglang.srt.layers.moe.shared_ep.backend.get_parallel",
+            return_value=parallel,
+        ),
+        patch(
+            "sglang.srt.layers.moe.shared_ep.backend.torch.cuda.current_device",
+            return_value=0,
+        ),
+    ):
+        lane0 = _get_shared_state(
+            _config(),
+            profile,
+            runtime,
+            model_namespace="target",
+            lane_id=0,
+        )
+        lane0_again = _get_shared_state(
+            _config(),
+            profile,
+            runtime,
+            model_namespace="target",
+            lane_id=0,
+        )
+        lane1 = _get_shared_state(
+            _config(),
+            profile,
+            runtime,
+            model_namespace="target",
+            lane_id=1,
+        )
+
+    assert lane0 is lane0_again
+    assert lane0 is not lane1
+    assert lane0.input_allocation is not lane1.input_allocation
+    assert lane0.output_allocation is not lane1.output_allocation
+    assert lane0.input_epoch is not lane1.input_epoch
+    assert lane0.output_epoch is not lane1.output_epoch
+    assert runtime.create_state.call_count == 2
+
+
+def test_lane_wrapper_routes_staged_tbo_calls_to_disjoint_inners():
+    inner0 = Mock()
+    inner1 = Mock()
+    wrapper = SharedEpLaneDispatcher(
+        [inner0, inner1],
+        SharedEpLaneProtocol(tbo_width=2, generation_width=1),
+    )
+
+    with patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_generation=0),
+    ):
+        wrapper.dispatch_a(
+            hidden_states="h0",
+            topk_output="t0",
+            tbo_subbatch_index=0,
+        )
+        wrapper.dispatch_a(
+            hidden_states="h1",
+            topk_output="t1",
+            tbo_subbatch_index=1,
+        )
+        wrapper.dispatch_b(tbo_subbatch_index=0)
+        wrapper.dispatch_b(tbo_subbatch_index=1)
+        wrapper.combine_a(
+            combine_input="c0",
+            tbo_subbatch_index=0,
+        )
+        wrapper.combine_a(
+            combine_input="c1",
+            tbo_subbatch_index=1,
+        )
+        wrapper.combine_b(tbo_subbatch_index=0)
+        wrapper.combine_b(tbo_subbatch_index=1)
+
+    inner0.dispatch_a.assert_called_once_with(hidden_states="h0", topk_output="t0")
+    inner1.dispatch_a.assert_called_once_with(hidden_states="h1", topk_output="t1")
+    inner0.dispatch_b.assert_called_once_with()
+    inner1.dispatch_b.assert_called_once_with()
+    inner0.combine_a.assert_called_once_with(combine_input="c0")
+    inner1.combine_a.assert_called_once_with(combine_input="c1")
+    inner0.combine_b.assert_called_once_with()
+    inner1.combine_b.assert_called_once_with()
+
+
+def test_lane_wrapper_routes_generation_to_a_disjoint_state_lane():
+    inners = [Mock() for _ in range(4)]
+    protocol = SharedEpLaneProtocol(tbo_width=2, generation_width=2)
+    wrapper = SharedEpLaneDispatcher(inners, protocol)
+    forward_flags = SimpleNamespace(shared_ep_generation=1)
+    inners[2].dispatch.return_value = "generation-one"
+    inners[2].combine.return_value = "combined-generation-one"
+
+    with patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=forward_flags,
+    ):
+        assert wrapper.dispatch("hidden", "topk") == "generation-one"
+        assert wrapper.combine("combine-input") == "combined-generation-one"
+
+    inners[2].dispatch.assert_called_once_with(
+        hidden_states="hidden",
+        topk_output="topk",
+    )
+    inners[2].combine.assert_called_once_with(combine_input="combine-input")
+    for index, inner in enumerate(inners):
+        if index != 2:
+            inner.dispatch.assert_not_called()
+            inner.combine.assert_not_called()
+
+
+def test_shared_lane_stages_conservative_dispatch_and_combine():
+    dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+    dispatcher.lane_id = 0
+    dispatcher._stage = "initial"
+    dispatcher._active_uses_shared_ep = None
+    dispatcher.fallback_dispatcher = Mock()
+    dispatch_output = object()
+    dispatcher._dispatch_shared_ep = Mock(return_value=dispatch_output)
+    hidden_states = torch.ones((2, 4))
+
+    with patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_is_decode=True),
+    ):
+        dispatcher.dispatch_a("hidden", "topk")
+        assert dispatcher.dispatch_b() is dispatch_output
+        dispatcher.combine_a(StandardCombineInput(hidden_states=hidden_states))
+        assert dispatcher.combine_b() is hidden_states
+
+    dispatcher._dispatch_shared_ep.assert_called_once_with("hidden", "topk")
+    dispatcher.fallback_dispatcher.dispatch_a.assert_not_called()
+    assert dispatcher._stage == "initial"
+
+
+def test_non_decode_stages_route_entire_transaction_through_fallback():
+    fallback = Mock()
+    dispatch_output = object()
+    hidden_states = torch.zeros((2, 4))
+    combined = torch.arange(16).view(4, 4)
+    fallback.dispatch_b.return_value = dispatch_output
+    fallback.combine_b.return_value = combined
+    dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+    dispatcher.lane_id = 1
+    dispatcher._stage = "initial"
+    dispatcher._active_uses_shared_ep = None
+    dispatcher.fallback_dispatcher = fallback
+    dispatcher._dispatch_shared_ep = Mock()
+
+    with patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_is_decode=False),
+    ):
+        dispatcher.dispatch_a(hidden_states, "verify-topk")
+        assert dispatcher.dispatch_b() is dispatch_output
+        dispatcher.combine_a("fallback-combine-input")
+        torch.testing.assert_close(dispatcher.combine_b(), combined[:2])
+
+    fallback.dispatch_a.assert_called_once_with(
+        hidden_states=hidden_states,
+        topk_output="verify-topk",
+    )
+    fallback.combine_a.assert_called_once_with(combine_input="fallback-combine-input")
+    dispatcher._dispatch_shared_ep.assert_not_called()
+    assert dispatcher._stage == "initial"
+
+
+def test_same_lane_rejects_a_second_writer_before_combine():
+    dispatcher = SharedEpDispatcher.__new__(SharedEpDispatcher)
+    dispatcher.lane_id = 7
+    dispatcher._stage = "initial"
+    dispatcher._active_uses_shared_ep = None
+    dispatcher.fallback_dispatcher = Mock()
+    dispatcher._dispatch_shared_ep = Mock(return_value=object())
+
+    with patch(
+        "sglang.srt.layers.moe.shared_ep.backend.get_forward",
+        return_value=SimpleNamespace(shared_ep_is_decode=True),
+    ):
+        dispatcher.dispatch_a("hidden", "topk")
+        with pytest.raises(RuntimeError, match="Concurrent writers"):
+            dispatcher.dispatch_a("other", "other-topk")

--- a/test/registered/moe/test_shared_ep_lanes.py
+++ b/test/registered/moe/test_shared_ep_lanes.py
@@ -24,6 +24,10 @@ from sglang.srt.layers.moe.shared_ep.runtime import (
     SharedEpRuntimeHooks,
 )
 from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=5, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _server_args(**overrides):
@@ -257,7 +261,11 @@ def test_shared_lane_stages_conservative_dispatch_and_combine():
         dispatcher.combine_a(StandardCombineInput(hidden_states=hidden_states))
         assert dispatcher.combine_b() is hidden_states
 
-    dispatcher._dispatch_shared_ep.assert_called_once_with("hidden", "topk")
+    dispatcher._dispatch_shared_ep.assert_called_once_with(
+        "hidden",
+        "topk",
+        phase="decode",
+    )
     dispatcher.fallback_dispatcher.dispatch_a.assert_not_called()
     assert dispatcher._stage == "initial"
 
@@ -309,3 +317,7 @@ def test_same_lane_rejects_a_second_writer_before_combine():
         dispatcher.dispatch_a("hidden", "topk")
         with pytest.raises(RuntimeError, match="Concurrent writers"):
             dispatcher.dispatch_a("other", "other-topk")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/registered/moe/test_shared_ep_layout.py
+++ b/test/registered/moe/test_shared_ep_layout.py
@@ -1,0 +1,175 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe.shared_ep.layout import (
+    SharedEpInputFormat,
+    SharedEpLayout,
+    align_output_layout,
+    shared_ep_fp8_dtype,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestSharedEpLayout(unittest.TestCase):
+    def test_fp8_storage_uses_ocp_e4m3_on_supported_devices(self):
+        with patch.object(torch.version, "hip", None):
+            self.assertIs(shared_ep_fp8_dtype(), torch.float8_e4m3fn)
+        with patch.object(torch.version, "hip", "7.2.0"):
+            self.assertIs(shared_ep_fp8_dtype(), torch.float8_e4m3fn)
+
+    def test_registered_model_shapes_have_disjoint_owner_slots(self):
+        """Owner/route address math must never alias a peer contribution."""
+        for hidden_size, top_k in ((6144, 8), (4096, 6)):
+            with self.subTest(hidden_size=hidden_size, top_k=top_k):
+                layout = SharedEpLayout.build(
+                    hidden_size=hidden_size,
+                    top_k=top_k,
+                    max_tokens_per_rank=32,
+                )
+                self.assertEqual(layout.scale_groups, hidden_size // 128)
+                self.assertEqual(layout.input_row_bytes, 64 * 1024)
+                self.assertEqual(layout.output_row_bytes, 16 * 1024)
+
+                intervals = []
+                for token in range(layout.max_tokens_per_rank):
+                    for route in range(layout.top_k):
+                        start = layout.output_slot_offset(token, route)
+                        end = start + layout.output_payload_bytes
+                        self.assertLessEqual(end, layout.output_rank_bytes)
+                        intervals.append((start, end))
+                intervals.sort()
+                for left, right in zip(intervals, intervals[1:]):
+                    self.assertLessEqual(left[1], right[0])
+
+    def test_global_input_views_preserve_vmm_rank_padding(self):
+        """A mapped-rank gap must not shift peer activation or route fields."""
+        layout = SharedEpLayout.build(
+            hidden_size=4096,
+            top_k=6,
+            max_tokens_per_rank=32,
+        )
+        world_size = 2
+        mapped_rank_bytes = layout.input_rank_bytes + 64 * 1024
+        storage = torch.zeros(
+            world_size * mapped_rank_bytes,
+            dtype=torch.uint8,
+        )
+
+        views = layout.input_views(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+        )
+        views.topk_ids[1, 2, 3] = 197
+        views.topk_weights[1, 2, 3] = 0.25
+
+        row_start = mapped_rank_bytes + 2 * layout.input_row_bytes
+        id_start = row_start + layout.topk_id_offset + 3 * 4
+        weight_start = row_start + layout.topk_weight_offset + 3 * 4
+        self.assertEqual(storage[id_start : id_start + 4].view(torch.int32).item(), 197)
+        self.assertEqual(
+            storage[weight_start : weight_start + 4].view(torch.float32).item(),
+            0.25,
+        )
+        self.assertEqual(
+            views.activations.stride(0) * views.activations.element_size(),
+            mapped_rank_bytes,
+        )
+
+    def test_global_output_view_preserves_vmm_rank_padding(self):
+        """Direct W2 stores must address owner slots across a padded rank stride."""
+        layout = SharedEpLayout.build(
+            hidden_size=6144,
+            top_k=8,
+            max_tokens_per_rank=32,
+        )
+        world_size = 2
+        mapped_rank_bytes = layout.output_rank_bytes + 64 * 1024
+        storage = torch.zeros(
+            world_size * mapped_rank_bytes,
+            dtype=torch.uint8,
+        )
+
+        output = layout.output_view(
+            storage,
+            world_size=world_size,
+            mapped_rank_bytes=mapped_rank_bytes,
+        )
+        output[1, 4, 5, 7] = 3.5
+
+        byte_offset = (
+            mapped_rank_bytes
+            + layout.output_slot_offset(4, 5)
+            + 7 * torch.empty((), dtype=torch.bfloat16).element_size()
+        )
+        self.assertEqual(
+            storage[byte_offset : byte_offset + 2].view(torch.bfloat16).item(),
+            3.5,
+        )
+        self.assertEqual(
+            output.stride(0) * output.element_size(),
+            mapped_rank_bytes,
+        )
+
+    def test_dsv4_pro_bf16_input_and_direct_output_are_dense(self):
+        layout = SharedEpLayout.build(
+            hidden_size=7168,
+            top_k=6,
+            max_tokens_per_rank=32,
+            input_format=SharedEpInputFormat.BF16,
+            direct_output=True,
+        )
+        self.assertEqual(layout.scale_groups, 0)
+        self.assertEqual(layout.scale_offset, 7168 * 2)
+        self.assertEqual(layout.output_row_bytes, 7168 * 2)
+        self.assertEqual(layout.output_rank_bytes, 42 * 64 * 1024)
+        self.assertIs(align_output_layout(layout, granularity=64 * 1024), layout)
+        with self.assertRaisesRegex(RuntimeError, "densely contiguous"):
+            align_output_layout(layout, granularity=2 * 1024 * 1024)
+
+        input_storage = torch.zeros(
+            2 * layout.input_rank_bytes,
+            dtype=torch.uint8,
+        )
+        inputs = layout.input_views(
+            input_storage,
+            world_size=2,
+            mapped_rank_bytes=layout.input_rank_bytes,
+        )
+        self.assertEqual(inputs.activations.dtype, torch.bfloat16)
+        self.assertIsNone(inputs.scales)
+        inputs.activations[1, 3, 7] = 2.5
+        byte_offset = (
+            layout.input_rank_bytes
+            + 3 * layout.input_row_bytes
+            + 7 * torch.bfloat16.itemsize
+        )
+        self.assertEqual(
+            input_storage[byte_offset : byte_offset + 2].view(torch.bfloat16).item(),
+            2.5,
+        )
+
+        output_storage = torch.zeros(
+            2 * layout.output_rank_bytes,
+            dtype=torch.uint8,
+        )
+        output = layout.output_view(
+            output_storage,
+            world_size=2,
+            mapped_rank_bytes=layout.output_rank_bytes,
+        )
+        self.assertTrue(output.is_contiguous())
+        direct = output.view(-1, layout.hidden_size)
+        direct[layout.output_rows_per_rank + 11, 9] = 4.0
+        self.assertEqual(
+            output[1].view(-1, layout.hidden_size)[11, 9].item(),
+            4.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_profiles.py
+++ b/test/registered/moe/test_shared_ep_profiles.py
@@ -5,10 +5,15 @@ import torch
 
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.shared_ep import SharedEpQuantization
-from sglang.srt.layers.moe.shared_ep.profiles import select_profile
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.srt.layers.moe.shared_ep.profiles import (
+    make_pull_cache_prefill_profile,
+    resolve_prefill_capacity,
+    select_profile,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=10, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _config(
@@ -200,6 +205,59 @@ class TestSharedEpProfiles(unittest.TestCase):
                         block_shape=block_shape,
                         max_tokens_per_rank=32,
                     )
+
+    def test_pull_cache_prefill_profiles_are_rocm_block_fp8_only(self):
+        for hidden_size, top_k in ((6144, 8), (4096, 6)):
+            with self.subTest(hidden_size=hidden_size):
+                decode = select_profile(
+                    _config(hidden_size=hidden_size, top_k=top_k),
+                    platform="rocm",
+                    capability=(9, 5),
+                    ep_size=8,
+                    block_shape=(128, 128),
+                    max_tokens_per_rank=32,
+                )
+                prefill = make_pull_cache_prefill_profile(decode, 1024)
+                self.assertIsNotNone(prefill)
+                self.assertEqual(prefill.max_tokens_per_rank, 1024)
+                self.assertEqual(prefill.block_size_m, 64)
+                self.assertEqual(prefill.w13_kernel_config(1024)["BLOCK_SIZE_M"], 64)
+                self.assertEqual(prefill.w2_kernel_config(1024)["BLOCK_SIZE_M"], 64)
+
+        cuda_profile = select_profile(
+            _config(hidden_size=4096, top_k=6),
+            platform="cuda",
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        self.assertIsNone(make_pull_cache_prefill_profile(cuda_profile, 1024))
+
+        mxfp4_profile = select_profile(
+            _config(
+                hidden_size=7168,
+                intermediate_size=3072,
+                top_k=6,
+                num_experts=384,
+                num_local_experts=48,
+            ),
+            platform="rocm",
+            capability=(9, 5),
+            ep_size=8,
+            quantization=SharedEpQuantization.MXFP4,
+            block_shape=(1, 32),
+            max_tokens_per_rank=32,
+        )
+        self.assertIsNone(make_pull_cache_prefill_profile(mxfp4_profile, 1024))
+
+    def test_prefill_capacity_is_dp_local_and_bounded(self):
+        self.assertEqual(resolve_prefill_capacity(1), 1)
+        self.assertEqual(resolve_prefill_capacity(1024), 1024)
+        for invalid in (None, -1, 0, 1025):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    resolve_prefill_capacity(invalid)
 
     def test_every_unsupported_admission_dimension_is_rejected(self):
         """A near-match must fail before graph capture instead of misdispatching."""

--- a/test/registered/moe/test_shared_ep_profiles.py
+++ b/test/registered/moe/test_shared_ep_profiles.py
@@ -1,0 +1,234 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.shared_ep import SharedEpQuantization
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+def _config(
+    *,
+    hidden_size,
+    top_k,
+    intermediate_size=2048,
+    num_experts=256,
+    num_local_experts=32,
+):
+    return MoeRunnerConfig(
+        hidden_size=hidden_size,
+        intermediate_size_per_partition=intermediate_size,
+        top_k=top_k,
+        num_experts=num_experts,
+        num_local_experts=num_local_experts,
+        params_dtype=torch.bfloat16,
+    )
+
+
+class TestSharedEpProfiles(unittest.TestCase):
+    def test_exact_glm_and_dsv4_shapes_select_registered_profiles(self):
+        """The release registry must cover both promised model contracts."""
+        glm = select_profile(
+            _config(hidden_size=6144, top_k=8),
+            platform="cuda",
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        dsv4 = select_profile(
+            _config(hidden_size=4096, top_k=6),
+            platform="cuda",
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+
+        self.assertEqual(glm.name, "glm52")
+        self.assertEqual(dsv4.name, "dsv4_flash")
+        self.assertEqual(glm.route_kernel_config, {"num_threads": 1024})
+        self.assertEqual(dsv4.route_kernel_config, {"num_threads": 1024})
+        self.assertEqual(dsv4.kernel_config(4)["BLOCK_SIZE_N"], 64)
+        self.assertEqual(dsv4.kernel_config(8)["BLOCK_SIZE_N"], 128)
+
+    def test_w13_and_w2_profiles_are_selected_independently(self):
+        """Measured stage profiles must not be collapsed into one compromise."""
+        glm = select_profile(
+            _config(hidden_size=6144, top_k=8),
+            platform="cuda",
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        dsv4 = select_profile(
+            _config(hidden_size=4096, top_k=6),
+            platform="cuda",
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+
+        expected = {
+            ("dsv4", 0): ((64, 4, 3), (64, 4, 3)),
+            ("dsv4", 4): ((64, 4, 3), (64, 4, 3)),
+            ("dsv4", 8): ((128, 4, 4), (64, 4, 3)),
+            ("dsv4", 32): ((128, 4, 4), (64, 4, 3)),
+            ("glm", 0): ((64, 4, 3), (128, 4, 3)),
+            ("glm", 4): ((64, 4, 3), (128, 4, 3)),
+            ("glm", 8): ((128, 8, 4), (128, 4, 3)),
+            ("glm", 32): ((128, 8, 4), (128, 4, 3)),
+        }
+        for model, profile in (("dsv4", dsv4), ("glm", glm)):
+            for tokens in (0, 4, 8, 32):
+                with self.subTest(model=model, tokens=tokens):
+                    w13 = profile.w13_kernel_config(tokens)
+                    w2 = profile.w2_kernel_config(tokens)
+                    self.assertEqual(
+                        (
+                            w13["BLOCK_SIZE_N"],
+                            w13["num_warps"],
+                            w13["num_stages"],
+                        ),
+                        expected[(model, tokens)][0],
+                    )
+                    self.assertEqual(
+                        (
+                            w2["BLOCK_SIZE_N"],
+                            w2["num_warps"],
+                            w2["num_stages"],
+                        ),
+                        expected[(model, tokens)][1],
+                    )
+
+        for profile in (dsv4, glm):
+            for tokens in (-1, 33):
+                with self.subTest(profile=profile.name, tokens=tokens):
+                    with self.assertRaisesRegex(ValueError, "profile capacity"):
+                        profile.w13_kernel_config(tokens)
+                    with self.assertRaisesRegex(ValueError, "profile capacity"):
+                        profile.w2_kernel_config(tokens)
+
+    def test_gfx950_profiles_use_rocm_keys_and_conservative_configs(self):
+        for hidden_size, top_k, expected_name in (
+            (6144, 8, "glm52_gfx950"),
+            (4096, 6, "dsv4_flash_gfx950"),
+        ):
+            with self.subTest(expected_name=expected_name):
+                profile = select_profile(
+                    _config(hidden_size=hidden_size, top_k=top_k),
+                    platform="rocm",
+                    capability=(9, 5),
+                    ep_size=8,
+                    block_shape=(128, 128),
+                    max_tokens_per_rank=32,
+                )
+                self.assertEqual(profile.name, expected_name)
+                self.assertEqual(profile.platform, "rocm")
+                self.assertEqual(profile.route_kernel_config, {"num_threads": 256})
+                for config in (
+                    profile.w13_kernel_config(4),
+                    profile.w13_kernel_config(32),
+                    profile.w2_kernel_config(4),
+                    profile.w2_kernel_config(32),
+                ):
+                    self.assertEqual(config["BLOCK_SIZE_N"], 64)
+                    self.assertEqual(config["BLOCK_SIZE_K"], 128)
+                    self.assertLessEqual(config["num_warps"], 4)
+                    self.assertLessEqual(config["num_stages"], 2)
+
+        with patch(
+            "sglang.srt.layers.moe.shared_ep.profiles._runtime_platform_key",
+            return_value="rocm",
+        ):
+            inferred = select_profile(
+                _config(hidden_size=4096, top_k=6),
+                capability=(9, 5),
+                ep_size=8,
+                block_shape=(128, 128),
+                max_tokens_per_rank=32,
+            )
+        self.assertEqual(inferred.name, "dsv4_flash_gfx950")
+
+    def test_exact_dsv4_pro_mxfp4_gfx950_profile_is_quantization_gated(self):
+        config = _config(
+            hidden_size=7168,
+            intermediate_size=3072,
+            top_k=6,
+            num_experts=384,
+            num_local_experts=48,
+        )
+        profile = select_profile(
+            config,
+            platform="rocm",
+            capability=(9, 5),
+            ep_size=8,
+            quantization=SharedEpQuantization.MXFP4,
+            block_shape=(1, 32),
+            max_tokens_per_rank=32,
+        )
+
+        self.assertEqual(profile.name, "dsv4_pro_mxfp4_gfx950")
+        self.assertIs(profile.quantization, SharedEpQuantization.MXFP4)
+        self.assertEqual(profile.block_shape, (1, 32))
+        self.assertEqual(profile.num_local_experts, 48)
+        self.assertEqual(profile.block_size_m, 128)
+        self.assertEqual(profile.w13_kernel_config(32)["BLOCK_SIZE_K"], 128)
+        self.assertEqual(profile.w2_kernel_config(32)["BLOCK_SIZE_N"], 128)
+
+        for quantization, block_shape in (
+            (SharedEpQuantization.BLOCK_FP8, (1, 32)),
+            (SharedEpQuantization.MXFP4, (128, 128)),
+        ):
+            with self.subTest(
+                quantization=quantization,
+                block_shape=block_shape,
+            ):
+                with self.assertRaisesRegex(ValueError, "observed=.*supported="):
+                    select_profile(
+                        config,
+                        platform="rocm",
+                        capability=(9, 5),
+                        ep_size=8,
+                        quantization=quantization,
+                        block_shape=block_shape,
+                        max_tokens_per_rank=32,
+                    )
+
+    def test_every_unsupported_admission_dimension_is_rejected(self):
+        """A near-match must fail before graph capture instead of misdispatching."""
+        base = dict(
+            config=_config(hidden_size=4096, top_k=6),
+            platform="cuda",
+            capability=(9, 0),
+            ep_size=8,
+            block_shape=(128, 128),
+            max_tokens_per_rank=32,
+        )
+        mutations = (
+            {"capability": (10, 0)},
+            {"platform": "rocm"},
+            {"ep_size": 4},
+            {"block_shape": (64, 128)},
+            {"max_tokens_per_rank": 64},
+            {"config": _config(hidden_size=4096, top_k=8)},
+            {"config": _config(hidden_size=4096, top_k=6, intermediate_size=2560)},
+        )
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                observed = {**base, **mutation}
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "observed=.*supported=",
+                ):
+                    select_profile(**observed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_pull_cache_prefill.py
+++ b/test/registered/moe/test_shared_ep_pull_cache_prefill.py
@@ -1,0 +1,306 @@
+import unittest
+
+import torch
+import triton.language as tl
+
+from sglang.kernels.ops.moe.fused_moe_triton_kernels import (
+    invoke_fused_moe_kernel,
+)
+from sglang.srt.layers.moe.shared_ep.layout import shared_ep_fp8_dtype
+from sglang.srt.layers.moe.shared_ep.pull_cache_prefill import (
+    PullCache,
+    allocate_pull_cache,
+    invoke_pull_cache_w13,
+    make_pull_cache_prefill_plan,
+    pull_cache_rows,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-large")
+register_amd_ci(est_time=20, stage="stage-b", runner_config="1-gpu-small-amd")
+
+
+class TestPullCachePrefillPlan(unittest.TestCase):
+    def test_release_profiles_have_exact_route_bounds(self):
+        glm = make_pull_cache_prefill_plan(
+            owners=8,
+            source_tokens_per_owner=1024,
+            hidden_size=6144,
+            top_k=8,
+            num_local_experts=32,
+            expert_alignment=64,
+        )
+        dsv4 = make_pull_cache_prefill_plan(
+            owners=8,
+            source_tokens_per_owner=1024,
+            hidden_size=4096,
+            top_k=6,
+            num_local_experts=32,
+            expert_alignment=64,
+        )
+        self.assertEqual(glm.source_route_capacity, 65536)
+        self.assertEqual(glm.cache_rows, 67552)
+        self.assertEqual(glm.scale_groups, 48)
+        self.assertEqual(dsv4.source_route_capacity, 49152)
+        self.assertEqual(dsv4.cache_rows, 51168)
+        self.assertEqual(dsv4.scale_groups, 32)
+
+    def test_invalid_dimensions_are_rejected(self):
+        valid = {
+            "owners": 8,
+            "source_tokens_per_owner": 1024,
+            "hidden_size": 4096,
+            "top_k": 6,
+            "num_local_experts": 32,
+            "expert_alignment": 64,
+        }
+        for name in valid:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "positive"):
+                    make_pull_cache_prefill_plan(**{**valid, name: 0})
+        with self.assertRaisesRegex(ValueError, "divisible by 128"):
+            make_pull_cache_prefill_plan(**{**valid, "hidden_size": 4097})
+        with self.assertRaisesRegex(ValueError, "power of two"):
+            make_pull_cache_prefill_plan(**{**valid, "expert_alignment": 96})
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires a GPU")
+class TestPullCachePrefillGpu(unittest.TestCase):
+    def _plan(self):
+        return make_pull_cache_prefill_plan(
+            owners=3,
+            source_tokens_per_owner=4,
+            hidden_size=256,
+            top_k=2,
+            num_local_experts=2,
+            expert_alignment=8,
+        )
+
+    def test_permuted_rows_padding_tail_and_reuse(self):
+        plan = self._plan()
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=plan.cache_rows,
+            device=torch.device("cuda"),
+        )
+        cache.activations.fill_(7)
+        cache.scales.fill_(7)
+        source_values = (
+            torch.arange(plan.source_rows * plan.hidden_size, device="cuda")
+            .view(plan.source_rows, plan.hidden_size)
+            .remainder(31)
+            .sub(15)
+            .to(shared_ep_fp8_dtype())
+        )
+        source_scales = (
+            torch.arange(plan.source_rows * plan.scale_groups, device="cuda")
+            .view(plan.source_rows, plan.scale_groups)
+            .float()
+        )
+        sorted_ids = torch.full(
+            (plan.cache_rows,),
+            plan.source_route_capacity,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        sorted_ids[:3] = torch.tensor([7, 0, 22], dtype=torch.int32, device="cuda")
+        sorted_ids[8:10] = torch.tensor([2, 15], dtype=torch.int32, device="cuda")
+        padded = torch.tensor([16], dtype=torch.int32, device="cuda")
+
+        for delta in (0, 1):
+            if delta:
+                source_values.copy_((source_values.float() + 1).to(source_values.dtype))
+                source_scales.add_(1)
+            pull_cache_rows(
+                source_activations=source_values,
+                source_scales=source_scales,
+                sorted_token_ids=sorted_ids,
+                num_tokens_post_padded=padded,
+                cache=cache,
+                top_k=plan.top_k,
+                source_route_capacity=plan.source_route_capacity,
+            )
+            expected_activations = torch.zeros_like(cache.activations)
+            expected_scales = torch.zeros_like(cache.scales)
+            expected_activations[16:].fill_(7)
+            expected_scales[16:].fill_(7)
+            for target_row, route in ((0, 7), (1, 0), (2, 22), (8, 2), (9, 15)):
+                source_row = route // plan.top_k
+                expected_activations[target_row].copy_(source_values[source_row])
+                expected_scales[target_row].copy_(source_scales[source_row])
+            self.assertTrue(torch.equal(cache.activations, expected_activations))
+            self.assertTrue(torch.equal(cache.scales, expected_scales))
+
+    def test_pull_w13_matches_direct_indexing(self):
+        plan = self._plan()
+        cache = allocate_pull_cache(
+            plan,
+            active_rows=plan.cache_rows,
+            device=torch.device("cuda"),
+        )
+        source_values = (
+            torch.arange(plan.source_rows * plan.hidden_size, device="cuda")
+            .view(plan.source_rows, plan.hidden_size)
+            .remainder(17)
+            .sub(8)
+            .to(shared_ep_fp8_dtype())
+        )
+        source_scales = torch.ones(
+            (plan.source_rows, plan.scale_groups),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        sorted_ids = torch.full(
+            (plan.cache_rows,),
+            plan.source_route_capacity,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        sorted_ids[:3] = torch.tensor([7, 0, 22], dtype=torch.int32, device="cuda")
+        sorted_ids[8:10] = torch.tensor([2, 15], dtype=torch.int32, device="cuda")
+        expert_ids = torch.full(
+            ((plan.cache_rows + 7) // 8,),
+            -1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+        expert_ids[:2] = torch.tensor([1, 0], dtype=torch.int32, device="cuda")
+        padded = torch.tensor([16], dtype=torch.int32, device="cuda")
+        pull_cache_rows(
+            source_activations=source_values,
+            source_scales=source_scales,
+            sorted_token_ids=sorted_ids,
+            num_tokens_post_padded=padded,
+            cache=cache,
+            top_k=plan.top_k,
+            source_route_capacity=plan.source_route_capacity,
+        )
+
+        config = {
+            "BLOCK_SIZE_M": 8,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 128,
+            "GROUP_SIZE_M": 1,
+            "num_warps": 4,
+            "num_stages": 1,
+        }
+        weights = torch.randint(
+            -4,
+            5,
+            (2, 512, 256),
+            dtype=torch.int8,
+            device="cuda",
+        ).to(shared_ep_fp8_dtype())
+        weight_scales = torch.ones((2, 4, 2), dtype=torch.float32, device="cuda")
+        actual = torch.full(
+            (plan.cache_rows, 512),
+            7,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        reference = torch.full_like(actual, 7)
+        invoke_pull_cache_w13(
+            cache=cache,
+            weight=weights,
+            weight_scale=weight_scales,
+            output=actual,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=padded,
+            config=config,
+            block_shape=(128, 128),
+        )
+        invoke_fused_moe_kernel(
+            A=source_values,
+            B=weights,
+            bias=None,
+            C=reference,
+            A_scale=source_scales,
+            B_scale=weight_scales,
+            B_zp=None,
+            topk_weights=torch.ones(
+                (plan.source_rows, plan.top_k),
+                dtype=torch.float32,
+                device="cuda",
+            ),
+            topk_ids=torch.zeros(
+                (plan.source_rows, plan.top_k),
+                dtype=torch.int32,
+                device="cuda",
+            ),
+            sorted_token_ids=sorted_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=padded,
+            mul_routed_weight=False,
+            top_k=plan.top_k,
+            config=config,
+            compute_type=tl.bfloat16,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=[128, 128],
+            filter_expert=True,
+            c_sorted=True,
+            a_is_prequantized=True,
+        )
+        valid_positions = sorted_ids[:16] < plan.source_route_capacity
+        torch.testing.assert_close(
+            actual[:16][valid_positions],
+            reference[:16][valid_positions],
+            rtol=1e-2,
+            atol=2e-2,
+        )
+        self.assertTrue(torch.all(actual[:16][~valid_positions] == 0))
+        self.assertTrue(torch.all(actual[16:] == 7))
+
+    def test_invalid_cache_contract_is_rejected(self):
+        plan = self._plan()
+        allocated = allocate_pull_cache(
+            plan,
+            active_rows=plan.cache_rows,
+            device=torch.device("cuda"),
+        )
+        forged = PullCache(
+            plan=allocated.plan,
+            active_rows=allocated.active_rows,
+            activations=allocated.activations,
+            scales=torch.empty(
+                (allocated.active_rows, allocated.plan.scale_groups * 2),
+                dtype=torch.float32,
+                device="cuda",
+            )[:, ::2],
+            row_ids=allocated.row_ids,
+            row_weights=allocated.row_weights,
+        )
+        with self.assertRaisesRegex(ValueError, "contiguous row-major"):
+            pull_cache_rows(
+                source_activations=torch.zeros(
+                    (plan.source_rows, plan.hidden_size),
+                    dtype=shared_ep_fp8_dtype(),
+                    device="cuda",
+                ),
+                source_scales=torch.ones(
+                    (plan.source_rows, plan.scale_groups),
+                    dtype=torch.float32,
+                    device="cuda",
+                ),
+                sorted_token_ids=torch.full(
+                    (plan.cache_rows,),
+                    plan.source_route_capacity,
+                    dtype=torch.int32,
+                    device="cuda",
+                ),
+                num_tokens_post_padded=torch.zeros(
+                    1,
+                    dtype=torch.int32,
+                    device="cuda",
+                ),
+                cache=forged,
+                top_k=plan.top_k,
+                source_route_capacity=plan.source_route_capacity,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_routes.py
+++ b/test/registered/moe/test_shared_ep_routes.py
@@ -1,0 +1,279 @@
+import unittest
+from pathlib import Path
+
+import torch
+
+import sglang.kernels.ops.moe.shared_ep_route_prep as route_module
+from sglang.kernels.ops.moe.shared_ep_route_prep import (
+    _route_specialization_key,
+    prepare_routes_cuda,
+)
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.shared_ep.kernels import (
+    prepare_routes,
+    quantize_pack_input,
+    reduce_owner_output,
+)
+from sglang.srt.layers.moe.shared_ep.layout import SharedEpInputViews
+from sglang.srt.layers.moe.shared_ep.profiles import select_profile
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+
+def _profile(hidden_size, top_k):
+    return select_profile(
+        MoeRunnerConfig(
+            hidden_size=hidden_size,
+            intermediate_size_per_partition=2048,
+            top_k=top_k,
+            num_experts=256,
+            num_local_experts=32,
+        ),
+        platform="cuda",
+        capability=(9, 0),
+        ep_size=8,
+        block_shape=(128, 128),
+        max_tokens_per_rank=32,
+    )
+
+
+def _ready(owner_count: int) -> tuple[torch.Tensor, torch.Tensor]:
+    return (
+        torch.zeros(owner_count * 4, dtype=torch.uint8, device="cuda"),
+        torch.zeros(1, dtype=torch.int32, device="cuda"),
+    )
+
+
+class TestSharedEpRoutes(unittest.TestCase):
+    def test_route_specialization_key_is_shape_based(self):
+        """JIT variants must be selected by kernel shape, never model name."""
+        glm_key = _route_specialization_key(
+            (8, 32, 8),
+            num_local_experts=32,
+            block_size_m=16,
+            num_threads=1024,
+        )
+        dsv4_key = _route_specialization_key(
+            (8, 32, 6),
+            num_local_experts=32,
+            block_size_m=16,
+            num_threads=1024,
+        )
+
+        self.assertEqual(glm_key, (8, 32, 8, 32, 16, 1024))
+        self.assertEqual(dsv4_key, (8, 32, 6, 32, 16, 1024))
+        self.assertNotEqual(glm_key, dsv4_key)
+
+    def test_route_specialization_rejects_invalid_configs(self):
+        invalid_configs = (
+            ((8, 32), 32, 16, 1024),
+            ((8, 0, 6), 32, 16, 1024),
+            ((8, 32, 6), 0, 16, 1024),
+            ((8, 32, 6), 32, 0, 1024),
+            ((8, 32, 6), 32, 16, 1000),
+            ((8, 32, 6), 32, 16, 1056),
+            ((8, 32, 6), 32.0, 16, 1024),
+            ((8, 32, 6), 32, 16, 1024.0),
+        )
+        for shape, num_local_experts, block_size_m, num_threads in invalid_configs:
+            with self.subTest(
+                shape=shape,
+                num_local_experts=num_local_experts,
+                block_size_m=block_size_m,
+                num_threads=num_threads,
+            ):
+                with self.assertRaises(ValueError):
+                    _route_specialization_key(
+                        shape,
+                        num_local_experts=num_local_experts,
+                        block_size_m=block_size_m,
+                        num_threads=num_threads,
+                    )
+
+    def test_route_specialization_uses_wave64_on_rocm(self):
+        self.assertEqual(
+            _route_specialization_key(
+                (8, 32, 6),
+                num_local_experts=32,
+                block_size_m=16,
+                num_threads=256,
+                thread_group_size=64,
+            ),
+            (8, 32, 6, 32, 16, 256),
+        )
+        with self.assertRaisesRegex(ValueError, "64-thread wave"):
+            _route_specialization_key(
+                (8, 32, 6),
+                num_local_experts=32,
+                block_size_m=16,
+                num_threads=96,
+                thread_group_size=64,
+            )
+
+    def test_native_route_kernel_selects_rocm_device_and_wave_scope(self):
+        package_root = next(
+            parent
+            for parent in Path(route_module.__file__).resolve().parents
+            if parent.name == "sglang"
+        )
+        source = (
+            package_root
+            / "kernels"
+            / "jit"
+            / "csrc"
+            / "moe"
+            / "shared_ep_route_prep.cu"
+        ).read_text()
+        self.assertIn("kSharedEpDeviceType = kDLROCM", source)
+        self.assertIn("kRouteThreadGroupSize = 64", source)
+        self.assertIn("shared_ep_load_acquire_system", source)
+
+    def test_cuda_route_prep_rejects_cpu_tensors_before_jit(self):
+        ids = torch.zeros((8, 32, 6), dtype=torch.int32)
+        weights = torch.zeros_like(ids, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "GPU tensors"):
+            prepare_routes_cuda(
+                ids,
+                weights,
+                torch.zeros(8 * 4, dtype=torch.uint8),
+                torch.zeros(1, dtype=torch.int32),
+                local_expert_start=0,
+                num_local_experts=32,
+                block_size_m=16,
+                num_threads=1024,
+            )
+
+    def test_production_route_prep_rejects_cpu_tensors(self):
+        ids = torch.zeros((8, 32, 6), dtype=torch.int32)
+        weights = torch.zeros_like(ids, dtype=torch.float32)
+        with self.assertRaisesRegex(ValueError, "GPU tensors"):
+            prepare_routes(
+                _profile(4096, 6),
+                ids,
+                weights,
+                torch.zeros(8 * 4, dtype=torch.uint8),
+                torch.zeros(1, dtype=torch.int32),
+                local_expert_start=0,
+            )
+
+    def test_owner_reduction_rejects_cpu_storage_before_launch(self):
+        with self.assertRaisesRegex(ValueError, "requires a GPU tensor"):
+            reduce_owner_output(
+                torch.zeros((32, 6, 128), dtype=torch.bfloat16),
+                num_tokens=4,
+            )
+
+    def test_input_quantization_rejects_cpu_storage_before_launch(self):
+        target = SharedEpInputViews(
+            activations=torch.empty((2, 128), dtype=torch.float8_e4m3fn),
+            scales=torch.empty((2, 1), dtype=torch.float32),
+            topk_ids=torch.empty((2, 1), dtype=torch.int32),
+            topk_weights=torch.empty((2, 1), dtype=torch.float32),
+        )
+        with self.assertRaisesRegex(ValueError, "requires GPU tensors"):
+            quantize_pack_input(
+                target,
+                source=torch.zeros((1, 128), dtype=torch.bfloat16),
+                source_ids=torch.zeros((1, 1), dtype=torch.int32),
+                source_weights=torch.ones((1, 1), dtype=torch.float32),
+                group_size=128,
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires GPU Triton")
+    def test_owner_reduction_handles_strided_route_rows(self):
+        backing = torch.randn(
+            (5, 6, 256),
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        source = backing[..., :128]
+        actual = reduce_owner_output(source, num_tokens=3)
+        expected = source[:3].float().sum(dim=1).to(torch.bfloat16)
+        torch.testing.assert_close(actual, expected, rtol=0.02, atol=0.02)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA JIT")
+    def test_route_multiset_and_padding_for_glm_and_dsv4(self):
+        """Every local route must be consumed once by its selected expert."""
+        fixtures = (
+            (_profile(6144, 8), 8),
+            (_profile(4096, 6), 6),
+        )
+        for profile, top_k in fixtures:
+            with self.subTest(profile=profile.name):
+                ids = torch.arange(2 * 3 * top_k, dtype=torch.int32).view(
+                    2,
+                    3,
+                    top_k,
+                )
+                ids = (ids * 13) % 256
+                ids[0, 0, 0] = -1
+                weights = torch.arange(ids.numel(), dtype=torch.float32).view_as(ids)
+                ready_signals, ready_epoch = _ready(ids.shape[0])
+                result = prepare_routes(
+                    profile,
+                    ids.cuda(),
+                    weights.cuda(),
+                    ready_signals,
+                    ready_epoch,
+                    local_expert_start=64,
+                )
+
+                expected_local = ids - 64
+                expected_local = torch.where(
+                    (expected_local >= 0) & (expected_local < 32),
+                    expected_local,
+                    -1,
+                )
+                self.assertTrue(torch.equal(result.local_ids.cpu(), expected_local))
+                self.assertTrue(torch.equal(result.local_weights.cpu(), weights))
+
+                flat_local = result.local_ids.flatten()
+                padded = int(result.num_tokens_post_padded.item())
+                self.assertEqual(padded % profile.block_size_m, 0)
+                for block_start in range(0, padded, profile.block_size_m):
+                    block = result.sorted_token_ids[
+                        block_start : block_start + profile.block_size_m
+                    ]
+                    expert = int(result.expert_ids[block_start // profile.block_size_m])
+                    valid = block[block < flat_local.numel()]
+                    self.assertTrue(torch.all(flat_local[valid] == expert))
+
+                consumed = result.sorted_token_ids[:padded]
+                consumed = consumed[consumed < flat_local.numel()]
+                expected = torch.nonzero(flat_local >= 0).flatten()
+                self.assertEqual(
+                    sorted(consumed.tolist()),
+                    sorted(expected.tolist()),
+                )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA JIT")
+    def test_skew_and_empty_experts_do_not_create_fake_routes(self):
+        """Invalid and non-local routes must not be encoded as a dummy expert."""
+        profile = _profile(4096, 6)
+        ids = torch.full((1, 32, 6), 255, dtype=torch.int32)
+        ids[0, :7, 0] = 96
+        ids[0, :3, 1] = 127
+        weights = torch.ones_like(ids, dtype=torch.float32)
+        ready_signals, ready_epoch = _ready(ids.shape[0])
+
+        result = prepare_routes(
+            profile,
+            ids.cuda(),
+            weights.cuda(),
+            ready_signals,
+            ready_epoch,
+            local_expert_start=96,
+        )
+
+        padded = int(result.num_tokens_post_padded.item())
+        self.assertEqual(padded, 32)
+        self.assertEqual(result.expert_ids[:2].tolist(), [0, 31])
+        self.assertTrue(torch.all(result.expert_ids[2:] == -1))
+        consumed = result.sorted_token_ids[:padded]
+        valid = consumed[consumed < ids.numel()]
+        self.assertEqual(valid.numel(), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_vmm.py
+++ b/test/registered/moe/test_shared_ep_vmm.py
@@ -1,0 +1,474 @@
+import unittest
+from unittest.mock import MagicMock, Mock, call, patch
+
+import torch
+
+from sglang.srt.distributed.device_communicators import vmm_utils
+from sglang.srt.layers.moe.shared_ep import vmm
+from sglang.srt.layers.moe.shared_ep.state import SharedEpState
+from sglang.srt.layers.moe.shared_ep.vmm import (
+    SharedEpVmmAllocation,
+    _construct_rank_major_views,
+    _release_partial_vmm_mapping,
+    _release_vmm_handles_synchronized,
+    _synchronize_vmm_stage,
+    _validate_same_host_group,
+    allocate_rank_major_vmm,
+    round_up_to_granularity,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestSharedEpStateLifecycle(unittest.TestCase):
+    def test_close_invalidates_views_before_unmap(self):
+        input_epoch = Mock()
+        output_epoch = Mock()
+        input_allocation = Mock()
+        output_allocation = Mock()
+        state = SharedEpState(
+            layout=Mock(),
+            input_allocation=input_allocation,
+            output_allocation=output_allocation,
+            input_epoch=input_epoch,
+            output_epoch=output_epoch,
+            global_input=object(),
+            local_input=object(),
+            global_output=object(),
+            local_output=object(),
+        )
+
+        def assert_views_invalidated():
+            self.assertIsNone(state.global_input)
+            self.assertIsNone(state.local_input)
+            self.assertIsNone(state.global_output)
+            self.assertIsNone(state.local_output)
+
+        output_allocation.close.side_effect = assert_views_invalidated
+        input_allocation.close.side_effect = assert_views_invalidated
+
+        state.close()
+        state.close()
+
+        input_epoch.close.assert_called_once_with()
+        output_epoch.close.assert_called_once_with()
+        input_allocation.close.assert_called_once_with()
+        output_allocation.close.assert_called_once_with()
+
+
+class TestSharedEpVmmHelpers(unittest.TestCase):
+    def test_round_up_to_granularity(self):
+        with self.assertRaisesRegex(ValueError, "positive"):
+            round_up_to_granularity(1, 0)
+        self.assertEqual(round_up_to_granularity(1, 65536), 65536)
+        self.assertEqual(round_up_to_granularity(65536, 65536), 65536)
+        self.assertEqual(round_up_to_granularity(65537, 65536), 131072)
+
+    def test_allocator_rejects_empty_rank_segment_before_cuda_setup(self):
+        with self.assertRaisesRegex(ValueError, "logical_rank_bytes"):
+            allocate_rank_major_vmm(
+                cpu_group=object(),
+                device=torch.device("cpu"),
+                logical_rank_bytes=0,
+            )
+
+    def test_rank_major_offsets_use_mapped_stride(self):
+        storage = torch.empty(0, dtype=torch.uint8)
+        allocation = SharedEpVmmAllocation(
+            local_storage=storage,
+            global_storage=storage,
+            rank=3,
+            world_size=8,
+            logical_rank_bytes=50000,
+            mapped_rank_bytes=65536,
+            granularity=65536,
+        )
+
+        self.assertEqual(allocation.rank_offset(0), 0)
+        self.assertEqual(allocation.rank_offset(3), 3 * 65536)
+        self.assertEqual(allocation.rank_offset(7), 7 * 65536)
+        with self.assertRaisesRegex(IndexError, "rank 8"):
+            allocation.rank_offset(8)
+
+    def test_all_ranks_ok_uses_collective_backend_device(self):
+        cases = (
+            ("gloo", torch.device("cpu")),
+            ("nccl", torch.device("cuda", 3)),
+        )
+        for backend, expected_device in cases:
+            with self.subTest(backend=backend):
+                seen = {}
+                group = object()
+                flag = Mock()
+                flag.item.return_value = 1
+
+                def fake_all_reduce(flag, *, op, group):
+                    seen.update(device=flag.device, op=op, group=group)
+
+                with (
+                    patch.object(vmm_utils.dist, "get_backend", return_value=backend),
+                    patch.object(
+                        vmm_utils.torch.cuda, "current_device", return_value=3
+                    ),
+                    patch.object(
+                        vmm_utils.torch,
+                        "tensor",
+                        return_value=flag,
+                    ) as make_tensor,
+                    patch.object(
+                        vmm_utils.dist,
+                        "all_reduce",
+                        side_effect=fake_all_reduce,
+                    ),
+                ):
+                    flag.device = expected_device
+                    self.assertTrue(vmm_utils.all_ranks_ok(group, True))
+
+                make_tensor.assert_called_once_with(
+                    [1],
+                    dtype=torch.int32,
+                    device=expected_device,
+                )
+                self.assertEqual(seen["device"], expected_device)
+                self.assertEqual(seen["op"], torch.distributed.ReduceOp.BAND)
+                self.assertIs(seen["group"], group)
+
+    def test_posix_listener_failure_is_published_before_path_exchange(self):
+        group = object()
+        server = MagicMock()
+        server.bind.side_effect = OSError("bind failed")
+        published = []
+
+        def fake_all_gather(output, value, *, group):
+            published.append(value)
+            output[:] = [value, None]
+
+        with (
+            patch("socket.socket", return_value=server),
+            patch("tempfile.mkdtemp", return_value="/tmp/shared_ep_fd_test"),
+            patch.object(vmm_utils.os, "unlink"),
+            patch.object(vmm_utils.os, "rmdir"),
+            patch.object(
+                vmm_utils.dist,
+                "all_gather_object",
+                side_effect=fake_all_gather,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "POSIX fd listener setup failed on rank 0.*bind failed",
+            ),
+        ):
+            vmm_utils.exchange_posix_fds(
+                group=group,
+                rank=0,
+                world_size=2,
+                local_fds=[10],
+                peer_base_counts=[1, 1],
+            )
+
+        self.assertEqual(published, ["OSError: bind failed"])
+
+    def test_posix_send_failure_is_published_after_exchange_attempt(self):
+        group = object()
+        server = MagicMock()
+        server.accept.side_effect = OSError("accept stopped")
+        outgoing = MagicMock()
+        outgoing.__enter__.return_value = outgoing
+        outgoing.connect.side_effect = OSError("connect failed")
+        published = []
+
+        def fake_all_gather(output, value, *, group):
+            published.append(value)
+            if len(published) == 1:
+                output[:] = [None, None]
+            elif len(published) == 2:
+                output[:] = [
+                    "/tmp/shared_ep_fd_test/rank_0.sock",
+                    "/tmp/shared_ep_fd_test/rank_1.sock",
+                ]
+            else:
+                output[:] = [value, None]
+
+        with (
+            patch("socket.socket", side_effect=[server, outgoing]),
+            patch("tempfile.mkdtemp", return_value="/tmp/shared_ep_fd_test"),
+            patch.object(vmm_utils.os, "unlink"),
+            patch.object(vmm_utils.os, "rmdir"),
+            patch.object(
+                vmm_utils.dist,
+                "all_gather_object",
+                side_effect=fake_all_gather,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "POSIX fd exchange failed on rank 0.*connect failed",
+            ),
+        ):
+            vmm_utils.exchange_posix_fds(
+                group=group,
+                rank=0,
+                world_size=2,
+                local_fds=[10],
+                peer_base_counts=[1, 1],
+            )
+
+        self.assertEqual(
+            published,
+            [None, "/tmp/shared_ep_fd_test/rank_0.sock", "OSError: connect failed"],
+        )
+
+    def test_posix_descriptor_mismatch_is_published_before_mapping(self):
+        group = object()
+        server = MagicMock()
+        incoming = MagicMock()
+        incoming.__enter__.return_value = incoming
+        server.accept.return_value = (incoming, None)
+        outgoing = MagicMock()
+        outgoing.__enter__.return_value = outgoing
+        published = []
+
+        def fake_all_gather(output, value, *, group):
+            published.append(value)
+            if len(published) == 1:
+                output[:] = [None, None]
+            elif len(published) == 2:
+                output[:] = [
+                    "/tmp/shared_ep_fd_test/rank_0.sock",
+                    "/tmp/shared_ep_fd_test/rank_1.sock",
+                ]
+            else:
+                output[:] = [value, None]
+
+        with (
+            patch("socket.socket", side_effect=[server, outgoing]),
+            patch("tempfile.mkdtemp", return_value="/tmp/shared_ep_fd_test"),
+            patch.object(vmm_utils, "_recv_fd", return_value=None),
+            patch.object(vmm_utils, "_send_fd"),
+            patch.object(vmm_utils.os, "unlink"),
+            patch.object(vmm_utils.os, "rmdir"),
+            patch.object(
+                vmm_utils.dist,
+                "all_gather_object",
+                side_effect=fake_all_gather,
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"POSIX fd validation failed on rank 0.*missing=\[\(1, 0\)\]",
+            ),
+        ):
+            vmm_utils.exchange_posix_fds(
+                group=group,
+                rank=0,
+                world_size=2,
+                local_fds=[10],
+                peer_base_counts=[1, 1],
+            )
+
+        self.assertEqual(
+            published,
+            [
+                None,
+                "/tmp/shared_ep_fd_test/rank_0.sock",
+                None,
+                "missing=[(1, 0)], extra=[]",
+            ],
+        )
+
+    def test_preflight_failure_is_synchronized_before_first_allocation(self):
+        local_error = RuntimeError("HIP VMM is unsupported")
+
+        with (
+            patch.object(vmm, "_validate_same_host_group"),
+            patch.object(vmm.dist, "get_rank", return_value=1),
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(vmm, "require_vmm_backend", side_effect=local_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric preflight failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric preflight failure"),
+        ):
+            allocate_rank_major_vmm(
+                cpu_group="group",
+                device=torch.device("cuda:1"),
+                logical_rank_bytes=4096,
+            )
+
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "preflight",
+            local_error,
+        )
+
+    def test_same_host_query_failure_is_synchronized(self):
+        local_error = RuntimeError("hostname unavailable")
+
+        with (
+            patch.object(vmm.dist, "get_rank", return_value=1),
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(vmm.os, "uname", side_effect=local_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric host-query failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric host-query failure"),
+        ):
+            _validate_same_host_group("group")
+
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "host query",
+            local_error,
+        )
+
+    def test_stage_failure_reports_local_rank_and_preserves_cause(self):
+        local_error = RuntimeError("cuMemCreate: CUDA_ERROR_OUT_OF_MEMORY")
+
+        with (
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(
+                vmm.dist,
+                "all_gather_object",
+                side_effect=lambda output, value, group: output.__setitem__(0, value),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "SharedEP VMM allocation failed on rank 0.*OUT_OF_MEMORY",
+            ) as raised,
+        ):
+            _synchronize_vmm_stage("group", 0, "allocation", local_error)
+
+        self.assertIs(raised.exception.__cause__, local_error)
+
+    def test_stage_failure_reports_remote_rank(self):
+        gathered_errors = [None, "cuMemMap(rank=0): CUDA_ERROR_INVALID_VALUE"]
+
+        with (
+            patch.object(vmm.dist, "get_world_size", return_value=2),
+            patch.object(
+                vmm.dist,
+                "all_gather_object",
+                side_effect=lambda output, _value, group: output.__setitem__(
+                    slice(None), gathered_errors
+                ),
+            ),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "SharedEP VMM mapping failed on rank 1.*cuMemMap",
+            ),
+        ):
+            _synchronize_vmm_stage("group", 0, "mapping", None)
+
+    def test_partial_mapping_cleanup_is_reverse_order(self):
+        backend = MagicMock()
+        mapped_addresses = [0x1000, 0x3000]
+
+        _release_partial_vmm_mapping(
+            backend,
+            base_va=0x1000,
+            total_bytes=0x4000,
+            mapped_addresses=mapped_addresses,
+            segment_bytes=0x1000,
+        )
+
+        self.assertEqual(
+            backend.unmap.call_args_list,
+            [call(0x3000, 0x1000), call(0x1000, 0x1000)],
+        )
+        backend.address_free.assert_called_once_with(0x1000, 0x4000)
+        self.assertEqual(mapped_addresses, [])
+
+    def test_local_handle_release_failure_is_synchronized_and_retained(self):
+        backend = MagicMock()
+        retained_handles = [11, 22]
+        release_error = RuntimeError("hipMemRelease: hipErrorInvalidHandle")
+        backend.release.side_effect = release_error
+
+        with (
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric handle-release failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric handle-release failure"),
+        ):
+            _release_vmm_handles_synchronized(
+                backend,
+                retained_handles=retained_handles,
+                cpu_group="group",
+                rank=1,
+            )
+
+        self.assertEqual(retained_handles, [11, 22])
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "handle release",
+            release_error,
+        )
+
+    def test_remote_handle_release_failure_arrives_after_local_release(self):
+        backend = MagicMock()
+        retained_handles = [11, 22]
+
+        with (
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("handle release failed on rank 0"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "failed on rank 0"),
+        ):
+            _release_vmm_handles_synchronized(
+                backend,
+                retained_handles=retained_handles,
+                cpu_group="group",
+                rank=1,
+            )
+
+        self.assertEqual(retained_handles, [])
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "handle release",
+            None,
+        )
+
+    def test_tensor_view_failure_is_synchronized(self):
+        view_error = RuntimeError("torch.from_dlpack rejected CUDA pointer")
+
+        with (
+            patch.object(vmm, "_uint8_tensor_from_cuda_ptr", side_effect=view_error),
+            patch.object(
+                vmm,
+                "_synchronize_vmm_stage",
+                side_effect=RuntimeError("symmetric tensor-view failure"),
+            ) as synchronize,
+            self.assertRaisesRegex(RuntimeError, "symmetric tensor-view failure"),
+        ):
+            _construct_rank_major_views(
+                cpu_group="group",
+                rank=1,
+                base_va=0x1000,
+                total_bytes=0x4000,
+                mapped_rank_bytes=0x2000,
+                logical_rank_bytes=0x1000,
+                device_id=1,
+                refs=[],
+            )
+
+        synchronize.assert_called_once_with(
+            "group",
+            1,
+            "tensor view construction",
+            view_error,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/moe/test_shared_ep_vmm_ep8.py
+++ b/test/registered/moe/test_shared_ep_vmm_ep8.py
@@ -1,0 +1,117 @@
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.moe.shared_ep.epoch import create_gpu_epoch
+from sglang.srt.layers.moe.shared_ep.vmm import allocate_rank_major_vmm
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=40, stage="extra-b", runner_config="8-gpu-h200")
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and "RANK" in os.environ,
+    "run with torchrun on a CUDA node",
+)
+class TestSharedEpVmmEp8(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rank = int(os.environ["RANK"])
+        cls.world_size = int(os.environ["WORLD_SIZE"])
+        cls.local_rank = int(os.environ["LOCAL_RANK"])
+        if cls.world_size != 8:
+            raise AssertionError(f"expected EP8, got world size {cls.world_size}")
+        torch.cuda.set_device(cls.local_rank)
+        dist.init_process_group("gloo")
+
+    @classmethod
+    def tearDownClass(cls):
+        if dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()
+
+    def test_every_rank_reads_every_owner_segment(self):
+        allocation = None
+        try:
+            logical_rank_bytes = 4096
+            allocation = allocate_rank_major_vmm(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                logical_rank_bytes=logical_rank_bytes,
+            )
+            allocation.local_storage.fill_(self.rank + 1)
+            torch.cuda.synchronize()
+            dist.barrier()
+
+            for owner in range(self.world_size):
+                segment = allocation.global_storage.narrow(
+                    0,
+                    allocation.rank_offset(owner),
+                    logical_rank_bytes,
+                )
+                self.assertTrue(
+                    torch.all(segment == owner + 1).item(),
+                    f"rank {self.rank} observed wrong data for owner {owner}",
+                )
+            dist.barrier()
+        finally:
+            if allocation is not None:
+                allocation.close()
+
+    def test_gpu_epoch_publishes_two_generations_without_host_barrier(self):
+        """Release/acquire epochs must order peer payloads and safe reuse."""
+        allocation = None
+        input_epoch = None
+        completion_epoch = None
+        try:
+            logical_rank_bytes = 4096
+            allocation = allocate_rank_major_vmm(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                logical_rank_bytes=logical_rank_bytes,
+            )
+            input_epoch = create_gpu_epoch(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+            completion_epoch = create_gpu_epoch(
+                cpu_group=dist.group.WORLD,
+                device=torch.device("cuda", self.local_rank),
+                rank=self.rank,
+                world_size=self.world_size,
+            )
+
+            for generation in (1, 2):
+                allocation.local_storage.fill_(generation * 16 + self.rank)
+                input_epoch.publish()
+                input_epoch.wait_all()
+                for owner in range(self.world_size):
+                    segment = allocation.global_storage.narrow(
+                        0,
+                        allocation.rank_offset(owner),
+                        logical_rank_bytes,
+                    )
+                    self.assertTrue(
+                        torch.all(segment == generation * 16 + owner).item(),
+                        f"rank {self.rank} expected {generation * 16 + owner} for "
+                        f"owner {owner}, observed {torch.unique(segment).tolist()}",
+                    )
+                completion_epoch.publish()
+                completion_epoch.wait_all()
+            dist.barrier()
+        finally:
+            if completion_epoch is not None:
+                completion_epoch.close()
+            if input_epoch is not None:
+                input_epoch.close()
+            if allocation is not None:
+                allocation.close()
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(8,))

--- a/test/registered/moe/test_shared_ep_vmm_ep8.py
+++ b/test/registered/moe/test_shared_ep_vmm_ep8.py
@@ -114,4 +114,7 @@ class TestSharedEpVmmEp8(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    multigpu_pytest_main(__name__, __file__, num_gpus=(8,))
+    if "WORLD_SIZE" in os.environ:
+        unittest.main()
+    else:
+        multigpu_pytest_main(__name__, __file__, num_gpus=(8,))

--- a/test/registered/unit/distributed/test_shared_ep_hip_vmm.py
+++ b/test/registered/unit/distributed/test_shared_ep_hip_vmm.py
@@ -1,0 +1,265 @@
+"""CPU-only tests for the ROCm SharedEP VMM facade."""
+
+import ctypes
+import importlib
+import inspect
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import torch
+
+from sglang.srt.distributed.device_communicators import hip_vmm, vmm_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# SharedEP's public package imports its GPU compute backend eagerly. Bypass that
+# package initializer so these facade tests remain genuinely CPU-only.
+_SHARED_EP_PACKAGE = "sglang.srt.layers.moe.shared_ep"
+_created_package_stub = False
+if _SHARED_EP_PACKAGE not in sys.modules:
+    package = types.ModuleType(_SHARED_EP_PACKAGE)
+    srt_root = Path(vmm_utils.__file__).resolve().parents[2]
+    package.__path__ = [str(srt_root / "layers" / "moe" / "shared_ep")]
+    sys.modules[_SHARED_EP_PACKAGE] = package
+    _created_package_stub = True
+vmm = importlib.import_module(f"{_SHARED_EP_PACKAGE}.vmm")
+epoch = importlib.import_module(f"{_SHARED_EP_PACKAGE}.epoch")
+if _created_package_stub:
+    del sys.modules[_SHARED_EP_PACKAGE]
+
+
+def test_pointer_table_epoch_api_is_rocm_only_and_validates_gpu_views():
+    create = epoch.create_gpu_pointer_table_epoch
+    with (
+        patch.object(epoch, "_IS_HIP", False),
+        pytest.raises(RuntimeError, match="ROCm"),
+    ):
+        create(peer_signals=[], rank=0)
+
+    with (
+        patch.object(epoch, "_IS_HIP", True),
+        pytest.raises(ValueError, match="GPU tensors"),
+    ):
+        create(peer_signals=[torch.zeros(4, dtype=torch.uint8)], rank=0)
+
+    source = inspect.getsource(create)
+    assert "dtype=torch.uint64" in source
+    assert "signals.data_ptr()" in source
+
+
+def test_hip_allocation_properties_are_uncached_and_posix_shareable():
+    prop = hip_vmm._allocation_prop(7)
+
+    assert prop.type == hip_vmm._HIP_MEM_ALLOCATION_TYPE_UNCACHED
+    assert prop.requested_handle_type == hip_vmm._HIP_MEM_HANDLE_TYPE_POSIX_FD
+    assert prop.location.type == hip_vmm._HIP_MEM_LOCATION_TYPE_DEVICE
+    assert prop.location.id == 7
+    assert ctypes.sizeof(prop) == 32
+
+
+def test_hip_capability_probe_exercises_full_primitive_chain_and_cleans_up():
+    runtime = MagicMock()
+    runtime.runtime_version.return_value = 70_200_000
+    runtime.allocation_granularity.return_value = 65_536
+    runtime.create.return_value = 0xA11
+    runtime.import_fd.return_value = 0xB22
+    runtime.reserve.return_value = 0xC000
+    exported_fd, other_end = os.pipe()
+    runtime.export_fd.return_value = exported_fd
+    backend = hip_vmm.HipVmmBackend()
+
+    try:
+        with patch.object(hip_vmm, "_load_hip_runtime", return_value=runtime):
+            backend.ensure_supported(3)
+    finally:
+        os.close(other_end)
+
+    runtime.set_device.assert_called_once_with(3)
+    runtime.allocation_granularity.assert_called_once_with(3)
+    runtime.create.assert_called_once_with(65_536, 3)
+    runtime.export_fd.assert_called_once_with(0xA11)
+    imported_fd = runtime.import_fd.call_args.args[0]
+    assert imported_fd != exported_fd
+    runtime.reserve.assert_called_once_with(65_536, 65_536)
+    runtime.map.assert_called_once_with(0xC000, 65_536, 0xB22)
+    runtime.set_access.assert_called_once_with(0xC000, 65_536, 3)
+    runtime.unmap.assert_called_once_with(0xC000, 65_536)
+    runtime.address_free.assert_called_once_with(0xC000, 65_536)
+    assert runtime.release.call_args_list == [call(0xB22), call(0xA11)]
+    with pytest.raises(OSError):
+        os.fstat(exported_fd)
+    with pytest.raises(OSError):
+        os.fstat(imported_fd)
+
+
+def test_hip_capability_rejects_pre_72_runtime_clearly():
+    runtime = MagicMock()
+    runtime.runtime_version.return_value = 70_152_802
+    backend = hip_vmm.HipVmmBackend()
+
+    with (
+        patch.object(hip_vmm, "_load_hip_runtime", return_value=runtime),
+        pytest.raises(RuntimeError, match=r"ROCm 7\.2 or newer.*7\.1\.52802"),
+    ):
+        backend.ensure_supported(0)
+
+    runtime.set_device.assert_not_called()
+    runtime.create.assert_not_called()
+
+
+def test_capability_result_preserves_backend_failure_reason():
+    backend = MagicMock()
+    backend.platform = "rocm"
+    backend.ensure_supported.side_effect = RuntimeError(
+        "hipMemCreate: HIP error 801 (operation not supported)"
+    )
+
+    capability = vmm_utils.query_vmm_capability(
+        torch.device("cuda:2"),
+        backend=backend,
+    )
+
+    assert not capability.supported
+    assert capability.platform == "rocm"
+    assert capability.device_id == 2
+    assert "operation not supported" in capability.reason
+    with pytest.raises(RuntimeError, match="SharedEP VMM.*operation not supported"):
+        vmm_utils.require_vmm_backend(
+            torch.device("cuda:2"),
+            backend=backend,
+        )
+
+
+@pytest.mark.parametrize("device_type", [2, 10])
+def test_dlpack_wrapper_publishes_platform_device_type(device_type):
+    observed = {}
+    get_pointer = ctypes.pythonapi.PyCapsule_GetPointer
+    get_pointer.restype = ctypes.c_void_p
+    get_pointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+    sentinel = object()
+
+    def consume(capsule):
+        pointer = get_pointer(capsule, b"dltensor")
+        managed = ctypes.cast(pointer, ctypes.POINTER(vmm._DLManagedTensor))
+        observed["device_type"] = managed.contents.dl_tensor.device.device_type
+        observed["device_id"] = managed.contents.dl_tensor.device.device_id
+        observed["length"] = managed.contents.dl_tensor.shape[0]
+        managed.contents.deleter(managed)
+        return sentinel
+
+    refs = []
+    with patch.object(vmm.torch, "from_dlpack", side_effect=consume):
+        result = vmm._uint8_tensor_from_cuda_ptr(
+            0x1000,
+            4096,
+            5,
+            refs,
+            dlpack_device_type=device_type,
+        )
+
+    assert result is sentinel
+    assert observed == {
+        "device_type": device_type,
+        "device_id": 5,
+        "length": 4096,
+    }
+    assert refs == []
+
+
+def test_rank_major_allocator_uses_platform_neutral_backend():
+    backend = MagicMock()
+    backend.platform = "rocm"
+    backend.supports_fabric = False
+    backend.dlpack_device_type = 10
+    backend.get_allocation_granularity.return_value = 64
+    backend.create_allocation.return_value = 0x11
+    backend.import_posix_fd.return_value = 0x22
+    backend.reserve.return_value = 0x1000
+    global_storage = torch.empty(128, dtype=torch.uint8)
+    local_storage = global_storage[:10]
+
+    with (
+        patch.object(vmm.dist, "get_rank", return_value=0),
+        patch.object(vmm.dist, "get_world_size", return_value=2),
+        patch.object(vmm, "_validate_same_host_group"),
+        patch.object(vmm, "require_vmm_backend", return_value=backend),
+        patch.object(vmm, "_synchronize_vmm_stage"),
+        patch.object(
+            vmm,
+            "_select_handle_transport",
+            return_value=(False, [None, None], [], {(1, 0): 91}),
+        ),
+        patch.object(
+            vmm,
+            "_construct_rank_major_views",
+            return_value=(global_storage, local_storage),
+        ) as construct_views,
+    ):
+        allocation = vmm.allocate_rank_major_vmm(
+            cpu_group="group",
+            device=torch.device("cuda:0"),
+            logical_rank_bytes=10,
+        )
+
+    backend.create_allocation.assert_called_once_with(
+        64,
+        0,
+        allow_fabric=False,
+    )
+    backend.import_posix_fd.assert_called_once_with(91)
+    assert backend.map.call_args_list == [
+        call(0x1000, 64, 0x11),
+        call(0x1040, 64, 0x22),
+    ]
+    assert backend.set_access.call_args_list == [
+        call(0x1000, 64, 0),
+        call(0x1040, 64, 0),
+    ]
+    assert backend.release.call_args_list == [call(0x11), call(0x22)]
+    construct_views.assert_called_once_with(
+        cpu_group="group",
+        rank=0,
+        base_va=0x1000,
+        total_bytes=128,
+        mapped_rank_bytes=64,
+        logical_rank_bytes=10,
+        device_id=0,
+        refs=[],
+        dlpack_device_type=10,
+    )
+    assert allocation._vmm_backend is backend
+
+
+def test_allocation_close_unmaps_every_segment_then_frees_address():
+    backend = MagicMock()
+    storage = torch.empty(0, dtype=torch.uint8)
+    allocation = vmm.SharedEpVmmAllocation(
+        local_storage=storage,
+        global_storage=storage,
+        rank=0,
+        world_size=2,
+        logical_rank_bytes=32,
+        mapped_rank_bytes=64,
+        granularity=64,
+        _base_va=0x1000,
+        _total_bytes=128,
+        _vmm_backend=backend,
+    )
+
+    with patch.object(vmm.torch.cuda, "synchronize"):
+        allocation.close()
+        allocation.close()
+
+    assert backend.unmap.call_args_list == [
+        call(0x1000, 64),
+        call(0x1040, 64),
+    ]
+    backend.address_free.assert_called_once_with(0x1000, 128)
+    assert allocation._base_va == 0
+    assert allocation.local_storage.numel() == 0
+    assert allocation.global_storage.numel() == 0

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -5,7 +5,7 @@ import socket
 import tempfile
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.arg_groups import pd_disaggregation_hook
@@ -19,6 +19,10 @@ from sglang.srt.entrypoints.sidecar import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
+from sglang.srt.layers.moe.shared_ep.admission import (
+    validate_shared_ep_server_args,
+)
+from sglang.srt.layers.moe.utils import get_shared_ep_prefill_backend
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     CudaGraphConfig,
@@ -1908,6 +1912,251 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         # require dp-attention there.
         args = self._args(moe_a2a_backend="deepep", enable_dp_attention=False)
         args._check_two_batch_overlap()
+
+
+class TestSharedEpConstraints(CustomTestCase):
+    def _args(self, **overrides):
+        args = ServerArgs(model_path="dummy")
+        args.moe_a2a_backend = "shared_ep"
+        args.moe_runner_backend = get_shared_ep_prefill_backend().value
+        args.tp_size = 8
+        args.ep_size = 8
+        args.dp_size = 8
+        args.nnodes = 1
+        args.enable_dp_attention = True
+        args.enable_lora = False
+        args.lora_paths = None
+        args.enable_two_batch_overlap = False
+        args.enable_single_batch_overlap = False
+        args.speculative_algorithm = None
+        args.speculative_moe_a2a_backend = None
+        args.speculative_moe_runner_backend = None
+        args.speculative_num_steps = None
+        args.speculative_eagle_topk = None
+        args.speculative_num_draft_tokens = None
+        args.cuda_graph_config = CudaGraphConfig(
+            decode=PhaseConfig(
+                backend=Backend.FULL, max_bs=32, bs=[1, 2, 4, 8, 16, 32]
+            ),
+            prefill=PhaseConfig(backend=Backend.DISABLED),
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_release_decode_capacity_is_admitted(self):
+        validate_shared_ep_server_args(self._args())
+
+    def test_release_defaults_global_request_limit_to_dp_capacity(self):
+        args = self._args(max_running_requests=None)
+
+        validate_shared_ep_server_args(args)
+
+        self.assertEqual(args.max_running_requests, 32 * 8)
+
+    def test_release_rejects_global_request_limit_above_dp_capacity(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "max-running-requests 256",
+        ):
+            validate_shared_ep_server_args(self._args(max_running_requests=257))
+
+    def test_release_requires_dp8_with_dp_attention(self):
+        for overrides, pattern in (
+            ({"ep_size": 4}, "EP8"),
+            ({"dp_size": 4}, "DP8"),
+            ({"enable_dp_attention": False}, "enable-dp-attention"),
+        ):
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, pattern):
+                    validate_shared_ep_server_args(self._args(**overrides))
+
+    def test_release_rejects_cross_node(self):
+        with self.assertRaisesRegex(ValueError, "same-host"):
+            validate_shared_ep_server_args(self._args(nnodes=2))
+
+    def test_release_rejects_lora(self):
+        for overrides in (
+            {"enable_lora": True},
+            {"lora_paths": ["adapter"]},
+        ):
+            with self.subTest(overrides=overrides):
+                with self.assertRaisesRegex(ValueError, "LoRA"):
+                    validate_shared_ep_server_args(self._args(**overrides))
+
+    def test_release_rejects_unlaned_pdmux_streams(self):
+        with self.assertRaisesRegex(ValueError, "PD-Multiplexing"):
+            validate_shared_ep_server_args(self._args(enable_pdmux=True))
+
+    def test_auto_target_runner_resolves_to_platform_backend(self):
+        args = self._args(moe_runner_backend="auto")
+
+        validate_shared_ep_server_args(args)
+
+        self.assertEqual(
+            args.moe_runner_backend,
+            get_shared_ep_prefill_backend().value,
+        )
+
+    @patch("sglang.srt.layers.moe.utils.is_hip", return_value=True)
+    def test_rocm_resolution_pass_selects_aiter(self, _is_hip):
+        from sglang.srt.arg_groups.overrides import (
+            _shared_ep_runner_resolution,
+        )
+
+        self.assertEqual(
+            _shared_ep_runner_resolution(
+                SimpleNamespace(
+                    moe_a2a_backend="shared_ep",
+                    moe_runner_backend="auto",
+                )
+            ),
+            {"moe_runner_backend": "aiter"},
+        )
+
+    def test_conflicting_target_runner_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "moe-runner-backend"):
+            validate_shared_ep_server_args(self._args(moe_runner_backend="triton"))
+
+    @patch("sglang.srt.layers.moe.shared_ep.admission.get_shared_ep_prefill_backend")
+    def test_rocm_auto_runner_resolves_to_aiter(self, get_prefill_backend):
+        from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+        get_prefill_backend.return_value = MoeRunnerBackend.AITER
+        args = self._args(moe_runner_backend="auto")
+        with patch.dict(os.environ, {"SGLANG_USE_AITER": "0"}):
+            validate_shared_ep_server_args(args)
+            self.assertEqual(args.moe_runner_backend, "aiter")
+            self.assertTrue(envs.SGLANG_USE_AITER.get())
+
+    @patch("sglang.srt.layers.moe.shared_ep.admission.get_shared_ep_prefill_backend")
+    def test_rocm_rejects_non_aiter_runner(self, get_prefill_backend):
+        from sglang.srt.layers.moe.utils import MoeRunnerBackend
+
+        get_prefill_backend.return_value = MoeRunnerBackend.AITER
+        with self.assertRaisesRegex(ValueError, "moe-runner-backend aiter"):
+            validate_shared_ep_server_args(self._args(moe_runner_backend="deep_gemm"))
+
+    def test_tbo_is_admitted_but_sbo_is_rejected(self):
+        validate_shared_ep_server_args(self._args(enable_two_batch_overlap=True))
+        with self.assertRaisesRegex(ValueError, "SBO"):
+            validate_shared_ep_server_args(self._args(enable_single_batch_overlap=True))
+
+    def test_mtp_without_algorithm_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "MTP"):
+            validate_shared_ep_server_args(
+                self._args(
+                    speculative_algorithm=None,
+                    speculative_num_steps=1,
+                )
+            )
+
+    def test_linear_nextn_mtp_with_materialized_fallback_is_admitted(self):
+        backend = get_shared_ep_prefill_backend()
+        speculative_a2a = "mori" if backend.is_aiter() else "deepep"
+        validate_shared_ep_server_args(
+            self._args(
+                enable_two_batch_overlap=True,
+                speculative_algorithm="EAGLE",
+                speculative_num_steps=1,
+                speculative_eagle_topk=1,
+                speculative_num_draft_tokens=2,
+                speculative_moe_a2a_backend=speculative_a2a,
+                speculative_moe_runner_backend=backend.value,
+            )
+        )
+
+    def test_speculative_tree_and_unmaterialized_draft_are_rejected(self):
+        backend = get_shared_ep_prefill_backend()
+        speculative_a2a = "mori" if backend.is_aiter() else "deepep"
+        base = dict(
+            speculative_algorithm="EAGLE",
+            speculative_num_steps=1,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=2,
+            speculative_moe_a2a_backend=speculative_a2a,
+            speculative_moe_runner_backend=backend.value,
+        )
+        with self.assertRaisesRegex(ValueError, "topk 1"):
+            validate_shared_ep_server_args(
+                self._args(**{**base, "speculative_eagle_topk": 2})
+            )
+        with self.assertRaisesRegex(ValueError, "materialized draft fallback"):
+            validate_shared_ep_server_args(
+                self._args(**{**base, "speculative_moe_a2a_backend": "none"})
+            )
+
+    def test_lane_count_above_fixed_cap_is_rejected(self):
+        backend = get_shared_ep_prefill_backend()
+        speculative_a2a = "mori" if backend.is_aiter() else "deepep"
+        with self.assertRaisesRegex(ValueError, "fixed release cap"):
+            validate_shared_ep_server_args(
+                self._args(
+                    enable_two_batch_overlap=True,
+                    speculative_algorithm="EAGLE",
+                    speculative_num_steps=4,
+                    speculative_eagle_topk=1,
+                    speculative_num_draft_tokens=5,
+                    speculative_moe_a2a_backend=speculative_a2a,
+                    speculative_moe_runner_backend=backend.value,
+                )
+            )
+
+    def test_release_rejects_unregistered_model_architecture(self):
+        args = self._args()
+        args.model_path = "unsupported-model"
+        args.get_model_config = Mock(
+            return_value=SimpleNamespace(
+                hf_config=SimpleNamespace(architectures=["UnsupportedMoeForCausalLM"])
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "GLM-5.2"):
+            validate_shared_ep_server_args(args)
+
+    def test_release_accepts_registered_model_architectures(self):
+        for architecture in (
+            "GlmMoeDsaForCausalLM",
+            "DeepseekV4ForCausalLM",
+        ):
+            with self.subTest(architecture=architecture):
+                args = self._args()
+                args.model_path = "supported-model"
+                args.get_model_config = Mock(
+                    return_value=SimpleNamespace(
+                        hf_config=SimpleNamespace(architectures=[architecture])
+                    )
+                )
+                validate_shared_ep_server_args(args)
+
+    def test_oversized_decode_cuda_graph_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "32"):
+            validate_shared_ep_server_args(
+                self._args(
+                    cuda_graph_config=CudaGraphConfig(
+                        decode=PhaseConfig(
+                            backend=Backend.FULL,
+                            max_bs=64,
+                            bs=[1, 32, 64],
+                        ),
+                        prefill=PhaseConfig(backend=Backend.DISABLED),
+                    )
+                )
+            )
+
+    def test_disabled_decode_cuda_graph_ignores_capture_size(self):
+        validate_shared_ep_server_args(
+            self._args(
+                cuda_graph_config=CudaGraphConfig(
+                    decode=PhaseConfig(
+                        backend=Backend.DISABLED,
+                        max_bs=64,
+                        bs=[64],
+                    ),
+                    prefill=PhaseConfig(backend=Backend.DISABLED),
+                )
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2019,6 +2019,12 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             ),
             {},
         )
+        self.assertEqual(
+            _a2a_ep_size(
+                ResolvedView(SimpleNamespace(moe_a2a_backend="shared_ep", tp_size=8))
+            ),
+            {"ep_size": 8},
+        )
 
     def test_deepseek_family_order_safe_declarations(self):
         from sglang.srt.arg_groups.overrides import _deepseek_family_overrides

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -725,6 +725,7 @@ class TestForwardFlags(_IsolatedServerArgs):
             )
         )
         self.assertTrue(get_forward().shared_ep_is_decode)
+        self.assertFalse(get_forward().shared_ep_is_prefill)
         self.assertEqual(get_forward().shared_ep_generation, 3)
 
         publish_shared_ep_forward_flags(
@@ -735,6 +736,82 @@ class TestForwardFlags(_IsolatedServerArgs):
             )
         )
         self.assertFalse(get_forward().shared_ep_is_decode)
+        self.assertFalse(get_forward().shared_ep_is_prefill)
+
+        publish_shared_ep_forward_flags(
+            SimpleNamespace(
+                forward_mode=ForwardMode.IDLE,
+                global_forward_mode=ForwardMode.EXTEND,
+                shared_ep_generation=0,
+            )
+        )
+        self.assertFalse(get_forward().shared_ep_is_decode)
+        self.assertTrue(get_forward().shared_ep_is_prefill)
+
+    def test_shared_ep_gathers_rank_consistent_counts_before_forward(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+        from sglang.srt.runtime_context import (
+            get_forward,
+            publish_shared_ep_forward_flags,
+        )
+
+        parallel = SimpleNamespace(
+            moe_ep_group=SimpleNamespace(cpu_group="cpu_group"),
+            moe_ep_size=8,
+            attn_dp_size=8,
+            attn_dp_rank=0,
+        )
+
+        def gather_counts(output, value, *, group):
+            self.assertEqual(group, "cpu_group")
+            self.assertEqual(value, (3, int(ForwardMode.DECODE)))
+            output[:] = [
+                (3, int(ForwardMode.DECODE)),
+                (4, int(ForwardMode.IDLE)),
+                (2, int(ForwardMode.IDLE)),
+                (1, int(ForwardMode.IDLE)),
+                (1, int(ForwardMode.IDLE)),
+                (1, int(ForwardMode.IDLE)),
+                (1, int(ForwardMode.IDLE)),
+                (1, int(ForwardMode.IDLE)),
+            ]
+
+        reset_context()
+        with (
+            patch(
+                "sglang.srt.runtime_context.get_exec",
+                return_value=SimpleNamespace(
+                    moe=SimpleNamespace(moe_a2a_backend="shared_ep")
+                ),
+            ),
+            patch(
+                "sglang.srt.runtime_context.get_parallel",
+                return_value=parallel,
+            ),
+            patch("torch.distributed.get_world_size", return_value=8),
+            patch(
+                "torch.distributed.all_gather_object",
+                side_effect=gather_counts,
+            ),
+        ):
+            publish_shared_ep_forward_flags(
+                SimpleNamespace(
+                    forward_mode=ForwardMode.DECODE,
+                    global_forward_mode=ForwardMode.DECODE,
+                    shared_ep_generation=0,
+                    global_num_tokens_cpu=(3,),
+                )
+            )
+
+        self.assertEqual(
+            get_forward().shared_ep_global_num_tokens,
+            (3, 4, 2, 1, 1, 1, 1, 1),
+        )
+        self.assertTrue(get_forward().shared_ep_counts_synchronized)
+        self.assertTrue(get_forward().shared_ep_is_decode)
+        self.assertFalse(get_forward().shared_ep_is_prefill)
 
     def test_scoped_restores_on_exception_and_validates_keys(self):
         from sglang.srt.runtime_context import get_forward

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -751,6 +751,8 @@ class TestForwardFlags(_IsolatedServerArgs):
     def test_shared_ep_gathers_rank_consistent_counts_before_forward(self):
         from types import SimpleNamespace
 
+        import torch
+
         from sglang.srt.model_executor.forward_batch_info import ForwardMode
         from sglang.srt.runtime_context import (
             get_forward,
@@ -766,17 +768,22 @@ class TestForwardFlags(_IsolatedServerArgs):
 
         def gather_counts(output, value, *, group):
             self.assertEqual(group, "cpu_group")
-            self.assertEqual(value, (3, int(ForwardMode.DECODE)))
-            output[:] = [
-                (3, int(ForwardMode.DECODE)),
-                (4, int(ForwardMode.IDLE)),
-                (2, int(ForwardMode.IDLE)),
-                (1, int(ForwardMode.IDLE)),
-                (1, int(ForwardMode.IDLE)),
-                (1, int(ForwardMode.IDLE)),
-                (1, int(ForwardMode.IDLE)),
-                (1, int(ForwardMode.IDLE)),
-            ]
+            self.assertEqual(value.tolist(), [3, int(ForwardMode.DECODE)])
+            output.copy_(
+                torch.tensor(
+                    [
+                        (3, int(ForwardMode.DECODE)),
+                        (4, int(ForwardMode.IDLE)),
+                        (2, int(ForwardMode.IDLE)),
+                        (1, int(ForwardMode.IDLE)),
+                        (1, int(ForwardMode.IDLE)),
+                        (1, int(ForwardMode.IDLE)),
+                        (1, int(ForwardMode.IDLE)),
+                        (1, int(ForwardMode.IDLE)),
+                    ],
+                    dtype=torch.int64,
+                ).view(-1)
+            )
 
         reset_context()
         with (
@@ -792,7 +799,7 @@ class TestForwardFlags(_IsolatedServerArgs):
             ),
             patch("torch.distributed.get_world_size", return_value=8),
             patch(
-                "torch.distributed.all_gather_object",
+                "torch.distributed.all_gather_into_tensor",
                 side_effect=gather_counts,
             ),
         ):
@@ -812,6 +819,74 @@ class TestForwardFlags(_IsolatedServerArgs):
         self.assertTrue(get_forward().shared_ep_counts_synchronized)
         self.assertTrue(get_forward().shared_ep_is_decode)
         self.assertFalse(get_forward().shared_ep_is_prefill)
+
+    def test_shared_ep_mixed_dp_phases_force_materialized_fallback(self):
+        from types import SimpleNamespace
+
+        import torch
+
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+        from sglang.srt.runtime_context import (
+            get_forward,
+            publish_shared_ep_forward_flags,
+        )
+
+        parallel = SimpleNamespace(
+            moe_ep_group=SimpleNamespace(cpu_group="cpu_group"),
+            moe_ep_size=8,
+            attn_dp_size=8,
+            attn_dp_rank=0,
+        )
+
+        def gather_state(output, value, *, group):
+            self.assertEqual(group, "cpu_group")
+            self.assertEqual(value.tolist(), [1024, int(ForwardMode.EXTEND)])
+            output.copy_(
+                torch.tensor(
+                    [
+                        (1024, int(ForwardMode.EXTEND)),
+                        (1024, int(ForwardMode.EXTEND)),
+                        (1024, int(ForwardMode.EXTEND)),
+                        (1024, int(ForwardMode.EXTEND)),
+                        (1, int(ForwardMode.DECODE)),
+                        (1024, int(ForwardMode.EXTEND)),
+                        (1024, int(ForwardMode.EXTEND)),
+                        (1024, int(ForwardMode.EXTEND)),
+                    ],
+                    dtype=torch.int64,
+                ).view(-1)
+            )
+
+        reset_context()
+        with (
+            patch(
+                "sglang.srt.runtime_context.get_exec",
+                return_value=SimpleNamespace(
+                    moe=SimpleNamespace(moe_a2a_backend="shared_ep")
+                ),
+            ),
+            patch(
+                "sglang.srt.runtime_context.get_parallel",
+                return_value=parallel,
+            ),
+            patch("torch.distributed.get_world_size", return_value=8),
+            patch(
+                "torch.distributed.all_gather_into_tensor",
+                side_effect=gather_state,
+            ),
+        ):
+            publish_shared_ep_forward_flags(
+                SimpleNamespace(
+                    forward_mode=ForwardMode.EXTEND,
+                    global_forward_mode=None,
+                    shared_ep_generation=0,
+                    global_num_tokens_cpu=(1024,),
+                )
+            )
+
+        self.assertFalse(get_forward().shared_ep_is_decode)
+        self.assertFalse(get_forward().shared_ep_is_prefill)
+        self.assertTrue(get_forward().shared_ep_counts_synchronized)
 
     def test_scoped_restores_on_exception_and_validates_keys(self):
         from sglang.srt.runtime_context import get_forward

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -669,6 +669,26 @@ class TestEpBufferState(_IsolatedServerArgs):
         reset_context()
         self.assertIsNone(DeepEPBuffer._state().buffer)
 
+    def test_deepep_mode_transition_before_lazy_buffer_allocation(self):
+        try:
+            from sglang.srt.layers.moe.token_dispatcher.deepep import (
+                DeepEPBuffer,
+                DeepEPDispatchMode,
+            )
+        except ImportError:
+            self.skipTest("deep_ep not installed")
+
+        reset_context()
+        DeepEPBuffer.set_dispatch_mode_as_normal()
+
+        # CUDA Graph adapters publish the phase before the dispatcher's first
+        # lazy buffer allocation. NORMAL -> LOW_LATENCY has nothing to clean.
+        DeepEPBuffer.set_dispatch_mode_as_low_latency()
+
+        state = DeepEPBuffer._state()
+        self.assertIsNone(state.buffer)
+        self.assertEqual(state.dispatch_mode, DeepEPDispatchMode.LOW_LATENCY)
+
 
 class TestForwardFlags(_IsolatedServerArgs):
     """ctx.forward: contextvar-backed per-forward flags; scoped() restores,
@@ -686,6 +706,35 @@ class TestForwardFlags(_IsolatedServerArgs):
                 self.assertFalse(fwd.multi_stream)
             self.assertTrue(fwd.multi_stream)
         self.assertFalse(fwd.multi_stream)
+
+    def test_shared_ep_route_follows_global_mode_on_idle_rank(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+        from sglang.srt.runtime_context import (
+            get_forward,
+            publish_shared_ep_forward_flags,
+        )
+
+        reset_context()
+        publish_shared_ep_forward_flags(
+            SimpleNamespace(
+                forward_mode=ForwardMode.IDLE,
+                global_forward_mode=ForwardMode.DECODE,
+                shared_ep_generation=3,
+            )
+        )
+        self.assertTrue(get_forward().shared_ep_is_decode)
+        self.assertEqual(get_forward().shared_ep_generation, 3)
+
+        publish_shared_ep_forward_flags(
+            SimpleNamespace(
+                forward_mode=ForwardMode.IDLE,
+                global_forward_mode=ForwardMode.TARGET_VERIFY,
+                shared_ep_generation=0,
+            )
+        )
+        self.assertFalse(get_forward().shared_ep_is_decode)
 
     def test_scoped_restores_on_exception_and_validates_keys(self):
         from sglang.srt.runtime_context import get_forward
@@ -744,6 +793,9 @@ class TestForwardFlags(_IsolatedServerArgs):
                 x = x + 8
             if fwd.flashinfer_trtllm_bypass:
                 x = x + 16
+            if fwd.shared_ep_is_decode:
+                x = x + 32
+            x = x + fwd.shared_ep_generation * 64
             return x
 
         self.assertEqual(probe(torch.zeros(())).item(), 0)
@@ -758,6 +810,11 @@ class TestForwardFlags(_IsolatedServerArgs):
             flashinfer_trtllm_bypass=True,
         ):
             self.assertEqual(probe(torch.zeros(())).item(), 28)
+        with get_forward().scoped(
+            shared_ep_is_decode=True,
+            shared_ep_generation=2,
+        ):
+            self.assertEqual(probe(torch.zeros(())).item(), 160)
         self.assertEqual(probe(torch.zeros(())).item(), 0)
 
     def test_parallel_config_leaves_trace_under_torch_compile(self):


### PR DESCRIPTION
## Motivation

Provide a ROCm SharedEP implementation for MI355X/gfx950 that keeps expert objects in rank-major HIP VMM mappings and avoids materialized A2A on admitted phases. This is the ROCm counterpart to the pull-cache semantics in #32482.

## Modifications

- Rebased the self-contained SharedEP backend onto current `main@131bd51b01` and resolved the latest conflict.
- Direct decode supports GLM-5.2 / DSV4-Flash block-FP8 and DSV4-Pro canonical MXFP4 through ROCm/aiter#4407.
- Added single-lane ROCm pull-cache prefill for ordinary eager block-FP8: rank-major publication, expert-sorted local W13 cache, and direct W2 return to owner slots.
- Synchronizes DP token counts and modes. Mixed prefill/decode DP steps select the materialized fallback instead of entering incompatible SharedEP epochs.
- Clears owner output slots before reuse, masks invalid routes, adds gfx950 M64 prefill profiles, and fixes the ROCm wave shuffle mask.

## Scope Boundary

Native pull-cache prefill is enabled only for gfx950 block-FP8, one state lane, eager prefill, and DP-adjusted chunks up to 1024 tokens/rank.

The materialized fallback remains mandatory for mixed DP prefill/decode, DSV4-Pro MXFP4 prefill, TARGET_VERIFY, DRAFT_EXTEND, prefill CUDA Graph, and TBO/MTP or other multi-lane configurations.

Native MXFP4 prefill (sorted-input aiter ABI plus ~0.8 GiB/GPU BF16 cache) is deferred.

## Accuracy / Correctness Tests

ROCm 7.2 containers on healthy 8x MI355X nodes, using pre/post KFD + raw-VRAM gates:

- Aiter contract/numerical/graph tests: **11 passed**.
- SharedEP-focused unit/kernel suite: **209 passed**.
- Runtime-context phase synchronization tests: **69 passed**.
- EP8 HIP VMM remote reads/writes, cleanup, and multi-epoch publication: passed.
- Block-FP8 pull-cache matched direct/materialized references.
- Production-shape DSV4-Pro MXFP4 passed with idle ranks and **80 consecutive epoch reuses**.
- GLM-5.2 pull-cache versus direct production-shape comparison passed (`rtol=5e-2`, `atol=2e-2`).
- DSV4-Pro and GLM-5.2 serving smokes passed.

## Aligned Performance Validation

The workload matches #32482 as closely as ROCm permits:

- GLM-5.2 FP8, one 8x MI355X node
- TP8 + DP8 + DP-Attention + EP8
- 8K input / 1K output, global batch 64
- scheduler chunk 8192 (1024 tokens/rank)
- BF16 KV cache, zero cache hits, decode CUDA Graph, seed 20260730
- same node and command for both arms
- ROCm baseline: MoRI+AITER (DeepEP+DeepGEMM and MegaMoE are CUDA-only)
- **64 warmup requests**, so every DP rank and fallback instance is initialized before measurement

| Backend | Mean TTFT | Mean TPOT | Mean E2E | Throughput |
|---|---:|---:|---:|---:|
| MoRI+AITER | 22.86 s | 53.33 ms | 77.41 s | 0.83 req/s |
| SharedEP | 22.34 s (**-2.27%**) | 53.16 ms (**-0.32%**) | 76.72 s (**-0.89%**) | 0.83 req/s |

SharedEP is slightly faster after complete warmup, but the gain is much smaller than the H20 result in #32482. This is functional parity, not yet a compelling ROCm speedup.

Reproducer: `python test/manual/ep/benchmark_shared_ep_glm52.py`

- SharedEP: Slurm job `23940`
- MoRI+AITER: Slurm job `23942`

## Torch Profiler Findings

Matched CPU+GPU traces were collected for four prefill and four decode steps:

- SharedEP trace: Slurm `23937`
- MoRI trace: Slurm `23939`

The earlier apparent regression was primarily cold-path contamination. During the first mixed DP phase, SharedEP correctly falls back to MoRI, but the fallback was still lazy:

- `init_mori_op`: **30.74 s** in the profiled rank
- MoRI JIT compile: **23.56 s**
- SHMEM initialization: **1.21 s**
- 553 HIP stream creations: **3.01 s**
- 550 HIP stream destructions: **2.82 s**

One warmup request only initialized one DP rank, so the first batch-64 measurement included lazy initialization on the remaining ranks. With 64 warmups, the apparent +57% E2E regression disappears.

Remaining steady-state optimization targets:

1. SharedEP adds one DP phase/count collective per forward. In the profiled window it produced 8 all-gathers versus 4 for MoRI.
2. Prefill route preparation cost **256 ms / 300 layer calls**, epoch waits **90 ms / 300**, and pull-cache gather **33 ms / 300**.
3. ROCm profiles are still conservative (`BM16/N64` decode, `BM64/N64` prefill) and lack the mature tuning used by Aiter/MoRI.
4. The next meaningful gain requires fusing/reducing route-prep + epoch overhead and evaluating Aiter sorted-input/canonical-output kernels, not simply changing the server flag to `--moe-runner-backend aiter`.

## Checklist

- [x] Rebased onto latest main and resolved conflicts.
- [x] Format/pre-commit checks pass.
- [x] Unit, gfx950 kernel, HIP Graph, and EP8 tests added.
- [x] Batch-64 8K/1K benchmark aligned with #32482 completed.
- [x] Matched Torch Profiler traces collected and analyzed.
- [ ] Complete the 64/256/512/1024-token chunk sweep and accuracy suite.
- [ ] Optimize the remaining route/epoch/collective overhead.
- [ ] Update user-facing documentation before merge.

## Dependency

- aiter PR: https://github.com/ROCm/aiter/pull/4407
- validated aiter head: `a0fa09333027fd9a8a034dba4396ab8682865d37`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30734767339](https://github.com/sgl-project/sglang/actions/runs/30734767339)<!-- slot:pr-test-extra:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30734767311](https://github.com/sgl-project/sglang/actions/runs/30734767311)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->