### PR TITLE
perf(kimi-k3): free the gemm_ag producer grid from the AR push-counter array

### DIFF
--- a/python/sglang/kernels/jit/csrc/kimi_k3/comm/gemm_ag.cuh
+++ b/python/sglang/kernels/jit/csrc/kimi_k3/comm/gemm_ag.cuh
@@ -83,7 +83,11 @@ __global__ __launch_bounds__(K / kVecSize) void gemm_ag_gemv_kernel(
   }
 
   PDLWaitPrimary<kUsePDL>();
-  const uint32_t phase = params.counter[bx].get() & 1;
+  // Every push-workspace consumer flips the WHOLE counter array each round
+  // (each has a tail loop up to num_counters), so all counters hold the same
+  // phase at this point and counter[0] is equivalent to counter[bx]. Reading a
+  // single counter is what frees the producer grid from num_push_blocks.
+  const uint32_t phase = params.counter[0].get() & 1;
 
   vec_t input_vec[M];
 #pragma unroll
@@ -225,7 +229,16 @@ template <uint32_t K, uint32_t N, uint32_t kMaxM, bool kUsePDL>
 struct GEMMAGKernel {
   using TensorView = tvm::ffi::TensorView;
 
-  static constexpr uint32_t N_SPLIT = 8;
+  // Columns of this rank's slice per producer block; sets the grid to
+  // kNLocal / N_SPLIT. Measured on 2x4 GB300 TP8 at bs=1 (three reps each,
+  // mean TPOT): 8 -> grid 112, 8.36 ms; 4 -> 224, 8.29 ms; 2 -> 448, 8.21 ms.
+  // Standalone GEMV at the same shape: 4.15 / 3.20 / 2.56 us, and 16 -> 4.42 us,
+  // so the trend is monotonic and 2 is the floor (the epilogue stores column
+  // pairs, so N_SPLIT must stay even). 8 used to be the largest grid that fit
+  // the old kNumProducerBlocks <= num_push_blocks bound; the producer now reads
+  // a single phase counter, so the grid is free and 112 blocks did not even
+  // fill one per SM.
+  static constexpr uint32_t N_SPLIT = 2;
   static constexpr uint32_t kNLocal = N / gemm_ag::kWorld;
   static constexpr uint32_t kGemvBlock = K / gemm_ag::kVecSize;
   static constexpr uint32_t kNumProducerBlocks = kNLocal / N_SPLIT;
@@ -266,7 +279,8 @@ struct GEMMAGKernel {
     CHECK_HOST(ws_mc_base != 0) << "requires a multicast-capable workspace";
     CHECK_HOST(int64_t(num_tokens) * kNLocal * 2 <= data.push_bytes)
         << "staging slice exceeds the push slot size " << data.push_bytes;
-    CHECK_HOST(kNumProducerBlocks <= data.num_push_blocks);
+    // The producer grid is no longer bound to the counter array: it reads only
+    // counter[0] (see gemm_ag_gemv_kernel). The consumer grid still is.
     CHECK_HOST(data.num_push_blocks > 0) << "no push blocks available";
     // producer: GEMV
     const auto producer_params = gemm_ag::ProducerParams{

--- a/python/sglang/srt/layers/k3_ar_fusion.py
+++ b/python/sglang/srt/layers/k3_ar_fusion.py
@@ -329,7 +329,10 @@ def gemm_ag_up_fits(num_tokens: int) -> bool:
         0 < num_tokens <= mod.MAX_TOKENS
         and state.world_size == 8
         and num_tokens * (2 * NORM_DIM // 8) * 2 <= comm.max_push_size
-        and comm.config.num_push_blocks >= 112  # GEMV grid (896 / 8)
+        # The GEMV producer reads a single phase counter, so its grid is not
+        # bound to the counter array; the spin consumer still needs one block
+        # per counter slot plus the cleanup block.
+        and comm.config.num_push_blocks >= 2
     )
 
 


### PR DESCRIPTION
## Motivation

`gemm_ag_gemv` is the producer half of the latent-MoE up_proj fusion: every rank
computes its own 896-column slice of the replicated `[M, 3584] x [3584, 7168]`
GEMM, multicast-stores it into the CustomAllReduceV2 push workspace, and a
Lamport-spin consumer assembles `out = up_proj(x) + b (+ c)`.

It was reading a **per-block** phase counter out of that push workspace:

```c++
const uint32_t phase = params.counter[bx].get() & 1;
```

which forced a host-side bound on the grid:

```c++
CHECK_HOST(kNumProducerBlocks <= data.num_push_blocks);   // num_push_blocks = num_sm
```

`N_SPLIT = 8` was therefore not a tuning choice but the only usable value: the
grid is `kNLocal / N_SPLIT = 896 / N_SPLIT`, and 896's even divisors give grids
of 448 / 224 / **112** / 64 / …, so 112 was the largest that fit under the SM
count. The old comment `# GEMV grid (896 / 8)` in `k3_ar_fusion.py` was locking
exactly this coupling.

112 blocks on a 152-SM GB300 is **less than one block per SM** — 7 of 64 warp
slots occupied, ~11% occupancy. For a memory-bound streaming GEMV that is not
enough memory-level parallelism to cover HBM latency. A grid sweep at this
shape shows how strongly the achieved bandwidth depends on the grid:

| grid | 24 | 36 | 64 | **112** | 152 | more |
|---|---:|---:|---:|---:|---:|---:|
| % of achievable HBM BW | 41% | 56% | 70% | **79%** | 81% | 83% |

## Modifications

The producer only needs the phase *bit*, and it never writes a counter. Every
push-workspace consumer already flips the **whole** counter array each round
through a tail loop — `spin_add3_kernel` ("the last block flips its own counter
and every one past the grid"), `ar_fusion`'s cluster push, and
`sp_collective` — precisely so that users with different grid sizes all observe
the same phase. All counters are therefore in lockstep, and `counter[0]` is
equivalent to `counter[bx]`.

Reading a single counter removes the only per-block shared state in the
producer (everything else it does with `blockIdx` is its own weight/output
addressing), so the grid becomes independent of the counter array and the host
check goes away. **The all-reduce grid, the counter array size and the
double-buffer protocol are all untouched** — this does not change the
collective's shared infrastructure, only which counter one kernel samples.

With the grid free, `N_SPLIT` drops to 2 (448 blocks, ~3 per SM). It stays even
because the epilogue stores adjacent column pairs, so 2 is the floor.

## Accuracy Test

GSM8K 200 questions, 5-shot, `--parallel 64`: **0.990 / 0.990** (two runs, in
band). Also spot-checked determinism on fixed arithmetic prompts across
repeated requests — relevant here because a mis-read phase would show up as
intermittently reading the previous round's buffer half rather than as a clean
failure.

## Benchmark and Profiling

2x4 GB300 (sm_103) TP8, single NVLink domain, `random` 4096-in / 1024-out,
greedy, three reps per cell with the radix cache flushed before every rep.

| N_SPLIT | grid | mean TPOT | output tok/s | standalone GEMV |
|---:|---:|---:|---:|---:|
| 8 (before) | 112 | 8.36 ms | 115.50 | 4.15 us |
| 4 | 224 | 8.29 ms | 115.78 | 3.20 us |
| **2 (this PR)** | **448** | **8.21 ms** | **116.83** | **2.56 us** |
| 16 | 56 | — | — | 4.42 us |

**bs=1: 115.50 -> 116.83 tok/s (+1.2%), mean TPOT 8.36 -> 8.21 ms (-1.8%).**
The trend is monotonic in grid size and 16 is worse than 8, so there is no
interior optimum to miss.

bs=64 is unchanged (33.19 -> 33.22 ms), as expected: `gemm_ag_up_fits` only
covers `num_tokens <= MAX_TOKENS = 12`, so larger decode batches never take
this path.

Kernel level, rank 0 bs=1 GPU trace, 25 steady-state decode steps:

| | busy/step | per call | exclusive (non-overlapped)/step |
|---|---:|---:|---:|
| `gemm_ag_gemv` before | 812 us | 8.82 us | 375 us |
| `gemm_ag_gemv` after | **656 us** | **7.13 us** | **217 us** |

The 158 us/step of serial time removed lines up with the ~150 us/step of
measured end-to-end step time, and `spin_add3` (199 / 115 us/step) and the
dense TGV GEMM (3949 / 1579 us/step) are unchanged, so the effect is
contained to this kernel.

An isolated single-GPU replica of the GEMV — same 224-thread block, same
strided 32B weight loads, same warp + shared-memory reduction, with the PDL
wait and the multicast store removed — reproduces the same improvement
(4.15 -> 2.56 us at the same shape). That confirms the win comes from the GEMV
half. The remaining ~4.6 us of the in-situ 7.13 us is upstream dependency wait
plus fabric cost, is constant across N_SPLIT, and is not addressed here.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#running-unit-tests-adding-file-to-test-suite). — no new unit test: `gemm_ag` needs 8 ranks with a multicast-capable symmetric-memory workspace, so it is not reachable from the single-GPU kernel suites. Validated end-to-end instead (GSM8K x2 plus the trace-level attribution above), which is how the kernel was validated originally.
- [x] Update documentation / docstrings / example tutorials as needed, according to the model / feature it is about.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to the model / feature it is about.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30443410716](https://github.com/sgl-project/sglang/actions/runs/30443410716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30443410529](https://github.com/sgl-project/sglang/actions/runs/30443410529)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->