### PR TITLE
[diffusion] fix: dual-DiT models crash with (1,)-placeholder weights after compile-time offload

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -55,7 +55,10 @@ class LayerwiseOffloadManager:
         # Armed on the first denoise forward, so that the load-time prefetch below
         # does not pin the whole resident set before the DiT is the active component.
         self._residency_active = False
-
+        # True once _initialize builds the CPU buffers; unlike `enabled` it
+        # never flips back, so disable_offload/enable_offload can toggle
+        # `enabled` without losing track of which managers can be re-armed.
+        self._configured = False
         self.enabled = bool(enabled and torch.get_device_module().is_available())
         if not self.enabled:
             return
@@ -254,6 +257,7 @@ class LayerwiseOffloadManager:
         self.prepare_for_next_req(non_blocking=False)
 
         self.register_forward_hooks()
+        self._configured = True
         logger.info(
             f"LayerwiseOffloadManager initialized with num prefetched layer: {self.prefetch_size}, num resident layers: {self.resident_layers}, total num layers: {self.num_layers}"
         )
@@ -663,20 +667,31 @@ class LayerwiseOffloadableModuleMixin:
             manager.prepare_for_next_req(non_blocking=True)
 
     def disable_offload(self) -> None:
-        """Disable layerwise offload: load all layers to GPU and remove hooks."""
+        """Disable layerwise offload: load all layers to GPU and remove hooks.
+
+        Also flips `manager.enabled` off so every layerwise path —
+        is_layerwise_offloaded_module(), release_all(), prepare_for_next_req()
+        — short-circuits until enable_offload() re-arms it. Without this, a
+        residency strategy built while the module was offloaded (e.g. the
+        temporary offload_during_compile window) keeps calling release_all()
+        on use-site switches after the hooks are gone, replacing restored
+        weights with (1,) placeholders that nothing swaps back in.
+        """
         if self.layerwise_offload_managers is None:
             return
         for manager in self.layerwise_offload_managers:
             if manager.enabled:
                 manager.remove_forward_hooks()
                 manager.load_all_layers()
+                manager.enabled = False
 
     def enable_offload(self) -> None:
         """Re-enable layerwise offload: sync weights to CPU, release layers, and restore hooks."""
         if self.layerwise_offload_managers is None:
             return
         for manager in self.layerwise_offload_managers:
-            if manager.enabled:
+            if manager._configured:
+                manager.enabled = True
                 manager.sync_all_layers_to_cpu()
                 manager.release_all()
                 manager.register_forward_hooks()

--- a/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
+++ b/python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py
@@ -689,3 +689,71 @@ def test_configure_resolves_resident_layers_ratio(monkeypatch):
     comp.configure_layerwise_offload(_server_args(dit_layerwise_resident_layers=0.5))
     # 0.5 * 8 = 4 leading layers resident
     assert comp.layerwise_offload_managers[0].resident_layers == 4
+
+
+class _MixinBlock(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.arange(9, dtype=torch.float32).reshape(3, 3)
+        )
+        self.bias = torch.nn.Parameter(torch.arange(3, dtype=torch.float32))
+
+
+class _MixinModel(torch.nn.Module, LayerwiseOffloadableModuleMixin):
+    layer_names = ["blocks"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.blocks = torch.nn.ModuleList([_MixinBlock() for _ in range(3)])
+
+
+def _configure_mixin_model(monkeypatch) -> _MixinModel:
+    _patch_fake_device(monkeypatch)
+    model = _MixinModel()
+    model.configure_layerwise_offload(_server_args())
+    assert is_layerwise_offloaded_module(model)
+    return model
+
+
+def test_disable_offload_short_circuits_residency_release(monkeypatch):
+    """disable_offload() must make later layerwise calls no-ops.
+
+    Regression test: a ComponentResidencyManager strategy built while the
+    module was offloaded (the offload_during_compile window) keeps calling
+    release_all() on use-site switches. After disable_offload() removed the
+    hooks, those releases replaced restored weights with (1,) placeholders
+    that nothing ever swapped back in, crashing dual-DiT models (Wan2.2-A14B
+    boundary experts, Ideogram-4 paired towers) on the first real request.
+    """
+    model = _configure_mixin_model(monkeypatch)
+    model.disable_offload()
+
+    assert not is_layerwise_offloaded_module(model)
+    for name, param in model.named_parameters():
+        assert tuple(param.shape) != (1,), name
+
+    # The exact call path the residency strategy takes on use-site switches.
+    LayerwiseOffloadStrategy().exit(model)
+    model.prepare_for_next_req()
+    for name, param in model.named_parameters():
+        assert tuple(param.shape) != (1,), name
+
+
+def test_enable_offload_rearms_after_disable(monkeypatch):
+    model = _configure_mixin_model(monkeypatch)
+    # blocks[2] holds a placeholder right after configure; the real values are
+    # what _MixinBlock was constructed with.
+    original = torch.arange(9, dtype=torch.float32).reshape(3, 3)
+
+    model.disable_offload()
+    assert not is_layerwise_offloaded_module(model)
+
+    model.enable_offload()
+    assert is_layerwise_offloaded_module(model)
+
+    manager = model.layerwise_offload_managers[0]
+    manager.release_layer(2)
+    assert tuple(model.blocks[2].weight.shape) == (1,)
+    manager.prefetch_layer(2, non_blocking=False)
+    assert torch.equal(model.blocks[2].weight.data, original)


### PR DESCRIPTION
## Motivation

Dual-DiT models crash on the first real request when served with `--enable-torch-compile`, even with every offload flag explicitly off (`--dit-layerwise-offload false --dit-cpu-offload false`):

- **Wan2.2-T2V/I2V-A14B** (boundary experts, `transformer` + `transformer_2`): dynamo tracing fails with `RuntimeError('b must be 2D')` — `to_q`'s weight and bias are fake-tensors of shape `(1,)`.
- **Ideogram-4 FP8** (paired conditional/unconditional towers, 2-GPU TP): eager forward raises `ValueError: FP8 linear weight must be 2-D, got shape torch.Size([1])` in `adaln_modulation`.

Single-DiT models (Wan2.1, FLUX, Qwen-Image, ...) are unaffected, which is why this survived until a full dual-DiT benchmark pass ([diffusion-bench-framework h100x4-full-20260728](https://github.com/mickqian/diffusion-bench-framework/tree/main/reports/h100x4-full-20260728)).

## Root cause

1. `offload_during_compile` (default **on**) layerwise-offloads every DiT during warmup **regardless of `--dit-layerwise-offload false`** — parameters become shared `(1,)` placeholders with per-block swap-in hooks.
2. `ComponentResidencyManager` builds each component's residency strategy while the module is in that temporarily-offloaded state, so the DiT components get pinned to `LayerwiseOffloadStrategy`.
3. On the first non-warmup request, `DenoisingStage._offload_for_torch_compile_warmup` calls `disable_offload()` — hooks removed, all layers loaded back. **But `manager.enabled` stays `True`**, so `is_layerwise_offloaded_module()` keeps reporting the module as offloaded and the pinned strategy keeps acting on it.
4. Dual-DiT models switch use-sites between the two towers every step (paired towers) or at the boundary timestep (experts). Each switch runs `LayerwiseOffloadStrategy.exit()` → `manager.release_all()` on the tower being left, **replacing its restored weights with `(1,)` placeholders**. The hooks that would swap them back are gone and `prepare_for_next_req()` only prefetches the first layer, so the next forward of that tower reads a placeholder and crashes.

Single-DiT models never switch use-sites mid-request, so step 4 never fires for them.

Verified with a live probe on the failing setups: immediately after `disable_offload()` a full `named_parameters()` scan shows **zero** `(1,)`-shaped parameters; one use-site switch later the crash fires — the placeholders provably come from the post-restore `release_all()`, not from a failed restore.

## Modifications

- `disable_offload()` now flips `manager.enabled = False` after restoring weights, so every layerwise path (`is_layerwise_offloaded_module`, `release_all`, `prepare_for_next_req`, the residency strategy's `enter`/`exit`) short-circuits and the module becomes genuinely resident — matching what `--dit-layerwise-offload false` promised in the first place.
- `enable_offload()` re-arms via a new `_configured` marker (set once `_initialize` completes), preserving the disable→enable round-trip the LoRA merge path relies on.
- Two regression tests: the exact residency-strategy call path (`LayerwiseOffloadStrategy.exit()` after `disable_offload()` must not reintroduce placeholders), and the LoRA-style re-arm round-trip.

## Verification

- 2×H100, `ideogram-ai/ideogram-4-fp8`, `--tp-size 2 --performance-mode speed --enable-torch-compile --warmup`: previously HTTP 500 at denoising step 1 (~716 ms in), now completes 20/20 steps on both towers, HTTP 200.
- 4×H100, `Wan-AI/Wan2.2-T2V-A14B-Diffusers`, `--enable-cfg-parallel --ulysses-degree 2 --performance-mode speed --enable-torch-compile --warmup`: previously failed at the boundary switch to `transformer_2` (dynamo `b must be 2D`), now completes with `transformer_2` steps (t=837/749/571) forwarding normally, video generated.
- `python/sglang/multimodal_gen/test/unit/test_layerwise_offload.py`: 17/17 pass (15 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30448598810](https://github.com/sgl-project/sglang/actions/runs/30448598810)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30448598610](https://github.com/sgl-project/sglang/actions/runs/30448598610)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->