### PR TITLE
[Fix] missing max_context_len on HybridAttnBackend

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -36,6 +36,7 @@ class HybridAttnBackend(AttentionBackend):
         self.needs_cpu_seq_lens = (
             prefill_backend.needs_cpu_seq_lens or decode_backend.needs_cpu_seq_lens
         )
+        self.max_context_len = model_runner.model_config.context_len
 
     def _select_backend(self, forward_mode: ForwardMode) -> AttentionBackend:
         """

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -146,6 +146,7 @@ def test_hybrid_wrappers_forward_in_graph_hook():
             token_to_kv_pool=None,
             req_to_token_pool=None,
             server_args=SimpleNamespace(speculative_attention_mode="decode"),
+            model_config=SimpleNamespace(context_len=2048),
         ),
         prefill_backend=make_fake("prefill", calls),
         decode_backend=make_fake("decode", calls),

--- a/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
@@ -26,6 +26,7 @@ class _FakeBackend:
 def test_split_full_attention_applies_model_wrapper_once():
     runner = SimpleNamespace(
         server_args=SimpleNamespace(speculative_attention_mode="prefill"),
+        model_config=SimpleNamespace(context_len=2048),
         kv_cache_dtype=None,
         token_to_kv_pool=object(),
         req_to_token_pool=object(),

--- a/test/registered/unit/spec/test_dflash_overlap_hostsync.py
+++ b/test/registered/unit/spec/test_dflash_overlap_hostsync.py
@@ -231,6 +231,7 @@ class TestHybridNeedsCpuSeqLens(CustomTestCase):
             kv_cache_dtype=torch.bfloat16,
             token_to_kv_pool=None,
             req_to_token_pool=None,
+            model_config=SimpleNamespace(context_len=2048),
         )
         return HybridAttnBackend(runner, backend(prefill_flag), backend(decode_flag))
 


### PR DESCRIPTION


## Modifications

When both sub-backends set `needs_cpu_seq_lens=False`, the EAGLE verify fallback reads `attn_backend.max_context_len`, which the hybrid wrapper did not define, crashing with an `AttributeError`. 

## Fix

Expose it on the wrapper like [_every other_ leaf backend does](https://github.com/search?q=repo%3Asgl-project%2Fsglang+self.max_context_len+%3D++path%3A%2F%5Epython%5C%2Fsglang%5C%2Fsrt%5C%2Flayers%5C%2Fattention%5C%2F%2F&type=code).

## Tests

CI






<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30411071907](https://github.com/sgl-project/sglang/actions/runs/30411071907)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30411071775](https://github.com/sgl-project/sglang/actions/runs/30411071775)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->