### PR TITLE
Add fixed output vocabulary mapping for Qwen2

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -155,6 +155,10 @@ from sglang.srt.model_executor.model_runner_components.weight_exporter import (
 from sglang.srt.model_executor.model_runner_components.weight_updater import (
     WeightUpdater,
 )
+from sglang.srt.model_executor.output_token_map import (
+    map_output_token_indices,
+    validate_output_token_ids,
+)
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.model_executor.runner import (
     EagerRunner,
@@ -176,7 +180,10 @@ from sglang.srt.server_args import (  # noqa: F401  (re-export)
     set_global_server_args_for_scheduler,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
+from sglang.srt.speculative.spec_utils import (
+    load_token_map,
+    resolve_num_tokens_per_req,
+)
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 from sglang.srt.state_capturer.indexer_topk import (
     create_indexer_capturer,
@@ -568,6 +575,7 @@ class ModelRunner:
         self.maybe_init_elastic_ep()
         self.init_token_oracle()
         self.sampler = create_sampler()
+        self.init_output_token_map()
         self.load_model()
         prepare_moe_topk(
             model=self.model,
@@ -601,6 +609,30 @@ class ModelRunner:
         self.maybe_init_lora_manager()
         self.maybe_enable_batch_invariant_mode()
         self.configure_kv_cache_dtype()
+
+    def init_output_token_map(self):
+        self.output_token_map = None
+        token_map_path = self.server_args.output_token_map
+        if token_map_path is None or self.is_draft_worker:
+            return
+        if self.ps.tp_size != 1 or self.ps.pp_size != 1:
+            raise ValueError("Output token mapping currently requires TP1 and PP1.")
+        if self.model_config.quantization is not None:
+            raise ValueError("Output token mapping does not support quantized models.")
+        if self.server_args.enable_lora:
+            raise ValueError("Output token mapping does not support LoRA.")
+        if self.server_args.enable_dp_lm_head:
+            raise ValueError("Output token mapping does not support DP LM head.")
+        if self.spec_algorithm.is_some():
+            raise ValueError(
+                "Output token mapping does not support speculative decoding."
+            )
+
+        self.output_token_map = validate_output_token_ids(
+            load_token_map(token_map_path),
+            self.model_config.vocab_size,
+        )
+        self.model_config.hf_config.output_token_ids = self.output_token_map.tolist()
 
     def init_memory_saver_adapter(self):
         self.memory_saver_adapter = TorchMemorySaverAdapter.create(
@@ -1026,6 +1058,18 @@ class ModelRunner:
         )
         self.loader = loaded.loader
         self.model = loaded.model
+        if self.output_token_map is not None:
+            model_output_token_ids = getattr(self.model, "output_token_ids", None)
+            if model_output_token_ids is None:
+                raise ValueError(
+                    f"{type(self.model).__name__} does not support output token mapping."
+                )
+            if not torch.equal(
+                torch.as_tensor(model_output_token_ids, device="cpu"),
+                self.output_token_map,
+            ):
+                raise ValueError("The model loaded a different output token map.")
+            self.output_token_map = self.output_token_map.to(self.device)
         if loaded.remote_instance_weight_info is not None:
             self.remote_instance_weight_transporter.weight_info = (
                 loaded.remote_instance_weight_info
@@ -1587,7 +1631,16 @@ class ModelRunner:
 
         # Calculate logits bias and apply it to next_token_logits.
         sampling_info.update_regex_vocab_mask()
-        sampling_info.apply_logits_bias(logits_output.next_token_logits)
+        if (
+            self.output_token_map is not None
+            and sampling_info.has_custom_logit_processor
+        ):
+            raise ValueError(
+                "Custom logit processors are not supported with output token mapping."
+            )
+        sampling_info.apply_logits_bias(
+            logits_output.next_token_logits, self.output_token_map
+        )
 
         # Release the vocab_mask GPU tensor immediately after it has been applied
         # to the logits. In overlap scheduling, the sampling_info (and its
@@ -1626,6 +1679,22 @@ class ModelRunner:
                 else forward_batch.seq_lens - 1
             ),
         )
+        if self.output_token_map is not None:
+            next_token_ids = map_output_token_indices(
+                next_token_ids, self.output_token_map
+            )
+            logits_output.next_token_top_logprobs_idx = map_output_token_indices(
+                logits_output.next_token_top_logprobs_idx,
+                self.output_token_map,
+            )
+            logits_output.next_token_token_ids_logprobs_idx = map_output_token_indices(
+                logits_output.next_token_token_ids_logprobs_idx,
+                self.output_token_map,
+            )
+            logits_output.next_token_sampling_mask_idx = map_output_token_indices(
+                logits_output.next_token_sampling_mask_idx,
+                self.output_token_map,
+            )
         self.ngram_embedding_manager.update_after_decode(
             next_token_ids=next_token_ids,
             forward_batch=forward_batch,

--- a/python/sglang/srt/model_executor/output_token_map.py
+++ b/python/sglang/srt/model_executor/output_token_map.py
@@ -1,0 +1,74 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import torch
+
+
+def validate_output_token_ids(
+    token_ids: Sequence[int] | torch.Tensor,
+    vocab_size: int,
+) -> torch.Tensor:
+    output_token_ids = torch.as_tensor(token_ids, dtype=torch.int64, device="cpu")
+    if output_token_ids.ndim != 1 or output_token_ids.numel() == 0:
+        raise ValueError("The output token map must be a non-empty 1D tensor.")
+    if output_token_ids.min().item() < 0:
+        raise ValueError("The output token map contains a negative token ID.")
+    if output_token_ids.max().item() >= vocab_size:
+        raise ValueError(
+            "The output token map contains a token ID outside the model vocabulary."
+        )
+    if torch.unique(output_token_ids).numel() != output_token_ids.numel():
+        raise ValueError("The output token map contains duplicate token IDs.")
+    return output_token_ids.contiguous()
+
+
+def project_vocab_tensor(
+    tensor: torch.Tensor,
+    output_token_ids: torch.Tensor | None,
+) -> torch.Tensor:
+    if output_token_ids is None or tensor.shape[-1] == output_token_ids.numel():
+        return tensor
+    return tensor.index_select(-1, output_token_ids.to(tensor.device))
+
+
+def apply_projected_vocab_mask(
+    logits: torch.Tensor,
+    vocab_mask: torch.Tensor,
+    output_token_ids: torch.Tensor,
+) -> None:
+    token_ids = output_token_ids.to(vocab_mask.device)
+    word_indices = torch.div(token_ids, 32, rounding_mode="floor")
+    bit_indices = torch.remainder(token_ids, 32).to(torch.int32)
+    words = vocab_mask.index_select(-1, word_indices).to(torch.int32)
+    allowed = ((words >> bit_indices) & 1).bool().to(logits.device)
+    logits.masked_fill_(~allowed, float("-inf"))
+
+
+def map_output_token_indices(value: Any, output_token_ids: torch.Tensor) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        indices = value.to(torch.long)
+        mapped = output_token_ids.to(value.device)[indices.clamp_min(0)]
+        return torch.where(indices >= 0, mapped, indices)
+    if isinstance(value, list):
+        return [map_output_token_indices(item, output_token_ids) for item in value]
+    if isinstance(value, tuple):
+        return tuple(map_output_token_indices(item, output_token_ids) for item in value)
+    index = int(value)
+    return output_token_ids[index].item() if index >= 0 else index

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -16,6 +16,7 @@
 # Modify details for the adaptation of Qwen2 model.
 """Inference-only Qwen2 model compatible with HuggingFace weights."""
 
+import copy
 import logging
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -493,13 +494,30 @@ class Qwen2ForCausalLM(nn.Module):
         self.pp_group = get_pp_group()
         self.config = config
         self.quant_config = quant_config
+        output_token_ids = getattr(config, "output_token_ids", None)
+        self.output_token_ids = (
+            torch.as_tensor(output_token_ids, dtype=torch.int64, device="cpu")
+            if output_token_ids is not None
+            else None
+        )
+        if self.output_token_ids is not None and not config.tie_word_embeddings:
+            raise ValueError(
+                "Qwen2 output token mapping requires tied word embeddings."
+            )
         self.model = Qwen2Model(
             config, quant_config=quant_config, prefix=add_prefix("model", prefix)
         )
 
         # handle the lm head on different pp ranks
         if self.pp_group.is_last_rank:
-            if self.pp_group.world_size == 1 and config.tie_word_embeddings:
+            if self.output_token_ids is not None:
+                self.lm_head = ParallelLMHead(
+                    self.output_token_ids.numel(),
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=add_prefix("lm_head", prefix),
+                )
+            elif self.pp_group.world_size == 1 and config.tie_word_embeddings:
                 self.lm_head = self.model.embed_tokens
             else:
                 self.lm_head = ParallelLMHead(
@@ -512,7 +530,10 @@ class Qwen2ForCausalLM(nn.Module):
             # ranks other than the last rank will have a placeholder layer
             self.lm_head = PPMissingLayer()
 
-        self.logits_processor = LogitsProcessor(config)
+        logits_config = copy.copy(config)
+        if self.output_token_ids is not None:
+            logits_config.vocab_size = self.output_token_ids.numel()
+        self.logits_processor = LogitsProcessor(logits_config)
         self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=True)
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
@@ -533,6 +554,10 @@ class Qwen2ForCausalLM(nn.Module):
         get_embedding: bool = False,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
+        if self.output_token_ids is not None and forward_batch.return_logprob:
+            raise ValueError(
+                "Output token mapping does not support returning log probabilities."
+            )
         hidden_states = self.model(
             input_ids,
             positions,
@@ -567,6 +592,10 @@ class Qwen2ForCausalLM(nn.Module):
         split_interval: Tuple[int, int],  # [start, end) 0-based
         input_embeds: torch.Tensor = None,
     ):
+        if self.output_token_ids is not None and forward_batch.return_logprob:
+            raise ValueError(
+                "Output token mapping does not support returning log probabilities."
+            )
         start, end = split_interval
         # embed
         if start == 0:
@@ -646,7 +675,18 @@ class Qwen2ForCausalLM(nn.Module):
                         weight_loader = getattr(
                             param, "weight_loader", default_weight_loader
                         )
-                        weight_loader(param, loaded_weight)
+                        lm_head_weight = loaded_weight
+                        if self.output_token_ids is not None:
+                            lm_head_weight = loaded_weight.index_select(
+                                0,
+                                self.output_token_ids.to(loaded_weight.device),
+                            )
+                        weight_loader(param, lm_head_weight)
+            elif name == "lm_head.weight" and self.output_token_ids is not None:
+                loaded_weight = loaded_weight.index_select(
+                    0,
+                    self.output_token_ids.to(loaded_weight.device),
+                )
 
             if "rotary_emb.inv_freq" in name or "projector" in name:
                 continue
@@ -725,7 +765,13 @@ class Qwen2ForCausalLM(nn.Module):
                 if embed is not None:
                     lm_head = params_dict["lm_head.weight"]
                     wl = getattr(lm_head, "weight_loader", default_weight_loader)
-                    wl(lm_head, embed.data)
+                    lm_head_weight = embed.data
+                    if self.output_token_ids is not None:
+                        lm_head_weight = embed.data.index_select(
+                            0,
+                            self.output_token_ids.to(embed.device),
+                        )
+                    wl(lm_head, lm_head_weight)
                     loaded.add("lm_head.weight")
 
         return loaded
@@ -734,6 +780,14 @@ class Qwen2ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
+        if (
+            self.output_token_ids is not None
+            and head.shape[0] != self.output_token_ids.numel()
+        ):
+            head = head.index_select(
+                0,
+                self.output_token_ids.to(head.device),
+            )
         del self.model.embed_tokens.weight
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed

--- a/python/sglang/srt/sampling/penaltylib/orchestrator.py
+++ b/python/sglang/srt/sampling/penaltylib/orchestrator.py
@@ -52,7 +52,12 @@ class BatchedPenalizerOrchestrator:
         for penalizer in self.penalizers.values():
             penalizer.cumulate_output_tokens(output_ids=output_ids)
 
-    def apply(self, logits: torch.Tensor, repeat: Optional[int] = None):
+    def apply(
+        self,
+        logits: torch.Tensor,
+        repeat: Optional[int] = None,
+        output_token_ids: Optional[torch.Tensor] = None,
+    ):
         """
         Apply all penalizers to the logits in-place.
 
@@ -63,25 +68,34 @@ class BatchedPenalizerOrchestrator:
                 Additive penalties are captured into a zeros tensor, expanded,
                 then added; scaling penalties are accumulated, expanded, then
                 applied directly.
+            output_token_ids: If set, project full-vocabulary penalties onto
+                the compact output vocabulary before applying them.
         """
-        if repeat is None:
+        if repeat is None and output_token_ids is None:
             for penalizer in self.penalizers.values():
                 penalizer.apply(logits)
         else:
-            # Additive: capture into zeros, expand, add
+            repeat = repeat or 1
             bs = logits.shape[0] // repeat
             additive = torch.zeros(
-                (bs, logits.shape[1]), dtype=torch.float32, device=logits.device
+                (bs, self.vocab_size), dtype=torch.float32, device=logits.device
             )
             self.accumulate_additive_penalties(additive)
+            if output_token_ids is not None:
+                additive = additive.index_select(
+                    -1, output_token_ids.to(additive.device)
+                )
             logits.add_(torch.repeat_interleave(additive, repeat, dim=0))
-            # Scaling: accumulate, expand, apply
             accumulated = self.accumulate_scaling_penalties()
             if accumulated is not None:
                 from sglang.srt.sampling.penaltylib.repetition_penalty import (
                     apply_scaling_penalties,
                 )
 
+                if output_token_ids is not None:
+                    accumulated = accumulated.index_select(
+                        -1, output_token_ids.to(accumulated.device)
+                    )
                 expanded = torch.repeat_interleave(accumulated, repeat, dim=0)
                 apply_scaling_penalties(logits, expanded)
 

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -12,6 +12,10 @@ from sglang.srt.constrained.base_grammar_backend import (
     GrammarMask,
     GrammarRow,
 )
+from sglang.srt.model_executor.output_token_map import (
+    apply_projected_vocab_mask,
+    project_vocab_tensor,
+)
 from sglang.srt.runtime_context import get_server_args
 from sglang.srt.sampling.custom_logit_processor import CustomLogitProcessor
 from sglang.srt.sampling.penaltylib.repetition_penalty import apply_scaling_penalties
@@ -281,24 +285,40 @@ class SamplingBatchInfo:
             self.acc_additive_penalties = None
             self.acc_scaling_penalties = None
 
-    def apply_logits_bias(self, logits: torch.Tensor):
+    def apply_logits_bias(
+        self,
+        logits: torch.Tensor,
+        output_token_ids: Optional[torch.Tensor] = None,
+    ):
         if self.acc_additive_penalties is not None:
             # Used in the overlap mode
-            logits.add_(self.acc_additive_penalties)
+            logits.add_(
+                project_vocab_tensor(self.acc_additive_penalties, output_token_ids)
+            )
 
         if self.acc_scaling_penalties is not None:
             # Used in the overlap mode
-            apply_scaling_penalties(logits, self.acc_scaling_penalties)
+            apply_scaling_penalties(
+                logits,
+                project_vocab_tensor(self.acc_scaling_penalties, output_token_ids),
+            )
 
         if self.penalizer_orchestrator and self.penalizer_orchestrator.is_required:
             # Used in the non-overlap mode
-            self.penalizer_orchestrator.apply(logits)
+            self.penalizer_orchestrator.apply(logits, output_token_ids=output_token_ids)
 
         if self.grammar_mask is not None:
-            self.grammar_mask.apply(logits)
+            if output_token_ids is None:
+                self.grammar_mask.apply(logits)
+            else:
+                apply_projected_vocab_mask(
+                    logits,
+                    self.grammar_mask.vocab_mask,
+                    output_token_ids,
+                )
 
         if self.logit_bias is not None:
-            logits.add_(self.logit_bias)
+            logits.add_(project_vocab_tensor(self.logit_bias, output_token_ids))
 
     def filter_batch(self, keep_indices: List[int], keep_indices_device: torch.Tensor):
         self.penalizer_orchestrator.filter(keep_indices_device)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -598,6 +598,18 @@ class ServerArgs:
         "A dictionary in JSON string format used to override default model configurations.",
         NS("model"),
     ] = "{}"
+    output_token_map: A[
+        Optional[str],
+        (
+            "Path to a 1D torch tensor containing the global token IDs that may "
+            "be generated. Supported models replace the full LM head with the "
+            "selected rows and map sampled indices back to global token IDs. "
+            "The initial implementation supports tied-embedding Qwen2 models "
+            "with TP1, PP1, no quantization, no LoRA, no speculative decoding, "
+            "and no returned log probabilities."
+        ),
+        NS("model"),
+    ] = None
 
     # -------------------------------------------------------------------------
     # Quantization and data type

--- a/test/registered/unit/model_executor/test_output_token_map.py
+++ b/test/registered/unit/model_executor/test_output_token_map.py
@@ -1,0 +1,124 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.srt.model_executor.output_token_map import (
+    apply_projected_vocab_mask,
+    map_output_token_indices,
+    project_vocab_tensor,
+    validate_output_token_ids,
+)
+from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+from sglang.srt.sampling.sampling_params import TOP_K_ALL
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestOutputTokenMap(unittest.TestCase):
+    def test_validate_output_token_ids(self):
+        actual = validate_output_token_ids([5, 1, 9], vocab_size=10)
+        torch.testing.assert_close(actual, torch.tensor([5, 1, 9]))
+
+        for invalid in ([], [-1], [10], [1, 1], [[1, 2]]):
+            with self.assertRaises(ValueError):
+                validate_output_token_ids(invalid, vocab_size=10)
+
+    def test_project_vocab_tensor(self):
+        tensor = torch.arange(20).reshape(2, 10)
+        output_token_ids = torch.tensor([7, 2, 9])
+        expected = torch.tensor([[7, 2, 9], [17, 12, 19]])
+        torch.testing.assert_close(
+            project_vocab_tensor(tensor, output_token_ids), expected
+        )
+
+    def test_apply_projected_vocab_mask(self):
+        logits = torch.zeros(2, 3)
+        output_token_ids = torch.tensor([1, 33, 63])
+        vocab_mask = torch.tensor(
+            [[2, 2], [0, -2147483646]],
+            dtype=torch.int32,
+        )
+
+        apply_projected_vocab_mask(logits, vocab_mask, output_token_ids)
+
+        self.assertTrue(torch.isfinite(logits[0, 0]))
+        self.assertTrue(torch.isfinite(logits[0, 1]))
+        self.assertTrue(torch.isneginf(logits[0, 2]))
+        self.assertTrue(torch.isneginf(logits[1, 0]))
+        self.assertTrue(torch.isfinite(logits[1, 1]))
+        self.assertTrue(torch.isfinite(logits[1, 2]))
+
+    def test_map_output_token_indices(self):
+        output_token_ids = torch.tensor([10, 30, 20])
+        actual = map_output_token_indices(
+            [torch.tensor([2, 0, -1]), [1, None]],
+            output_token_ids,
+        )
+        torch.testing.assert_close(actual[0], torch.tensor([20, 10, -1]))
+        self.assertEqual(actual[1], [30, None])
+
+    def test_sampling_biases_are_projected(self):
+        info = SamplingBatchInfo(
+            temperatures=torch.ones(1, 1),
+            top_ps=torch.ones(1),
+            top_ks=torch.full((1,), TOP_K_ALL, dtype=torch.int32),
+            min_ps=torch.zeros(1),
+            is_all_greedy=True,
+            is_any_greedy=True,
+            need_top_p_sampling=False,
+            need_top_k_sampling=False,
+            need_min_p_sampling=False,
+            vocab_size=5,
+            device="cpu",
+            penalizer_orchestrator=MagicMock(is_required=False),
+            acc_additive_penalties=torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0]]),
+            acc_scaling_penalties=None,
+            logit_bias=torch.tensor([[10.0, 20.0, 30.0, 40.0, 50.0]]),
+        )
+        logits = torch.zeros(1, 2)
+
+        info.apply_logits_bias(logits, torch.tensor([3, 1]))
+
+        torch.testing.assert_close(logits, torch.tensor([[43.0, 21.0]]))
+
+    def test_compact_softmax_matches_conditioned_full_softmax(self):
+        torch.manual_seed(20260729)
+        full_logits = torch.randn(1000, 128)
+        output_token_ids = torch.randperm(128)[:37]
+        compact_logits = project_vocab_tensor(full_logits, output_token_ids)
+
+        full_probs = torch.softmax(full_logits, dim=-1)
+        conditioned_probs = full_probs.index_select(-1, output_token_ids)
+        conditioned_probs /= conditioned_probs.sum(dim=-1, keepdim=True)
+        compact_probs = torch.softmax(compact_logits, dim=-1)
+
+        torch.testing.assert_close(
+            compact_probs,
+            conditioned_probs,
+            rtol=1e-5,
+            atol=1e-7,
+        )
+        torch.testing.assert_close(
+            compact_logits.argmax(dim=-1),
+            full_logits.index_select(-1, output_token_ids).argmax(dim=-1),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds fixed output vocabulary mapping for tied-embedding Qwen2 models.

A new `--output-token-map` server argument accepts a one-dimensional torch tensor containing the global token IDs allowed during generation. The model builds a compact LM head using only the selected embedding rows, performs sampling over the compact vocabulary, and maps sampled indices back to global token IDs.

## Motivation

Some autoregressive models only generate tokens from a small subset of their full vocabulary. Audio language models are one example: the input vocabulary may contain text, control, speaker, and audio tokens, while generation only permits audio tokens and EOS.

Computing the LM head and Softmax over the complete vocabulary wastes GPU computation and may allow invalid token categories to enter the sampling path.

## Implementation

The implementation adds:

- `--output-token-map` for loading the allowed global token IDs
- A compact Qwen2 LM head initialized from selected tied-embedding rows
- Local-to-global token ID mapping after sampling
- Projection of repetition penalties, additive penalties, scaling penalties, logit bias, and grammar masks onto the compact vocabulary
- Validation for empty, duplicated, negative, and out-of-range token IDs
- Explicit compatibility checks for unsupported configurations

External APIs, EOS handling, history tokens, and the next-step embedding path continue to use global token IDs.

## Sampling semantics

Let `A` be the allowed output token set and `B` be the remaining vocabulary.

The compact Softmax computes:

`P(i | i in A) = exp(z_i) / sum_{j in A} exp(z_j)`

This matches full-vocabulary sampling conditioned on generation being restricted to `A`. The implementation therefore preserves sampling semantics when the model's generation contract already limits output to the mapped token set.

## Initial scope

The initial implementation supports:

- Qwen2 models
- Tied word embeddings
- TP1 and PP1
- Non-quantized models
- Standard sampling without speculative decoding
- Models without LoRA or DP LM head

Returning log probabilities and custom logit processors are rejected explicitly when output mapping is enabled.

## Validation

The following checks passed:

- Python compilation and diff checks
- Six output-token-map unit tests
- 1,000 randomized conditional Softmax equivalence cases
- Compact vocabulary projection for penalties, bias, and packed grammar masks
- End-to-end model loading and generation on NVIDIA RTX PRO 6000
- 100 randomized requests producing 2,524 tokens
- Zero generated tokens outside the configured audio-token and EOS set
- Global EOS token ID preserved after compact sampling

A shape-matched LM head microbenchmark used vocabulary size 176,000, output vocabulary size 16,385, and hidden size 896.

| Batch size | Full LM head | Compact LM head | Reduction |
|---:|---:|---:|---:|
| 1 | 0.2313 ms | 0.0099 ms | 95.7% |
| 8 | 0.2153 ms | 0.0259 ms | 87.9% |
| 16 | 0.2195 ms | 0.0264 ms | 88.0% |

These numbers measure the isolated LM head operation and do not represent end-to-end serving latency.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30434976126](https://github.com/sgl-project/sglang/actions/runs/30434976126)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30434975695](https://github.com/sgl-project/sglang/actions/runs/30434975695)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->