### PR TITLE
[MiniMax-M3] Fix DeepEP forward batch propagation

### DIFF
--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -1276,7 +1276,14 @@ class MiniMaxM3DecoderLayer(nn.Module):
             forward_batch
         )
 
-        if self.is_layer_sparse or hidden_states.shape[0] != 0:
+        if self.is_layer_sparse:
+            hidden_states = self.mlp(
+                hidden_states,
+                forward_batch,
+                should_allreduce_fusion,
+                use_reduce_scatter,
+            )
+        elif hidden_states.shape[0] != 0:
             hidden_states = self.mlp(
                 hidden_states,
                 should_allreduce_fusion,


### PR DESCRIPTION
# Title

[MiniMax-M3] Fix DeepEP forward batch propagation

# Body

## Motivation

`MiniMaxM3DecoderLayer` passed `should_allreduce_fusion` where sparse `MiniMaxM3MoE` expects `forward_batch`. Standard EP ignores this argument, but DeepEP reads `forward_batch.num_token_non_padded` and fails with:

```text
AttributeError: 'bool' object has no attribute 'num_token_non_padded'
```

## Modifications

Split the dense and sparse MLP calls and pass `forward_batch` to `MiniMaxM3MoE`. Existing dense-layer and zero-token behavior is unchanged.

## Accuracy Tests

All tests ran on a 6x NVIDIA H20 NVLink 96 GB node with DeepGEMM and CUDA graph disabled. A third-party MXFP4 checkpoint was dequantized to FP8 at load time using changes outside this PR.

**Isolated before/after.** Using four GPUs and the first four MiniMax-M3 layers (three dense and one sparse), we tested TP=4 and EP=4. Reverting only this patch reproduced the error on all four ranks. With the patch applied, standard EP and DeepEP completed repeated single-request and three-request batch runs. All requests returned HTTP 200, repeats were deterministic, and both backends produced the same 32 output token IDs for every item.

**Full-model smoke test.** Using all six GPUs, the full 60-layer/128-expert model ran with TP=2, PP=3, EP=2, and DeepEP. Two deterministic 128-token generations returned identical, non-empty responses without a scheduler exception. This run also included independent PP/MoE-A2A fixes, so it is supplemental rather than isolated evidence.

Static checks:

```bash
uvx --from pre-commit pre-commit run \
  --files python/sglang/srt/models/minimax_m3.py
```

All applicable hooks passed.

## Speed Tests and Profiling

N/A. This change only fixes argument propagation and does not modify kernels or collectives.

## Checklist

- [x] Format the code with the repository's pre-commit hooks.
- Unit test not added: a mock positional-call test would duplicate the implementation; the actual 4-GPU DeepEP path was validated before and after.
- Documentation update: N/A.
- [x] Provide isolated DeepEP accuracy validation and a supplemental full-model smoke test.
- [x] Follow the SGLang code style guidance.
