### PR TITLE
Avoid raising ValueError in schedule_batch.py

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1663,12 +1663,12 @@ class Req(ReqDllmMixin):
         if not isinstance(token_id, list):
             token_id = [token_id]
 
-        try:
-            end_pos = token_id.index(think_end_id)
-            self.reasoning_tokens += end_pos + 1
-            self._is_reasoning_over = True
-        except ValueError:
-            self.reasoning_tokens += len(token_id)
+        for i, val in enumerate(token_id)):
+            if val == think_end_id:
+                self.reasoning_tokens += i + 1
+                self._is_reasoning_over = True
+                return
+        self.reasoning_tokens += len(token_id)
 
     def __repr__(self):
         return (


### PR DESCRIPTION
## Motivation

I'm toying around with some local benchmarking of sglang and I saw something that was suboptimal.

## Modifications

`update_reasoning_tokens()` calls `list.index()` to determine if reasoning is over.  This will raise a `ValueError` if the expected end ID is not found in the list.  It's cheaper to do an explicit scan of the `token_id` list and not raise the exception.

There's no expected behavior changes in this change.

## Speed Tests and Profiling

On some local, generated benchmarks for the radix cache, this specific function goes from 1.688ms to 1.575ms on CPython 3.12.  I haven't included them here because this is a fairly small change and I don't think they'll be particularly relevant long-term.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30409675896](https://github.com/sgl-project/sglang/actions/runs/30409675896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30409675679](https://github.com/sgl-project/sglang/actions/runs/30409675679)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->