### PR TITLE
[FPM] Guard seq_lens_cpu=None in decode batch forward-pass metrics

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -280,8 +280,12 @@ class SchedulerMetricsReporter:
             for req in batch.decoding_reqs or []:
                 decode_kv.add(req.seqlen)
         elif batch.forward_mode.is_decode():
-            for sl in batch.seq_lens_cpu:
-                decode_kv.add(int(sl))
+            if batch.seq_lens_cpu is not None:
+                for sl in batch.seq_lens_cpu:
+                    decode_kv.add(int(sl))
+            else:
+                for req in batch.reqs:
+                    decode_kv.add(req.seqlen)
 
         return ScheduledRequestMetrics(
             num_prefill_requests=num_prefill_requests,


### PR DESCRIPTION
## Problem

`_build_scheduled_request_metrics` crashes with `TypeError: 'NoneType' object is not iterable` when forward-pass metrics are enabled on a deployment using `--enable-dp-attention` + `--enable-mixed-chunk`.

The crash is at `metrics_reporter.py:283`:
```python
elif batch.forward_mode.is_decode():
    for sl in batch.seq_lens_cpu:   # TypeError when seq_lens_cpu is None
```

`ScheduleBatch.merge_batch()` explicitly nulls `seq_lens_cpu` whenever either operand lacks a CPU tensor:
```python
if self.seq_lens_cpu is None or other.seq_lens_cpu is None:
    self.seq_lens_cpu = None
```

This is a valid, expected state for decode batches produced by the dp-attention + mixed-chunk path, so the crash surfaces in production under normal load.

Fixes #31309.

## Fix

Mirror the existing `_decode_total_seq_lens` helper (line 49 of the same file), which already handles the `None` case with a `req.seqlen` fallback:

```python
elif batch.forward_mode.is_decode():
    if batch.seq_lens_cpu is not None:
        for sl in batch.seq_lens_cpu:
            decode_kv.add(int(sl))
    else:
        for req in batch.reqs:
            decode_kv.add(req.seqlen)
```

## Testing

- Crash is deterministic with `--enable-dp-attention --enable-mixed-chunk --enable-forward-pass-metrics` under the configuration in #31309.
- Fix is a guard around an existing iteration; no logic changes on the happy path where `seq_lens_cpu` is populated.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30419219302](https://github.com/sgl-project/sglang/actions/runs/30419219302)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30419219172](https://github.com/sgl-project/sglang/actions/runs/30419219172)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->