### PR TITLE
Fix glm47 parser dropping the outer } on object-valued final arguments

### DIFF
--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -613,8 +613,9 @@ class Glm47MoeDetector(BaseFormatDetector):
             self._last_arguments += "{}"
             self.streamed_args_for_tool[self.current_tool_id] += "{}"
             self._sent_empty_object = True
-        elif not self._last_arguments.endswith("}") and not self._sent_empty_object:
-            # Need to close brace
+        elif not self._sent_empty_object:
+            # The converter opens the outer argument object but never closes it,
+            # and a trailing `}` may belong to an object-valued final argument.
             calls.append(
                 ToolCallItem(
                     tool_index=self.current_tool_id,

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -3137,6 +3137,43 @@ class TestGlm47MoeDetector(unittest.TestCase):
         ]
         self.detector = Glm47MoeDetector()
 
+    @staticmethod
+    def _make_tool(properties, required, name="set_options"):
+        return Tool(
+            type="function",
+            function=Function(
+                name=name,
+                description="Regression-test tool",
+                parameters={
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+            ),
+        )
+
+    @staticmethod
+    def _stream_source(tools, source):
+        calls = {}
+        detector = Glm47MoeDetector()
+        for chunk in source:
+            result = detector.parse_streaming_increment(chunk, tools)
+            for call in result.calls:
+                item = calls.setdefault(call.tool_index, {"name": "", "parameters": ""})
+                if call.name:
+                    item["name"] = call.name
+                item["parameters"] += call.parameters
+        return calls
+
+    def _stream_call(self, tool, arguments):
+        source = [f"<tool_call>{tool.function.name}"]
+        source.extend(
+            f"<arg_key>{key}</arg_key><arg_value>{value}</arg_value>"
+            for key, value in arguments
+        )
+        source.append("</tool_call>")
+        return self._stream_source([tool], "".join(source))[0]
+
     def test_multiple_tool_calls(self):
         text = (
             "<tool_call>get_weather"
@@ -3194,6 +3231,128 @@ class TestGlm47MoeDetector(unittest.TestCase):
         self.assertEqual(tool_calls[1]["name"], "get_weather")
         self.assertEqual(
             tool_calls[1]["parameters"], '{"city": "Shanghai", "date": "2024-06-28"}'
+        )
+
+    def test_streaming_object_final_argument_closes_outer_object(self):
+        object_tool = self._make_tool(
+            {
+                "mode": {"type": "string"},
+                "options": {"type": "object"},
+            },
+            ["mode", "options"],
+        )
+        single_object_tool = self._make_tool(
+            {"options": {"type": "object"}}, ["options"]
+        )
+        cases = [
+            (
+                "object-valued final argument",
+                object_tool,
+                [("mode", "fast"), ("options", '{"topic":"t"}')],
+                {"mode": "fast", "options": {"topic": "t"}},
+            ),
+            (
+                "nested object final argument",
+                object_tool,
+                [
+                    ("mode", "fast"),
+                    ("options", '{"topic":"t","meta":{"attempt":1}}'),
+                ],
+                {
+                    "mode": "fast",
+                    "options": {"topic": "t", "meta": {"attempt": 1}},
+                },
+            ),
+            (
+                "empty object final argument",
+                object_tool,
+                [("mode", "fast"), ("options", "{}")],
+                {"mode": "fast", "options": {}},
+            ),
+            (
+                "single object argument",
+                single_object_tool,
+                [("options", '{"nested":{"ok":true}}')],
+                {"options": {"nested": {"ok": True}}},
+            ),
+        ]
+
+        for name, tool, arguments, expected in cases:
+            with self.subTest(name=name):
+                call = self._stream_call(tool, arguments)
+                self.assertEqual(call["name"], tool.function.name)
+                self.assertEqual(json.loads(call["parameters"]), expected)
+                self.assertTrue(call["parameters"].endswith("}}"))
+
+    def test_streaming_finalizer_preserves_unaffected_argument_shapes(self):
+        cases = [
+            (
+                "scalar final argument",
+                self._make_tool(
+                    {
+                        "options": {"type": "object"},
+                        "mode": {"type": "string"},
+                    },
+                    ["options", "mode"],
+                ),
+                [("options", '{"topic":"t"}'), ("mode", "fast")],
+                {"options": {"topic": "t"}, "mode": "fast"},
+                '"}',
+            ),
+            (
+                "array final argument",
+                self._make_tool(
+                    {"items": {"type": "array"}}, ["items"], name="collect"
+                ),
+                [("items", '[{"n":1},{"n":2}]')],
+                {"items": [{"n": 1}, {"n": 2}]},
+                "]}",
+            ),
+            (
+                "no arguments",
+                self._make_tool({}, [], name="noop"),
+                [],
+                {},
+                "{}",
+            ),
+        ]
+
+        for name, tool, arguments, expected, suffix in cases:
+            with self.subTest(name=name):
+                call = self._stream_call(tool, arguments)
+                self.assertEqual(json.loads(call["parameters"]), expected)
+                self.assertTrue(call["parameters"].endswith(suffix))
+
+    def test_streaming_finalizer_resets_between_calls(self):
+        noop = self._make_tool({}, [], name="noop")
+        set_options = self._make_tool(
+            {
+                "mode": {"type": "string"},
+                "options": {"type": "object"},
+            },
+            ["mode", "options"],
+        )
+        source = (
+            "<tool_call>noop</tool_call>"
+            "<tool_call>set_options"
+            "<arg_key>mode</arg_key><arg_value>fast</arg_value>"
+            '<arg_key>options</arg_key><arg_value>{"topic":"first"}</arg_value>'
+            "</tool_call>"
+            "<tool_call>set_options"
+            "<arg_key>mode</arg_key><arg_value>fast</arg_value>"
+            '<arg_key>options</arg_key><arg_value>{"topic":"second"}</arg_value>'
+            "</tool_call>"
+        )
+        calls = self._stream_source([noop, set_options], source)
+
+        self.assertEqual(sorted(calls), [0, 1, 2])
+        self.assertEqual(
+            [json.loads(calls[index]["parameters"]) for index in range(3)],
+            [
+                {},
+                {"mode": "fast", "options": {"topic": "first"}},
+                {"mode": "fast", "options": {"topic": "second"}},
+            ],
         )
 
     def test_tool_call_id(self):


### PR DESCRIPTION
## Motivation

`_process_xml_to_json_streaming()` emits the outer `{` of the argument object on the first parameter, but it never emits a matching `}`. Every other brace it writes comes from `json.dumps()` of an argument *value*. Closing the outer object is therefore solely `_finalize_tool_call()`'s job.

Today the finalizer skips that close whenever the accumulated argument text already ends in `}`:

```python
elif not self._last_arguments.endswith("}") and not self._sent_empty_object:
```

That suffix test conflates *the close of an object-valued final argument* with *the close of the outer argument object*. When the last argument is itself an object, the trailing `}` belongs to that argument, so the finalizer concludes the outer object is already closed and skips it:

| final argument | streamed on `main` | with this PR |
|---|---|---|
| object-valued | `{"mode": "fast", "options": {"topic": "t"}` — **outer `}` missing, invalid JSON** | `{"mode": "fast", "options": {"topic": "t"}}` |
| scalar | `{"options": {"topic": "t"}, "mode": "fast"}` — valid | identical, unchanged |

As a result, agent frameworks can reject otherwise-correct tool calls whenever the final argument is object-valued.

## Modifications

Drop the suffix heuristic; close the outer object whenever it is still open.

`not self._sent_empty_object` is sufficient here. Reaching this branch already excludes the "no parameters seen yet" case, so if `_sent_empty_object` is false at this point, at least one parameter has been streamed and the outer object is open. Equivalently, at this branch `not _sent_empty_object` implies `not _is_first_param` — which is why the latter is not spelled out in the condition.

The state invariants this rests on:

- `_is_first_param` is cleared exactly when the outer `{` is appended (`json_output += "{" if self._is_first_param else ", "`).
- `_sent_empty_object` is set only on paths that have already emitted a complete empty `{}` object, so if it is false in this branch, the non-empty outer object still needs its closing `}`.
- `_reset_streaming_state()` resets these flags together after each finalized tool call, so they cannot drift apart between calls.

**Scope.** Only final arguments whose serialization ends in `}` are affected — object values, including empty and nested ones. Arrays, numbers and strings (which end in `"` even when the text inside ends in `}`) are byte-identical before and after, and the no-argument `{}` path is untouched.

This PR extends the existing `TestGlm47MoeDetector` suite in `test/registered/unit/function_call/test_function_call_parser.py`. Three grouped regression tests cover the nine scenarios below; six of them fail on `main` and pass with this PR:

| case | `main` | this PR |
|---|---|---|
| object-valued final argument | ✗ | ✓ |
| empty object `{}` as final value | ✗ | ✓ |
| nested object final | ✗ | ✓ |
| single object argument | ✗ | ✓ |
| two object-final calls in one response | ✗ | ✓ |
| no-arg call followed by object-final call | ✗ | ✓ |
| scalar final | ✓ | ✓ |
| array final (asserts no over-close) | ✓ | ✓ |
| no-argument tool → `{}` | ✓ | ✓ |

Note: #24147 is open against the same file. It fixes a different bug in a different function, where a closing tag is dropped when a value ends with `<`, and does not overlap textually with this change.

## Accuracy Tests

Not applicable — this changes only the JSON framing of streamed tool-call arguments, never model outputs. No kernel or model forward code is touched.

## Speed Tests and Profiling

Not applicable — the change removes one string comparison from a path that runs once per tool call.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30505650747](https://github.com/sgl-project/sglang/actions/runs/30505650747)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30505650600](https://github.com/sgl-project/sglang/actions/runs/30505650600)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->