### PR TITLE
[HiCache] Scope NIXL clear() to the clearing instance's key suffix

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -609,7 +609,9 @@ class HiCacheNixl(HiCacheStorage):
     def clear(self) -> None:
         if self.file_manager is None:
             return
-        self.file_manager.clear()
+        # Scope the clear to this instance's keys; the base directories may
+        # be a shared mount holding other models'/deployments' cache files.
+        self.file_manager.clear(suffix=self.config_suffix)
 
     def close(self):
         if self._l3_cleaner is not None:

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
@@ -11,6 +11,24 @@ from sglang.srt.mem_cache.storage.nixl.nixl_routing import (
 
 logger = logging.getLogger(__name__)
 
+
+def _name_matches_suffix(name: str, suffix: str) -> bool:
+    """True if ``name`` contains ``suffix`` at a key-component boundary.
+
+    Physical file names are ``{hash}{config_suffix}`` optionally followed by
+    ``_{component}`` parts, so a match is an occurrence of ``suffix`` followed
+    by either the end of the name or an underscore. Plain substring matching
+    would cross model boundaries (``_llama`` is a substring of ``_llama-2``).
+    """
+    start = 0
+    while (idx := name.find(suffix, start)) != -1:
+        rest = name[idx + len(suffix) :]
+        if not rest or rest.startswith("_"):
+            return True
+        start = idx + 1
+    return False
+
+
 _SGLANG_NIXL_CONFIG_KEYS = {
     "use_direct_io",
     "l3_cleaner_enabled",
@@ -233,16 +251,32 @@ class NixlFileManager:
                 f"Initialized file manager with base directories: {self.base_dirs}. Direct I/O: {use_direct_io}"
             )
 
-    def clear(self) -> None:
-        """Clear all files below every configured base directory."""
+    def clear(self, suffix: Optional[str] = None) -> None:
+        """Delete cache files below every configured base directory.
+
+        Only files whose name carries ``suffix`` at a key-component boundary
+        are removed. ``suffix`` is the clearing instance's config suffix; on
+        a shared mount this keeps one instance's clear from deleting other
+        models'/deployments' files. A missing or degenerate suffix falls back
+        to clearing everything, with a warning.
+        """
         if not self.base_dirs:
             logger.warning("Base directories are empty, skipping clear operation")
             return
 
+        scoped = bool(suffix) and suffix != "_"
+        if not scoped:
+            logger.warning(
+                f"clear called without a usable key suffix (suffix={suffix!r}); "
+                f"deleting ALL files under {self.base_dirs}. Other instances "
+                "sharing these directories will lose their cached data."
+            )
         for base in self.base_dirs:
             try:
                 for root, _dirs, files in os.walk(base):
                     for file in files:
+                        if scoped and not _name_matches_suffix(file, suffix):
+                            continue
                         file_path = os.path.join(root, file)
                         try:
                             os.remove(file_path)
@@ -250,7 +284,10 @@ class NixlFileManager:
                             logger.warning(f"Failed to remove file {file_path}: {e}")
             except Exception as e:
                 logger.error(f"Failed to clear base directory {base}: {e}")
-        logger.debug(f"Cleared all files in base directories: {self.base_dirs}")
+        logger.debug(
+            f"Cleared files with suffix {suffix!r} in base directories: "
+            f"{self.base_dirs}"
+        )
 
     def ensure_all_bucket_dirs(self) -> None:
         """Pre-create every possible bucket directory under each base dir.

--- a/test/registered/unit/mem_cache/test_hicache_nixl_file_manager.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_file_manager.py
@@ -1,0 +1,108 @@
+"""Unit tests for NixlFileManager scoped clear -- no server, no NIXL agent."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from sglang.srt.mem_cache.storage.nixl.nixl_utils import (
+    NixlFileManager,
+    _name_matches_suffix,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestNameMatchesSuffix(CustomTestCase):
+    """Derived boundary property of the suffix matcher.
+
+    A match must land on a key-component boundary (suffix followed by end of
+    name or an underscore). A "looks equivalent" rewrite to plain substring
+    matching would let an instance of model ``x`` delete model ``x-2`` files.
+    """
+
+    def test_matches_at_end_and_before_component_parts(self):
+        self.assertTrue(_name_matches_suffix("page-a_qwen_0_8", "_qwen_0_8"))
+        self.assertTrue(_name_matches_suffix("page-a_qwen_0_8_swa_k", "_qwen_0_8"))
+        self.assertTrue(_name_matches_suffix("page-a_qwen", "_qwen"))
+        self.assertTrue(_name_matches_suffix("page-a_qwen_mamba_temporal", "_qwen"))
+
+    def test_rejects_partial_model_and_rank_overlaps(self):
+        self.assertFalse(_name_matches_suffix("page-a_qwen-72b_0_8", "_qwen_0_8"))
+        self.assertFalse(_name_matches_suffix("page-a_qwen_0_80", "_qwen_0_8"))
+        self.assertFalse(_name_matches_suffix("page-a_qwen-72b", "_qwen"))
+
+
+class TestNixlFileManagerClear(CustomTestCase):
+    """Regression tests for #32693.
+
+    clear() used to delete every file under every base directory, so one
+    instance's /clear_hicache_storage destroyed the cached data of all other
+    models/deployments sharing an L3 mount. It must only remove files that
+    carry the clearing instance's key suffix.
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="test_nixl_file_manager_")
+        self.base_dirs = [os.path.join(self.test_dir, f"disk{i}") for i in range(2)]
+        self.file_manager = NixlFileManager(self.base_dirs, use_direct_io=False)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _write_key(self, key: str) -> str:
+        path = self.file_manager.get_file_path(key)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(b"x")
+        return path
+
+    def test_scoped_clear_spares_other_instances(self):
+        mine = [
+            self._write_key("page-a_qwen_0_8"),
+            self._write_key("page-b_qwen_0_8"),
+            self._write_key("page-b_qwen_0_8_swa_k"),
+        ]
+        others = [
+            self._write_key("page-a_glm_0_8"),
+            self._write_key("page-a_qwen-72b_0_8"),
+            self._write_key("page-a_qwen_0_82"),
+        ]
+
+        self.file_manager.clear(suffix="_qwen_0_8")
+
+        for path in mine:
+            self.assertFalse(os.path.exists(path), path)
+        for path in others:
+            self.assertTrue(os.path.exists(path), path)
+
+    def test_unscoped_clear_removes_everything_and_warns(self):
+        paths = [
+            self._write_key("page-a_qwen_0_8"),
+            self._write_key("page-a_glm_0_8"),
+        ]
+
+        with self.assertLogs(
+            "sglang.srt.mem_cache.storage.nixl.nixl_utils", level="WARNING"
+        ):
+            self.file_manager.clear()
+
+        for path in paths:
+            self.assertFalse(os.path.exists(path), path)
+
+    def test_degenerate_suffix_falls_back_to_unscoped(self):
+        path = self._write_key("page-a_glm_0_8")
+
+        with self.assertLogs(
+            "sglang.srt.mem_cache.storage.nixl.nixl_utils", level="WARNING"
+        ):
+            self.file_manager.clear(suffix="_")
+
+        self.assertFalse(os.path.exists(path), path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #32693.

`NixlFileManager.clear()` deletes every file under every configured base directory, with no scoping to the instance that issued the clear. Isolation in this backend lives only in the key suffix (`config_suffix`), not the directory layout, so on a shared L3 mount one instance's `POST /clear_hicache_storage` destroys the cached data of every other model/deployment sharing that mount, plus any unrelated files under the base dirs. Full trigger path and repro in #32693.

## Modifications

- `HiCacheNixl.clear()` passes its `config_suffix` down to the file manager.
- `NixlFileManager.clear(suffix=...)` only deletes files carrying the suffix at a key-component boundary: an occurrence of the suffix followed by end-of-name or `_` (`_name_matches_suffix`), so clearing model `llama` cannot delete `llama-2` files.
- A missing or degenerate suffix (empty model name on MLA yields `_`) falls back to the previous clear-all behavior with a warning, keeping backward compatibility for callers of the old API shape.
- New CPU-CI unit tests in `test/registered/unit/mem_cache/test_hicache_nixl_file_manager.py`: matcher boundary cases, scoped clear sparing other instances' files and both unscoped fallbacks. The regression case is red on pre-fix code (unscoped clear deletes the other instance's file) and green on this branch.

The minimal fix keeps today's flat layout. A namespaced directory layout (`base_dir/<config_suffix>/<bucket>/<key>`) would make scoped clears O(1) directory removals and also help the cleaner grouping issue (#32702); that lines up with the tenant-aware layout discussed on #26693 but is a migration, so out of scope here.

## Accuracy Tests

Not applicable: no change to inference outputs.

## Speed Tests and Profiling

Not applicable: `clear()` is an admin-endpoint path; the added per-file check is a string scan during an explicit cache wipe.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30413120891](https://github.com/sgl-project/sglang/actions/runs/30413120891)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30413120606](https://github.com/sgl-project/sglang/actions/runs/30413120606)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->