### PR TITLE
Add a consecutive-prefill budget to bound decode starvation

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1027,6 +1027,11 @@ class Scheduler(
         self.waiting_queue: List[Req] = []
         # The running decoding batch for continuous batching
         self.running_batch: ScheduleBatch = ScheduleBatch(reqs=[], batch_is_full=False)
+        # Fairness state for bounding decode starvation under sustained prefill load.
+        self.max_consecutive_prefill_batches = (
+            self.server_args.max_consecutive_prefill_batches
+        )
+        self.consecutive_prefill_batches = 0
         # The current forward batch
         self.cur_batch_for_debug: Optional[ScheduleBatch] = None
         # The last forward batch
@@ -2853,8 +2858,25 @@ class Scheduler(
             if running_batch.is_empty():
                 running_batch.batch_is_full = False
 
+        prefill_decode_fairness_enabled = (
+            self.dllm_config is None and self.max_consecutive_prefill_batches > 0
+        )
+        decode_is_runnable = (
+            prefill_decode_fairness_enabled
+            and not running_batch.is_empty()
+            and not running_batch.is_prefill_only
+        )
+        force_decode = (
+            decode_is_runnable
+            # A partially processed request must continue its next chunk.
+            and self.chunked_req is None
+            and self.consecutive_prefill_batches >= self.max_consecutive_prefill_batches
+        )
+
         if self.dllm_config is not None:
             new_batch = self.get_new_batch_dllm(running_batch)
+        elif force_decode:
+            new_batch = None
         else:
             prefill_plan = self.get_new_batch_prefill(running_batch)
             new_batch = prefill_plan.batch_to_run
@@ -2876,13 +2898,21 @@ class Scheduler(
         if new_batch is not None:
             # Run prefill first if possible
             ret = new_batch
+            if prefill_decode_fairness_enabled:
+                if decode_is_runnable and not new_batch.decoding_reqs:
+                    self.consecutive_prefill_batches += 1
+                else:
+                    self.consecutive_prefill_batches = 0
         else:
             # Run decode (skip for prefill-only batches)
             if not running_batch.is_empty() and not running_batch.is_prefill_only:
                 running_batch = self.update_running_batch(running_batch)
                 ret = running_batch if not running_batch.is_empty() else None
+                if ret is not None:
+                    self.consecutive_prefill_batches = 0
             else:
                 ret = None
+                self.consecutive_prefill_batches = 0
 
         # Handle DP attention and log stats
         ret = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -790,6 +790,17 @@ class ServerArgs:
         "The maximum number of requests in a prefill batch. If not specified, there is no limit.",
         NS("schedule"),
     ] = None
+    max_consecutive_prefill_batches: A[
+        int,
+        (
+            "The maximum number of consecutive pure prefill batches that may run "
+            "while a decode batch is waiting to run. After this many prefills, "
+            "the scheduler runs one decode batch before admitting more prefills. "
+            "An active chunked request is allowed to finish its next chunk. Set "
+            "to 0 to disable this fairness limit."
+        ),
+        NS("schedule"),
+    ] = 0
     schedule_policy: A[
         str,
         Arg(
@@ -8320,6 +8331,11 @@ class ServerArgs:
                 "(DeepSeek-V4 non-EP DP TBO path)."
             )
 
+    def _validate_max_consecutive_prefill_batches(self) -> None:
+        assert (
+            self.max_consecutive_prefill_batches >= 0
+        ), "--max-consecutive-prefill-batches must be non-negative."
+
     def check_server_args(self):
         # Check parallel size constraints
         if self.ep_join_mode != "scale":
@@ -8424,6 +8440,7 @@ class ServerArgs:
         )
 
         # Check scheduling policy
+        self._validate_max_consecutive_prefill_batches()
         if self.enable_priority_scheduling:
             assert self.schedule_policy in [
                 "fcfs",

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -105,6 +105,8 @@ def _scheduler_for_get_next_batch(*, tree_cache, chunked_req) -> Scheduler:
     s.tree_cache = tree_cache
     s.chunked_req = chunked_req
     s._pending_chunked_abort_req = None
+    s.max_consecutive_prefill_batches = 0
+    s.consecutive_prefill_batches = 0
     return s
 
 

--- a/test/registered/unit/managers/test_scheduler_prefill_decode_fairness.py
+++ b/test/registered/unit/managers/test_scheduler_prefill_decode_fairness.py
@@ -1,0 +1,156 @@
+"""Regression tests for decode starvation under sustained prefill load (#32549)."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import NextBatchPlan
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _batch(*, empty: bool, prefill_only: bool = False, decoding_reqs=None):
+    batch = MagicMock()
+    batch.is_empty.return_value = empty
+    batch.is_prefill_only = prefill_only
+    batch.batch_is_full = False
+    batch.reqs = [] if empty else [object()]
+    batch.decoding_reqs = decoding_reqs
+    return batch
+
+
+def _scheduler(*, max_consecutive_prefills: int, speculative: bool) -> Scheduler:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._abort_on_waiting_timeout = MagicMock()
+    scheduler._abort_on_running_timeout = MagicMock()
+    scheduler.dllm_config = None
+    scheduler.dllm_manager = None
+    scheduler.enable_hisparse = False
+    scheduler.enable_fpm = False
+    scheduler.require_mlp_sync = speculative
+    scheduler.spec_algorithm = MagicMock()
+    scheduler.spec_algorithm.is_none.return_value = not speculative
+    scheduler.server_args = SimpleNamespace(speculative_skip_dp_mlp_sync=False)
+    scheduler.dp_attn_adapter = MagicMock()
+    scheduler.dp_attn_adapter.maybe_prepare_mlp_sync_batch.side_effect = (
+        lambda batch, **_: batch
+    )
+    scheduler.ngram_embedding_manager = MagicMock()
+    scheduler.ngram_embedding_manager.prepare_for_forward.side_effect = (
+        lambda batch, **_: batch
+    )
+    scheduler.update_running_batch = MagicMock(side_effect=lambda batch: batch)
+    scheduler.tree_cache = MagicMock()
+    scheduler.chunked_req = None
+    scheduler._pending_chunked_abort_req = None
+    scheduler.is_mixed_chunk = False
+    scheduler.max_consecutive_prefill_batches = max_consecutive_prefills
+    scheduler.consecutive_prefill_batches = 0
+    return scheduler
+
+
+class TestPrefillDecodeFairness(CustomTestCase):
+    def _assert_bounded_prefill_streak(self, *, speculative: bool):
+        scheduler = _scheduler(max_consecutive_prefills=2, speculative=speculative)
+        running_batch = _batch(empty=False)
+        prefill_batch = _batch(empty=False)
+        scheduler.get_new_batch_prefill = MagicMock(
+            side_effect=lambda running: NextBatchPlan(
+                batch_to_run=prefill_batch, running_batch=running
+            )
+        )
+
+        selected = []
+        for _ in range(6):
+            plan = Scheduler.get_next_batch_to_run(
+                scheduler, running_batch=running_batch, last_batch=None
+            )
+            selected.append(
+                "decode" if plan.batch_to_run is running_batch else "prefill"
+            )
+
+        self.assertEqual(
+            selected,
+            ["prefill", "prefill", "decode", "prefill", "prefill", "decode"],
+        )
+        self.assertEqual(scheduler.get_new_batch_prefill.call_count, 4)
+
+    def test_bounds_prefill_streak(self):
+        self._assert_bounded_prefill_streak(speculative=False)
+
+    def test_bounds_prefill_streak_with_speculative_decode(self):
+        self._assert_bounded_prefill_streak(speculative=True)
+
+    def test_zero_disables_fairness_limit(self):
+        scheduler = _scheduler(max_consecutive_prefills=0, speculative=True)
+        running_batch = _batch(empty=False)
+        prefill_batch = _batch(empty=False)
+        scheduler.get_new_batch_prefill = MagicMock(
+            side_effect=lambda running: NextBatchPlan(
+                batch_to_run=prefill_batch, running_batch=running
+            )
+        )
+
+        selected = [
+            Scheduler.get_next_batch_to_run(
+                scheduler, running_batch=running_batch, last_batch=None
+            ).batch_to_run
+            for _ in range(4)
+        ]
+
+        self.assertTrue(all(batch is prefill_batch for batch in selected))
+        self.assertEqual(scheduler.consecutive_prefill_batches, 0)
+
+    def test_active_chunked_request_continues_prefill(self):
+        scheduler = _scheduler(max_consecutive_prefills=1, speculative=True)
+        scheduler.consecutive_prefill_batches = 1
+        scheduler.chunked_req = MagicMock()
+        scheduler.chunked_req.extend_range.end = 0
+        scheduler.chunked_req.prefix_indices = []
+        running_batch = _batch(empty=False)
+        prefill_batch = _batch(empty=False)
+        scheduler.get_new_batch_prefill = MagicMock(
+            return_value=NextBatchPlan(
+                batch_to_run=prefill_batch, running_batch=running_batch
+            )
+        )
+
+        plan = Scheduler.get_next_batch_to_run(
+            scheduler, running_batch=running_batch, last_batch=None
+        )
+
+        self.assertIs(plan.batch_to_run, prefill_batch)
+
+        scheduler.chunked_req = None
+        plan = Scheduler.get_next_batch_to_run(
+            scheduler, running_batch=running_batch, last_batch=None
+        )
+        self.assertIs(plan.batch_to_run, running_batch)
+
+    def test_mixed_prefill_that_advances_decode_resets_streak(self):
+        scheduler = _scheduler(max_consecutive_prefills=1, speculative=False)
+        scheduler.is_mixed_chunk = True
+        running_batch = _batch(empty=False)
+        mixed_batch = _batch(empty=False, decoding_reqs=[object()])
+        scheduler.get_new_batch_prefill = MagicMock(
+            return_value=NextBatchPlan(
+                batch_to_run=mixed_batch, running_batch=running_batch
+            )
+        )
+
+        plan = Scheduler.get_next_batch_to_run(
+            scheduler, running_batch=running_batch, last_batch=None
+        )
+
+        self.assertIs(plan.batch_to_run, mixed_batch)
+        self.assertEqual(scheduler.consecutive_prefill_batches, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -66,6 +66,26 @@ class TestPrepareServerArgs(CustomTestCase):
             os.unlink(config_file)
 
 
+class TestMaxConsecutivePrefillBatchesArgs(CustomTestCase):
+    def test_accepts_non_negative_budget(self):
+        for budget in (0, 2):
+            with self.subTest(budget=budget):
+                server_args = ServerArgs(
+                    model_path="dummy",
+                    max_consecutive_prefill_batches=budget,
+                )
+                server_args._validate_max_consecutive_prefill_batches()
+
+    def test_rejects_negative_budget(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            max_consecutive_prefill_batches=-1,
+        )
+
+        with self.assertRaisesRegex(AssertionError, "must be non-negative"):
+            server_args._validate_max_consecutive_prefill_batches()
+
+
 class TestMultimodalFeatureTransport(CustomTestCase):
     @patch("sglang.srt.server_args.is_cuda", return_value=True)
     def test_cuda_ipc_is_explicit_and_bounded(self, _mock_is_cuda):


### PR DESCRIPTION
## Motivation

Addresses #32549.

Under a sustained open-loop stream of long prompts, `get_next_batch_to_run()` can keep selecting newly admitted chunked-prefill batches while a resident decode batch waits. The issue reports 2,863 prefills versus 36–38 decodes over 15 minutes at heavy load, or roughly one decode batch every 24 seconds.

#31395 is closely related, but its interleave budget applies after mixed-chunk prefills and requires `--enable-mixed-chunk`. Speculative decoding currently disables mixed chunking, so it does not cover the DSPARK/EAGLE configuration in #32549. This change adds a complementary escape hatch for consecutive pure-prefill batches.

## Modifications

- Add `--max-consecutive-prefill-batches` under the scheduling arguments.
  - `0` keeps the existing behavior and is the default.
  - A positive value forces one runnable decode batch after that many consecutive pure-prefill batches.
- Do not interrupt an active chunked request; its next chunk remains eligible before the forced decode.
- Do not count a mixed prefill that already carries decoding requests as a decode-starving prefill.
- Short-circuit the fairness bookkeeping when the option is disabled.
- Add scheduler state-machine coverage for normal and speculative decode, the disabled behavior, active chunks, and mixed batches.
- Add argument validation coverage and initialize the new state in the existing `Scheduler.__new__` test fixture.

## Accuracy Tests

Not applicable. This changes batch selection order but not model forward logic, sampling, or token computation.

## Speed Tests and Profiling

Serving benchmarks are pending, which is why this PR is a draft.

I attempted to prepare the available L40S host, but its reusable runtime is a vLLM environment with incompatible SGLang/FlashInfer/CUTLASS components and could not launch the current SGLang serving stack. No throughput or latency result is claimed from that host.

The intended benchmark is the #32549 open-loop workload with the budget disabled and with representative values such as `1`, `2`, and `4`, using both DSPARK and EAGLE where compatible. Results should include request/output throughput, TTFT, TPOT, p95/p99 and worst-case inter-token gap, and prefill/decode batch counts. The implementation keeps the default policy unchanged and gates the additional batch-state checks behind the opt-in value.

## Tests

- `uvx pre-commit run --files <five changed files>` — passed
- `python -m pytest -q test/registered/unit/managers/test_scheduler_prefill_decode_fairness.py test/registered/unit/managers/test_scheduler_chunked_req_gate.py test/registered/unit/server_args/test_server_args.py::TestMaxConsecutivePrefillBatchesArgs` — 10 passed, 2 subtests passed
- `python -m compileall -q <changed Python files>` — passed

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). The new CLI argument includes its user-facing help and default in `ServerArgs`.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy is not applicable; serving speed/latency results are pending.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30456277077](https://github.com/sgl-project/sglang/actions/runs/30456277077)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30456276445](https://github.com/sgl-project/sglang/actions/runs/30456276445)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->