### PR TITLE
Eliminate redundant DSA state transfers (Mooncake)

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -974,6 +974,21 @@ class MooncakeKVManager(CommonKVManager):
     ) -> Tuple[bool, bool]:
         skip_kv = False
         skip_state = False
+
+        # Must be checked before the non-hybrid early return below, or every CP
+        # rank re-sends the same state and we transfer it cp_size times over.
+        # Prefill CP all-gathers before writing the pool, so every CP rank holds
+        # the full state regardless of whether the pool is hybrid. We assume no
+        # structure about the state rows, so we don't split them across CP ranks
+        # -- just let rank 0 send the whole thing (unless layer split already
+        # shards it per rank).
+        if (
+            self.attn_cp_size > 1
+            and self.attn_cp_rank != 0
+            and not self.server_args.enable_dsa_cache_layer_split
+        ):
+            skip_state = True
+
         if not self.is_hybrid_mla_backend:
             return skip_kv, skip_state
 
@@ -985,13 +1000,6 @@ class MooncakeKVManager(CommonKVManager):
                 skip_kv = True
                 # Hybrid-MLA KV is replicated across these source ranks, but
                 # TP-sharded state needs every rank for the aggregation path.
-
-        if (
-            self.attn_cp_size > 1
-            and self.attn_cp_rank != 0
-            and not self.server_args.enable_dsa_cache_layer_split
-        ):
-            skip_state = True
 
         return skip_kv, skip_state
 


### PR DESCRIPTION
## Motivation

With Prefill CP + Decode TP and `SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER=1`, DSA MLA models send the same bytes many times over, wasting bandwidth and inflating TTFT.

Take Prefill CP8 + Decode TP8 as an example.

- **`ALL_CP_RANKS_TRANSFER=0`** — only CP rank 0 transfers, once per decode rank: 8 full-size transfers.
- **`ALL_CP_RANKS_TRANSFER=1`** — every CP rank transfers. Each rank sends 1/8 of the KV cache to all decode ranks: 8 x 8 transfers of 1/8 the size, so the same total bytes but spread over 8 senders.

The per-model state alongside the KV cache — for DSA models the indexer-K cache, addressed by `state_indices` in the transfer path — does not follow that split. It is replicated on every CP rank, and today every rank sends the *full* state, so the state crosses the wire 8 x 8 times instead of 8.

Bytes per layer per token for GLM-5.2-FP8 is as follows (KV cache 656 B, indexer-K cache 132 B):

| | KV | State | Total |
| -- | -- | -- | -- |
| `ALL_CP_RANKS_TRANSFER=0` | 8 x 656 | 8 x 132 | 6304 |
| `ALL_CP_RANKS_TRANSFER=1` | 8 x 8 x (656/8) | 8 x 8 x 132 | 13696 |

So enabling `ALL_CP_RANKS_TRANSFER=1` currently more than doubles the bytes transferred; the fix brings the total back to the `=0` baseline while keeping the 8-way sender parallelism.

## Fix

Implementation done on Mooncake transfer engine.

KV cache transfer is unchanged: each prefill rank still sends its shard to all decode ranks.

Only prefill CP rank 0 transfers the state; other CP ranks skip it. This condition already existed in `_get_dsa_cache_transfer_skip_flags()` but sat after the `is_hybrid_mla_backend` early return, so it only fired for hybrid-MLA pools. Moving it above the return applies it to non-hybrid pools as well. It still does not apply under `--enable-dsa-cache-layer-split`, where the state is sharded by layer across CP ranks and each rank has to send the layers it owns.

## Accuracy

No change to model forward or kernels — the dedup only drops redundant writes of identical state. Correctness rests on the CP all-gather invariant: every CP rank holds the full state before the pool is written.

## Tests

Environment:
- NVIDIA H100
- Prefill CP8, Decode TP8
- GLM-5.2-FP8, `num_hidden_layers` set to 30
- `SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER=1`
- Number of prompt tokens = 91904

Integration tests were done. TTFT is observed to decrease by 30% in this case. Actual bytes transferred are measured by checking the hardware counter provided by Infiniband NIC.

|  | Before | After |
| -- | ------ | ----- |
| TTFT (ms) | 552 | 388 |
| Actual bytes transferred (MiB) | 36741 | 16911 |


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30335655888](https://github.com/sgl-project/sglang/actions/runs/30335655888)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30335655723](https://github.com/sgl-project/sglang/actions/runs/30335655723)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->