### PR TITLE
[RED regression] Test GLM-5.2 PD + DP attention + MTP

### DIFF
--- a/test/registered/disaggregation/test_glm52_nvfp4_pd_dpa_mtp.py
+++ b/test/registered/disaggregation/test_glm52_nvfp4_pd_dpa_mtp.py
@@ -1,0 +1,125 @@
+import os
+import unittest
+
+import requests
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+)
+
+register_cuda_ci(
+    est_time=7200,
+    suite="nightly-4-gpu-gb300-glm5-nvfp4",
+    nightly=True,
+)
+
+MODEL_PATH = "nvidia/GLM-5.2-NVFP4"
+
+COMMON_ARGS = [
+    "--trust-remote-code",
+    "--reasoning-parser=glm45",
+    "--tool-call-parser=glm47",
+    "--quantization=modelopt_fp4",
+    "--moe-runner-backend=flashinfer_trtllm",
+]
+
+DP_MTP_ARGS = [
+    "--dp-size=2",
+    "--enable-dp-attention",
+    "--speculative-algorithm=EAGLE",
+    "--speculative-num-steps=1",
+    "--speculative-eagle-topk=1",
+    "--speculative-num-draft-tokens=2",
+]
+
+
+class TestGlm52Nvfp4PdDpaMtp(PDDisaggregationServerBase):
+    """Regression coverage for GLM-5.2 PD + DP attention + MTP."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        os.environ["SGLANG_MOONCAKE_CUSTOM_MEM_POOL"] = "true"
+        os.environ["MC_FORCE_MNNVL"] = "true"
+        cls.model = MODEL_PATH
+
+        cls.start_prefill()
+        cls.start_decode()
+
+        cls.wait_server_ready(cls.prefill_url + "/health", process=cls.process_prefill)
+        cls.wait_server_ready(cls.decode_url + "/health", process=cls.process_decode)
+
+        cls.launch_lb()
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.pop("SGLANG_MOONCAKE_CUSTOM_MEM_POOL")
+        os.environ.pop("MC_FORCE_MNNVL")
+        super().tearDownClass()
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = COMMON_ARGS + [
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "2",
+        ]
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = (
+            COMMON_ARGS
+            + [
+                "--disaggregation-mode",
+                "decode",
+                "--disaggregation-bootstrap-port",
+                cls.bootstrap_port,
+                "--tp",
+                "2",
+                "--base-gpu-id",
+                "2",
+            ]
+            + DP_MTP_ARGS
+        )
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+        )
+
+    def test_first_routed_request_completes(self):
+        response = requests.post(
+            self.lb_url + "/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 16},
+            },
+            timeout=60,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        data = response.json()
+        self.assertIn("text", data, f"Unexpected response shape: {data}")
+        self.assertIsInstance(data["text"], str)
+        self.assertTrue(data["text"].strip(), "Generated text should not be empty")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Status: intentionally RED on current `main`

This draft adds regression coverage for #32209. The first routed request is expected to hang on current `main` because the fix has not merged. This test should land together with, or after, #32209; it is not presented as a currently passing test.

## Coverage added

The new nightly case starts `nvidia/GLM-5.2-NVFP4` as a real 2+2 PD deployment on four GB300 GPUs:

- prefill: TP2 on GPUs 0-1;
- decode: TP2, DP2 attention, and one-step EAGLE MTP on GPUs 2-3;
- assertion: one routed `/generate` request must return non-empty text within 60 seconds.

The existing four-GPU disaggregation test already exercises a real TP2+TP2 PD topology, but with Qwen3-8B and without DP attention or speculative decoding. The existing GLM-5.2 NVFP4 nightly test exercises DP attention plus MTP, but only in aggregated TP4 deployments. This case covers the missing intersection: GLM-5.2 + PD disaggregation + DP attention + MTP.

A related earlier discussion attributed this gap to missing multi-GPU CI. The `4-gpu-gb300` runner does exist, and the disaggregation group already runs on it. The actionable coverage gap is the split described above: each existing test covers one side of the matrix, while neither covers their intersection.

## CI placement

This test reuses `suite="nightly-4-gpu-gb300-glm5-nvfp4"`, `nightly=True`, and its existing 7200-second estimate. GLM-5.2 NVFP4 has large weights and an existing dedicated GB300 nightly, so placing this in the 300-second `base-c` PR gate would not be appropriate. Reusing 7200 seconds is a suite-budget choice inherited from the existing test, not a measured runtime claim for this new case.

## Unverified memory-fit prerequisite

We have **not** verified that `nvidia/GLM-5.2-NVFP4` starts at TP2 on two GB300 GPUs. The existing nightly uses TP4, while this four-GPU PD topology requires two independent TP2 instances. No on-hardware execution is claimed here.

If TP2 does not fit, the topology should move to an eight-GPU runner with TP4 prefill + TP4 decode instead of weakening the DP/MTP condition.

## Validation

- Repository pre-commit hooks pass for the new file, including the registered-test registry validator.
- Python syntax compilation passes.
- The GPU integration test was not run locally; on current `main`, its routed request is expected to reproduce #32209 and time out.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30422056388](https://github.com/sgl-project/sglang/actions/runs/30422056388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30422056273](https://github.com/sgl-project/sglang/actions/runs/30422056273)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->