### PR TITLE
【NPU】fix decode MTP + eagle shape error

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -515,7 +515,7 @@ class AscendAttnBackend(AttentionBackend):
                 dtype=torch.int32,
                 device=self.device,
             )
-        else:
+        elif forward_batch.forward_mode.is_decode_or_idle():
             self.forward_metadata.actual_seq_lengths_q = torch.tensor(
                 [1 + i for i in range(forward_batch.seq_lens.shape[0])],
                 dtype=torch.int32,

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -497,6 +497,31 @@ class AscendAttnBackend(AttentionBackend):
         ):
             self.forward_metadata.seq_lens_cpu_int += self.speculative_step_id + 1
 
+        # Set actual_seq_lengths_q from the pre-pad batch size so that the DSA
+        # indexer reads a value consistent with actual_seq_lengths_kv /
+        # block_tables (which are also built from the pre-pad batch here).
+        # Without this, eager decode under DP attention pads q to the global
+        # max while kv stays local, causing a shape mismatch in
+        # npu_lightning_indexer.
+        if (
+            forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ):
+            self.forward_metadata.actual_seq_lengths_q = torch.arange(
+                self.speculative_num_draft_tokens,
+                self.speculative_num_draft_tokens
+                + forward_batch.seq_lens.shape[0] * self.speculative_num_draft_tokens,
+                self.speculative_num_draft_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
+        else:
+            self.forward_metadata.actual_seq_lengths_q = torch.tensor(
+                [1 + i for i in range(forward_batch.seq_lens.shape[0])],
+                dtype=torch.int32,
+                device=self.device,
+            )
+
         if (
             self.use_mla
             and forward_batch.forward_mode.is_extend()
@@ -720,6 +745,27 @@ class AscendAttnBackend(AttentionBackend):
         self.forward_metadata = metadata
 
         self.graph_mode = True
+
+    def _pad_topk_indices(
+        self, topk_indices: torch.Tensor, num_tokens: int
+    ) -> torch.Tensor:
+        current_tokens = topk_indices.shape[0]
+        if current_tokens == num_tokens:
+            return topk_indices
+
+        assert current_tokens <= num_tokens, (
+            f"topk_indices rows ({current_tokens}) > num_tokens ({num_tokens}); "
+            "this indicates a mismatch between indexer output and q layout."
+        )
+
+        pad_size = num_tokens - current_tokens
+        padding = torch.full(
+            (pad_size, topk_indices.shape[1]),
+            -1,
+            dtype=topk_indices.dtype,
+            device=topk_indices.device,
+        )
+        return torch.cat([topk_indices, padding], dim=0)
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 0
@@ -1072,6 +1118,8 @@ class AscendAttnBackend(AttentionBackend):
                 actual_seq_lengths_kv,
             )
         else:
+            if topk_indices is not None:
+                topk_indices = self._pad_topk_indices(topk_indices, q_nope.shape[0])
             topk_indices = _expand_dsa_sparse_indices(topk_indices)
             attn_out, _, _ = torch_npu.npu_sparse_flash_attention(
                 query=q_nope,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

1 In Eagle mode, init_forward_metadata is invoked first, followed by _prepare_eager_forward_batch which performs padding. This execution sequence causes q to be padded, while the KV stored in forward_metadata retains values from before padding, resulting in a shape mismatch.
2 The topk_indices from draft_extend_for_decode can be reused in the draft step. However, the draft's q may undergo padding, which causes a shape mismatch between q_nope and topk_indices inside npu_sparse_flash_attention.


## Modifications

ascend_backend.py

## Accuracy Tests
start command
```
# cpu高性能
echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
sysctl -w vm.swappiness=0
sysctl -w kernel.numa_balancing=0
sysctl -w kernel.sched_migration_cost_ns=50000
# 绑核
export SGLANG_SET_CPU_AFFINITY=1

unset https_proxy
unset http_proxy
unset HTTPS_PROXY
unset HTTP_PROXY
unset ASCEND_LAUNCH_BLOCKING
source /usr/local/Ascend/ascend-toolkit/set_env.sh
source /usr/local/Ascend/nnal/atb/set_env.sh
export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/opp/vendors/customize/op_api/lib/:${LD_LIBRARY_PATH}
export PATH=/usr/local/Ascend/8.5.0/compiler/bishengir/bin:$PATH

export PYTHONPATH=/home/***/sglang_shan/sglang/python:$PYTHONPATH

export TRANSFORMERS_VERBOSITY=error

# 内存碎片
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export STREAMS_PER_DEVICE=32
# pd传输, IP设置为p节点首节点
export ASCEND_MF_STORE_URL="tcp://61.47.19.70:24709"
export SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=1200
export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=1200


# p节点IP
P_IP=('61.47.19.70')
# D节点IP D节点首节点IP
D_IP=('61.47.19.71')


MODEL_PATH=/home/weights/GLM-5.2-0610-Provider-w4a8

# enable mlapo
# export SGLANG_NPU_USE_MLAPO=1

#export SGLANG_USE_FIA_NZ=1
#export SGLANG_SPEC_ENABLE_OVERLAP_REFLOW=1

LOCAL_HOST1=`hostname -I|awk -F " " '{print$1}'`
LOCAL_HOST2=`hostname -I|awk -F " " '{print$2}'`
echo "${LOCAL_HOST1}"
echo "${LOCAL_HOST2}"
#export USE_DEEPEP_INT8=1
# prefill
for i in "${!P_IP[@]}";
do
    if [[ "$LOCAL_HOST1" == "${P_IP[$i]}" || "$LOCAL_HOST2" == "${P_IP[$i]}" ]];
    then
        echo "${P_IP[$i]}"
    # #    export SGLANG_USE_AG_AFTER_QLORA=1 # ??
    #     export HCCL_BUFFSIZE=1200
    # #    export DEEPEP_NORMAL_LONG_SEQ_ROUND=4
    # #    export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=512
    #     export DEEPEP_NORMAL_LONG_SEQ_ROUND=72
    #     export DEEPEP_NORMAL_LONG_SEQ_PER_ROUND_TOKENS=1024
    #     export DEEPEP_NORMAL_COMBINE_ENABLE_LONG_SEQ=1
        export DEEP_NORMAL_MODE_USE_INT8_QUANT=1
        export TASK_QUEUE_ENABLE=2
        export ENABLE_PROFILING=0
        export HCCL_SOCKET_IFNAME=enp196s0f0
        export GLOO_SOCKET_IFNAME=enp196s0f0
        ### eplb
        # export SGLANG_EXPERT_DISTRIBUTION_RECORDER_DIR=/home/luochen/hot_map

        ### zero buffer
        # zbal
        # export ZBAL_HCCL_OP="_allgather_base,allgather"
        export ZBAL_HCCL_OP="send,recv"
        export HCCL_BUFFSIZE=128
        unset PYTORCH_NPU_ALLOC_CONF
        export SGLANG_ZBAL_LOCAL_MEM_SIZE=61184
        export SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0
        # # zbal if use mix alloc （开启混合分配减少内存碎片）
        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
        export ZBAL_NPU_ALLOC_CONF=use_vmm_for_static_memory:True
        export SGLANG_ZBAL_BOOTSTRAP_URL="tcp://${P_IP[$i]}:24691"
        # zbal if support graph（need custom pta） （开启图下沉支持）
        # export ZBAL_ENABLE_GRAPH=1

        ### 这个不能去掉，开启pp时需要首层有topk_idnex
        # export SGLANG_PP_LAYER_PARTITION=18,20,24,16
        ### 性能优化all2all
        export DEEP_USE_ALLTOALL_MODE=1

        # P节点
        python -m sglang.launch_server --model-path ${MODEL_PATH}  --disaggregation-mode prefill --host ${P_IP[$i]} \
        --port 8000 --disaggregation-bootstrap-port $((8998 + i)) --trust-remote-code --nnodes 1 --node-rank 0 \
        --tp-size 16 --mem-fraction-static 0.8 --attention-backend ascend --device npu --quantization modelslim \
        --disaggregation-transfer-backend ascend --max-running-requests 16 \
        --served-model-name glm-5 --chunked-prefill-size 16384 --max-prefill-tokens 180000 --moe-a2a-backend deepep --deepep-mode normal \
        --disable-shared-experts-fusion --disable-cuda-graph --dtype bfloat16 \
        --speculative-draft-model-quantization unquant \
        --enable-nsa-prefill-context-parallel \
        --nsa-prefill-cp-mode in-seq-split \
        --attn-cp-size 16 \
        --enable-dp-lm-head --moe-dense-tp 1 \
        --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2

        # --pp-size 4 \
        # --dist-init-addr 61.47.19.68:5000
        # --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2 \
        #  --dp-size 2 --enable-dp-attention --load-balance-method round_robin \
        # --eplb-rebalance-num-iterations 2 --expert-distribution-recorder-buffer-size 2048 --expert-distribution-recorder-mode stat --ep-dispatch-algorithm static
        #        --enable-attn-tp-input-scattered
        # --speculative-algorithm NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2  \
        # --tool-call-parser glm47 --reasoning-parser glm45 --speculative-algorithm EAGLE --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2  \
        NODE_RANK=$i
        break
    fi
done

# decode
for i in "${!D_IP[@]}";
do
    if [[ "$LOCAL_HOST1" == "${D_IP[$i]}" || "$LOCAL_HOST2" == "${D_IP[$i]}" ]];
    then
        echo "${D_IP[$i]}"
        export SGLANG_SPEC_ENABLE_OVERLAP_REFLOW=1
        export SGLANG_ENABLE_OVERLAP_PLAN_STREAM=1
        export SGLANG_ENABLE_SPEC_V2=1
        export HCCL_BUFFSIZE=300
        # export ENABLE_PROFILING=1
        export SGLANG_DEEPEP_NUM_MAX_DISPATCH_TOKENS_PER_RANK=40
        export TASK_QUEUE_ENABLE=0
        # export SGLANG_SCHEDULER_SKIP_ALL_GATHER=1
        # export ENABLE_FUSED_MOE=1
        export HCCL_SOCKET_IFNAME=enp196s0f0
        export GLOO_SOCKET_IFNAME=enp196s0f0

        ###p不开双流 / p回退到native算子
        export SGLANG_NPU_USE_MULTI_STREAM=1

        python -m sglang.launch_server --model-path ${MODEL_PATH} --disaggregation-mode decode --host ${D_IP[$i]} \
        --port 8003 --trust-remote-code --dist-init-addr 61.47.19.71:5000 --nnodes 1 --node-rank $i --tp-size 16 --dp-size 16 --enable-dp-attention --ep-size 16 \
        --mem-fraction-static 0.88 --max-running-requests 64 --attention-backend ascend --device npu --quantization modelslim \
        --served-model-name glm-5 --moe-a2a-backend deepep --deepep-mode low_latency \
        --cuda-graph-bs 1 2 3 4   --disaggregation-transfer-backend ascend --watchdog-timeout 9000 --context-length 180000 \
        --tokenizer-worker-num 16 --prefill-round-robin-balance --disable-shared-experts-fusion --dtype bfloat16  --load-balance-method round_robin \
        --speculative-draft-model-quantization unquant \
        --speculative-algorithm NEXTN --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 
        
        # --disaggregation-decode-enable-radix-cache

        # --disable-cuda-graph \
        # --skip-server-warmup 
        # --disaggregation-decode-enable-radix-cache

        # --enable-dp-lm-head --moe-dense-tp 1  --cuda-graph-bs 1 2 4 8 10 12 14 16 export SGLANG_SCHEDULER_SKIP_ALL_GATHER=1
        # --ep-dispatch-algorithm static --init-expert-location /home/luochen/hot_map/expert_distribution_recorder_1774942092.5829542.pt
        # --speculative-algorithm NEXTN --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3  \
        # --tool-call-parser glm47 --reasoning-parser glm45 --speculative-algorithm EAGLE --speculative-num-steps 2 --speculative-eagle-topk 1 --speculative-num-draft-tokens 3  \
        NODE_RANK=$i
        break
    fi
done


```

```
/home/luochen/sglang/python/sglang/test/few_shot_gsm8k.py:166: DeprecationWarning: sglang.test.few_shot_gsm8k is deprecated. Use sglang.test.run_eval with eval_name='gsm8k' instead.
  run_eval(args)
/home/***/sglang/python/sglang/test/few_shot_gsm8k.py:66: DeprecationWarning: Including the scheme in --host ('http://61.47.19.68') is deprecated. Pass just the hostname (e.g. '127.0.0.1') instead.
  set_default_backend(RuntimeEndpoint(normalize_base_url(args.host, args.port)))
100%|█████████████████████████████████████████████████████████| 1319/1319 [08:14<00:00,  2.67it/s]
Accuracy: 0.936
Invalid: 0.000
Latency: 495.252 s

```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30528505682](https://github.com/sgl-project/sglang/actions/runs/30528505682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30528504972](https://github.com/sgl-project/sglang/actions/runs/30528504972)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->