### PR TITLE
fix(relay): skip user stop checks during reasoning phase and report correct Anthropic stop_reason

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -71,6 +71,30 @@ STOP_REASON_MAP = {
     "tool_calls": "tool_use",
 }
 
+
+def _resolve_stop_reason_and_sequence(
+    finish_reason: Optional[str], matched_stop: Union[None, int, str]
+) -> tuple[str, Optional[str]]:
+    """Map an OpenAI finish_reason + matched_stop to an Anthropic
+    (stop_reason, stop_sequence) pair.
+
+    sglang's OpenAI adapter carries the matched stop in ``matched_stop``: a
+    ``str`` means a user ``stop`` / ``stop_sequences`` string matched; an
+    ``int`` or ``None`` means an EOS / system stop token. Only the former is a
+    genuine Anthropic ``stop_sequence`` — otherwise ``end_turn`` (or the
+    mapped reason for length / tool_use) is correct. Without this, every stop
+    match (including user stop_sequences) is reported as ``end_turn`` because
+    the engine flattens both into OpenAI ``finish_reason="stop"``.
+    """
+    if matched_stop is not None and isinstance(matched_stop, str):
+        return "stop_sequence", matched_stop
+    if finish_reason not in STOP_REASON_MAP:
+        logger.warning(
+            "Unmapped OpenAI finish_reason %r; defaulting to end_turn",
+            finish_reason,
+        )
+    return STOP_REASON_MAP.get(finish_reason or "stop", "end_turn"), None
+
 ERROR_TYPE_MAP = {
     400: "invalid_request_error",
     401: "authentication_error",
@@ -827,6 +851,7 @@ class AnthropicServing:
         content_block_type: Optional[str] = None
         captured_thinking_signature: str = ""
         finish_reason: Optional[str] = None
+        matched_stop: Union[None, int, str] = None
         final_usage: Optional[AnthropicUsage] = None
         message_started = False
         had_content_delta = False
@@ -1040,18 +1065,18 @@ class AnthropicServing:
                 for event in _close_content_block_events():
                     yield _emit(event)
 
-                # Emit message_delta with stop_reason and usage
-                effective_finish = finish_reason or "stop"
-                if effective_finish not in STOP_REASON_MAP:
-                    logger.warning(
-                        "Unmapped streaming finish_reason %r; defaulting "
-                        "to end_turn",
-                        effective_finish,
-                    )
-                stop_reason = STOP_REASON_MAP.get(effective_finish, "end_turn")
+                # Emit message_delta with stop_reason and usage. Distinguish
+                # user stop_sequences hits (matched_stop is a str) from EOS so
+                # the Anthropic stop_reason is accurate.
+                stop_reason, stop_sequence = _resolve_stop_reason_and_sequence(
+                    finish_reason, matched_stop
+                )
                 yield _emit(
                     MessageDeltaEvent(
-                        delta=AnthropicMessageEndDelta(stop_reason=stop_reason),
+                        delta=AnthropicMessageEndDelta(
+                            stop_reason=stop_reason,
+                            stop_sequence=stop_sequence,
+                        ),
                         usage=final_usage or AnthropicUsage(output_tokens=0),
                     )
                 )
@@ -1114,6 +1139,9 @@ class AnthropicServing:
             # one-token reply. Fall through to the delta handlers below.
             if choice.finish_reason is not None:
                 finish_reason = choice.finish_reason
+                # Capture matched_stop (str = user stop_sequences hit) to
+                # report an accurate Anthropic stop_reason downstream.
+                matched_stop = getattr(choice, "matched_stop", None)
 
             delta = choice.delta
 
@@ -1282,14 +1310,11 @@ class AnthropicServing:
                     )
                 )
 
-        # Map stop reason
-        finish_reason = choice.finish_reason or "stop"
-        if finish_reason not in STOP_REASON_MAP:
-            logger.warning(
-                "Unmapped OpenAI finish_reason %r; defaulting to end_turn",
-                finish_reason,
-            )
-        stop_reason = STOP_REASON_MAP.get(finish_reason, "end_turn")
+        # Map stop reason. Distinguish user stop_sequences hits (matched_stop
+        # is a str) from natural EOS so the Anthropic stop_reason is accurate.
+        stop_reason, stop_sequence = _resolve_stop_reason_and_sequence(
+            choice.finish_reason, getattr(choice, "matched_stop", None)
+        )
 
         # Anthropic requires ``content`` to contain at least one block.
         # Empty string completions (max_tokens=1 stop, content filter, etc.)
@@ -1302,6 +1327,7 @@ class AnthropicServing:
             content=content,
             model=response.model,
             stop_reason=stop_reason,
+            stop_sequence=stop_sequence,
             usage=_anthropic_usage_from_openai(
                 response.usage,
                 include_input=True,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1373,7 +1373,9 @@ class Req(ReqDllmMixin):
 
         return False
 
-    def _check_token_based_finish(self, new_accepted_tokens: List[int]) -> bool:
+    def _check_token_based_finish(
+        self, new_accepted_tokens: List[int], skip_user_stop: bool = False
+    ) -> bool:
         if self.sampling_params.ignore_eos:
             return False
 
@@ -1381,7 +1383,11 @@ class Req(ReqDllmMixin):
         matched_eos = False
 
         for i, token_id in enumerate(new_accepted_tokens):
-            if self.sampling_params.stop_token_ids:
+            # User-specified stop_token_ids: skipped during the reasoning phase
+            # (they are an explicit stop intent meant for the final answer, not
+            # the thinking content). System eos / think_end / chat-stop tokens
+            # below are always checked so reasoning can still end normally.
+            if not skip_user_stop and self.sampling_params.stop_token_ids:
                 matched_eos |= token_id in self.sampling_params.stop_token_ids
             if self.eos_token_ids:
                 matched_eos |= token_id in self.eos_token_ids
@@ -1496,13 +1502,22 @@ class Req(ReqDllmMixin):
         if self._check_vocab_boundary_finish(new_accepted_tokens):
             return
 
+        # When reasoning is enabled, skip user-provided stop checks (stop
+        # strings/regex and user stop_token_ids) during the reasoning phase —
+        # they are meant to delimit the final answer, not the thinking content.
+        # System eos / think_end detection still runs so reasoning can end
+        # normally. (stop_sequences + thinking bug)
+        in_reasoning = self.require_reasoning and not self._is_reasoning_over
+
         # Stop string beats EOS/stop-token matched in the same step (speculative
         # decoding can accept >1 token): token-based would trim only the last
         # token and leak the stop string.
-        if self._check_str_based_finish(new_accepted_len):
+        if not in_reasoning and self._check_str_based_finish(new_accepted_len):
             return
 
-        if self._check_token_based_finish(new_accepted_tokens):
+        if self._check_token_based_finish(
+            new_accepted_tokens, skip_user_stop=in_reasoning
+        ):
             return
 
         if self.grammar is not None and self.grammar.is_terminated():


### PR DESCRIPTION
## Problem

When a request enables **thinking (reasoning)** and also sets `stop_sequences`, sglang terminates the whole generation as soon as a stop string matches **inside the thinking content**. The result is that only `reasoning_content` is returned and the final answer (`content`) is empty/lost.

This is an sglang engine-layer bug (not a model bug, not a gateway bug): the stop checks scan the full output stream without distinguishing the reasoning phase from the final-answer phase, even though sglang already tracks `_is_reasoning_over`.

### Repro (non-stream, Anthropic `/v1/messages`)

```json
{
  "model": "zai-org/GLM-5.2-FP8",
  "max_tokens": 1500,
  "thinking": {"type": "enabled", "budget_tokens": 1024},
  "stop_sequences": ["\n\n"],
  "messages": [{"role": "user", "content": "a handshake counting problem"}]
}
```

Before fix: with `stop_sequences=["\n\n"]`, generation truncates at ~53 tokens into thinking, `content` is empty, only `reasoning_content` is returned. A stop string that naturally occurs in thinking text truncates the whole request mid-thinking, so the answer never gets produced.

## Root cause

`update_finish_state` (`schedule_batch.py`) calls `_check_str_based_finish` and `_check_token_based_finish` without consulting `_is_reasoning_over`. The call order in `batch_result_processor.py` already updates reasoning state (`_maybe_update_reasoning_tokens`) **before** `update_finish_state`, so the guard is safe to use.

After the engine truncates mid-thinking, the protocol-layer `reasoning_parser` sees no think_end close token and classifies the entire truncated text as `reasoning_text`, leaving `normal_text` empty, which is why the answer completely disappears rather than partially surviving.

## Fix 1 — schedule_batch.py: skip user stop checks during reasoning

- Guard `_check_str_based_finish` at the call site with `not in_reasoning`, so stop strings/regex are ignored while reasoning is in progress.
- Add a `skip_user_stop` param to `_check_token_based_finish` so user `stop_token_ids` are skipped during reasoning, while system eos / think_end / `additional_stop_token_ids` are still detected. Reasoning must still be able to end normally via `think_end`; only user-supplied stop intents are deferred to the answer phase.

| Check | Reasoning phase | Answer phase |
|-------|-----------------|--------------|
| user stop strings / regex | skip | detect |
| user stop_token_ids | skip | detect |
| system eos / think_end / additional_stop_token_ids | detect | detect |

## Fix 2 — anthropic/serving.py: report correct stop_reason

Independent second bug: when a user `stop_sequence` matches, the Anthropic `stop_reason` was reported as `end_turn` instead of `stop_sequence`.

The engine flattens both EOS and user-stop matches into OpenAI `finish_reason=stop`, but sglang OpenAI adapter already carries the matched stop in `choice.matched_stop` (str = user stop string, int/None = EOS). Add `_resolve_stop_reason_and_sequence` to map a str `matched_stop` to `("stop_sequence", matched)` and populate the `stop_sequence` field on both streaming (`MessageDeltaEvent`) and non-streaming (`AnthropicMessagesResponse`) responses. The protocol models already define `stop_sequence: Optional[str]`; it was just never populated.

## Verification

Tested on GLM-5.2-FP8 and Qwen3-14B (sglang main). With a stop word that appears inside thinking (stop word reused by the model while drafting the thinking content):

- Thinking is now generated in full (was ~53-99 chars truncated, now 600-3700 chars).
- The answer is produced normally when the stop word does not appear in the answer (correct `end_turn`).
- When the stop word appears in the answer, generation truncates at the match and `stop_reason=stop_sequence` with `stop_sequence` carrying the matched string (was wrongly `end_turn`).

| Case | thinking | answer | stop_reason |
|------|----------|--------|-------------|
| stop word only in thinking | full | full | end_turn |
| stop word reaches answer | full | truncated at match | stop_sequence |

## Related

- #24839 — "Model generates EOS inside thinking block" — same family (token-based path), closed without a real fix; this PR also covers it via `skip_user_stop` (system eos/think_end still detected, only user stop_token_ids deferred).
- #27021 — "stops after thinking phase with no output" — different root cause (`finish_reason=length`, max_tokens budget exhausted by thinking), not addressed here.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30425628729](https://github.com/sgl-project/sglang/actions/runs/30425628729)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30425628649](https://github.com/sgl-project/sglang/actions/runs/30425628649)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->