### PR TITLE
[Test] Add unit tests for usage_processor and chat_encoding

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_chat_encoding.py
+++ b/test/registered/unit/entrypoints/openai/test_chat_encoding.py
@@ -1,0 +1,162 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for chat_encoding dispatch helpers — no server, no model loading."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from sglang.srt.entrypoints.openai.chat_encoding import (
+    encode_simple_chat,
+    resolve_chat_encoding_spec,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestResolveChatEncodingSpec(unittest.TestCase):
+    def test_tool_call_parser_deepseekv4(self):
+        self.assertEqual(
+            resolve_chat_encoding_spec(
+                hf_config=None, tokenizer=None, tool_call_parser="deepseekv4"
+            ),
+            "dsv4",
+        )
+
+    def test_tool_call_parser_deepseekv32(self):
+        self.assertEqual(
+            resolve_chat_encoding_spec(
+                hf_config=None, tokenizer=None, tool_call_parser="deepseekv32"
+            ),
+            "dsv32",
+        )
+
+    def test_deepseekv4_architecture(self):
+        hf_config = Mock(architectures=["DeepseekV4ForCausalLM"])
+        self.assertEqual(
+            resolve_chat_encoding_spec(hf_config=hf_config, tokenizer=Mock()), "dsv4"
+        )
+
+    def test_inkling_architecture_no_chat_template(self):
+        hf_config = Mock(architectures=["InklingForConditionalGeneration"])
+        tokenizer = Mock(chat_template=None)
+        self.assertEqual(
+            resolve_chat_encoding_spec(hf_config=hf_config, tokenizer=tokenizer),
+            "inkling",
+        )
+
+    def test_deepseekv3_no_chat_template(self):
+        hf_config = Mock(architectures=["DeepseekV3ForCausalLM"])
+        tokenizer = Mock(chat_template=None)
+        self.assertEqual(
+            resolve_chat_encoding_spec(hf_config=hf_config, tokenizer=tokenizer),
+            "dsv32",
+        )
+
+    def test_deepseekv3_with_chat_template_defaults_to_none(self):
+        hf_config = Mock(architectures=["DeepseekV3ForCausalLM"])
+        tokenizer = Mock(chat_template="{{ messages }}")
+        self.assertIsNone(
+            resolve_chat_encoding_spec(hf_config=hf_config, tokenizer=tokenizer)
+        )
+
+    def test_llama_architecture_with_chat_template_defaults_to_none(self):
+        hf_config = Mock(architectures=["LlamaForCausalLM"])
+        tokenizer = Mock(chat_template="{{ messages }}")
+        self.assertIsNone(
+            resolve_chat_encoding_spec(hf_config=hf_config, tokenizer=tokenizer)
+        )
+
+    def test_empty_architectures_defaults_to_none(self):
+        hf_config = Mock(architectures=[])
+        tokenizer = Mock(chat_template=None)
+        self.assertIsNone(
+            resolve_chat_encoding_spec(hf_config=hf_config, tokenizer=tokenizer)
+        )
+
+
+class TestEncodeSimpleChat(unittest.TestCase):
+    def test_default_hf_chat_template(self):
+        tokenizer = Mock()
+        tokenizer.chat_template = "{{ messages }}"
+        tokenizer.apply_chat_template.return_value = [1, 2, 3]
+
+        messages = [{"role": "user", "content": "hello"}]
+        result = encode_simple_chat(tokenizer=tokenizer, spec=None, messages=messages)
+
+        self.assertEqual(result, [1, 2, 3])
+        tokenizer.apply_chat_template.assert_called_once_with(
+            messages, add_generation_prompt=True, tokenize=True
+        )
+
+    def test_no_chat_template_and_no_spec_raises(self):
+        tokenizer = Mock()
+        tokenizer.chat_template = None
+        tokenizer.name_or_path = "test/model"
+
+        with self.assertRaises(ValueError) as ctx:
+            encode_simple_chat(
+                tokenizer=tokenizer,
+                spec=None,
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        self.assertIn("no HF chat template", str(ctx.exception))
+        self.assertIn("test/model", str(ctx.exception))
+
+    def test_dsv4_prepends_empty_system_message(self):
+        tokenizer = Mock()
+        tokenizer.encode.return_value = [10, 20]
+
+        messages = [{"role": "user", "content": "hi"}]
+        with patch(
+            "sglang.srt.entrypoints.openai.encoding_dsv4.encode_messages",
+            return_value="encoded_text",
+        ) as mock_encode:
+            result = encode_simple_chat(
+                tokenizer=tokenizer,
+                spec="dsv4",
+                messages=messages,
+                thinking_mode="chat",
+            )
+
+        self.assertEqual(result, [10, 20])
+        tokenizer.encode.assert_called_once_with("encoded_text")
+        mock_encode.assert_called_once()
+        passed_messages = mock_encode.call_args[0][0]
+        self.assertEqual(passed_messages[0]["role"], "system")
+        self.assertEqual(passed_messages[0]["content"], "")
+        self.assertEqual(passed_messages[1], {"role": "user", "content": "hi"})
+        self.assertEqual(mock_encode.call_args.kwargs["thinking_mode"], "chat")
+
+    def test_dsv32_uses_dsv32_encoder(self):
+        tokenizer = Mock()
+        tokenizer.encode.return_value = [30, 40]
+
+        messages = [{"role": "user", "content": "hi"}]
+        with patch(
+            "sglang.srt.entrypoints.openai.encoding_dsv32.encode_messages",
+            return_value="encoded_text",
+        ) as mock_encode:
+            result = encode_simple_chat(
+                tokenizer=tokenizer, spec="dsv32", messages=messages
+            )
+
+        self.assertEqual(result, [30, 40])
+        mock_encode.assert_called_once()
+        passed_messages = mock_encode.call_args[0][0]
+        self.assertEqual(passed_messages[0]["role"], "system")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_usage_processor.py
+++ b/test/registered/unit/entrypoints/openai/test_usage_processor.py
@@ -1,0 +1,187 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests for UsageProcessor — no server, no model loading."""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import PromptTokensDetails
+from sglang.srt.entrypoints.openai.usage_processor import UsageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestUsageProcessor(unittest.TestCase):
+    def test_calculate_response_usage_single_response(self):
+        responses = [
+            {
+                "meta_info": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 5,
+                    "reasoning_tokens": 2,
+                }
+            }
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses)
+        self.assertEqual(usage.prompt_tokens, 3)
+        self.assertEqual(usage.completion_tokens, 5)
+        self.assertEqual(usage.total_tokens, 8)
+        self.assertEqual(usage.reasoning_tokens, 2)
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_calculate_response_usage_n_choices_counts_prompt_once(self):
+        # Two prompts, each with two choices (n=2).
+        responses = [
+            {"meta_info": {"prompt_tokens": 10, "completion_tokens": 1}},
+            {"meta_info": {"prompt_tokens": 10, "completion_tokens": 2}},
+            {"meta_info": {"prompt_tokens": 20, "completion_tokens": 3}},
+            {"meta_info": {"prompt_tokens": 20, "completion_tokens": 4}},
+        ]
+        usage = UsageProcessor.calculate_response_usage(responses, n_choices=2)
+        self.assertEqual(usage.prompt_tokens, 30)
+        self.assertEqual(usage.completion_tokens, 10)
+        self.assertEqual(usage.total_tokens, 40)
+
+    def test_calculate_response_usage_cache_report_enabled(self):
+        responses = [
+            {
+                "meta_info": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "cached_tokens": 4,
+                }
+            }
+        ]
+        usage = UsageProcessor.calculate_response_usage(
+            responses, enable_cache_report=True
+        )
+        self.assertIsNotNone(usage.prompt_tokens_details)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 4)
+
+    def test_calculate_response_usage_cache_report_zero_is_omitted(self):
+        responses = [
+            {
+                "meta_info": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "cached_tokens": 0,
+                }
+            }
+        ]
+        usage = UsageProcessor.calculate_response_usage(
+            responses, enable_cache_report=True
+        )
+        # _details_if_cached suppresses the details object when the count is 0.
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_calculate_response_usage_multimodal_counts_with_cache(self):
+        responses = [
+            {
+                "meta_info": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "cached_tokens": 2,
+                }
+            }
+        ]
+        usage = UsageProcessor.calculate_response_usage(
+            responses,
+            enable_cache_report=True,
+            image_tokens=3,
+            audio_tokens=1,
+            video_tokens=1,
+        )
+        details = usage.prompt_tokens_details
+        self.assertIsNotNone(details)
+        self.assertEqual(details.cached_tokens, 2)
+        self.assertEqual(details.image_tokens, 3)
+        self.assertEqual(details.audio_tokens, 1)
+        self.assertEqual(details.video_tokens, 1)
+
+    def test_calculate_response_usage_missing_meta_info_keys_default_to_zero(self):
+        responses = [{"meta_info": {}}]
+        usage = UsageProcessor.calculate_response_usage(responses)
+        self.assertEqual(usage.prompt_tokens, 0)
+        self.assertEqual(usage.completion_tokens, 0)
+        self.assertEqual(usage.reasoning_tokens, 0)
+        self.assertEqual(usage.total_tokens, 0)
+
+    def test_calculate_streaming_usage_basic(self):
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10, 1: 5},
+            reasoning_tokens={0: 2},
+            completion_tokens={0: 3, 1: 4},
+            cached_tokens={0: 10, 1: 0},
+            n_choices=1,
+            enable_cache_report=True,
+        )
+        self.assertEqual(usage.prompt_tokens, 15)
+        self.assertEqual(usage.completion_tokens, 7)
+        self.assertEqual(usage.reasoning_tokens, 2)
+        self.assertIsNotNone(usage.prompt_tokens_details)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 10)
+
+    def test_calculate_streaming_usage_n_choices_filters_prompt_and_cache(self):
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 10, 1: 99, 2: 20, 3: 99},
+            reasoning_tokens={},
+            completion_tokens={0: 1, 1: 2, 2: 3, 3: 4},
+            cached_tokens={0: 5, 1: 99, 2: 6, 3: 99},
+            n_choices=2,
+            enable_cache_report=True,
+        )
+        # Only indices divisible by n_choices belong to the first (charged) choice.
+        self.assertEqual(usage.prompt_tokens, 30)
+        self.assertEqual(usage.completion_tokens, 10)
+        self.assertIsNotNone(usage.prompt_tokens_details)
+        self.assertEqual(usage.prompt_tokens_details.cached_tokens, 11)
+
+    def test_calculate_streaming_usage_cache_report_disabled(self):
+        usage = UsageProcessor.calculate_streaming_usage(
+            prompt_tokens={0: 1},
+            reasoning_tokens={},
+            completion_tokens={0: 1},
+            cached_tokens={0: 5},
+            n_choices=1,
+            enable_cache_report=False,
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+
+    def test_calculate_token_usage_no_details_without_multimodal_or_cache(self):
+        usage = UsageProcessor.calculate_token_usage(
+            prompt_tokens=1, completion_tokens=2
+        )
+        self.assertIsNone(usage.prompt_tokens_details)
+        self.assertEqual(usage.total_tokens, 3)
+
+    def test_calculate_token_usage_multimodal_details_without_cache(self):
+        usage = UsageProcessor.calculate_token_usage(
+            prompt_tokens=1, completion_tokens=2, image_tokens=3
+        )
+        details = usage.prompt_tokens_details
+        self.assertIsInstance(details, PromptTokensDetails)
+        self.assertEqual(details.image_tokens, 3)
+        self.assertEqual(details.cached_tokens, 0)
+
+    def test_calculate_token_usage_reasoning_tokens_preserved(self):
+        usage = UsageProcessor.calculate_token_usage(
+            prompt_tokens=1,
+            completion_tokens=2,
+            reasoning_tokens=4,
+        )
+        self.assertEqual(usage.reasoning_tokens, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds CPU-only unit tests for two OpenAI entrypoint helpers that previously had only indirect coverage:

- `sglang.srt.entrypoints.openai.usage_processor` (`UsageProcessor`)
- `sglang.srt.entrypoints.openai.chat_encoding` (`resolve_chat_encoding_spec`, `encode_simple_chat`)

No production code is changed. The tests do not launch a server or load model weights.

Coverage focuses on behavior that is easy to break silently:
- `n_choices` handling in response/streaming usage so prompt tokens and cached tokens are counted only for the first choice of each prompt
- cache-report toggling and zero-count omission
- multimodal token details merged with cached-token details
- chat-encoding spec dispatch by `tool_call_parser` and by architecture/chat-template combinations
- `encode_simple_chat` falling back to HF chat template or raising when no template/spec exists

Local verification:

```bash
PYTHONPATH=python .venv/bin/pytest \
  test/registered/unit/entrypoints/openai/test_usage_processor.py \
  test/registered/unit/entrypoints/openai/test_chat_encoding.py -v
```

Result: 24 passed.

Related to #20865.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30342416684](https://github.com/sgl-project/sglang/actions/runs/30342416684)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30342409172](https://github.com/sgl-project/sglang/actions/runs/30342409172)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->