### PR TITLE
[Refactor] Move sampling tokenizer validation helper

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -42,36 +42,6 @@ TOP_K_ALL = 1 << 30
 logger = logging.getLogger(__name__)
 
 
-def raise_if_tokenizer_required(
-    tokenizer, stop_strs, stop_regex_strs, min_new_tokens=0
-):
-    """Raise ValueError if tokenizer-dependent features are used without a tokenizer.
-
-    String-based stop conditions (stop_strs, stop_regex_strs) require tokenizer.decode()
-    to convert output token IDs to text for matching. min_new_tokens requires the
-    tokenizer's eos_token_id to penalize. When skip_tokenizer_init=True, these cannot
-    be used.
-    """
-    if tokenizer is not None:
-        return
-
-    if stop_strs:
-        raise ValueError(
-            f"stop={stop_strs!r} is unavailable when skip_tokenizer_init=True "
-            "(requires tokenizer to decode tokens to text for matching)."
-        )
-    if stop_regex_strs:
-        raise ValueError(
-            f"stop_regex={stop_regex_strs!r} is unavailable when skip_tokenizer_init=True "
-            "(requires tokenizer to decode tokens to text for matching)."
-        )
-    if min_new_tokens > 0:
-        raise ValueError(
-            f"min_new_tokens={min_new_tokens} is unavailable when skip_tokenizer_init=True "
-            "(requires tokenizer for eos_token_id)."
-        )
-
-
 class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
     """
     The sampling parameters.
@@ -321,3 +291,33 @@ def _max_length_from_subpattern(subpattern: sre_parse.SubPattern):
             total += MAX_LEN
 
     return total
+
+
+def raise_if_tokenizer_required(
+    tokenizer, stop_strs, stop_regex_strs, min_new_tokens=0
+):
+    """Raise ValueError if tokenizer-dependent features are used without a tokenizer.
+
+    String-based stop conditions (stop_strs, stop_regex_strs) require tokenizer.decode()
+    to convert output token IDs to text for matching. min_new_tokens requires the
+    tokenizer's eos_token_id to penalize. When skip_tokenizer_init=True, these cannot
+    be used.
+    """
+    if tokenizer is not None:
+        return
+
+    if stop_strs:
+        raise ValueError(
+            f"stop={stop_strs!r} is unavailable when skip_tokenizer_init=True "
+            "(requires tokenizer to decode tokens to text for matching)."
+        )
+    if stop_regex_strs:
+        raise ValueError(
+            f"stop_regex={stop_regex_strs!r} is unavailable when skip_tokenizer_init=True "
+            "(requires tokenizer to decode tokens to text for matching)."
+        )
+    if min_new_tokens > 0:
+        raise ValueError(
+            f"min_new_tokens={min_new_tokens} is unavailable when skip_tokenizer_init=True "
+            "(requires tokenizer for eos_token_id)."
+        )


### PR DESCRIPTION
## Motivation

Keep the `SamplingParams` declaration near the top of its module while retaining tokenizer-dependent validation as a module-level helper.

## Modifications

Move `raise_if_tokenizer_required` below the sampling-parameter and regex helper definitions. The function body and call sites are unchanged.

## Accuracy Tests

Not applicable; this is a pure code relocation with no behavior change.

## Speed Tests and Profiling

Not applicable.

## Tests

- Pre-commit hooks passed for `python/sglang/srt/sampling/sampling_params.py`.
- Sampling parameter unit tests: 71 passed.
- Mechanical-refactor reproduction: PASS; commit reproduced byte-for-byte.

Reproduction command:

```bash
python3 .claude/skills/mechanical-refactor-verify/scripts/mechanical_refactor_proof_generator.py db9b4c9ab7
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Existing tests cover the unchanged helper.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation changes needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30408722965](https://github.com/sgl-project/sglang/actions/runs/30408722965)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30408722800](https://github.com/sgl-project/sglang/actions/runs/30408722800)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->