### PR TITLE
[Router] Add optional admin auth for /flush_cache

### DIFF
--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -68,6 +68,7 @@ kube = { version = "0.96", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.23", features = ["v1_31"] }
 tokio-util = "0.7"
 uuid = { version = "1", features = ["v4"] }
+subtle = "2.6"
 
 # KV-event subsystem — msgpack-encoded events over ZMQ and sha256-based
 # block hashing matching SGLang's `radix_cache`.  Wire format authority is

--- a/experimental/sgl-router/README.md
+++ b/experimental/sgl-router/README.md
@@ -50,6 +50,28 @@ Omit `--service-discovery-namespace` to watch all namespaces (requires
 cluster-wide RBAC). For prefill/decode disaggregation, replace `--selector`
 with `--prefill-selector` and `--decode-selector`.
 
+## Admin Endpoints
+
+`POST /flush_cache` fans out SGLang's cache flush to every registered worker.
+For backward compatibility it is unauthenticated by default. To protect router
+admin calls, set `--admin-api-key` and send the key as a bearer token:
+
+```bash
+sgl-router \
+  --host 0.0.0.0 --port 30000 \
+  --model-id qwen3 \
+  --tokenizer-path /models/qwen3/tokenizer.json \
+  --worker-urls http://10.0.0.1:30000 \
+  --admin-api-key router-admin-secret
+
+curl -X POST \
+  -H 'Authorization: Bearer router-admin-secret' \
+  http://127.0.0.1:30000/flush_cache
+```
+
+This protects inbound requests to the router's admin endpoint. It is separate
+from any credentials the router may use for outbound requests to workers.
+
 ## License
 
 Apache-2.0.

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -11,7 +11,7 @@ use std::num::NonZeroU32;
 
 use crate::config::{
     default_cb_cool_down, default_proxy_request_timeout_secs, default_stale_request_timeout_secs,
-    resolve_mode, ActiveLoadConfig, CacheAwareConfig, CircuitBreakerConfig, Config,
+    resolve_mode, ActiveLoadConfig, AdminConfig, CacheAwareConfig, CircuitBreakerConfig, Config,
     DiscoveryBackend, K8sDiscoveryConfig, LogFormat, ModelConfig, ObservabilityConfig, PolicyKind,
     ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
 };
@@ -35,6 +35,12 @@ pub struct Cli {
     /// Port to bind the HTTP server to.
     #[arg(long, default_value_t = 30000)]
     pub port: u16,
+
+    // ---- admin ----
+    /// Admin API key for router admin endpoints such as `/flush_cache`.
+    /// When unset, admin endpoints remain unauthenticated.
+    #[arg(long)]
+    pub admin_api_key: Option<String>,
 
     // ---- model (exactly one) ----
     /// Model id this router serves (the OpenAI `model` field).
@@ -258,6 +264,9 @@ impl Cli {
                 log_level: self.log_level,
                 log_format: self.log_format,
             },
+            admin: AdminConfig {
+                api_key: self.admin_api_key,
+            },
             model: ModelConfig {
                 // Default the tokenizer source to the model id (treated as a
                 // HuggingFace repo id) when --tokenizer-path is omitted.
@@ -391,6 +400,51 @@ mod tests {
         assert_eq!(c.model.id, "qwen3-0.6b");
         assert_eq!(c.proxy.request_timeout_secs, 300);
         assert_eq!(c.active_load.stale_request_timeout_secs, 600);
+        assert!(c.admin.api_key.is_none());
+    }
+
+    #[test]
+    fn admin_api_key_flag_sets_admin_config() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://10.0.0.1:30000",
+            "--admin-api-key",
+            "router-secret",
+        ]))
+        .unwrap();
+        assert_eq!(c.admin.api_key.as_deref(), Some("router-secret"));
+    }
+
+    #[test]
+    fn rejects_empty_admin_api_key() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://10.0.0.1:30000",
+            "--admin-api-key",
+            "",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("admin.api_key must be non-empty"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_admin_api_key_with_surrounding_whitespace() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://10.0.0.1:30000",
+            "--admin-api-key",
+            " router-secret ",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("admin.api_key must not contain leading or trailing whitespace"),
+            "got: {err}"
+        );
     }
 
     /// With `--tokenizer-path` omitted, the tokenizer source defaults to the

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -15,6 +15,16 @@ impl Config {
         if self.model.id.is_empty() {
             return Err(anyhow!("model id must be non-empty"));
         }
+        if let Some(api_key) = &self.admin.api_key {
+            if api_key.trim().is_empty() {
+                return Err(anyhow!("admin.api_key must be non-empty"));
+            }
+            if api_key.trim() != api_key {
+                return Err(anyhow!(
+                    "admin.api_key must not contain leading or trailing whitespace"
+                ));
+            }
+        }
         match &self.discovery {
             DiscoveryBackend::StaticUrls(s) => {
                 if s.urls.is_empty() {
@@ -94,6 +104,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            admin: AdminConfig::default(),
         }
     }
 
@@ -109,6 +120,35 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("model id"), "got: {err}");
+    }
+
+    #[test]
+    fn accepts_admin_api_key() {
+        let mut cfg = cfg("qwen3", &["http://10.0.0.1:30000"]);
+        cfg.admin.api_key = Some("router-secret".to_string());
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_admin_api_key() {
+        let mut cfg = cfg("qwen3", &["http://10.0.0.1:30000"]);
+        cfg.admin.api_key = Some("".to_string());
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("admin.api_key must be non-empty"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_admin_api_key_with_surrounding_whitespace() {
+        let mut cfg = cfg("qwen3", &["http://10.0.0.1:30000"]);
+        cfg.admin.api_key = Some(" router-secret ".to_string());
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("admin.api_key must not contain leading or trailing whitespace"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -7,6 +7,7 @@ use std::num::NonZeroU32;
 pub struct Config {
     pub server: ServerConfig,
     pub observability: ObservabilityConfig,
+    pub admin: AdminConfig,
     pub model: ModelConfig,
     /// Selected discovery backend. Built from CLI flags by
     /// [`crate::config::cli::Cli::into_config`]: the static-vs-k8s choice
@@ -16,6 +17,14 @@ pub struct Config {
     pub discovery: DiscoveryBackend,
     pub proxy: ProxyConfig,
     pub active_load: ActiveLoadConfig,
+}
+
+/// Inbound router-admin authentication. When `api_key` is unset, admin
+/// endpoints keep their legacy unauthenticated behavior; when set, callers
+/// must present `Authorization: Bearer <api_key>`.
+#[derive(Debug, Clone, Default)]
+pub struct AdminConfig {
+    pub api_key: Option<String>,
 }
 
 /// Outbound proxy tuning. Default mirrors SGLang's typical prefill /

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -308,6 +308,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            admin: crate::config::AdminConfig::default(),
         };
         Arc::new(TokenizerRegistry::load_from_config(&cfg).expect("load tiny tokenizer"))
     }

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -178,6 +178,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            admin: crate::config::AdminConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/server/admin_auth.rs
+++ b/experimental/sgl-router/src/server/admin_auth.rs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Authentication helpers for inbound router-admin endpoints.
+
+use axum::http::{header::AUTHORIZATION, HeaderMap};
+use subtle::ConstantTimeEq;
+
+/// Returns whether a request is authorized for router-admin endpoints.
+///
+/// `expected_api_key = None` preserves the legacy behavior: admin endpoints
+/// are open unless an operator explicitly configures a router admin key.
+pub fn is_admin_authorized(headers: &HeaderMap, expected_api_key: Option<&str>) -> bool {
+    let Some(expected_api_key) = expected_api_key else {
+        return true;
+    };
+
+    let Some(header) = headers.get(AUTHORIZATION) else {
+        return false;
+    };
+    let Ok(header) = header.to_str() else {
+        return false;
+    };
+    let Some((scheme, token)) = header.split_once(' ') else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return false;
+    }
+
+    token.as_bytes().ct_eq(expected_api_key.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_authorization(value: HeaderValue) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, value);
+        headers
+    }
+
+    fn headers_with_authorization_str(value: &str) -> HeaderMap {
+        headers_with_authorization(HeaderValue::from_str(value).unwrap())
+    }
+
+    #[test]
+    fn no_configured_key_allows_missing_header() {
+        assert!(is_admin_authorized(&HeaderMap::new(), None));
+    }
+
+    #[test]
+    fn configured_key_rejects_missing_header() {
+        assert!(!is_admin_authorized(&HeaderMap::new(), Some("secret")));
+    }
+
+    #[test]
+    fn configured_key_accepts_exact_bearer_token() {
+        let headers = headers_with_authorization_str("Bearer secret");
+        assert!(is_admin_authorized(&headers, Some("secret")));
+    }
+
+    #[test]
+    fn configured_key_accepts_case_insensitive_bearer_scheme() {
+        let headers = headers_with_authorization_str("bEaReR secret");
+        assert!(is_admin_authorized(&headers, Some("secret")));
+    }
+
+    #[test]
+    fn configured_key_rejects_wrong_scheme() {
+        let headers = headers_with_authorization_str("Basic secret");
+        assert!(!is_admin_authorized(&headers, Some("secret")));
+    }
+
+    #[test]
+    fn configured_key_rejects_malformed_authorization() {
+        let headers = headers_with_authorization_str("secret");
+        assert!(!is_admin_authorized(&headers, Some("secret")));
+    }
+
+    #[test]
+    fn configured_key_rejects_wrong_token() {
+        let headers = headers_with_authorization_str("Bearer wrong");
+        assert!(!is_admin_authorized(&headers, Some("secret")));
+    }
+
+    #[test]
+    fn configured_key_rejects_token_with_extra_spaces() {
+        let leading = headers_with_authorization_str("Bearer  secret");
+        let trailing = headers_with_authorization_str("Bearer secret ");
+        assert!(!is_admin_authorized(&leading, Some("secret")));
+        assert!(!is_admin_authorized(&trailing, Some("secret")));
+    }
+
+    #[test]
+    fn configured_key_rejects_non_visible_ascii_header() {
+        let headers = headers_with_authorization(HeaderValue::from_bytes(b"Bearer \xff").unwrap());
+        assert!(!is_admin_authorized(&headers, Some("secret")));
+    }
+}

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -120,6 +120,7 @@ impl AppContext {
                 ),
                 proxy: crate::config::ProxyConfig::default(),
                 active_load: crate::config::ActiveLoadConfig::default(),
+                admin: crate::config::AdminConfig::default(),
             },
             tokenizers: Arc::new(TokenizerRegistry::default()),
             proxy: Arc::new(Proxy::new(std::time::Duration::from_secs(60)).expect("stub proxy")),

--- a/experimental/sgl-router/src/server/error.rs
+++ b/experimental/sgl-router/src/server/error.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::http::{header::WWW_AUTHENTICATE, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::Serialize;
@@ -11,6 +11,9 @@ pub const X_ROUTER_ERROR_CODE: HeaderName = HeaderName::from_static("x-router-er
 
 #[derive(Debug, Error)]
 pub enum ApiError {
+    #[error("unauthorized")]
+    Unauthorized,
+
     #[error("bad request: {0}")]
     BadRequest(String),
 
@@ -113,6 +116,7 @@ pub enum ApiError {
 impl ApiError {
     fn status_and_code(&self) -> (StatusCode, &'static str) {
         match self {
+            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized"),
             ApiError::BadRequest(_) => (StatusCode::BAD_REQUEST, "bad_request"),
             ApiError::ModelNotFound(_) => (StatusCode::NOT_FOUND, "model_not_found"),
             ApiError::UpstreamUnreachable { .. } => {
@@ -245,6 +249,7 @@ impl IntoResponse for ApiError {
                 );
                 "service unavailable".to_string()
             }
+            ApiError::Unauthorized => "unauthorized".to_string(),
             ApiError::BadRequest(_) | ApiError::ModelNotFound(_) => self.to_string(),
         };
         let mut resp = (
@@ -256,6 +261,10 @@ impl IntoResponse for ApiError {
             .into_response();
         resp.headers_mut()
             .insert(X_ROUTER_ERROR_CODE, HeaderValue::from_static(code));
+        if status == StatusCode::UNAUTHORIZED {
+            resp.headers_mut()
+                .insert(WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+        }
         resp
     }
 }
@@ -388,6 +397,24 @@ mod tests {
         );
         assert_ne!(env.error.code, "internal_error");
         assert_ne!(env.error.code, "model_not_found");
+    }
+
+    #[test]
+    fn unauthorized_envelope_has_expected_shape_and_challenge() {
+        let resp = ApiError::Unauthorized.into_response();
+        assert_eq!(
+            resp.headers()
+                .get("www-authenticate")
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer"),
+        );
+        let (status, code_header, env) = parse_envelope(resp);
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(code_header.as_deref(), Some("unauthorized"));
+        assert_eq!(env.error.code, "unauthorized");
+        assert_eq!(env.error.typ, "invalid_request_error");
+        assert_eq!(env.error.message, "unauthorized");
     }
 
     #[test]

--- a/experimental/sgl-router/src/server/mod.rs
+++ b/experimental/sgl-router/src/server/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod admin_auth;
 pub mod app;
 pub mod app_context;
 pub mod error;

--- a/experimental/sgl-router/src/server/routes/cache.rs
+++ b/experimental/sgl-router/src/server/routes/cache.rs
@@ -3,10 +3,12 @@
 
 //! Cache-management admin endpoints.
 
+use crate::server::admin_auth::is_admin_authorized;
 use crate::server::app_context::AppContext;
+use crate::server::error::ApiError;
 use crate::workers::worker::Worker;
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures::stream::{self, StreamExt};
@@ -84,7 +86,11 @@ impl FlushCacheResult {
 /// Status: `200 OK` when every worker flushed successfully (or the fleet is
 /// empty); `502 BAD_GATEWAY` when at least one worker failed. The JSON body
 /// always carries the full breakdown so a partial failure is actionable.
-pub async fn flush_cache(State(ctx): State<Arc<AppContext>>) -> Response {
+pub async fn flush_cache(headers: HeaderMap, State(ctx): State<Arc<AppContext>>) -> Response {
+    if !is_admin_authorized(&headers, ctx.config.admin.api_key.as_deref()) {
+        return ApiError::Unauthorized.into_response();
+    }
+
     let workers = ctx.registry.all();
     let total_workers = workers.len();
 
@@ -187,11 +193,12 @@ mod tests {
     use crate::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
     use crate::server::app_context::AppContext;
     use axum::body::Body;
-    use axum::http::Request;
+    use axum::http::{header::AUTHORIZATION, HeaderValue, Request};
     use axum::routing::post;
     use axum::Router;
     use http_body_util::BodyExt;
     use serde_json::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::net::TcpListener;
     use tokio::sync::oneshot;
     use tower::ServiceExt;
@@ -213,6 +220,35 @@ mod tests {
         (format!("http://127.0.0.1:{port}"), tx)
     }
 
+    /// Spawn a fake worker that records how many flushes reached it.
+    async fn spawn_counting_flush_worker(
+        status: StatusCode,
+    ) -> (String, Arc<AtomicUsize>, oneshot::Sender<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let hits = Arc::new(AtomicUsize::new(0));
+        let route_hits = Arc::clone(&hits);
+        let app = Router::new().route(
+            "/flush_cache",
+            post(move || {
+                let route_hits = Arc::clone(&route_hits);
+                async move {
+                    route_hits.fetch_add(1, Ordering::SeqCst);
+                    status
+                }
+            }),
+        );
+        let (tx, rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = rx.await;
+                })
+                .await;
+        });
+        (format!("http://127.0.0.1:{port}"), hits, tx)
+    }
+
     /// Reserve a port then drop the listener so a connect attempt fails fast
     /// with ConnectionRefused (no waiting on the connect timeout).
     fn unused_port() -> u16 {
@@ -221,8 +257,12 @@ mod tests {
         l.local_addr().unwrap().port()
     }
 
-    fn ctx_with_workers(urls: &[&str]) -> Arc<AppContext> {
-        let ctx = AppContext::stub();
+    fn ctx_with_workers_and_admin_key(
+        urls: &[&str],
+        admin_api_key: Option<&str>,
+    ) -> Arc<AppContext> {
+        let mut ctx = AppContext::stub();
+        ctx.config.admin.api_key = admin_api_key.map(str::to_string);
         for (i, url) in urls.iter().enumerate() {
             ctx.registry
                 .add(WorkerSpec {
@@ -237,22 +277,37 @@ mod tests {
         Arc::new(ctx)
     }
 
-    async fn post_flush(ctx: Arc<AppContext>) -> (StatusCode, Value) {
+    fn ctx_with_workers(urls: &[&str]) -> Arc<AppContext> {
+        ctx_with_workers_and_admin_key(urls, None)
+    }
+
+    fn ctx_with_admin_key(admin_api_key: &str) -> Arc<AppContext> {
+        let mut ctx = AppContext::stub();
+        ctx.config.admin.api_key = Some(admin_api_key.to_string());
+        Arc::new(ctx)
+    }
+
+    async fn post_flush_with_authorization(
+        ctx: Arc<AppContext>,
+        authorization: Option<&str>,
+    ) -> (StatusCode, Value) {
         let app = crate::server::app::build_router(ctx);
+        let mut builder = Request::builder().method("POST").uri("/flush_cache");
+        if let Some(authorization) = authorization {
+            builder = builder.header(AUTHORIZATION, HeaderValue::from_str(authorization).unwrap());
+        }
         let res = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/flush_cache")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(builder.body(Body::empty()).unwrap())
             .await
             .unwrap();
         let status = res.status();
         let bytes = res.into_body().collect().await.unwrap().to_bytes();
         let body: Value = serde_json::from_slice(&bytes).unwrap();
         (status, body)
+    }
+
+    async fn post_flush(ctx: Arc<AppContext>) -> (StatusCode, Value) {
+        post_flush_with_authorization(ctx, None).await
     }
 
     #[tokio::test]
@@ -290,6 +345,70 @@ mod tests {
         assert_eq!(body["total_workers"], 0);
         assert!(body["successful"].as_array().unwrap().is_empty());
         assert!(body["failed"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn admin_key_requires_authorization_before_fanout() {
+        let (url, hits, _s) = spawn_counting_flush_worker(StatusCode::OK).await;
+        let (status, body) = post_flush(ctx_with_workers_and_admin_key(
+            &[&url],
+            Some("router-secret"),
+        ))
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"]["code"], "unauthorized");
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn admin_key_rejects_wrong_authorization_before_fanout() {
+        let (url, hits, _s) = spawn_counting_flush_worker(StatusCode::OK).await;
+        let (status, body) = post_flush_with_authorization(
+            ctx_with_workers_and_admin_key(&[&url], Some("router-secret")),
+            Some("Bearer wrong"),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"]["code"], "unauthorized");
+        assert_eq!(hits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn admin_key_accepts_bearer_authorization() {
+        let (url, hits, _s) = spawn_counting_flush_worker(StatusCode::OK).await;
+        let (status, body) = post_flush_with_authorization(
+            ctx_with_workers_and_admin_key(&[&url], Some("router-secret")),
+            Some("Bearer router-secret"),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total_workers"], 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn admin_key_accepts_case_insensitive_bearer_scheme() {
+        let (url, hits, _s) = spawn_counting_flush_worker(StatusCode::OK).await;
+        let (status, body) = post_flush_with_authorization(
+            ctx_with_workers_and_admin_key(&[&url], Some("router-secret")),
+            Some("bEaReR router-secret"),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["total_workers"], 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn admin_key_protects_empty_registry_before_zero_worker_success() {
+        let (status, body) = post_flush(ctx_with_admin_key("router-secret")).await;
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["error"]["code"], "unauthorized");
     }
 
     #[tokio::test]

--- a/experimental/sgl-router/src/server/routes/tokenize.rs
+++ b/experimental/sgl-router/src/server/routes/tokenize.rs
@@ -129,6 +129,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            admin: crate::config::AdminConfig::default(),
         };
         let registry = crate::tokenizer::TokenizerRegistry::load_from_config(&cfg).unwrap();
         let proxy = Arc::new(

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -243,6 +243,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            admin: crate::config::AdminConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -487,6 +487,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            admin: crate::config::AdminConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/tests/component/discovery/static_urls.rs
+++ b/experimental/sgl-router/tests/component/discovery/static_urls.rs
@@ -139,6 +139,7 @@ async fn static_urls_pd_role_resolved_end_to_end() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     };
 
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -80,6 +80,7 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
         ),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
 

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -60,6 +60,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -43,6 +43,7 @@ fn config_for(_worker_url: &str) -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/failover.rs
+++ b/experimental/sgl-router/tests/proxy/failover.rs
@@ -47,6 +47,7 @@ async fn failover_when_one_worker_dies() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: AdminConfig::default(),
     };
 
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -53,6 +53,7 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -40,6 +40,7 @@ async fn forwards_whitelisted_headers_strips_others() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -55,6 +55,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -54,6 +54,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -51,6 +51,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -70,6 +70,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -56,6 +56,7 @@ fn build_sticky_ctx(header_name: &str, worker_urls: &[String]) -> Arc<AppContext
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -47,6 +47,7 @@ fn config(_worker_url: &str) -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        admin: sgl_router::config::AdminConfig::default(),
     }
 }
 


### PR DESCRIPTION
## Motivation

`experimental/sgl-router` currently allows any caller that can reach the router to call `POST /flush_cache`, which then fans out a cache flush request to every registered worker.

This PR adds optional inbound admin authentication for the router admin endpoint while preserving backward compatibility: if no admin key is configured, `/flush_cache` behaves as before.

Closes #32772.

## Modifications

- Add `AdminConfig` and a new CLI flag: `--admin-api-key`.
- Validate that configured admin keys are non-empty and do not contain leading/trailing whitespace.
- Add a router admin auth helper that checks `Authorization: Bearer <key>`.
- Protect `POST /flush_cache` before worker lookup/fan-out.
- Return a structured `401 unauthorized` response with:
  - `x-router-error-code: unauthorized`
  - `WWW-Authenticate: Bearer`
- Add unit tests for:
  - default unauthenticated compatibility
  - valid bearer auth
  - missing/wrong/malformed auth rejection
  - unauthorized requests not reaching workers
- Document the new flag in `experimental/sgl-router/README.md`.

## Accuracy Tests

N/A. This PR only changes router admin endpoint authentication and does not affect model outputs.

## Speed Tests and Profiling

N/A. This PR only adds a small auth check on `/flush_cache`, which is an admin endpoint and not on the inference hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). N/A: no model output or inference-speed impact.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Validation run locally:

- `cargo fmt -- --check`
- `git diff --check`
- `cargo check --all-targets`
- `cargo test --lib admin -- --nocapture`
- `cargo test --lib server::routes::cache -- --nocapture`
- `cargo test --lib server::error -- --nocapture`
- `cargo test --test component`
- `cargo test --bins`

Note: two unrelated tests also fail on the clean baseline commit in this local environment:

- `policies::kv_events::subscriber::tests::dp_size_eight_per_worker`
- `graceful_shutdown::shutdown_drains_100_inflight_streaming_chat_completions`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30447660844](https://github.com/sgl-project/sglang/actions/runs/30447660844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30447660699](https://github.com/sgl-project/sglang/actions/runs/30447660699)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->