### PR TITLE
fix(kda): preserve accumulator precision for radix checkpoints

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
+++ b/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
@@ -61,6 +61,10 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     initial_state,
     initial_state_indices,
     stride_init_state,
+    snapshot_state,
+    snapshot_chunk_indices,
+    snapshot_state_indices,
+    stride_snapshot_state,
     cu_seqlens,
     chunk_offsets,
     T,
@@ -75,6 +79,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     USE_INITIAL_STATE: tl.constexpr,
     INPLACE_UPDATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
+    SAVE_SNAPSHOT: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     NT_BUCKET: tl.constexpr,
     USE_EXP2: tl.constexpr,
@@ -125,6 +130,13 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
         h0 = h0 + i_h * V * K
     if INPLACE_UPDATE:
         ht = ht + i_h * V * K
+    if SAVE_SNAPSHOT:
+        snapshot_chunk = tl.load(snapshot_chunk_indices + i_n).to(tl.int32)
+        snapshot_index = tl.load(snapshot_state_indices + i_n).to(tl.int64)
+        snapshot_index_safe = tl.maximum(snapshot_index, 0)
+        snapshot_base = (
+            snapshot_state + snapshot_index_safe * stride_snapshot_state + i_h * V * K
+        )
 
     # load initial state
     if USE_INITIAL_STATE:
@@ -167,6 +179,45 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 h + i_t * stride_h, (V, K), (K, 1), (i_v * BV, 192), (BV, 64), (1, 0)
             )
             tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+
+        # `h` intentionally stays in the Q/K dtype because the output kernel
+        # consumes every chunk row. Prefix caching only needs one selected
+        # boundary per sequence, so preserve that row directly from the FP32
+        # recurrence accumulator instead of round-tripping through BF16 `h`.
+        if SAVE_SNAPSHOT:
+            o_v = i_v * BV + tl.arange(0, BV)
+            o_k1 = tl.arange(0, 64)
+            snapshot_mask = (i_t == snapshot_chunk) & (snapshot_index >= 0)
+            p_snapshot1 = snapshot_base + o_v[:, None] * K + o_k1[None, :]
+            tl.store(
+                p_snapshot1,
+                b_h1,
+                mask=snapshot_mask & (o_v[:, None] < V) & (o_k1[None, :] < K),
+            )
+            if K > 64:
+                o_k2 = 64 + o_k1
+                p_snapshot2 = snapshot_base + o_v[:, None] * K + o_k2[None, :]
+                tl.store(
+                    p_snapshot2,
+                    b_h2,
+                    mask=snapshot_mask & (o_v[:, None] < V) & (o_k2[None, :] < K),
+                )
+            if K > 128:
+                o_k3 = 128 + o_k1
+                p_snapshot3 = snapshot_base + o_v[:, None] * K + o_k3[None, :]
+                tl.store(
+                    p_snapshot3,
+                    b_h3,
+                    mask=snapshot_mask & (o_v[:, None] < V) & (o_k3[None, :] < K),
+                )
+            if K > 192:
+                o_k4 = 192 + o_k1
+                p_snapshot4 = snapshot_base + o_v[:, None] * K + o_k4[None, :]
+                tl.store(
+                    p_snapshot4,
+                    b_h4,
+                    mask=snapshot_mask & (o_v[:, None] < V) & (o_k4[None, :] < K),
+                )
 
         p_w = tl.make_block_ptr(
             w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
@@ -322,6 +373,9 @@ def chunk_gated_delta_rule_fwd_h(
     cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_indices: Optional[torch.LongTensor] = None,
     use_exp2: bool = False,
+    snapshot_state: Optional[torch.Tensor] = None,
+    snapshot_chunk_indices: Optional[torch.Tensor] = None,
+    snapshot_state_indices: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert not (
         use_exp2 and g is not None
@@ -342,6 +396,31 @@ def chunk_gated_delta_rule_fwd_h(
             prepare_chunk_offsets(cu_seqlens, BT),
         )
     assert K <= 256, "current kernel does not support head dimension larger than 256."
+    snapshot_args = (
+        snapshot_state,
+        snapshot_chunk_indices,
+        snapshot_state_indices,
+    )
+    if any(arg is not None for arg in snapshot_args) and not all(
+        arg is not None for arg in snapshot_args
+    ):
+        raise ValueError(
+            "snapshot_state, snapshot_chunk_indices, and snapshot_state_indices "
+            "must be provided together"
+        )
+    save_snapshot = snapshot_state is not None
+    if save_snapshot:
+        if snapshot_chunk_indices.numel() != N or snapshot_state_indices.numel() != N:
+            raise ValueError(
+                "KDA snapshot metadata must contain one entry per sequence: "
+                f"got chunks={snapshot_chunk_indices.numel()}, "
+                f"states={snapshot_state_indices.numel()}, sequences={N}"
+            )
+        if tuple(snapshot_state.shape[1:]) != (H, V, K):
+            raise ValueError(
+                "KDA snapshot state must have [slot, H, V, K] layout: "
+                f"got {tuple(snapshot_state.shape)}, expected [slot, {H}, {V}, {K}]"
+            )
 
     h = k.new_empty(B, NT, H, V, K)
 
@@ -363,6 +442,10 @@ def chunk_gated_delta_rule_fwd_h(
         # Envelope-strided state pools (page-major / unified memory) have a
         # per-slot pitch != H*V*K; contiguous pools pass exactly H*V*K.
         stride_init_state=(initial_state.stride(0) if initial_state is not None else 0),
+        snapshot_state=snapshot_state,
+        snapshot_chunk_indices=snapshot_chunk_indices,
+        snapshot_state_indices=snapshot_state_indices,
+        stride_snapshot_state=(snapshot_state.stride(0) if save_snapshot else 0),
         cu_seqlens=cu_seqlens,
         chunk_offsets=chunk_offsets,
         T=T,
@@ -376,6 +459,7 @@ def chunk_gated_delta_rule_fwd_h(
         USE_INITIAL_STATE=initial_state is not None,
         INPLACE_UPDATE=True,
         SAVE_NEW_VALUE=v_new is not None,
+        SAVE_SNAPSHOT=save_snapshot,
         IS_VARLEN=cu_seqlens is not None,
         NT_BUCKET=(0 if NT <= 32 else (1 if NT <= 128 else 2)),
         USE_EXP2=use_exp2,

--- a/python/sglang/kernels/ops/attention/fla/kda.py
+++ b/python/sglang/kernels/ops/attention/fla/kda.py
@@ -1095,6 +1095,9 @@ def chunk_kda_fwd(
     dt_bias: Optional[torch.Tensor] = None,
     lower_bound: Optional[float] = None,
     output_intermediate_states: bool = False,
+    snapshot_state: Optional[torch.Tensor] = None,
+    snapshot_chunk_indices: Optional[torch.Tensor] = None,
+    snapshot_state_indices: Optional[torch.Tensor] = None,
 ):
     chunk_size = 64
     # Pre-compute chunk indices once and thread through all downstream kernels.
@@ -1159,6 +1162,19 @@ def chunk_kda_fwd(
         fuse_recompute=_small_grid,
     )
 
+    if is_intel and snapshot_state is not None:
+        raise NotImplementedError(
+            "Selected KDA state snapshots are not supported on XPU"
+        )
+    snapshot_kwargs = (
+        {}
+        if is_intel
+        else {
+            "snapshot_state": snapshot_state,
+            "snapshot_chunk_indices": snapshot_chunk_indices,
+            "snapshot_state_indices": snapshot_state_indices,
+        }
+    )
     h, v_new = chunk_gated_delta_rule_fwd_h(
         k=kg,
         w=w,
@@ -1169,6 +1185,7 @@ def chunk_kda_fwd(
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         use_exp2=True,
+        **snapshot_kwargs,
     )
     del w, u, kg
 
@@ -1188,8 +1205,9 @@ def chunk_kda_fwd(
 
     if output_intermediate_states:
         # h holds the recurrent state at every chunk-size boundary
-        # ([1, NT, H, V, K] packed across cu_seqlens) — the mamba radix
-        # track path snapshots per-chunk states from it during extend.
+        # ([1, NT, H, V, K] packed across cu_seqlens). Callers without direct
+        # snapshot support can still copy a selected boundary from it; KDA's
+        # CUDA radix-cache path writes that boundary from the FP32 accumulator.
         return o, h
     del h
     return o
@@ -1210,6 +1228,9 @@ def chunk_kda(
     dt_bias: Optional[torch.Tensor] = None,
     lower_bound: Optional[float] = None,
     output_intermediate_states: bool = False,
+    snapshot_state: Optional[torch.Tensor] = None,
+    snapshot_chunk_indices: Optional[torch.Tensor] = None,
+    snapshot_state_indices: Optional[torch.Tensor] = None,
     **kwargs,
 ):
     if scale is None:
@@ -1234,4 +1255,7 @@ def chunk_kda(
         dt_bias=dt_bias,
         lower_bound=lower_bound,
         output_intermediate_states=output_intermediate_states,
+        snapshot_state=snapshot_state,
+        snapshot_chunk_indices=snapshot_chunk_indices,
+        snapshot_state_indices=snapshot_state_indices,
     )

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -69,6 +69,8 @@ class MambaAttnBackendBase(AttentionBackend):
         track_conv_indices = None
         track_ssm_h_src = None
         track_ssm_h_dst = None
+        track_ssm_snapshot_chunk = None
+        track_ssm_snapshot_dst = None
         track_ssm_final_src = None
         track_ssm_final_dst = None
 
@@ -197,6 +199,8 @@ class MambaAttnBackendBase(AttentionBackend):
                     (
                         track_ssm_h_src,
                         track_ssm_h_dst,
+                        track_ssm_snapshot_chunk,
+                        track_ssm_snapshot_dst,
                         track_ssm_final_src,
                         track_ssm_final_dst,
                     ) = self._init_track_ssm_indices(mamba_cache_indices, forward_batch)
@@ -220,6 +224,8 @@ class MambaAttnBackendBase(AttentionBackend):
             track_conv_indices=track_conv_indices,
             track_ssm_h_src=track_ssm_h_src,
             track_ssm_h_dst=track_ssm_h_dst,
+            track_ssm_snapshot_chunk=track_ssm_snapshot_chunk,
+            track_ssm_snapshot_dst=track_ssm_snapshot_dst,
             track_ssm_final_src=track_ssm_final_src,
             track_ssm_final_dst=track_ssm_final_dst,
             has_mamba_track_mask=has_mamba_track_mask,
@@ -313,9 +319,22 @@ class MambaAttnBackendBase(AttentionBackend):
         )
         track_ssm_h_dst = dst_masked[not_aligned]
 
+        # Keep a dense per-request representation for KDA's direct FP32
+        # snapshot path. The Triton recurrence kernel indexes these with i_n,
+        # avoiding a scan over the packed global h rows in every CTA.
+        track_ssm_snapshot_chunk = torch.full_like(num_h_states, -1)
+        track_ssm_snapshot_dst = torch.full_like(mamba_cache_indices, -1)
+        snapshot_rows = mamba_track_mask.nonzero(as_tuple=True)[0][not_aligned]
+        track_ssm_snapshot_chunk[snapshot_rows] = (
+            lens_masked[not_aligned] // mamba_cache_chunk_size
+        )
+        track_ssm_snapshot_dst[snapshot_rows] = track_ssm_h_dst
+
         return (
             track_ssm_h_src.to(self.device, non_blocking=True),
             track_ssm_h_dst.to(self.device, non_blocking=True),
+            track_ssm_snapshot_chunk.to(self.device, non_blocking=True),
+            track_ssm_snapshot_dst.to(self.device, non_blocking=True),
             track_ssm_final_src.to(self.device, non_blocking=True),
             track_ssm_final_dst.to(self.device, non_blocking=True),
         )
@@ -750,13 +769,18 @@ class MambaAttnBackendBase(AttentionBackend):
         h: torch.Tensor,
         ssm_states: torch.Tensor,
         forward_metadata: ForwardMetadata,
+        *,
+        intermediate_snapshot_written: bool = False,
     ):
         """Copy extend SSM state at the last chunk boundary to track slots (source
         depends on chunk alignment; see `_init_track_ssm_indices`)."""
         if forward_metadata.has_mamba_track_mask:
             h = h.squeeze(0)
 
-            if forward_metadata.track_ssm_h_src.numel() > 0:
+            if (
+                not intermediate_snapshot_written
+                and forward_metadata.track_ssm_h_src.numel() > 0
+            ):
                 ssm_states[forward_metadata.track_ssm_h_dst] = h[
                     forward_metadata.track_ssm_h_src
                 ].to(ssm_states.dtype, copy=False)

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -641,6 +641,11 @@ class KDAAttnBackend(MambaAttnBackendBase):
         v = v.unflatten(-1, (-1, layer.head_v_dim)).unsqueeze(0)  # n (h d) -> 1 n h d
 
         track_ssm = self.forward_metadata.has_mamba_track_mask
+        direct_snapshot = (
+            track_ssm
+            and is_cuda()
+            and self.forward_metadata.track_ssm_h_src.numel() > 0
+        )
         core_attn_out = self.kernel_dispatcher.extend(
             q=q,
             k=k,
@@ -664,6 +669,16 @@ class KDAAttnBackend(MambaAttnBackendBase):
             track_ssm_h_src=(
                 self.forward_metadata.track_ssm_h_src if track_ssm else None
             ),
+            track_ssm_snapshot_chunk=(
+                self.forward_metadata.track_ssm_snapshot_chunk
+                if direct_snapshot
+                else None
+            ),
+            track_ssm_snapshot_dst=(
+                self.forward_metadata.track_ssm_snapshot_dst
+                if direct_snapshot
+                else None
+            ),
         )
         if track_ssm:
             # Snapshot the SSM state at the last track-aligned chunk boundary
@@ -671,7 +686,11 @@ class KDAAttnBackend(MambaAttnBackendBase):
             # ping-pong track slots (see _init_track_ssm_indices).
             core_attn_out, h = core_attn_out
             self._track_mamba_state_extend(
-                forward_batch, h, ssm_states, self.forward_metadata
+                forward_batch,
+                h,
+                ssm_states,
+                self.forward_metadata,
+                intermediate_snapshot_written=direct_snapshot,
             )
 
         return core_attn_out

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_flashkda.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_flashkda.py
@@ -40,6 +40,9 @@ def _triton_fallback(
     dt_bias=None,
     lower_bound=None,
     return_intermediate_states=False,
+    track_ssm_h_src=None,
+    track_ssm_snapshot_chunk=None,
+    track_ssm_snapshot_dst=None,
 ):
     """Fall back to the Triton chunk_kda kernel (handles all preprocessing).
 
@@ -51,6 +54,12 @@ def _triton_fallback(
     """
     from sglang.kernels.ops.attention.fla.kda import chunk_kda
 
+    has_snapshot = (
+        track_ssm_h_src is not None
+        and track_ssm_h_src.numel() > 0
+        and track_ssm_snapshot_chunk is not None
+        and track_ssm_snapshot_dst is not None
+    )
     return chunk_kda(
         q=q,
         k=k,
@@ -65,6 +74,9 @@ def _triton_fallback(
         dt_bias=dt_bias,
         lower_bound=lower_bound,
         output_intermediate_states=return_intermediate_states,
+        snapshot_state=ssm_states if has_snapshot else None,
+        snapshot_chunk_indices=(track_ssm_snapshot_chunk if has_snapshot else None),
+        snapshot_state_indices=(track_ssm_snapshot_dst if has_snapshot else None),
     )
 
 
@@ -137,6 +149,9 @@ class FlashKDAKernel(LinearAttnKernelBase):
                 dt_bias=dt_bias,
                 lower_bound=lower_bound,
                 return_intermediate_states=return_intermediate_states,
+                track_ssm_h_src=kwargs.get("track_ssm_h_src"),
+                track_ssm_snapshot_chunk=kwargs.get("track_ssm_snapshot_chunk"),
+                track_ssm_snapshot_dst=kwargs.get("track_ssm_snapshot_dst"),
             )
 
         return self._flashkda_extend(

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -227,6 +227,16 @@ class TritonKDAKernel(LinearAttnKernelBase):
         return_intermediate_states: bool = False,
         **kwargs,
     ) -> torch.Tensor:
+        snapshot_chunk_indices = kwargs.get("track_ssm_snapshot_chunk")
+        snapshot_state_indices = kwargs.get("track_ssm_snapshot_dst")
+        track_h_src = kwargs.get("track_ssm_h_src")
+        has_snapshot = (
+            snapshot_chunk_indices is not None
+            and snapshot_state_indices is not None
+            and track_h_src is not None
+            and track_h_src.numel() > 0
+        )
+        snapshot_state = ssm_states if has_snapshot else None
         return chunk_kda(
             q=q,
             k=k,
@@ -241,4 +251,11 @@ class TritonKDAKernel(LinearAttnKernelBase):
             dt_bias=dt_bias,
             lower_bound=lower_bound,
             output_intermediate_states=return_intermediate_states,
+            snapshot_state=snapshot_state,
+            snapshot_chunk_indices=(
+                snapshot_chunk_indices if snapshot_state is not None else None
+            ),
+            snapshot_state_indices=(
+                snapshot_state_indices if snapshot_state is not None else None
+            ),
         )

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -53,6 +53,11 @@ class ForwardMetadata:
     track_conv_indices: Optional[torch.Tensor] = None
     track_ssm_h_src: Optional[torch.Tensor] = None
     track_ssm_h_dst: Optional[torch.Tensor] = None
+    # Per-request local chunk index and destination slot for kernels that can
+    # write the selected boundary state directly from their FP32 accumulator.
+    # Untracked/aligned rows carry -1 and keep using the existing paths below.
+    track_ssm_snapshot_chunk: Optional[torch.Tensor] = None
+    track_ssm_snapshot_dst: Optional[torch.Tensor] = None
     track_ssm_final_src: Optional[torch.Tensor] = None
     track_ssm_final_dst: Optional[torch.Tensor] = None
 
@@ -191,6 +196,8 @@ class Mamba2Metadata(ForwardMetadata):
             track_conv_indices=forward_metadata.track_conv_indices,
             track_ssm_h_src=forward_metadata.track_ssm_h_src,
             track_ssm_h_dst=forward_metadata.track_ssm_h_dst,
+            track_ssm_snapshot_chunk=forward_metadata.track_ssm_snapshot_chunk,
+            track_ssm_snapshot_dst=forward_metadata.track_ssm_snapshot_dst,
             track_ssm_final_src=forward_metadata.track_ssm_final_src,
             track_ssm_final_dst=forward_metadata.track_ssm_final_dst,
             has_mamba_track_mask=forward_metadata.has_mamba_track_mask,
@@ -282,6 +289,8 @@ class Mamba2Metadata(ForwardMetadata):
             track_conv_indices=forward_metadata.track_conv_indices,
             track_ssm_h_src=forward_metadata.track_ssm_h_src,
             track_ssm_h_dst=forward_metadata.track_ssm_h_dst,
+            track_ssm_snapshot_chunk=forward_metadata.track_ssm_snapshot_chunk,
+            track_ssm_snapshot_dst=forward_metadata.track_ssm_snapshot_dst,
             track_ssm_final_src=forward_metadata.track_ssm_final_src,
             track_ssm_final_dst=forward_metadata.track_ssm_final_dst,
             has_mamba_track_mask=forward_metadata.has_mamba_track_mask,

--- a/test/registered/attention/test_kda_kernels.py
+++ b/test/registered/attention/test_kda_kernels.py
@@ -384,6 +384,112 @@ class TestKDAChunkExponentDomain(CustomTestCase):
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+class TestKDAChunkCheckpointSnapshot(unittest.TestCase):
+    """The selected radix boundary must bypass BF16 intermediate `h`."""
+
+    @torch.inference_mode()
+    def test_selected_boundary_is_written_from_fp32_accumulator(self):
+        torch.manual_seed(42)
+        device = "cuda"
+        dtype = torch.bfloat16
+        lengths = [257, 129, 65]
+        boundaries = [256, 128]
+        num_heads, head_dim = 2, 128
+        total_tokens = sum(lengths)
+        shape = (1, total_tokens, num_heads, head_dim)
+
+        q = torch.nn.functional.normalize(
+            torch.randn(shape, dtype=torch.float32, device=device), dim=-1
+        ).to(dtype)
+        k = torch.nn.functional.normalize(
+            torch.randn(shape, dtype=torch.float32, device=device), dim=-1
+        ).to(dtype)
+        v = torch.randn(shape, dtype=dtype, device=device) * 0.1
+        g = -(torch.rand(shape, dtype=dtype, device=device) * 0.1 + 0.01)
+        beta = torch.rand(
+            1, total_tokens, num_heads, dtype=dtype, device=device
+        ).sigmoid()
+        cu_seqlens = torch.tensor(
+            [0, *torch.tensor(lengths).cumsum(0).tolist()],
+            dtype=torch.int32,
+            device=device,
+        )
+
+        active_slots = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+        snapshot_slots = torch.tensor([3, 4, -1], dtype=torch.int64, device=device)
+        snapshot_chunks = torch.tensor([4, 2, -1], dtype=torch.int64, device=device)
+        initial_pool = (
+            torch.randn(
+                5,
+                num_heads,
+                head_dim,
+                head_dim,
+                dtype=torch.float32,
+                device=device,
+            )
+            * 0.05
+        )
+
+        baseline_pool = initial_pool.clone()
+        baseline_output, baseline_h = chunk_kda(
+            q=q.clone(),
+            k=k.clone(),
+            v=v.clone(),
+            g=g.clone(),
+            beta=beta.clone(),
+            initial_state=baseline_pool,
+            initial_state_indices=active_slots,
+            cu_seqlens=cu_seqlens,
+            output_intermediate_states=True,
+        )
+
+        snapshot_pool = initial_pool.clone()
+        snapshot_output, snapshot_h = chunk_kda(
+            q=q.clone(),
+            k=k.clone(),
+            v=v.clone(),
+            g=g.clone(),
+            beta=beta.clone(),
+            initial_state=snapshot_pool,
+            initial_state_indices=active_slots,
+            cu_seqlens=cu_seqlens,
+            output_intermediate_states=True,
+            snapshot_state=snapshot_pool,
+            snapshot_chunk_indices=snapshot_chunks,
+            snapshot_state_indices=snapshot_slots,
+        )
+
+        self.assertTrue(torch.equal(snapshot_output, baseline_output))
+        self.assertTrue(torch.equal(snapshot_h, baseline_h))
+        self.assertTrue(
+            torch.equal(snapshot_pool[active_slots], baseline_pool[active_slots])
+        )
+
+        token_start = 0
+        for sequence_index, boundary in enumerate(boundaries):
+            reference_state = initial_pool[sequence_index : sequence_index + 1].clone()
+            token_end = token_start + boundary
+            chunk_kda(
+                q=q[:, token_start:token_end].clone(),
+                k=k[:, token_start:token_end].clone(),
+                v=v[:, token_start:token_end].clone(),
+                g=g[:, token_start:token_end].clone(),
+                beta=beta[:, token_start:token_end].clone(),
+                initial_state=reference_state,
+                initial_state_indices=torch.zeros(1, dtype=torch.int32, device=device),
+                cu_seqlens=torch.tensor(
+                    [0, boundary], dtype=torch.int32, device=device
+                ),
+            )
+            self.assertTrue(
+                torch.equal(
+                    snapshot_pool[snapshot_slots[sequence_index]], reference_state[0]
+                )
+            )
+            token_start += lengths[sequence_index]
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
 class TestKDAPackedDecode(unittest.TestCase):
     """Verify ``fused_recurrent_kda_packed_decode`` matches the existing decode
     path (split + unflatten + ``fused_sigmoid_gating_delta_rule_update``)."""


### PR DESCRIPTION
## Summary

- keep KDA's full intermediate `h` tensor in the existing Q/K dtype
- write only the selected radix boundary directly from the recurrence accumulator into the checkpoint state slot
- thread dense per-sequence snapshot metadata through the Triton path and its prefill fallbacks
- add a CUDA regression test for variable-length batches and mixed tracked/untracked sequences

## Motivation

The KDA chunk recurrence keeps its state accumulator in FP32, while the intermediate `h` tensor follows the Q/K dtype. The radix `extra_buffer` path previously copied an interior checkpoint from `h` into the recurrent-state pool. With BF16 Q/K, that silently rounded the checkpoint before it was restored into the default FP32 state slot, so uninterrupted prefill and checkpoint replay could continue from different recurrent states.

This change preserves the existing `h` layout and memory cost. For an interior radix checkpoint, the chunk kernel stores only the selected boundary directly from the accumulator into the destination state slot. Boundary-aligned final-state checkpoints continue to use the existing path.

## Validation

- `python3 -m py_compile` on all eight changed Python files
- `ruff check --select E9,F63,F7,F82` on all eight changed Python files
- `git diff --check`
- added `TestKDAChunkCheckpointSnapshot`, which checks that outputs, intermediate `h`, and active final states remain unchanged, while selected snapshots exactly match independently computed FP32 boundary states

The CUDA regression test was not executed locally because the development host has neither CUDA nor Triton.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30359890639](https://github.com/sgl-project/sglang/actions/runs/30359890639)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30359890447](https://github.com/sgl-project/sglang/actions/runs/30359890447)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->