### PR TITLE
[AMD][Not-Merge]: torch fallbacks for top-k/top-p renorm so DSPARK/DFLASH works on ROCm

### DIFF
--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -46,9 +46,45 @@ if is_cuda() or is_musa():
         top_p_renorm_prob = None
         tree_speculative_sampling_target_only = None
 else:
-    top_k_renorm_prob = None
-    top_p_renorm_prob = None
+    # sgl_kernel ships these sampling ops for CUDA/MUSA only, but
+    # build_dflash_verify_target_probs() calls the top-k/top-p renorm helpers
+    # unconditionally. Leaving them as None crashes DSPARK/DFLASH on ROCm as soon
+    # as a request sets top_p < 1 or top_k > 1 (issue #32569). Both ops are plain
+    # probability renormalisation, so provide portable torch fallbacks.
+    # tree_speculative_sampling_target_only has no cheap equivalent and stays
+    # None; _DFLASH_SAMPLING_VERIFY_AVAILABLE therefore remains False, so no
+    # additional code path is enabled by this fallback.
     tree_speculative_sampling_target_only = None
+
+    def top_k_renorm_prob(probs: torch.Tensor, top_k) -> torch.Tensor:
+        """Keep the top_k largest probabilities per row and renormalise."""
+        if not torch.is_tensor(top_k):
+            top_k = torch.full(
+                (probs.shape[0],), int(top_k), device=probs.device, dtype=torch.long
+            )
+        top_k = top_k.to(probs.device).long().clamp_(min=1, max=probs.shape[-1])
+        sorted_probs, sorted_idx = torch.sort(probs, dim=-1, descending=True)
+        ranks = torch.arange(probs.shape[-1], device=probs.device).expand_as(probs)
+        keep = ranks < top_k.unsqueeze(-1)
+        out = torch.zeros_like(probs).scatter_(-1, sorted_idx, sorted_probs * keep)
+        return out / out.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    def top_p_renorm_prob(probs: torch.Tensor, top_p) -> torch.Tensor:
+        """Nucleus: keep the smallest prefix whose mass reaches top_p, renormalise."""
+        if not torch.is_tensor(top_p):
+            top_p = torch.full(
+                (probs.shape[0],), float(top_p), device=probs.device, dtype=probs.dtype
+            )
+        top_p = top_p.to(device=probs.device, dtype=probs.dtype)
+        sorted_probs, sorted_idx = torch.sort(probs, dim=-1, descending=True)
+        # Exclusive cumsum: a token survives when the mass *before* it is < top_p.
+        exclusive = sorted_probs.cumsum(dim=-1) - sorted_probs
+        keep = exclusive < top_p.unsqueeze(-1)
+        # top_p <= 0 would mask everything and yield an all-zero row; always keep
+        # the most likely token.
+        keep[..., 0] = True
+        out = torch.zeros_like(probs).scatter_(-1, sorted_idx, sorted_probs * keep)
+        return out / out.sum(dim=-1, keepdim=True).clamp_min(1e-12)
 
 
 def is_dflash_sampling_verify_available() -> bool:


### PR DESCRIPTION
## Problem

`build_dflash_verify_target_probs()` calls `top_k_renorm_prob()` and `top_p_renorm_prob()` unconditionally, but `sgl_kernel` only exports them under CUDA/MUSA. On ROCm both are `None`, so DSPARK/DFLASH speculative decoding dies with:

```
TypeError: 'NoneType' object is not callable
```

as soon as a request sets `top_p < 1` **or** `top_k > 1`. That includes any client inheriting sampling defaults from a model's `generation_config`, so in practice the server serves for a few minutes and then dies on the first such request.

Fixes #32569 (reported on 8x MI350X; AMD confirmed it as "a valid issue on ROCm").

## Fix

Both ops are plain probability renormalisation with exact, portable torch equivalents, so the `else` branch now defines them instead of setting them to `None`.

Deliberately minimal:
- `tree_speculative_sampling_target_only` has no cheap equivalent and **stays `None`**
- `_DFLASH_SAMPLING_VERIFY_AVAILABLE` stays `False`, so **no additional code path is enabled** by this change
- no new imports (`torch` is already imported in this module)

One edge case worth noting: `top_p <= 0` would mask every token and produce an all-zero row, so the most likely token is always kept.

## Verification

Hardware: 8x MI350X (gfx950), ROCm 7.2.1, image `lmsysorg/sglang-rocm:rocm720-mi35x-k3-20260727`, Kimi-K3 MXFP4, TP8, DSPARK with a `block_size=7` draft model.

**Reproduced the crash, then confirmed the fix** with requests that previously killed the server:
- `temperature=0.7, top_p=0.8` → OK
- `temperature=0.8, top_k=20` → OK

**Semantics checked** against hand-computed expectations (top-k = 1/2/V, top-p = 0/0.8/1.0, batched mixed k/p, row sums == 1, scalar and tensor inputs).

**Throughput on that box** (SGLang's own `bench_serving.py`, 1k in / 300 out, `--random-range-ratio 1.0 --seed 42 --flush-cache`, median of 3 runs):

| | DSPARK off | DSPARK on (this fix) |
|---|---|---|
| single stream | 37.5 tok/s | **149–167 tok/s** |
| TPOT | 26.1 ms | **~5 ms** |
| output @ conc 128 | 1000.9 tok/s | **1606–1644 tok/s** |
| total @ conc 128 | 4417 tok/s | **7090–7256 tok/s** |
| median TTFT @ conc 8 | 717 ms | **490 ms** |

Also verified unaffected: needle-in-a-haystack retrieval up to 641,779 prompt tokens, tool calling, and vision input. No restarts over several hours of load.

I did not add a unit test since the fallbacks only activate off-CUDA and CI presumably runs on NVIDIA - happy to add one under `test/srt/` if you'd prefer.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30342976482](https://github.com/sgl-project/sglang/actions/runs/30342976482)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30396990531](https://github.com/sgl-project/sglang/actions/runs/30396990531)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->