### PR TITLE
[NPU] fix dsv4 mtp condition on NPU graph

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_extend_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_extend_npu_graph_runner.py
@@ -36,7 +36,7 @@ class EAGLEDraftExtendNpuGraphRunner(EAGLEDraftExtendCudaGraphRunner):
 
     def _replay_graph(self, shape_key, forward_batch):
         hf_config = self.model_runner.model_config.hf_config
-        if not (is_deepseek_dsa(hf_config) and is_deepseek_v4(hf_config)):
+        if not (is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config)):
             seq_lens = forward_batch.seq_lens_cpu.tolist() + [0] * (
                 self.bs - self.raw_bs
             )

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
@@ -88,7 +88,7 @@ class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
 
     def _replay_graph(self, shape_key, forward_batch):
         hf_config = self.model_runner.model_config.hf_config
-        if not (is_deepseek_dsa(hf_config) and is_deepseek_v4(hf_config)):
+        if not (is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config)):
             seq_lens_for_each_draft_step = []
             for speculative_step_id in range(self.speculative_num_steps - 1):
                 seq_lens_cpu = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DeepSeek DSA and DeepSeek V4 use dedicated NPU graph replay paths and do not rely on `NPUGraph.update()` to refresh CPU-side sequence-length attributes.

For DeepSeek-V4-Flash MTP with:
```
--speculative-algorithm EAGLE
--speculative-num-steps 3
--speculative-eagle-topk 1
--speculative-num-draft-tokens 4
```
the draft graph attempted to submit two CPU update entries even though the captured DSV4 graph contained no operators requiring CPU-side updates. This caused the following runtime error:
```
RuntimeError: Currently, there are 0 operators that need to be updated by
capture, and there are 2 elements in the incoming cpu_update_input list
```

Fix DeepSeek V4 MTP graph replay on NPU. The previous `and` condition incorrectly called `NPUGraph.update()`, causing an update-record count mismatch.

## Modifications

Replace `is_deepseek_dsa(...) and is_deepseek_v4(...)` with `or` in the EAGLE draft and draft-extend NPU graph runners.

## Accuracy Tests
```
2026-07-29 03:55:06 - evalscope - INFO: Overall report table: 
┌───────────────────────────────┬───────────┬──────────┬──────────┬───────┬─────────┬─────────┐
│ Model                         │ Dataset   │ Metric   │ Subset   │   Num │   Score │ Cat.0   │
├───────────────────────────────┼───────────┼──────────┼──────────┼───────┼─────────┼─────────┤
│ DeepSeek-V4-Flash-w8a8-mtp-ms │ aime26    │ mean_acc │ default  │    29 │  0.9655 │ default │
└───────────────────────────────┴───────────┴──────────┴──────────┴───────┴─────────┴─────────┘ 

2026-07-29 03:55:06 - evalscope - INFO: Overall perf table: 
Model                          Dataset      Num    Avg Lat    Avg TTFT    Avg TPOT    Avg Thpt    Avg In    Avg Out
                                                       (s)        (ms)        (ms)     (tok/s)       Tok        Tok
-----------------------------  ---------  -----  ---------  ----------  ----------  ----------  --------  ---------
DeepSeek-V4-Flash-w8a8-mtp-ms  aime26        29    346.795      961.28       22.73       43.65   154.621    15138.7 
```

## Speed Tests and Profiling

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30415210314](https://github.com/sgl-project/sglang/actions/runs/30415210314)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30415210215](https://github.com/sgl-project/sglang/actions/runs/30415210215)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->