### PR TITLE
[Spec] Add draft-side mamba state plane addressed by target mamba slots

### DIFF
--- a/python/sglang/srt/mem_cache/draft_mamba_state_plane.py
+++ b/python/sglang/srt/mem_cache/draft_mamba_state_plane.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, MambaPool
+
+
+class DraftMambaStatePlane:
+    """Per-request draft states living in the target's mamba slot index space.
+
+    A speculative-draft worker with linear-attention layers keeps its recurrent
+    states in its own MambaPool but owns no slot allocator: states are addressed
+    by the mamba slot ids the target's HybridReqToTokenPool hands out, so slot
+    lifecycle (alloc, radix reuse, free) stays entirely on the target side and a
+    slot's draft states survive radix resurrection without copies. The plane
+    only tracks whether its copy of each slot is current against the target's
+    fresh-assignment generation; the caller must rebuild stale slots before
+    reading them.
+    """
+
+    def __init__(
+        self,
+        target_req_to_token_pool: HybridReqToTokenPool,
+        mamba_pool: MambaPool,
+    ):
+        target_size = target_req_to_token_pool.mamba_pool.size
+        if mamba_pool.size != target_size:
+            raise ValueError(
+                "DraftMambaStatePlane must cover every target mamba slot. "
+                f"draft pool size={mamba_pool.size}, target pool size={target_size}."
+            )
+        self.target_req_to_token_pool = target_req_to_token_pool
+        self.mamba_pool = mamba_pool
+        # -1 = never built, distinct from every target generation (>= 0).
+        self.built_generation = torch.full(
+            (target_size,),
+            -1,
+            dtype=torch.int64,
+            device=target_req_to_token_pool.mamba_slot_generation.device,
+        )
+
+    def lookup(self, req_indices: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return (mamba_indices, current_mask) for a batch of req_pool_indices.
+
+        current_mask[i] is False when the target allocator recycled the slot
+        after the draft last built states there.
+        """
+        mamba_indices = self.target_req_to_token_pool.get_mamba_indices(req_indices)
+        target_generation = self.target_req_to_token_pool.mamba_slot_generation
+        current_mask = (
+            self.built_generation[mamba_indices] == target_generation[mamba_indices]
+        )
+        return mamba_indices, current_mask
+
+    def mark_built(self, mamba_indices: torch.Tensor) -> None:
+        """Record that the draft states at these slots match the live requests."""
+        target_generation = self.target_req_to_token_pool.mamba_slot_generation
+        self.built_generation[mamba_indices] = target_generation[mamba_indices]

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1222,6 +1222,12 @@ class HybridReqToTokenPool(ReqToTokenPool):
         self.req_index_to_mamba_index_mapping: torch.Tensor = torch.zeros(
             req_pool_size, dtype=torch.int32, device=self.device
         )
+        # Fresh-assignment generation per mamba slot, bumped when the allocator
+        # recycles a slot for a new request. A draft-side state plane compares
+        # it against the generation it last built states at to detect staleness.
+        self.mamba_slot_generation: torch.Tensor = torch.zeros(
+            mamba_size, dtype=torch.int64, device=self.device
+        )
         if enable_mamba_extra_buffer:
             self.req_index_to_mamba_ping_pong_track_buffer_mapping: torch.Tensor = (
                 torch.zeros(
@@ -1260,6 +1266,9 @@ class HybridReqToTokenPool(ReqToTokenPool):
             speculative_eagle_topk=speculative_eagle_topk,
         )
         clone.req_index_to_mamba_index_mapping = self.req_index_to_mamba_index_mapping
+        # Slot ids in the shared mapping are issued by the original pool, so the
+        # clone must observe the original's recycling generations as well.
+        clone.mamba_slot_generation = self.mamba_slot_generation
         if enable_mamba_extra_buffer:
             clone.req_index_to_mamba_ping_pong_track_buffer_mapping = (
                 self.req_index_to_mamba_ping_pong_track_buffer_mapping
@@ -1288,6 +1297,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
                 ), f"Not enough space for mamba cache, try to increase --mamba-full-memory-ratio or --max-mamba-cache-size. {mid=}, {self.mamba_pool.size=}, {self.mamba_allocator.available_size()=}, {len(reqs)=}"
                 req.mamba_pool_idx = mid[0]
                 req.mamba_needs_clear = True
+                self.mamba_slot_generation[req.mamba_pool_idx] += 1
                 # GDN ReplaySSM: a freshly (re)assigned slot starts an empty
                 # ring. write_pos=0 means "ring empty", so the decode kernel
                 # ignores ring contents and reads only the checkpoint state

--- a/test/registered/unit/mem_cache/test_draft_mamba_state_plane.py
+++ b/test/registered/unit/mem_cache/test_draft_mamba_state_plane.py
@@ -1,0 +1,128 @@
+"""Unit tests for srt/mem_cache/draft_mamba_state_plane.py"""
+
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.configs.mamba_utils import Mamba2CacheParams, Mamba2StateShape
+from sglang.srt.environ import envs
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.draft_mamba_state_plane import DraftMambaStatePlane
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, MambaPool
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.utils import get_device
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
+
+MAX_CONTEXT_LEN = 128
+
+
+def _make_req(rid: int) -> Req:
+    return Req(
+        rid=rid,
+        origin_input_text="",
+        origin_input_ids=array("q"),
+        sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+    )
+
+
+def _make_state_shape() -> Mamba2StateShape:
+    return Mamba2StateShape.create(
+        tp_world_size=1,
+        intermediate_size=512,
+        n_groups=4,
+        num_heads=8,
+        head_dim=64,
+        state_size=64,
+        conv_kernel=4,
+    )
+
+
+def _make_target_pool(num_reqs: int, mamba_size: int) -> HybridReqToTokenPool:
+    with envs.SGLANG_MAMBA_SSM_DTYPE.override("bfloat16"):
+        cache_params = Mamba2CacheParams(shape=_make_state_shape(), layers=[0, 1, 2])
+    return HybridReqToTokenPool(
+        size=num_reqs,
+        mamba_size=mamba_size,
+        mamba_spec_state_size=num_reqs,
+        max_context_len=MAX_CONTEXT_LEN,
+        device=get_device(),
+        enable_memory_saver=False,
+        cache_params=cache_params,
+        mamba_layer_ids=[0, 1, 2],
+        enable_mamba_extra_buffer=False,
+    )
+
+
+def _make_draft_pool(num_reqs: int, mamba_size: int) -> MambaPool:
+    with envs.SGLANG_MAMBA_SSM_DTYPE.override("bfloat16"):
+        cache_params = Mamba2CacheParams(shape=_make_state_shape(), layers=[0])
+    return MambaPool(
+        size=mamba_size,
+        spec_state_size=num_reqs,
+        cache_params=cache_params,
+        mamba_layer_ids=[0],
+        device=get_device(),
+    )
+
+
+class TestDraftMambaStatePlane(CustomTestCase):
+    def _req_indices(self, req: Req) -> torch.Tensor:
+        return torch.tensor([req.req_pool_idx], dtype=torch.int64, device=get_device())
+
+    def test_lookup_reports_stale_until_marked_built(self):
+        target_pool = _make_target_pool(num_reqs=8, mamba_size=16)
+        plane = DraftMambaStatePlane(target_pool, _make_draft_pool(8, 16))
+
+        req = _make_req(0)
+        target_pool.alloc([req])
+        self.assertEqual(int(target_pool.mamba_slot_generation[req.mamba_pool_idx]), 1)
+
+        mamba_indices, current_mask = plane.lookup(self._req_indices(req))
+        self.assertFalse(bool(current_mask[0]))
+
+        plane.mark_built(mamba_indices)
+        _, current_mask = plane.lookup(self._req_indices(req))
+        self.assertTrue(bool(current_mask[0]))
+
+        # Radix-style reuse: the req keeps its mamba slot across a req-slot
+        # free/alloc cycle, so the built draft states stay current (no bump).
+        target_pool.free(req)
+        target_pool.alloc([req])
+        self.assertEqual(int(target_pool.mamba_slot_generation[req.mamba_pool_idx]), 1)
+        _, current_mask = plane.lookup(self._req_indices(req))
+        self.assertTrue(bool(current_mask[0]))
+
+    def test_slot_recycle_invalidates_built_states(self):
+        # mamba_size == num_reqs so a full re-allocation is guaranteed to
+        # recycle the freed slot with a fresh assignment.
+        target_pool = _make_target_pool(num_reqs=4, mamba_size=4)
+        plane = DraftMambaStatePlane(target_pool, _make_draft_pool(4, 4))
+
+        req = _make_req(0)
+        target_pool.alloc([req])
+        slot = int(req.mamba_pool_idx)
+        mamba_indices, _ = plane.lookup(self._req_indices(req))
+        plane.mark_built(mamba_indices)
+
+        target_pool.free_mamba_cache(req)
+        target_pool.free(req)
+
+        reqs = [_make_req(rid) for rid in range(1, 5)]
+        target_pool.alloc(reqs)
+        holder = next(r for r in reqs if int(r.mamba_pool_idx) == slot)
+        self.assertEqual(int(target_pool.mamba_slot_generation[slot]), 2)
+        _, current_mask = plane.lookup(self._req_indices(holder))
+        self.assertFalse(bool(current_mask[0]))
+
+    def test_size_mismatch_rejected(self):
+        target_pool = _make_target_pool(num_reqs=4, mamba_size=8)
+        with self.assertRaises(ValueError):
+            DraftMambaStatePlane(target_pool, _make_draft_pool(4, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Give speculative-draft workers with linear-attention layers a per-request recurrent-state plane addressed by the target's mamba slot ids: slot lifecycle (alloc, radix reuse, free) stays on the target side, and a per-slot fresh-assignment generation detects recycled slots so the draft rebuilds only stale states. Groundwork for hybrid linear-attention draft models.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30434677477](https://github.com/sgl-project/sglang/actions/runs/30434677477)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30434677266](https://github.com/sgl-project/sglang/actions/runs/30434677266)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->