### PR TITLE
[MoE] Add LFM2 MoE tuned config for H200 (Triton 3.5.1)

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_5_1/E=32,N=1792,device_name=NVIDIA_H200.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_5_1/E=32,N=1792,device_name=NVIDIA_H200.json
@@ -1,0 +1,140 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 5
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "8192": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
## Motivation

Fixes #32806.

`LFM2.5-8B-A1B` (E=32, N=1792) has no tuned MoE config for **H200**, so the shape falls back to the two-branch heuristic in `get_default_config` and leaves a large amount of prefill throughput unused.

#22791 added LFM2 MoE tuning support along with tuned configs for H100, B200 and MI325X. H200 was not included, and it cannot inherit one of the others: `device_name` is part of the config filename, and the fallback in `get_moe_configs` only swaps the `triton_*` directory while keeping the filename. Confirmed by lookup rather than by reading the code:

```
triton: 3.5.1 | device_name: NVIDIA_H200
  E=32,N=1792,device_name=NVIDIA_H200.json -> not found in any triton_* dir

E=32,N=1792 is present for:
  triton_3_5_1/E=32,N=1792,device_name=NVIDIA_B200.json
  triton_3_5_1/E=32,N=1792,device_name=NVIDIA_H100_80GB_HBM3.json
  triton_3_6_0/E=32,N=1792,device_name=AMD_Instinct_MI325X.json
```

So the shape runs on two branches for the entire M range, with `num_warps`/`num_stages` left unset.

## Modifications

Adds one file: `python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_5_1/E=32,N=1792,device_name=NVIDIA_H200.json`. No code changes.

Tuned with the same guardrail as the existing files: specialise a bucket only where the measured speedup over the runtime default clears a threshold (1.15×), and write the default heuristic's own values everywhere else.

Consequently **every bucket at `M <= 32` is field-for-field identical to `get_default_config`**. The CUDA-graph decode batch sizes all land in that range, so the decode path is unchanged by construction and the gain comes from prefill. The bucket set matches the H100/B200 files exactly (19 buckets).

Sweep protocol: 468–906 candidate configs per bucket, `warmup=25 iters=100 repeats=5`, median of 5 rounds, compared against the un-overridden default path.

## Accuracy Tests

N/A — this changes only the Triton launch configuration (tile shapes, `num_warps`, `num_stages`) of an existing kernel. No kernel source, numerics, dtype or accumulation order is modified, and `M <= 32` buckets are byte-identical to the current default. There is no mechanism by which model outputs can change.

## Speed Tests and Profiling

**Kernel level.** `LFM2.5-8B-A1B` (E=32, N=1792, top_k=4), H200, BF16, Triton 3.5.1, against the heuristic the server uses today:

| M | speedup | | M | speedup |
|---|---|---|---|---|
| 48 | 1.372× | | 1536 | 1.562× |
| 96 | 1.391× | | 2048 | 1.641× |
| 256 | 1.463× | | 3072 | 1.626× |
| 1024 | 1.399× | | 8192 | 1.740× |

M=24 measured 1.078×, below the threshold, so it keeps the default.

**End-to-end.** sglang 0.5.12.post1, torch 2.9.1+cu128, Triton 3.5.1, driver 580.105.08, 1×H200, TP1, BF16. Serving flags frozen; only `SGLANG_MOE_CONFIG_DIR` varies between arms:

| regime | default | this config | change |
|---|---|---|---|
| long prefill (in=4000, out=32, conc=4) | 12.277 req/s | **15.142** | **+23.3%**, p=1.3e-10 |
| low-batch decode (in=100, out=256, conc=1) | 1.6847 req/s | 1.6825 | neutral, p=0.079 |

Long prefill is 8/8 non-overlapping — default max 12.34 < tuned min 14.75.

**On the decode number.** It first measured −0.37% at p=4.9e-04, which would have been a real regression. The arms run sequentially, so I reran with the order reversed:

| ordering | ratio |
|---|---|
| default first | 0.9963 (−0.37%) |
| tuned first | 1.0012 (+0.12%) |

The sign flips, and in both runs whichever arm ran first was faster — a position effect, not a config effect. Counterbalanced across both orderings, n=16 per arm: **−0.13%, p=0.079, not significant**.

I also checked the obvious alternative explanation: the new `96` bucket does change which bucket `M=100` lands in (previously `128`), but that config is *faster* at M=100 (1.399× vs 1.379×), so it cannot be the source.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — JSON-only change; formatting (indent, key order, trailing newline) matches the existing H100/B200 files byte-for-byte in style.
- [ ] Add unit tests — N/A, this is tuning data for an existing kernel, not new code. Covered by whatever already exercises `fused_moe`.
- [ ] Update documentation — N/A, no user-facing behaviour or API change.
- [x] Provide accuracy and speed benchmark results — above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Scope and limitations

- The baseline is the heuristic default, not a previously tuned config — the honest framing is that this model/GPU pair was never tuned, not that the kernel was made faster.
- Tuned and measured on **Triton 3.5.1**, which is why the file targets `triton_3_5_1/`. Whether the same headroom exists on Triton 3.6 has not been measured. Pairing 822/894 individual configs across the two versions shows the same config performs within 1–4%, so the tuned values themselves appear to carry over; what is untested is how fast the *heuristic default* is on 3.6. Happy to add a `triton_3_6_0/` file once measured.
- Single H200, TP1, BF16.

Related: #22791.

Note: this PR has not had real CI coverage yet — the checks currently shown are gates (`Require run-ci label`) that I cannot set. Happy to have someone run `/tag-and-rerun-ci`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30404436638](https://github.com/sgl-project/sglang/actions/runs/30404436638)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30404436646](https://github.com/sgl-project/sglang/actions/runs/30404436646)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->