### PR TITLE
Use parameterized SiTU for FlashInfer MXFP4

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -83,7 +83,10 @@ class FlashInferCutlassMxfp4MoeQuantInfo(MoeQuantInfo):
     w13_bias: Optional[torch.Tensor] = None  # bf16 [E, 2*N]
     w2_bias: Optional[torch.Tensor] = None  # bf16 [E, K]
 
-    # Optional per-expert SwiGLU overrides, fp32 [E].
+    # Optional per-expert activation overrides, fp32 [E].
+    # For ActivationType.Swiglu these are alpha/beta/limit. For
+    # ActivationType.Situ, swiglu_alpha carries situ_beta and swiglu_limit
+    # carries situ_linear_beta.
     swiglu_alpha: Optional[torch.Tensor] = None
     swiglu_beta: Optional[torch.Tensor] = None
     swiglu_limit: Optional[torch.Tensor] = None
@@ -364,6 +367,20 @@ def fused_experts_none_to_flashinfer_mxfp4(
     with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
         out = torch.empty(x.shape[0], out_hidden, dtype=output_dtype, device=x.device)
 
+    activation_type = ActivationType.Swiglu
+    if runner_config.activation == "situ":
+        if not hasattr(ActivationType, "Situ"):
+            raise RuntimeError(
+                "Kimi-K3 SiTU on SM90 flashinfer_mxfp4 requires a FlashInfer "
+                "build with ActivationType.Situ support."
+            )
+        activation_type = ActivationType.Situ
+    elif runner_config.activation != "silu":
+        raise RuntimeError(
+            "flashinfer_mxfp4 CUTLASS MXFP4 supports only silu/swiglu or "
+            f"situ activations, got {runner_config.activation!r}."
+        )
+
     flashinfer_cutlass_fused_moe(
         input=x,
         token_selected_experts=topk_ids.to(torch.int32),
@@ -384,7 +401,7 @@ def fused_experts_none_to_flashinfer_mxfp4(
         ep_rank=quant_info.moe_ep_rank,
         use_w4_group_scaling=not use_mxfp8_act_scaling,
         use_mxfp8_act_scaling=use_mxfp8_act_scaling,
-        activation_type=ActivationType.Swiglu,
+        activation_type=activation_type,
         tune_max_num_tokens=next_power_of_2(x.shape[0]),
         output=out,
     )

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -84,12 +84,13 @@ class FlashInferCutlassMxfp4MoeQuantInfo(MoeQuantInfo):
     w2_bias: Optional[torch.Tensor] = None  # bf16 [E, K]
 
     # Optional per-expert activation overrides, fp32 [E].
-    # For ActivationType.Swiglu these are alpha/beta/limit. For
-    # ActivationType.Situ, swiglu_alpha carries situ_beta and swiglu_limit
-    # carries situ_linear_beta.
+    # SwiGLU uses swiglu_alpha/beta/limit. Kimi-K3 SiTU uses
+    # ActivationType.Swiglu with explicit situ_beta/situ_linear_beta.
     swiglu_alpha: Optional[torch.Tensor] = None
     swiglu_beta: Optional[torch.Tensor] = None
     swiglu_limit: Optional[torch.Tensor] = None
+    situ_beta: Optional[torch.Tensor] = None
+    situ_linear_beta: Optional[torch.Tensor] = None
 
     # TP/EP topology (forwarded to the FlashInfer kernel)
     moe_tp_size: int = 1
@@ -369,12 +370,11 @@ def fused_experts_none_to_flashinfer_mxfp4(
 
     activation_type = ActivationType.Swiglu
     if runner_config.activation == "situ":
-        if not hasattr(ActivationType, "Situ"):
+        if quant_info.situ_beta is None or quant_info.situ_linear_beta is None:
             raise RuntimeError(
-                "Kimi-K3 SiTU on SM90 flashinfer_mxfp4 requires a FlashInfer "
-                "build with ActivationType.Situ support."
+                "Kimi-K3 SiTU on SM90 flashinfer_mxfp4 requires "
+                "situ_beta and situ_linear_beta tensors."
             )
-        activation_type = ActivationType.Situ
     elif runner_config.activation != "silu":
         raise RuntimeError(
             "flashinfer_mxfp4 CUTLASS MXFP4 supports only silu/swiglu or "
@@ -395,6 +395,8 @@ def fused_experts_none_to_flashinfer_mxfp4(
         swiglu_alpha=quant_info.swiglu_alpha,
         swiglu_beta=quant_info.swiglu_beta,
         swiglu_limit=quant_info.swiglu_limit,
+        situ_beta=quant_info.situ_beta,
+        situ_linear_beta=quant_info.situ_linear_beta,
         tp_size=quant_info.moe_tp_size,
         tp_rank=quant_info.moe_tp_rank,
         ep_size=quant_info.moe_ep_size,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1087,7 +1087,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_bias_padded = torch.zeros(E, K_pad, dtype=bias_dtype, device=device)
         w2_bias_padded[:, :K_un] = layer.w2_weight_bias.data
 
-        # ---- Per-expert SwiGLU scalars (read from runner config, fallback to GPT-OSS defaults)
+        # ---- Per-expert gated activation scalars ---------------------------
+        # SwiGLU uses alpha/beta/limit. Kimi-K3 SiTU reuses alpha as
+        # situ_beta and limit as situ_linear_beta.
         _sm90_alpha = getattr(layer.moe_runner_config, "gemm1_alpha", None) or 1.702
         _sm90_limit = getattr(layer.moe_runner_config, "gemm1_clamp_limit", None) or 7.0
         layer.swiglu_alpha = Parameter(

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1088,22 +1088,41 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         w2_bias_padded[:, :K_un] = layer.w2_weight_bias.data
 
         # ---- Per-expert gated activation scalars ---------------------------
-        # SwiGLU uses alpha/beta/limit. Kimi-K3 SiTU reuses alpha as
-        # situ_beta and limit as situ_linear_beta.
-        _sm90_alpha = getattr(layer.moe_runner_config, "gemm1_alpha", None) or 1.702
-        _sm90_limit = getattr(layer.moe_runner_config, "gemm1_clamp_limit", None) or 7.0
-        layer.swiglu_alpha = Parameter(
-            torch.full((E,), _sm90_alpha, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-        layer.swiglu_beta = Parameter(
-            torch.full((E,), 1.0, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
-        layer.swiglu_limit = Parameter(
-            torch.full((E,), _sm90_limit, dtype=torch.float32, device=device),
-            requires_grad=False,
-        )
+        # Keep SiTU separate from SwiGLU-Bias: FlashInfer selects SiTU via
+        # ActivationType.Swiglu + situ_beta/situ_linear_beta, not a new enum.
+        if layer.moe_runner_config.activation == "situ":
+            _situ_beta = getattr(layer.moe_runner_config, "gemm1_alpha", None) or 4.0
+            _situ_linear_beta = (
+                getattr(layer.moe_runner_config, "gemm1_clamp_limit", None) or 25.0
+            )
+            layer.swiglu_alpha = None
+            layer.swiglu_beta = None
+            layer.swiglu_limit = None
+            layer.situ_beta = Parameter(
+                torch.full((E,), _situ_beta, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
+            layer.situ_linear_beta = Parameter(
+                torch.full((E,), _situ_linear_beta, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
+        else:
+            _sm90_alpha = getattr(layer.moe_runner_config, "gemm1_alpha", None) or 1.702
+            _sm90_limit = getattr(layer.moe_runner_config, "gemm1_clamp_limit", None) or 7.0
+            layer.swiglu_alpha = Parameter(
+                torch.full((E,), _sm90_alpha, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
+            layer.swiglu_beta = Parameter(
+                torch.full((E,), 1.0, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
+            layer.swiglu_limit = Parameter(
+                torch.full((E,), _sm90_limit, dtype=torch.float32, device=device),
+                requires_grad=False,
+            )
+            layer.situ_beta = None
+            layer.situ_linear_beta = None
 
         # ---- FlashInfer SM90 byte / scale interleave -----------------------
         # The padded buffers above are contiguous by construction (allocated
@@ -1189,6 +1208,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             swiglu_alpha=layer.swiglu_alpha,
             swiglu_beta=layer.swiglu_beta,
             swiglu_limit=layer.swiglu_limit,
+            situ_beta=layer.situ_beta,
+            situ_linear_beta=layer.situ_linear_beta,
             moe_tp_size=layer.moe_tp_size,
             moe_tp_rank=layer.moe_tp_rank,
             moe_ep_size=layer.moe_ep_size,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary

This PR updates the SGLang SM90 `flashinfer_mxfp4` integration for Kimi-K3 to use FlashInfer's parameterized SiTU interface.  https://github.com/flashinfer-ai/flashinfer/pull/4209

Instead of requiring `ActivationType.Situ`, Kimi-K3 now calls FlashInfer CUTLASS MoE with:

- `activation_type=ActivationType.Swiglu`
- `situ_beta`
- `situ_linear_beta`

This matches the FlashInfer-side parameterized design and avoids relying on a new activation enum.

## Changes

- Removed the SGLang dependency on `ActivationType.Situ` for the SM90 FlashInfer MXFP4 path.
- Added explicit `situ_beta` and `situ_linear_beta` fields to the FlashInfer CUTLASS MXFP4 MoE quant payload.
- Mapped Kimi-K3 `gemm1_alpha` to `situ_beta`.
- Mapped Kimi-K3 `gemm1_clamp_limit` to `situ_linear_beta`.
- Kept SiTU parameters separate from `swiglu_alpha/beta/limit` so the FlashInfer backend does not incorrectly select the `SwigluBias` path.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30356710244](https://github.com/sgl-project/sglang/actions/runs/30356710244)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30356710313](https://github.com/sgl-project/sglang/actions/runs/30356710313)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->