### PR TITLE
Fix Responses reasoning state propagation

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1795,22 +1795,6 @@ class RequestResponseMetadata(BaseModel):
 
 @dataclass
 class MessageProcessingResult:
-    """Result of processing chat messages and applying templates.
-
-    This dataclass encapsulates all the outputs from message processing including
-    prompt generation, multimodal data extraction, and constraint preparation.
-    Used internally by OpenAIServingChat to pass processed data between methods.
-
-    Args:
-        prompt: The final text prompt after applying chat template
-        prompt_ids: Either the text prompt (str) or tokenized IDs (List[int])
-        image_data: Extracted image data from messages, if any
-        audio_data: Extracted audio data from messages, if any
-        modalities: List of modality types present in the messages
-        stop: Combined stop strings from template and request
-        tool_call_constraint: Optional constraint for structured tool calls
-    """
-
     prompt: str
     prompt_ids: Union[str, List[int]]
     image_data: Optional[Any]
@@ -1819,6 +1803,7 @@ class MessageProcessingResult:
     modalities: List[str]
     stop: List[str]
     tool_call_constraint: Optional[ToolCallConstraint] = None
+    require_reasoning: bool = False
 
 
 class ToolCallProcessingResult(NamedTuple):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -800,8 +800,6 @@ class OpenAIServingChat(OpenAIServingBase):
         img_max_dynamic_patch, vid_max_dynamic_patch = _extract_max_dynamic_patch(
             request
         )
-        require_reasoning = self._get_reasoning_from_request(request)
-
         adapted_request = GenerateReqInput(
             **prompt_kwargs,
             image_data=processed_messages.image_data,
@@ -826,7 +824,7 @@ class OpenAIServingChat(OpenAIServingBase):
             rid=request.rid,
             session_id=request.session_id,
             extra_key=self._compute_extra_key(request),
-            require_reasoning=require_reasoning,
+            require_reasoning=processed_messages.require_reasoning,
             priority=request.priority,
             routing_key=self.extract_routing_key(raw_request),
             custom_labels=custom_labels,
@@ -942,6 +940,7 @@ class OpenAIServingChat(OpenAIServingBase):
             result = self._apply_conversation_template(request, is_multimodal)
 
         result.tool_call_constraint = tool_call_constraint
+        result.require_reasoning = thinking_mode
         return result
 
     def _apply_jinja_template(

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -231,6 +231,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 messages, request_prompts, engine_prompts = (
                     self._make_request_with_harmony(request, prev_response)
                 )
+                require_reasoning = self._is_thinking_enabled_for_request(request)
             else:
                 (
                     messages,
@@ -238,6 +239,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                     engine_prompts,
                     processed_messages,
                 ) = await self._make_request(request, prev_response, tokenizer)
+                require_reasoning = processed_messages.require_reasoning
 
         except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
@@ -363,9 +365,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         session_id=request.session_id,
                         extra_key=self._compute_extra_key(request),
                         background=request.background,
-                        require_reasoning=self._is_thinking_enabled_for_request(
-                            request
-                        ),
+                        require_reasoning=require_reasoning,
                     )
 
                     generator = self._generate_with_builtin_tools(
@@ -413,6 +413,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         tokenizer,
                         request_metadata,
                         created_time,
+                        require_reasoning=require_reasoning,
                     ),
                     name=f"create_{response.id}",
                 )
@@ -434,6 +435,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         model_name,
                         tokenizer,
                         request_metadata,
+                        require_reasoning=require_reasoning,
                     )
                 return self.responses_stream_generator_non_harmony(
                     request,
@@ -442,6 +444,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                     model_name,
                     tokenizer,
                     request_metadata,
+                    require_reasoning=require_reasoning,
                 )
             try:
                 result: Union[ORJSONResponse, ResponsesResponse] = (
@@ -453,6 +456,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                         model_name,
                         tokenizer,
                         request_metadata,
+                        require_reasoning=require_reasoning,
                     )
                 )
                 return result
@@ -520,6 +524,8 @@ class OpenAIServingResponses(OpenAIServingChat):
         tokenizer: Any,
         request_metadata: RequestResponseMetadata,
         created_time: Optional[int] = None,
+        *,
+        require_reasoning: bool,
     ) -> Union[ResponsesResponse, ORJSONResponse]:
         if created_time is None:
             created_time = int(time.time())
@@ -546,7 +552,10 @@ class OpenAIServingResponses(OpenAIServingChat):
             assert final_res is not None
 
             output = self._make_response_output_items(
-                request, final_res["text"], tokenizer
+                request,
+                final_res["text"],
+                tokenizer,
+                require_reasoning=require_reasoning,
             )
 
             # Calculate usage from actual output
@@ -629,7 +638,6 @@ class OpenAIServingResponses(OpenAIServingChat):
         return request.reasoning is not None and request.reasoning.summary is not None
 
     def _is_thinking_enabled_for_request(self, request: ResponsesRequest) -> bool:
-        """Whether to start the reasoning detector in thinking mode."""
         if not self.reasoning_parser:
             return False
         effort = request.reasoning.effort if request.reasoning is not None else None
@@ -667,14 +675,14 @@ class OpenAIServingResponses(OpenAIServingChat):
         request: ResponsesRequest,
         final_output: Any,
         tokenizer: Any,
+        *,
+        require_reasoning: bool,
     ):
         if self.reasoning_parser:
-            # Templates that prefill ``<think>`` only emit the close tag, so
-            # start the detector in thinking mode.
             reasoning_parser = ReasoningParser(
                 model_type=self.reasoning_parser,
                 stream_reasoning=False,
-                force_reasoning=self._is_thinking_enabled_for_request(request),
+                force_reasoning=require_reasoning,
                 request=request,
                 tokenizer=self.tokenizer_manager.tokenizer,
             )
@@ -1194,8 +1202,8 @@ class OpenAIServingResponses(OpenAIServingChat):
         tokenizer: Any,
         request_metadata: RequestResponseMetadata,
         created_time: Optional[int] = None,
-        *args,
-        **kwargs,
+        *,
+        require_reasoning: bool,
     ):
         try:
             # Update the status to "in_progress"
@@ -1213,8 +1221,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 tokenizer,
                 request_metadata,
                 created_time,
-                *args,
-                **kwargs,
+                require_reasoning=require_reasoning,
             )
         except Exception as e:
             logger.exception("Background request failed for %s", request.request_id)
@@ -1304,6 +1311,8 @@ class OpenAIServingResponses(OpenAIServingChat):
         tokenizer: Any,
         request_metadata: RequestResponseMetadata,
         created_time: Optional[int] = None,
+        *,
+        require_reasoning: bool,
     ) -> AsyncGenerator[str, None]:
         # TODO:
         # 1. Handle disconnect
@@ -1710,6 +1719,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             tokenizer,
             request_metadata,
             created_time=created_time,
+            require_reasoning=require_reasoning,
         )
         # Convert final_response to the format expected by ResponseCompletedEvent
         response_dict = final_response.model_dump()
@@ -1748,6 +1758,8 @@ class OpenAIServingResponses(OpenAIServingChat):
         tokenizer: Any,
         request_metadata: RequestResponseMetadata,
         created_time: Optional[int] = None,
+        *,
+        require_reasoning: bool,
     ) -> AsyncGenerator[str, None]:
         """Stream a /v1/responses response as typed OpenAI SSE events for
         non-harmony models. Each engine chunk is run through the reasoning
@@ -1829,7 +1841,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             reasoning_parser_obj = ReasoningParser(
                 model_type=self.reasoning_parser,
                 stream_reasoning=True,
-                force_reasoning=self._is_thinking_enabled_for_request(request),
+                force_reasoning=require_reasoning,
                 request=request,
                 tokenizer=self.tokenizer_manager.tokenizer,
             )

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -334,11 +334,39 @@ class ServingChatTestCase(unittest.TestCase):
                 [],
                 [],
                 None,
+                require_reasoning=True,
             )
 
             adapted, _ = self.chat._convert_to_internal_request(req)
 
         self.assertTrue(adapted.require_reasoning)
+
+    def test_process_messages_records_template_reasoning_state(self):
+        self.chat.default_chat_template_kwargs = {"thinking": True}
+        self.template_manager.reasoning_config = ReasoningToggleConfig(
+            toggle_param="thinking", default_enabled=False
+        )
+        self.chat.reasoning_parser = "deepseek-v3"
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "What is 2+2?"}],
+        )
+        rendered = MessageProcessingResult(
+            prompt="prompt",
+            prompt_ids=[1, 2, 3],
+            image_data=None,
+            audio_data=None,
+            video_data=None,
+            modalities=[],
+            stop=[],
+        )
+
+        with patch.object(
+            self.chat, "_apply_conversation_template", return_value=rendered
+        ):
+            processed = self.chat._process_messages(request, is_multimodal=False)
+
+        self.assertTrue(processed.require_reasoning)
 
     def test_kimi_tool_call_respects_explicit_reasoning_disable(self):
         self.template_manager.reasoning_config = ReasoningToggleConfig(

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -18,6 +18,7 @@ from sglang.srt.entrypoints.openai.protocol import (
 )
 from sglang.srt.entrypoints.openai.serving_responses import OpenAIServingResponses
 from sglang.srt.function_call.core_types import ToolCallItem
+from sglang.srt.parser.template_detection import ReasoningToggleConfig
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=8, suite="base-a-test-cpu")
@@ -206,6 +207,70 @@ class ChatToolForwardingTestCase(unittest.TestCase):
         self.assertEqual(getattr(result, "status_code", None), 400)
 
 
+class ReasoningRequestForwardingTestCase(unittest.TestCase):
+    def test_create_responses_uses_processed_reasoning_state(self):
+        serving = make_serving()
+        serving.reasoning_parser = "deepseek-r1"
+        serving.default_chat_template_kwargs = {"thinking": False}
+        serving.template_manager.reasoning_config = ReasoningToggleConfig(
+            toggle_param="thinking", default_enabled=True
+        )
+        rendered = MessageProcessingResult(
+            prompt="prompt",
+            prompt_ids=[1, 2, 3],
+            image_data=None,
+            audio_data=None,
+            video_data=None,
+            modalities=[],
+            stop=[],
+        )
+        captured = {}
+
+        async def fake_generate(
+            request_id,
+            request_prompt,
+            adapted_request,
+            sampling_params,
+            context,
+            **kwargs,
+        ):
+            captured["adapted_request"] = adapted_request
+            context.append_output(
+                {
+                    "text": "done",
+                    "meta_info": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": 1,
+                        "cached_tokens": 0,
+                    },
+                }
+            )
+            yield context
+
+        serving._generate_with_builtin_tools = fake_generate
+        request = ResponsesRequest(
+            model="x",
+            input="answer",
+            request_id="resp_reasoning",
+            store=False,
+        )
+
+        with (
+            patch.object(
+                serving, "_apply_conversation_template", return_value=rendered
+            ),
+            patch(
+                "sglang.srt.entrypoints.openai.serving_responses.ReasoningParser"
+            ) as parser_cls,
+        ):
+            parser_cls.return_value.parse_non_stream.return_value = (None, "done")
+            response = asyncio.run(serving.create_responses(request))
+
+        self.assertEqual(response.status, "completed")
+        self.assertFalse(captured["adapted_request"].require_reasoning)
+        self.assertFalse(parser_cls.call_args.kwargs["force_reasoning"])
+
+
 class InputItemNormalizationTestCase(unittest.TestCase):
     def test_function_call_becomes_assistant_tool_call(self):
         normalized = OpenAIServingResponses._normalize_response_message_for_chat(
@@ -293,6 +358,7 @@ class FullResponseUsageTestCase(unittest.TestCase):
                 tokenizer=serving.tokenizer_manager.tokenizer,
                 request_metadata=metadata,
                 created_time=123,
+                require_reasoning=False,
             )
         )
 
@@ -405,6 +471,7 @@ class OutputItemsTestCase(unittest.TestCase):
                 self._function_tool_request(),
                 "raw model output with <tool_call>",
                 tokenizer=Mock(),
+                require_reasoning=False,
             )
 
         tool_calls = [
@@ -437,7 +504,10 @@ class OutputItemsTestCase(unittest.TestCase):
                 [fake_call],
             )
             output_items = serving._make_response_output_items(
-                self._function_tool_request(), "raw model output", tokenizer=Mock()
+                self._function_tool_request(),
+                "raw model output",
+                tokenizer=Mock(),
+                require_reasoning=False,
             )
 
         types = [type(item).__name__ for item in output_items]
@@ -462,7 +532,7 @@ class OutputItemsTestCase(unittest.TestCase):
         raw = '[{"name": "get_weather", "parameters": {"city": "Beijing"}}]'
 
         output_items = serving._make_response_output_items(
-            request, raw, tokenizer=Mock()
+            request, raw, tokenizer=Mock(), require_reasoning=False
         )
 
         tool_calls = [
@@ -497,7 +567,10 @@ class OutputItemsTestCase(unittest.TestCase):
             "sglang.srt.entrypoints.openai.serving_responses.FunctionCallParser"
         ) as parser_cls:
             output_items = serving._make_response_output_items(
-                request, "just a plain answer", tokenizer=Mock()
+                request,
+                "just a plain answer",
+                tokenizer=Mock(),
+                require_reasoning=False,
             )
             parser_cls.assert_not_called()
 

--- a/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses_stream.py
@@ -20,9 +20,10 @@ register_cpu_ci(est_time=4, suite="base-a-test-cpu")
 
 
 class _StreamFixture:
-    def __init__(self, serving, request):
+    def __init__(self, serving, request, *, require_reasoning=False):
         self.serving = serving
         self.request = request
+        self.require_reasoning = require_reasoning
         self.request_metadata = RequestResponseMetadata(request_id=request.request_id)
 
     def run(self, chunks):
@@ -39,6 +40,7 @@ class _StreamFixture:
                     model_name="x",
                     tokenizer=Mock(),
                     request_metadata=self.request_metadata,
+                    require_reasoning=self.require_reasoning,
                 )
             )
 
@@ -60,6 +62,20 @@ def _engine_chunk(text, completion_tokens, *, finish=False):
 
 
 class NonHarmonyStreamTestCase(unittest.TestCase):
+    def test_reasoning_parser_uses_processed_reasoning_state(self):
+        serving = make_serving()
+        serving.reasoning_parser = "deepseek-r1"
+        request = ResponsesRequest(model="x", input="hi", stream=True, store=False)
+
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_responses.ReasoningParser"
+        ) as parser_cls:
+            parser_cls.return_value.parse_stream_chunk.return_value = (None, "done")
+            fixture = _StreamFixture(serving, request, require_reasoning=True)
+            fixture.run([_engine_chunk("done", 1, finish=True)])
+
+        self.assertTrue(parser_cls.call_args.kwargs["force_reasoning"])
+
     def test_emits_typed_sse_events_in_order(self):
         serving = make_serving()
         serving.reasoning_parser = None

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -297,8 +297,6 @@ class TestKimiK2Detector(CustomTestCase):
 
 
 class TestKimiK3Detector(CustomTestCase):
-    """Test cases for the Kimi K3 XTML think channel detector."""
-
     TOOLS = (
         '<|open|>tools<|sep|><|open|>call tool="get_weather" index="1"<|sep|>'
         '<|open|>argument key="city" type="string"<|sep|>San Francisco'
@@ -320,24 +318,17 @@ class TestKimiK3Detector(CustomTestCase):
         )
 
     def test_unsealed_think_close_keeps_response_out_of_reasoning(self):
-        """Guard the /v1/responses regression where the think channel closed as
-        ``<|close|>think`` with no trailing ``<|sep|>``: the detector found no
-        think_end_token, so the whole response channel plus its raw markers were
-        emitted as reasoning_text and the assistant message vanished."""
         result = KimiK3Detector().detect_and_parse(self._unsealed())
         self.assertEqual(result.reasoning_text, self.THINK)
         self.assertEqual(result.normal_text, self.RESPONSE + self.TOOLS)
 
     def test_sealed_and_unsealed_agree(self):
-        """A well-formed close marker must parse identically to the degraded one."""
         sealed = KimiK3Detector().detect_and_parse(self._sealed())
         unsealed = KimiK3Detector().detect_and_parse(self._unsealed())
         self.assertEqual(sealed.reasoning_text, unsealed.reasoning_text)
         self.assertEqual(sealed.normal_text, unsealed.normal_text)
 
     def test_streaming_matches_non_streaming(self):
-        """Marker-straddling chunks must not leak a dangling ``<|close|>think``
-        into the streamed reasoning deltas."""
         for text in (self._sealed(), self._unsealed()):
             expected = KimiK3Detector().detect_and_parse(text)
             for chunk_size in (1, 7, 13):


### PR DESCRIPTION
## Summary

- Preserve the reasoning state resolved while applying the chat template.
- Reuse that state for constrained generation and non-streaming, streaming, and background Responses output parsing.
- Remove redundant parser-test docstrings and the obsolete `MessageProcessingResult` field documentation.

## Root cause

This is a follow-up to #32757. That fix forwards `require_reasoning`, but the Responses path recomputes it from `ResponsesRequest` after prompt preprocessing.

Server-level default chat-template kwargs are merged only while `_process_messages` builds and renders the corresponding chat request. Recomputing from the original Responses request cannot observe those resolved values. For example, a server default can disable thinking even when the template's own default is enabled, leaving the rendered prompt in chat mode while the grammar gate and output parser start in reasoning mode.

`MessageProcessingResult` now carries the resolved state so prompt rendering, generation, and response parsing share one source of truth.

## Validation

- `205 passed, 33 subtests passed` across the reasoning parser, Chat, Responses, and Responses streaming unit suites.
- `pre-commit` passed for all seven changed files.
- `py_compile` and `git diff --check` passed.
- 1x B300 serving smoke with public `Qwen/Qwen3-0.6B`, `--reasoning-parser qwen3`, and `--default-chat-template-kwargs '{"enable_thinking": false}'`:
  - non-streaming: completed assistant message `OK.`, zero reasoning tokens
  - streaming: ordered output-text events followed by `response.completed`, zero reasoning tokens
  - background: queued response reached completed assistant message `OK.`, zero reasoning tokens

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30446066378](https://github.com/sgl-project/sglang/actions/runs/30446066378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30446069099](https://github.com/sgl-project/sglang/actions/runs/30446069099)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->