### PR TITLE
[PoC] Optimize GPT-OSS CP4+EP4 prefill with breakable graphs and single-call zigzag attention

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -75,6 +75,9 @@ class TRTLLMMHAMetadata:
     page_table: torch.Tensor = None
     # Page table for SWA layers (translated from full pool indices to SWA pool indices)
     swa_page_table: torch.Tensor = None
+    # CP-v2 zigzag treats prev/next halves as a synthetic 2 * batch_size batch.
+    zigzag_page_table: torch.Tensor = None
+    zigzag_swa_page_table: torch.Tensor = None
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: torch.Tensor = None
     is_ragged_verify: bool = False
@@ -314,6 +317,35 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             if is_swa:
                 return swa_pt
         return self.forward_metadata.page_table
+
+    def _build_zigzag_page_tables(
+        self,
+        metadata: TRTLLMMHAMetadata,
+        forward_batch: ForwardBatch,
+    ) -> None:
+        """Duplicate request rows once for the combined prev-then-next CP launch."""
+        if not is_cp_v2_active(forward_batch):
+            return
+
+        metadata.zigzag_page_table = torch.cat(
+            (metadata.page_table, metadata.page_table), dim=0
+        )
+        if metadata.swa_page_table is not None:
+            metadata.zigzag_swa_page_table = torch.cat(
+                (metadata.swa_page_table, metadata.swa_page_table), dim=0
+            )
+
+    def _get_zigzag_layer_page_table(
+        self,
+        layer: RadixAttention,
+    ) -> torch.Tensor:
+        """Return the duplicated full or SWA page table for zigzag CP."""
+        zigzag_swa_pt = self.forward_metadata.zigzag_swa_page_table
+        if zigzag_swa_pt is not None:
+            _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
+            if is_swa:
+                return zigzag_swa_pt
+        return self.forward_metadata.zigzag_page_table
 
     @staticmethod
     def _get_scalar_scale(
@@ -938,6 +970,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self._fill_page_table_device(
             metadata, forward_batch.req_pool_indices, metadata.cache_seqlens_int32
         )
+        self._build_zigzag_page_tables(metadata, forward_batch)
 
         if self._needs_encoder_only_expand(forward_batch.forward_mode, metadata):
             row_map = (
@@ -1252,13 +1285,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 cu_seqlens_q,
                 cache_seqlens,
                 max_seqlen_q,
+                *,
                 cu_seqlens_kv,
+                use_zigzag_page_table=False,
             ):
+                block_tables = (
+                    self._get_zigzag_layer_page_table(layer)
+                    if use_zigzag_page_table
+                    else page_table
+                )
                 return flashinfer.prefill.trtllm_batch_context_with_kv_cache(
                     query=q_chunk,
                     kv_cache=kv_cache,
                     workspace_buffer=self.workspace_buffer,
-                    block_tables=page_table,
+                    block_tables=block_tables,
                     seq_lens=cache_seqlens,
                     max_q_len=max_seqlen_q,
                     max_kv_len=self.max_context_len,

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -79,11 +79,18 @@ class ZigzagContextParallelMetadata(BaseContextParallelMetadata):
     cu_seqlens_q_prev_tensor: Optional[Any] = None
     cu_seqlens_q_next_tensor: Optional[Any] = None
 
+    # Combined prev-then-next TRT-LLM geometry (shape [2 * bs] or [2 * bs + 1]).
+    actual_seq_q_combined_tensor: Optional[Any] = None
+    kv_len_combined_tensor: Optional[Any] = None
+    cu_seqlens_q_combined_tensor: Optional[Any] = None
+    cu_seqlens_kv_combined_tensor: Optional[Any] = None
+
     # Scalars derived from the per-sequence lists above.
     total_q_prev_tokens: int = 0
     total_q_next_tokens: int = 0
     max_seqlen_q_prev: int = 0
     max_seqlen_q_next: int = 0
+    max_seqlen_q_combined: int = 0
 
     # Per-sequence CPU lists, useful for indexers and diagnostics.
     kv_len_prev_list: Optional[List[int]] = None
@@ -218,6 +225,10 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         cu_next = [0] + list(accumulate(actual_seq_q_next_list))
         cu_kv_prev = [0] + list(accumulate(kv_len_prev_list))
         cu_kv_next = [0] + list(accumulate(kv_len_next_list))
+        actual_seq_q_combined_list = actual_seq_q_prev_list + actual_seq_q_next_list
+        kv_len_combined_list = kv_len_prev_list + kv_len_next_list
+        cu_q_combined = [0] + list(accumulate(actual_seq_q_combined_list))
+        cu_kv_combined = [0] + list(accumulate(kv_len_combined_list))
 
         total_seq_lens = sum(extend_seqs_len)
         assert len(split_list) == bs * cp_segment_num
@@ -258,6 +269,18 @@ class ZigzagCPStrategy(ContextParallelStrategy):
             cu_seqlens_q_next_tensor=torch.tensor(
                 cu_next, device=device, dtype=torch.int32
             ),
+            actual_seq_q_combined_tensor=torch.tensor(
+                actual_seq_q_combined_list, device=device, dtype=torch.int32
+            ),
+            kv_len_combined_tensor=torch.tensor(
+                kv_len_combined_list, device=device, dtype=torch.int32
+            ),
+            cu_seqlens_q_combined_tensor=torch.tensor(
+                cu_q_combined, device=device, dtype=torch.int32
+            ),
+            cu_seqlens_kv_combined_tensor=torch.tensor(
+                cu_kv_combined, device=device, dtype=torch.int32
+            ),
             total_q_prev_tokens=cu_prev[-1],
             total_q_next_tokens=cu_next[-1],
             max_seqlen_q_prev=(
@@ -265,6 +288,9 @@ class ZigzagCPStrategy(ContextParallelStrategy):
             ),
             max_seqlen_q_next=(
                 max(actual_seq_q_next_list) if actual_seq_q_next_list else 0
+            ),
+            max_seqlen_q_combined=(
+                max(actual_seq_q_combined_list) if actual_seq_q_combined_list else 0
             ),
             kv_len_prev_list=kv_len_prev_list,
             kv_len_next_list=kv_len_next_list,
@@ -329,31 +355,33 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         ), f"{self.name} CP does not support {attention_backend=}"
 
         meta = forward_batch.attn_cp_metadata
-        q_prev = q[: meta.total_q_prev_tokens]
         logical_tokens = meta.total_q_prev_tokens + meta.total_q_next_tokens
-        q_next = q[meta.total_q_prev_tokens : logical_tokens]
-
-        prev_kwargs = {}
-        next_kwargs = {}
         if attention_backend == CPAttentionBackendKind.TRTLLM_MHA:
-            prev_kwargs["cu_seqlens_kv"] = meta.cu_seqlens_kv_prev_tensor
-            next_kwargs["cu_seqlens_kv"] = meta.cu_seqlens_kv_next_tensor
+            result = attn_fn(
+                q[:logical_tokens],
+                meta.cu_seqlens_q_combined_tensor,
+                meta.kv_len_combined_tensor,
+                meta.max_seqlen_q_combined,
+                cu_seqlens_kv=meta.cu_seqlens_kv_combined_tensor,
+                use_zigzag_page_table=True,
+            )
+        else:
+            q_prev = q[: meta.total_q_prev_tokens]
+            q_next = q[meta.total_q_prev_tokens : logical_tokens]
+            result_prev = attn_fn(
+                q_prev,
+                meta.cu_seqlens_q_prev_tensor,
+                meta.kv_len_prev_tensor,
+                meta.max_seqlen_q_prev,
+            )
+            result_next = attn_fn(
+                q_next,
+                meta.cu_seqlens_q_next_tensor,
+                meta.kv_len_next_tensor,
+                meta.max_seqlen_q_next,
+            )
+            result = torch.cat([result_prev, result_next], dim=0)
 
-        result_prev = attn_fn(
-            q_prev,
-            meta.cu_seqlens_q_prev_tensor,
-            meta.kv_len_prev_tensor,
-            meta.max_seqlen_q_prev,
-            **prev_kwargs,
-        )
-        result_next = attn_fn(
-            q_next,
-            meta.cu_seqlens_q_next_tensor,
-            meta.kv_len_next_tensor,
-            meta.max_seqlen_q_next,
-            **next_kwargs,
-        )
-        result = torch.cat([result_prev, result_next], dim=0)
         pad_size = q.shape[0] - logical_tokens
         assert pad_size >= 0
         if pad_size > 0:

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -276,7 +276,12 @@ class FusedMoE(torch.nn.Module):
         self._pending_fp8_shared_scales: dict[tuple[int, str], torch.Tensor] = {}
 
         assert intermediate_size % self.moe_tp_size == 0
-        self.intermediate_size_per_partition = intermediate_size // self.moe_tp_size
+        self.intermediate_size_per_partition_unpadded = (
+            intermediate_size // self.moe_tp_size
+        )
+        self.intermediate_size_per_partition = (
+            self.intermediate_size_per_partition_unpadded
+        )
         self.reduce_results = reduce_results
         self.use_presharded_weights = use_presharded_weights
 
@@ -680,8 +685,8 @@ class FusedMoE(torch.nn.Module):
             shard_size = expert_data.shape[shard_dim]
 
         if self.use_padded_loading:
-            if _is_cpu and is_bias:
-                shard_dim = 1
+            if is_bias:
+                shard_dim = -1
             expert_data, loaded_weight = narrow_padded_param_and_loaded_weight(
                 expert_data,
                 loaded_weight,

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator, Optional, cast
 
 import torch
+import torch.nn.functional as F
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
@@ -1157,6 +1158,11 @@ class FlashInferTrtllmBf16MoeQuantInfo(MoeQuantInfo):
     # Expert-parallel metadata
     global_num_experts: int
     local_expert_offset: int
+    kernel_hidden_size: int
+    input_pad_value: float
+    gemm1_alpha: Optional[torch.Tensor] = None
+    gemm1_beta: Optional[torch.Tensor] = None
+    gemm1_clamp_limit: Optional[torch.Tensor] = None
 
 
 def fused_experts_none_to_flashinfer_trtllm_bf16(
@@ -1206,6 +1212,19 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
     )
 
     hidden_states = dispatch_output.hidden_states
+    logical_hidden_size = hidden_states.shape[-1]
+    if quant_info.kernel_hidden_size < logical_hidden_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM BF16 kernel hidden size cannot be smaller than "
+            f"the logical hidden size: {quant_info.kernel_hidden_size} < "
+            f"{logical_hidden_size}"
+        )
+    if quant_info.kernel_hidden_size != logical_hidden_size:
+        hidden_states = F.pad(
+            hidden_states,
+            (0, quant_info.kernel_hidden_size - logical_hidden_size),
+            value=quant_info.input_pad_value,
+        )
     topk_output = dispatch_output.topk_output
 
     with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
@@ -1240,6 +1259,9 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
                 ),
                 tune_max_num_tokens=next_power_of_2(hidden_states.shape[0]),
                 activation_type=activation_type,
+                gemm1_alpha=quant_info.gemm1_alpha,
+                gemm1_beta=quant_info.gemm1_beta,
+                gemm1_clamp_limit=quant_info.gemm1_clamp_limit,
             )
         else:
             assert TopKOutputChecker.format_is_bypassed(topk_output)
@@ -1263,9 +1285,14 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
                 routed_scaling_factor=runner_config.routed_scaling_factor,
                 tune_max_num_tokens=next_power_of_2(hidden_states.shape[0]),
                 activation_type=activation_type,
+                gemm1_alpha=quant_info.gemm1_alpha,
+                gemm1_beta=quant_info.gemm1_beta,
+                gemm1_clamp_limit=quant_info.gemm1_clamp_limit,
             )
 
-    return StandardCombineInput(hidden_states=final_hidden_states)
+    return StandardCombineInput(
+        hidden_states=final_hidden_states[:, :logical_hidden_size].contiguous()
+    )
 
 
 @register_fused_func("none", "flashinfer_trtllm")

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
 
@@ -133,6 +134,128 @@ def get_bf16_gemm_backend() -> Bf16GemmBackend:
     if _BF16_GEMM_BACKEND is None:
         _BF16_GEMM_BACKEND = Bf16GemmBackend.AUTO
     return _BF16_GEMM_BACKEND
+
+
+def _prepare_flashinfer_trtllm_bf16_weights(
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    w13_bias: Optional[torch.Tensor],
+    w2_bias: Optional[torch.Tensor],
+    *,
+    hidden_size: int,
+    intermediate_size: int,
+    gemm1_alpha: Optional[float],
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Pad canonical BF16 MoE weights and fold static biases into them.
+
+    FlashInfer's TRT-LLM kernel consumes [up, gate] W13 rows and has no bias
+    arguments. The first padded hidden and intermediate channels therefore
+    provide constant-one features for the two bias terms respectively.
+    """
+    kernel_hidden_size = ((hidden_size + 127) // 128) * 128
+    kernel_intermediate_size = w2.shape[-1]
+    if kernel_intermediate_size < intermediate_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM W2 has fewer columns than the logical "
+            f"intermediate size: {kernel_intermediate_size} < {intermediate_size}"
+        )
+    if w2.shape[-2] < hidden_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM W2 has fewer rows than the logical hidden "
+            f"size: {w2.shape[-2]} < {hidden_size}"
+        )
+
+    num_experts = w13.shape[0]
+    if w2.shape[0] != num_experts:
+        raise ValueError("W13 and W2 must have the same number of experts")
+
+    def get_w13_halves(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        compact_rows = 2 * intermediate_size
+        padded_rows = 2 * kernel_intermediate_size
+        row_dim = -2 if tensor.dim() == 3 else -1
+        if tensor.shape[row_dim] == compact_rows:
+            gate_start = intermediate_size
+        elif tensor.shape[row_dim] == padded_rows:
+            gate_start = kernel_intermediate_size
+        else:
+            raise ValueError(
+                "W13 must have either logical or kernel-padded rows, got "
+                f"{tensor.shape[row_dim]} rows for logical={intermediate_size} and "
+                f"kernel={kernel_intermediate_size}"
+            )
+        return (
+            tensor.narrow(row_dim, 0, intermediate_size),
+            tensor.narrow(row_dim, gate_start, intermediate_size),
+        )
+
+    if w13.shape[-1] < hidden_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM W13 has fewer columns than the logical hidden "
+            f"size: {w13.shape[-1]} < {hidden_size}"
+        )
+    up_weight, gate_weight = get_w13_halves(w13)
+    prepared_w13 = torch.zeros(
+        num_experts,
+        2 * kernel_intermediate_size,
+        kernel_hidden_size,
+        dtype=w13.dtype,
+        device=w13.device,
+    )
+    prepared_w13[:, :intermediate_size, :hidden_size] = up_weight[:, :, :hidden_size]
+    prepared_w13[
+        :,
+        kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+        :hidden_size,
+    ] = gate_weight[:, :, :hidden_size]
+
+    prepared_w2 = torch.zeros(
+        num_experts,
+        kernel_hidden_size,
+        kernel_intermediate_size,
+        dtype=w2.dtype,
+        device=w2.device,
+    )
+    prepared_w2[:, :hidden_size, :intermediate_size] = w2[
+        :, :hidden_size, :intermediate_size
+    ]
+
+    if w13_bias is not None:
+        if kernel_hidden_size == hidden_size:
+            raise ValueError(
+                "FlashInfer TRT-LLM W13 bias folding requires a padded hidden channel"
+            )
+        up_bias, gate_bias = get_w13_halves(w13_bias)
+        prepared_w13[:, :intermediate_size, hidden_size] = up_bias[
+            :, :intermediate_size
+        ].to(prepared_w13.dtype)
+        prepared_w13[
+            :,
+            kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+            hidden_size,
+        ] = gate_bias[:, :intermediate_size].to(prepared_w13.dtype)
+
+    if w2_bias is not None:
+        if kernel_hidden_size == hidden_size:
+            raise ValueError(
+                "FlashInfer TRT-LLM W2 bias folding requires a padded hidden channel"
+            )
+        if kernel_intermediate_size == intermediate_size:
+            raise ValueError(
+                "FlashInfer TRT-LLM W2 bias folding requires a padded intermediate channel"
+            )
+        if gemm1_alpha is None:
+            raise ValueError("FlashInfer TRT-LLM W2 bias folding requires gemm1_alpha")
+        gate = 1.0
+        up = 1.0 / (gate / (1.0 + math.exp(-gemm1_alpha * gate))) - 1.0
+        prepared_w13[:, intermediate_size, hidden_size] = up
+        prepared_w13[:, kernel_intermediate_size + intermediate_size, hidden_size] = (
+            gate
+        )
+        prepared_w2[:, :hidden_size, intermediate_size] = w2_bias[:, :hidden_size].to(
+            prepared_w2.dtype
+        )
+
+    return prepared_w13, prepared_w2, kernel_hidden_size
 
 
 class UnquantizedEmbeddingMethod(QuantizeMethodBase):
@@ -374,6 +497,57 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
+            hidden_size = layer.moe_runner_config.hidden_size
+            intermediate_size = layer.intermediate_size_per_partition_unpadded
+            prepared_w13, prepared_w2, kernel_hidden_size = (
+                _prepare_flashinfer_trtllm_bf16_weights(
+                    layer.w13_weight.data,
+                    layer.w2_weight.data,
+                    getattr(layer, "w13_weight_bias", None),
+                    getattr(layer, "w2_weight_bias", None),
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                    gemm1_alpha=layer.moe_runner_config.gemm1_alpha,
+                )
+            )
+            copy_or_rebind_param(layer, "w13_weight", prepared_w13)
+            copy_or_rebind_param(layer, "w2_weight", prepared_w2)
+
+            num_local_experts = layer.num_local_experts
+            device = prepared_w13.device
+            gemm1_alpha = layer.moe_runner_config.gemm1_alpha
+            gemm1_clamp_limit = layer.moe_runner_config.gemm1_clamp_limit
+            self._flashinfer_kernel_hidden_size = kernel_hidden_size
+            self._flashinfer_input_pad_value = float(
+                getattr(layer, "w13_weight_bias", None) is not None
+                or getattr(layer, "w2_weight_bias", None) is not None
+            )
+            self._flashinfer_gemm1_alpha = (
+                torch.full(
+                    (num_local_experts,),
+                    gemm1_alpha,
+                    dtype=torch.float32,
+                    device=device,
+                )
+                if gemm1_alpha is not None
+                else None
+            )
+            self._flashinfer_gemm1_beta = (
+                torch.ones(num_local_experts, dtype=torch.float32, device=device)
+                if gemm1_alpha is not None
+                else None
+            )
+            self._flashinfer_gemm1_clamp_limit = (
+                torch.full(
+                    (num_local_experts,),
+                    gemm1_clamp_limit,
+                    dtype=torch.float32,
+                    device=device,
+                )
+                if gemm1_clamp_limit is not None
+                else None
+            )
+
             from flashinfer.fused_moe.core import (
                 _maybe_get_cached_w3_w1_permute_indices,
                 convert_to_block_layout,
@@ -548,8 +722,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
     @property
     def load_up_proj_weight_first(self) -> bool:
-        # FlashInfer CUTLASS kernel assumes [Up, Gate] Proj as W13
-        return self.use_flashinfer_cutlass
+        # FlashInfer kernels assume [Up, Gate] projections in W13.
+        return self.use_flashinfer_cutlass or self.use_flashinfer_trtllm_moe
 
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -169,6 +169,27 @@ def _prepare_flashinfer_trtllm_bf16_weights(
     if w2.shape[0] != num_experts:
         raise ValueError("W13 and W2 must have the same number of experts")
 
+    def validate_w13_bias_shape(bias: torch.Tensor) -> None:
+        valid_rows = {2 * intermediate_size, 2 * kernel_intermediate_size}
+        if (
+            bias.dim() != 2
+            or bias.shape[0] != num_experts
+            or bias.shape[1] not in valid_rows
+        ):
+            raise ValueError(
+                "W13 bias must have shape "
+                f"({num_experts}, {2 * intermediate_size}) or "
+                f"({num_experts}, {2 * kernel_intermediate_size}), got "
+                f"{tuple(bias.shape)}"
+            )
+
+    def validate_w2_bias_shape(bias: torch.Tensor) -> None:
+        if bias.dim() != 2 or tuple(bias.shape) != (num_experts, hidden_size):
+            raise ValueError(
+                f"W2 bias must have shape ({num_experts}, {hidden_size}), got "
+                f"{tuple(bias.shape)}"
+            )
+
     def get_w13_halves(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         compact_rows = 2 * intermediate_size
         padded_rows = 2 * kernel_intermediate_size
@@ -220,6 +241,7 @@ def _prepare_flashinfer_trtllm_bf16_weights(
     ]
 
     if w13_bias is not None:
+        validate_w13_bias_shape(w13_bias)
         if kernel_hidden_size == hidden_size:
             raise ValueError(
                 "FlashInfer TRT-LLM W13 bias folding requires a padded hidden channel"
@@ -235,6 +257,7 @@ def _prepare_flashinfer_trtllm_bf16_weights(
         ] = gate_bias[:, :intermediate_size].to(prepared_w13.dtype)
 
     if w2_bias is not None:
+        validate_w2_bias_shape(w2_bias)
         if kernel_hidden_size == hidden_size:
             raise ValueError(
                 "FlashInfer TRT-LLM W2 bias folding requires a padded hidden channel"
@@ -497,56 +520,57 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
-            hidden_size = layer.moe_runner_config.hidden_size
-            intermediate_size = layer.intermediate_size_per_partition_unpadded
-            prepared_w13, prepared_w2, kernel_hidden_size = (
-                _prepare_flashinfer_trtllm_bf16_weights(
-                    layer.w13_weight.data,
-                    layer.w2_weight.data,
-                    getattr(layer, "w13_weight_bias", None),
-                    getattr(layer, "w2_weight_bias", None),
-                    hidden_size=hidden_size,
-                    intermediate_size=intermediate_size,
-                    gemm1_alpha=layer.moe_runner_config.gemm1_alpha,
+            if layer.moe_runner_config.is_gated:
+                hidden_size = layer.moe_runner_config.hidden_size
+                intermediate_size = layer.intermediate_size_per_partition_unpadded
+                prepared_w13, prepared_w2, kernel_hidden_size = (
+                    _prepare_flashinfer_trtllm_bf16_weights(
+                        layer.w13_weight.data,
+                        layer.w2_weight.data,
+                        getattr(layer, "w13_weight_bias", None),
+                        getattr(layer, "w2_weight_bias", None),
+                        hidden_size=hidden_size,
+                        intermediate_size=intermediate_size,
+                        gemm1_alpha=layer.moe_runner_config.gemm1_alpha,
+                    )
                 )
-            )
-            copy_or_rebind_param(layer, "w13_weight", prepared_w13)
-            copy_or_rebind_param(layer, "w2_weight", prepared_w2)
+                copy_or_rebind_param(layer, "w13_weight", prepared_w13)
+                copy_or_rebind_param(layer, "w2_weight", prepared_w2)
 
-            num_local_experts = layer.num_local_experts
-            device = prepared_w13.device
-            gemm1_alpha = layer.moe_runner_config.gemm1_alpha
-            gemm1_clamp_limit = layer.moe_runner_config.gemm1_clamp_limit
-            self._flashinfer_kernel_hidden_size = kernel_hidden_size
-            self._flashinfer_input_pad_value = float(
-                getattr(layer, "w13_weight_bias", None) is not None
-                or getattr(layer, "w2_weight_bias", None) is not None
-            )
-            self._flashinfer_gemm1_alpha = (
-                torch.full(
-                    (num_local_experts,),
-                    gemm1_alpha,
-                    dtype=torch.float32,
-                    device=device,
+                num_local_experts = layer.num_local_experts
+                device = prepared_w13.device
+                gemm1_alpha = layer.moe_runner_config.gemm1_alpha
+                gemm1_clamp_limit = layer.moe_runner_config.gemm1_clamp_limit
+                self._flashinfer_kernel_hidden_size = kernel_hidden_size
+                self._flashinfer_input_pad_value = float(
+                    getattr(layer, "w13_weight_bias", None) is not None
+                    or getattr(layer, "w2_weight_bias", None) is not None
                 )
-                if gemm1_alpha is not None
-                else None
-            )
-            self._flashinfer_gemm1_beta = (
-                torch.ones(num_local_experts, dtype=torch.float32, device=device)
-                if gemm1_alpha is not None
-                else None
-            )
-            self._flashinfer_gemm1_clamp_limit = (
-                torch.full(
-                    (num_local_experts,),
-                    gemm1_clamp_limit,
-                    dtype=torch.float32,
-                    device=device,
+                self._flashinfer_gemm1_alpha = (
+                    torch.full(
+                        (num_local_experts,),
+                        gemm1_alpha,
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    if gemm1_alpha is not None
+                    else None
                 )
-                if gemm1_clamp_limit is not None
-                else None
-            )
+                self._flashinfer_gemm1_beta = (
+                    torch.ones(num_local_experts, dtype=torch.float32, device=device)
+                    if gemm1_alpha is not None
+                    else None
+                )
+                self._flashinfer_gemm1_clamp_limit = (
+                    torch.full(
+                        (num_local_experts,),
+                        gemm1_clamp_limit,
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    if gemm1_clamp_limit is not None
+                    else None
+                )
 
             from flashinfer.fused_moe.core import (
                 _maybe_get_cached_w3_w1_permute_indices,
@@ -653,6 +677,29 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             return
 
         expected_numel = expected_shape[0] * expected_shape[1] * expected_shape[2]
+        kernel_hidden_size = ((layer.hidden_size + 127) // 128) * 128
+        if weight_name.endswith(".experts.w13_weight"):
+            prepared_shape = (
+                layer.num_local_experts,
+                expected_shape[1],
+                kernel_hidden_size,
+            )
+        else:
+            prepared_shape = (
+                layer.num_local_experts,
+                kernel_hidden_size,
+                expected_shape[2],
+            )
+        prepared_numel = prepared_shape[0] * prepared_shape[1] * prepared_shape[2]
+        if (
+            layer.moe_runner_config.is_gated
+            and kernel_hidden_size != layer.hidden_size
+            and param.data.numel() == prepared_numel
+        ):
+            param.data = torch.empty(
+                expected_shape, dtype=param.data.dtype, device=param.data.device
+            )
+            return
         if param.data.numel() != expected_numel:
             raise RuntimeError(
                 f"Cannot restore flashinfer TRT-LLM BF16 MoE weight shape for {weight_name}: "

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -145,12 +145,14 @@ def _prepare_flashinfer_trtllm_bf16_weights(
     hidden_size: int,
     intermediate_size: int,
     gemm1_alpha: Optional[float],
+    gate_up_interleaved: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, int]:
     """Pad canonical BF16 MoE weights and fold static biases into them.
 
-    FlashInfer's TRT-LLM kernel consumes [up, gate] W13 rows and has no bias
-    arguments. The first padded hidden and intermediate channels therefore
-    provide constant-one features for the two bias terms respectively.
+    FlashInfer's TRT-LLM kernel consumes split [up, gate] W13 rows and has no
+    bias arguments. GPT-OSS checkpoints instead store [gate0, up0, ...], so
+    deinterleave those rows before padding. The first padded hidden and
+    intermediate channels provide constant-one features for the two bias terms.
     """
     kernel_hidden_size = ((hidden_size + 127) // 128) * 128
     kernel_intermediate_size = w2.shape[-1]
@@ -194,16 +196,24 @@ def _prepare_flashinfer_trtllm_bf16_weights(
         compact_rows = 2 * intermediate_size
         padded_rows = 2 * kernel_intermediate_size
         row_dim = -2 if tensor.dim() == 3 else -1
-        if tensor.shape[row_dim] == compact_rows:
-            gate_start = intermediate_size
-        elif tensor.shape[row_dim] == padded_rows:
-            gate_start = kernel_intermediate_size
-        else:
+        if tensor.shape[row_dim] not in {compact_rows, padded_rows}:
             raise ValueError(
                 "W13 must have either logical or kernel-padded rows, got "
                 f"{tensor.shape[row_dim]} rows for logical={intermediate_size} and "
                 f"kernel={kernel_intermediate_size}"
             )
+        if gate_up_interleaved:
+            compact = tensor.narrow(row_dim, 0, compact_rows)
+            row_indices = torch.arange(
+                compact_rows, device=tensor.device, dtype=torch.long
+            )
+            gate = compact.index_select(row_dim, row_indices[0::2])
+            up = compact.index_select(row_dim, row_indices[1::2])
+            return up, gate
+        if tensor.shape[row_dim] == compact_rows:
+            gate_start = intermediate_size
+        else:
+            gate_start = kernel_intermediate_size
         return (
             tensor.narrow(row_dim, 0, intermediate_size),
             tensor.narrow(row_dim, gate_start, intermediate_size),
@@ -532,6 +542,9 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                         hidden_size=hidden_size,
                         intermediate_size=intermediate_size,
                         gemm1_alpha=layer.moe_runner_config.gemm1_alpha,
+                        gate_up_interleaved=(
+                            layer.moe_runner_config.gate_up_interleaved
+                        ),
                     )
                 )
                 copy_or_rebind_param(layer, "w13_weight", prepared_w13)

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -838,11 +838,23 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 FlashInferTrtllmBf16MoeQuantInfo,
             )
 
+            is_gated = layer.moe_runner_config.is_gated
             quant_info = FlashInferTrtllmBf16MoeQuantInfo(
                 gemm1_weights=layer.w13_weight,
                 gemm2_weights=layer.w2_weight,
                 global_num_experts=layer.num_experts,
                 local_expert_offset=layer.moe_ep_rank * layer.num_local_experts,
+                kernel_hidden_size=(
+                    self._flashinfer_kernel_hidden_size
+                    if is_gated
+                    else layer.hidden_size
+                ),
+                input_pad_value=(self._flashinfer_input_pad_value if is_gated else 0.0),
+                gemm1_alpha=self._flashinfer_gemm1_alpha if is_gated else None,
+                gemm1_beta=self._flashinfer_gemm1_beta if is_gated else None,
+                gemm1_clamp_limit=(
+                    self._flashinfer_gemm1_clamp_limit if is_gated else None
+                ),
             )
             return self.runner.run(dispatch_output, quant_info)
         else:

--- a/python/sglang/srt/lora/trtllm_lora_temp/lora_layer.py
+++ b/python/sglang/srt/lora/trtllm_lora_temp/lora_layer.py
@@ -120,6 +120,7 @@ def init_experimental_sgl_trtllm_lora(layer, base_layer) -> None:
             FlashInferTrtllmBf16MoeQuantInfo,
         )
 
+        is_gated = base_layer.moe_runner_config.is_gated
         layer._lora_runner = None
         layer._quant_info = FlashInferTrtllmBf16MoeQuantInfo(
             gemm1_weights=base_layer.w13_weight.data,
@@ -127,6 +128,35 @@ def init_experimental_sgl_trtllm_lora(layer, base_layer) -> None:
             global_num_experts=int(base_layer.num_experts),
             local_expert_offset=int(base_layer.moe_ep_rank)
             * int(base_layer.num_local_experts),
+            kernel_hidden_size=(
+                getattr(
+                    quant_method,
+                    "_flashinfer_kernel_hidden_size",
+                    base_layer.hidden_size,
+                )
+                if is_gated
+                else base_layer.hidden_size
+            ),
+            input_pad_value=(
+                getattr(quant_method, "_flashinfer_input_pad_value", 0.0)
+                if is_gated
+                else 0.0
+            ),
+            gemm1_alpha=(
+                getattr(quant_method, "_flashinfer_gemm1_alpha", None)
+                if is_gated
+                else None
+            ),
+            gemm1_beta=(
+                getattr(quant_method, "_flashinfer_gemm1_beta", None)
+                if is_gated
+                else None
+            ),
+            gemm1_clamp_limit=(
+                getattr(quant_method, "_flashinfer_gemm1_clamp_limit", None)
+                if is_gated
+                else None
+            ),
         )
         # Expose w13_weight/w2_weight on the bf16 quant-info so the backend-agnostic
         # cuda-graph MoE buffer init (BaseLoRABackend.init_cuda_graph_moe_buffers) reads

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -229,6 +229,13 @@ elif current_platform.is_out_of_tree():
 logger = logging.getLogger(__name__)
 
 
+def _prefill_cuda_graph_allows_context_parallel(prefill_runner) -> bool:
+    """Allow CP only through a runner that captured the validated CP-v2 body."""
+    return get_cp_strategy() is None or bool(
+        getattr(prefill_runner, "enable_cp_v2_body_capture", False)
+    )
+
+
 @dataclass
 class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]
@@ -1543,7 +1550,9 @@ class ModelRunner:
                 and not isinstance(self.prefill_cuda_graph_runner, EagerRunner)
                 and self.prefill_cuda_graph_runner is not None
                 and self.prefill_cuda_graph_runner.can_run_graph(forward_batch)
-                and get_cp_strategy() is None
+                and _prefill_cuda_graph_allows_context_parallel(
+                    self.prefill_cuda_graph_runner
+                )
             ):
                 category = (
                     "target_verify"

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -52,6 +52,12 @@ from sglang.kernels.ops.kvcache.kv_indices import (
 )
 from sglang.srt.distributed.parallel_state import graph_capture
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
+from sglang.srt.layers.cp.utils import (
+    cp_gather_after_forward,
+    cp_split_before_forward,
+    enable_cp_v2,
+    prepare_cp_forward,
+)
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
     set_dp_buffer_len,
@@ -344,6 +350,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         self._is_full_backend = False
         # Same ordering requirement: capture_prepare reads this.
         self._capture_lora = False
+        self.enable_cp_v2_body_capture = False
+        self.cp_input_embeds: Optional[torch.Tensor] = None
+        self.cp_positions: Optional[torch.Tensor] = None
+        self.cp_bucket_local_tokens: Dict[int, int] = {}
+        self._cp_live_local_tokens = 0
         # TcPiecewise does its compile pass during backend construction.
         # Wrap only that path with the prefill CUDA graph failure hint.
         try:
@@ -441,6 +452,28 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                     name: torch.zeros((self.max_bs,), dtype=torch.int64)
                     for name in _PREFILL_STATIC_FIELDS
                 }
+
+        server_args = model_runner.server_args
+        self.enable_cp_v2_body_capture = (
+            isinstance(self.backend, BreakableCudaGraphBackend)
+            and enable_cp_v2()
+            and server_args.enable_prefill_cp
+            and server_args.attn_cp_size == server_args.tp_size
+            and server_args._supports_breakable_prefill_cp()
+        )
+        if self.enable_cp_v2_body_capture:
+            with torch.device(self.device):
+                self.cp_input_embeds = torch.zeros(
+                    (
+                        self.max_num_tokens,
+                        model_runner.model_config.hidden_size,
+                    ),
+                    dtype=model_runner.dtype,
+                )
+                self.cp_positions = torch.zeros(
+                    (self.max_num_tokens,),
+                    dtype=torch.int64,
+                )
 
         # Static hidden_states buffer giving the captured graph a stable
         # address; load_batch refreshes it from live spec_info at replay.
@@ -575,6 +608,133 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             return forward_batch.mrope_positions
 
         return forward_batch.positions
+
+    def _prepare_cp_static_inputs(
+        self,
+        forward_batch: ForwardBatch,
+        *,
+        static_num_tokens: int,
+        capture: bool,
+    ) -> int:
+        """Shard global prefill inputs into fixed-address CP-local buffers."""
+        assert self.cp_input_embeds is not None
+        assert self.cp_positions is not None
+
+        # Replay batches may reuse a ForwardBatch object whose metadata was
+        # built for a different request layout. CP metadata contains Python
+        # lists and tensors derived from that layout, so always rebuild it
+        # before sharding the current inputs.
+        forward_batch.attn_cp_metadata = None
+        prepare_cp_forward(forward_batch)
+
+        captured_local_tokens = None
+        if not capture:
+            try:
+                captured_local_tokens = self.cp_bucket_local_tokens[static_num_tokens]
+            except KeyError as exc:
+                raise RuntimeError(
+                    "Missing CP-local capture capacity for global prefill bucket "
+                    f"{static_num_tokens}"
+                ) from exc
+
+            # Breakable graph segments retain the captured token-row geometry
+            # even when a smaller live batch reuses this bucket. Preserve the
+            # live logical lengths used to discard padding, but make every CP
+            # physical tensor and collective use the captured local capacity.
+            metadata = forward_batch.attn_cp_metadata
+            if hasattr(metadata, "per_rank_actual_token"):
+                live_physical_tokens = max(metadata.per_rank_actual_token)
+                if live_physical_tokens > captured_local_tokens:
+                    raise RuntimeError(
+                        f"Live batch needs {live_physical_tokens} local CP rows, "
+                        f"but global prefill bucket {static_num_tokens} has "
+                        f"captured capacity {captured_local_tokens}"
+                    )
+                cp_size = len(metadata.per_rank_actual_token)
+                metadata.per_rank_actual_token = [captured_local_tokens] * cp_size
+                metadata.max_rank_len = [captured_local_tokens] * cp_size
+
+        raw_tokens = int(forward_batch.extend_num_tokens)
+        global_input_ids = forward_batch.input_ids[:raw_tokens]
+        global_positions = forward_batch.positions[:raw_tokens]
+        global_input_embeds = self.model_runner.model.get_input_embeddings()(
+            global_input_ids
+        )
+        local_input_embeds, local_positions = cp_split_before_forward(
+            global_input_embeds,
+            global_positions,
+            forward_batch,
+        )
+        live_local_tokens = int(local_input_embeds.shape[0])
+
+        if capture:
+            captured_local_tokens = live_local_tokens
+            self.cp_bucket_local_tokens[static_num_tokens] = captured_local_tokens
+        else:
+            assert captured_local_tokens is not None
+            if live_local_tokens > captured_local_tokens:
+                raise RuntimeError(
+                    f"Live batch needs {live_local_tokens} local CP rows, but global "
+                    f"prefill bucket {static_num_tokens} has captured capacity "
+                    f"{captured_local_tokens}"
+                )
+
+        if captured_local_tokens > self.cp_input_embeds.shape[0]:
+            raise RuntimeError(
+                f"CP-local capture needs {captured_local_tokens} rows, but the "
+                f"fixed input buffer has capacity {self.cp_input_embeds.shape[0]}"
+            )
+
+        input_embeds = self.cp_input_embeds[:captured_local_tokens]
+        positions = self.cp_positions[:captured_local_tokens]
+        input_embeds.zero_()
+        positions.zero_()
+        input_embeds[:live_local_tokens].copy_(local_input_embeds)
+        positions[:live_local_tokens].copy_(local_positions)
+        forward_batch.input_embeds = input_embeds
+        forward_batch.positions = positions
+        return live_local_tokens
+
+    def _validate_cp_flashinfer_dispatch_capacity(
+        self,
+        *,
+        global_bucket_tokens: int,
+        required_local_tokens: int,
+    ) -> None:
+        """Validate FlashInfer's fixed A2A workspace before graph capture."""
+        from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+            FlashinferDispatcher,
+        )
+
+        capacities = []
+        seen_dispatchers = set()
+        for layer in self.moe_layers:
+            dispatcher = getattr(layer, "dispatcher", None)
+            if not isinstance(dispatcher, FlashinferDispatcher):
+                continue
+            dispatcher_id = id(dispatcher)
+            if dispatcher_id in seen_dispatchers:
+                continue
+            seen_dispatchers.add(dispatcher_id)
+            capacity = int(dispatcher.max_num_tokens)
+            capacities.append(capacity)
+            if capacity < required_local_tokens:
+                raise ValueError(
+                    f"Breakable prefill CP global bucket {global_bucket_tokens} "
+                    f"has required local rows {required_local_tokens}, but "
+                    f"FlashInfer A2A configured capacity {capacity} is smaller. "
+                    "Increase "
+                    "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK."
+                )
+
+        if capacities:
+            logger.info(
+                "Breakable prefill CP capture capacity: global_bucket=%d, "
+                "required_local_rows=%d, flashinfer_dispatch_capacities=%s",
+                global_bucket_tokens,
+                required_local_tokens,
+                sorted(set(capacities)),
+            )
 
     @contextmanager
     def _prefill_forward_context(
@@ -1239,6 +1399,16 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         """
         num_tokens = size
         forward_batch, attn_backend = self.capture_prepare(num_tokens)
+        if self.enable_cp_v2_body_capture:
+            required_local_tokens = self._prepare_cp_static_inputs(
+                forward_batch,
+                static_num_tokens=num_tokens,
+                capture=True,
+            )
+            self._validate_cp_flashinfer_dispatch_capacity(
+                global_bucket_tokens=num_tokens,
+                required_local_tokens=required_local_tokens,
+            )
         if forward_batch.lora_ids is not None:
             # Fill the static prefill LoRA batch info the captured kernels
             # will read (all-None ids: ranks stay 0, kernels no-op).
@@ -1475,11 +1645,74 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 forward_batch.spec_info.hidden_states
             )
 
+        metadata_forward_batch = forward_batch
+        if self.enable_cp_v2_body_capture:
+            self._cp_live_local_tokens = self._prepare_cp_static_inputs(
+                static_forward_batch,
+                static_num_tokens=static_num_tokens,
+                capture=False,
+            )
+            metadata_forward_batch = static_forward_batch
+
         self._prepare_forward_metadata_for_replay(
-            forward_batch, static_forward_batch, static_num_tokens
+            metadata_forward_batch, static_forward_batch, static_num_tokens
         )
 
         return static_forward_batch
+
+    def _execute_cp_body_capture(
+        self,
+        forward_batch: ForwardBatch,
+        static_forward_batch: ForwardBatch,
+        static_num_tokens: int,
+        raw_num_tokens: int,
+        **kwargs,
+    ):
+        """Replay a CP-local body and run the global gather/logits tail eagerly."""
+        model = self.model_runner.model
+        with self._prefill_forward_context(
+            static_forward_batch,
+            num_tokens=static_num_tokens,
+            raw_num_tokens=raw_num_tokens,
+        ):
+            local_output = self.backend.replay(
+                ShapeKey(size=static_num_tokens),
+                static_forward_batch,
+                **kwargs,
+            )
+            local_output = _slice_output_rows(
+                local_output,
+                self._cp_live_local_tokens,
+            )
+
+            capture_aux_hidden_states = getattr(
+                model, "capture_aux_hidden_states", False
+            )
+            aux_hidden_states = None
+            if capture_aux_hidden_states:
+                hidden_states, aux_hidden_states = local_output
+            else:
+                hidden_states = local_output
+
+            if not model.pp_group.is_last_rank:
+                return (
+                    (hidden_states, aux_hidden_states)
+                    if capture_aux_hidden_states
+                    else hidden_states
+                )
+
+            hidden_states = cp_gather_after_forward(
+                hidden_states,
+                static_forward_batch,
+                torch.cuda.current_stream(),
+            )
+            return model.logits_processor(
+                forward_batch.input_ids,
+                hidden_states,
+                model.lm_head,
+                forward_batch,
+                aux_hidden_states,
+            )
 
     def _execute_body_capture(
         self,
@@ -1608,7 +1841,15 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             if shape_key.variant_label is not None:
                 self._prepare_chunked_prefix_replay(shape_key, forward_batch)
 
-            if self._uses_eager_prefill_tail():
+            if self.enable_cp_v2_body_capture:
+                output = self._execute_cp_body_capture(
+                    forward_batch,
+                    static_forward_batch,
+                    static_num_tokens,
+                    raw_num_tokens,
+                    **kwargs,
+                )
+            elif self._uses_eager_prefill_tail():
                 output = self._execute_body_capture(
                     forward_batch,
                     static_forward_batch,

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -167,6 +167,9 @@ class TinyGemmLinear(ReplicatedLinear):
         )
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if x.ndim == 2 and x.shape[0] == 0:
+            return x.new_empty((0, self.output_size)), None
+
         if (
             self._use_tinygemm
             and x.ndim == 2

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -44,7 +44,10 @@ from sglang.srt.layers.linear import (
     RowParallelLinear,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.moe import get_moe_a2a_backend
+from sglang.srt.layers.moe import (
+    get_moe_a2a_backend,
+    should_skip_post_experts_all_reduce,
+)
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
@@ -353,7 +356,9 @@ class GptOssSparseMoeBlock(nn.Module):
             topk_output = self.topk(router_input, router_logits)
             final_hidden_states = self.experts(hidden_states, topk_output)
 
-        if self.tp_size > 1 and not get_forward().fuse_mlp_allreduce:
+        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
+            is_tp_path=True
+        ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         # When input was pre-padded, FusedMoE.forward_impl captured the

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -118,6 +118,26 @@ class GptOssConfig(PretrainedConfig):
 logger = logging.getLogger(__name__)
 
 
+def _narrow_fused_moe_ep_weight(
+    loaded_weight: torch.Tensor, num_experts: int
+) -> torch.Tensor:
+    parallel = get_parallel()
+    if parallel.moe_ep_size == 1:
+        return loaded_weight
+    assert num_experts % parallel.moe_ep_size == 0
+    num_local_experts = num_experts // parallel.moe_ep_size
+    if loaded_weight.shape[0] == num_local_experts:
+        return loaded_weight
+    if loaded_weight.shape[0] != num_experts:
+        raise ValueError(
+            f"Expected {num_experts} global or {num_local_experts} local experts, "
+            f"got {loaded_weight.shape[0]}"
+        )
+    return loaded_weight.narrow(
+        0, parallel.moe_ep_rank * num_local_experts, num_local_experts
+    )
+
+
 # Aligned with HF's implementation, using sliding window inclusive with the last token
 # SGLang assumes exclusive
 def get_attention_sliding_window_size(config):
@@ -1253,6 +1273,9 @@ class GptOssForCausalLM(nn.Module):
                         continue
                     param = params_dict[name]
                     weight_loader = param.weight_loader
+                    loaded_weight = _narrow_fused_moe_ep_weight(
+                        loaded_weight, self.config.num_local_experts
+                    )
                     if "bias" not in name:
                         loaded_weight = loaded_weight.transpose(-2, -1)
                     if "w2_weight_bias" in name and get_parallel().moe_tp_rank != 0:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6505,6 +6505,14 @@ class ServerArgs:
                 f"(e.g. --max-prefill-tokens) to <= {max_cutedsl_tokens}."
             )
 
+    def _supports_flashinfer_a2a_parallelism(self) -> bool:
+        from sglang.srt.arg_groups.overrides import resolved_view
+
+        resolved = resolved_view(self)
+        return (resolved.enable_dp_attention and self.dp_size == self.tp_size) or (
+            self.enable_prefill_cp and resolved.attn_cp_size == self.tp_size
+        )
+
     def _handle_a2a_moe(self):
         # The backend overrides and the ep_size=tp_size adjustments moved to
         # the resolution pipeline (arg_groups/overrides.py:
@@ -6586,8 +6594,8 @@ class ServerArgs:
             )
         if self.moe_a2a_backend == "flashinfer":
             assert (
-                resolved_view(self).enable_dp_attention and self.dp_size == self.tp_size
-            ), "Flashinfer MoE A2A is only supported with dp_size == tp_size and --enable-dp-attention"
+                self._supports_flashinfer_a2a_parallelism()
+            ), "Flashinfer MoE A2A is only supported with either dp_size == tp_size and --enable-dp-attention, or full prefill context parallelism with attn_cp_size == tp_size"
             logger.warning(
                 f"Flashinfer MoE A2A is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{self.tp_size}]."
             )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4371,9 +4371,28 @@ class ServerArgs:
             if predicate():
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
-    def _disable_breakable_cudagraph_if_incompatible(self):
-        from sglang.srt.arg_groups.overrides import resolved_view as _resolved_view
+    def _supports_breakable_prefill_cp(self) -> bool:
+        resolved = self._resolved()
+        prefill_attention_backend, _ = self._resolved_attention_backends()
+        return (
+            self.enable_prefill_cp
+            and resolved.attn_cp_size == self.tp_size
+            and self.cp_strategy == "zigzag"
+            and prefill_attention_backend == "trtllm_mha"
+            and self.get_model_config().hf_config.architectures == ["GptOssForCausalLM"]
+        )
 
+    def _supports_breakable_moe_a2a(self) -> bool:
+        resolved = self._resolved()
+        if resolved.moe_a2a_backend == "none":
+            return True
+        return (
+            resolved.moe_a2a_backend == "flashinfer"
+            and self.moe_runner_backend == "flashinfer_trtllm_routed"
+            and self._supports_breakable_prefill_cp()
+        )
+
+    def _disable_breakable_cudagraph_if_incompatible(self):
         """Breakable (segmented capture, no torch.compile). Breakable enforces
         memory-saver rejection in its own __init__; config-time rules can be
         added here as they're discovered.
@@ -4392,7 +4411,8 @@ class ServerArgs:
             # CP all_gather replay size mismatch under BCG.
             (
                 "context parallel (attn_cp_size > 1)",
-                lambda: self._resolved().attn_cp_size > 1,
+                lambda: self._resolved().attn_cp_size > 1
+                and not self._supports_breakable_prefill_cp(),
             ),
             # Capture builds a dummy extend forward with attn_dcp_metadata=None.
             (
@@ -4402,7 +4422,7 @@ class ServerArgs:
             # BCG bucket sizes exceed FlashInfer MoE A2A's dispatch cap.
             (
                 "MoE A2A backend",
-                lambda: _resolved_view(self).moe_a2a_backend != "none",
+                lambda: not self._supports_breakable_moe_a2a(),
             ),
             # Multimodal prefill replay faults under BCG; allowlisted archs opt back in.
             (

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -1,4 +1,5 @@
 import unittest
+from itertools import accumulate
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -6,6 +7,7 @@ import torch
 
 from sglang.srt.layers.cp.base import (
     ContextParallelStrategyKind,
+    CPAttentionBackendKind,
     get_cp_strategy,
     get_cp_strategy_kind,
     init_cp_strategy,
@@ -218,6 +220,9 @@ class TestCPZigzagStrategy(CustomTestCase):
             actual_seq_q_prev_list.append(block_sizes[rank])
             actual_seq_q_next_list.append(block_sizes[cp_segment_num - rank - 1])
 
+        actual_seq_q_combined_list = actual_seq_q_prev_list + actual_seq_q_next_list
+        kv_len_combined_list = kv_len_prev_list + kv_len_next_list
+
         return {
             "bs": bs,
             "total_seq_lens": sum(extend_seq_lens),
@@ -231,6 +236,10 @@ class TestCPZigzagStrategy(CustomTestCase):
             "kv_len_next_list": kv_len_next_list,
             "actual_seq_q_prev_list": actual_seq_q_prev_list,
             "actual_seq_q_next_list": actual_seq_q_next_list,
+            "actual_seq_q_combined_list": actual_seq_q_combined_list,
+            "kv_len_combined_list": kv_len_combined_list,
+            "cu_seqlens_q_combined": [0] + list(accumulate(actual_seq_q_combined_list)),
+            "cu_seqlens_kv_combined": [0] + list(accumulate(kv_len_combined_list)),
         }
 
     def _assert_metadata_matches(self, metadata, expected):
@@ -265,6 +274,45 @@ class TestCPZigzagStrategy(CustomTestCase):
             + list(
                 torch.tensor(expected["actual_seq_q_next_list"]).cumsum(dim=0).tolist()
             ),
+        )
+        self.assertEqual(
+            metadata.actual_seq_q_combined_tensor.cpu().tolist(),
+            expected["actual_seq_q_combined_list"],
+        )
+        self.assertEqual(
+            metadata.kv_len_combined_tensor.cpu().tolist(),
+            expected["kv_len_combined_list"],
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_q_combined_tensor.cpu().tolist(),
+            expected["cu_seqlens_q_combined"],
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_kv_combined_tensor.cpu().tolist(),
+            expected["cu_seqlens_kv_combined"],
+        )
+        for tensor in (
+            metadata.actual_seq_q_combined_tensor,
+            metadata.kv_len_combined_tensor,
+            metadata.cu_seqlens_q_combined_tensor,
+            metadata.cu_seqlens_kv_combined_tensor,
+        ):
+            self.assertEqual(tensor.dtype, torch.int32)
+        self.assertEqual(metadata.actual_seq_q_combined_tensor.numel(), 2 * metadata.bs)
+        self.assertEqual(metadata.kv_len_combined_tensor.numel(), 2 * metadata.bs)
+        self.assertEqual(
+            metadata.cu_seqlens_q_combined_tensor.numel(), 2 * metadata.bs + 1
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_kv_combined_tensor.numel(), 2 * metadata.bs + 1
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_q_combined_tensor[-1].item(),
+            metadata.total_q_prev_tokens + metadata.total_q_next_tokens,
+        )
+        self.assertEqual(
+            metadata.max_seqlen_q_combined,
+            max(expected["actual_seq_q_combined_list"]),
         )
 
     def _padded_rank_tensors(self, x, *, cp_size, seq_lens, extend_seq_lens):
@@ -318,6 +366,35 @@ class TestCPZigzagStrategy(CustomTestCase):
                         extend_seq_lens=extend_seq_lens,
                     )
                     self._assert_metadata_matches(metadata, expected)
+
+    def test_zigzag_combined_metadata_preserves_nonzero_prefix_order(self):
+        cp_size = 4
+        seq_lens = [19, 27]
+        extend_seq_lens = [11, 13]
+
+        for rank in range(cp_size):
+            with self.subTest(rank=rank):
+                metadata = self._metadata_for_rank(
+                    rank,
+                    cp_size=cp_size,
+                    seq_lens=seq_lens,
+                    extend_seq_lens=extend_seq_lens,
+                )
+                expected = self._expected_metadata(
+                    rank=rank,
+                    cp_size=cp_size,
+                    seq_lens=seq_lens,
+                    extend_seq_lens=extend_seq_lens,
+                )
+                self._assert_metadata_matches(metadata, expected)
+                self.assertEqual(
+                    metadata.kv_len_combined_tensor[: metadata.bs].tolist(),
+                    expected["kv_len_prev_list"],
+                )
+                self.assertEqual(
+                    metadata.kv_len_combined_tensor[metadata.bs :].tolist(),
+                    expected["kv_len_next_list"],
+                )
 
     def test_zigzag_shards_hidden_states_and_position_ids(self):
         cp_size = 4
@@ -510,7 +587,7 @@ class TestCPZigzagStrategy(CustomTestCase):
         self.assertTrue(torch.equal(written_value, value))
         self.assertEqual((k_scale, v_scale), ("key-scale", "value-scale"))
 
-    def test_zigzag_attention_dispatch_runs_prev_then_next(self):
+    def test_zigzag_flashattention_dispatch_runs_prev_then_next(self):
         cp_size = 2
         seq_lens = [8]
         extend_seq_lens = [8]
@@ -543,6 +620,197 @@ class TestCPZigzagStrategy(CustomTestCase):
         self.assertTrue(torch.equal(calls[0][0], q[:2]))
         self.assertTrue(torch.equal(calls[1][0], q[2:]))
         self.assertTrue(torch.equal(out, q + 100))
+
+    def test_zigzag_trtllm_dispatch_uses_one_combined_call(self):
+        cp_size = 2
+        metadata = self._metadata_for_rank(
+            0,
+            cp_size=cp_size,
+            seq_lens=[8],
+            extend_seq_lens=[8],
+        )
+        fb = SimpleNamespace(attn_cp_metadata=metadata)
+        q = torch.arange(4 * 2).view(4, 2)
+        calls = []
+
+        def attn_fn(
+            q_chunk,
+            cu_seqlens_q,
+            cache_seqlens,
+            max_seqlen_q,
+            *,
+            cu_seqlens_kv,
+            use_zigzag_page_table=False,
+        ):
+            calls.append(
+                (
+                    q_chunk.clone(),
+                    cu_seqlens_q.clone(),
+                    cache_seqlens.clone(),
+                    max_seqlen_q,
+                    cu_seqlens_kv.clone(),
+                    use_zigzag_page_table,
+                )
+            )
+            return q_chunk + 100
+
+        out = ZigzagCPStrategy(cp_size=cp_size).run_attention(
+            q,
+            fb,
+            device=torch.device("cpu"),
+            attn_fn=attn_fn,
+            attention_backend=CPAttentionBackendKind.TRTLLM_MHA,
+        )
+
+        self.assertEqual(len(calls), 1)
+        call = calls[0]
+        self.assertTrue(torch.equal(call[0], q))
+        self.assertTrue(torch.equal(call[1], metadata.cu_seqlens_q_combined_tensor))
+        self.assertTrue(torch.equal(call[2], metadata.kv_len_combined_tensor))
+        self.assertEqual(call[3], metadata.max_seqlen_q_combined)
+        self.assertTrue(torch.equal(call[4], metadata.cu_seqlens_kv_combined_tensor))
+        self.assertTrue(call[5])
+        self.assertTrue(torch.equal(out, q + 100))
+
+    def test_zigzag_trtllm_single_call_zeroes_physical_padding(self):
+        cp_size = 2
+        metadata = self._metadata_for_rank(
+            0,
+            cp_size=cp_size,
+            seq_lens=[8],
+            extend_seq_lens=[8],
+        )
+        fb = SimpleNamespace(attn_cp_metadata=metadata)
+        logical_q = torch.arange(4 * 2).view(4, 2)
+        q = torch.cat([logical_q, torch.full((2, 2), -1)], dim=0)
+        calls = []
+
+        def attn_fn(
+            q_chunk,
+            cu_seqlens_q,
+            cache_seqlens,
+            max_seqlen_q,
+            *,
+            cu_seqlens_kv,
+            use_zigzag_page_table=False,
+        ):
+            calls.append(q_chunk.clone())
+            return q_chunk + 100
+
+        out = ZigzagCPStrategy(cp_size=cp_size).run_attention(
+            q,
+            fb,
+            device=torch.device("cpu"),
+            attn_fn=attn_fn,
+            attention_backend=CPAttentionBackendKind.TRTLLM_MHA,
+        )
+
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(torch.equal(calls[0], logical_q))
+        self.assertTrue(torch.equal(out[:4], logical_q + 100))
+        self.assertTrue(torch.equal(out[4:], torch.zeros_like(out[4:])))
+
+    def test_zigzag_combined_attention_matches_two_half_reference(self):
+        def reference_attention(
+            q,
+            cu_seqlens_q,
+            cache_seqlens,
+            cu_seqlens_kv,
+            *,
+            sequence_offset,
+        ):
+            outputs = []
+            for seq_id in range(cache_seqlens.numel()):
+                q_start = int(cu_seqlens_q[seq_id])
+                q_end = int(cu_seqlens_q[seq_id + 1])
+                q_seq = q[q_start:q_end]
+                q_len = q_end - q_start
+                kv_len = int(cache_seqlens[seq_id])
+                self.assertEqual(
+                    int(cu_seqlens_kv[seq_id + 1] - cu_seqlens_kv[seq_id]),
+                    kv_len,
+                )
+
+                absolute_seq_id = sequence_offset + seq_id + 1
+                positions = torch.arange(kv_len, dtype=q.dtype)
+                k_seq = torch.stack(
+                    (
+                        positions / (kv_len + 1),
+                        torch.sin(positions + absolute_seq_id),
+                        torch.full_like(positions, absolute_seq_id / 10),
+                    ),
+                    dim=1,
+                )
+                v_seq = torch.stack(
+                    (
+                        torch.cos(positions + absolute_seq_id),
+                        positions / (absolute_seq_id + 1),
+                        torch.full_like(positions, absolute_seq_id),
+                    ),
+                    dim=1,
+                )
+                q_positions = kv_len - q_len + torch.arange(q_len)
+                allowed = torch.arange(kv_len)[None, :] <= q_positions[:, None]
+                scores = q_seq @ k_seq.T / q.shape[-1] ** 0.5
+                outputs.append(
+                    torch.softmax(scores.masked_fill(~allowed, -torch.inf), dim=-1)
+                    @ v_seq
+                )
+            return torch.cat(outputs, dim=0)
+
+        cp_size = 4
+        seq_lens = [19, 27]
+        extend_seq_lens = [11, 13]
+        for rank in range(cp_size):
+            with self.subTest(rank=rank):
+                metadata = self._metadata_for_rank(
+                    rank,
+                    cp_size=cp_size,
+                    seq_lens=seq_lens,
+                    extend_seq_lens=extend_seq_lens,
+                )
+                logical_tokens = (
+                    metadata.total_q_prev_tokens + metadata.total_q_next_tokens
+                )
+                q = torch.linspace(
+                    -0.75,
+                    0.75,
+                    steps=logical_tokens * 3,
+                    dtype=torch.float32,
+                ).view(logical_tokens, 3)
+                q_prev = q[: metadata.total_q_prev_tokens]
+                q_next = q[metadata.total_q_prev_tokens :]
+
+                two_half_out = torch.cat(
+                    (
+                        reference_attention(
+                            q_prev,
+                            metadata.cu_seqlens_q_prev_tensor,
+                            metadata.kv_len_prev_tensor,
+                            metadata.cu_seqlens_kv_prev_tensor,
+                            sequence_offset=0,
+                        ),
+                        reference_attention(
+                            q_next,
+                            metadata.cu_seqlens_q_next_tensor,
+                            metadata.kv_len_next_tensor,
+                            metadata.cu_seqlens_kv_next_tensor,
+                            sequence_offset=metadata.bs,
+                        ),
+                    ),
+                    dim=0,
+                )
+                combined_out = reference_attention(
+                    q,
+                    metadata.cu_seqlens_q_combined_tensor,
+                    metadata.kv_len_combined_tensor,
+                    metadata.cu_seqlens_kv_combined_tensor,
+                    sequence_offset=0,
+                )
+
+                torch.testing.assert_close(
+                    combined_out, two_half_out, atol=1e-5, rtol=1e-5
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/attention/test_trtllm_mha_zigzag.py
+++ b/test/registered/unit/layers/attention/test_trtllm_mha_zigzag.py
@@ -1,0 +1,252 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.layers.attention.trtllm_mha_backend as trtllm_mha_backend
+from sglang.srt.layers.attention.trtllm_mha_backend import (
+    TRTLLMHAAttnBackend,
+    TRTLLMMHAMetadata,
+)
+from sglang.srt.layers.cp.base import CPAttentionBackendKind
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class TestTRTLLMMHAZigzagPageTables(CustomTestCase):
+    def _backend(self, swa_pool=None):
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        backend._swa_kv_pool = swa_pool
+        return backend
+
+    def _metadata(self):
+        return TRTLLMMHAMetadata(
+            page_table=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+            swa_page_table=torch.tensor([[30, 31], [40, 41]], dtype=torch.int32),
+        )
+
+    def test_builds_prev_then_next_page_tables_for_cp_v2(self):
+        backend = self._backend()
+        metadata = self._metadata()
+
+        with patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+            return_value=True,
+        ):
+            backend._build_zigzag_page_tables(metadata, SimpleNamespace())
+
+        self.assertEqual(
+            metadata.zigzag_page_table.tolist(),
+            [[10, 11], [20, 21], [10, 11], [20, 21]],
+        )
+        self.assertEqual(
+            metadata.zigzag_swa_page_table.tolist(),
+            [[30, 31], [40, 41], [30, 31], [40, 41]],
+        )
+
+    def test_leaves_zigzag_page_tables_unset_without_cp_v2(self):
+        backend = self._backend()
+        metadata = self._metadata()
+
+        with patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+            return_value=False,
+        ):
+            backend._build_zigzag_page_tables(metadata, SimpleNamespace())
+
+        self.assertIsNone(metadata.zigzag_page_table)
+        self.assertIsNone(metadata.zigzag_swa_page_table)
+
+    def test_selects_full_or_swa_zigzag_page_table_per_layer(self):
+        swa_pool = SimpleNamespace(
+            layers_mapping={
+                0: (None, False),
+                1: (None, True),
+            }
+        )
+        backend = self._backend(swa_pool=swa_pool)
+        metadata = self._metadata()
+        metadata.zigzag_page_table = torch.tensor([[1], [2]], dtype=torch.int32)
+        metadata.zigzag_swa_page_table = torch.tensor([[3], [4]], dtype=torch.int32)
+        backend.forward_metadata = metadata
+
+        full_table = backend._get_zigzag_layer_page_table(SimpleNamespace(layer_id=0))
+        swa_table = backend._get_zigzag_layer_page_table(SimpleNamespace(layer_id=1))
+
+        self.assertIs(full_table, metadata.zigzag_page_table)
+        self.assertIs(swa_table, metadata.zigzag_swa_page_table)
+
+    def _forward_backend(self):
+        backend = self._backend()
+        backend.decode_uses_native_fp4 = False
+        backend.data_type = torch.bfloat16
+        backend.q_data_type = torch.bfloat16
+        backend.page_size = 1
+        backend.device = torch.device("cpu")
+        backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+        backend.max_context_len = 64
+        backend.token_to_kv_pool = SimpleNamespace(
+            get_kv_buffer=lambda layer_id: (
+                torch.zeros(16, 2, 2, dtype=torch.bfloat16),
+                torch.zeros(16, 2, 2, dtype=torch.bfloat16),
+            )
+        )
+        backend.forward_metadata = TRTLLMMHAMetadata(
+            cache_seqlens_int32=torch.tensor([3, 4], dtype=torch.int32),
+            max_seq_len_q=2,
+            cu_seqlens_q=torch.tensor([0, 2, 4], dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, 3, 7], dtype=torch.int32),
+            page_table=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+            zigzag_page_table=torch.tensor(
+                [[10, 11], [20, 21], [10, 11], [20, 21]],
+                dtype=torch.int32,
+            ),
+        )
+        return backend
+
+    def _layer_and_batch(self):
+        layer = SimpleNamespace(
+            layer_id=0,
+            tp_q_head_num=2,
+            tp_k_head_num=2,
+            tp_v_head_num=2,
+            head_dim=2,
+            scaling=0.5,
+            sliding_window_size=-1,
+        )
+        forward_mode = SimpleNamespace(
+            is_target_verify=lambda: False,
+            is_draft_extend_v2=lambda: False,
+        )
+        forward_batch = SimpleNamespace(
+            out_cache_loc=torch.arange(4),
+            forward_mode=forward_mode,
+        )
+        return layer, forward_batch
+
+    def test_forward_extend_selects_combined_zigzag_page_table(self):
+        backend = self._forward_backend()
+        layer, forward_batch = self._layer_and_batch()
+        q = torch.arange(16, dtype=torch.bfloat16).view(4, 4)
+        combined_cu_q = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32)
+        combined_cache_lens = torch.tensor([3, 4, 3, 4], dtype=torch.int32)
+        combined_cu_kv = torch.tensor([0, 3, 7, 10, 14], dtype=torch.int32)
+
+        class _CombinedStrategy:
+            def run_attention(
+                self,
+                query,
+                batch,
+                device,
+                attn_fn,
+                attention_backend,
+            ):
+                self.asserted_attention_backend = attention_backend
+                return attn_fn(
+                    query,
+                    combined_cu_q,
+                    combined_cache_lens,
+                    1,
+                    cu_seqlens_kv=combined_cu_kv,
+                    use_zigzag_page_table=True,
+                )
+
+        strategy = _CombinedStrategy()
+        with (
+            patch.object(
+                trtllm_mha_backend.flashinfer.prefill,
+                "trtllm_batch_context_with_kv_cache",
+                side_effect=lambda **kwargs: kwargs["query"],
+            ) as context_attn,
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.get_cp_strategy",
+                return_value=strategy,
+            ),
+        ):
+            out = backend.forward_extend(
+                q,
+                None,
+                None,
+                layer,
+                forward_batch,
+                save_kv_cache=False,
+            )
+
+        self.assertEqual(
+            strategy.asserted_attention_backend,
+            CPAttentionBackendKind.TRTLLM_MHA,
+        )
+        call = context_attn.call_args.kwargs
+        self.assertTrue(
+            torch.equal(
+                call["block_tables"],
+                backend.forward_metadata.zigzag_page_table,
+            )
+        )
+        self.assertEqual(call["batch_size"], 4)
+        self.assertTrue(torch.equal(call["seq_lens"], combined_cache_lens))
+        self.assertTrue(torch.equal(call["cum_seq_lens_q"], combined_cu_q))
+        self.assertTrue(torch.equal(call["cum_seq_lens_kv"], combined_cu_kv))
+        self.assertTrue(torch.equal(call["query"].reshape(4, 4), q))
+        self.assertTrue(torch.equal(out, q))
+
+    def test_forward_extend_keeps_original_non_cp_page_table(self):
+        backend = self._forward_backend()
+        layer, forward_batch = self._layer_and_batch()
+        q = torch.arange(16, dtype=torch.bfloat16).view(4, 4)
+
+        with (
+            patch.object(
+                trtllm_mha_backend.flashinfer.prefill,
+                "trtllm_batch_context_with_kv_cache",
+                side_effect=lambda **kwargs: kwargs["query"],
+            ) as context_attn,
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=False,
+            ),
+        ):
+            out = backend.forward_extend(
+                q,
+                None,
+                None,
+                layer,
+                forward_batch,
+                save_kv_cache=False,
+            )
+
+        call = context_attn.call_args.kwargs
+        self.assertTrue(
+            torch.equal(call["block_tables"], backend.forward_metadata.page_table)
+        )
+        self.assertEqual(call["batch_size"], 2)
+        self.assertTrue(
+            torch.equal(
+                call["seq_lens"],
+                backend.forward_metadata.cache_seqlens_int32,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                call["cum_seq_lens_q"],
+                backend.forward_metadata.cu_seqlens_q,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                call["cum_seq_lens_kv"],
+                backend.forward_metadata.cu_seqlens_k,
+            )
+        )
+        self.assertTrue(torch.equal(out, q))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
+++ b/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
@@ -142,6 +142,55 @@ class TestFlashInferTrtllmBf16Padding(CustomTestCase):
             w13[:, intermediate_size:],
         )
 
+    def test_preparation_deinterleaves_gpt_oss_gate_up_checkpoint_rows(self):
+        """GPT-OSS checkpoint [gate0, up0, ...] rows become FlashInfer [up, gate]."""
+        hidden_size = 3
+        intermediate_size = 5
+        kernel_intermediate_size = 128
+        gate = torch.arange(
+            intermediate_size * hidden_size, dtype=torch.float32
+        ).reshape(intermediate_size, hidden_size)
+        up = gate + 100
+        interleaved = torch.stack((gate, up), dim=1).reshape(
+            1, 2 * intermediate_size, hidden_size
+        )
+        runtime_padded = torch.zeros(
+            1,
+            2 * kernel_intermediate_size,
+            hidden_size,
+            dtype=torch.bfloat16,
+        )
+        runtime_padded[:, : 2 * intermediate_size] = interleaved.to(torch.bfloat16)
+
+        prepared_w13, _, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            runtime_padded,
+            torch.zeros(
+                1,
+                hidden_size,
+                kernel_intermediate_size,
+                dtype=torch.bfloat16,
+            ),
+            None,
+            None,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            gemm1_alpha=1.702,
+            gate_up_interleaved=True,
+        )
+
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, :hidden_size],
+            up.unsqueeze(0).to(torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            prepared_w13[
+                :,
+                kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+                :hidden_size,
+            ],
+            gate.unsqueeze(0).to(torch.bfloat16),
+        )
+
     def test_preparation_reads_runtime_padded_w13_layout(self):
         """Only logical [up, gate] rows survive a runtime-padded W13 input."""
         hidden_size = 3

--- a/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
+++ b/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
@@ -1,0 +1,157 @@
+"""CPU coverage for biased BF16 FlashInfer TRT-LLM MoE weight preparation."""
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.quantization.unquant import (
+    _prepare_flashinfer_trtllm_bf16_weights,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+def gpt_oss_activation(
+    gate_up: torch.Tensor, alpha: float, limit: float
+) -> torch.Tensor:
+    """GPT-OSS SwiGLU for the FlashInfer [up, gate] projection order."""
+    up, gate = gate_up.chunk(2, dim=-1)
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    return gate * torch.sigmoid(gate * alpha) * (up + 1.0)
+
+
+class TestFlashInferTrtllmBf16Padding(CustomTestCase):
+    def test_biased_bf16_weights_match_bias_free_padded_moe(self):
+        """Bias folding must preserve each expert's GPT-OSS MoE output."""
+        torch.manual_seed(0)
+        num_experts = 2
+        hidden_size = 3
+        intermediate_size = 5
+        kernel_intermediate_size = 128
+        alpha = 1.702
+        limit = 7.0
+
+        x = torch.randn(4, hidden_size, dtype=torch.bfloat16)
+        w13 = torch.randn(
+            num_experts, 2 * intermediate_size, hidden_size, dtype=torch.bfloat16
+        )
+        w2 = torch.zeros(
+            num_experts,
+            hidden_size,
+            kernel_intermediate_size,
+            dtype=torch.bfloat16,
+        )
+        w2[..., :intermediate_size] = torch.randn(
+            num_experts, hidden_size, intermediate_size, dtype=torch.bfloat16
+        )
+        w13_bias = torch.randn(num_experts, 2 * intermediate_size, dtype=torch.float32)
+        w2_bias = torch.randn(num_experts, hidden_size, dtype=torch.float32)
+
+        prepared_w13, prepared_w2, kernel_hidden_size = (
+            _prepare_flashinfer_trtllm_bf16_weights(
+                w13,
+                w2,
+                w13_bias,
+                w2_bias,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                gemm1_alpha=alpha,
+            )
+        )
+
+        self.assertEqual(kernel_hidden_size, 128)
+        self.assertEqual(prepared_w13.shape, (num_experts, 256, 128))
+        self.assertEqual(prepared_w2.shape, (num_experts, 128, 128))
+
+        x_padded = F.pad(x, (0, kernel_hidden_size - hidden_size), value=1.0)
+        for expert in range(num_experts):
+            expected = F.linear(
+                gpt_oss_activation(
+                    F.linear(x.float(), w13[expert].float(), w13_bias[expert]),
+                    alpha,
+                    limit,
+                ),
+                w2[expert, :, :intermediate_size].float(),
+                w2_bias[expert],
+            )
+            actual = F.linear(
+                gpt_oss_activation(
+                    F.linear(x_padded, prepared_w13[expert]), alpha, limit
+                ),
+                prepared_w2[expert],
+            )[:, :hidden_size]
+
+            torch.testing.assert_close(actual.float(), expected, atol=0.03, rtol=0.03)
+
+    def test_preparation_preserves_up_then_gate_projection_order(self):
+        """FlashInfer weights must retain FusedMoE's [up, gate] row order."""
+        hidden_size = 3
+        intermediate_size = 5
+        w13 = (
+            torch.arange(2 * 2 * intermediate_size * hidden_size, dtype=torch.float32)
+            .reshape(2, 2 * intermediate_size, hidden_size)
+            .to(torch.bfloat16)
+        )
+        w2 = torch.zeros(2, hidden_size, 128, dtype=torch.bfloat16)
+
+        prepared_w13, _, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            w2,
+            None,
+            None,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            gemm1_alpha=1.702,
+        )
+
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, :hidden_size],
+            w13[:, :intermediate_size],
+        )
+        torch.testing.assert_close(
+            prepared_w13[:, 128 : 128 + intermediate_size, :hidden_size],
+            w13[:, intermediate_size:],
+        )
+
+    def test_bias_folding_requires_spare_padded_channels(self):
+        """Bias folding must reject kernel shapes with no synthetic channels."""
+        with self.assertRaises(ValueError):
+            _prepare_flashinfer_trtllm_bf16_weights(
+                torch.zeros(2, 10, 128, dtype=torch.bfloat16),
+                torch.zeros(2, 128, 128, dtype=torch.bfloat16),
+                torch.zeros(2, 10, dtype=torch.float32),
+                None,
+                hidden_size=128,
+                intermediate_size=5,
+                gemm1_alpha=1.702,
+            )
+
+        with self.assertRaises(ValueError):
+            _prepare_flashinfer_trtllm_bf16_weights(
+                torch.zeros(2, 10, 128, dtype=torch.bfloat16),
+                torch.zeros(2, 128, 128, dtype=torch.bfloat16),
+                None,
+                torch.zeros(2, 128, dtype=torch.float32),
+                hidden_size=128,
+                intermediate_size=5,
+                gemm1_alpha=1.702,
+            )
+
+        with self.assertRaises(ValueError):
+            _prepare_flashinfer_trtllm_bf16_weights(
+                torch.zeros(2, 256, 3, dtype=torch.bfloat16),
+                torch.zeros(2, 3, 128, dtype=torch.bfloat16),
+                None,
+                torch.zeros(2, 3, dtype=torch.float32),
+                hidden_size=3,
+                intermediate_size=128,
+                gemm1_alpha=1.702,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
+++ b/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
@@ -1,6 +1,7 @@
 """CPU coverage for biased BF16 FlashInfer TRT-LLM MoE weight preparation."""
 
 import unittest
+from contextlib import nullcontext
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
@@ -15,6 +16,15 @@ from sglang.srt.layers.quantization.unquant import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
+
+# The runner imports quantization registry state, so initialize unquant first.
+# isort: off
+from sglang.srt.layers.moe.moe_runner import flashinfer_trtllm
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import BypassedTopKOutput, PackedTopKOutput, TopKConfig
+
+# isort: on
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
@@ -342,6 +352,186 @@ class TestFlashInferTrtllmBf16Padding(CustomTestCase):
             calls,
             ["w13_permute", "w2_permute", "block_layout", "block_layout"],
         )
+
+    def test_bf16_runner_pads_inputs_and_restores_logical_width(self):
+        """Both BF16 kernels receive padded inputs and return logical outputs."""
+        tokens, hidden_size, kernel_hidden_size = 3, 2880, 2944
+        input_pad_value = 1.0
+        alpha = torch.tensor([1.702])
+        beta = torch.tensor([1.0])
+        clamp_limit = torch.tensor([7.0])
+        quant_info = flashinfer_trtllm.FlashInferTrtllmBf16MoeQuantInfo(
+            gemm1_weights=torch.empty(1),
+            gemm2_weights=torch.empty(1),
+            global_num_experts=1,
+            local_expert_offset=0,
+            kernel_hidden_size=kernel_hidden_size,
+            input_pad_value=input_pad_value,
+            gemm1_alpha=alpha,
+            gemm1_beta=beta,
+            gemm1_clamp_limit=clamp_limit,
+        )
+        runner_config = MoeRunnerConfig(
+            activation="silu",
+            is_gated=True,
+            num_fused_shared_experts=0,
+            num_local_experts=1,
+            intermediate_size_per_partition=128,
+            top_k=1,
+        )
+        hidden_states = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
+        kernel_result = torch.randn(kernel_hidden_size, tokens).transpose(0, 1)
+
+        flashinfer = ModuleType("flashinfer")
+        flashinfer.__path__ = []
+        fused_moe = ModuleType("flashinfer.fused_moe")
+        fused_moe.__path__ = []
+        core = ModuleType("flashinfer.fused_moe.core")
+        core.ActivationType = SimpleNamespace(
+            Swiglu=SimpleNamespace(value=1),
+            Geglu=SimpleNamespace(value=2),
+        )
+
+        for use_routed_topk in (False, True):
+            with self.subTest(use_routed_topk=use_routed_topk):
+                kernel_calls = []
+
+                def mock_kernel(**kwargs):
+                    kernel_calls.append(kwargs)
+                    return kernel_result
+
+                if use_routed_topk:
+                    fused_moe.trtllm_bf16_routed_moe = mock_kernel
+                    topk_output = PackedTopKOutput(
+                        packed_topk_ids=torch.zeros(tokens, 1, dtype=torch.int32),
+                        router_logits=torch.empty(tokens, 1),
+                    )
+                else:
+                    fused_moe.trtllm_bf16_moe = mock_kernel
+                    topk_output = BypassedTopKOutput(
+                        hidden_states=hidden_states,
+                        router_logits=torch.empty(tokens, 1),
+                        topk_config=TopKConfig(top_k=1),
+                    )
+
+                dispatch_output = StandardDispatchOutput(
+                    hidden_states=hidden_states,
+                    hidden_states_scale=None,
+                    topk_output=topk_output,
+                )
+                with (
+                    patch.dict(
+                        "sys.modules",
+                        {
+                            "flashinfer": flashinfer,
+                            "flashinfer.fused_moe": fused_moe,
+                            "flashinfer.fused_moe.core": core,
+                        },
+                    ),
+                    patch.object(flashinfer_trtllm, "get_tp_group", return_value=None),
+                    patch.object(
+                        flashinfer_trtllm,
+                        "use_symmetric_memory",
+                        return_value=nullcontext(),
+                    ),
+                    patch.object(
+                        flashinfer_trtllm, "is_allocation_symmetric", return_value=False
+                    ),
+                ):
+                    output = (
+                        flashinfer_trtllm.fused_experts_none_to_flashinfer_trtllm_bf16(
+                            dispatch_output,
+                            quant_info,
+                            runner_config,
+                            use_routed_topk=use_routed_topk,
+                        )
+                    )
+
+                self.assertEqual(len(kernel_calls), 1)
+                kernel_input = kernel_calls[0]["hidden_states"]
+                self.assertEqual(
+                    tuple(kernel_input.shape), (tokens, kernel_hidden_size)
+                )
+                torch.testing.assert_close(kernel_input[:, :hidden_size], hidden_states)
+                torch.testing.assert_close(
+                    kernel_input[:, hidden_size:],
+                    torch.full(
+                        (tokens, kernel_hidden_size - hidden_size),
+                        input_pad_value,
+                        dtype=hidden_states.dtype,
+                    ),
+                )
+                self.assertIs(kernel_calls[0]["gemm1_alpha"], alpha)
+                self.assertIs(kernel_calls[0]["gemm1_beta"], beta)
+                self.assertIs(kernel_calls[0]["gemm1_clamp_limit"], clamp_limit)
+                self.assertEqual(
+                    tuple(output.hidden_states.shape), (tokens, hidden_size)
+                )
+                self.assertTrue(output.hidden_states.is_contiguous())
+                torch.testing.assert_close(
+                    output.hidden_states, kernel_result[:, :hidden_size]
+                )
+
+    def test_forward_cuda_builds_bf16_padding_payload_for_gated_and_non_gated(self):
+        """Gated preparation values flow through, while non-gated uses safe defaults."""
+
+        class FakeBackend:
+            def is_triton_kernels(self):
+                return False
+
+            def is_deep_gemm(self):
+                return False
+
+        class CaptureRunner:
+            runner_backend = FakeBackend()
+
+            def run(self, dispatch_output, quant_info):
+                self.quant_info = quant_info
+                return dispatch_output
+
+        dispatch_output = StandardDispatchOutput(
+            hidden_states=torch.empty(2, 2880, dtype=torch.bfloat16),
+            hidden_states_scale=None,
+            topk_output=SimpleNamespace(),
+        )
+        alpha = torch.tensor([1.702])
+        beta = torch.tensor([1.0])
+        clamp_limit = torch.tensor([7.0])
+
+        for is_gated in (True, False):
+            with self.subTest(is_gated=is_gated):
+                method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+                method.use_flashinfer_cutlass = False
+                method.use_flashinfer_trtllm_moe = True
+                method.runner = CaptureRunner()
+                if is_gated:
+                    method._flashinfer_kernel_hidden_size = 2944
+                    method._flashinfer_input_pad_value = 1.0
+                    method._flashinfer_gemm1_alpha = alpha
+                    method._flashinfer_gemm1_beta = beta
+                    method._flashinfer_gemm1_clamp_limit = clamp_limit
+                layer = SimpleNamespace(
+                    w13_weight=Parameter(torch.empty(1)),
+                    w2_weight=Parameter(torch.empty(1)),
+                    num_experts=4,
+                    moe_ep_rank=1,
+                    num_local_experts=2,
+                    hidden_size=2880,
+                    moe_runner_config=SimpleNamespace(is_gated=is_gated),
+                )
+
+                method.forward_cuda(layer, dispatch_output)
+                quant_info = method.runner.quant_info
+
+                self.assertEqual(
+                    quant_info.kernel_hidden_size, 2944 if is_gated else 2880
+                )
+                self.assertEqual(quant_info.input_pad_value, 1.0 if is_gated else 0.0)
+                self.assertIs(quant_info.gemm1_alpha, alpha if is_gated else None)
+                self.assertIs(quant_info.gemm1_beta, beta if is_gated else None)
+                self.assertIs(
+                    quant_info.gemm1_clamp_limit, clamp_limit if is_gated else None
+                )
 
     def test_bias_folding_requires_spare_padded_channels(self):
         """Bias folding must reject kernel shapes with no synthetic channels."""

--- a/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
+++ b/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
@@ -1,11 +1,16 @@
 """CPU coverage for biased BF16 FlashInfer TRT-LLM MoE weight preparation."""
 
 import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
 
 import torch
 import torch.nn.functional as F
+from torch.nn import Parameter
 
+from sglang.srt.layers.quantization import unquant
 from sglang.srt.layers.quantization.unquant import (
+    UnquantizedFusedMoEMethod,
     _prepare_flashinfer_trtllm_bf16_weights,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -25,6 +30,15 @@ def gpt_oss_activation(
 
 
 class TestFlashInferTrtllmBf16Padding(CustomTestCase):
+    @staticmethod
+    def _make_restore_layer() -> SimpleNamespace:
+        return SimpleNamespace(
+            num_local_experts=1,
+            hidden_size=2880,
+            intermediate_size_per_partition=128,
+            moe_runner_config=SimpleNamespace(is_gated=True),
+        )
+
     def test_biased_bf16_weights_match_bias_free_padded_moe(self):
         """Bias folding must preserve each expert's GPT-OSS MoE output."""
         torch.manual_seed(0)
@@ -115,6 +129,218 @@ class TestFlashInferTrtllmBf16Padding(CustomTestCase):
         torch.testing.assert_close(
             prepared_w13[:, 128 : 128 + intermediate_size, :hidden_size],
             w13[:, intermediate_size:],
+        )
+
+    def test_preparation_reads_runtime_padded_w13_layout(self):
+        """Only logical [up, gate] rows survive a runtime-padded W13 input."""
+        hidden_size = 3
+        intermediate_size = 5
+        w13 = torch.full((2, 256, hidden_size), 9.0, dtype=torch.bfloat16)
+        up = torch.full((2, intermediate_size, hidden_size), 2.0, dtype=torch.bfloat16)
+        gate = torch.full(
+            (2, intermediate_size, hidden_size), 3.0, dtype=torch.bfloat16
+        )
+        w13[:, :intermediate_size] = up
+        w13[:, 128 : 128 + intermediate_size] = gate
+
+        prepared_w13, _, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            torch.zeros(2, hidden_size, 128, dtype=torch.bfloat16),
+            None,
+            None,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            gemm1_alpha=1.702,
+        )
+
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, :hidden_size], up
+        )
+        torch.testing.assert_close(
+            prepared_w13[:, 128 : 128 + intermediate_size, :hidden_size], gate
+        )
+        self.assertEqual(prepared_w13[:, intermediate_size:128].count_nonzero(), 0)
+        self.assertEqual(
+            prepared_w13[:, 128 + intermediate_size :, :hidden_size].count_nonzero(),
+            0,
+        )
+
+    def test_preparation_supports_each_bias_independently(self):
+        """W13 and W2 bias folding must not require the other bias tensor."""
+        w13 = torch.zeros(2, 10, 3, dtype=torch.bfloat16)
+        w2 = torch.zeros(2, 3, 128, dtype=torch.bfloat16)
+        w13_bias = torch.arange(20, dtype=torch.float32).view(2, 10)
+        w2_bias = torch.arange(6, dtype=torch.float32).view(2, 3)
+
+        w13_only, w2_without_bias, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            w2,
+            w13_bias,
+            None,
+            hidden_size=3,
+            intermediate_size=5,
+            gemm1_alpha=1.702,
+        )
+        torch.testing.assert_close(w13_only[:, :5, 3], w13_bias[:, :5].bfloat16())
+        torch.testing.assert_close(w13_only[:, 128:133, 3], w13_bias[:, 5:].bfloat16())
+        self.assertEqual(w2_without_bias.count_nonzero(), 0)
+
+        w2_only_w13, w2_only, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            w2,
+            None,
+            w2_bias,
+            hidden_size=3,
+            intermediate_size=5,
+            gemm1_alpha=1.702,
+        )
+        self.assertNotEqual(w2_only_w13[:, 5, 3].count_nonzero(), 0)
+        torch.testing.assert_close(w2_only[:, :3, 5], w2_bias.bfloat16())
+
+    def test_preparation_rejects_invalid_bias_shapes_without_broadcasting(self):
+        """Per-expert bias tensors must exactly match the prepared weights."""
+        w13 = torch.zeros(2, 10, 3, dtype=torch.bfloat16)
+        w2 = torch.zeros(2, 3, 128, dtype=torch.bfloat16)
+
+        for bad_w13_bias in (
+            torch.zeros(1, 10, dtype=torch.float32),
+            torch.zeros(2, 9, dtype=torch.float32),
+        ):
+            with self.subTest(w13_bias_shape=tuple(bad_w13_bias.shape)):
+                with self.assertRaises(ValueError):
+                    _prepare_flashinfer_trtllm_bf16_weights(
+                        w13,
+                        w2,
+                        bad_w13_bias,
+                        None,
+                        hidden_size=3,
+                        intermediate_size=5,
+                        gemm1_alpha=1.702,
+                    )
+
+        for bad_w2_bias in (
+            torch.zeros(1, 3, dtype=torch.float32),
+            torch.zeros(2, 4, dtype=torch.float32),
+        ):
+            with self.subTest(w2_bias_shape=tuple(bad_w2_bias.shape)):
+                with self.assertRaises(ValueError):
+                    _prepare_flashinfer_trtllm_bf16_weights(
+                        w13,
+                        w2,
+                        None,
+                        bad_w2_bias,
+                        hidden_size=3,
+                        intermediate_size=5,
+                        gemm1_alpha=1.702,
+                    )
+
+    @patch.object(
+        unquant,
+        "get_moe_runner_backend",
+        return_value=unquant.MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
+    )
+    def test_hot_load_replaces_prepared_w13_with_canonical_shape(self, _):
+        """Prepared W13's padded hidden width must be discarded before reload."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+        layer = self._make_restore_layer()
+        param = Parameter(torch.empty(1, 256, 2944, dtype=torch.bfloat16))
+
+        method.maybe_restore_flashinfer_trtllm_bf16_weight_shape_for_load(
+            layer, param, "model.experts.w13_weight"
+        )
+
+        self.assertEqual(tuple(param.shape), (1, 256, 2880))
+
+    @patch.object(
+        unquant,
+        "get_moe_runner_backend",
+        return_value=unquant.MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
+    )
+    def test_hot_load_replaces_prepared_w2_with_canonical_shape(self, _):
+        """Prepared W2's padded output width must be discarded before reload."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+        layer = self._make_restore_layer()
+        param = Parameter(torch.empty(1, 2944, 128, dtype=torch.bfloat16))
+
+        method.maybe_restore_flashinfer_trtllm_bf16_weight_shape_for_load(
+            layer, param, "model.experts.w2_weight"
+        )
+
+        self.assertEqual(tuple(param.shape), (1, 2880, 128))
+
+    @patch.object(
+        unquant,
+        "get_moe_runner_backend",
+        return_value=unquant.MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
+    )
+    def test_hot_load_rejects_unrecognized_weight_numel(self, _):
+        """Hot reload must not reshape tensors outside either known layout."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+
+        with self.assertRaisesRegex(RuntimeError, "Cannot restore"):
+            method.maybe_restore_flashinfer_trtllm_bf16_weight_shape_for_load(
+                self._make_restore_layer(),
+                Parameter(torch.empty(1, 17, 17, dtype=torch.bfloat16)),
+                "model.experts.w13_weight",
+            )
+
+    def test_non_gated_flashinfer_path_skips_bf16_preparation(self):
+        """Non-gated FlashInfer MoE keeps its pre-existing block-layout path."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+        method.use_flashinfer_trtllm_moe = True
+        method.use_deep_gemm = False
+        method._cache_permute_indices = {}
+        layer = SimpleNamespace(
+            moe_runner_config=SimpleNamespace(is_gated=False),
+            w13_weight=Parameter(torch.zeros(1, 5, 3, dtype=torch.bfloat16)),
+            w2_weight=Parameter(torch.zeros(1, 3, 128, dtype=torch.bfloat16)),
+            num_local_experts=1,
+        )
+        flashinfer = ModuleType("flashinfer")
+        flashinfer.__path__ = []
+        fused_moe = ModuleType("flashinfer.fused_moe")
+        fused_moe.__path__ = []
+        core = ModuleType("flashinfer.fused_moe.core")
+        calls = []
+
+        def w13_permute(_, weight, *__, **kwargs):
+            calls.append("w13_permute")
+            self.assertFalse(kwargs["is_gated_act_gemm"])
+            return torch.arange(weight.shape[0])
+
+        def w2_permute(_, weight, __):
+            calls.append("w2_permute")
+            return torch.arange(weight.shape[0])
+
+        def block_layout(weight, _):
+            calls.append("block_layout")
+            return weight
+
+        core._maybe_get_cached_w3_w1_permute_indices = w13_permute
+        core.convert_to_block_layout = block_layout
+        core.get_w2_permute_indices_with_cache = w2_permute
+
+        with (
+            patch.object(unquant, "_is_cpu", False),
+            patch.object(
+                unquant,
+                "_prepare_flashinfer_trtllm_bf16_weights",
+                side_effect=AssertionError("non-gated path must not prepare weights"),
+            ),
+            patch.dict(
+                "sys.modules",
+                {
+                    "flashinfer": flashinfer,
+                    "flashinfer.fused_moe": fused_moe,
+                    "flashinfer.fused_moe.core": core,
+                },
+            ),
+        ):
+            method.process_weights_after_loading(layer)
+
+        self.assertEqual(
+            calls,
+            ["w13_permute", "w2_permute", "block_layout", "block_layout"],
         )
 
     def test_bias_folding_requires_spare_padded_channels(self):

--- a/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
+++ b/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
@@ -14,6 +14,7 @@ from sglang.srt.layers.quantization.unquant import (
     UnquantizedFusedMoEMethod,
     _prepare_flashinfer_trtllm_bf16_weights,
 )
+from sglang.srt.lora.trtllm_lora_temp import lora_layer
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -523,6 +524,47 @@ class TestFlashInferTrtllmBf16Padding(CustomTestCase):
                 method.forward_cuda(layer, dispatch_output)
                 quant_info = method.runner.quant_info
 
+                self.assertEqual(
+                    quant_info.kernel_hidden_size, 2944 if is_gated else 2880
+                )
+                self.assertEqual(quant_info.input_pad_value, 1.0 if is_gated else 0.0)
+                self.assertIs(quant_info.gemm1_alpha, alpha if is_gated else None)
+                self.assertIs(quant_info.gemm1_beta, beta if is_gated else None)
+                self.assertIs(
+                    quant_info.gemm1_clamp_limit, clamp_limit if is_gated else None
+                )
+
+    def test_bf16_lora_payload_uses_prepared_values_or_non_gated_fallback(self):
+        """BF16 LoRA construction must satisfy the padded runner payload contract."""
+        alpha = torch.tensor([1.702])
+        beta = torch.tensor([1.0])
+        clamp_limit = torch.tensor([7.0])
+
+        for is_gated in (True, False):
+            with self.subTest(is_gated=is_gated):
+                quant_method = SimpleNamespace(quant_config=None, block_quant=False)
+                if is_gated:
+                    quant_method._flashinfer_kernel_hidden_size = 2944
+                    quant_method._flashinfer_input_pad_value = 1.0
+                    quant_method._flashinfer_gemm1_alpha = alpha
+                    quant_method._flashinfer_gemm1_beta = beta
+                    quant_method._flashinfer_gemm1_clamp_limit = clamp_limit
+                base_layer = SimpleNamespace(
+                    quant_method=quant_method,
+                    w13_weight=Parameter(torch.empty(1, 2, 2, 2)),
+                    w2_weight=Parameter(torch.empty(1, 2, 2, 2)),
+                    num_experts=4,
+                    moe_ep_rank=1,
+                    num_local_experts=2,
+                    hidden_size=2880,
+                    moe_runner_config=SimpleNamespace(is_gated=is_gated),
+                )
+                layer = SimpleNamespace()
+
+                with patch.object(lora_layer, "_warm_sgl_trtllm_moe_module"):
+                    lora_layer.init_experimental_sgl_trtllm_lora(layer, base_layer)
+
+                quant_info = layer._quant_info
                 self.assertEqual(
                     quant_info.kernel_hidden_size, 2944 if is_gated else 2880
                 )

--- a/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
+++ b/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
@@ -161,6 +161,13 @@ class TestFlashInferTrtllmBf16Padding(CustomTestCase):
             dtype=torch.bfloat16,
         )
         runtime_padded[:, : 2 * intermediate_size] = interleaved.to(torch.bfloat16)
+        gate_bias = torch.arange(intermediate_size, dtype=torch.float32)
+        up_bias = gate_bias + 100
+        interleaved_bias = torch.stack((gate_bias, up_bias), dim=1).reshape(1, -1)
+        runtime_padded_bias = torch.zeros(
+            1, 2 * kernel_intermediate_size, dtype=torch.float32
+        )
+        runtime_padded_bias[:, : 2 * intermediate_size] = interleaved_bias
 
         prepared_w13, _, _ = _prepare_flashinfer_trtllm_bf16_weights(
             runtime_padded,
@@ -170,7 +177,7 @@ class TestFlashInferTrtllmBf16Padding(CustomTestCase):
                 kernel_intermediate_size,
                 dtype=torch.bfloat16,
             ),
-            None,
+            runtime_padded_bias,
             None,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
@@ -189,6 +196,18 @@ class TestFlashInferTrtllmBf16Padding(CustomTestCase):
                 :hidden_size,
             ],
             gate.unsqueeze(0).to(torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, hidden_size],
+            up_bias.unsqueeze(0).to(torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            prepared_w13[
+                :,
+                kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+                hidden_size,
+            ],
+            gate_bias.unsqueeze(0).to(torch.bfloat16),
         )
 
     def test_preparation_reads_runtime_padded_w13_layout(self):

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
@@ -1,0 +1,513 @@
+import unittest
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.moe.token_dispatcher.flashinfer import FlashinferDispatcher
+from sglang.srt.model_executor import model_runner as model_runner_module
+from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    PrefillCudaGraphRunner,
+)
+from sglang.srt.model_executor.runner.shape_key import ShapeKey
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class _FakeEmbedding:
+    def __call__(self, input_ids: torch.Tensor) -> torch.Tensor:
+        values = input_ids.to(torch.float32)
+        return torch.stack((values, values + 100), dim=-1)
+
+
+class TestPrefillCudaGraphCPStaticInputs(CustomTestCase):
+    def _runner(self) -> PrefillCudaGraphRunner:
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.model_runner = SimpleNamespace(
+            model=SimpleNamespace(get_input_embeddings=lambda: _FakeEmbedding())
+        )
+        runner.cp_input_embeds = torch.full((16, 2), -1.0)
+        runner.cp_positions = torch.full((16,), -1, dtype=torch.int64)
+        runner.cp_bucket_local_tokens = {}
+        return runner
+
+    @staticmethod
+    def _batch(num_tokens: int, batch_size: int = 1):
+        input_ids = torch.arange(num_tokens, dtype=torch.int64)
+        return SimpleNamespace(
+            batch_size=batch_size,
+            input_ids=input_ids,
+            input_embeds=None,
+            positions=torch.arange(num_tokens, dtype=torch.int64),
+            extend_num_tokens=num_tokens,
+            attn_cp_metadata=object(),
+        )
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
+    def test_capture_and_replay_use_fixed_local_buffers(self, mock_prepare, mock_split):
+        runner = self._runner()
+        capture_batch = self._batch(16)
+        capture_input_ids = capture_batch.input_ids
+        capture_metadata = object()
+
+        def prepare(batch):
+            self.assertIsNone(batch.attn_cp_metadata)
+            batch.attn_cp_metadata = capture_metadata
+
+        mock_prepare.side_effect = prepare
+        capture_embeds = torch.tensor(
+            [[1.0, 101.0], [4.0, 104.0], [11.0, 111.0], [14.0, 114.0]]
+        )
+        capture_positions = torch.tensor([1, 4, 11, 14], dtype=torch.int64)
+        mock_split.return_value = (capture_embeds, capture_positions)
+
+        live_rows = runner._prepare_cp_static_inputs(
+            capture_batch,
+            static_num_tokens=16,
+            capture=True,
+        )
+
+        self.assertEqual(live_rows, 4)
+        self.assertIs(capture_batch.input_ids, capture_input_ids)
+        self.assertIs(capture_batch.attn_cp_metadata, capture_metadata)
+        self.assertEqual(runner.cp_bucket_local_tokens, {16: 4})
+        self.assertEqual(
+            capture_batch.input_embeds.data_ptr(), runner.cp_input_embeds.data_ptr()
+        )
+        self.assertEqual(
+            capture_batch.positions.data_ptr(), runner.cp_positions.data_ptr()
+        )
+        torch.testing.assert_close(capture_batch.input_embeds, capture_embeds)
+        torch.testing.assert_close(capture_batch.positions, capture_positions)
+
+        replay_batch = self._batch(12, batch_size=2)
+        replay_metadata = object()
+        seen_metadata = []
+
+        def prepare_replay(batch):
+            seen_metadata.append(batch.attn_cp_metadata)
+            batch.attn_cp_metadata = replay_metadata
+
+        mock_prepare.side_effect = prepare_replay
+        replay_embeds = torch.tensor([[2.0, 102.0], [7.0, 107.0], [10.0, 110.0]])
+        replay_positions = torch.tensor([2, 7, 10], dtype=torch.int64)
+        mock_split.return_value = (replay_embeds, replay_positions)
+
+        live_rows = runner._prepare_cp_static_inputs(
+            replay_batch,
+            static_num_tokens=16,
+            capture=False,
+        )
+
+        self.assertEqual(live_rows, 3)
+        self.assertEqual(seen_metadata, [None])
+        self.assertIs(replay_batch.attn_cp_metadata, replay_metadata)
+        self.assertEqual(
+            replay_batch.input_embeds.data_ptr(), runner.cp_input_embeds.data_ptr()
+        )
+        self.assertEqual(
+            replay_batch.positions.data_ptr(), runner.cp_positions.data_ptr()
+        )
+        torch.testing.assert_close(
+            replay_batch.input_embeds[:3],
+            replay_embeds,
+        )
+        torch.testing.assert_close(
+            replay_batch.positions[:3],
+            replay_positions,
+        )
+        torch.testing.assert_close(
+            replay_batch.input_embeds[3],
+            torch.zeros(2),
+        )
+        self.assertEqual(replay_batch.positions[3].item(), 0)
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
+    def test_replay_rebuilds_metadata_when_request_count_changes(
+        self, mock_prepare, mock_split
+    ):
+        runner = self._runner()
+        metadata = []
+
+        def prepare(batch):
+            self.assertIsNone(batch.attn_cp_metadata)
+            current = object()
+            metadata.append(current)
+            batch.attn_cp_metadata = current
+
+        mock_prepare.side_effect = prepare
+        mock_split.side_effect = (
+            (torch.ones((4, 2)), torch.arange(4)),
+            (torch.ones((3, 2)), torch.arange(3)),
+        )
+
+        capture_batch = self._batch(16)
+        runner._prepare_cp_static_inputs(
+            capture_batch, static_num_tokens=16, capture=True
+        )
+        replay_batch = self._batch(12, batch_size=2)
+        runner._prepare_cp_static_inputs(
+            replay_batch, static_num_tokens=16, capture=False
+        )
+
+        self.assertIsNot(metadata[0], metadata[1])
+        self.assertIs(capture_batch.attn_cp_metadata, metadata[0])
+        self.assertIs(replay_batch.attn_cp_metadata, metadata[1])
+        self.assertEqual(
+            capture_batch.input_embeds.data_ptr(),
+            replay_batch.input_embeds.data_ptr(),
+        )
+        self.assertEqual(
+            capture_batch.positions.data_ptr(),
+            replay_batch.positions.data_ptr(),
+        )
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
+    def test_replay_keeps_logical_rows_but_uses_captured_physical_rows(
+        self, mock_prepare, mock_split
+    ):
+        runner = self._runner()
+        runner.cp_bucket_local_tokens = {16: 4}
+        batch = self._batch(12)
+        metadata = SimpleNamespace(
+            per_rank_logical_token=[3, 3, 3, 3],
+            per_rank_actual_token=[3, 3, 3, 3],
+            max_rank_len=[3, 3, 3, 3],
+        )
+        mock_prepare.side_effect = lambda forward_batch: setattr(
+            forward_batch, "attn_cp_metadata", metadata
+        )
+
+        def split(_, __, forward_batch):
+            self.assertEqual(
+                forward_batch.attn_cp_metadata.per_rank_logical_token,
+                [3, 3, 3, 3],
+            )
+            self.assertEqual(
+                forward_batch.attn_cp_metadata.per_rank_actual_token,
+                [4, 4, 4, 4],
+            )
+            self.assertEqual(
+                forward_batch.attn_cp_metadata.max_rank_len,
+                [4, 4, 4, 4],
+            )
+            return torch.ones((4, 2)), torch.arange(4)
+
+        mock_split.side_effect = split
+
+        live_rows = runner._prepare_cp_static_inputs(
+            batch,
+            static_num_tokens=16,
+            capture=False,
+        )
+
+        self.assertEqual(live_rows, 4)
+        self.assertIs(batch.attn_cp_metadata, metadata)
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
+    def test_replay_rejects_more_local_rows_than_captured(
+        self, mock_prepare, mock_split
+    ):
+        runner = self._runner()
+        mock_prepare.side_effect = lambda batch: setattr(
+            batch, "attn_cp_metadata", object()
+        )
+        mock_split.return_value = (torch.ones((4, 2)), torch.arange(4))
+        runner._prepare_cp_static_inputs(
+            self._batch(16), static_num_tokens=16, capture=True
+        )
+
+        mock_split.return_value = (torch.ones((5, 2)), torch.arange(5))
+        with self.assertRaisesRegex(
+            RuntimeError, "5 local CP rows.*captured capacity 4"
+        ):
+            runner._prepare_cp_static_inputs(
+                self._batch(16), static_num_tokens=16, capture=False
+            )
+
+
+class TestPrefillCudaGraphCPBodyCapture(CustomTestCase):
+    @patch(
+        "sglang.srt.model_executor.model_runner.get_cp_strategy",
+        return_value=object(),
+    )
+    def test_model_runner_dispatch_allows_validated_cp_body_capture(self, _):
+        runner = SimpleNamespace(enable_cp_v2_body_capture=True)
+
+        self.assertTrue(
+            model_runner_module._prefill_cuda_graph_allows_context_parallel(runner)
+        )
+
+    @patch(
+        "sglang.srt.model_executor.model_runner.get_cp_strategy",
+        return_value=object(),
+    )
+    def test_model_runner_dispatch_rejects_other_cp_graphs(self, _):
+        runner = SimpleNamespace(enable_cp_v2_body_capture=False)
+
+        self.assertFalse(
+            model_runner_module._prefill_cuda_graph_allows_context_parallel(runner)
+        )
+
+    def test_capture_prepares_cp_before_attention_metadata(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        forward_batch = SimpleNamespace(lora_ids=None)
+        attn_backend = MagicMock()
+        events = []
+        runner.enable_cp_v2_body_capture = True
+        runner._is_full_backend = False
+        runner._capture_chunked_prefix = False
+        runner.use_captured_attn_metadata = False
+        runner.capture_prepare = MagicMock(return_value=(forward_batch, attn_backend))
+        runner._prepare_cp_static_inputs = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("cp") or 4
+        )
+        runner._validate_cp_flashinfer_dispatch_capacity = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("capacity")
+        )
+        runner._init_forward_metadata_for_capture = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("metadata")
+        )
+        runner._run_forward = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("forward")
+            or torch.zeros((4, 2))
+        )
+        runner.backend = MagicMock()
+        runner.backend.capture_one.side_effect = (
+            lambda shape_key, run_once, **kwargs: run_once()
+        )
+
+        runner.capture_one_shape(16)
+
+        self.assertEqual(events, ["cp", "capacity", "metadata", "forward"])
+        runner._prepare_cp_static_inputs.assert_called_once_with(
+            forward_batch,
+            static_num_tokens=16,
+            capture=True,
+        )
+        runner._validate_cp_flashinfer_dispatch_capacity.assert_called_once_with(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
+        self.assertEqual(
+            runner.backend.capture_one.call_args.args[0],
+            ShapeKey(size=16),
+        )
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_gather_after_forward",
+        create=True,
+    )
+    @patch("torch.cuda.current_stream")
+    def test_replay_trims_local_rows_gathers_and_runs_live_logits(
+        self, mock_current_stream, mock_gather
+    ):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        local_padded = torch.arange(8, dtype=torch.float32).view(4, 2)
+        gathered = torch.arange(12, dtype=torch.float32).view(6, 2)
+        output = object()
+        stream = object()
+        logits_processor = MagicMock(return_value=output)
+        model = SimpleNamespace(
+            capture_aux_hidden_states=False,
+            forward=MagicMock(),
+            lm_head=object(),
+            logits_processor=logits_processor,
+            pp_group=SimpleNamespace(is_last_rank=True),
+        )
+        runner.model_runner = SimpleNamespace(model=model)
+        runner.backend = MagicMock()
+        context_state = {"active": False}
+
+        @contextmanager
+        def prefill_context(*args, **kwargs):
+            context_state["active"] = True
+            try:
+                yield
+            finally:
+                context_state["active"] = False
+
+        runner._prefill_forward_context = prefill_context
+
+        def replay(*args, **kwargs):
+            self.assertTrue(context_state["active"])
+            return local_padded
+
+        runner.backend.replay.side_effect = replay
+        runner._cp_live_local_tokens = 3
+        forward_batch = SimpleNamespace(input_ids=torch.arange(6))
+        static_forward_batch = SimpleNamespace()
+        mock_current_stream.return_value = stream
+        mock_gather.return_value = gathered
+
+        actual = runner._execute_cp_body_capture(
+            forward_batch,
+            static_forward_batch,
+            static_num_tokens=16,
+            raw_num_tokens=6,
+        )
+
+        self.assertIs(actual, output)
+        self.assertFalse(context_state["active"])
+        runner.backend.replay.assert_called_once_with(
+            ShapeKey(size=16),
+            static_forward_batch,
+        )
+        mock_gather.assert_called_once()
+        torch.testing.assert_close(mock_gather.call_args.args[0], local_padded[:3])
+        self.assertIs(mock_gather.call_args.args[1], static_forward_batch)
+        self.assertIs(mock_gather.call_args.args[2], stream)
+        logits_processor.assert_called_once_with(
+            forward_batch.input_ids,
+            gathered,
+            model.lm_head,
+            forward_batch,
+            None,
+        )
+        model.forward.assert_not_called()
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_gather_after_forward",
+        create=True,
+    )
+    @patch("torch.cuda.current_stream")
+    def test_replay_preserves_auxiliary_hidden_states(
+        self, mock_current_stream, mock_gather
+    ):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        local_hidden = torch.ones((4, 2))
+        local_aux = [torch.full((4, 2), 2.0)]
+        gathered = torch.full((6, 2), 3.0)
+        output = object()
+        logits_processor = MagicMock(return_value=output)
+        model = SimpleNamespace(
+            capture_aux_hidden_states=True,
+            lm_head=object(),
+            logits_processor=logits_processor,
+            pp_group=SimpleNamespace(is_last_rank=True),
+        )
+        runner.model_runner = SimpleNamespace(model=model)
+        runner.backend = MagicMock()
+        runner.backend.replay.return_value = (local_hidden, local_aux)
+        runner._prefill_forward_context = lambda *args, **kwargs: nullcontext()
+        runner._cp_live_local_tokens = 3
+        forward_batch = SimpleNamespace(input_ids=torch.arange(6))
+        static_forward_batch = SimpleNamespace()
+        mock_gather.return_value = gathered
+
+        actual = runner._execute_cp_body_capture(
+            forward_batch,
+            static_forward_batch,
+            static_num_tokens=16,
+            raw_num_tokens=6,
+        )
+
+        self.assertIs(actual, output)
+        logits_processor.assert_called_once()
+        logits_args = logits_processor.call_args.args
+        self.assertIs(logits_args[0], forward_batch.input_ids)
+        self.assertIs(logits_args[1], gathered)
+        self.assertIs(logits_args[2], model.lm_head)
+        self.assertIs(logits_args[3], forward_batch)
+        self.assertEqual(len(logits_args[4]), 1)
+        torch.testing.assert_close(logits_args[4][0], local_aux[0][:3])
+
+
+class TestPrefillCudaGraphCPFlashInferCapacity(CustomTestCase):
+    @staticmethod
+    def _dispatcher(capacity: int) -> FlashinferDispatcher:
+        dispatcher = FlashinferDispatcher.__new__(FlashinferDispatcher)
+        dispatcher.max_num_tokens = capacity
+        return dispatcher
+
+    def test_accepts_equal_or_larger_flashinfer_capacity(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        dispatcher = self._dispatcher(4)
+        runner.moe_layers = [
+            SimpleNamespace(dispatcher=dispatcher),
+            SimpleNamespace(dispatcher=dispatcher),
+        ]
+
+        runner._validate_cp_flashinfer_dispatch_capacity(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
+        dispatcher.max_num_tokens = 8
+        runner._validate_cp_flashinfer_dispatch_capacity(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
+
+    def test_rejects_flashinfer_capacity_smaller_than_local_capture(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.moe_layers = [
+            SimpleNamespace(dispatcher=self._dispatcher(3)),
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "global bucket 16.*required local rows 4.*configured capacity 3.*"
+            "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK",
+        ):
+            runner._validate_cp_flashinfer_dispatch_capacity(
+                global_bucket_tokens=16,
+                required_local_tokens=4,
+            )
+
+    def test_ignores_non_flashinfer_dispatchers(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.moe_layers = [
+            SimpleNamespace(
+                dispatcher=SimpleNamespace(max_num_tokens=1),
+            )
+        ]
+
+        runner._validate_cp_flashinfer_dispatch_capacity(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
+++ b/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
@@ -9,7 +9,7 @@ import torch
 from sglang.srt.layers.moe import MoeRunnerBackend
 from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.models.gpt_oss import _narrow_fused_moe_ep_weight
+from sglang.srt.models.gpt_oss import TinyGemmLinear, _narrow_fused_moe_ep_weight
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -83,6 +83,20 @@ class TestGptOssEpWeightLoading(CustomTestCase):
         )
 
         torch.testing.assert_close(expert_data, loaded_weight)
+
+    def test_tinygemm_linear_accepts_empty_idle_batch(self):
+        """DP ranks without work must not launch tinygemm with zero M."""
+        layer = TinyGemmLinear.__new__(TinyGemmLinear)
+        torch.nn.Module.__init__(layer)
+        layer.output_size = 128
+        layer._use_tinygemm = True
+        x = torch.empty((0, 64), dtype=torch.bfloat16)
+
+        output, output_bias = layer(x)
+
+        self.assertEqual(output.shape, (0, 128))
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertIsNone(output_bias)
 
     @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_moe_runner")
     @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_weights")

--- a/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
+++ b/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
@@ -2,14 +2,18 @@
 
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
 from sglang.srt.layers.moe import MoeRunnerBackend
 from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.models.gpt_oss import TinyGemmLinear, _narrow_fused_moe_ep_weight
+from sglang.srt.models.gpt_oss import (
+    GptOssSparseMoeBlock,
+    TinyGemmLinear,
+    _narrow_fused_moe_ep_weight,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -97,6 +101,41 @@ class TestGptOssEpWeightLoading(CustomTestCase):
         self.assertEqual(output.shape, (0, 128))
         self.assertEqual(output.dtype, torch.bfloat16)
         self.assertIsNone(output_bias)
+
+    @patch(
+        "sglang.srt.models.gpt_oss.should_skip_post_experts_all_reduce",
+        create=True,
+        return_value=True,
+    )
+    @patch("sglang.srt.models.gpt_oss.tensor_model_parallel_all_reduce")
+    @patch(
+        "sglang.srt.models.gpt_oss.get_forward",
+        return_value=SimpleNamespace(fuse_mlp_allreduce=False),
+    )
+    @patch(
+        "sglang.srt.models.gpt_oss.is_in_tc_piecewise_cuda_graph",
+        return_value=False,
+    )
+    def test_flashinfer_a2a_output_is_not_all_reduced(
+        self, _is_piecewise, _get_forward, all_reduce, _should_skip
+    ):
+        """FlashInfer combine already returns the complete source-rank output."""
+        block = GptOssSparseMoeBlock.__new__(GptOssSparseMoeBlock)
+        torch.nn.Module.__init__(block)
+        block.tp_size = 4
+        block.hidden_size = 3
+        block.__dict__["router"] = Mock(
+            return_value=(torch.zeros((2, 4), dtype=torch.float32), None)
+        )
+        topk_output = object()
+        block.__dict__["topk"] = Mock(return_value=topk_output)
+        block.__dict__["experts"] = Mock(side_effect=lambda x, _: x + 1)
+        hidden_states = torch.zeros((2, 3), dtype=torch.bfloat16)
+
+        actual = block.forward_normal(hidden_states)
+
+        torch.testing.assert_close(actual, hidden_states + 1)
+        all_reduce.assert_not_called()
 
     @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_moe_runner")
     @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_weights")

--- a/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
+++ b/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
@@ -6,6 +6,9 @@ from unittest.mock import patch
 
 import torch
 
+from sglang.srt.layers.moe import MoeRunnerBackend
+from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.models.gpt_oss import _narrow_fused_moe_ep_weight
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -14,6 +17,15 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestGptOssEpWeightLoading(CustomTestCase):
+    def _make_fused_moe_shell(self) -> FusedMoE:
+        """Build the minimum loader surface without allocating expert weights."""
+        layer = FusedMoE.__new__(FusedMoE)
+        torch.nn.Module.__init__(layer)
+        layer.__dict__["use_padded_loading"] = True
+        layer.quant_config = None
+        layer.use_presharded_weights = False
+        return layer
+
     @patch("sglang.srt.models.gpt_oss.get_parallel")
     def test_global_expert_weights_are_sliced_for_ep_rank(self, get_parallel):
         """Global checkpoint experts must be narrowed to the current EP rank."""
@@ -54,6 +66,69 @@ class TestGptOssEpWeightLoading(CustomTestCase):
             ValueError, "Expected 128 global or 32 local experts, got 64"
         ):
             _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+    def test_w2_bias_loading_uses_its_last_dimension(self):
+        """Fused down-projection biases must ignore the weight shard dimension."""
+        layer = self._make_fused_moe_shell()
+        expert_data = torch.empty(2, 4)
+        loaded_weight = torch.arange(8, dtype=torch.float32).view(2, 4)
+
+        layer._load_w2(
+            expert_data=expert_data,
+            shard_dim=2,
+            shard_id="w2",
+            loaded_weight=loaded_weight,
+            tp_rank=0,
+            is_bias=True,
+        )
+
+        torch.testing.assert_close(expert_data, loaded_weight)
+
+    @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_moe_runner")
+    @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_weights")
+    @patch.object(fused_moe_layer, "create_moe_dispatcher")
+    @patch.object(
+        fused_moe_layer,
+        "get_moe_a2a_backend",
+        return_value=SimpleNamespace(is_ascend_fuseep=lambda: False),
+    )
+    @patch.object(
+        fused_moe_layer,
+        "get_server_args",
+        return_value=SimpleNamespace(
+            ep_join_mode="none", moe_runner_backend="flashinfer_trtllm"
+        ),
+    )
+    @patch.object(
+        fused_moe_layer,
+        "get_parallel",
+        return_value=SimpleNamespace(
+            moe_ep_size=1, moe_ep_rank=0, moe_tp_size=1, moe_tp_rank=0
+        ),
+    )
+    @patch.object(
+        fused_moe_layer, "has_per_rank_fused_shared_slots", return_value=False
+    )
+    @patch.object(
+        fused_moe_layer, "create_kt_config_from_server_args", return_value=None
+    )
+    @patch.object(
+        fused_moe_layer,
+        "get_moe_runner_backend",
+        return_value=MoeRunnerBackend.FLASHINFER_TRTLLM,
+    )
+    def test_flashinfer_constructor_keeps_logical_intermediate_size(self, *_):
+        """Kernel allocation padding must not overwrite the logical MoE size."""
+        layer = FusedMoE(
+            num_experts=1,
+            hidden_size=1,
+            intermediate_size=2880,
+            layer_id=0,
+            params_dtype=torch.float32,
+        )
+
+        self.assertEqual(layer.intermediate_size_per_partition_unpadded, 2880)
+        self.assertEqual(layer.intermediate_size_per_partition, 2944)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
+++ b/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
@@ -96,7 +96,7 @@ class TestGptOssEpWeightLoading(CustomTestCase):
         fused_moe_layer,
         "get_server_args",
         return_value=SimpleNamespace(
-            ep_join_mode="none", moe_runner_backend="flashinfer_trtllm"
+            ep_join_mode="none", moe_runner_backend="flashinfer_trtllm_routed"
         ),
     )
     @patch.object(
@@ -115,7 +115,7 @@ class TestGptOssEpWeightLoading(CustomTestCase):
     @patch.object(
         fused_moe_layer,
         "get_moe_runner_backend",
-        return_value=MoeRunnerBackend.FLASHINFER_TRTLLM,
+        return_value=MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
     )
     def test_flashinfer_constructor_keeps_logical_intermediate_size(self, *_):
         """Kernel allocation padding must not overwrite the logical MoE size."""

--- a/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
+++ b/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
@@ -1,0 +1,60 @@
+"""Unit tests for GPT-OSS expert-parallel checkpoint slicing."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.models.gpt_oss import _narrow_fused_moe_ep_weight
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestGptOssEpWeightLoading(CustomTestCase):
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_global_expert_weights_are_sliced_for_ep_rank(self, get_parallel):
+        """Global checkpoint experts must be narrowed to the current EP rank."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=4, moe_ep_rank=2)
+        weight = torch.arange(128 * 2).view(128, 2)
+
+        actual = _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+        torch.testing.assert_close(actual, weight[64:96])
+
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_ep_one_keeps_global_expert_weights(self, get_parallel):
+        """EP1 must preserve the checkpoint tensor without an unnecessary copy."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=1, moe_ep_rank=0)
+        weight = torch.arange(128 * 2).view(128, 2)
+
+        actual = _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+        self.assertIs(actual, weight)
+
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_local_expert_weights_are_not_sliced_again(self, get_parallel):
+        """Already-local checkpoint experts must not be narrowed a second time."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=4, moe_ep_rank=2)
+        weight = torch.arange(32 * 2).view(32, 2)
+
+        actual = _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+        self.assertIs(actual, weight)
+
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_invalid_expert_dimension_is_rejected(self, get_parallel):
+        """A checkpoint must contain either all experts or this rank's experts."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=4, moe_ep_rank=2)
+        weight = torch.arange(64 * 2).view(64, 2)
+
+        with self.assertRaisesRegex(
+            ValueError, "Expected 128 global or 32 local experts, got 64"
+        ):
+            _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_flashinfer_a2a_cp.py
+++ b/test/registered/unit/server_args/test_flashinfer_a2a_cp.py
@@ -1,7 +1,13 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from sglang.srt.arg_groups.overrides import resolved_view
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -93,6 +99,175 @@ class TestFlashInferA2APrefillCP(CustomTestCase):
             "full prefill context parallelism with attn_cp_size == tp_size",
         ):
             args._handle_a2a_moe()
+
+    def _breakable_args(
+        self,
+        *,
+        enable_prefill_cp: bool,
+        attn_cp_size: int,
+        cp_strategy: str,
+        attention_backend: str,
+        moe_a2a_backend: str,
+        moe_runner_backend: str,
+        architecture: str = "GptOssForCausalLM",
+    ) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.tp_size = 4
+        args.dp_size = 1
+        args.enable_dp_attention = False
+        args.enable_prefill_cp = enable_prefill_cp
+        args.attn_cp_size = attn_cp_size
+        args.cp_strategy = cp_strategy
+        args.attention_backend = attention_backend
+        args.prefill_attention_backend = None
+        args.decode_attention_backend = None
+        args.moe_a2a_backend = moe_a2a_backend
+        args.moe_runner_backend = moe_runner_backend
+        args.dcp_size = 1
+        args.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=[architecture]),
+            is_multimodal=False,
+            is_multimodal_breakable_cuda_graph_supported=False,
+        )
+        args.cuda_graph_config = CudaGraphConfig(
+            prefill=PhaseConfig(backend=Backend.BREAKABLE)
+        )
+        return args
+
+    def test_breakable_cuda_graph_support_truth_table(self):
+        cases = (
+            dict(
+                name="validated",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=True,
+                a2a_allowed=True,
+                graph_allowed=True,
+            ),
+            dict(
+                name="partial_cp",
+                enable_prefill_cp=True,
+                attn_cp_size=2,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=False,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="interleave",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="interleave",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=False,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="wrong_attention",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="flashinfer",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=False,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="other_a2a",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="deepep",
+                moe_runner_backend="deep_gemm",
+                cp_allowed=True,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="wrong_runner",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="triton",
+                cp_allowed=True,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="no_cp_no_a2a",
+                enable_prefill_cp=False,
+                attn_cp_size=1,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="none",
+                moe_runner_backend="triton",
+                cp_allowed=False,
+                a2a_allowed=True,
+                graph_allowed=True,
+            ),
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                kwargs = {
+                    key: value
+                    for key, value in case.items()
+                    if key
+                    not in {
+                        "name",
+                        "cp_allowed",
+                        "a2a_allowed",
+                        "graph_allowed",
+                    }
+                }
+                args = self._breakable_args(**kwargs)
+                self.assertEqual(
+                    args._supports_breakable_prefill_cp(), case["cp_allowed"]
+                )
+                self.assertEqual(
+                    args._supports_breakable_moe_a2a(), case["a2a_allowed"]
+                )
+                with patch.object(ServerArgs, "use_mla_backend", return_value=False):
+                    args._disable_breakable_cudagraph_if_incompatible()
+                self.assertEqual(
+                    args.cuda_graph_config.prefill.backend,
+                    (Backend.BREAKABLE if case["graph_allowed"] else Backend.DISABLED),
+                )
+
+    def test_breakable_cuda_graph_rejects_other_model_architectures(self):
+        args = self._breakable_args(
+            enable_prefill_cp=True,
+            attn_cp_size=4,
+            cp_strategy="zigzag",
+            attention_backend="trtllm_mha",
+            moe_a2a_backend="flashinfer",
+            moe_runner_backend="flashinfer_trtllm_routed",
+            architecture="LlamaForCausalLM",
+        )
+
+        self.assertFalse(args._supports_breakable_prefill_cp())
+        self.assertFalse(args._supports_breakable_moe_a2a())
+        with patch.object(ServerArgs, "use_mla_backend", return_value=False):
+            args._disable_breakable_cudagraph_if_incompatible()
+        self.assertEqual(
+            args.cuda_graph_config.prefill.backend,
+            Backend.DISABLED,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_flashinfer_a2a_cp.py
+++ b/test/registered/unit/server_args/test_flashinfer_a2a_cp.py
@@ -1,0 +1,99 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.arg_groups.overrides import resolved_view
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestFlashInferA2APrefillCP(CustomTestCase):
+    def _args(
+        self,
+        *,
+        enable_dp_attention: bool,
+        dp_size: int,
+        enable_prefill_cp: bool,
+        attn_cp_size: int,
+    ) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.tp_size = 4
+        args.dp_size = dp_size
+        args.enable_dp_attention = enable_dp_attention
+        args.enable_prefill_cp = enable_prefill_cp
+        args.attn_cp_size = attn_cp_size
+        args.moe_a2a_backend = "flashinfer"
+        args.moe_runner_backend = "flashinfer_trtllm_routed"
+        return args
+
+    def test_parallelism_support_truth_table(self):
+        for case in (
+            dict(
+                enable_dp_attention=True,
+                dp_size=4,
+                enable_prefill_cp=False,
+                attn_cp_size=1,
+                expected=True,
+            ),
+            dict(
+                enable_dp_attention=False,
+                dp_size=1,
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                expected=True,
+            ),
+            dict(
+                enable_dp_attention=False,
+                dp_size=1,
+                enable_prefill_cp=True,
+                attn_cp_size=2,
+                expected=False,
+            ),
+            dict(
+                enable_dp_attention=False,
+                dp_size=1,
+                enable_prefill_cp=False,
+                attn_cp_size=1,
+                expected=False,
+            ),
+        ):
+            with self.subTest(case=case):
+                args = self._args(**{k: v for k, v in case.items() if k != "expected"})
+                self.assertEqual(
+                    args._supports_flashinfer_a2a_parallelism(), case["expected"]
+                )
+
+    def test_handle_a2a_moe_admits_full_prefill_cp_with_routed_runner(self):
+        args = self._args(
+            enable_dp_attention=False,
+            dp_size=1,
+            enable_prefill_cp=True,
+            attn_cp_size=4,
+        )
+        args.get_model_config = lambda: SimpleNamespace(nvfp4_moe_meta=None)
+
+        args._handle_a2a_moe()
+
+        view = resolved_view(args)
+        self.assertEqual(view.moe_a2a_backend, "flashinfer")
+        self.assertEqual(view.moe_runner_backend, "flashinfer_trtllm_routed")
+
+    def test_handle_a2a_moe_rejects_partial_prefill_cp_with_diagnostic(self):
+        args = self._args(
+            enable_dp_attention=False,
+            dp_size=1,
+            enable_prefill_cp=True,
+            attn_cp_size=2,
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            "full prefill context parallelism with attn_cp_size == tp_size",
+        ):
+            args._handle_a2a_moe()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Support flashinfer a2a + trtllm routed moe runner for GPT-OSS-bf16
- Support Breakable Cuda Graph for Prefill CP zigzag strategy
- Fuse two attention calls in zigzag strategy into a single one

## Optimized CP4 + EP4 launch

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 \
SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK=65536 \
python3 -m sglang.launch_server \
  --model-path /scratch/models/gpt-oss-120b-bf16 \
  --host 127.0.0.1 --port 30000 \
  --tp 4 --ep 4 \
  --enable-prefill-cp --attn-cp-size 4 --cp-strategy zigzag \
  --moe-a2a-backend flashinfer \
  --moe-runner-backend flashinfer_trtllm_routed \
  --attention-backend trtllm_mha \
  --context-length 139264 \
  --chunked-prefill-size 139264 \
  --max-prefill-tokens 139264 \
  --mem-fraction-static 0.75 \
  --disable-decode-cuda-graph \
  --cuda-graph-backend-prefill breakable \
  --cuda-graph-bs-prefill 4096 65536 139264
  
  
  # TP4 baseline
 CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 \
python3 -m sglang.launch_server \
  --model-path /scratch/models/gpt-oss-120b-bf16 \
  --host 127.0.0.1 --port 30000 \
  --tp 4 \
  --attention-backend trtllm_mha \
  --context-length 139264 \
  --chunked-prefill-size 131072 \
  --max-prefill-tokens 131072 \
  --mem-fraction-static 0.75 \
  --disable-decode-cuda-graph \
  --cuda-graph-backend-prefill disabled
```


The 139264 prefill bucket is intentional for the benchmark client used below: its requested 131072 random token IDs are decoded to text and retokenized by the server as 134848 tokens. Keeping that request in one prefill wave removed the extra 3776-token scheduler wave, especially helping concurrency 4.

## Benchmark

Hardware: 4x NVIDIA GB300 on `baizhou-dev`.
Model: `lmsys/gpt-oss-120b-bf16`.
Workload: random-ids, requested ISL 131072, OSL 1000, seed 42, concurrency 1 and 4, warmup 0. Every measurement used an explicit `/flush_cache` call.

Acceptance method: five paired TP4/CP4+EP4 measurements with alternating order; compare the median of each run's mean TTFT and require a majority of pair wins.

| Concurrency | CP TTFT median | TP TTFT median | CP delta | CP pair wins |
| --- | ---: | ---: | ---: | ---: |
| 1 | 1649.63 ms | 1811.61 ms | -8.94% | 4/5 |
| 4 | 3664.59 ms | 4139.23 ms | -11.47% | 5/5 |


Another round:
| Concurrency | CP TTFT median | TP TTFT median | CP delta | CP pair wins | CP TPOT median | TP TPOT median |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1610.10 ms | 1752.89 ms | -8.15% | 3/5 | 54.55 ms | 78.48 ms |
| 4 | 3696.80 ms | 4107.95 ms | -10.01% | 5/5 | 54.52 ms | 79.95 ms |


TPOT was not the target, but remained lower on CP4+EP4 (roughly 52–57 ms versus 80–85 ms in these runs).

The single-call attention profile reduced the per-rank TRT-LLM context-attention kernel count from 72 to 36 (288 to 144 across four ranks). Breakable graph replay passed at 4K, 64K, and 128K with `cuda graph: True`.

## GPQA

CP4+EP4 was evaluated with all 198 examples, `reasoning-effort=high`, and a 131072-token generation cap:

```bash
python3 -m sglang.test.run_eval --host 127.0.0.1 --port 30000 --model /scratch/models/gpt-oss-120b-bf16 --eval-name gpqa --num-examples 198 --num-threads 198 --max-tokens 131072 --temperature 0.1 --reasoning-effort high
```

Result: `gpqa_score=0.6868686868686869` (136/198), completed in 1:39:41.



\n

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30429743726](https://github.com/sgl-project/sglang/actions/runs/30429743726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30429743694](https://github.com/sgl-project/sglang/actions/runs/30429743694)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->