### PR TITLE
[AMD] Add moonmath MLA attention backend with A16W8 decode for CDNA3 (MI300X)

### DIFF
--- a/docs/docs/advanced_features/attention_backend.mdx
+++ b/docs/docs/advanced_features/attention_backend.mdx
@@ -299,6 +299,15 @@ The support matrix is split into two parts: MHA (standard attention) and MLA (mu
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>❌</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>**Moonmath MLA (ROCm)**</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>1</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅ (aiter)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅ (aiter)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>❌</td>
+    </tr>
   </tbody>
 </table>
 
@@ -692,6 +701,18 @@ python3 -m sglang.launch_server \
 python3 -m sglang.launch_server \
   --model meta-llama/Meta-Llama-3.1-8B-Instruct \
   --attention-backend wave
+```
+
+- Moonmath MLA (AMD ROCm, MI300X)
+  - Requires `pip install moonmath-attention` ([github.com/moonmath-ai/amd-kernels](https://github.com/moonmath-ai/amd-kernels))
+  - Pure decode A16W8 (bf16 Q / fp8 KV) for H≤16 on gfx942. Prefill and spec-verify fall back to aiter.
+```bash Command
+python3 -m sglang.launch_server \
+  --tp 4 \
+  --model moonshotai/Kimi-K2.7 \
+  --attention-backend moonmath_mla \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code
 ```
 
 - FlexAttention

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -102,6 +102,15 @@ def create_aiter_backend(runner):
     return AiterAttnBackend(runner)
 
 
+@register_attention_backend("moonmath_mla")
+def create_moonmath_mla_backend(runner):
+    if not runner.use_mla_backend:
+        raise ValueError("moonmath_mla backend can only be used with MLA models.")
+    from sglang.srt.layers.attention.moonmath_mla_backend import MoonmathMLABackend
+
+    return MoonmathMLABackend(runner)
+
+
 @register_attention_backend("wave")
 def create_wave_backend(runner):
     from sglang.srt.layers.attention.wave_backend import WaveAttnBackend

--- a/python/sglang/srt/layers/attention/moonmath_mla_backend.py
+++ b/python/sglang/srt/layers/attention/moonmath_mla_backend.py
@@ -1,0 +1,120 @@
+"""Moonmath MLA decode backend for DeepSeek-V3 on CDNA3 (MI300X / gfx942).
+
+Subclasses AiterAttnBackend: decode with fp8 KV and H<=16 routes to the
+moonmath_attention A16W8 kernel (bf16 Q / fp8 KV, device-driven paged,
+cuda-graph-safe, reads sglang's existing fused-576 MLATokenToKVPool directly).
+Everything else (bf16 KV, H>16, prefill, spec-verify) falls back to aiter.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+KV_LORA_RANK = 512
+KV_CACHE_DIM = 576  # 512 latent + 64 rope
+
+
+class MoonmathMLABackend(AiterAttnBackend):
+    """MLA decode backend: A16W8 kernel for H<=16 fp8 KV, else aiter."""
+
+    def __init__(self, model_runner):
+        super().__init__(model_runner)
+        import moonmath_attention.mla as mla  # fail fast if missing
+
+        self._mla = mla
+        self._mla_ok = bool(self.use_mla)
+        self._disabled = os.environ.get("SGLANG_MOONMATH_MLA_DISABLE") == "1"
+        self._fp8_dtype = torch.float8_e4m3fnuz
+        self._fp8_kv = self._mla_ok and (self.kv_cache_dtype == self._fp8_dtype)
+
+        # Per-bs FIXED kv-split (frozen at first call / capture; reused on replay).
+        self._dec_parts: dict[int, int] = {}
+        model_config = getattr(model_runner, "model_config", None)
+        self._mla_max_ctx = (
+            model_config.context_len if model_config is not None else 131072
+        )
+        # int32 staging for device seq_lens (sglang gives int64 in eager mode).
+        self._mla_seqlen_i32 = torch.zeros(
+            8192, dtype=torch.int32, device=model_runner.device
+        )
+
+    # A16W8 kernel serves H<=16. H=128 (DSV3) falls back to aiter.
+    _A16W8_DECODE_MAX_HEADS = 16
+
+    def _decode_eligible(self, q, layer: RadixAttention, fb: ForwardBatch) -> bool:
+        return (
+            self._mla_ok
+            and not self._disabled
+            and self._fp8_kv
+            and q.dtype == torch.bfloat16
+            and layer.tp_q_head_num <= self._A16W8_DECODE_MAX_HEADS
+            and layer.qk_head_dim == KV_CACHE_DIM
+            and layer.v_head_dim == KV_LORA_RANK
+            and layer.tp_k_head_num == 1
+            and layer.logit_cap == 0
+            and fb.forward_mode.is_decode()
+            and fb.spec_info is None
+            and fb.batch_size <= self._mla_seqlen_i32.numel()
+            and self.forward_metadata is not None
+            and self.forward_metadata.kv_indices is not None
+            and self.forward_metadata.kv_indptr is not None
+        )
+
+    # ── decode ───────────────────────────────────────────────────────────────
+    def forward_decode(
+        self, q, k, v, layer, forward_batch, save_kv_cache=True, sinks=None
+    ):
+        if sinks is not None or not self._decode_eligible(q, layer, forward_batch):
+            return super().forward_decode(
+                q, k, v, layer, forward_batch, save_kv_cache, sinks
+            )
+
+        mla = self._mla
+        fb = forward_batch
+        B = fb.batch_size
+        H = layer.tp_q_head_num
+
+        if save_kv_cache and k is not None:
+            self.token_to_kv_pool.set_kv_buffer(layer, fb.out_cache_loc, k, v)
+
+        kv_pool = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        kv_indices = self.forward_metadata.kv_indices.to(torch.int32)
+        kv_indptr = self.forward_metadata.kv_indptr.to(torch.int32)
+        seq_lens = self._mla_seqlen_i32[:B]
+        seq_lens.copy_(fb.seq_lens)
+        k_descale = (
+            float(layer.k_scale) if getattr(layer, "k_scale", None) is not None else 1.0
+        )
+
+        parts = self._dec_parts.get(B)
+        if parts is None:
+            parts = mla.mla_decode_a16w8_plan_parts_capped(
+                B, H, self._mla_max_ctx, KV_LORA_RANK
+            )
+            self._dec_parts[B] = parts
+
+        q = q.reshape(B, H, layer.qk_head_dim)
+        q_lat = q[..., :KV_LORA_RANK].contiguous()
+        q_pe = q[..., KV_LORA_RANK:].contiguous()
+        out = torch.empty(B, H, KV_LORA_RANK, dtype=torch.bfloat16, device=q.device)
+        mla.mla_decode_a16w8_paged_dev(
+            q_lat,
+            q_pe,
+            kv_pool,
+            out,
+            seq_lens,
+            None,
+            kv_indices,
+            kv_indptr,
+            parts,
+            layer.scaling,
+            k_descale,
+            1.0,
+        )
+        return out.reshape(B, H * KV_LORA_RANK)

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -175,6 +175,16 @@ def handle_attention_aiter(attn, forward_batch):
         return AttnForwardMethod.MLA
 
 
+def handle_attention_moonmath_mla(attn, forward_batch):
+    # Same split as aiter (our backend subclasses AiterAttnBackend): pure prefill -> non-absorbed
+    # MHA (materialized K[192]/V[128]); decode + spec -> absorbed MLA (q[576] -> o[512] latent).
+    # Ineligible shapes fall back to aiter inside the backend's forward_decode / forward_extend.
+    if forward_batch.forward_mode.is_extend_without_speculative():
+        return AttnForwardMethod.MHA
+    else:
+        return AttnForwardMethod.MLA
+
+
 def handle_attention_dsa(attn, forward_batch):
     """
     Dispatch logic is centralized in DeepseekSparseAttnBackend.set_dsa_prefill_impl and executed
@@ -219,6 +229,7 @@ AttentionBackendRegistry.register("fa4", handle_attention_fa4)
 AttentionBackendRegistry.register("trtllm_mla", handle_attention_trtllm_mla)
 AttentionBackendRegistry.register("tokenspeed_mla", handle_attention_tokenspeed_mla)
 AttentionBackendRegistry.register("aiter", handle_attention_aiter)
+AttentionBackendRegistry.register("moonmath_mla", handle_attention_moonmath_mla)
 AttentionBackendRegistry.register("dsa", handle_attention_dsa)
 AttentionBackendRegistry.register(
     "nsa", handle_attention_dsa

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -195,6 +195,7 @@ ATTENTION_BACKEND_CHOICES = [
     "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), Hopper (SM90) only, requires --page-size 64
     # AMD specific
     "aiter",
+    "moonmath_mla",
     "wave",
     # Other platforms
     "intel_amx",

--- a/test/registered/unit/layers/attention/test_moonmath_mla_backend.py
+++ b/test/registered/unit/layers/attention/test_moonmath_mla_backend.py
@@ -1,0 +1,248 @@
+"""Unit tests for the moonmath MLA attention backend.
+
+Two layers of testing:
+  1. Eligibility: _decode_eligible() gate routing (no GPU, mocked kernel).
+  2. Correctness: real A16W8 kernel output vs fp32 reference on dequantized
+     fp8 KV (requires ROCm GPU + moonmath_attention installed).
+
+Requires: moonmath_attention installed (the backend imports it at __init__).
+Requires: AMD ROCm (torch.float8_e4m3fnuz is a ROCm-only dtype).
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+
+
+def _make_layer(
+    q_head_num=16,
+    qk_head_dim=576,
+    v_head_dim=512,
+    tp_k_head_num=1,
+    logit_cap=0,
+    scaling=0.0884,
+    k_scale=None,
+):
+    """Create a mock RadixAttention layer with MLA defaults."""
+    layer = MagicMock()
+    layer.tp_q_head_num = q_head_num
+    layer.qk_head_dim = qk_head_dim
+    layer.v_head_dim = v_head_dim
+    layer.tp_k_head_num = tp_k_head_num
+    layer.logit_cap = logit_cap
+    layer.scaling = scaling
+    layer.k_scale = k_scale
+    return layer
+
+
+def _make_fb(batch_size=4, forward_mode="decode", spec_info=None):
+    """Create a mock ForwardBatch."""
+    fb = MagicMock()
+    fb.batch_size = batch_size
+    fb.spec_info = spec_info
+    mode = MagicMock()
+    mode.is_decode.return_value = forward_mode == "decode"
+    mode.is_target_verify.return_value = forward_mode == "target_verify"
+    mode.is_extend.return_value = forward_mode == "extend"
+    fb.forward_mode = mode
+    return fb
+
+
+def _make_backend(kv_cache_dtype=None, use_mla=True):
+    """Create a MoonmathMLABackend with mocked dependencies."""
+    with patch(
+        "sglang.srt.layers.attention.aiter_backend.AiterAttnBackend.__init__"
+    ), patch("moonmath_attention.mla") as mock_mla:
+        mock_mla.mla_decode_a16w8_plan_parts_capped.return_value = 1
+        from sglang.srt.layers.attention.moonmath_mla_backend import (
+            MoonmathMLABackend,
+        )
+
+        runner = MagicMock()
+        runner.use_mla = use_mla
+        runner.device = torch.device("cuda")
+        runner.model_config.context_len = 131072
+
+        backend = MoonmathMLABackend.__new__(MoonmathMLABackend)
+        backend._mla = mock_mla
+        backend._mla_ok = use_mla
+        backend._disabled = False
+        backend._fp8_dtype = torch.float8_e4m3fnuz
+        backend._fp8_kv = use_mla and (kv_cache_dtype == torch.float8_e4m3fnuz)
+        backend._dec_parts = {}
+        backend._mla_max_ctx = 131072
+        backend._mla_seqlen_i32 = torch.zeros(8192, dtype=torch.int32, device="cpu")
+        backend.kv_cache_dtype = kv_cache_dtype
+        backend.forward_metadata = MagicMock()
+        backend.forward_metadata.kv_indices = torch.zeros(1, dtype=torch.int32)
+        backend.forward_metadata.kv_indptr = torch.zeros(1, dtype=torch.int32)
+        return backend
+
+
+class TestMoonmathMLAEligibility(unittest.TestCase):
+    """Test _decode_eligible gates correctly for all input combinations."""
+
+    def test_eligible_h16_fp8_decode(self):
+        """The supported case: H=16, fp8 KV, pure decode, MLA dims."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertTrue(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_h128(self):
+        """H=128 (DSV3) should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=128)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_bf16_kv(self):
+        """bf16 KV should fall back to aiter (A16W8 requires fp8 KV)."""
+        backend = _make_backend(kv_cache_dtype=torch.bfloat16)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_extend(self):
+        """Prefill/extend should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="extend")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_spec_verify(self):
+        """Spec-verify should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, spec_info=MagicMock())
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_disabled(self):
+        """SGLANG_MOONMATH_MLA_DISABLE=1 should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        backend._disabled = True
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_wrong_dims(self):
+        """Non-MLA dims (e.g. head_dim=128) should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16, qk_head_dim=128, v_head_dim=128)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_non_mla(self):
+        """Non-MLA model should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz, use_mla=False)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+
+def _has_moonmath():
+    try:
+        import moonmath_attention.mla  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+class TestMoonmathMLAKernelCorrectness(unittest.TestCase):
+    """Correctness of the A16W8 decode kernel vs fp32 reference.
+
+    The kernel carries Q in bf16 and computes softmax in fp32.  The fp32
+    reference dequantizes the same fp8 KV bytes and runs the absorbed-MLA
+    decode math in full fp32.  Relative error must stay below 1e-2.
+    """
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and _has_moonmath(),
+        "Requires ROCm GPU and moonmath_attention",
+    )
+    def test_decode_matches_fp32_reference(self):
+        import math
+
+        import moonmath_attention.mla as mla
+
+        DEV = "cuda"
+        FP8 = torch.float8_e4m3fnuz
+        KV_LAT = 512
+        ROPE = 64
+        KV_DIM = KV_LAT + ROPE
+        H = 16
+        SCALE = 1.0 / math.sqrt(KV_DIM)
+
+        for B, S in [(1, 128), (2, 256)]:
+            with self.subTest(B=B, S=S):
+                torch.manual_seed(42 + B * 1000 + S)
+
+                q_lat = torch.randn(B, H, KV_LAT, dtype=torch.bfloat16, device=DEV)
+                q_pe = torch.randn(B, H, ROPE, dtype=torch.bfloat16, device=DEV)
+
+                num_slots = S * B + 1
+                kv_pool = torch.zeros(num_slots, 1, KV_DIM, dtype=FP8, device=DEV)
+                kv_indices = torch.zeros(S * B, dtype=torch.int32, device=DEV)
+                kv_indptr = torch.zeros(B + 1, dtype=torch.int32, device=DEV)
+                seq_lens = torch.full((B,), S, dtype=torch.int32, device=DEV)
+
+                c_refs, k_refs = [], []
+                for b in range(B):
+                    off = b * S
+                    slots = torch.arange(
+                        off + 1, off + S + 1, device=DEV, dtype=torch.int32
+                    )
+                    kv_indices[off : off + S] = slots
+                    kv_indptr[b + 1] = off + S
+                    c = torch.randn(S, KV_LAT, device=DEV)
+                    k = torch.randn(S, ROPE, device=DEV)
+                    kv_pool[slots.long(), 0, :KV_LAT] = c.to(FP8)
+                    kv_pool[slots.long(), 0, KV_LAT:] = k.to(FP8)
+                    c_refs.append(kv_pool[slots.long(), 0, :KV_LAT].float())
+                    k_refs.append(kv_pool[slots.long(), 0, KV_LAT:].float())
+
+                out = torch.empty(B, H, KV_LAT, dtype=torch.bfloat16, device=DEV)
+                parts = mla.mla_decode_a16w8_plan_parts_capped(B, H, S, KV_LAT)
+                mla.mla_decode_a16w8_paged_dev(
+                    q_lat,
+                    q_pe,
+                    kv_pool,
+                    out,
+                    seq_lens,
+                    None,
+                    kv_indices,
+                    kv_indptr,
+                    parts,
+                    SCALE,
+                    1.0,
+                    1.0,
+                )
+                torch.cuda.synchronize()
+
+                ref = torch.empty(B, H, KV_LAT, dtype=torch.float32, device=DEV)
+                for b in range(B):
+                    c, k = c_refs[b], k_refs[b]
+                    ql, qp = q_lat[b].float(), q_pe[b].float()
+                    scores = (ql @ c.t() + qp @ k.t()) * SCALE
+                    ref[b] = torch.softmax(scores, dim=-1) @ c
+
+                relerr = (out.float() - ref).abs().max().item() / ref.abs().max().item()
+                self.assertLess(relerr, 1e-2, f"B={B} S={S}: relerr={relerr:.3e}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the moonmath_mla attention backend for MLA on AMD CDNA3 (MI300X/gfx942). Subclasses AiterAttnBackend: decode with fp8 KV and H<=16 routes to the moonmath_attention A16W8 kernel (bf16 Q / fp8 KV, device-driven paged, cuda-graph-safe, reads sglang's existing fused-576 MLATokenToKVPool directly). Everything else falls back to aiter.

Usage: --attention-backend moonmath_mla
Requires: pip install moonmath-attention (from moonmath-ai/amd-kernels)

## Motivation

Kimi-K2.7 Code TP=4 has 16 query heads per GPU and uses fp8 KV cache. The default aiter MLA decode kernel works but we have a hand-tuned CDNA3 kernel (A16W8: bf16 Q / fp8 KV) that is faster for this configuration. This PR adds a moonmath_mla attention backend that routes H≤16 fp8 decode to our kernel and falls back to aiter for everything else.

## Modifications

- moonmath_mla_backend.py (new, 120 lines): MoonmathMLABackend subclasses AiterAttnBackend. forward_decode checks eligibility (fp8 KV, H≤16, MLA dims, pure decode) and routes to moonmath_attention.mla.mla_decode_a16w8_paged_dev — a device-driven paged kernel that reads sglang's existing fused-576 MLATokenToKVPool directly (no special KV layout, cuda-graph-safe). Prefill, spec-verify, and ineligible configs fall through to aiter unchanged.
- attention_registry.py (+9 lines): Register moonmath_mla backend.
- attention_backend_handler.py (+11 lines): DeepSeek MLA dispatch (prefill→MHA, decode→MLA), mirroring the aiter handler.
- server_args.py (+1 line): Add moonmath_mla to ATTENTION_BACKEND_CHOICES.
- test_moonmath_mla_backend.py (new, 157 lines): 8 unit tests covering the eligibility gate (supported case + 7 rejection cases: H=128, bf16 KV, extend, spec-verify, disabled, wrong dims, non-MLA).

## Accuracy Tests

The underlying A16W8 kernel is owned by the moonmath_attention project; its numerical correctness is verified there (relerr ≤6.6e-3 vs fp32 reference across B=1–32 × S=1k–256k, bit-identical across runs). The sglang-side unit tests assert routing/fallback logic plus a kernel correctness check against an fp32 reference on small shapes.

## Speed Tests and Profiling

Benchmarked on MI300X (gfx942), interleaved A/B median timing. Both kernels run at q_len=1 (pure decode), H=16, fp8 KV
The aiter comparison uses mla_a16w8_qh16_m16x4_n16x1_coex0_mask1_ps — aiter's persistent-mode A16W8 ASM kernel (the same kernel sglang dispatches for H=16 A16W8 decode). Our kernel only handles q_len=1 — spec-decode/target-verify falls back to aiter unchanged.

| Shape   | ZRO (µs) | AITER (µs) | Speedup |
|---------|---------:|-----------:|--------:|
| 1×32k   |    27.08 |     184.96 |   6.83× |
| 1×64k   |    29.73 |     351.79 |  11.83× |
| 1×128k  |    41.71 |     684.64 |  16.41× |
| 1×256k  |    59.21 |    1356.62 |  22.91× |
| 2×32k   |    30.19 |     186.46 |   6.18× |
| 2×64k   |    41.76 |     353.95 |   8.48× |
| 2×128k  |    59.09 |     689.09 |  11.66× |
| 2×256k  |   121.76 |    1358.18 |  11.15× |
| 4×32k   |    42.27 |     187.35 |   4.43× |
| 4×64k   |    59.10 |     356.03 |   6.02× |
| 4×128k  |   125.06 |     692.57 |   5.54× |
| 4×256k  |   229.78 |    1365.86 |   5.94× |
| 8×32k   |    59.17 |     190.50 |   3.22× |
| 8×64k   |   121.04 |     361.86 |   2.99× |
| 8×128k  |   229.23 |     711.21 |   3.10× |
| 8×256k  |   455.81 |    1427.36 |   3.13× |
| 16×32k  |   119.45 |     230.71 |   1.93× |
| 16×64k  |   225.54 |     449.94 |   1.99× |
| 16×128k |   451.39 |     890.29 |   1.97× |
| 16×256k |   921.25 |    1783.90 |   1.94× |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30890793142](https://github.com/sgl-project/sglang/actions/runs/30890793142)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30890792475](https://github.com/sgl-project/sglang/actions/runs/30890792475)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->