### PR TITLE
fix: honor MiniMax thinking controls

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -717,6 +717,10 @@ ReasoningEffortType = Optional[
 ]
 
 
+class ChatCompletionThinkingParam(BaseModel):
+    type: Literal["disabled", "adaptive"]
+
+
 class ChatCompletionRequest(BaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
@@ -773,6 +777,11 @@ class ChatCompletionRequest(BaseModel):
         "'max' is an sglang extension to the OpenAI schema for "
         "models that expose a maximum-effort tier above 'high'; models that don't "
         "support it treat it the same as 'high'.",
+    )
+    thinking: Optional[ChatCompletionThinkingParam] = Field(
+        default=None,
+        description="Minimax reasoning control. 'disabled' disables reasoning and "
+        "'adaptive' enables it.",
     )
     task: Optional[
         Literal["action", "query", "authority", "domain", "title", "read_url"]
@@ -877,6 +886,18 @@ class ChatCompletionRequest(BaseModel):
     def normalize_reasoning_inputs(cls, values: Dict):
         r = values.get("reasoning")
         thinking = None
+        minimax_thinking = values.get("thinking")
+        if isinstance(minimax_thinking, dict):
+            thinking_type = minimax_thinking.get("type")
+            if thinking_type in {"disabled", "adaptive"}:
+                ctk = values.get("chat_template_kwargs")
+                if not isinstance(ctk, dict):
+                    ctk = {}
+                ctk.setdefault(
+                    "thinking_mode",
+                    "disabled" if thinking_type == "disabled" else "enabled",
+                )
+                values["chat_template_kwargs"] = ctk
 
         if r is not None and isinstance(r, dict):
             effort = r.get("effort")

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -259,6 +259,42 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertFalse(request.chat_template_kwargs.get("thinking"))
         self.assertFalse(request.chat_template_kwargs.get("enable_thinking"))
 
+    def test_chat_completion_minimax_thinking_disabled(self):
+        request = ChatCompletionRequest(
+            model="MiniMaxAI/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hello"}],
+            thinking={"type": "disabled"},
+        )
+        self.assertEqual(request.thinking.type, "disabled")
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking_mode": "disabled"},
+        )
+
+    def test_chat_completion_minimax_thinking_adaptive(self):
+        request = ChatCompletionRequest(
+            model="MiniMaxAI/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hello"}],
+            thinking={"type": "adaptive"},
+        )
+        self.assertEqual(request.thinking.type, "adaptive")
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking_mode": "enabled"},
+        )
+
+    def test_chat_completion_minimax_thinking_keeps_explicit_template_mode(self):
+        request = ChatCompletionRequest(
+            model="MiniMaxAI/MiniMax-M3",
+            messages=[{"role": "user", "content": "Hello"}],
+            thinking={"type": "adaptive"},
+            chat_template_kwargs={"thinking_mode": "disabled"},
+        )
+        self.assertEqual(
+            request.chat_template_kwargs,
+            {"thinking_mode": "disabled"},
+        )
+
     def test_chat_completion_extended_reasoning_effort_levels(self):
         """Extended effort levels work in both supported request forms."""
         from pydantic import ValidationError


### PR DESCRIPTION
## Motivation

MiniMax-M3 exposes reasoning control through the OpenAI-compatible
`thinking: {"type": "disabled" | "adaptive"}` request field.

SGLang did not declare this field on `ChatCompletionRequest`, so Pydantic
discarded it and the model continued reasoning when callers requested
`disabled`.

Fixes #32276.

This continues the approach from #32301, which was closed without merging.

## Modifications

- Add a typed MiniMax thinking parameter to chat completion requests.
- Map `disabled` to `chat_template_kwargs.thinking_mode="disabled"`.
- Map `adaptive` to `chat_template_kwargs.thinking_mode="enabled"`.
- Preserve an explicitly supplied `thinking_mode`.
- Add CPU-only regression tests for both modes and override precedence.

## Validation

- `python -m pytest test/registered/unit/entrypoints/openai/test_protocol.py -q`
  - 35 passed, 16 subtests passed
- `uvx pre-commit run --files python/sglang/srt/entrypoints/openai/protocol.py test/registered/unit/entrypoints/openai/test_protocol.py`
- `git diff --check`

## Accuracy Tests

Not applicable. This only maps the request field to the existing MiniMax-M3
chat-template control.

## Speed Tests and Profiling

Not applicable. No inference or kernel paths were changed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30344586378](https://github.com/sgl-project/sglang/actions/runs/30344586378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30344586043](https://github.com/sgl-project/sglang/actions/runs/30344586043)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->