### PR TITLE
[Diffusion] Return scheduler sigmas snapshot in rollout dit_trajectory

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -130,6 +130,7 @@ def _slice_rollout_trajectory_for_sample(
         dit_trajectory = RolloutDitTrajectory(
             latents=_extract_single_sample_tensor(dit.latents, sample_idx, batch_size),
             timesteps=dit.timesteps,
+            sigmas=dit.sigmas,
         )
     return RolloutTrajectoryData(
         rollout_log_probs=log_probs,
@@ -143,6 +144,7 @@ def _serialize_rollout_trajectory(
     rtd: RolloutTrajectoryData | None,
     *,
     serialized_dit_timesteps: dict | None = None,
+    serialized_dit_sigmas: dict | None = None,
 ) -> tuple[dict | None, dict | None, dict | None, dict | None]:
     """Return order: rollout_log_probs, rollout_debug_tensors, denoising_env, dit_trajectory."""
     if rtd is None:
@@ -182,6 +184,7 @@ def _serialize_rollout_trajectory(
                 _maybe_serialize(dit.latents) if dit.latents is not None else None
             ),
             "timesteps": serialized_dit_timesteps,
+            "sigmas": serialized_dit_sigmas,
         }
     return (
         serialized_log_probs,
@@ -211,9 +214,13 @@ def _build_response(
         ), "rollout_trajectory_data must be present when rollout=True"
 
     serialized_dit_timesteps = None
+    serialized_dit_sigmas = None
     if rollout and rollout_trajectory_data and rollout_trajectory_data.dit_trajectory:
         serialized_dit_timesteps = _maybe_serialize(
             rollout_trajectory_data.dit_trajectory.timesteps
+        )
+        serialized_dit_sigmas = _maybe_serialize(
+            rollout_trajectory_data.dit_trajectory.sigmas
         )
 
     responses: list[RolloutResponse] = []
@@ -245,6 +252,7 @@ def _build_response(
         ) = _serialize_rollout_trajectory(
             per_sample_trajectory,
             serialized_dit_timesteps=serialized_dit_timesteps,
+            serialized_dit_sigmas=serialized_dit_sigmas,
         )
         responses.append(
             RolloutResponse(

--- a/python/sglang/multimodal_gen/runtime/post_training/rl_dataclasses.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/rl_dataclasses.py
@@ -52,6 +52,8 @@ class RolloutDitTrajectory:
     # final denoised latent x_{t_T} (last scheduler.step output).
     latents: torch.Tensor | None = None
     timesteps: torch.Tensor | None = None  # [T]
+    # [T+1] scheduler.sigmas snapshot (post-shift, includes terminal 0).
+    sigmas: torch.Tensor | None = None
 
 
 @dataclass

--- a/python/sglang/multimodal_gen/runtime/post_training/rollout_denoising_mixin.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/rollout_denoising_mixin.py
@@ -186,6 +186,7 @@ class RolloutDenoisingMixin:
             batch.rollout_trajectory_data.dit_trajectory = RolloutDitTrajectory(
                 latents=step_latents_tensor.cpu(),
                 timesteps=torch.stack(step_timesteps, dim=0).cpu(),
+                sigmas=batch.scheduler.sigmas.detach().cpu().clone(),
             )
 
         if env is not None and batch.rollout_return_denoising_env:

--- a/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
@@ -207,11 +207,13 @@ class TestSerializeRolloutTrajectory(unittest.TestCase):
             dit_trajectory=RolloutDitTrajectory(
                 latents=torch.randn(1, 5, 4, 2, 2, 2),
                 timesteps=torch.tensor([1.0, 0.75, 0.5, 0.25]),
+                sigmas=torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]),
             ),
         )
         _, _, env, dit_traj = _serialize_rollout_trajectory(
             rtd,
             serialized_dit_timesteps=_maybe_serialize(rtd.dit_trajectory.timesteps),
+            serialized_dit_sigmas=_maybe_serialize(rtd.dit_trajectory.sigmas),
         )
         self.assertIsNotNone(env)
         self.assertIn("pos_cond_kwargs", env)
@@ -219,8 +221,10 @@ class TestSerializeRolloutTrajectory(unittest.TestCase):
         self.assertIsNotNone(dit_traj)
         self.assertIn("latents", dit_traj)
         self.assertIn("timesteps", dit_traj)
+        self.assertIn("sigmas", dit_traj)
         self.assertTrue(dit_traj["latents"]["__tensor__"])
         self.assertTrue(dit_traj["timesteps"]["__tensor__"])
+        self.assertTrue(dit_traj["sigmas"]["__tensor__"])
 
 
 class TestBuildResponse(unittest.TestCase):
@@ -327,6 +331,7 @@ class TestBuildResponse(unittest.TestCase):
                 dit_trajectory=RolloutDitTrajectory(
                     latents=torch.randn(B, T + 1, D),
                     timesteps=torch.linspace(1.0, 0.0, T),
+                    sigmas=torch.linspace(1.0, 0.0, T + 1),
                 ),
             ),
         )
@@ -339,6 +344,10 @@ class TestBuildResponse(unittest.TestCase):
         ts1 = bytes_to_tensor(resps[1].dit_trajectory["timesteps"]["data"])
         self.assertEqual(ts0.shape, (T,))
         self.assertTrue(torch.equal(ts0, ts1))
+        sg0 = bytes_to_tensor(resps[0].dit_trajectory["sigmas"]["data"])
+        sg1 = bytes_to_tensor(resps[1].dit_trajectory["sigmas"]["data"])
+        self.assertEqual(sg0.shape, (T + 1,))
+        self.assertTrue(torch.equal(sg0, sg1))
         self.assertEqual(
             _maybe_deserialize(resps[1].dit_trajectory["latents"]).shape, (T + 1, D)
         )


### PR DESCRIPTION
## What

- Add `sigmas` to `RolloutDitTrajectory`: a `[T+1]` snapshot of `scheduler.sigmas` (post-shift, includes the terminal 0), captured when the trajectory is finalized and returned alongside `timesteps` in `POST /rollout/generate` responses.

## Why

Training-side consumers currently recompute sigmas from trajectory timesteps as `timesteps / num_train_timesteps`. That round-trips `sigma * 1000 / 1000` and drifts ULPs, which amplifies into observable log-prob differences when the division happens in bf16. The scheduler already holds the exact per-request schedule (`set_timesteps` rebuilds `self.sigmas` for the request's actual `num_inference_steps`), so return it directly.

Semantics worth noting for reviewers:

- `sigmas` is schedule metadata, not per-entry data: it stays the full `[T+1]` schedule and is not affected by `rollout_return_step_indices` filtering. When filtering is used, consumers must align by absolute step index rather than zipping positionally with the filtered `timesteps`.
- It is batch-global: with `num_outputs_per_prompt > 1` all samples of a request share one scheduler schedule, so the per-sample slicer passes it through unsliced (same pattern as `timesteps`). This also avoids `_extract_single_sample_tensor` mis-slicing a 1-D schedule whose length happens to equal `batch_size`.
- Samplers that call `set_timesteps` more than once per generation (multi-stage pipelines) would snapshot the last schedule; this matches the existing `timesteps` behavior and single-stage rollout is the only supported RL path today.

## Validation

- `python -m pytest python/sglang/multimodal_gen/test/unit/test_rollout_api.py -q`: 34 passed (H200).
- E2E on H200: launched `stabilityai/stable-diffusion-3.5-medium`, 10-step rollout via `POST /rollout/generate` with `rollout_return_dit_trajectory=true`; response `dit_trajectory.sigmas` is fp32 `(11,)` with terminal 0, and `sigma * 1000` bitwise-equals the returned `timesteps`.

## Files

- `runtime/post_training/rl_dataclasses.py` — add the `sigmas` field.
- `runtime/post_training/rollout_denoising_mixin.py` — snapshot `batch.scheduler.sigmas` at trajectory finalize.
- `runtime/entrypoints/post_training/rollout_api.py` — pass `sigmas` through per-sample extraction and response serialization.
- `test/unit/test_rollout_api.py` — extend serialization and batched-response tests.

## Checklist

- [x] `pre-commit run --files <changed files>` passes (all hooks, no auto-fixes needed)
- [x] Added/updated tests for new behaviour
- [x] `pytest -x` is green (scoped to `test_rollout_api.py`, 34 passed)
- [x] No launch flags changed
- [x] No public flag added
- [x] No example added

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30410262021](https://github.com/sgl-project/sglang/actions/runs/30410262021)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30410261848](https://github.com/sgl-project/sglang/actions/runs/30410261848)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->