### PR TITLE
[AMD] Add Kimi K3 ROCm 7.2 nightly image

### DIFF
--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -10,6 +10,7 @@ on:
         options:
           - 'all'
           - publish
+          - publish-k3
   schedule:
     - cron: '0 12 * * *'
 
@@ -125,6 +126,83 @@ jobs:
         run: |
           docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
           docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
+
+  publish_k3_mi35x:
+    if: github.repository == 'sgl-project/sglang' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.job_select == 'publish-k3'))
+    runs-on: amd-docker-scale
+    environment: 'prod'
+    steps:
+      - name: Checkout Kimi K3 branch
+        uses: actions/checkout@v4
+        with:
+          ref: kimi-k3
+          fetch-depth: 0  # Required for git describe to find tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set build metadata
+        run: |
+          set -euo pipefail
+
+          DATE=$(date -u +%Y%m%d)
+          SOURCE_SHA=$(git rev-parse HEAD)
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
+
+          if [ -z "${VERSION}" ]; then
+            echo "::error::Could not determine version from git tags"
+            exit 1
+          fi
+
+          PRETEND_VERSION="${VERSION}.dev${DATE}+g${COMMIT_HASH}"
+          IMAGE_TAG="rocm720-mi35x-k3-${DATE}"
+
+          {
+            echo "SOURCE_SHA=${SOURCE_SHA}"
+            echo "PRETEND_VERSION=${PRETEND_VERSION}"
+            echo "IMAGE_TAG=${IMAGE_TAG}"
+          } >> "$GITHUB_ENV"
+
+          echo "Source commit: ${SOURCE_SHA}"
+          echo "Pretend version for pip: ${PRETEND_VERSION}"
+          echo "Image tag: ${IMAGE_TAG}"
+
+      - name: Login to Docker Hub (lmsys)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Kimi K3 image for MI35x
+        run: |
+          set -euo pipefail
+
+          docker build \
+            -f docker/rocm.Dockerfile \
+            --build-arg BRANCH_TYPE=local \
+            --build-arg BUILD_TYPE=all \
+            --build-arg GPU_ARCH=gfx950-rocm720 \
+            --build-arg ENABLE_MORI=1 \
+            --build-arg ENABLE_NIXL=1 \
+            --build-arg SETUPTOOLS_SCM_PRETEND_VERSION="${PRETEND_VERSION}" \
+            --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com \
+            --label org.opencontainers.image.source=https://github.com/sgl-project/sglang/tree/kimi-k3 \
+            --label org.opencontainers.image.revision="${SOURCE_SHA}" \
+            -t "lmsysorg/sglang-rocm:${IMAGE_TAG}" \
+            --no-cache \
+            .
+
+      - name: Smoke test Kimi K3 image
+        run: |
+          docker run --rm "lmsysorg/sglang-rocm:${IMAGE_TAG}" \
+            python3 -c "import importlib; [importlib.import_module(name) for name in ('sglang', 'sglang.srt.models.kimi_k3', 'sglang.kernels.ops.sampling.top_p_renorm_triton')]"
+
+      - name: Push Kimi K3 image
+        run: |
+          docker push "lmsysorg/sglang-rocm:${IMAGE_TAG}"
 
   # Mirror the freshly published rocm/sgl-dev image to the in-network Docker
   # registry so AMD CI runners can pull without hitting Docker Hub rate limits.


### PR DESCRIPTION
## Motivation

Publish a daily ROCm 7.2 image for MI35X from the temporary `kimi-k3` branch without changing the existing ROCm nightly release outputs.

The image is published as:

`lmsysorg/sglang-rocm:rocm720-mi35x-k3-YYYYMMDD`

This PR is intentionally a draft and is blocked by #32621. It should not be merged until that PR lands in `kimi-k3`, because the image smoke test imports the sampling module added there.

## Modifications

- Add an independent `publish_k3_mi35x` job to the existing ROCm 7.2 nightly schedule.
- Explicitly check out `kimi-k3` and build that exact checkout with `BRANCH_TYPE=local`.
- Build only `gfx950-rocm720` and push only the K3 tag to `lmsysorg/sglang-rocm`.
- Record the source commit in the OCI image metadata.
- Add a `publish-k3` manual selector for isolated canary runs.
- Leave the existing `publish` and `push_local_registry` jobs unchanged.

## Accuracy Tests

Not applicable; this is a release-workflow-only change. The new job runs import smoke checks for SGLang, the Kimi K3 model module, and the AMD sampling fix before pushing.

Validation performed:

- `pre-commit run --files .github/workflows/release-docker-amd-rocm720-nightly.yml`
- YAML parsing and assertions that the existing release jobs are unchanged
- IDE workflow lint: no diagnostics

A full Docker build was not run locally; the first `publish-k3` workflow dispatch will serve as the canary after #32621 merges.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Workflow validation and image smoke test added.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable to workflow-only changes.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30338228329](https://github.com/sgl-project/sglang/actions/runs/30338228329)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30338228101](https://github.com/sgl-project/sglang/actions/runs/30338228101)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->