### PR TITLE
[Qwen3.5] Slice GDN qkvz projection instead of split/reshape/cat in decode

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -40,6 +40,7 @@ from sglang.srt.configs.qwen3_5 import (
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.layers.attention.linear.utils import get_linear_attn_decode_backend
 from sglang.srt.layers.attention.mamba.mamba import mamba_v2_sharded_weight_loader
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.dp_attention import (
@@ -370,6 +371,12 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             prefix=add_prefix("out_proj", prefix),
         )
 
+        # Whether decode can consume the projection outputs as views (see
+        # forward()). Resolved on the first forward, not here: the linear-attn
+        # kernel backend is chosen when the attention backend is built, which
+        # happens after the model is constructed.
+        self._decode_takes_projection_views: Optional[bool] = None
+
     @staticmethod
     def _override_weight_loader(param, loader):
         """Robustly override loader for:
@@ -631,15 +638,39 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             hidden_states
         )
 
-        # Qwen3.5 stores in_proj_qkvz contiguously as [q | k | v | z]
-        # (Qwen3-Next interleaves it per head group), so mixed_qkv is exactly
-        # the leading 2 * k_tp + v_tp columns: slice it as a view instead of
-        # the split/reshape/cat round trip that rebuilds the same bytes.
-        # Decode only -- causal_conv1d_update and packed_decode honor real
-        # row strides, but the extend kernels assume a contiguous layout (see the
-        # TODO in HybridLinearAttnBackend.forward_extend) and target-verify
-        # calls .view() on mixed_qkv.
-        if not (_is_cpu or _is_npu) and forward_batch.forward_mode.is_decode():
+        if self._decode_takes_projection_views is None:
+            self._decode_takes_projection_views = (
+                _is_cuda or _is_hip
+            ) and get_linear_attn_decode_backend().is_triton()
+
+        # Qwen3.5 stores in_proj_qkvz contiguously as [q | k | v | z] (Qwen3-Next
+        # interleaves it per head group), so mixed_qkv is exactly the leading
+        # 2 * k_tp + v_tp columns and z the trailing v_tp: take all four tensors as
+        # views instead of the split/reshape/cat round trip that rebuilds the same
+        # bytes. The views are non-contiguous -- one row per token with a gap --
+        # so this is restricted to the consumers that provably handle that:
+        #
+        # * Decode only. forward_extend() reshapes mixed_qkv into (dim, seqlen) for
+        #   causal_conv1d_fn, and the target-verify branch calls
+        #   mixed_qkv.view(batch_size, draft_token_num, -1), which merges the token
+        #   axis and cannot be expressed on a row-strided view.
+        # * Triton GDN kernels only. a and b reach the decode kernel exactly as
+        #   split here. The Triton kernels take a.stride(0)/b.stride(0) explicitly,
+        #   but the CuTe DSL kernel is compiled against contiguous exemplars and
+        #   cached without strides, so it reads a strided a/b as if compact --
+        #   wrong values, no error -- and both it and FlashInfer reject the
+        #   16B-unaligned pointer that projected_states_ba[:, nv_tp:] has whenever
+        #   nv_tp % 8 != 0 (e.g. num_v_heads=48 at TP4/TP8).
+        # * CUDA / ROCm only. The CPU, NPU and XPU causal_conv1d_update bindings
+        #   are out-of-tree, so their stride handling is not verifiable here.
+        #
+        # mixed_qkv itself never reaches the recurrent kernel strided:
+        # causal_conv1d_update writes into torch.empty_like(x), which falls back to
+        # a contiguous layout for a non-dense view.
+        if (
+            self._decode_takes_projection_views
+            and forward_batch.forward_mode.is_decode()
+        ):
             k_tp = self.key_dim // self.attn_tp_size
             v_tp = self.value_dim // self.attn_tp_size
             nv_tp = self.num_v_heads // self.attn_tp_size

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -631,7 +631,24 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             hidden_states
         )
 
-        if self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_npu:
+        # Qwen3.5 stores in_proj_qkvz contiguously as [q | k | v | z]
+        # (Qwen3-Next interleaves it per head group), so mixed_qkv is exactly
+        # the leading 2 * k_tp + v_tp columns: slice it as a view instead of
+        # the split/reshape/cat round trip that rebuilds the same bytes.
+        # Decode only -- causal_conv1d_update and packed_decode honor real
+        # row strides, but the extend kernels assume a contiguous layout (see the
+        # TODO in HybridLinearAttnBackend.forward_extend) and target-verify
+        # calls .view() on mixed_qkv.
+        if not (_is_cpu or _is_npu) and forward_batch.forward_mode.is_decode():
+            k_tp = self.key_dim // self.attn_tp_size
+            v_tp = self.value_dim // self.attn_tp_size
+            nv_tp = self.num_v_heads // self.attn_tp_size
+            mixed_qkv, z_flat = projected_states_qkvz.split(
+                [k_tp * 2 + v_tp, v_tp], dim=-1
+            )
+            z = z_flat.reshape(z_flat.shape[0], -1, self.head_v_dim)
+            b, a = projected_states_ba.split([nv_tp, nv_tp], dim=-1)
+        elif self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_npu:
             if _is_cpu:
                 num_k_heads_tp = self.num_k_heads // self.attn_tp_size
                 num_v_heads_tp = self.num_v_heads // self.attn_tp_size


### PR DESCRIPTION
## Motivation

`Qwen3_5GatedDeltaNet.forward()` derives `mixed_qkv` from the fused `in_proj_qkvz` output by splitting it into q/k/v/z and immediately concatenating q/k/v back together. Qwen3.5 stores that projection in **contiguous** `[q | k | v | z]` order (unlike Qwen3-Next per-head-group interleaved layout), so the concatenated result is byte-for-byte the leading `2 * k_tp + v_tp` columns of the input — the round trip rebuilds exactly what it started from.

Qwen3.6-27B additionally never reaches the fused kernel: it has `num_v_heads // num_k_heads == 3`, which is not in the `[1, 2, 4]` whitelist guarding `fused_qkvzba_split_reshape_cat_contiguous()`, so every GDN layer falls back to the copy path.

## Change

Take `mixed_qkv`, `z`, `b` and `a` as views in the decode path.

## Benchmarks

Qwen3.6-27B-FP8, 1xH200, bs=16, 8k input / 1k output:

| | baseline | this PR |
|---|---|---|
| decode throughput | 1143 tok/s | **1178 tok/s** (+3.1%) |
| GSM8K | 0.485 | 0.480 |
| AIME25 pass@1 | 90.00% | 91.67% |
| AIME25 pass@2 | 90.00% | 93.33% |

Accuracy is unchanged within run-to-run noise (GSM8K moves down by 0.5pt, AIME25 up by 1.7/3.3pt). Note that end-to-end outputs are not expected to be bitwise identical even though the tensor derivation is: `stride_mixed_qkv_tok` / `stride_a_tok` / `stride_b_tok` are `tl.constexpr` in `fused_recurrent_gated_delta_rule_packed_decode_kernel`, so a different row stride compiles a different kernel specialization.

## Kernel-level measurement

Profiler attribution of the previous branch shows exactly three kernels per layer; the `split` / `reshape` calls were already zero-copy views:

| op | kernels |
|---|---|
| `split` (qkvz + ba) | 0 |
| `q/k/v .reshape(N, -1)` | 0 |
| `z.reshape(N, -1, head_v_dim)` | 0 |
| `b.contiguous()` | 1 |
| `a.contiguous()` | 1 |
| `torch.cat((q, k, v))` | 1 |

Removing them: **5.43 us -> 0.00 us per layer**, i.e. ~0.26 ms per decode step over 48 GDN layers.

## Why decode only

`forward_decode()` `causal_conv1d_update` and `packed_decode` take real row strides (the latter validates `stride(-1) == 1` and passes `stride_*_tok` explicitly). `forward_extend()` `causal_conv1d_fn` / `chunk_gated_delta_rule` assume a contiguous layout — see the existing TODO in `HybridLinearAttnBackend.forward_extend` — and the target-verify branch calls `.view()` on `mixed_qkv`, which rejects non-contiguous tensors. Prefill, extend and target-verify keep the previous behaviour unchanged.

## On the fused kernel

`fused_qkvzba_split_reshape_cat_contiguous()` performs no permutation for this layout: its input and output row offsets are identical for q, k and v. It was verified bit-identical to this slice for every ratio it accepts (1, 2, 4), so for the contiguous layout no kernel is required at all. The `[1, 2, 4]` whitelist stems from `tl.arange(0, ratio * head_v_dim)`, which Triton requires to be a power of two — ratio 3, 5 and 6 fail to compile while 8 and 16 do compile but are not whitelisted. That constraint is inherent to the interleaved variant and is left untouched here.

## Verification

- `torch.equal` on `mixed_qkv`, `z`, `b`, `a` against the previous path using Qwen3.6-27B dimensions (`key_dim=2048`, `value_dim=6144`, `num_v_heads=48`, `head_v_dim=128`) — all four bit-exact.
- `causal_conv1d_update` fed the strided view vs a contiguous copy of the same values: identical output and identical in-place `conv_state` (max abs diff 0), and the aliased `z` region of the projection buffer is left untouched.
- `black` clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30475236099](https://github.com/sgl-project/sglang/actions/runs/30475236099)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30475234325](https://github.com/sgl-project/sglang/actions/runs/30475234325)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->