### PR TITLE
[LoRA] Disable full prefill CUDA graph when LoRA is enabled

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4404,8 +4404,13 @@ class ServerArgs:
                 return
 
     def _disable_full_prefill_cudagraph_if_incompatible(self):
-        """Full prefill CG: empty rule list today; see the experimental warning."""
-        rules = []
+        """Full prefill CG: see the experimental warning for anything not listed."""
+        rules = [
+            # Capture runs before any prepare_lora_batch, so the recorded graph
+            # applies no adapter; adapter-bearing prefill batches would replay
+            # it and silently drop their LoRA deltas.
+            ("LoRA", lambda: bool(self.lora_paths) or bool(self.enable_lora)),
+        ]
         for name, predicate in rules:
             if predicate():
                 logger.warning(


### PR DESCRIPTION
Full-prefill-graph capture runs before any `prepare_lora_batch()`, so the recorded graph applies no adapter; adapter-bearing prefill batches would replay it and silently drop their LoRA deltas. Add LoRA to the full-prefill-CG disable rules. The existing lora_manager gating already keeps unsupported LoRA configurations off the breakable prefill graph; this covers the full-graph mode.

Split out of #32584 (not dp-attention-specific).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30412776512](https://github.com/sgl-project/sglang/actions/runs/30412776512)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #30412822898](https://github.com/sgl-project/sglang/actions/runs/30412822898)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->