### PR TITLE
Add a benchmark script for the HPC-Ops bf16xfp32 router GEMM

### DIFF
--- a/test/registered/kernels/benchmark/gemm/bench_bf16xfp32_router_gemm.py
+++ b/test/registered/kernels/benchmark/gemm/bench_bf16xfp32_router_gemm.py
@@ -1,0 +1,68 @@
+"""Benchmark for the HPC-Ops bf16xfp32 router GEMM (HPC-Ops vs cublas fp32).
+
+`linear_bf16_fp32` computes `x[m, k](bf16) @ w[n, k](fp32)^T`. The `hpc`
+provider requires HPC-Ops (https://github.com/Tencent/hpc-ops) installed and
+a Hopper GPU (sm90a); it decomposes the fp32 weight into two cached bf16
+halves and runs both bf16 GEMMs fused on tensor cores. The `cublas` provider
+upcasts the activation to fp32 and is what every model uses without HPC-Ops.
+
+Shapes are the LongCat-Flash router shapes: (hidden_size, n_routed_experts +
+zero_experts) = (6144, 768) for Chat and (3072, 384) for Lite.
+
+Run on a Hopper (SM90) GPU with HPC-Ops installed:
+    python -m sglang.kernels.jit.benchmark.bench_bf16xfp32_router_gemm
+"""
+
+import torch
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import create_random
+from sglang.kernels.jit.utils import get_jit_cuda_arch, is_hip_runtime
+from sglang.kernels.ops.attention.dsv4.gemm import (
+    _linear_bf16_fp32_hpc,
+    mark_hpc_bf16xfp32_gemm_enabled,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=5, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+mark_hpc_bf16xfp32_gemm_enabled()
+
+
+def _cublas_fp32(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    return torch.mm(x.float(), w.t())
+
+
+def _hpc(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+    out = _linear_bf16_fp32_hpc(x, w, min_m=1)
+    if out is None:
+        marker.skip("HPC-Ops is not installed, or this GPU is not Hopper (sm90a)")
+    return out
+
+
+FN_MAP = {
+    "cublas": _cublas_fp32,
+    "hpc": _hpc,
+}
+
+
+@marker.parametrize(
+    "m", [1, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192], [1, 64, 8192]
+)
+@marker.parametrize("n,k", [(768, 6144), (384, 3072)], [(768, 6144)])
+@marker.benchmark("provider", ["cublas", "hpc"])
+def benchmark(m, n, k, provider):
+    x = create_random(m, k, dtype=torch.bfloat16)
+    w = create_random(n, k, dtype=torch.float32)
+    return marker.do_bench(FN_MAP[provider], input_args=(x, w))
+
+
+if __name__ == "__main__":
+    if is_hip_runtime() or get_jit_cuda_arch().major != 9:
+        print(
+            "The HPC-Ops bf16xfp32 GEMM requires a Hopper (sm90a) CUDA GPU. Skipping."
+        )
+    else:
+        benchmark.run()


### PR DESCRIPTION
## Motivation

#30247 wired LongCat-Flash's router GEMM (`bf16` activation × `fp32` router weight) to `hpc.gemm_bf16xfp32` from [HPC-Ops](https://github.com/Tencent/hpc-ops), but the perf table in that PR's description was produced with an ad-hoc script that never got committed. This adds a proper benchmark under `test/registered/kernels/benchmark/gemm/`, following the existing `marker.benchmark` convention (see `bench_dsv3_router_gemm.py`), so the numbers are reproducible and the crossover point where the kernel starts beating cublas is easy to check on any Hopper box.

## What it does

Compares `hpc.gemm_bf16xfp32` (via `sglang.kernels.ops.attention.dsv4.gemm._linear_bf16_fp32_hpc`) against the cublas fp32 fallback (`x.float() @ w.t()`) across:

- the two LongCat-Flash router shapes: Chat `(n=768, k=6144)`, Lite `(n=384, k=3072)`
- `m` from 1 to 8192

The `hpc` provider calls `marker.skip(...)` when HPC-Ops isn't installed or the GPU isn't Hopper (sm90a-only), so the benchmark degrades gracefully instead of crashing.

```
python -m sglang.kernels.jit.benchmark.bench_bf16xfp32_router_gemm
```

## Results (H200, HPC-Ops built from the pinned commit in the image)

Median microseconds, `do_bench` with CUDA graph replay:

| m | n,k | cublas (us) | hpc (us) | speedup |
|---|---|---:|---:|---:|
| 1 | 768,6144 | 10.10 | 15.44 | 0.65x |
| 8 | 768,6144 | 28.99 | 15.78 | 1.84x |
| 64 | 768,6144 | 35.36 | 21.84 | 1.62x |
| 512 | 768,6144 | 116.01 | 43.41 | 2.67x |
| 2048 | 768,6144 | 425.66 | 113.25 | 3.76x |
| 8192 | 768,6144 | 1683.91 | 432.60 | 3.89x |
| 1 | 384,3072 | 6.87 | 12.89 | 0.53x |
| 8 | 384,3072 | 18.06 | 13.28 | 1.36x |
| 64 | 384,3072 | 20.39 | 17.12 | 1.19x |
| 512 | 384,3072 | 44.15 | 26.14 | 1.69x |
| 2048 | 384,3072 | 132.01 | 42.24 | 3.12x |
| 8192 | 384,3072 | 514.89 | 113.54 | 4.53x |

At `m=1` the HPC-Ops kernel is slower than cublas on both shapes (fixed per-call overhead, not amortized yet); from `m=8` on it's consistently faster and the gap widens with `m`. This matches the `min_m` dispatch guard already used by `LongcatFlashRouter` (>= 64 for Chat, >= 128 for Lite) — comfortably inside the region where the kernel wins.

## Tests

- `pre-commit run --files test/registered/kernels/benchmark/gemm/bench_bf16xfp32_router_gemm.py`: passes (isort/black/ruff/codespell/CI-registry validation).
- Ran the benchmark script end-to-end on an H200 (output above).
- Re-ran the existing `test/registered/gemm/test_linear_bf16_fp32_hpc.py` and `test/registered/unit/models/test_longcat_flash_router_hpc_gemm.py` against the same HPC-Ops build as a correctness sanity check: `9 passed, 6 subtests passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30350423762](https://github.com/sgl-project/sglang/actions/runs/30350423762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30358723260](https://github.com/sgl-project/sglang/actions/runs/30358723260)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->