### PR TITLE
fix(kimi-k3): named persistent symmetric buffers for the fused collectives

### DIFF
--- a/python/sglang/srt/layers/k3_ar_fusion.py
+++ b/python/sglang/srt/layers/k3_ar_fusion.py
@@ -4,21 +4,13 @@ Auto-enabled on SM100/SM103 when CustomAllReduceV2 with multicast is
 available; ``SGLANG_K3_AR_FUSION`` overrides in either direction (0 = off,
 1 = attempt anywhere and warn when unavailable).
 
-Glue between the model and the ``kernels.ops.kimi_k3.all_reduce`` kernels,
-mirroring the NCCL-window design (pool + registered segments + find-window
-dispatch), but backed by torch symmetric memory:
-
-* :func:`symm_alloc` — allocation context that routes tensor allocations into
-  the torch symm-mem pool (with the pause-the-graph-pool dance under CUDA
-  graph capture, same as ``pynccl_allocator.SymmetricMemoryContext``).
-* :func:`all_reduce` — in-place ``x = allreduce(x) [+ residual]``:
-  small messages take the 1shot multicast-push (any tensor; reuses the
-  group's CustomAllReduceV2 workspace), large ones take the in-place NVLS
-  2shot on ``x``'s multicast address (rendezvous cached per segment).
+Glue between the model and the ``kernels.ops.kimi_k3.all_reduce`` kernels. Small
+messages take the 1shot multicast-push through the group's CustomAllReduceV2
+workspace; large ones take the in-place NVLS 2shot, which needs its input to be a
+:func:`symm_buffer` slice and otherwise falls back to the regular all-reduce.
 
 Call-site contract when the fusion is active: ``enabled()`` was
 checked once (which initializes the state), ``x`` is bf16 and contiguous,
-tensors above the push threshold are allocated under :func:`symm_alloc`,
 and the residual is identical on every rank (a fully reduced tensor such
 as the attn-res prefix sum) or ``None``.
 """
@@ -27,10 +19,12 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 import torch
 
+import sglang.srt.runtime_context as ctx
+from sglang.kernels.jit.utils import cache_once
 from sglang.srt.environ import envs
 
 if TYPE_CHECKING:
@@ -49,44 +43,32 @@ _PUSH_MAX_BYTES = 512 * 1024
 # csrc/kimi_k3/comm/ar_fusion.cuh — the mod hardcodes this row width.
 NORM_DIM = 3584
 
-
-class _State:
-    def __init__(self, comm: CustomAllReduceV2, world_size: int, group_name: str):
-        self.comm = comm  # CustomAllReduceV2 (storage plane owner)
-        self.world_size = world_size
-        self.group_name = group_name
+# :func:`symm_buffer` names: o_proj's [rows, hidden_size] output, and the MoE
+# [latent | shared] pair flattened to rows x (moe_hidden_size + hidden_size).
+ATTN_O_PROJ = "attn_o_proj"
+MOE_LATENT_SHARED = "moe_latent_shared"
 
 
-_STATE: Optional[_State] = None
-_INITIALIZED = False
+class _State(NamedTuple):
+    comm: CustomAllReduceV2
+    world_size: int
+    group_name: str
 
 
-def _init_state() -> Optional[_State]:
-    global _STATE, _INITIALIZED
-    if _INITIALIZED:
-        return _STATE
-    _INITIALIZED = True
+@cache_once
+def _get_state() -> Optional[_State]:
     explicit = envs.SGLANG_K3_AR_FUSION.is_set()
     if explicit:
         if not envs.SGLANG_K3_AR_FUSION.get():
             return None
     else:
-        # Auto: attempt only inside the validated envelope — SM100/SM103
-        # (the arches the fused kernels were measured on) and no
-        # --enable-symm-mem (its pynccl allocator context misroutes the
-        # o_proj/MoE outputs away from the k3 symm pool -> the pull path's
-        # symm-pool contract fails, see _find_mc_ptr). DCP composes: the
-        # TP-group reduces the fusion covers (KDA o_proj, latent|shared MoE)
-        # are DCP-transparent, validated on DCP8 fp8/fi_a2a GB300 (GSM8K
-        # in-band; bs=1 +19%, bs=64 +9%). The CustomAllReduceV2 multicast
-        # probe below is the remaining capability gate.
-        # SGLANG_K3_AR_FUSION=1 still force-attempts anywhere.
-        from sglang.srt.runtime_context import get_server_args
+        # Auto-probe: only SM100/SM103, and not under --enable-symm-mem or EP
+        # a2a (their allocator contexts misroute the buffers the pull needs).
         from sglang.srt.utils.common import get_device_sm
 
         if get_device_sm() not in (100, 103):
             return None
-        server_args = get_server_args()
+        server_args = ctx.get_server_args()
         if server_args.enable_symm_mem or server_args.moe_a2a_backend != "none":
             logger.info(
                 "K3 all-reduce fusion auto-probe: skipping "
@@ -127,24 +109,18 @@ def _init_state() -> Optional[_State]:
     from sglang.kernels.ops.kimi_k3 import all_reduce as mod
 
     mod.register_comm(comm.obj, pull_sem_mc_ptr=comm.pull_sem_mc_ptr)
-    _STATE = _State(comm, comm.world_size, group.cpu_group.group_name)
     logger.info("K3 all-reduce fusion enabled (world_size=%d)", comm.world_size)
-    return _STATE
+    return _State(comm, comm.world_size, group.cpu_group.group_name)
 
 
 def enabled() -> bool:
-    return _init_state() is not None
+    return _get_state() is not None
 
 
 @contextmanager
 def symm_alloc():
-    """Route tensor allocations into the torch symm-mem pool.
-
-    Only entered when the fusion is enabled (call-site contract). Under CUDA
-    graph capture the graph's own pool is paused first (allocating to two
-    pools at once is rejected), mirroring
-    pynccl_allocator.SymmetricMemoryContext.
-    """
+    """Route tensor allocations into the torch symm-mem pool. Under capture the
+    graph's own pool is paused first (two pools at once is rejected)."""
     import torch.distributed._symmetric_memory as torch_symm_mem
     from torch._C import (
         _cuda_beginAllocateCurrentThreadToPool,
@@ -172,114 +148,112 @@ def symm_alloc():
             _cuda_beginAllocateCurrentThreadToPool(device_index, graph_pool_id)
 
 
-_GRAPHS_ACTIVE: Optional[bool] = None
+class _Buffer(NamedTuple):
+    region: torch.Tensor  # flat [max_rows * width]
+    base: int  # local VA of region[0]
+    mc_base: int  # multicast VA of region[0]
+    max_rows: int
+    width: int
 
 
-def _eager_call_with_graphs_active() -> bool:
-    """True for a fused-AR call issued OUTSIDE capture on a server that uses
-    CUDA graphs.
-
-    The fused comm family assumes allocation and dispatch stay TP-uniform
-    (see _find_mc_ptr). With captured graphs in the process, eager forwards
-    (prefill / small extends) lose that uniformity -- the graph pool shifts
-    the symm allocator's reuse phase per rank, so ranks resolve different
-    (segment, offset) pairs for the same logical call and the NVLS reduce
-    sums misaligned multicast windows (garbage output, worst on extends
-    <= attn_res_block_size). Route those calls to the regular all-reduce;
-    captured graphs keep the fused path (capture is lockstep and replays
-    are pointer-stable).
-    """
-    global _GRAPHS_ACTIVE
-    if _GRAPHS_ACTIVE is None:
-        try:
-            from sglang.srt.runtime_context import get_server_args
-
-            _GRAPHS_ACTIVE = not get_server_args().disable_cuda_graph
-        except Exception:
-            _GRAPHS_ACTIVE = True  # conservative: prefer the safe path
-    return _GRAPHS_ACTIVE and not torch.cuda.is_current_stream_capturing()
+# Reverse pointer -> multicast lookup for get_mc_ptr().
+_BUFS: List[_Buffer] = []
 
 
-def _fallback_all_reduce(
-    x: torch.Tensor, residual: Optional[torch.Tensor]
-) -> torch.Tensor:
-    from sglang.srt.distributed import tensor_model_parallel_all_reduce
-
-    out = tensor_model_parallel_all_reduce(x)
-    if residual is not None:
-        # writing the sum into x absorbs the copy-back when the all-reduce
-        # is out-of-place, and degenerates to an in-place add when it is not
-        torch.add(out, residual, out=x)
-    elif out is not x:
-        x.copy_(out)
-    return x
+@cache_once
+def _max_buffer_rows() -> int:
+    """Rows to reserve per buffer: the largest batch the server args allow."""
+    server_args = ctx.get_server_args()
+    chunked = server_args.chunked_prefill_size
+    if chunked is not None and chunked > 0:
+        return int(chunked)
+    return int(server_args.max_prefill_tokens or 0)
 
 
-def _fallback_all_reduce_norm(
-    x: torch.Tensor, weight: torch.Tensor, eps: float, num_tokens: int
-) -> torch.Tensor:
-    from flashinfer.norm import rmsnorm
+def _create_buffer(name: str, width: int, dtype: torch.dtype) -> _Buffer:
+    """One symmetric buffer, rendezvoused once. ``empty_strided_p2p`` skips the
+    caching allocator, so this is right for a persistent buffer only."""
+    from torch._C._distributed_c10d import _SymmetricMemory
 
-    from sglang.srt.distributed import tensor_model_parallel_all_reduce
+    from sglang.srt.distributed.parallel_state import get_tp_group
 
-    # Same epilogue as the fused kernels (fp32 accumulate, fp32 weight
-    # multiply, one bf16 store -- see ar_fusion.cuh). Norming straight into
-    # x absorbs the copy-back when the all-reduce is out-of-place, and is a
-    # safe in-place update when it is not (each thread only stores back the
-    # elements it loaded). Only the un-normed tail -- the shared rows of the
-    # flat latent|shared buffer -- is left to copy.
-    out = tensor_model_parallel_all_reduce(x)
-    rmsnorm(out[:num_tokens], weight, eps, out=x[:num_tokens])
-    if out is not x and out.shape[0] > num_tokens:
-        x[num_tokens:].copy_(out[num_tokens:])
-    return x
-
-
-def _find_mc_ptr(state: _State, x: torch.Tensor) -> int:
-    """Multicast VA of ``x`` (contract: allocated under :func:`symm_alloc`).
-
-    Rendezvous per call: torch caches the handle per allocation (~2us on a
-    hit), tracks segment lifetime itself, and the first touch of a fresh
-    segment is a lockstep collective (allocation and dispatch are
-    TP-uniform), so no extra Python-side registry is needed or safe.
-    """
-    import torch.distributed._symmetric_memory as torch_symm_mem
-
-    hdl = torch_symm_mem.rendezvous(x, state.group_name)
-    assert hdl is not None and hdl.multicast_ptr != 0, (
-        "all_reduce input above the push threshold is not a "
-        "symm-pool tensor (allocate it under k3_ar_fusion.symm_alloc())"
+    max_rows = _max_buffer_rows()
+    # outside inference mode on purpose: created inside it the buffer would be an
+    # inference tensor, and the in-place write from a no_grad path (CUDA graph
+    # capture) is then rejected
+    with torch.inference_mode(False):
+        region = _SymmetricMemory.empty_strided_p2p(
+            (max_rows * width,),
+            [1],
+            dtype,
+            torch.device("cuda", torch.cuda.current_device()),
+            get_tp_group().cpu_group.group_name,
+        ).view(max_rows, width)
+    handle = _SymmetricMemory.rendezvous(region)
+    assert handle is not None and handle.multicast_ptr != 0
+    buf = _Buffer(
+        region=region,
+        base=int(region.data_ptr()),
+        mc_base=int(handle.multicast_ptr),
+        max_rows=max_rows,
+        width=width,
     )
-    offset = x.data_ptr() - hdl.buffer_ptrs[state.comm.rank]
-    return hdl.multicast_ptr + offset
+    _BUFS.append(buf)
+    logger.info(
+        "K3 symm buffer %r: %d rows x %d, %.1f MB (rendezvoused once on first "
+        "use; no per-forward symmetric allocation)",
+        name,
+        max_rows,
+        width,
+        region.numel() * region.element_size() / (1024 * 1024),
+    )
+    return buf
+
+
+def symm_buffer(name: str, rows: int, width: int, dtype: torch.dtype):
+    """``[rows, width]`` view of a named persistent symmetric buffer.
+
+    The pull reduces in place on the input's multicast alias, so every rank must
+    resolve the same ``(buffer, offset)``; a per-forward symm-pool allocation does
+    not, because torch's caching allocator breaks ties on the absolute address and
+    ``rendezvous`` validates sizes only.
+    """
+    buf: _Buffer = ctx.get_buffer(
+        f"k3_symm:{name}", lambda: _create_buffer(name, width, dtype)
+    )
+    assert 0 < rows <= buf.max_rows and width == buf.width and dtype == buf.region.dtype
+    return buf.region[:rows]
+
+
+def get_mc_ptr(x: torch.Tensor) -> int:
+    """Multicast VA of ``x``, which must be a :func:`symm_buffer` slice."""
+    ptr = int(x.data_ptr())
+    end = ptr + x.numel() * x.element_size()
+    for buf in _BUFS:
+        if buf.base <= ptr and end <= buf.base + buf.region.nbytes:
+            return buf.mc_base + (ptr - buf.base)
+    raise AssertionError("K3 fused pull input is not a symm_buffer slice")
 
 
 def all_reduce(
     x: torch.Tensor,
     residual: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """In-place ``x = allreduce(x) [+ residual]``; returns ``x``.
-
-    Call-site contract (see module docstring): the state is initialized,
-    ``x`` is bf16 and contiguous, and large inputs live in the symm pool.
-    """
+    """In-place ``x = allreduce(x) [+ residual]``; returns ``x``."""
     from sglang.kernels.ops.kimi_k3 import all_reduce as mod
 
-    state = _STATE
+    state = _get_state()
     assert state is not None
     if x.shape[0] == 0:
         return x if residual is None else x + residual
-    if _eager_call_with_graphs_active():
-        return _fallback_all_reduce(x, residual)
     nbytes = x.numel() * 2
     if nbytes <= min(_PUSH_MAX_BYTES, state.comm.max_push_size):
         return mod.all_reduce_push_res(
             state.world_size, x, residual, ws_mc_base=state.comm.mc_base_ptr
         )
-    else:
-        return mod.all_reduce_pull_res(
-            state.world_size, x, residual, input_mc_ptr=_find_mc_ptr(state, x)
-        )
+    return mod.all_reduce_pull_res(
+        state.world_size, x, residual, input_mc_ptr=get_mc_ptr(x)
+    )
 
 
 def all_reduce_low_sm(
@@ -289,28 +263,22 @@ def all_reduce_low_sm(
     num_blocks: Optional[int] = None,
     unroll: Optional[int] = None,
 ) -> torch.Tensor:
-    """In-place ``x = allreduce(x) [+ residual]`` pinned to the low-SM NVLS
-    pull, with the launch geometry exposed; returns ``x``.
+    """In-place ``x = allreduce(x) [+ residual]``, pinned to the low-SM NVLS pull.
 
-    For side-stream use (the shared-expert all-reduce): unlike
-    :func:`all_reduce` it never dispatches to the push kernel — push fans
-    out over many blocks and would steal SMs from the main-stream GEMMs it
-    is meant to overlap. ``x`` must live in the symm pool at ANY size.
-    ``num_blocks`` / ``unroll`` default to the tuned tables when None.
+    For side-stream use: push would fan out over many blocks and steal SMs from
+    the GEMMs it overlaps. ``num_blocks`` / ``unroll`` default to the tuned tables.
     """
     from sglang.kernels.ops.kimi_k3 import all_reduce as mod
 
-    state = _STATE
+    state = _get_state()
     assert state is not None
     if x.shape[0] == 0:
         return x if residual is None else x + residual
-    if _eager_call_with_graphs_active():
-        return _fallback_all_reduce(x, residual)
     return mod.all_reduce_pull_res(
         state.world_size,
         x,
         residual,
-        input_mc_ptr=_find_mc_ptr(state, x),
+        input_mc_ptr=get_mc_ptr(x),
         num_blocks=num_blocks,
         unroll=unroll,
     )
@@ -324,21 +292,13 @@ def all_reduce_norm(
     num_tokens: int,
 ) -> torch.Tensor:
     """In-place ``x = allreduce(x)`` with a fused RMSNorm over the first
-    ``num_tokens`` rows; returns ``x``.
-
-    ``x`` is a 2D ``[rows, NORM_DIM]`` bf16 tensor (a latent-only
-    ``[N, NORM_DIM]`` tensor with ``num_tokens = N``, or the flat K3
-    latent|shared buffer viewed as ``[3N, NORM_DIM]`` with ``num_tokens =
-    N``). Same dispatch and call-site contract as :func:`all_reduce`.
-    """
+    ``num_tokens`` rows of the 2D ``[rows, NORM_DIM]`` input."""
     from sglang.kernels.ops.kimi_k3 import all_reduce as mod
 
-    state = _STATE
+    state = _get_state()
     assert state is not None
     if x.shape[0] == 0:
         return x
-    if _eager_call_with_graphs_active():
-        return _fallback_all_reduce_norm(x, weight, eps, num_tokens)
     nbytes = x.numel() * 2
     if nbytes <= min(_PUSH_MAX_BYTES, state.comm.max_push_size):
         return mod.all_reduce_push_norm(
@@ -349,40 +309,32 @@ def all_reduce_norm(
             num_norm_rows=num_tokens,
             ws_mc_base=state.comm.mc_base_ptr,
         )
-    else:
-        return mod.all_reduce_pull_norm(
-            state.world_size,
-            x,
-            weight,
-            eps,
-            num_norm_rows=num_tokens,
-            input_mc_ptr=_find_mc_ptr(state, x),
-        )
+    return mod.all_reduce_pull_norm(
+        state.world_size,
+        x,
+        weight,
+        eps,
+        num_norm_rows=num_tokens,
+        input_mc_ptr=get_mc_ptr(x),
+    )
 
 
 def finalize_push_fits(num_tokens: int) -> bool:
-    """Whether a [num_tokens, NORM_DIM] latent fits the 1shot push window
-    (the finalize-fused AR is push-only; larger sizes keep the in-op
-    finalize + :func:`all_reduce_norm` NVLS path)."""
-    state = _STATE
+    """Whether a [num_tokens, NORM_DIM] latent fits the push window; the
+    finalize-fused AR is push-only."""
+    state = _get_state()
     assert state is not None
-    if _eager_call_with_graphs_active():
-        return False
     nbytes = num_tokens * NORM_DIM * 2
     return nbytes <= min(_PUSH_MAX_BYTES, state.comm.max_push_size)
 
 
 def gemm_ag_up_fits(num_tokens: int) -> bool:
-    """Whether the column-parallel up_proj + multicast all-gather tail
-    (:func:`gemm_ag_up_proj`) covers this decode batch: TP8, the batch is
-    within the kernel's win range, one [num_tokens, 896] staging slice fits
-    a push slot, and the phase-counter array covers both launch grids."""
+    """Whether :func:`gemm_ag_up_proj` covers this decode batch: TP8, within the
+    kernel's win range, and the staging slice fits a push slot."""
     from sglang.kernels.ops.kimi_k3 import gemm_ag as mod
 
-    state = _STATE
+    state = _get_state()
     assert state is not None
-    if _eager_call_with_graphs_active():
-        return False
     comm = state.comm
     return (
         0 < num_tokens <= mod.MAX_TOKENS
@@ -398,16 +350,12 @@ def gemm_ag_up_proj(
     b: torch.Tensor,
     c: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    """``up_proj(x) + b (+ c)`` via the column-parallel GEMV + multicast
-    all-gather + fused add3 (one more push-workspace user). ``x`` is the
-    normed [T, 3584] latent, ``weight`` the FULL replicated [7168, 3584]
-    up_proj weight (the kernel slices out this rank's row block itself),
-    ``b`` / ``c`` the [T, 7168] addends. Caller checked
-    :func:`gemm_ag_up_fits`; same call-site contract as
-    :func:`all_reduce`."""
+    """``up_proj(x) + b (+ c)`` via column-parallel GEMV + multicast all-gather +
+    fused add3. ``weight`` is the FULL replicated up_proj (the kernel slices this
+    rank's rows). Caller checked :func:`gemm_ag_up_fits`."""
     from sglang.kernels.ops.kimi_k3 import gemm_ag as mod
 
-    state = _STATE
+    state = _get_state()
     assert state is not None
     return mod.gemm_ag_up_proj(
         state.world_size,
@@ -428,13 +376,11 @@ def finalize_all_reduce_push_norm(
     weight: torch.Tensor,
     eps: float = 1e-6,
 ) -> torch.Tensor:
-    """Deferred MoE finalize fused into the 1shot push AR + RMSNorm on every
-    row; ``out`` ([T, NORM_DIM] bf16) is output-only. Caller checked
-    :func:`finalize_push_fits`; same call-site contract as
-    :func:`all_reduce`."""
+    """Deferred MoE finalize fused into the 1shot push AR + RMSNorm; ``out`` is
+    output-only. Caller checked :func:`finalize_push_fits`."""
     from sglang.kernels.ops.kimi_k3 import all_reduce as mod
 
-    state = _STATE
+    state = _get_state()
     assert state is not None
     return mod.finalize_all_reduce_push_norm(
         state.world_size,

--- a/python/sglang/srt/layers/k3_ar_fusion.py
+++ b/python/sglang/srt/layers/k3_ar_fusion.py
@@ -18,7 +18,6 @@ as the attn-res prefix sum) or ``None``.
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
 from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 import torch
@@ -117,37 +116,6 @@ def enabled() -> bool:
     return _get_state() is not None
 
 
-@contextmanager
-def symm_alloc():
-    """Route tensor allocations into the torch symm-mem pool. Under capture the
-    graph's own pool is paused first (two pools at once is rejected)."""
-    import torch.distributed._symmetric_memory as torch_symm_mem
-    from torch._C import (
-        _cuda_beginAllocateCurrentThreadToPool,
-        _cuda_endAllocateToPool,
-        _cuda_releasePool,
-    )
-
-    device_index = torch.cuda.current_device()
-    pool = torch_symm_mem.get_mem_pool(torch.device("cuda", device_index))
-    in_capture = torch.cuda.is_current_stream_capturing()
-    graph_pool_id = None
-    if in_capture:
-        from sglang.srt.distributed.device_communicators import pynccl_allocator
-
-        graph_pool_id = pynccl_allocator._graph_pool_id
-        assert graph_pool_id is not None, "graph_pool_id not set under capture"
-        _cuda_endAllocateToPool(device_index, graph_pool_id)
-    _cuda_beginAllocateCurrentThreadToPool(device_index, pool.id)
-    try:
-        yield
-    finally:
-        _cuda_endAllocateToPool(device_index, pool.id)
-        _cuda_releasePool(device_index, pool.id)
-        if in_capture:
-            _cuda_beginAllocateCurrentThreadToPool(device_index, graph_pool_id)
-
-
 class _Buffer(NamedTuple):
     region: torch.Tensor  # flat [max_rows * width]
     base: int  # local VA of region[0]
@@ -170,12 +138,12 @@ def _max_buffer_rows() -> int:
     return int(server_args.max_prefill_tokens or 0)
 
 
-def _create_buffer(name: str, width: int, dtype: torch.dtype) -> _Buffer:
+def _create_buffer(
+    name: str, width: int, dtype: torch.dtype, group_name: str
+) -> _Buffer:
     """One symmetric buffer, rendezvoused once. ``empty_strided_p2p`` skips the
     caching allocator, so this is right for a persistent buffer only."""
     from torch._C._distributed_c10d import _SymmetricMemory
-
-    from sglang.srt.distributed.parallel_state import get_tp_group
 
     max_rows = _max_buffer_rows()
     # outside inference mode on purpose: created inside it the buffer would be an
@@ -187,7 +155,7 @@ def _create_buffer(name: str, width: int, dtype: torch.dtype) -> _Buffer:
             [1],
             dtype,
             torch.device("cuda", torch.cuda.current_device()),
-            get_tp_group().cpu_group.group_name,
+            group_name,
         ).view(max_rows, width)
     handle = _SymmetricMemory.rendezvous(region)
     assert handle is not None and handle.multicast_ptr != 0
@@ -210,29 +178,50 @@ def _create_buffer(name: str, width: int, dtype: torch.dtype) -> _Buffer:
     return buf
 
 
-def symm_buffer(name: str, rows: int, width: int, dtype: torch.dtype):
+def symm_buffer(
+    name: str,
+    rows: int,
+    width: int,
+    dtype: torch.dtype,
+    group_name: Optional[str] = None,
+):
     """``[rows, width]`` view of a named persistent symmetric buffer.
 
     The pull reduces in place on the input's multicast alias, so every rank must
     resolve the same ``(buffer, offset)``; a per-forward symm-pool allocation does
     not, because torch's caching allocator breaks ties on the absolute address and
     ``rendezvous`` validates sizes only.
+
+    ``group_name`` defaults to the TP group, the one the fused all-reduce reduces
+    over; a caller reducing over another group (SP-MoE's attention TP group) passes
+    its own. Each name belongs to one group, so the name alone identifies it.
     """
+    if group_name is None:
+        from sglang.srt.distributed.parallel_state import get_tp_group
+
+        group_name = get_tp_group().cpu_group.group_name
     buf: _Buffer = ctx.get_buffer(
-        f"k3_symm:{name}", lambda: _create_buffer(name, width, dtype)
+        f"k3_symm:{name}", lambda: _create_buffer(name, width, dtype, group_name)
     )
     assert 0 < rows <= buf.max_rows and width == buf.width and dtype == buf.region.dtype
     return buf.region[:rows]
 
 
-def get_mc_ptr(x: torch.Tensor) -> int:
-    """Multicast VA of ``x``, which must be a :func:`symm_buffer` slice."""
+def find_mc_ptr(x: torch.Tensor) -> Optional[int]:
+    """Multicast VA of ``x`` if it lies inside a named buffer, else None."""
     ptr = int(x.data_ptr())
     end = ptr + x.numel() * x.element_size()
     for buf in _BUFS:
         if buf.base <= ptr and end <= buf.base + buf.region.nbytes:
             return buf.mc_base + (ptr - buf.base)
-    raise AssertionError("K3 fused pull input is not a symm_buffer slice")
+    return None
+
+
+def get_mc_ptr(x: torch.Tensor) -> int:
+    """Multicast VA of ``x``, which must be a :func:`symm_buffer` slice."""
+    mc = find_mc_ptr(x)
+    assert mc is not None, "K3 fused pull input is not a symm_buffer slice"
+    return mc
 
 
 def all_reduce(

--- a/python/sglang/srt/layers/k3_sp_collective.py
+++ b/python/sglang/srt/layers/k3_sp_collective.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.layers import k3_ar_fusion
 
 if TYPE_CHECKING:
     from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
@@ -28,6 +29,13 @@ logger = logging.getLogger(__name__)
 _HIDDEN_SIZE = 7168
 _SUPPORTED_WORLD_SIZES = (4, 8)
 
+# Named persistent symmetric buffers, one per NVLS-aliased tensor. Every rank
+# must resolve the same (buffer, offset) for these, which a per-forward
+# allocation does not give -- see k3_ar_fusion.symm_buffer.
+_O_PROJ = "sp_o_proj"  # TP-partial o_proj output, read by the pull RS
+_ALL_GATHER = "sp_all_gather"  # full-batch output of the direct AG
+_ATTN_RES_AG = "sp_attn_res_ag"  # ... and of its attention-residual fusion
+
 
 class _State:
     def __init__(self, group: GroupCoordinator, comm: CustomAllReduceV2):
@@ -37,9 +45,7 @@ class _State:
 
 _STATE: Optional[_State] = None
 _INITIALIZED = False
-_O_PROJ_BUFFERS: dict[tuple, torch.Tensor] = {}
 _O_PROJ_RESULT_BUFFERS: dict[int, torch.Tensor] = {}
-_SYMM_MC_PTRS: dict[int, int] = {}
 _O_PROJ_OUTPUT_ROWS: ContextVar[Optional[int]] = ContextVar(
     "k3_sp_o_proj_output_rows", default=None
 )
@@ -118,11 +124,13 @@ def enabled() -> bool:
     return _init_state() is not None
 
 
-def symm_alloc():
-    """Allocate a tensor from torch's multicast-bound symmetric pool."""
-    from sglang.srt.layers.k3_ar_fusion import symm_alloc as _symm_alloc
-
-    return _symm_alloc()
+def _symm_buffer(
+    state: _State, name: str, rows: int, width: int, dtype: torch.dtype
+) -> torch.Tensor:
+    """Named persistent symmetric buffer over the group this module reduces on."""
+    return k3_ar_fusion.symm_buffer(
+        name, rows, width, dtype, group_name=state.group.cpu_group.group_name
+    )
 
 
 def requires_symmetric_rs(num_tokens: int, device: torch.device) -> bool:
@@ -153,55 +161,13 @@ def requires_symmetric_rs(num_tokens: int, device: torch.device) -> bool:
     return fusion is not None and fusion.strategy == "fused_pull"
 
 
-def _find_mc_ptr(state: _State, tensor: torch.Tensor) -> int:
-    cached = _SYMM_MC_PTRS.get(tensor.data_ptr())
-    if cached is not None:
-        return cached
-
-    import torch.distributed._symmetric_memory as torch_symm_mem
-
-    handle = torch_symm_mem.rendezvous(tensor, state.group.cpu_group.group_name)
-    if handle is None or handle.multicast_ptr == 0:
-        return 0
-    ptr = handle.multicast_ptr + tensor.data_ptr() - handle.buffer_ptrs[state.comm.rank]
-    _SYMM_MC_PTRS[tensor.data_ptr()] = ptr
-    return ptr
-
-
 def get_o_proj_output_buffer(
-    num_tokens: int,
-    dtype: torch.dtype,
-    device: torch.device,
-    hidden_size: int = _HIDDEN_SIZE,
+    num_tokens: int, dtype: torch.dtype, hidden_size: int = _HIDDEN_SIZE
 ) -> torch.Tensor:
-    """Return persistent symmetric storage for a TP-partial o_proj output."""
+    """Persistent symmetric storage for a TP-partial o_proj output."""
     state = _init_state()
-    if state is None:
-        raise RuntimeError("K3 SP collective is not initialized")
-    device = torch.device(device)
-    device_index = (
-        device.index if device.index is not None else torch.cuda.current_device()
-    )
-    key = (device.type, device_index, dtype, num_tokens, hidden_size)
-    output = _O_PROJ_BUFFERS.get(key)
-    if output is None:
-        with symm_alloc():
-            output = torch.empty(
-                (num_tokens, hidden_size),
-                dtype=dtype,
-                device=device,
-            )
-        if _find_mc_ptr(state, output) == 0:
-            raise RuntimeError("failed to multicast-bind K3 o_proj output buffer")
-        _O_PROJ_BUFFERS[key] = output
-        logger.info(
-            "Allocated persistent symmetric K3 o_proj buffer "
-            "(tokens=%d, hidden=%d, ptr=%#x)",
-            num_tokens,
-            hidden_size,
-            output.data_ptr(),
-        )
-    return output
+    assert state is not None, "K3 SP collective is not initialized"
+    return _symm_buffer(state, _O_PROJ, num_tokens, hidden_size, dtype)
 
 
 @contextmanager
@@ -245,17 +211,18 @@ def finish_padded_o_proj_output(
     return output
 
 
-def _resolve_symmetric_o_proj_input(
-    state: _State, tensor: torch.Tensor
-) -> tuple[torch.Tensor, int]:
-    """Recover the persistent o_proj buffer if a model wrapper rebound its view."""
-    input_mc_ptr = _find_mc_ptr(state, tensor)
-    if input_mc_ptr != 0:
+def _resolve_symmetric_o_proj_input(tensor: torch.Tensor) -> tuple[torch.Tensor, int]:
+    """Recover the persistent o_proj buffer if a model wrapper rebound its view.
+
+    The second element is 0 when neither is symmetric, and the caller falls back.
+    """
+    input_mc_ptr = k3_ar_fusion.find_mc_ptr(tensor)
+    if input_mc_ptr is not None:
         return tensor, input_mc_ptr
     output = _O_PROJ_RESULT_BUFFERS.get(tensor.data_ptr())
     if output is None:
         return tensor, 0
-    return output, _find_mc_ptr(state, output)
+    return output, k3_ar_fusion.find_mc_ptr(output) or 0
 
 
 def _eligible(
@@ -316,7 +283,7 @@ def reduce_scatter_res(
             tuning=dispatch.tuning,
         )
     if dispatch.strategy == "pull":
-        tensor, input_mc_ptr = _resolve_symmetric_o_proj_input(state, tensor)
+        tensor, input_mc_ptr = _resolve_symmetric_o_proj_input(tensor)
         if input_mc_ptr == 0:
             logger.warning("K3 pull RS input is not symmetric; using NCCL.")
             return None
@@ -369,7 +336,7 @@ def reduce_scatter_attn_res(
     )
     if dispatch is None or dispatch.strategy != "fused_pull":
         return None
-    tensor, input_mc_ptr = _resolve_symmetric_o_proj_input(state, tensor)
+    tensor, input_mc_ptr = _resolve_symmetric_o_proj_input(tensor)
     if input_mc_ptr == 0:
         logger.warning("K3 fused pull RS input is not symmetric; using separate path.")
         return None
@@ -431,22 +398,14 @@ def all_gather(tensor: torch.Tensor) -> Optional[torch.Tensor]:
             tuning=dispatch.tuning,
         )
     if dispatch.strategy == "direct":
-        import torch.distributed._symmetric_memory as torch_symm_mem
-
-        with symm_alloc():
-            output = torch.empty(output_shape, dtype=tensor.dtype, device=tensor.device)
-        handle = torch_symm_mem.rendezvous(output, state.group.cpu_group.group_name)
-        assert handle is not None and handle.multicast_ptr != 0
-        output_mc_ptr = (
-            handle.multicast_ptr
-            + output.data_ptr()
-            - handle.buffer_ptrs[state.comm.rank]
+        output = _symm_buffer(
+            state, _ALL_GATHER, global_tokens, tensor.shape[1], tensor.dtype
         )
         return sp_collective.all_gather_direct(
             state.group.world_size,
             tensor,
             output,
-            output_mc_ptr=output_mc_ptr,
+            output_mc_ptr=k3_ar_fusion.get_mc_ptr(output),
             tuning=dispatch.tuning,
         )
     raise AssertionError(f"unknown K3 all-gather strategy: {dispatch.strategy}")
@@ -492,15 +451,9 @@ def attn_res_all_gather(
     )
     if dispatch is None or dispatch.strategy != "fused_direct":
         return None
-    output_shape = (global_tokens, prefix.shape[1])
-    with symm_alloc():
-        output = torch.empty(output_shape, dtype=prefix.dtype, device=prefix.device)
-    output_mc_ptr = _find_mc_ptr(state, output)
-    if output_mc_ptr == 0:
-        logger.warning(
-            "K3 fused direct AG output is not symmetric; using separate path."
-        )
-        return None
+    output = _symm_buffer(
+        state, _ATTN_RES_AG, global_tokens, prefix.shape[1], prefix.dtype
+    )
     attn_res.attn_res_fused_direct_ag(
         state.group.world_size,
         prefix,
@@ -510,7 +463,7 @@ def attn_res_all_gather(
         output,
         nvb,
         eps,
-        output_mc_ptr=output_mc_ptr,
+        output_mc_ptr=k3_ar_fusion.get_mc_ptr(output),
         max_blocks=dispatch.max_blocks,
         write_prefix=write_prefix,
     )

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -2028,18 +2028,15 @@ class KimiK3DecoderLayer(nn.Module):
             o_proj.reduce_results = False
             if k3_sp_collective.enabled():
                 # The table selects NVLS pull RS for larger token buckets.
-                # Allocate only those o_proj outputs in multicast symmetric
-                # memory; small push RS keeps the regular graph allocator.
+                # Only those o_proj outputs come from the persistent symmetric
+                # buffer; small push RS keeps the regular graph allocator.
                 _sp_inner_o_proj_forward = o_proj.forward
 
                 def _sp_o_proj_forward(x, *args, **kwargs):
                     output_rows = k3_sp_collective.get_o_proj_output_rows(x.shape[0])
                     if k3_sp_collective.requires_symmetric_rs(output_rows, x.device):
                         output = k3_sp_collective.get_o_proj_output_buffer(
-                            output_rows,
-                            x.dtype,
-                            x.device,
-                            o_proj.output_size,
+                            output_rows, x.dtype, o_proj.output_size
                         )
                         result = _sp_inner_o_proj_forward(
                             x, *args, output_tensor=output[: x.shape[0]], **kwargs

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -351,6 +351,20 @@ def _add3(
 _EP_FRONT_LOGGED = False
 
 
+def _o_proj_takes_output(o_proj: RowParallelLinear) -> bool:
+    """Whether o_proj can write into caller-owned storage. ``apply_into`` is an
+    optional quant-method capability; only the unquantized method has it."""
+    return getattr(o_proj.quant_method, "apply_into", None) is not None
+
+
+def _k3_symm_o_proj_out(o_proj: RowParallelLinear, x: torch.Tensor) -> torch.Tensor:
+    """Symmetric storage for o_proj's TP-partial output; the fused attention
+    all-reduce reduces it in place."""
+    return k3_ar_fusion.symm_buffer(
+        k3_ar_fusion.ATTN_O_PROJ, x.shape[0], o_proj.weight.shape[0], x.dtype
+    )
+
+
 class KimiK3MoE(nn.Module):
     def __init__(
         self,
@@ -1036,8 +1050,14 @@ class KimiK3MoE(nn.Module):
             routed_input = routed_input.contiguous()
         latent_numel = num_tokens * self.moe_hidden_size
         if k3_ar_fusion.enabled():
-            with k3_ar_fusion.symm_alloc():
-                buf = hidden_states.new_empty(latent_numel + num_tokens * hidden_size)
+            # the shared-expert AR is pull-only, so its input must be a
+            # symm_buffer slice for every rank to resolve the same offset
+            buf = k3_ar_fusion.symm_buffer(
+                k3_ar_fusion.MOE_LATENT_SHARED,
+                num_tokens,
+                self.moe_hidden_size + hidden_size,
+                hidden_states.dtype,
+            ).view(-1)
         else:
             with use_symmetric_memory(
                 get_tp_group(), disabled=not is_allocation_symmetric()
@@ -1449,14 +1469,20 @@ class KimiK3DeltaAttention(nn.Module):
             # group (sums across DP groups) and asymmetric vs idle DP ranks
             # (deadlocks the per-layer DP gather). Off under all_reduce_fusion:
             # the fused AR does the reduce itself (reduce_results=False) and the
-            # forward wraps o_proj in k3 symm_alloc — leaving this True would
-            # nest use_symmetric_memory(attn_tp) inside symm_alloc and misroute
-            # the GEMM output away from the k3 pool (rendezvous miss). At the
-            # fusion config attn_tp==tp so the fused full-TP reduce is the same
-            # group anyway.
+            # forward hands o_proj a slice of a persistent symmetric region —
+            # leaving this True would wrap the GEMM in
+            # use_symmetric_memory(attn_tp), which allocates its own output and
+            # so defeats the caller-owned buffer. At the fusion config
+            # attn_tp==tp so the fused full-TP reduce is the same group anyway.
             use_dp_attention_reduce=not self.all_reduce_fusion,
             prefix=f"{prefix}.o_proj",
         )
+        if self.all_reduce_fusion and not _o_proj_takes_output(self.o_proj):
+            # the fused AR reduces o_proj's output in place out of a symmetric
+            # buffer, which needs the GEMM to write into caller-owned storage
+            self.all_reduce_fusion = False
+            self.o_proj.reduce_results = True
+            self.o_proj.use_dp_attention_reduce = True
         k3_gemm_ar.maybe_wrap_o_proj(self.o_proj)
         conv_weights = self.qkv_conv1d.weight.squeeze(1)
         bias = self.qkv_conv1d.bias
@@ -1661,8 +1687,8 @@ class KimiK3DeltaAttention(nn.Module):
             core_attn_out = self.o_norm(core_attn_out, norm_gate)
         core_attn_out = core_attn_out.squeeze(0).flatten(-2)
         if self.all_reduce_fusion:
-            with k3_ar_fusion.symm_alloc():
-                partial, _ = self.o_proj(core_attn_out)
+            out = _k3_symm_o_proj_out(self.o_proj, core_attn_out)
+            partial, _ = self.o_proj(core_attn_out, output_tensor=out)
             return partial
         return self.o_proj(core_attn_out)[0]
 
@@ -1705,26 +1731,38 @@ class KimiK3MLAAttention(DeepseekV2AttentionMLA):
         )
         # Installed before the output-gate wrap below so the gate multiply is
         # applied to x before the fused GEMM+AR sees it.
+        if self.all_reduce_fusion and not _o_proj_takes_output(self.o_proj):
+            # the fused AR reduces o_proj's output in place out of a symmetric
+            # buffer, which needs the GEMM to write into caller-owned storage
+            self.all_reduce_fusion = False
+            self.o_proj.reduce_results = True
+            self.o_proj.use_dp_attention_reduce = True
         k3_gemm_ar.maybe_wrap_o_proj(self.o_proj)
         if self.all_reduce_fusion:
             # reduce_results=False was passed through super().__init__ above;
-            # the fused all-reduce does the reduce itself and needs the o_proj
-            # output in the k3 symm pool, so install the symm-pool wrap and do
-            # NOT set use_dp_attention_reduce (its inner attn_tp symm_ctx would
-            # nest inside symm_alloc and misroute the GEMM output away from the
-            # k3 pool → rendezvous miss). At the fusion config (attn_tp==tp) the
-            # fused full-TP reduce is the same group as the attn_tp reduce.
+            # the fused all-reduce does the reduce itself and reduces the o_proj
+            # output in place, so hand the GEMM a slice of the persistent
+            # symmetric buffer (k3_ar_fusion.symm_buffer) and do NOT set
+            # use_dp_attention_reduce — its inner attn_tp symm_ctx allocates its
+            # own output and would defeat the caller-owned buffer. At the fusion
+            # config (attn_tp==tp) the fused full-TP reduce is the same group as
+            # the attn_tp reduce.
             # The wrap is installed before the output-gate wrap below so the
-            # gate multiply stays outside the pool and only the o_proj GEMM
-            # output lands in it. NOTE: the captured name must differ from the
+            # gate multiply stays outside it and only the o_proj GEMM writes the
+            # region slice. NOTE: the captured name must differ from the
             # gate block's `_orig_o_proj_forward` — closures capture the
             # __init__ local by reference, and reusing the name would rebind it
             # to this wrapper (infinite recursion + nested pool enter).
             _symm_inner_o_proj_forward = self.o_proj.forward
+            _symm_o_proj = self.o_proj
 
             def _symm_o_proj_forward(x, *args, **kwargs):
-                with k3_ar_fusion.symm_alloc():
-                    return _symm_inner_o_proj_forward(x, *args, **kwargs)
+                return _symm_inner_o_proj_forward(
+                    x,
+                    *args,
+                    output_tensor=_k3_symm_o_proj_out(_symm_o_proj, x),
+                    **kwargs,
+                )
 
             self.o_proj.forward = _symm_o_proj_forward
         else:
@@ -1928,6 +1966,10 @@ class KimiK3DecoderLayer(nn.Module):
                 alt_stream=alt_streams[1] if alt_streams is not None else None,
                 gate_alt_stream=alt_streams[2] if alt_streams is not None else None,
             )
+
+        # the attention drops the fusion when its o_proj cannot write into
+        # caller-owned storage; the layer's own AR call-site must agree
+        self.all_reduce_fusion = self.self_attn.all_reduce_fusion
 
         # MLP / MoE
         if self._is_moe_layer:

--- a/test/registered/kernels/ops/kimi_k3/test_symm_buffers.py
+++ b/test/registered/kernels/ops/kimi_k3/test_symm_buffers.py
@@ -1,0 +1,154 @@
+"""Invariants of the named persistent symmetric buffers behind the K3 fused pull.
+
+The NVLS pull reduces in place on its input's multicast alias, so every rank must
+resolve the same ``(buffer, offset)``. These tests pin the properties the design
+rests on:
+
+* a slice's offset is a pure function of its row count -- in particular it does
+  not depend on rank-local allocator state, which is exactly what broke when the
+  buffer came from a per-forward symm-pool allocation instead;
+* every rank resolves the same offset, including after rank-asymmetric memory
+  churn (a real server has that: routing-dependent temporaries differ per rank);
+* a buffer is created once per name, so no rendezvous runs on the hot path;
+
+Usage::
+
+    python test/registered/kernels/ops/kimi_k3/test_symm_buffers.py
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+import sglang.srt.distributed.parallel_state as ps
+from sglang.kernels.jit.utils import cache_once
+from sglang.srt.layers import k3_ar_fusion as ar
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(
+    est_time=60,
+    stage="extra-b",
+    runner_config="8-gpu-h200",
+)
+
+HIDDEN = 7168
+MOE_WIDTH = 3584 + HIDDEN
+# The buffers size themselves from the server args on first use; keep the bound
+# small here so the test's buffers stay small. What the tests check is the
+# offsets and the reporting, not the number.
+MAX_ROWS = 64
+
+
+@cache_once
+def _init_ctx():
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = coord = ps.init_world_group(
+        ranks=list(range(world_size)),
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    ps._TP = coord  # symm_buffer takes the group from the TP group
+    server_args = ServerArgs(model_path="dummy")
+    server_args.chunked_prefill_size = MAX_ROWS
+    set_global_server_args_for_scheduler(server_args)
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    return coord.cpu_group
+
+
+def _device() -> torch.device:
+    return torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+
+
+def _buf(name: str, rows: int, width: int):
+    _init_ctx()
+    return ar.symm_buffer(name, rows, width, torch.bfloat16)
+
+
+def _all_gather_ints(values: list[int]) -> list[list[int]]:
+    t = torch.tensor(values, dtype=torch.int64, device=_device())
+    out = [torch.empty_like(t) for _ in range(dist.get_world_size())]
+    dist.all_gather(out, t)
+    return [o.tolist() for o in out]
+
+
+_CASES = ((ar.ATTN_O_PROJ, HIDDEN), (ar.MOE_LATENT_SHARED, MOE_WIDTH))
+
+
+@pytest.mark.parametrize("name,width", _CASES)
+@torch.inference_mode()
+def test_buffer_is_created_once_and_multicast_capable(name: str, width: int):
+    first = _buf(name, 1, width)
+    mc = ar.get_mc_ptr(first)
+    assert mc != 0
+    # keyed by name: a second call reuses the same storage, so nothing is
+    # allocated and no rendezvous runs again
+    again = _buf(name, 1, width)
+    assert again.data_ptr() == first.data_ptr()
+    assert ar.get_mc_ptr(again) == mc
+
+
+@pytest.mark.parametrize("name,width", _CASES)
+@torch.inference_mode()
+def test_offsets_are_uniform_across_ranks(name: str, width: int):
+    base = ar.get_mc_ptr(_buf(name, 1, width))
+    offsets = []
+    for rows in (1, 5, 12, MAX_ROWS):
+        view = _buf(name, rows, width)
+        assert view.shape == (rows, width)
+        offsets.append(ar.get_mc_ptr(view) - base)
+    per_rank = _all_gather_ints(offsets)
+    assert all(o == per_rank[0] for o in per_rank), per_rank
+    # one slice per name, always from the buffer's base, so the offset carries no
+    # allocator state at all
+    assert offsets == [0, 0, 0, 0], offsets
+
+
+@torch.inference_mode()
+def test_offsets_survive_rank_asymmetric_churn():
+    """Rank-local allocator state must not reach the offset.
+
+    A real server's ranks have different VA histories (mxfp4's routing-dependent
+    temporaries, for one). Under the old per-forward symm-pool allocation that was
+    enough to make ranks pick different segments; here it must change nothing.
+    """
+    bases = [ar.get_mc_ptr(_buf(n, 1, w)) for n, w in _CASES]
+    rank = dist.get_rank()
+    churn = [
+        torch.empty((7 + rank) << 20, dtype=torch.uint8, device=_device())
+        for _ in range(rank + 1)
+    ]
+    del churn
+    torch.cuda.synchronize()
+    deltas = [ar.get_mc_ptr(_buf(n, 12, w)) - b for (n, w), b in zip(_CASES, bases)]
+    per_rank = _all_gather_ints(deltas)
+    assert all(d == per_rank[0] for d in per_rank), per_rank
+
+
+@torch.inference_mode()
+def test_slices_are_aligned_and_the_two_buffers_are_disjoint():
+    a = _buf(ar.ATTN_O_PROJ, MAX_ROWS, HIDDEN)
+    b = _buf(ar.MOE_LATENT_SHARED, MAX_ROWS, MOE_WIDTH)
+    for t in (a, b):
+        assert t.data_ptr() % 16 == 0
+        assert t.is_contiguous()
+    a_lo, a_hi = a.data_ptr(), a.data_ptr() + a.numel() * 2
+    b_lo, b_hi = b.data_ptr(), b.data_ptr() + b.numel() * 2
+    # the attention output and the MoE latent|shared buffer are live at the same
+    # time, so they must not overlap
+    assert a_hi <= b_lo or b_hi <= a_lo, (hex(a_lo), hex(a_hi), hex(b_lo), hex(b_hi))
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(8,))


### PR DESCRIPTION
The NVLS pull reduces in place on its input's multicast alias, so every rank must resolve the same `(buffer, offset)`. Allocating that input per forward out of torch's symm-mem pool does not give it: the pool routes through a `MemPool` whose block comparator breaks ties on the absolute address, `CUDASymmetricMemoryAllocator::alloc` is a purely local `cuMemCreate`, and `rendezvous` is cached per block and validates sizes only. Measured on 8xB300 (tp8, short prompts): one rank kept its old segment while the others moved, the multicast group split into `{0}` and `{1..7}`, and each side's reduce silently dropped the other's contribution -- garbage output.

Both fused families now take their storage from one named persistent buffer per NVLS-aliased tensor, rendezvoused once on the first cold forward and sliced per call, so multicast addresses are plain arithmetic and no rendezvous runs on the hot path. `symm_alloc` is gone.

* commit 1 -- the fused all-reduce path (`attn_o_proj`, `moe_latent_shared`); supersedes the earlier stopgap that disabled the fusion outside CUDA graphs.
* commit 2 -- the SP collective (`sp_o_proj`, `sp_all_gather`, `sp_attn_res_ag`). Its old o_proj dict allocated and rendezvoused per `(num_tokens, hidden)` bucket, i.e. during that bucket's CUDA graph capture, carrying the same hazard.

Verified on 8xB300: `test_symm_buffers` 6, `test_ar_fusion` 58, `test_gemm_ag` 29 passed; end-to-end tp8 correct with one buffer per name per rank and no fallback. The SP path is unexercised there -- its tuning tables only cover `NVIDIA_GB300`, so the collective never enables; that half needs a GB300 SP-MoE run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQiAHF7ykPjyaJ1sfhZikw

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30371547105](https://github.com/sgl-project/sglang/actions/runs/30371547105)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30371548076](https://github.com/sgl-project/sglang/actions/runs/30371548076)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
