### PR TITLE
Prevent DeepGEMM startup warmup OOMs when smaller buffers fit

### DIFF
--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -6,7 +6,7 @@ import time
 from contextlib import contextmanager, nullcontext
 from enum import IntEnum, auto
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 from tqdm import tqdm
@@ -186,6 +186,28 @@ def _maybe_compile_deep_gemm_one_type_all(
             )
 
 
+def _select_max_m_within_budget(
+    kernel_type: DeepGemmKernelType,
+    m_list: List[int],
+    n: int,
+    k: int,
+    num_groups: int,
+    memory_budget: float,
+) -> Optional[int]:
+    # Reduce geometrically because the estimate is monotonic in max_m.
+    min_m, max_m = min(m_list), max(m_list)
+    while (
+        _BaseWarmupExecutor.get_memory_requirement(
+            kernel_type, max_m=max_m, n=n, k=k, num_groups=num_groups
+        )
+        > memory_budget
+    ):
+        if max_m <= min_m:
+            return None
+        max_m = max(max_m // 2, min_m)
+    return max_m
+
+
 # NOTE(alcanderian): get_num_sms should be change when 2-batch-overlap is introduced
 def _compile_deep_gemm_one_type_all(
     kernel_type: DeepGemmKernelType,
@@ -219,15 +241,20 @@ def _compile_deep_gemm_one_type_all(
             f"Required memory for warmup: {required_memory}GB, Available memory: {memory_budget}GB"
         )
         if memory_budget < required_memory:
-            # TODO: Maybe compute the max_m based on the memory budget
-            while (
-                _BaseWarmupExecutor.get_memory_requirement(
-                    kernel_type, max_m=max_m, n=n, k=k, num_groups=num_groups
+            max_m = _select_max_m_within_budget(
+                kernel_type,
+                m_list=m_list,
+                n=n,
+                k=k,
+                num_groups=num_groups,
+                memory_budget=memory_budget,
+            )
+            if max_m is None:
+                logger.warning(
+                    f"Available memory {memory_budget}GB is not enough for warmup even at M={min(m_list)}, "
+                    f"skipping warmup for <{kernel_type.name}> N={n}, K={k}, num_groups={num_groups}"
                 )
-                > memory_budget
-                and max_m > 2048
-            ):
-                max_m = max_m // 2
+                return
             logger.warning(
                 f"Available memory {memory_budget}GB is less than required memory {required_memory}GB for warmup, reducing max_m to {max_m} to avoid out of memory"
             )

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -4,7 +4,7 @@ import os
 import time
 from contextlib import contextmanager, nullcontext
 from enum import IntEnum, auto
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 from tqdm import tqdm
@@ -155,6 +155,28 @@ def _maybe_compile_deep_gemm_one_type_all(
         )
 
 
+def _select_max_m_within_budget(
+    kernel_type: DeepGemmKernelType,
+    m_list: List[int],
+    n: int,
+    k: int,
+    num_groups: int,
+    memory_budget: float,
+) -> Optional[int]:
+    # Reduce geometrically because the estimate is monotonic in max_m.
+    min_m, max_m = min(m_list), max(m_list)
+    while (
+        _BaseWarmupExecutor.get_memory_requirement(
+            kernel_type, max_m=max_m, n=n, k=k, num_groups=num_groups
+        )
+        > memory_budget
+    ):
+        if max_m <= min_m:
+            return None
+        max_m = max(max_m // 2, min_m)
+    return max_m
+
+
 # NOTE(alcanderian): get_num_sms should be change when 2-batch-overlap is introduced
 def _compile_deep_gemm_one_type_all(
     kernel_type: DeepGemmKernelType,
@@ -186,15 +208,20 @@ def _compile_deep_gemm_one_type_all(
             f"Required memory for warmup: {required_memory}GB, Available memory: {memory_budget}GB"
         )
         if memory_budget < required_memory:
-            # TODO: Maybe compute the max_m based on the memory budget
-            while (
-                _BaseWarmupExecutor.get_memory_requirement(
-                    kernel_type, max_m=max_m, n=n, k=k, num_groups=num_groups
+            max_m = _select_max_m_within_budget(
+                kernel_type,
+                m_list=m_list,
+                n=n,
+                k=k,
+                num_groups=num_groups,
+                memory_budget=memory_budget,
+            )
+            if max_m is None:
+                logger.warning(
+                    f"Available memory {memory_budget}GB is not enough for warmup even at M={min(m_list)}, "
+                    f"skipping warmup for <{kernel_type.name}> N={n}, K={k}, num_groups={num_groups}"
                 )
-                > memory_budget
-                and max_m > 4096
-            ):
-                max_m = max_m // 2
+                return
             logger.warning(
                 f"Available memory {memory_budget}GB is less than required memory {required_memory}GB for warmup, reducing max_m to {max_m} to avoid out of memory"
             )

--- a/test/registered/unit/layers/deep_gemm_wrapper/test_compile_utils.py
+++ b/test/registered/unit/layers/deep_gemm_wrapper/test_compile_utils.py
@@ -1,0 +1,138 @@
+"""Tests for DeepGEMM warmup memory-budget selection."""
+
+import unittest
+from contextlib import ExitStack
+from typing import Optional
+from unittest.mock import MagicMock, call, patch
+
+from sglang.srt.layers.deep_gemm_wrapper import compile_utils
+from sglang.srt.layers.deep_gemm_wrapper.compile_utils import (
+    DeepGemmKernelType,
+    _BaseWarmupExecutor,
+    _compile_deep_gemm_one_type_all,
+    _select_max_m_within_budget,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_M_LIST = list(range(1, 16 * 1024 + 1))
+_KERNEL_TYPE = DeepGemmKernelType.GEMM_NT_F8F8BF16
+
+
+def _select(memory_budget: float) -> Optional[int]:
+    return _select_max_m_within_budget(
+        _KERNEL_TYPE,
+        m_list=_M_LIST,
+        n=4096,
+        k=7168,
+        num_groups=1,
+        memory_budget=memory_budget,
+    )
+
+
+class TestSelectMaxMWithinBudget(CustomTestCase):
+    def _patch_memory_requirement(self, fn):
+        return patch.object(
+            _BaseWarmupExecutor, "get_memory_requirement", staticmethod(fn)
+        )
+
+    def test_original_max_m_fits(self):
+        with self._patch_memory_requirement(lambda *a, **kw: 1.0):
+            self.assertEqual(_select(memory_budget=8.0), max(_M_LIST))
+
+    def test_reduces_below_4096(self):
+        with self._patch_memory_requirement(lambda *a, max_m, **kw: max_m / 1024):
+            self.assertEqual(_select(memory_budget=2.5), 2048)
+
+    def test_returns_none_when_min_m_does_not_fit(self):
+        with self._patch_memory_requirement(lambda *a, **kw: 100.0):
+            self.assertIsNone(_select(memory_budget=8.0))
+
+
+class TestCompileDeepGemmOneTypeAll(CustomTestCase):
+    """Covers how the caller reacts to the max_m selection outcome."""
+
+    def _patch_common(self, stack, available_memory: float, memory_requirement):
+        stack.enter_context(
+            patch.object(
+                _BaseWarmupExecutor,
+                "get_memory_requirement",
+                staticmethod(memory_requirement),
+            )
+        )
+        saved_context = object()
+        stack.enter_context(
+            patch.object(
+                compile_utils,
+                "disable_symmetric_memory_context",
+                return_value=saved_context,
+            )
+        )
+        restore = stack.enter_context(
+            patch.object(compile_utils, "restore_symmetric_memory_context")
+        )
+        stack.enter_context(
+            patch.object(
+                compile_utils, "get_available_gpu_memory", return_value=available_memory
+            )
+        )
+        return saved_context, restore
+
+    def test_skips_warmup_when_min_m_does_not_fit(self):
+        with ExitStack() as stack:
+            saved_context, restore = self._patch_common(
+                stack, available_memory=1.0, memory_requirement=lambda *a, **kw: 100.0
+            )
+            create = stack.enter_context(
+                patch.object(_BaseWarmupExecutor, "create", MagicMock())
+            )
+            with self.assertLogs(compile_utils.logger, level="WARNING") as logs:
+                _compile_deep_gemm_one_type_all(
+                    kernel_type=_KERNEL_TYPE,
+                    n=4096,
+                    k=7168,
+                    num_groups=1,
+                    m_list=[1024, 2048, 4096],
+                )
+
+        create.assert_not_called()
+        self.assertIn("skipping warmup", "\n".join(logs.output))
+        restore.assert_called_once_with(saved_context)
+
+    def test_warms_up_reduced_m_list(self):
+        with ExitStack() as stack:
+            saved_context, restore = self._patch_common(
+                stack,
+                available_memory=2.5,
+                memory_requirement=lambda *a, max_m, **kw: max_m / 1024,
+            )
+            executor = MagicMock()
+            create = stack.enter_context(
+                patch.object(_BaseWarmupExecutor, "create", MagicMock())
+            )
+            create.return_value = executor
+            stack.enter_context(
+                patch.object(compile_utils, "deep_gemm", MagicMock(), create=True)
+            )
+            stack.enter_context(patch("torch.cuda.current_stream"))
+            stack.enter_context(patch("torch.cuda.empty_cache"))
+
+            _compile_deep_gemm_one_type_all(
+                kernel_type=_KERNEL_TYPE,
+                n=4096,
+                k=7168,
+                num_groups=1,
+                m_list=[1024, 2048, 4096],
+            )
+
+        create.assert_called_once_with(
+            _KERNEL_TYPE, max_m=2048, n=4096, k=7168, num_groups=1
+        )
+        self.assertEqual(executor.execute.call_args_list, [call(m=1024), call(m=2048)])
+        restore.assert_called_once_with(saved_context)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/deep_gemm_wrapper/test_compile_utils.py
+++ b/test/registered/unit/layers/deep_gemm_wrapper/test_compile_utils.py
@@ -1,0 +1,139 @@
+"""Tests for DeepGEMM warmup memory-budget selection."""
+
+import unittest
+from contextlib import ExitStack
+from typing import Optional
+from unittest.mock import MagicMock, call, patch
+
+from sglang.srt.layers.deep_gemm_wrapper import compile_utils
+from sglang.srt.layers.deep_gemm_wrapper.compile_utils import (
+    DeepGemmKernelType,
+    _BaseWarmupExecutor,
+    _compile_deep_gemm_one_type_all,
+    _select_max_m_within_budget,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_M_LIST = list(range(1, 16 * 1024 + 1))
+_KERNEL_TYPE = DeepGemmKernelType.GEMM_NT_F8F8BF16
+
+
+def _select(memory_budget: float) -> Optional[int]:
+    return _select_max_m_within_budget(
+        _KERNEL_TYPE,
+        m_list=_M_LIST,
+        n=4096,
+        k=7168,
+        num_groups=1,
+        memory_budget=memory_budget,
+    )
+
+
+class TestSelectMaxMWithinBudget(CustomTestCase):
+    def _patch_memory_requirement(self, fn):
+        return patch.object(
+            _BaseWarmupExecutor, "get_memory_requirement", staticmethod(fn)
+        )
+
+    def test_original_max_m_fits(self):
+        with self._patch_memory_requirement(lambda *a, **kw: 1.0):
+            self.assertEqual(_select(memory_budget=8.0), max(_M_LIST))
+
+    def test_reduces_below_2048(self):
+        with self._patch_memory_requirement(lambda *a, max_m, **kw: max_m / 1024):
+            self.assertEqual(_select(memory_budget=1.5), 1024)
+
+    def test_returns_none_when_min_m_does_not_fit(self):
+        with self._patch_memory_requirement(lambda *a, **kw: 100.0):
+            self.assertIsNone(_select(memory_budget=8.0))
+
+
+class TestCompileDeepGemmOneTypeAll(CustomTestCase):
+    """Covers how the caller reacts to the max_m selection outcome."""
+
+    def _patch_common(self, stack, available_memory: float, memory_requirement):
+        stack.enter_context(
+            patch.object(
+                _BaseWarmupExecutor,
+                "get_memory_requirement",
+                staticmethod(memory_requirement),
+            )
+        )
+        saved_context = object()
+        stack.enter_context(
+            patch.object(
+                compile_utils,
+                "disable_symmetric_memory_context",
+                return_value=saved_context,
+            )
+        )
+        restore = stack.enter_context(
+            patch.object(compile_utils, "restore_symmetric_memory_context")
+        )
+        stack.enter_context(
+            patch.object(
+                compile_utils, "get_available_gpu_memory", return_value=available_memory
+            )
+        )
+        stack.enter_context(patch("torch.cuda.current_device", return_value=0))
+        return saved_context, restore
+
+    def test_skips_warmup_when_min_m_does_not_fit(self):
+        with ExitStack() as stack:
+            saved_context, restore = self._patch_common(
+                stack, available_memory=1.0, memory_requirement=lambda *a, **kw: 100.0
+            )
+            create = stack.enter_context(
+                patch.object(_BaseWarmupExecutor, "create", MagicMock())
+            )
+            with self.assertLogs(compile_utils.logger, level="WARNING") as logs:
+                _compile_deep_gemm_one_type_all(
+                    kernel_type=_KERNEL_TYPE,
+                    n=4096,
+                    k=7168,
+                    num_groups=1,
+                    m_list=[1024, 2048, 4096],
+                )
+
+        create.assert_not_called()
+        self.assertIn("skipping warmup", "\n".join(logs.output))
+        restore.assert_called_once_with(saved_context)
+
+    def test_warms_up_reduced_m_list(self):
+        with ExitStack() as stack:
+            saved_context, restore = self._patch_common(
+                stack,
+                available_memory=2.5,
+                memory_requirement=lambda *a, max_m, **kw: max_m / 1024,
+            )
+            executor = MagicMock()
+            create = stack.enter_context(
+                patch.object(_BaseWarmupExecutor, "create", MagicMock())
+            )
+            create.return_value = executor
+            stack.enter_context(
+                patch.object(compile_utils, "deep_gemm", MagicMock(), create=True)
+            )
+            stack.enter_context(patch("torch.cuda.current_stream"))
+            stack.enter_context(patch("torch.cuda.empty_cache"))
+
+            _compile_deep_gemm_one_type_all(
+                kernel_type=_KERNEL_TYPE,
+                n=4096,
+                k=7168,
+                num_groups=1,
+                m_list=[1024, 2048, 4096],
+            )
+
+        create.assert_called_once_with(
+            _KERNEL_TYPE, max_m=2048, n=4096, k=7168, num_groups=1
+        )
+        self.assertEqual(executor.execute.call_args_list, [call(m=1024), call(m=2048)])
+        restore.assert_called_once_with(saved_context)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DeepGEMM compile-all warmup stops reducing its buffer size at `M=2048`, even when a smaller requested shape would fit. If the smallest requested shape cannot fit, attempting the allocation still risks a startup OOM.

## Modifications

Continue halving the buffer size down to the smallest requested M. Skip compile-all warmup if that minimum exceeds the available-memory estimate; first use may still JIT the uncached shape. Preserve main's compile lock and current-device memory query, kernel selection and cache keys.

## Accuracy Tests

Author CPU validation passed five tests covering reduced allocation, skipping an oversized minimum and symmetric-memory context restoration. The regression now exercises reduction below main's 2,048 floor. No model accuracy run was repeated.

Rebased on main `2c05ed4e77`. [Author test logs and source bindings](https://github.com/ormandj/sglang-glm53-flash-sm120/blob/main/evidence/v0.3.2/pr-maintenance/README.md) record the tested snapshots. The subsequent main refresh changes only unrelated ROCm/NPU files; each repaired patch is byte-identical across that refresh.

## Speed Tests and Profiling

No throughput benchmark was run. The change only affects compile-all warmup; a skipped shape may compile on first use. Earlier startup observations on the old 4,096-floor implementation do not qualify this rebased source.

## Checklist

- [x] Format changed code and retain registered CPU tests.
- [x] Preserve current-main locking and device selection.
- [x] State skipped-warmup and validation limits.

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34058833699](https://github.com/sgl-project/sglang/actions/runs/34058833699)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34058833522](https://github.com/sgl-project/sglang/actions/runs/34058833522)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34058833707](https://github.com/sgl-project/sglang/actions/runs/34058833707)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->