### PR TITLE
[P/D disagg] Support decode radix cache for mamba/SSM hybrid models (KDA/MLA)

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -404,6 +404,42 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             swa_len + swa_reserved,
         )
 
+    def _mamba_slots_per_req(self) -> int:
+        """Number of mamba pool slots required per admitted request."""
+        if not isinstance(self.req_to_token_pool, HybridReqToTokenPool):
+            return 0
+        slots = 1  # main running state slot
+        if self.req_to_token_pool.enable_mamba_extra_buffer:
+            slots += self.req_to_token_pool.mamba_ping_pong_track_buffer_size
+        return slots
+
+    def _required_alloc_mamba_states(self, req: Req) -> int:
+        """Number of mamba slots still needed for *req* (not yet allocated)."""
+        if not isinstance(self.req_to_token_pool, HybridReqToTokenPool):
+            return 0
+        needed = 0
+        if req.mamba_pool_idx is None:
+            needed += 1
+        if (
+            self.req_to_token_pool.enable_mamba_extra_buffer
+            and req.mamba_ping_pong_track_buffer is None
+        ):
+            needed += self.req_to_token_pool.mamba_ping_pong_track_buffer_size
+        return needed
+
+    def _allocatable_mamba_budgets(self, count_retracted: bool = True) -> int:
+        """Available mamba pool slots, counting evictable tree entries."""
+        if not isinstance(self.req_to_token_pool, HybridReqToTokenPool):
+            return 0
+        allocatable = (
+            self.req_to_token_pool.mamba_allocator.available_size()
+            + self.tree_cache.mamba_evictable_size()
+        )
+        if count_retracted:
+            for entry in self.retracted_queue:
+                allocatable -= self._required_alloc_mamba_states(entry.req)
+        return allocatable
+
     def _init_kv_manager(self) -> CommonKVManager:
         kv_args_class = get_kv_class(self.transfer_backend, KVClassType.KVARGS)
         kv_args = kv_args_class()
@@ -540,13 +576,21 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         """
         Match a request against the decode-side radix cache, lock the matched
         node to prevent eviction, and return the matched prefix information.
+
+        For mamba/SSM models in PD decode mode, the mamba state is transferred
+        from prefill via RDMA rather than copied from the radix tree. We skip
+        mamba-value checks during matching (skip_mamba_match=True) and disable
+        copy-on-write (cow_mamba=False). The radix tree still accumulates mamba
+        state over time via cache_unfinished_req / cache_finished_req.
         """
+        supports_mamba = self.tree_cache.supports_mamba()
         result = match_prefix_for_req(
             self.tree_cache,
             req,
             req.origin_input_ids,
-            cow_mamba=self.tree_cache.supports_mamba(),
+            cow_mamba=False,  # state arrives via RDMA, not from radix tree
             include_req=True,
+            skip_mamba_match=supports_mamba,  # ignore mamba presence in tree
         )
         # Always lock to match aggregated scheduling behavior
         self.tree_cache.inc_lock_ref(result.last_device_node)
@@ -965,6 +1009,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if hisparse_req_budget <= 0:
                 break
 
+            # Mamba slot budget: each admitted request needs mamba pool slots.
+            # Skip admission if the pool (plus evictable tree entries) is full.
+            if self.tree_cache.supports_mamba():
+                required_states = self._mamba_slots_per_req()
+                allocatable_states = self._allocatable_mamba_budgets(
+                    count_retracted=True
+                )
+                if required_states > allocatable_states:
+                    break
+
             # Memory estimation: don't add if the projected memory cannot be met
             # TODO: add new_token ratio
             origin_input_len = self._rebootstrap_prefill_len(decode_req.req)
@@ -1072,6 +1126,20 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 # the SWA pool, so page-rounding drift is negligible).
                 swa_allocatable_tokens -= swa_required
             decode_req.req.cache_protected_len = total_prefix_len
+
+            # Seed mamba track state for extra_buffer radix cache inserts.
+            # The mamba state was pre-allocated (but is still empty; RDMA
+            # will fill it). cache_unfinished_req in process_prebuilt reads
+            # mamba_last_track_seqlen to decide the cached prefix length;
+            # seed it now so the first insert correctly records the node.
+            if (
+                use_decode_radix_cache
+                and self.tree_cache.supports_mamba()
+                and isinstance(self.req_to_token_pool, HybridReqToTokenPool)
+                and self.req_to_token_pool.enable_mamba_extra_buffer
+                and decode_req.req.mamba_ping_pong_track_buffer is not None
+            ):
+                decode_req.req.mamba_last_track_seqlen = fill_len
 
             page_size = self.token_to_kv_pool_allocator.page_size
             kv_transfer_page_size = page_size
@@ -1421,6 +1489,20 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             prefix_len = 0
         if total_prefix_len is None:
             total_prefix_len = prefix_len
+
+        # Evict mamba states from the radix tree if the mamba pool is low.
+        # The mamba slot is allocated inside req_to_token_pool.alloc() below.
+        if (
+            self.scheduler.server_args.disaggregation_decode_enable_radix_cache
+            and self.tree_cache.supports_mamba()
+            and isinstance(self.req_to_token_pool, HybridReqToTokenPool)
+        ):
+            mamba_available = self.req_to_token_pool.mamba_allocator.available_size()
+            mamba_needed = 1  # main running state slot
+            if mamba_available < mamba_needed:
+                self.tree_cache.evict(
+                    EvictParams(num_tokens=0, mamba_num=mamba_needed - mamba_available)
+                )
 
         req_pool_indices = self.req_to_token_pool.alloc([req])
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -96,6 +96,7 @@ def match_prefix_for_req(
     *,
     cow_mamba: bool = False,
     include_req: bool = False,
+    skip_mamba_match: bool = False,
 ):
     if token_ids is None:
         token_ids = req.origin_input_ids + req.output_ids
@@ -112,6 +113,7 @@ def match_prefix_for_req(
             key=RadixKey(token_ids=token_ids, extra_key=req.extra_key, limit=key_limit),
             cow_mamba=cow_mamba,
             req=req if include_req else None,
+            skip_mamba_match=skip_mamba_match,
         )
     )
     if envs.SGLANG_RADIX_FORCE_MISS.get():

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -736,6 +736,7 @@ class SchedulerMetricsReporter:
         self.last_gen_throughput = self.num_generated_tokens / gap_latency
 
         self.num_generated_tokens = 0
+        num_decode_cached_tokens = 0
         num_running_reqs = len(batch.reqs)
 
         pool_stats = self.scheduler.pool_stats_observer.get_pool_stats()
@@ -752,7 +753,7 @@ class SchedulerMetricsReporter:
             else self.scheduler.forward_ct
         )
         iter_msg = f" [{batch_iter}]" if LOG_FORWARD_ITERS else ""
-        msg = f"Decode batch{iter_msg}, #running-req: {num_running_reqs}, {token_usage_msg}"
+        msg = f"Decode batch{iter_msg}, #running-req: {num_running_reqs}, #cached-token: {num_decode_cached_tokens}, {token_usage_msg}"
 
         spec_num_steps = 0
         spec_num_draft_tokens = 0
@@ -813,6 +814,18 @@ class SchedulerMetricsReporter:
                 spec_num_draft_tokens = spec_snapshot["num_draft_tokens"]
 
         cache_hit_rate = 0.0
+        if (
+            self.scheduler.server_args.disaggregation_decode_enable_radix_cache
+            and batch is not None
+        ):
+            total_tokens = 0
+            num_decode_cached_tokens = 0
+            for req in batch.reqs:
+                cached = getattr(req, "cached_tokens", 0)
+                total_tokens += len(req.origin_input_ids) + len(req.output_ids)
+                num_decode_cached_tokens += cached
+            if total_tokens > 0:
+                cache_hit_rate = num_decode_cached_tokens / total_tokens
 
         if self.scheduler.disaggregation_mode == DisaggregationMode.DECODE:
             msg += f"pre-allocated usage: {self.scheduler.disagg_decode_prealloc_queue.num_tokens_pre_allocated / self.scheduler.max_total_num_tokens:.2f}, "

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -53,6 +53,9 @@ class MatchPrefixParams:
     # Mamba specific
     cow_mamba: bool = False
     req: Optional[Req] = None
+    # When True, match prefix without requiring mamba_value on each node.
+    # Used by PD decode where the mamba state is always transferred from prefill.
+    skip_mamba_match: bool = False
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -194,11 +194,6 @@ def build_kv_cache(
                 "--disaggregation-decode-enable-radix-cache is incompatible "
                 "with sliding window attention (SWA) models"
             )
-        if is_hybrid_ssm:
-            raise ValueError(
-                "--disaggregation-decode-enable-radix-cache is incompatible "
-                "with Mamba/SSM models"
-            )
 
     effective_chunked_prefill_size = server_args.chunked_prefill_size
     if model_config.is_multimodal and uses_transformers_backend:

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -519,7 +519,9 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 best_match_node=self.root_node,
             )
 
-        value, last_node, best_value_len = self._match_prefix_helper(key)
+        value, last_node, best_value_len = self._match_prefix_helper(
+            key, skip_mamba_match=params.skip_mamba_match
+        )
         return self._match_post_processor(params, value, last_node, best_value_len)
 
     def insert(self, params: InsertParams) -> InsertResult:
@@ -1060,13 +1062,17 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
             self.req_to_token_pool.mamba_allocator.free(mamba_value)
 
     def _match_prefix_helper(
-        self, key: RadixKey
+        self, key: RadixKey, skip_mamba_match: bool = False
     ) -> Tuple[List[torch.Tensor], TreeNode, int]:
         """
         Mamba prefix matching helper. It factors in the sliding window size such that
         the matched node is guaranteed to either 1. connected to root without mamba tombstone,
         or 2. the number of matching tokens from the matched node to the last mamba tombstone
         node is greater than or equal to the sliding window size.
+
+        When skip_mamba_match is True, every node is treated as having a valid mamba
+        checkpoint (KV-only matching). Used by PD decode where the mamba state is
+        always transferred from prefill.
         """
         node = self.root_node
         child_key = key.child_key(self.page_size)
@@ -1077,7 +1083,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         while len(key) > 0 and child_key in node.children.keys():
             child = node.children[child_key]
             # update best_value_len and best_last_node if needed
-            if node.mamba_value is not None:
+            if skip_mamba_match or node.mamba_value is not None:
                 best_value_len = len(value)
                 best_last_node = node
 
@@ -1095,7 +1101,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
                 if len(key):
                     child_key = key.child_key(self.page_size)
         # handle best_value_len and best_last_node, for the case that last node is fully matched
-        if node.mamba_value is not None:
+        if skip_mamba_match or node.mamba_value is not None:
             best_value_len = len(value)
             best_last_node = node
 

--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -45,7 +45,7 @@ class FullComponent(TreeComponent):
         self._full_kv_pool_host = None
 
     def create_match_validator(
-        self, match_device_only: bool = False
+        self, match_device_only: bool = False, skip_mamba_match: bool = False
     ) -> Callable[[UnifiedTreeNode], bool]:
         if match_device_only:
             return (

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -95,8 +95,17 @@ class MambaComponent(TreeComponent):
                 raise ValueError(f"Unknown LRURefreshPhase: {phase}")
 
     def create_match_validator(
-        self, match_device_only: bool = False
+        self, match_device_only: bool = False, skip_mamba_match: bool = False
     ) -> Callable[[UnifiedTreeNode], bool]:
+        """Return a validator that decides whether a node is a valid mamba match boundary.
+
+        When skip_mamba_match is True (PD decode mode), mamba state is transferred
+        from prefill via RDMA, so every node is treated as valid — only Full-KV
+        matching matters.
+        """
+        if skip_mamba_match:
+            return lambda node: True
+
         ct = self.component_type
         if match_device_only:
             return lambda node: node.component_data[ct].value is not None
@@ -114,6 +123,11 @@ class MambaComponent(TreeComponent):
         value_chunks: list[torch.Tensor],
         best_value_len: int,
     ) -> MatchResult:
+        # PD decode: mamba state comes from prefill via RDMA, not from the radix
+        # tree. Skip mamba boundary / branching seqlen computation.
+        if params.skip_mamba_match:
+            return result
+
         last_node = result.best_match_node
 
         mamba_boundary_len = len(result.device_indices) + result.host_hit_length

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -106,7 +106,7 @@ class SWAComponent(TreeComponent):
                 raise ValueError(f"Unknown LRURefreshPhase: {phase}")
 
     def create_match_validator(
-        self, match_device_only: bool = False
+        self, match_device_only: bool = False, skip_mamba_match: bool = False
     ) -> Callable[[UnifiedTreeNode], bool]:
         sliding_window_size = self.sliding_window_size
         ct = self.component_type

--- a/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
@@ -158,7 +158,7 @@ class TreeComponent(ABC):
 
     @abstractmethod
     def create_match_validator(
-        self, match_device_only: bool = False
+        self, match_device_only: bool = False, skip_mamba_match: bool = False
     ) -> Callable[[UnifiedTreeNode], bool]:
         """Return a per-match stateful predicate that decides whether a node
         is a valid match boundary for this component.
@@ -168,7 +168,8 @@ class TreeComponent(ABC):
         - Full: returns True if the node has full component data.
         - SWA: tracks accumulated length since last gap; returns True only
           when the contiguous window reaches swa_sliding_window_size.
-        - Mamba: returns True iff the node has mamba component data."""
+        - Mamba: returns True iff the node has mamba component data.
+          When skip_mamba_match is True (PD decode), always returns True."""
         ...
 
     def finalize_match_result_in_tree_core(

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -522,7 +522,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             best_match_device_value_len,
             full_kv_hit_length,
             action,
-        ) = self._match_prefix_helper(key)
+        ) = self._match_prefix_helper(key, skip_mamba_match=params.skip_mamba_match)
         return self._match_post_processor(
             params,
             value,
@@ -533,7 +533,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             action,
         )
 
-    def _match_prefix_helper(self, key: RadixKey) -> tuple[
+    def _match_prefix_helper(
+        self, key: RadixKey, skip_mamba_match: bool = False
+    ) -> tuple[
         list[torch.Tensor],
         UnifiedTreeNode,
         UnifiedTreeNode,
@@ -556,15 +558,20 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         separate_device_match = self.enable_hicache
         if separate_device_match:
             validators = tuple(
-                comp.create_match_validator() for comp in self.components
+                comp.create_match_validator(skip_mamba_match=skip_mamba_match)
+                for comp in self.components
             )
             device_validators = tuple(
-                comp.create_match_validator(match_device_only=True)
+                comp.create_match_validator(
+                    match_device_only=True, skip_mamba_match=skip_mamba_match
+                )
                 for comp in self.components
             )
         else:
             validators = tuple(
-                comp.create_match_validator(match_device_only=True)
+                comp.create_match_validator(
+                    match_device_only=True, skip_mamba_match=skip_mamba_match
+                )
                 for comp in self.components
             )
 

--- a/test/registered/unit/mem_cache/test_decode_mamba_skip_match.py
+++ b/test/registered/unit/mem_cache/test_decode_mamba_skip_match.py
@@ -1,0 +1,318 @@
+"""
+Unit tests for skip_mamba_match + cow_mamba control in decode-side radix cache
+for mamba/SSM hybrid models (PD disaggregation).
+
+Verifies:
+1. skip_mamba_match=True matching works when mamba state is present
+   (the flag is a no-op on nodes that already have mamba_value).
+2. cow_mamba=False does NOT trigger mamba slot allocation during matching.
+3. lock_ref stays balanced when matching and releasing with skip_mamba_match.
+4. cow_mamba=True allocates mamba slot (guards single-server behavior).
+
+Tombstone-straddling (matching past nodes where mamba_value=None) is tested
+indirectly through the UnifiedRadixCache component pathway (not MambaRadixCache).
+This file guards the skip_mamba_match flag plumbing in MambaRadixCache.
+
+Usage:
+    FLASHINFER_DISABLE_VERSION_CHECK=1 python -m pytest \
+        test/registered/unit/mem_cache/test_decode_mamba_skip_match.py -v
+"""
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=9, suite="stage-b-test-1-gpu-small-amd")
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.kernels.ops.attention.fla.chunk_delta_h import CHUNK_SIZE as FLA_CHUNK_SIZE
+from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
+from sglang.srt.environ import envs
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import (
+    InsertParams,
+    MatchPrefixParams,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache
+from sglang.srt.mem_cache.memory_pool import (
+    HybridLinearKVPool,
+    HybridReqToTokenPool,
+)
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.utils import get_device
+
+
+def _setup_tree_and_allocator():
+    """Create a MambaRadixCache with allocator for testing."""
+    server_args = ServerArgs(model_path="dummy", page_size=1)
+    server_args._mamba_cache_chunk_size = FLA_CHUNK_SIZE
+    set_global_server_args_for_scheduler(server_args)
+
+    size = 128
+    dtype = torch.bfloat16
+    head_num = 2
+    head_dim = 256
+    num_layers = 48
+    global_interval = 4
+    max_num_reqs = 10
+    mamba_cache_size = 20
+    max_context_len = 128
+    device = get_device()
+
+    full_attention_layer_ids = [
+        i for i in range(global_interval - 1, num_layers, global_interval)
+    ]
+    mamba_layers = [i for i in range(num_layers) if i not in full_attention_layer_ids]
+
+    with envs.SGLANG_MAMBA_SSM_DTYPE.override("bfloat16"):
+        shape = Mamba2StateShape.create(
+            tp_world_size=1,
+            intermediate_size=4096,
+            n_groups=16,
+            num_heads=32,
+            head_dim=128,
+            state_size=128,
+            conv_kernel=4,
+        )
+        mamba2_cache_params = Mamba2CacheParams(shape=shape, layers=mamba_layers)
+
+    req_to_token_pool = HybridReqToTokenPool(
+        size=max_num_reqs,
+        mamba_size=mamba_cache_size,
+        mamba_spec_state_size=max_num_reqs,
+        max_context_len=max_context_len,
+        device=device,
+        enable_memory_saver=False,
+        cache_params=mamba2_cache_params,
+        mamba_layer_ids=mamba_layers,
+        enable_mamba_extra_buffer=False,
+        speculative_num_draft_tokens=3,
+    )
+    pool = HybridLinearKVPool(
+        size=size,
+        dtype=dtype,
+        page_size=1,
+        head_num=head_num,
+        head_dim=head_dim,
+        full_attention_layer_ids=full_attention_layer_ids,
+        device=device,
+        enable_memory_saver=False,
+        mamba_pool=req_to_token_pool.mamba_pool,
+    )
+    allocator = TokenToKVPoolAllocator(
+        size=size,
+        dtype=dtype,
+        device=device,
+        kvcache=pool,
+        need_sort=False,
+    )
+    params = CacheInitParams(
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=allocator,
+        page_size=1,
+        disable=False,
+    )
+    tree = MambaRadixCache(params=params)
+    return tree, allocator, req_to_token_pool
+
+
+class TestDecodeMambaSkipMatch(unittest.TestCase):
+    """Test skip_mamba_match flag plumbing and cow_mamba control."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tree, cls.allocator, cls.req_to_token_pool = _setup_tree_and_allocator()
+        cls.mamba_allocator = cls.req_to_token_pool.mamba_allocator
+
+    def setUp(self):
+        """Allocate a fresh request for each test."""
+        sampling_params = SamplingParams(temperature=0, max_new_tokens=1)
+        self.req = Req(
+            rid=0,
+            origin_input_text="",
+            origin_input_ids=array("q"),
+            sampling_params=sampling_params,
+        )
+        self.req_to_token_pool.alloc([self.req])
+        self.addCleanup(self._cleanup_req)
+
+    def _cleanup_req(self):
+        if self.req.mamba_pool_idx is not None:
+            self.req_to_token_pool.free_mamba_cache(self.req)
+        self.req_to_token_pool.free(self.req)
+
+    def _make_donor_and_insert(self, token_ids):
+        """Insert a prefix with a real mamba_value from a donor request."""
+        donor = Req(
+            rid=999,
+            origin_input_text="",
+            origin_input_ids=array("q"),
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        self.req_to_token_pool.alloc([donor])
+        kv_indices = self.allocator.alloc(len(token_ids))
+        self.tree.insert(
+            InsertParams(
+                key=RadixKey(array("q", token_ids)),
+                value=kv_indices[: len(token_ids)],
+                mamba_value=donor.mamba_pool_idx.unsqueeze(0),
+            )
+        )
+        return donor
+
+    def test_skip_mamba_match_true_matches_with_mamba(self):
+        """skip_mamba_match=True: matches normally when mamba_value IS present."""
+        tok_ids = [1, 2, 3, 4]
+        donor = self._make_donor_and_insert(tok_ids)
+
+        result = self.tree.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(array("q", tok_ids)),
+                cow_mamba=False,
+                req=self.req,
+                skip_mamba_match=True,
+            )
+        )
+        self.assertEqual(
+            len(result.device_indices),
+            len(tok_ids),
+            "skip_mamba_match=True should match full prefix",
+        )
+
+        self.req_to_token_pool.free_mamba_cache(donor)
+        self.req_to_token_pool.free(donor)
+
+    def test_skip_mamba_match_false_matches_with_mamba(self):
+        """skip_mamba_match=False: matches normally when mamba_value IS present."""
+        tok_ids = [10, 11, 12, 13]
+        donor = self._make_donor_and_insert(tok_ids)
+
+        result = self.tree.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(array("q", tok_ids)),
+                cow_mamba=False,
+                req=self.req,
+                skip_mamba_match=False,
+            )
+        )
+        self.assertEqual(
+            len(result.device_indices),
+            len(tok_ids),
+            "skip_mamba_match=False should match full prefix when mamba is present",
+        )
+
+        self.req_to_token_pool.free_mamba_cache(donor)
+        self.req_to_token_pool.free(donor)
+
+    def test_cow_mamba_false_no_mamba_alloc(self):
+        """cow_mamba=False: matching does not consume an extra mamba slot.
+
+        In PD decode, state comes from prefill via RDMA, so even when the
+        request already has a mamba slot (from req_to_token_pool.alloc),
+        cow_mamba=False should not allocate a second one.
+        """
+        tok_ids = [20, 21, 22]
+        donor = self._make_donor_and_insert(tok_ids)
+
+        # Free self.req's mamba slot so we can check whether cow allocates one.
+        self.req_to_token_pool.free_mamba_cache(self.req)
+        self.req.mamba_pool_idx = None
+
+        mamba_avail_before = self.mamba_allocator.available_size()
+
+        result = self.tree.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(array("q", tok_ids)),
+                cow_mamba=False,
+                req=self.req,
+                skip_mamba_match=False,
+            )
+        )
+        self.assertGreater(len(result.device_indices), 0)
+        self.assertEqual(
+            self.mamba_allocator.available_size(),
+            mamba_avail_before,
+            "cow_mamba=False must not allocate a mamba slot",
+        )
+
+        self.req_to_token_pool.free_mamba_cache(donor)
+        self.req_to_token_pool.free(donor)
+
+    def test_cow_mamba_true_allocates_mamba(self):
+        """cow_mamba=True: matching allocates a mamba slot for COW.
+
+        Guards the non-PD single-server behavior: a request without a mamba
+        slot gets one allocated during prefix matching.
+        """
+        tok_ids = [30, 31, 32]
+        donor = self._make_donor_and_insert(tok_ids)
+
+        # Free self.req's mamba slot so cow allocates a fresh one.
+        self.req_to_token_pool.free_mamba_cache(self.req)
+        self.req.mamba_pool_idx = None
+
+        mamba_avail_before = self.mamba_allocator.available_size()
+
+        result = self.tree.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(array("q", tok_ids)),
+                cow_mamba=True,
+                req=self.req,
+                skip_mamba_match=False,
+            )
+        )
+        self.assertGreater(len(result.device_indices), 0)
+        self.assertEqual(
+            self.mamba_allocator.available_size(),
+            mamba_avail_before - 1,
+            "cow_mamba=True allocates one mamba slot",
+        )
+
+        self.req_to_token_pool.free_mamba_cache(donor)
+        self.req_to_token_pool.free(donor)
+
+    def test_skip_mamba_match_lock_ref_balance(self):
+        """lock-ref stays balanced with skip_mamba_match=True."""
+        tok_ids = [40, 41, 42]
+        donor = self._make_donor_and_insert(tok_ids)
+
+        result = self.tree.match_prefix(
+            MatchPrefixParams(
+                key=RadixKey(array("q", tok_ids)),
+                cow_mamba=False,
+                req=self.req,
+                skip_mamba_match=True,
+            )
+        )
+        self.assertGreater(len(result.device_indices), 0)
+
+        full_prot_before = self.tree.full_protected_size()
+        mamba_prot_before = self.tree.mamba_protected_size()
+
+        self.tree.inc_lock_ref(result.last_device_node)
+        self.tree.dec_lock_ref(result.last_device_node)
+
+        self.assertEqual(
+            self.tree.full_protected_size(),
+            full_prot_before,
+            "Full-KV protected size balanced after inc+dec",
+        )
+        self.assertEqual(
+            self.tree.mamba_protected_size(),
+            mamba_prot_before,
+            "Mamba protected size balanced after inc+dec",
+        )
+
+        self.req_to_token_pool.free_mamba_cache(donor)
+        self.req_to_token_pool.free(donor)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--disaggregation-decode-enable-radix-cache` is currently hard-blocked for mamba/SSM hybrid models (KDA, GDN, Mamba2, etc.). This PR removes that block and makes decode-side radix caching work for the entire class of **KDA hybrid-attention models** (Kimi-Linear, Kimi K3, and similar architectures that combine linear attention layers with full-attention MLA layers).

In PD decode mode, the mamba state is always transferred from the prefill server via RDMA (nixl/mooncake), so:
- The radix tree does **not** need to hold mamba state for prefix matching — `skip_mamba_match=True` allows matching on Full KV alone
- `cow_mamba=False` — no copy-on-write from the tree, state arrives via network

The radix tree still accumulates mamba state over time via `cache_unfinished_req` / `cache_finished_req`, enabling prefix reuse across requests.

**Verified on Kimi-Linear-48B-A3B-Instruct.** Expected to work on Kimi K3 once that model lands on main (K3 uses the same KimiLinear text backbone + UnifiedRadixCache path).

## Modifications

1. **Remove hard block** — `kv_cache_builder.py`: delete `ValueError` for `is_hybrid_ssm`
2. **Add `skip_mamba_match` flag** — `MatchPrefixParams` + `schedule_policy.py`: new flag to skip mamba-value checks during prefix matching
3. **Unified tree** — `mamba_component.py`, `unified_tree_core.py`, etc.: `create_match_validator` returns always-True when `skip_mamba_match=True`; skip branching seqlen computation
4. **Old cache path** — `mamba_radix_cache.py`: `_match_prefix_helper` supports `skip_mamba_match`
5. **Decode server** — `decode.py`: use `skip_mamba_match=True` + `cow_mamba=False`; add mamba slot budget tracking and eviction; seed `mamba_last_track_seqlen` for extra_buffer mode
6. **Metrics** — `metrics_reporter.py`: report actual `cache_hit_rate` and `#cached-token` in decode stats
7. **Tests** — `test_decode_mamba_skip_match.py`: 5 unit tests covering skip_mamba_match, cow_mamba control, and lock_ref balance

## Speed Tests and Profiling

Kimi-Linear-48B-A3B-Instruct, TP=4, 1P1D on 8×H20.  
Benchmark: `generated-shared-prefix`, 8 groups × 32 req/group, 8192-token system prompt, 128-token question, 256-token output, 256 total requests at max concurrency 32.

| Metric | w/o Cache (baseline) | w/ Cache | Change |
| :--- | :--- | :--- | :--- |
| **Mean TTFT** | 435.85 ms | 408.53 ms | **-6.3%** |
| **Median TTFT** | 219.67 ms | 228.22 ms | +3.9% |
| **P90 TTFT** | 1843.56 ms | 1769.42 ms | **-4.0%** |
| **P95 TTFT** | 2186.82 ms | 1900.63 ms | **-13.1%** |
| **P99 TTFT** | 2201.61 ms | 2005.72 ms | **-8.9%** |
| **Mean E2E Latency** | 2584.56 ms | 2514.19 ms | **-2.7%** |
| **Mean TPOT** | 8.43 ms | 8.26 ms | -2.0% |
| **Request Throughput** | 11.93 req/s | 12.29 req/s | **+3.0%** |
| **Token Throughput** | 104601 tok/s | 107733 tok/s | **+3.0%** |

- TTFT improves because cached system-prompt KV skips RDMA transfer from prefill.
- TPOT is unchanged (decode generation is unaffected by radix cache).
- P95/P99 tail TTFT benefits most — the 2nd–32nd request in each group all hit the cached 8192-token prefix.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests (`test_decode_mamba_skip_match.py`, 5/5 pass)
- [x] E2E benchmark on real hardware (8×H20)
- [ ] CI: /tag-and-rerun-ci