### PR TITLE
fix(gemma3): fuse high-rank RMSNorm and guard mixed-dtype weights

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1077,15 +1077,43 @@ class Gemma3RMSNorm(MultiPlatformOp):
         return self.forward_native(x)
 
     def forward_cuda(self, x, residual: Optional[torch.Tensor] = None):
+        # The fused kernels read the weight in the activation dtype and do not
+        # validate it. `self.weight` is `nn.Parameter(torch.zeros(dim))`, so its
+        # dtype follows whatever default was in effect at construction; under
+        # the loader's `set_default_torch_dtype` that matches the activations,
+        # but a module built outside that context keeps an fp32 weight and the
+        # kernel then returns NaNs instead of raising. Fall back to the eager
+        # path in that case rather than silently producing garbage.
+        if (
+            x.dtype not in (torch.float16, torch.bfloat16)
+            or self.weight.dtype != x.dtype
+            or self.weight.device != x.device
+        ):
+            return self.forward_native(x, residual)
+
         if residual is not None:
             # The decoder residual is token-major and contiguous. The fused
             # kernel updates both tensors in place: x becomes the normalized
             # output and residual becomes x + residual for the next layer.
             gemma_fused_add_rmsnorm(x, residual, self.weight.data, self.eps)
             return x, residual
+
+        if x.shape[-1] != self.weight.numel():
+            return self.forward_native(x)
+
         if x.dim() == 2:
             return gemma_rmsnorm(x, self.weight.data, self.eps)
-        return self.forward_native(x)
+
+        # q_norm / k_norm are called with [tokens, heads, head_dim]. RMSNorm
+        # reduces over the last dimension only, so flattening the leading
+        # dimensions and restoring the shape afterwards is exact.
+        # `reshape` returns a view when the strides allow it, and that view is
+        # not always contiguous -- e.g. a slice along the last dimension keeps a
+        # row stride wider than the row. The kernel happens to honour a row
+        # stride today; `contiguous()` is a no-op for the shapes the model
+        # actually produces and removes the dependency on that detail.
+        flat = x.reshape(-1, x.shape[-1]).contiguous()
+        return gemma_rmsnorm(flat, self.weight.data, self.eps).view_as(x)
 
     def forward_npu(self, x, residual: Optional[torch.Tensor] = None):
         if residual is not None:

--- a/test/manual/layers/test_layernorm.py
+++ b/test/manual/layers/test_layernorm.py
@@ -3,7 +3,12 @@ import unittest
 
 import torch
 
-from sglang.srt.layers.layernorm import GemmaRMSNorm, LayerNorm, RMSNorm
+from sglang.srt.layers.layernorm import (
+    Gemma3RMSNorm,
+    GemmaRMSNorm,
+    LayerNorm,
+    RMSNorm,
+)
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -107,6 +112,124 @@ class TestGemmaRMSNorm(CustomTestCase):
                 seed=params[4],
             ):
                 self._run_gemma_rms_norm_test(*params)
+
+
+class TestGemma3RMSNorm(CustomTestCase):
+    """Covers Gemma3RMSNorm, whose CUDA path had no test.
+
+    Includes the rank-3 shapes that q_norm/k_norm receive, non-contiguous
+    inputs, the residual path, and an fp32 weight against half-precision
+    activations -- which is how the module is constructed when it is built
+    outside the loader's `set_default_torch_dtype` context
+    (`nn.Parameter(torch.zeros(dim))`).
+    """
+
+    DTYPES = [torch.half, torch.bfloat16]
+    NUM_TOKENS = [1, 7, 83, 4096]
+    HIDDEN_SIZES = [256, 768, 1152, 5120, 5126]
+    SEEDS = [0]
+
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is not available")
+        torch.set_default_device("cuda")
+
+    def _make(self, hidden_size, dtype, seed, weight_fp32):
+        torch.manual_seed(seed)
+        layer = Gemma3RMSNorm(hidden_size)
+        layer.weight.data.normal_(mean=0.0, std=0.1)
+        if not weight_fp32:
+            layer.weight.data = layer.weight.data.to(dtype)
+        return layer
+
+    def _check(self, layer, x):
+        with torch.inference_mode():
+            ref_out = layer.forward_native(x)
+            out = layer(x)
+        self.assertEqual(out.shape, ref_out.shape)
+        self.assertFalse(torch.isnan(out).any() or torch.isinf(out).any())
+        self.assertTrue(torch.allclose(out, ref_out, atol=1e-2, rtol=1e-2))
+
+    def test_gemma3_rms_norm(self):
+        for num_tokens, hidden_size, dtype, seed, weight_fp32 in itertools.product(
+            self.NUM_TOKENS,
+            self.HIDDEN_SIZES,
+            self.DTYPES,
+            self.SEEDS,
+            [True, False],
+        ):
+            with self.subTest(
+                num_tokens=num_tokens,
+                hidden_size=hidden_size,
+                dtype=dtype,
+                seed=seed,
+                weight_fp32=weight_fp32,
+            ):
+                scale = 1 / (2 * hidden_size)
+                x = torch.randn(num_tokens, hidden_size, dtype=dtype) * scale
+                self._check(self._make(hidden_size, dtype, seed, weight_fp32), x)
+
+    def test_gemma3_rms_norm_3d(self):
+        """q_norm / k_norm are called with [tokens, heads, head_dim]."""
+        for num_tokens, heads, head_dim, dtype, weight_fp32 in itertools.product(
+            [1, 37], [1, 4, 8], [128, 256], self.DTYPES, [True, False]
+        ):
+            with self.subTest(
+                num_tokens=num_tokens,
+                heads=heads,
+                head_dim=head_dim,
+                dtype=dtype,
+                weight_fp32=weight_fp32,
+            ):
+                scale = 1 / (2 * head_dim)
+                x = torch.randn(num_tokens, heads, head_dim, dtype=dtype) * scale
+                self._check(self._make(head_dim, dtype, 0, weight_fp32), x)
+
+    def test_gemma3_rms_norm_non_contiguous(self):
+        """A transposed or sliced view must not be assumed contiguous."""
+        for dtype in self.DTYPES:
+            head_dim = 256
+            scale = 1 / (2 * head_dim)
+            layer = self._make(head_dim, dtype, 0, weight_fp32=False)
+
+            # [tokens, heads, head_dim] produced by transposing [heads, tokens, .]
+            base = torch.randn(4, 37, head_dim, dtype=dtype) * scale
+            transposed = base.transpose(0, 1)
+            self.assertFalse(transposed.is_contiguous())
+            with self.subTest(dtype=dtype, case="transposed"):
+                self._check(layer, transposed)
+
+            # a strided slice along the last dimension
+            wide = torch.randn(37, 4, head_dim * 2, dtype=dtype) * scale
+            sliced = wide[..., :head_dim]
+            self.assertFalse(sliced.is_contiguous())
+            with self.subTest(dtype=dtype, case="sliced"):
+                self._check(layer, sliced)
+
+    def test_gemma3_rms_norm_residual(self):
+        """The residual path updates both tensors in place."""
+        for hidden_size, dtype, weight_fp32 in itertools.product(
+            [256, 1152], self.DTYPES, [True, False]
+        ):
+            with self.subTest(
+                hidden_size=hidden_size, dtype=dtype, weight_fp32=weight_fp32
+            ):
+                scale = 1 / (2 * hidden_size)
+                layer = self._make(hidden_size, dtype, 0, weight_fp32)
+                x = torch.randn(83, hidden_size, dtype=dtype) * scale
+                residual = torch.randn(83, hidden_size, dtype=dtype) * scale
+
+                with torch.inference_mode():
+                    ref_out, ref_residual = layer.forward_native(
+                        x.clone(), residual.clone()
+                    )
+                    out, out_residual = layer(x.clone(), residual.clone())
+
+                for got, ref in ((out, ref_out), (out_residual, ref_residual)):
+                    self.assertEqual(got.shape, ref.shape)
+                    self.assertFalse(torch.isnan(got).any() or torch.isinf(got).any())
+                    self.assertTrue(torch.allclose(got, ref, atol=1e-2, rtol=1e-2))
 
 
 class TestLayerNorm(CustomTestCase):


### PR DESCRIPTION
## Motivation

Fixes #32807.

#32383 landed fused paths for the 2-D and residual cases of `Gemma3RMSNorm`. Two gaps remain.

**1. Higher-rank inputs still take the eager path.** The dispatch is guarded by `x.dim() == 2`, but `q_norm` and `k_norm` are called with `[tokens, heads, head_dim]` — **52 of the 157 norm calls per forward** on `gemma-3-1b`. The eager path is `pow -> mean -> add -> rsqrt -> mul` plus fp32 casts, roughly six kernels where one would do. RMSNorm reduces over the last dimension only, so flattening the leading dimensions and restoring the shape is exact.

**2. Both fused paths pass `self.weight.data` unchecked.** The weight is `nn.Parameter(torch.zeros(dim))`, so its dtype follows whatever default is in effect at construction, and the fused kernels do not raise on a mismatch — they return NaNs:

```
gemma_rmsnorm(bf16_input, bf16_weight) -> finite
gemma_rmsnorm(bf16_input, fp32_weight) -> NaN/Inf, no exception
```

Under the loader's `set_default_torch_dtype` production weights already match the activations, so this is a **robustness gap rather than a live bug on `main`**.

Prior art: #21962 proposed the general high-rank reshape; #32383 landed the 2-D and residual paths. This PR is rebased on that state and covers what is left.

## Modifications

`python/sglang/srt/layers/layernorm.py` — `Gemma3RMSNorm.forward_cuda`:

- fall back to `forward_native` when the activation dtype is not fp16/bf16, or when the weight's dtype or device does not match the activation. Falling back rather than casting preserves fp32-weight semantics, leaves the residual path byte-identical to `main`, and adds no cached state to the module;
- add a shape guard (`x.shape[-1] != self.weight.numel()` -> native);
- for rank > 2, flatten to 2-D, call `gemma_rmsnorm`, and restore the shape with `view_as`.

`test/manual/layers/test_layernorm.py` — adds `TestGemma3RMSNorm`, which this class had none of.

Net diff is +30/-2 in `layernorm.py`.

## Accuracy Tests

Outputs are **not** bit-identical to the eager path — the fused kernel applies the weight in the activation dtype rather than promoting to fp32. 97.8–98.4% of elements are bit-identical and the rest differ at the BF16 rounding scale. This is the same trade-off the existing 2-D path already accepted; it is not introduced here.

New unit tests cover:

- 2-D hidden-state shapes and 3-D `q_norm`/`k_norm` shapes
- bf16 and fp16 activations; fp32 and half weights
- non-contiguous inputs — a transposed view and a slice along the last dimension, since `reshape` returns a non-contiguous *view* in the slice case rather than copying
- the residual path, checking both returned tensors against `forward_native`
- no NaN/Inf anywhere, including the fp32-weight case that currently produces them

The tests are mutation-checked rather than merely written: removing the dtype guard fails **68** subtests, removing the shape restore fails **28**. (Removing the `contiguous()` call does *not* fail, because the kernel honours a row stride today — it is kept as a cheap no-op so correctness does not depend on that detail, and this is stated rather than implied.)

## Speed Tests and Profiling

These are the increment attributable to *this* change, not to fusing `Gemma3RMSNorm` from scratch — most of that was already taken by #32383.

I could not run current `main` directly in this environment (it wants `transformers==5.12.1`; the available envs have 4.57.1 and 5.6.0, and mixing toolchains across envs broke the JIT link). The baseline arm therefore reproduces main's norm coverage exactly — 2-D fused, higher rank eager — and the patched arm adds the high-rank path, so the A/B measures the increment directly.

`gemma-3-1b-it`, 1×H200, BF16, sglang 0.5.12.post1, torch 2.9.1+cu128, Triton 3.5.1, driver 580.105.08. 6 reps per arm, Welch t-test with the exact Student-t tail:

| regime | baseline | patched | gain | p |
|---|---|---|---|---|
| low-batch decode (in=100, out=256, conc=1) | 1.300 req/s | 1.776 req/s | **+36.6%** | 2.4e-14 |
| concurrent decode (in=200, out=256, conc=32) | 33.648 req/s | 41.891 req/s | **+24.5%** | 1.2e-06 |
| 4K prefill-heavy (in=4000, out=32, conc=4) | 23.385 req/s | 25.085 req/s | +7.3% | 0.053 |

The prefill-heavy regime is **statistically neutral with a positive trend** — reported for completeness, not claimed as a win. The two decode regimes are where this change pays.

Mechanism: the norm goes from ~6 kernels and 7 HBM round trips to 1, on 52 of 157 norm calls per forward. The gain is largest in decode, where each forward is short enough that fixed per-forward kernel cost dominates, and smallest in prefill, where it is amortised over far more work — which is the shape the numbers show.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — ran `black` (26.1.0, the pinned rev), `isort`, `codespell` and `ruff` on both files; all clean.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — `TestGemma3RMSNorm` added, 4 tests, mutation-checked.
- [ ] Update documentation — N/A, no user-facing behaviour or API change.
- [x] Provide accuracy and speed benchmark results — above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Note: this PR has not had real CI coverage yet — the checks currently shown are the draft gate and `Require run-ci label`, which I cannot set. Happy to have someone run `/tag-and-rerun-ci`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30427315046](https://github.com/sgl-project/sglang/actions/runs/30427315046)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30427314801](https://github.com/sgl-project/sglang/actions/runs/30427314801)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->