### PR TITLE
[Qwen3.5] Fuse GDN decode split and causal conv

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/layernorm_gated.py
+++ b/python/sglang/kernels/ops/attention/fla/layernorm_gated.py
@@ -16,6 +16,12 @@ import triton.language as tl
 from einops import rearrange
 
 from sglang.kernels.jit.utils import is_arch_support_pdl
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    create_per_token_group_quant_fp8_output_scale,
+    fp8_dtype,
+    fp8_max,
+    fp8_min,
+)
 from sglang.srt.batch_invariant_ops import is_batch_invariant_mode_enabled
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -183,6 +189,91 @@ def _layer_norm_fwd_1pass_kernel(
         tl.extra.cuda.gdc_launch_dependents()
 
 
+@triton.jit
+def _rms_norm_gated_fp8_quant_kernel(
+    X,
+    Z,
+    W,
+    Y,
+    S,
+    stride_x_row,
+    stride_z_row,
+    stride_y_row,
+    stride_s_token,
+    stride_s_group,
+    M,
+    N: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    eps,
+    quant_eps,
+    BLOCK_N: tl.constexpr,
+    ROWS_PER_BLOCK: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    FP8_MIN: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    SCALE_UE8M0: tl.constexpr,
+    USE_GDC: tl.constexpr = False,
+):
+    if USE_GDC:
+        tl.extra.cuda.gdc_wait()
+
+    row_start = tl.program_id(0) * ROWS_PER_BLOCK
+    rows = row_start + tl.arange(0, ROWS_PER_BLOCK)
+    cols = tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < M) & (cols[None, :] < N)
+
+    x = tl.load(
+        X + rows[:, None] * stride_x_row + cols[None, :],
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    z = tl.load(
+        Z + rows[:, None] * stride_z_row + cols[None, :],
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    w = tl.load(W + cols, mask=cols < N, other=0.0).to(tl.float32)
+
+    variance = tl.sum(tl.where(mask, x * x, 0.0), axis=1) / N
+    y = x * tl.rsqrt(variance + eps)[:, None] * w[None, :]
+    if ACTIVATION == "swish" or ACTIVATION == "silu":
+        y *= z * tl.sigmoid(z)
+    elif ACTIVATION == "sigmoid":
+        y *= tl.sigmoid(z)
+
+    # The unfused path materializes BF16 before quantization; preserve that boundary.
+    y = y.to(tl.bfloat16).to(tl.float32)
+    absmax = tl.maximum(tl.max(tl.abs(y), axis=1), quant_eps)
+    scale = absmax / FP8_MAX
+    if SCALE_UE8M0:
+        exponent = tl.ceil(tl.log2(tl.abs(scale)))
+        scale = tl.exp2(exponent)
+    quantized = tl.clamp(y / scale[:, None], FP8_MIN, FP8_MAX)
+
+    tl.store(
+        Y + rows[:, None] * stride_y_row + cols[None, :],
+        quantized,
+        mask=mask,
+    )
+    if SCALE_UE8M0:
+        shifts = tl.arange(0, ROWS_PER_BLOCK) * 8
+        packed = tl.sum((exponent.to(tl.int32) + 127) << shifts, axis=0)
+        token = row_start // NUM_GROUPS
+        group = (row_start % NUM_GROUPS) // 4
+        tl.store(S + token * stride_s_token + group * stride_s_group, packed)
+    else:
+        token = rows // NUM_GROUPS
+        group = rows % NUM_GROUPS
+        tl.store(
+            S + token * stride_s_token + group * stride_s_group,
+            scale,
+            mask=rows < M,
+        )
+
+    if USE_GDC:
+        tl.extra.cuda.gdc_launch_dependents()
+
+
 @lru_cache
 def _get_sm_count(device: torch.device) -> int:
     """Get and cache the SM count for a given device."""
@@ -342,6 +433,78 @@ def rms_norm_gated(
         activation=activation,
     )
     return y.reshape(x_shape_og)
+
+
+def rms_norm_gated_fp8_quant(
+    *,
+    x,
+    weight,
+    z,
+    eps,
+    num_groups,
+    activation: str = "swish",
+    scale_ue8m0: bool = False,
+):
+    x_shape = x.shape
+    x = x.reshape(-1, x.shape[-1])
+    z = z.reshape(-1, z.shape[-1])
+    if x.stride(-1) != 1:
+        x = x.contiguous()
+    if z.stride(-1) != 1:
+        z = z.contiguous()
+    weight = weight.contiguous()
+
+    M, N = x.shape
+    assert x.shape == z.shape
+    assert x.dtype == torch.bfloat16
+    assert z.dtype == torch.bfloat16
+    assert weight.shape == (N,)
+    assert M % num_groups == 0
+    assert not scale_ue8m0 or num_groups % 4 == 0
+
+    quantized = torch.empty_like(x, dtype=fp8_dtype)
+    scale = create_per_token_group_quant_fp8_output_scale(
+        x_shape=(M // num_groups, N * num_groups),
+        device=x.device,
+        group_size=N,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=scale_ue8m0,
+    )
+    if M == 0:
+        return quantized.reshape(x_shape), scale
+
+    block_n = triton.next_power_of_2(N)
+    rows_per_block = 4 if scale_ue8m0 else calc_rows_per_block(M, x.device)
+    grid = (cdiv(M, rows_per_block),)
+    pdl_kwargs = {"USE_GDC": True, "launch_pdl": True} if is_arch_support_pdl() else {}
+    with device_context(x.device):
+        _rms_norm_gated_fp8_quant_kernel[grid](
+            x,
+            z,
+            weight,
+            quantized,
+            scale,
+            x.stride(0),
+            z.stride(0),
+            quantized.stride(0),
+            scale.stride(0),
+            scale.stride(1),
+            M,
+            N,
+            num_groups,
+            eps,
+            1e-10,
+            BLOCK_N=block_n,
+            ROWS_PER_BLOCK=rows_per_block,
+            ACTIVATION=activation,
+            FP8_MIN=fp8_min,
+            FP8_MAX=fp8_max,
+            SCALE_UE8M0=scale_ue8m0,
+            num_warps=min(max(block_n // 256, 1), 8),
+            **pdl_kwargs,
+        )
+    return quantized.reshape(x_shape), scale
 
 
 class LayerNormFn(torch.autograd.Function):

--- a/python/sglang/kernels/ops/attention/triton_gdn_fused_proj.py
+++ b/python/sglang/kernels/ops/attention/triton_gdn_fused_proj.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import torch
 import triton
 import triton.language as tl
+
+
+class GDNDecodeProjection(NamedTuple):
+    projected_qkvz: torch.Tensor
+    projected_ba: torch.Tensor
+    mixed_qkv: torch.Tensor
+    z: torch.Tensor
+
 
 # =============================================================================
 # Fused kernel — reads INTERLEAVED input format
@@ -308,6 +318,142 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         num_stages=3,
     )
     return mixed_qkv, z, b, a
+
+
+@triton.jit
+def fused_qkvz_split_conv1d_update_contiguous_kernel(
+    projected_qkvz,
+    projected_ba,
+    mixed_qkv,
+    z,
+    b,
+    a,
+    conv_state,
+    weight,
+    cache_indices,
+    stride_projected_token: tl.constexpr,
+    stride_projected_ba_token: tl.constexpr,
+    stride_mixed_token: tl.constexpr,
+    stride_z_token: tl.constexpr,
+    stride_b_token: tl.constexpr,
+    stride_a_token: tl.constexpr,
+    stride_state_sequence: tl.constexpr,
+    stride_state_feature: tl.constexpr,
+    stride_state_token: tl.constexpr,
+    stride_weight_feature: tl.constexpr,
+    stride_weight_width: tl.constexpr,
+    stride_cache_indices: tl.constexpr,
+    QKV_DIM: tl.constexpr,
+    Z_DIM: tl.constexpr,
+    PAD_SLOT_ID: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    feature_offsets = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    qkv_mask = feature_offsets < QKV_DIM
+    projected_base = projected_qkvz + token_idx * stride_projected_token
+    values = tl.load(projected_base + feature_offsets, mask=qkv_mask)
+
+    z_mask = feature_offsets < Z_DIM
+    z_values = tl.load(
+        projected_base + QKV_DIM + feature_offsets,
+        mask=z_mask,
+    )
+    tl.store(z + token_idx * stride_z_token + feature_offsets, z_values, mask=z_mask)
+
+    if tl.program_id(1) == 0:
+        ba_offsets = tl.arange(0, 16)
+        projected_ba_base = projected_ba + token_idx * stride_projected_ba_token
+        tl.store(
+            b + token_idx * stride_b_token + ba_offsets,
+            tl.load(projected_ba_base + ba_offsets),
+        )
+        tl.store(
+            a + token_idx * stride_a_token + ba_offsets,
+            tl.load(projected_ba_base + 16 + ba_offsets),
+        )
+
+    state_idx = tl.load(cache_indices + token_idx * stride_cache_indices)
+    if state_idx == PAD_SLOT_ID:
+        return
+
+    state_base = (
+        conv_state
+        + state_idx * stride_state_sequence
+        + feature_offsets * stride_state_feature
+    )
+    state_0 = tl.load(state_base, mask=qkv_mask)
+    state_1 = tl.load(state_base + stride_state_token, mask=qkv_mask)
+    state_2 = tl.load(state_base + 2 * stride_state_token, mask=qkv_mask)
+
+    weight_base = weight + feature_offsets * stride_weight_feature
+    weight_0 = tl.load(weight_base, mask=qkv_mask)
+    weight_1 = tl.load(weight_base + stride_weight_width, mask=qkv_mask)
+    weight_2 = tl.load(weight_base + 2 * stride_weight_width, mask=qkv_mask)
+    weight_3 = tl.load(weight_base + 3 * stride_weight_width, mask=qkv_mask)
+
+    tl.debug_barrier()
+    tl.store(state_base, state_1, mask=qkv_mask)
+    tl.store(state_base + stride_state_token, state_2, mask=qkv_mask)
+    tl.store(state_base + 2 * stride_state_token, values, mask=qkv_mask)
+
+    output = tl.zeros((BLOCK_N,), dtype=tl.float32)
+    output += state_0 * weight_0
+    output += state_1 * weight_1
+    output += state_2 * weight_2
+    output += values * weight_3
+    output = output / (1 + tl.exp(-output))
+    tl.store(
+        mixed_qkv + token_idx * stride_mixed_token + feature_offsets,
+        output,
+        mask=qkv_mask,
+    )
+
+
+def fused_qkvz_split_conv1d_update_contiguous(
+    projected_qkvz: torch.Tensor,
+    projected_ba: torch.Tensor,
+    mixed_qkv: torch.Tensor,
+    z: torch.Tensor,
+    b: torch.Tensor,
+    a: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    cache_indices: torch.Tensor,
+    pad_slot_id: int,
+) -> None:
+    qkv_dim = mixed_qkv.shape[1]
+    z_dim = z.shape[1] * z.shape[2]
+    grid = (projected_qkvz.shape[0], triton.cdiv(qkv_dim, 256))
+    fused_qkvz_split_conv1d_update_contiguous_kernel[grid](
+        projected_qkvz,
+        projected_ba,
+        mixed_qkv,
+        z,
+        b,
+        a,
+        conv_state,
+        weight,
+        cache_indices,
+        projected_qkvz.stride(0),
+        projected_ba.stride(0),
+        mixed_qkv.stride(0),
+        z.stride(0),
+        b.stride(0),
+        a.stride(0),
+        conv_state.stride(0),
+        conv_state.stride(1),
+        conv_state.stride(2),
+        weight.stride(0),
+        weight.stride(1),
+        cache_indices.stride(0),
+        qkv_dim,
+        z_dim,
+        pad_slot_id,
+        BLOCK_N=256,
+        num_warps=1,
+        num_stages=3,
+    )
 
 
 @triton.jit

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1101,6 +1101,7 @@ class Envs:
     SGLANG_MINIMAX_M3_FUSED_MOE_COMBINE = EnvBool(False)
 
     # GEMM / kernel fusion
+    SGLANG_DISABLE_QWEN_GDN_NORM_QUANT_FUSION = EnvBool(False)
     SGLANG_OPT_FP8_WO_A_GEMM = EnvBool(True)
     SGLANG_OPT_BF16_FP32_GEMM_ALGO = EnvStr("cublas")
     SGLANG_OPT_USE_JIT_EP_ACTIVATION = EnvBool(True)

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -32,6 +32,11 @@ if is_cuda() or is_hip():
         fused_qkv_split_gdn_prefill,
     )
 
+if is_cuda():
+    from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+        fused_qkvz_split_conv1d_update_contiguous,
+    )
+
 MAX_FUSED_QKV_SPLIT_DIM = 8192
 
 if is_cuda():
@@ -389,15 +394,30 @@ class GDNAttnBackend(MambaAttnBackendBase):
         replayssm_k = layer_cache.replayssm_k
         replayssm_g = layer_cache.replayssm_g
 
-        assert isinstance(mixed_qkv, torch.Tensor)
-        mixed_qkv = causal_conv1d_update(
-            mixed_qkv,
-            conv_states,
-            layer.conv_weights,
-            layer.bias,
-            layer.activation,
-            conv_state_indices=cache_indices,
-        )
+        if isinstance(mixed_qkv, tuple):
+            projected_qkvz, projected_ba, mixed_qkv, z = mixed_qkv
+            fused_qkvz_split_conv1d_update_contiguous(
+                projected_qkvz,
+                projected_ba,
+                mixed_qkv,
+                z,
+                b,
+                a,
+                conv_states,
+                layer.conv_weights,
+                cache_indices,
+                self.pad_slot_id,
+            )
+        else:
+            assert isinstance(mixed_qkv, torch.Tensor)
+            mixed_qkv = causal_conv1d_update(
+                mixed_qkv,
+                conv_states,
+                layer.conv_weights,
+                layer.bias,
+                layer.activation,
+                conv_state_indices=cache_indices,
+            )
 
         # Skip split + reshape + separate gating kernel by consuming
         # the packed mixed_qkv directly in a single fused Triton kernel.

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -822,13 +822,15 @@ def deepgemm_w8a8_block_fp8_linear_with_fallback(
     input_scale: Optional[torch.Tensor] = None,
     bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    assert input_scale is None
-
-    output_dtype = input.dtype
+    prequantized = input_scale is not None
+    output_dtype = torch.bfloat16 if prequantized else input.dtype
     dtype_supported = output_dtype == torch.bfloat16
 
     # TODO: https://github.com/sgl-project/sglang/pull/6890#issuecomment-2943395737
     shape_supported = weight.shape[0] % 64 == 0 and weight.shape[1] % 128 == 0
+
+    if prequantized and not shape_supported:
+        raise ValueError("Prequantized DeepGEMM input requires a supported GEMM shape")
 
     if not (shape_supported and dtype_supported):
         # fall back to triton
@@ -846,7 +848,25 @@ def deepgemm_w8a8_block_fp8_linear_with_fallback(
     input_2d = input.view(-1, input.shape[-1])
     output_shape = [*input.shape[:-1], weight.shape[0]]
 
-    if not _is_musa:
+    if prequantized:
+        scale_groups = input_2d.shape[1] // block_size[1]
+        if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+            expected_scale_shape = (input_2d.shape[0], ceil_div(scale_groups, 4))
+            expected_scale_dtype = torch.int32
+        else:
+            expected_scale_shape = (input_2d.shape[0], scale_groups)
+            expected_scale_dtype = torch.float32
+        if input.dtype != fp8_dtype or input_scale.dtype != expected_scale_dtype:
+            raise TypeError(
+                "Prequantized DeepGEMM input has an incompatible data or scale dtype"
+            )
+        if input_scale.shape != expected_scale_shape or input_scale.stride(0) != 1:
+            raise ValueError(
+                "Prequantized DeepGEMM scales require a TMA-aligned column-major "
+                f"{expected_scale_shape} layout"
+            )
+        q_input, x_scale = input_2d, input_scale
+    elif not _is_musa:
         q_input, x_scale = sglang_per_token_group_quant_fp8(
             input_2d,
             block_size[1],

--- a/python/sglang/srt/layers/radix_linear_attention.py
+++ b/python/sglang/srt/layers/radix_linear_attention.py
@@ -78,7 +78,7 @@ class RadixLinearAttention(nn.Module):
     def forward(
         self,
         forward_batch: ForwardBatch,
-        mixed_qkv: torch.Tensor,
+        mixed_qkv: Union[torch.Tensor, Tuple[torch.Tensor, ...]],
         a: torch.Tensor,
         b: torch.Tensor,
     ) -> torch.Tensor:

--- a/python/sglang/srt/managers/scheduler_components/profiler_manager.py
+++ b/python/sglang/srt/managers/scheduler_components/profiler_manager.py
@@ -22,7 +22,7 @@ from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.utils import is_mps, is_npu
 from sglang.srt.utils.profile_merger import ProfileMerger
-from sglang.srt.utils.profile_utils import ProfileManager
+from sglang.srt.utils.profile_utils import ProfileManager, get_profile_stage
 from sglang.srt.utils.torch_npu_patch_utils import apply_torch_npu_patches
 
 if TYPE_CHECKING:
@@ -390,14 +390,15 @@ class SchedulerProfilerManager:
             return
 
         if self.profile_by_stage:
-            if batch.forward_mode.is_prefill():
+            stage = get_profile_stage(batch.forward_mode)
+            if stage == "prefill":
                 if self.profiler_prefill_ct == 0:
                     self._start_profile(batch.forward_mode)
                 self.profiler_prefill_ct += 1
                 if self.profiler_prefill_ct > self.profiler_target_prefill_ct:
                     if self.profile_in_progress:
                         self._stop_profile(stage=ForwardMode.EXTEND)
-            elif batch.forward_mode.is_decode():
+            elif stage == "decode":
                 if self.profiler_decode_ct == 0:
                     if self.profile_in_progress:
                         # force trace flush
@@ -407,10 +408,8 @@ class SchedulerProfilerManager:
                 if self.profiler_decode_ct > self.profiler_target_decode_ct:
                     if self.profile_in_progress:
                         self._stop_profile(stage=ForwardMode.DECODE)
-            elif batch.forward_mode.is_idle():
+            elif stage is None:
                 pass
-            else:
-                raise RuntimeError(f"unsupported profile stage: {batch.forward_mode}")
         else:
             # Check profiler
             if (

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -28,6 +28,7 @@ from sglang.kernels.ops.attention.fla.layernorm_gated import (
     rms_norm_gated_fp8_quant,
 )
 from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+    GDNDecodeProjection,
     fused_qkvzba_split_reshape_cat_contiguous,
 )
 from sglang.kernels.ops.elementwise.elementwise import fused_sigmoid_mul
@@ -45,6 +46,7 @@ from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers import deep_gemm_wrapper
+from sglang.srt.layers.attention.linear.utils import get_linear_attn_decode_backend
 from sglang.srt.layers.attention.mamba.mamba import mamba_v2_sharded_weight_loader
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.dp_attention import (
@@ -650,6 +652,32 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             projected_states_ba, _ = self.in_proj_ba(hs_bf16)
         return projected_states_qkvz, projected_states_ba
 
+    def _can_fuse_decode_split_conv(
+        self,
+        projected_states_qkvz: torch.Tensor,
+        projected_states_ba: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> bool:
+        server_args = get_server_args()
+        return (
+            _is_cuda
+            and forward_batch.forward_mode.is_decode()
+            and forward_batch.spec_info is None
+            and get_linear_attn_decode_backend().is_triton()
+            and not server_args.enable_linear_replayssm
+            and not server_args.enable_gdn_replayssm_spec
+            and self.conv_kernel_size == 4
+            and self.attn.bias is None
+            and self.activation in ("silu", "swish")
+            and projected_states_qkvz.is_contiguous()
+            and projected_states_ba.is_contiguous()
+            and projected_states_qkvz.shape[1] == 6144
+            and projected_states_ba.shape[1] == 32
+            and self.attn.q_dim == 1024
+            and self.attn.k_dim == 1024
+            and self.attn.v_dim == 2048
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -665,7 +693,26 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             hidden_states
         )
 
-        if self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_npu:
+        if self._can_fuse_decode_split_conv(
+            projected_states_qkvz,
+            projected_states_ba,
+            forward_batch,
+        ):
+            mixed_qkv_output = projected_states_qkvz.new_empty(
+                projected_states_qkvz.shape[0], 4096
+            )
+            z = projected_states_qkvz.new_empty(
+                projected_states_qkvz.shape[0], 16, self.head_v_dim
+            )
+            b = projected_states_ba.new_empty(projected_states_ba.shape[0], 16)
+            a = torch.empty_like(b)
+            mixed_qkv = GDNDecodeProjection(
+                projected_states_qkvz,
+                projected_states_ba,
+                mixed_qkv_output,
+                z,
+            )
+        elif self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_npu:
             if _is_cpu:
                 num_k_heads_tp = self.num_k_heads // self.attn_tp_size
                 num_v_heads_tp = self.num_v_heads // self.attn_tp_size

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -24,6 +24,9 @@ import triton
 
 # Layers - Attention
 from sglang.kernels.ops.attention.fla.layernorm_gated import RMSNorm as RMSNormGated
+from sglang.kernels.ops.attention.fla.layernorm_gated import (
+    rms_norm_gated_fp8_quant,
+)
 from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
     fused_qkvzba_split_reshape_cat_contiguous,
 )
@@ -40,6 +43,7 @@ from sglang.srt.configs.qwen3_5 import (
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.attention.mamba.mamba import mamba_v2_sharded_weight_loader
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.dp_attention import (
@@ -62,6 +66,9 @@ from sglang.srt.layers.parameter import (
     PerTensorScaleParameter,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.fp8_utils import (
+    deepgemm_w8a8_block_fp8_linear_with_fallback,
+)
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -188,6 +195,25 @@ def _linear_accepts_fp8_tuple(linear: nn.Module) -> bool:
     return quant_method.__class__.__name__ == "Fp8LinearMethod" and (
         getattr(quant_method, "block_quant", False)
         or getattr(quant_method, "use_mxfp8", False)
+    )
+
+
+def _can_fuse_gdn_norm_quant(
+    linear: nn.Module, head_v_dim: int, num_groups: int, activation: str
+) -> bool:
+    quant_method = getattr(linear, "quant_method", None)
+    return (
+        _is_cuda
+        and head_v_dim == 128
+        and activation in ("swish", "silu", "sigmoid")
+        and (not deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or num_groups % 4 == 0)
+        and quant_method.__class__.__name__ == "Fp8LinearMethod"
+        and getattr(quant_method, "block_quant", False)
+        and getattr(quant_method, "weight_block_size", None) == [128, 128]
+        and getattr(linear, "orig_dtype", None) == torch.bfloat16
+        and quant_method.w8a8_block_fp8_linear
+        is deepgemm_w8a8_block_fp8_linear_with_fallback
+        and not get_bool_env_var("SGLANG_DISABLE_QWEN_GDN_NORM_QUANT_FUSION")
     )
 
 
@@ -368,6 +394,12 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             tp_rank=self.attn_tp_rank,
             tp_size=self.attn_tp_size,
             prefix=add_prefix("out_proj", prefix),
+        )
+        self.fuse_gdn_norm_quant = _can_fuse_gdn_norm_quant(
+            self.out_proj,
+            self.head_v_dim,
+            self.num_v_heads // self.attn_tp_size,
+            self.norm.activation,
         )
 
     @staticmethod
@@ -676,9 +708,23 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             core_attn_out_pad[: core_attn_out.shape[0], :] = core_attn_out
             core_attn_out = core_attn_out_pad
 
-        core_attn_out = self.norm(core_attn_out, z)
-        core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = core_attn_out.reshape(*core_attn_out.shape[:-2], -1)
+        if self.fuse_gdn_norm_quant:
+            core_attn_out, input_scale = rms_norm_gated_fp8_quant(
+                x=core_attn_out,
+                weight=self.norm.weight,
+                z=z,
+                eps=self.norm.eps,
+                num_groups=self.num_v_heads // self.attn_tp_size,
+                activation=self.norm.activation,
+                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
+            )
+            core_attn_out = core_attn_out.reshape(z_shape_og)
+            core_attn_out = core_attn_out.reshape(*core_attn_out.shape[:-2], -1)
+            core_attn_out = (core_attn_out, input_scale)
+        else:
+            core_attn_out = self.norm(core_attn_out, z)
+            core_attn_out = core_attn_out.reshape(z_shape_og)
+            core_attn_out = core_attn_out.reshape(*core_attn_out.shape[:-2], -1)
 
         output, _ = self.out_proj(core_attn_out)
         return output

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -41,6 +41,7 @@ from sglang.srt.configs.qwen3_5 import (
 
 # Distributed
 from sglang.srt.distributed import get_pp_group
+from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers import deep_gemm_wrapper
@@ -201,19 +202,20 @@ def _linear_accepts_fp8_tuple(linear: nn.Module) -> bool:
 def _can_fuse_gdn_norm_quant(
     linear: nn.Module, head_v_dim: int, num_groups: int, activation: str
 ) -> bool:
-    quant_method = getattr(linear, "quant_method", None)
+    quant_method = linear.quant_method
+    if quant_method.__class__.__name__ != "Fp8LinearMethod":
+        return False
     return (
         _is_cuda
         and head_v_dim == 128
         and activation in ("swish", "silu", "sigmoid")
         and (not deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or num_groups % 4 == 0)
-        and quant_method.__class__.__name__ == "Fp8LinearMethod"
-        and getattr(quant_method, "block_quant", False)
-        and getattr(quant_method, "weight_block_size", None) == [128, 128]
-        and getattr(linear, "orig_dtype", None) == torch.bfloat16
+        and quant_method.block_quant
+        and quant_method.weight_block_size == [128, 128]
+        and linear.orig_dtype == torch.bfloat16
         and quant_method.w8a8_block_fp8_linear
         is deepgemm_w8a8_block_fp8_linear_with_fallback
-        and not get_bool_env_var("SGLANG_DISABLE_QWEN_GDN_NORM_QUANT_FUSION")
+        and not envs.SGLANG_DISABLE_QWEN_GDN_NORM_QUANT_FUSION.get()
     )
 
 

--- a/python/sglang/srt/utils/profile_utils.py
+++ b/python/sglang/srt/utils/profile_utils.py
@@ -67,7 +67,7 @@ class ProfileManager:
         self.profiler = None
 
     def step(self, forward_mode: ForwardMode):
-        stage = _get_stage_from_forward_mode(forward_mode)
+        stage = get_profile_stage(forward_mode)
         if stage is None:
             return
 
@@ -148,7 +148,9 @@ class ProfileManager:
         self.profiler = None
 
 
-def _get_stage_from_forward_mode(forward_mode: ForwardMode):
+def get_profile_stage(forward_mode: ForwardMode):
+    if forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
+        return "decode"
     if forward_mode.is_prefill():
         return "prefill"
     elif forward_mode.is_decode():

--- a/test/registered/attention/test_gdn_qkvz_split_conv.py
+++ b/test/registered/attention/test_gdn_qkvz_split_conv.py
@@ -1,0 +1,193 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+    fused_qkvz_split_conv1d_update_contiguous,
+    fused_qkvzba_split_reshape_cat_contiguous,
+)
+from sglang.kernels.ops.mamba.causal_conv1d_triton import (
+    PAD_SLOT_ID,
+    causal_conv1d_update,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-large")
+
+QK_HEADS = 8
+V_HEADS = 16
+HEAD_DIM = 128
+QKV_DIM = 4096
+Z_DIM = 2048
+BA_DIM = 32
+
+
+def _make_inputs(batch: int, seed: int):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    projected_qkvz = torch.randn(
+        batch,
+        QKV_DIM + Z_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    projected_ba = torch.randn(
+        batch,
+        BA_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    weight = torch.randn(
+        QKV_DIM,
+        4,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    storage = torch.randn(
+        batch + 9,
+        3,
+        QKV_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    state = storage.transpose(1, 2)
+    cache_indices = torch.randperm(
+        batch + 9,
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )[:batch]
+    if batch > 1:
+        cache_indices[-1] = PAD_SLOT_ID
+    return projected_qkvz, projected_ba, weight, state, cache_indices
+
+
+def _reference(projected_qkvz, projected_ba, weight, state, cache_indices):
+    mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat_contiguous(
+        projected_qkvz,
+        projected_ba,
+        QK_HEADS,
+        V_HEADS,
+        HEAD_DIM,
+        HEAD_DIM,
+    )
+    mixed_qkv = causal_conv1d_update(
+        mixed_qkv,
+        state,
+        weight,
+        activation="silu",
+        conv_state_indices=cache_indices,
+    )
+    return mixed_qkv, z, b, a
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("batch", [1, 32])
+def test_matches_split_then_conv(batch):
+    projected_qkvz, projected_ba, weight, state, cache_indices = _make_inputs(
+        batch, seed=batch
+    )
+    reference_state = state.clone(memory_format=torch.preserve_format)
+    mixed_ref, z_ref, b_ref, a_ref = _reference(
+        projected_qkvz,
+        projected_ba,
+        weight,
+        reference_state,
+        cache_indices,
+    )
+
+    mixed = torch.empty_like(mixed_ref)
+    z = torch.empty_like(z_ref)
+    b = torch.empty_like(b_ref)
+    a = torch.empty_like(a_ref)
+    fused_qkvz_split_conv1d_update_contiguous(
+        projected_qkvz,
+        projected_ba,
+        mixed,
+        z,
+        b,
+        a,
+        state,
+        weight,
+        cache_indices,
+        PAD_SLOT_ID,
+    )
+
+    valid = cache_indices != PAD_SLOT_ID
+    torch.testing.assert_close(mixed[valid], mixed_ref[valid], atol=0, rtol=0)
+    torch.testing.assert_close(z, z_ref, atol=0, rtol=0)
+    torch.testing.assert_close(b, b_ref, atol=0, rtol=0)
+    torch.testing.assert_close(a, a_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state, reference_state, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_cuda_graph_replay():
+    batch = 32
+    projected_qkvz, projected_ba, weight, state, cache_indices = _make_inputs(
+        batch, seed=101
+    )
+    initial_state = state.clone(memory_format=torch.preserve_format)
+    mixed = torch.empty(batch, QKV_DIM, dtype=torch.bfloat16, device="cuda")
+    z = torch.empty(batch, V_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    b = torch.empty(batch, V_HEADS, dtype=torch.bfloat16, device="cuda")
+    a = torch.empty_like(b)
+
+    fused_qkvz_split_conv1d_update_contiguous(
+        projected_qkvz,
+        projected_ba,
+        mixed,
+        z,
+        b,
+        a,
+        state,
+        weight,
+        cache_indices,
+        PAD_SLOT_ID,
+    )
+    state.copy_(initial_state)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fused_qkvz_split_conv1d_update_contiguous(
+            projected_qkvz,
+            projected_ba,
+            mixed,
+            z,
+            b,
+            a,
+            state,
+            weight,
+            cache_indices,
+            PAD_SLOT_ID,
+        )
+
+    new_qkvz, new_ba, new_weight, new_state, _ = _make_inputs(batch, seed=202)
+    projected_qkvz.copy_(new_qkvz)
+    projected_ba.copy_(new_ba)
+    weight.copy_(new_weight)
+    state.copy_(new_state)
+    reference_state = new_state.clone(memory_format=torch.preserve_format)
+    mixed_ref, z_ref, b_ref, a_ref = _reference(
+        projected_qkvz,
+        projected_ba,
+        weight,
+        reference_state,
+        cache_indices,
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    valid = cache_indices != PAD_SLOT_ID
+    torch.testing.assert_close(mixed[valid], mixed_ref[valid], atol=0, rtol=0)
+    torch.testing.assert_close(z, z_ref, atol=0, rtol=0)
+    torch.testing.assert_close(b, b_ref, atol=0, rtol=0)
+    torch.testing.assert_close(a, a_ref, atol=0, rtol=0)
+    torch.testing.assert_close(state, reference_state, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/kernels/ops/attention/test_rms_norm_gated_fp8_quant.py
+++ b/test/registered/kernels/ops/attention/test_rms_norm_gated_fp8_quant.py
@@ -1,0 +1,72 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.fla.layernorm_gated import (
+    rms_norm_gated,
+    rms_norm_gated_fp8_quant,
+)
+from sglang.kernels.ops.quantization.fp8_kernel import (
+    sglang_per_token_group_quant_fp8,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+HEAD_DIM = 128
+NUM_HEADS = 16
+EPS = 1e-6
+
+
+@pytest.mark.parametrize("scale_ue8m0", [False, True])
+@pytest.mark.parametrize("num_tokens", [1, 4, 8, 16, 257, 16384])
+def test_rms_norm_gated_fp8_quant(num_tokens, scale_ue8m0):
+    torch.manual_seed(num_tokens)
+    shape = (num_tokens * NUM_HEADS, HEAD_DIM)
+    x = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    z = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+
+    normalized = rms_norm_gated(
+        x=x,
+        weight=weight,
+        bias=None,
+        z=z,
+        eps=EPS,
+        norm_before_gate=True,
+        is_rms_norm=True,
+        activation="swish",
+    ).reshape(num_tokens, NUM_HEADS * HEAD_DIM)
+    expected_q, expected_scale = sglang_per_token_group_quant_fp8(
+        normalized,
+        HEAD_DIM,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=scale_ue8m0,
+    )
+
+    actual_q, actual_scale = rms_norm_gated_fp8_quant(
+        x=x,
+        weight=weight,
+        z=z,
+        eps=EPS,
+        num_groups=NUM_HEADS,
+        activation="swish",
+        scale_ue8m0=scale_ue8m0,
+    )
+    actual_q = actual_q.reshape(num_tokens, NUM_HEADS * HEAD_DIM)
+
+    assert actual_q.dtype == expected_q.dtype
+    assert actual_scale.shape == expected_scale.shape
+    assert actual_scale.stride() == expected_scale.stride()
+    torch.testing.assert_close(actual_scale, expected_scale, rtol=0, atol=0)
+    mismatch_rate = (actual_q != expected_q).float().mean().item()
+    assert mismatch_rate <= (3e-6 if scale_ue8m0 else 2e-3)
+    torch.testing.assert_close(
+        actual_q.float(), expected_q.float(), rtol=0.13, atol=0.002
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/unit/layers/quantization/test_deepgemm_prequant.py
+++ b/test/registered/unit/layers/quantization/test_deepgemm_prequant.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.quantization.fp8_utils as fp8_utils
+from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDeepGemmPrequant(unittest.TestCase):
+    def _run_prequantized_input(self, scale_ue8m0):
+        q_input = torch.zeros((3, 128), dtype=fp8_dtype)
+        scale_dtype = torch.int32 if scale_ue8m0 else torch.float32
+        input_scale = torch.empty((1, 4), dtype=scale_dtype).transpose(0, 1)[:3]
+        input_scale.fill_(1)
+        weight = torch.zeros((64, 128), dtype=fp8_dtype)
+        weight_scale = torch.ones((1, 1), dtype=torch.float32)
+        matmul_output = torch.zeros((3, 64), dtype=torch.bfloat16)
+
+        with (
+            patch.object(
+                fp8_utils.deep_gemm_wrapper,
+                "DEEPGEMM_SCALE_UE8M0",
+                scale_ue8m0,
+            ),
+            patch.object(fp8_utils, "sglang_per_token_group_quant_fp8") as quantizer,
+            patch.object(
+                fp8_utils,
+                "w8a8_block_fp8_matmul_deepgemm",
+                return_value=matmul_output,
+            ) as matmul,
+        ):
+            output = fp8_utils.deepgemm_w8a8_block_fp8_linear_with_fallback(
+                input=q_input,
+                weight=weight,
+                block_size=[128, 128],
+                weight_scale=weight_scale,
+                input_scale=input_scale,
+            )
+
+        quantizer.assert_not_called()
+        matmul.assert_called_once()
+        args = matmul.call_args.args
+        self.assertEqual(args[0].data_ptr(), q_input.data_ptr())
+        self.assertIs(args[1], weight)
+        self.assertIs(args[2], input_scale)
+        self.assertIs(args[3], weight_scale)
+        self.assertEqual(args[4], [128, 128])
+        self.assertEqual(matmul.call_args.kwargs["output_dtype"], torch.bfloat16)
+        self.assertEqual(output.shape, (3, 64))
+        self.assertEqual(output.dtype, torch.bfloat16)
+
+    def test_prequantized_fp32_scale_input_skips_quantizer(self):
+        self._run_prequantized_input(scale_ue8m0=False)
+
+    def test_prequantized_ue8m0_scale_input_skips_quantizer(self):
+        self._run_prequantized_input(scale_ue8m0=True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/unit/test_profile_stage.py
+++ b/test/registered/unit/test_profile_stage.py
@@ -1,0 +1,29 @@
+import unittest
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.utils.profile_utils import get_profile_stage
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestProfileStage(unittest.TestCase):
+    def test_profile_stage(self):
+        expected = {
+            ForwardMode.EXTEND: "prefill",
+            ForwardMode.MIXED: "prefill",
+            ForwardMode.SPLIT_PREFILL: "prefill",
+            ForwardMode.DLLM_EXTEND: "prefill",
+            ForwardMode.DECODE: "decode",
+            ForwardMode.TARGET_VERIFY: "decode",
+            ForwardMode.DRAFT_EXTEND_V2: "decode",
+            ForwardMode.IDLE: None,
+        }
+
+        for forward_mode, stage in expected.items():
+            with self.subTest(forward_mode=forward_mode):
+                self.assertEqual(get_profile_stage(forward_mode), stage)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fuse the contiguous QKVZ/BA split with the width-4 causal-conv update for the guarded Qwen3.5 normal CUDA Triton decode path.
- Keep the packed recurrent kernel and all unsupported decode, speculative, ReplaySSM, and alternate-backend paths unchanged.
- Add focused B200 coverage for batch 1/32, non-monotonic cache indices, the padding slot, untouched cache rows, and CUDA graph replay.

This PR is stacked on sgl-project/sglang#32443. The performance comparison below uses its head commit `ba466b8bf6` as the control.

For a one-commit, five-file diff against that parent head, see JustinTong0323/sglang#45.

## Performance

Model: `Qwen/Qwen3.6-35B-A3B-FP8` at revision `95a723d0`, 2× B200, TP2.

The retained decode profiles contain 150 affected launches per rank:

| Rank | Split + conv control | Fused | Reduction |
| --- | ---: | ---: | ---: |
| TP0 | 866.458 µs | 478.560–484.158 µs | 44.1–44.8% |
| TP1 | 871.936 µs | 481.062–483.953 µs | 44.5–44.8% |

The serving benchmark used 80 random-ID requests at QPS 4, exact 1,000-token outputs, `--flush-cache` before every run, and paired seeds 42/43/44:

| Workload | Control median | Candidate median | Delta |
| --- | ---: | ---: | ---: |
| `1000→1000` | 3.405943 req/s | 3.421262 req/s | +0.45% |
| `8000→1000` | 3.137935 req/s | 3.161666 req/s | +0.76% |

The two-workload geomean improves 0.60%. All six paired runs improve, and the median TTFT, TPOT, ITL, and E2E latency improve in both workloads.

Server configuration:

```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.6-35B-A3B-FP8 \
  --revision 95a723d08a9490559dae23d0cff1d9466213d989 \
  --tp-size 2 --context-length 65536 --quantization fp8 \
  --mem-fraction-static 0.80 --attention-backend trtllm_mha \
  --linear-attn-prefill-backend triton \
  --linear-attn-decode-backend triton \
  --chunked-prefill-size 8192 --max-running-requests 32
```

## Validation

- `pre-commit run --files <changed files>`
- `python -m pytest -q test/registered/attention/test_gdn_qkvz_split_conv.py` — 3 passed
- Full GSM8K, 1,319 examples × 2 repeats:
  - candidate/control accuracy: 95.75% / 95.41%
  - candidate/control stop-rate: 96.93% / 96.06%
  - 2,638/2,638 predictions and zero errors for both
