### PR TITLE
Fix Kimi K3 reasoning leak in the Responses API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -363,6 +363,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                         session_id=request.session_id,
                         extra_key=self._compute_extra_key(request),
                         background=request.background,
+                        require_reasoning=self._is_thinking_enabled_for_request(
+                            request
+                        ),
                     )
 
                     generator = self._generate_with_builtin_tools(
@@ -2386,6 +2389,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 return_text_in_logprobs=adapted_request.return_text_in_logprobs,
                 return_hidden_states=adapted_request.return_hidden_states,
                 background=adapted_request.background,
+                require_reasoning=adapted_request.require_reasoning,
             )
 
             # Update sampling params with reduced max_tokens

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -412,6 +412,9 @@ class KimiK2Detector(BaseReasoningFormatDetector):
         )
 
 
+_THINK_CLOSE_WITHOUT_SEP = THINK_CLOSE.split("<|sep|>")[0]
+
+
 class KimiK3Detector(BaseReasoningFormatDetector):
     """Detector for the Kimi K3 XTML think channel.
 
@@ -461,6 +464,18 @@ class KimiK3Detector(BaseReasoningFormatDetector):
             return _strip_response_wrappers(text[:tools_idx]) + text[tools_idx:]
         return _strip_response_wrappers(text)
 
+    def _next_channel_idx(self, text: str, start: int = 0) -> int:
+        found = [
+            idx
+            for token in (RESPONSE_OPEN, self.tool_start_token)
+            if (idx := text.find(token, start)) != -1
+        ]
+        return min(found) if found else -1
+
+    @staticmethod
+    def _strip_dangling_think_close(text: str) -> str:
+        return text.removesuffix(_THINK_CLOSE_WITHOUT_SEP)
+
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         in_reasoning = self._in_reasoning or self.think_start_token in text
         if not in_reasoning and self.think_end_token not in text:
@@ -470,13 +485,17 @@ class KimiK3Detector(BaseReasoningFormatDetector):
         start = open_idx + len(self.think_start_token) if open_idx != -1 else 0
         close_idx = text.find(self.think_end_token, start)
         if close_idx == -1:
-            tools_idx = text.find(self.tool_start_token, start)
-            if tools_idx != -1:
+            channel_idx = self._next_channel_idx(text, start)
+            if channel_idx != -1:
                 return StreamingParseResult(
-                    reasoning_text=text[start:tools_idx],
-                    normal_text=text[tools_idx:],
+                    reasoning_text=self._strip_dangling_think_close(
+                        text[start:channel_idx]
+                    ),
+                    normal_text=self._clean_content(text[channel_idx:]),
                 )
-            return StreamingParseResult(reasoning_text=text[start:])
+            return StreamingParseResult(
+                reasoning_text=self._strip_dangling_think_close(text[start:])
+            )
 
         reasoning_text = text[start:close_idx]
         rest = text[close_idx + len(self.think_end_token) :]
@@ -518,13 +537,15 @@ class KimiK3Detector(BaseReasoningFormatDetector):
                     normal_text=self._drain_content() or None,
                 )
 
-            tools_idx = buf.find(self.tool_start_token)
-            if tools_idx != -1:
-                reasoning_text = buf[:tools_idx]
-                self._buffer = buf[tools_idx:]
+            channel_idx = self._next_channel_idx(buf)
+            if channel_idx != -1:
+                reasoning_text = self._strip_dangling_think_close(buf[:channel_idx])
+                self._buffer = buf[channel_idx:]
                 self._in_reasoning = False
                 self._reasoning_done = True
-                self._tools_passthrough = True
+                self._tools_passthrough = buf.startswith(
+                    self.tool_start_token, channel_idx
+                )
                 return StreamingParseResult(
                     reasoning_text=reasoning_text or None,
                     normal_text=self._drain_content() or None,
@@ -532,11 +553,12 @@ class KimiK3Detector(BaseReasoningFormatDetector):
 
             if not self.stream_reasoning:
                 return StreamingParseResult()
-            markers = [self.think_end_token, self.tool_start_token]
+            markers = [self.think_end_token, self.tool_start_token, RESPONSE_OPEN]
             if not self.stripped_think_start:
                 markers.append(self.think_start_token)
             holdback = _partial_suffix_len(buf, markers)
             emit = buf[: len(buf) - holdback] if holdback else buf
+            emit = self._strip_dangling_think_close(emit)
             self._buffer = buf[len(emit) :]
             return StreamingParseResult(reasoning_text=emit)
 

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -12,6 +12,7 @@ from sglang.srt.parser.reasoning_parser import (
     InklingDetector,
     KimiDetector,
     KimiK2Detector,
+    KimiK3Detector,
     Nemotron3Detector,
     Qwen3Detector,
     ReasoningParser,
@@ -293,6 +294,64 @@ class TestKimiK2Detector(CustomTestCase):
         self.assertEqual(self.detector.tool_start_token, "<|tool_calls_section_begin|>")
         self.assertFalse(self.detector._in_reasoning)
         self.assertTrue(self.detector.stream_reasoning)
+
+
+class TestKimiK3Detector(CustomTestCase):
+    """Test cases for the Kimi K3 XTML think channel detector."""
+
+    TOOLS = (
+        '<|open|>tools<|sep|><|open|>call tool="get_weather" index="1"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>San Francisco'
+        "<|close|>argument<|sep|><|close|>call<|sep|><|close|>tools<|sep|>"
+    )
+    THINK = "The user asks about SF weather."
+    RESPONSE = "I'll check SF weather for you."
+
+    def _sealed(self):
+        return (
+            f"{self.THINK}<|close|>think<|sep|><|open|>response<|sep|>"
+            f"{self.RESPONSE}<|close|>response<|sep|>{self.TOOLS}"
+        )
+
+    def _unsealed(self):
+        return (
+            f"{self.THINK}<|close|>think<|open|>response<|sep|>"
+            f"{self.RESPONSE}<|close|>response<|sep|>{self.TOOLS}"
+        )
+
+    def test_unsealed_think_close_keeps_response_out_of_reasoning(self):
+        """Guard the /v1/responses regression where the think channel closed as
+        ``<|close|>think`` with no trailing ``<|sep|>``: the detector found no
+        think_end_token, so the whole response channel plus its raw markers were
+        emitted as reasoning_text and the assistant message vanished."""
+        result = KimiK3Detector().detect_and_parse(self._unsealed())
+        self.assertEqual(result.reasoning_text, self.THINK)
+        self.assertEqual(result.normal_text, self.RESPONSE + self.TOOLS)
+
+    def test_sealed_and_unsealed_agree(self):
+        """A well-formed close marker must parse identically to the degraded one."""
+        sealed = KimiK3Detector().detect_and_parse(self._sealed())
+        unsealed = KimiK3Detector().detect_and_parse(self._unsealed())
+        self.assertEqual(sealed.reasoning_text, unsealed.reasoning_text)
+        self.assertEqual(sealed.normal_text, unsealed.normal_text)
+
+    def test_streaming_matches_non_streaming(self):
+        """Marker-straddling chunks must not leak a dangling ``<|close|>think``
+        into the streamed reasoning deltas."""
+        for text in (self._sealed(), self._unsealed()):
+            expected = KimiK3Detector().detect_and_parse(text)
+            for chunk_size in (1, 7, 13):
+                detector = KimiK3Detector()
+                reasoning, normal = [], []
+                for start in range(0, len(text), chunk_size):
+                    result = detector.parse_streaming_increment(
+                        text[start : start + chunk_size]
+                    )
+                    reasoning.append(result.reasoning_text or "")
+                    normal.append(result.normal_text or "")
+                with self.subTest(text=text, chunk_size=chunk_size):
+                    self.assertEqual("".join(reasoning), expected.reasoning_text)
+                    self.assertEqual("".join(normal), expected.normal_text)
 
 
 class TestGlm45Detector(CustomTestCase):


### PR DESCRIPTION
The /v1/responses path never set require_reasoning on GenerateReqInput, so the reasoner grammar gate started in generation mode and xgrammar enforced the tool-call structural tag from the first token of the think channel. Its excludes list contains the think close marker, which masked the trailing <|sep|> and made the model emit <|close|>think<|open|>response<|sep|>. The K3 reasoning detector then found no close marker and dumped the whole response channel into reasoning_text.

Pass require_reasoning through, and make the detector fall back to the next channel marker (and strip a dangling <|close|>think) when the close marker is missing, in both the batch and streaming paths.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30438008979](https://github.com/sgl-project/sglang/actions/runs/30438008979)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30438008800](https://github.com/sgl-project/sglang/actions/runs/30438008800)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->