### PR TITLE
fix(quantization): restore serialized Marlin checkpoint support

### DIFF
--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -35,6 +35,7 @@ from sglang.srt.layers.quantization.gptq import (
     GPTQMarlinConfig,
 )
 from sglang.srt.layers.quantization.humming import HummingConfig
+from sglang.srt.layers.quantization.marlin_utils import MarlinConfig
 from sglang.srt.layers.quantization.mlx import MlxQuantizationConfig
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
@@ -87,6 +88,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "gguf": GGUFConfig,
     "gptq": GPTQConfig,
     "gptq_marlin": GPTQMarlinConfig,
+    "marlin": MarlinConfig,
     "moe_wna16": MoeWNA16Config,
     "compressed-tensors": CompressedTensorsConfig,
     "w4afp8": W4AFp8Config,

--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -37,12 +37,6 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
 )
 
-try:
-    from vllm import _custom_ops as ops
-except ImportError:
-    ops = None
-
-
 _is_cuda = is_cuda()
 
 if _is_cuda:
@@ -648,6 +642,7 @@ class MarlinConfig(QuantizationConfig):
 
         # 4 Bits packed into 32 bit datatype.
         self.pack_factor = 32 // 4
+        self.quant_type = scalar_types.uint4b8
 
         # Tile size used by marlin kernels.
         self.tile_size = 16
@@ -670,6 +665,9 @@ class MarlinConfig(QuantizationConfig):
             f"MarlinConfig(group_size={self.group_size}, "
             f"lm_head_quantized={self.lm_head_quantized})"
         )
+
+    def get_scaled_act_names(self) -> list[str]:
+        return []
 
     @classmethod
     def get_name(cls) -> str:
@@ -836,13 +834,8 @@ class MarlinLinearMethod(LinearMethodBase):
                 output_dim=1, input_dim=0, **weight_scale_args
             )
 
-        # Allocate workspace (Used for internal locking mechanism)
-        max_workspace_size = (
-            output_size_per_partition // self.quant_config.min_n_threads
-        ) * self.quant_config.max_parallel
-
         workspace = BasevLLMParameter(
-            data=torch.zeros(max_workspace_size, device="cuda", dtype=torch.int),
+            data=marlin_make_workspace(qweight.device),
             weight_loader=weight_loader,
         )
 
@@ -855,6 +848,9 @@ class MarlinLinearMethod(LinearMethodBase):
         layer.B = torch.nn.Parameter(layer.B.data, requires_grad=False)
         layer.s = torch.nn.Parameter(layer.s.data, requires_grad=False)
         layer.workspace = torch.nn.Parameter(layer.workspace.data, requires_grad=False)
+        layer.zp = marlin_make_empty_zp(layer.B.device)
+        layer.g_idx = marlin_make_empty_g_idx(layer.B.device)
+        layer.g_idx_sort_indices = marlin_make_empty_g_idx(layer.B.device)
 
     def apply(
         self,
@@ -862,26 +858,20 @@ class MarlinLinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        qweight = layer.B
-        scales = layer.s
-        workspace = layer.workspace
-
-        x_2d = x.view(-1, x.shape[-1])
-
-        size_m = x_2d.shape[0]
-        size_k = x_2d.shape[1]
-        size_n = scales.shape[1]
-
-        output_2d = ops.marlin_gemm(
-            x_2d, qweight, scales, workspace, size_m, size_n, size_k
+        return apply_gptq_marlin_linear(
+            input=x,
+            weight=layer.B,
+            weight_scale=layer.s,
+            weight_zp=layer.zp,
+            g_idx=layer.g_idx,
+            g_idx_sort_indices=layer.g_idx_sort_indices,
+            workspace=layer.workspace,
+            wtype=self.quant_config.quant_type,
+            output_size_per_partition=layer.s.shape[1],
+            input_size_per_partition=x.shape[-1],
+            is_k_full=True,
+            bias=bias,
         )
-
-        output = output_2d.view(x.shape[:-1] + (output_2d.shape[1],))
-
-        if bias is not None:
-            output.add_(bias)  # In-place add
-
-        return output
 
 
 def fake_unified_apply_gptq_marlin_gemm(

--- a/test/registered/unit/layers/quantization/test_marlin_config.py
+++ b/test/registered/unit/layers/quantization/test_marlin_config.py
@@ -1,0 +1,75 @@
+"""Unit tests for serialized Marlin checkpoint configuration."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization import get_quantization_config
+from sglang.srt.layers.quantization.marlin_utils import (
+    MarlinConfig,
+    MarlinLinearMethod,
+    scalar_types,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMarlinConfig(CustomTestCase):
+    @patch("sglang.srt.utils.is_cpu", return_value=False)
+    def test_direct_quantization_resolution(self, _):
+        self.assertIs(get_quantization_config("marlin"), MarlinConfig)
+
+    def test_serialized_checkpoint_detection(self):
+        for quant_config in (
+            {"checkpoint_format": "marlin"},
+            {"is_marlin_format": True},
+        ):
+            with self.subTest(quant_config=quant_config):
+                self.assertEqual(
+                    MarlinConfig.override_quantization_method(
+                        quant_config, user_quant="marlin"
+                    ),
+                    "marlin",
+                )
+
+    def test_config_parsing(self):
+        config = MarlinConfig.from_config({"group_size": 128, "lm_head": True})
+
+        self.assertEqual(config.group_size, 128)
+        self.assertTrue(config.lm_head_quantized)
+        self.assertEqual(config.quant_type, scalar_types.uint4b8)
+
+    @patch("sglang.srt.layers.quantization.marlin_utils.apply_gptq_marlin_linear")
+    def test_linear_method_uses_native_marlin_kernel(self, apply_mock):
+        config = MarlinConfig(group_size=128, lm_head_quantized=False)
+        method = MarlinLinearMethod(config)
+        layer = SimpleNamespace(
+            B=torch.empty(8, 512, dtype=torch.int32),
+            s=torch.empty(1, 64),
+            zp=torch.empty(0, dtype=torch.int32),
+            g_idx=torch.empty(0, dtype=torch.int32),
+            g_idx_sort_indices=torch.empty(0, dtype=torch.int32),
+            workspace=torch.empty(1, dtype=torch.int32),
+        )
+        x = torch.empty(2, 128)
+        expected = torch.empty(2, 64)
+        apply_mock.return_value = expected
+
+        output = method.apply(layer, x)
+
+        self.assertIs(output, expected)
+        kwargs = apply_mock.call_args.kwargs
+        self.assertIs(kwargs["input"], x)
+        self.assertIs(kwargs["weight"], layer.B)
+        self.assertIs(kwargs["weight_scale"], layer.s)
+        self.assertIs(kwargs["wtype"], scalar_types.uint4b8)
+        self.assertEqual(kwargs["input_size_per_partition"], 128)
+        self.assertEqual(kwargs["output_size_per_partition"], 64)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--quantization marlin` is advertised by the CLI, but `marlin` is missing from the quantization registry, so direct resolution fails. The existing serialized-Marlin configuration also cannot be instantiated because it does not implement the current `QuantizationConfig` interface, and its linear method still calls the legacy `vllm._custom_ops.marlin_gemm` path.

This leaves checkpoints serialized with `checkpoint_format: marlin` unusable in a standalone SGLang installation.

Fixes #32250.

## Modifications

- Register `MarlinConfig` as the `marlin` quantization method.
- Complete the current quantization-config interface and preserve both current and legacy serialized-checkpoint detection.
- Route prepacked Marlin weights through SGLang's native `gptq_marlin_gemm` helper, including the native workspace and empty zero-point/activation-order metadata.
- Remove the final `vllm._custom_ops` consumer from `marlin_utils.py`, which also eliminates the eager import described in #24310.
- Add CPU unit coverage for direct resolution, metadata detection, config parsing, and native-kernel dispatch.

## Accuracy Tests

Unit tests:

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/layers/quantization/test_marlin_config.py \
  test/registered/quant/test_quant_config_parsing.py
```

Result: `9 passed`.

End-to-end validation used an NVIDIA H20 and `LnL-AI/TinyLlama-1.1B-Chat-v1.0-GPTQ-Marlin-4bit`.

The server was tested both with explicit selection:

```bash
python -m sglang.launch_server \
  --model-path LnL-AI/TinyLlama-1.1B-Chat-v1.0-GPTQ-Marlin-4bit \
  --quantization marlin --dtype float16 \
  --attention-backend triton --sampling-backend pytorch
```

and without `--quantization`, relying only on `checkpoint_format: marlin` auto-detection.

Both modes completed model loading and warmup, returned HTTP 200 from `/health`, and produced the deterministic completion:

```text
Prompt: The capital of France is
Output: Paris.
```

## Speed Tests and Profiling

No kernel implementation changes. This restores a previously unreachable path, so there is no meaningful before/after benchmark: before this change direct resolution fails, or the first serialized-Marlin GEMM raises because the legacy custom op is unavailable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not needed: this restores an already-advertised CLI option.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30351802588](https://github.com/sgl-project/sglang/actions/runs/30351802588)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30351802428](https://github.com/sgl-project/sglang/actions/runs/30351802428)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->