### PR TITLE
[Router] Add KV event gap replay for sgl-router

### DIFF
--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -173,6 +173,7 @@ async fn main() -> Result<()> {
             active_load,
         ),
     );
+    kv_index.attach_metrics(Arc::clone(&ctx.metrics));
     ctx.mark_ready();
 
     let app = sgl_router::server::app::build_router(ctx.clone());

--- a/experimental/sgl-router/src/policies/kv_events/discovery.rs
+++ b/experimental/sgl-router/src/policies/kv_events/discovery.rs
@@ -48,6 +48,9 @@ pub struct EventConfig {
     /// many SUB connections (one per rank), skipping any rank whose
     /// `port_base + dp_rank` overflows `u16`.
     pub dp_size: u32,
+    /// Optional replay ROUTER endpoint advertised by the worker. When present,
+    /// per-rank replay endpoint = `tcp://host:<port_base + dp_rank>`.
+    pub replay: Option<ReplayConfig>,
     /// Whether the worker uses EAGLE-family speculative decoding (EAGLE /
     /// EAGLE3 / FROZEN_KV_MTP), reported via `/server_info`'s top-level
     /// `speculative_algorithm`. When true the worker hashes KV blocks over
@@ -56,6 +59,18 @@ pub struct EventConfig {
     /// match the worker's stored hashes — otherwise cache-aware routing
     /// silently never matches and degrades to min-load.
     pub is_bigram: bool,
+}
+
+/// Replay ROUTER endpoint configuration resolved from `/server_info`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplayConfig {
+    /// Host the gateway should connect to, with wildcard bind hosts replaced
+    /// by the worker URL's host.
+    pub host: String,
+    /// Base port for rank 0. Per-rank port = `port_base + dp_rank`.
+    pub port_base: u16,
+    /// Worker replay buffer capacity in event-batch steps.
+    pub buffer_steps: usize,
 }
 
 /// Default timeout for the `/server_info` introspection request. The
@@ -114,13 +129,18 @@ pub async fn fetch_event_config(
     // Wildcard bind hosts mean "any interface" on the worker side — the
     // gateway has to connect to a routable address, which it learns from
     // the worker URL.
-    let host = if matches!(
-        block.endpoint_host.as_str(),
-        "*" | "0.0.0.0" | "::" | "[::]"
+    let host = resolve_published_host(block.endpoint_host, &worker_host);
+    let replay = match (
+        block.replay_endpoint_host,
+        block.replay_endpoint_port_base,
+        block.replay_buffer_steps,
     ) {
-        worker_host
-    } else {
-        block.endpoint_host
+        (Some(replay_host), Some(replay_port), Some(buffer_steps)) => Some(ReplayConfig {
+            host: resolve_published_host(replay_host, &worker_host),
+            port_base: replay_port,
+            buffer_steps,
+        }),
+        _ => None,
     };
 
     Ok(Some(EventConfig {
@@ -129,8 +149,17 @@ pub async fn fetch_event_config(
         topic: block.topic,
         block_size: block.block_size,
         dp_size: block.dp_size,
+        replay,
         is_bigram,
     }))
+}
+
+fn resolve_published_host(advertised_host: String, worker_host: &str) -> String {
+    if matches!(advertised_host.as_str(), "*" | "0.0.0.0" | "::" | "[::]") {
+        worker_host.to_owned()
+    } else {
+        advertised_host
+    }
 }
 
 /// Issue the `/server_info` request with bounded retry on transient errors
@@ -254,6 +283,12 @@ struct KvEventsBlock {
     topic: String,
     block_size: u32,
     dp_size: u32,
+    #[serde(default)]
+    replay_endpoint_host: Option<String>,
+    #[serde(default)]
+    replay_endpoint_port_base: Option<u16>,
+    #[serde(default)]
+    replay_buffer_steps: Option<usize>,
 }
 
 #[cfg(test)]
@@ -320,9 +355,58 @@ mod tests {
                 topic: "kv".to_string(),
                 block_size: 64,
                 dp_size: 2,
+                replay: None,
                 is_bigram: false,
             })
         );
+    }
+
+    /// Replay endpoint fields are optional but, when present, are resolved with
+    /// the same wildcard-host substitution as the live PUB endpoint.
+    #[tokio::test]
+    async fn fetch_parses_replay_config_and_substitutes_wildcard_host() {
+        let body = Arc::new(json!({
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv",
+                "block_size": 64,
+                "dp_size": 2,
+                "replay_endpoint_host": "*",
+                "replay_endpoint_port_base": 5657,
+                "replay_buffer_steps": 1234,
+            }
+        }));
+        let (url, _shutdown) = spawn_fake_worker(body).await;
+        let got = fetch_event_config(&url, &client()).await.unwrap().unwrap();
+        assert_eq!(
+            got.replay,
+            Some(ReplayConfig {
+                host: "127.0.0.1".to_string(),
+                port_base: 5657,
+                buffer_steps: 1234,
+            })
+        );
+    }
+
+    /// Older workers and workers without replay configured still expose usable
+    /// live PUB metadata; the replay config should simply be absent.
+    #[tokio::test]
+    async fn fetch_omits_replay_when_fields_missing() {
+        let body = Arc::new(json!({
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "",
+                "block_size": 64,
+                "dp_size": 1,
+            }
+        }));
+        let (url, _shutdown) = spawn_fake_worker(body).await;
+        let got = fetch_event_config(&url, &client()).await.unwrap().unwrap();
+        assert_eq!(got.replay, None);
     }
 
     /// EAGLE-family `speculative_algorithm` (and only those) must set

--- a/experimental/sgl-router/src/policies/kv_events/index.rs
+++ b/experimental/sgl-router/src/policies/kv_events/index.rs
@@ -25,7 +25,7 @@
 //! event through this set before mutating the tree.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use parking_lot::Mutex;
@@ -36,9 +36,11 @@ use tracing::{debug, info, warn};
 
 use super::block_size_oracle::BlockSizeOracle;
 use super::discovery::{fetch_event_config, EventConfig};
+use super::replay::{fetch_replay_batches, ReplayError};
 use super::subscriber::{KvEventSubscriberRegistry, WorkerEvent};
 use super::tree::{HashTree, KvWorkerId};
-use super::wire::KvCacheEvent;
+use super::wire::{KvCacheEvent, KvEventBatch};
+use crate::server::metrics::{KvEventGapOutcome, MetricsRegistry};
 
 /// Channel buffer between the subscriber registry and the pump task.
 ///
@@ -58,6 +60,13 @@ struct WorkerEntry {
     dp_ranks: Vec<u32>,
 }
 
+/// Per-rank replay socket target, derived from `EventConfig.replay`.
+#[derive(Debug, Clone)]
+struct ReplayTarget {
+    endpoint: String,
+    buffer_steps: usize,
+}
+
 /// Bundle of `HashTree` + `KvEventSubscriberRegistry` + pump task.
 ///
 /// Construct one instance per router process and hand it to the worker
@@ -75,6 +84,10 @@ pub struct KvEventIndex {
     /// queued by a subscriber that was torn down by `remove_worker` does
     /// not re-pollute the tree after `clear_worker` ran.
     live_workers: Arc<Mutex<HashSet<KvWorkerId>>>,
+    /// Optional per-rank replay endpoint. Missing means the worker can still be
+    /// subscribed live, but a sequence gap can only be logged/metriced before
+    /// falling back to legacy current-batch application.
+    replay_targets: Arc<Mutex<HashMap<KvWorkerId, ReplayTarget>>>,
     /// Per-`(worker_url, dp_rank)` last-applied sequence number. The
     /// subscriber forwards every batch with no de-dup; this map filters
     /// any batch whose `seq` is not strictly greater than the previously
@@ -88,6 +101,7 @@ pub struct KvEventIndex {
     /// rejected (logged + not subscribed). The policy reads it at routing
     /// time to size its `compute_block_hashes` call.
     block_size_oracle: Arc<BlockSizeOracle>,
+    metrics: Arc<OnceLock<Arc<MetricsRegistry>>>,
 }
 
 impl KvEventIndex {
@@ -120,11 +134,16 @@ impl KvEventIndex {
         let subscribers = Arc::new(KvEventSubscriberRegistry::new(tx));
         let cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>> = Arc::new(Mutex::new(HashMap::new()));
         let live_workers: Arc<Mutex<HashSet<KvWorkerId>>> = Arc::new(Mutex::new(HashSet::new()));
+        let replay_targets: Arc<Mutex<HashMap<KvWorkerId, ReplayTarget>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let metrics = Arc::new(OnceLock::new());
         let pump_cancel = CancellationToken::new();
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
             cursors.clone(),
             live_workers.clone(),
+            replay_targets.clone(),
+            metrics.clone(),
             pump_cancel.clone(),
             rx,
         ));
@@ -136,9 +155,16 @@ impl KvEventIndex {
             workers: Mutex::new(HashMap::new()),
             http,
             live_workers,
+            replay_targets,
             cursors,
             block_size_oracle,
+            metrics,
         })
+    }
+
+    /// Attach the process metrics registry to the background pump.
+    pub fn attach_metrics(&self, metrics: Arc<MetricsRegistry>) {
+        let _ = self.metrics.set(metrics);
     }
 
     /// Shared accessor for the per-process block-size oracle. The
@@ -236,11 +262,28 @@ impl KvEventIndex {
         // it queues is accepted by the pump.
         {
             let mut live = self.live_workers.lock();
+            let mut replay_targets = self.replay_targets.lock();
             for &rank in &dp_ranks {
-                live.insert(KvWorkerId {
+                let id = KvWorkerId {
                     url: worker_url.to_string(),
                     dp_rank: rank,
-                });
+                };
+                live.insert(id.clone());
+                match replay_target_for_rank(&cfg, rank) {
+                    Some(target) => {
+                        replay_targets.insert(id, target);
+                    }
+                    None => {
+                        if cfg.replay.is_some() {
+                            warn!(
+                                worker_url = %worker_url,
+                                dp_rank = rank,
+                                "kv-events: replay endpoint port overflows u16 for rank; gap recovery disabled for this rank",
+                            );
+                        }
+                        replay_targets.remove(&id);
+                    }
+                }
             }
         }
         self.workers.lock().insert(
@@ -285,9 +328,11 @@ impl KvEventIndex {
         //    the mpsc buffer at this point will be filtered by the
         //    live-set check inside the pump.
         let mut cursors = self.cursors.lock();
+        let mut replay_targets = self.replay_targets.lock();
         for id in &ids {
             self.tree.clear_worker(id);
             cursors.remove(id);
+            replay_targets.remove(id);
         }
     }
 
@@ -320,14 +365,30 @@ impl KvEventIndex {
     }
 }
 
+fn replay_target_for_rank(cfg: &EventConfig, rank: u32) -> Option<ReplayTarget> {
+    let replay = cfg.replay.as_ref()?;
+    let port = u32::from(replay.port_base) + rank;
+    if port > u32::from(u16::MAX) {
+        return None;
+    }
+    Some(ReplayTarget {
+        endpoint: format!("tcp://{}:{port}", replay.host),
+        buffer_steps: replay.buffer_steps,
+    })
+}
+
 /// Drain `WorkerEvent`s and apply each batch to the tree. Out-of-order
-/// (seq ≤ last_applied) and stale (worker not in `live_workers`) batches
-/// are skipped. `PublisherReset` events clear the cursor so a publisher
-/// restarting from seq=1 (after sending END_SEQ) is not filtered.
+/// (seq ≤ last_applied) and stale (worker not in `live_workers`) batches are
+/// skipped. A sequence gap triggers replay when the worker advertised a replay
+/// endpoint; if replay is unavailable or cannot prove a continuous prefix, the
+/// pump records/logs the gap and falls back to the original behavior of applying
+/// the current live batch.
 async fn pump_loop(
     tree: Arc<HashTree>,
     cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
     live_workers: Arc<Mutex<HashSet<KvWorkerId>>>,
+    replay_targets: Arc<Mutex<HashMap<KvWorkerId, ReplayTarget>>>,
+    metrics: Arc<OnceLock<Arc<MetricsRegistry>>>,
     cancel: CancellationToken,
     mut rx: mpsc::Receiver<WorkerEvent>,
 ) {
@@ -362,7 +423,8 @@ async fn pump_loop(
 
         match ev {
             WorkerEvent::PublisherReset { worker } => {
-                if cursors.lock().remove(&worker).is_some() {
+                let had_cursor = cursors.lock().remove(&worker).is_some();
+                if had_cursor {
                     info!(
                         worker = ?worker,
                         "kv-events pump: publisher reset; cursor cleared",
@@ -382,22 +444,177 @@ async fn pump_loop(
                         continue;
                     }
                 }
-                for event in &batch.events {
-                    match event {
-                        KvCacheEvent::BlockStored(b) => {
-                            tree.insert(&worker, b.parent_block_hash, &b.block_hashes);
-                        }
-                        KvCacheEvent::BlockRemoved(b) => {
-                            tree.remove(&worker, &b.block_hashes);
-                        }
-                        KvCacheEvent::AllBlocksCleared => {
-                            tree.clear_worker(&worker);
+
+                let prev = cursors.lock().get(&worker).copied();
+                if let Some(p) = prev {
+                    if seq > p.saturating_add(1) {
+                        let expected = p.saturating_add(1);
+                        let target = replay_targets.lock().get(&worker).cloned();
+                        let Some(target) = target else {
+                            record_gap_metric(&metrics, KvEventGapOutcome::NoReplayEndpoint);
+                            warn!(
+                                worker_url = %worker.url,
+                                dp_rank = worker.dp_rank,
+                                gap_start_seq = expected,
+                                live_seq = seq,
+                                "kv-events pump: sequence gap observed but worker has no replay endpoint; applying current live batch with legacy behavior",
+                            );
+                            apply_batch(&tree, &worker, &batch);
+                            cursors.lock().insert(worker, seq);
+                            continue;
+                        };
+                        match fetch_replay_batches(&target.endpoint, expected, target.buffer_steps)
+                            .await
+                        {
+                            Ok(replayed) => {
+                                match apply_replayed_batches(
+                                    &tree, &cursors, &worker, expected, seq, replayed,
+                                ) {
+                                    Ok(last_replayed) => {
+                                        record_gap_metric(&metrics, KvEventGapOutcome::Replayed);
+                                        info!(
+                                            worker_url = %worker.url,
+                                            dp_rank = worker.dp_rank,
+                                            gap_start_seq = expected,
+                                            live_seq = seq,
+                                            last_replayed_seq = last_replayed,
+                                            "kv-events pump: gap replayed successfully",
+                                        );
+                                    }
+                                    Err(err) => {
+                                        record_gap_metric(&metrics, KvEventGapOutcome::BufferMiss);
+                                        warn!(
+                                            worker_url = %worker.url,
+                                            dp_rank = worker.dp_rank,
+                                            gap_start_seq = expected,
+                                            live_seq = seq,
+                                            error = %err,
+                                            "kv-events pump: replay did not cover gap; applying current live batch with legacy behavior",
+                                        );
+                                        apply_batch(&tree, &worker, &batch);
+                                        cursors.lock().insert(worker, seq);
+                                        continue;
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                let outcome = match err {
+                                    ReplayError::BatchLimitExceeded { .. } => {
+                                        KvEventGapOutcome::BufferMiss
+                                    }
+                                    _ => KvEventGapOutcome::ReplayFailed,
+                                };
+                                record_gap_metric(&metrics, outcome);
+                                warn!(
+                                    worker_url = %worker.url,
+                                    dp_rank = worker.dp_rank,
+                                    gap_start_seq = expected,
+                                    live_seq = seq,
+                                    error = %err,
+                                    "kv-events pump: replay request failed; applying current live batch with legacy behavior",
+                                );
+                                apply_batch(&tree, &worker, &batch);
+                                cursors.lock().insert(worker, seq);
+                                continue;
+                            }
                         }
                     }
                 }
+
+                let prev = cursors.lock().get(&worker).copied();
+                if let Some(p) = prev {
+                    if seq <= p {
+                        debug!(
+                            worker = ?worker,
+                            seq,
+                            last_applied = p,
+                            "kv-events pump: live batch already covered by replay; skipping",
+                        );
+                        continue;
+                    }
+                    if seq > p.saturating_add(1) {
+                        record_gap_metric(&metrics, KvEventGapOutcome::BufferMiss);
+                        warn!(
+                            worker_url = %worker.url,
+                            dp_rank = worker.dp_rank,
+                            gap_start_seq = p.saturating_add(1),
+                            live_seq = seq,
+                            "kv-events pump: sequence gap remains after replay attempt; applying current live batch with legacy behavior",
+                        );
+                    }
+                }
+
+                apply_batch(&tree, &worker, &batch);
                 cursors.lock().insert(worker, seq);
             }
         }
+    }
+}
+
+fn apply_batch(tree: &HashTree, worker: &KvWorkerId, batch: &KvEventBatch) {
+    for event in &batch.events {
+        match event {
+            KvCacheEvent::BlockStored(b) => {
+                tree.insert(worker, b.parent_block_hash, &b.block_hashes);
+            }
+            KvCacheEvent::BlockRemoved(b) => {
+                tree.remove(worker, &b.block_hashes);
+            }
+            KvCacheEvent::AllBlocksCleared => {
+                tree.clear_worker(worker);
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ReplayContinuityError {
+    #[error("replay returned no batches")]
+    Empty,
+    #[error("replay sequence discontinuity: expected {expected}, got {got}")]
+    NonContiguous { expected: i64, got: i64 },
+    #[error("replay ended at {last:?}, needed at least {needed}")]
+    Short { last: Option<i64>, needed: i64 },
+}
+
+fn apply_replayed_batches(
+    tree: &HashTree,
+    cursors: &Mutex<HashMap<KvWorkerId, i64>>,
+    worker: &KvWorkerId,
+    start_seq: i64,
+    live_seq: i64,
+    replayed: Vec<(i64, KvEventBatch)>,
+) -> Result<i64, ReplayContinuityError> {
+    if replayed.is_empty() {
+        return Err(ReplayContinuityError::Empty);
+    }
+    let mut expected = start_seq;
+    let mut last_applied = None;
+    for (seq, batch) in replayed {
+        if seq != expected {
+            return Err(ReplayContinuityError::NonContiguous { expected, got: seq });
+        }
+        apply_batch(tree, worker, &batch);
+        cursors.lock().insert(worker.clone(), seq);
+        last_applied = Some(seq);
+        if seq >= live_seq {
+            return Ok(seq);
+        }
+        expected = seq.saturating_add(1);
+    }
+    let needed = live_seq.saturating_sub(1);
+    match last_applied {
+        Some(last) if last >= needed => Ok(last),
+        other => Err(ReplayContinuityError::Short {
+            last: other,
+            needed,
+        }),
+    }
+}
+
+fn record_gap_metric(metrics: &OnceLock<Arc<MetricsRegistry>>, outcome: KvEventGapOutcome) {
+    if let Some(registry) = metrics.get() {
+        registry.record_kv_event_gap(outcome);
     }
 }
 
@@ -405,6 +622,9 @@ async fn pump_loop(
 mod tests {
     use super::*;
     use crate::policies::kv_events::wire::{BlockRemoved, BlockStored, KvEventBatch};
+    use bytes::Bytes;
+    use rmp::encode as mp;
+    use zeromq::{Endpoint, RouterSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
 
     fn worker_id(url: &str, rank: u32) -> KvWorkerId {
         KvWorkerId {
@@ -421,6 +641,81 @@ mod tests {
         }
     }
 
+    fn block_stored_batch(block_hashes: &[i64]) -> KvEventBatch {
+        batch(vec![KvCacheEvent::BlockStored(BlockStored {
+            parent_block_hash: None,
+            block_hashes: block_hashes.to_vec(),
+            token_ids: vec![],
+            block_size: 64,
+            lora_id: None,
+            medium: None,
+        })])
+    }
+
+    fn encode_block_stored_batch(block_hashes: &[i64]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        mp::write_array_len(&mut buf, 3).unwrap();
+        mp::write_f64(&mut buf, 0.0).unwrap();
+        mp::write_array_len(&mut buf, 1).unwrap();
+        mp::write_array_len(&mut buf, 7).unwrap();
+        mp::write_str(&mut buf, "BlockStored").unwrap();
+        mp::write_array_len(&mut buf, block_hashes.len() as u32).unwrap();
+        for hash in block_hashes {
+            mp::write_sint(&mut buf, *hash).unwrap();
+        }
+        mp::write_nil(&mut buf).unwrap();
+        mp::write_array_len(&mut buf, 0).unwrap();
+        mp::write_uint(&mut buf, 64).unwrap();
+        mp::write_nil(&mut buf).unwrap();
+        mp::write_nil(&mut buf).unwrap();
+        mp::write_nil(&mut buf).unwrap();
+        buf
+    }
+
+    async fn spawn_replay_router(
+        expected_start_seq: i64,
+        replies: Vec<(i64, Vec<u8>)>,
+    ) -> (String, JoinHandle<()>) {
+        let mut router = RouterSocket::new();
+        let endpoint = router
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("bind replay ROUTER");
+        let port = match endpoint {
+            Endpoint::Tcp(_, port) => port,
+            other => panic!("unexpected endpoint: {other:?}"),
+        };
+        let handle = tokio::spawn(async move {
+            let request = router.recv().await.expect("receive replay request");
+            assert_eq!(request.len(), 3);
+            let identity = request.get(0).expect("identity").clone();
+            assert!(request.get(1).expect("delimiter").is_empty());
+            assert_eq!(
+                request.get(2).expect("start seq").as_ref(),
+                &expected_start_seq.to_be_bytes()
+            );
+            for (seq, payload) in replies {
+                router
+                    .send(replay_reply(identity.clone(), seq, payload))
+                    .await
+                    .expect("send replay reply");
+            }
+            router
+                .send(replay_reply(identity, -1, Vec::new()))
+                .await
+                .expect("send replay END");
+        });
+        (format!("tcp://127.0.0.1:{port}"), handle)
+    }
+
+    fn replay_reply(identity: Bytes, seq: i64, payload: Vec<u8>) -> ZmqMessage {
+        let mut msg = ZmqMessage::from(identity);
+        msg.push_back(Bytes::new());
+        msg.push_back(Bytes::copy_from_slice(&seq.to_be_bytes()));
+        msg.push_back(Bytes::from(payload));
+        msg
+    }
+
     /// Bundle of plumbing returned by `spawn_pump` so individual tests
     /// can destructure just the bits they need.
     struct PumpHarness {
@@ -428,6 +723,8 @@ mod tests {
         cursors: Arc<Mutex<HashMap<KvWorkerId, i64>>>,
         #[allow(dead_code)]
         live_set: Arc<Mutex<HashSet<KvWorkerId>>>,
+        replay_targets: Arc<Mutex<HashMap<KvWorkerId, ReplayTarget>>>,
+        metrics: Arc<MetricsRegistry>,
         #[allow(dead_code)]
         cancel: CancellationToken,
         tx: mpsc::Sender<WorkerEvent>,
@@ -441,12 +738,19 @@ mod tests {
         let cursors = Arc::new(Mutex::new(HashMap::new()));
         let live_set: Arc<Mutex<HashSet<KvWorkerId>>> =
             Arc::new(Mutex::new(live.iter().cloned().collect()));
+        let replay_targets: Arc<Mutex<HashMap<KvWorkerId, ReplayTarget>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let metrics_lock = Arc::new(OnceLock::new());
+        let metrics = MetricsRegistry::new();
+        metrics_lock.set(Arc::clone(&metrics)).unwrap();
         let cancel = CancellationToken::new();
         let (tx, rx) = mpsc::channel(4);
         let pump = tokio::spawn(pump_loop(
             tree.clone(),
             cursors.clone(),
             live_set.clone(),
+            replay_targets.clone(),
+            metrics_lock,
             cancel.clone(),
             rx,
         ));
@@ -454,6 +758,8 @@ mod tests {
             tree,
             cursors,
             live_set,
+            replay_targets,
+            metrics,
             cancel,
             tx,
             pump,
@@ -539,6 +845,93 @@ mod tests {
             "out-of-order remove must not undo the prior insert",
         );
         assert_eq!(cursors.lock().get(&id).copied(), Some(5));
+    }
+
+    /// Conservative gap fallback: without a replay endpoint, the new code must
+    /// keep the original behavior of applying the current live batch.
+    #[tokio::test]
+    async fn pump_gap_without_replay_keeps_legacy_current_batch_application() {
+        let id = worker_id("http://w1", 0);
+        let h = spawn_pump(std::slice::from_ref(&id));
+        let (tree, cursors, metrics, tx, pump) = (h.tree, h.cursors, h.metrics, h.tx, h.pump);
+
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 1,
+            batch: block_stored_batch(&[10]),
+        })
+        .await
+        .unwrap();
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 3,
+            batch: block_stored_batch(&[30]),
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        pump.await.unwrap();
+
+        assert_eq!(tree.match_prefix(None, &[10]).matched_blocks, 1);
+        assert_eq!(
+            tree.match_prefix(None, &[30]).matched_blocks,
+            1,
+            "gap fallback should still apply the current live batch like upstream/main",
+        );
+        assert_eq!(cursors.lock().get(&id).copied(), Some(3));
+        let out = metrics.render();
+        assert!(out.contains(r#"sgl_router_kv_event_gaps_total{outcome="no_replay_endpoint"} 1"#));
+    }
+
+    /// With replay metadata, a gap is filled from the ROUTER socket before the
+    /// triggering live batch is considered.
+    #[tokio::test]
+    async fn pump_replays_gap_before_current_live_batch() {
+        let id = worker_id("http://w1", 0);
+        let (endpoint, replay_server) =
+            spawn_replay_router(2, vec![(2, encode_block_stored_batch(&[20]))]).await;
+        let h = spawn_pump(std::slice::from_ref(&id));
+        h.replay_targets.lock().insert(
+            id.clone(),
+            ReplayTarget {
+                endpoint,
+                buffer_steps: 16,
+            },
+        );
+        let (tree, cursors, metrics, tx, pump) = (h.tree, h.cursors, h.metrics, h.tx, h.pump);
+
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 1,
+            batch: block_stored_batch(&[10]),
+        })
+        .await
+        .unwrap();
+        tx.send(WorkerEvent::Batch {
+            worker: id.clone(),
+            seq: 3,
+            batch: block_stored_batch(&[30]),
+        })
+        .await
+        .unwrap();
+        drop(tx);
+        pump.await.unwrap();
+        replay_server.await.unwrap();
+
+        assert_eq!(tree.match_prefix(None, &[10]).matched_blocks, 1);
+        assert_eq!(
+            tree.match_prefix(None, &[20]).matched_blocks,
+            1,
+            "replayed seq=2 batch should be applied",
+        );
+        assert_eq!(
+            tree.match_prefix(None, &[30]).matched_blocks,
+            1,
+            "triggering live seq=3 batch should still be applied",
+        );
+        assert_eq!(cursors.lock().get(&id).copied(), Some(3));
+        let out = metrics.render();
+        assert!(out.contains(r#"sgl_router_kv_event_gaps_total{outcome="replayed"} 1"#));
     }
 
     /// AllBlocksCleared wipes the worker's tree state entirely.
@@ -651,6 +1044,7 @@ mod tests {
             topic: String::new(),
             block_size: 128,
             dp_size: 1,
+            replay: None,
             is_bigram: false,
         };
         index
@@ -680,6 +1074,7 @@ mod tests {
             topic: String::new(),
             block_size: 64,
             dp_size: 0,
+            replay: None,
             is_bigram: false,
         };
         index.add_worker("http://127.0.0.1:30200", Some(cfg)).await;
@@ -701,6 +1096,7 @@ mod tests {
             topic: String::new(),
             block_size: 64,
             dp_size: 0,
+            replay: None,
             is_bigram: true,
         };
         index.add_worker("http://127.0.0.1:30300", Some(cfg)).await;

--- a/experimental/sgl-router/src/policies/kv_events/mod.rs
+++ b/experimental/sgl-router/src/policies/kv_events/mod.rs
@@ -18,13 +18,14 @@ pub mod block_size_oracle;
 pub mod discovery;
 pub mod hash;
 pub mod index;
+pub(crate) mod replay;
 pub mod subscriber;
 pub mod tree;
 pub mod wire;
 
 pub use block_size_oracle::BlockSizeOracle;
 pub(crate) use discovery::classify_bigram;
-pub use discovery::{fetch_event_config, EventConfig};
+pub use discovery::{fetch_event_config, EventConfig, ReplayConfig};
 pub use hash::{compute_block_hashes, compute_block_hashes_bigram, sha256_to_i64};
 pub use index::KvEventIndex;
 pub use subscriber::{KvEventSubscriberRegistry, WorkerEvent};

--- a/experimental/sgl-router/src/policies/kv_events/replay.rs
+++ b/experimental/sgl-router/src/policies/kv_events/replay.rs
@@ -1,0 +1,330 @@
+//! Replay client for SGLang's engine-side `ZmqEventPublisher`.
+//!
+//! Python binds a ROUTER socket for replay and expects DEALER clients to send
+//! `[empty_delim, start_seq_bytes]`. The ROUTER observes
+//! `[client_id, empty_delim, start_seq_bytes]` and replies with one message per
+//! buffered batch: `[empty_delim, seq_bytes, payload]`, terminated by
+//! `[empty_delim, END_SEQ, b""]`.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use thiserror::Error;
+use tokio::time::timeout;
+use zeromq::{DealerSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+use super::wire::{decode_event_batch, DecodeError, KvEventBatch};
+
+/// Python `ZmqEventPublisher.END_SEQ = (-1).to_bytes(8, "big", signed=True)`.
+const END_SEQ_SENTINEL: i64 = -1;
+
+/// Default end-to-end ceiling for a single replay request.
+pub(crate) const DEFAULT_REPLAY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Hard cap even if the worker advertises a very large replay buffer.
+const HARD_REPLAY_BATCH_LIMIT: usize = 100_000;
+
+#[derive(Debug, Error)]
+pub(crate) enum ReplayError {
+    #[error("replay request to {endpoint} timed out after {timeout:?}")]
+    Timeout { endpoint: String, timeout: Duration },
+    #[error("replay ZMQ error at {endpoint}: {source}")]
+    Zmq {
+        endpoint: String,
+        source: zeromq::ZmqError,
+    },
+    #[error("replay reply has {got} frames, expected 3")]
+    InvalidFrameCount { got: usize },
+    #[error("replay reply delimiter frame is not empty")]
+    InvalidDelimiter,
+    #[error("replay reply seq frame has {len} bytes, expected 8")]
+    InvalidSeqLength { len: usize },
+    #[error("replay END_SEQ frame carried {len} payload bytes, expected 0")]
+    InvalidEndPayload { len: usize },
+    #[error("replay payload decode failed at seq {seq}: {source}")]
+    Decode { seq: i64, source: DecodeError },
+    #[error("replay response exceeded batch limit {limit} before END_SEQ")]
+    BatchLimitExceeded { limit: usize },
+}
+
+/// Fetch replay batches starting at `start_seq` from one per-rank replay
+/// endpoint. The returned vector excludes the terminating END_SEQ sentinel.
+pub(crate) async fn fetch_replay_batches(
+    endpoint: &str,
+    start_seq: i64,
+    buffer_steps: usize,
+) -> Result<Vec<(i64, KvEventBatch)>, ReplayError> {
+    fetch_replay_batches_with_timeout(endpoint, start_seq, buffer_steps, DEFAULT_REPLAY_TIMEOUT)
+        .await
+}
+
+pub(crate) async fn fetch_replay_batches_with_timeout(
+    endpoint: &str,
+    start_seq: i64,
+    buffer_steps: usize,
+    timeout_duration: Duration,
+) -> Result<Vec<(i64, KvEventBatch)>, ReplayError> {
+    let endpoint_owned = endpoint.to_owned();
+    timeout(
+        timeout_duration,
+        fetch_replay_batches_inner(endpoint, start_seq, buffer_steps),
+    )
+    .await
+    .map_err(|_| ReplayError::Timeout {
+        endpoint: endpoint_owned,
+        timeout: timeout_duration,
+    })?
+}
+
+async fn fetch_replay_batches_inner(
+    endpoint: &str,
+    start_seq: i64,
+    buffer_steps: usize,
+) -> Result<Vec<(i64, KvEventBatch)>, ReplayError> {
+    let limit = buffer_steps.clamp(1, HARD_REPLAY_BATCH_LIMIT);
+    let mut sock = DealerSocket::new();
+    sock.connect(endpoint)
+        .await
+        .map_err(|source| ReplayError::Zmq {
+            endpoint: endpoint.to_owned(),
+            source,
+        })?;
+
+    let mut request = ZmqMessage::from(Bytes::new());
+    request.push_back(Bytes::copy_from_slice(&start_seq.to_be_bytes()));
+    sock.send(request)
+        .await
+        .map_err(|source| ReplayError::Zmq {
+            endpoint: endpoint.to_owned(),
+            source,
+        })?;
+
+    let mut batches = Vec::new();
+    loop {
+        if batches.len() >= limit {
+            return Err(ReplayError::BatchLimitExceeded { limit });
+        }
+        let reply = sock.recv().await.map_err(|source| ReplayError::Zmq {
+            endpoint: endpoint.to_owned(),
+            source,
+        })?;
+        let (seq, payload) = parse_reply(reply)?;
+        if seq == END_SEQ_SENTINEL {
+            if !payload.is_empty() {
+                return Err(ReplayError::InvalidEndPayload { len: payload.len() });
+            }
+            return Ok(batches);
+        }
+        let batch =
+            decode_event_batch(&payload).map_err(|source| ReplayError::Decode { seq, source })?;
+        batches.push((seq, batch));
+    }
+}
+
+fn parse_reply(reply: ZmqMessage) -> Result<(i64, Bytes), ReplayError> {
+    if reply.len() != 3 {
+        return Err(ReplayError::InvalidFrameCount { got: reply.len() });
+    }
+    let mut frames = reply.into_vecdeque();
+    let delimiter = frames.pop_front().expect("len checked");
+    if !delimiter.is_empty() {
+        return Err(ReplayError::InvalidDelimiter);
+    }
+    let seq_frame = frames.pop_front().expect("len checked");
+    if seq_frame.len() != 8 {
+        return Err(ReplayError::InvalidSeqLength {
+            len: seq_frame.len(),
+        });
+    }
+    let mut seq_bytes = [0_u8; 8];
+    seq_bytes.copy_from_slice(&seq_frame);
+    let seq = i64::from_be_bytes(seq_bytes);
+    let payload = frames.pop_front().expect("len checked");
+    Ok((seq, payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rmp::encode as mp;
+    use tokio::task::JoinHandle;
+    use zeromq::{Endpoint, RouterSocket, SocketSend};
+
+    fn encode_all_blocks_cleared_batch() -> Vec<u8> {
+        let mut buf = Vec::new();
+        mp::write_array_len(&mut buf, 3).unwrap();
+        mp::write_f64(&mut buf, 0.0).unwrap();
+        mp::write_array_len(&mut buf, 1).unwrap();
+        mp::write_array_len(&mut buf, 1).unwrap();
+        mp::write_str(&mut buf, "AllBlocksCleared").unwrap();
+        mp::write_nil(&mut buf).unwrap();
+        buf
+    }
+
+    async fn spawn_router<F>(serve: F) -> (String, JoinHandle<()>)
+    where
+        F: FnOnce(RouterSocket) -> JoinHandle<()> + Send + 'static,
+    {
+        let mut router = RouterSocket::new();
+        let endpoint = router
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("bind replay ROUTER");
+        let port = match endpoint {
+            Endpoint::Tcp(_, port) => port,
+            other => panic!("unexpected endpoint: {other:?}"),
+        };
+        let handle = serve(router);
+        (format!("tcp://127.0.0.1:{port}"), handle)
+    }
+
+    fn reply(identity: Bytes, seq: i64, payload: Vec<u8>) -> ZmqMessage {
+        let mut msg = ZmqMessage::from(identity);
+        msg.push_back(Bytes::new());
+        msg.push_back(Bytes::copy_from_slice(&seq.to_be_bytes()));
+        msg.push_back(Bytes::from(payload));
+        msg
+    }
+
+    async fn recv_request(router: &mut RouterSocket, expected_start: i64) -> Bytes {
+        let request = router.recv().await.expect("receive replay request");
+        assert_eq!(request.len(), 3);
+        let identity = request.get(0).expect("identity").clone();
+        assert!(request.get(1).expect("delimiter").is_empty());
+        assert_eq!(
+            request.get(2).expect("start seq").as_ref(),
+            &expected_start.to_be_bytes()
+        );
+        identity
+    }
+
+    #[tokio::test]
+    async fn sends_dealer_request_and_reads_batches_until_end() {
+        let payload1 = encode_all_blocks_cleared_batch();
+        let payload2 = encode_all_blocks_cleared_batch();
+        let (endpoint, server) = spawn_router(move |mut router| {
+            tokio::spawn(async move {
+                let identity = recv_request(&mut router, 7).await;
+                router
+                    .send(reply(identity.clone(), 7, payload1))
+                    .await
+                    .expect("send seq 7");
+                router
+                    .send(reply(identity.clone(), 8, payload2))
+                    .await
+                    .expect("send seq 8");
+                router
+                    .send(reply(identity, END_SEQ_SENTINEL, Vec::new()))
+                    .await
+                    .expect("send END");
+            })
+        })
+        .await;
+
+        let batches = fetch_replay_batches_with_timeout(&endpoint, 7, 16, Duration::from_secs(1))
+            .await
+            .expect("replay succeeds");
+        server.await.expect("server task");
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].0, 7);
+        assert_eq!(batches[1].0, 8);
+    }
+
+    #[tokio::test]
+    async fn end_only_is_successful_empty_replay() {
+        let (endpoint, server) = spawn_router(|mut router| {
+            tokio::spawn(async move {
+                let identity = recv_request(&mut router, 9).await;
+                router
+                    .send(reply(identity, END_SEQ_SENTINEL, Vec::new()))
+                    .await
+                    .expect("send END");
+            })
+        })
+        .await;
+
+        let batches = fetch_replay_batches_with_timeout(&endpoint, 9, 16, Duration::from_secs(1))
+            .await
+            .expect("END-only replay is valid");
+        server.await.expect("server task");
+        assert!(batches.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_frame_count_is_error() {
+        let (endpoint, server) = spawn_router(|mut router| {
+            tokio::spawn(async move {
+                let identity = recv_request(&mut router, 1).await;
+                let mut msg = ZmqMessage::from(identity);
+                msg.push_back(Bytes::new());
+                router.send(msg).await.expect("send short frame");
+            })
+        })
+        .await;
+
+        let err = fetch_replay_batches_with_timeout(&endpoint, 1, 16, Duration::from_secs(1))
+            .await
+            .expect_err("invalid frame count");
+        server.await.expect("server task");
+        assert!(matches!(err, ReplayError::InvalidFrameCount { got: 1 }));
+    }
+
+    #[tokio::test]
+    async fn bad_seq_length_is_error() {
+        let (endpoint, server) = spawn_router(|mut router| {
+            tokio::spawn(async move {
+                let identity = recv_request(&mut router, 1).await;
+                let mut msg = ZmqMessage::from(identity);
+                msg.push_back(Bytes::new());
+                msg.push_back(Bytes::from_static(b"bad"));
+                msg.push_back(Bytes::new());
+                router.send(msg).await.expect("send bad seq");
+            })
+        })
+        .await;
+
+        let err = fetch_replay_batches_with_timeout(&endpoint, 1, 16, Duration::from_secs(1))
+            .await
+            .expect_err("bad seq length");
+        server.await.expect("server task");
+        assert!(matches!(err, ReplayError::InvalidSeqLength { len: 3 }));
+    }
+
+    #[tokio::test]
+    async fn payload_decode_failure_is_error() {
+        let (endpoint, server) = spawn_router(|mut router| {
+            tokio::spawn(async move {
+                let identity = recv_request(&mut router, 1).await;
+                router
+                    .send(reply(identity, 1, b"not-msgpack".to_vec()))
+                    .await
+                    .expect("send bad payload");
+            })
+        })
+        .await;
+
+        let err = fetch_replay_batches_with_timeout(&endpoint, 1, 16, Duration::from_secs(1))
+            .await
+            .expect_err("decode failure");
+        server.await.expect("server task");
+        assert!(matches!(err, ReplayError::Decode { seq: 1, .. }));
+    }
+
+    #[tokio::test]
+    async fn missing_end_hits_timeout() {
+        let (endpoint, server) = spawn_router(|mut router| {
+            tokio::spawn(async move {
+                let _identity = recv_request(&mut router, 1).await;
+                std::future::pending::<()>().await;
+            })
+        })
+        .await;
+
+        let err = fetch_replay_batches_with_timeout(&endpoint, 1, 16, Duration::from_millis(50))
+            .await
+            .expect_err("timeout");
+        server.abort();
+        assert!(matches!(err, ReplayError::Timeout { .. }));
+    }
+}

--- a/experimental/sgl-router/src/policies/kv_events/subscriber.rs
+++ b/experimental/sgl-router/src/policies/kv_events/subscriber.rs
@@ -593,6 +593,7 @@ mod tests {
                 topic: String::new(),
                 block_size: 64,
                 dp_size,
+                replay: None,
                 is_bigram: false,
             }
         }

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -28,7 +28,8 @@ pub struct AppContext {
     /// `/metrics`. Shared with the chat handler (requests_total),
     /// cache-aware-zmq policy (overlap_blocks), active-load registry
     /// (active_load gauge + stale_requests_total), and PD resolver
-    /// (decode_affinity_total).
+    /// (decode_affinity_total). The KV-event index is wired from `main`
+    /// after the context exists because it is constructed before policies.
     pub metrics: Arc<MetricsRegistry>,
     ready: AtomicBool,
 }

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -32,6 +32,7 @@
 //! | `sgl_router_stale_requests_total` | Counter | `outcome` |
 //! | `sgl_router_decode_affinity_total` | Counter | `outcome` |
 //! | `sgl_router_sticky_total` | Counter | `outcome` |
+//! | `sgl_router_kv_event_gaps_total` | Counter | `outcome` |
 //! | `sgl_router_ingress_tokenize_errors_total` | Counter | `model_id` |
 //!
 //! The four `sgl_router_worker*` gauges and `sgl_router_workers` are sampled
@@ -200,6 +201,27 @@ impl ActiveLoadKind {
     }
 }
 
+/// KV-event gap handling outcome label. Kept intentionally small and fixed:
+/// worker/rank/seq details belong in structured logs, not metric labels.
+#[derive(Debug, Clone, Copy)]
+pub enum KvEventGapOutcome {
+    Replayed,
+    NoReplayEndpoint,
+    ReplayFailed,
+    BufferMiss,
+}
+
+impl KvEventGapOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Replayed => "replayed",
+            Self::NoReplayEndpoint => "no_replay_endpoint",
+            Self::ReplayFailed => "replay_failed",
+            Self::BufferMiss => "buffer_miss",
+        }
+    }
+}
+
 /// The shared metrics registry, held on `AppContext`. Cheap to clone — all
 /// internal state is `Arc`/`Atomic`/`Mutex`-protected.
 #[derive(Debug, Default)]
@@ -224,6 +246,7 @@ pub struct MetricsRegistry {
     stale_requests_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     decode_affinity_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     sticky_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
+    kv_event_gaps_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     ingress_tokenize_errors_total: Mutex<HashMap<String, Arc<AtomicU64>>>,
 }
 
@@ -473,6 +496,17 @@ impl MetricsRegistry {
     /// Bump `sgl_router_sticky_total{outcome}`.
     pub fn record_sticky(&self, outcome: StickyOutcome) {
         let mut guard = self.sticky_total.lock();
+        let counter = guard
+            .entry(outcome.as_str())
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .clone();
+        drop(guard);
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump `sgl_router_kv_event_gaps_total{outcome}`.
+    pub fn record_kv_event_gap(&self, outcome: KvEventGapOutcome) {
+        let mut guard = self.kv_event_gaps_total.lock();
         let counter = guard
             .entry(outcome.as_str())
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
@@ -785,6 +819,25 @@ impl MetricsRegistry {
         }
         drop(guard);
 
+        // kv_event_gaps_total
+        out.push_str(
+            "# HELP sgl_router_kv_event_gaps_total KV-event sequence gaps observed by the router-side cache index, by fixed handling outcome.\n",
+        );
+        out.push_str("# TYPE sgl_router_kv_event_gaps_total counter\n");
+        let guard = self.kv_event_gaps_total.lock();
+        let mut entries: Vec<(&&str, u64)> = guard
+            .iter()
+            .map(|(k, v)| (k, v.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by_key(|e| *e.0);
+        for (outcome, value) in entries {
+            out.push_str(&format!(
+                "sgl_router_kv_event_gaps_total{{outcome=\"{}\"}} {}\n",
+                outcome, value,
+            ));
+        }
+        drop(guard);
+
         // ingress_tokenize_errors_total
         out.push_str(
             "# HELP sgl_router_ingress_tokenize_errors_total Chat requests on a chat-encoder model whose ingress tokenization failed, silently falling back to engine-side tokenization (the input_ids offload was defeated).\n",
@@ -870,6 +923,7 @@ mod tests {
         assert!(out.contains("# TYPE sgl_router_stale_requests_total counter"));
         assert!(out.contains("# TYPE sgl_router_decode_affinity_total counter"));
         assert!(out.contains("# TYPE sgl_router_sticky_total counter"));
+        assert!(out.contains("# TYPE sgl_router_kv_event_gaps_total counter"));
         assert!(out.contains("# TYPE sgl_router_ingress_tokenize_errors_total counter"));
         // Pool-size series exist (at 0) for all three modes even with no
         // workers, so dashboards have a stable series to graph.
@@ -1170,6 +1224,21 @@ mod tests {
         assert!(out.contains(r#"sgl_router_sticky_total{outcome="assigned"} 1"#));
         assert!(out.contains(r#"sgl_router_sticky_total{outcome="remap"} 1"#));
         assert!(out.contains(r#"sgl_router_sticky_total{outcome="no_routing_key"} 1"#));
+    }
+
+    #[test]
+    fn kv_event_gap_counter_emits_fixed_outcomes() {
+        let reg = MetricsRegistry::new();
+        reg.record_kv_event_gap(KvEventGapOutcome::Replayed);
+        reg.record_kv_event_gap(KvEventGapOutcome::Replayed);
+        reg.record_kv_event_gap(KvEventGapOutcome::NoReplayEndpoint);
+        reg.record_kv_event_gap(KvEventGapOutcome::ReplayFailed);
+        reg.record_kv_event_gap(KvEventGapOutcome::BufferMiss);
+        let out = reg.render();
+        assert!(out.contains(r#"sgl_router_kv_event_gaps_total{outcome="replayed"} 2"#));
+        assert!(out.contains(r#"sgl_router_kv_event_gaps_total{outcome="no_replay_endpoint"} 1"#));
+        assert!(out.contains(r#"sgl_router_kv_event_gaps_total{outcome="replay_failed"} 1"#));
+        assert!(out.contains(r#"sgl_router_kv_event_gaps_total{outcome="buffer_miss"} 1"#));
     }
 
     #[test]

--- a/experimental/sgl-router/src/workers/introspect.rs
+++ b/experimental/sgl-router/src/workers/introspect.rs
@@ -25,7 +25,7 @@ use serde::Deserialize;
 use tracing::warn;
 use url::Url;
 
-use crate::policies::kv_events::EventConfig;
+use crate::policies::kv_events::{EventConfig, ReplayConfig};
 
 /// Default timeout for `/server_info`. Conservative for a small JSON
 /// payload served by SGLang's HTTP server.
@@ -276,25 +276,21 @@ pub(crate) fn resolve_event_config(
     worker_url: &str,
     is_bigram: bool,
 ) -> EventConfig {
-    let host = if matches!(
-        block.endpoint_host.as_str(),
-        "*" | "0.0.0.0" | "::" | "[::]"
+    let worker_host = Url::parse(worker_url)
+        .ok()
+        .and_then(|u| u.host_str().map(|s| s.to_owned()));
+    let host = resolve_published_host(block.endpoint_host, worker_url, worker_host.as_deref());
+    let replay = match (
+        block.replay_endpoint_host,
+        block.replay_endpoint_port_base,
+        block.replay_buffer_steps,
     ) {
-        match Url::parse(worker_url)
-            .ok()
-            .and_then(|u| u.host_str().map(|s| s.to_owned()))
-        {
-            Some(h) => h,
-            None => {
-                warn!(
-                    worker_url = %worker_url,
-                    "introspect: cannot parse worker_url for wildcard substitution; keeping advertised host"
-                );
-                block.endpoint_host
-            }
-        }
-    } else {
-        block.endpoint_host
+        (Some(replay_host), Some(replay_port), Some(buffer_steps)) => Some(ReplayConfig {
+            host: resolve_published_host(replay_host, worker_url, worker_host.as_deref()),
+            port_base: replay_port,
+            buffer_steps,
+        }),
+        _ => None,
     };
     EventConfig {
         host,
@@ -302,7 +298,29 @@ pub(crate) fn resolve_event_config(
         topic: block.topic,
         block_size: block.block_size,
         dp_size: block.dp_size,
+        replay,
         is_bigram,
+    }
+}
+
+fn resolve_published_host(
+    advertised_host: String,
+    worker_url: &str,
+    worker_host: Option<&str>,
+) -> String {
+    if matches!(advertised_host.as_str(), "*" | "0.0.0.0" | "::" | "[::]") {
+        match worker_host {
+            Some(h) => h.to_owned(),
+            None => {
+                warn!(
+                    worker_url = %worker_url,
+                    "introspect: cannot parse worker_url for wildcard substitution; keeping advertised host"
+                );
+                advertised_host
+            }
+        }
+    } else {
+        advertised_host
     }
 }
 
@@ -348,6 +366,12 @@ pub(crate) struct KvEventsBlock {
     pub topic: String,
     pub block_size: u32,
     pub dp_size: u32,
+    #[serde(default)]
+    pub replay_endpoint_host: Option<String>,
+    #[serde(default)]
+    pub replay_endpoint_port_base: Option<u16>,
+    #[serde(default)]
+    pub replay_buffer_steps: Option<usize>,
 }
 
 #[cfg(test)]
@@ -460,6 +484,7 @@ mod tests {
         assert_eq!(cfg.topic, "kv");
         assert_eq!(cfg.block_size, 64);
         assert_eq!(cfg.dp_size, 2);
+        assert_eq!(cfg.replay, None);
     }
 
     #[tokio::test]
@@ -479,6 +504,55 @@ mod tests {
         let got = fast_introspector().fetch(&url).await;
         let cfg = got.event_config.expect("kv_events present");
         assert_eq!(cfg.host, "127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn fetch_parses_replay_config_and_substitutes_wildcard_host() {
+        let (url, _shutdown) = spawn_fake_worker(json!({
+            "served_model_name": "m",
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv",
+                "block_size": 64,
+                "dp_size": 2,
+                "replay_endpoint_host": "*",
+                "replay_endpoint_port_base": 5657,
+                "replay_buffer_steps": 1234,
+            }
+        }))
+        .await;
+        let got = fast_introspector().fetch(&url).await;
+        let cfg = got.event_config.expect("kv_events present");
+        assert_eq!(
+            cfg.replay,
+            Some(ReplayConfig {
+                host: "127.0.0.1".to_string(),
+                port_base: 5657,
+                buffer_steps: 1234,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_keeps_live_config_when_replay_fields_absent() {
+        let (url, _shutdown) = spawn_fake_worker(json!({
+            "served_model_name": "m",
+            "kv_events": {
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv",
+                "block_size": 64,
+                "dp_size": 1,
+            }
+        }))
+        .await;
+        let got = fast_introspector().fetch(&url).await;
+        let cfg = got.event_config.expect("kv_events present");
+        assert_eq!(cfg.host, "127.0.0.1");
+        assert_eq!(cfg.replay, None);
     }
 
     #[tokio::test]

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -126,6 +126,7 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
         topic: String::new(),
         block_size,
         dp_size: 1,
+        replay: None,
         is_bigram: false,
     };
     kv_index.add_worker(url_a, Some(preresolved.clone())).await;

--- a/experimental/sgl-router/tests/component/policies/kv_events_replay_e2e.rs
+++ b/experimental/sgl-router/tests/component/policies/kv_events_replay_e2e.rs
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Near-E2E gap replay test for KV events.
+//!
+//! This exercises the production Rust path end-to-end without a model server:
+//! `/server_info` discovery -> live ZMQ SUB -> pump gap detection -> replay
+//! DEALER -> `HashTree` update. The live publisher deliberately sends seq 1
+//! and seq 3 only; the replay ROUTER returns seq 2.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::{routing::get, Json, Router};
+use bytes::Bytes;
+use serde_json::{json, Value};
+use std::process::Stdio;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::net::TcpListener;
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::oneshot;
+use zeromq::{Endpoint, RouterSocket, Socket, SocketRecv, SocketSend, ZmqMessage};
+
+use sgl_router::policies::kv_events::{KvEventIndex, KvWorkerId};
+use sgl_router::server::metrics::MetricsRegistry;
+
+use super::zmq_helpers::{
+    build_multipart, encode_block_stored_event, encode_event_batch, make_pub_bound,
+};
+
+#[tokio::test]
+async fn kv_event_index_discovers_worker_and_replays_live_sequence_gap() {
+    let (mut publisher, live_port) = make_pub_bound().await;
+    let replay_payload = block_stored_payload(20);
+    let (replay_port, replay_server) = spawn_replay_router(2, vec![(2, replay_payload)]).await;
+    let (worker_url, shutdown_http) = spawn_fake_worker(live_port, replay_port).await;
+
+    let index = KvEventIndex::new();
+    let metrics = MetricsRegistry::new();
+    index.attach_metrics(Arc::clone(&metrics));
+    index.add_worker(&worker_url, None).await;
+    assert_eq!(
+        index.known_worker_count(),
+        1,
+        "worker should be discovered from fake /server_info"
+    );
+
+    let worker = KvWorkerId {
+        url: worker_url.clone(),
+        dp_rank: 0,
+    };
+    let seq1 = block_stored_payload(10);
+    let seq3 = block_stored_payload(30);
+
+    // PUB/SUB has an async subscription handshake. Publish seq=1 until the
+    // tree proves the real subscriber + pump path is live; then publish seq=3.
+    let start = Instant::now();
+    loop {
+        publisher
+            .send(build_multipart(1, seq1.clone()))
+            .await
+            .expect("publish seq=1");
+        if tree_has_block(&index, &worker, 10) {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "seq=1 never reached the HashTree through the live subscriber"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Now deliberately skip live seq=2 and send seq=3. The replay ROUTER must
+    // be asked for seq=2, and the tree should end up with both replayed block
+    // 20 and live block 30.
+    let start = Instant::now();
+    loop {
+        publisher
+            .send(build_multipart(3, seq3.clone()))
+            .await
+            .expect("publish seq=3");
+        if tree_has_block(&index, &worker, 20)
+            && tree_has_block(&index, &worker, 30)
+            && metrics
+                .render()
+                .contains(r#"sgl_router_kv_event_gaps_total{outcome="replayed"} 1"#)
+        {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "gap replay did not apply replayed seq=2 and live seq=3"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    replay_server.await.expect("replay server task");
+    index.shutdown().await;
+    let _ = shutdown_http.send(());
+}
+
+#[tokio::test]
+async fn kv_event_index_replays_gap_from_python_pyzmq_harness_when_available() {
+    let python = std::env::var("PYTHON").unwrap_or_else(|_| "python3".to_string());
+    if !python_has_pyzmq(&python).await {
+        eprintln!("skipping Python pyzmq harness test: `{python}` cannot import zmq");
+        return;
+    }
+
+    let mut harness = PythonHarness::spawn(&python).await;
+    let index = KvEventIndex::new();
+    let metrics = MetricsRegistry::new();
+    index.attach_metrics(Arc::clone(&metrics));
+    index.add_worker(&harness.worker_url, None).await;
+    assert_eq!(
+        index.known_worker_count(),
+        1,
+        "worker should be discovered from Python /server_info"
+    );
+
+    let worker = KvWorkerId {
+        url: harness.worker_url.clone(),
+        dp_rank: 0,
+    };
+
+    let start = Instant::now();
+    loop {
+        harness.command("publish 1 10").await;
+        if tree_has_block(&index, &worker, 10) {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "Python live seq=1 never reached the HashTree"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    harness.command("buffer 2 20").await;
+    let start = Instant::now();
+    loop {
+        // Send seq=3 live-only so the Python replay ROUTER returns exactly the
+        // missing seq=2 batch, matching the synthetic Rust near-E2E above.
+        harness.command("live 3 30").await;
+        if tree_has_block(&index, &worker, 20)
+            && tree_has_block(&index, &worker, 30)
+            && metrics
+                .render()
+                .contains(r#"sgl_router_kv_event_gaps_total{outcome="replayed"} 1"#)
+        {
+            break;
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "Python harness gap replay did not apply seq=2 and live seq=3"
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    index.shutdown().await;
+    harness.stop().await;
+}
+
+fn block_stored_payload(block_hash: i64) -> Vec<u8> {
+    encode_event_batch(
+        0.0,
+        vec![encode_block_stored_event(&[block_hash], None, &[], 64)],
+        Some(0),
+    )
+}
+
+fn tree_has_block(index: &KvEventIndex, worker: &KvWorkerId, block_hash: i64) -> bool {
+    let matched = index.tree().match_prefix(None, &[block_hash]);
+    matched.matched_blocks == 1 && matched.workers.contains(worker)
+}
+
+async fn spawn_fake_worker(live_port: u16, replay_port: u16) -> (String, oneshot::Sender<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake worker HTTP");
+    let http_port = listener.local_addr().expect("local addr").port();
+    let body = Arc::new(json!({
+        "kv_events": {
+            "publisher": "zmq",
+            "endpoint_host": "127.0.0.1",
+            "endpoint_port_base": live_port,
+            "topic": "",
+            "block_size": 64,
+            "dp_size": 1,
+            "replay_endpoint_host": "127.0.0.1",
+            "replay_endpoint_port_base": replay_port,
+            "replay_buffer_steps": 16,
+        }
+    }));
+    let app = Router::new().route(
+        "/server_info",
+        get(move || {
+            let body = Arc::clone(&body);
+            async move { Json::<Value>((*body).clone()) }
+        }),
+    );
+    let (tx, rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+    });
+    (format!("http://127.0.0.1:{http_port}"), tx)
+}
+
+async fn spawn_replay_router(
+    expected_start_seq: i64,
+    replies: Vec<(i64, Vec<u8>)>,
+) -> (u16, tokio::task::JoinHandle<()>) {
+    let mut router = RouterSocket::new();
+    let endpoint = router
+        .bind("tcp://127.0.0.1:0")
+        .await
+        .expect("bind replay ROUTER");
+    let port = match endpoint {
+        Endpoint::Tcp(_, port) => port,
+        other => panic!("unexpected replay endpoint: {other:?}"),
+    };
+    let handle = tokio::spawn(async move {
+        let request = router.recv().await.expect("receive replay request");
+        assert_eq!(request.len(), 3);
+        let identity = request.get(0).expect("identity").clone();
+        assert!(request.get(1).expect("delimiter").is_empty());
+        assert_eq!(
+            request.get(2).expect("start seq").as_ref(),
+            &expected_start_seq.to_be_bytes()
+        );
+        for (seq, payload) in replies {
+            router
+                .send(replay_reply(identity.clone(), seq, payload))
+                .await
+                .expect("send replay batch");
+        }
+        router
+            .send(replay_reply(identity, -1, Vec::new()))
+            .await
+            .expect("send replay END");
+    });
+    (port, handle)
+}
+
+fn replay_reply(identity: Bytes, seq: i64, payload: Vec<u8>) -> ZmqMessage {
+    let mut msg = ZmqMessage::from(identity);
+    msg.push_back(Bytes::new());
+    msg.push_back(Bytes::copy_from_slice(&seq.to_be_bytes()));
+    msg.push_back(Bytes::from(payload));
+    msg
+}
+
+async fn python_has_pyzmq(python: &str) -> bool {
+    let status = Command::new(python)
+        .arg("-c")
+        .arg("import zmq")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await;
+    matches!(status, Ok(status) if status.success())
+}
+
+struct PythonHarness {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: Lines<BufReader<ChildStdout>>,
+    worker_url: String,
+}
+
+impl PythonHarness {
+    async fn spawn(python: &str) -> Self {
+        let mut child = Command::new(python)
+            .arg("tests/scripts/kv_replay_gap_py_worker.py")
+            .env("PYTHONDONTWRITEBYTECODE", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn Python pyzmq harness");
+        let stdin = child.stdin.take().expect("Python harness stdin");
+        let stdout = child.stdout.take().expect("Python harness stdout");
+        let mut stdout = BufReader::new(stdout).lines();
+        let ready = tokio::time::timeout(Duration::from_secs(5), stdout.next_line())
+            .await
+            .expect("Python harness READY timeout")
+            .expect("read Python harness READY")
+            .expect("Python harness exited before READY");
+        let body = ready
+            .strip_prefix("READY ")
+            .unwrap_or_else(|| panic!("unexpected Python harness READY line: {ready}"));
+        let ready_json: Value = serde_json::from_str(body).expect("parse Python harness READY");
+        let worker_url = ready_json
+            .get("worker_url")
+            .and_then(Value::as_str)
+            .expect("Python harness READY worker_url")
+            .to_string();
+
+        Self {
+            child,
+            stdin,
+            stdout,
+            worker_url,
+        }
+    }
+
+    async fn command(&mut self, command: &str) {
+        self.stdin
+            .write_all(command.as_bytes())
+            .await
+            .expect("write Python harness command");
+        self.stdin
+            .write_all(b"\n")
+            .await
+            .expect("write Python harness newline");
+        self.stdin
+            .flush()
+            .await
+            .expect("flush Python harness command");
+        let response = tokio::time::timeout(Duration::from_secs(5), self.stdout.next_line())
+            .await
+            .unwrap_or_else(|_| panic!("Python harness command timed out: {command}"))
+            .expect("read Python harness command response")
+            .unwrap_or_else(|| panic!("Python harness exited after command: {command}"));
+        assert!(
+            response.starts_with("OK "),
+            "Python harness rejected `{command}`: {response}"
+        );
+    }
+
+    async fn stop(mut self) {
+        self.command("stop").await;
+        let status = tokio::time::timeout(Duration::from_secs(5), self.child.wait())
+            .await
+            .expect("Python harness stop timeout")
+            .expect("wait for Python harness");
+        assert!(status.success(), "Python harness exited with {status}");
+    }
+}
+
+impl Drop for PythonHarness {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}

--- a/experimental/sgl-router/tests/component/policies/kv_events_two_subscribers.rs
+++ b/experimental/sgl-router/tests/component/policies/kv_events_two_subscribers.rs
@@ -41,6 +41,7 @@ async fn two_independent_subscribers_converge_to_same_tree_state() {
         topic: String::new(),
         block_size,
         dp_size: 1,
+        replay: None,
         is_bigram: false,
     };
 
@@ -174,6 +175,7 @@ async fn two_subscribers_merge_events_from_two_publishers() {
         topic: String::new(),
         block_size,
         dp_size: 1,
+        replay: None,
         is_bigram: false,
     };
     let cfg_y = EventConfig {
@@ -182,6 +184,7 @@ async fn two_subscribers_merge_events_from_two_publishers() {
         topic: String::new(),
         block_size,
         dp_size: 1,
+        replay: None,
         is_bigram: false,
     };
 

--- a/experimental/sgl-router/tests/component/policies/mod.rs
+++ b/experimental/sgl-router/tests/component/policies/mod.rs
@@ -5,6 +5,7 @@ mod zmq_helpers;
 
 mod cache_aware_zmq;
 mod kv_events_hash_parity;
+mod kv_events_replay_e2e;
 mod kv_events_tree_concurrent;
 mod kv_events_two_subscribers;
 mod power_of_two;

--- a/experimental/sgl-router/tests/scripts/kv_replay_gap_py_worker.py
+++ b/experimental/sgl-router/tests/scripts/kv_replay_gap_py_worker.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# Copyright 2026 The SGLang Authors
+# Licensed under the Apache License, Version 2.0
+"""Small Python fake worker for KV replay gap validation.
+
+This is a manual/automation harness, not a model server. It exposes the three
+interfaces the Rust router needs:
+
+* HTTP `/server_info` with live and replay KV event metadata.
+* ZMQ PUB for live KV events.
+* ZMQ ROUTER for replay requests, using `ZmqEventPublisher`'s wire format.
+
+Example command stream after startup prints `READY {...}`:
+
+    publish 1 10
+    buffer 2 20
+    live 3 30
+    stop
+
+`publish` sends a live event and stores it in the replay buffer. `buffer`
+stores an event without publishing it, which deterministically creates a live
+sequence gap while keeping replay able to recover it. `live` sends without
+storing, useful when the replay socket should return only the missing batch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Dict
+
+END_SEQ = (-1).to_bytes(8, "big", signed=True)
+
+
+def pack_array_len(n: int) -> bytes:
+    if n < 16:
+        return bytes([0x90 | n])
+    if n <= 0xFFFF:
+        return b"\xdc" + n.to_bytes(2, "big")
+    raise ValueError(f"array too large: {n}")
+
+
+def pack_str(value: str) -> bytes:
+    raw = value.encode("utf-8")
+    if len(raw) < 32:
+        return bytes([0xA0 | len(raw)]) + raw
+    if len(raw) <= 0xFF:
+        return b"\xd9" + bytes([len(raw)]) + raw
+    raise ValueError(f"string too large: {value!r}")
+
+
+def pack_uint(value: int) -> bytes:
+    if value < 0:
+        raise ValueError("expected unsigned integer")
+    if value < 128:
+        return bytes([value])
+    if value <= 0xFF:
+        return b"\xcc" + bytes([value])
+    if value <= 0xFFFF:
+        return b"\xcd" + value.to_bytes(2, "big")
+    if value <= 0xFFFFFFFF:
+        return b"\xce" + value.to_bytes(4, "big")
+    return b"\xcf" + value.to_bytes(8, "big")
+
+
+def pack_i64(value: int) -> bytes:
+    return b"\xd3" + struct.pack(">q", value)
+
+
+def encode_block_stored_payload(block_hash: int, block_size: int) -> bytes:
+    # KVEventBatch = [ts, [event], attn_dp_rank]
+    event = b"".join(
+        [
+            pack_array_len(7),
+            pack_str("BlockStored"),
+            pack_array_len(1),
+            pack_i64(block_hash),
+            b"\xc0",  # parent_block_hash = None
+            pack_array_len(0),  # token_ids
+            pack_uint(block_size),
+            b"\xc0",  # lora_id
+            pack_str("GPU"),
+        ]
+    )
+    return b"".join(
+        [
+            pack_array_len(3),
+            b"\xcb" + struct.pack(">d", 0.0),
+            pack_array_len(1),
+            event,
+            pack_uint(0),  # attn_dp_rank
+        ]
+    )
+
+
+def make_handler(body: Dict[str, object]):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path != "/server_info":
+                self.send_error(404)
+                return
+            payload = json.dumps(body).encode("utf-8")
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    return Handler
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--block-size", type=int, default=64)
+    parser.add_argument("--buffer-steps", type=int, default=16)
+    parser.add_argument("--topic", default="")
+    args = parser.parse_args()
+
+    try:
+        import zmq
+    except ModuleNotFoundError as exc:
+        print(f"ERROR missing dependency: {exc}", file=sys.stderr, flush=True)
+        return 2
+
+    ctx = zmq.Context.instance()
+    pub = ctx.socket(zmq.PUB)
+    replay = ctx.socket(zmq.ROUTER)
+    live_port = pub.bind_to_random_port("tcp://127.0.0.1")
+    replay_port = replay.bind_to_random_port("tcp://127.0.0.1")
+
+    body = {
+        "kv_events": {
+            "publisher": "zmq",
+            "endpoint_host": "127.0.0.1",
+            "endpoint_port_base": live_port,
+            "topic": args.topic,
+            "block_size": args.block_size,
+            "dp_size": 1,
+            "replay_endpoint_host": "127.0.0.1",
+            "replay_endpoint_port_base": replay_port,
+            "replay_buffer_steps": args.buffer_steps,
+        }
+    }
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), make_handler(body))
+    http_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    http_thread.start()
+
+    buffer: Dict[int, bytes] = {}
+    running = True
+
+    def replay_loop() -> None:
+        poller = zmq.Poller()
+        poller.register(replay, zmq.POLLIN)
+        while running:
+            events = dict(poller.poll(50))
+            if replay not in events:
+                continue
+            frames = replay.recv_multipart()
+            if len(frames) != 3:
+                continue
+            client_id, _empty, start_seq_bytes = frames
+            start_seq = int.from_bytes(start_seq_bytes, "big")
+            for seq in sorted(buffer):
+                if seq >= start_seq:
+                    replay.send_multipart(
+                        [client_id, b"", seq.to_bytes(8, "big"), buffer[seq]]
+                    )
+            replay.send_multipart([client_id, b"", END_SEQ, b""])
+
+    replay_thread = threading.Thread(target=replay_loop, daemon=True)
+    replay_thread.start()
+
+    ready = {
+        "worker_url": f"http://127.0.0.1:{httpd.server_port}",
+        "live_endpoint": f"tcp://127.0.0.1:{live_port}",
+        "replay_endpoint": f"tcp://127.0.0.1:{replay_port}",
+    }
+    print("READY " + json.dumps(ready, sort_keys=True), flush=True)
+
+    topic = args.topic.encode("utf-8")
+    try:
+        for raw in sys.stdin:
+            parts = raw.strip().split()
+            if not parts:
+                continue
+            cmd = parts[0]
+            if cmd == "stop":
+                print("OK stop", flush=True)
+                break
+            if cmd not in {"publish", "buffer", "live"} or len(parts) != 3:
+                print(f"ERR bad command: {raw.strip()}", flush=True)
+                continue
+            seq = int(parts[1])
+            block_hash = int(parts[2])
+            payload = encode_block_stored_payload(block_hash, args.block_size)
+            if cmd != "live":
+                buffer[seq] = payload
+            if cmd == "publish":
+                pub.send_multipart([topic, seq.to_bytes(8, "big"), payload])
+            elif cmd == "live":
+                pub.send_multipart([topic, seq.to_bytes(8, "big"), payload])
+            print(f"OK {cmd} {seq} {block_hash}", flush=True)
+    finally:
+        running = False
+        time.sleep(0.1)
+        httpd.shutdown()
+        pub.close(linger=0)
+        replay.close(linger=0)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -8810,6 +8810,13 @@ class ServerArgs:
                                                   # prompts at this size
                 "dp_size": <dp_size>,             # number of SUB sockets
                                                   # to open
+                # Present only when a valid TCP replay endpoint is
+                # configured. Routers construct the per-DP-rank DEALER
+                # endpoint as
+                # tcp://<worker_host>:<replay_endpoint_port_base + dp_rank>.
+                "replay_endpoint_host": "*",
+                "replay_endpoint_port_base": 5657,
+                "replay_buffer_steps": 10000,
             }
 
         Returns None (i.e. "no publisher to describe") when any of:
@@ -8823,14 +8830,28 @@ class ServerArgs:
           ipc://, missing port, non-integer port, or port outside
           1..65535).
 
-        Reuses KVEventsConfig.from_cli for JSON parsing; the inline
-        rfind(":") endpoint split mirrors
-        ZmqEventPublisher.offset_endpoint_port rather than adding a
-        new module-level helper.
+        Reuses KVEventsConfig.from_cli for JSON parsing. The endpoint
+        split mirrors ZmqEventPublisher.offset_endpoint_port.
         """
         # Lazy import so loading server_args doesn't pull in
         # disaggregation / msgspec / zmq at module top level.
         from sglang.srt.disaggregation.kv_events import KVEventsConfig
+
+        def parse_tcp_endpoint(endpoint: Optional[str]) -> Optional[tuple[str, int]]:
+            if not endpoint or not endpoint.startswith("tcp://"):
+                return None
+            body = endpoint[len("tcp://") :]
+            last_colon = body.rfind(":")
+            if last_colon < 0:
+                return None
+            host = body[:last_colon]
+            try:
+                port = int(body[last_colon + 1 :])
+            except ValueError:
+                return None
+            if not host or not (0 < port < 65536):
+                return None
+            return host, port
 
         raw = self.kv_events_config
         page_size = self.page_size
@@ -8845,21 +8866,12 @@ class ServerArgs:
             return None
         if cfg.publisher == "null" or not cfg.endpoint:
             return None
-        if not cfg.endpoint.startswith("tcp://"):
+        live_endpoint = parse_tcp_endpoint(cfg.endpoint)
+        if live_endpoint is None:
             return None
-        body = cfg.endpoint[len("tcp://") :]
-        last_colon = body.rfind(":")
-        if last_colon < 0:
-            return None
-        host = body[:last_colon]
-        try:
-            port = int(body[last_colon + 1 :])
-        except ValueError:
-            return None
-        if not host or not (0 < port < 65536):
-            return None
+        host, port = live_endpoint
 
-        return {
+        descriptor = {
             "publisher": cfg.publisher,
             "endpoint_host": host,
             "endpoint_port_base": port,
@@ -8867,6 +8879,17 @@ class ServerArgs:
             "block_size": page_size,
             "dp_size": self.dp_size,
         }
+        replay_endpoint = parse_tcp_endpoint(cfg.replay_endpoint)
+        if replay_endpoint is not None:
+            replay_host, replay_port = replay_endpoint
+            descriptor.update(
+                {
+                    "replay_endpoint_host": replay_host,
+                    "replay_endpoint_port_base": replay_port,
+                    "replay_buffer_steps": cfg.buffer_steps,
+                }
+            )
+        return descriptor
 
 
 # NOTE: The process-wide ServerArgs is owned by the runtime context

--- a/test/registered/unit/disaggregation/test_kv_events.py
+++ b/test/registered/unit/disaggregation/test_kv_events.py
@@ -71,6 +71,21 @@ class TestSelectKvPublisherDpRank(CustomTestCase):
         ]
         self.assertEqual(dp_attention, expected)
 
+    def test_replay_endpoint_binds_sequential_ports_per_replica(self):
+        # The replay ROUTER socket is offset by the same DP rank as the live PUB
+        # socket. `/server_info` advertises only the base port; routers derive
+        # rank-local replay endpoints with port_base + rank.
+        endpoint = "tcp://*:5657"
+        expected = [f"tcp://*:{5657 + r}" for r in range(4)]
+
+        replay_endpoints = [
+            ZmqEventPublisher.offset_endpoint_port(
+                endpoint, select_kv_publisher_dp_rank(1, 0, r)
+            )
+            for r in range(4)
+        ]
+        self.assertEqual(replay_endpoints, expected)
+
     def test_publisher_rank_count_matches_advertised_dp_size(self):
         # The router subscribes to `dp_size` per-rank ports (from /server_info).
         # The engine must produce exactly `dp_size` distinct publisher ranks in

--- a/test/registered/unit/entrypoints/test_server_info.py
+++ b/test/registered/unit/entrypoints/test_server_info.py
@@ -117,6 +117,69 @@ class TestServerInfoKvEventsField(CustomTestCase):
         self.assertEqual(info["kv_events"]["block_size"], 128)
         self.assertEqual(info["kv_events"]["dp_size"], 1)
 
+    def test_kv_events_descriptor_exposes_valid_replay_endpoint(self):
+        args = ServerArgs(
+            model_path="dummy",
+            kv_events_config=(
+                '{"publisher": "zmq", "endpoint": "tcp://*:5557", '
+                '"replay_endpoint": "tcp://*:5657", "buffer_steps": 1234, '
+                '"topic": "kv"}'
+            ),
+            page_size=64,
+            dp_size=2,
+        )
+
+        info = _call_server_info_with(args)
+
+        self.assertIsNotNone(info["kv_events"])
+        self.assertEqual(info["kv_events"]["replay_endpoint_host"], "*")
+        self.assertEqual(info["kv_events"]["replay_endpoint_port_base"], 5657)
+        self.assertEqual(info["kv_events"]["replay_buffer_steps"], 1234)
+
+    def test_kv_events_descriptor_omits_replay_when_unconfigured(self):
+        args = ServerArgs(
+            model_path="dummy",
+            kv_events_config=(
+                '{"publisher": "zmq", "endpoint": "tcp://*:5557", "topic": "kv"}'
+            ),
+            page_size=64,
+            dp_size=2,
+        )
+
+        info = _call_server_info_with(args)
+
+        self.assertIsNotNone(info["kv_events"])
+        self.assertNotIn("replay_endpoint_host", info["kv_events"])
+        self.assertNotIn("replay_endpoint_port_base", info["kv_events"])
+        self.assertNotIn("replay_buffer_steps", info["kv_events"])
+
+    def test_kv_events_descriptor_omits_invalid_replay_without_hiding_live(self):
+        for replay_endpoint in (
+            "inproc://cache",
+            "tcp://0.0.0.0",
+            "tcp://0.0.0.0:abc",
+            "tcp://0.0.0.0:0",
+            "tcp://0.0.0.0:65536",
+        ):
+            with self.subTest(replay_endpoint=replay_endpoint):
+                args = ServerArgs(
+                    model_path="dummy",
+                    kv_events_config=(
+                        '{"publisher": "zmq", "endpoint": "tcp://*:5557", '
+                        f'"replay_endpoint": "{replay_endpoint}", "topic": "kv"}}'
+                    ),
+                    page_size=64,
+                    dp_size=2,
+                )
+
+                info = _call_server_info_with(args)
+
+                self.assertIsNotNone(info["kv_events"])
+                self.assertEqual(info["kv_events"]["endpoint_port_base"], 5557)
+                self.assertNotIn("replay_endpoint_host", info["kv_events"])
+                self.assertNotIn("replay_endpoint_port_base", info["kv_events"])
+                self.assertNotIn("replay_buffer_steps", info["kv_events"])
+
     # ----- disabled / unconfigured -------------------------------------
 
     def test_kv_events_is_null_when_no_publisher_configured(self):


### PR DESCRIPTION
## Motivation

Closes #32728.

The Rust `experimental/sgl-router` maintains a router-side KV `HashTree` from engine-side live KV events. The Python `ZmqEventPublisher` already has an optional replay `ROUTER` socket backed by an in-memory replay buffer, but the Rust router could not discover or use it. When live ZMQ events are dropped and the router observes `seq > last_seq + 1`, the router previously had no way to recover the missing event batches.

This PR wires the existing Python replay capability into the Rust router while preserving the current fallback behavior when replay is unavailable or incomplete.

## Modifications

- Extend Python `/server_info` KV event metadata to optionally expose replay metadata when `kv_events_config.replay_endpoint` is a valid TCP endpoint:
  - `replay_endpoint_host`
  - `replay_endpoint_port_base`
  - `replay_buffer_steps`
- Add Rust `ReplayConfig` discovery/introspection support, including wildcard host replacement and DP-rank port offsets.
- Add a Rust replay client using `zeromq::DealerSocket`, aligned with the existing Python `ZmqEventPublisher` wire format:
  - request sent by DEALER: `[empty_delim, start_seq_bytes]`
  - Python ROUTER observes: `[client_id, empty_delim, start_seq_bytes]`
  - Python ROUTER replies: `[client_id, empty_delim, seq_bytes, payload] ... [client_id, empty_delim, END_SEQ, b""]`
  - Rust DEALER receives: `[empty_delim, seq_bytes, payload] ... [empty_delim, END_SEQ, b""]`
- Teach the Rust KV event pump to attempt replay when it detects `seq > last_seq + 1`.
  - On successful continuous replay, it applies replayed batches before applying the live batch that revealed the gap.
  - On no replay endpoint, replay failure, buffer miss, decode error, or non-continuous replay, it records/logs the outcome and preserves the existing behavior: apply the current live batch and advance the cursor.
- Add fixed-label metrics: `sgl_router_kv_event_gaps_total{outcome=...}`.
- Add deterministic component near-E2E coverage for the real Rust path: fake `/server_info`, live PUB seq 1/3, replay ROUTER seq 2, and production `KvEventIndex.add_worker(None)` discovery/subscriber/pump/replay.
- Add a Python `pyzmq` harness that exposes fake `/server_info`, live PUB, and replay ROUTER using the Python publisher wire shape, plus a component test that runs it when `PYTHON` can import `zmq`.

## Accuracy Tests

Not applicable. This PR does not change model execution, kernels, sampling, or output numerics. It only changes router-side KV event metadata handling and gap recovery for cache-aware routing signals.

## Speed Tests and Profiling

Not run. The added replay path is only used when the router detects a KV event sequence gap. The normal live event path and routing decision hot path are unchanged except for storing optional replay endpoint metadata and incrementing gap metrics on gap handling.

## Validation

Passed locally from `experimental/sgl-router` unless otherwise noted:

- `cargo check --all-targets`
- `cargo +nightly fmt -- --check`
- `cargo +nightly clippy --all-targets -- -D warnings`
- `cargo test policies::kv_events::replay --lib`
- `cargo test policies::kv_events::index --lib`
- `cargo test policies::kv_events::discovery --lib`
- `cargo test workers::introspect --lib`
- `cargo test kv_event_gap_counter_emits_fixed_outcomes --lib`
- `cargo test --test component kv_event_index_discovers_worker_and_replays_live_sequence_gap`
- `PYTHON=/tmp/sgl-router-kv-replay-pyzmq-venv/bin/python cargo test --test component kv_event_index_replays_gap_from_python_pyzmq_harness_when_available -- --nocapture`
- `python3 tests/scripts/generate_kv_events_hash_parity.py` and confirmed `tests/fixtures/kv_events_hash_parity.json` had no diff
- From repo root: `python3 -m py_compile python/sglang/srt/server_args.py test/registered/unit/entrypoints/test_server_info.py test/registered/unit/disaggregation/test_kv_events.py experimental/sgl-router/tests/scripts/kv_replay_gap_py_worker.py`
- `git diff --check`

Additional validation notes:

- Default local `cargo clippy --all-targets -- -D warnings` was blocked because the local stable `1.90-aarch64-apple-darwin` toolchain reports `cargo-clippy` as not applicable. Nightly clippy passed.
- `PYTHONPATH=python python3 -m unittest test.registered.unit.entrypoints.test_server_info test.registered.unit.disaggregation.test_kv_events` was blocked locally by a missing `pybase64` dependency. The edited Python files pass `py_compile`.
- `cargo test --release -- --skip parity_matrix` compiled and ran; the new replay/gap tests passed, but the suite failed on existing `policies::kv_events::subscriber::*` timeout tests. A serial subscriber rerun reduced this to `dp_size_three_per_worker` and `dp_size_eight_per_worker` timeouts.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing docs were added; the new contract is covered in code comments/tests.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; see sections above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30427443206](https://github.com/sgl-project/sglang/actions/runs/30427443206)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30427443017](https://github.com/sgl-project/sglang/actions/runs/30427443017)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->