### PR TITLE
[AMD] Run AITER Scout on Saturdays

### DIFF
--- a/.github/workflows/amd-aiter-scout.yml
+++ b/.github/workflows/amd-aiter-scout.yml
@@ -2,7 +2,7 @@ name: AMD AITER Scout
 
 on:
   schedule:
-    - cron: '0 20 * * 1'   # Monday 20:00 UTC
+    - cron: '0 20 * * 6'   # Saturday 20:00 UTC
     # - cron: '0 20 * * 4'   # Thursday 20:00 UTC (temporarily disabled)
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Motivation

Move the weekly AMD AITER Scout run from Monday to Saturday while keeping the existing 20:00 UTC start time.

## Modifications

- Change the scheduled cron day-of-week from Monday (`1`) to Saturday (`6`).
- Update the inline schedule comment accordingly.

## Accuracy Tests

Not applicable; workflow-only change.

## Speed Tests and Profiling

Not applicable; workflow-only change.

## Checklist

- [x] Format checks pass (pre-commit).
- [x] Unit tests are not applicable.
- [x] Documentation updates are not applicable.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30343387205](https://github.com/sgl-project/sglang/actions/runs/30343387205)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30343386752](https://github.com/sgl-project/sglang/actions/runs/30343386752)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->