### PR TITLE
perf(kimi-k3): fuse MoE-front prep (route + trtllm pack + mxfp8 quant) into one launch

### DIFF
--- a/python/sglang/kernels/jit/csrc/moe/route_quant_fused.cuh
+++ b/python/sglang/kernels/jit/csrc/moe/route_quant_fused.cuh
@@ -1,0 +1,142 @@
+// K3 MoE-front prep in one launch: radix routing (+ trtllm packed ids) on the
+// first M CTAs, mxfp8 per-token-group quant of the routed activations on the
+// next M. At decode batch sizes the unfused chain is three tiny back-to-back
+// kernels (route 3.8us + quant 2.6us + pack 1.4us per layer) each leaving the
+// SMs idle; fused, the quant CTAs run concurrently with the routing CTA and
+// the pack is a 16-store epilogue.
+//
+// Both halves are the existing kernels verbatim: route_radix_block is the
+// standalone route_radix body (same TU, same flags — no fast-math, which the
+// routing bit-exactness contract requires and the quant math tolerates: its
+// only transcendentals are explicit intrinsics and exact bit manipulation),
+// and QuantTrait::run is the per_token_group_quant math. Specialized like
+// route_radix itself: 896 experts, top-16, and a 3584-wide bf16 activation row
+// (112 ue8m0 groups of 32 = 224 lanes, exactly the routing block width).
+
+#include "../gemm/per_token_group_quant.cuh"
+#include "route_radix.cuh"
+
+namespace sglang {
+
+struct RouteQuantFusedParams {
+  RouteRadixParams route;
+  QuantKernelParams quant;
+};
+
+// One quant CTA covers one token row: thread pairs (2g, 2g+1) hold group g
+// with lanes (0, 1) — the same subwarp layout the flat quant kernel derives
+// from global_tid, so the group reduction and stores are bit-identical.
+using RouteQuantTrait = QuantTrait<
+    bf16_t,
+    fp8_e4m3_t,
+    /*kGroupSize=*/32,
+    /*kUe8m0=*/true,
+    /*kRowMajor=*/true,
+    /*kAligned=*/true,
+    /*kFuseSiluAndMul=*/false>;
+
+inline constexpr uint32_t kQuantGroupsPerRow_ = LargeRouterRadixTrait::kBlockSize / RouteQuantTrait::kNumLanes;
+inline constexpr uint32_t kQuantHidden_ = kQuantGroupsPerRow_ * RouteQuantTrait::kGroupSize;  // 3584
+
+template <bool kUsePDL, typename TScore>
+__global__ __launch_bounds__(LargeRouterRadixTrait::kBlockSize)  //
+    void route_quant_fused_kernel(const __grid_constant__ RouteQuantFusedParams params) {
+  const auto M = static_cast<uint32_t>(params.route.M);
+  if (blockIdx.x < M) {
+    __shared__ typename LargeRouterRadixTrait::Smem smem;
+    route_radix_block<kUsePDL, TScore>(params.route, smem);
+  } else {
+    // Quant CTAs read the same primary-kernel output (the fused-front GEMM)
+    // as the routing CTAs, so they carry their own PDL wait/trigger.
+    device::PDLWaitPrimary<kUsePDL>();
+    const uint32_t token_idx = blockIdx.x - M;
+    const uint32_t group_idx = threadIdx.x / RouteQuantTrait::kNumLanes;
+    const uint32_t lane_id = threadIdx.x % RouteQuantTrait::kNumLanes;
+    RouteQuantTrait::run(params.quant, /*expert_idx=*/0, token_idx, group_idx, lane_id);
+    device::PDLTriggerSecondary<kUsePDL>();
+  }
+}
+
+}  // namespace sglang
+
+template <bool kUsePDL>
+struct RouteQuantFusedKernel {
+  static void
+  run(const tvm::ffi::TensorView scores,
+      const tvm::ffi::TensorView bias,
+      const tvm::ffi::TensorView out_w,
+      const tvm::ffi::TensorView out_i,
+      const tvm::ffi::TensorView out_packed,
+      const tvm::ffi::TensorView x,
+      const tvm::ffi::TensorView out_q,
+      const tvm::ffi::TensorView out_s,
+      int64_t topk,
+      double routed_scaling_factor,
+      bool renormalize,
+      bool apply_scale) {
+    using namespace host;
+    using Trait = sglang::RouteQuantTrait;
+
+    auto M_ = SymbolicSize{"num_tokens"};
+    auto N_ = SymbolicSize{"num_experts"};
+    auto K_ = SymbolicSize{"topk"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+
+    auto score_dtype = SymbolicDType{};
+    TensorMatcher({M_, N_})
+        .with_dtype<bf16_t, fp32_t>(score_dtype)
+        .with_device(device)
+        .with_strides({-1, 1})
+        .verify(scores);
+    TensorMatcher({N_}).with_dtype<fp32_t>().with_device(device).verify(bias);
+    TensorMatcher({M_, K_}).with_dtype<fp32_t>().with_device(device).verify(out_w);
+    TensorMatcher({M_, K_}).with_dtype<int32_t>().with_device(device).verify(out_i);
+    TensorMatcher({M_, K_}).with_dtype<int32_t>().with_strides({-1, 1}).with_device(device).verify(out_packed);
+
+    RuntimeCheck(
+        N_.unwrap() == sglang::kNumExperts_ && K_.unwrap() == sglang::kTopK_ && topk == sglang::kTopK_,
+        "route_quant_fused is specialized for N=896, K=16");
+    RuntimeCheck(scores.stride(0) % 4 == 0, "route_quant_fused: scores row stride must be a multiple of 4");
+
+    // Quant half: shape/stride/alignment checks + byte-stride munging shared
+    // with the standalone flat kernel.
+    const auto ctx = build_quant_context<Trait, /*kMasked=*/false>(x, out_q, out_s);
+    RuntimeCheck(
+        ctx.params.hidden_size == sglang::kQuantHidden_,
+        "route_quant_fused is specialized for a 3584-wide activation row");
+    RuntimeCheck(
+        ctx.params.num_tokens == static_cast<uint32_t>(M_.unwrap()),
+        "route_quant_fused: scores and activations must have the same token count");
+
+    const auto M = static_cast<uint32_t>(M_.unwrap());
+    if (M == 0) return;
+
+    const auto params = sglang::RouteQuantFusedParams{
+        .route =
+            {scores.data_ptr(),
+             static_cast<const fp32_t*>(bias.data_ptr()),
+             static_cast<fp32_t*>(out_w.data_ptr()),
+             static_cast<int32_t*>(out_i.data_ptr()),
+             static_cast<int32_t*>(out_packed.data_ptr()),
+             static_cast<int>(M),
+             static_cast<long long>(scores.stride(0)),
+             static_cast<long long>(out_w.stride(0)),
+             static_cast<long long>(out_i.stride(0)),
+             static_cast<long long>(out_packed.stride(0)),
+             static_cast<float>(routed_scaling_factor),
+             renormalize ? 1 : 0,
+             apply_scale ? 1 : 0,
+             /*sorted=*/0},
+        .quant = ctx.params,
+    };
+
+    if (score_dtype.is_type<fp32_t>()) {
+      LaunchKernel(2 * M, sglang::LargeRouterRadixTrait::kBlockSize, device.unwrap())
+          .enable_pdl(kUsePDL)(sglang::route_quant_fused_kernel<kUsePDL, fp32_t>, params);
+    } else {
+      LaunchKernel(2 * M, sglang::LargeRouterRadixTrait::kBlockSize, device.unwrap())
+          .enable_pdl(kUsePDL)(sglang::route_quant_fused_kernel<kUsePDL, bf16_t>, params);
+    }
+  }
+};

--- a/python/sglang/kernels/jit/csrc/moe/route_radix.cuh
+++ b/python/sglang/kernels/jit/csrc/moe/route_radix.cuh
@@ -50,10 +50,14 @@ struct RouteRadixParams {
   const fp32_t* __restrict__ bias;
   fp32_t* __restrict__ out_w;
   int32_t* __restrict__ out_i;
+  // Optional trtllm-gen routed-MoE packing: (id << 16) | bf16(weight) bits,
+  // bit-identical to the standalone triton pack. nullptr skips the store.
+  int32_t* __restrict__ out_packed;
   int M;
   long long scores_stride;
   long long out_w_stride;
   long long out_i_stride;
+  long long out_packed_stride;
   float routed_scaling_factor;
   int renormalize;
   int apply_scale;
@@ -105,15 +109,16 @@ SGL_DEVICE uint32_t block_exclusive_sum(uint32_t cnt, uint32_t lane_id, uint32_t
   return base + inc - cnt;
 }
 
+// Whole-CTA routing body, callable from other kernels (the fused
+// route+quant launch runs it on its first M CTAs). Routes row `blockIdx.x`;
+// every thread of the 224-wide CTA must enter (block barriers inside).
 template <bool kUsePDL, typename TScore>
-__global__ __launch_bounds__(LargeRouterRadixTrait::kBlockSize)  //
-    void route_radix_kernel(const __grid_constant__ RouteRadixParams params) {
+SGL_DEVICE void route_radix_block(const RouteRadixParams& params, typename LargeRouterRadixTrait::Smem& smem) {
   using namespace device;
   using T = LargeRouterRadixTrait;
   constexpr uint32_t kVecSize = T::kVecSize;
   constexpr uint32_t kRadixLanes = T::kRadixSize / 2;  // 128: 2 bins per thread
   enum { BAR_RESERVED = 0, BAR_SUM = 1 };
-  __shared__ typename T::Smem smem;
 
   const auto bx = blockIdx.x;
   const auto tx = threadIdx.x;
@@ -304,7 +309,20 @@ __global__ __launch_bounds__(LargeRouterRadixTrait::kBlockSize)  //
     if (params.apply_scale) w = w * params.routed_scaling_factor;
     params.out_w[bx * params.out_w_stride + rank] = w;
     params.out_i[bx * params.out_i_stride + rank] = id;
+    if (params.out_packed != nullptr) {
+      // (id << 16) | bf16(w) bits — RN float->bf16 matches the triton pack.
+      const auto bits = static_cast<uint32_t>(__bfloat16_as_ushort(__float2bfloat16_rn(w)));
+      params.out_packed[bx * params.out_packed_stride + rank] =
+          static_cast<int32_t>((static_cast<uint32_t>(id) << 16) | bits);
+    }
   }
+}
+
+template <bool kUsePDL, typename TScore>
+__global__ __launch_bounds__(LargeRouterRadixTrait::kBlockSize)  //
+    void route_radix_kernel(const __grid_constant__ RouteRadixParams params) {
+  __shared__ typename LargeRouterRadixTrait::Smem smem;
+  route_radix_block<kUsePDL, TScore>(params, smem);
 }
 
 }  // namespace sglang
@@ -354,10 +372,12 @@ struct RouteRadixKernel {
         static_cast<const fp32_t*>(bias.data_ptr()),
         static_cast<fp32_t*>(out_w.data_ptr()),
         static_cast<int32_t*>(out_i.data_ptr()),
+        /*out_packed=*/nullptr,
         static_cast<int>(M),
         static_cast<long long>(scores.stride(0)),
         static_cast<long long>(out_w.stride(0)),
         static_cast<long long>(out_i.stride(0)),
+        /*out_packed_stride=*/0,
         static_cast<float>(routed_scaling_factor),
         renormalize ? 1 : 0,
         apply_scale ? 1 : 0,

--- a/python/sglang/kernels/ops/moe/moe_route_quant_fused.py
+++ b/python/sglang/kernels/ops/moe/moe_route_quant_fused.py
@@ -1,0 +1,125 @@
+"""Fused K3 MoE-front prep: radix routing + trtllm id pack + mxfp8 quant.
+
+One launch replaces the three tiny kernels between the K3 fused-front GEMM and
+the trtllm-gen routed-MoE op at decode batch sizes (route_radix -> triton
+(id<<16|bf16(w)) pack -> per_token_group_quant, ~7.5us busy + 2 extra launches
+per MoE layer with the SMs near idle). CTAs [0, M) run the route_radix body
+with the pack folded into its epilogue; CTAs [M, 2M) run the
+per_token_group_quant math, one CTA per token row. Both halves reuse the
+standalone kernels' device code, so ids/weights, packed ids, and quantized
+activations are bit-identical to the unfused chain.
+
+Specialized like route_radix itself: 896 experts, top-16, bf16/fp32 scores,
+and a 3584-wide bf16 activation row quantized to fp8 with row-major packed
+UE8M0 group-32 scales (the trtllm-gen SiTU MoE input format). Wired into
+serving through sglang.srt.layers.moe.route_quant_handoff.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Tuple
+
+import torch
+
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_arch_support_pdl,
+    load_jit,
+    make_cpp_args,
+)
+from sglang.kernels.ops.moe import moe_route_radix
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+_HIDDEN = 3584
+_GROUP_SIZE = 32
+_NUM_GROUPS = _HIDDEN // _GROUP_SIZE
+# Fusion trades the flat quant grid for one 224-thread CTA per token; that (and
+# the win itself, which is launch overhead) only makes sense at small decode
+# batches. Above the cap the callers run the unfused chain.
+_MAX_TOKENS = 64
+
+
+@cache_once
+def _jit_module() -> Module:
+    args = make_cpp_args(is_arch_support_pdl())
+    return load_jit(
+        "moe_route_quant_fused",
+        *args,
+        cuda_files=["moe/route_quant_fused.cuh"],
+        cuda_wrappers=[("run", f"RouteQuantFusedKernel<{args}>::run")],
+        # No fast-math: the routing half must stay bit-identical to
+        # route_radix (see its module comment); the quant half's math is
+        # fast-math-independent (explicit intrinsics + bit manipulation).
+        extra_cuda_cflags=["-O3"],
+    )
+
+
+@cache_once
+def available() -> bool:
+    import logging
+
+    try:
+        _jit_module()
+        return True
+    except Exception as e:  # pragma: no cover - toolchain dependent
+        logging.getLogger(__name__).warning(
+            f"Failed to load the JIT fused route+quant kernel: {e}"
+        )
+        return False
+
+
+def covered(
+    scores: torch.Tensor, bias: torch.Tensor, topk: int, x: torch.Tensor
+) -> bool:
+    """route_radix coverage plus the quant half: [M<=64, 3584] bf16 rows with
+    32B-aligned starts (base and stride), same token count as the scores."""
+    return (
+        moe_route_radix.covered(scores, bias, topk)
+        and x.dim() == 2
+        and x.shape[0] == scores.shape[0]
+        and 0 < x.shape[0] <= _MAX_TOKENS
+        and x.shape[1] == _HIDDEN
+        and x.dtype == torch.bfloat16
+        and x.stride(1) == 1
+        and x.data_ptr() % 32 == 0
+        and (x.stride(0) * x.element_size()) % 32 == 0
+    )
+
+
+def route_quant_fused(
+    scores: torch.Tensor,
+    bias: torch.Tensor,
+    x: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    apply_scale: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Returns ``(weights [M, topk] fp32, ids [M, topk] int32, packed [M, topk]
+    int32, x_q [M, 3584] fp8_e4m3, x_s [M, 28] int32 row-major packed UE8M0)``.
+    Caller must have checked covered(). Winners come out in expert-id-ascending
+    order (the standalone production dispatch's sorted=False)."""
+    M = scores.shape[0]
+    device = scores.device
+    out_w = torch.empty((M, topk), dtype=torch.float32, device=device)
+    out_i = torch.empty((M, topk), dtype=torch.int32, device=device)
+    out_packed = torch.empty((M, topk), dtype=torch.int32, device=device)
+    out_q = torch.empty((M, _HIDDEN), dtype=torch.float8_e4m3fn, device=device)
+    out_s = torch.empty((M, _NUM_GROUPS // 4), dtype=torch.int32, device=device)
+    _jit_module().run(
+        scores,
+        bias,
+        out_w,
+        out_i,
+        out_packed,
+        x,
+        out_q,
+        out_s,
+        topk,
+        float(routed_scaling_factor),
+        bool(renormalize),
+        bool(apply_scale),
+    )
+    return out_w, out_i, out_packed, out_q, out_s

--- a/python/sglang/srt/layers/moe/route_quant_handoff.py
+++ b/python/sglang/srt/layers/moe/route_quant_handoff.py
@@ -1,0 +1,130 @@
+"""Attempt-and-verify handoff for the fused K3 MoE-front prep launch.
+
+At decode batch sizes the chain between the K3 fused-front GEMM and the
+trtllm-gen SiTU MoE op is three tiny back-to-back kernels on the critical
+path — route_radix (top-16 of 896), the triton ``(id << 16) | bf16(weight)``
+pack, and per_token_group_quant (mxfp8, ``[T, 3584]``) — about 7.5 us busy
+plus two extra launches per MoE layer, each leaving the SMs near idle. The
+fused kernel (kernels/ops/moe/moe_route_quant_fused.py) runs all three in one
+launch: routing CTAs and one quant CTA per token, concurrently.
+
+The inputs live in different modules (router logits reach the router through
+TopK, activations through the MoE runner), so the fusion is wired as a
+consume-once stash instead of new signatures:
+
+    KimiK3MoE._forward_routed*      stage(x) before self.topk, clear() after
+                                    the experts call
+    biased_grouped_topk_gpu         try_route_quant_fused() replaces the
+                                    moe_fused_gate call on a hit
+    Mxfp4MoEMethod.apply (situ)     take(x) skips the quant and the pack
+
+Every step is fallback-safe: if the routing dispatch never consumes the staged
+request (different model, uncovered shape, triton fallback) or the runner's
+``take`` misses (activations re-viewed or copied), the unfused chain runs as
+before. The stage/clear bracket in the model layer guarantees a published
+entry can never leak into another layer whose allocator reused the same
+activation address.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import msgspec
+import torch
+
+
+class _Handoff(msgspec.Struct):
+    # staged by the model layer: the activation rows the runner will quantize
+    request_x: Optional[torch.Tensor] = None
+    # published by the routing dispatch, keyed by the staged activations
+    produced_x: Optional[torch.Tensor] = None
+    packed: Optional[torch.Tensor] = None
+    x_q: Optional[torch.Tensor] = None
+    x_s: Optional[torch.Tensor] = None
+
+
+_handoff = _Handoff()
+
+
+def stage(x: torch.Tensor) -> None:
+    """Publish the routed activations for the upcoming topk call. Caller pairs
+    this with clear() after the experts call (try/finally)."""
+    _handoff.request_x = x
+    _handoff.produced_x = None
+
+
+def clear() -> None:
+    _handoff.request_x = None
+    _handoff.produced_x = None
+    _handoff.packed = None
+    _handoff.x_q = None
+    _handoff.x_s = None
+
+
+def try_route_quant_fused(
+    gating_output: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    num_fused_shared_experts: int,
+    renormalize: bool,
+    routed_scaling_factor: Optional[float],
+    apply_routed_scaling_factor_on_output: bool,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    """Fused replacement for the ungrouped-sigmoid moe_fused_gate call when a
+    staged request covers it. Returns (weights, ids) on a hit, None otherwise
+    (caller falls through to the unfused router)."""
+    x = _handoff.request_x
+    if x is None or num_fused_shared_experts != 0:
+        return None
+
+    from sglang.kernels.ops.moe import moe_route_quant_fused
+
+    if (
+        not moe_route_quant_fused.covered(gating_output, correction_bias, topk, x)
+        or not moe_route_quant_fused.available()
+    ):
+        return None
+
+    weights, ids, packed, x_q, x_s = moe_route_quant_fused.route_quant_fused(
+        gating_output,
+        correction_bias,
+        x,
+        topk,
+        renormalize=renormalize,
+        routed_scaling_factor=(
+            routed_scaling_factor if routed_scaling_factor is not None else 1.0
+        ),
+        apply_scale=apply_routed_scaling_factor_on_output,
+    )
+    _handoff.request_x = None
+    _handoff.produced_x = x
+    _handoff.packed = packed
+    _handoff.x_q = x_q
+    _handoff.x_s = x_s
+    return weights, ids
+
+
+def take(
+    x: torch.Tensor,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Consume the published (packed_topk, x_q, x_s int32) for these exact
+    activation rows, or None. Storage identity is verified so a re-viewed or
+    copied tensor simply misses."""
+    produced = _handoff.produced_x
+    if produced is None:
+        return None
+    if (
+        produced.data_ptr() != x.data_ptr()
+        or produced.shape != x.shape
+        or produced.dtype != x.dtype
+        or produced.stride() != x.stride()
+    ):
+        return None
+    out = (_handoff.packed, _handoff.x_q, _handoff.x_s)
+    _handoff.produced_x = None
+    _handoff.packed = None
+    _handoff.x_q = None
+    _handoff.x_s = None
+    return out

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1626,6 +1626,25 @@ def biased_grouped_topk_gpu(
                 if gating_output.dtype == torch.bfloat16
                 else gating_output.to(dtype=torch.float32)
             )
+            # K3 staged fusion: when the model layer staged the routed
+            # activations (route_quant_handoff), the radix route, the trtllm id
+            # pack and the mxfp8 quant run as one launch. Bit-identical
+            # (weights, ids); a miss falls through to the unfused router.
+            from sglang.srt.layers.moe import route_quant_handoff
+
+            fused = route_quant_handoff.try_route_quant_fused(
+                _gating,
+                correction_bias.to(dtype=torch.float32),
+                topk,
+                num_fused_shared_experts=num_fused_shared_experts,
+                renormalize=renormalize,
+                routed_scaling_factor=routed_scaling_factor,
+                apply_routed_scaling_factor_on_output=bool(
+                    apply_routed_scaling_factor_on_output
+                ),
+            )
+            if fused is not None:
+                return fused
             return jit_gate(
                 _gating,
                 correction_bias.to(dtype=torch.float32),

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1295,6 +1295,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             # TRT-LLM automatically handles quantization in the kernel implementation and pipelines it with GEMM operations,
             # which can theoretically improve performance
             origin_hidden_states_dim = x.shape[-1]
+            # Filled by the staged K3 route+pack+quant fusion below; the pack
+            # site further down falls back to PackTopkIds when it is None.
+            prepared_packed_topk = None
             if self.flashinfer_mxfp4_moe_precision == "bf16":
                 assert x.dtype == torch.bfloat16
                 x_quant = x
@@ -1310,16 +1313,28 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     )
             elif self.flashinfer_mxfp4_moe_precision == "default":
                 if x.shape[-1] == self.hidden_size:
-                    from sglang.kernels.ops.quantization.per_token_group_quant import (
-                        per_token_group_quant,
-                    )
-
                     if x.dim() > 2:
                         x = x.view(-1, x.shape[-1])
-                    x_quant, x_scale = per_token_group_quant(
-                        x, group_size=32, scale_ue8m0=True
-                    )
-                    x_scale = x_scale.view(torch.float8_e4m3fn)
+                    # K3 staged fusion (route_quant_handoff): the routing
+                    # dispatch already quantized these rows and packed the
+                    # topk ids in the fused route launch — consume both and
+                    # skip the two standalone kernels. Identity-verified;
+                    # a miss runs the unfused chain below.
+                    from sglang.srt.layers.moe import route_quant_handoff
+
+                    prepared = route_quant_handoff.take(x)
+                    if prepared is not None:
+                        prepared_packed_topk, x_quant, x_scale = prepared
+                        x_scale = x_scale.view(torch.float8_e4m3fn)
+                    else:
+                        from sglang.kernels.ops.quantization.per_token_group_quant import (
+                            per_token_group_quant,
+                        )
+
+                        x_quant, x_scale = per_token_group_quant(
+                            x, group_size=32, scale_ue8m0=True
+                        )
+                        x_scale = x_scale.view(torch.float8_e4m3fn)
                 else:
                     x_quant, x_scale = mxfp8_quantize(
                         x, False, alignment=self.hidden_size
@@ -1393,11 +1408,14 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     # in-op routing kernels entirely. At small T the in-op
                     # single-CTA routing costs ~22 us/layer vs ~6 us for the
                     # external radix router.
-                    from sglang.kernels.ops.moe.pack_topk_ids import PackTopkIds
+                    if prepared_packed_topk is not None:
+                        packed_topk = prepared_packed_topk
+                    else:
+                        from sglang.kernels.ops.moe.pack_topk_ids import PackTopkIds
 
-                    packed_topk = PackTopkIds.execute(
-                        topk_output.topk_ids, topk_output.topk_weights
-                    )
+                        packed_topk = PackTopkIds.execute(
+                            topk_output.topk_ids, topk_output.topk_weights
+                        )
                     # Deferred finalize (K3 forward_deferred_finalize): return
                     # the finalize inputs instead of the finalized output.
                     from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -57,6 +57,7 @@ from sglang.srt.layers.linear import (
     RowParallelLinear,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
+from sglang.srt.layers.moe import route_quant_handoff
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import (
@@ -986,10 +987,31 @@ class KimiK3MoE(nn.Module):
             return _add3(out, shared_output, prefix_sum)
         return out if prefix_sum is None else out + prefix_sum
 
+    @cached_property
+    def _route_quant_fuse_eligible(self) -> bool:
+        """Whether to stage routed_input for the fused route+pack+quant launch
+        (route_quant_handoff). Only the trtllm-gen SiTU runner with mxfp8
+        activations consumes the staged quant, so only that runner stages."""
+        from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
+
+        method = self.experts.quant_method
+        return (
+            isinstance(method, Mxfp4MoEMethod)
+            and method.use_flashinfer
+            and not method.use_marlin
+            and method.flashinfer_mxfp4_moe_precision == "default"
+            and self.experts.moe_runner_config.activation == "situ"
+        )
+
     def _forward_routed(self, hidden_states, router_logits, routed_input, latent):
-        topk_output = self.topk(hidden_states, router_logits)
-        with zero_copy_context.set_moe_output(latent):
-            expert_output = self.experts(routed_input, topk_output)
+        if self._route_quant_fuse_eligible:
+            route_quant_handoff.stage(routed_input)
+        try:
+            topk_output = self.topk(hidden_states, router_logits)
+            with zero_copy_context.set_moe_output(latent):
+                expert_output = self.experts(routed_input, topk_output)
+        finally:
+            route_quant_handoff.clear()
         if expert_output.data_ptr() != latent.data_ptr():
             latent.copy_(expert_output)
 
@@ -998,8 +1020,13 @@ class KimiK3MoE(nn.Module):
         FlashInferTrtllmDeferredFinalizeOutput triple (permuted gemm2 output,
         expanded_idx_to_permuted_idx, expert_weights) for the finalize-fused
         all-reduce."""
-        topk_output = self.topk(hidden_states, router_logits)
-        return self.experts.forward_deferred_finalize(routed_input, topk_output)
+        if self._route_quant_fuse_eligible:
+            route_quant_handoff.stage(routed_input)
+        try:
+            topk_output = self.topk(hidden_states, router_logits)
+            return self.experts.forward_deferred_finalize(routed_input, topk_output)
+        finally:
+            route_quant_handoff.clear()
 
     def _forward_shared(self, gate_up, shared_output):
         shared = self.shared_experts

--- a/test/registered/kernels/ops/test_moe_route_quant_fused.py
+++ b/test/registered/kernels/ops/test_moe_route_quant_fused.py
@@ -1,0 +1,130 @@
+"""Fused route+pack+quant vs the unfused chain, bit-exact.
+
+The fused kernel (kernels/ops/moe/moe_route_quant_fused.py) must reproduce all
+three of its constituents exactly: route_radix (weights, ids), the triton
+(id << 16 | bf16(weight)) pack, and per_token_group_quant (fp8 rows + packed
+UE8M0 group-32 scales) — including on row-strided activation views (the K3
+fused-front split) and the route kernel's tie/NaN adversarial cases.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.moe import moe_route_quant_fused
+from sglang.kernels.ops.moe.moe_route_radix import covered as route_covered
+from sglang.kernels.ops.moe.moe_route_radix import route_radix
+from sglang.kernels.ops.moe.pack_topk_ids import PackTopkIds
+from sglang.kernels.ops.quantization.per_token_group_quant import (
+    per_token_group_quant,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+NUM_EXPERTS = 896
+TOPK = 16
+HIDDEN = 3584
+
+
+def _make_scores(case: str, num_tokens: int) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = torch.randn(num_tokens, NUM_EXPERTS, dtype=torch.bfloat16, device="cuda")
+    bias = torch.randn(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+    if case == "random":
+        pass
+    elif case == "all_equal":
+        # Full 896-way key tie: min-id tie-break must pick experts 0..15.
+        scores.fill_(0.5)
+        bias.zero_()
+    elif case == "nan_mixed":
+        scores[:, ::3] = float("nan")
+    else:
+        raise AssertionError(case)
+    return scores, bias
+
+
+def _make_x(num_tokens: int, strided: bool) -> torch.Tensor:
+    if not strided:
+        return torch.randn(num_tokens, HIDDEN, dtype=torch.bfloat16, device="cuda")
+    # Row-strided view with 32B-aligned rows, like the K3 fused-front split
+    # ([gate_up | router | latent] slices of one GEMM output).
+    full = torch.randn(num_tokens, HIDDEN + 1024, dtype=torch.bfloat16, device="cuda")
+    x = full[:, 512 : 512 + HIDDEN]
+    assert x.data_ptr() % 32 == 0 and (x.stride(0) * x.element_size()) % 32 == 0
+    return x
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 8, 64])
+@pytest.mark.parametrize("case", ["random", "all_equal", "nan_mixed"])
+@pytest.mark.parametrize("strided", [False, True])
+def test_fused_matches_unfused_chain(num_tokens: int, case: str, strided: bool):
+    if not moe_route_quant_fused.available():
+        pytest.skip("JIT fused route+quant kernel unavailable")
+    torch.manual_seed(0x5EED + num_tokens)
+    scores, bias = _make_scores(case, num_tokens)
+    x = _make_x(num_tokens, strided)
+    routed_scaling_factor = 2.446
+    assert route_covered(scores, bias, TOPK)
+    assert moe_route_quant_fused.covered(scores, bias, TOPK, x)
+
+    ref_w, ref_i = route_radix(
+        scores,
+        bias,
+        TOPK,
+        renormalize=True,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_scale=True,
+        sorted=False,
+    )
+    ref_packed = PackTopkIds.execute(ref_i, ref_w)
+    ref_q, ref_s = per_token_group_quant(x, group_size=32, scale_ue8m0=True)
+
+    w, i, packed, x_q, x_s = moe_route_quant_fused.route_quant_fused(
+        scores,
+        bias,
+        x,
+        TOPK,
+        renormalize=True,
+        routed_scaling_factor=routed_scaling_factor,
+        apply_scale=True,
+    )
+
+    # NaN-selected weights (raw sigmoid of NaN) compare by bit pattern.
+    torch.testing.assert_close(i, ref_i, rtol=0, atol=0)
+    assert torch.equal(w.view(torch.int32), ref_w.view(torch.int32))
+    torch.testing.assert_close(packed, ref_packed, rtol=0, atol=0)
+    assert torch.equal(x_q.view(torch.uint8), ref_q.view(torch.uint8))
+    torch.testing.assert_close(x_s, ref_s, rtol=0, atol=0)
+
+
+def test_covered_rejects():
+    if not moe_route_quant_fused.available():
+        pytest.skip("JIT fused route+quant kernel unavailable")
+    scores = torch.randn(2, NUM_EXPERTS, dtype=torch.bfloat16, device="cuda")
+    bias = torch.randn(NUM_EXPERTS, dtype=torch.float32, device="cuda")
+    ok = torch.randn(2, HIDDEN, dtype=torch.bfloat16, device="cuda")
+    assert moe_route_quant_fused.covered(scores, bias, TOPK, ok)
+    # wrong hidden width
+    assert not moe_route_quant_fused.covered(
+        scores, bias, TOPK, torch.randn(2, 4096, dtype=torch.bfloat16, device="cuda")
+    )
+    # token-count mismatch
+    assert not moe_route_quant_fused.covered(
+        scores, bias, TOPK, torch.randn(3, HIDDEN, dtype=torch.bfloat16, device="cuda")
+    )
+    # misaligned row start (offset 1 element = 2B)
+    full = torch.randn(2, HIDDEN + 32, dtype=torch.bfloat16, device="cuda")
+    assert not moe_route_quant_fused.covered(
+        scores, bias, TOPK, full[:, 1 : 1 + HIDDEN]
+    )
+    # over the batch cap
+    big_scores = torch.randn(65, NUM_EXPERTS, dtype=torch.bfloat16, device="cuda")
+    assert not moe_route_quant_fused.covered(
+        big_scores,
+        bias,
+        TOPK,
+        torch.randn(65, HIDDEN, dtype=torch.bfloat16, device="cuda"),
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Motivation

At decode batch sizes the chain between the K3 fused-front GEMM and the trtllm-gen SiTU MoE op is
three tiny back-to-back kernels sitting on the critical path, one set per MoE layer:

| kernel | per layer | role |
|---|---:|---|
| `route_radix` | ~3.8 us | radix-select top-16 of 896 experts |
| `per_token_group_quant` | ~2.6 us | MXFP8 group-32 activation quant (packed UE8M0) |
| triton `pack_topk_ids` | ~1.4 us | `(id << 16) | bf16(w)` pack for trtllm-gen |

With 92 MoE layers that is ~0.7 ms/step of busy time plus 2 extra launches per layer, and each of the
three leaves the SMs nearly idle — at M=1 they are pure launch-latency and memory-latency work.

## Modifications

`route_quant_fused` runs all three in a single launch:

- CTAs `[0, M)` execute the `route_radix` body, extracted verbatim into a reusable
  `route_radix_block` device function, with the `(id << 16) | bf16(w)` pack folded into its epilogue.
- CTAs `[M, 2M)` run the `per_token_group_quant` math (`QuantTrait::run`, one 224-thread CTA per
  token, same subwarp layout as the flat schedule), so the quant hides under the routing CTAs
  instead of following them.

All outputs are bit-identical to the unfused chain, and the routing half keeps the existing
no-fast-math contract.

The three inputs live in different modules, so serving wires it as a consume-once
attempt-and-verify stash (`srt/layers/moe/route_quant_handoff.py`, same pattern as the existing
`zero_copy_context` handoff):

1. `KimiK3MoE._forward_routed{,_deferred}` stages `routed_input` before `self.topk`.
2. `biased_grouped_topk_gpu` launches the fused kernel in place of `moe_fused_gate` on a hit.
3. `Mxfp4MoEMethod.apply` consumes the published quant + packed ids and skips the two standalone
   kernels.

Every miss (shape not covered, identity check fails, different runner) falls through to the unfused
chain, so the fallback is the current code path unchanged — no env var is added, and the coverage
predicate (`M <= 64` on the 896-expert / top-16 / 3584-latent K3 shapes, trtllm-gen SiTU runner with
mxfp8 activations) is the only gate.

## Accuracy Test

`test/registered/kernels/ops/test_moe_route_quant_fused.py`: 25/25 pass — the fused kernel is
bit-exact against the unfused `route_radix` + `pack_topk_ids` + `per_token_group_quant` chain,
including strided rows, full-tie scores, and NaN adversarial cases.

GSM8K 200 questions, 5-shot, `--parallel 64`, on the fusion path: **0.995 / 0.995** (two runs), unchanged from the branch baseline and inside the K3 gate band.

## Benchmark and Profiling

2x4 GB300 TP8 (sm_103), canonical serving command, `random` 4096-in / 1024-out. Both arms are the
same build: the measurement tree carried a temporary env gate purely so the unfused arm could be
produced without swapping binaries. The shipped commit drops that gate, so the shipped path is the
"fused" row here with one always-true check removed.

| | bs=1 output tok/s (3 reps, median) | Mean TPOT | bs=64 output tok/s (2 reps) | Mean TPOT |
|---|---:|---:|---:|---:|
| unfused (= current `kimi-k3`) | 111.90 (111.43 / 111.90 / 112.08) | 8.60 ms | 1626.03 (1619.06 / 1626.03) | 33.47 ms |
| fused (this PR) | **114.85** (113.96 / 114.85 / 114.88) | **8.36 ms** | **1635.53** (1634.50 / 1635.53) | **33.20 ms** |
| delta | **+2.6%** | -2.8% | +0.6% | -0.8% |

bs=1 torch profiler, GPU-only, 25 steady-state decode steps, rank 0 (92 MoE layers x 25 steps =
2300 launches per kernel):

| kernel | off | on |
|---|---:|---:|
| `route_radix_kernel` | 8375.1 us | absent |
| `per_token_group_quant_flat_kernel` | 6240.6 us | absent |
| `_pack_topk_ids_triton_kernel` | 2863.1 us | absent |
| `route_quant_fused_kernel` | absent | 8485.6 us |
| **MoE-front prep total** | **17478.8 us** (7.60 us/layer) | **8485.6 us** (3.69 us/layer) |

That is 359.7 us/step less busy time and 184 fewer launches/step; whole-trace GPU busy drops
342.90 -> 339.60 ms and distinct kernel count 45 -> 43. The bs=1 end-to-end gain (+2.95 tok/s) is
larger than the busy-time saving alone because the removed kernels were serialized launch-latency
work on the decode critical path.

At bs=64 the chain is a smaller fraction of the step and mostly overlapped, so the gain is within
noise-adjacent territory (+0.6%) — the change is aimed at low-batch decode and is neutral-to-positive
at higher concurrency.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#running-unit-tests-adding-file-to-test-suite).
- [x] Update documentation / docstrings / example tutorials as needed, according to the model / feature it is about.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to the model / feature it is about.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30412355460](https://github.com/sgl-project/sglang/actions/runs/30412355460)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30412355304](https://github.com/sgl-project/sglang/actions/runs/30412355304)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->