### PR TITLE
[Fix] gRPC: correct smg-grpc-servicer version requirement (≥0.5.3→≥0.5.5) so --enable-metrics works out of the box

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
   "setproctitle",
   "sgl-deep-gemm==0.1.5",
   "sglang-kernel==0.4.5",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "tilelang==0.1.11",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -55,7 +55,7 @@ dependencies = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tabulate",
   "tiktoken",

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -56,7 +56,7 @@ dependencies = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -57,7 +57,7 @@ runtime_common = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -55,7 +55,7 @@ dependencies = [
   "sentencepiece",
   "setproctitle",
   "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -221,7 +221,7 @@ async def serve_grpc(server_args, model_info=None):
                 exc_info=True,
             )
 
-    # Older smg-grpc-servicer releases (≤ 0.5.2) accept only (server_args,
+    # Older smg-grpc-servicer releases (≤ 0.5.4) accept only (server_args,
     # model_info) and reject the on_request_manager_ready hook. The hook is
     # what calls _start_sidecar_server, so dropping the kwarg disables the
     # entire HTTP sidecar (Prometheus /metrics and /start_profile +
@@ -237,7 +237,7 @@ async def serve_grpc(server_args, model_info=None):
         # start the sidecar that serves them — fail loud rather than silently
         # produce a server with no /metrics endpoint.
         raise RuntimeError(
-            "--enable-metrics requires smg-grpc-servicer ≥ 0.5.3 (the version "
+            "--enable-metrics requires smg-grpc-servicer ≥ 0.5.5 (the version "
             "that accepts 'on_request_manager_ready'); installed version "
             "lacks the hook so the HTTP sidecar would never start. Upgrade "
             "smg-grpc-servicer or remove --enable-metrics."
@@ -247,7 +247,7 @@ async def serve_grpc(server_args, model_info=None):
             "Installed smg-grpc-servicer does not accept "
             "'on_request_manager_ready'; HTTP sidecar disabled "
             "(no /metrics, /start_profile, /stop_profile). "
-            "Upgrade smg-grpc-servicer to ≥ 0.5.3 to enable it."
+            "Upgrade smg-grpc-servicer to ≥ 0.5.5 to enable it."
         )
 
     try:


### PR DESCRIPTION
## Summary

Fixes #28298

Two bugs in the gRPC metrics path:

### Bug A — Wrong version in error messages and comments

`grpc_server.py` said `smg-grpc-servicer ≥ 0.5.3` is required for `on_request_manager_ready`, but 0.5.4 still lacks the hook (verified by the issue reporter). The first working version is **0.5.5**.

**Fixed in `python/sglang/srt/entrypoints/grpc_server.py`:**
- Comment: `≤ 0.5.2` → `≤ 0.5.4`
- RuntimeError message: `≥ 0.5.3` → `≥ 0.5.5`
- Warning message: `≥ 0.5.3` → `≥ 0.5.5`

A user following the old error's advice and installing 0.5.3/0.5.4 would still crash — now they'll get the correct version.

### Bug B — Pin too loose to guarantee the hook

`smg-grpc-servicer>=0.5.0` allowed pip to resolve to 0.5.4 (bundled in `lmsysorg/sglang:v0.5.13`), which lacks the hook. Bumped to `>=0.5.5` to guarantee availability.

**Fixed in:**
- `python/pyproject.toml`
- `python/pyproject_cpu.toml`
- `python/pyproject_npu.toml`
- `python/pyproject_xpu.toml`
- `python/pyproject_other.toml`

## Verification

```python
# 0.5.4 (broken): no on_request_manager_ready
import inspect; from smg_grpc_servicer.sglang.server import serve_grpc
print(list(inspect.signature(serve_grpc).parameters))
# ['server_args', 'model_info']

# 0.5.5 (working): hook present
# ['server_args', 'model_info', 'on_request_manager_ready']
```

## Related

- Closes #28298

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30434495312](https://github.com/sgl-project/sglang/actions/runs/30434495312)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30434491080](https://github.com/sgl-project/sglang/actions/runs/30434491080)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->