### PR TITLE
[cuda_graph] Gate breakable-CG capture_inputs retention to DP-gather paths

### DIFF
--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1392,7 +1392,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             run_once,
             # DP padding can install capture-only tensors on this dummy batch;
             # BCG retains it so their recorded addresses remain valid.
-            capture_inputs=forward_batch,
+            capture_inputs=(
+                forward_batch
+                if forward_batch.global_num_tokens_gpu is not None
+                else None
+            ),
             post_warmup_hook=post_warmup_hook,
         )
 


### PR DESCRIPTION
## Problem

#31682 made `PrefillCudaGraphRunner` pass `forward_batch` as `capture_inputs` to `capture_one`, so `BreakableCudaGraphBackend` retains the batch per captured shape (`self._capture_inputs[shape_key]`). This keeps the CUDA-graph-recorded addresses of DP-padding *capture-only* tensors (`global_num_tokens_gpu` / `global_dp_buffer_len`) valid across replays.

But the retention is **unconditional**. Those capture-only tensors exist only under `require_mlp_tp_gather` / `require_attn_tp_gather` (DP attention, or MoE/MLP data parallelism). For a non-DP model there is nothing to keep alive, yet the runner still pins one `forward_batch` per prefill-graph bucket — pure overhead that inflates prefill CUDA-graph capture memory.

## Fix

Runner-side gate; the backend is unchanged. Pass `capture_inputs` only when the capture-only tensors are actually present:

```python
capture_inputs=(
    forward_batch
    if forward_batch.global_num_tokens_gpu is not None
    else None
)
```

DP and MoE/MLP-DP paths (`global_num_tokens_gpu is not None`) retain exactly as in #31682; the non-gather (non-DP) path no longer pins the batches.

## Impact

Measured on a non-DP TP=1 model (8k input + 1k output prefill):

| | prefill CG capture |
|---|---|
| before (main) | 7.04 GB |
| after (this PR) | 6.17 GB |

~0.87 GB of prefill CUDA-graph capture memory recovered. For deployments running at high `mem_fraction_static` with post-capture KV sizing, that memory goes straight back into the KV cache pool (larger max batch size / longer sequences).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30874112870](https://github.com/sgl-project/sglang/actions/runs/30874112870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30874112795](https://github.com/sgl-project/sglang/actions/runs/30874112795)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->