### PR TITLE
[sglang-miles] Back up the CUDA graph pool across TMS pause/resume

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/full_cuda_graph_backend.py
@@ -103,6 +103,10 @@ class FullCudaGraphBackend(BaseCudaGraphBackend):
             graph_ctx = partial(
                 self._memory_saver_adapter.cuda_graph,
                 tag=GPU_MEMORY_TYPE_CUDA_GRAPH,
+                # The pool holds capture-time-initialized device state that replays
+                # read but never rewrite, so pausing must preserve the pool contents
+                # instead of discarding them.
+                enable_cpu_backup=True,
             )
         else:
             graph_ctx = self._device_module.graph


### PR DESCRIPTION
## Motivation

In colocated RL, engines sleep/wake via `torch_memory_saver`, and `release_memory_occupation` pauses the `cuda_graph` region. TMS pause discards page contents, but the CUDA graph private pool holds capture-time-initialized device state that replays read and never rewrite (kernel workspace metadata, scheduler counters). After resume the pool comes back with undefined contents, and replays consume garbage — surfacing as nondeterministic device-side crashes (`CUDA error: misaligned address`) within a few RL steps. Backends whose kernels keep no cross-launch device state (e.g. triton) are unaffected; bare servers never pause and never crash.

Root-caused by tag ablation: keeping the graph pool resident across sleep/wake eliminates the crashes; releasing it reproduces them on the first cycle.

## Modifications

Pass `enable_cpu_backup=True` at the TMS CUDA graph capture site, so pause backs the pool up to host and resume restores its contents. One-line change plus a comment.

## Accuracy Tests

No numeric change: the pool contents are restored bit-exact; behavior without sleep/wake is untouched.

## Speed Tests and Profiling

Measured pool size ~0.8 GB per rank (GLM-4.7-Flash, trtllm_mla). The host round-trip adds milliseconds per phase switch and ~0.8 GB host RAM per rank; steady-state serving is unaffected. With the fix, an RL workload that previously crashed within its first sleep/wake cycle runs multiple full cycles cleanly.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30493039455](https://github.com/sgl-project/sglang/actions/runs/30493039455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30493039521](https://github.com/sgl-project/sglang/actions/runs/30493039521)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->