### PR TITLE
fix(diffusion): size VSA top-k from padded blocks

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
@@ -98,9 +98,7 @@ def construct_variable_block_sizes(
         t_sizes[:, None, None]  # [n_t, 1,   1]
         * h_sizes[None, :, None]  # [1,   n_h, 1]
         * w_sizes[None, None, :]  # [1,   1,   n_w]
-    ).reshape(
-        -1
-    )  # [n_t * n_h * n_w]
+    ).reshape(-1)  # [n_t * n_h * n_w]
 
     return block_sizes
 
@@ -124,7 +122,6 @@ def get_non_pad_index(
 
 
 class VideoSparseAttentionBackend(AttentionBackend):
-
     accept_output_buffer: bool = True
 
     @staticmethod
@@ -170,8 +167,13 @@ class VideoSparseAttentionMetadata(AttentionMetadata):
     max_seqlen_k: int = 0
 
 
-class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
+def _compute_cur_topk(attn_metadata: VideoSparseAttentionMetadata) -> int:
+    num_kv_blocks = attn_metadata.variable_block_sizes.numel()
+    cur_topk = math.ceil((1 - attn_metadata.VSA_sparsity) * num_kv_blocks)
+    return max(1, min(cur_topk, num_kv_blocks))
 
+
+class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
     def __init__(self):
         pass
 
@@ -230,7 +232,6 @@ class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
 
 
 class VideoSparseAttentionImpl(AttentionImpl):
-
     def __init__(
         self,
         num_heads: int,
@@ -308,12 +309,7 @@ class VideoSparseAttentionImpl(AttentionImpl):
         value = value.transpose(1, 2).contiguous()
         gate_compress = gate_compress.transpose(1, 2).contiguous()
 
-        VSA_sparsity = attn_metadata.VSA_sparsity
-
-        cur_topk = math.ceil(
-            (1 - VSA_sparsity)
-            * (attn_metadata.total_seq_length / math.prod(VSA_TILE_SIZE))
-        )
+        cur_topk = _compute_cur_topk(attn_metadata)
 
         if video_sparse_attn is None:
             raise NotImplementedError("video_sparse_attn is not installed")

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/video_sparse_attn.py
@@ -98,7 +98,9 @@ def construct_variable_block_sizes(
         t_sizes[:, None, None]  # [n_t, 1,   1]
         * h_sizes[None, :, None]  # [1,   n_h, 1]
         * w_sizes[None, None, :]  # [1,   1,   n_w]
-    ).reshape(-1)  # [n_t * n_h * n_w]
+    ).reshape(
+        -1
+    )  # [n_t * n_h * n_w]
 
     return block_sizes
 

--- a/python/sglang/multimodal_gen/test/unit/test_video_sparse_attention.py
+++ b/python/sglang/multimodal_gen/test/unit/test_video_sparse_attention.py
@@ -1,8 +1,15 @@
+import math
+
 import torch
 
+from sglang.multimodal_gen.runtime.layers.attention.backends import (
+    video_sparse_attn as vsa_module,
+)
 from sglang.multimodal_gen.runtime.layers.attention.backends.video_sparse_attn import (
+    VSA_TILE_SIZE,
     VideoSparseAttentionImpl,
     VideoSparseAttentionMetadataBuilder,
+    _compute_cur_topk,
 )
 
 
@@ -37,3 +44,63 @@ def test_video_sparse_attention_tile_buffer_reuse_and_untile():
     pad_mask = torch.ones(next_tiled.shape[1], dtype=torch.bool)
     pad_mask[metadata.non_pad_index.cpu()] = False
     assert torch.all(next_tiled[:, pad_mask] == 0)
+
+
+def test_vsa_forward_cur_topk_uses_padded_kv_block_count(monkeypatch):
+    metadata = VideoSparseAttentionMetadataBuilder().build(
+        current_timestep=0,
+        raw_latent_shape=(5, 32, 32),
+        patch_size=(1, 1, 1),
+        VSA_sparsity=0.75,
+        device=torch.device("cpu"),
+    )
+    num_kv_blocks = metadata.variable_block_sizes.numel()
+    block_elements = math.prod(VSA_TILE_SIZE)
+    padded_seq_len = num_kv_blocks * block_elements
+    expected_topk = math.ceil((1 - metadata.VSA_sparsity) * num_kv_blocks)
+    unpadded_topk = math.ceil(
+        (1 - metadata.VSA_sparsity) * (metadata.total_seq_length / block_elements)
+    )
+    captured = {}
+
+    def fake_video_sparse_attn(
+        query,
+        key,
+        value,
+        variable_block_sizes,
+        topk,
+        block_size,
+        compress_attn_weight,
+    ):
+        captured["topk"] = topk
+        captured["block_size"] = block_size
+        assert torch.equal(variable_block_sizes, metadata.variable_block_sizes)
+        return query
+
+    monkeypatch.setattr(vsa_module, "video_sparse_attn", fake_video_sparse_attn)
+
+    query = torch.ones(1, padded_seq_len, 1, 1)
+    output = object.__new__(VideoSparseAttentionImpl).forward(
+        query, query, query, query, metadata
+    )
+
+    assert unpadded_topk < expected_topk
+    assert captured["topk"] == expected_topk
+    assert captured["block_size"] == VSA_TILE_SIZE
+    assert output.shape == query.shape
+
+
+def test_vsa_cur_topk_clamps_to_valid_block_range():
+    metadata = VideoSparseAttentionMetadataBuilder().build(
+        current_timestep=0,
+        raw_latent_shape=(5, 32, 32),
+        patch_size=(1, 1, 1),
+        VSA_sparsity=1.0,
+        device=torch.device("cpu"),
+    )
+    num_kv_blocks = metadata.variable_block_sizes.numel()
+
+    assert _compute_cur_topk(metadata) == 1
+
+    metadata.VSA_sparsity = -0.01
+    assert _compute_cur_topk(metadata) == num_kv_blocks


### PR DESCRIPTION
## Summary

- compute VSA `topk` from the padded KV-block count
- clamp `topk` to the valid `[1, num_kv_blocks]` range
- add partial-tile forward coverage and boundary tests

## Root cause

SGLang builds `variable_block_sizes` for the padded latent grid, but derived `topk` from the unpadded sequence length. When any temporal or spatial tile is partial, that undercounts the KV blocks passed to the sparse-attention kernel and selects fewer blocks than the requested sparsity ratio.

This aligns SGLang with FastVideo's padded-block correction:

- fused compression/top-k: https://github.com/hao-ai-lab/FastVideo/pull/1421
- padded-block fix: https://github.com/hao-ai-lab/FastVideo/pull/1517

## H100 Validation

The kernel smoke used a local CUDA 13 / SM90 build of FastVideo commit `1b2b2a0161bc6b3b80158d1fa6380a051c6530c7`.

| Validation | Workload | Result |
| --- | --- | ---: |
| SGLang VSA unit suite | padded-block top-k boundaries and partial tiles | `3 passed` |
| FastVideo fused compression/top-k CUDA suite | latest fused kernel on H100 / SM90 | `13 passed` |
| Real sparse-attention smoke | 8,192 padded tokens, 128 KV blocks, `topk=32` | finite output |

## NVIDIA Diffusion CI

| Hardware / check | Coverage | Result |
| --- | --- | ---: |
| B200 | diffusion server tests | passed |
| RTX 5090 | diffusion canary | passed |
| H100 | component accuracy and all one-/two-GPU partitions | passed |
| Workflow | diffusion coverage and final aggregation | passed |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30410244166](https://github.com/sgl-project/sglang/actions/runs/30410244166)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30410243860](https://github.com/sgl-project/sglang/actions/runs/30410243860)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->