### PR TITLE
[Feature] Add experimental Redis-backed KV indexer and bridge

### DIFF
--- a/.github/workflows/pr-test-sgl-kv-indexer.yml
+++ b/.github/workflows/pr-test-sgl-kv-indexer.yml
@@ -1,0 +1,242 @@
+name: PR Test (sgl-kv-indexer)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "experimental/sgl-kv-indexer/**"
+      - ".github/workflows/pr-test-sgl-kv-indexer.yml"
+  pull_request:
+    branches: [main]
+    # `labeled` is required for the run-ci gate below: without it, applying the
+    # label after the last push would never re-trigger the cluster tier.
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "experimental/sgl-kv-indexer/**"
+      - ".github/workflows/pr-test-sgl-kv-indexer.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Must match experimental/sgl-kv-indexer/rust-toolchain.toml.
+  RUST_TOOLCHAIN: "1.97.0"
+
+jobs:
+  gate:
+    name: run-ci label gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should_run: ${{ steps.label.outputs.has_run_ci }}
+    steps:
+      # Only the six-node cluster tier is gated. `default-build` and `test` are
+      # cheap enough to always run, so a PR without the label still gets the
+      # crate compiled, linted, and tested against a single Redis.
+      - name: Check run-ci label
+        id: label
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "has_run_ci=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event (${{ github.event_name }}); label gate bypassed."
+            exit 0
+          fi
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci') }}" == "true" ]]; then
+            echo "has_run_ci=true" >> "$GITHUB_OUTPUT"
+            echo "PR has run-ci label; the Redis Cluster tier will run."
+          else
+            echo "has_run_ci=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::PR is missing the 'run-ci' label; skipping the six-node Redis Cluster tier. Apply the label to opt in."
+          fi
+
+  default-build:
+    name: default features build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: experimental/sgl-kv-indexer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: clippy
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: experimental/sgl-kv-indexer -> target
+
+      # Every other job enables `redis-backend`, so without this one the default
+      # feature set -- what a plain `cargo build` produces -- is never compiled.
+      - name: Run Clippy without optional features
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests without optional features
+        run: cargo test
+
+  test:
+    name: fmt, clippy, and Redis tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 20
+
+    defaults:
+      run:
+        working-directory: experimental/sgl-kv-indexer
+
+    env:
+      KV_INDEXER_REDIS_URL: redis://127.0.0.1:6379
+      # Turn a store that failed to come up into a red job rather than a green
+      # one in which every Redis test quietly skipped itself.
+      KV_INDEXER_REQUIRE_REDIS: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: experimental/sgl-kv-indexer -> target
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --features redis-backend -- -D warnings
+
+      - name: Run Redis-enabled tests
+        run: cargo test --features redis-backend
+
+  redis-cluster:
+    name: Redis Cluster redirects and failover
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      KV_INDEXER_REQUIRE_REDIS: "1"
+    defaults:
+      run:
+        working-directory: experimental/sgl-kv-indexer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: rustfmt, clippy
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: experimental/sgl-kv-indexer -> target
+
+      - name: Start six-node Redis Cluster
+        run: |
+          set -euo pipefail
+          docker network create kvidx-cluster
+          for i in 1 2 3 4 5 6; do
+            docker run -d --name "kvidx-c$i" --network kvidx-cluster \
+              --tmpfs /data:rw,size=16m redis:7-alpine \
+              redis-server --port 6379 --cluster-enabled yes \
+              --cluster-config-file /data/nodes.conf \
+              --cluster-node-timeout 1000 --appendonly no \
+              --protected-mode no
+          done
+          docker exec kvidx-c1 redis-cli --cluster create \
+            kvidx-c1:6379 kvidx-c2:6379 kvidx-c3:6379 \
+            kvidx-c4:6379 kvidx-c5:6379 kvidx-c6:6379 \
+            --cluster-replicas 1 --cluster-yes
+          ip1=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kvidx-c1)
+          ip2=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kvidx-c2)
+          ip3=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kvidx-c3)
+          echo "KV_INDEXER_REDIS_CLUSTER_NODES=redis://$ip1:6379,redis://$ip2:6379,redis://$ip3:6379" >> "$GITHUB_ENV"
+
+      - name: Run full Redis Cluster integration suite
+        run: cargo test --features redis-backend --test redis_integration -- --test-threads=1
+
+      - name: Exercise ASK redirect
+        run: |
+          set -euo pipefail
+          slot=$(docker exec kvidx-c1 redis-cli cluster keyslot failover-hash)
+          source_id=$(docker exec kvidx-c1 redis-cli cluster myid)
+          target_id=$(docker exec kvidx-c2 redis-cli cluster myid)
+          docker exec kvidx-c1 redis-cli cluster setslot "$slot" migrating "$target_id"
+          docker exec kvidx-c2 redis-cli cluster setslot "$slot" importing "$source_id"
+          KV_INDEXER_ASK_HASH=failover-hash \
+            cargo test --features redis-backend --test redis_integration \
+              cluster_client_follows_ask_redirect -- --exact --nocapture --test-threads=1
+          for i in 1 2 3; do docker exec "kvidx-c$i" redis-cli flushall; done
+          docker exec kvidx-c1 redis-cli cluster setslot "$slot" stable
+          docker exec kvidx-c2 redis-cli cluster setslot "$slot" stable
+
+          worker=ask-heartbeat-worker
+          slot=$(docker exec kvidx-c1 redis-cli cluster keyslot "{w:$worker}")
+          if (( slot <= 5460 )); then
+            source=kvidx-c1
+            target=kvidx-c2
+          elif (( slot <= 10922 )); then
+            source=kvidx-c2
+            target=kvidx-c3
+          else
+            source=kvidx-c3
+            target=kvidx-c1
+          fi
+          source_id=$(docker exec "$source" redis-cli cluster myid)
+          target_id=$(docker exec "$target" redis-cli cluster myid)
+          docker exec "$source" redis-cli cluster setslot "$slot" migrating "$target_id"
+          docker exec "$target" redis-cli cluster setslot "$slot" importing "$source_id"
+          KV_INDEXER_ASK_HEARTBEAT_WORKER="$worker" \
+            cargo test --features redis-backend --test redis_integration \
+              cluster_heartbeat_follows_ask_redirect -- --exact --nocapture --test-threads=1
+          for i in 1 2 3; do docker exec "kvidx-c$i" redis-cli flushall; done
+          docker exec "$source" redis-cli cluster setslot "$slot" stable
+          docker exec "$target" redis-cli cluster setslot "$slot" stable
+
+      - name: Exercise master failover on existing client
+        run: |
+          set -euo pipefail
+          cargo test --features redis-backend --test redis_integration --no-run
+          KV_INDEXER_FAILOVER_HASH=failover-hash \
+          KV_INDEXER_FAILOVER_PAUSE_SECS=12 \
+            cargo test --features redis-backend --test redis_integration \
+              cluster_client_recovers_after_master_failover \
+              -- --exact --nocapture --test-threads=1 &
+          test_pid=$!
+          sleep 3
+          docker stop kvidx-c1
+          wait "$test_pid"
+
+      - name: Clean up Redis Cluster
+        if: always()
+        working-directory: .
+        run: |
+          docker rm -f kvidx-c1 kvidx-c2 kvidx-c3 kvidx-c4 kvidx-c5 kvidx-c6 || true
+          docker network rm kvidx-cluster || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,12 @@ repos:
         language: system
         files: ^sgl-model-gateway/.*\.rs$
         pass_filenames: false
+      - id: rustfmt-sgl-kv-indexer
+        name: rustfmt experimental/sgl-kv-indexer
+        entry: bash -c 'cd experimental/sgl-kv-indexer && cargo fmt -- --check'
+        language: system
+        files: ^experimental/sgl-kv-indexer/.*\.rs$
+        pass_filenames: false
       - id: rustfmt-sgl-router
         name: rustfmt experimental/sgl-router
         entry: bash -c 'cd experimental/sgl-router && cargo fmt -- --check'

--- a/experimental/sgl-kv-indexer/.gitignore
+++ b/experimental/sgl-kv-indexer/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.rs.bk
+.DS_Store

--- a/experimental/sgl-kv-indexer/Cargo.toml
+++ b/experimental/sgl-kv-indexer/Cargo.toml
@@ -1,0 +1,50 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "sgl-kv-indexer"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Redis-backed KV cache indexer with a SGLang KV-event bridge"
+publish = false  # experimental crate; not published to crates.io
+
+[lib]
+name = "sgl_kv_indexer"
+path = "src/lib.rs"
+
+[features]
+default = []
+# Enables the Redis storage backend. Kept off by default so the standard build
+# does not pull the redis client and its transitive deps.
+redis-backend = ["dep:redis", "dep:futures"]
+
+[[bin]]
+name = "kv-indexer-server"
+path = "src/bin/kv-indexer-server.rs"
+
+[[bin]]
+name = "kv-indexer-bridge"
+path = "src/bin/kv-indexer-bridge.rs"
+
+[dependencies]
+bytes = "1"
+futures = { version = "0.3", optional = true }
+prost = "0.14"
+redis = { version = "0.27", optional = true, features = [
+    "tokio-comp",
+    "cluster-async",
+    "connection-manager",
+] }
+rmpv = "1.3.1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
+tonic = { version = "0.14.6", features = ["transport"] }
+tonic-health = "0.14"
+tonic-prost = "0.14.6"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+zeromq = "0.6.0"
+
+[build-dependencies]
+tonic-prost-build = "0.14.6"

--- a/experimental/sgl-kv-indexer/README.md
+++ b/experimental/sgl-kv-indexer/README.md
@@ -1,0 +1,221 @@
+# SGL KV Indexer
+
+`sgl-kv-indexer` is an experimental shared metadata index for SGLang KV-cache
+blocks. It records which worker and storage tier currently holds each
+content-addressed block, allowing a router to query likely cache hits without
+moving KV data itself.
+
+## Architecture
+
+```text
+SGLang worker ── ZMQ PUB + replay ROUTER ──> bridge ── gRPC ──> indexer ──> Redis
+```
+
+- SGLang publishes `BlockStored`, `BlockRemoved`, and `AllBlocksCleared` events.
+- One `kv-indexer-bridge` follows each independent worker/rank event stream.
+- `kv-indexer-server` applies ordered event batches and serves match queries.
+- Redis, Dragonfly, or Redis Cluster stores durable placement metadata.
+
+The bridge detects sequence gaps and requests missing batches from SGLang's
+replay endpoint. The indexer uses per-worker sequence gating and incarnation
+fencing so duplicate or delayed batches cannot overwrite newer state.
+
+## Recommended deployment
+
+For production, run one bridge as a sidecar alongside each independent SGLang
+KV-event stream (for example, per DP rank):
+
+```text
+SGLang worker ──local ZMQ──> bridge ──gRPC──> indexer ──> Redis
+```
+
+- Co-locate the bridge and publisher in one Pod or container group, keep ZMQ
+  traffic local, and give each stream a unique `KV_INDEXER_WORKER_ID`.
+- Configure `SGLANG_KV_EVENT_REPLAY_ENDPOINT` in production. Size SGLang's
+  replay `buffer_steps` to cover the longest expected bridge or indexer outage.
+- Persist `KV_INDEXER_WORKER_INCARNATION_FILE` across bridge-only restarts; a
+  shared Kubernetes `emptyDir` is normally sufficient.
+- Assign each bridge to exactly one indexer server. Apply traffic for one worker
+  must not be distributed across servers; match queries may be load-balanced.
+- Keep inference readiness independent of this advisory index, and monitor
+  bridge and indexer health separately.
+- Prefer a single Redis or Dragonfly instance when sufficient; use Redis Cluster
+  when horizontal throughput or shard-level failover is required.
+
+## Best-effort fault tolerance
+
+The index is advisory routing metadata, not the source of truth. Callers must
+tolerate misses and stale candidates; workers remain authoritative.
+
+- The bridge replays sequence gaps while SGLang still has the missing batches.
+- An unrecoverable gap retires the worker incarnation, drops its placements, and
+  resumes the live stream. This favors bounded recovery and temporary
+  under-reporting over infinite catch-up or unverifiable state.
+- Incarnation checkpointing never blocks startup. If persistence fails, the next
+  restart performs a full resync. There is no periodic full-state reconciliation.
+
+## Current status and limitations
+
+This crate is experimental.
+
+- Multiple indexer servers may share one Redis namespace when worker ownership
+  is statically partitioned between them. All events for one worker must go to
+  exactly one indexer server at a time because per-worker apply serialization is
+  process-local.
+- Deploy one bridge per independent SGLang KV-event stream (for example, per DP
+  rank), each with a unique `KV_INDEXER_WORKER_ID`.
+- Configure the replay endpoint in production, and size SGLang's `buffer_steps`
+  to cover the longest expected bridge outage.
+- Redis Cluster is supported, but an apply batch spans multiple hash slots and
+  is not globally atomic. Per-worker sequence and generation fencing preserve
+  replay convergence.
+
+### Known gaps
+
+These are accepted for an experimental crate and are listed so operators are not
+surprised by them:
+
+- After an incarnation is retired, the bridge resumes from the live event stream
+  rather than replaying the new publisher's earlier history. Blocks that SGLang
+  cached before the rotation and never re-reports stay absent from the index
+  until they are evicted and cached again, so routing may temporarily miss a
+  reusable prefix.
+- Retired incarnation tokens accumulate as `retired:<token>` fields in each
+  worker's meta hash and are never pruned. Growth is one small field per bridge
+  restart, so it is slow, but a worker restarted continuously for a long time
+  will keep a large meta hash. Deleting the worker's meta key clears it.
+- Sequence numbers are compared inside Lua, which uses double-precision
+  arithmetic, so values above 2^53 are not exact even though the proto field is
+  `uint64`. A publisher would have to emit ~9e15 batches to reach that point.
+- There is no periodic full-state reconciliation between SGLang and the index.
+  Convergence relies on replay and on incarnation rotation; a placement lost to
+  a gap is only restored when the block is reported again.
+
+## Horizontal scaling
+
+Indexer servers share no persistent local state, so they can scale horizontally
+by statically assigning each worker's bridge to one server while all servers use
+the same Redis namespace:
+
+```text
+bridge(worker-0) ──> indexer-0 ─┐
+bridge(worker-1) ──> indexer-1 ─┼─> shared Redis namespace
+bridge(worker-2) ──> indexer-0 ─┤
+bridge(worker-3) ──> indexer-1 ─┘
+```
+
+Set each bridge's existing `KV_INDEXER_ENDPOINT` to its assigned server. Match
+queries can be sent to any indexer server because every server reads the shared
+Redis state.
+
+The deployment must guarantee that two indexer servers do not concurrently
+process events for the same `KV_INDEXER_WORKER_ID`. Automatic endpoint
+selection, rebalancing, and failover are intentionally out of scope; reassign
+and restart the affected bridge when changing ownership.
+
+## Build
+
+```bash
+cd experimental/sgl-kv-indexer
+cargo build --release --features redis-backend
+```
+
+This produces:
+
+- `target/release/kv-indexer-server`
+- `target/release/kv-indexer-bridge`
+
+The `redis-backend` feature is required to run the Redis-backed server.
+
+## Run locally
+
+Start Redis:
+
+```bash
+redis-server --port 6379
+```
+
+Start the indexer:
+
+```bash
+KV_INDEXER_BACKEND=redis \
+KV_INDEXER_REDIS_URL=redis://127.0.0.1:6379 \
+KV_INDEXER_LISTEN_ADDR=127.0.0.1:50051 \
+RUST_LOG=info \
+  cargo run --release --features redis-backend --bin kv-indexer-server
+```
+
+Start one bridge for a SGLang worker:
+
+```bash
+KV_INDEXER_WORKER_ID=worker-0 \
+KV_INDEXER_WORKER_ADDRESS=http://127.0.0.1:30000 \
+KV_INDEXER_ENDPOINT=http://127.0.0.1:50051 \
+SGLANG_KV_EVENT_ENDPOINT=tcp://127.0.0.1:5567 \
+SGLANG_KV_EVENT_REPLAY_ENDPOINT=tcp://127.0.0.1:5590 \
+RUST_LOG=info \
+  cargo run --release --bin kv-indexer-bridge
+```
+
+The corresponding SGLang server must publish KV events at those endpoints, for
+example with a `kv-events-config` containing a ZMQ publisher endpoint and replay
+endpoint.
+
+## Configuration
+
+### Indexer server
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `KV_INDEXER_LISTEN_ADDR` | `[::1]:50051` | gRPC listen address |
+| `KV_INDEXER_BACKEND` | required | `redis` for the production backend |
+| `KV_INDEXER_REDIS_URL` | none | Single Redis/Dragonfly URL |
+| `KV_INDEXER_REDIS_CLUSTER_NODES` | none | Comma-separated Redis Cluster seed URLs; takes precedence over the single URL |
+| `KV_INDEXER_REDIS_NAMESPACE` | `kvidx` | Redis key prefix |
+| `KV_INDEXER_REDIS_REQUIRED` | `1` | Fail startup if Redis is unavailable; `0` enables degraded lazy connection |
+| `KV_INDEXER_WORKER_TTL_SECS` | `120` | Worker liveness TTL; `0` disables expiry |
+
+### Bridge
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `KV_INDEXER_WORKER_ID` | required | Unique ID for this worker event stream |
+| `KV_INDEXER_WORKER_ADDRESS` | empty | Address returned to match callers |
+| `KV_INDEXER_ENDPOINT` | `http://[::1]:50051` | Indexer gRPC endpoint |
+| `SGLANG_KV_EVENT_ENDPOINT` | `tcp://127.0.0.1:5557` | SGLang event PUB endpoint |
+| `SGLANG_KV_EVENT_REPLAY_ENDPOINT` | none | SGLang replay ROUTER endpoint |
+| `SGLANG_KV_EVENT_TOPIC` | empty | ZMQ subscription topic |
+| `KV_INDEXER_CLEAR_TIERS` | `HBM,DRAM,SSD` | Tiers affected by `AllBlocksCleared` |
+| `KV_INDEXER_HEARTBEAT_SECS` | `30` | Worker heartbeat interval; `0` disables it |
+| `KV_INDEXER_WORKER_INCARNATION` | generated | Optional observable prefix for generated incarnation tokens |
+| `KV_INDEXER_WORKER_INCARNATION_FILE` | `/tmp/sgl-kv-indexer-<worker-id-hex>.incarnation` | Local checkpoint that preserves the publisher incarnation across bridge-only restarts; place it on a sidecar-persistent volume when Bridge and SGLang have different container lifecycles. Best effort: an unwritable location only costs a full resync on restart, it never blocks startup |
+
+## API
+
+The protobuf service in `proto/kv_indexer.proto` provides:
+
+- `ApplyExternalKvBatch`: ordered placement reports, revocations, and clears.
+- `MatchExternalKv`: workers and tiers holding requested block hashes.
+- `GetExternalKvHitCounts`: per-block hit counters.
+
+The server also exposes the standard gRPC health service. Redis readiness is
+checked periodically and reflected as `SERVING` or `NOT_SERVING`.
+
+## Tests
+
+Single Redis:
+
+```bash
+KV_INDEXER_REDIS_URL=redis://127.0.0.1:6379 \
+  cargo test --features redis-backend -- --test-threads=1
+```
+
+Static checks:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --features redis-backend -- -D warnings
+```
+
+The repository CI additionally starts a six-node Redis Cluster and exercises
+normal Cluster routing, ASK redirects, and master failover.

--- a/experimental/sgl-kv-indexer/build.rs
+++ b/experimental/sgl-kv-indexer/build.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_prost_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .compile_protos(&["proto/kv_indexer.proto"], &["proto"])?;
+    Ok(())
+}

--- a/experimental/sgl-kv-indexer/proto/kv_indexer.proto
+++ b/experimental/sgl-kv-indexer/proto/kv_indexer.proto
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package kv_indexer.v1;
+
+// Storage tier for externally managed KV cache blocks.
+enum TierType {
+  TIER_UNKNOWN = 0;
+  TIER_HBM = 1;
+  TIER_DRAM = 2;
+  TIER_SSD = 3;
+}
+
+message MatchExternalKvRequest {
+  // MVP semantics: these are block-level hashes to match against placement
+  // metadata. The indexer returns block placement matches and does not compute
+  // the longest reusable prefix.
+  repeated string hashes = 1;
+
+  // When true, only hashes that are actually matched should increase hit
+  // counters. Diagnostic callers should leave this false.
+  bool count_as_hit = 2;
+}
+
+// The kind of mutation a single ExternalKvAction carries. A whole SGLang
+// KVEventBatch is applied in one call while preserving exact action order.
+enum ExternalKvActionType {
+  ACTION_UNKNOWN = 0;
+  ACTION_REPORT = 1;
+  ACTION_REVOKE = 2;
+  ACTION_CLEAR_ALL_AT_TIER = 3;
+}
+
+message ExternalKvAction {
+  ExternalKvActionType type = 1;
+  TierType tier = 2;
+  // Non-empty for REPORT/REVOKE; ignored for CLEAR_ALL_AT_TIER.
+  repeated string hashes = 3;
+}
+
+message ApplyExternalKvBatchRequest {
+  string worker_id = 1;
+  // The SGLang batch sequence number, monotonic per worker. The indexer stores
+  // the last applied seq per worker and uses it as an idempotency key: a batch
+  // whose seq is <= the stored value is treated as a duplicate and skipped.
+  uint64 seq = 2;
+  repeated ExternalKvAction actions = 3;
+  // The worker's KV-transfer address, used to populate MatchExternalKvResponse.
+  // Supplied by the bridge; may be empty, in which case matches for this worker
+  // carry an empty address.
+  string worker_address = 4;
+  // Opaque per-lifetime token identifying the worker's current incarnation
+  // (e.g. bridge process start id). When it changes for a worker, the indexer
+  // treats it as a restart: it wipes that worker's stale placement/reverse
+  // entries and resets its durable seq, so the fresh (restarted-from-zero)
+  // sequence is accepted instead of being skipped as a duplicate. Empty
+  // disables the behavior (backward compatible).
+  string incarnation = 5;
+}
+
+message ApplyExternalKvBatchResponse {
+  // The worker's durable last-applied seq after this call. For an applied batch
+  // this equals the request seq; for a duplicate it is the previously stored
+  // (higher-or-equal) seq. The bridge uses `last_applied_seq + 1` as the next
+  // expected seq so it can resume correctly after a restart.
+  uint64 last_applied_seq = 1;
+  // True when the batch was skipped because its seq was already applied.
+  bool duplicate = 2;
+  // False only when this worker incarnation has not committed any event batch
+  // yet. Heartbeat callers use this to distinguish a real durable seq=0 from
+  // the empty checkpoint of a fresh incarnation.
+  bool has_applied_seq = 3;
+}
+
+message TierHashes {
+  TierType tier = 1;
+  repeated string hashes = 2;
+}
+
+message ExternalKvNodeMatch {
+  string worker_id = 1;
+  string address = 2;
+  repeated TierHashes hashes_by_tier = 3;
+}
+
+message MatchExternalKvResponse {
+  repeated ExternalKvNodeMatch matches = 1;
+}
+
+message HitCountEntry {
+  string hash = 1;
+  uint64 hit_count_total = 2;
+}
+
+message GetExternalKvHitCountsRequest {
+  repeated string hashes = 1;
+}
+
+message GetExternalKvHitCountsResponse {
+  repeated HitCountEntry entries = 1;
+}
+
+service KVIndexer {
+  // The sole mutation API: applies an ordered SGLang KVEventBatch.
+  rpc ApplyExternalKvBatch(ApplyExternalKvBatchRequest) returns (ApplyExternalKvBatchResponse);
+
+  rpc MatchExternalKv(MatchExternalKvRequest) returns (MatchExternalKvResponse);
+  rpc GetExternalKvHitCounts(GetExternalKvHitCountsRequest) returns (GetExternalKvHitCountsResponse);
+}

--- a/experimental/sgl-kv-indexer/rust-toolchain.toml
+++ b/experimental/sgl-kv-indexer/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]

--- a/experimental/sgl-kv-indexer/src/bin/kv-indexer-bridge.rs
+++ b/experimental/sgl-kv-indexer/src/bin/kv-indexer-bridge.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use sgl_kv_indexer::bridge::{run_bridge_until, BridgeConfig};
+use sgl_kv_indexer::shutdown_signal;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let config = BridgeConfig::from_env()?;
+    run_bridge_until(config, shutdown_signal()).await?;
+    Ok(())
+}

--- a/experimental/sgl-kv-indexer/src/bin/kv-indexer-server.rs
+++ b/experimental/sgl-kv-indexer/src/bin/kv-indexer-server.rs
@@ -1,0 +1,215 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use sgl_kv_indexer::pb::kv_indexer_server::KvIndexerServer;
+use sgl_kv_indexer::pb::{
+    ApplyExternalKvBatchRequest, ApplyExternalKvBatchResponse, ExternalKvActionType,
+    GetExternalKvHitCountsRequest, GetExternalKvHitCountsResponse, MatchExternalKvRequest,
+    MatchExternalKvResponse,
+};
+use sgl_kv_indexer::{shutdown_signal, KvIndexerBackend, KvIndexerService};
+use tonic::transport::Server;
+use tonic::Status;
+use tracing::info;
+
+/// A small stateful backend for joint debugging: it keeps the live set of
+/// (tier, hash) blocks in memory and logs running totals on every apply, so the
+/// indexer side of the SGLang -> bridge -> indexer chain is observable.
+#[derive(Default)]
+struct LoggingKvIndexerBackend {
+    live: Mutex<HashSet<(i32, String)>>,
+    seqs: Mutex<HashMap<String, u64>>,
+}
+
+impl LoggingKvIndexerBackend {
+    fn total(&self) -> usize {
+        self.live.lock().unwrap().len()
+    }
+}
+
+#[tonic::async_trait]
+impl KvIndexerBackend for LoggingKvIndexerBackend {
+    async fn apply_external_kv_batch(
+        &self,
+        request: ApplyExternalKvBatchRequest,
+    ) -> Result<ApplyExternalKvBatchResponse, Status> {
+        let (mut reported, mut revoked, mut cleared) = (0usize, 0usize, 0usize);
+        {
+            let mut live = self.live.lock().unwrap();
+            for action in &request.actions {
+                match ExternalKvActionType::try_from(action.r#type) {
+                    Ok(ExternalKvActionType::ActionReport) => {
+                        for hash in &action.hashes {
+                            if live.insert((action.tier, hash.clone())) {
+                                reported += 1;
+                            }
+                        }
+                    }
+                    Ok(ExternalKvActionType::ActionRevoke) => {
+                        for hash in &action.hashes {
+                            if live.remove(&(action.tier, hash.clone())) {
+                                revoked += 1;
+                            }
+                        }
+                    }
+                    Ok(ExternalKvActionType::ActionClearAllAtTier) => {
+                        let before = live.len();
+                        live.retain(|(tier, _)| *tier != action.tier);
+                        cleared += before - live.len();
+                    }
+                    _ => {}
+                }
+            }
+        }
+        info!(
+            worker = %request.worker_id,
+            seq = request.seq,
+            reported,
+            revoked,
+            cleared,
+            live_total = self.total(),
+            "APPLY external kv batch"
+        );
+        let checkpoint = if request.actions.is_empty() {
+            self.seqs.lock().unwrap().get(&request.worker_id).copied()
+        } else {
+            self.seqs
+                .lock()
+                .unwrap()
+                .insert(request.worker_id.clone(), request.seq);
+            Some(request.seq)
+        };
+        Ok(ApplyExternalKvBatchResponse {
+            last_applied_seq: checkpoint.unwrap_or_default(),
+            duplicate: false,
+            has_applied_seq: checkpoint.is_some(),
+        })
+    }
+
+    async fn match_external_kv(
+        &self,
+        _request: MatchExternalKvRequest,
+    ) -> Result<MatchExternalKvResponse, Status> {
+        Ok(MatchExternalKvResponse { matches: vec![] })
+    }
+
+    async fn get_external_kv_hit_counts(
+        &self,
+        _request: GetExternalKvHitCountsRequest,
+    ) -> Result<GetExternalKvHitCountsResponse, Status> {
+        Ok(GetExternalKvHitCountsResponse { entries: vec![] })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let addr = std::env::var("KV_INDEXER_LISTEN_ADDR")
+        .unwrap_or_else(|_| "[::1]:50051".to_string())
+        .parse::<SocketAddr>()?;
+
+    let backend = select_backend().await?;
+
+    // Standard gRPC health service (grpc.health.v1). A background prober flips
+    // the status to reflect backend readiness (e.g. Redis connectivity), so
+    // k8s / the router can tell whether this indexer can actually serve.
+    let (health_reporter, health_service) = tonic_health::server::health_reporter();
+    tokio::spawn(health_prober(health_reporter, backend.clone()));
+
+    let service = KvIndexerServer::new(KvIndexerService::new(backend));
+
+    info!(%addr, "starting SGLang KV Indexer gRPC server");
+    Server::builder()
+        .add_service(health_service)
+        .add_service(service)
+        .serve_with_shutdown(addr, shutdown_signal())
+        .await?;
+
+    Ok(())
+}
+
+/// The concrete gRPC service type, used to name it in the health registry.
+type GrpcService = KvIndexerServer<KvIndexerService<Arc<dyn KvIndexerBackend>>>;
+
+/// How often readiness is re-probed against the backend.
+const HEALTH_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Periodically reflects backend readiness into the gRPC health service, for
+/// both the named `KvIndexer` service and the overall (empty-name) status that
+/// k8s' built-in gRPC probe checks by default.
+async fn health_prober(
+    reporter: tonic_health::server::HealthReporter,
+    backend: Arc<dyn KvIndexerBackend>,
+) {
+    use tonic_health::ServingStatus::{NotServing, Serving};
+    let mut tick = tokio::time::interval(HEALTH_PROBE_INTERVAL);
+    let mut last: Option<bool> = None;
+    loop {
+        tick.tick().await;
+        let ok = backend.health().await;
+        if last == Some(ok) {
+            continue;
+        }
+        last = Some(ok);
+        let status = if ok { Serving } else { NotServing };
+        reporter.set_service_status("", status).await;
+        reporter
+            .set_service_status(<GrpcService as tonic::server::NamedService>::NAME, status)
+            .await;
+        if !ok {
+            tracing::warn!("backend not ready: reporting NOT_SERVING");
+        }
+    }
+}
+
+/// Selects the storage backend from `KV_INDEXER_BACKEND`:
+///   * `logging` — in-memory, logs running totals; for joint debugging.
+///   * `redis` — the Redis backend (requires the `redis-backend` cargo feature).
+///
+/// The variable is required: silently defaulting to a fake backend makes a
+/// misconfigured production process look healthy while returning no real matches.
+/// The Redis backend lives behind the feature so the default build stays light;
+/// requesting `redis` without it is a loud startup error rather than a silent
+/// fallback.
+async fn select_backend(
+) -> Result<Arc<dyn KvIndexerBackend>, Box<dyn std::error::Error + Send + Sync>> {
+    let backend = match std::env::var("KV_INDEXER_BACKEND") {
+        Ok(value) => value,
+        Err(_) => {
+            return Err(
+                "KV_INDEXER_BACKEND is required; set it explicitly to redis or logging".into(),
+            )
+        }
+    };
+    match backend.as_str() {
+        "logging" => {
+            info!("using logging backend");
+            Ok(Arc::new(LoggingKvIndexerBackend::default()))
+        }
+        "redis" => {
+            #[cfg(feature = "redis-backend")]
+            {
+                info!("using redis backend");
+                let backend = sgl_kv_indexer::RedisKvIndexerBackend::from_env().await?;
+                Ok(Arc::new(backend))
+            }
+            #[cfg(not(feature = "redis-backend"))]
+            {
+                Err(
+                    "KV_INDEXER_BACKEND=redis requires building with --features redis-backend"
+                        .into(),
+                )
+            }
+        }
+        other => Err(format!("unknown KV_INDEXER_BACKEND: {other}").into()),
+    }
+}

--- a/experimental/sgl-kv-indexer/src/bridge.rs
+++ b/experimental/sgl-kv-indexer/src/bridge.rs
@@ -1,0 +1,1622 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::{self, OpenOptions};
+use std::io::{Cursor, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use rmpv::decode::value::read_value;
+use rmpv::Value;
+use tonic::transport::{Channel, Endpoint};
+use tonic::{Code, Status};
+use tracing::{debug, info, warn};
+use zeromq::{DealerSocket, Socket, SocketRecv, SocketSend, SubSocket, ZmqMessage};
+
+use crate::pb::kv_indexer_client::KvIndexerClient;
+use crate::pb::{ApplyExternalKvBatchRequest, ExternalKvAction, ExternalKvActionType, TierType};
+
+/// Backoff bounds for the reconnect supervisor loop.
+const RECONNECT_MIN_DELAY: Duration = Duration::from_millis(500);
+const RECONNECT_MAX_DELAY: Duration = Duration::from_secs(10);
+const REPLAY_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const GRPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const GRPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+static INCARNATION_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone)]
+pub struct BridgeConfig {
+    pub worker_id: String,
+    /// The worker's KV-transfer address, forwarded on every apply batch so the
+    /// indexer can answer MatchExternalKv with an address. Empty if unset.
+    pub worker_address: String,
+    pub event_endpoint: String,
+    pub event_replay_endpoint: Option<String>,
+    pub event_topic: String,
+    pub indexer_endpoint: String,
+    pub clear_tiers: Vec<i32>,
+    /// How often to send an empty-actions heartbeat that refreshes the worker's
+    /// liveness on the indexer, independent of KV-event traffic. Must be well
+    /// below the server's `KV_INDEXER_WORKER_TTL_SECS`. `None` disables it.
+    pub heartbeat_interval: Option<Duration>,
+    /// Opaque token identifying the current SGLang publisher lifetime.
+    pub incarnation: String,
+    /// Local checkpoint that keeps the incarnation stable across bridge-only
+    /// process restarts. A publisher sequence rollback rotates it atomically.
+    pub incarnation_path: Option<PathBuf>,
+}
+
+impl BridgeConfig {
+    pub fn from_env() -> Result<Self, BridgeError> {
+        let worker_id = std::env::var("KV_INDEXER_WORKER_ID")
+            .map_err(|_| BridgeError::Config("KV_INDEXER_WORKER_ID is required".to_string()))?;
+        let worker_address = std::env::var("KV_INDEXER_WORKER_ADDRESS").unwrap_or_default();
+        let event_endpoint = std::env::var("SGLANG_KV_EVENT_ENDPOINT")
+            .unwrap_or_else(|_| "tcp://127.0.0.1:5557".to_string());
+        let event_replay_endpoint = std::env::var("SGLANG_KV_EVENT_REPLAY_ENDPOINT").ok();
+        // Match SGLang's upstream ZMQ publisher default. Deployments that use a
+        // non-empty topic must configure the same value on both sides.
+        let event_topic = std::env::var("SGLANG_KV_EVENT_TOPIC").unwrap_or_default();
+        let indexer_endpoint = std::env::var("KV_INDEXER_ENDPOINT")
+            .unwrap_or_else(|_| "http://[::1]:50051".to_string());
+        let clear_tiers = parse_clear_tiers(
+            &std::env::var("KV_INDEXER_CLEAR_TIERS").unwrap_or_else(|_| "HBM,DRAM,SSD".to_string()),
+        )?;
+        let heartbeat_interval = parse_heartbeat_interval()?;
+        let incarnation_path = std::env::var_os("KV_INDEXER_WORKER_INCARNATION_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| default_incarnation_path(&worker_id));
+        let incarnation_prefix = std::env::var("KV_INDEXER_WORKER_INCARNATION").ok();
+        let incarnation =
+            load_or_create_incarnation(&incarnation_path, incarnation_prefix.as_deref());
+
+        Ok(Self {
+            worker_id,
+            worker_address,
+            event_endpoint,
+            event_replay_endpoint,
+            event_topic,
+            indexer_endpoint,
+            clear_tiers,
+            heartbeat_interval,
+            incarnation,
+            incarnation_path: Some(incarnation_path),
+        })
+    }
+}
+
+fn default_incarnation_path(worker_id: &str) -> PathBuf {
+    let encoded = worker_id
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    std::env::temp_dir().join(format!("sgl-kv-indexer-{encoded}.incarnation"))
+}
+
+fn new_incarnation(prefix: Option<&str>) -> String {
+    match prefix {
+        Some(prefix) => format!("{prefix}:{}", generate_incarnation()),
+        None => generate_incarnation(),
+    }
+}
+
+fn warn_checkpoint(path: &Path, error: &std::io::Error) {
+    warn!(
+        path = %path.display(),
+        %error,
+        "publisher incarnation checkpoint unavailable; a bridge restart will resync from scratch"
+    );
+}
+
+/// Reads the stored token. `None` when the checkpoint is absent, empty (a write
+/// interrupted mid-rotation), or unreadable.
+fn read_incarnation(path: &Path) -> Option<String> {
+    match fs::read_to_string(path) {
+        Ok(value) => Some(value.trim().to_string()).filter(|value| !value.is_empty()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            warn_checkpoint(path, &error);
+            None
+        }
+    }
+}
+
+/// Returns the token this bridge lifetime presents to the indexer, minting and
+/// persisting a fresh one when the checkpoint holds nothing usable.
+///
+/// Persistence is best effort: on a read-only or otherwise unusable location the
+/// bridge still starts, it just cannot resume a publisher's sequence across its
+/// own restart and falls back to a full resync.
+fn load_or_create_incarnation(path: &Path, prefix: Option<&str>) -> String {
+    if let Some(stored) = read_incarnation(path) {
+        return stored;
+    }
+
+    let incarnation = new_incarnation(prefix);
+    match OpenOptions::new().write(true).create_new(true).open(path) {
+        Ok(mut file) => {
+            if let Err(error) = file.write_all(incarnation.as_bytes()) {
+                warn_checkpoint(path, &error);
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            // Either a concurrently started bridge won the race, in which case
+            // adopting its token keeps a single live incarnation per worker, or
+            // the file is the unusable one we just rejected and gets replaced.
+            if let Some(stored) = read_incarnation(path) {
+                return stored;
+            }
+            if let Err(error) = fs::write(path, &incarnation) {
+                warn_checkpoint(path, &error);
+            }
+        }
+        Err(error) => warn_checkpoint(path, &error),
+    }
+    incarnation
+}
+
+/// Retires the current token in favour of a fresh one.
+///
+/// A checkpoint that cannot be updated is removed rather than left stale: the
+/// indexer rejects a retired token with a permanent error, so a later bridge
+/// start must mint a new token instead of replaying this one.
+fn rotate_incarnation(config: &BridgeConfig, incarnation: &mut String) {
+    let prefix = std::env::var("KV_INDEXER_WORKER_INCARNATION").ok();
+    let next = new_incarnation(prefix.as_deref());
+    if let Some(path) = &config.incarnation_path {
+        if let Err(error) = fs::write(path, &next) {
+            warn_checkpoint(path, &error);
+            let _ = fs::remove_file(path);
+        }
+    }
+    *incarnation = next;
+}
+
+#[derive(Debug)]
+pub enum BridgeError {
+    Config(String),
+    Decode(String),
+    Replay(String),
+    Rpc(tonic::Status),
+    PermanentRpc(tonic::Status),
+    Timeout(String),
+    Transport(tonic::transport::Error),
+    Zmq(zeromq::ZmqError),
+}
+
+impl std::fmt::Display for BridgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BridgeError::Config(message) => write!(f, "bridge config error: {message}"),
+            BridgeError::Decode(message) => write!(f, "bridge decode error: {message}"),
+            BridgeError::Replay(message) => write!(f, "bridge replay error: {message}"),
+            BridgeError::Rpc(status) => write!(f, "indexer rpc error: {status}"),
+            BridgeError::PermanentRpc(status) => {
+                write!(f, "permanent indexer rpc error: {status}")
+            }
+            BridgeError::Timeout(message) => write!(f, "bridge timeout: {message}"),
+            BridgeError::Transport(error) => write!(f, "indexer transport error: {error}"),
+            BridgeError::Zmq(error) => write!(f, "zmq error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for BridgeError {}
+
+impl BridgeError {
+    fn is_permanent(&self) -> bool {
+        matches!(self, BridgeError::Config(_) | BridgeError::PermanentRpc(_))
+    }
+}
+
+impl From<zeromq::ZmqError> for BridgeError {
+    fn from(error: zeromq::ZmqError) -> Self {
+        BridgeError::Zmq(error)
+    }
+}
+
+impl From<tonic::transport::Error> for BridgeError {
+    fn from(error: tonic::transport::Error) -> Self {
+        BridgeError::Transport(error)
+    }
+}
+
+fn classify_rpc(status: Status) -> BridgeError {
+    match status.code() {
+        Code::InvalidArgument
+        | Code::FailedPrecondition
+        | Code::NotFound
+        | Code::AlreadyExists
+        | Code::OutOfRange
+        | Code::ResourceExhausted
+        | Code::Unauthenticated
+        | Code::PermissionDenied
+        | Code::Unimplemented
+        | Code::DataLoss => BridgeError::PermanentRpc(status),
+        _ => BridgeError::Rpc(status),
+    }
+}
+
+/// A single indexer mutation, kept in the exact order it appeared in the event
+/// batch so that store/remove/clear operations on the same hash are never
+/// reordered relative to each other.
+#[derive(Debug, PartialEq, Eq)]
+enum Action {
+    Report { tier: i32, hashes: Vec<String> },
+    Revoke { tier: i32, hashes: Vec<String> },
+    ClearAll,
+}
+
+#[derive(Debug, Default)]
+struct EventActions {
+    actions: Vec<Action>,
+}
+
+#[derive(Debug, Clone)]
+struct RawBatch {
+    seq: u64,
+    payload: Vec<u8>,
+}
+
+impl EventActions {
+    /// Append a store, coalescing only with an immediately-preceding store to
+    /// the same tier. Coalescing never crosses a revoke/clear, so ordering (and
+    /// therefore the final per-hash state) is preserved.
+    fn report(&mut self, tier: i32, hashes: Vec<String>) {
+        if hashes.is_empty() {
+            return;
+        }
+        if let Some(Action::Report {
+            tier: last_tier,
+            hashes: last,
+        }) = self.actions.last_mut()
+        {
+            if *last_tier == tier {
+                last.extend(hashes);
+                return;
+            }
+        }
+        self.actions.push(Action::Report { tier, hashes });
+    }
+
+    fn revoke(&mut self, tier: i32, hashes: Vec<String>) {
+        if hashes.is_empty() {
+            return;
+        }
+        if let Some(Action::Revoke {
+            tier: last_tier,
+            hashes: last,
+        }) = self.actions.last_mut()
+        {
+            if *last_tier == tier {
+                last.extend(hashes);
+                return;
+            }
+        }
+        self.actions.push(Action::Revoke { tier, hashes });
+    }
+
+    fn clear_all(&mut self) {
+        self.actions.push(Action::ClearAll);
+    }
+}
+
+pub async fn run_bridge(config: BridgeConfig) -> Result<(), BridgeError> {
+    run_bridge_until(config, std::future::pending()).await
+}
+
+/// [`run_bridge`], but returns as soon as `shutdown` resolves.
+///
+/// Interrupting an in-flight apply is safe rather than merely tolerable: the
+/// indexer fences each worker's sequence, so a batch that was applied but never
+/// acknowledged is rejected as a duplicate when the next process replays it
+/// from the indexer's checkpoint.
+pub async fn run_bridge_until<F>(config: BridgeConfig, shutdown: F) -> Result<(), BridgeError>
+where
+    F: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        result = supervise(config) => result,
+        () = shutdown => {
+            info!("bridge stopped by shutdown signal");
+            Ok(())
+        }
+    }
+}
+
+async fn supervise(config: BridgeConfig) -> Result<(), BridgeError> {
+    info!(
+        worker_id = %config.worker_id,
+        event_endpoint = %config.event_endpoint,
+        event_replay_endpoint = ?config.event_replay_endpoint,
+        event_topic = %config.event_topic,
+        indexer_endpoint = %config.indexer_endpoint,
+        "starting SGLang KV event bridge"
+    );
+
+    // Supervisor loop: (re)connect to both the indexer and the ZMQ publisher,
+    // run until a connection-level error, then back off and retry. Decode-level
+    // problems are handled inside the session and never tear down the bridge.
+    let mut delay = RECONNECT_MIN_DELAY;
+    let mut next_seq: Option<u64> = None;
+    let mut pending_batch: Option<RawBatch> = None;
+    let mut incarnation = config.incarnation.clone();
+    if config.heartbeat_interval.is_some() && config.event_replay_endpoint.is_none() {
+        warn!(
+            "periodic liveness heartbeat disabled: configure \
+             SGLANG_KV_EVENT_REPLAY_ENDPOINT so the bridge can prove the worker publisher is alive"
+        );
+    }
+    loop {
+        match connect(&config).await {
+            Ok((client, subscriber)) => {
+                delay = RECONNECT_MIN_DELAY;
+                match run_session(
+                    &config,
+                    client,
+                    subscriber,
+                    &mut next_seq,
+                    &mut pending_batch,
+                    &mut incarnation,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        info!("bridge shut down cleanly");
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        if error.is_permanent() {
+                            return Err(error);
+                        }
+                        warn!(%error, retry_in = ?delay, "bridge session lost; reconnecting");
+                    }
+                }
+            }
+            Err(error) => {
+                if error.is_permanent() {
+                    return Err(error);
+                }
+                warn!(%error, retry_in = ?delay, "bridge connect failed; retrying");
+            }
+        }
+
+        tokio::time::sleep(delay).await;
+        delay = (delay * 2).min(RECONNECT_MAX_DELAY);
+    }
+}
+
+async fn connect(
+    config: &BridgeConfig,
+) -> Result<(KvIndexerClient<Channel>, SubSocket), BridgeError> {
+    let channel = Endpoint::from_shared(config.indexer_endpoint.clone())?
+        .connect_timeout(GRPC_CONNECT_TIMEOUT)
+        .timeout(GRPC_REQUEST_TIMEOUT)
+        .connect()
+        .await?;
+    let client = KvIndexerClient::new(channel);
+    let mut subscriber = SubSocket::new();
+    subscriber.subscribe(&config.event_topic).await?;
+    subscriber.connect(&config.event_endpoint).await?;
+    info!("bridge session established");
+    Ok((client, subscriber))
+}
+
+/// Forwards one raw batch, marking it pending for the duration so an
+/// interrupted forward is re-driven verbatim after a reconnect. Returns the
+/// indexer's durable `last_applied_seq` so the caller can advance `next_seq`
+/// from the authoritative position rather than the locally observed seq.
+async fn commit_batch(
+    config: &BridgeConfig,
+    incarnation: &str,
+    client: &mut KvIndexerClient<Channel>,
+    batch: &RawBatch,
+    pending_batch: &mut Option<RawBatch>,
+) -> Result<u64, BridgeError> {
+    *pending_batch = Some(batch.clone());
+    let last_applied_seq = forward_raw_batch(config, incarnation, client, batch).await?;
+    *pending_batch = None;
+    Ok(last_applied_seq)
+}
+
+/// Runs a single connected session. Returns `Ok(())` only on a clean shutdown
+/// (ctrl-c); any connection-level error is propagated so the supervisor can
+/// reconnect. Malformed frames / undecodable batches are logged and skipped.
+async fn run_session(
+    config: &BridgeConfig,
+    mut client: KvIndexerClient<Channel>,
+    mut subscriber: SubSocket,
+    next_seq: &mut Option<u64>,
+    pending_batch: &mut Option<RawBatch>,
+    incarnation: &mut String,
+) -> Result<(), BridgeError> {
+    // Only a response from the worker-owned replay endpoint proves that SGLang
+    // is alive. Announce/refresh the incarnation immediately after that proof.
+    if config.event_replay_endpoint.is_some() {
+        match probe_publisher(config).await {
+            Ok(()) => {
+                let checkpoint = send_heartbeat(config, incarnation, &mut client).await?;
+                if next_seq.is_none() {
+                    *next_seq = checkpoint.and_then(|seq| seq.checked_add(1));
+                }
+            }
+            Err(error) => {
+                warn!(%error, "publisher startup probe failed; not refreshing worker liveness");
+            }
+        }
+    }
+
+    // A batch left pending by the previous disconnect is re-driven once before
+    // consuming new events. It can only be set at session entry: every in-loop
+    // commit either clears it or returns an error that ends the session.
+    if let Some(batch) = pending_batch.clone() {
+        let last_applied_seq =
+            commit_batch(config, incarnation, &mut client, &batch, pending_batch).await?;
+        *next_seq = last_applied_seq.checked_add(1);
+    }
+
+    // Liveness heartbeat: an empty-actions apply that refreshes the worker's
+    // TTL on the indexer even when no KV events are flowing. When disabled, a
+    // far-future interval is used so the branch never fires.
+    let mut heartbeat = tokio::time::interval(
+        config
+            .heartbeat_interval
+            .unwrap_or_else(|| Duration::from_secs(u64::MAX / 2)),
+    );
+    // The first tick resolves immediately; skip it so we don't heartbeat before
+    // any real work and so a disabled heartbeat never fires at startup.
+    heartbeat.tick().await;
+
+    loop {
+        let message = tokio::select! {
+            result = subscriber.recv() => result?,
+            _ = heartbeat.tick(),
+                if config.heartbeat_interval.is_some()
+                    && config.event_replay_endpoint.is_some() =>
+            {
+                match probe_publisher(config).await {
+                    Ok(()) => {
+                        send_heartbeat(config, incarnation, &mut client).await?;
+                    }
+                    Err(error) => {
+                        warn!(%error, "publisher liveness probe failed; heartbeat suppressed");
+                    }
+                }
+                continue;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                info!("received ctrl-c; shutting down bridge");
+                return Ok(());
+            }
+        };
+
+        let (seq, payload) = match parse_zmq_frames(&message.into_vec()) {
+            Ok((seq, payload)) => (seq, payload.to_vec()),
+            Err(error) => {
+                warn!(%error, "skipping malformed ZMQ message");
+                continue;
+            }
+        };
+        if let Err(error) = decode_event_batch_impl(&payload, false) {
+            warn!(
+                seq,
+                %error,
+                "skipping malformed event batch before sequence-state changes"
+            );
+            continue;
+        }
+
+        if let Some(expected) = *next_seq {
+            if seq < expected {
+                warn!(
+                    expected,
+                    actual = seq,
+                    "SGLang KV event sequence moved backwards; treating publisher as restarted"
+                );
+                rotate_incarnation(config, incarnation);
+                *next_seq = None;
+                *pending_batch = None;
+                send_heartbeat(config, incarnation, &mut client).await?;
+            }
+            if seq > expected {
+                warn!(expected, actual = seq, "SGLang KV event sequence gap");
+                match replay_missing_batches(
+                    config,
+                    incarnation,
+                    &mut client,
+                    expected,
+                    seq,
+                    pending_batch,
+                )
+                .await
+                {
+                    Ok(()) => {}
+                    // Gap recovery is best effort. Once the publisher's replay
+                    // buffer no longer covers the gap, no amount of retrying can
+                    // close it, so retire the incarnation to have the indexer
+                    // wipe the state we can no longer reconstruct and resync
+                    // from the live stream. Stalling instead would leave the
+                    // worker unindexed for as long as it runs.
+                    Err(BridgeError::Replay(reason)) => {
+                        warn!(
+                            expected,
+                            actual = seq,
+                            %reason,
+                            "unrecoverable SGLang KV event gap; retiring worker incarnation and resyncing"
+                        );
+                        rotate_incarnation(config, incarnation);
+                        *next_seq = None;
+                        *pending_batch = None;
+                        send_heartbeat(config, incarnation, &mut client).await?;
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+
+        let last_applied_seq = commit_batch(
+            config,
+            incarnation,
+            &mut client,
+            &RawBatch { seq, payload },
+            pending_batch,
+        )
+        .await?;
+        // Advance from the indexer's durable position: on a duplicate this is
+        // >= seq, so a restart that re-observes already-applied batches resyncs
+        // without reprocessing them.
+        *next_seq = last_applied_seq.max(seq).checked_add(1);
+    }
+}
+
+/// Proves the SGLang publisher is alive without replaying data. Upstream treats
+/// the requested sequence as a lower bound, so `u64::MAX` yields only END_SEQ.
+async fn probe_publisher(config: &BridgeConfig) -> Result<(), BridgeError> {
+    let endpoint = config.event_replay_endpoint.as_ref().ok_or_else(|| {
+        BridgeError::Config(
+            "publisher liveness probe requires SGLANG_KV_EVENT_REPLAY_ENDPOINT".to_string(),
+        )
+    })?;
+    let mut socket = request_replay(endpoint, u64::MAX).await?;
+    let frames = receive_replay(&mut socket).await?;
+    parse_probe_response(&frames)
+}
+
+async fn request_replay(endpoint: &str, start_seq: u64) -> Result<DealerSocket, BridgeError> {
+    let mut socket = DealerSocket::new();
+    socket.connect(endpoint).await?;
+    // DEALER supplies no REQ delimiter, so add one for the ROUTER protocol.
+    let mut request = ZmqMessage::from(bytes::Bytes::copy_from_slice(&start_seq.to_be_bytes()));
+    request.push_front(bytes::Bytes::new());
+    tokio::time::timeout(REPLAY_REQUEST_TIMEOUT, socket.send(request))
+        .await
+        .map_err(|_| BridgeError::Timeout("SGLang replay request timed out".to_string()))??;
+    Ok(socket)
+}
+
+async fn receive_replay(socket: &mut DealerSocket) -> Result<Vec<bytes::Bytes>, BridgeError> {
+    Ok(tokio::time::timeout(REPLAY_REQUEST_TIMEOUT, socket.recv())
+        .await
+        .map_err(|_| BridgeError::Timeout("SGLang replay response timed out".to_string()))??
+        .into_vec())
+}
+
+async fn replay_missing_batches(
+    config: &BridgeConfig,
+    incarnation: &str,
+    client: &mut KvIndexerClient<Channel>,
+    start_seq: u64,
+    stop_before_seq: u64,
+    pending_batch: &mut Option<RawBatch>,
+) -> Result<(), BridgeError> {
+    let Some(endpoint) = &config.event_replay_endpoint else {
+        return Err(BridgeError::Replay(format!(
+            "cannot recover SGLang KV event gap {start_seq}..{stop_before_seq} without replay endpoint"
+        )));
+    };
+
+    let mut socket = request_replay(endpoint, start_seq).await?;
+    let mut replay_expected = start_seq;
+    let mut recovered = 0_u64;
+    loop {
+        let frames = receive_replay(&mut socket).await?;
+        let (seq, payload) = parse_replay_frames(&frames)?;
+        if seq < 0 {
+            break;
+        }
+
+        let seq = seq as u64;
+        if seq < start_seq {
+            continue;
+        }
+        if seq != replay_expected {
+            warn!(
+                expected = replay_expected,
+                actual = seq,
+                "SGLang replay buffer did not return a contiguous batch"
+            );
+            break;
+        }
+        if seq >= stop_before_seq {
+            break;
+        }
+
+        let batch = RawBatch {
+            seq,
+            payload: payload.to_vec(),
+        };
+        commit_batch(config, incarnation, client, &batch, pending_batch).await?;
+        replay_expected = seq.checked_add(1).unwrap_or(seq);
+        recovered += 1;
+    }
+
+    if replay_expected < stop_before_seq {
+        return Err(BridgeError::Replay(format!(
+            "SGLang KV event gap remains after replay: missing {replay_expected}..{stop_before_seq}"
+        )));
+    }
+
+    info!(
+        start_seq,
+        stop_before_seq, recovered, "replayed missing SGLang KV event batches"
+    );
+    Ok(())
+}
+
+fn parse_replay_frames(frames: &[bytes::Bytes]) -> Result<(i64, &[u8]), BridgeError> {
+    // A DEALER connected to the publisher's ROUTER receives replies with the
+    // leading empty delimiter intact: [b"", seq, payload]. Tolerate a bare
+    // [seq, payload] variant too.
+    match frames.len() {
+        3 => Ok((decode_signed_seq(&frames[1])?, frames[2].as_ref())),
+        2 => Ok((decode_signed_seq(&frames[0])?, frames[1].as_ref())),
+        n => Err(BridgeError::Decode(format!(
+            "expected 2 or 3 replay frames, got {n}"
+        ))),
+    }
+}
+
+fn parse_probe_response(frames: &[bytes::Bytes]) -> Result<(), BridgeError> {
+    if frames.len() != 3 {
+        return Err(BridgeError::Decode(format!(
+            "liveness probe expected 3 frames, got {}",
+            frames.len()
+        )));
+    }
+    if !frames[0].is_empty() {
+        return Err(BridgeError::Decode(
+            "liveness probe delimiter must be empty".to_string(),
+        ));
+    }
+    let seq = decode_signed_seq(&frames[1])?;
+    if seq != -1 {
+        return Err(BridgeError::Decode(format!(
+            "liveness probe expected END_SEQ -1, got {seq}"
+        )));
+    }
+    if !frames[2].is_empty() {
+        return Err(BridgeError::Decode(
+            "liveness probe END payload must be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn decode_signed_seq(bytes: &[u8]) -> Result<i64, BridgeError> {
+    let seq_bytes: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| BridgeError::Decode("sequence frame must be 8 bytes".to_string()))?;
+    Ok(i64::from_be_bytes(seq_bytes))
+}
+
+fn parse_zmq_frames(frames: &[bytes::Bytes]) -> Result<(u64, &[u8]), BridgeError> {
+    match frames.len() {
+        2 => Ok((decode_seq(&frames[0])?, frames[1].as_ref())),
+        3 => Ok((decode_seq(&frames[1])?, frames[2].as_ref())),
+        n => Err(BridgeError::Decode(format!(
+            "expected 2 or 3 ZMQ frames, got {n}"
+        ))),
+    }
+}
+
+fn decode_seq(bytes: &[u8]) -> Result<u64, BridgeError> {
+    let seq_bytes: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| BridgeError::Decode("sequence frame must be 8 bytes".to_string()))?;
+    Ok(u64::from_be_bytes(seq_bytes))
+}
+
+async fn forward_raw_batch(
+    config: &BridgeConfig,
+    incarnation: &str,
+    client: &mut KvIndexerClient<Channel>,
+    batch: &RawBatch,
+) -> Result<u64, BridgeError> {
+    let actions = match decode_event_batch(&batch.payload) {
+        Ok(actions) => actions,
+        Err(error) => {
+            warn!(seq = batch.seq, %error, "skipping undecodable event batch");
+            return Ok(batch.seq);
+        }
+    };
+
+    let request = build_apply_request(config, incarnation, batch.seq, actions);
+    // Nothing decodable to a supported mutation (e.g. only ignored event tags):
+    // preserve the previous no-op behaviour and skip the RPC entirely. The batch
+    // still counts as consumed, so report its seq as the applied position.
+    if request.actions.is_empty() {
+        return Ok(batch.seq);
+    }
+    let response = client
+        .apply_external_kv_batch(request)
+        .await
+        .map_err(classify_rpc)?
+        .into_inner();
+    Ok(response.last_applied_seq)
+}
+
+/// Sends an empty-actions apply as a liveness heartbeat. It mutates nothing on
+/// the indexer beyond refreshing the worker's TTL, so `seq` is irrelevant and
+/// the returned position is ignored (never advances `next_seq`). Errors are
+/// propagated so a broken connection ends the session and triggers reconnect.
+async fn send_heartbeat(
+    config: &BridgeConfig,
+    incarnation: &str,
+    client: &mut KvIndexerClient<Channel>,
+) -> Result<Option<u64>, BridgeError> {
+    let request = ApplyExternalKvBatchRequest {
+        worker_id: config.worker_id.clone(),
+        seq: 0,
+        actions: Vec::new(),
+        worker_address: config.worker_address.clone(),
+        incarnation: incarnation.to_string(),
+    };
+    let response = client
+        .apply_external_kv_batch(request)
+        .await
+        .map_err(classify_rpc)?
+        .into_inner();
+    debug!(worker_id = %config.worker_id, "sent liveness heartbeat");
+    Ok(response
+        .has_applied_seq
+        .then_some(response.last_applied_seq))
+}
+
+/// Maps a decoded `EventActions` into a single `ApplyExternalKvBatchRequest`,
+/// preserving the exact per-action order. A `ClearAll` is expanded, in place,
+/// into one `CLEAR_ALL_AT_TIER` action per configured clear tier so the batch
+/// carries the same semantics as the legacy per-tier revoke-all RPCs.
+fn build_apply_request(
+    config: &BridgeConfig,
+    incarnation: &str,
+    seq: u64,
+    events: EventActions,
+) -> ApplyExternalKvBatchRequest {
+    let mut actions = Vec::with_capacity(events.actions.len());
+    for action in events.actions {
+        match action {
+            Action::Report { tier, hashes } => actions.push(ExternalKvAction {
+                r#type: ExternalKvActionType::ActionReport as i32,
+                tier,
+                hashes,
+            }),
+            Action::Revoke { tier, hashes } => actions.push(ExternalKvAction {
+                r#type: ExternalKvActionType::ActionRevoke as i32,
+                tier,
+                hashes,
+            }),
+            Action::ClearAll => {
+                for tier in &config.clear_tiers {
+                    actions.push(ExternalKvAction {
+                        r#type: ExternalKvActionType::ActionClearAllAtTier as i32,
+                        tier: *tier,
+                        hashes: Vec::new(),
+                    });
+                }
+            }
+        }
+    }
+
+    ApplyExternalKvBatchRequest {
+        worker_id: config.worker_id.clone(),
+        seq,
+        actions,
+        worker_address: config.worker_address.clone(),
+        incarnation: incarnation.to_string(),
+    }
+}
+
+fn decode_event_batch(payload: &[u8]) -> Result<EventActions, BridgeError> {
+    decode_event_batch_impl(payload, true)
+}
+
+fn decode_event_batch_impl(
+    payload: &[u8],
+    log_event_errors: bool,
+) -> Result<EventActions, BridgeError> {
+    let mut cursor = Cursor::new(payload);
+    let value = read_value(&mut cursor).map_err(|error| BridgeError::Decode(error.to_string()))?;
+    let batch = expect_array(&value, "KVEventBatch")?;
+    if batch.len() < 2 {
+        return Err(BridgeError::Decode(
+            "KVEventBatch must contain timestamp and events".to_string(),
+        ));
+    }
+
+    let events = expect_array(&batch[1], "KVEventBatch.events")?;
+    let mut actions = EventActions::default();
+    for (event_index, event) in events.iter().enumerate() {
+        if let Err(error) = decode_event(event, &mut actions) {
+            if log_event_errors {
+                warn!(
+                    event_index,
+                    %error,
+                    "skipping one undecodable SGLang KV event; preserving valid siblings"
+                );
+            }
+        }
+    }
+    Ok(actions)
+}
+
+fn decode_event(event: &Value, actions: &mut EventActions) -> Result<(), BridgeError> {
+    let event = expect_array(event, "KV event")?;
+    let event_type = expect_str(
+        event
+            .first()
+            .ok_or_else(|| BridgeError::Decode("KV event is empty".to_string()))?,
+        "KV event tag",
+    )?;
+
+    match event_type {
+        "BlockStored" => {
+            if event.len() < 7 {
+                return Err(BridgeError::Decode(
+                    "BlockStored must have 7 array fields".to_string(),
+                ));
+            }
+            let tier = medium_to_tier(expect_optional_str(&event[6], "BlockStored.medium")?)?;
+            actions.report(tier, decode_hashes(&event[1])?);
+        }
+        "BlockRemoved" => {
+            if event.len() < 3 {
+                return Err(BridgeError::Decode(
+                    "BlockRemoved must have 3 array fields".to_string(),
+                ));
+            }
+            let tier = medium_to_tier(expect_optional_str(&event[2], "BlockRemoved.medium")?)?;
+            actions.revoke(tier, decode_hashes(&event[1])?);
+        }
+        "AllBlocksCleared" => {
+            actions.clear_all();
+        }
+        other => {
+            debug!(event_type = other, "ignoring unsupported SGLang KV event");
+        }
+    }
+    Ok(())
+}
+
+fn decode_hashes(value: &Value) -> Result<Vec<String>, BridgeError> {
+    expect_array(value, "block_hashes")?
+        .iter()
+        .map(|value| {
+            if let Some(value) = value.as_i64() {
+                return Ok(value.to_string());
+            }
+            if let Some(value) = value.as_u64() {
+                return Ok(value.to_string());
+            }
+            Err(BridgeError::Decode(
+                "block hash must be an integer".to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn medium_to_tier(medium: Option<&str>) -> Result<i32, BridgeError> {
+    match medium {
+        Some("GPU") => Ok(TierType::TierHbm as i32),
+        Some("CPU_PINNED") => Ok(TierType::TierDram as i32),
+        Some("DISK") => Ok(TierType::TierSsd as i32),
+        Some("EXTERNAL") => Err(BridgeError::Decode(
+            "EXTERNAL medium does not map to a local indexer tier".to_string(),
+        )),
+        Some(other) => Err(BridgeError::Decode(format!(
+            "unsupported SGLang storage medium: {other}"
+        ))),
+        None => Err(BridgeError::Decode(
+            "SGLang storage medium is missing".to_string(),
+        )),
+    }
+}
+
+fn parse_clear_tiers(value: &str) -> Result<Vec<i32>, BridgeError> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| match part {
+            "HBM" | "GPU" => Ok(TierType::TierHbm as i32),
+            "DRAM" | "CPU" | "CPU_PINNED" => Ok(TierType::TierDram as i32),
+            "SSD" | "DISK" => Ok(TierType::TierSsd as i32),
+            other => Err(BridgeError::Config(format!(
+                "unsupported clear tier: {other}"
+            ))),
+        })
+        .collect()
+}
+
+/// Generates a fresh incarnation token. The atomic suffix guarantees uniqueness
+/// across multiple publisher restarts observed within this bridge process.
+fn generate_incarnation() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let counter = INCARNATION_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{nanos}-{}-{counter}", std::process::id())
+}
+
+/// Parses `KV_INDEXER_HEARTBEAT_SECS` (default `30`; `0` disables heartbeats).
+/// Keep this comfortably below the server's `KV_INDEXER_WORKER_TTL_SECS`.
+fn parse_heartbeat_interval() -> Result<Option<Duration>, BridgeError> {
+    const DEFAULT_HEARTBEAT_SECS: u64 = 30;
+    let secs = match std::env::var("KV_INDEXER_HEARTBEAT_SECS") {
+        Ok(v) => v.trim().parse::<u64>().map_err(|_| {
+            BridgeError::Config(format!(
+                "KV_INDEXER_HEARTBEAT_SECS must be a non-negative integer, got {v:?}"
+            ))
+        })?,
+        Err(_) => DEFAULT_HEARTBEAT_SECS,
+    };
+    Ok((secs > 0).then(|| Duration::from_secs(secs)))
+}
+
+fn expect_array<'a>(value: &'a Value, field: &str) -> Result<&'a [Value], BridgeError> {
+    value
+        .as_array()
+        .map(Vec::as_slice)
+        .ok_or_else(|| BridgeError::Decode(format!("{field} must be an array")))
+}
+
+fn expect_str<'a>(value: &'a Value, field: &str) -> Result<&'a str, BridgeError> {
+    value
+        .as_str()
+        .ok_or_else(|| BridgeError::Decode(format!("{field} must be a string")))
+}
+
+fn expect_optional_str<'a>(value: &'a Value, field: &str) -> Result<Option<&'a str>, BridgeError> {
+    if matches!(value, Value::Nil) {
+        return Ok(None);
+    }
+    expect_str(value, field).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use rmpv::Value;
+
+    fn hbm() -> i32 {
+        TierType::TierHbm as i32
+    }
+    fn dram() -> i32 {
+        TierType::TierDram as i32
+    }
+    fn ssd() -> i32 {
+        TierType::TierSsd as i32
+    }
+
+    fn encode(value: &Value) -> Vec<u8> {
+        let mut buf = Vec::new();
+        rmpv::encode::write_value(&mut buf, value).unwrap();
+        buf
+    }
+
+    fn ints(values: &[i64]) -> Value {
+        Value::Array(values.iter().map(|v| Value::from(*v)).collect())
+    }
+
+    fn stored(hashes: &[i64], medium: &str) -> Value {
+        Value::Array(vec![
+            Value::String("BlockStored".into()),
+            ints(hashes),
+            Value::Nil,         // parent_block_hash
+            ints(&[1]),         // token_ids
+            Value::from(1_i64), // block_size
+            Value::Nil,         // lora_id
+            Value::String(medium.into()),
+        ])
+    }
+
+    fn removed(hashes: &[i64], medium: &str) -> Value {
+        Value::Array(vec![
+            Value::String("BlockRemoved".into()),
+            ints(hashes),
+            Value::String(medium.into()),
+        ])
+    }
+
+    fn cleared() -> Value {
+        Value::Array(vec![Value::String("AllBlocksCleared".into())])
+    }
+
+    /// Wrap events in a 3-element batch [ts, events, attn_dp_rank].
+    fn batch(events: Vec<Value>) -> Vec<u8> {
+        encode(&Value::Array(vec![
+            Value::from(1.0_f64),
+            Value::Array(events),
+            Value::from(0_i64),
+        ]))
+    }
+
+    fn actions_of(events: Vec<Value>) -> Vec<Action> {
+        decode_event_batch(&batch(events)).unwrap().actions
+    }
+
+    fn golden_bytes(hex: &str) -> Vec<u8> {
+        assert_eq!(hex.len() % 2, 0);
+        hex.as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let high = (pair[0] as char).to_digit(16).unwrap();
+                let low = (pair[1] as char).to_digit(16).unwrap();
+                ((high << 4) | low) as u8
+            })
+            .collect()
+    }
+
+    fn test_config(clear_tiers: Vec<i32>) -> BridgeConfig {
+        BridgeConfig {
+            worker_id: "worker-1".to_string(),
+            worker_address: "127.0.0.1:9000".to_string(),
+            event_endpoint: "tcp://127.0.0.1:5557".to_string(),
+            event_replay_endpoint: None,
+            event_topic: "kv-events".to_string(),
+            indexer_endpoint: "http://[::1]:50051".to_string(),
+            clear_tiers,
+            heartbeat_interval: None,
+            incarnation: "test-incarnation".to_string(),
+            incarnation_path: None,
+        }
+    }
+
+    fn temp_checkpoint(name: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("sgl-kv-indexer-test-{name}-{unique}"))
+    }
+
+    #[test]
+    fn incarnation_checkpoint_is_reused_across_loads() {
+        let path = temp_checkpoint("reuse");
+        let first = load_or_create_incarnation(&path, None);
+        let second = load_or_create_incarnation(&path, None);
+        assert!(!first.is_empty());
+        assert_eq!(
+            first, second,
+            "a bridge restart must present the same publisher incarnation"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn empty_incarnation_checkpoint_is_replaced() {
+        let path = temp_checkpoint("empty");
+        fs::write(&path, "").expect("seed empty checkpoint");
+        let minted = load_or_create_incarnation(&path, Some("worker-a"));
+        assert!(minted.starts_with("worker-a:"));
+        assert_eq!(
+            fs::read_to_string(&path).expect("read checkpoint").trim(),
+            minted,
+            "an interrupted rotation must self-heal instead of wedging startup"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unwritable_incarnation_checkpoint_does_not_block_startup() {
+        // Parent directory does not exist, so every write attempt fails.
+        let path = temp_checkpoint("unwritable").join("nested.incarnation");
+        assert!(!load_or_create_incarnation(&path, None).is_empty());
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn rotation_drops_a_checkpoint_it_cannot_update() {
+        // A directory in place of the checkpoint fails every write.
+        let path = temp_checkpoint("rotate-unwritable");
+        fs::create_dir(&path).expect("seed directory in place of checkpoint");
+        let config = BridgeConfig {
+            incarnation_path: Some(path.clone()),
+            ..test_config(vec![])
+        };
+        let mut incarnation = config.incarnation.clone();
+        rotate_incarnation(&config, &mut incarnation);
+        assert_ne!(
+            incarnation, config.incarnation,
+            "rotation must proceed even when the checkpoint cannot be persisted"
+        );
+        let _ = fs::remove_dir(&path);
+    }
+
+    /// Build the apply-batch request the bridge would send for a set of events.
+    fn request_of(
+        config: &BridgeConfig,
+        seq: u64,
+        events: Vec<Value>,
+    ) -> ApplyExternalKvBatchRequest {
+        build_apply_request(
+            config,
+            &config.incarnation,
+            seq,
+            decode_event_batch(&batch(events)).unwrap(),
+        )
+    }
+
+    fn report(tier: i32, hashes: &[&str]) -> ExternalKvAction {
+        ExternalKvAction {
+            r#type: ExternalKvActionType::ActionReport as i32,
+            tier,
+            hashes: hashes.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    fn revoke(tier: i32, hashes: &[&str]) -> ExternalKvAction {
+        ExternalKvAction {
+            r#type: ExternalKvActionType::ActionRevoke as i32,
+            tier,
+            hashes: hashes.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    fn clear_at(tier: i32) -> ExternalKvAction {
+        ExternalKvAction {
+            r#type: ExternalKvActionType::ActionClearAllAtTier as i32,
+            tier,
+            hashes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn request_carries_worker_id_and_seq() {
+        let config = test_config(vec![hbm()]);
+        let request = request_of(&config, 42, vec![stored(&[1], "GPU")]);
+        assert_eq!(request.worker_id, "worker-1");
+        assert_eq!(request.seq, 42);
+    }
+
+    #[test]
+    fn request_carries_worker_address() {
+        let config = test_config(vec![hbm()]);
+        let request = request_of(&config, 0, vec![stored(&[1], "GPU")]);
+        assert_eq!(request.worker_address, "127.0.0.1:9000");
+    }
+
+    #[test]
+    fn request_carries_incarnation() {
+        let config = test_config(vec![hbm()]);
+        let request = request_of(&config, 0, vec![stored(&[1], "GPU")]);
+        assert_eq!(request.incarnation, "test-incarnation");
+    }
+
+    #[test]
+    fn report_and_revoke_map_to_actions_in_order() {
+        let config = test_config(vec![hbm()]);
+        let request = request_of(
+            &config,
+            0,
+            vec![removed(&[9], "GPU"), stored(&[9], "CPU_PINNED")],
+        );
+        assert_eq!(
+            request.actions,
+            vec![revoke(hbm(), &["9"]), report(dram(), &["9"])]
+        );
+    }
+
+    #[test]
+    fn clear_all_expands_to_one_action_per_clear_tier_in_place() {
+        let config = test_config(vec![hbm(), dram(), ssd()]);
+        let request = request_of(
+            &config,
+            7,
+            vec![stored(&[1], "GPU"), cleared(), stored(&[2], "GPU")],
+        );
+        assert_eq!(
+            request.actions,
+            vec![
+                report(hbm(), &["1"]),
+                clear_at(hbm()),
+                clear_at(dram()),
+                clear_at(ssd()),
+                report(hbm(), &["2"]),
+            ]
+        );
+    }
+
+    #[test]
+    fn batch_with_only_ignored_events_has_no_actions() {
+        let config = test_config(vec![hbm()]);
+        let events = vec![Value::Array(vec![Value::String("BlockUpdated".into())])];
+        assert!(request_of(&config, 0, events).actions.is_empty());
+    }
+
+    #[test]
+    fn block_stored_maps_to_report_on_tier() {
+        assert_eq!(
+            actions_of(vec![stored(&[123], "GPU")]),
+            vec![Action::Report {
+                tier: hbm(),
+                hashes: vec!["123".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn mediums_map_to_expected_tiers() {
+        assert_eq!(
+            actions_of(vec![stored(&[1], "CPU_PINNED")]),
+            vec![Action::Report {
+                tier: dram(),
+                hashes: vec!["1".to_string()],
+            }]
+        );
+        assert_eq!(
+            actions_of(vec![removed(&[2], "DISK")]),
+            vec![Action::Revoke {
+                tier: ssd(),
+                hashes: vec!["2".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn bad_event_does_not_drop_valid_siblings() {
+        assert_eq!(
+            actions_of(vec![
+                stored(&[1], "GPU"),
+                stored(&[2], "EXTERNAL"),
+                removed(&[3], "DISK"),
+            ]),
+            vec![
+                Action::Report {
+                    tier: hbm(),
+                    hashes: vec!["1".to_string()],
+                },
+                Action::Revoke {
+                    tier: ssd(),
+                    hashes: vec!["3".to_string()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn permanent_rpc_codes_are_not_retried() {
+        for code in [
+            Code::InvalidArgument,
+            Code::FailedPrecondition,
+            Code::ResourceExhausted,
+            Code::PermissionDenied,
+        ] {
+            assert!(classify_rpc(Status::new(code, "bad batch")).is_permanent());
+        }
+        assert!(!classify_rpc(Status::unavailable("retry")).is_permanent());
+        assert!(!classify_rpc(Status::deadline_exceeded("retry")).is_permanent());
+    }
+
+    // --- ordering regressions (the whole point of the in-order rewrite) ---
+
+    #[test]
+    fn remove_then_store_same_hash_keeps_order() {
+        // Net state must be "stored"; reordering to report-then-revoke would drop it.
+        assert_eq!(
+            actions_of(vec![removed(&[9], "GPU"), stored(&[9], "GPU")]),
+            vec![
+                Action::Revoke {
+                    tier: hbm(),
+                    hashes: vec!["9".to_string()],
+                },
+                Action::Report {
+                    tier: hbm(),
+                    hashes: vec!["9".to_string()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn clear_then_store_keeps_order() {
+        assert_eq!(
+            actions_of(vec![cleared(), stored(&[7], "GPU")]),
+            vec![
+                Action::ClearAll,
+                Action::Report {
+                    tier: hbm(),
+                    hashes: vec!["7".to_string()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn store_then_clear_keeps_order() {
+        assert_eq!(
+            actions_of(vec![stored(&[7], "GPU"), cleared()]),
+            vec![
+                Action::Report {
+                    tier: hbm(),
+                    hashes: vec!["7".to_string()],
+                },
+                Action::ClearAll,
+            ]
+        );
+    }
+
+    // --- coalescing rules ---
+
+    #[test]
+    fn adjacent_same_tier_stores_coalesce() {
+        assert_eq!(
+            actions_of(vec![stored(&[1], "GPU"), stored(&[2], "GPU")]),
+            vec![Action::Report {
+                tier: hbm(),
+                hashes: vec!["1".to_string(), "2".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn different_tier_stores_do_not_coalesce() {
+        assert_eq!(
+            actions_of(vec![stored(&[1], "GPU"), stored(&[2], "CPU_PINNED")]),
+            vec![
+                Action::Report {
+                    tier: hbm(),
+                    hashes: vec!["1".to_string()],
+                },
+                Action::Report {
+                    tier: dram(),
+                    hashes: vec!["2".to_string()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn store_then_remove_same_tier_do_not_merge() {
+        assert_eq!(
+            actions_of(vec![stored(&[1], "GPU"), removed(&[1], "GPU")]),
+            vec![
+                Action::Report {
+                    tier: hbm(),
+                    hashes: vec!["1".to_string()],
+                },
+                Action::Revoke {
+                    tier: hbm(),
+                    hashes: vec!["1".to_string()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn unknown_event_tag_is_ignored() {
+        let events = vec![Value::Array(vec![Value::String("BlockUpdated".into())])];
+        assert!(actions_of(events).is_empty());
+    }
+
+    #[test]
+    fn two_element_batch_without_dp_rank_decodes() {
+        let payload = encode(&Value::Array(vec![
+            Value::from(1.0_f64),
+            Value::Array(vec![stored(&[5], "GPU")]),
+        ]));
+        assert_eq!(
+            decode_event_batch(&payload).unwrap().actions,
+            vec![Action::Report {
+                tier: hbm(),
+                hashes: vec!["5".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn python_msgspec_mixed_batch_golden_decodes() {
+        // Generated by msgspec.msgpack.Encoder from the authoritative Python
+        // KVEventBatch schema in sglang.srt.disaggregation.kv_events.
+        let payload = golden_bytes(concat!(
+            "93cb405edd2f1a9fbe779397ab426c6f636b53746f72656492",
+            "cf0000011f71fb04cbd2c521974f2a940a141e280407a3475055",
+            "93ac426c6f636b52656d6f7665649264ccc8a44449534b",
+            "91b0416c6c426c6f636b73436c656172656402"
+        ));
+        assert_eq!(
+            decode_event_batch(&payload).unwrap().actions,
+            vec![
+                Action::Report {
+                    tier: hbm(),
+                    hashes: vec!["1234567890123".to_string(), "-987654321".to_string()],
+                },
+                Action::Revoke {
+                    tier: ssd(),
+                    hashes: vec!["100".to_string(), "200".to_string()],
+                },
+                Action::ClearAll,
+            ]
+        );
+    }
+
+    #[test]
+    fn python_msgspec_bigram_tokens_golden_decodes() {
+        // token_ids contains Python tuples, encoded as nested msgpack arrays.
+        // The bridge intentionally ignores token payload shape and indexes the
+        // publisher-provided block hashes.
+        let payload = golden_bytes(concat!(
+            "93cb3ff80000000000009197ab426c6f636b53746f726564916f",
+            "c092920a1492141e02c0a347505503"
+        ));
+        assert_eq!(
+            decode_event_batch(&payload).unwrap().actions,
+            vec![Action::Report {
+                tier: hbm(),
+                hashes: vec!["111".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn python_msgspec_nil_medium_golden_is_safely_skipped() {
+        // The Python schema permits medium=None. Such events cannot be mapped
+        // to an Indexer tier, so they are isolated rather than poisoning the
+        // batch or inventing a placement.
+        let payload = golden_bytes(concat!(
+            "93cb00000000000000009297ab426c6f636b53746f7265649101",
+            "c092050602c0c093ac426c6f636b52656d6f7665649102c0c0"
+        ));
+        assert!(decode_event_batch(&payload).unwrap().actions.is_empty());
+    }
+
+    #[test]
+    fn negative_hashes_are_stringified() {
+        assert_eq!(
+            actions_of(vec![stored(&[-1905904552702706914], "GPU")]),
+            vec![Action::Report {
+                tier: hbm(),
+                hashes: vec!["-1905904552702706914".to_string()],
+            }]
+        );
+    }
+
+    // --- error / mapping units ---
+
+    #[test]
+    fn external_medium_event_is_skipped() {
+        assert!(decode_event_batch(&batch(vec![stored(&[1], "EXTERNAL")]))
+            .unwrap()
+            .actions
+            .is_empty());
+    }
+
+    #[test]
+    fn unknown_medium_event_is_skipped() {
+        assert!(decode_event_batch(&batch(vec![stored(&[1], "TAPE")]))
+            .unwrap()
+            .actions
+            .is_empty());
+    }
+
+    #[test]
+    fn medium_to_tier_mapping() {
+        assert_eq!(medium_to_tier(Some("GPU")).unwrap(), hbm());
+        assert_eq!(medium_to_tier(Some("CPU_PINNED")).unwrap(), dram());
+        assert_eq!(medium_to_tier(Some("DISK")).unwrap(), ssd());
+        assert!(medium_to_tier(Some("EXTERNAL")).is_err());
+        assert!(medium_to_tier(None).is_err());
+    }
+
+    #[test]
+    fn parse_clear_tiers_defaults_and_aliases() {
+        assert_eq!(
+            parse_clear_tiers("HBM,DRAM,SSD").unwrap(),
+            vec![hbm(), dram(), ssd()]
+        );
+        assert_eq!(
+            parse_clear_tiers(" GPU , CPU_PINNED , DISK ").unwrap(),
+            vec![hbm(), dram(), ssd()]
+        );
+        assert!(parse_clear_tiers("HBM,NVME").is_err());
+    }
+
+    #[test]
+    fn decode_hashes_accepts_signed_and_unsigned() {
+        let value = Value::Array(vec![
+            Value::from(1_i64),
+            Value::from(-2_i64),
+            Value::from(u64::MAX),
+        ]);
+        assert_eq!(
+            decode_hashes(&value).unwrap(),
+            vec!["1".to_string(), "-2".to_string(), u64::MAX.to_string()]
+        );
+        assert!(decode_hashes(&Value::Array(vec![Value::String("x".into())])).is_err());
+    }
+
+    // --- frame / sequence parsing ---
+
+    #[test]
+    fn parse_zmq_frames_two_and_three() {
+        let seq = 42_u64;
+        let two = [
+            Bytes::copy_from_slice(&seq.to_be_bytes()),
+            Bytes::from_static(b"p"),
+        ];
+        assert_eq!(parse_zmq_frames(&two).unwrap().0, seq);
+        let three = [
+            Bytes::from_static(b"kv-events"),
+            Bytes::copy_from_slice(&seq.to_be_bytes()),
+            Bytes::from_static(b"p"),
+        ];
+        assert_eq!(parse_zmq_frames(&three).unwrap().0, seq);
+        let one = [Bytes::from_static(b"p")];
+        assert!(parse_zmq_frames(&one).is_err());
+    }
+
+    #[test]
+    fn parse_replay_frames_dealer_three_and_bare_two() {
+        let seq = 7_i64;
+        // DEALER keeps the empty delimiter: [b"", seq, payload]
+        let three = [
+            Bytes::new(),
+            Bytes::copy_from_slice(&seq.to_be_bytes()),
+            Bytes::from_static(b"payload"),
+        ];
+        let (parsed, payload) = parse_replay_frames(&three).unwrap();
+        assert_eq!(parsed, seq);
+        assert_eq!(payload, b"payload");
+        // bare 2-frame form
+        let two = [
+            Bytes::copy_from_slice(&seq.to_be_bytes()),
+            Bytes::from_static(b"p"),
+        ];
+        assert_eq!(parse_replay_frames(&two).unwrap().0, seq);
+        assert!(parse_replay_frames(&[Bytes::new()]).is_err());
+    }
+
+    #[test]
+    fn probe_response_requires_exact_end_frame() {
+        let valid = [
+            Bytes::new(),
+            Bytes::copy_from_slice(&(-1_i64).to_be_bytes()),
+            Bytes::new(),
+        ];
+        assert!(parse_probe_response(&valid).is_ok());
+        assert!(parse_probe_response(&valid[1..]).is_err());
+
+        let mut bad_delimiter = valid.clone();
+        bad_delimiter[0] = Bytes::from_static(b"not-empty");
+        assert!(parse_probe_response(&bad_delimiter).is_err());
+
+        let mut bad_seq = valid.clone();
+        bad_seq[1] = Bytes::copy_from_slice(&(-2_i64).to_be_bytes());
+        assert!(parse_probe_response(&bad_seq).is_err());
+
+        let mut bad_payload = valid;
+        bad_payload[2] = Bytes::from_static(b"unexpected");
+        assert!(parse_probe_response(&bad_payload).is_err());
+    }
+
+    #[test]
+    fn seq_decoders_are_big_endian() {
+        assert_eq!(decode_seq(&5_u64.to_be_bytes()).unwrap(), 5);
+        // END_SEQ sentinel: -1 as 8-byte big-endian signed
+        assert_eq!(decode_signed_seq(&(-1_i64).to_be_bytes()).unwrap(), -1);
+        assert!(decode_seq(&[0_u8; 4]).is_err());
+    }
+}

--- a/experimental/sgl-kv-indexer/src/lib.rs
+++ b/experimental/sgl-kv-indexer/src/lib.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! SGLang KV Indexer: a gRPC service that tracks externally-managed KV cache
+//! block placements (as reported by inference engines such as SGLang HiCache)
+//! and answers placement-match queries for KV-aware routing.
+
+pub mod bridge;
+
+pub mod pb {
+    tonic::include_proto!("kv_indexer.v1");
+}
+
+mod service;
+mod shutdown;
+
+#[cfg(feature = "redis-backend")]
+pub mod redis_backend;
+
+pub use service::{KvIndexerBackend, KvIndexerService};
+pub use shutdown::shutdown_signal;
+
+#[cfg(feature = "redis-backend")]
+pub use redis_backend::RedisKvIndexerBackend;

--- a/experimental/sgl-kv-indexer/src/redis_backend/conn.rs
+++ b/experimental/sgl-kv-indexer/src/redis_backend/conn.rs
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Topology-agnostic connection seam. The backend logic issues commands and
+//! script invocations through `RedisConn`, so the same apply/match code runs on
+//! a single Redis/Dragonfly instance or a Redis Cluster. Connections are cheaply
+//! cloneable and multiplexed, so per-hash operations are issued concurrently
+//! (one connection, many in-flight commands) rather than serialized.
+//!
+//! Connections are established lazily and cached: an eager constructor forces
+//! the first connect (and surfaces its error) for the "Redis is required"
+//! startup path, while a deferred constructor lets the server come up before
+//! Redis is reachable and connect on first use. Every attempt is bounded by a
+//! connection timeout / limited retries so an unreachable Redis can never wedge
+//! startup or a request indefinitely.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use redis::{
+    Cmd, ConnectionAddr, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError, RedisResult,
+    Value,
+};
+
+use super::scripts::RedisScript;
+
+/// Per-attempt connect timeout and bounded retry policy. Without this the
+/// redis `ConnectionManager` default has no connection timeout, so a single
+/// attempt against an unreachable endpoint can block indefinitely.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+const CONNECT_RETRIES: usize = 2;
+const CLUSTER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn manager_config() -> redis::aio::ConnectionManagerConfig {
+    redis::aio::ConnectionManagerConfig::new()
+        .set_connection_timeout(CONNECT_TIMEOUT)
+        .set_response_timeout(RESPONSE_TIMEOUT)
+        .set_number_of_retries(CONNECT_RETRIES)
+        .set_factor(100)
+        .set_max_delay(1000)
+}
+
+fn response_timeout_error() -> RedisError {
+    RedisError::from((ErrorKind::IoError, "redis response timed out"))
+}
+
+fn eval_command(script: &RedisScript, keys: &[String], args: &[String]) -> Cmd {
+    let mut command = redis::cmd("EVAL");
+    command.arg(script.code).arg(keys.len());
+    for key in keys {
+        command.arg(key);
+    }
+    for arg in args {
+        command.arg(arg);
+    }
+    command
+}
+
+fn redirected_info(base: &ConnectionInfo, address: &str) -> RedisResult<ConnectionInfo> {
+    let (host, port) = if let Some(rest) = address.strip_prefix('[') {
+        let (host, port) = rest.rsplit_once("]:").ok_or_else(|| {
+            RedisError::from((ErrorKind::InvalidClientConfig, "invalid redirect address"))
+        })?;
+        (host.to_string(), port)
+    } else {
+        let (host, port) = address.rsplit_once(':').ok_or_else(|| {
+            RedisError::from((ErrorKind::InvalidClientConfig, "invalid redirect address"))
+        })?;
+        (host.to_string(), port)
+    };
+    let port = port.parse::<u16>().map_err(|_| {
+        RedisError::from((
+            ErrorKind::InvalidClientConfig,
+            "invalid redirect address port",
+        ))
+    })?;
+    let addr = match &base.addr {
+        ConnectionAddr::Tcp(_, _) => ConnectionAddr::Tcp(host, port),
+        ConnectionAddr::TcpTls {
+            insecure,
+            tls_params,
+            ..
+        } => ConnectionAddr::TcpTls {
+            host,
+            port,
+            insecure: *insecure,
+            tls_params: tls_params.clone(),
+        },
+        ConnectionAddr::Unix(_) => {
+            return Err(RedisError::from((
+                ErrorKind::InvalidClientConfig,
+                "Redis Cluster does not support Unix redirect addresses",
+            )));
+        }
+    };
+    Ok(ConnectionInfo {
+        addr,
+        redis: base.redis.clone(),
+    })
+}
+
+#[tonic::async_trait]
+pub(crate) trait RedisConn: Send + Sync + 'static {
+    /// Runs a single command, routed by its key on Cluster.
+    async fn query(&self, cmd: Cmd) -> RedisResult<Value>;
+
+    /// Runs a Lua script (EVALSHA with automatic NOSCRIPT fallback), routed by
+    /// `keys[0]` on Cluster. All `keys` must share a hash tag.
+    async fn invoke(
+        &self,
+        script: &RedisScript,
+        keys: Vec<String>,
+        args: Vec<String>,
+    ) -> RedisResult<Value>;
+}
+
+/// Single Redis/Dragonfly instance via an auto-reconnecting multiplexed manager,
+/// established lazily so the server can start before Redis is reachable.
+pub(crate) struct SingleConn {
+    url: String,
+    conn: Mutex<Option<redis::aio::ConnectionManager>>,
+}
+
+impl SingleConn {
+    /// Eager: force the first connect now, surfacing any error (used when Redis
+    /// is a required dependency and we want a fast, loud startup failure).
+    pub(crate) async fn connect(url: &str) -> RedisResult<Self> {
+        let this = Self::deferred(url);
+        this.manager().await?;
+        Ok(this)
+    }
+
+    /// Deferred: hold only the target; connect on first use. Never fails here,
+    /// so the server can start degraded and self-heal once Redis is up.
+    pub(crate) fn deferred(url: &str) -> Self {
+        Self {
+            url: url.to_string(),
+            conn: Mutex::new(None),
+        }
+    }
+
+    fn cached(&self) -> Option<redis::aio::ConnectionManager> {
+        self.conn.lock().unwrap().clone()
+    }
+
+    /// Returns the cached manager or builds one. The (async) build happens
+    /// without holding the lock; a lost race just drops the redundant manager.
+    async fn manager(&self) -> RedisResult<redis::aio::ConnectionManager> {
+        if let Some(c) = self.cached() {
+            return Ok(c);
+        }
+        let client = redis::Client::open(self.url.as_str())?;
+        let built =
+            redis::aio::ConnectionManager::new_with_config(client, manager_config()).await?;
+        let mut guard = self.conn.lock().unwrap();
+        if let Some(existing) = guard.clone() {
+            return Ok(existing);
+        }
+        *guard = Some(built.clone());
+        Ok(built)
+    }
+}
+
+#[tonic::async_trait]
+impl RedisConn for SingleConn {
+    async fn query(&self, cmd: Cmd) -> RedisResult<Value> {
+        let mut c = self.manager().await?;
+        cmd.query_async(&mut c).await
+    }
+
+    async fn invoke(
+        &self,
+        script: &RedisScript,
+        keys: Vec<String>,
+        args: Vec<String>,
+    ) -> RedisResult<Value> {
+        let mut c = self.manager().await?;
+        let mut inv = script.prepare_invoke();
+        for k in &keys {
+            inv.key(k.as_str());
+        }
+        for a in &args {
+            inv.arg(a.as_str());
+        }
+        let v: Value = inv.invoke_async(&mut c).await?;
+        Ok(v)
+    }
+}
+
+/// Redis Cluster via the async cluster connection. MOVED/ASK redirects and slot
+/// map refresh are handled by the client; each command/script is routed by key.
+/// Established lazily and bounded by a connect timeout, mirroring `SingleConn`.
+pub(crate) struct ClusterConn {
+    nodes: Vec<String>,
+    conn: Mutex<Option<redis::cluster_async::ClusterConnection>>,
+}
+
+impl ClusterConn {
+    pub(crate) async fn connect(nodes: Vec<String>) -> RedisResult<Self> {
+        let this = Self::deferred(nodes);
+        this.connection().await?;
+        Ok(this)
+    }
+
+    pub(crate) fn deferred(nodes: Vec<String>) -> Self {
+        Self {
+            nodes,
+            conn: Mutex::new(None),
+        }
+    }
+
+    fn cached(&self) -> Option<redis::cluster_async::ClusterConnection> {
+        self.conn.lock().unwrap().clone()
+    }
+
+    fn invalidate(&self) {
+        *self.conn.lock().unwrap() = None;
+    }
+
+    async fn connection(&self) -> RedisResult<redis::cluster_async::ClusterConnection> {
+        if let Some(c) = self.cached() {
+            return Ok(c);
+        }
+        let client = redis::cluster::ClusterClient::new(self.nodes.clone())?;
+        let built = match tokio::time::timeout(
+            CLUSTER_CONNECT_TIMEOUT,
+            client.get_async_connection(),
+        )
+        .await
+        {
+            Ok(res) => res?,
+            Err(_) => {
+                return Err(RedisError::from((
+                    ErrorKind::IoError,
+                    "redis cluster connect timed out",
+                )))
+            }
+        };
+        let mut guard = self.conn.lock().unwrap();
+        if let Some(existing) = guard.clone() {
+            return Ok(existing);
+        }
+        *guard = Some(built.clone());
+        Ok(built)
+    }
+
+    async fn invoke_ask(
+        &self,
+        address: &str,
+        script: &RedisScript,
+        keys: &[String],
+        args: &[String],
+    ) -> RedisResult<Value> {
+        let base = self.nodes[0].as_str().into_connection_info()?;
+        let target = redirected_info(&base, address)?;
+        let client = redis::Client::open(target)?;
+        let mut connection =
+            tokio::time::timeout(CONNECT_TIMEOUT, client.get_multiplexed_async_connection())
+                .await
+                .map_err(|_| {
+                    RedisError::from((ErrorKind::IoError, "Redis ASK connect timed out"))
+                })??;
+        // ASKING only applies to the immediately following command. A pipeline
+        // keeps it adjacent to EVAL on this dedicated target connection.
+        let mut pipeline = redis::pipe();
+        pipeline.cmd("ASKING").ignore();
+        pipeline.add_command(eval_command(script, keys, args));
+        tokio::time::timeout(
+            RESPONSE_TIMEOUT,
+            pipeline.query_async::<Value>(&mut connection),
+        )
+        .await
+        .map_err(|_| response_timeout_error())?
+    }
+}
+
+#[tonic::async_trait]
+impl RedisConn for ClusterConn {
+    async fn query(&self, cmd: Cmd) -> RedisResult<Value> {
+        let mut c = self.connection().await?;
+        match tokio::time::timeout(RESPONSE_TIMEOUT, cmd.query_async(&mut c)).await {
+            Ok(result) => result,
+            Err(_) => {
+                self.invalidate();
+                Err(response_timeout_error())
+            }
+        }
+    }
+
+    async fn invoke(
+        &self,
+        script: &RedisScript,
+        keys: Vec<String>,
+        args: Vec<String>,
+    ) -> RedisResult<Value> {
+        match self.query(eval_command(script, &keys, &args)).await {
+            Err(error) if error.kind() == ErrorKind::Ask => {
+                let Some((address, _)) = error.redirect_node() else {
+                    return Err(error);
+                };
+                self.invoke_ask(address, script, &keys, &args).await
+            }
+            result => result,
+        }
+    }
+}

--- a/experimental/sgl-kv-indexer/src/redis_backend/fault_tests.rs
+++ b/experimental/sgl-kv-indexer/src/redis_backend/fault_tests.rs
@@ -1,0 +1,474 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Failure-boundary tests for placement/reverse-index convergence.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use super::*;
+
+/// Delegates to a real Redis connection but fails the first selected
+/// reverse-index command, after the placement Lua script has committed.
+struct FailOnceConn {
+    inner: SingleConn,
+    command: &'static [u8],
+    failed: AtomicBool,
+}
+
+/// Simulates a newer incarnation winning after an old batch has passed
+/// TOUCH_META/SEQ_CHECK but before that old batch commits its sequence.
+struct ChangeGenerationBeforeCommitConn {
+    inner: SingleConn,
+    invokes: AtomicUsize,
+}
+
+#[tonic::async_trait]
+impl RedisConn for ChangeGenerationBeforeCommitConn {
+    async fn query(&self, cmd: redis::Cmd) -> redis::RedisResult<redis::Value> {
+        self.inner.query(cmd).await
+    }
+
+    async fn invoke(
+        &self,
+        script: &super::scripts::RedisScript,
+        keys: Vec<String>,
+        args: Vec<String>,
+    ) -> redis::RedisResult<redis::Value> {
+        // Report apply invokes TOUCH_META, SEQ_CHECK, PLACEMENT_SET, SEQ_COMMIT.
+        if self.invokes.fetch_add(1, Ordering::SeqCst) == 3 {
+            let mut cmd = redis::cmd("HINCRBY");
+            cmd.arg(&keys[0]).arg("generation").arg(1);
+            self.inner.query(cmd).await?;
+        }
+        self.inner.invoke(script, keys, args).await
+    }
+}
+
+#[tonic::async_trait]
+impl RedisConn for FailOnceConn {
+    async fn query(&self, cmd: redis::Cmd) -> redis::RedisResult<redis::Value> {
+        let is_target = {
+            let mut args = cmd.args_iter();
+            matches!(
+                args.next(),
+                Some(redis::Arg::Simple(name)) if name.eq_ignore_ascii_case(self.command)
+            )
+        };
+        if is_target && !self.failed.swap(true, Ordering::SeqCst) {
+            return Err(redis::RedisError::from((
+                redis::ErrorKind::IoError,
+                "injected reverse-index failure",
+            )));
+        }
+        self.inner.query(cmd).await
+    }
+
+    async fn invoke(
+        &self,
+        script: &super::scripts::RedisScript,
+        keys: Vec<String>,
+        args: Vec<String>,
+    ) -> redis::RedisResult<redis::Value> {
+        self.inner.invoke(script, keys, args).await
+    }
+}
+
+async fn backend(test: &str, command: &'static [u8]) -> Option<RedisKvIndexerBackend> {
+    let inner = test_connection(test).await?;
+    Some(test_backend(
+        test,
+        FailOnceConn {
+            inner,
+            command,
+            failed: AtomicBool::new(false),
+        },
+    ))
+}
+
+async fn generation_race_backend(test: &str) -> Option<RedisKvIndexerBackend> {
+    let inner = test_connection(test).await?;
+    Some(test_backend(
+        test,
+        ChangeGenerationBeforeCommitConn {
+            inner,
+            invokes: AtomicUsize::new(0),
+        },
+    ))
+}
+
+async fn test_connection(test: &str) -> Option<SingleConn> {
+    let Ok(url) = std::env::var("KV_INDEXER_REDIS_URL") else {
+        // Same contract as tests/common/require.rs, which the integration
+        // suites use; this module lives in the library and cannot share it.
+        if std::env::var("KV_INDEXER_REQUIRE_REDIS").is_ok_and(|v| v == "1") {
+            panic!("{test} requires a store but KV_INDEXER_REDIS_URL is not set");
+        }
+        eprintln!("skipping {test}: KV_INDEXER_REDIS_URL is not set");
+        return None;
+    };
+    Some(SingleConn::connect(&url).await.expect("connect redis"))
+}
+
+fn test_backend(test: &str, conn: impl RedisConn) -> RedisKvIndexerBackend {
+    RedisKvIndexerBackend::new(Arc::new(conn), format!("fault:{test}:{}", now_ms()))
+}
+
+fn batch(worker: &str, seq: u64, kind: ExternalKvActionType) -> ApplyExternalKvBatchRequest {
+    ApplyExternalKvBatchRequest {
+        worker_id: worker.to_string(),
+        seq,
+        actions: vec![crate::pb::ExternalKvAction {
+            r#type: kind as i32,
+            tier: crate::pb::TierType::TierHbm as i32,
+            hashes: vec!["hash-a".to_string()],
+        }],
+        worker_address: String::new(),
+        incarnation: String::new(),
+    }
+}
+
+fn batch_inc(
+    worker: &str,
+    seq: u64,
+    incarnation: &str,
+    kind: ExternalKvActionType,
+) -> ApplyExternalKvBatchRequest {
+    ApplyExternalKvBatchRequest {
+        incarnation: incarnation.to_string(),
+        ..batch(worker, seq, kind)
+    }
+}
+
+fn report(worker: &str, seq: u64, incarnation: &str) -> ApplyExternalKvBatchRequest {
+    batch_inc(worker, seq, incarnation, ExternalKvActionType::ActionReport)
+}
+
+fn heartbeat(worker: &str, incarnation: &str) -> ApplyExternalKvBatchRequest {
+    ApplyExternalKvBatchRequest {
+        worker_id: worker.to_string(),
+        seq: 0,
+        actions: Vec::new(),
+        worker_address: String::new(),
+        incarnation: incarnation.to_string(),
+    }
+}
+
+async fn matched_workers(backend: &RedisKvIndexerBackend, hash: &str) -> Vec<String> {
+    backend
+        .do_match(MatchExternalKvRequest {
+            hashes: vec![hash.to_string()],
+            count_as_hit: false,
+        })
+        .await
+        .expect("match")
+        .matches
+        .into_iter()
+        .map(|matched| matched.worker_id)
+        .collect()
+}
+
+async fn reverse_hashes(backend: &RedisKvIndexerBackend, worker: &str) -> Vec<String> {
+    let mut cmd = redis::cmd("SMEMBERS");
+    cmd.arg(worker_blocks_key(&backend.ns, worker));
+    let value = backend.conn.query(cmd).await.expect("read reverse index");
+    Vec::<String>::from_redis_value(&value)
+        .expect("decode reverse index")
+        .into_iter()
+        .map(|member| parse_reverse_member(&member).1.to_string())
+        .collect()
+}
+
+async fn meta_field(backend: &RedisKvIndexerBackend, worker: &str, field: &str) -> Option<String> {
+    let mut cmd = redis::cmd("HGET");
+    cmd.arg(worker_meta_key(&backend.ns, worker)).arg(field);
+    let value = backend.conn.query(cmd).await.expect("read meta field");
+    Option::<String>::from_redis_value(&value).expect("decode meta field")
+}
+
+async fn assert_meta(
+    backend: &RedisKvIndexerBackend,
+    worker: &str,
+    field: &str,
+    expected: Option<&str>,
+) {
+    assert_eq!(
+        meta_field(backend, worker, field).await.as_deref(),
+        expected
+    );
+}
+
+async fn assert_reverse(backend: &RedisKvIndexerBackend, worker: &str, expected: &[&str]) {
+    let actual = reverse_hashes(backend, worker).await;
+    assert_eq!(
+        actual.iter().map(String::as_str).collect::<Vec<_>>(),
+        expected
+    );
+}
+
+async fn apply_ok(backend: &RedisKvIndexerBackend, request: ApplyExternalKvBatchRequest) {
+    backend.apply(request).await.expect("apply");
+}
+
+#[tokio::test]
+async fn report_replay_repairs_missing_reverse_index_after_sadd_failure() {
+    let Some(backend) = backend("report_repair", b"SADD").await else {
+        return;
+    };
+    let request = report("worker-0", 1, "");
+
+    // PLACEMENT_SET commits, then SADD fails.
+    assert!(backend.apply(request.clone()).await.is_err());
+    assert_reverse(&backend, "worker-0", &[]).await;
+
+    // Replay must run SADD although placement is already set.
+    apply_ok(&backend, request).await;
+    assert_reverse(&backend, "worker-0", &["hash-a"]).await;
+
+    apply_ok(
+        &backend,
+        batch("worker-0", 2, ExternalKvActionType::ActionRevoke),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn incarnation_reset_hides_orphan_placement_missing_from_reverse_index() {
+    let Some(backend) = backend("orphan_generation", b"SADD").await else {
+        return;
+    };
+    let worker = "worker-orphan";
+
+    // Generation A writes placement, then the injected reverse SADD fails.
+    assert!(backend.apply(report(worker, 1, "inc-a")).await.is_err());
+    assert_reverse(&backend, worker, &[]).await;
+
+    // Simulate losing the bridge's volatile pending batch. Generation B reset
+    // cannot discover the orphan through reverse, but generation filtering must
+    // still make it permanently unroutable.
+    apply_ok(&backend, heartbeat(worker, "inc-b")).await;
+    assert!(matched_workers(&backend, "hash-a").await.is_empty());
+    assert_meta(&backend, worker, "generation", Some("1")).await;
+}
+
+#[tokio::test]
+async fn retired_incarnation_cannot_roll_current_generation_back() {
+    let Some(backend) = backend("retired_incarnation", b"NEVER").await else {
+        return;
+    };
+    let worker = "worker-fenced";
+    apply_ok(&backend, report(worker, 1, "inc-a")).await;
+    apply_ok(&backend, heartbeat(worker, "inc-b")).await;
+
+    let error = backend
+        .apply(report(worker, 2, "inc-a"))
+        .await
+        .expect_err("retired incarnation must be fenced");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert_meta(&backend, worker, "incarnation", Some("inc-b")).await;
+}
+
+#[tokio::test]
+async fn empty_incarnation_uses_retirable_legacy_token() {
+    let Some(backend) = backend("legacy_incarnation", b"NEVER").await else {
+        return;
+    };
+    let worker = "worker-legacy";
+    apply_ok(&backend, report(worker, 1, "")).await;
+    apply_ok(&backend, heartbeat(worker, "inc-b")).await;
+    let error = backend
+        .apply(report(worker, 2, ""))
+        .await
+        .expect_err("legacy token must be retired");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+}
+
+#[tokio::test]
+async fn in_flight_old_generation_cannot_commit_sequence_after_restart() {
+    let Some(backend) = generation_race_backend("generation_commit_fence").await else {
+        return;
+    };
+    let worker = "worker-race";
+    let error = backend
+        .apply(report(worker, 99, "inc-a"))
+        .await
+        .expect_err("generation change before commit must fence old batch");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert_meta(&backend, worker, "seq", None).await;
+    assert!(
+        matched_workers(&backend, "hash-a").await.is_empty(),
+        "old-generation placement written by the in-flight batch must be filtered"
+    );
+}
+
+#[tokio::test]
+async fn late_concurrent_reset_cannot_delete_current_generation_state() {
+    let Some(backend) = backend("late_reset", b"NEVER").await else {
+        return;
+    };
+    let worker = "worker-reset-race";
+    apply_ok(&backend, report(worker, 9, "inc-a")).await;
+    let meta = worker_meta_key(&backend.ns, worker);
+    let touch = backend
+        .touch_meta(&meta, "", "inc-b")
+        .await
+        .expect("touch generation B");
+    assert!(touch.reset_needed);
+    backend
+        .reset_worker(worker, &meta, touch.generation)
+        .await
+        .expect("first reset");
+    apply_ok(&backend, report(worker, 1, "inc-b")).await;
+
+    // Simulate another resetter that started before the first one finished but
+    // reaches cleanup after current-generation data has already committed.
+    backend
+        .reset_worker(worker, &meta, touch.generation)
+        .await
+        .expect("late reset");
+    assert_eq!(matched_workers(&backend, "hash-a").await, vec![worker]);
+    assert_meta(&backend, worker, "seq", Some("1")).await;
+}
+
+#[tokio::test]
+async fn in_flight_old_placement_mutation_cannot_clobber_new_generation() {
+    let Some(backend) = backend("placement_generation_fence", b"NEVER").await else {
+        return;
+    };
+    let worker = "worker-placement-race";
+    apply_ok(&backend, report(worker, 9, "inc-a")).await;
+    apply_ok(&backend, heartbeat(worker, "inc-b")).await;
+    apply_ok(&backend, report(worker, 1, "inc-b")).await;
+
+    assert!(backend
+        .report_one(
+            worker,
+            "hash-a",
+            tier_bit(crate::pb::TierType::TierHbm as i32),
+            0
+        )
+        .await
+        .is_err());
+    assert!(backend
+        .revoke_one(
+            worker,
+            "hash-a",
+            tier_bit(crate::pb::TierType::TierHbm as i32),
+            0
+        )
+        .await
+        .is_err());
+    assert_eq!(matched_workers(&backend, "hash-a").await, vec![worker]);
+}
+
+#[tokio::test]
+async fn revoke_replay_repairs_stale_reverse_index_after_srem_failure() {
+    let Some(backend) = backend("revoke_repair", b"SREM").await else {
+        return;
+    };
+    apply_ok(&backend, report("worker-0", 1, "")).await;
+
+    let request = batch("worker-0", 2, ExternalKvActionType::ActionRevoke);
+
+    // PLACEMENT_CLEAR commits, then SREM fails.
+    assert!(backend.apply(request.clone()).await.is_err());
+    assert_reverse(&backend, "worker-0", &["hash-a"]).await;
+
+    // Replay sees placement already absent but must retry SREM.
+    apply_ok(&backend, request).await;
+    assert_reverse(&backend, "worker-0", &[]).await;
+}
+
+#[tokio::test]
+async fn restart_reset_retried_after_mid_reset_failure() {
+    // P1 regression: a worker restart bumps the durable incarnation and sets a
+    // `reset_pending` flag BEFORE the (non-atomic) reset runs. If the reset fails
+    // partway, the flag must survive so the next apply retries and finishes it —
+    // otherwise the incarnation already looks current and the stale state sticks.
+    let Some(backend) = backend("reset_retry", b"SREM").await else {
+        return;
+    };
+
+    // Incarnation "A" reports hash-a.
+    apply_ok(&backend, report("worker-0", 1, "A")).await;
+    assert_reverse(&backend, "worker-0", &["hash-a"]).await;
+
+    // Incarnation "B" (a restart): reset_pending is set, but the reverse-index
+    // SREM inside reset_worker fails once, aborting the reset mid-flight.
+    let restart = report("worker-0", 1, "B");
+    assert!(backend.apply(restart.clone()).await.is_err());
+    assert_meta(&backend, "worker-0", "reset_pending", Some("1")).await;
+
+    // Retry: incarnation is already "B" (unchanged), yet the lingering
+    // reset_pending must still drive an idempotent reset to completion.
+    apply_ok(&backend, restart).await;
+    assert_meta(&backend, "worker-0", "reset_pending", None).await;
+    assert_reverse(&backend, "worker-0", &["hash-a"]).await;
+}
+
+#[tokio::test]
+async fn reset_window_hides_worker_from_match_until_reset_completes() {
+    // P1: while a restart reset is pending, the worker's still-present placement
+    // must not be routed to. Fail the reset's very first step (the reverse-index
+    // SSCAN) so the stale placement/reverse entries survive with
+    // reset_pending=1, then assert `match` drops the worker (even with liveness
+    // TTL disabled) until a retry finishes the reset.
+    let Some(backend) = backend("reset_window", b"SSCAN").await else {
+        return;
+    };
+
+    // Incarnation "A" reports hash-a: matchable while healthy.
+    apply_ok(&backend, report("worker-0", 1, "A")).await;
+    assert_eq!(matched_workers(&backend, "hash-a").await, vec!["worker-0"]);
+
+    // Incarnation "B": reset_pending is set, but the SSCAN fails so the reset
+    // never clears the stale placement. The worker must now be hidden from match.
+    let restart = report("worker-0", 1, "B");
+    assert!(backend.apply(restart.clone()).await.is_err());
+    assert_meta(&backend, "worker-0", "reset_pending", Some("1")).await;
+    assert!(
+        matched_workers(&backend, "hash-a").await.is_empty(),
+        "worker with reset_pending must be dropped from match"
+    );
+
+    // Retry completes the reset and re-indexes the fresh report; routable again.
+    apply_ok(&backend, restart).await;
+    assert_meta(&backend, "worker-0", "reset_pending", None).await;
+    assert_eq!(matched_workers(&backend, "hash-a").await, vec!["worker-0"]);
+}
+
+#[tokio::test]
+async fn touch_meta_persists_meta_left_with_ttl_by_old_build() {
+    // P1 (rolling upgrade): an older build set a TTL on the whole meta hash. The
+    // new build must PERSIST it on first contact so `incarnation`/`seq` can no
+    // longer expire (which would silently resurrect stale placements).
+    let Some(backend) = backend("ttl_persist", b"UNUSED-CMD").await else {
+        return;
+    };
+    let worker = "worker-0";
+    let meta = worker_meta_key(&backend.ns, worker);
+
+    // Simulate the legacy meta hash: incarnation + seq, with a TTL on the key.
+    let mut hset = redis::cmd("HSET");
+    hset.arg(&meta)
+        .arg("incarnation")
+        .arg("A")
+        .arg("seq")
+        .arg("3");
+    backend.conn.query(hset).await.expect("seed legacy meta");
+    let mut pexpire = redis::cmd("PEXPIRE");
+    pexpire.arg(&meta).arg(60_000);
+    backend.conn.query(pexpire).await.expect("seed ttl");
+
+    // Any apply from the same incarnation (no reset) must persist the key.
+    apply_ok(&backend, report(worker, 4, "A")).await;
+
+    let mut pttl = redis::cmd("PTTL");
+    pttl.arg(&meta);
+    let v = backend.conn.query(pttl).await.expect("pttl");
+    let ttl = i64::from_redis_value(&v).expect("decode pttl");
+    assert_eq!(
+        ttl, -1,
+        "meta key must be persisted (no TTL) after touch_meta"
+    );
+    assert_meta(&backend, worker, "incarnation", Some("A")).await;
+}

--- a/experimental/sgl-kv-indexer/src/redis_backend/mod.rs
+++ b/experimental/sgl-kv-indexer/src/redis_backend/mod.rs
@@ -1,0 +1,903 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Redis storage backend for the KV indexer.
+//!
+//! Data model (see [`schema`]): placement is a per-block-hash HASH of
+//! `worker -> tier bitmask`; a per-worker SET is the reverse index; a per-worker
+//! durable HASH holds the registry, sequence, incarnation fencing, retired
+//! tokens, and liveness deadline; hit counts live in a per-hash HASH co-located
+//! with placement (and are deleted together with the placement
+//! when a block is fully revoked, so they never outlive the block). All writes
+//! flow through
+//! [`RedisKvIndexerBackend::apply`], which is naturally idempotent (bit set/clear,
+//! SADD/SREM), so a verbatim batch replay (same `seq`) is a no-op and never
+//! double-counts hits (hits are only bumped on match).
+//!
+//! Ordering / idempotency is anchored by a durable per-worker seq stored in the
+//! worker meta hash (`{w:worker}:meta` field `seq`). Each apply first runs a
+//! seq gate: a batch whose seq is `<= last_applied` is skipped as a duplicate;
+//! otherwise the batch is applied and the stored seq is advanced to
+//! `max(last, seq)` *after* the mutations commit. The response carries
+//! `last_applied_seq` so the bridge can resume from the durable position after a
+//! restart. Crash between mutations and the seq advance is safe: the stored seq
+//! stays behind, so the next (idempotent) replay re-applies rather than skips.
+//!
+//! On Cluster an apply batch spans many slots and is therefore not globally
+//! atomic; each block-hash mutation is atomic on its own slot and the batch is
+//! idempotent, so a partial failure is corrected by the bridge replaying the
+//! whole batch under the same seq.
+
+mod conn;
+mod schema;
+mod scripts;
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use futures::future::try_join_all;
+use redis::FromRedisValue;
+use tonic::Status;
+
+use crate::pb::{
+    ApplyExternalKvBatchRequest, ApplyExternalKvBatchResponse, ExternalKvActionType,
+    ExternalKvNodeMatch, GetExternalKvHitCountsRequest, GetExternalKvHitCountsResponse,
+    HitCountEntry, MatchExternalKvRequest, MatchExternalKvResponse, TierHashes,
+};
+use crate::service::KvIndexerBackend;
+
+use conn::{ClusterConn, RedisConn, SingleConn};
+use schema::{
+    hit_key, placement_key, tier_bit, tiers_from_mask, worker_blocks_key, worker_meta_key,
+};
+use scripts::{
+    HIT_BUMP, MATCH_HASH, PLACEMENT_CLEAR, PLACEMENT_CLEAR_WORKER, PLACEMENT_SET, RESET_FINISH,
+    SEQ_CHECK, SEQ_COMMIT, TOUCH_META, WORKER_VIEW,
+};
+
+/// Boxed error for construction paths (env parsing / connect / ping).
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+const DEFAULT_NAMESPACE: &str = "kvidx";
+/// Per-request bound on concurrent Redis operations. Requests may contain more
+/// hashes (up to the service-layer protocol limit), but every read/write path
+/// processes them in sequential chunks so one request cannot create unbounded
+/// in-flight work against Redis.
+const REDIS_FANOUT_CHUNK: usize = 256;
+/// `COUNT` hint for reverse-index `SSCAN` iteration. Sized to match the fanout
+/// chunk so one scanned page turns into one round of concurrent cleanup.
+const REVERSE_SCAN_PAGE: usize = 256;
+
+/// Resolved connection target parsed from the environment.
+enum Target {
+    Single(String),
+    Cluster(Vec<String>),
+}
+
+struct WorkerTouch {
+    reset_needed: bool,
+    generation: i64,
+}
+
+struct ReverseMember {
+    encoded: String,
+    generation: i64,
+    hash: String,
+}
+
+impl ReverseMember {
+    fn parse(encoded: String) -> Self {
+        let (generation, hash) = parse_reverse_member(&encoded);
+        let hash = hash.to_string();
+        Self {
+            generation,
+            hash,
+            encoded,
+        }
+    }
+}
+
+pub struct RedisKvIndexerBackend {
+    conn: Arc<dyn RedisConn>,
+    ns: String,
+    worker_locks: Mutex<HashMap<String, Weak<tokio::sync::Mutex<()>>>>,
+    /// When set, every apply refreshes a separate per-worker liveness key with
+    /// this TTL, and `match` ignores workers whose liveness key has expired.
+    /// The durable meta key never expires. `None` disables liveness filtering.
+    worker_ttl: Option<Duration>,
+}
+
+impl RedisKvIndexerBackend {
+    fn new(conn: Arc<dyn RedisConn>, ns: impl Into<String>) -> Self {
+        Self {
+            conn,
+            ns: ns.into(),
+            worker_locks: Mutex::new(HashMap::new()),
+            worker_ttl: None,
+        }
+    }
+
+    /// Connects to a single Redis/Dragonfly instance.
+    pub async fn connect_single(url: &str, ns: impl Into<String>) -> Result<Self, BoxError> {
+        let conn = SingleConn::connect(url).await?;
+        Ok(Self::new(Arc::new(conn), ns))
+    }
+
+    /// Connects to a Redis Cluster from a list of seed node URLs.
+    pub async fn connect_cluster(
+        nodes: Vec<String>,
+        ns: impl Into<String>,
+    ) -> Result<Self, BoxError> {
+        let conn = ClusterConn::connect(nodes).await?;
+        Ok(Self::new(Arc::new(conn), ns))
+    }
+
+    /// Builds a single-instance backend without connecting: the connection is
+    /// established lazily on first use. Used for degraded startup so the server
+    /// can come up before Redis is reachable and self-heal once it is.
+    pub fn connect_single_deferred(url: &str, ns: impl Into<String>) -> Self {
+        Self::new(Arc::new(SingleConn::deferred(url)), ns)
+    }
+
+    /// Cluster counterpart to [`connect_single_deferred`].
+    pub fn connect_cluster_deferred(nodes: Vec<String>, ns: impl Into<String>) -> Self {
+        Self::new(Arc::new(ClusterConn::deferred(nodes)), ns)
+    }
+
+    /// Sets the per-worker liveness TTL (0 / `None` disables it).
+    pub fn with_worker_ttl(mut self, ttl: Option<Duration>) -> Self {
+        self.worker_ttl = ttl;
+        self
+    }
+
+    /// Builds the backend from the environment:
+    ///   * `KV_INDEXER_REDIS_NAMESPACE` (default `kvidx`)
+    ///   * `KV_INDEXER_REDIS_CLUSTER_NODES` (comma-separated) → Cluster, else
+    ///   * `KV_INDEXER_REDIS_URL` → single instance (required)
+    ///   * `KV_INDEXER_REDIS_REQUIRED` (default `1`): connect + PING on startup
+    ///     and fail fast (bounded, with a clear error) if Redis is unreachable;
+    ///     set `0` to start degraded — the server comes up immediately and the
+    ///     connection is established lazily / retried on demand.
+    ///   * `KV_INDEXER_WORKER_TTL_SECS` (default `120`): per-worker liveness TTL;
+    ///     a worker that stops applying/heartbeating for this long is dropped
+    ///     from `match`. `0` disables liveness (keys never expire).
+    pub async fn from_env() -> Result<Self, BoxError> {
+        let ns = std::env::var("KV_INDEXER_REDIS_NAMESPACE")
+            .unwrap_or_else(|_| DEFAULT_NAMESPACE.into());
+        let required = std::env::var("KV_INDEXER_REDIS_REQUIRED")
+            .map(|v| v != "0")
+            .unwrap_or(true);
+        let worker_ttl = parse_worker_ttl()?;
+
+        let target = if let Ok(nodes) = std::env::var("KV_INDEXER_REDIS_CLUSTER_NODES") {
+            let nodes: Vec<String> = nodes
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect();
+            if nodes.is_empty() {
+                return Err("KV_INDEXER_REDIS_CLUSTER_NODES is empty".into());
+            }
+            Target::Cluster(nodes)
+        } else {
+            let url = std::env::var("KV_INDEXER_REDIS_URL").map_err(|_| {
+                "KV_INDEXER_REDIS_URL (or KV_INDEXER_REDIS_CLUSTER_NODES) is required for the redis backend"
+            })?;
+            Target::Single(url)
+        };
+
+        if required {
+            // Fast, loud startup failure: the connect is bounded by a timeout /
+            // limited retries (see conn.rs), then we PING to confirm readiness.
+            let backend = match target {
+                Target::Cluster(nodes) => Self::connect_cluster(nodes, ns)
+                    .await
+                    .map_err(|e| format!("redis connect failed: {e}"))?,
+                Target::Single(url) => Self::connect_single(&url, ns)
+                    .await
+                    .map_err(|e| format!("redis connect failed: {e}"))?,
+            };
+            backend
+                .ping()
+                .await
+                .map_err(|e| format!("redis readiness probe (PING) failed: {e}"))?;
+            Ok(backend.with_worker_ttl(worker_ttl))
+        } else {
+            // Degraded: do not verify Redis now; start serving immediately and
+            // connect lazily on first use (requests fail with Unavailable until
+            // Redis is reachable, then the manager reconnects automatically).
+            tracing::warn!(
+                "KV_INDEXER_REDIS_REQUIRED=0: starting degraded; Redis not verified at startup"
+            );
+            Ok(match target {
+                Target::Cluster(nodes) => Self::connect_cluster_deferred(nodes, ns),
+                Target::Single(url) => Self::connect_single_deferred(&url, ns),
+            }
+            .with_worker_ttl(worker_ttl))
+        }
+    }
+
+    async fn ping(&self) -> redis::RedisResult<()> {
+        let _: redis::Value = self.conn.query(redis::cmd("PING").clone()).await?;
+        Ok(())
+    }
+
+    fn worker_lock(&self, worker: &str) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.worker_locks.lock().unwrap();
+        if let Some(lock) = locks.get(worker).and_then(Weak::upgrade) {
+            return lock;
+        }
+        if locks.len() >= 1024 {
+            locks.retain(|_, lock| lock.strong_count() > 0);
+        }
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        locks.insert(worker.to_string(), Arc::downgrade(&lock));
+        lock
+    }
+
+    // --- write path ---------------------------------------------------------
+
+    async fn apply(
+        &self,
+        req: ApplyExternalKvBatchRequest,
+    ) -> Result<ApplyExternalKvBatchResponse, Status> {
+        let worker = req.worker_id.as_str();
+        // The bridge is sequential, but request timeout/retry overlap and other
+        // callers can still reach one server concurrently. Serialize a worker's
+        // gate/mutations/commit within this backend process.
+        let worker_lock = self.worker_lock(worker);
+        let _worker_guard = worker_lock.lock().await;
+        let meta_key = worker_meta_key(&self.ns, worker);
+
+        // Every accepted apply proves liveness and checks whether its incarnation
+        // owes a new or previously interrupted reset.
+        let touch = self
+            .touch_meta(&meta_key, &req.worker_address, &req.incarnation)
+            .await?;
+        if touch.reset_needed {
+            // Reset is idempotent; reset_pending clears only after full success.
+            self.reset_worker(worker, &meta_key, touch.generation)
+                .await?;
+        }
+
+        // An empty-actions batch is a pure heartbeat: liveness was just
+        // refreshed; report the current durable seq and return.
+        if req.actions.is_empty() {
+            let stored = self.read_worker_seq(&meta_key).await?;
+            return Ok(ApplyExternalKvBatchResponse {
+                last_applied_seq: stored.max(0) as u64,
+                duplicate: false,
+                has_applied_seq: stored >= 0,
+            });
+        }
+
+        // Durable idempotency gate: skip a batch whose seq was already applied.
+        // `last == -1` means the worker has no stored seq yet (accept any start).
+        let gate = self
+            .conn
+            .invoke(
+                &SEQ_CHECK,
+                vec![meta_key.clone()],
+                vec![req.seq.to_string(), touch.generation.to_string()],
+            )
+            .await
+            .map_err(to_status)?;
+        let (gate_status, last) = script_pair(&gate)?;
+        require_current(
+            gate_status,
+            "worker incarnation changed while applying batch",
+        )?;
+        let proceed = gate_status == 1;
+        if !proceed {
+            return Ok(ApplyExternalKvBatchResponse {
+                last_applied_seq: last.max(0) as u64,
+                duplicate: true,
+                has_applied_seq: last >= 0,
+            });
+        }
+
+        for action in &req.actions {
+            let bit = tier_bit(action.tier);
+            match ExternalKvActionType::try_from(action.r#type) {
+                Ok(ExternalKvActionType::ActionReport) => {
+                    for chunk in action.hashes.chunks(REDIS_FANOUT_CHUNK) {
+                        try_join_all(
+                            chunk
+                                .iter()
+                                .map(|hash| self.report_one(worker, hash, bit, touch.generation)),
+                        )
+                        .await?;
+                    }
+                }
+                Ok(ExternalKvActionType::ActionRevoke) => {
+                    self.revoke_many(worker, &action.hashes, bit, touch.generation)
+                        .await?;
+                }
+                Ok(ExternalKvActionType::ActionClearAllAtTier) => {
+                    self.clear_all_at_tier(worker, bit, touch.generation)
+                        .await?;
+                }
+                _ => return Err(Status::invalid_argument("unsupported action type")),
+            }
+        }
+
+        // Commit seq last so replay repairs a crash after partial mutations.
+        let committed = self
+            .conn
+            .invoke(
+                &SEQ_COMMIT,
+                vec![meta_key],
+                vec![req.seq.to_string(), touch.generation.to_string()],
+            )
+            .await
+            .map_err(to_status)?;
+        let (status, committed) = script_pair(&committed)?;
+        require_current(status, "worker incarnation changed while applying batch")?;
+        Ok(ApplyExternalKvBatchResponse {
+            last_applied_seq: committed.max(0) as u64,
+            duplicate: false,
+            has_applied_seq: committed >= 0,
+        })
+    }
+
+    /// Refreshes liveness and records address/incarnation. The returned generation
+    /// fences mutations; `reset_needed` also survives interrupted resets.
+    async fn touch_meta(
+        &self,
+        meta_key: &str,
+        addr: &str,
+        incarnation: &str,
+    ) -> Result<WorkerTouch, Status> {
+        let ttl_ms = self.worker_ttl.map(|d| d.as_millis() as u64).unwrap_or(0);
+        // Empty incarnation is retained for wire compatibility but participates
+        // in fencing as one stable legacy token.
+        let incarnation = if incarnation.is_empty() {
+            "__legacy__"
+        } else {
+            incarnation
+        };
+        let v = self
+            .conn
+            .invoke(
+                &TOUCH_META,
+                vec![meta_key.to_string()],
+                vec![
+                    now_ms().to_string(),
+                    ttl_ms.to_string(),
+                    addr.to_string(),
+                    incarnation.to_string(),
+                ],
+            )
+            .await
+            .map_err(to_status)?;
+        let (status, generation) = script_pair(&v)?;
+        if status < 0 {
+            return Err(Status::failed_precondition(format!(
+                "worker incarnation has been retired: {incarnation}"
+            )));
+        }
+        Ok(WorkerTouch {
+            reset_needed: status == 1,
+            generation,
+        })
+    }
+
+    /// Removes older-generation state, then atomically opens the current
+    /// generation. All cleanup steps are idempotent.
+    async fn reset_worker(
+        &self,
+        worker: &str,
+        meta_key: &str,
+        generation: i64,
+    ) -> Result<(), Status> {
+        let mut cursor = 0;
+        loop {
+            let (next, page) = self.reverse_page(worker, cursor).await?;
+            let stale: Vec<ReverseMember> = page
+                .into_iter()
+                .filter(|member| member.generation < generation)
+                .collect();
+            for chunk in stale.chunks(REDIS_FANOUT_CHUNK) {
+                try_join_all(chunk.iter().map(|member| {
+                    self.clear_old_reverse_member(worker, &member.encoded, &member.hash, generation)
+                }))
+                .await?;
+            }
+            cursor = next;
+            if cursor == 0 {
+                break;
+            }
+        }
+
+        // Finish exactly once. A concurrent resetter arriving after another
+        // request has already opened the generation must not delete its seq.
+        let v = self
+            .conn
+            .invoke(
+                &RESET_FINISH,
+                vec![meta_key.to_string()],
+                vec![generation.to_string()],
+            )
+            .await
+            .map_err(to_status)?;
+        require_current(
+            i64::from_redis_value(&v).map_err(to_status)?,
+            "worker generation changed while resetting",
+        )?;
+        Ok(())
+    }
+
+    async fn clear_old_reverse_member(
+        &self,
+        worker: &str,
+        member: &str,
+        hash: &str,
+        generation: i64,
+    ) -> Result<(), Status> {
+        let v = self
+            .conn
+            .invoke(
+                &PLACEMENT_CLEAR_WORKER,
+                vec![placement_key(&self.ns, hash), hit_key(&self.ns, hash)],
+                vec![worker.to_string(), generation.to_string()],
+            )
+            .await
+            .map_err(to_status)?;
+        let _: i64 = i64::from_redis_value(&v).map_err(to_status)?;
+        let mut srem = redis::cmd("SREM");
+        srem.arg(worker_blocks_key(&self.ns, worker)).arg(member);
+        self.conn.query(srem).await.map_err(to_status)?;
+        Ok(())
+    }
+
+    /// Reads one `SSCAN` page of a worker's reverse index, returning the next
+    /// cursor (`0` once the iteration is complete) alongside the members.
+    ///
+    /// `SMEMBERS` would occupy Redis for the whole set and materialize it in a
+    /// single reply, and a worker legitimately owns as many blocks as its cache
+    /// holds. Scanning may return a member more than once and may miss members
+    /// added or removed mid-iteration; both callers are idempotent and only act
+    /// on generations that are already settled, so neither matters here.
+    async fn reverse_page(
+        &self,
+        worker: &str,
+        cursor: u64,
+    ) -> Result<(u64, Vec<ReverseMember>), Status> {
+        let mut cmd = redis::cmd("SSCAN");
+        cmd.arg(worker_blocks_key(&self.ns, worker))
+            .arg(cursor)
+            .arg("COUNT")
+            .arg(REVERSE_SCAN_PAGE);
+        let value = self.conn.query(cmd).await.map_err(to_status)?;
+        let (next, members) = <(u64, Vec<String>)>::from_redis_value(&value).map_err(to_status)?;
+        Ok((
+            next,
+            members.into_iter().map(ReverseMember::parse).collect(),
+        ))
+    }
+
+    /// Reads the worker's durable seq (`-1` when none has been stored yet).
+    async fn read_worker_seq(&self, meta_key: &str) -> Result<i64, Status> {
+        let mut cmd = redis::cmd("HGET");
+        cmd.arg(meta_key).arg("seq");
+        let v = self.conn.query(cmd).await.map_err(to_status)?;
+        Ok(Option::<i64>::from_redis_value(&v)
+            .map_err(to_status)?
+            .unwrap_or(-1))
+    }
+
+    async fn report_one(
+        &self,
+        worker: &str,
+        hash: &str,
+        bit: i64,
+        generation: i64,
+    ) -> Result<(), Status> {
+        let v = self
+            .conn
+            .invoke(
+                &PLACEMENT_SET,
+                vec![placement_key(&self.ns, hash)],
+                vec![worker.to_string(), bit.to_string(), generation.to_string()],
+            )
+            .await
+            .map_err(to_status)?;
+        require_current(
+            i64::from_redis_value(&v).map_err(to_status)?,
+            "newer worker generation already owns placement",
+        )?;
+
+        // Always reassert reverse state so replay repairs a failed prior SADD.
+        let mut cmd = redis::cmd("SADD");
+        cmd.arg(worker_blocks_key(&self.ns, worker))
+            .arg(reverse_member(generation, hash));
+        self.conn.query(cmd).await.map_err(to_status)?;
+        Ok(())
+    }
+
+    async fn revoke_many(
+        &self,
+        worker: &str,
+        hashes: &[String],
+        bit: i64,
+        generation: i64,
+    ) -> Result<(), Status> {
+        for chunk in hashes.chunks(REDIS_FANOUT_CHUNK) {
+            try_join_all(
+                chunk
+                    .iter()
+                    .map(|hash| self.revoke_one(worker, hash, bit, generation)),
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn revoke_one(
+        &self,
+        worker: &str,
+        hash: &str,
+        bit: i64,
+        generation: i64,
+    ) -> Result<(), Status> {
+        // Placement and hit keys share a slot; the script drops hits when the
+        // final placement disappears.
+        let v = self
+            .conn
+            .invoke(
+                &PLACEMENT_CLEAR,
+                vec![placement_key(&self.ns, hash), hit_key(&self.ns, hash)],
+                vec![worker.to_string(), bit.to_string(), generation.to_string()],
+            )
+            .await
+            .map_err(to_status)?;
+        let (status, _) = script_pair(&v)?;
+        require_current(status, "newer worker generation already owns placement")?;
+        let worker_gone = status == 1;
+        if worker_gone {
+            let mut cmd = redis::cmd("SREM");
+            cmd.arg(worker_blocks_key(&self.ns, worker))
+                .arg(reverse_member(generation, hash));
+            if generation == 0 {
+                cmd.arg(hash);
+            }
+            self.conn.query(cmd).await.map_err(to_status)?;
+        }
+        Ok(())
+    }
+
+    async fn clear_all_at_tier(
+        &self,
+        worker: &str,
+        bit: i64,
+        generation: i64,
+    ) -> Result<(), Status> {
+        let mut cursor = 0;
+        loop {
+            let (next, page) = self.reverse_page(worker, cursor).await?;
+            let hashes: Vec<String> = page
+                .into_iter()
+                .filter_map(|member| (member.generation == generation).then_some(member.hash))
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+            self.revoke_many(worker, &hashes, bit, generation).await?;
+            cursor = next;
+            if cursor == 0 {
+                return Ok(());
+            }
+        }
+    }
+
+    // --- read path ----------------------------------------------------------
+
+    async fn do_match(
+        &self,
+        req: MatchExternalKvRequest,
+    ) -> Result<MatchExternalKvResponse, Status> {
+        let hashes = dedup_preserve_order(&req.hashes);
+
+        // Per-hash placement read, preserving hash order. Hit counting happens
+        // after worker liveness and generation have been validated.
+        let mut per_hash = Vec::with_capacity(hashes.len());
+        for chunk in hashes.chunks(REDIS_FANOUT_CHUNK) {
+            let values = try_join_all(chunk.iter().map(|hash| async move {
+                let v = self
+                    .conn
+                    .invoke(&MATCH_HASH, vec![placement_key(&self.ns, hash)], Vec::new())
+                    .await?;
+                let flat: Vec<String> = Vec::<String>::from_redis_value(&v)?;
+                Ok::<_, redis::RedisError>(flat)
+            }))
+            .await
+            .map_err(to_status)?;
+            per_hash.extend(values);
+        }
+
+        // Keep the placement generation alongside each candidate. Legacy
+        // numeric values are generation zero.
+        let mut worker_order: Vec<String> = Vec::new();
+        let mut by_worker: HashMap<String, Vec<(String, i64, i64)>> = HashMap::new();
+        for (hash, flat) in hashes.iter().zip(per_hash) {
+            for pair in flat.chunks(2) {
+                if pair.len() != 2 {
+                    continue;
+                }
+                let worker = &pair[0];
+                let (generation, mask) = parse_placement_value(&pair[1]);
+                let entry = by_worker.entry(worker.clone()).or_insert_with(|| {
+                    worker_order.push(worker.clone());
+                    Vec::new()
+                });
+                entry.push((hash.clone(), generation, mask));
+            }
+        }
+
+        // Fetch each matched worker's `addr` (for routing) and liveness. The
+        // durable meta hash stores `live_until_ms`; stale workers are dropped so
+        // `match` never routes to a dead node while placement entries linger.
+        let ttl_flag = if self.worker_ttl.is_some() { "1" } else { "0" };
+        let view_now_ms = now_ms().to_string();
+        let mut metas = Vec::with_capacity(worker_order.len());
+        for chunk in worker_order.chunks(REDIS_FANOUT_CHUNK) {
+            let values = try_join_all(chunk.iter().map(|worker| {
+                let view_now_ms = view_now_ms.clone();
+                async move {
+                    let v = self
+                        .conn
+                        .invoke(
+                            &WORKER_VIEW,
+                            vec![worker_meta_key(&self.ns, worker)],
+                            vec![view_now_ms, ttl_flag.to_string()],
+                        )
+                        .await?;
+                    let (addr, alive, generation): (String, i64, i64) =
+                        <(String, i64, i64)>::from_redis_value(&v)?;
+                    Ok::<_, redis::RedisError>((addr, alive == 1, generation))
+                }
+            }))
+            .await
+            .map_err(to_status)?;
+            metas.extend(values);
+        }
+
+        let mut matches = Vec::new();
+        let mut matched_hashes: HashMap<String, Vec<(String, i64)>> = HashMap::new();
+        for (worker, (address, alive, current_generation)) in worker_order.into_iter().zip(metas) {
+            if !alive {
+                continue;
+            }
+            let mut by_tier: BTreeMap<i32, Vec<String>> = BTreeMap::new();
+            for (hash, generation, mask) in by_worker.remove(&worker).unwrap_or_default() {
+                if generation != current_generation {
+                    continue;
+                }
+                for tier in tiers_from_mask(mask) {
+                    by_tier.entry(tier).or_default().push(hash.clone());
+                }
+                matched_hashes
+                    .entry(hash)
+                    .or_default()
+                    .push((worker.clone(), current_generation));
+            }
+            if by_tier.is_empty() {
+                continue;
+            }
+            matches.push(ExternalKvNodeMatch {
+                worker_id: worker,
+                address,
+                hashes_by_tier: by_tier
+                    .into_iter()
+                    .map(|(tier, hashes)| TierHashes { tier, hashes })
+                    .collect(),
+            });
+        }
+
+        if req.count_as_hit {
+            let matched_hashes: Vec<(String, Vec<(String, i64)>)> =
+                matched_hashes.into_iter().collect();
+            let now = now_ms().to_string();
+            for chunk in matched_hashes.chunks(REDIS_FANOUT_CHUNK) {
+                try_join_all(chunk.iter().map(|(hash, owners)| {
+                    let mut args = Vec::with_capacity(1 + owners.len() * 2);
+                    args.push(now.clone());
+                    for (worker, generation) in owners {
+                        args.push(worker.clone());
+                        args.push(generation.to_string());
+                    }
+                    self.conn.invoke(
+                        &HIT_BUMP,
+                        vec![placement_key(&self.ns, hash), hit_key(&self.ns, hash)],
+                        args,
+                    )
+                }))
+                .await
+                .map_err(to_status)?;
+            }
+        }
+
+        Ok(MatchExternalKvResponse { matches })
+    }
+
+    async fn do_hit_counts(
+        &self,
+        req: GetExternalKvHitCountsRequest,
+    ) -> Result<GetExternalKvHitCountsResponse, Status> {
+        let hashes = dedup_preserve_order(&req.hashes);
+        let mut counts = Vec::with_capacity(hashes.len());
+        for chunk in hashes.chunks(REDIS_FANOUT_CHUNK) {
+            let values = try_join_all(chunk.iter().map(|hash| async move {
+                let mut cmd = redis::cmd("HGET");
+                cmd.arg(hit_key(&self.ns, hash)).arg("c");
+                let v = self.conn.query(cmd).await?;
+                let count: Option<i64> = Option::<i64>::from_redis_value(&v)?;
+                Ok::<_, redis::RedisError>(count)
+            }))
+            .await
+            .map_err(to_status)?;
+            counts.extend(values);
+        }
+
+        let entries = hashes
+            .into_iter()
+            .zip(counts)
+            .filter_map(|(hash, count)| {
+                count.map(|c| HitCountEntry {
+                    hash,
+                    hit_count_total: c.max(0) as u64,
+                })
+            })
+            .collect();
+        Ok(GetExternalKvHitCountsResponse { entries })
+    }
+}
+
+#[tonic::async_trait]
+impl KvIndexerBackend for RedisKvIndexerBackend {
+    async fn apply_external_kv_batch(
+        &self,
+        request: ApplyExternalKvBatchRequest,
+    ) -> Result<ApplyExternalKvBatchResponse, Status> {
+        self.apply(request).await
+    }
+
+    async fn match_external_kv(
+        &self,
+        request: MatchExternalKvRequest,
+    ) -> Result<MatchExternalKvResponse, Status> {
+        self.do_match(request).await
+    }
+
+    async fn get_external_kv_hit_counts(
+        &self,
+        request: GetExternalKvHitCountsRequest,
+    ) -> Result<GetExternalKvHitCountsResponse, Status> {
+        self.do_hit_counts(request).await
+    }
+
+    /// Ready only when Redis answers a PING (covers degraded/lazy-connect starts
+    /// and transient store outages).
+    async fn health(&self) -> bool {
+        self.ping().await.is_ok()
+    }
+}
+
+fn dedup_preserve_order(hashes: &[String]) -> Vec<String> {
+    let mut seen = HashSet::new();
+    hashes
+        .iter()
+        .filter(|h| seen.insert(h.as_str().to_string()))
+        .cloned()
+        .collect()
+}
+
+fn script_pair(value: &redis::Value) -> Result<(i64, i64), Status> {
+    let values = Vec::<i64>::from_redis_value(value).map_err(to_status)?;
+    values
+        .first()
+        .zip(values.get(1))
+        .map(|(&first, &second)| (first, second))
+        .ok_or_else(|| Status::internal("invalid Redis script response"))
+}
+
+fn require_current(status: i64, message: &'static str) -> Result<(), Status> {
+    (status >= 0)
+        .then_some(())
+        .ok_or_else(|| Status::failed_precondition(message))
+}
+
+fn parse_placement_value(value: &str) -> (i64, i64) {
+    match value.split_once(':') {
+        Some((generation, mask)) => (generation.parse().unwrap_or(0), mask.parse().unwrap_or(0)),
+        None => (0, value.parse().unwrap_or(0)),
+    }
+}
+
+fn reverse_member(generation: i64, hash: &str) -> String {
+    format!("{generation}:{hash}")
+}
+
+fn parse_reverse_member(member: &str) -> (i64, &str) {
+    match member.split_once(':') {
+        Some((generation, hash)) => match generation.parse() {
+            Ok(generation) => (generation, hash),
+            Err(_) => (0, member),
+        },
+        None => (0, member),
+    }
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn to_status(err: redis::RedisError) -> Status {
+    Status::unavailable(format!("redis backend error: {err}"))
+}
+
+/// Parses `KV_INDEXER_WORKER_TTL_SECS` (default `120`; `0` disables liveness).
+fn parse_worker_ttl() -> Result<Option<Duration>, BoxError> {
+    const DEFAULT_WORKER_TTL_SECS: u64 = 120;
+    let secs = match std::env::var("KV_INDEXER_WORKER_TTL_SECS") {
+        Ok(v) => v.trim().parse::<u64>().map_err(|_| {
+            format!("KV_INDEXER_WORKER_TTL_SECS must be a non-negative integer, got {v:?}")
+        })?,
+        Err(_) => DEFAULT_WORKER_TTL_SECS,
+    };
+    Ok((secs > 0).then(|| Duration::from_secs(secs)))
+}
+
+#[cfg(test)]
+mod fault_tests;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_preserves_first_seen_order() {
+        let input = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "a".to_string(),
+            "c".to_string(),
+            "b".to_string(),
+        ];
+        assert_eq!(dedup_preserve_order(&input), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn placement_value_parser_is_backward_compatible() {
+        assert_eq!(parse_placement_value("6"), (0, 6));
+        assert_eq!(parse_placement_value("3:10"), (3, 10));
+        assert_eq!(parse_placement_value("bad"), (0, 0));
+    }
+
+    #[test]
+    fn reverse_member_parser_is_backward_compatible() {
+        assert_eq!(parse_reverse_member("hash-a"), (0, "hash-a"));
+        assert_eq!(parse_reverse_member("legacy:hash"), (0, "legacy:hash"));
+        assert_eq!(parse_reverse_member("3:hash-a"), (3, "hash-a"));
+        assert_eq!(reverse_member(3, "hash-a"), "3:hash-a");
+    }
+
+    #[test]
+    fn worker_lock_is_shared_while_active_and_prunes_inactive_entries() {
+        let backend = RedisKvIndexerBackend::connect_single_deferred("redis://127.0.0.1:1", "test");
+        let first = backend.worker_lock("worker-a");
+        let same = backend.worker_lock("worker-a");
+        assert!(Arc::ptr_eq(&first, &same));
+        drop(first);
+        drop(same);
+
+        for index in 0..1100 {
+            drop(backend.worker_lock(&format!("worker-{index}")));
+        }
+        assert!(backend.worker_locks.lock().unwrap().len() < 1024);
+    }
+}

--- a/experimental/sgl-kv-indexer/src/redis_backend/schema.rs
+++ b/experimental/sgl-kv-indexer/src/redis_backend/schema.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Redis key schema and tier-bitmask helpers.
+//!
+//! Two hash-tag families keep related keys in one cluster slot:
+//!   * `{<hash>}`      — placement (`:p`) and hit (`:h`) for a block hash, so a
+//!     match can read placement and bump the hit counter in one single-slot Lua.
+//!   * `{w:<worker>}`  — the worker's reverse index (`:blocks`) and registry
+//!     (`:meta`), so per-worker mutations stay in one slot.
+//!
+//! A tier is stored as a bit in a per-`(hash, worker)` bitmask: `bit = 1 << tier`
+//! (TierType HBM=1, DRAM=2, SSD=3). The bitmask is manipulated with plain integer
+//! arithmetic in Lua so the scripts run unchanged on Redis, Dragonfly and Valkey.
+
+/// Placement key for a block hash: HASH of
+/// `worker_id -> "<generation>:<tier bitmask>"`.
+pub fn placement_key(ns: &str, hash: &str) -> String {
+    format!("{ns}:{{{hash}}}:p")
+}
+
+/// Hit key for a block hash: HASH with fields `c` (count) and `ls` (last_seen ms).
+pub fn hit_key(ns: &str, hash: &str) -> String {
+    format!("{ns}:{{{hash}}}:h")
+}
+
+/// Reverse index for a worker: SET of `"<generation>:<hash>"` members. Legacy
+/// plain hash members are generation zero.
+pub fn worker_blocks_key(ns: &str, worker_id: &str) -> String {
+    format!("{ns}:{{w:{worker_id}}}:blocks")
+}
+
+/// Durable registry for a worker: HASH with fields `addr`, `seq`,
+/// `incarnation`, `generation`, `reset_pending`, `live_until_ms`, and
+/// `retired:<incarnation>`. Never expires. Keeping worker metadata in one key
+/// lets heartbeat Lua remain valid during Redis Cluster slot migration.
+pub fn worker_meta_key(ns: &str, worker_id: &str) -> String {
+    format!("{ns}:{{w:{worker_id}}}:meta")
+}
+
+/// The bit representing a tier in a placement bitmask.
+pub fn tier_bit(tier: i32) -> i64 {
+    1i64 << tier
+}
+
+/// Decodes the tiers present in a placement bitmask, ascending. Only valid tiers
+/// (HBM=1, DRAM=2, SSD=3) are considered.
+pub fn tiers_from_mask(mask: i64) -> Vec<i32> {
+    (1..=3).filter(|t| mask & (1i64 << t) != 0).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_share_hash_tag_across_placement_and_hit() {
+        assert_eq!(placement_key("kvidx", "123"), "kvidx:{123}:p");
+        assert_eq!(hit_key("kvidx", "123"), "kvidx:{123}:h");
+    }
+
+    #[test]
+    fn worker_keys_share_worker_tag() {
+        assert_eq!(worker_blocks_key("kvidx", "w1"), "kvidx:{w:w1}:blocks");
+        assert_eq!(worker_meta_key("kvidx", "w1"), "kvidx:{w:w1}:meta");
+    }
+
+    #[test]
+    fn tier_bit_matches_shift() {
+        assert_eq!(tier_bit(1), 2);
+        assert_eq!(tier_bit(2), 4);
+        assert_eq!(tier_bit(3), 8);
+    }
+
+    #[test]
+    fn mask_round_trips_through_tiers() {
+        assert_eq!(tiers_from_mask(0), Vec::<i32>::new());
+        assert_eq!(tiers_from_mask(tier_bit(1)), vec![1]);
+        assert_eq!(tiers_from_mask(tier_bit(1) | tier_bit(3)), vec![1, 3]);
+        assert_eq!(
+            tiers_from_mask(tier_bit(1) | tier_bit(2) | tier_bit(3)),
+            vec![1, 2, 3]
+        );
+    }
+}

--- a/experimental/sgl-kv-indexer/src/redis_backend/scripts.rs
+++ b/experimental/sgl-kv-indexer/src/redis_backend/scripts.rs
@@ -1,0 +1,366 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lua scripts. Every script declares all keys it touches in `KEYS[]` and all
+//! keys share one hash tag, so each script runs in a single cluster slot (legal
+//! and atomic on Redis Cluster) and, on Dragonfly, runs per-slot in parallel
+//! without needing `allow-undeclared-keys`. Bitmasks are manipulated with plain
+//! arithmetic (no `bit`/bitop library) for cross-engine portability.
+
+use std::sync::LazyLock;
+
+use redis::Script;
+
+/// Script code plus redis-rs' cached-SHA invocation helper.
+///
+/// Cluster connections use `code` with EVAL so ASK redirects do not depend on
+/// the importing node already having the SHA cached.
+pub struct RedisScript {
+    pub code: &'static str,
+    inner: Script,
+}
+
+impl RedisScript {
+    fn new(code: &'static str) -> Self {
+        Self {
+            code,
+            inner: Script::new(code),
+        }
+    }
+}
+
+impl std::ops::Deref for RedisScript {
+    type Target = Script;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Refreshes a worker's liveness, records its address/incarnation in the durable
+/// meta hash, and reports whether a restart reset is owed.
+///
+/// KEYS: `[worker_meta_key]`
+/// ARGV: `[now_ms, ttl_ms, addr, incarnation]`
+///
+/// The durable meta hash (`seq`, `incarnation`, `addr`, `reset_pending`) never
+/// expires. Liveness is a `live_until_ms` field; retired incarnations are
+/// `retired:<token>` fields in the same hash. Keeping this operation single-key
+/// is required for ASK redirects during Redis Cluster slot migration.
+/// `PERSIST`s the meta key so that a meta left with a TTL by an older build (which
+/// used to expire the whole hash) is made durable on first contact — otherwise it
+/// could still expire and lose `incarnation`, resurrecting a restarted worker's
+/// stale placements. When `incarnation` is non-empty and *differs* from the
+/// stored one (a restart), the new value is stored and a durable `reset_pending`
+/// flag is set so the caller wipes the previous incarnation's state. The old
+/// token is retained as a field in the durable hash; a later request carrying a
+/// retired token returns status `-1` and cannot roll the incarnation backwards.
+/// Returns `{status, generation}` where status is `-1` for a retired token, `1`
+/// when reset is pending, and `0` otherwise. Generation starts at zero and is
+/// incremented on every accepted incarnation change.
+pub static TOUCH_META: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+redis.call('PERSIST', KEYS[1])
+local generation = tonumber(redis.call('HGET', KEYS[1], 'generation')) or 0
+if ARGV[4] ~= '' then
+  local prev = redis.call('HGET', KEYS[1], 'incarnation')
+  if not prev then
+    redis.call('HSET', KEYS[1], 'incarnation', ARGV[4], 'generation', generation)
+  elseif prev ~= ARGV[4] then
+    if redis.call('HEXISTS', KEYS[1], 'retired:' .. ARGV[4]) == 1 then
+      return {-1, generation}
+    end
+    redis.call('HSET', KEYS[1], 'retired:' .. prev, '1')
+    generation = redis.call('HINCRBY', KEYS[1], 'generation', 1)
+    redis.call('HSET', KEYS[1], 'incarnation', ARGV[4])
+    redis.call('HSET', KEYS[1], 'reset_pending', '1')
+  end
+end
+if ARGV[3] ~= '' then
+  redis.call('HSET', KEYS[1], 'addr', ARGV[3])
+end
+if tonumber(ARGV[2]) > 0 then
+  redis.call('HSET', KEYS[1], 'live_until_ms', tonumber(ARGV[1]) + tonumber(ARGV[2]))
+else
+  redis.call('HDEL', KEYS[1], 'live_until_ms')
+end
+if redis.call('HGET', KEYS[1], 'reset_pending') == '1' then
+  return {1, generation}
+end
+return {0, generation}
+"#,
+    )
+});
+
+/// Reads a worker's routing address and liveness for `match`.
+///
+/// KEYS: `[worker_meta_key]`
+/// ARGV: `[now_ms, ttl_enabled ("0"|"1")]`
+/// Returns `{addr, alive, generation}`.
+/// `alive` is `0` when a restart reset is still pending (`reset_pending=1`) — the
+/// worker's placement is being wiped and must not be routed to, regardless of the
+/// TTL setting — or, when liveness is enabled, when `live_until_ms` is in the
+/// past (the worker stopped applying/heartbeating). Otherwise `1`.
+pub static WORKER_VIEW: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+local addr = redis.call('HGET', KEYS[1], 'addr')
+if not addr then addr = '' end
+local generation = tonumber(redis.call('HGET', KEYS[1], 'generation')) or 0
+if redis.call('HGET', KEYS[1], 'reset_pending') == '1' then
+  return {addr, 0, generation}
+end
+local alive = 1
+if ARGV[2] == '1' then
+  local live_until_ms = tonumber(redis.call('HGET', KEYS[1], 'live_until_ms')) or 0
+  if live_until_ms < tonumber(ARGV[1]) then alive = 0 end
+end
+return {addr, alive, generation}
+"#,
+    )
+});
+
+/// Removes a worker from a placement hash only when the stored generation is
+/// older than the current reset generation.
+///
+/// KEYS: `[placement_key, hit_key]`
+/// ARGV: `[worker_id, current_generation]`
+/// Deletes the co-located hit key when the placement hash becomes empty, mirror-
+/// ing [`PLACEMENT_CLEAR`] so an evicted block cannot leak its `:h` key.
+pub static PLACEMENT_CLEAR_WORKER: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+local raw = redis.call('HGET', KEYS[1], ARGV[1])
+if raw then
+  local stored_generation = 0
+  local sep = string.find(raw, ':', 1, true)
+  if sep then
+    stored_generation = tonumber(string.sub(raw, 1, sep - 1)) or 0
+  end
+  if stored_generation < tonumber(ARGV[2]) then
+    redis.call('HDEL', KEYS[1], ARGV[1])
+  end
+end
+if redis.call('HLEN', KEYS[1]) == 0 then
+  redis.call('DEL', KEYS[1])
+  redis.call('DEL', KEYS[2])
+end
+return 1
+"#,
+    )
+});
+
+/// Idempotency gate for a worker's apply batch, keyed on the monotonic per-worker
+/// seq stored in the worker meta hash (`{w:worker}:meta` field `seq`).
+///
+/// KEYS: `[worker_meta_key]`
+/// ARGV: `[seq, expected_generation]`
+/// Returns `{proceed, last}`: `proceed=-1` if the worker generation changed
+/// after TOUCH_META, `0` for a duplicate, and `1` otherwise.
+pub static SEQ_CHECK: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+local last = redis.call('HGET', KEYS[1], 'seq')
+local generation = tonumber(redis.call('HGET', KEYS[1], 'generation')) or 0
+if generation ~= tonumber(ARGV[2]) then
+  return {-1, last or '-1'}
+end
+if last ~= false and tonumber(ARGV[1]) <= tonumber(last) then
+  return {0, last}
+end
+if last == false then
+  return {1, '-1'}
+end
+return {1, last}
+"#,
+    )
+});
+
+/// Monotonically advances a worker's stored seq after its batch is applied.
+///
+/// KEYS: `[worker_meta_key]`
+/// ARGV: `[seq, expected_generation]`
+/// Returns `{status, last}` where status is `-1` if generation changed during
+/// the batch and `1` otherwise. Sets `seq` to `max(stored, seq)`. Run only on
+/// the apply path (never for a duplicate), and only after the batch mutations
+/// have committed, so a crash between mutations and this call simply leaves the
+/// stored seq behind and the next (idempotent) replay repairs it.
+pub static SEQ_COMMIT: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+local last = redis.call('HGET', KEYS[1], 'seq')
+local generation = tonumber(redis.call('HGET', KEYS[1], 'generation')) or 0
+if generation ~= tonumber(ARGV[2]) then
+  return {-1, last or '-1'}
+end
+if last == false or tonumber(ARGV[1]) > tonumber(last) then
+  redis.call('HSET', KEYS[1], 'seq', ARGV[1])
+  return {1, ARGV[1]}
+end
+return {1, last}
+"#,
+    )
+});
+
+/// Finishes a generation reset exactly once. Concurrent resetters may clean the
+/// same old entries, but only the first one that still observes reset_pending
+/// removes the old seq and opens the generation for applies.
+///
+/// KEYS: `[worker_meta_key]`
+/// ARGV: `[expected_generation]`
+pub static RESET_FINISH: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+local generation = tonumber(redis.call('HGET', KEYS[1], 'generation')) or 0
+if generation ~= tonumber(ARGV[1]) then return -1 end
+if redis.call('HGET', KEYS[1], 'reset_pending') ~= '1' then return 0 end
+redis.call('HDEL', KEYS[1], 'seq')
+redis.call('HDEL', KEYS[1], 'reset_pending')
+return 1
+"#,
+    )
+});
+
+/// Sets a tier bit for a worker in a placement hash.
+///
+/// KEYS: `[placement_key]`
+/// ARGV: `[worker_id, bit, generation]`
+/// Returns `-1` if a newer generation owns the field, `1` if the placement
+/// changed, else `0`. The caller always performs
+/// the idempotent reverse-index `SADD`, even when this script returns `0`, so a
+/// replay repairs a prior failure between the two index updates.
+pub static PLACEMENT_SET: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+local raw = redis.call('HGET', KEYS[1], ARGV[1])
+local cur = 0
+local stored_generation = 0
+if raw then
+  local sep = string.find(raw, ':', 1, true)
+  if sep then
+    stored_generation = tonumber(string.sub(raw, 1, sep - 1)) or 0
+    cur = tonumber(string.sub(raw, sep + 1)) or 0
+  else
+    cur = tonumber(raw) or 0
+  end
+end
+local generation = tonumber(ARGV[3])
+if stored_generation > generation then return -1 end
+if stored_generation < generation then cur = 0 end
+local bit = tonumber(ARGV[2])
+if math.floor(cur / bit) % 2 == 1 then
+  return 0
+end
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[3] .. ':' .. (cur + bit))
+return 1
+"#,
+    )
+});
+
+/// Clears a tier bit for a worker in a placement hash.
+///
+/// KEYS: `[placement_key, hit_key]`
+/// ARGV: `[worker_id, bit, generation]`
+/// Returns `{worker_gone, key_empty}`; `worker_gone=-1` fences an older writer,
+/// and `worker_gone=1` when the worker no longer
+/// holds the hash at any tier (caller should remove it from the reverse index);
+/// `key_empty=1` when the placement hash became empty and was deleted.
+///
+/// When the placement hash becomes empty the block no longer exists anywhere, so
+/// the co-located hit key (same `{hash}` slot) is deleted in the same script.
+/// Otherwise a matched-then-evicted block would leak its `:h` key forever, since
+/// the hit key is created lazily on match and nothing else ever removes it.
+pub static PLACEMENT_CLEAR: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+local raw = redis.call('HGET', KEYS[1], ARGV[1])
+local cur = nil
+local stored_generation = 0
+if raw then
+  local sep = string.find(raw, ':', 1, true)
+  if sep then
+    stored_generation = tonumber(string.sub(raw, 1, sep - 1)) or 0
+    cur = tonumber(string.sub(raw, sep + 1))
+  else
+    cur = tonumber(raw)
+  end
+end
+local generation = tonumber(ARGV[3])
+local bit = tonumber(ARGV[2])
+local worker_gone = 0
+if cur == nil then
+  -- Placement already reached the target state, but a previous SREM may have
+  -- failed. Ask the caller to retry the idempotent reverse-index removal.
+  worker_gone = 1
+elseif stored_generation ~= generation then
+  if stored_generation > generation then
+    return {-1, 0}
+  else
+    -- A stale orphan from an older generation is never part of the current
+    -- worker state. Remove it while repairing the reverse-index postcondition.
+    redis.call('HDEL', KEYS[1], ARGV[1])
+    worker_gone = 1
+  end
+else
+  local new = cur
+  if math.floor(cur / bit) % 2 == 1 then new = cur - bit end
+  if new == 0 then
+    redis.call('HDEL', KEYS[1], ARGV[1])
+    worker_gone = 1
+  else
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[3] .. ':' .. new)
+  end
+end
+local empty = 0
+if redis.call('HLEN', KEYS[1]) == 0 then
+  redis.call('DEL', KEYS[1])
+  redis.call('DEL', KEYS[2])
+  empty = 1
+end
+return {worker_gone, empty}
+"#,
+    )
+});
+
+/// Reads a placement hash. Hit counting happens only after Rust filters
+/// liveness and generation, so stale placement cannot count as a returned hit.
+///
+/// KEYS: `[placement_key]`
+/// Returns `[worker, "generation:mask", ...]`. Legacy numeric masks are
+/// interpreted by the caller as generation zero.
+pub static MATCH_HASH: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+return redis.call('HGETALL', KEYS[1])
+"#,
+    )
+});
+
+/// Increments a hit only after at least one routable current-generation worker
+/// was included in the final match response.
+///
+/// KEYS: `[placement_key, hit_key]`
+/// ARGV: `[now_ms, worker_id, generation, ...]`
+pub static HIT_BUMP: LazyLock<RedisScript> = LazyLock::new(|| {
+    RedisScript::new(
+        r#"
+for i = 2, #ARGV, 2 do
+  local raw = redis.call('HGET', KEYS[1], ARGV[i])
+  if raw then
+    local stored_generation = 0
+    local sep = string.find(raw, ':', 1, true)
+    if sep then
+      stored_generation = tonumber(string.sub(raw, 1, sep - 1)) or 0
+    end
+    if stored_generation == tonumber(ARGV[i + 1]) then
+      redis.call('HINCRBY', KEYS[2], 'c', 1)
+      redis.call('HSET', KEYS[2], 'ls', ARGV[1])
+      return 1
+    end
+  end
+end
+return 0
+"#,
+    )
+});

--- a/experimental/sgl-kv-indexer/src/service.rs
+++ b/experimental/sgl-kv-indexer/src/service.rs
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use tonic::{Request, Response, Status};
+
+use crate::pb::kv_indexer_server::KvIndexer;
+use crate::pb::{
+    ApplyExternalKvBatchRequest, ApplyExternalKvBatchResponse, ExternalKvAction,
+    ExternalKvActionType, GetExternalKvHitCountsRequest, GetExternalKvHitCountsResponse,
+    MatchExternalKvRequest, MatchExternalKvResponse,
+};
+
+/// Protocol-level resource bounds. The Redis backend additionally chunks its
+/// fan-out, but rejecting oversized requests here prevents any backend from
+/// allocating or scheduling work proportional to an unbounded repeated field.
+const MAX_HASHES_PER_REQUEST: usize = 16_384;
+const MAX_ACTIONS_PER_BATCH: usize = 256;
+
+/// Storage backend for the indexer. Deliberately narrow: every mutation flows
+/// through `apply_external_kv_batch`, preserving one ordered write path.
+///
+/// Async because real backends (e.g. Redis) do network IO; the trait is made
+/// dyn-safe via `#[tonic::async_trait]` so the server can select a backend at
+/// runtime and hold it as `Arc<dyn KvIndexerBackend>`.
+#[tonic::async_trait]
+pub trait KvIndexerBackend: Send + Sync + 'static {
+    /// Applies a whole SGLang KVEventBatch. The actions are pre-validated and
+    /// must be applied in order. `seq` is a per-worker monotonic idempotency
+    /// key: a durable backend stores the last applied seq per worker, skips a
+    /// batch whose seq was already applied (a duplicate), and reports its
+    /// durable position back in [`ApplyExternalKvBatchResponse::last_applied_seq`].
+    async fn apply_external_kv_batch(
+        &self,
+        request: ApplyExternalKvBatchRequest,
+    ) -> Result<ApplyExternalKvBatchResponse, Status>;
+
+    async fn match_external_kv(
+        &self,
+        request: MatchExternalKvRequest,
+    ) -> Result<MatchExternalKvResponse, Status>;
+
+    async fn get_external_kv_hit_counts(
+        &self,
+        request: GetExternalKvHitCountsRequest,
+    ) -> Result<GetExternalKvHitCountsResponse, Status>;
+
+    /// Readiness probe: `true` when the backend can serve requests. Stateless
+    /// backends are always ready; a durable backend (Redis) overrides this to
+    /// reflect store connectivity so the gRPC health service can report it.
+    async fn health(&self) -> bool {
+        true
+    }
+}
+
+/// Blanket impl so the server can hold the selected backend as
+/// `Arc<dyn KvIndexerBackend>` and still satisfy `KvIndexerService<B>`.
+#[tonic::async_trait]
+impl KvIndexerBackend for std::sync::Arc<dyn KvIndexerBackend> {
+    async fn apply_external_kv_batch(
+        &self,
+        request: ApplyExternalKvBatchRequest,
+    ) -> Result<ApplyExternalKvBatchResponse, Status> {
+        (**self).apply_external_kv_batch(request).await
+    }
+
+    async fn match_external_kv(
+        &self,
+        request: MatchExternalKvRequest,
+    ) -> Result<MatchExternalKvResponse, Status> {
+        (**self).match_external_kv(request).await
+    }
+
+    async fn get_external_kv_hit_counts(
+        &self,
+        request: GetExternalKvHitCountsRequest,
+    ) -> Result<GetExternalKvHitCountsResponse, Status> {
+        (**self).get_external_kv_hit_counts(request).await
+    }
+
+    async fn health(&self) -> bool {
+        (**self).health().await
+    }
+}
+
+#[derive(Debug)]
+pub struct KvIndexerService<B> {
+    backend: B,
+}
+
+impl<B> KvIndexerService<B>
+where
+    B: KvIndexerBackend,
+{
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+
+#[tonic::async_trait]
+impl<B> KvIndexer for KvIndexerService<B>
+where
+    B: KvIndexerBackend,
+{
+    async fn match_external_kv(
+        &self,
+        request: Request<MatchExternalKvRequest>,
+    ) -> Result<Response<MatchExternalKvResponse>, Status> {
+        let request = request.into_inner();
+        validate_hashes(&request.hashes)?;
+        let response = self.backend.match_external_kv(request).await?;
+        Ok(Response::new(response))
+    }
+
+    async fn get_external_kv_hit_counts(
+        &self,
+        request: Request<GetExternalKvHitCountsRequest>,
+    ) -> Result<Response<GetExternalKvHitCountsResponse>, Status> {
+        let request = request.into_inner();
+        validate_hashes(&request.hashes)?;
+        let response = self.backend.get_external_kv_hit_counts(request).await?;
+        Ok(Response::new(response))
+    }
+
+    async fn apply_external_kv_batch(
+        &self,
+        request: Request<ApplyExternalKvBatchRequest>,
+    ) -> Result<Response<ApplyExternalKvBatchResponse>, Status> {
+        let request = request.into_inner();
+        validate_worker_id(&request.worker_id)?;
+        validate_actions(&request.actions)?;
+        let response = self.backend.apply_external_kv_batch(request).await?;
+        Ok(Response::new(response))
+    }
+}
+
+fn validate_worker_id(worker_id: &str) -> Result<(), Status> {
+    if worker_id.is_empty() {
+        return Err(Status::invalid_argument("worker_id must not be empty"));
+    }
+    Ok(())
+}
+
+fn validate_hashes(hashes: &[String]) -> Result<(), Status> {
+    if hashes.is_empty() {
+        return Err(Status::invalid_argument("hashes must not be empty"));
+    }
+    if hashes.len() > MAX_HASHES_PER_REQUEST {
+        return Err(Status::resource_exhausted(format!(
+            "request contains {} hashes; maximum is {MAX_HASHES_PER_REQUEST}",
+            hashes.len()
+        )));
+    }
+    if hashes.iter().any(|hash| hash.is_empty()) {
+        return Err(Status::invalid_argument(
+            "hashes must not contain empty values",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_tier(tier: i32) -> Result<(), Status> {
+    match tier {
+        1..=3 => Ok(()),
+        0 => Err(Status::invalid_argument("tier must not be TIER_UNKNOWN")),
+        _ => Err(Status::invalid_argument("tier is not supported")),
+    }
+}
+
+fn validate_actions(actions: &[ExternalKvAction]) -> Result<(), Status> {
+    // An empty actions list is a valid heartbeat: it carries no mutation and
+    // simply refreshes the worker's liveness on the server. Non-empty batches
+    // still have every action validated below.
+    if actions.len() > MAX_ACTIONS_PER_BATCH {
+        return Err(Status::resource_exhausted(format!(
+            "batch contains {} actions; maximum is {MAX_ACTIONS_PER_BATCH}",
+            actions.len()
+        )));
+    }
+    let total_hashes: usize = actions.iter().map(|action| action.hashes.len()).sum();
+    if total_hashes > MAX_HASHES_PER_REQUEST {
+        return Err(Status::resource_exhausted(format!(
+            "batch contains {total_hashes} hashes; maximum is {MAX_HASHES_PER_REQUEST}"
+        )));
+    }
+    for action in actions {
+        validate_tier(action.tier)?;
+        match ExternalKvActionType::try_from(action.r#type) {
+            Ok(ExternalKvActionType::ActionReport) | Ok(ExternalKvActionType::ActionRevoke) => {
+                validate_hashes(&action.hashes)?;
+            }
+            // CLEAR_ALL_AT_TIER carries only a tier; hashes are ignored.
+            Ok(ExternalKvActionType::ActionClearAllAtTier) => {}
+            Ok(ExternalKvActionType::ActionUnknown) | Err(_) => {
+                return Err(Status::invalid_argument("action type is not supported"));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hbm() -> i32 {
+        crate::pb::TierType::TierHbm as i32
+    }
+
+    fn action(r#type: ExternalKvActionType, tier: i32, hashes: &[&str]) -> ExternalKvAction {
+        ExternalKvAction {
+            r#type: r#type as i32,
+            tier,
+            hashes: hashes.iter().map(|h| h.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn validate_actions_allows_empty_as_heartbeat() {
+        // An empty batch is a liveness heartbeat, not an error.
+        assert!(validate_actions(&[]).is_ok());
+    }
+
+    #[test]
+    fn validate_actions_rejects_unknown_type() {
+        let actions = [action(ExternalKvActionType::ActionUnknown, hbm(), &["1"])];
+        assert!(validate_actions(&actions).is_err());
+    }
+
+    #[test]
+    fn validate_actions_rejects_bad_tier() {
+        let actions = [action(ExternalKvActionType::ActionReport, 0, &["1"])];
+        assert!(validate_actions(&actions).is_err());
+    }
+
+    #[test]
+    fn validate_actions_requires_hashes_for_report_and_revoke() {
+        assert!(
+            validate_actions(&[action(ExternalKvActionType::ActionReport, hbm(), &[])]).is_err()
+        );
+        assert!(
+            validate_actions(&[action(ExternalKvActionType::ActionRevoke, hbm(), &[])]).is_err()
+        );
+    }
+
+    #[test]
+    fn validate_actions_allows_empty_hashes_for_clear_all_at_tier() {
+        let actions = [action(
+            ExternalKvActionType::ActionClearAllAtTier,
+            hbm(),
+            &[],
+        )];
+        assert!(validate_actions(&actions).is_ok());
+    }
+
+    #[test]
+    fn validate_hashes_rejects_oversized_query() {
+        let hashes = vec!["1".to_string(); MAX_HASHES_PER_REQUEST + 1];
+        let error = validate_hashes(&hashes).unwrap_err();
+        assert_eq!(error.code(), tonic::Code::ResourceExhausted);
+    }
+
+    #[test]
+    fn validate_actions_rejects_oversized_batch() {
+        let hashes = vec!["1"; MAX_HASHES_PER_REQUEST / 2 + 1];
+        let actions = [
+            action(ExternalKvActionType::ActionReport, hbm(), &hashes),
+            action(ExternalKvActionType::ActionReport, hbm(), &hashes),
+        ];
+        let error = validate_actions(&actions).unwrap_err();
+        assert_eq!(error.code(), tonic::Code::ResourceExhausted);
+    }
+
+    #[test]
+    fn validate_actions_rejects_too_many_actions() {
+        let clear = action(ExternalKvActionType::ActionClearAllAtTier, hbm(), &[]);
+        let actions = vec![clear; MAX_ACTIONS_PER_BATCH + 1];
+        let error = validate_actions(&actions).unwrap_err();
+        assert_eq!(error.code(), tonic::Code::ResourceExhausted);
+    }
+
+    #[test]
+    fn validate_worker_id_rejects_empty_value() {
+        assert!(validate_worker_id("").is_err());
+        assert!(validate_worker_id("worker-1").is_ok());
+    }
+}

--- a/experimental/sgl-kv-indexer/src/shutdown.rs
+++ b/experimental/sgl-kv-indexer/src/shutdown.rs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Termination signalling shared by the server and bridge binaries.
+
+use tracing::{info, warn};
+
+/// Resolves once the process has been asked to terminate.
+///
+/// Container runtimes send `SIGTERM` first and only escalate to `SIGKILL` after
+/// a grace period, so handling it is what turns a hard kill into a drained
+/// exit. `SIGINT` is also handled to keep interactive runs responsive.
+///
+/// A handler that cannot be installed never resolves: firing immediately would
+/// shut the process down at startup instead of leaving it running unsupervised.
+pub async fn shutdown_signal() {
+    let interrupt = async {
+        if let Err(error) = tokio::signal::ctrl_c().await {
+            warn!(%error, "cannot handle SIGINT");
+            std::future::pending::<()>().await;
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{signal, SignalKind};
+        match signal(SignalKind::terminate()) {
+            Ok(mut stream) => {
+                stream.recv().await;
+            }
+            Err(error) => {
+                warn!(%error, "cannot handle SIGTERM");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = interrupt => info!("received SIGINT; shutting down"),
+        () = terminate => info!("received SIGTERM; shutting down"),
+    }
+}

--- a/experimental/sgl-kv-indexer/tests/bridge_replay.rs
+++ b/experimental/sgl-kv-indexer/tests/bridge_replay.rs
@@ -1,0 +1,541 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end reliability tests for the bridge's sequence-gap handling. A fake
+//! SGLang publisher (ZMQ PUB for live events + ROUTER for the replay buffer)
+//! emits batches with deliberate holes in the `seq` stream; a capturing
+//! in-memory gRPC indexer records the `seq` and incarnation of every applied
+//! batch.
+//!
+//! Both branches of the gap contract are covered, in this order:
+//!   * recoverable -- the bridge pulls the missing batches from the replay
+//!     endpoint (DEALER -> ROUTER) and applies everything exactly once in
+//!     monotonic order, keeping its incarnation;
+//!   * unrecoverable -- once the replay buffer can no longer close the gap the
+//!     bridge retires the incarnation, which is how the indexer is told to wipe
+//!     placements it can no longer reconstruct. This is the destructive path,
+//!     asserted in `bridge_recovers_seq_gap_via_replay`.
+//!
+//! No Redis required: the capturing backend implements `KvIndexerBackend`
+//! directly, so this runs in the default `cargo test`.
+
+#[path = "common/net.rs"]
+mod test_net;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bytes::Bytes;
+use tonic::transport::Server;
+use tonic::Status;
+use zeromq::{PubSocket, RouterSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+use sgl_kv_indexer::bridge::{run_bridge, run_bridge_until, BridgeConfig};
+use sgl_kv_indexer::pb::kv_indexer_server::KvIndexerServer;
+use sgl_kv_indexer::pb::{
+    ApplyExternalKvBatchRequest, ApplyExternalKvBatchResponse, GetExternalKvHitCountsRequest,
+    GetExternalKvHitCountsResponse, MatchExternalKvRequest, MatchExternalKvResponse,
+};
+use sgl_kv_indexer::{KvIndexerBackend, KvIndexerService};
+use test_net::free_addr;
+
+/// Sequence-tagged batches the fake publisher has emitted, shared between the
+/// test body and the replay responder.
+type ReplayBuffer = Arc<Mutex<Vec<(u64, Vec<u8>)>>>;
+
+/// gRPC backend that just records the seq of every applied batch, in order.
+#[derive(Clone, Default)]
+struct CapturingBackend {
+    seqs: Arc<Mutex<Vec<u64>>>,
+    incarnations: Arc<Mutex<Vec<String>>>,
+    last_seq: Arc<Mutex<Option<u64>>>,
+}
+
+#[tonic::async_trait]
+impl KvIndexerBackend for CapturingBackend {
+    async fn apply_external_kv_batch(
+        &self,
+        request: ApplyExternalKvBatchRequest,
+    ) -> Result<ApplyExternalKvBatchResponse, Status> {
+        let checkpoint = if request.actions.is_empty() {
+            *self.last_seq.lock().unwrap()
+        } else {
+            self.seqs.lock().unwrap().push(request.seq);
+            self.incarnations
+                .lock()
+                .unwrap()
+                .push(request.incarnation.clone());
+            *self.last_seq.lock().unwrap() = Some(request.seq);
+            Some(request.seq)
+        };
+        Ok(ApplyExternalKvBatchResponse {
+            last_applied_seq: checkpoint.unwrap_or_default(),
+            duplicate: false,
+            has_applied_seq: checkpoint.is_some(),
+        })
+    }
+
+    async fn match_external_kv(
+        &self,
+        _request: MatchExternalKvRequest,
+    ) -> Result<MatchExternalKvResponse, Status> {
+        Ok(MatchExternalKvResponse { matches: vec![] })
+    }
+
+    async fn get_external_kv_hit_counts(
+        &self,
+        _request: GetExternalKvHitCountsRequest,
+    ) -> Result<GetExternalKvHitCountsResponse, Status> {
+        Ok(GetExternalKvHitCountsResponse { entries: vec![] })
+    }
+}
+
+/// Encodes a minimal SGLang `KVEventBatch` = [ts, [events]] carrying one
+/// `BlockStored` (7 fields; [1]=block_hashes, [6]=medium) so the bridge decodes
+/// it into a single REPORT action.
+fn stored_payload(hash: i64, medium: &str) -> Vec<u8> {
+    use rmpv::Value;
+    let event = Value::Array(vec![
+        Value::from("BlockStored"),
+        Value::Array(vec![Value::from(hash)]),
+        Value::Nil,
+        Value::Nil,
+        Value::Nil,
+        Value::Nil,
+        Value::from(medium),
+    ]);
+    let batch = Value::Array(vec![Value::from(0u64), Value::Array(vec![event])]);
+    let mut buf = Vec::new();
+    rmpv::encode::write_value(&mut buf, &batch).expect("encode msgpack");
+    buf
+}
+
+/// One live PUB frame: [seq(8B BE u64), payload]. Empty topic => the bridge's
+/// empty subscription receives it.
+fn pub_frame(seq: u64, payload: Vec<u8>) -> ZmqMessage {
+    let mut m = ZmqMessage::from(Bytes::copy_from_slice(&seq.to_be_bytes()));
+    m.push_back(Bytes::from(payload));
+    m
+}
+
+/// One ROUTER reply routed to `peer`: [peer, b"", seq(8B BE i64), payload].
+/// After ROUTER pops `peer`, the bridge's DEALER sees [b"", seq, payload].
+fn reply_frame(peer: Bytes, seq: i64, payload: Vec<u8>) -> ZmqMessage {
+    let mut m = ZmqMessage::from(peer);
+    m.push_back(Bytes::new());
+    m.push_back(Bytes::copy_from_slice(&seq.to_be_bytes()));
+    m.push_back(Bytes::from(payload));
+    m
+}
+
+#[tokio::test]
+async fn bridge_recovers_seq_gap_via_replay() {
+    // --- capturing gRPC indexer ---
+    let backend = CapturingBackend::default();
+    let seqs = backend.seqs.clone();
+    let incarnations = backend.incarnations.clone();
+    let grpc_addr = free_addr();
+    let svc = KvIndexerServer::new(KvIndexerService::new(backend));
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve(grpc_addr)
+            .await
+            .expect("grpc serve");
+    });
+
+    // --- fake SGLang: PUB (live) + ROUTER (replay buffer) ---
+    let mut publisher = PubSocket::new();
+    let pub_ep = publisher.bind("tcp://127.0.0.1:0").await.expect("bind pub");
+    let mut router = RouterSocket::new();
+    let router_ep = router.bind("tcp://127.0.0.1:0").await.expect("bind router");
+
+    // ROUTER responder: first answer the bridge's liveness probe (u64::MAX),
+    // then stream buffered missing batches (2, 3) for the real gap request.
+    tokio::spawn(async move {
+        loop {
+            let req = router.recv().await.expect("router recv").into_vec();
+            let peer = req[0].clone();
+            let start = u64::from_be_bytes(req[2].as_ref().try_into().unwrap());
+            if start == u64::MAX {
+                router
+                    .send(reply_frame(peer, -1, Vec::new()))
+                    .await
+                    .expect("router send probe terminator");
+                continue;
+            }
+            let replay_seqs: &[i64] = match start {
+                // Deliberately incomplete: seq 2 is absent, so a later live
+                // seq 3 must not be committed past the unresolved gap.
+                1 => &[1],
+                2 => &[2, 3],
+                other => panic!("unexpected replay start {other}"),
+            };
+            for &seq in replay_seqs {
+                router
+                    .send(reply_frame(
+                        peer.clone(),
+                        seq,
+                        stored_payload(1000 + seq, "GPU"),
+                    ))
+                    .await
+                    .expect("router send batch");
+            }
+            router
+                .send(reply_frame(peer, -1, Vec::new()))
+                .await
+                .expect("router send terminator");
+        }
+    });
+
+    // --- bridge under test ---
+    let config = BridgeConfig {
+        worker_id: "worker-test".to_string(),
+        worker_address: String::new(),
+        event_endpoint: pub_ep.to_string(),
+        event_replay_endpoint: Some(router_ep.to_string()),
+        event_topic: String::new(),
+        indexer_endpoint: format!("http://{grpc_addr}"),
+        clear_tiers: vec![],
+        heartbeat_interval: None,
+        incarnation: "replay-test".to_string(),
+        incarnation_path: None,
+    };
+    tokio::spawn(async move {
+        let _ = run_bridge(config).await;
+    });
+
+    // Let the bridge's SUB connect/subscribe and gRPC client connect before we
+    // publish (PUB/SUB has no handshake; early sends would be dropped).
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+
+    // Live stream with a hole: 0, 1, then jump to 4 (2 and 3 are "missed").
+    publisher
+        .send(pub_frame(0, stored_payload(1000, "GPU")))
+        .await
+        .expect("pub 0");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    publisher
+        .send(pub_frame(1, stored_payload(1001, "GPU")))
+        .await
+        .expect("pub 1");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    publisher
+        .send(pub_frame(4, stored_payload(1004, "GPU")))
+        .await
+        .expect("pub 4");
+
+    // Wait until all five seqs are applied (or time out).
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        {
+            let got = seqs.lock().unwrap();
+            if got.len() >= 5 {
+                break;
+            }
+        }
+        if std::time::Instant::now() > deadline {
+            panic!(
+                "timed out; applied seqs so far: {:?}",
+                *seqs.lock().unwrap()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let got = seqs.lock().unwrap().clone();
+    assert_eq!(
+        got,
+        vec![0, 1, 2, 3, 4],
+        "bridge must apply every batch exactly once in monotonic order (gap 2,3 recovered via replay)"
+    );
+
+    publisher
+        .send(pub_frame(0, vec![0xc1]))
+        .await
+        .expect("pub malformed rollback");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        seqs.lock().unwrap().len(),
+        5,
+        "malformed rollback must not reset sequence/incarnation state"
+    );
+
+    // A worker-owned publisher restart resets SGLang's sequence generator. The
+    // still-running bridge must rotate incarnation instead of discarding the
+    // new stream forever as stale.
+    publisher
+        .send(pub_frame(0, stored_payload(2000, "GPU")))
+        .await
+        .expect("pub restarted seq 0");
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while seqs.lock().unwrap().len() < 6 {
+        assert!(
+            std::time::Instant::now() <= deadline,
+            "timed out waiting for restarted publisher batch"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(seqs.lock().unwrap().as_slice(), &[0, 1, 2, 3, 4, 0]);
+    {
+        let incarnations = incarnations.lock().unwrap();
+        assert!(incarnations[..5]
+            .iter()
+            .all(|incarnation| incarnation == "replay-test"));
+        assert_ne!(
+            incarnations[5], "replay-test",
+            "publisher restart must rotate the worker incarnation"
+        );
+    }
+
+    // The replay endpoint can only return seq 1 for the 1..3 gap. Recovery is
+    // best effort: the bridge commits the recoverable prefix, then retires the
+    // incarnation so the indexer wipes what can no longer be reconstructed, and
+    // resyncs from the live stream. Advancing past seq 2 under the *same*
+    // incarnation would silently keep stale placements alive.
+    publisher
+        .send(pub_frame(3, stored_payload(3003, "GPU")))
+        .await
+        .expect("pub incomplete-gap seq 3");
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while seqs.lock().unwrap().len() < 8 {
+        assert!(
+            std::time::Instant::now() <= deadline,
+            "timed out waiting for resync after an unrecoverable gap: {:?}",
+            *seqs.lock().unwrap()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        seqs.lock().unwrap().as_slice(),
+        &[0, 1, 2, 3, 4, 0, 1, 3],
+        "bridge must recover the replayable prefix and then resync past an unrecoverable gap"
+    );
+    {
+        let incarnations = incarnations.lock().unwrap();
+        assert_ne!(
+            incarnations[7], incarnations[6],
+            "an unrecoverable gap must retire the worker incarnation"
+        );
+    }
+}
+
+#[tokio::test]
+async fn bridge_process_restart_resumes_from_durable_checkpoint() {
+    let backend = CapturingBackend::default();
+    *backend.last_seq.lock().unwrap() = Some(1);
+    let seqs = backend.seqs.clone();
+    let incarnations = backend.incarnations.clone();
+    let grpc_addr = free_addr();
+    let svc = KvIndexerServer::new(KvIndexerService::new(backend));
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve(grpc_addr)
+            .await
+            .expect("grpc serve");
+    });
+
+    let mut publisher = PubSocket::new();
+    let pub_ep = publisher.bind("tcp://127.0.0.1:0").await.expect("bind pub");
+    let mut router = RouterSocket::new();
+    let router_ep = router.bind("tcp://127.0.0.1:0").await.expect("bind router");
+    tokio::spawn(async move {
+        loop {
+            let req = router.recv().await.expect("router recv").into_vec();
+            let peer = req[0].clone();
+            let start = u64::from_be_bytes(req[2].as_ref().try_into().unwrap());
+            if start == u64::MAX {
+                router
+                    .send(reply_frame(peer, -1, Vec::new()))
+                    .await
+                    .expect("router send probe");
+                continue;
+            }
+            assert_eq!(start, 2, "bridge must resume after durable seq 1");
+            for seq in [2_i64, 3] {
+                router
+                    .send(reply_frame(
+                        peer.clone(),
+                        seq,
+                        stored_payload(4000 + seq, "GPU"),
+                    ))
+                    .await
+                    .expect("router send replay");
+            }
+            router
+                .send(reply_frame(peer, -1, Vec::new()))
+                .await
+                .expect("router send terminator");
+        }
+    });
+
+    let config = BridgeConfig {
+        worker_id: "restart-worker".to_string(),
+        worker_address: String::new(),
+        event_endpoint: pub_ep.to_string(),
+        event_replay_endpoint: Some(router_ep.to_string()),
+        event_topic: String::new(),
+        indexer_endpoint: format!("http://{grpc_addr}"),
+        clear_tiers: vec![],
+        heartbeat_interval: None,
+        incarnation: "stable-publisher".to_string(),
+        incarnation_path: None,
+    };
+    tokio::spawn(async move {
+        let _ = run_bridge(config).await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    publisher
+        .send(pub_frame(4, stored_payload(4004, "GPU")))
+        .await
+        .expect("publish post-restart live batch");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while seqs.lock().unwrap().len() < 3 {
+        assert!(
+            std::time::Instant::now() <= deadline,
+            "timed out waiting for restart replay: {:?}",
+            *seqs.lock().unwrap()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert_eq!(seqs.lock().unwrap().as_slice(), &[2, 3, 4]);
+    assert!(incarnations
+        .lock()
+        .unwrap()
+        .iter()
+        .all(|value| value == "stable-publisher"));
+}
+
+/// A `SIGTERM`-style shutdown must return promptly and leave the indexer's
+/// checkpoint intact, so the replacement process replays what was published
+/// while nothing was listening rather than skipping it.
+#[tokio::test]
+async fn graceful_shutdown_keeps_the_replay_checkpoint_usable() {
+    let backend = CapturingBackend::default();
+    let seqs = backend.seqs.clone();
+    let grpc_addr = free_addr();
+    let svc = KvIndexerServer::new(KvIndexerService::new(backend));
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve(grpc_addr)
+            .await
+            .expect("grpc serve");
+    });
+
+    let mut publisher = PubSocket::new();
+    let pub_ep = publisher.bind("tcp://127.0.0.1:0").await.expect("bind pub");
+    let mut router = RouterSocket::new();
+    let router_ep = router.bind("tcp://127.0.0.1:0").await.expect("bind router");
+
+    // Stands in for SGLang's replay buffer: every batch the publisher has
+    // emitted, served from the requested sequence onwards.
+    let buffer: ReplayBuffer = Arc::new(Mutex::new(Vec::new()));
+    let replay = buffer.clone();
+    tokio::spawn(async move {
+        loop {
+            let req = router.recv().await.expect("router recv").into_vec();
+            let peer = req[0].clone();
+            let start = u64::from_be_bytes(req[2].as_ref().try_into().unwrap());
+            if start != u64::MAX {
+                let pending: Vec<(u64, Vec<u8>)> = replay
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .filter(|(seq, _)| *seq >= start)
+                    .cloned()
+                    .collect();
+                for (seq, payload) in pending {
+                    router
+                        .send(reply_frame(peer.clone(), seq as i64, payload))
+                        .await
+                        .expect("router send replay");
+                }
+            }
+            router
+                .send(reply_frame(peer, -1, Vec::new()))
+                .await
+                .expect("router send terminator");
+        }
+    });
+
+    let config = BridgeConfig {
+        worker_id: "shutdown-worker".to_string(),
+        worker_address: String::new(),
+        event_endpoint: pub_ep.to_string(),
+        event_replay_endpoint: Some(router_ep.to_string()),
+        event_topic: String::new(),
+        indexer_endpoint: format!("http://{grpc_addr}"),
+        clear_tiers: vec![],
+        heartbeat_interval: None,
+        incarnation: "stable-publisher".to_string(),
+        incarnation_path: None,
+    };
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let signalled = stop.clone();
+    let first = tokio::spawn(run_bridge_until(config.clone(), async move {
+        while !signalled.load(Ordering::Relaxed) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }));
+
+    // PUB drops messages sent before the subscriber has finished connecting.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    for seq in [0_u64, 1] {
+        let payload = stored_payload(5000 + seq as i64, "GPU");
+        buffer.lock().unwrap().push((seq, payload.clone()));
+        publisher
+            .send(pub_frame(seq, payload))
+            .await
+            .expect("publish live batch");
+    }
+    await_seqs(&seqs, 2).await;
+
+    stop.store(true, Ordering::Relaxed);
+    let stopped = tokio::time::timeout(Duration::from_secs(5), first)
+        .await
+        .expect("bridge must return promptly after a shutdown signal")
+        .expect("bridge task must not panic");
+    assert!(stopped.is_ok(), "clean shutdown must not surface an error");
+
+    // Published into the void: the first bridge is gone and the second has not
+    // started, so these only exist in the replay buffer.
+    for seq in [2_u64, 3] {
+        let payload = stored_payload(5000 + seq as i64, "GPU");
+        buffer.lock().unwrap().push((seq, payload.clone()));
+        publisher
+            .send(pub_frame(seq, payload))
+            .await
+            .expect("publish during downtime");
+    }
+
+    tokio::spawn(run_bridge_until(config, std::future::pending()));
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    let payload = stored_payload(5004, "GPU");
+    buffer.lock().unwrap().push((4, payload.clone()));
+    publisher
+        .send(pub_frame(4, payload))
+        .await
+        .expect("publish after restart");
+
+    await_seqs(&seqs, 5).await;
+    assert_eq!(seqs.lock().unwrap().as_slice(), &[0, 1, 2, 3, 4]);
+}
+
+async fn await_seqs(seqs: &Arc<Mutex<Vec<u64>>>, want: usize) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while seqs.lock().unwrap().len() < want {
+        assert!(
+            std::time::Instant::now() <= deadline,
+            "timed out waiting for {want} applied batches: {:?}",
+            *seqs.lock().unwrap()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}

--- a/experimental/sgl-kv-indexer/tests/common/id.rs
+++ b/experimental/sgl-kv-indexer/tests/common/id.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/experimental/sgl-kv-indexer/tests/common/kv.rs
+++ b/experimental/sgl-kv-indexer/tests/common/kv.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use sgl_kv_indexer::pb::{
+    ApplyExternalKvBatchRequest, ExternalKvAction, ExternalKvActionType, TierType,
+};
+
+pub fn hbm() -> i32 {
+    TierType::TierHbm as i32
+}
+
+pub fn dram() -> i32 {
+    TierType::TierDram as i32
+}
+
+pub fn hashes(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+pub fn action(kind: ExternalKvActionType, tier: i32, values: &[&str]) -> ExternalKvAction {
+    ExternalKvAction {
+        r#type: kind as i32,
+        tier,
+        hashes: hashes(values),
+    }
+}
+
+pub fn apply_request(
+    worker: &str,
+    address: &str,
+    seq: u64,
+    actions: Vec<ExternalKvAction>,
+) -> ApplyExternalKvBatchRequest {
+    ApplyExternalKvBatchRequest {
+        worker_id: worker.to_string(),
+        seq,
+        actions,
+        worker_address: address.to_string(),
+        incarnation: String::new(),
+    }
+}

--- a/experimental/sgl-kv-indexer/tests/common/net.rs
+++ b/experimental/sgl-kv-indexer/tests/common/net.rs
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::SocketAddr;
+
+/// Reserves an ephemeral loopback port. The listener is dropped immediately,
+/// so callers that spawn a server should retain their connect-retry loop.
+pub fn free_addr() -> SocketAddr {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+}

--- a/experimental/sgl-kv-indexer/tests/common/require.rs
+++ b/experimental/sgl-kv-indexer/tests/common/require.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared policy for tests that need a live Redis.
+
+/// Reports that `test` cannot run, and decides whether that is fatal.
+///
+/// Locally a missing store should skip so `cargo test` stays usable without
+/// Redis. In CI the store is always provisioned, so a skip means the harness
+/// broke and the job would otherwise report success having asserted nothing.
+/// `KV_INDEXER_REQUIRE_REDIS=1` selects the second interpretation.
+pub fn skip(test: &str, reason: &str) {
+    if std::env::var("KV_INDEXER_REQUIRE_REDIS").is_ok_and(|v| v == "1") {
+        panic!("{test} requires a store but {reason}");
+    }
+    eprintln!("skipping {test}: {reason}");
+}

--- a/experimental/sgl-kv-indexer/tests/grpc_contract.rs
+++ b/experimental/sgl-kv-indexer/tests/grpc_contract.rs
@@ -1,0 +1,492 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! gRPC contract tests: exercise all three RPCs of the `KVIndexer` service
+//! over the wire (real tonic server + client), not just the backend trait.
+//!
+//! Like the backend integration tests these require a live store and are
+//! opt-in via `KV_INDEXER_REDIS_URL` (or `KV_INDEXER_REDIS_CLUSTER_NODES`);
+//! when neither is set every test skips. Each test uses a unique namespace and
+//! unique worker/hash ids so a shared store never causes collisions.
+#![cfg(feature = "redis-backend")]
+
+#[path = "common/require.rs"]
+mod require;
+#[path = "common/id.rs"]
+mod test_id;
+#[path = "common/kv.rs"]
+mod test_kv;
+#[path = "common/net.rs"]
+mod test_net;
+
+use std::time::Duration;
+
+use tonic::transport::Server;
+use tonic::Code;
+
+use sgl_kv_indexer::pb::kv_indexer_client::KvIndexerClient;
+use sgl_kv_indexer::pb::kv_indexer_server::KvIndexerServer;
+use sgl_kv_indexer::pb::{
+    ApplyExternalKvBatchRequest, ExternalKvAction, ExternalKvActionType,
+    GetExternalKvHitCountsRequest, MatchExternalKvRequest,
+};
+use sgl_kv_indexer::{KvIndexerService, RedisKvIndexerBackend};
+use test_id::nanos;
+use test_kv::{action, apply_request, dram, hbm};
+use test_net::free_addr;
+
+async fn start_backend(
+    backend: RedisKvIndexerBackend,
+) -> KvIndexerClient<tonic::transport::Channel> {
+    let svc = KvIndexerServer::new(KvIndexerService::new(backend));
+    let addr = free_addr();
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve(addr)
+            .await
+            .expect("server serve");
+    });
+
+    let endpoint = format!("http://{addr}");
+    for _ in 0..50 {
+        if let Ok(c) = KvIndexerClient::connect(endpoint.clone()).await {
+            return c;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("client failed to connect to {endpoint}");
+}
+
+/// Starts a real gRPC server backed by Redis on a unique namespace and returns
+/// a connected client, or `None` (skip) when no store env is configured.
+async fn start(test: &str) -> Option<KvIndexerClient<tonic::transport::Channel>> {
+    let url = match std::env::var("KV_INDEXER_REDIS_URL") {
+        Ok(u) => u,
+        Err(_) => {
+            require::skip(test, "KV_INDEXER_REDIS_URL is not set");
+            return None;
+        }
+    };
+    let ns = format!("grpc:{test}:{}", nanos());
+    let backend = RedisKvIndexerBackend::connect_single(&url, ns)
+        .await
+        .expect("connect redis");
+    Some(start_backend(backend).await)
+}
+
+fn apply(
+    worker: &str,
+    addr: &str,
+    seq: u64,
+    action_type: ExternalKvActionType,
+    tier: i32,
+    hashes: &[&str],
+) -> ApplyExternalKvBatchRequest {
+    apply_request(worker, addr, seq, vec![action(action_type, tier, hashes)])
+}
+
+fn apply_report(
+    worker: &str,
+    addr: &str,
+    seq: u64,
+    tier: i32,
+    hashes: &[&str],
+) -> ApplyExternalKvBatchRequest {
+    apply(
+        worker,
+        addr,
+        seq,
+        ExternalKvActionType::ActionReport,
+        tier,
+        hashes,
+    )
+}
+
+#[tokio::test]
+async fn disjoint_workers_scale_across_two_indexer_servers() {
+    let Ok(url) = std::env::var("KV_INDEXER_REDIS_URL") else {
+        require::skip(
+            "disjoint_workers_scale_across_two_indexer_servers",
+            "KV_INDEXER_REDIS_URL is not set",
+        );
+        return;
+    };
+    let namespace = format!("grpc:horizontal:{}", nanos());
+    let backend_0 = RedisKvIndexerBackend::connect_single(&url, namespace.clone())
+        .await
+        .expect("connect indexer-0 backend");
+    let backend_1 = RedisKvIndexerBackend::connect_single(&url, namespace)
+        .await
+        .expect("connect indexer-1 backend");
+    let mut indexer_0 = start_backend(backend_0).await;
+    let mut indexer_1 = start_backend(backend_1).await;
+
+    let suffix = nanos();
+    let worker_0 = format!("worker-0-{suffix}");
+    let worker_1 = format!("worker-1-{suffix}");
+    let hash_0 = format!("horizontal-h0-{suffix}");
+    let hash_1 = format!("horizontal-h1-{suffix}");
+    let shared_hash = format!("horizontal-shared-{suffix}");
+
+    let apply_0 = indexer_0.apply_external_kv_batch(apply_report(
+        &worker_0,
+        "10.0.0.1:9000",
+        1,
+        hbm(),
+        &[&hash_0, &shared_hash],
+    ));
+    let apply_1 = indexer_1.apply_external_kv_batch(apply_report(
+        &worker_1,
+        "10.0.0.2:9000",
+        1,
+        hbm(),
+        &[&hash_1, &shared_hash],
+    ));
+    let (result_0, result_1) = tokio::join!(apply_0, apply_1);
+    result_0.expect("indexer-0 applies worker-0");
+    result_1.expect("indexer-1 applies worker-1");
+
+    let request = || MatchExternalKvRequest {
+        hashes: vec![hash_0.clone(), hash_1.clone(), shared_hash.clone()],
+        count_as_hit: false,
+    };
+    let from_0 = indexer_0
+        .match_external_kv(request())
+        .await
+        .expect("query indexer-0")
+        .into_inner();
+    let from_1 = indexer_1
+        .match_external_kv(request())
+        .await
+        .expect("query indexer-1")
+        .into_inner();
+
+    for response in [&from_0, &from_1] {
+        assert!(
+            response
+                .matches
+                .iter()
+                .any(|entry| entry.worker_id == worker_0),
+            "either indexer must see worker-0 through shared Redis"
+        );
+        assert!(
+            response
+                .matches
+                .iter()
+                .any(|entry| entry.worker_id == worker_1),
+            "either indexer must see worker-1 through shared Redis"
+        );
+    }
+}
+
+#[tokio::test]
+async fn apply_ack_reports_seq_and_duplicate_over_grpc() {
+    let Some(mut c) = start("apply_ack").await else {
+        return;
+    };
+    let w = format!("w-{}", nanos());
+    let h = "ack-h1";
+
+    let first = c
+        .apply_external_kv_batch(apply_report(&w, "10.0.0.9:9000", 1, hbm(), &[h]))
+        .await
+        .expect("apply ok")
+        .into_inner();
+    assert_eq!(first.last_applied_seq, 1);
+    assert!(!first.duplicate);
+
+    // Re-sending the same seq is acked as a duplicate at the same position.
+    let dup = c
+        .apply_external_kv_batch(apply_report(&w, "10.0.0.9:9000", 1, hbm(), &[h]))
+        .await
+        .expect("apply ok")
+        .into_inner();
+    assert!(dup.duplicate);
+    assert_eq!(dup.last_applied_seq, 1);
+
+    let second = c
+        .apply_external_kv_batch(apply_report(&w, "10.0.0.9:9000", 2, hbm(), &[h]))
+        .await
+        .expect("apply ok")
+        .into_inner();
+    assert_eq!(second.last_applied_seq, 2);
+    assert!(!second.duplicate);
+}
+
+#[tokio::test]
+async fn apply_match_and_hit_counts_over_grpc() {
+    let Some(mut c) = start("apply_match").await else {
+        return;
+    };
+    let w = format!("w-{}", nanos());
+    let (h1, h2, miss) = ("am-h1", "am-h2", "am-miss");
+
+    c.apply_external_kv_batch(apply_report(&w, "10.0.0.1:9000", 1, hbm(), &[h1, h2]))
+        .await
+        .expect("apply ok");
+
+    let resp = c
+        .match_external_kv(MatchExternalKvRequest {
+            hashes: vec![h1.into(), h2.into(), miss.into()],
+            count_as_hit: true,
+        })
+        .await
+        .expect("match ok")
+        .into_inner();
+
+    let m = resp
+        .matches
+        .iter()
+        .find(|m| m.worker_id == w)
+        .expect("worker present in matches");
+    assert_eq!(m.address, "10.0.0.1:9000");
+    let tier = m
+        .hashes_by_tier
+        .iter()
+        .find(|t| t.tier == hbm())
+        .expect("HBM tier present");
+    let mut got: Vec<&String> = tier.hashes.iter().collect();
+    got.sort();
+    assert_eq!(got, vec![&h1.to_string(), &h2.to_string()]);
+
+    let hc = c
+        .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+            hashes: vec![h1.into(), h2.into(), miss.into()],
+        })
+        .await
+        .expect("hit counts ok")
+        .into_inner();
+    let count = |h: &str| {
+        hc.entries
+            .iter()
+            .find(|e| e.hash == h)
+            .map(|e| e.hit_count_total)
+            .unwrap_or(0)
+    };
+    assert!(count(h1) >= 1, "h1 should have a hit");
+    assert!(count(h2) >= 1, "h2 should have a hit");
+    assert_eq!(count(miss), 0, "unmatched hash must not be counted");
+}
+
+#[tokio::test]
+async fn diagnostic_match_does_not_count_hits_over_grpc() {
+    let Some(mut c) = start("diag_match").await else {
+        return;
+    };
+    let w = format!("w-{}", nanos());
+    let h = "diag-h1";
+    c.apply_external_kv_batch(apply_report(&w, "10.0.0.2:9000", 1, hbm(), &[h]))
+        .await
+        .expect("apply ok");
+
+    // count_as_hit=false must not bump counters
+    c.match_external_kv(MatchExternalKvRequest {
+        hashes: vec![h.into()],
+        count_as_hit: false,
+    })
+    .await
+    .expect("match ok");
+
+    let hc = c
+        .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+            hashes: vec![h.into()],
+        })
+        .await
+        .expect("hit counts ok")
+        .into_inner();
+    let count = hc
+        .entries
+        .iter()
+        .find(|e| e.hash == h)
+        .map(|e| e.hit_count_total)
+        .unwrap_or(0);
+    assert_eq!(count, 0, "diagnostic match must not increase hit count");
+}
+
+#[tokio::test]
+async fn apply_report_then_revoke_over_grpc() {
+    let Some(mut c) = start("apply_rr").await else {
+        return;
+    };
+    let w = format!("w-{}", nanos());
+    let h = "apply-rr-h1";
+
+    c.apply_external_kv_batch(apply_report(&w, "10.0.0.3:9000", 1, hbm(), &[h]))
+        .await
+        .expect("report apply ok");
+
+    let before = c
+        .match_external_kv(MatchExternalKvRequest {
+            hashes: vec![h.into()],
+            count_as_hit: false,
+        })
+        .await
+        .expect("match ok")
+        .into_inner();
+    assert!(
+        before.matches.iter().any(|m| m.worker_id == w),
+        "reported hash should match"
+    );
+
+    c.apply_external_kv_batch(apply(
+        &w,
+        "10.0.0.3:9000",
+        2,
+        ExternalKvActionType::ActionRevoke,
+        hbm(),
+        &[h],
+    ))
+    .await
+    .expect("revoke apply ok");
+
+    let after = c
+        .match_external_kv(MatchExternalKvRequest {
+            hashes: vec![h.into()],
+            count_as_hit: false,
+        })
+        .await
+        .expect("match ok")
+        .into_inner();
+    assert!(
+        !after.matches.iter().any(|m| m.worker_id == w),
+        "revoked hash must not match"
+    );
+}
+
+#[tokio::test]
+async fn revoke_all_at_tier_over_grpc() {
+    let Some(mut c) = start("revoke_all").await else {
+        return;
+    };
+    let w = format!("w-{}", nanos());
+    let h = "ra-h1";
+
+    // same hash present in both HBM and DRAM
+    c.apply_external_kv_batch(apply_report(&w, "10.0.0.3:9000", 1, hbm(), &[h]))
+        .await
+        .expect("apply hbm");
+    c.apply_external_kv_batch(apply_report(&w, "10.0.0.3:9000", 2, dram(), &[h]))
+        .await
+        .expect("apply dram");
+
+    c.apply_external_kv_batch(apply(
+        &w,
+        "10.0.0.3:9000",
+        3,
+        ExternalKvActionType::ActionClearAllAtTier,
+        hbm(),
+        &[],
+    ))
+    .await
+    .expect("clear-all apply ok");
+
+    let resp = c
+        .match_external_kv(MatchExternalKvRequest {
+            hashes: vec![h.into()],
+            count_as_hit: false,
+        })
+        .await
+        .expect("match ok")
+        .into_inner();
+    let m = resp
+        .matches
+        .iter()
+        .find(|m| m.worker_id == w)
+        .expect("worker still present via DRAM");
+    let tiers: Vec<i32> = m.hashes_by_tier.iter().map(|t| t.tier).collect();
+    assert!(tiers.contains(&dram()), "DRAM tier must remain");
+    assert!(!tiers.contains(&hbm()), "HBM tier must be cleared");
+}
+
+#[tokio::test]
+async fn match_miss_returns_empty_over_grpc() {
+    let Some(mut c) = start("match_miss").await else {
+        return;
+    };
+    let resp = c
+        .match_external_kv(MatchExternalKvRequest {
+            hashes: vec![format!("never-reported-{}", nanos())],
+            count_as_hit: true,
+        })
+        .await
+        .expect("match ok")
+        .into_inner();
+    assert!(resp.matches.is_empty(), "unknown hash yields no matches");
+}
+
+#[tokio::test]
+async fn validation_errors_map_to_invalid_argument_over_grpc() {
+    let Some(mut c) = start("validation").await else {
+        return;
+    };
+
+    // empty worker_id
+    let err = c
+        .apply_external_kv_batch(apply_report("", "addr", 1, hbm(), &["h"]))
+        .await
+        .expect_err("empty worker_id must be rejected");
+    assert_eq!(
+        err.code(),
+        Code::InvalidArgument,
+        "empty worker_id -> InvalidArgument"
+    );
+
+    // REPORT action with no hashes
+    let err = c
+        .apply_external_kv_batch(apply(
+            "w",
+            "addr",
+            1,
+            ExternalKvActionType::ActionReport,
+            hbm(),
+            &[],
+        ))
+        .await
+        .expect_err("empty hashes must be rejected");
+    assert_eq!(
+        err.code(),
+        Code::InvalidArgument,
+        "empty hashes -> InvalidArgument"
+    );
+
+    // unknown action type
+    let bad = ApplyExternalKvBatchRequest {
+        worker_id: "w".into(),
+        seq: 1,
+        worker_address: String::new(),
+        actions: vec![ExternalKvAction {
+            r#type: 999,
+            tier: hbm(),
+            hashes: vec!["h".into()],
+        }],
+        incarnation: String::new(),
+    };
+    let err = c
+        .apply_external_kv_batch(bad)
+        .await
+        .expect_err("unknown action type rejected");
+    assert_eq!(
+        err.code(),
+        Code::InvalidArgument,
+        "unknown action type -> InvalidArgument"
+    );
+
+    // invalid tier in an ApplyBatch action
+    let err = c
+        .apply_external_kv_batch(apply(
+            "w",
+            "addr",
+            1,
+            ExternalKvActionType::ActionReport,
+            999,
+            &["h"],
+        ))
+        .await
+        .expect_err("bad tier rejected");
+    assert_eq!(
+        err.code(),
+        Code::InvalidArgument,
+        "bad tier -> InvalidArgument"
+    );
+}

--- a/experimental/sgl-kv-indexer/tests/redis_integration.rs
+++ b/experimental/sgl-kv-indexer/tests/redis_integration.rs
@@ -1,0 +1,1056 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the Redis backend.
+//!
+//! These require a live store and are opt-in via environment:
+//!   * `KV_INDEXER_REDIS_URL`            → single Redis/Dragonfly, or
+//!   * `KV_INDEXER_REDIS_CLUSTER_NODES`  → Redis Cluster (comma-separated seeds)
+//!
+//! When neither is set every test skips (prints a note and returns), so the
+//! default `cargo test --features redis-backend` run stays green without a store.
+//!
+//! Each test uses a unique namespace so a shared store never causes collisions.
+#![cfg(feature = "redis-backend")]
+
+#[path = "common/require.rs"]
+mod require;
+#[path = "common/id.rs"]
+mod test_id;
+#[path = "common/kv.rs"]
+mod test_kv;
+
+use sgl_kv_indexer::pb::{
+    ApplyExternalKvBatchRequest, ExternalKvAction, ExternalKvActionType,
+    GetExternalKvHitCountsRequest, MatchExternalKvRequest, MatchExternalKvResponse,
+};
+use sgl_kv_indexer::{KvIndexerBackend, RedisKvIndexerBackend};
+use test_id::nanos;
+use test_kv::{action, apply_request as apply_req, dram, hashes, hbm};
+
+/// Builds a backend against the configured store with a unique namespace, or
+/// returns `None` (skip) when no store env is set.
+async fn backend(test: &str) -> Option<RedisKvIndexerBackend> {
+    let ns = format!("itest:{test}:{}", nanos());
+    if let Ok(nodes) = std::env::var("KV_INDEXER_REDIS_CLUSTER_NODES") {
+        let nodes: Vec<String> = nodes
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+        Some(
+            RedisKvIndexerBackend::connect_cluster(nodes, ns)
+                .await
+                .expect("connect cluster"),
+        )
+    } else if let Ok(url) = std::env::var("KV_INDEXER_REDIS_URL") {
+        Some(
+            RedisKvIndexerBackend::connect_single(&url, ns)
+                .await
+                .expect("connect single"),
+        )
+    } else {
+        require::skip(
+            test,
+            "neither KV_INDEXER_REDIS_URL nor KV_INDEXER_REDIS_CLUSTER_NODES is set",
+        );
+        None
+    }
+}
+
+/// Like [`apply_req`] but tags the batch with a worker incarnation, so a change
+/// across calls simulates a worker restart.
+fn apply_req_inc(
+    worker: &str,
+    addr: &str,
+    incarnation: &str,
+    seq: u64,
+    actions: Vec<ExternalKvAction>,
+) -> ApplyExternalKvBatchRequest {
+    ApplyExternalKvBatchRequest {
+        incarnation: incarnation.to_string(),
+        ..apply_req(worker, addr, seq, actions)
+    }
+}
+
+fn match_req(hs: &[&str], count_as_hit: bool) -> MatchExternalKvRequest {
+    MatchExternalKvRequest {
+        hashes: hashes(hs),
+        count_as_hit,
+    }
+}
+
+/// Returns the tiers a worker holds a hash at, per the match response.
+fn tiers_for(resp: &MatchExternalKvResponse, worker: &str, hash: &str) -> Vec<i32> {
+    let mut tiers = Vec::new();
+    for m in &resp.matches {
+        if m.worker_id != worker {
+            continue;
+        }
+        for th in &m.hashes_by_tier {
+            if th.hashes.iter().any(|h| h == hash) {
+                tiers.push(th.tier);
+            }
+        }
+    }
+    tiers.sort_unstable();
+    tiers
+}
+
+macro_rules! itest {
+    ($name:ident, $b:ident, $body:block) => {
+        #[tokio::test]
+        async fn $name() {
+            let Some($b) = backend(stringify!($name)).await else {
+                return;
+            };
+            $body
+        }
+    };
+}
+
+itest!(report_then_match_returns_worker_and_address, b, {
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "10.0.0.1:9000",
+        1,
+        vec![action(
+            ExternalKvActionType::ActionReport,
+            hbm(),
+            &["1", "2"],
+        )],
+    ))
+    .await
+    .unwrap();
+
+    let resp = b
+        .match_external_kv(match_req(&["1", "2", "3"], false))
+        .await
+        .unwrap();
+    assert_eq!(resp.matches.len(), 1);
+    let m = &resp.matches[0];
+    assert_eq!(m.worker_id, "w1");
+    assert_eq!(m.address, "10.0.0.1:9000");
+    assert_eq!(tiers_for(&resp, "w1", "1"), vec![hbm()]);
+    assert_eq!(tiers_for(&resp, "w1", "2"), vec![hbm()]);
+    assert!(tiers_for(&resp, "w1", "3").is_empty());
+});
+
+itest!(large_request_crosses_redis_fanout_chunks, b, {
+    // The backend fan-out chunk is 256. Exercise more than one chunk on both
+    // write and read paths while preserving complete, ordered results.
+    let hashes: Vec<String> = (0..300).map(|i| format!("chunk-{i}")).collect();
+    let hash_refs: Vec<&str> = hashes.iter().map(String::as_str).collect();
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![action(
+            ExternalKvActionType::ActionReport,
+            hbm(),
+            &hash_refs,
+        )],
+    ))
+    .await
+    .unwrap();
+
+    let resp = b
+        .match_external_kv(match_req(&hash_refs, false))
+        .await
+        .unwrap();
+    let worker = resp
+        .matches
+        .iter()
+        .find(|m| m.worker_id == "w1")
+        .expect("worker must match");
+    let tier = worker
+        .hashes_by_tier
+        .iter()
+        .find(|t| t.tier == hbm())
+        .expect("HBM tier must match");
+    assert_eq!(tier.hashes, hashes);
+});
+
+itest!(duplicate_report_is_idempotent, b, {
+    for _ in 0..3 {
+        b.apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            1,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+    }
+    let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+    assert_eq!(tiers_for(&resp, "w1", "1"), vec![hbm()]);
+});
+
+itest!(same_seq_batch_replay_is_idempotent, b, {
+    // A batch that stores then removes then stores again the same hash; the net
+    // state is "stored". Replaying the identical batch (same seq) must not change it.
+    let batch = apply_req(
+        "w1",
+        "a",
+        7,
+        vec![
+            action(ExternalKvActionType::ActionReport, hbm(), &["9"]),
+            action(ExternalKvActionType::ActionRevoke, hbm(), &["9"]),
+            action(ExternalKvActionType::ActionReport, hbm(), &["9"]),
+        ],
+    );
+    b.apply_external_kv_batch(batch.clone()).await.unwrap();
+    let first = b.match_external_kv(match_req(&["9"], false)).await.unwrap();
+    b.apply_external_kv_batch(batch).await.unwrap();
+    let second = b.match_external_kv(match_req(&["9"], false)).await.unwrap();
+    assert_eq!(tiers_for(&first, "w1", "9"), vec![hbm()]);
+    assert_eq!(tiers_for(&second, "w1", "9"), vec![hbm()]);
+});
+
+itest!(recomputed_full_node_restores_hbm_placement, b, {
+    // HiRadixCache lifecycle for an exact-match recomputation:
+    // BlockStored(GPU) -> BlockRemoved(GPU) -> BlockStored(GPU).
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![action(ExternalKvActionType::ActionReport, hbm(), &["full"])],
+    ))
+    .await
+    .unwrap();
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        2,
+        vec![action(ExternalKvActionType::ActionRevoke, hbm(), &["full"])],
+    ))
+    .await
+    .unwrap();
+    let evicted = b
+        .match_external_kv(match_req(&["full"], false))
+        .await
+        .unwrap();
+    assert!(tiers_for(&evicted, "w1", "full").is_empty());
+
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        3,
+        vec![action(ExternalKvActionType::ActionReport, hbm(), &["full"])],
+    ))
+    .await
+    .unwrap();
+    let restored = b
+        .match_external_kv(match_req(&["full"], false))
+        .await
+        .unwrap();
+    assert_eq!(tiers_for(&restored, "w1", "full"), vec![hbm()]);
+});
+
+itest!(recomputed_split_reports_only_materialized_hashes, b, {
+    // An evicted [prefix -> old suffix] is partially recomputed as
+    // [prefix -> new suffix]. The old suffix must remain absent.
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![action(
+            ExternalKvActionType::ActionReport,
+            hbm(),
+            &["prefix", "old-suffix"],
+        )],
+    ))
+    .await
+    .unwrap();
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        2,
+        vec![action(
+            ExternalKvActionType::ActionRevoke,
+            hbm(),
+            &["prefix", "old-suffix"],
+        )],
+    ))
+    .await
+    .unwrap();
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        3,
+        vec![
+            action(ExternalKvActionType::ActionReport, hbm(), &["prefix"]),
+            action(ExternalKvActionType::ActionReport, hbm(), &["new-suffix"]),
+        ],
+    ))
+    .await
+    .unwrap();
+
+    let result = b
+        .match_external_kv(match_req(&["prefix", "old-suffix", "new-suffix"], false))
+        .await
+        .unwrap();
+    assert_eq!(tiers_for(&result, "w1", "prefix"), vec![hbm()]);
+    assert!(tiers_for(&result, "w1", "old-suffix").is_empty());
+    assert_eq!(tiers_for(&result, "w1", "new-suffix"), vec![hbm()]);
+});
+
+itest!(
+    recomputed_batch_replay_is_idempotent_and_keeps_cpu_copy,
+    b,
+    {
+        // Re-materializing on GPU must not revoke the existing host backup. If the
+        // bridge replays the same sequence, the durable sequence gate rejects the
+        // duplicate without changing either tier.
+        b.apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            1,
+            vec![action(
+                ExternalKvActionType::ActionReport,
+                dram(),
+                &["tiered"],
+            )],
+        ))
+        .await
+        .unwrap();
+        let recomputed = apply_req(
+            "w1",
+            "a",
+            2,
+            vec![action(
+                ExternalKvActionType::ActionReport,
+                hbm(),
+                &["tiered"],
+            )],
+        );
+        let first = b.apply_external_kv_batch(recomputed.clone()).await.unwrap();
+        let replay = b.apply_external_kv_batch(recomputed).await.unwrap();
+        assert!(!first.duplicate);
+        assert!(replay.duplicate);
+
+        let result = b
+            .match_external_kv(match_req(&["tiered"], false))
+            .await
+            .unwrap();
+        assert_eq!(tiers_for(&result, "w1", "tiered"), vec![hbm(), dram()]);
+    }
+);
+
+itest!(cluster_client_recovers_after_master_failover, b, {
+    if std::env::var("KV_INDEXER_REDIS_CLUSTER_NODES").is_err() {
+        eprintln!("skipping cluster failover test outside Redis Cluster");
+        return;
+    }
+    let Ok(hash) = std::env::var("KV_INDEXER_FAILOVER_HASH") else {
+        eprintln!("skipping cluster failover test: set KV_INDEXER_FAILOVER_HASH");
+        return;
+    };
+    let pause_secs = std::env::var("KV_INDEXER_FAILOVER_PAUSE_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(8);
+
+    b.apply_external_kv_batch(apply_req(
+        "failover-worker",
+        "a",
+        1,
+        vec![action(ExternalKvActionType::ActionReport, hbm(), &[&hash])],
+    ))
+    .await
+    .unwrap();
+    eprintln!("FAILOVER_READY hash={hash}; stop its Redis master within {pause_secs}s");
+    tokio::time::sleep(std::time::Duration::from_secs(pause_secs)).await;
+
+    // Revoke then report after the external harness has stopped the slot's
+    // original master. This exercises topology refresh, replica promotion,
+    // Lua reload and both forward/reverse writes on the existing client.
+    b.apply_external_kv_batch(apply_req(
+        "failover-worker",
+        "a",
+        2,
+        vec![action(ExternalKvActionType::ActionRevoke, hbm(), &[&hash])],
+    ))
+    .await
+    .unwrap();
+    b.apply_external_kv_batch(apply_req(
+        "failover-worker",
+        "a",
+        3,
+        vec![action(ExternalKvActionType::ActionReport, hbm(), &[&hash])],
+    ))
+    .await
+    .unwrap();
+
+    let result = b
+        .match_external_kv(match_req(&[&hash], false))
+        .await
+        .unwrap();
+    assert_eq!(tiers_for(&result, "failover-worker", &hash), vec![hbm()]);
+});
+
+itest!(cluster_client_follows_ask_redirect, b, {
+    if std::env::var("KV_INDEXER_REDIS_CLUSTER_NODES").is_err() {
+        eprintln!("skipping ASK redirect test outside Redis Cluster");
+        return;
+    }
+    let Ok(hash) = std::env::var("KV_INDEXER_ASK_HASH") else {
+        eprintln!("skipping ASK redirect test: set KV_INDEXER_ASK_HASH");
+        return;
+    };
+
+    // The external harness marks this hash's slot MIGRATING on its owner and
+    // IMPORTING on another master before starting the test. This namespace is
+    // unique, so the placement key is absent on the source and Redis responds
+    // with ASK. The cluster client must issue ASKING on the target and retry.
+    b.apply_external_kv_batch(apply_req(
+        "ask-worker",
+        "a",
+        1,
+        vec![action(ExternalKvActionType::ActionReport, hbm(), &[&hash])],
+    ))
+    .await
+    .unwrap();
+    let result = b
+        .match_external_kv(match_req(&[&hash], false))
+        .await
+        .unwrap();
+    assert_eq!(tiers_for(&result, "ask-worker", &hash), vec![hbm()]);
+});
+
+itest!(cluster_heartbeat_follows_ask_redirect, b, {
+    if std::env::var("KV_INDEXER_REDIS_CLUSTER_NODES").is_err() {
+        eprintln!("skipping heartbeat ASK test outside Redis Cluster");
+        return;
+    }
+    let Ok(worker) = std::env::var("KV_INDEXER_ASK_HEARTBEAT_WORKER") else {
+        eprintln!("skipping heartbeat ASK test: set KV_INDEXER_ASK_HEARTBEAT_WORKER");
+        return;
+    };
+
+    // The harness migrates the `{w:<worker>}` slot before this call. TOUCH_META
+    // is a multi-key Lua heartbeat in that slot and must follow ASK even when
+    // the importing master has not cached the script.
+    let response = b
+        .apply_external_kv_batch(apply_req_inc(&worker, "a", "ask-heartbeat", 0, vec![]))
+        .await
+        .unwrap();
+    assert!(
+        !response.has_applied_seq,
+        "a fresh heartbeat must not invent a durable event checkpoint"
+    );
+});
+
+itest!(revoke_partial_tier_keeps_other_tier, b, {
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![
+            action(ExternalKvActionType::ActionReport, hbm(), &["1"]),
+            action(ExternalKvActionType::ActionReport, dram(), &["1"]),
+            action(ExternalKvActionType::ActionRevoke, hbm(), &["1"]),
+        ],
+    ))
+    .await
+    .unwrap();
+    let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+    assert_eq!(tiers_for(&resp, "w1", "1"), vec![dram()]);
+});
+
+itest!(revoke_missing_hash_is_idempotent, b, {
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![action(ExternalKvActionType::ActionRevoke, hbm(), &["404"])],
+    ))
+    .await
+    .unwrap();
+    let resp = b
+        .match_external_kv(match_req(&["404"], false))
+        .await
+        .unwrap();
+    assert!(resp.matches.is_empty());
+});
+
+itest!(multi_worker_multi_tier, b, {
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a1",
+        1,
+        vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+    ))
+    .await
+    .unwrap();
+    b.apply_external_kv_batch(apply_req(
+        "w2",
+        "a2",
+        1,
+        vec![action(ExternalKvActionType::ActionReport, dram(), &["1"])],
+    ))
+    .await
+    .unwrap();
+    let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+    assert_eq!(resp.matches.len(), 2);
+    assert_eq!(tiers_for(&resp, "w1", "1"), vec![hbm()]);
+    assert_eq!(tiers_for(&resp, "w2", "1"), vec![dram()]);
+});
+
+itest!(clear_all_at_tier_removes_only_that_tier, b, {
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![
+            action(ExternalKvActionType::ActionReport, hbm(), &["1", "2", "3"]),
+            action(ExternalKvActionType::ActionReport, dram(), &["1"]),
+        ],
+    ))
+    .await
+    .unwrap();
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        2,
+        vec![action(
+            ExternalKvActionType::ActionClearAllAtTier,
+            hbm(),
+            &[],
+        )],
+    ))
+    .await
+    .unwrap();
+    let resp = b
+        .match_external_kv(match_req(&["1", "2", "3"], false))
+        .await
+        .unwrap();
+    assert_eq!(tiers_for(&resp, "w1", "1"), vec![dram()]);
+    assert!(tiers_for(&resp, "w1", "2").is_empty());
+    assert!(tiers_for(&resp, "w1", "3").is_empty());
+});
+
+itest!(
+    count_as_hit_only_counts_matched_and_replay_does_not_double,
+    b,
+    {
+        b.apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            1,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+
+        // Diagnostic match (count_as_hit=false) must not count.
+        b.match_external_kv(match_req(&["1", "2"], false))
+            .await
+            .unwrap();
+        let counts = b
+            .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+                hashes: hashes(&["1", "2"]),
+            })
+            .await
+            .unwrap();
+        assert!(counts.entries.is_empty());
+
+        // Counting match: only the matched hash "1" is counted, "2" (a miss) is not.
+        b.match_external_kv(match_req(&["1", "2"], true))
+            .await
+            .unwrap();
+        let counts = b
+            .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+                hashes: hashes(&["1", "2"]),
+            })
+            .await
+            .unwrap();
+        assert_eq!(counts.entries.len(), 1);
+        assert_eq!(counts.entries[0].hash, "1");
+        assert_eq!(counts.entries[0].hit_count_total, 1);
+
+        // Replaying the apply batch must not touch hit counts.
+        b.apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            1,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+        let counts = b
+            .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+                hashes: hashes(&["1"]),
+            })
+            .await
+            .unwrap();
+        assert_eq!(counts.entries[0].hit_count_total, 1);
+    }
+);
+
+itest!(full_revoke_drops_hit_key, b, {
+    // Report a block, count a hit (creates the co-located :h key), then fully
+    // revoke it. The hit key must be removed together with placement; otherwise a
+    // matched-then-evicted block leaks its :h key forever (slow Redis memory growth).
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+    ))
+    .await
+    .unwrap();
+
+    // Counting match creates the hit key with c=1.
+    b.match_external_kv(match_req(&["1"], true)).await.unwrap();
+    let counts = b
+        .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+            hashes: hashes(&["1"]),
+        })
+        .await
+        .unwrap();
+    assert_eq!(counts.entries.len(), 1);
+    assert_eq!(counts.entries[0].hit_count_total, 1);
+
+    // Fully revoke the block: placement empties, so the hit key must go too.
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        2,
+        vec![action(ExternalKvActionType::ActionRevoke, hbm(), &["1"])],
+    ))
+    .await
+    .unwrap();
+
+    // Placement is gone.
+    let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+    assert!(resp.matches.is_empty());
+
+    // Hit key is gone too: a leaked :h would still report a count here.
+    let counts = b
+        .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+            hashes: hashes(&["1"]),
+        })
+        .await
+        .unwrap();
+    assert!(
+        counts.entries.is_empty(),
+        "hit key leaked after full revoke: {:?}",
+        counts.entries
+    );
+});
+
+itest!(partial_revoke_keeps_hit_key, b, {
+    // Block present at two tiers; count a hit, then revoke only one tier. Placement
+    // is still non-empty, so the hit key must survive (guard against over-deletion).
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![
+            action(ExternalKvActionType::ActionReport, hbm(), &["1"]),
+            action(ExternalKvActionType::ActionReport, dram(), &["1"]),
+        ],
+    ))
+    .await
+    .unwrap();
+
+    b.match_external_kv(match_req(&["1"], true)).await.unwrap();
+
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        2,
+        vec![action(ExternalKvActionType::ActionRevoke, hbm(), &["1"])],
+    ))
+    .await
+    .unwrap();
+
+    let counts = b
+        .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+            hashes: hashes(&["1"]),
+        })
+        .await
+        .unwrap();
+    assert_eq!(counts.entries.len(), 1);
+    assert_eq!(counts.entries[0].hit_count_total, 1);
+});
+
+itest!(batch_action_order_is_preserved, b, {
+    // revoke-then-report on the same hash within one batch must net to "stored".
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        1,
+        vec![
+            action(ExternalKvActionType::ActionRevoke, hbm(), &["5"]),
+            action(ExternalKvActionType::ActionReport, hbm(), &["5"]),
+        ],
+    ))
+    .await
+    .unwrap();
+    let resp = b.match_external_kv(match_req(&["5"], false)).await.unwrap();
+    assert_eq!(tiers_for(&resp, "w1", "5"), vec![hbm()]);
+
+    // report-then-revoke on the same hash must net to "absent".
+    b.apply_external_kv_batch(apply_req(
+        "w1",
+        "a",
+        2,
+        vec![
+            action(ExternalKvActionType::ActionReport, hbm(), &["6"]),
+            action(ExternalKvActionType::ActionRevoke, hbm(), &["6"]),
+        ],
+    ))
+    .await
+    .unwrap();
+    let resp = b.match_external_kv(match_req(&["6"], false)).await.unwrap();
+    assert!(tiers_for(&resp, "w1", "6").is_empty());
+});
+
+// --- server-side seq gate (durable idempotency) -----------------------------
+
+itest!(duplicate_seq_batch_is_skipped_not_reapplied, b, {
+    // Apply a report at seq=1, then re-send seq=1 carrying a *different*
+    // mutation (a revoke). Because seq=1 was already applied, the whole batch
+    // is a duplicate and must be skipped, so the revoke has no effect.
+    let applied = b
+        .apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            1,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(applied.last_applied_seq, 1);
+    assert!(!applied.duplicate);
+
+    let dup = b
+        .apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            1,
+            vec![action(ExternalKvActionType::ActionRevoke, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+    assert!(dup.duplicate, "re-sent seq must be reported as a duplicate");
+    assert_eq!(dup.last_applied_seq, 1);
+
+    // The revoke was skipped: the hash is still present.
+    let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+    assert_eq!(tiers_for(&resp, "w1", "1"), vec![hbm()]);
+});
+
+itest!(lower_seq_batch_is_skipped_as_stale, b, {
+    // Advance to seq=5, then a late/out-of-order seq=3 arrives. It must be
+    // treated as stale (<= last) and skipped, leaving the ack at 5.
+    for seq in [1u64, 5] {
+        b.apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            seq,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+    }
+    let stale = b
+        .apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            3,
+            vec![action(ExternalKvActionType::ActionRevoke, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+    assert!(stale.duplicate);
+    assert_eq!(stale.last_applied_seq, 5);
+    let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+    assert_eq!(tiers_for(&resp, "w1", "1"), vec![hbm()]);
+});
+
+itest!(seq_is_per_worker_independent, b, {
+    // seq counters are independent per worker: the same seq value applied to a
+    // different worker is not a duplicate.
+    let a = b
+        .apply_external_kv_batch(apply_req(
+            "w1",
+            "a",
+            1,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+    let c = b
+        .apply_external_kv_batch(apply_req(
+            "w2",
+            "a",
+            1,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+    assert!(!a.duplicate && !c.duplicate);
+    let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+    assert_eq!(resp.matches.len(), 2);
+});
+
+// --- worker liveness / stale-entry cleanup ----------------------------------
+
+itest!(
+    stale_worker_is_dropped_from_match_then_revived_by_heartbeat,
+    b,
+    {
+        // Arm a short per-worker TTL so a worker that stops talking expires quickly.
+        let b = b.with_worker_ttl(Some(std::time::Duration::from_secs(1)));
+
+        // Report a block: immediately matchable while the worker is live.
+        b.apply_external_kv_batch(apply_req(
+            "w1",
+            "10.0.0.1:9000",
+            1,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+        let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+        assert_eq!(resp.matches.len(), 1, "live worker must be matchable");
+
+        // Let the worker go silent past its TTL: match must drop it so the router
+        // never targets a dead node, even though placement/reverse entries linger.
+        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+        let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+        assert!(
+            resp.matches.is_empty(),
+            "stale worker must be dropped from match, got {:?}",
+            resp.matches
+        );
+        let resp = b.match_external_kv(match_req(&["1"], true)).await.unwrap();
+        assert!(resp.matches.is_empty());
+        let counts = b
+            .get_external_kv_hit_counts(GetExternalKvHitCountsRequest {
+                hashes: hashes(&["1"]),
+            })
+            .await
+            .unwrap();
+        assert!(
+            counts.entries.is_empty(),
+            "a placement held only by dead workers must not count as a returned hit"
+        );
+
+        // A heartbeat (empty-actions apply) refreshes liveness; the placement was
+        // never deleted, so the old block is instantly routable again.
+        b.apply_external_kv_batch(apply_req("w1", "10.0.0.1:9000", 0, vec![]))
+            .await
+            .unwrap();
+        let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+        assert_eq!(
+            tiers_for(&resp, "w1", "1"),
+            vec![hbm()],
+            "heartbeat must revive the worker with its existing placement intact"
+        );
+    }
+);
+
+// --- worker restart / incarnation reset -------------------------------------
+
+itest!(
+    worker_restart_new_incarnation_wipes_stale_state_and_resets_seq,
+    b,
+    {
+        // Incarnation "A": report h1 at seq 5, so the durable seq climbs to 5.
+        b.apply_external_kv_batch(apply_req_inc(
+            "w1",
+            "10.0.0.1:9000",
+            "A",
+            5,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+        let resp = b.match_external_kv(match_req(&["1"], false)).await.unwrap();
+        assert_eq!(tiers_for(&resp, "w1", "1"), vec![hbm()]);
+
+        // Same incarnation, a stale/replayed low seq is still skipped as duplicate.
+        let dup = b
+            .apply_external_kv_batch(apply_req_inc(
+                "w1",
+                "10.0.0.1:9000",
+                "A",
+                2,
+                vec![action(ExternalKvActionType::ActionReport, hbm(), &["2"])],
+            ))
+            .await
+            .unwrap();
+        assert!(
+            dup.duplicate,
+            "low seq within same incarnation is a duplicate"
+        );
+
+        // Incarnation "B" (a restart) with a reset sequence (seq 1) reporting a new
+        // block. The restart must: (a) wipe the old placement for h1, (b) reset the
+        // durable seq so seq=1 is accepted (not skipped), (c) index the new block.
+        let after = b
+            .apply_external_kv_batch(apply_req_inc(
+                "w1",
+                "10.0.0.1:9000",
+                "B",
+                1,
+                vec![action(ExternalKvActionType::ActionReport, hbm(), &["9"])],
+            ))
+            .await
+            .unwrap();
+        assert!(
+            !after.duplicate,
+            "restarted worker's reset sequence must be accepted, not skipped"
+        );
+
+        let resp = b
+            .match_external_kv(match_req(&["1", "9"], false))
+            .await
+            .unwrap();
+        assert!(
+            tiers_for(&resp, "w1", "1").is_empty(),
+            "stale block from the previous incarnation must be wiped, got {:?}",
+            resp.matches
+        );
+        assert_eq!(
+            tiers_for(&resp, "w1", "9"),
+            vec![hbm()],
+            "new block from the restarted incarnation must be indexed"
+        );
+    }
+);
+
+itest!(
+    // P1 regression: a worker that expired out of `match` (its liveness TTL
+    // lapsed) and then slow-restarts with a NEW incarnation must still be reset.
+    // The durable meta (and thus the previous incarnation) must survive the TTL
+    // so the restart is detected and the stale placement is wiped — otherwise the
+    // dead incarnation's blocks would resurrect on the heartbeat that revives it.
+    expired_worker_new_incarnation_still_wipes_stale_state,
+    b,
+    {
+        let b = b.with_worker_ttl(Some(std::time::Duration::from_secs(1)));
+
+        // Incarnation "A" reports h1.
+        b.apply_external_kv_batch(apply_req_inc(
+            "w1",
+            "10.0.0.1:9000",
+            "A",
+            5,
+            vec![action(ExternalKvActionType::ActionReport, hbm(), &["1"])],
+        ))
+        .await
+        .unwrap();
+        assert_eq!(
+            tiers_for(
+                &b.match_external_kv(match_req(&["1"], false)).await.unwrap(),
+                "w1",
+                "1"
+            ),
+            vec![hbm()],
+        );
+
+        // The worker goes silent long enough for its liveness key to expire.
+        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+        assert!(
+            b.match_external_kv(match_req(&["1"], false))
+                .await
+                .unwrap()
+                .matches
+                .is_empty(),
+            "expired worker must be dropped from match",
+        );
+
+        // It slow-restarts as incarnation "B" (seq reset to 1) reporting h9. Even
+        // though the liveness key had expired, the durable incarnation "A" is
+        // still recorded, so the restart is detected: h1 is wiped, seq accepted.
+        let after = b
+            .apply_external_kv_batch(apply_req_inc(
+                "w1",
+                "10.0.0.1:9000",
+                "B",
+                1,
+                vec![action(ExternalKvActionType::ActionReport, hbm(), &["9"])],
+            ))
+            .await
+            .unwrap();
+        assert!(
+            !after.duplicate,
+            "restarted worker's reset seq must be accepted"
+        );
+
+        let resp = b
+            .match_external_kv(match_req(&["1", "9"], false))
+            .await
+            .unwrap();
+        assert!(
+            tiers_for(&resp, "w1", "1").is_empty(),
+            "stale block from expired-then-restarted incarnation must be wiped, got {:?}",
+            resp.matches
+        );
+        assert_eq!(tiers_for(&resp, "w1", "9"), vec![hbm()]);
+    }
+);
+
+// --- T5 regression: degraded-start / lazy-connect semantics -----------------
+
+/// A deferred backend (KV_INDEXER_REDIS_REQUIRED=0 path) does not connect at
+/// construction; it connects lazily on first use and serves correctly once the
+/// store is reachable. Requires a live store, so it skips when unset.
+#[tokio::test]
+async fn deferred_backend_connects_lazily_and_serves() {
+    let Ok(url) = std::env::var("KV_INDEXER_REDIS_URL") else {
+        eprintln!("skipping deferred_backend_connects_lazily_and_serves: set KV_INDEXER_REDIS_URL");
+        return;
+    };
+    let ns = format!("itest:deferred_serves:{}", nanos());
+    // Construction never touches the network.
+    let b = RedisKvIndexerBackend::connect_single_deferred(&url, ns);
+    // First use lazily establishes the connection and succeeds.
+    b.apply_external_kv_batch(apply_req(
+        "wd",
+        "10.9.9.9:9000",
+        1,
+        vec![action(
+            ExternalKvActionType::ActionReport,
+            hbm(),
+            &["100", "101"],
+        )],
+    ))
+    .await
+    .expect("lazy connect + apply should succeed against a live store");
+    let resp = b
+        .match_external_kv(match_req(&["100", "101"], false))
+        .await
+        .unwrap();
+    assert!(
+        resp.matches.iter().any(|m| m.worker_id == "wd"),
+        "reported hashes must be matchable after a lazy connect"
+    );
+}
+
+/// A deferred backend pointed at an unreachable Redis must fail requests with an
+/// error within a bounded time (connect timeout), never hang. No store needed.
+#[tokio::test]
+async fn deferred_backend_unreachable_errors_within_bound() {
+    let b = RedisKvIndexerBackend::connect_single_deferred(
+        "redis://127.0.0.1:6399",
+        "itest:deferred_dead",
+    );
+    let started = std::time::Instant::now();
+    let res = b.match_external_kv(match_req(&["x"], false)).await;
+    let elapsed = started.elapsed();
+    assert!(
+        res.is_err(),
+        "match against an unreachable redis must error, got {res:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "request must be bounded by the connect timeout, took {elapsed:?}"
+    );
+}


### PR DESCRIPTION
## Motivation

This PR implements the initial out-of-tree milestone proposed in #31458: a shared metadata index that tracks which SGLang worker and storage tier may hold each KV-cache block hash. The index is advisory and metadata-only; KV bytes remain owned by SGLang workers.

The implementation deliberately lives under `experimental/` while the API and deployment model stabilize. It consumes the existing SGLang KV event stream and does not change model execution or inference outputs.

Related RFC: #31458

## Modifications

- Add an experimental Rust crate with two binaries:
  - `kv-indexer-bridge` subscribes to SGLang ZMQ KV events, maps storage media to tiers, recovers replayable sequence gaps, and forwards ordered batches over gRPC.
  - `kv-indexer-server` applies metadata updates and serves placement-match and hit-count queries.
- Add a protobuf contract for ordered apply batches, placement lookup, and hit-count queries.
- Add a Redis/Dragonfly production backend with:
  - per-worker sequence deduplication and incarnation/generation fencing;
  - idempotent replay and retryable partial-failure recovery;
  - worker heartbeat/liveness filtering;
  - Redis Cluster hash-slot layout, MOVED/ASK handling, and master-failover recovery.
- Add unit, replay, fault-injection, gRPC contract, single-Redis, and Redis Cluster integration tests.
- Add an indexer-specific GitHub Actions workflow, including a label-gated six-node Redis Cluster tier.
- Add documentation for architecture, recommended sidecar deployment, configuration, fault tolerance, scaling, testing, and current limitations.

The current implementation intentionally favors temporary under-reporting over retaining unverifiable stale placement metadata. Router integration and periodic full-state reconciliation are follow-up work rather than part of this experimental service PR.

## Accuracy Tests

N/A. This PR does not modify model execution, kernels, logits, or generated outputs. The index is advisory routing metadata, and no router integration is enabled by this change.

Validation completed locally:

- Default-feature unit and bridge replay tests: passed.
- Redis-feature library, fault-injection, bridge replay, gRPC contract, and integration tests: passed.
- Single Redis required-mode suite (`KV_INDEXER_REQUIRE_REDIS=1`): passed.
- Six-node Redis Cluster suite: 26/26 integration tests passed.
- Explicit placement and heartbeat ASK redirects: passed, with `ASKING` observed on the importing node.
- Existing-client master failover: passed after the slot owner was stopped and its replica was promoted.

## Speed Tests and Profiling

N/A for inference performance because this PR does not connect the indexer to the routing request path. Performance and timeout budgets will be measured as part of the follow-up router integration.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable to the inference path; rationale above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

cc: @isytwu @TianDi101

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30368171003](https://github.com/sgl-project/sglang/actions/runs/30368171003)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30368170588](https://github.com/sgl-project/sglang/actions/runs/30368170588)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->