### PR TITLE
fix(kimi-k3): subtract generation stub tokens from cached_tokens report

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -508,7 +508,7 @@ class OpenAIServingChat(OpenAIServingBase):
         if not self.tokenizer_manager.server_args.enable_cache_report:
             return None
         return UsageProcessor._details_if_cached(
-            content["meta_info"].get("cached_tokens", 0)
+            self._reported_cached_tokens(content["meta_info"])
         )
 
     def _reported_prompt_tokens(self, meta_info: Dict[str, Any]) -> int:
@@ -518,6 +518,12 @@ class OpenAIServingChat(OpenAIServingBase):
             # reference API excludes it from billed/reported prompt tokens.
             prompt_tokens = max(0, prompt_tokens - self._KIMI_K3_GENERATION_STUB_TOKENS)
         return prompt_tokens
+
+    def _reported_cached_tokens(self, meta_info: Dict[str, Any]) -> int:
+        cached_tokens = meta_info.get("cached_tokens", 0)
+        if self.chat_encoding_spec == "kimi_k3":
+            cached_tokens = max(0, cached_tokens - self._KIMI_K3_GENERATION_STUB_TOKENS)
+        return cached_tokens
 
     async def _generate_stream_content(
         self,
@@ -1399,7 +1405,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 reasoning_tokens[index] = content["meta_info"].get(
                     "reasoning_tokens", 0
                 )
-                cached_tokens[index] = content["meta_info"].get("cached_tokens", 0)
+                cached_tokens[index] = self._reported_cached_tokens(content["meta_info"])
                 hidden_states[index] = content["meta_info"].get("hidden_states", None)
                 routed_experts[index] = content["meta_info"].get("routed_experts", None)
                 cached_tokens_details[index] = content["meta_info"].get(
@@ -1628,6 +1634,9 @@ class OpenAIServingChat(OpenAIServingBase):
                     "meta_info": {
                         **item["meta_info"],
                         "prompt_tokens": self._reported_prompt_tokens(
+                            item["meta_info"]
+                        ),
+                        "cached_tokens": self._reported_cached_tokens(
                             item["meta_info"]
                         ),
                     },


### PR DESCRIPTION
## Problem

K3's chat template appends a 3-token assistant generation stub (`<|open|>think<|sep|>`) to the prompt via `add_generation_prompt=True`. The existing code already subtracts these stub tokens from reported `prompt_tokens` via `_reported_prompt_tokens()`, but `cached_tokens` was reported raw without the same adjustment.

This causes `cached_tokens` to exceed `prompt_tokens` by up to 2:

```json
"usage": {
  "prompt_tokens": 126,
  "prompt_tokens_details": { "cached_tokens": 128 }
}
```

**Root cause:** The scheduler computes the radix cache hit over the full prompt (including the 3 stub tokens). Vanilla SGLang guarantees `cached_tokens <= prompt_tokens - 1`. But since `_reported_prompt_tokens()` subtracts 3 from `prompt_tokens` for kimi-k3 while `cached_tokens` is left unadjusted, the reported `cached_tokens` can be up to `3 - 1 = 2` larger than the reported `prompt_tokens`.

## Fix

Add `_reported_cached_tokens()` mirroring the existing `_reported_prompt_tokens()`, and route all `cached_tokens` reporting paths through it:

1. `_continuous_usage_cached_details` — continuous streaming usage path
2. Streaming `cached_tokens[index]` collection — non-continuous streaming usage path
3. `_build_chat_response` kimi_k3 block — non-streaming response path

```python
def _reported_cached_tokens(self, meta_info: Dict[str, Any]) -> int:
    cached_tokens = meta_info.get("cached_tokens", 0)
    if self.chat_encoding_spec == "kimi_k3":
        cached_tokens = max(0, cached_tokens - self._KIMI_K3_GENERATION_STUB_TOKENS)
    return cached_tokens
```

## Verification

Tested on a kimi-k3 deployment. Before the fix, a single-turn request returned `prompt_tokens=126, cached_tokens=128`. After the fix, the same request returns `prompt_tokens=126, cached_tokens=125`, satisfying `cached_tokens <= prompt_tokens - 1`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30441121580](https://github.com/sgl-project/sglang/actions/runs/30441121580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30441121509](https://github.com/sgl-project/sglang/actions/runs/30441121509)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->