### PR TITLE
docs(kimi-k3): clarify VLM compatibility

### DIFF
--- a/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -313,6 +313,16 @@ sglang serve \
 - Leave `--mm-attention-backend` unset — auto-selected, with a correctness fallback.
 - Don't add `--mm-enable-dp-encoder`; K3 already shards images across TP ranks.
 
+#### VLM compatibility
+
+| Feature | K3 behavior |
+|---|---|
+| PD | Supported. Image processing and ViT run on prefill; the PD transfer then moves both paged MLA KV and KDA recurrent state as described in [PD disaggregation](#pd-disaggregation). |
+| EPD | Supported on the public `kimi-k3` branch. Use an `--encoder-only` vision role and a `--language-only` prefill role; add the normal decode role for full EPD. See the [EPD guide](../../../docs/advanced_features/epd_disaggregation). |
+| MM encoder DP | Built in. K3 shards complete images across TP ranks, so leave `--mm-enable-dp-encoder` unset in unified, PD-prefill, and encoder-only roles. |
+| CUDA IPC | Compatible with the local processor-to-scheduler path on a single-node unified or PD-prefill role. It does not replace `--encoder-transfer-backend` for EPD or the PD KV/KDA transfer, and its bounded pool consumes HBM. |
+| ViT BCG | Compatible with unified and encoder-only roles, but recommended only for repeated encoder shapes after measuring the HBM trade-off below. |
+
 #### Should ViT BCG be enabled?
 
 Keep ViT BCG **off** for general serving; enable `SGLANG_VIT_ENABLE_CUDA_GRAPH=1` only for ViT-only / EPD encoder workloads with recurring image shapes and spare HBM.


### PR DESCRIPTION
## Summary

- add a concise Kimi-K3 VLM compatibility table for PD and EPD deployments
- document the built-in image-wise MM encoder sharding and when to leave `--mm-enable-dp-encoder` unset
- distinguish local CUDA IPC feature transport from EPD encoder transfer and PD KV/KDA transfer
- state where ViT BCG is compatible and keep its existing measurement caveat

The compatibility notes follow the public `kimi-k3` branch used as the cookbook's validation source.

## Test plan

- `pre-commit run --files docs_new/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx`
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30365873304](https://github.com/sgl-project/sglang/actions/runs/30365873304)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30365863703](https://github.com/sgl-project/sglang/actions/runs/30365863703)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->