### PR TITLE
[Feature] PP Support PD + DSpark

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -300,9 +300,13 @@ def _handle_dspark(server_args: ServerArgs) -> None:
                 f"(got {server_args.speculative_moe_a2a_backend!r})."
             )
 
-    if server_args.pp_size != 1:
+    if server_args.pp_size != 1 and server_args.disaggregation_mode not in (
+        "prefill",
+        "decode",
+    ):
         raise ValueError(
-            "Currently DSpark speculative decoding only supports pp_size == 1."
+            "Currently DSpark speculative decoding with pp_size > 1 is only "
+            "supported under PD disaggregation."
         )
 
     if server_args.speculative_draft_model_path is None:

--- a/python/sglang/srt/configs/kimi_k3.py
+++ b/python/sglang/srt/configs/kimi_k3.py
@@ -19,10 +19,10 @@ def _apply_keep_num_experts_override(text_config: KimiLinearConfig) -> None:
 
     original_num_experts = int(text_config.num_experts or 0)
     if original_num_experts <= 0:
-        raise ValueError(
-            "SGLANG_KIMI_K3_KEEP_NUM_EXPERTS requires a MoE config with "
-            f"num_experts > 0, got {text_config.num_experts!r}."
-        )
+        # Transformers builds a default config instance during __repr__ /
+        # to_diff_dict(). That default text config is dense (num_experts=None),
+        # so the debug-only expert truncation must not make config logging fail.
+        return
     if keep_num_experts > original_num_experts:
         raise ValueError(
             "SGLANG_KIMI_K3_KEEP_NUM_EXPERTS cannot exceed the checkpoint "

--- a/python/sglang/srt/configs/kimi_k3.py
+++ b/python/sglang/srt/configs/kimi_k3.py
@@ -5,42 +5,42 @@ from transformers.configuration_utils import PretrainedConfig
 from sglang.srt.configs.kimi_linear import KimiLinearConfig
 
 
-def _apply_keep_num_layers_override(text_config: KimiLinearConfig) -> None:
-    raw = os.getenv("SGLANG_KIMI_K3_KEEP_NUM_LAYERS")
+def _apply_keep_num_experts_override(text_config: KimiLinearConfig) -> None:
+    raw = os.getenv("SGLANG_KIMI_K3_KEEP_NUM_EXPERTS")
     if raw is None or raw.strip() in ("", "0"):
         return
 
-    keep_num_layers = int(raw)
-    if keep_num_layers <= 0:
+    keep_num_experts = int(raw)
+    if keep_num_experts <= 0:
         raise ValueError(
-            "SGLANG_KIMI_K3_KEEP_NUM_LAYERS must be a positive integer, "
-            f"got {keep_num_layers}."
+            "SGLANG_KIMI_K3_KEEP_NUM_EXPERTS must be a positive integer, "
+            f"got {keep_num_experts}."
         )
 
-    original_num_layers = int(text_config.num_hidden_layers)
-    if keep_num_layers > original_num_layers:
+    original_num_experts = int(text_config.num_experts or 0)
+    if original_num_experts <= 0:
         raise ValueError(
-            "SGLANG_KIMI_K3_KEEP_NUM_LAYERS cannot exceed the checkpoint layer "
-            f"count ({original_num_layers}), got {keep_num_layers}."
+            "SGLANG_KIMI_K3_KEEP_NUM_EXPERTS requires a MoE config with "
+            f"num_experts > 0, got {text_config.num_experts!r}."
         )
-    if keep_num_layers == original_num_layers:
+    if keep_num_experts > original_num_experts:
+        raise ValueError(
+            "SGLANG_KIMI_K3_KEEP_NUM_EXPERTS cannot exceed the checkpoint "
+            f"expert count ({original_num_experts}), got {keep_num_experts}."
+        )
+    if keep_num_experts == original_num_experts:
         return
 
-    text_config.num_hidden_layers = keep_num_layers
-    if text_config.linear_attn_config is not None:
-        cfg = dict(text_config.linear_attn_config)
-        # Kimi configs store these layer ids as 1-based ids.
-        cfg["kda_layers"] = [
-            int(layer_id)
-            for layer_id in cfg["kda_layers"]
-            if int(layer_id) <= keep_num_layers
-        ]
-        cfg["full_attn_layers"] = [
-            int(layer_id)
-            for layer_id in cfg["full_attn_layers"]
-            if int(layer_id) <= keep_num_layers
-        ]
-        text_config.linear_attn_config = cfg
+    text_config.num_experts = keep_num_experts
+    text_config.n_routed_experts = keep_num_experts
+    if text_config.num_experts_per_token is not None:
+        text_config.num_experts_per_token = min(
+            int(text_config.num_experts_per_token), keep_num_experts
+        )
+    # Debug expert truncation keeps only a prefix of experts. Collapse grouped
+    # top-k to a single group so arbitrary small expert counts remain legal.
+    text_config.num_expert_group = 1
+    text_config.topk_group = 1
 
 
 class KimiK3VisionConfig(PretrainedConfig):
@@ -136,7 +136,7 @@ class KimiK3Config(PretrainedConfig):
         else:
             self.text_config = text_config
 
-        _apply_keep_num_layers_override(self.text_config)
+        _apply_keep_num_experts_override(self.text_config)
 
         if vision_config is None:
             self.vision_config = KimiK3VisionConfig()

--- a/python/sglang/srt/configs/kimi_k3.py
+++ b/python/sglang/srt/configs/kimi_k3.py
@@ -1,6 +1,46 @@
+import os
+
 from transformers.configuration_utils import PretrainedConfig
 
 from sglang.srt.configs.kimi_linear import KimiLinearConfig
+
+
+def _apply_keep_num_layers_override(text_config: KimiLinearConfig) -> None:
+    raw = os.getenv("SGLANG_KIMI_K3_KEEP_NUM_LAYERS")
+    if raw is None or raw.strip() in ("", "0"):
+        return
+
+    keep_num_layers = int(raw)
+    if keep_num_layers <= 0:
+        raise ValueError(
+            "SGLANG_KIMI_K3_KEEP_NUM_LAYERS must be a positive integer, "
+            f"got {keep_num_layers}."
+        )
+
+    original_num_layers = int(text_config.num_hidden_layers)
+    if keep_num_layers > original_num_layers:
+        raise ValueError(
+            "SGLANG_KIMI_K3_KEEP_NUM_LAYERS cannot exceed the checkpoint layer "
+            f"count ({original_num_layers}), got {keep_num_layers}."
+        )
+    if keep_num_layers == original_num_layers:
+        return
+
+    text_config.num_hidden_layers = keep_num_layers
+    if text_config.linear_attn_config is not None:
+        cfg = dict(text_config.linear_attn_config)
+        # Kimi configs store these layer ids as 1-based ids.
+        cfg["kda_layers"] = [
+            int(layer_id)
+            for layer_id in cfg["kda_layers"]
+            if int(layer_id) <= keep_num_layers
+        ]
+        cfg["full_attn_layers"] = [
+            int(layer_id)
+            for layer_id in cfg["full_attn_layers"]
+            if int(layer_id) <= keep_num_layers
+        ]
+        text_config.linear_attn_config = cfg
 
 
 class KimiK3VisionConfig(PretrainedConfig):
@@ -95,6 +135,8 @@ class KimiK3Config(PretrainedConfig):
             self.text_config = KimiLinearConfig(**text_config)
         else:
             self.text_config = text_config
+
+        _apply_keep_num_layers_override(self.text_config)
 
         if vision_config is None:
             self.vision_config = KimiK3VisionConfig()

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -311,7 +311,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         bootstrap_port: int,
         max_total_num_tokens: int,
         pp_rank: int,
-        pp_size: int,
         num_reserved_decode_tokens: int,
         transfer_backend: TransferBackend,
     ):
@@ -333,7 +332,6 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self.bootstrap_port = bootstrap_port
         self.max_total_num_tokens = max_total_num_tokens
         self.pp_rank = pp_rank
-        self.pp_size = pp_size
         self.num_reserved_decode_tokens = num_reserved_decode_tokens
         self.transfer_backend = transfer_backend
         # Queue for requests pending pre-allocation
@@ -450,8 +448,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
             kv_layer_ids = []
             kv_data_mem_kinds += ["VRAM"] * len(device_kv_data_ptrs[c4_layer_num:])
-        transfer_draft_cache = self.pp_size <= 1 or self.pp_rank == self.pp_size - 1
-        if self.draft_token_to_kv_pool is not None and transfer_draft_cache:
+        if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
@@ -480,7 +477,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         setup_state_kv_args(
             kv_args,
             self.token_to_kv_pool,
-            self.draft_token_to_kv_pool if transfer_draft_cache else None,
+            self.draft_token_to_kv_pool,
             total_kv_layers=self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=getattr(self, "req_to_token_pool", None),
         )

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -311,6 +311,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         bootstrap_port: int,
         max_total_num_tokens: int,
         pp_rank: int,
+        pp_size: int,
         num_reserved_decode_tokens: int,
         transfer_backend: TransferBackend,
     ):
@@ -332,6 +333,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self.bootstrap_port = bootstrap_port
         self.max_total_num_tokens = max_total_num_tokens
         self.pp_rank = pp_rank
+        self.pp_size = pp_size
         self.num_reserved_decode_tokens = num_reserved_decode_tokens
         self.transfer_backend = transfer_backend
         # Queue for requests pending pre-allocation
@@ -448,7 +450,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
             kv_layer_ids = []
             kv_data_mem_kinds += ["VRAM"] * len(device_kv_data_ptrs[c4_layer_num:])
-        if self.draft_token_to_kv_pool is not None:
+        transfer_draft_cache = self.pp_size <= 1 or self.pp_rank == self.pp_size - 1
+        if self.draft_token_to_kv_pool is not None and transfer_draft_cache:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
@@ -477,7 +480,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         setup_state_kv_args(
             kv_args,
             self.token_to_kv_pool,
-            self.draft_token_to_kv_pool,
+            self.draft_token_to_kv_pool if transfer_draft_cache else None,
             total_kv_layers=self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=getattr(self, "req_to_token_pool", None),
         )

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -52,6 +52,7 @@ from sglang.srt.disaggregation.utils import (
     _is_fake_transfer,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_transfer_kv_layer_ids,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
@@ -427,6 +428,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             transfer_kv_pool.get_contiguous_buf_infos()
         )
+        kv_layer_ids = get_transfer_kv_layer_ids(
+            self.token_to_kv_pool, len(kv_data_ptrs)
+        )
         kv_data_mem_kinds = (
             ["DRAM"] * len(kv_data_ptrs)
             if self.scheduler.enable_hisparse
@@ -442,12 +446,16 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_data_ptrs += device_kv_data_ptrs[c4_layer_num:]
             kv_data_lens += device_kv_data_lens[c4_layer_num:]
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
+            kv_layer_ids = []
             kv_data_mem_kinds += ["VRAM"] * len(device_kv_data_ptrs[c4_layer_num:])
         if self.draft_token_to_kv_pool is not None:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
+            )
+            kv_layer_ids += get_transfer_kv_layer_ids(
+                self.draft_token_to_kv_pool, len(draft_kv_data_ptrs)
             )
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
@@ -457,12 +465,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
-        )
+        kv_args.kv_layer_ids = kv_layer_ids if len(kv_layer_ids) == len(kv_data_ptrs) else []
         if self.transfer_backend == TransferBackend.NIXL:
             kv_args.kv_data_mem_kinds = kv_data_mem_kinds
         kv_args.page_size = self.token_to_kv_pool.page_size

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -52,6 +52,7 @@ from sglang.srt.disaggregation.utils import (
     _is_fake_transfer,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_transfer_draft_kv_layer_ids,
     get_transfer_kv_layer_ids,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
@@ -454,9 +455,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
-            kv_layer_ids += get_transfer_kv_layer_ids(
-                self.draft_token_to_kv_pool, len(draft_kv_data_ptrs)
-            )
+            kv_layer_ids += get_transfer_draft_kv_layer_ids(len(draft_kv_data_ptrs))
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -24,7 +24,7 @@ import logging
 from array import array
 from collections import deque
 from http import HTTPStatus
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -441,6 +441,41 @@ class PrefillBootstrapQueue:
         else:
             return bootstrapped_reqs, failed_reqs
 
+    def get_ready_bootstrapped_rids_for_pp(self) -> Tuple[List[str], List[str]]:
+        """Return ordered PP candidates without reserving local resources."""
+        good_rids: List[str] = []
+        failed_rids: List[str] = []
+        if len(self.queue) == 0:
+            return good_rids, failed_rids
+
+        polls = poll_and_all_reduce_attn_cp_tp_group(
+            [req.disagg_kv_sender for req in self.queue],
+            self.scheduler.attn_cp_cpu_group,
+            self.scheduler.attn_tp_cpu_group,
+        )
+        metadata_credits = (
+            self.req_to_metadata_buffer_idx_allocator.available_size()
+        )
+
+        for req, poll in zip(self.queue, polls):
+            if poll == KVPoll.Failed:
+                failed_rids.append(req.rid)
+            elif poll == KVPoll.WaitingForInput:
+                metadata_cost = 1 if req.metadata_buffer_index < 0 else 0
+                if metadata_cost > metadata_credits:
+                    break
+                metadata_credits -= metadata_cost
+                good_rids.append(req.rid)
+            elif poll == KVPoll.Bootstrapping:
+                continue
+            else:
+                raise RuntimeError(
+                    f"Unexpected poll state {poll} for req {req.rid} "
+                    "in get_ready_bootstrapped_rids_for_pp"
+                )
+
+        return good_rids, failed_rids
+
     def release_memory_occupation(self):
         self.queue.clear()
         if hasattr(self.kv_manager, "deregister_buffer_to_engine"):
@@ -796,16 +831,19 @@ class SchedulerDisaggregationPrefillMixin:
         )
 
     def process_disagg_prefill_inflight_queue(
-        self: Scheduler, rids_to_check: Optional[List[str]] = None
+        self: Scheduler,
+        transfer_status: Optional[Tuple[List[str], List[str]]] = None,
     ) -> List[Req]:
         """
         Poll the requests in the middle of transfer. If done, return the request.
-        rids_to_check: For PP, on rank > 0, check the rids from the previous rank has consensus with the current rank.
+        transfer_status: For PP, the consensus success and failure request ids.
         """
         if len(self.disagg_prefill_inflight_queue) == 0:
             return []
 
         done_reqs = []
+        success_rids = set(transfer_status[0]) if transfer_status is not None else set()
+        failed_rids = set(transfer_status[1]) if transfer_status is not None else set()
 
         polls = poll_and_all_reduce_attn_cp_tp_group(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
@@ -816,8 +854,13 @@ class SchedulerDisaggregationPrefillMixin:
         undone_reqs: List[Req] = []
         # Check .poll() for the reqs in disagg_prefill_inflight_queue. If Success, respond to the client and remove it from the queue
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
-            if rids_to_check is not None:
-                if req.rid not in rids_to_check:
+            if transfer_status is not None:
+                if req.rid in failed_rids:
+                    self.handle_inflight_transfer_failure(req)
+                    done_reqs.append(req)
+                    continue
+
+                if req.rid not in success_rids:
                     undone_reqs.append(req)
                     continue
 
@@ -931,9 +974,11 @@ class SchedulerDisaggregationPrefillMixin:
             self.metrics_collector.increment_transfer_failed_reqs()
         return exc
 
-    def get_transferred_rids(self: Scheduler) -> List[str]:
+    def get_transferred_rids(
+        self: Scheduler,
+    ) -> Tuple[List[str], List[str]]:
         """
-        Used by PP, get the transferred rids but **do not pop**
+        Used by PP, inspect terminal transfer states without popping requests.
         """
         polls = poll_and_all_reduce_attn_cp_tp_group(
             [req.disagg_kv_sender for req in self.disagg_prefill_inflight_queue],
@@ -941,13 +986,16 @@ class SchedulerDisaggregationPrefillMixin:
             self.attn_tp_cpu_group,
         )
 
-        transferred_rids: List[str] = []
+        success_rids: List[str] = []
+        failed_rids: List[str] = []
 
         for req, poll in zip(self.disagg_prefill_inflight_queue, polls):
-            if poll == KVPoll.Success or poll == KVPoll.Failed:
-                transferred_rids.append(req.rid)
+            if poll == KVPoll.Success:
+                success_rids.append(req.rid)
+            elif poll == KVPoll.Failed:
+                failed_rids.append(req.rid)
 
-        return transferred_rids
+        return success_rids, failed_rids
 
     def handle_bootstrap_failure(self: Scheduler, req: Req) -> None:
         error_message = (

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -41,6 +41,7 @@ from sglang.srt.disaggregation.utils import (
     TransferBackend,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_transfer_kv_layer_ids,
     is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
@@ -200,6 +201,9 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
+        kv_layer_ids = get_transfer_kv_layer_ids(
+            self.token_to_kv_pool, len(kv_data_ptrs)
+        )
         kv_args.prefill_end_layer = (
             kv_args.prefill_start_layer + len(kv_data_ptrs)
             if layer_shard_enabled
@@ -212,6 +216,9 @@ class PrefillBootstrapQueue:
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
+            kv_layer_ids += get_transfer_kv_layer_ids(
+                self.draft_token_to_kv_pool, len(draft_kv_data_ptrs)
+            )
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
@@ -219,12 +226,7 @@ class PrefillBootstrapQueue:
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
-        )
+        kv_args.kv_layer_ids = kv_layer_ids if len(kv_layer_ids) == len(kv_data_ptrs) else []
         if not self.is_mla_backend:
             kv_args.kv_head_num = self.token_to_kv_pool.head_num
             kv_args.total_kv_head_num = (

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -41,6 +41,7 @@ from sglang.srt.disaggregation.utils import (
     TransferBackend,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_transfer_draft_kv_layer_ids,
     get_transfer_kv_layer_ids,
     is_aborted,
     is_dsv4_c128_online_enabled,
@@ -217,9 +218,7 @@ class PrefillBootstrapQueue:
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
-            kv_layer_ids += get_transfer_kv_layer_ids(
-                self.draft_token_to_kv_pool, len(draft_kv_data_ptrs)
-            )
+            kv_layer_ids += get_transfer_draft_kv_layer_ids(len(draft_kv_data_ptrs))
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -186,7 +186,8 @@ class PrefillBootstrapQueue:
         layer_shard_rank = getattr(self.token_to_kv_pool, "layer_shard_rank", None)
         layer_shard_size = getattr(self.token_to_kv_pool, "layer_shard_size", 1)
         transfer_draft_cache = (
-            not layer_shard_enabled or layer_shard_rank == layer_shard_size - 1
+            (self.pp_size <= 1 or self.pp_rank == self.pp_size - 1)
+            and (not layer_shard_enabled or layer_shard_rank == layer_shard_size - 1)
         )
         kv_args.prefill_start_layer = (
             getattr(

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -927,6 +927,33 @@ def resolve_dcp_dst_entry_indices(
     ]
 
 
+def get_transfer_kv_layer_ids(kv_pool, num_entries: int) -> List[int]:
+    """Return global layer ids aligned with ``kv_pool.get_contiguous_buf_infos``.
+
+    Pools with a custom sparse/MLA layout expose ``get_kv_layer_ids`` directly.
+    Plain MHA-like draft pools usually expose only ``start_layer``/``end_layer``;
+    infer either one entry per layer or K/V tensor-major entries.
+    """
+    if kv_pool is None or num_entries <= 0:
+        return []
+
+    if hasattr(kv_pool, "get_kv_layer_ids"):
+        layer_ids = list(kv_pool.get_kv_layer_ids())
+        if len(layer_ids) == num_entries:
+            return layer_ids
+
+    start_layer = int(getattr(kv_pool, "start_layer", 0) or 0)
+    end_layer = getattr(kv_pool, "end_layer", None)
+    if end_layer is not None:
+        layer_ids = list(range(start_layer, int(end_layer)))
+        if len(layer_ids) == num_entries:
+            return layer_ids
+        if len(layer_ids) * 2 == num_entries:
+            return layer_ids * 2
+
+    return []
+
+
 def append_state_component(
     kv_args: KVArgs,
     state_type: StateType,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -927,6 +927,9 @@ def resolve_dcp_dst_entry_indices(
     ]
 
 
+_DRAFT_KV_LAYER_ID_BASE = 1_000_000
+
+
 def get_transfer_kv_layer_ids(kv_pool, num_entries: int) -> List[int]:
     """Return global layer ids aligned with ``kv_pool.get_contiguous_buf_infos``.
 
@@ -952,6 +955,18 @@ def get_transfer_kv_layer_ids(kv_pool, num_entries: int) -> List[int]:
             return layer_ids * 2
 
     return []
+
+
+def get_transfer_draft_kv_layer_ids(num_entries: int) -> List[int]:
+    """Return layer-id metadata for draft KV entries.
+
+    Draft KV is not target-model KV and should not share the target layer-id
+    namespace, especially when PP prefill sends target KV by layer subset but a
+    single rank also sends replicated draft KV.
+    """
+    if num_entries <= 0:
+        return []
+    return [_DRAFT_KV_LAYER_ID_BASE + i for i in range(num_entries)]
 
 
 def append_state_component(

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -770,6 +770,9 @@ class Envs:
     # front reads hidden_states once, and run the top-k plus the bf16 cast in one
     # epilogue kernel. See kernels/ops/moe/moe_front.py. Default on.
     SGLANG_K3_FUSED_FRONT = EnvBool(True)
+    # Debug-only: instantiate only the first N Kimi-K3 text layers and skip
+    # loading later layer weights. 0/unset keeps the full checkpoint.
+    SGLANG_KIMI_K3_KEEP_NUM_LAYERS = EnvInt(0)
 
     # sgl-kernel
     SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -770,9 +770,11 @@ class Envs:
     # front reads hidden_states once, and run the top-k plus the bf16 cast in one
     # epilogue kernel. See kernels/ops/moe/moe_front.py. Default on.
     SGLANG_K3_FUSED_FRONT = EnvBool(True)
-    # Debug-only: instantiate only the first N Kimi-K3 text layers and skip
-    # loading later layer weights. 0/unset keeps the full checkpoint.
-    SGLANG_KIMI_K3_KEEP_NUM_LAYERS = EnvInt(0)
+    # Debug-only: instantiate only the first N Kimi-K3 routed experts per MoE
+    # layer and load the matching expert prefix. 0/unset keeps the full
+    # checkpoint. This preserves all transformer layers, so DSpark layer capture
+    # still observes the configured target layer ids.
+    SGLANG_KIMI_K3_KEEP_NUM_EXPERTS = EnvInt(0)
 
     # sgl-kernel
     SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK = EnvBool(False)

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -510,24 +510,40 @@ class FutureMap:
             self._lazy_init_forward_buf(payload)
         self._maybe_init_dsa_topk_indices_buf(payload)
         self.output_tokens_buf[indices] = payload.bonus_tokens.to(
-            self.output_tokens_buf.dtype
+            device=self.output_tokens_buf.device,
+            dtype=self.output_tokens_buf.dtype,
+            non_blocking=True,
         )
 
         if self.need_topk:
-            self.topk_p_buf[indices] = payload.topk_p.to(self.topk_p_buf.dtype)
+            self.topk_p_buf[indices] = payload.topk_p.to(
+                device=self.topk_p_buf.device,
+                dtype=self.topk_p_buf.dtype,
+                non_blocking=True,
+            )
             self.topk_index_buf[indices] = payload.topk_index.to(
-                self.topk_index_buf.dtype
+                device=self.topk_index_buf.device,
+                dtype=self.topk_index_buf.dtype,
+                non_blocking=True,
             )
         if self.need_hidden_states:
             self.hidden_states_buf[indices] = payload.hidden_states.to(
-                self.hidden_states_buf.dtype
+                device=self.hidden_states_buf.device,
+                dtype=self.hidden_states_buf.dtype,
+                non_blocking=True,
             )
         if self.draft_probs_buf is not None and payload.draft_probs is not None:
-            self.draft_probs_buf[indices] = payload.draft_probs
+            self.draft_probs_buf[indices] = payload.draft_probs.to(
+                device=self.draft_probs_buf.device,
+                dtype=self.draft_probs_buf.dtype,
+                non_blocking=True,
+            )
         if (
             self.dsa_topk_indices_buf is not None
             and payload.dsa_topk_indices is not None
         ):
             self.dsa_topk_indices_buf[indices] = payload.dsa_topk_indices.to(
-                self.dsa_topk_indices_buf.dtype
+                device=self.dsa_topk_indices_buf.device,
+                dtype=self.dsa_topk_indices_buf.dtype,
+                non_blocking=True,
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1232,6 +1232,7 @@ class Scheduler(
                 bootstrap_port=self.server_args.disaggregation_bootstrap_port,
                 max_total_num_tokens=self.max_total_num_tokens,
                 pp_rank=self.ps.pp_rank,
+                pp_size=self.ps.pp_size,
                 num_reserved_decode_tokens=self.server_args.num_reserved_decode_tokens,
                 transfer_backend=self.transfer_backend,
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3482,7 +3482,15 @@ class Scheduler(
                 # future_map relay / on_publish).
                 resolve_forward_inputs(batch, self.future_map)
                 with self._forward_isolation(batch, overlap=False):
-                    batch_result = self.model_worker.forward_batch_generation(batch)
+                    fwd_kwargs = {}
+                    if (
+                        pp_proxy_tensors is not None
+                        and batch.spec_algorithm.is_dspark()
+                    ):
+                        fwd_kwargs["pp_proxy_tensors"] = pp_proxy_tensors
+                    batch_result = self.model_worker.forward_batch_generation(
+                        batch, **fwd_kwargs
+                    )
                 # The isolation restore reverted the worker's in-forward SB edits;
                 # re-apply what must carry to the next iter.
                 batch.spec_info = batch_result.next_draft_input

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1232,7 +1232,6 @@ class Scheduler(
                 bootstrap_port=self.server_args.disaggregation_bootstrap_port,
                 max_total_num_tokens=self.max_total_num_tokens,
                 pp_rank=self.ps.pp_rank,
-                pp_size=self.ps.pp_size,
                 num_reserved_decode_tokens=self.server_args.num_reserved_decode_tokens,
                 transfer_backend=self.transfer_backend,
             )

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1142,6 +1142,17 @@ class SchedulerPPMixin:
         self.future_map.stash(
             batch.req_pool_indices, RelayPayload(bonus_tokens=next_token_ids)
         )
+        next_draft_input = None
+        if batch.spec_algorithm.is_dspark():
+            from sglang.srt.speculative.dspark_components.dspark_draft import (
+                make_next_draft_input,
+            )
+
+            next_draft_input = make_next_draft_input(
+                bonus_tokens=next_token_ids,
+                new_seq_lens=batch.seq_lens,
+            )
+            batch.spec_info = next_draft_input
         batch.input_ids = None
         output_result = GenerationBatchResult(
             logits_output=logits_output,
@@ -1150,6 +1161,7 @@ class SchedulerPPMixin:
             extend_input_len_per_req=extend_input_len_per_req,
             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
             can_run_cuda_graph=mb_metadata.can_run_cuda_graph,
+            next_draft_input=next_draft_input,
         )
         return output_result
 

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -6,7 +6,7 @@ import time
 from array import array
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -45,6 +45,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
 
+PPTransferStatus = Tuple[List[str], List[str]]
+PPReleasePayload = Union[List[str], PPTransferStatus]
+
 
 def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
     """Check if output send/recv can be skipped for this batch."""
@@ -56,6 +59,35 @@ def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
         and not batch.contains_last_prefill_chunk
         and not batch.return_logprob
     )
+
+
+def _pp_ordered_intersection(left: List[str], right: List[str]) -> List[str]:
+    right_set = set(right)
+    return [rid for rid in left if rid in right_set]
+
+
+def _pp_ordered_union(left: List[str], right: List[str]) -> List[str]:
+    seen = set(left)
+    merged = list(left)
+    for rid in right:
+        if rid not in seen:
+            seen.add(rid)
+            merged.append(rid)
+    return merged
+
+
+def _pp_merge_transfer_status(
+    previous: PPTransferStatus,
+    current: PPTransferStatus,
+) -> PPTransferStatus:
+    previous_success, previous_failed = previous
+    current_success, current_failed = current
+    failed = _pp_ordered_union(previous_failed, current_failed)
+    success = _pp_ordered_intersection(previous_success, current_success)
+    if failed:
+        failed_set = set(failed)
+        success = [rid for rid in success if rid not in failed_set]
+    return success, failed
 
 
 @dataclass
@@ -217,8 +249,8 @@ class SchedulerPPMixin:
         bmbs = [None] * self.pp_loop_size
         tmbs = [None] * self.pp_loop_size
         consensus_bootstrapped_rids: Optional[List[str]] = None
-        transferred_rids: List[str] = []
-        release_rids: Optional[List[str]] = None
+        transferred_rids: PPTransferStatus = ([], [])
+        release_rids: Optional[PPTransferStatus] = None
         send_bootstrapped_work = []
         send_transfer_work = []
         send_consensus_bootstrapped_work = []
@@ -816,18 +848,20 @@ class SchedulerPPMixin:
                 )
             )
             self.waiting_queue.extend(good_reqs)
-            return [[req.rid for req in good_reqs], [req.rid for req in failed_reqs]]
+            return [
+                [req.rid for req in good_reqs],
+                _pp_ordered_union(
+                    bad_consensus_bootstrapped_rids,
+                    [req.rid for req in failed_reqs],
+                ),
+            ]
         return None
 
     def _pp_pd_get_bootstrapped_ids(self: Scheduler):
         # communicate pre-consensus bootstrapp reqs
         if self.pp_group.is_first_rank:
-            # First rank, pop the bootstrap reqs from the bootstrap queue
-            good_bootstrapped_rids, bad_bootstrapped_rids = self.get_rids(
-                self.disagg_prefill_bootstrap_queue.queue,
-                True,
-                [KVPoll.WaitingForInput],
-                [KVPoll.Failed],
+            good_bootstrapped_rids, bad_bootstrapped_rids = (
+                self.disagg_prefill_bootstrap_queue.get_ready_bootstrapped_rids_for_pp()
             )
         else:
             # Other ranks, receive the bootstrap reqs info from the previous rank and ensure the consensus
@@ -835,42 +869,34 @@ class SchedulerPPMixin:
             prev_good_bootstrapped_rids, prev_bad_bootstrapped_rids = (
                 prev_bootstrapped_rids
             )
-            curr_good_bootstrapped_rids, curr_bad_bootstrapped_rids = self.get_rids(
-                self.disagg_prefill_bootstrap_queue.queue,
-                True,
-                [KVPoll.WaitingForInput],
-                [KVPoll.Failed],
+            curr_good_bootstrapped_rids, curr_bad_bootstrapped_rids = (
+                self.disagg_prefill_bootstrap_queue.get_ready_bootstrapped_rids_for_pp()
             )
-            good_bootstrapped_rids = list(
-                set(prev_good_bootstrapped_rids) & set(curr_good_bootstrapped_rids)
+            good_bootstrapped_rids = _pp_ordered_intersection(
+                prev_good_bootstrapped_rids,
+                curr_good_bootstrapped_rids,
             )
-            bad_bootstrapped_rids = list(
-                set(prev_bad_bootstrapped_rids) | set(curr_bad_bootstrapped_rids)
+            bad_bootstrapped_rids = _pp_ordered_union(
+                prev_bad_bootstrapped_rids,
+                curr_bad_bootstrapped_rids,
             )
         return [good_bootstrapped_rids, bad_bootstrapped_rids]
 
-    def _pp_pd_get_prefill_transferred_ids(self: Scheduler):
+    def _pp_pd_get_prefill_transferred_ids(
+        self: Scheduler,
+    ) -> PPTransferStatus:
         # get the current stage transfer success
+        current_status = self.get_transferred_rids()
         if self.pp_group.is_first_rank:
-            transferred_rids = self.get_rids(
-                self.disagg_prefill_inflight_queue,
-                True,
-                [KVPoll.Success, KVPoll.Failed],
-            )
+            transferred_rids = current_status
         # if other ranks, do intersection with the previous rank's transferred rids
         else:
             # 2 (Release): Receive the transferred rids from the previous rank
             # 1. recv previous stage's transferred reqs info
-            prev_transferred_rids = self._pp_recv_pyobj_from_prev_stage()
-            # 2. get the current stage's transferred reqs info
-            curr_transferred_rids = self.get_rids(
-                self.disagg_prefill_inflight_queue,
-                True,
-                [KVPoll.Success, KVPoll.Failed],
-            )
-            # 3. new consensus rids = intersection(previous consensus rids, transfer finished rids)
-            transferred_rids = list(
-                set(prev_transferred_rids) & set(curr_transferred_rids)
+            previous_status = self._pp_recv_pyobj_from_prev_stage()
+            transferred_rids = _pp_merge_transfer_status(
+                previous=previous_status,
+                current=current_status,
             )
         return transferred_rids
 
@@ -899,10 +925,10 @@ class SchedulerPPMixin:
 
     def _pp_pd_send_consensus_release_ids(
         self: Scheduler,
-        tmbs: List[List[str]],
+        tmbs: List[Optional[PPReleasePayload]],
         next_first_rank_mb_id: int,
-        release_rids: List[str],
-        transferred_rids: List[str],
+        release_rids: Optional[PPReleasePayload],
+        transferred_rids: PPReleasePayload,
     ):
         send_release_work = []
         if self.pp_group.is_last_rank:

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1161,7 +1161,13 @@ class SchedulerPPMixin:
                 extend_input_len_per_req,
                 extend_logprob_start_len_per_req,
             ) = get_logprob_from_pp_outputs(pp_outputs)
-        next_token_ids = pp_outputs["next_token_ids"].to(torch.int64)
+        # PP outputs may be on CPU after result processing, while draft state is
+        # filtered with device-resident batch indices.
+        next_token_ids = pp_outputs["next_token_ids"].to(
+            device=batch.device,
+            dtype=torch.int64,
+            non_blocking=True,
+        )
         # PP rank 0 also relays into output_tokens_buf so the next iter's
         # resolve_forward_inputs finds these tokens for the decode portion
         # of mixed-chunk batches (which gather via mix_running_indices).

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -115,7 +115,7 @@ class GenerationBatchResult:
         Only the tensors which are needed for processing results are copied,
         e.g., next_token_ids, logits outputs
         """
-        if return_logprob:
+        if self.logits_output is not None and return_logprob:
             if self.logits_output.next_token_logprobs is not None:
                 self.logits_output.next_token_logprobs = _async_d2h(
                     self.logits_output.next_token_logprobs
@@ -139,11 +139,16 @@ class GenerationBatchResult:
                     _async_d2h(v) if torch.is_tensor(v) else v
                     for v in self.logits_output.next_token_token_ids_logprobs_val
                 ]
-        if return_hidden_states and self.logits_output.hidden_states is not None:
+        if (
+            self.logits_output is not None
+            and return_hidden_states
+            and self.logits_output.hidden_states is not None
+        ):
             self.logits_output.hidden_states = _async_d2h(
                 self.logits_output.hidden_states
             )
-        self.next_token_ids = _async_d2h(self.next_token_ids)
+        if self.next_token_ids is not None:
+            self.next_token_ids = _async_d2h(self.next_token_ids)
 
         if self.accept_lens is not None:
             self.accept_lens = _async_d2h(self.accept_lens)

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -393,30 +393,36 @@ class DFlashDraftModel(nn.Module):
             )
         return self.hidden_norm(self.fc(target_hidden))
 
-    def select_target_context_features(self, feature_indices: list[int]) -> None:
-        """Keep only a subset of trained target context features for PP-local KV injection."""
+    def project_target_hidden_partial(
+        self, target_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        """Project PP-local target features into an additive pre-norm context."""
         if not feature_indices:
             raise ValueError("feature_indices must be non-empty.")
         feature_indices = [int(i) for i in feature_indices]
-        if feature_indices == list(range(self.num_context_features)):
-            return
         if min(feature_indices) < 0 or max(feature_indices) >= self.num_context_features:
             raise ValueError(
                 "feature_indices out of range for DFLASH context projection: "
                 f"{feature_indices=} {self.num_context_features=}."
             )
-
         hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "DFLASH partial target_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(target_hidden.shape)}."
+            )
+
         cols = []
         for idx in feature_indices:
             start = idx * hidden_size
             cols.extend(range(start, start + hidden_size))
         index = torch.tensor(cols, dtype=torch.long, device=self.fc.weight.device)
-        self.fc.weight = nn.Parameter(
-            self.fc.weight.index_select(1, index).contiguous(),
-            requires_grad=self.fc.weight.requires_grad,
-        )
-        self.num_context_features = len(feature_indices)
+        weight = self.fc.weight.index_select(1, index)
+        if target_hidden.dtype != weight.dtype:
+            target_hidden = target_hidden.to(weight.dtype)
+        return F.linear(target_hidden, weight)
 
     @torch.no_grad()
     def forward(
@@ -604,10 +610,33 @@ class DFlashLagunaForCausalLM(DFlashDraftModel):
         fused = normed.reshape(target_hidden.shape[0], -1)
         return self.hidden_norm(self.fc(fused))
 
-    def select_target_context_features(self, feature_indices: list[int]) -> None:
-        super().select_target_context_features(feature_indices)
-        self.aux_hidden_norms = nn.ModuleList(
-            [self.aux_hidden_norms[int(i)] for i in feature_indices]
+    def project_target_hidden_partial(
+        self, target_hidden: torch.Tensor, feature_indices: list[int]
+    ) -> torch.Tensor:
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(i) for i in feature_indices]
+        hidden_size = int(self.config.hidden_size)
+        expected = len(feature_indices) * hidden_size
+        if target_hidden.ndim != 2 or int(target_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "Laguna DFLASH partial target_hidden feature dim mismatch. "
+                f"Expected shape [N, {expected}] for {feature_indices=}, "
+                f"but got shape={tuple(target_hidden.shape)}."
+            )
+        slices = target_hidden.view(
+            target_hidden.shape[0], len(feature_indices), hidden_size
+        )
+        compute_dtype = self.fc.weight.dtype
+        if slices.dtype != compute_dtype:
+            slices = slices.to(compute_dtype)
+        normed = torch.empty_like(slices)
+        for out_idx, feature_idx in enumerate(feature_indices):
+            normed[:, out_idx, :] = self.aux_hidden_norms[feature_idx](
+                slices[:, out_idx, :]
+            )
+        return super().project_target_hidden_partial(
+            normed.reshape(target_hidden.shape[0], -1), feature_indices
         )
 
 

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -393,6 +393,31 @@ class DFlashDraftModel(nn.Module):
             )
         return self.hidden_norm(self.fc(target_hidden))
 
+    def select_target_context_features(self, feature_indices: list[int]) -> None:
+        """Keep only a subset of trained target context features for PP-local KV injection."""
+        if not feature_indices:
+            raise ValueError("feature_indices must be non-empty.")
+        feature_indices = [int(i) for i in feature_indices]
+        if feature_indices == list(range(self.num_context_features)):
+            return
+        if min(feature_indices) < 0 or max(feature_indices) >= self.num_context_features:
+            raise ValueError(
+                "feature_indices out of range for DFLASH context projection: "
+                f"{feature_indices=} {self.num_context_features=}."
+            )
+
+        hidden_size = int(self.config.hidden_size)
+        cols = []
+        for idx in feature_indices:
+            start = idx * hidden_size
+            cols.extend(range(start, start + hidden_size))
+        index = torch.tensor(cols, dtype=torch.long, device=self.fc.weight.device)
+        self.fc.weight = nn.Parameter(
+            self.fc.weight.index_select(1, index).contiguous(),
+            requires_grad=self.fc.weight.requires_grad,
+        )
+        self.num_context_features = len(feature_indices)
+
     @torch.no_grad()
     def forward(
         self,
@@ -578,6 +603,12 @@ class DFlashLagunaForCausalLM(DFlashDraftModel):
             normed[:, i, :] = norm(slices[:, i, :])
         fused = normed.reshape(target_hidden.shape[0], -1)
         return self.hidden_norm(self.fc(fused))
+
+    def select_target_context_features(self, feature_indices: list[int]) -> None:
+        super().select_target_context_features(feature_indices)
+        self.aux_hidden_norms = nn.ModuleList(
+            [self.aux_hidden_norms[int(i)] for i in feature_indices]
+        )
 
 
 EntryClass = [DFlashDraftModel, DFlashLagunaForCausalLM]

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -513,6 +513,44 @@ class DSparkDraftMixin:
         commit_lens: Optional[torch.Tensor] = None,
     ) -> None:
         ctx_hidden = self.project_target_hidden(target_hidden)
+        self.write_context_hidden_kv(
+            ctx_hidden=ctx_hidden,
+            pool=pool,
+            positions=positions,
+            cache_loc=cache_loc,
+            cache_loc_2d=cache_loc_2d,
+            commit_lens=commit_lens,
+        )
+
+    def write_projected_context_kv(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        pool,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+    ) -> None:
+        self.write_context_hidden_kv(
+            ctx_hidden=self.hidden_norm(projected_context),
+            pool=pool,
+            positions=positions,
+            cache_loc=cache_loc,
+            cache_loc_2d=cache_loc_2d,
+            commit_lens=commit_lens,
+        )
+
+    def write_context_hidden_kv(
+        self,
+        *,
+        ctx_hidden: torch.Tensor,
+        pool,
+        positions: torch.Tensor,
+        cache_loc: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+    ) -> None:
         stacked = self._stacked_ctx_kv_params()
         if stacked is not None:
             k_all, v_all = self._project_ctx_kv_stacked(

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -2721,6 +2721,35 @@ class KimiK3LinearForCausalLM(nn.Module):
         loaded_params: set[str] = set()
 
         num_hidden_layers = self.config.num_hidden_layers
+
+        def maybe_load_truncated_moe_gate(
+            param_name: str, param: torch.Tensor, loaded_weight: torch.Tensor
+        ) -> bool:
+            if self.config.num_experts is None:
+                return False
+            if not (
+                param_name.endswith(".mlp.gate.weight")
+                or param_name.endswith(".mlp.gate.e_score_correction_bias")
+            ):
+                return False
+            if loaded_weight.shape == param.data.shape:
+                return False
+            keep_num_experts = int(self.config.num_experts)
+            if loaded_weight.shape[0] < keep_num_experts:
+                raise ValueError(
+                    f"Cannot truncate Kimi-K3 MoE gate weight {param_name}: "
+                    f"checkpoint has {loaded_weight.shape[0]} experts, "
+                    f"requested {keep_num_experts}."
+                )
+            truncated_weight = loaded_weight.narrow(0, 0, keep_num_experts)
+            if truncated_weight.shape != param.data.shape:
+                raise ValueError(
+                    f"Unexpected truncated Kimi-K3 MoE gate shape for {param_name}: "
+                    f"{truncated_weight.shape=} {param.data.shape=}."
+                )
+            param.data.copy_(truncated_weight)
+            return True
+
         for args in weights:
             name, loaded_weight = args[:2]
             kwargs = args[2] if len(args) > 2 else {}
@@ -2827,6 +2856,9 @@ class KimiK3LinearForCausalLM(nn.Module):
                     if name not in params_dict:
                         continue
                     param = params_dict[name]
+                    if maybe_load_truncated_moe_gate(name, param, loaded_weight):
+                        loaded_params.add(name)
+                        continue
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -2466,16 +2466,29 @@ class KimiK3LinearModel(nn.Module):
                 )
 
         if not self.pp_group.is_last_rank:
+            proxy_tensors = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if self.dspark_layers_to_capture is not None:
+                if aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = hidden_states.new_empty(
+                        hidden_states.shape[0], 0
+                    )
             assert not sp_sharded
             if attn_res is not None:
                 if residual is not None:
                     # Materialize the delayed MLP add: the wire carries the
                     # full stream head (bit-identical to the fused fold).
                     hidden_states = residual + hidden_states
+                    proxy_tensors["hidden_states"] = hidden_states
                 residual = attn_res.block_residual  # raw bank across ranks
-            return PPProxyTensors(
-                {"hidden_states": hidden_states, "residual": residual}
-            )
+                proxy_tensors["residual"] = residual
+            return PPProxyTensors(proxy_tensors)
 
         if hidden_states.shape[0] != 0:
             if attn_res is not None:
@@ -2587,18 +2600,17 @@ class KimiK3LinearForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
-        if self.pp_group.world_size > 1:
-            # Capture layers living on non-last PP ranks would be silently
-            # skipped (the flag is only set on the last rank).
-            raise NotImplementedError("DSPARK aux hidden capture requires PP=1.")
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/models/kimi_linear.py
+++ b/python/sglang/srt/models/kimi_linear.py
@@ -623,12 +623,20 @@ class KimiLinearModel(nn.Module):
                 )
 
         if not self.pp_group.is_last_rank:
-            return PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
+            proxy_tensors = {
+                "hidden_states": hidden_states,
+                "residual": residual,
+            }
+            if self.dspark_layers_to_capture is not None:
+                if aux_hidden_states:
+                    proxy_tensors["dspark_aux_hidden_states"] = torch.cat(
+                        aux_hidden_states, dim=-1
+                    )
+                else:
+                    proxy_tensors["dspark_aux_hidden_states"] = hidden_states.new_empty(
+                        hidden_states.shape[0], 0
+                    )
+            return PPProxyTensors(proxy_tensors)
         else:
             if hidden_states.shape[0] != 0:
                 if residual is None:
@@ -674,16 +682,17 @@ class KimiLinearForCausalLM(nn.Module):
         return self.model.embed_tokens
 
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
-        if self.pp_group.world_size > 1:
-            raise NotImplementedError("DSPARK aux hidden capture requires PP=1.")
-        if not self.pp_group.is_last_rank:
-            return
         if layer_ids is None:
             raise ValueError(
                 "DSPARK requires explicit layer_ids for aux hidden capture."
             )
-        self.capture_aux_hidden_states = True
-        self.model.dspark_layers_to_capture = list(layer_ids)
+        local_layer_ids = [
+            int(layer_id)
+            for layer_id in layer_ids
+            if self.model.start_layer <= int(layer_id) < self.model.end_layer
+        ]
+        self.capture_aux_hidden_states = bool(local_layer_ids)
+        self.model.dspark_layers_to_capture = local_layer_ids or None
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6042,10 +6042,15 @@ class ServerArgs:
                         f"verify={verify!r}. Use SGLANG_RAGGED_VERIFY_MODE=static."
                     )
             if self.disaggregation_mode == "prefill":
-                raise ValueError(
-                    "--enable-linear-replayssm-spec is not supported on a PD "
-                    "prefill server: the ring is spec-verify-only scratch and "
-                    "the prefill server never runs spec verify."
+                if _algo != "DSPARK":
+                    raise ValueError(
+                        "--enable-linear-replayssm-spec is not supported on a PD "
+                        "prefill server: the ring is spec-verify-only scratch and "
+                        "the prefill server never runs spec verify."
+                    )
+                logger.warning(
+                    "--enable-linear-replayssm-spec is ignored on a DSPARK PD "
+                    "prefill server; spec verify runs on the decode server."
                 )
             if self.linear_replayssm_cache_len < 1:
                 raise ValueError(
@@ -8522,8 +8527,13 @@ class ServerArgs:
         )
 
         if self.pp_size > 1:
+            pp_dspark_pd = (
+                (self.speculative_algorithm or "").upper() == "DSPARK"
+                and self.disaggregation_mode in ("prefill", "decode")
+            )
             assert (
-                self.disable_overlap_schedule and self.speculative_algorithm is None
+                self.disable_overlap_schedule
+                and (self.speculative_algorithm is None or pp_dspark_pd)
             ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
 
         assert not (

--- a/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_kv_inject.py
@@ -77,6 +77,44 @@ class TargetHiddenKvInjector:
                 commit_lens=commit_lens,
             )
 
+    def inject_projected_context(
+        self,
+        *,
+        projected_context: torch.Tensor,
+        cache_loc: torch.Tensor,
+        positions: torch.Tensor,
+        cache_loc_2d: Optional[torch.Tensor] = None,
+        commit_lens: Optional[torch.Tensor] = None,
+    ) -> None:
+        if projected_context is None or projected_context.numel() == 0:
+            return
+        device = self.model_runner.device
+        cache_loc = cache_loc.to(device=device, dtype=torch.int64, non_blocking=True)
+        positions = positions.to(device=device, dtype=torch.int64, non_blocking=True)
+        projected_context = projected_context.to(device=device, non_blocking=True)
+        n_real = positions.shape[0]
+        if projected_context.shape[0] > n_real:
+            projected_context = projected_context[:n_real]
+        if cache_loc_2d is not None:
+            cache_loc_2d = cache_loc_2d.to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+        if commit_lens is not None:
+            commit_lens = commit_lens.to(
+                device=device, dtype=torch.int32, non_blocking=True
+            )
+
+        pool = self.draft_model_runner.token_to_kv_pool
+        with torch.inference_mode():
+            self.draft_model.write_projected_context_kv(
+                projected_context=projected_context,
+                pool=pool,
+                positions=positions,
+                cache_loc=cache_loc,
+                cache_loc_2d=cache_loc_2d,
+                commit_lens=commit_lens,
+            )
+
     def _inject_mla(
         self,
         *,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -1,6 +1,5 @@
 import logging
 from contextlib import nullcontext
-from dataclasses import replace
 from typing import Optional
 
 import torch
@@ -107,7 +106,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             bundle = build_draft_tp_worker(
                 server_args=server_args,
                 gpu_id=gpu_id,
-                ps=replace(ps, pp_rank=0),
+                ps=ps,
                 nccl_port=nccl_port,
                 target_model_config=target_worker.model_runner.model_config,
                 algo_label="DSPARK",
@@ -154,7 +153,13 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         target_model = self.target_worker.model_runner.model
         lm_head = getattr(target_model, "lm_head", None)
-        if lm_head is None or not hasattr(lm_head, "weight"):
+        needs_lm_head = not (
+            self._is_pd_prefill
+            and self.ps.pp_size > 1
+            and self.ps.pp_rank + 1 < self.ps.pp_size
+            and not self._draft_is_moe
+        )
+        if needs_lm_head and (lm_head is None or not hasattr(lm_head, "weight")):
             raise RuntimeError(
                 "DSpark requires the target model to expose `lm_head` with `weight`."
             )
@@ -409,16 +414,31 @@ class DSparkWorkerV2(BaseSpecWorker):
             batch, capture_hidden_mode=CaptureHiddenMode.FULL
         )
         logits_output = batch_output.logits_output
+        pp_proxy_tensors = batch_output.pp_hidden_states_proxy_tensors
+        target_hidden = (
+            logits_output.hidden_states
+            if logits_output is not None
+            else (
+                pp_proxy_tensors.tensors.get("dspark_aux_hidden_states")
+                if pp_proxy_tensors is not None
+                else None
+            )
+        )
         next_token_ids = batch_output.next_token_ids
         batch_output.new_seq_lens = batch.seq_lens
         if on_publish is not None:
             on_publish(batch_output.new_seq_lens)
 
-        if logits_output.hidden_states is None:
+        if target_hidden is None and self.ps.pp_size > 1:
+            target_hidden = torch.empty(
+                (0, 0), dtype=torch.float16, device=self.device
+            )
+        if target_hidden is None:
             raise RuntimeError(
                 "DSpark requires target aux hidden capture for prefill, but got None. "
                 "Make sure the target model has DFlash layers-to-capture configured."
             )
+        has_local_target_hidden = target_hidden.numel() > 0
         if batch.extend_lens is None or batch.prefix_lens is None:
             raise RuntimeError(
                 "DSpark expected extend_lens / prefix_lens in extend mode, got None."
@@ -439,18 +459,21 @@ class DSparkWorkerV2(BaseSpecWorker):
             ctx_lens,
             int(sum(batch.extend_lens)),
         )
-        self._kv_injector.inject_target_hidden(
-            target_hidden=logits_output.hidden_states,
-            cache_loc=batch.out_cache_loc,
-            positions=positions,
-        )
+        if has_local_target_hidden:
+            self._kv_injector.inject_target_hidden(
+                target_hidden=target_hidden,
+                cache_loc=batch.out_cache_loc,
+                positions=positions,
+            )
         # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
-        logits_output.hidden_states = None
+        if logits_output is not None:
+            logits_output.hidden_states = None
 
-        batch_output.next_draft_input = make_next_draft_input(
-            bonus_tokens=next_token_ids,
-            new_seq_lens=batch.seq_lens,
-        )
+        if next_token_ids is not None:
+            batch_output.next_draft_input = make_next_draft_input(
+                bonus_tokens=next_token_ids,
+                new_seq_lens=batch.seq_lens,
+            )
         return batch_output
 
     def _idle_verify_ragged_layout(self, batch: ScheduleBatch):

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -130,6 +130,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.verify_num_draft_tokens = runtime_config.verify_num_draft_tokens
         self.speculative_num_draft_tokens = self.verify_num_draft_tokens
         self._mask_token_id = runtime_config.mask_token_id
+        self._pp_context_feature_indices: Optional[list[int]] = None
 
         if self.ps.tp_rank == 0:
             logger.info(
@@ -272,17 +273,17 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         if self._is_pd_prefill and not self._draft_is_moe:
             self.draft_model.prune_to_ctx_kv_injection()
-            self._select_pp_local_context_features_for_injection()
+            self._init_pp_context_feature_indices()
 
     def _resolve_target_embed_tokens(self, target_model):
         if hasattr(target_model, "get_input_embeddings"):
             return target_model.get_input_embeddings()
         return target_model.model.get_input_embeddings()
 
-    def _select_pp_local_context_features_for_injection(self) -> None:
+    def _init_pp_context_feature_indices(self) -> None:
         if self.ps.pp_size <= 1:
             return
-        if not hasattr(self.draft_model, "select_target_context_features"):
+        if not hasattr(self.draft_model, "project_target_hidden_partial"):
             return
 
         target_layer_ids = getattr(
@@ -294,18 +295,21 @@ class DSparkWorkerV2(BaseSpecWorker):
         target_model = self.target_worker.model_runner.model
         start_layer = int(getattr(target_model, "start_layer", 0))
         end_layer = int(getattr(target_model, "end_layer", 0))
+        target_layer_to_feature = {
+            int(layer_id): idx for idx, layer_id in enumerate(target_layer_ids)
+        }
         local_feature_indices = [
-            idx
-            for idx, layer_id in enumerate(target_layer_ids)
-            if start_layer <= int(layer_id) < end_layer
+            target_layer_to_feature[layer_id]
+            for layer_id in range(start_layer, end_layer)
+            if layer_id in target_layer_to_feature
         ]
         if not local_feature_indices:
             return
 
-        self.draft_model.select_target_context_features(local_feature_indices)
+        self._pp_context_feature_indices = local_feature_indices
         if self.ps.tp_rank == 0:
             logger.info(
-                "DSpark PP-local context projection selected feature indices %s "
+                "DSpark PP-local context projection will accumulate feature indices %s "
                 "from target layers %s for PP rank %s local layers [%s, %s).",
                 local_feature_indices,
                 list(target_layer_ids),
@@ -423,6 +427,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         on_publish=None,
         grammar_barrier=None,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
         if getattr(batch, "return_logprob", False):
             raise ValueError(
@@ -432,31 +437,35 @@ class DSparkWorkerV2(BaseSpecWorker):
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
-            return self._forward_prefill(batch, on_publish)
+            return self._forward_prefill(batch, on_publish, pp_proxy_tensors)
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
 
     def _forward_prefill(
-        self, batch: ScheduleBatch, on_publish
+        self, batch: ScheduleBatch, on_publish, pp_proxy_tensors=None
     ) -> GenerationBatchResult:
         if batch.forward_mode.is_idle():
             if self.server_args.enable_dp_attention:
                 self.target_worker.forward_batch_generation(
-                    batch, capture_hidden_mode=CaptureHiddenMode.FULL
+                    batch,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                    capture_hidden_mode=CaptureHiddenMode.FULL,
                 )
             return self._decode_idle_result(on_publish=on_publish)
 
         batch_output = self.target_worker.forward_batch_generation(
-            batch, capture_hidden_mode=CaptureHiddenMode.FULL
+            batch,
+            pp_proxy_tensors=pp_proxy_tensors,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
         )
         logits_output = batch_output.logits_output
-        pp_proxy_tensors = batch_output.pp_hidden_states_proxy_tensors
+        output_pp_proxy_tensors = batch_output.pp_hidden_states_proxy_tensors
         target_hidden = (
             logits_output.hidden_states
             if logits_output is not None
             else (
-                pp_proxy_tensors.tensors.get("dspark_aux_hidden_states")
-                if pp_proxy_tensors is not None
+                output_pp_proxy_tensors.tensors.get("dspark_aux_hidden_states")
+                if output_pp_proxy_tensors is not None
                 else None
             )
         )
@@ -498,7 +507,41 @@ class DSparkWorkerV2(BaseSpecWorker):
             ctx_lens,
             int(sum(batch.extend_lens)),
         )
-        if has_local_target_hidden:
+        incoming_ctx = (
+            pp_proxy_tensors.tensors.get("dspark_ctx_acc")
+            if pp_proxy_tensors is not None
+            else None
+        )
+        local_ctx = None
+        if (
+            self.ps.pp_size > 1
+            and has_local_target_hidden
+            and self._pp_context_feature_indices is not None
+        ):
+            local_ctx = self.draft_model.project_target_hidden_partial(
+                target_hidden, self._pp_context_feature_indices
+            )
+        ctx_acc = None
+        if incoming_ctx is not None and local_ctx is not None:
+            ctx_acc = (
+                incoming_ctx.to(device=local_ctx.device, dtype=local_ctx.dtype)
+                + local_ctx
+            )
+        elif incoming_ctx is not None:
+            ctx_acc = incoming_ctx.to(device=self.device, non_blocking=True)
+        elif local_ctx is not None:
+            ctx_acc = local_ctx
+
+        if output_pp_proxy_tensors is not None:
+            if ctx_acc is not None:
+                output_pp_proxy_tensors.tensors["dspark_ctx_acc"] = ctx_acc
+        elif ctx_acc is not None:
+            self._kv_injector.inject_projected_context(
+                projected_context=ctx_acc,
+                cache_loc=batch.out_cache_loc,
+                positions=positions,
+            )
+        elif has_local_target_hidden and not (self.ps.pp_size > 1 and not self._draft_is_moe):
             self._kv_injector.inject_target_hidden(
                 target_hidden=target_hidden,
                 cache_loc=batch.out_cache_loc,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -14,6 +14,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     compute_position,
 )
+from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
@@ -345,6 +346,30 @@ class DSparkWorkerV2(BaseSpecWorker):
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
     ):
+        if (
+            memory_pool_config is not None
+            and self._is_pd_prefill
+            and not self._draft_is_moe
+            and self.ps.pp_rank < self.ps.pp_size - 1
+        ):
+            page_size = int(self.page_size)
+
+            def _minimal_capacity(capacity):
+                if capacity is None or capacity == 0:
+                    return capacity
+                return page_size
+
+            memory_pool_config = MemoryPoolConfig(
+                max_total_num_tokens=page_size,
+                max_running_requests=memory_pool_config.max_running_requests,
+                full_max_total_num_tokens=_minimal_capacity(
+                    memory_pool_config.full_max_total_num_tokens
+                ),
+                swa_max_total_num_tokens=_minimal_capacity(
+                    memory_pool_config.swa_max_total_num_tokens
+                ),
+                mem_fraction_static=memory_pool_config.mem_fraction_static,
+            )
         self._draft_worker.alloc_memory_pool(
             memory_pool_config=memory_pool_config,
             req_to_token_pool=req_to_token_pool,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -272,11 +272,47 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         if self._is_pd_prefill and not self._draft_is_moe:
             self.draft_model.prune_to_ctx_kv_injection()
+            self._select_pp_local_context_features_for_injection()
 
     def _resolve_target_embed_tokens(self, target_model):
         if hasattr(target_model, "get_input_embeddings"):
             return target_model.get_input_embeddings()
         return target_model.model.get_input_embeddings()
+
+    def _select_pp_local_context_features_for_injection(self) -> None:
+        if self.ps.pp_size <= 1:
+            return
+        if not hasattr(self.draft_model, "select_target_context_features"):
+            return
+
+        target_layer_ids = getattr(
+            self.model_runner.spec_aux_config, "dflash_target_layer_ids", None
+        )
+        if not target_layer_ids:
+            return
+
+        target_model = self.target_worker.model_runner.model
+        start_layer = int(getattr(target_model, "start_layer", 0))
+        end_layer = int(getattr(target_model, "end_layer", 0))
+        local_feature_indices = [
+            idx
+            for idx, layer_id in enumerate(target_layer_ids)
+            if start_layer <= int(layer_id) < end_layer
+        ]
+        if not local_feature_indices:
+            return
+
+        self.draft_model.select_target_context_features(local_feature_indices)
+        if self.ps.tp_rank == 0:
+            logger.info(
+                "DSpark PP-local context projection selected feature indices %s "
+                "from target layers %s for PP rank %s local layers [%s, %s).",
+                local_feature_indices,
+                list(target_layer_ids),
+                self.ps.pp_rank,
+                start_layer,
+                end_layer,
+            )
 
     @property
     def carries_confidence(self) -> bool:

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -448,7 +448,10 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         # Must inject before prefill returns: the scheduler may update radix
         # afterward, invalidating out_cache_loc.
-        device = next_token_ids.device
+        # Non-last PP ranks return PPProxyTensors and do not sample tokens, so
+        # next_token_ids is None there. Positions are still needed for local
+        # draft-KV injection, and should live on this worker's device.
+        device = self.device
         ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
         draft_seq_lens = torch.tensor(
             batch.prefix_lens, dtype=torch.int32, device=device

--- a/test/manual/dspark/test_dspark_pp_pd_e2e.py
+++ b/test/manual/dspark/test_dspark_pp_pd_e2e.py
@@ -1,0 +1,103 @@
+"""Manual PP-prefill/PP1-decode DSpark draft-KV handoff test.
+
+Required:
+  SGLANG_TEST_KIMI_K3_MODEL=/path/to/Kimi-K3
+  SGLANG_TEST_KIMI_K3_DSPARK_MODEL=/path/to/Kimi-K3-DSpark
+
+Optional topology variables are defined below. The default uses PP2/TP1 prefill
+and PP1/TP1 decode on three local GPUs.
+"""
+
+import os
+import unittest
+
+import requests
+
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+    assert_process_healthy,
+)
+
+TARGET_MODEL = os.environ.get("SGLANG_TEST_KIMI_K3_MODEL")
+DRAFT_MODEL = os.environ.get("SGLANG_TEST_KIMI_K3_DSPARK_MODEL")
+PREFILL_TP_SIZE = int(os.environ.get("SGLANG_TEST_PREFILL_TP_SIZE", "1"))
+PREFILL_PP_SIZE = int(os.environ.get("SGLANG_TEST_PREFILL_PP_SIZE", "2"))
+DECODE_TP_SIZE = int(os.environ.get("SGLANG_TEST_DECODE_TP_SIZE", "1"))
+DECODE_BASE_GPU_ID = int(
+    os.environ.get(
+        "SGLANG_TEST_DECODE_BASE_GPU_ID",
+        str(PREFILL_TP_SIZE * PREFILL_PP_SIZE),
+    )
+)
+SPEC_BLOCK_SIZE = os.environ.get("SGLANG_TEST_DSPARK_BLOCK_SIZE", "7")
+
+SPEC_ARGS = [
+    "--speculative-algorithm",
+    "DSPARK",
+    "--speculative-draft-model-path",
+    DRAFT_MODEL or "",
+    "--speculative-dspark-block-size",
+    SPEC_BLOCK_SIZE,
+    "--max-running-requests",
+    "8",
+    "--cuda-graph-backend-decode",
+    "disabled",
+    "--cuda-graph-backend-prefill",
+    "disabled",
+]
+
+
+@unittest.skipUnless(
+    TARGET_MODEL and DRAFT_MODEL,
+    "Set SGLANG_TEST_KIMI_K3_MODEL and SGLANG_TEST_KIMI_K3_DSPARK_MODEL.",
+)
+class TestDSparkPPPDHandoff(PDDisaggregationServerBase):
+    prefill_tp_size = PREFILL_TP_SIZE
+    decode_tp_size = DECODE_TP_SIZE
+    decode_base_gpu_id = DECODE_BASE_GPU_ID
+    extra_prefill_args = [
+        "--pp-size",
+        str(PREFILL_PP_SIZE),
+        "--disable-overlap-schedule",
+        *SPEC_ARGS,
+    ]
+    extra_decode_args = SPEC_ARGS
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = TARGET_MODEL
+        cls.launch_all()
+
+    def test_pp_prefill_to_pp1_decode_draft_kv_handoff(self):
+        accept_lengths = []
+        for prompt in (
+            "Explain why pipeline parallelism needs ordered consensus.",
+            "Write a Python function that returns the sum of a list.",
+            "Describe the difference between prefill and decode inference.",
+        ):
+            response = requests.post(
+                self.lb_url + "/generate",
+                json={
+                    "text": prompt,
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": 32,
+                        "ignore_eos": True,
+                    },
+                },
+                timeout=180,
+            )
+            response.raise_for_status()
+            meta_info = response.json()["meta_info"]
+            self.assertGreater(meta_info["spec_verify_ct"], 0)
+            accept_lengths.append(meta_info["spec_accept_length"])
+
+        self.assertGreater(max(accept_lengths), 1.0)
+        assert_process_healthy(self, "load balancer", self.process_lb, self.lb_url)
+        assert_process_healthy(self, "prefill", self.process_prefill, self.prefill_url)
+        assert_process_healthy(self, "decode", self.process_decode, self.decode_url)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_pp_pd_consensus.py
+++ b/test/registered/unit/disaggregation/test_pp_pd_consensus.py
@@ -1,0 +1,80 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.base import KVPoll  # noqa: E402
+from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue  # noqa: E402
+from sglang.srt.managers.scheduler_pp_mixin import (  # noqa: E402
+    _pp_merge_transfer_status,
+)
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestPPPDConsensus(CustomTestCase):
+    def test_transfer_failure_overrides_ordered_success_intersection(self):
+        """A failure on one PP rank must terminate an otherwise successful rid."""
+        status = _pp_merge_transfer_status(
+            previous=(["req-a", "req-b", "req-c"], ["req-x"]),
+            current=(["req-c", "req-a", "req-b"], ["req-b", "req-y"]),
+        )
+
+        self.assertEqual(
+            status,
+            (["req-a", "req-c"], ["req-x", "req-b", "req-y"]),
+        )
+
+    def test_bootstrap_probe_respects_local_metadata_credit_prefix(self):
+        """A slower PP rank must not advertise requests it cannot admit."""
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.queue = [
+            SimpleNamespace(
+                rid="req-failed",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-ready",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+            SimpleNamespace(
+                rid="req-blocked",
+                metadata_buffer_index=-1,
+                disagg_kv_sender=object(),
+            ),
+        ]
+        queue.scheduler = SimpleNamespace(
+            attn_cp_cpu_group=object(),
+            attn_tp_cpu_group=object(),
+        )
+        queue.req_to_metadata_buffer_idx_allocator = SimpleNamespace(
+            available_size=lambda: 1
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.prefill."
+            "poll_and_all_reduce_attn_cp_tp_group",
+            return_value=[
+                KVPoll.Failed,
+                KVPoll.WaitingForInput,
+                KVPoll.WaitingForInput,
+            ],
+        ):
+            good_rids, failed_rids = queue.get_ready_bootstrapped_rids_for_pp()
+
+        self.assertEqual(good_rids, ["req-ready"])
+        self.assertEqual(failed_rids, ["req-failed"])
+        self.assertEqual(
+            [req.metadata_buffer_index for req in queue.queue],
+            [-1, -1, -1],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_pp_pd_consensus.py
+++ b/test/registered/unit/disaggregation/test_pp_pd_consensus.py
@@ -9,6 +9,10 @@ maybe_stub_sgl_kernel()
 
 from sglang.srt.disaggregation.base import KVPoll  # noqa: E402
 from sglang.srt.disaggregation.prefill import PrefillBootstrapQueue  # noqa: E402
+from sglang.srt.disaggregation.utils import (  # noqa: E402
+    _DRAFT_KV_LAYER_ID_BASE,
+    build_transfer_entry_pairs,
+)
 from sglang.srt.managers.scheduler_pp_mixin import (  # noqa: E402
     _pp_merge_transfer_status,
 )
@@ -17,6 +21,55 @@ register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 class TestPPPDConsensus(CustomTestCase):
+    @staticmethod
+    def _make_prefill_queue(pp_rank):
+        class FakeKVArgs:
+            pass
+
+        class FakeManager:
+            def __init__(self, kv_args, *_args):
+                self.kv_args = kv_args
+
+        class FakePool:
+            start_layer = 4
+            end_layer = 6
+            head_num = 1
+            page_size = 64
+
+            @staticmethod
+            def get_contiguous_buf_infos():
+                return [10, 11], [100, 100], [10, 10]
+
+        class FakeDraftPool:
+            start_layer = 0
+            end_layer = 1
+
+            @staticmethod
+            def get_contiguous_buf_infos():
+                return [20], [100], [10]
+
+        queue = PrefillBootstrapQueue.__new__(PrefillBootstrapQueue)
+        queue.transfer_backend = "mooncake"
+        queue.tp_rank = 0
+        queue.pp_rank = pp_rank
+        queue.pp_size = 2
+        queue.scheduler = SimpleNamespace(
+            ps=SimpleNamespace(dp_rank=0, gpu_id=0),
+            server_args=SimpleNamespace(disaggregation_ib_device=None),
+            model_config=SimpleNamespace(
+                num_hidden_layers=8,
+                get_total_num_kv_heads=lambda: 1,
+            ),
+            req_to_token_pool=None,
+        )
+        queue.token_to_kv_pool = FakePool()
+        queue.draft_token_to_kv_pool = FakeDraftPool()
+        queue.metadata_buffers = SimpleNamespace(
+            get_buf_infos=lambda: ([], [], [])
+        )
+        queue.is_mla_backend = False
+        return queue, FakeKVArgs, FakeManager
+
     def test_transfer_failure_overrides_ordered_success_intersection(self):
         """A failure on one PP rank must terminate an otherwise successful rid."""
         status = _pp_merge_transfer_status(
@@ -74,6 +127,61 @@ class TestPPPDConsensus(CustomTestCase):
             [req.metadata_buffer_index for req in queue.queue],
             [-1, -1, -1],
         )
+
+    def test_only_last_pp_registers_draft_kv_for_transfer(self):
+        """Draft KV has one prefill owner even though every PP rank has a worker."""
+        layer_ids_by_rank = []
+        for pp_rank in (0, 1):
+            queue, fake_args, fake_manager = self._make_prefill_queue(pp_rank)
+
+            def get_kv_class(_backend, class_type):
+                return fake_args if class_type.value == "kvargs" else fake_manager
+
+            with (
+                patch(
+                    "sglang.srt.disaggregation.prefill.get_kv_class",
+                    side_effect=get_kv_class,
+                ),
+                patch(
+                    "sglang.srt.disaggregation.prefill.setup_state_kv_args",
+                ),
+            ):
+                manager = queue._init_kv_manager()
+            layer_ids_by_rank.append(manager.kv_args.kv_layer_ids)
+
+        self.assertEqual(layer_ids_by_rank[0], [4, 5])
+        self.assertEqual(
+            layer_ids_by_rank[1],
+            [4, 5, _DRAFT_KV_LAYER_ID_BASE],
+        )
+
+    def test_pp_prefill_entries_pair_with_pp1_decode_entries(self):
+        """Each PP source maps target layers plus the unique draft entry by id."""
+        decode_layer_ids = [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            _DRAFT_KV_LAYER_ID_BASE,
+        ]
+
+        rank_0_pairs = build_transfer_entry_pairs(
+            src_layer_ids=[0, 1, 2, 3],
+            dst_layer_ids=decode_layer_ids,
+            n_src=4,
+            n_dst=7,
+        )
+        rank_1_pairs = build_transfer_entry_pairs(
+            src_layer_ids=[4, 5, _DRAFT_KV_LAYER_ID_BASE],
+            dst_layer_ids=decode_layer_ids,
+            n_src=3,
+            n_dst=7,
+        )
+
+        self.assertEqual(rank_0_pairs, [(0, 0), (1, 1), (2, 2), (3, 3)])
+        self.assertEqual(rank_1_pairs, [(0, 4), (1, 5), (2, 6)])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_dspark_pp_context.py
+++ b/test/registered/unit/spec/test_dspark_pp_context.py
@@ -1,0 +1,92 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.layernorm import RMSNorm  # noqa: E402
+from sglang.srt.models.dflash import DFlashDraftModel  # noqa: E402
+from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig  # noqa: E402
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import (  # noqa: E402
+    DSparkWorkerV2,
+)
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestDSparkPPContext(CustomTestCase):
+    def test_partial_projection_sum_matches_full_projection(self):
+        """PP partial projections must preserve the full pre-norm FC result."""
+        torch.manual_seed(0)
+        hidden_size = 4
+        model = DFlashDraftModel.__new__(DFlashDraftModel)
+        torch.nn.Module.__init__(model)
+        model.config = SimpleNamespace(hidden_size=hidden_size)
+        model.num_context_features = 3
+        model.fc = torch.nn.Linear(3 * hidden_size, hidden_size, bias=False)
+        model.hidden_norm = RMSNorm(hidden_size, eps=1e-6)
+
+        feature_hidden = [
+            torch.randn(5, hidden_size, dtype=torch.float32) for _ in range(3)
+        ]
+        full_hidden = torch.cat(feature_hidden, dim=-1)
+        full_projected = model.project_target_hidden(full_hidden)
+
+        stage_0 = model.project_target_hidden_partial(
+            torch.cat([feature_hidden[0], feature_hidden[2]], dim=-1),
+            [0, 2],
+        )
+        stage_1 = model.project_target_hidden_partial(feature_hidden[1], [1])
+        pp_projected = model.hidden_norm(stage_0 + stage_1)
+
+        torch.testing.assert_close(pp_projected, full_projected)
+
+    def test_non_last_pp_prefill_uses_minimal_draft_kv_pool(self):
+        """A context-only PP rank must not reserve the full draft KV capacity."""
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_pd_prefill = True
+        worker._draft_is_moe = False
+        worker.ps = SimpleNamespace(pp_rank=0, pp_size=2)
+        worker.page_size = 64
+        full_config = MemoryPoolConfig(
+            max_total_num_tokens=4096,
+            max_running_requests=32,
+        )
+
+        worker.alloc_memory_pool(memory_pool_config=full_config)
+
+        passed_config = worker._draft_worker.alloc_memory_pool.call_args.kwargs[
+            "memory_pool_config"
+        ]
+        self.assertEqual(passed_config.max_total_num_tokens, 64)
+        self.assertEqual(passed_config.max_running_requests, 32)
+        self.assertEqual(full_config.max_total_num_tokens, 4096)
+
+    def test_last_pp_prefill_keeps_full_draft_kv_pool(self):
+        worker = DSparkWorkerV2.__new__(DSparkWorkerV2)
+        worker._draft_worker = Mock()
+        worker._is_pd_prefill = True
+        worker._draft_is_moe = False
+        worker.ps = SimpleNamespace(pp_rank=1, pp_size=2)
+        worker.page_size = 64
+        full_config = MemoryPoolConfig(
+            max_total_num_tokens=4096,
+            max_running_requests=32,
+        )
+
+        worker.alloc_memory_pool(memory_pool_config=full_config)
+
+        passed_config = worker._draft_worker.alloc_memory_pool.call_args.kwargs[
+            "memory_pool_config"
+        ]
+        self.assertIs(passed_config, full_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #32750.

The existing PD + DSpark path works without Pipeline Parallelism because the prefill worker captures all required target hidden states, injects draft KV locally, and transfers target KV + draft KV to the decode worker.

With PP enabled, the captured target hidden states are distributed across PP stages. Each stage only owns a subset of the features required by the DSpark context projection. Injecting draft KV independently on each stage is not equivalent to the non-PP computation because RMSNorm must be applied after the full context projection is accumulated.

## Design

This PR keeps the existing PD data plane unchanged:

```text
Prefill -> target KV + draft KV -> Decode
```

Hidden states are not transferred across the PD boundary.
Each prefill PP stage computes its local pre-norm context contribution:

```text
ctx_i = h_i @ W_i.T
```

The accumulated context is carried through PP proxy tensors:

```text
ctx_acc = recv_ctx_acc + ctx_i
```

The last PP stage performs:

```text
ctx_norm = RMSNorm(ctx_acc)
K, V = KVProj(ctx_norm)
```

and writes draft KV into the prefill-side draft KV pool.

This preserves the original non-PP computation:

```text
concat(h1, ..., hk) @ W_fc.T == sum_i(h_i @ W_i.T)
```

while keeping the additional PP payload fixed at `[num_tokens, hidden_size]`.

## Changes

- Add `project_target_hidden_partial()` to compute PP-local context contributions without applying the final RMSNorm.
- Capture only target layers owned by the local PP stage.
- Carry `dspark_ctx_acc` through `PPProxyTensors`.
- Inject draft KV only on the last prefill PP stage.
- Transfer draft KV only from the last prefill PP stage.
- Register the full draft KV destination on the non-PP decode worker.
- Add an independent layer-ID namespace for draft KV entries so they cannot collide with target-model layer IDs.
- Reduce the draft KV pool on non-last prefill PP stages to a single page. These stages only need the draft projection weights and never read or write draft KV.
- Preserve the existing non-PP PD + DSpark behavior.

## Why `scheduler_pp_mixin.py` Is Modified

The last PP stage performs additional work because it injects and transfers draft KV, while the other PP stages only transfer their local target KV. This creates asymmetric transfer completion times.

The previous PP scheduler logic treated successful and failed transfers as one unordered set. It could also admit requests based only on `KVPoll.WaitingForInput`, before confirming that every PP stage had sufficient local metadata credits. Under sustained load, these behaviors could cause:

- different PP stages to admit requests in different orders;
- early KV release on stages that completed before the last PP stage;
- inflight queue divergence after a transfer failure;
- PP send/receive or proxy-tensor scheduling desynchronization.

The scheduler changes make the control plane deterministic:

- bootstrap readiness is probed without reserving resources;
- request order is preserved during PP intersection and union;
- transfer success requires intersection across all PP stages;
- transfer failure is propagated as a union across all PP stages;
- release occurs only after the last PP stage has completed both target KV and draft KV transfer;
- DSpark draft input is reconstructed after PP output processing;
- PP output tokens are moved to the batch device before creating the next draft state.

The scheduler does not transfer hidden states or draft KV itself. Its role is to keep admission, completion, and release decisions consistent across PP stages despite the extra work performed by the last stage.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30468401131](https://github.com/sgl-project/sglang/actions/runs/30468401131)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30468402528](https://github.com/sgl-project/sglang/actions/runs/30468402528)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->