### PR TITLE
[Router] Wire decode-affinity outcome metric

### DIFF
--- a/experimental/sgl-router/monitoring/README.md
+++ b/experimental/sgl-router/monitoring/README.md
@@ -32,7 +32,7 @@ The dashboard graphs every family the router emits:
 | `sgl_router_worker_cb_state` | Gauge | Per-worker circuit breaker state (0=closed, 1=open, 2=half_open) |
 | `sgl_router_worker_inflight_requests` | Gauge | In-flight requests per worker |
 | `sgl_router_stale_requests_total` | Counter | Stale-request cancellations |
-| `sgl_router_decode_affinity_total` | Counter | PD decode-affinity outcomes |
+| `sgl_router_decode_affinity_total` | Counter | PD decode-affinity outcomes (`same_host_picked`, `fallback_no_same_host`, `fallback_breaker`, `fallback_load_imbalance`) |
 | `sgl_router_sticky_total` | Counter | Sticky-session selection outcomes |
 
 The `sgl_router_workers` / `sgl_router_worker_*` gauges are sampled from the

--- a/experimental/sgl-router/monitoring/grafana-dashboard.json
+++ b/experimental/sgl-router/monitoring/grafana-dashboard.json
@@ -1819,7 +1819,7 @@
     {
       "type": "timeseries",
       "title": "Decode-affinity outcomes",
-      "description": "same_host_picked / fallback_breaker / fallback_load_imbalance.",
+      "description": "same_host_picked / fallback_no_same_host / fallback_breaker / fallback_load_imbalance.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"

--- a/experimental/sgl-router/src/policies/registry.rs
+++ b/experimental/sgl-router/src/policies/registry.rs
@@ -34,6 +34,7 @@
 //!    — only the resolver has the cohort context to tell which is which.
 
 use crate::discovery::{ModelId, WorkerMode};
+use crate::server::metrics::DecodeAffinityOutcome;
 use crate::workers::{Worker, WorkerRegistry};
 use std::sync::Arc;
 
@@ -79,6 +80,14 @@ pub enum PdResolveError {
     /// PD-mode deployment whose decode pool is empty.
     /// Surfaced as 503 `no_decode_workers_available`.
     NoDecodeWorkersAvailable,
+}
+
+/// Successful decode-affinity selection, including the metric outcome that
+/// explains which affinity branch produced the chosen worker.
+#[derive(Debug, Clone)]
+pub struct DecodeAffinitySelection {
+    pub worker: Arc<Worker>,
+    pub outcome: DecodeAffinityOutcome,
 }
 
 /// Thin façade over [`WorkerRegistry`] that returns the per-pool
@@ -195,8 +204,20 @@ impl PdPoolResolver {
         &self,
         model: &ModelId,
         prefill_url: &str,
-    ) -> Result<Arc<Worker>, PdResolveError> {
-        let candidates = self.decode_candidates(model)?;
+    ) -> Result<DecodeAffinitySelection, PdResolveError> {
+        let candidates = match self.resolve(model)? {
+            PdPools::Plain { workers } => workers,
+            PdPools::Pd { decode, .. } => {
+                if decode.is_empty() {
+                    return Err(PdResolveError::NoDecodeWorkersAvailable);
+                }
+                self.workers
+                    .workers_for(model)
+                    .into_iter()
+                    .filter(|w| w.mode() == WorkerMode::Decode)
+                    .collect()
+            }
+        };
         select_decode_with_affinity(prefill_url, &candidates)
             .ok_or(PdResolveError::NoDecodeWorkersAvailable)
     }
@@ -235,7 +256,7 @@ impl PdPoolResolver {
 pub fn select_decode_with_affinity(
     prefill_url: &str,
     candidates: &[Arc<Worker>],
-) -> Option<Arc<Worker>> {
+) -> Option<DecodeAffinitySelection> {
     if candidates.is_empty() {
         return None;
     }
@@ -263,6 +284,16 @@ pub fn select_decode_with_affinity(
         ((median as f64) * AFFINITY_LOAD_TOLERANCE).ceil() as usize
     };
 
+    let same_host_candidates: Vec<&Arc<Worker>> = prefill_host
+        .as_deref()
+        .map(|host| {
+            candidates
+                .iter()
+                .filter(|w| host_of(&w.url).as_deref() == Some(host))
+                .collect()
+        })
+        .unwrap_or_default();
+
     // Rule 1: same-host AND healthy AND not overloaded.
     if let Some(host) = prefill_host.as_deref() {
         let affinity_peer = healthy.iter().find(|w| {
@@ -270,19 +301,40 @@ pub fn select_decode_with_affinity(
                 && (load_tolerance == 0 || w.active_load() <= load_tolerance)
         });
         if let Some(w) = affinity_peer {
-            return Some(Arc::clone(w));
+            return Some(DecodeAffinitySelection {
+                worker: Arc::clone(w),
+                outcome: DecodeAffinityOutcome::SameHostPicked,
+            });
         }
     }
 
+    let fallback_outcome = if prefill_host.is_none() || same_host_candidates.is_empty() {
+        DecodeAffinityOutcome::FallbackNoSameHost
+    } else if same_host_candidates.iter().any(|w| w.breaker.would_allow()) {
+        DecodeAffinityOutcome::FallbackLoadImbalance
+    } else {
+        DecodeAffinityOutcome::FallbackBreaker
+    };
+
     // Rule 2: min-load among healthy.
     if let Some(w) = healthy.iter().min_by_key(|w| w.active_load()) {
-        return Some(Arc::clone(w));
+        return Some(DecodeAffinitySelection {
+            worker: Arc::clone(w),
+            outcome: fallback_outcome,
+        });
     }
 
     // Rule 3: last-resort min-load over all candidates (every
     // breaker is open). The caller's dispatch will likely fail and
     // surface `BreakerOpen`, but the selection function stays total.
-    candidates.iter().min_by_key(|w| w.active_load()).cloned()
+    candidates
+        .iter()
+        .min_by_key(|w| w.active_load())
+        .cloned()
+        .map(|worker| DecodeAffinitySelection {
+            worker,
+            outcome: fallback_outcome,
+        })
 }
 
 /// Parse the host portion of a worker URL. Returns `None` when the URL
@@ -502,6 +554,15 @@ mod tests {
         }
     }
 
+    fn assert_selection(
+        selection: DecodeAffinitySelection,
+        expected_url: &str,
+        expected_outcome: DecodeAffinityOutcome,
+    ) {
+        assert_eq!(selection.worker.url, expected_url);
+        assert_eq!(selection.outcome, expected_outcome);
+    }
+
     /// Same-host affinity: a request that lands on `prefill@host_a`
     /// picks `decode@host_a` even when `decode@host_b` has lower load.
     /// Pin: the affinity branch wins over load tiebreak when both
@@ -516,12 +577,13 @@ mod tests {
         let resolver = PdPoolResolver::new(r);
         let prefill_url = "http://host_a:30000";
 
-        let chosen = resolver
+        let selection = resolver
             .decode_with_affinity(&ModelId("m".into()), prefill_url)
             .unwrap();
-        assert_eq!(
-            chosen.url, "http://host_a:30001",
-            "same-host decode peer must win over remote peer",
+        assert_selection(
+            selection,
+            "http://host_a:30001",
+            DecodeAffinityOutcome::SameHostPicked,
         );
     }
 
@@ -551,12 +613,13 @@ mod tests {
         }
         assert!(!d1.breaker.allow(), "d1 breaker must be open");
 
-        let chosen = resolver
+        let selection = resolver
             .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
             .unwrap();
-        assert_eq!(
-            chosen.url, "http://host_b:30001",
-            "breaker-open affinity peer must fall back to the remote healthy peer",
+        assert_selection(
+            selection,
+            "http://host_b:30001",
+            DecodeAffinityOutcome::FallbackBreaker,
         );
     }
 
@@ -603,13 +666,18 @@ mod tests {
             guards.push(d3.load_guard());
         }
 
-        let chosen = resolver
+        let selection = resolver
             .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
             .unwrap();
         assert!(
-            chosen.url == "http://host_b:30001" || chosen.url == "http://host_c:30001",
+            selection.worker.url == "http://host_b:30001"
+                || selection.worker.url == "http://host_c:30001",
             "overloaded affinity peer must fall back to a remote min-load peer, got: {}",
-            chosen.url,
+            selection.worker.url,
+        );
+        assert_eq!(
+            selection.outcome,
+            DecodeAffinityOutcome::FallbackLoadImbalance
         );
         // Drop guards explicitly so the test cleanup doesn't depend on
         // RAII order against the resolver / registry.
@@ -639,12 +707,13 @@ mod tests {
             .unwrap();
         let _g = d1.load_guard();
 
-        let chosen = resolver
+        let selection = resolver
             .decode_with_affinity(&ModelId("m".into()), "http://host_a:30000")
             .unwrap();
-        assert_eq!(
-            chosen.url, "http://host_c:30001",
-            "no same-host peer → min-load fallback over remote candidates",
+        assert_selection(
+            selection,
+            "http://host_c:30001",
+            DecodeAffinityOutcome::FallbackNoSameHost,
         );
     }
 
@@ -675,17 +744,19 @@ mod tests {
             spec_with_url("d2", "http://host_b:30001", WorkerMode::Decode, "m"),
         ]);
         let resolver = PdPoolResolver::new(r);
-        let chosen = resolver
+        let selection = resolver
             .decode_with_affinity(&ModelId("m".into()), "not-a-url")
             .unwrap();
         // Both d1 and d2 are at load 0 → either is acceptable. The
         // assertion is only that the function returns Some, not None
         // / panic.
         assert!(
-            chosen.url == "http://host_a:30001" || chosen.url == "http://host_b:30001",
+            selection.worker.url == "http://host_a:30001"
+                || selection.worker.url == "http://host_b:30001",
             "unexpected decode worker chosen: {}",
-            chosen.url,
+            selection.worker.url,
         );
+        assert_eq!(selection.outcome, DecodeAffinityOutcome::FallbackNoSameHost);
     }
 
     /// All decode peers' breakers are open → `decode_with_affinity`
@@ -733,9 +804,10 @@ mod tests {
         // stays total, caller sees `BreakerOpen` on dispatch.
         let any = select_decode_with_affinity("http://host_a:30000", &pool).unwrap();
         assert!(
-            any.url == "http://host_a:30001" || any.url == "http://host_b:30001",
+            any.worker.url == "http://host_a:30001" || any.worker.url == "http://host_b:30001",
             "last-resort path must return some candidate, got: {}",
-            any.url,
+            any.worker.url,
         );
+        assert_eq!(any.outcome, DecodeAffinityOutcome::FallbackBreaker);
     }
 }

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -127,10 +127,11 @@ impl WorkerModeLabel {
 }
 
 /// Decode-affinity outcome — see `select_decode_with_affinity` for the
-/// three reasons the affinity may not be honored.
-#[derive(Debug, Clone, Copy)]
+/// reasons the affinity may not be honored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecodeAffinityOutcome {
     SameHostPicked,
+    FallbackNoSameHost,
     FallbackBreaker,
     FallbackLoadImbalance,
 }
@@ -139,6 +140,7 @@ impl DecodeAffinityOutcome {
     fn as_str(self) -> &'static str {
         match self {
             Self::SameHostPicked => "same_host_picked",
+            Self::FallbackNoSameHost => "fallback_no_same_host",
             Self::FallbackBreaker => "fallback_breaker",
             Self::FallbackLoadImbalance => "fallback_load_imbalance",
         }
@@ -1144,14 +1146,18 @@ mod tests {
     }
 
     #[test]
-    fn decode_affinity_counter_emits_three_outcomes() {
+    fn decode_affinity_counter_emits_all_outcomes() {
         let reg = MetricsRegistry::new();
         reg.record_decode_affinity(DecodeAffinityOutcome::SameHostPicked);
         reg.record_decode_affinity(DecodeAffinityOutcome::SameHostPicked);
+        reg.record_decode_affinity(DecodeAffinityOutcome::FallbackNoSameHost);
         reg.record_decode_affinity(DecodeAffinityOutcome::FallbackBreaker);
         reg.record_decode_affinity(DecodeAffinityOutcome::FallbackLoadImbalance);
         let out = reg.render();
         assert!(out.contains(r#"sgl_router_decode_affinity_total{outcome="same_host_picked"} 2"#));
+        assert!(
+            out.contains(r#"sgl_router_decode_affinity_total{outcome="fallback_no_same_host"} 1"#)
+        );
         assert!(out.contains(r#"sgl_router_decode_affinity_total{outcome="fallback_breaker"} 1"#));
         assert!(out
             .contains(r#"sgl_router_decode_affinity_total{outcome="fallback_load_imbalance"} 1"#,));

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -202,25 +202,21 @@ pub async fn chat_completions(
     // decode peer (`NoDecodeWorkersAvailable`) bubble up as 503 so
     // operators can alert on prefill-vs-decode pool imbalance.
     let decode_peer: Option<Arc<Worker>> = if worker.mode() == WorkerMode::Prefill {
-        Some(
-            resolver
-                .decode_with_affinity(&model_id, &worker.url)
-                .map_err(|e| match e {
-                    PdResolveError::NoHealthyWorkers => ApiError::NoHealthyWorkers {
-                        model: model_str.clone(),
-                    },
-                    PdResolveError::NoDecodeWorkersAvailable => {
-                        ApiError::NoDecodeWorkersAvailable {
-                            model: model_str.clone(),
-                        }
-                    }
-                    PdResolveError::NoPrefillWorkersAvailable => {
-                        ApiError::NoPrefillWorkersAvailable {
-                            model: model_str.clone(),
-                        }
-                    }
-                })?,
-        )
+        let selection = resolver
+            .decode_with_affinity(&model_id, &worker.url)
+            .map_err(|e| match e {
+                PdResolveError::NoHealthyWorkers => ApiError::NoHealthyWorkers {
+                    model: model_str.clone(),
+                },
+                PdResolveError::NoDecodeWorkersAvailable => ApiError::NoDecodeWorkersAvailable {
+                    model: model_str.clone(),
+                },
+                PdResolveError::NoPrefillWorkersAvailable => ApiError::NoPrefillWorkersAvailable {
+                    model: model_str.clone(),
+                },
+            })?;
+        ctx.metrics.record_decode_affinity(selection.outcome);
+        Some(selection.worker)
     } else {
         None
     };

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -19,6 +19,7 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use bytes::Bytes;
+use http_body_util::BodyExt;
 use serde_json::{json, Value};
 use sgl_router::config::{
     ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
@@ -153,8 +154,26 @@ async fn pd_mode_chat_injects_bootstrap_fields_into_both_bodies() {
     ]);
     let app = build_router(ctx);
 
-    let res = app.oneshot(chat_request()).await.unwrap();
+    let res = app.clone().oneshot(chat_request()).await.unwrap();
     assert_eq!(res.status(), StatusCode::OK, "decode side should 200");
+    let _ = res.into_body().collect().await.unwrap().to_bytes();
+
+    let metrics_res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let metrics_body = metrics_res.into_body().collect().await.unwrap().to_bytes();
+    let metrics = std::str::from_utf8(&metrics_body).unwrap();
+    assert!(
+        metrics.contains(r#"sgl_router_decode_affinity_total{outcome="same_host_picked"} 1"#),
+        "decode affinity counter must be recorded through the PD chat path; got:\n{metrics}",
+    );
 
     let prefill_body = await_captured_body(&prefill, Duration::from_secs(2), "prefill").await;
     let decode_body = await_captured_body(&decode, Duration::from_secs(2), "decode").await;


### PR DESCRIPTION
## Motivation

Fixes #32752.

`experimental/sgl-router` already exposes and documents `sgl_router_decode_affinity_total`, but the real PD chat-completions path did not record it. That means a PD deployment could successfully select a decode peer while the decode-affinity counter stayed empty, leaving operators unable to tell whether decode selection stayed on the same host or fell back because of topology, circuit breaker state, or load imbalance.

This PR wires the existing metric to the real PD decode-affinity path without changing the scheduling strategy.

## Modifications

- Return a `DecodeAffinitySelection` from decode-affinity selection, carrying both the selected decode worker and the outcome.
- Record `sgl_router_decode_affinity_total{outcome="..."}` after successful PD decode peer selection in the chat route.
- Keep plain-mode routing from recording this PD-only metric.
- Keep decode-pool-empty failures from recording a selection outcome, since no decode worker selection occurred.
- Add `fallback_no_same_host` to distinguish missing/unparseable same-host affinity from breaker and load-imbalance fallbacks.
- Update monitoring docs and the Grafana panel description with the full outcome set.

The outcome set is now:

- `same_host_picked`
- `fallback_no_same_host`
- `fallback_breaker`
- `fallback_load_imbalance`

## Accuracy Tests

Not applicable. This PR only changes router observability and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This PR does not change the decode worker selection policy; it records one counter after an existing successful PD decode selection.

## Validation

Local macOS validation:

```bash
cargo test --lib policies::registry
cargo test --lib server::metrics
cargo test --test proxy pd_bootstrap_injection
cargo test --test component policies::registry
cargo fmt -- --check
cargo +nightly fmt -- --check
cargo check --all-targets
cargo +nightly clippy --all-targets -- -D warnings
```

Remote Linux validation:

```bash
cargo test --lib policies::registry
cargo test --lib server::metrics
cargo test --test proxy pd_bootstrap_injection
cargo test --test component policies::registry
cargo fmt -- --check
cargo +nightly fmt -- --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test --release --test proxy pd_bootstrap_injection
```

The proxy test exercises the real HTTP route with mock prefill/decode workers, sends `/v1/chat/completions`, scrapes `/metrics`, and verifies `sgl_router_decode_affinity_total{outcome="same_host_picked"} 1`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed), or explain why they are not applicable.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30435919721](https://github.com/sgl-project/sglang/actions/runs/30435919721)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30435919465](https://github.com/sgl-project/sglang/actions/runs/30435919465)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->