### PR TITLE
fix: record MLX overlap launch timestamps

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
+++ b/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
@@ -16,6 +16,7 @@ the GPU runs both steps back-to-back with no idle gap.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
@@ -85,6 +86,11 @@ class MlxPendingJob:
 class SchedulerMlxOverlapMixin:
     """Mixin that adds MLX overlap scheduling to :class:`Scheduler`."""
 
+    @staticmethod
+    def _record_mlx_launch(batch: ScheduleBatch) -> None:
+        """Record the start time for an MLX overlap forward step."""
+        batch.launch_ts = time.monotonic()
+
     def _finalize_mlx_pending_job(self: Scheduler, pending: MlxPendingJob):
         # Account for this completed forward step. The standard scheduler does
         # this inside run_batch(), but the MLX overlap loop bypasses run_batch,
@@ -153,6 +159,7 @@ class SchedulerMlxOverlapMixin:
         pending_next: Optional[MlxPendingJob] = None
 
         def _launch_fresh(batch: ScheduleBatch) -> MlxPendingJob:
+            self._record_mlx_launch(batch)
             # Materialize batch.input_ids from CPU staging (prefill) or the
             # FutureMap relay (decode) before the forward. With deferred input
             # materialization, get_next_batch_to_run leaves input_ids unset; the
@@ -182,13 +189,16 @@ class SchedulerMlxOverlapMixin:
             # Composition is identical to prev: reuse a fresh batch copy
             # of the same underlying ScheduleBatch so process_batch_result
             # updates the same req objects with the new token.
+
+            batch_copy = prev.batch_copy.copy()
+            self._record_mlx_launch(batch_copy)
             return MlxPendingJob(
                 lazy_tokens=lazy_tokens,
                 prefills=prefills,
                 extends=extends,
                 decode=decode,
                 mode=mode,
-                batch_copy=prev.batch_copy.copy(),
+                batch_copy=batch_copy,
                 schedule_batch=prev.schedule_batch,
                 reqs=prev.reqs,
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

On macOS with Apple Silicon, launching an MLX model fails shortly after startup during the MLX prefill scheduling stage. The server process may briefly report that it is running, but the scheduler then crashes and the model cannot be used reliably.

The MLX overlap scheduler was introduced in [#32245](https://github.com/sgl-project/sglang/pull/32245), which added prefill and decode load counters.

PR #32245 made `_record_step_counters()` depend on `batch.launch_ts`. The standard `Scheduler.run_batch()` initializes this field, but the MLX overlap scheduler bypasses `run_batch()` and launches asynchronous MLX forward passes directly. As a result, `batch.launch_ts` remains `None` during the startup prefill stage.

```text
Scheduler hit an exception: Traceback (most recent call last):
  File "python/sglang/srt/managers/scheduler.py", line 3669, in _record_step_counters
    span_us = int((time.monotonic() - batch.launch_ts) * 1e6)
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```

## Modifications

<!-- Detail the changes made in this pull request. -->

Add MLX-specific launch timestamp recording for fresh forward steps.
Record a new timestamp for every chained decode step.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

After fixing the restart issue, the model starts normally.

```test
[2026-07-28 14:07:14] Failed to load generation config for mlx-community/Qwen3-0.6B-4bit: Can't load the configuration of 'mlx-community/Qwen3-0.6B-4bit'. If you were trying to load it from 'https://huggingface.co/models', make sure you don't have a local directory with the same name. Otherwise, make sure 'mlx-community/Qwen3-0.6B-4bit' is the correct path to a directory containing a generation_config.json file. Proceeding without generation config.
[2026-07-28 14:07:14] mlx_q4 quantization is not fully optimized yet. The speed can be slower than non-quantized models.
[2026-07-28 14:07:14] load snapshot writer init failed: [Errno 2] No such file or directory: '/dev/shm/sglang_loads_06dc2625ce5c_20259e45.shm'
[2026-07-28 14:09:36] Using default HuggingFace chat template with detected content format: string
[2026-07-28 14:09:36] Auto-detected template features: reasoning_config=ReasoningToggleConfig(toggle_param='enable_thinking', default_enabled=True, special_case=None, effort_kwarg=None), reasoning_parser=qwen3, tool_call_parser=qwen
[2026-07-28 14:11:20] mlx_q4 quantization is not fully optimized yet. The speed can be slower than non-quantized models.
[2026-07-28 14:11:20] Initializing MlxModelRunner for end-to-end MLX inference
[2026-07-28 14:11:20] Loading MLX model: mlx-community/Qwen3-0.6B-4bit
[2026-07-28 14:12:36] MLX model loaded in 75.81s
[2026-07-28 14:12:36] Wired memory limit set to 11.8 GB
[2026-07-28 14:12:36] Auto-sized attention KV pool: sys_available=2.64 GB, mlx_limit=11.8 GB, mlx_used=0.31 GB, kv_budget=2.32 GB, bytes_per_slot=114688, pool_size=21740
[2026-07-28 14:12:36] Init torch distributed begin.
[W728 14:12:36.680946000 ProcessGroupGloo.cpp:555] Warning: Unable to resolve hostname to a (local) address. Using the loopback address as fallback. Manually set the network interface to bind to with GLOO_SOCKET_IFNAME. (function operator())
[2026-07-28 14:12:36] Init torch distributed ends. elapsed=0.05 s, mem usage=0.01 GB
[2026-07-28 14:12:36] MLX stub: skipping PyTorch model weight loading (inference runs through MLX)
[2026-07-28 14:12:36] MLX stub: initialized minimal pools (max_total_num_tokens=21740, max_running_requests=4096, zero GPU KV cache allocation)
[2026-07-28 14:16:42] Disable prefill CUDA graph because cuda_graph_config resolved prefill.backend='disabled' (e.g. via --cuda-graph-backend-prefill=disabled or auto-disable rules).
[2026-07-28 14:16:42] max_total_num_tokens=21740, chunked_prefill_size=4096, max_prefill_tokens=16384, max_running_requests=4096, context_len=40960, available_gpu_mem=2.66 GB
[2026-07-28 14:16:42] Ignore import error when loading sglang.srt.models.bailing_moe_linear: No module named 'vllm'
[2026-07-28 14:16:42] Ignore import error when loading sglang.srt.models.bailing_moe_nextn: No module named 'vllm'
[2026-07-28 14:16:43] Ignore import error when loading sglang.srt.models.inkling: No module named 'helion'
[2026-07-28 14:16:43] Init Unified RadixTree with components (<ComponentType.FULL: 0>,)
[2026-07-28 14:16:43] Tree cache initialized: source=default impl=UnifiedRadixCache hybrid_swa=False hybrid_ssm=False hierarchical=False streaming_wrapped=False
[2026-07-28 14:16:44] INFO:     Started server process [83031]
[2026-07-28 14:16:44] INFO:     Waiting for application startup.
[2026-07-28 14:16:44] INFO:     Application startup complete.
[2026-07-28 14:16:44] INFO:     Uvicorn running on http://127.0.0.1:30000 (Press CTRL+C to quit)
[2026-07-28 14:16:45] INFO:     127.0.0.1:60193 - "GET /model_info HTTP/1.1" 200 OK
[2026-07-28 14:19:20] MlxAttentionKVPool: 21741 slots x 28 layers x 8 heads x 128 dim, dtype=mlx.core.bfloat16, ~2377.9 MB
[2026-07-28 14:19:20] Attention KV pool initialized: pool_size=21740 (buffer size 21741 incl. padding slot 0), 28 attention layers, 8 kv_heads, 128 head_dim
[2026-07-28 14:19:26] Prefill batch, #new-seq: 1, #new-token: 6, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0, #pending-token: 0, cuda graph: False, input throughput (token/s): 0.04
[2026-07-28 14:19:32] INFO:     127.0.0.1:60194 - "POST /generate HTTP/1.1" 200 OK
[2026-07-28 14:19:32] The server is fired up and ready to roll!
```



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30336014933](https://github.com/sgl-project/sglang/actions/runs/30336014933)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30336014811](https://github.com/sgl-project/sglang/actions/runs/30336014811)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->