### PR TITLE
[Bugfix] Accept GDN ReplaySSM arg in unified Mamba pool

### DIFF
--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -765,10 +765,12 @@ class UnifiedHybridReqToTokenPool(HybridReqToTokenPool):
         mamba_envelope_layout: bool = False,
         enable_linear_replayssm: bool = False,
         linear_replayssm_cache_len: int = 16,
+        enable_gdn_replayssm_spec: bool = False,
     ):
         # mamba_envelope_layout / speculative_eagle_topk / enable_linear_replayssm /
-        # linear_replayssm_cache_len: accepted to match the parent signature but NOT
-        # forwarded — the shared pool's conv/temporal state are fixed-shape views.
+        # linear_replayssm_cache_len / enable_gdn_replayssm_spec: accepted to match
+        # the parent signature but NOT forwarded — the shared pool's conv/temporal
+        # state are fixed-shape views.
         assert mamba_size == self._shared_mamba_size, (
             f"UnifiedHybridReqToTokenPool._init_mamba_pool: mamba_size={mamba_size} "
             f"!= unified_buffer.max_slots({self._mamba_sub_pool_name!r}) - 1 "

--- a/test/registered/unit/mem_cache/test_unified_memory_pool.py
+++ b/test/registered/unit/mem_cache/test_unified_memory_pool.py
@@ -1,0 +1,30 @@
+"""Unit tests for the unified memory pool."""
+
+import inspect
+import unittest
+
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
+from sglang.srt.mem_cache.unified_memory_pool import UnifiedHybridReqToTokenPool
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestUnifiedHybridReqToTokenPool(CustomTestCase):
+    def test_mamba_pool_override_accepts_parent_keyword_arguments(self):
+        parent_parameters = inspect.signature(
+            HybridReqToTokenPool._init_mamba_pool
+        ).parameters
+        override_parameters = inspect.signature(
+            UnifiedHybridReqToTokenPool._init_mamba_pool
+        ).parameters
+
+        self.assertLessEqual(
+            parent_parameters.keys(),
+            override_parameters.keys(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Starting a hybrid Mamba/GDN model with `--enable-unified-memory` fails during
memory-pool initialization with the following error:

```text
TypeError: UnifiedHybridReqToTokenPool._init_mamba_pool()
got an unexpected keyword argument 'enable_gdn_replayssm_spec'
```

The unified memory pool was introduced in #29678. At that point,
`UnifiedHybridReqToTokenPool._init_mamba_pool()` matched the parent
initialization contract.

GDN ReplaySSM speculative verification was later added in #28695, merged as
commit
[`c41c573ce`](https://github.com/sgl-project/sglang/commit/c41c573ce9ed2053d38aa711582e19a67a5e9755).
That change added `enable_gdn_replayssm_spec` to `HybridReqToTokenPool` and
began forwarding it to `_init_mamba_pool()`:

```python
self._init_mamba_pool(
    ...,
    enable_gdn_replayssm_spec=enable_gdn_replayssm_spec,
)
```

However, the corresponding override in `UnifiedHybridReqToTokenPool` was not
updated to accept the new keyword. Python dispatches the parent call to the
incompatible unified-pool override, causing server startup to fail before the
unified radix cache is initialized.

The failure occurs even when `enable_gdn_replayssm_spec=False`, because
`HybridReqToTokenPool.__init__()` always forwards the keyword.

A minimal reproduction is:

```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.5-0.8B \
  --enable-unified-memory \
  --attention-backend triton \
  --linear-attn-backend triton \
  --mamba-backend triton
```

## Modifications

- Restore the initialization contract after #28695 by adding
  `enable_gdn_replayssm_spec: bool = False` to
  `UnifiedHybridReqToTokenPool._init_mamba_pool()`.
- Keep the argument intentionally unused because the unified pool does not
  forward ReplaySSM-specific configuration. It is accepted only to maintain
  compatibility with the parent initialization contract.
- Add a CPU unit test that verifies the unified override accepts every keyword
  parameter supported by the parent `_init_mamba_pool()` method.
- Register the test in the CPU CI suite.

This change does not enable GDN ReplaySSM speculative verification for the
unified pool. It only restores constructor compatibility for the existing
unified-memory path.

### Validation

Unit test:

```bash
python test/registered/unit/mem_cache/test_unified_memory_pool.py
```

Result:

```text
Ran 1 test in 0.000s

OK
```

CI registry validation:

```bash
python scripts/ci/check_registered_tests.py
```

Changed-file pre-commit checks:

```bash
pre-commit run --files \
  python/sglang/srt/mem_cache/unified_memory_pool.py \
  test/registered/unit/mem_cache/test_unified_memory_pool.py
```

All applicable hooks passed.

The reproduction command was also validated on an NVIDIA GeForce RTX 5090
with `Qwen/Qwen3.5-0.8B`. After this fix:

- The unified Mamba memory pool was initialized successfully.
- The unified radix tree was initialized successfully.
- The server reached `The server is fired up and ready to roll!`.
- `GET /health` returned HTTP 200.

## Accuracy Tests

Not applicable. This change only restores keyword compatibility during
memory-pool initialization. It does not modify model computation, kernels,
cache contents, or generated outputs.

A server startup and health-check smoke test with `Qwen/Qwen3.5-0.8B` passed
on an NVIDIA GeForce RTX 5090.

## Speed Tests and Profiling

Not applicable. The new argument is accepted only during initialization and is
not used or forwarded by the unified-pool implementation. There is no change
to the inference hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is required because this change restores the documented unified-memory behavior without changing its public interface.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). These are not applicable to this initialization-only compatibility fix; startup validation is provided above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, and `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.