### PR TITLE
[Fix] DSA Indexer: pad heads for DeepGEMM paged MQA logits on decode/target-verify

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -1005,11 +1005,14 @@ class Indexer(MultiPlatformOp):
                 get_paged_mqa_logits_metadata_fn=deep_gemm.get_paged_mqa_logits_metadata,
             )
         elif use_dg_native:
+            q_fp8_padded, weights_padded, _ = self._pad_heads_for_deep_gemm(
+                q_fp8, weights
+            )
             logits = deepgemm_paged_mqa_logits_native(
                 deep_gemm.fp8_paged_mqa_logits,
-                q_fp8,
+                q_fp8_padded,
                 kv_cache_fp8,
-                weights,
+                weights_padded,
                 seqlens_32_2d,
                 block_tables,
                 schedule_metadata,
@@ -1019,11 +1022,14 @@ class Indexer(MultiPlatformOp):
                 next_n=next_n,
             )
         else:
+            q_fp8_padded, weights_padded, _ = self._pad_heads_for_deep_gemm(
+                q_fp8, weights
+            )
             logits = deepgemm_paged_mqa_logits_split(
                 deep_gemm.fp8_paged_mqa_logits,
-                q_fp8,
+                q_fp8_padded,
                 kv_cache_fp8,
-                weights,
+                weights_padded,
                 seqlens_32_2d,
                 block_tables,
                 schedule_metadata,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

`deep_gemm.fp8_paged_mqa_logits` hard-asserts the DSA indexer's head count against a fixed per-architecture allow-list (e.g. `{8, 16, 32, 64}` on sm90/100/120). Models whose `index_n_heads` falls outside this allow-list crash on the very first paged decode step:

```
sglang/srt/layers/attention/dsa/dsa_indexer.py: _get_topk_paged -> deepgemm_paged_mqa_logits_split
RuntimeError: Assertion error (/deepgemm/csrc/apis/attention.hpp:317):
  (arch_major == 10 and (num_heads in {8,16,32,64})) or
  (arch_major == 12 and (num_heads in {8,16,32,64})) or
  (arch_major == 9 and (num_heads in {32,64}))
```

The indexer already handles this on the prefill path: `_pad_heads_for_deep_gemm()` zero-pads `q_fp8`/`weights` up to 32 heads before calling the ragged kernels (`_get_topk_ragged` / `_get_topk_ragged_with_cp`), which does not affect topk correctness since the padded heads carry zero weight. However, this padding was never wired up on the paged path (`_get_topk_paged`) used for decode, target-verify, and draft-extend, so any model with `index_n_heads < 32` fails as soon as it reaches decode.

## Modifications

<!-- Detail the changes made in this pull request. -->

In `python/sglang/srt/layers/attention/dsa/dsa_indexer.py`, apply the existing `_pad_heads_for_deep_gemm()` helper before both `fp8_paged_mqa_logits` call sites inside `_get_topk_paged`:

- `use_dg_native` branch (`deepgemm_paged_mqa_logits_native`)
- fallback branch (`deepgemm_paged_mqa_logits_split`)

Both call sites now pass the padded `q_fp8_padded` / `weights_padded` instead of the raw `q_fp8` / `weights`, mirroring the padding already done on the ragged (prefill) path. No new parameters or behavior changes are introduced for models whose head count already satisfies the DeepGEMM allow-list (`_pad_heads_for_deep_gemm` is a no-op when `num_heads >= 32`).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Verified end-to-end with a model (MoE + MLA + DSA, `index_n_heads=16`) on 8 × H20-3e with `--tp 8 --ep 8`. Before the fix, decode crashed with the assertion above; after the fix, prefill and decode (including CUDA Graph capture/replay for bs=1~64) complete successfully and return correct completions via the OpenAI-compatible API.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Not applicable — this change only adds zero-weighted head padding on a path that previously crashed (no valid baseline to compare against for affected models), and is a no-op for models whose indexer head count already meets the DeepGEMM allow-list.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30431307904](https://github.com/sgl-project/sglang/actions/runs/30431307904)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30431307642](https://github.com/sgl-project/sglang/actions/runs/30431307642)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->