### PR TITLE
[DWDP] Lazy-import cuda.bindings to fix crash on non-CUDA platforms

### DIFF
--- a/python/sglang/srt/layers/moe/dwdp/transport.py
+++ b/python/sglang/srt/layers/moe/dwdp/transport.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
-from cuda.bindings import driver as cuda
 
 from sglang.srt.distributed.device_communicators.vmm_utils import (
     check_drv,
@@ -76,6 +75,7 @@ def _copy_local_weights_to_handles(
         set_access(temp_va, phys_size, device_id)
 
         nbytes = param.numel() * param.element_size()
+        from cuda.bindings import driver as cuda  # CUDA-only; imported lazily to avoid crash on non-CUDA platforms
         check_drv(
             cuda.cuMemcpyDtoD(temp_va + data_offset, param.data_ptr(), nbytes),
             "cuMemcpyDtoD",

--- a/python/sglang/srt/layers/moe/dwdp/vmm.py
+++ b/python/sglang/srt/layers/moe/dwdp/vmm.py
@@ -8,7 +8,6 @@ import logging
 from typing import Tuple
 
 import torch
-from cuda.bindings import driver as cuda
 
 from sglang.srt.distributed.device_communicators.vmm_utils import (
     check_drv,
@@ -16,6 +15,42 @@ from sglang.srt.distributed.device_communicators.vmm_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _LazyCudaDriver:
+    """Proxy for cuda.bindings.driver that defers the import until first use.
+
+    DWDP is CUDA/NVLink-only, but vmm.py sits on an import chain that is
+    resolved on every platform (layout.py imports align_up/align_down from
+    here).  A top-level ``from cuda.bindings import driver`` crashes on XPU,
+    CPU, and ROCm builds where cuda-python is absent, even though no VMM
+    symbol is ever referenced on those platforms.  This proxy defers the
+    import to the first attribute access so non-CUDA platforms can load the
+    module safely.
+    """
+
+    __slots__ = ("_mod",)
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "_mod", None)
+
+    def __getattr__(self, name: str):
+        mod = object.__getattribute__(self, "_mod")
+        if mod is None:
+            try:
+                from cuda.bindings import driver as _d
+            except ImportError as exc:
+                raise ImportError(
+                    "DWDP requires cuda-python >= 13.0. "
+                    "Install it with: pip install 'cuda-python>=13.0'. "
+                    "This feature is only supported on CUDA platforms."
+                ) from exc
+            object.__setattr__(self, "_mod", _d)
+            mod = _d
+        return getattr(mod, name)
+
+
+cuda = _LazyCudaDriver()
 
 
 def align_up(value: int, alignment: int) -> int:


### PR DESCRIPTION
## Problem

`vmm.py` has a top-level `from cuda.bindings import driver as cuda` that is triggered on **every** ModelRunner init via the import chain:

```
dwdp/__init__.py → dwdp_manager.py → layout.py → vmm.py → cuda.bindings
```

On XPU, CPU, and ROCm builds where `cuda-python` is not installed, this raises `ModuleNotFoundError: No module named 'cuda'` even when `dwdp_size <= 1` (the fast-path that skips all VMM usage). The `model_runner.py` guard around `DwdpManager` import is already lazy, but the module-level import in `vmm.py` fires the moment `layout.py` is imported transitively.

Reported in #31995.

## Fix

**`vmm.py`** — replace the top-level import with a `_LazyCudaDriver` proxy that defers `from cuda.bindings import driver` until the first attribute access:

```python
class _LazyCudaDriver:
    __slots__ = ("_mod",)

    def __init__(self) -> None:
        object.__setattr__(self, "_mod", None)

    def __getattr__(self, name: str):
        mod = object.__getattribute__(self, "_mod")
        if mod is None:
            try:
                from cuda.bindings import driver as _d
            except ImportError as exc:
                raise ImportError(
                    "DWDP requires cuda-python >= 13.0. "
                    "Install it with: pip install 'cuda-python>=13.0'. "
                    "This feature is only supported on CUDA platforms."
                ) from exc
            object.__setattr__(self, "_mod", _d)
            mod = _d
        return getattr(mod, name)

cuda = _LazyCudaDriver()
```

All 23 existing `cuda.X` call sites in `vmm.py` are unchanged — the proxy's `__getattr__` delegates transparently.

**`transport.py`** — the single `cuda.cuMemcpyDtoD` usage is moved to a local import inside `_copy_local_weights_to_handles`, the only function that needs it.

## Behavior after fix

| Platform | `layout.py` import | `vmm.align_up/align_down` | DWDP init |
|---|---|---|---|
| Non-CUDA (XPU/CPU/ROCm) | ✅ no crash | ✅ pure Python | ❌ clear error at first VMM call |
| CUDA without cuda-python | ✅ no crash | ✅ pure Python | ❌ clear error at first VMM call |
| CUDA with cuda-python | ✅ | ✅ | ✅ unchanged |

The error message on non-CUDA platforms is now explicit and actionable instead of a bare `ModuleNotFoundError`.

## Testing

- Confirmed: `vmm.py` module loads and `align_up`/`align_down` return correct values when `cuda.bindings` is absent (mocked `ImportError` in test harness)
- Confirmed: proxy raises `ImportError: DWDP requires cuda-python >= 13.0` on first attribute access when `cuda.bindings` is absent
- Existing DWDP functionality is unaffected (proxy delegates transparently via `__getattr__`)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30417124158](https://github.com/sgl-project/sglang/actions/runs/30417124158)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30417124043](https://github.com/sgl-project/sglang/actions/runs/30417124043)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->