### PR TITLE
perf(hicache): proactively finalize completed prefetch at scheduler safe point

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1450,6 +1450,7 @@ class HiRadixCache(RadixCache):
         self.loading_check()
         if self.enable_storage:
             self.drain_storage_control_queues()
+            self.check_ready_prefetch_progress()
         if self.enable_storage_metrics:
             self.storage_metrics_collector.log_storage_metrics(
                 self.cache_controller.storage_backend.get_stats()
@@ -1540,6 +1541,49 @@ class HiRadixCache(RadixCache):
         cc.prefetch_tokens_occupied = max(
             0, cc.prefetch_tokens_occupied - len(prefetch_key)
         )
+
+    def _can_check_prefetch_progress_proactively(
+        self, operation: PrefetchOperation
+    ) -> bool:
+        if operation.host_indices is None or operation.is_terminated():
+            return True
+
+        if (
+            len(operation.hash_value) > 0
+            and operation.completed_tokens
+            == len(operation.hash_value) * self.page_size
+        ):
+            return True
+
+        return self.prefetch_stop_policy == "timeout" and self.is_prefetch_timeout(
+            operation
+        )
+
+    def check_ready_prefetch_progress(self):
+        """
+        Finalize prefetches that have already finished IO at the scheduler safe point.
+
+        The normal waiting-queue scan still checks each request before admission. This
+        proactive path only decouples scheduler_ready confirmation from FCFS
+        waiting-queue position; admission into the prefill batch is unchanged.
+        """
+        if not self.ongoing_prefetch:
+            return
+
+        # Sort by req_id so every rank evaluates candidates in the same order.
+        candidates = sorted(self.ongoing_prefetch.items(), key=lambda item: item[0])
+        local_ready = torch.tensor(
+            [
+                int(self._can_check_prefetch_progress_proactively(operation))
+                for _, (_, _, operation) in candidates
+            ],
+            dtype=torch.int,
+        )
+        self._all_reduce_attn_groups(local_ready, torch.distributed.ReduceOp.MIN)
+
+        for (req_id, _), ready in zip(candidates, local_ready.tolist()):
+            if ready and req_id in self.ongoing_prefetch:
+                self.check_prefetch_progress(req_id)
 
     def check_prefetch_progress(self, req_id: str) -> bool:
         if req_id not in self.ongoing_prefetch:


### PR DESCRIPTION
# perf(hicache): proactively finalize completed prefetch at scheduler safe point

## Motivation

Fixes #32724

With HiCache + a storage backend (L3, e.g. Mooncake), a storage prefetch is only finalized when the scheduler's FCFS waiting-queue scan reaches that request and calls `check_prefetch_progress(rid)`. When the prefill token budget is saturated by requests at the head of the queue, an IO-completed prefetch deep in the queue is not confirmed until the scan finally reaches its rid — the *scheduler_ready* confirmation lags IO completion by up to seconds (observed: IO ~91 ms vs. ~2.4 s scheduler-side delay under high concurrency, see the linked issue). The stale `ongoing_prefetch` entries also keep host memory and `prefetch_tokens_occupied` budget pinned longer than necessary.

This PR decouples the finalization confirmation from the FCFS waiting-queue position by proactively finalizing ready prefetches at an existing scheduler safe point. Scheduling semantics are unchanged: admission into the prefill batch is still governed by waiting queue order, batch size, token budget, and chunked prefill exactly as before.

## Modifications

All changes are in `python/sglang/srt/mem_cache/hiradix_cache.py` (+44 lines, no behavior change outside the storage-enabled path):

1. New `_can_check_prefetch_progress_proactively(operation)` — a cheap, local readiness check that mirrors the states `can_terminate_prefetch()` already treats as terminal:
   - `operation.host_indices is None` or `operation.is_terminated()`;
   - IO complete: `completed_tokens == len(hash_value) * page_size` (same completion
     predicate as `can_terminate_prefetch`);
   - under `prefetch_stop_policy == "timeout"`, `is_prefetch_timeout(operation)`.

2. New `check_ready_prefetch_progress()` — at the scheduler safe point, scans `ongoing_prefetch` and calls the existing `check_prefetch_progress(req_id)` for requests that are ready on **all** ranks:
   - candidates are sorted by `req_id` so every rank evaluates them in the same order;
   - the per-candidate local readiness vector is combined with a
     `ReduceOp.MIN` all-reduce over the ATTN TP/CP groups
     (`_all_reduce_attn_groups`), so a request is only finalized when every rank
     agrees it is ready — no rank can diverge on the finalized set;
   - the actual finalization still goes through `check_prefetch_progress()` /
     `can_terminate_prefetch()`, which performs its own cross-rank synchronization,
     so this proactive path adds no new termination semantics.

3. Call site: in `check_hicache_events()`, inside the `if self.enable_storage:` branch, `check_ready_prefetch_progress()` is invoked right after `drain_storage_control_queues()`. All ranks reach this point together, making it a safe point for the collective above.

The proactive path only moves the *scheduler_ready* confirmation earlier; it does not admit any request into the prefill batch, reorder the waiting queue, or change any prefetch termination policy.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
      (The change is exercised by existing hierarchical-cache storage tests, e.g.
      `test/registered/hicache/`; a targeted unit test for
      `check_ready_prefetch_progress` can be added on request.)
- [x] Update documentation / docstrings as needed (new method carries a docstring; no
      user-facing behavior change, so no doc update required).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as
      needed (io-done → scheduler-ready gap reduced from ~2.4 s to the next
      `check_hicache_events()` round in our 4P1D Mooncake deployment; details in the
      linked issue).
