### PR TITLE
[Fix] Capture Eagle3/DFlash aux hidden states inside the two-batch-overlap region

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -4,8 +4,9 @@ import copy
 import dataclasses
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Container, Dict, List, Optional, Sequence
 
+import msgspec
 import torch
 
 from sglang.srt.batch_overlap.operations import (
@@ -865,6 +866,18 @@ def _compute_extend_num_tokens(input_ids, forward_mode: ForwardMode):
 # -------------------------------- Execution ---------------------------------------
 
 
+class TboAuxCaptureSink(msgspec.Struct):
+    """Per-sub-batch collector for Eagle3/DFlash captures taken inside the TBO region.
+
+    ``layer_ids`` is the model's ``layers_to_capture``; each sub-batch fills its own
+    ``captures`` with sub-batch-wide tensors, which the caller merges back by token
+    range once both sub-batches finish.
+    """
+
+    layer_ids: Container[int]
+    captures: List[torch.Tensor] = []
+
+
 def model_forward_maybe_tbo(
     layers,
     enable_tbo: bool,
@@ -874,7 +887,12 @@ def model_forward_maybe_tbo(
     input_data_scatter_mode: ScatterMode,
     residual: Optional[torch.Tensor],
     zero_allocator: Optional[BumpAllocator] = None,
+    captured_last_layer_outputs=None,
+    layers_to_capture: Optional[Container[int]] = None,
 ):
+    """``captured_last_layer_outputs`` is the same accumulator the non-TBO layer loop
+    appends to, so captures from both regions land in one layer-ordered sequence."""
+    capture_wanted = captured_last_layer_outputs is not None and layers_to_capture
     inputs = dict(
         positions=positions,
         hidden_states=hidden_states,
@@ -887,14 +905,56 @@ def model_forward_maybe_tbo(
         layers, forward_batch.global_forward_mode
     )
     if enable_tbo:
-        return _model_forward_tbo(
+        sinks = (
+            [TboAuxCaptureSink(layer_ids=layers_to_capture) for _ in range(2)]
+            if capture_wanted
+            else None
+        )
+        outputs = _model_forward_tbo(
             inputs=inputs,
             operations_strategy=operations_strategy,
             input_data_scatter_mode=input_data_scatter_mode,
             layer_input_scatter_mode=layer_input_scatter_mode,
+            aux_capture_sinks=sinks,
         )
+        if sinks is not None:
+            for merged in _merge_tbo_aux_captures(
+                sinks, forward_batch, original_len=hidden_states.shape[0]
+            ):
+                captured_last_layer_outputs.append(merged)
+        return outputs
     else:
+        if capture_wanted:
+            inputs["aux_capture_sink"] = TboAuxCaptureSink(
+                layer_ids=layers_to_capture, captures=captured_last_layer_outputs
+            )
         return _model_forward_non_tbo(inputs, operations_strategy)
+
+
+def _merge_tbo_aux_captures(
+    sinks: Sequence[TboAuxCaptureSink],
+    forward_batch: ForwardBatch,
+    original_len: int,
+) -> List[torch.Tensor]:
+    """Scatter each sub-batch's captures back into full-batch tensors, layer by layer."""
+    captures_a, captures_b = (sink.captures for sink in sinks)
+    assert len(captures_a) == len(captures_b), (
+        f"sub-batches captured different layer counts: "
+        f"{len(captures_a)} vs {len(captures_b)}"
+    )
+    s0, t0 = forward_batch.tbo_children[0].tbo_parent_token_range
+    s1, t1 = forward_batch.tbo_children[1].tbo_parent_token_range
+    merged = []
+    for value_a, value_b in zip(captures_a, captures_b):
+        res = torch.zeros(
+            (original_len, *value_a.shape[1:]),
+            dtype=value_a.dtype,
+            device=value_a.device,
+        )
+        res[slice(s0, t0)] = value_a[: t0 - s0]
+        res[slice(s1, t1)] = value_b[: t1 - s1]
+        merged.append(res)
+    return merged
 
 
 def _model_forward_tbo(
@@ -902,11 +962,13 @@ def _model_forward_tbo(
     operations_strategy: OperationsStrategy,
     input_data_scatter_mode: ScatterMode,
     layer_input_scatter_mode: ScatterMode,
+    aux_capture_sinks: Optional[Sequence[TboAuxCaptureSink]] = None,
 ):
     inputs_arr = _model_forward_tbo_split_inputs(
         **inputs,
         input_data_scatter_mode=input_data_scatter_mode,
         layer_input_scatter_mode=layer_input_scatter_mode,
+        aux_capture_sinks=aux_capture_sinks,
     )
     original_hidden_states_len = inputs["hidden_states"].shape[0]
     del inputs
@@ -942,6 +1004,7 @@ def _model_forward_tbo_split_inputs(
     zero_allocator: Optional[BumpAllocator],
     input_data_scatter_mode: ScatterMode,
     layer_input_scatter_mode: ScatterMode,
+    aux_capture_sinks: Optional[Sequence[TboAuxCaptureSink]] = None,
 ) -> List[Dict]:
     tbo_splitter_scatter_mode = ScatterMode.TP_ATTN_FULL
     context = CommunicateContext.init_new()
@@ -962,6 +1025,7 @@ def _model_forward_tbo_split_inputs(
         positions=positions,
         forward_batch=forward_batch,
         zero_allocator=zero_allocator,
+        aux_capture_sinks=aux_capture_sinks,
     )
 
     def _post_transform(hidden_states, residual, forward_batch, **kwargs):
@@ -990,6 +1054,7 @@ def _model_forward_tbo_split_inputs_raw(
     positions: torch.Tensor,
     forward_batch: ForwardBatch,
     zero_allocator: Optional[BumpAllocator],
+    aux_capture_sinks: Optional[Sequence[TboAuxCaptureSink]] = None,
 ) -> List[Dict]:
     return [
         dict(
@@ -999,6 +1064,11 @@ def _model_forward_tbo_split_inputs_raw(
                 positions=positions,
                 output_forward_batch=output_forward_batch,
                 tbo_subbatch_index=tbo_subbatch_index,
+                aux_capture_sink=(
+                    None
+                    if aux_capture_sinks is None
+                    else aux_capture_sinks[tbo_subbatch_index]
+                ),
             ),
             **(
                 dict(zero_allocator=zero_allocator)
@@ -1018,6 +1088,7 @@ def _model_forward_filter_inputs(
     positions: torch.Tensor,
     output_forward_batch: ForwardBatch,
     tbo_subbatch_index: int,
+    aux_capture_sink: Optional[TboAuxCaptureSink] = None,
 ) -> Dict:
     token_slice = slice(*output_forward_batch.tbo_parent_token_range)
     hidden_states = hidden_states[token_slice]
@@ -1043,6 +1114,9 @@ def _model_forward_filter_inputs(
         positions=_pad(positions),
         forward_batch=output_forward_batch,
         tbo_subbatch_index=tbo_subbatch_index,
+        # Omitted when unused: models that never capture have no such op parameter,
+        # and the ops chain forwards this dict as kwargs.
+        **({} if aux_capture_sink is None else dict(aux_capture_sink=aux_capture_sink)),
     )
 
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -39,6 +39,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
 from sglang.srt.batch_overlap.single_batch_overlap import SboFlags, compute_overlap_args
 from sglang.srt.batch_overlap.two_batch_overlap import (
     MaybeTboDeepEPDispatcher,
+    TboAuxCaptureSink,
     model_forward_maybe_tbo,
 )
 from sglang.srt.configs.model_config import (
@@ -2334,9 +2335,22 @@ class DeepseekV2DecoderLayer(nn.Module):
         residual: Optional[torch.Tensor],
         zero_allocator: BumpAllocator,
         tbo_subbatch_index: Optional[int] = None,
+        aux_capture_sink: Optional[TboAuxCaptureSink] = None,
     ):
+        # Passing None for captured_last_layer_outputs makes this identical to
+        # plain prepare_attn, so non-capturing layers take the same path.
         state.hidden_states_after_comm_pre_attn, state.residual_after_input_ln = (
-            self.layer_communicator.prepare_attn(hidden_states, residual, forward_batch)
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=(
+                    aux_capture_sink.captures
+                    if aux_capture_sink is not None
+                    and self.layer_id in aux_capture_sink.layer_ids
+                    else None
+                ),
+            )
         )
         if get_moe_a2a_backend().is_mori():
             state.num_tokens = hidden_states.shape[0]
@@ -2346,6 +2360,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                 positions=positions,
                 zero_allocator=zero_allocator,
                 tbo_subbatch_index=tbo_subbatch_index,
+                aux_capture_sink=aux_capture_sink,
             )
         )
 
@@ -2372,6 +2387,7 @@ class DeepseekV2DecoderLayer(nn.Module):
             forward_batch=state.forward_batch,
             zero_allocator=state.zero_allocator,
             tbo_subbatch_index=state.tbo_subbatch_index,
+            aux_capture_sink=state.aux_capture_sink,
         )
 
         state.clear(
@@ -2380,6 +2396,7 @@ class DeepseekV2DecoderLayer(nn.Module):
                 "forward_batch",
                 "zero_allocator",
                 "tbo_subbatch_index",
+                "aux_capture_sink",
             }
         )
         return output
@@ -2664,6 +2681,10 @@ class DeepseekV2Model(nn.Module):
                     normal_end_layer - 1
                 ].layer_scatter_modes.layer_output_mode,
                 zero_allocator=zero_allocator,
+                # The loop above covers [start, normal_end_layer) and this covers
+                # [normal_end_layer, end), so appending here keeps layer order.
+                captured_last_layer_outputs=aux_hidden_states,
+                layers_to_capture=self.layers_to_capture,
             )
 
         if not self.pp_group.is_last_rank:

--- a/test/registered/unit/batch_overlap/test_tbo_aux_capture.py
+++ b/test/registered/unit/batch_overlap/test_tbo_aux_capture.py
@@ -1,0 +1,109 @@
+"""Eagle3/DFlash aux capture inside the TBO region.
+
+Each sub-batch captures over its own contiguous slice of the parent's tokens, padded
+to ``tbo_padded_len``; the merge scatters both back into full-batch tensors. CPU-only.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.batch_overlap.two_batch_overlap import (
+    TboAuxCaptureSink,
+    _merge_tbo_aux_captures,
+    _model_forward_filter_inputs,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+HIDDEN = 3
+
+
+def _fake_parent(ranges, padded_lens=None):
+    padded_lens = padded_lens or [t - s for s, t in ranges]
+    return SimpleNamespace(
+        tbo_children=[
+            SimpleNamespace(tbo_parent_token_range=r, tbo_padded_len=p)
+            for r, p in zip(ranges, padded_lens)
+        ]
+    )
+
+
+class TestMergeTboAuxCaptures(CustomTestCase):
+    def test_scatters_both_sub_batches_by_token_range(self):
+        original_len = 6
+        parent = _fake_parent([(0, 4), (4, 6)])
+        full = [torch.randn(original_len, HIDDEN) for _ in range(3)]
+        sinks = [
+            TboAuxCaptureSink(layer_ids={2}, captures=[t[0:4] for t in full]),
+            TboAuxCaptureSink(layer_ids={2}, captures=[t[4:6] for t in full]),
+        ]
+
+        merged = _merge_tbo_aux_captures(sinks, parent, original_len=original_len)
+
+        self.assertEqual(len(merged), 3)
+        for got, want in zip(merged, full):
+            self.assertEqual(got.shape, want.shape)
+            torch.testing.assert_close(got, want)
+
+    def test_trims_sub_batch_padding(self):
+        # A sub-batch tensor is padded past its token range; the tail must be dropped.
+        original_len = 5
+        parent = _fake_parent([(0, 3), (3, 5)], padded_lens=[4, 4])
+        a = torch.arange(4 * HIDDEN, dtype=torch.float32).reshape(4, HIDDEN)
+        b = torch.arange(4 * HIDDEN, dtype=torch.float32).reshape(4, HIDDEN) + 100
+
+        merged = _merge_tbo_aux_captures(
+            [
+                TboAuxCaptureSink(layer_ids={0}, captures=[a]),
+                TboAuxCaptureSink(layer_ids={0}, captures=[b]),
+            ],
+            parent,
+            original_len=original_len,
+        )
+
+        self.assertEqual(merged[0].shape, (original_len, HIDDEN))
+        torch.testing.assert_close(merged[0][0:3], a[:3])
+        torch.testing.assert_close(merged[0][3:5], b[:2])
+
+    def test_rejects_mismatched_capture_counts(self):
+        parent = _fake_parent([(0, 2), (2, 4)])
+        with self.assertRaises(AssertionError):
+            _merge_tbo_aux_captures(
+                [
+                    TboAuxCaptureSink(layer_ids={0}, captures=[torch.zeros(2, HIDDEN)]),
+                    TboAuxCaptureSink(layer_ids={0}, captures=[]),
+                ],
+                parent,
+                original_len=4,
+            )
+
+
+class TestFilterInputsSinkKey(CustomTestCase):
+    """The ops chain forwards this dict as kwargs, so the key must be absent for
+    models whose ``op_comm_prepare_attn`` has no ``aux_capture_sink`` parameter."""
+
+    def _filter(self, sink):
+        child = SimpleNamespace(tbo_parent_token_range=(0, 2), tbo_padded_len=2)
+        return _model_forward_filter_inputs(
+            hidden_states=torch.zeros(4, HIDDEN),
+            residual=torch.zeros(4, HIDDEN),
+            positions=torch.zeros(4, dtype=torch.int64),
+            output_forward_batch=child,
+            tbo_subbatch_index=0,
+            aux_capture_sink=sink,
+        )
+
+    def test_key_omitted_without_sink(self):
+        self.assertNotIn("aux_capture_sink", self._filter(None))
+
+    def test_key_present_with_sink(self):
+        sink = TboAuxCaptureSink(layer_ids={1})
+        self.assertIs(self._filter(sink)["aux_capture_sink"], sink)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
With two-batch-overlap on, the layers that run under TBO never captured aux hidden states, so an Eagle3/DFlash target produced a too-narrow aux tensor (on DeepSeek-V2-Lite: 0 of 3 layers captured). Each sub-batch now captures over its own token slice and the results are merged back by token range.

Verified by unit tests only; a TBO end-to-end run was not possible locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30401269324](https://github.com/sgl-project/sglang/actions/runs/30401269324)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30401269284](https://github.com/sgl-project/sglang/actions/runs/30401269284)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->