### PR TITLE
[Fix] Convert OE vocab size to Python int in NgramEmbedding to avoid Triton constexpr TypeError

### DIFF
--- a/python/sglang/srt/layers/n_gram_embedding.py
+++ b/python/sglang/srt/layers/n_gram_embedding.py
@@ -49,7 +49,7 @@ class NgramEmbedding(torch.nn.Module):
                 + int(over_embedding_m + i * 2 + 1)
             )
         self.oe_embeder = VocabParallelEmbedding(
-            num_embeddings=self.exclusive_oe_embedder_size_sums[-1],
+            num_embeddings=int(self.exclusive_oe_embedder_size_sums[-1].item()),
             embedding_dim=oe_hidden_dim,
             use_attn_tp_group=use_attn_tp_group,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When constructing `NgramEmbedding.oe_embeder` (the over-embedding layer used by LongCat-Flash's n-gram composite encoding), `num_embeddings` was passed as `self.exclusive_oe_embedder_size_sums[-1]`, which is a 0-d CUDA `torch.Tensor`, instead of the plain Python `int` required by `VocabParallelEmbedding.__init__`'s type contract.

This tensor silently propagates through `VocabParallelEmbedding` (e.g. `pad_vocab_size`, `org_vocab_size`) because `torch.Tensor` overloads Python arithmetic operators, so no error surfaces at construction time. It later reaches `VocabParallelEmbeddingShardIndices._get_indices`, where Python's built-in `min()` does not unify types:

```python
org_vocab_start_index = min(padded_org_vocab_start_index, org_vocab_size)
```

This tensor is then passed as a `tl.constexpr` argument into the fused Triton kernel `_vocab_parallel_embedding_kernel`, which only accepts Triton `tl.tensor`/`tl.constexpr`/Python scalars — not `torch.Tensor` — causing a hard compile-time failure:

```
sglang/kernels/ops/embeddings/vocab_parallel_embedding.py: _vocab_parallel_embedding_kernel
triton.compiler.errors.CompilationError: at 25:22:
    org_vocab_mask = (token >= org_vocab_start_index) & (token < org_vocab_end_index)
TypeError("cannot convert 76677240 of type <class 'torch.Tensor'> to tensor")
```

**Why this surfaced only recently:** this line has passed a `torch.Tensor` instead of an `int` ever since `NgramEmbedding` was introduced, but it stayed harmless because `VocabParallelEmbedding.forward` used to compute the vocab mask via a `torch.compile(dynamic=True, ...)` function, which happily traces through tensor inputs without type checking. That changed in `dc0b3eb68` (#30948, "Fuse TP vocab-parallel embedding"), which replaced it with a native `@triton.jit` kernel and marked the vocab boundary arguments as `tl.constexpr` — a compile-time-only mechanism that requires plain Python scalars. Once that optimization landed, the same tensor value found no more tolerant type coercion path and instead an existing, previously-latent bug become a compile-time `TypeError`.

## Modifications

<!-- Detail the changes made in this pull request. -->

- In `python/sglang/srt/layers/n_gram_embedding.py`, convert `self.exclusive_oe_embedder_size_sums[-1]` to a Python `int` via `.item()` before passing it as `num_embeddings` to `VocabParallelEmbedding`, matching the type used by `word_embeder`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

This is a type-only fix (converts a 0-d CUDA tensor to the equivalent Python int) and does not change any numerical computation. Verified end-to-end on a model (n-gram architecture, TP=8/EP=8): the server starts successfully, the previously-failing `oe_embeder` construction and Triton `_vocab_parallel_embedding_kernel` compilation now succeed, and both prefill and decode complete correctly (including with CUDA Graph enabled) for real inference requests.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Not applicable — this change does not affect the inference hot path or kernel computation, only a one-time scalar conversion during model initialization.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30431383329](https://github.com/sgl-project/sglang/actions/runs/30431383329)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30431383048](https://github.com/sgl-project/sglang/actions/runs/30431383048)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->