### PR TITLE
[Bugfix] Wire the model's packed_modules_mapping into its quantization config

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -83,6 +83,7 @@ from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     trigger_transferring_weights_request,
 )
 from sglang.srt.model_loader.utils import (
+    configure_quant_config,
     get_model_architecture,
     set_default_torch_dtype,
 )
@@ -308,6 +309,9 @@ def _initialize_model(
 ) -> nn.Module:
     """Initialize a model with the given configurations."""
     model_class, _ = get_model_architecture(model_config)
+    # Must run before the model is built: layers resolve their quant method
+    # during __init__, so a fused module needs the mapping already in place.
+    configure_quant_config(quant_config, model_class)
     kwargs = {
         "config": model_config.hf_config,
         "quant_config": quant_config,

--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -20,6 +20,39 @@ from sglang.srt.layers import deep_gemm_wrapper
 logger = logging.getLogger(__name__)
 
 
+def configure_quant_config(quant_config: Any, model_class: Type[nn.Module]) -> None:
+    """Give the quantization config the model's fused-module mapping.
+
+    Quantized checkpoints name the *unfused* projections (``q_proj``, ``k_proj``,
+    ``v_proj``) while sglang builds fused modules (``qkv_proj``). Quantization
+    configs bridge that with ``packed_modules_mapping``, and
+    ``QuantizationConfig`` documents it as "updated by models as they
+    initialize" -- but only two of the 39 models that declare the attribute
+    actually assign it, so for the rest the mapping stays empty and a fused
+    module either silently misses its scheme or raises "Unable to find matching
+    target ...". Wiring it here covers every model and every loader.
+
+    Any mapping already on the config (e.g. supplied through
+    ``quantization_config.packed_modules_mapping`` in ``config.json``) wins, so
+    existing overrides keep working. Models that still assign the mapping in
+    their ``__init__`` are unaffected: they simply overwrite it with the same
+    value.
+    """
+    if quant_config is None:
+        return
+
+    packed_mapping = getattr(model_class, "packed_modules_mapping", None)
+    if not packed_mapping:
+        return
+
+    existing = getattr(quant_config, "packed_modules_mapping", None) or {}
+    merged = {**packed_mapping, **existing}
+    if hasattr(quant_config, "update_packed_modules_mapping"):
+        quant_config.update_packed_modules_mapping(merged)
+    else:
+        quant_config.packed_modules_mapping = merged
+
+
 @contextlib.contextmanager
 def set_default_torch_dtype(dtype: torch.dtype):
     """Sets the default torch dtype to the given dtype."""

--- a/test/registered/unit/model_loader/test_configure_quant_config.py
+++ b/test/registered/unit/model_loader/test_configure_quant_config.py
@@ -1,0 +1,129 @@
+"""CPU unit tests for wiring a model's packed_modules_mapping into its quant config.
+
+Quantized checkpoints name the unfused projections (``q_proj``/``k_proj``/
+``v_proj``) while sglang builds fused modules (``qkv_proj``). Quantization
+configs bridge the two through ``packed_modules_mapping``, which
+``QuantizationConfig`` documents as "updated by models as they initialize" --
+but only 2 of the 39 models declaring the attribute actually assigned it, so for
+everything else the mapping stayed empty and a fused module could not be matched
+against the checkpoint's targets ("Unable to find matching target ...").
+
+``_initialize_model`` now calls ``configure_quant_config`` for every model and
+every loader. These tests are pure attribute plumbing plus one end-to-end match
+through the compressed-tensors matcher, so they run on CPU.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+from sglang.srt.layers.quantization.compressed_tensors.utils import find_matched_target
+from sglang.srt.model_loader.utils import configure_quant_config
+from sglang.test.test_utils import CustomTestCase
+
+QKV_MAPPING = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+}
+
+
+class _ModelWithMapping:
+    packed_modules_mapping = QKV_MAPPING
+
+
+class _ModelWithoutMapping:
+    pass
+
+
+def _make_fp8_config(packed_modules_mapping=None):
+    """FP8 W8A8 config whose targets name the *unfused* attention projections."""
+    config = {
+        "quant_method": "compressed-tensors",
+        "format": "float-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["re:.*self_attn\\.(q|k|v)_proj$"],
+                "weights": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "symmetric": True,
+                    "strategy": "channel",
+                    "dynamic": False,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "float",
+                    "symmetric": True,
+                    "strategy": "token",
+                    "dynamic": True,
+                },
+            }
+        },
+        "ignore": [],
+    }
+    if packed_modules_mapping is not None:
+        config["packed_modules_mapping"] = packed_modules_mapping
+    return config
+
+
+class TestConfigureQuantConfig(CustomTestCase):
+    def test_mapping_is_copied_from_model_class(self):
+        quant_config = CompressedTensorsConfig.from_config(_make_fp8_config())
+        self.assertEqual(quant_config.packed_modules_mapping, {})
+
+        configure_quant_config(quant_config, _ModelWithMapping)
+        self.assertEqual(quant_config.packed_modules_mapping, QKV_MAPPING)
+
+    def test_checkpoint_mapping_wins_and_is_extended(self):
+        # An override supplied through config.json must survive, while keys it
+        # does not mention are still filled in from the model class.
+        override = {"qkv_proj": ["q_proj"]}
+        quant_config = CompressedTensorsConfig.from_config(_make_fp8_config(override))
+
+        configure_quant_config(quant_config, _ModelWithMapping)
+        self.assertEqual(quant_config.packed_modules_mapping["qkv_proj"], ["q_proj"])
+        self.assertEqual(
+            quant_config.packed_modules_mapping["gate_up_proj"],
+            ["gate_proj", "up_proj"],
+        )
+
+    def test_no_quant_config_or_no_mapping_is_a_noop(self):
+        configure_quant_config(None, _ModelWithMapping)  # must not raise
+
+        quant_config = CompressedTensorsConfig.from_config(_make_fp8_config())
+        configure_quant_config(quant_config, _ModelWithoutMapping)
+        self.assertEqual(quant_config.packed_modules_mapping, {})
+
+    def test_fused_layer_resolves_against_unfused_targets(self):
+        quant_config = CompressedTensorsConfig.from_config(_make_fp8_config())
+        fused_layer_name = "model.layers.0.self_attn.qkv_proj"
+        targets = quant_config.target_scheme_map.keys()
+
+        # Without the mapping the fused module matches nothing.
+        with self.assertRaises(ValueError):
+            find_matched_target(
+                layer_name=fused_layer_name,
+                module=torch.nn.Module(),
+                targets=targets,
+                fused_mapping=quant_config.packed_modules_mapping,
+            )
+
+        configure_quant_config(quant_config, _ModelWithMapping)
+        matched = find_matched_target(
+            layer_name=fused_layer_name,
+            module=torch.nn.Module(),
+            targets=targets,
+            fused_mapping=quant_config.packed_modules_mapping,
+        )
+        self.assertEqual(matched, "re:.*self_attn\\.(q|k|v)_proj$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Quantized checkpoints name the **unfused** projections (`q_proj` / `k_proj` / `v_proj`) while sglang builds **fused** modules (`qkv_proj`). Quantization configs bridge the two through `packed_modules_mapping`, which the base class documents as filled in by the model:

```python
# python/sglang/srt/layers/quantization/base_config.py
class QuantizationConfig(ABC):
    def __init__(self):
        super().__init__()
        # mapping is updated by models as they initialize
        self.packed_modules_mapping: Dict[str, List[str]] = dict()
```

In practice almost nothing does. **39 models declare `packed_modules_mapping`; 2 actually assign it to the quant config** — `qwen3_next.py` and `qwen3_5_text.py`, each carrying its own copy of the same three lines:

```python
if quant_config is not None and hasattr(quant_config, "packed_modules_mapping"):
    quant_config.packed_modules_mapping = self.packed_modules_mapping
```

For the other 37 the mapping stays empty, and both consumers of it silently degrade:

- `should_ignore_layer` cannot unfuse a fused name to check it against `ignore`.
- `find_matched_target` cannot match a fused module against unfused targets, so it raises `ValueError: Unable to find matching target for <layer> in the compressed-tensors config.`

Concretely, `Qwen3_5MoeForConditionalGeneration` inherits `packed_modules_mapping` (`qwen3_5.py:1926`) including `in_proj_qkvz: [in_proj_qkv, in_proj_z]`, but never assigns it — so a compressed-tensors checkpoint targeting `re:.*linear_attn\.(in_proj_qkv|in_proj_z|out_proj)$` cannot resolve the fused `linear_attn.in_proj_qkvz`. The text-only sibling in `qwen3_5_text.py` works, because that one happens to have the three lines.

Today the only workaround is to put `packed_modules_mapping` into `quantization_config` in the checkpoint's `config.json`, since `CompressedTensorsConfig.from_config` reads it from there — a checkpoint carrying engine-internal module names it should not need to know about.

vLLM solves this centrally in `configure_quant_config()`, called from the loader before the model is built.

## Modifications

`python/sglang/srt/model_loader/utils.py`

- New `configure_quant_config(quant_config, model_class)`: copies `model_class.packed_modules_mapping` onto the quant config, through the existing `QuantizationConfig.update_packed_modules_mapping()` API when available. No-ops when there is no quant config or the model declares no mapping.

`python/sglang/srt/model_loader/loader.py`

- `_initialize_model` — the single entry point all loaders funnel through — calls it right after resolving `model_class`, **before** `model_class(**kwargs)`. It has to run first: layers resolve their quant method during `__init__`, so a fused module needs the mapping already in place. (The two existing in-model assignments happen mid-`__init__` and therefore only work for layers built after that point.)

Backwards compatibility:

- A mapping already on the config — e.g. supplied via `quantization_config.packed_modules_mapping` in `config.json` — takes precedence per key, and keys it does not mention are filled in from the model class. Nobody loses an override.
- The two models that assign the mapping themselves are unaffected; they overwrite it with the same value. Their now-redundant blocks can be dropped in a follow-up, left alone here to keep this diff to the loader.

## Accuracy Tests

No model output path is touched. The effect is that fused layers of a quantized checkpoint resolve their scheme instead of raising, or being skipped and left unquantized.

## Speed Tests and Profiling

N/A. One dict merge at load time.

## Unit tests

New: `test/registered/unit/model_loader/test_configure_quant_config.py` (CPU, `base-a-test-cpu`, ~5s):

- the model class mapping lands on the quant config
- a `config.json`-supplied override wins per key, other keys still filled in
- `quant_config=None` and a model class without the attribute are both no-ops
- end-to-end through the real matcher: `find_matched_target` on `model.layers.0.self_attn.qkv_proj` against a config targeting `re:.*self_attn\.(q|k|v)_proj$` raises `ValueError` before the call and resolves the target after it

I could not run the suite locally — this box has a broken `sgl_kernel` wheel (SM89 GPU, only the `sm100` `.so` shipped), so pre-existing tests in this directory fail to import here too. `configure_quant_config` was instead executed directly from its patched source against a stub config (6/6 cases, including a config without `update_packed_modules_mapping`). `black` and `isort --profile black` are clean. Please run CI.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Related

Independent of, but found alongside, #32736 (compressed-tensors `ignore` prefix matching + per-group `format`). Both came out of https://huggingface.co/beyoru/KAT-Coder-V2.5-Dev-VL-Flash/discussions/1, where a Qwen3.5-VL NVFP4 checkpoint could not be served by SGLang. Either PR can land on its own.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30431579977](https://github.com/sgl-project/sglang/actions/runs/30431579977)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30431579812](https://github.com/sgl-project/sglang/actions/runs/30431579812)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->