### PR TITLE
[AMD] Add Kimi K3 ROCm 7.2 nightly image

### DIFF
--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -10,6 +10,7 @@ on:
         options:
           - 'all'
           - publish
+          - publish-k3
   schedule:
     - cron: '0 12 * * *'
 
@@ -114,6 +115,81 @@ jobs:
           name: image-tag-${{ matrix.gpu_arch }}
           path: image-tag/${{ matrix.gpu_arch }}.txt
           retention-days: 1
+
+      - name: Login to Docker Hub (lmsys)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push to lmsysorg/sglang-rocm
+        run: |
+          docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
+          docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
+
+  publish_k3_mi35x:
+    if: github.repository == 'sgl-project/sglang' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.job_select == 'publish-k3'))
+    runs-on: amd-docker-scale
+    environment: 'prod'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: kimi-k3
+          fetch-depth: 0  # Required for git describe to find tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: "Set Date"
+        run: |
+          echo "DATE=$(date -u +%Y%m%d)" >> $GITHUB_ENV
+
+      - name: Get version from latest tag
+        id: version
+        run: |
+          # Use the shared helper so stable/post releases sort above rc tags.
+          VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine version from git tags"
+            exit 1
+          fi
+
+          # Get short commit hash of current HEAD
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+
+          # Compose pretend version for setuptools_scm: e.g., 0.5.8.post1.dev20260211+g1a2b3c4
+          PRETEND_VERSION="${VERSION}.dev${{ env.DATE }}+g${COMMIT_HASH}"
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "pretend_version=${PRETEND_VERSION}" >> $GITHUB_OUTPUT
+          echo "Detected version: ${VERSION}"
+          echo "Pretend version for pip: ${PRETEND_VERSION}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+
+      - name: Build and Push to rocm/sgl-dev
+        run: |
+          version=${{ steps.version.outputs.version }}
+          pretend_version=${{ steps.version.outputs.pretend_version }}
+          echo "Version: ${version}"
+          echo "Pretend version: ${pretend_version}"
+
+          tag=rocm720-mi35x-k3
+          echo "IMAGE_TAG=${tag}-${{ env.DATE }}" >> $GITHUB_ENV
+
+          # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
+          # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
+          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=kimi-k3 --build-arg BUILD_TYPE=all --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 --build-arg ENABLE_NIXL=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       - name: Login to Docker Hub (lmsys)
         uses: docker/login-action@v2


### PR DESCRIPTION
## Motivation

Publish a daily ROCm 7.2 image for MI35X from the temporary upstream `kimi-k3` branch without changing the existing ROCm nightly release outputs.

The public image is published as:

`lmsysorg/sglang-rocm:rocm720-mi35x-k3-YYYYMMDD`

This PR is intentionally a draft and is blocked by #32621. It should not be merged until that PR lands in `kimi-k3`.

## Modifications

- Add an independent `publish_k3_mi35x` job to the existing ROCm 7.2 nightly schedule.
- Explicitly check out the upstream `kimi-k3` branch.
- Reuse the existing ROCm release flow: build `gfx950-rocm720`, push to `rocm/sgl-dev`, then retag and push to `lmsysorg/sglang-rocm`.
- Pass `SGL_BRANCH=kimi-k3` so the ROCm Dockerfile installs code from the upstream K3 branch.
- Add a `publish-k3` manual selector for isolated canary runs.
- Leave the existing `publish` and `push_local_registry` jobs unchanged.

## Accuracy Tests

Not applicable; this is a release-workflow-only change.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Workflow validation performed.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable to workflow-only changes.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30351320646](https://github.com/sgl-project/sglang/actions/runs/30351320646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30351320407](https://github.com/sgl-project/sglang/actions/runs/30351320407)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->