### PR TITLE
Optimize GPT-OSS CP4+EP4 prefill with breakable graphs and single-call zigzag attention

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -1285,13 +1285,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 cu_seqlens_q,
                 cache_seqlens,
                 max_seqlen_q,
+                *,
                 cu_seqlens_kv,
+                use_zigzag_page_table=False,
             ):
+                block_tables = (
+                    self._get_zigzag_layer_page_table(layer)
+                    if use_zigzag_page_table
+                    else page_table
+                )
                 return flashinfer.prefill.trtllm_batch_context_with_kv_cache(
                     query=q_chunk,
                     kv_cache=kv_cache,
                     workspace_buffer=self.workspace_buffer,
-                    block_tables=page_table,
+                    block_tables=block_tables,
                     seq_lens=cache_seqlens,
                     max_q_len=max_seqlen_q,
                     max_kv_len=self.max_context_len,

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -75,6 +75,9 @@ class TRTLLMMHAMetadata:
     page_table: torch.Tensor = None
     # Page table for SWA layers (translated from full pool indices to SWA pool indices)
     swa_page_table: torch.Tensor = None
+    # CP-v2 zigzag treats prev/next halves as a synthetic 2 * batch_size batch.
+    zigzag_page_table: torch.Tensor = None
+    zigzag_swa_page_table: torch.Tensor = None
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: torch.Tensor = None
     is_ragged_verify: bool = False
@@ -314,6 +317,35 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             if is_swa:
                 return swa_pt
         return self.forward_metadata.page_table
+
+    def _build_zigzag_page_tables(
+        self,
+        metadata: TRTLLMMHAMetadata,
+        forward_batch: ForwardBatch,
+    ) -> None:
+        """Duplicate request rows once for the combined prev-then-next CP launch."""
+        if not is_cp_v2_active(forward_batch):
+            return
+
+        metadata.zigzag_page_table = torch.cat(
+            (metadata.page_table, metadata.page_table), dim=0
+        )
+        if metadata.swa_page_table is not None:
+            metadata.zigzag_swa_page_table = torch.cat(
+                (metadata.swa_page_table, metadata.swa_page_table), dim=0
+            )
+
+    def _get_zigzag_layer_page_table(
+        self,
+        layer: RadixAttention,
+    ) -> torch.Tensor:
+        """Return the duplicated full or SWA page table for zigzag CP."""
+        zigzag_swa_pt = self.forward_metadata.zigzag_swa_page_table
+        if zigzag_swa_pt is not None:
+            _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
+            if is_swa:
+                return zigzag_swa_pt
+        return self.forward_metadata.zigzag_page_table
 
     @staticmethod
     def _get_scalar_scale(
@@ -938,6 +970,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self._fill_page_table_device(
             metadata, forward_batch.req_pool_indices, metadata.cache_seqlens_int32
         )
+        self._build_zigzag_page_tables(metadata, forward_batch)
 
         if self._needs_encoder_only_expand(forward_batch.forward_mode, metadata):
             row_map = (

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -79,11 +79,18 @@ class ZigzagContextParallelMetadata(BaseContextParallelMetadata):
     cu_seqlens_q_prev_tensor: Optional[Any] = None
     cu_seqlens_q_next_tensor: Optional[Any] = None
 
+    # Combined prev-then-next TRT-LLM geometry (shape [2 * bs] or [2 * bs + 1]).
+    actual_seq_q_combined_tensor: Optional[Any] = None
+    kv_len_combined_tensor: Optional[Any] = None
+    cu_seqlens_q_combined_tensor: Optional[Any] = None
+    cu_seqlens_kv_combined_tensor: Optional[Any] = None
+
     # Scalars derived from the per-sequence lists above.
     total_q_prev_tokens: int = 0
     total_q_next_tokens: int = 0
     max_seqlen_q_prev: int = 0
     max_seqlen_q_next: int = 0
+    max_seqlen_q_combined: int = 0
 
     # Per-sequence CPU lists, useful for indexers and diagnostics.
     kv_len_prev_list: Optional[List[int]] = None
@@ -218,6 +225,10 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         cu_next = [0] + list(accumulate(actual_seq_q_next_list))
         cu_kv_prev = [0] + list(accumulate(kv_len_prev_list))
         cu_kv_next = [0] + list(accumulate(kv_len_next_list))
+        actual_seq_q_combined_list = actual_seq_q_prev_list + actual_seq_q_next_list
+        kv_len_combined_list = kv_len_prev_list + kv_len_next_list
+        cu_q_combined = [0] + list(accumulate(actual_seq_q_combined_list))
+        cu_kv_combined = [0] + list(accumulate(kv_len_combined_list))
 
         total_seq_lens = sum(extend_seqs_len)
         assert len(split_list) == bs * cp_segment_num
@@ -258,6 +269,18 @@ class ZigzagCPStrategy(ContextParallelStrategy):
             cu_seqlens_q_next_tensor=torch.tensor(
                 cu_next, device=device, dtype=torch.int32
             ),
+            actual_seq_q_combined_tensor=torch.tensor(
+                actual_seq_q_combined_list, device=device, dtype=torch.int32
+            ),
+            kv_len_combined_tensor=torch.tensor(
+                kv_len_combined_list, device=device, dtype=torch.int32
+            ),
+            cu_seqlens_q_combined_tensor=torch.tensor(
+                cu_q_combined, device=device, dtype=torch.int32
+            ),
+            cu_seqlens_kv_combined_tensor=torch.tensor(
+                cu_kv_combined, device=device, dtype=torch.int32
+            ),
             total_q_prev_tokens=cu_prev[-1],
             total_q_next_tokens=cu_next[-1],
             max_seqlen_q_prev=(
@@ -265,6 +288,9 @@ class ZigzagCPStrategy(ContextParallelStrategy):
             ),
             max_seqlen_q_next=(
                 max(actual_seq_q_next_list) if actual_seq_q_next_list else 0
+            ),
+            max_seqlen_q_combined=(
+                max(actual_seq_q_combined_list) if actual_seq_q_combined_list else 0
             ),
             kv_len_prev_list=kv_len_prev_list,
             kv_len_next_list=kv_len_next_list,

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -355,31 +355,33 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         ), f"{self.name} CP does not support {attention_backend=}"
 
         meta = forward_batch.attn_cp_metadata
-        q_prev = q[: meta.total_q_prev_tokens]
         logical_tokens = meta.total_q_prev_tokens + meta.total_q_next_tokens
-        q_next = q[meta.total_q_prev_tokens : logical_tokens]
-
-        prev_kwargs = {}
-        next_kwargs = {}
         if attention_backend == CPAttentionBackendKind.TRTLLM_MHA:
-            prev_kwargs["cu_seqlens_kv"] = meta.cu_seqlens_kv_prev_tensor
-            next_kwargs["cu_seqlens_kv"] = meta.cu_seqlens_kv_next_tensor
+            result = attn_fn(
+                q[:logical_tokens],
+                meta.cu_seqlens_q_combined_tensor,
+                meta.kv_len_combined_tensor,
+                meta.max_seqlen_q_combined,
+                cu_seqlens_kv=meta.cu_seqlens_kv_combined_tensor,
+                use_zigzag_page_table=True,
+            )
+        else:
+            q_prev = q[: meta.total_q_prev_tokens]
+            q_next = q[meta.total_q_prev_tokens : logical_tokens]
+            result_prev = attn_fn(
+                q_prev,
+                meta.cu_seqlens_q_prev_tensor,
+                meta.kv_len_prev_tensor,
+                meta.max_seqlen_q_prev,
+            )
+            result_next = attn_fn(
+                q_next,
+                meta.cu_seqlens_q_next_tensor,
+                meta.kv_len_next_tensor,
+                meta.max_seqlen_q_next,
+            )
+            result = torch.cat([result_prev, result_next], dim=0)
 
-        result_prev = attn_fn(
-            q_prev,
-            meta.cu_seqlens_q_prev_tensor,
-            meta.kv_len_prev_tensor,
-            meta.max_seqlen_q_prev,
-            **prev_kwargs,
-        )
-        result_next = attn_fn(
-            q_next,
-            meta.cu_seqlens_q_next_tensor,
-            meta.kv_len_next_tensor,
-            meta.max_seqlen_q_next,
-            **next_kwargs,
-        )
-        result = torch.cat([result_prev, result_next], dim=0)
         pad_size = q.shape[0] - logical_tokens
         assert pad_size >= 0
         if pad_size > 0:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -229,6 +229,13 @@ elif current_platform.is_out_of_tree():
 logger = logging.getLogger(__name__)
 
 
+def _prefill_cuda_graph_allows_context_parallel(prefill_runner) -> bool:
+    """Allow CP only through a runner that captured the validated CP-v2 body."""
+    return get_cp_strategy() is None or bool(
+        getattr(prefill_runner, "enable_cp_v2_body_capture", False)
+    )
+
+
 @dataclass
 class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]
@@ -1543,7 +1550,9 @@ class ModelRunner:
                 and not isinstance(self.prefill_cuda_graph_runner, EagerRunner)
                 and self.prefill_cuda_graph_runner is not None
                 and self.prefill_cuda_graph_runner.can_run_graph(forward_batch)
-                and get_cp_strategy() is None
+                and _prefill_cuda_graph_allows_context_parallel(
+                    self.prefill_cuda_graph_runner
+                )
             ):
                 category = (
                     "target_verify"

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -627,6 +627,33 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         forward_batch.attn_cp_metadata = None
         prepare_cp_forward(forward_batch)
 
+        captured_local_tokens = None
+        if not capture:
+            try:
+                captured_local_tokens = self.cp_bucket_local_tokens[static_num_tokens]
+            except KeyError as exc:
+                raise RuntimeError(
+                    "Missing CP-local capture capacity for global prefill bucket "
+                    f"{static_num_tokens}"
+                ) from exc
+
+            # Breakable graph segments retain the captured token-row geometry
+            # even when a smaller live batch reuses this bucket. Preserve the
+            # live logical lengths used to discard padding, but make every CP
+            # physical tensor and collective use the captured local capacity.
+            metadata = forward_batch.attn_cp_metadata
+            if hasattr(metadata, "per_rank_actual_token"):
+                live_physical_tokens = max(metadata.per_rank_actual_token)
+                if live_physical_tokens > captured_local_tokens:
+                    raise RuntimeError(
+                        f"Live batch needs {live_physical_tokens} local CP rows, "
+                        f"but global prefill bucket {static_num_tokens} has "
+                        f"captured capacity {captured_local_tokens}"
+                    )
+                cp_size = len(metadata.per_rank_actual_token)
+                metadata.per_rank_actual_token = [captured_local_tokens] * cp_size
+                metadata.max_rank_len = [captured_local_tokens] * cp_size
+
         raw_tokens = int(forward_batch.extend_num_tokens)
         global_input_ids = forward_batch.input_ids[:raw_tokens]
         global_positions = forward_batch.positions[:raw_tokens]
@@ -644,13 +671,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             captured_local_tokens = live_local_tokens
             self.cp_bucket_local_tokens[static_num_tokens] = captured_local_tokens
         else:
-            try:
-                captured_local_tokens = self.cp_bucket_local_tokens[static_num_tokens]
-            except KeyError as exc:
-                raise RuntimeError(
-                    "Missing CP-local capture capacity for global prefill bucket "
-                    f"{static_num_tokens}"
-                ) from exc
+            assert captured_local_tokens is not None
             if live_local_tokens > captured_local_tokens:
                 raise RuntimeError(
                     f"Live batch needs {live_local_tokens} local CP rows, but global "

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -52,6 +52,11 @@ from sglang.kernels.ops.kvcache.kv_indices import (
 )
 from sglang.srt.distributed.parallel_state import graph_capture
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
+from sglang.srt.layers.cp.utils import (
+    cp_split_before_forward,
+    enable_cp_v2,
+    prepare_cp_forward,
+)
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
     set_dp_buffer_len,
@@ -344,6 +349,11 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         self._is_full_backend = False
         # Same ordering requirement: capture_prepare reads this.
         self._capture_lora = False
+        self.enable_cp_v2_body_capture = False
+        self.cp_input_embeds: Optional[torch.Tensor] = None
+        self.cp_positions: Optional[torch.Tensor] = None
+        self.cp_bucket_local_tokens: Dict[int, int] = {}
+        self._cp_live_local_tokens = 0
         # TcPiecewise does its compile pass during backend construction.
         # Wrap only that path with the prefill CUDA graph failure hint.
         try:
@@ -441,6 +451,28 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                     name: torch.zeros((self.max_bs,), dtype=torch.int64)
                     for name in _PREFILL_STATIC_FIELDS
                 }
+
+        server_args = model_runner.server_args
+        self.enable_cp_v2_body_capture = (
+            isinstance(self.backend, BreakableCudaGraphBackend)
+            and enable_cp_v2()
+            and server_args.enable_prefill_cp
+            and server_args.attn_cp_size == server_args.tp_size
+            and server_args._supports_breakable_prefill_cp()
+        )
+        if self.enable_cp_v2_body_capture:
+            with torch.device(self.device):
+                self.cp_input_embeds = torch.zeros(
+                    (
+                        self.max_num_tokens,
+                        model_runner.model_config.hidden_size,
+                    ),
+                    dtype=model_runner.dtype,
+                )
+                self.cp_positions = torch.zeros(
+                    (self.max_num_tokens,),
+                    dtype=torch.int64,
+                )
 
         # Static hidden_states buffer giving the captured graph a stable
         # address; load_batch refreshes it from live spec_info at replay.
@@ -575,6 +607,71 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             return forward_batch.mrope_positions
 
         return forward_batch.positions
+
+    def _prepare_cp_static_inputs(
+        self,
+        forward_batch: ForwardBatch,
+        *,
+        static_num_tokens: int,
+        capture: bool,
+    ) -> int:
+        """Shard global prefill inputs into fixed-address CP-local buffers."""
+        assert self.cp_input_embeds is not None
+        assert self.cp_positions is not None
+
+        # Replay batches may reuse a ForwardBatch object whose metadata was
+        # built for a different request layout. CP metadata contains Python
+        # lists and tensors derived from that layout, so always rebuild it
+        # before sharding the current inputs.
+        forward_batch.attn_cp_metadata = None
+        prepare_cp_forward(forward_batch)
+
+        raw_tokens = int(forward_batch.extend_num_tokens)
+        global_input_ids = forward_batch.input_ids[:raw_tokens]
+        global_positions = forward_batch.positions[:raw_tokens]
+        global_input_embeds = self.model_runner.model.get_input_embeddings()(
+            global_input_ids
+        )
+        local_input_embeds, local_positions = cp_split_before_forward(
+            global_input_embeds,
+            global_positions,
+            forward_batch,
+        )
+        live_local_tokens = int(local_input_embeds.shape[0])
+
+        if capture:
+            captured_local_tokens = live_local_tokens
+            self.cp_bucket_local_tokens[static_num_tokens] = captured_local_tokens
+        else:
+            try:
+                captured_local_tokens = self.cp_bucket_local_tokens[static_num_tokens]
+            except KeyError as exc:
+                raise RuntimeError(
+                    "Missing CP-local capture capacity for global prefill bucket "
+                    f"{static_num_tokens}"
+                ) from exc
+            if live_local_tokens > captured_local_tokens:
+                raise RuntimeError(
+                    f"Live batch needs {live_local_tokens} local CP rows, but global "
+                    f"prefill bucket {static_num_tokens} has captured capacity "
+                    f"{captured_local_tokens}"
+                )
+
+        if captured_local_tokens > self.cp_input_embeds.shape[0]:
+            raise RuntimeError(
+                f"CP-local capture needs {captured_local_tokens} rows, but the "
+                f"fixed input buffer has capacity {self.cp_input_embeds.shape[0]}"
+            )
+
+        input_embeds = self.cp_input_embeds[:captured_local_tokens]
+        positions = self.cp_positions[:captured_local_tokens]
+        input_embeds.zero_()
+        positions.zero_()
+        input_embeds[:live_local_tokens].copy_(local_input_embeds)
+        positions[:live_local_tokens].copy_(local_positions)
+        forward_batch.input_embeds = input_embeds
+        forward_batch.positions = positions
+        return live_local_tokens
 
     @contextmanager
     def _prefill_forward_context(

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -53,6 +53,7 @@ from sglang.kernels.ops.kvcache.kv_indices import (
 from sglang.srt.distributed.parallel_state import graph_capture
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
 from sglang.srt.layers.cp.utils import (
+    cp_gather_after_forward,
     cp_split_before_forward,
     enable_cp_v2,
     prepare_cp_forward,
@@ -672,6 +673,47 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         forward_batch.input_embeds = input_embeds
         forward_batch.positions = positions
         return live_local_tokens
+
+    def _validate_cp_flashinfer_dispatch_capacity(
+        self,
+        *,
+        global_bucket_tokens: int,
+        required_local_tokens: int,
+    ) -> None:
+        """Validate FlashInfer's fixed A2A workspace before graph capture."""
+        from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+            FlashinferDispatcher,
+        )
+
+        capacities = []
+        seen_dispatchers = set()
+        for layer in self.moe_layers:
+            dispatcher = getattr(layer, "dispatcher", None)
+            if not isinstance(dispatcher, FlashinferDispatcher):
+                continue
+            dispatcher_id = id(dispatcher)
+            if dispatcher_id in seen_dispatchers:
+                continue
+            seen_dispatchers.add(dispatcher_id)
+            capacity = int(dispatcher.max_num_tokens)
+            capacities.append(capacity)
+            if capacity < required_local_tokens:
+                raise ValueError(
+                    f"Breakable prefill CP global bucket {global_bucket_tokens} "
+                    f"has required local rows {required_local_tokens}, but "
+                    f"FlashInfer A2A configured capacity {capacity} is smaller. "
+                    "Increase "
+                    "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK."
+                )
+
+        if capacities:
+            logger.info(
+                "Breakable prefill CP capture capacity: global_bucket=%d, "
+                "required_local_rows=%d, flashinfer_dispatch_capacities=%s",
+                global_bucket_tokens,
+                required_local_tokens,
+                sorted(set(capacities)),
+            )
 
     @contextmanager
     def _prefill_forward_context(
@@ -1336,6 +1378,16 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         """
         num_tokens = size
         forward_batch, attn_backend = self.capture_prepare(num_tokens)
+        if self.enable_cp_v2_body_capture:
+            required_local_tokens = self._prepare_cp_static_inputs(
+                forward_batch,
+                static_num_tokens=num_tokens,
+                capture=True,
+            )
+            self._validate_cp_flashinfer_dispatch_capacity(
+                global_bucket_tokens=num_tokens,
+                required_local_tokens=required_local_tokens,
+            )
         if forward_batch.lora_ids is not None:
             # Fill the static prefill LoRA batch info the captured kernels
             # will read (all-None ids: ranks stay 0, kernels no-op).
@@ -1572,11 +1624,66 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 forward_batch.spec_info.hidden_states
             )
 
+        metadata_forward_batch = forward_batch
+        if self.enable_cp_v2_body_capture:
+            self._cp_live_local_tokens = self._prepare_cp_static_inputs(
+                static_forward_batch,
+                static_num_tokens=static_num_tokens,
+                capture=False,
+            )
+            metadata_forward_batch = static_forward_batch
+
         self._prepare_forward_metadata_for_replay(
-            forward_batch, static_forward_batch, static_num_tokens
+            metadata_forward_batch, static_forward_batch, static_num_tokens
         )
 
         return static_forward_batch
+
+    def _execute_cp_body_capture(
+        self,
+        forward_batch: ForwardBatch,
+        static_forward_batch: ForwardBatch,
+        static_num_tokens: int,
+        **kwargs,
+    ):
+        """Replay a CP-local body and run the global gather/logits tail eagerly."""
+        model = self.model_runner.model
+        local_output = self.backend.replay(
+            ShapeKey(size=static_num_tokens),
+            static_forward_batch,
+            **kwargs,
+        )
+        local_output = _slice_output_rows(
+            local_output,
+            self._cp_live_local_tokens,
+        )
+
+        capture_aux_hidden_states = getattr(model, "capture_aux_hidden_states", False)
+        aux_hidden_states = None
+        if capture_aux_hidden_states:
+            hidden_states, aux_hidden_states = local_output
+        else:
+            hidden_states = local_output
+
+        if not model.pp_group.is_last_rank:
+            return (
+                (hidden_states, aux_hidden_states)
+                if capture_aux_hidden_states
+                else hidden_states
+            )
+
+        hidden_states = cp_gather_after_forward(
+            hidden_states,
+            static_forward_batch,
+            torch.cuda.current_stream(),
+        )
+        return model.logits_processor(
+            forward_batch.input_ids,
+            hidden_states,
+            model.lm_head,
+            forward_batch,
+            aux_hidden_states,
+        )
 
     def _execute_body_capture(
         self,
@@ -1705,7 +1812,14 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             if shape_key.variant_label is not None:
                 self._prepare_chunked_prefix_replay(shape_key, forward_batch)
 
-            if self._uses_eager_prefill_tail():
+            if self.enable_cp_v2_body_capture:
+                output = self._execute_cp_body_capture(
+                    forward_batch,
+                    static_forward_batch,
+                    static_num_tokens,
+                    **kwargs,
+                )
+            elif self._uses_eager_prefill_tail():
                 output = self._execute_body_capture(
                     forward_batch,
                     static_forward_batch,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1644,46 +1644,54 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         forward_batch: ForwardBatch,
         static_forward_batch: ForwardBatch,
         static_num_tokens: int,
+        raw_num_tokens: int,
         **kwargs,
     ):
         """Replay a CP-local body and run the global gather/logits tail eagerly."""
         model = self.model_runner.model
-        local_output = self.backend.replay(
-            ShapeKey(size=static_num_tokens),
+        with self._prefill_forward_context(
             static_forward_batch,
-            **kwargs,
-        )
-        local_output = _slice_output_rows(
-            local_output,
-            self._cp_live_local_tokens,
-        )
-
-        capture_aux_hidden_states = getattr(model, "capture_aux_hidden_states", False)
-        aux_hidden_states = None
-        if capture_aux_hidden_states:
-            hidden_states, aux_hidden_states = local_output
-        else:
-            hidden_states = local_output
-
-        if not model.pp_group.is_last_rank:
-            return (
-                (hidden_states, aux_hidden_states)
-                if capture_aux_hidden_states
-                else hidden_states
+            num_tokens=static_num_tokens,
+            raw_num_tokens=raw_num_tokens,
+        ):
+            local_output = self.backend.replay(
+                ShapeKey(size=static_num_tokens),
+                static_forward_batch,
+                **kwargs,
+            )
+            local_output = _slice_output_rows(
+                local_output,
+                self._cp_live_local_tokens,
             )
 
-        hidden_states = cp_gather_after_forward(
-            hidden_states,
-            static_forward_batch,
-            torch.cuda.current_stream(),
-        )
-        return model.logits_processor(
-            forward_batch.input_ids,
-            hidden_states,
-            model.lm_head,
-            forward_batch,
-            aux_hidden_states,
-        )
+            capture_aux_hidden_states = getattr(
+                model, "capture_aux_hidden_states", False
+            )
+            aux_hidden_states = None
+            if capture_aux_hidden_states:
+                hidden_states, aux_hidden_states = local_output
+            else:
+                hidden_states = local_output
+
+            if not model.pp_group.is_last_rank:
+                return (
+                    (hidden_states, aux_hidden_states)
+                    if capture_aux_hidden_states
+                    else hidden_states
+                )
+
+            hidden_states = cp_gather_after_forward(
+                hidden_states,
+                static_forward_batch,
+                torch.cuda.current_stream(),
+            )
+            return model.logits_processor(
+                forward_batch.input_ids,
+                hidden_states,
+                model.lm_head,
+                forward_batch,
+                aux_hidden_states,
+            )
 
     def _execute_body_capture(
         self,
@@ -1817,6 +1825,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                     forward_batch,
                     static_forward_batch,
                     static_num_tokens,
+                    raw_num_tokens,
                     **kwargs,
                 )
             elif self._uses_eager_prefill_tail():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4371,9 +4371,28 @@ class ServerArgs:
             if predicate():
                 self.cuda_graph_config.prefill.backend = Backend.DISABLED
 
-    def _disable_breakable_cudagraph_if_incompatible(self):
-        from sglang.srt.arg_groups.overrides import resolved_view as _resolved_view
+    def _supports_breakable_prefill_cp(self) -> bool:
+        resolved = self._resolved()
+        prefill_attention_backend, _ = self._resolved_attention_backends()
+        return (
+            self.enable_prefill_cp
+            and resolved.attn_cp_size == self.tp_size
+            and self.cp_strategy == "zigzag"
+            and prefill_attention_backend == "trtllm_mha"
+            and self.get_model_config().hf_config.architectures == ["GptOssForCausalLM"]
+        )
 
+    def _supports_breakable_moe_a2a(self) -> bool:
+        resolved = self._resolved()
+        if resolved.moe_a2a_backend == "none":
+            return True
+        return (
+            resolved.moe_a2a_backend == "flashinfer"
+            and self.moe_runner_backend == "flashinfer_trtllm_routed"
+            and self._supports_breakable_prefill_cp()
+        )
+
+    def _disable_breakable_cudagraph_if_incompatible(self):
         """Breakable (segmented capture, no torch.compile). Breakable enforces
         memory-saver rejection in its own __init__; config-time rules can be
         added here as they're discovered.
@@ -4392,7 +4411,8 @@ class ServerArgs:
             # CP all_gather replay size mismatch under BCG.
             (
                 "context parallel (attn_cp_size > 1)",
-                lambda: self._resolved().attn_cp_size > 1,
+                lambda: self._resolved().attn_cp_size > 1
+                and not self._supports_breakable_prefill_cp(),
             ),
             # Capture builds a dummy extend forward with attn_dcp_metadata=None.
             (
@@ -4402,7 +4422,7 @@ class ServerArgs:
             # BCG bucket sizes exceed FlashInfer MoE A2A's dispatch cap.
             (
                 "MoE A2A backend",
-                lambda: _resolved_view(self).moe_a2a_backend != "none",
+                lambda: not self._supports_breakable_moe_a2a(),
             ),
             # Multimodal prefill replay faults under BCG; allowlisted archs opt back in.
             (

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -7,6 +7,7 @@ import torch
 
 from sglang.srt.layers.cp.base import (
     ContextParallelStrategyKind,
+    CPAttentionBackendKind,
     get_cp_strategy,
     get_cp_strategy_kind,
     init_cp_strategy,
@@ -586,7 +587,7 @@ class TestCPZigzagStrategy(CustomTestCase):
         self.assertTrue(torch.equal(written_value, value))
         self.assertEqual((k_scale, v_scale), ("key-scale", "value-scale"))
 
-    def test_zigzag_attention_dispatch_runs_prev_then_next(self):
+    def test_zigzag_flashattention_dispatch_runs_prev_then_next(self):
         cp_size = 2
         seq_lens = [8]
         extend_seq_lens = [8]
@@ -619,6 +620,197 @@ class TestCPZigzagStrategy(CustomTestCase):
         self.assertTrue(torch.equal(calls[0][0], q[:2]))
         self.assertTrue(torch.equal(calls[1][0], q[2:]))
         self.assertTrue(torch.equal(out, q + 100))
+
+    def test_zigzag_trtllm_dispatch_uses_one_combined_call(self):
+        cp_size = 2
+        metadata = self._metadata_for_rank(
+            0,
+            cp_size=cp_size,
+            seq_lens=[8],
+            extend_seq_lens=[8],
+        )
+        fb = SimpleNamespace(attn_cp_metadata=metadata)
+        q = torch.arange(4 * 2).view(4, 2)
+        calls = []
+
+        def attn_fn(
+            q_chunk,
+            cu_seqlens_q,
+            cache_seqlens,
+            max_seqlen_q,
+            *,
+            cu_seqlens_kv,
+            use_zigzag_page_table=False,
+        ):
+            calls.append(
+                (
+                    q_chunk.clone(),
+                    cu_seqlens_q.clone(),
+                    cache_seqlens.clone(),
+                    max_seqlen_q,
+                    cu_seqlens_kv.clone(),
+                    use_zigzag_page_table,
+                )
+            )
+            return q_chunk + 100
+
+        out = ZigzagCPStrategy(cp_size=cp_size).run_attention(
+            q,
+            fb,
+            device=torch.device("cpu"),
+            attn_fn=attn_fn,
+            attention_backend=CPAttentionBackendKind.TRTLLM_MHA,
+        )
+
+        self.assertEqual(len(calls), 1)
+        call = calls[0]
+        self.assertTrue(torch.equal(call[0], q))
+        self.assertTrue(torch.equal(call[1], metadata.cu_seqlens_q_combined_tensor))
+        self.assertTrue(torch.equal(call[2], metadata.kv_len_combined_tensor))
+        self.assertEqual(call[3], metadata.max_seqlen_q_combined)
+        self.assertTrue(torch.equal(call[4], metadata.cu_seqlens_kv_combined_tensor))
+        self.assertTrue(call[5])
+        self.assertTrue(torch.equal(out, q + 100))
+
+    def test_zigzag_trtllm_single_call_zeroes_physical_padding(self):
+        cp_size = 2
+        metadata = self._metadata_for_rank(
+            0,
+            cp_size=cp_size,
+            seq_lens=[8],
+            extend_seq_lens=[8],
+        )
+        fb = SimpleNamespace(attn_cp_metadata=metadata)
+        logical_q = torch.arange(4 * 2).view(4, 2)
+        q = torch.cat([logical_q, torch.full((2, 2), -1)], dim=0)
+        calls = []
+
+        def attn_fn(
+            q_chunk,
+            cu_seqlens_q,
+            cache_seqlens,
+            max_seqlen_q,
+            *,
+            cu_seqlens_kv,
+            use_zigzag_page_table=False,
+        ):
+            calls.append(q_chunk.clone())
+            return q_chunk + 100
+
+        out = ZigzagCPStrategy(cp_size=cp_size).run_attention(
+            q,
+            fb,
+            device=torch.device("cpu"),
+            attn_fn=attn_fn,
+            attention_backend=CPAttentionBackendKind.TRTLLM_MHA,
+        )
+
+        self.assertEqual(len(calls), 1)
+        self.assertTrue(torch.equal(calls[0], logical_q))
+        self.assertTrue(torch.equal(out[:4], logical_q + 100))
+        self.assertTrue(torch.equal(out[4:], torch.zeros_like(out[4:])))
+
+    def test_zigzag_combined_attention_matches_two_half_reference(self):
+        def reference_attention(
+            q,
+            cu_seqlens_q,
+            cache_seqlens,
+            cu_seqlens_kv,
+            *,
+            sequence_offset,
+        ):
+            outputs = []
+            for seq_id in range(cache_seqlens.numel()):
+                q_start = int(cu_seqlens_q[seq_id])
+                q_end = int(cu_seqlens_q[seq_id + 1])
+                q_seq = q[q_start:q_end]
+                q_len = q_end - q_start
+                kv_len = int(cache_seqlens[seq_id])
+                self.assertEqual(
+                    int(cu_seqlens_kv[seq_id + 1] - cu_seqlens_kv[seq_id]),
+                    kv_len,
+                )
+
+                absolute_seq_id = sequence_offset + seq_id + 1
+                positions = torch.arange(kv_len, dtype=q.dtype)
+                k_seq = torch.stack(
+                    (
+                        positions / (kv_len + 1),
+                        torch.sin(positions + absolute_seq_id),
+                        torch.full_like(positions, absolute_seq_id / 10),
+                    ),
+                    dim=1,
+                )
+                v_seq = torch.stack(
+                    (
+                        torch.cos(positions + absolute_seq_id),
+                        positions / (absolute_seq_id + 1),
+                        torch.full_like(positions, absolute_seq_id),
+                    ),
+                    dim=1,
+                )
+                q_positions = kv_len - q_len + torch.arange(q_len)
+                allowed = torch.arange(kv_len)[None, :] <= q_positions[:, None]
+                scores = q_seq @ k_seq.T / q.shape[-1] ** 0.5
+                outputs.append(
+                    torch.softmax(scores.masked_fill(~allowed, -torch.inf), dim=-1)
+                    @ v_seq
+                )
+            return torch.cat(outputs, dim=0)
+
+        cp_size = 4
+        seq_lens = [19, 27]
+        extend_seq_lens = [11, 13]
+        for rank in range(cp_size):
+            with self.subTest(rank=rank):
+                metadata = self._metadata_for_rank(
+                    rank,
+                    cp_size=cp_size,
+                    seq_lens=seq_lens,
+                    extend_seq_lens=extend_seq_lens,
+                )
+                logical_tokens = (
+                    metadata.total_q_prev_tokens + metadata.total_q_next_tokens
+                )
+                q = torch.linspace(
+                    -0.75,
+                    0.75,
+                    steps=logical_tokens * 3,
+                    dtype=torch.float32,
+                ).view(logical_tokens, 3)
+                q_prev = q[: metadata.total_q_prev_tokens]
+                q_next = q[metadata.total_q_prev_tokens :]
+
+                two_half_out = torch.cat(
+                    (
+                        reference_attention(
+                            q_prev,
+                            metadata.cu_seqlens_q_prev_tensor,
+                            metadata.kv_len_prev_tensor,
+                            metadata.cu_seqlens_kv_prev_tensor,
+                            sequence_offset=0,
+                        ),
+                        reference_attention(
+                            q_next,
+                            metadata.cu_seqlens_q_next_tensor,
+                            metadata.kv_len_next_tensor,
+                            metadata.cu_seqlens_kv_next_tensor,
+                            sequence_offset=metadata.bs,
+                        ),
+                    ),
+                    dim=0,
+                )
+                combined_out = reference_attention(
+                    q,
+                    metadata.cu_seqlens_q_combined_tensor,
+                    metadata.kv_len_combined_tensor,
+                    metadata.cu_seqlens_kv_combined_tensor,
+                    sequence_offset=0,
+                )
+
+                torch.testing.assert_close(
+                    combined_out, two_half_out, atol=1e-5, rtol=1e-5
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/cp/test_cp_strategy_unit.py
+++ b/test/registered/cp/test_cp_strategy_unit.py
@@ -1,4 +1,5 @@
 import unittest
+from itertools import accumulate
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -218,6 +219,9 @@ class TestCPZigzagStrategy(CustomTestCase):
             actual_seq_q_prev_list.append(block_sizes[rank])
             actual_seq_q_next_list.append(block_sizes[cp_segment_num - rank - 1])
 
+        actual_seq_q_combined_list = actual_seq_q_prev_list + actual_seq_q_next_list
+        kv_len_combined_list = kv_len_prev_list + kv_len_next_list
+
         return {
             "bs": bs,
             "total_seq_lens": sum(extend_seq_lens),
@@ -231,6 +235,10 @@ class TestCPZigzagStrategy(CustomTestCase):
             "kv_len_next_list": kv_len_next_list,
             "actual_seq_q_prev_list": actual_seq_q_prev_list,
             "actual_seq_q_next_list": actual_seq_q_next_list,
+            "actual_seq_q_combined_list": actual_seq_q_combined_list,
+            "kv_len_combined_list": kv_len_combined_list,
+            "cu_seqlens_q_combined": [0] + list(accumulate(actual_seq_q_combined_list)),
+            "cu_seqlens_kv_combined": [0] + list(accumulate(kv_len_combined_list)),
         }
 
     def _assert_metadata_matches(self, metadata, expected):
@@ -265,6 +273,45 @@ class TestCPZigzagStrategy(CustomTestCase):
             + list(
                 torch.tensor(expected["actual_seq_q_next_list"]).cumsum(dim=0).tolist()
             ),
+        )
+        self.assertEqual(
+            metadata.actual_seq_q_combined_tensor.cpu().tolist(),
+            expected["actual_seq_q_combined_list"],
+        )
+        self.assertEqual(
+            metadata.kv_len_combined_tensor.cpu().tolist(),
+            expected["kv_len_combined_list"],
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_q_combined_tensor.cpu().tolist(),
+            expected["cu_seqlens_q_combined"],
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_kv_combined_tensor.cpu().tolist(),
+            expected["cu_seqlens_kv_combined"],
+        )
+        for tensor in (
+            metadata.actual_seq_q_combined_tensor,
+            metadata.kv_len_combined_tensor,
+            metadata.cu_seqlens_q_combined_tensor,
+            metadata.cu_seqlens_kv_combined_tensor,
+        ):
+            self.assertEqual(tensor.dtype, torch.int32)
+        self.assertEqual(metadata.actual_seq_q_combined_tensor.numel(), 2 * metadata.bs)
+        self.assertEqual(metadata.kv_len_combined_tensor.numel(), 2 * metadata.bs)
+        self.assertEqual(
+            metadata.cu_seqlens_q_combined_tensor.numel(), 2 * metadata.bs + 1
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_kv_combined_tensor.numel(), 2 * metadata.bs + 1
+        )
+        self.assertEqual(
+            metadata.cu_seqlens_q_combined_tensor[-1].item(),
+            metadata.total_q_prev_tokens + metadata.total_q_next_tokens,
+        )
+        self.assertEqual(
+            metadata.max_seqlen_q_combined,
+            max(expected["actual_seq_q_combined_list"]),
         )
 
     def _padded_rank_tensors(self, x, *, cp_size, seq_lens, extend_seq_lens):
@@ -318,6 +365,35 @@ class TestCPZigzagStrategy(CustomTestCase):
                         extend_seq_lens=extend_seq_lens,
                     )
                     self._assert_metadata_matches(metadata, expected)
+
+    def test_zigzag_combined_metadata_preserves_nonzero_prefix_order(self):
+        cp_size = 4
+        seq_lens = [19, 27]
+        extend_seq_lens = [11, 13]
+
+        for rank in range(cp_size):
+            with self.subTest(rank=rank):
+                metadata = self._metadata_for_rank(
+                    rank,
+                    cp_size=cp_size,
+                    seq_lens=seq_lens,
+                    extend_seq_lens=extend_seq_lens,
+                )
+                expected = self._expected_metadata(
+                    rank=rank,
+                    cp_size=cp_size,
+                    seq_lens=seq_lens,
+                    extend_seq_lens=extend_seq_lens,
+                )
+                self._assert_metadata_matches(metadata, expected)
+                self.assertEqual(
+                    metadata.kv_len_combined_tensor[: metadata.bs].tolist(),
+                    expected["kv_len_prev_list"],
+                )
+                self.assertEqual(
+                    metadata.kv_len_combined_tensor[metadata.bs :].tolist(),
+                    expected["kv_len_next_list"],
+                )
 
     def test_zigzag_shards_hidden_states_and_position_ids(self):
         cp_size = 4

--- a/test/registered/unit/layers/attention/test_trtllm_mha_zigzag.py
+++ b/test/registered/unit/layers/attention/test_trtllm_mha_zigzag.py
@@ -1,0 +1,82 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.trtllm_mha_backend import (
+    TRTLLMHAAttnBackend,
+    TRTLLMMHAMetadata,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class TestTRTLLMMHAZigzagPageTables(CustomTestCase):
+    def _backend(self, swa_pool=None):
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        backend._swa_kv_pool = swa_pool
+        return backend
+
+    def _metadata(self):
+        return TRTLLMMHAMetadata(
+            page_table=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+            swa_page_table=torch.tensor([[30, 31], [40, 41]], dtype=torch.int32),
+        )
+
+    def test_builds_prev_then_next_page_tables_for_cp_v2(self):
+        backend = self._backend()
+        metadata = self._metadata()
+
+        with patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+            return_value=True,
+        ):
+            backend._build_zigzag_page_tables(metadata, SimpleNamespace())
+
+        self.assertEqual(
+            metadata.zigzag_page_table.tolist(),
+            [[10, 11], [20, 21], [10, 11], [20, 21]],
+        )
+        self.assertEqual(
+            metadata.zigzag_swa_page_table.tolist(),
+            [[30, 31], [40, 41], [30, 31], [40, 41]],
+        )
+
+    def test_leaves_zigzag_page_tables_unset_without_cp_v2(self):
+        backend = self._backend()
+        metadata = self._metadata()
+
+        with patch(
+            "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+            return_value=False,
+        ):
+            backend._build_zigzag_page_tables(metadata, SimpleNamespace())
+
+        self.assertIsNone(metadata.zigzag_page_table)
+        self.assertIsNone(metadata.zigzag_swa_page_table)
+
+    def test_selects_full_or_swa_zigzag_page_table_per_layer(self):
+        swa_pool = SimpleNamespace(
+            layers_mapping={
+                0: (None, False),
+                1: (None, True),
+            }
+        )
+        backend = self._backend(swa_pool=swa_pool)
+        metadata = self._metadata()
+        metadata.zigzag_page_table = torch.tensor([[1], [2]], dtype=torch.int32)
+        metadata.zigzag_swa_page_table = torch.tensor([[3], [4]], dtype=torch.int32)
+        backend.forward_metadata = metadata
+
+        full_table = backend._get_zigzag_layer_page_table(SimpleNamespace(layer_id=0))
+        swa_table = backend._get_zigzag_layer_page_table(SimpleNamespace(layer_id=1))
+
+        self.assertIs(full_table, metadata.zigzag_page_table)
+        self.assertIs(swa_table, metadata.zigzag_swa_page_table)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_trtllm_mha_zigzag.py
+++ b/test/registered/unit/layers/attention/test_trtllm_mha_zigzag.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 
 import torch
 
+import sglang.srt.layers.attention.trtllm_mha_backend as trtllm_mha_backend
 from sglang.srt.layers.attention.trtllm_mha_backend import (
     TRTLLMHAAttnBackend,
     TRTLLMMHAMetadata,
 )
+from sglang.srt.layers.cp.base import CPAttentionBackendKind
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -76,6 +78,174 @@ class TestTRTLLMMHAZigzagPageTables(CustomTestCase):
 
         self.assertIs(full_table, metadata.zigzag_page_table)
         self.assertIs(swa_table, metadata.zigzag_swa_page_table)
+
+    def _forward_backend(self):
+        backend = self._backend()
+        backend.decode_uses_native_fp4 = False
+        backend.data_type = torch.bfloat16
+        backend.q_data_type = torch.bfloat16
+        backend.page_size = 1
+        backend.device = torch.device("cpu")
+        backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+        backend.max_context_len = 64
+        backend.token_to_kv_pool = SimpleNamespace(
+            get_kv_buffer=lambda layer_id: (
+                torch.zeros(16, 2, 2, dtype=torch.bfloat16),
+                torch.zeros(16, 2, 2, dtype=torch.bfloat16),
+            )
+        )
+        backend.forward_metadata = TRTLLMMHAMetadata(
+            cache_seqlens_int32=torch.tensor([3, 4], dtype=torch.int32),
+            max_seq_len_q=2,
+            cu_seqlens_q=torch.tensor([0, 2, 4], dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, 3, 7], dtype=torch.int32),
+            page_table=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+            zigzag_page_table=torch.tensor(
+                [[10, 11], [20, 21], [10, 11], [20, 21]],
+                dtype=torch.int32,
+            ),
+        )
+        return backend
+
+    def _layer_and_batch(self):
+        layer = SimpleNamespace(
+            layer_id=0,
+            tp_q_head_num=2,
+            tp_k_head_num=2,
+            tp_v_head_num=2,
+            head_dim=2,
+            scaling=0.5,
+            sliding_window_size=-1,
+        )
+        forward_mode = SimpleNamespace(
+            is_target_verify=lambda: False,
+            is_draft_extend_v2=lambda: False,
+        )
+        forward_batch = SimpleNamespace(
+            out_cache_loc=torch.arange(4),
+            forward_mode=forward_mode,
+        )
+        return layer, forward_batch
+
+    def test_forward_extend_selects_combined_zigzag_page_table(self):
+        backend = self._forward_backend()
+        layer, forward_batch = self._layer_and_batch()
+        q = torch.arange(16, dtype=torch.bfloat16).view(4, 4)
+        combined_cu_q = torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32)
+        combined_cache_lens = torch.tensor([3, 4, 3, 4], dtype=torch.int32)
+        combined_cu_kv = torch.tensor([0, 3, 7, 10, 14], dtype=torch.int32)
+
+        class _CombinedStrategy:
+            def run_attention(
+                self,
+                query,
+                batch,
+                device,
+                attn_fn,
+                attention_backend,
+            ):
+                self.asserted_attention_backend = attention_backend
+                return attn_fn(
+                    query,
+                    combined_cu_q,
+                    combined_cache_lens,
+                    1,
+                    cu_seqlens_kv=combined_cu_kv,
+                    use_zigzag_page_table=True,
+                )
+
+        strategy = _CombinedStrategy()
+        with (
+            patch.object(
+                trtllm_mha_backend.flashinfer.prefill,
+                "trtllm_batch_context_with_kv_cache",
+                side_effect=lambda **kwargs: kwargs["query"],
+            ) as context_attn,
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.get_cp_strategy",
+                return_value=strategy,
+            ),
+        ):
+            out = backend.forward_extend(
+                q,
+                None,
+                None,
+                layer,
+                forward_batch,
+                save_kv_cache=False,
+            )
+
+        self.assertEqual(
+            strategy.asserted_attention_backend,
+            CPAttentionBackendKind.TRTLLM_MHA,
+        )
+        call = context_attn.call_args.kwargs
+        self.assertTrue(
+            torch.equal(
+                call["block_tables"],
+                backend.forward_metadata.zigzag_page_table,
+            )
+        )
+        self.assertEqual(call["batch_size"], 4)
+        self.assertTrue(torch.equal(call["seq_lens"], combined_cache_lens))
+        self.assertTrue(torch.equal(call["cum_seq_lens_q"], combined_cu_q))
+        self.assertTrue(torch.equal(call["cum_seq_lens_kv"], combined_cu_kv))
+        self.assertTrue(torch.equal(call["query"].reshape(4, 4), q))
+        self.assertTrue(torch.equal(out, q))
+
+    def test_forward_extend_keeps_original_non_cp_page_table(self):
+        backend = self._forward_backend()
+        layer, forward_batch = self._layer_and_batch()
+        q = torch.arange(16, dtype=torch.bfloat16).view(4, 4)
+
+        with (
+            patch.object(
+                trtllm_mha_backend.flashinfer.prefill,
+                "trtllm_batch_context_with_kv_cache",
+                side_effect=lambda **kwargs: kwargs["query"],
+            ) as context_attn,
+            patch(
+                "sglang.srt.layers.attention.trtllm_mha_backend.is_cp_v2_active",
+                return_value=False,
+            ),
+        ):
+            out = backend.forward_extend(
+                q,
+                None,
+                None,
+                layer,
+                forward_batch,
+                save_kv_cache=False,
+            )
+
+        call = context_attn.call_args.kwargs
+        self.assertTrue(
+            torch.equal(call["block_tables"], backend.forward_metadata.page_table)
+        )
+        self.assertEqual(call["batch_size"], 2)
+        self.assertTrue(
+            torch.equal(
+                call["seq_lens"],
+                backend.forward_metadata.cache_seqlens_int32,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                call["cum_seq_lens_q"],
+                backend.forward_metadata.cu_seqlens_q,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                call["cum_seq_lens_kv"],
+                backend.forward_metadata.cu_seqlens_k,
+            )
+        )
+        self.assertTrue(torch.equal(out, q))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
@@ -1,4 +1,5 @@
 import unittest
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -305,7 +306,23 @@ class TestPrefillCudaGraphCPBodyCapture(CustomTestCase):
         )
         runner.model_runner = SimpleNamespace(model=model)
         runner.backend = MagicMock()
-        runner.backend.replay.return_value = local_padded
+        context_state = {"active": False}
+
+        @contextmanager
+        def prefill_context(*args, **kwargs):
+            context_state["active"] = True
+            try:
+                yield
+            finally:
+                context_state["active"] = False
+
+        runner._prefill_forward_context = prefill_context
+
+        def replay(*args, **kwargs):
+            self.assertTrue(context_state["active"])
+            return local_padded
+
+        runner.backend.replay.side_effect = replay
         runner._cp_live_local_tokens = 3
         forward_batch = SimpleNamespace(input_ids=torch.arange(6))
         static_forward_batch = SimpleNamespace()
@@ -316,9 +333,11 @@ class TestPrefillCudaGraphCPBodyCapture(CustomTestCase):
             forward_batch,
             static_forward_batch,
             static_num_tokens=16,
+            raw_num_tokens=6,
         )
 
         self.assertIs(actual, output)
+        self.assertFalse(context_state["active"])
         runner.backend.replay.assert_called_once_with(
             ShapeKey(size=16),
             static_forward_batch,
@@ -360,6 +379,7 @@ class TestPrefillCudaGraphCPBodyCapture(CustomTestCase):
         runner.model_runner = SimpleNamespace(model=model)
         runner.backend = MagicMock()
         runner.backend.replay.return_value = (local_hidden, local_aux)
+        runner._prefill_forward_context = lambda *args, **kwargs: nullcontext()
         runner._cp_live_local_tokens = 3
         forward_batch = SimpleNamespace(input_ids=torch.arange(6))
         static_forward_batch = SimpleNamespace()
@@ -369,6 +389,7 @@ class TestPrefillCudaGraphCPBodyCapture(CustomTestCase):
             forward_batch,
             static_forward_batch,
             static_num_tokens=16,
+            raw_num_tokens=6,
         )
 
         self.assertIs(actual, output)

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
@@ -1,0 +1,214 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
+    PrefillCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+class _FakeEmbedding:
+    def __call__(self, input_ids: torch.Tensor) -> torch.Tensor:
+        values = input_ids.to(torch.float32)
+        return torch.stack((values, values + 100), dim=-1)
+
+
+class TestPrefillCudaGraphCPStaticInputs(CustomTestCase):
+    def _runner(self) -> PrefillCudaGraphRunner:
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.model_runner = SimpleNamespace(
+            model=SimpleNamespace(get_input_embeddings=lambda: _FakeEmbedding())
+        )
+        runner.cp_input_embeds = torch.full((16, 2), -1.0)
+        runner.cp_positions = torch.full((16,), -1, dtype=torch.int64)
+        runner.cp_bucket_local_tokens = {}
+        return runner
+
+    @staticmethod
+    def _batch(num_tokens: int, batch_size: int = 1):
+        input_ids = torch.arange(num_tokens, dtype=torch.int64)
+        return SimpleNamespace(
+            batch_size=batch_size,
+            input_ids=input_ids,
+            input_embeds=None,
+            positions=torch.arange(num_tokens, dtype=torch.int64),
+            extend_num_tokens=num_tokens,
+            attn_cp_metadata=object(),
+        )
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
+    def test_capture_and_replay_use_fixed_local_buffers(self, mock_prepare, mock_split):
+        runner = self._runner()
+        capture_batch = self._batch(16)
+        capture_input_ids = capture_batch.input_ids
+        capture_metadata = object()
+
+        def prepare(batch):
+            self.assertIsNone(batch.attn_cp_metadata)
+            batch.attn_cp_metadata = capture_metadata
+
+        mock_prepare.side_effect = prepare
+        capture_embeds = torch.tensor(
+            [[1.0, 101.0], [4.0, 104.0], [11.0, 111.0], [14.0, 114.0]]
+        )
+        capture_positions = torch.tensor([1, 4, 11, 14], dtype=torch.int64)
+        mock_split.return_value = (capture_embeds, capture_positions)
+
+        live_rows = runner._prepare_cp_static_inputs(
+            capture_batch,
+            static_num_tokens=16,
+            capture=True,
+        )
+
+        self.assertEqual(live_rows, 4)
+        self.assertIs(capture_batch.input_ids, capture_input_ids)
+        self.assertIs(capture_batch.attn_cp_metadata, capture_metadata)
+        self.assertEqual(runner.cp_bucket_local_tokens, {16: 4})
+        self.assertEqual(
+            capture_batch.input_embeds.data_ptr(), runner.cp_input_embeds.data_ptr()
+        )
+        self.assertEqual(
+            capture_batch.positions.data_ptr(), runner.cp_positions.data_ptr()
+        )
+        torch.testing.assert_close(capture_batch.input_embeds, capture_embeds)
+        torch.testing.assert_close(capture_batch.positions, capture_positions)
+
+        replay_batch = self._batch(12, batch_size=2)
+        replay_metadata = object()
+        seen_metadata = []
+
+        def prepare_replay(batch):
+            seen_metadata.append(batch.attn_cp_metadata)
+            batch.attn_cp_metadata = replay_metadata
+
+        mock_prepare.side_effect = prepare_replay
+        replay_embeds = torch.tensor([[2.0, 102.0], [7.0, 107.0], [10.0, 110.0]])
+        replay_positions = torch.tensor([2, 7, 10], dtype=torch.int64)
+        mock_split.return_value = (replay_embeds, replay_positions)
+
+        live_rows = runner._prepare_cp_static_inputs(
+            replay_batch,
+            static_num_tokens=16,
+            capture=False,
+        )
+
+        self.assertEqual(live_rows, 3)
+        self.assertEqual(seen_metadata, [None])
+        self.assertIs(replay_batch.attn_cp_metadata, replay_metadata)
+        self.assertEqual(
+            replay_batch.input_embeds.data_ptr(), runner.cp_input_embeds.data_ptr()
+        )
+        self.assertEqual(
+            replay_batch.positions.data_ptr(), runner.cp_positions.data_ptr()
+        )
+        torch.testing.assert_close(
+            replay_batch.input_embeds[:3],
+            replay_embeds,
+        )
+        torch.testing.assert_close(
+            replay_batch.positions[:3],
+            replay_positions,
+        )
+        torch.testing.assert_close(
+            replay_batch.input_embeds[3],
+            torch.zeros(2),
+        )
+        self.assertEqual(replay_batch.positions[3].item(), 0)
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
+    def test_replay_rebuilds_metadata_when_request_count_changes(
+        self, mock_prepare, mock_split
+    ):
+        runner = self._runner()
+        metadata = []
+
+        def prepare(batch):
+            self.assertIsNone(batch.attn_cp_metadata)
+            current = object()
+            metadata.append(current)
+            batch.attn_cp_metadata = current
+
+        mock_prepare.side_effect = prepare
+        mock_split.side_effect = (
+            (torch.ones((4, 2)), torch.arange(4)),
+            (torch.ones((3, 2)), torch.arange(3)),
+        )
+
+        capture_batch = self._batch(16)
+        runner._prepare_cp_static_inputs(
+            capture_batch, static_num_tokens=16, capture=True
+        )
+        replay_batch = self._batch(12, batch_size=2)
+        runner._prepare_cp_static_inputs(
+            replay_batch, static_num_tokens=16, capture=False
+        )
+
+        self.assertIsNot(metadata[0], metadata[1])
+        self.assertIs(capture_batch.attn_cp_metadata, metadata[0])
+        self.assertIs(replay_batch.attn_cp_metadata, metadata[1])
+        self.assertEqual(
+            capture_batch.input_embeds.data_ptr(),
+            replay_batch.input_embeds.data_ptr(),
+        )
+        self.assertEqual(
+            capture_batch.positions.data_ptr(),
+            replay_batch.positions.data_ptr(),
+        )
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
+    def test_replay_rejects_more_local_rows_than_captured(
+        self, mock_prepare, mock_split
+    ):
+        runner = self._runner()
+        mock_prepare.side_effect = lambda batch: setattr(
+            batch, "attn_cp_metadata", object()
+        )
+        mock_split.return_value = (torch.ones((4, 2)), torch.arange(4))
+        runner._prepare_cp_static_inputs(
+            self._batch(16), static_num_tokens=16, capture=True
+        )
+
+        mock_split.return_value = (torch.ones((5, 2)), torch.arange(5))
+        with self.assertRaisesRegex(
+            RuntimeError, "5 local CP rows.*captured capacity 4"
+        ):
+            runner._prepare_cp_static_inputs(
+                self._batch(16), static_num_tokens=16, capture=False
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
@@ -193,6 +193,57 @@ class TestPrefillCudaGraphCPStaticInputs(CustomTestCase):
         "prepare_cp_forward",
         create=True,
     )
+    def test_replay_keeps_logical_rows_but_uses_captured_physical_rows(
+        self, mock_prepare, mock_split
+    ):
+        runner = self._runner()
+        runner.cp_bucket_local_tokens = {16: 4}
+        batch = self._batch(12)
+        metadata = SimpleNamespace(
+            per_rank_logical_token=[3, 3, 3, 3],
+            per_rank_actual_token=[3, 3, 3, 3],
+            max_rank_len=[3, 3, 3, 3],
+        )
+        mock_prepare.side_effect = lambda forward_batch: setattr(
+            forward_batch, "attn_cp_metadata", metadata
+        )
+
+        def split(_, __, forward_batch):
+            self.assertEqual(
+                forward_batch.attn_cp_metadata.per_rank_logical_token,
+                [3, 3, 3, 3],
+            )
+            self.assertEqual(
+                forward_batch.attn_cp_metadata.per_rank_actual_token,
+                [4, 4, 4, 4],
+            )
+            self.assertEqual(
+                forward_batch.attn_cp_metadata.max_rank_len,
+                [4, 4, 4, 4],
+            )
+            return torch.ones((4, 2)), torch.arange(4)
+
+        mock_split.side_effect = split
+
+        live_rows = runner._prepare_cp_static_inputs(
+            batch,
+            static_num_tokens=16,
+            capture=False,
+        )
+
+        self.assertEqual(live_rows, 4)
+        self.assertIs(batch.attn_cp_metadata, metadata)
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_split_before_forward",
+        create=True,
+    )
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "prepare_cp_forward",
+        create=True,
+    )
     def test_replay_rejects_more_local_rows_than_captured(
         self, mock_prepare, mock_split
     ):

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from sglang.srt.layers.moe.token_dispatcher.flashinfer import FlashinferDispatcher
+from sglang.srt.model_executor import model_runner as model_runner_module
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
@@ -213,6 +214,28 @@ class TestPrefillCudaGraphCPStaticInputs(CustomTestCase):
 
 
 class TestPrefillCudaGraphCPBodyCapture(CustomTestCase):
+    @patch(
+        "sglang.srt.model_executor.model_runner.get_cp_strategy",
+        return_value=object(),
+    )
+    def test_model_runner_dispatch_allows_validated_cp_body_capture(self, _):
+        runner = SimpleNamespace(enable_cp_v2_body_capture=True)
+
+        self.assertTrue(
+            model_runner_module._prefill_cuda_graph_allows_context_parallel(runner)
+        )
+
+    @patch(
+        "sglang.srt.model_executor.model_runner.get_cp_strategy",
+        return_value=object(),
+    )
+    def test_model_runner_dispatch_rejects_other_cp_graphs(self, _):
+        runner = SimpleNamespace(enable_cp_v2_body_capture=False)
+
+        self.assertFalse(
+            model_runner_module._prefill_cuda_graph_allows_context_parallel(runner)
+        )
+
     def test_capture_prepares_cp_before_attention_metadata(self):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
         forward_batch = SimpleNamespace(lora_ids=None)

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py
@@ -1,12 +1,14 @@
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 
+from sglang.srt.layers.moe.token_dispatcher.flashinfer import FlashinferDispatcher
 from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
+from sglang.srt.model_executor.runner.shape_key import ShapeKey
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -208,6 +210,208 @@ class TestPrefillCudaGraphCPStaticInputs(CustomTestCase):
             runner._prepare_cp_static_inputs(
                 self._batch(16), static_num_tokens=16, capture=False
             )
+
+
+class TestPrefillCudaGraphCPBodyCapture(CustomTestCase):
+    def test_capture_prepares_cp_before_attention_metadata(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        forward_batch = SimpleNamespace(lora_ids=None)
+        attn_backend = MagicMock()
+        events = []
+        runner.enable_cp_v2_body_capture = True
+        runner._is_full_backend = False
+        runner._capture_chunked_prefix = False
+        runner.use_captured_attn_metadata = False
+        runner.capture_prepare = MagicMock(return_value=(forward_batch, attn_backend))
+        runner._prepare_cp_static_inputs = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("cp") or 4
+        )
+        runner._validate_cp_flashinfer_dispatch_capacity = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("capacity")
+        )
+        runner._init_forward_metadata_for_capture = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("metadata")
+        )
+        runner._run_forward = MagicMock(
+            side_effect=lambda *args, **kwargs: events.append("forward")
+            or torch.zeros((4, 2))
+        )
+        runner.backend = MagicMock()
+        runner.backend.capture_one.side_effect = (
+            lambda shape_key, run_once, **kwargs: run_once()
+        )
+
+        runner.capture_one_shape(16)
+
+        self.assertEqual(events, ["cp", "capacity", "metadata", "forward"])
+        runner._prepare_cp_static_inputs.assert_called_once_with(
+            forward_batch,
+            static_num_tokens=16,
+            capture=True,
+        )
+        runner._validate_cp_flashinfer_dispatch_capacity.assert_called_once_with(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
+        self.assertEqual(
+            runner.backend.capture_one.call_args.args[0],
+            ShapeKey(size=16),
+        )
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_gather_after_forward",
+        create=True,
+    )
+    @patch("torch.cuda.current_stream")
+    def test_replay_trims_local_rows_gathers_and_runs_live_logits(
+        self, mock_current_stream, mock_gather
+    ):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        local_padded = torch.arange(8, dtype=torch.float32).view(4, 2)
+        gathered = torch.arange(12, dtype=torch.float32).view(6, 2)
+        output = object()
+        stream = object()
+        logits_processor = MagicMock(return_value=output)
+        model = SimpleNamespace(
+            capture_aux_hidden_states=False,
+            forward=MagicMock(),
+            lm_head=object(),
+            logits_processor=logits_processor,
+            pp_group=SimpleNamespace(is_last_rank=True),
+        )
+        runner.model_runner = SimpleNamespace(model=model)
+        runner.backend = MagicMock()
+        runner.backend.replay.return_value = local_padded
+        runner._cp_live_local_tokens = 3
+        forward_batch = SimpleNamespace(input_ids=torch.arange(6))
+        static_forward_batch = SimpleNamespace()
+        mock_current_stream.return_value = stream
+        mock_gather.return_value = gathered
+
+        actual = runner._execute_cp_body_capture(
+            forward_batch,
+            static_forward_batch,
+            static_num_tokens=16,
+        )
+
+        self.assertIs(actual, output)
+        runner.backend.replay.assert_called_once_with(
+            ShapeKey(size=16),
+            static_forward_batch,
+        )
+        mock_gather.assert_called_once()
+        torch.testing.assert_close(mock_gather.call_args.args[0], local_padded[:3])
+        self.assertIs(mock_gather.call_args.args[1], static_forward_batch)
+        self.assertIs(mock_gather.call_args.args[2], stream)
+        logits_processor.assert_called_once_with(
+            forward_batch.input_ids,
+            gathered,
+            model.lm_head,
+            forward_batch,
+            None,
+        )
+        model.forward.assert_not_called()
+
+    @patch(
+        "sglang.srt.model_executor.runner.prefill_cuda_graph_runner."
+        "cp_gather_after_forward",
+        create=True,
+    )
+    @patch("torch.cuda.current_stream")
+    def test_replay_preserves_auxiliary_hidden_states(
+        self, mock_current_stream, mock_gather
+    ):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        local_hidden = torch.ones((4, 2))
+        local_aux = [torch.full((4, 2), 2.0)]
+        gathered = torch.full((6, 2), 3.0)
+        output = object()
+        logits_processor = MagicMock(return_value=output)
+        model = SimpleNamespace(
+            capture_aux_hidden_states=True,
+            lm_head=object(),
+            logits_processor=logits_processor,
+            pp_group=SimpleNamespace(is_last_rank=True),
+        )
+        runner.model_runner = SimpleNamespace(model=model)
+        runner.backend = MagicMock()
+        runner.backend.replay.return_value = (local_hidden, local_aux)
+        runner._cp_live_local_tokens = 3
+        forward_batch = SimpleNamespace(input_ids=torch.arange(6))
+        static_forward_batch = SimpleNamespace()
+        mock_gather.return_value = gathered
+
+        actual = runner._execute_cp_body_capture(
+            forward_batch,
+            static_forward_batch,
+            static_num_tokens=16,
+        )
+
+        self.assertIs(actual, output)
+        logits_processor.assert_called_once()
+        logits_args = logits_processor.call_args.args
+        self.assertIs(logits_args[0], forward_batch.input_ids)
+        self.assertIs(logits_args[1], gathered)
+        self.assertIs(logits_args[2], model.lm_head)
+        self.assertIs(logits_args[3], forward_batch)
+        self.assertEqual(len(logits_args[4]), 1)
+        torch.testing.assert_close(logits_args[4][0], local_aux[0][:3])
+
+
+class TestPrefillCudaGraphCPFlashInferCapacity(CustomTestCase):
+    @staticmethod
+    def _dispatcher(capacity: int) -> FlashinferDispatcher:
+        dispatcher = FlashinferDispatcher.__new__(FlashinferDispatcher)
+        dispatcher.max_num_tokens = capacity
+        return dispatcher
+
+    def test_accepts_equal_or_larger_flashinfer_capacity(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        dispatcher = self._dispatcher(4)
+        runner.moe_layers = [
+            SimpleNamespace(dispatcher=dispatcher),
+            SimpleNamespace(dispatcher=dispatcher),
+        ]
+
+        runner._validate_cp_flashinfer_dispatch_capacity(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
+        dispatcher.max_num_tokens = 8
+        runner._validate_cp_flashinfer_dispatch_capacity(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
+
+    def test_rejects_flashinfer_capacity_smaller_than_local_capture(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.moe_layers = [
+            SimpleNamespace(dispatcher=self._dispatcher(3)),
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "global bucket 16.*required local rows 4.*configured capacity 3.*"
+            "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK",
+        ):
+            runner._validate_cp_flashinfer_dispatch_capacity(
+                global_bucket_tokens=16,
+                required_local_tokens=4,
+            )
+
+    def test_ignores_non_flashinfer_dispatchers(self):
+        runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
+        runner.moe_layers = [
+            SimpleNamespace(
+                dispatcher=SimpleNamespace(max_num_tokens=1),
+            )
+        ]
+
+        runner._validate_cp_flashinfer_dispatch_capacity(
+            global_bucket_tokens=16,
+            required_local_tokens=4,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_flashinfer_a2a_cp.py
+++ b/test/registered/unit/server_args/test_flashinfer_a2a_cp.py
@@ -1,7 +1,13 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from sglang.srt.arg_groups.overrides import resolved_view
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -93,6 +99,175 @@ class TestFlashInferA2APrefillCP(CustomTestCase):
             "full prefill context parallelism with attn_cp_size == tp_size",
         ):
             args._handle_a2a_moe()
+
+    def _breakable_args(
+        self,
+        *,
+        enable_prefill_cp: bool,
+        attn_cp_size: int,
+        cp_strategy: str,
+        attention_backend: str,
+        moe_a2a_backend: str,
+        moe_runner_backend: str,
+        architecture: str = "GptOssForCausalLM",
+    ) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.tp_size = 4
+        args.dp_size = 1
+        args.enable_dp_attention = False
+        args.enable_prefill_cp = enable_prefill_cp
+        args.attn_cp_size = attn_cp_size
+        args.cp_strategy = cp_strategy
+        args.attention_backend = attention_backend
+        args.prefill_attention_backend = None
+        args.decode_attention_backend = None
+        args.moe_a2a_backend = moe_a2a_backend
+        args.moe_runner_backend = moe_runner_backend
+        args.dcp_size = 1
+        args.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=[architecture]),
+            is_multimodal=False,
+            is_multimodal_breakable_cuda_graph_supported=False,
+        )
+        args.cuda_graph_config = CudaGraphConfig(
+            prefill=PhaseConfig(backend=Backend.BREAKABLE)
+        )
+        return args
+
+    def test_breakable_cuda_graph_support_truth_table(self):
+        cases = (
+            dict(
+                name="validated",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=True,
+                a2a_allowed=True,
+                graph_allowed=True,
+            ),
+            dict(
+                name="partial_cp",
+                enable_prefill_cp=True,
+                attn_cp_size=2,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=False,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="interleave",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="interleave",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=False,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="wrong_attention",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="flashinfer",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="flashinfer_trtllm_routed",
+                cp_allowed=False,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="other_a2a",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="deepep",
+                moe_runner_backend="deep_gemm",
+                cp_allowed=True,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="wrong_runner",
+                enable_prefill_cp=True,
+                attn_cp_size=4,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="flashinfer",
+                moe_runner_backend="triton",
+                cp_allowed=True,
+                a2a_allowed=False,
+                graph_allowed=False,
+            ),
+            dict(
+                name="no_cp_no_a2a",
+                enable_prefill_cp=False,
+                attn_cp_size=1,
+                cp_strategy="zigzag",
+                attention_backend="trtllm_mha",
+                moe_a2a_backend="none",
+                moe_runner_backend="triton",
+                cp_allowed=False,
+                a2a_allowed=True,
+                graph_allowed=True,
+            ),
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                kwargs = {
+                    key: value
+                    for key, value in case.items()
+                    if key
+                    not in {
+                        "name",
+                        "cp_allowed",
+                        "a2a_allowed",
+                        "graph_allowed",
+                    }
+                }
+                args = self._breakable_args(**kwargs)
+                self.assertEqual(
+                    args._supports_breakable_prefill_cp(), case["cp_allowed"]
+                )
+                self.assertEqual(
+                    args._supports_breakable_moe_a2a(), case["a2a_allowed"]
+                )
+                with patch.object(ServerArgs, "use_mla_backend", return_value=False):
+                    args._disable_breakable_cudagraph_if_incompatible()
+                self.assertEqual(
+                    args.cuda_graph_config.prefill.backend,
+                    (Backend.BREAKABLE if case["graph_allowed"] else Backend.DISABLED),
+                )
+
+    def test_breakable_cuda_graph_rejects_other_model_architectures(self):
+        args = self._breakable_args(
+            enable_prefill_cp=True,
+            attn_cp_size=4,
+            cp_strategy="zigzag",
+            attention_backend="trtllm_mha",
+            moe_a2a_backend="flashinfer",
+            moe_runner_backend="flashinfer_trtllm_routed",
+            architecture="LlamaForCausalLM",
+        )
+
+        self.assertFalse(args._supports_breakable_prefill_cp())
+        self.assertFalse(args._supports_breakable_moe_a2a())
+        with patch.object(ServerArgs, "use_mla_backend", return_value=False):
+            args._disable_breakable_cudagraph_if_incompatible()
+        self.assertEqual(
+            args.cuda_graph_config.prefill.backend,
+            Backend.DISABLED,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Stacked on #32714.

- enable breakable prefill CUDA graphs for the validated CP4 + FlashInfer A2A path
- stage CP-local rows and replay graph buckets with the captured CP forward context intact
- preserve logical CP row counts when graph buckets are padded
- represent zigzag prev/next attention as one synthetic batch and invoke TRT-LLM context attention once
- duplicate the TRT-LLM page table once per forward for the combined zigzag batch
- keep FlashAttention zigzag behavior unchanged

## Optimized CP4 + EP4 launch

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 \
SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 \
SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK=65536 \
python3 -m sglang.launch_server \
  --model-path /scratch/models/gpt-oss-120b-bf16 \
  --host 127.0.0.1 --port 30000 \
  --tp 4 --ep 4 \
  --enable-prefill-cp --attn-cp-size 4 --cp-strategy zigzag \
  --moe-a2a-backend flashinfer \
  --moe-runner-backend flashinfer_trtllm_routed \
  --attention-backend trtllm_mha \
  --context-length 139264 \
  --chunked-prefill-size 139264 \
  --max-prefill-tokens 139264 \
  --mem-fraction-static 0.75 \
  --disable-decode-cuda-graph \
  --cuda-graph-backend-prefill breakable \
  --cuda-graph-bs-prefill 4096 65536 139264
```

The 139264 prefill bucket is intentional for the benchmark client used below: its requested 131072 random token IDs are decoded to text and retokenized by the server as 134848 tokens. Keeping that request in one prefill wave removed the extra 3776-token scheduler wave, especially helping concurrency 4.

## Benchmark

Hardware: 4x NVIDIA GB300 on `baizhou-dev`.
Model: `lmsys/gpt-oss-120b-bf16`.
Workload: random-ids, requested ISL 131072, OSL 1000, seed 42, concurrency 1 and 4, warmup 0. Every measurement used an explicit `/flush_cache` call.

Acceptance method: five paired TP4/CP4+EP4 measurements with alternating order; compare the median of each run's mean TTFT and require a majority of pair wins.

| Concurrency | CP TTFT median | TP TTFT median | CP delta | CP pair wins |
| --- | ---: | ---: | ---: | ---: |
| 1 | 1649.63 ms | 1811.61 ms | -8.94% | 4/5 |
| 4 | 3664.59 ms | 4139.23 ms | -11.47% | 5/5 |

TPOT was not the target, but remained lower on CP4+EP4 (roughly 52–57 ms versus 80–85 ms in these runs).

The single-call attention profile reduced the per-rank TRT-LLM context-attention kernel count from 72 to 36 (288 to 144 across four ranks). Breakable graph replay passed at 4K, 64K, and 128K with `cuda graph: True`.

## Verification

Tested stacked head: `12e990b123bddad06d26dc9be12beae84318bb23`.

```bash
PYTHONPATH=$PWD/python python3 -m pytest -q \
  test/registered/unit/server_args/test_flashinfer_a2a_cp.py \
  test/registered/unit/model_executor/runner/test_prefill_cuda_graph_cp.py \
  test/registered/cp/test_cp_strategy_unit.py \
  test/registered/unit/layers/attention/test_trtllm_mha_zigzag.py \
  test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py \
  test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
```

Result: `59 passed`, plus `43 subtests passed`.

End-to-end checks on the patch-equivalent pre-rebase head also covered deterministic 4K/128K output parity, concurrency 4, and a 20-example GSM8K run.

## Profiles

Collected both TP4 and CP4+EP4 traces with exact 262144 input IDs (`--tokenize-prompt`), concurrency 1, 20 output tokens, CPU+GPU activities, and 20 profile steps. Four per-rank traces were produced for each configuration and all eight gzip files pass integrity checks.

## Explored and rejected

Two additional changes were intentionally excluded:

- fusing zigzag KV reorder/split reduced the microkernel by about 28%, but introduced device-metadata synchronization and regressed end-to-end TTFT
- returning the balanced all-gather buffer directly removed a repack, but changed output and regressed TTFT

The final stack contains neither experiment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30427986323](https://github.com/sgl-project/sglang/actions/runs/30427986323)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30427986196](https://github.com/sgl-project/sglang/actions/runs/30427986196)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->