### PR TITLE
fix: guard paged allocator before kernel launch

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -190,6 +190,15 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         ):
             self.merge_and_sort_free()
 
+        if num_new_pages is None:
+            num_new_pages = get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=self.page_size,
+                prefix_lens=prefix_lens_cpu,
+            )
+        if num_new_pages > len(self.free_pages):
+            return None
+
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
@@ -206,15 +215,6 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
-
-        if num_new_pages is None:
-            num_new_pages = get_num_new_pages(
-                seq_lens=seq_lens_cpu,
-                page_size=self.page_size,
-                prefix_lens=prefix_lens_cpu,
-            )
-        if num_new_pages > len(self.free_pages):
-            return None
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices
@@ -234,6 +234,14 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if self.need_sort and bs > len(self.free_pages):
             self.merge_and_sort_free()
 
+        num_new_pages = get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=self.page_size,
+            decode=True,
+        )
+        if num_new_pages > len(self.free_pages):
+            return None
+
         out_indices = torch.empty((bs,), dtype=torch.int64, device=self.device)
         alloc_decode_kernel[(bs,)](
             seq_lens,
@@ -246,14 +254,6 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
-
-        num_new_pages = get_num_new_pages(
-            seq_lens=seq_lens_cpu,
-            page_size=self.page_size,
-            decode=True,
-        )
-        if num_new_pages > len(self.free_pages):
-            return None
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices

--- a/test/registered/unit/mem_cache/test_paged_allocator_oom_gate.py
+++ b/test/registered/unit/mem_cache/test_paged_allocator_oom_gate.py
@@ -1,0 +1,76 @@
+"""Regression tests for paged allocator OOM gating."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+PAGE_SIZE = 4
+
+
+class _UnexpectedKernelLaunch:
+    def __getitem__(self, _):
+        raise AssertionError("the allocator must reject OOM before launching Triton")
+
+
+def _make_allocator() -> PagedTokenToKVPoolAllocator:
+    return PagedTokenToKVPoolAllocator(
+        size=PAGE_SIZE,
+        page_size=PAGE_SIZE,
+        dtype=torch.float16,
+        device="cpu",
+        kvcache=None,
+        need_sort=False,
+    )
+
+
+class TestPagedAllocatorOOMGate(CustomTestCase):
+    def test_extend_rejects_insufficient_pages_before_kernel_launch(self):
+        """An oversized prefill returns OOM without reading past the free-page list."""
+        allocator = _make_allocator()
+        prefix_lens = torch.tensor([0], dtype=torch.int64)
+        seq_lens = torch.tensor([2 * PAGE_SIZE], dtype=torch.int64)
+
+        with patch(
+            "sglang.srt.mem_cache.allocator.paged.alloc_extend_kernel",
+            _UnexpectedKernelLaunch(),
+        ):
+            result = allocator.alloc_extend(
+                prefix_lens=prefix_lens,
+                prefix_lens_cpu=prefix_lens,
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens,
+                last_loc=torch.tensor([-1], dtype=torch.int64),
+                extend_num_tokens=2 * PAGE_SIZE,
+            )
+
+        self.assertIsNone(result)
+
+    def test_decode_rejects_insufficient_pages_before_kernel_launch(self):
+        """A page-wrapping decode returns OOM without reading past the free-page list."""
+        allocator = _make_allocator()
+        allocated = allocator.alloc(PAGE_SIZE)
+        self.assertIsNotNone(allocated)
+        seq_lens = torch.tensor([PAGE_SIZE + 1], dtype=torch.int64)
+
+        with patch(
+            "sglang.srt.mem_cache.allocator.paged.alloc_decode_kernel",
+            _UnexpectedKernelLaunch(),
+        ):
+            result = allocator.alloc_decode(
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens,
+                last_loc=allocated[-1:],
+            )
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Move paged KV allocator capacity checks ahead of the Triton launches for extend and decode allocation.

## Root cause

The allocator returned `None` only after kernels had already indexed the free-page list. An allocation needing more pages than available could therefore access beyond that list before the intended OOM result was returned.

## Validation

- `python3 -m py_compile python/sglang/srt/mem_cache/allocator/paged.py test/registered/unit/mem_cache/test_paged_allocator_oom_gate.py`
- Static guard-order assertion for both allocator paths
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30452418708](https://github.com/sgl-project/sglang/actions/runs/30452418708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30452418270](https://github.com/sgl-project/sglang/actions/runs/30452418270)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->