### PR TITLE
fix: avoid piecewise prefill graph for trtllm_mla

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4272,6 +4272,12 @@ class ServerArgs:
         if (
             self.cuda_graph_config.prefill.backend == Backend.BREAKABLE
             and self.get_model_config().is_multimodal_piecewise_cuda_graph_supported
+            # Keep trtllm_mla on the preferred breakable path. Its current
+            # breakable compatibility rule disables the graph, avoiding the
+            # tc_piecewise FlashInfer paged-MLA fallback; once breakable gains
+            # native support, that rule can be relaxed without re-enabling the
+            # deprecated tc_piecewise path.
+            and self._resolved_attention_backends()[0] != "trtllm_mla"
         ):
             logger.info(
                 "Using tc_piecewise CUDA graph for validated multimodal "

--- a/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
+++ b/test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py
@@ -10,6 +10,7 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
     CudaGraphConfig,
+    Phase,
     PhaseConfig,
 )
 from sglang.srt.model_executor.forward_batch_info import (
@@ -77,13 +78,56 @@ class TestMultimodalPiecewiseCudaGraph(CustomTestCase):
         )
         args._cuda_graph_config_locked = set()
 
-        with patch.object(
-            ServerArgs, "_disable_tc_piecewise_cudagraph_if_incompatible"
-        ) as disable_if_incompatible:
+        with (
+            patch.object(
+                ServerArgs, "_disable_tc_piecewise_cudagraph_if_incompatible"
+            ) as disable_if_incompatible,
+            patch.object(
+                args, "_resolved_attention_backends", return_value=("fa3", "fa3")
+            ),
+        ):
             args._apply_cuda_graph_compatibility()
 
         self.assertEqual(args.cuda_graph_config.prefill.backend, Backend.TC_PIECEWISE)
         disable_if_incompatible.assert_called_once()
+
+    def test_trtllm_mla_stays_on_breakable_and_is_disabled_by_compatibility(self):
+        args = ServerArgs(model_path="dummy")
+        args.model_config = SimpleNamespace(
+            is_multimodal_piecewise_cuda_graph_supported=True
+        )
+        args.cuda_graph_config = CudaGraphConfig(
+            prefill=PhaseConfig(backend=Backend.BREAKABLE)
+        )
+        args._cuda_graph_config_locked = set()
+
+        with (
+            patch.object(
+                args,
+                "_resolved_attention_backends",
+                return_value=("trtllm_mla", "trtllm_mla"),
+            ),
+            patch.object(args, "use_mla_backend", return_value=True),
+        ):
+            args._apply_cuda_graph_compatibility()
+
+        self.assertEqual(args.cuda_graph_config.prefill.backend, Backend.DISABLED)
+
+    def test_explicit_tc_piecewise_overrides_trtllm_mla_default(self):
+        args = ServerArgs(model_path="dummy")
+        args.cuda_graph_config = CudaGraphConfig(
+            prefill=PhaseConfig(backend=Backend.TC_PIECEWISE)
+        )
+        args._cuda_graph_config_locked = {(Phase.PREFILL, "backend")}
+
+        with patch.object(
+            args,
+            "_resolved_attention_backends",
+            return_value=("trtllm_mla", "trtllm_mla"),
+        ):
+            args._apply_cuda_graph_compatibility()
+
+        self.assertEqual(args.cuda_graph_config.prefill.backend, Backend.TC_PIECEWISE)
 
     def test_multimodal_inputs_keep_tc_piecewise_prefill_enabled(self):
         runner = self._make_prefill_runner(Backend.TC_PIECEWISE)


### PR DESCRIPTION
## Motivation

Fixes #32655.

#30889 upgrades the default prefill CUDA graph backend from `breakable` to `tc_piecewise` for allowlisted multimodal models. Kimi-K2.6 on Blackwell auto-selects `trtllm_mla`, so that upgrade moves prefill capture onto the FlashInfer paged-MLA fallback. The fallback converts the full FP8 KV cache buffer and substantially regresses TTFT, while decode TPOT remains unchanged.

This is orthogonal to #32288: that PR fixed stale fallback state leaking into speculative verify; this PR fixes the default prefill backend selection and its throughput regression.

## Changes

- Keep the default `breakable` prefill backend when the resolved prefill attention backend is `trtllm_mla`.
- Let the existing breakable/MLA compatibility rule disable prefill CUDA graph for now, restoring the eager TRT-LLM ragged-MLA path used before #30889.
- Preserve the existing `tc_piecewise` upgrade for other validated multimodal attention backends.
- Continue honoring an explicitly selected `tc_piecewise` backend.

This also keeps `breakable` as the preferred future path: once BCG gains native MLA support, its compatibility rule can be relaxed without re-enabling the deprecating PCG path for `trtllm_mla`.

## Validation

On the latest `main` source in a remote B300 environment:

- `python3 -m pytest test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py -q` — 9 passed
- `pre-commit run --files python/sglang/srt/server_args.py test/registered/unit/configs/test_multimodal_piecewise_cuda_graph.py` — passed

A full 4x GB300 performance A/B is not included in this patch. The selected prefill execution path is restored to the same graph-disabled TRT-LLM path used before #30889; decode graph selection is unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30456623153](https://github.com/sgl-project/sglang/actions/runs/30456623153)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30456622464](https://github.com/sgl-project/sglang/actions/runs/30456622464)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->