### PR TITLE
[metrics] Split tokenizer request metrics by stream

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2783,6 +2783,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 self._request_has_grammar(state.obj),
                 cached_tokens_details,
                 spec_verify_ct=spec_verify_ct,
+                stream=getattr(state.obj, "stream", False),
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2783,7 +2783,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 self._request_has_grammar(state.obj),
                 cached_tokens_details,
                 spec_verify_ct=spec_verify_ct,
-                stream=getattr(state.obj, "stream", False),
+                is_streaming=getattr(state.obj, "stream", False),
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1445,12 +1445,12 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.prompt_tokens_total = Counter(
             name="sglang:prompt_tokens_total",
             documentation="Number of prefill tokens processed.",
-            labelnames=list(labels.keys()) + ["stream"],
+            labelnames=list(labels.keys()) + ["is_streaming"],
         )
         self.generation_tokens_total = Counter(
             name="sglang:generation_tokens_total",
             documentation="Number of generation tokens processed.",
-            labelnames=list(labels.keys()) + ["stream"],
+            labelnames=list(labels.keys()) + ["is_streaming"],
         )
         self.spec_verify_calls_total = Counter(
             name="sglang:spec_verify_calls_total",
@@ -1530,7 +1530,7 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.num_requests_total = Counter(
             name="sglang:num_requests_total",
             documentation="Number of requests processed.",
-            labelnames=list(labels.keys()) + ["stream"],
+            labelnames=list(labels.keys()) + ["is_streaming"],
         )
 
         self.get_loads_duration_seconds = Histogram(
@@ -1630,8 +1630,10 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.histogram_time_to_first_token = Histogram(
             name="sglang:time_to_first_token_seconds",
             documentation="Histogram of time to first token in seconds.",
-            # "stream" splits streaming vs non-streaming requests.
-            labelnames=[*labels.keys(), "stream"],
+            # "is_streaming" splits streaming vs non-streaming requests (named to
+            # match downstream storage dimensions exactly - "stream" is a
+            # reserved thrift keyword, so schema columns cannot carry it).
+            labelnames=[*labels.keys(), "is_streaming"],
             buckets=bucket_time_to_first_token,
         )
 
@@ -1645,7 +1647,7 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.histogram_e2e_request_latency = Histogram(
             name="sglang:e2e_request_latency_seconds",
             documentation="Histogram of End-to-end request latency in seconds",
-            labelnames=list(labels.keys()) + ["stream"],
+            labelnames=list(labels.keys()) + ["is_streaming"],
             buckets=bucket_e2e_request_latency,
         )
 
@@ -1661,7 +1663,7 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         spec_verify_ct: int = 0,
         stream: bool = False,
     ):
-        stream_labels = {**labels, "stream": "true" if stream else "false"}
+        stream_labels = {**labels, "is_streaming": "true" if stream else "false"}
         self.prompt_tokens_total.labels(**stream_labels).inc(prompt_tokens)
         self.generation_tokens_total.labels(**stream_labels).inc(generation_tokens)
         if spec_verify_ct > 0:
@@ -1710,11 +1712,11 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self, labels: Dict[str, str], value: float, *, stream: bool
     ):
         self.histogram_time_to_first_token.labels(
-            **labels, stream="true" if stream else "false"
+            **labels, is_streaming="true" if stream else "false"
         ).observe(value)
 
     def check_time_to_first_token_straggler(self, value: float) -> bool:
-        his = self.histogram_time_to_first_token.labels(**self.labels, stream="true")
+        his = self.histogram_time_to_first_token.labels(**self.labels, is_streaming="true")
         total_observations = sum(bucket._value for bucket in his._buckets)
         if total_observations < 100:
             return False

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1445,12 +1445,12 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.prompt_tokens_total = Counter(
             name="sglang:prompt_tokens_total",
             documentation="Number of prefill tokens processed.",
-            labelnames=labels.keys(),
+            labelnames=list(labels.keys()) + ["stream"],
         )
         self.generation_tokens_total = Counter(
             name="sglang:generation_tokens_total",
             documentation="Number of generation tokens processed.",
-            labelnames=labels.keys(),
+            labelnames=list(labels.keys()) + ["stream"],
         )
         self.spec_verify_calls_total = Counter(
             name="sglang:spec_verify_calls_total",
@@ -1530,7 +1530,7 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.num_requests_total = Counter(
             name="sglang:num_requests_total",
             documentation="Number of requests processed.",
-            labelnames=labels.keys(),
+            labelnames=list(labels.keys()) + ["stream"],
         )
 
         self.get_loads_duration_seconds = Histogram(
@@ -1645,7 +1645,7 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         self.histogram_e2e_request_latency = Histogram(
             name="sglang:e2e_request_latency_seconds",
             documentation="Histogram of End-to-end request latency in seconds",
-            labelnames=labels.keys(),
+            labelnames=list(labels.keys()) + ["stream"],
             buckets=bucket_e2e_request_latency,
         )
 
@@ -1659,9 +1659,11 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         has_grammar: bool,
         cached_tokens_details: Optional[Dict[str, Any]] = None,
         spec_verify_ct: int = 0,
+        stream: bool = False,
     ):
-        self.prompt_tokens_total.labels(**labels).inc(prompt_tokens)
-        self.generation_tokens_total.labels(**labels).inc(generation_tokens)
+        stream_labels = {**labels, "stream": "true" if stream else "false"}
+        self.prompt_tokens_total.labels(**stream_labels).inc(prompt_tokens)
+        self.generation_tokens_total.labels(**stream_labels).inc(generation_tokens)
         if spec_verify_ct > 0:
             self.spec_verify_calls_total.labels(**labels).inc(spec_verify_ct)
 
@@ -1690,10 +1692,12 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
                 labels_total = {**labels, "cache_source": "total"}
                 self.cached_tokens_total.labels(**labels_total).inc(cached_tokens)
 
-        self.num_requests_total.labels(**labels).inc(1)
+        self.num_requests_total.labels(**stream_labels).inc(1)
         if has_grammar:
             self.num_so_requests_total.labels(**labels).inc(1)
-        self.histogram_e2e_request_latency.labels(**labels).observe(float(e2e_latency))
+        self.histogram_e2e_request_latency.labels(**stream_labels).observe(
+            float(e2e_latency)
+        )
         self.prompt_tokens_histogram.labels(**labels).observe(float(prompt_tokens))
         self.uncached_prompt_tokens_histogram.labels(**labels).observe(
             float(prompt_tokens - cached_tokens)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1661,9 +1661,12 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         has_grammar: bool,
         cached_tokens_details: Optional[Dict[str, Any]] = None,
         spec_verify_ct: int = 0,
-        stream: bool = False,
+        is_streaming: bool = False,
     ):
-        stream_labels = {**labels, "is_streaming": "true" if stream else "false"}
+        stream_labels = {
+            **labels,
+            "is_streaming": "true" if is_streaming else "false",
+        }
         self.prompt_tokens_total.labels(**stream_labels).inc(prompt_tokens)
         self.generation_tokens_total.labels(**stream_labels).inc(generation_tokens)
         if spec_verify_ct > 0:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1716,7 +1716,9 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         ).observe(value)
 
     def check_time_to_first_token_straggler(self, value: float) -> bool:
-        his = self.histogram_time_to_first_token.labels(**self.labels, is_streaming="true")
+        his = self.histogram_time_to_first_token.labels(
+            **self.labels, is_streaming="true"
+        )
         total_observations = sum(bucket._value for bucket in his._buckets)
         if total_observations < 100:
             return False


### PR DESCRIPTION
## Motivation

Streaming and non-streaming requests have fundamentally different latency distributions (streaming requests are long-lived by design), but the tokenizer's per-request metrics carry no `stream` dimension — request counts, e2e latency, and token throughput cannot be segmented by traffic class, and the e2e latency histogram mixes two distribution shapes.

## Modifications

Add a `stream` label (`"true"`/`"false"`) to five tokenizer metrics, threading the request's `stream` flag through the collector:

- `sglang:time_to_first_token_seconds`
- `sglang:num_requests_total`
- `sglang:e2e_request_latency_seconds`
- `sglang:prompt_tokens_total`
- `sglang:generation_tokens_total`

Cardinality doubles for these five metrics only. The TTFT straggler check pins `stream="true"`, since streaming requests are the ones observed for first-token stragglers.

Deliberately out of scope: `num_aborted_requests_total` (its call site only has a `rid`, so the flag is ambiguous for `abort_all`) and per-batch scheduler metrics (mixed batches).

## Original commits

- `fe19165dc`

## Checklist

- [x] Format your code: `python3 -m py_compile` and black clean on both files; whitespace clean.
- [x] Verified on an internal deployment: the five metrics export with the `stream` label and remain scrapeable; existing dashboards keyed on the base labels aggregate across the new dimension.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30900686807](https://github.com/sgl-project/sglang/actions/runs/30900686807)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30900686459](https://github.com/sgl-project/sglang/actions/runs/30900686459)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->