### PR TITLE
Support DCP and speculative decode in TRTLLM MHA

### DIFF
--- a/python/sglang/kernels/ops/kvcache/trtllm_mha_graph_metadata.py
+++ b/python/sglang/kernels/ops/kvcache/trtllm_mha_graph_metadata.py
@@ -57,6 +57,8 @@ def update_trtllm_mha_graph_metadata_kernel(
     swa_page_table_stride,
     # constexpr
     PAGE_SIZE: tl.constexpr,
+    DCP_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
     HAS_SWA: tl.constexpr,
     HAS_SWA_OUT: tl.constexpr,
     Q_MODE: tl.constexpr,
@@ -68,7 +70,10 @@ def update_trtllm_mha_graph_metadata_kernel(
     if pid < bs:
         # One program per batch row: cache_seqlens + page table row(s).
         req_pool_index = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
-        seqlen = (tl.load(seq_lens_ptr + pid) + seqlen_offset).to(tl.int32)
+        global_seqlen = (tl.load(seq_lens_ptr + pid) + seqlen_offset).to(tl.int32)
+        seqlen = (global_seqlen // DCP_SIZE + (DCP_RANK < global_seqlen % DCP_SIZE)).to(
+            tl.int32
+        )
         tl.store(cache_seqlens_ptr + pid, seqlen)
 
         row_in = req_to_token_ptr + req_pool_index * req_to_token_stride
@@ -82,9 +87,12 @@ def update_trtllm_mha_graph_metadata_kernel(
             page_idx = i * PAGE_BLOCK + tl.arange(0, PAGE_BLOCK)
             mask = page_idx < num_live_pages
             token = tl.load(
-                row_in + page_idx.to(tl.int64) * PAGE_SIZE, mask=mask, other=0
+                row_in + page_idx.to(tl.int64) * PAGE_SIZE * DCP_SIZE + DCP_RANK,
+                mask=mask,
+                other=0,
             )
-            tl.store(row_out + page_idx, token // PAGE_SIZE, mask=mask)
+            local_token = token // DCP_SIZE
+            tl.store(row_out + page_idx, local_token // PAGE_SIZE, mask=mask)
             if HAS_SWA:
                 token64 = token.to(tl.int64)
                 # Real req_to_token slots are >=0; the token>=0 guard + other=-1 mirror
@@ -98,8 +106,13 @@ def update_trtllm_mha_graph_metadata_kernel(
         # Single program: cu_seqlens_k (+ optional cu_seqlens_q) cumsum.
         offs = tl.arange(0, BS_BLOCK)
         mask = offs < bs
-        seqlens = (tl.load(seq_lens_ptr + offs, mask=mask, other=0)).to(tl.int32)
-        seqlens = tl.where(mask, seqlens + seqlen_offset, 0)
+        global_seqlens = (
+            tl.load(seq_lens_ptr + offs, mask=mask, other=0) + seqlen_offset
+        ).to(tl.int32)
+        seqlens = (
+            global_seqlens // DCP_SIZE + (DCP_RANK < global_seqlens % DCP_SIZE)
+        ).to(tl.int32)
+        seqlens = tl.where(mask, seqlens, 0)
         tl.store(cu_seqlens_k_ptr + 1 + offs, tl.cumsum(seqlens, axis=0), mask=mask)
         if Q_MODE == 1:  # Q_MODE_CUMSUM
             qlens = tl.load(qlens_ptr + offs, mask=mask, other=0).to(tl.int32)
@@ -145,6 +158,8 @@ def update_trtllm_mha_graph_metadata(
     qlens=None,
     q_stride: int = 0,
     q_mode: int = Q_MODE_NONE,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
 ):
     """Launch the fused metadata update (one kernel for the whole replay init).
 
@@ -198,6 +213,8 @@ def update_trtllm_mha_graph_metadata(
         page_table.stride(0),
         swa_page_table.stride(0) if has_swa else 0,
         PAGE_SIZE=page_size,
+        DCP_SIZE=dcp_size,
+        DCP_RANK=dcp_rank,
         HAS_SWA=has_swa,
         HAS_SWA_OUT=has_swa_out,
         Q_MODE=q_mode,

--- a/python/sglang/kernels/ops/kvcache/trtllm_mha_graph_metadata.py
+++ b/python/sglang/kernels/ops/kvcache/trtllm_mha_graph_metadata.py
@@ -38,6 +38,7 @@ def update_trtllm_mha_graph_metadata_kernel(
     swa_mapping_ptr,  # [full_size + page_size + 1] int64, or None
     out_cache_loc_ptr,  # [num_out_tokens] int64, or None
     qlens_ptr,  # [bs] int, or None (Q_MODE_CUMSUM only)
+    causal_seqlens_kv_global_ptr,  # [bs] int32, or None
     # outputs
     cache_seqlens_ptr,  # [bs] int32
     cu_seqlens_k_ptr,  # [bs + 1] int32
@@ -50,6 +51,7 @@ def update_trtllm_mha_graph_metadata_kernel(
     seqlen_offset,  # added to seq_lens for cache_seqlens / cu_seqlens_k
     max_seq_pages,  # page-table columns to (re)write per row
     q_stride,  # Q_MODE_STRIDED stride
+    causal_seqlen_offset,  # added to raw seq_lens for the speculative prefix
     num_out_tokens,  # valid prefix of out_cache_loc
     swa_out_len,  # full swa_out_cache_loc length (zero-padded tail)
     req_to_token_stride,
@@ -62,6 +64,7 @@ def update_trtllm_mha_graph_metadata_kernel(
     HAS_SWA: tl.constexpr,
     HAS_SWA_OUT: tl.constexpr,
     Q_MODE: tl.constexpr,
+    HAS_CAUSAL_SEQLENS: tl.constexpr,
     PAGE_BLOCK: tl.constexpr,
     BS_BLOCK: tl.constexpr,
 ):
@@ -70,7 +73,13 @@ def update_trtllm_mha_graph_metadata_kernel(
     if pid < bs:
         # One program per batch row: cache_seqlens + page table row(s).
         req_pool_index = tl.load(req_pool_indices_ptr + pid).to(tl.int64)
-        global_seqlen = (tl.load(seq_lens_ptr + pid) + seqlen_offset).to(tl.int32)
+        raw_seqlen = tl.load(seq_lens_ptr + pid)
+        global_seqlen = (raw_seqlen + seqlen_offset).to(tl.int32)
+        if HAS_CAUSAL_SEQLENS:
+            tl.store(
+                causal_seqlens_kv_global_ptr + pid,
+                (raw_seqlen + causal_seqlen_offset).to(tl.int32),
+            )
         seqlen = (global_seqlen // DCP_SIZE + (DCP_RANK < global_seqlen % DCP_SIZE)).to(
             tl.int32
         )
@@ -158,6 +167,8 @@ def update_trtllm_mha_graph_metadata(
     qlens=None,
     q_stride: int = 0,
     q_mode: int = Q_MODE_NONE,
+    causal_seqlens_kv_global=None,
+    causal_seqlen_offset: int = 0,
     dcp_size: int = 1,
     dcp_rank: int = 0,
 ):
@@ -177,6 +188,7 @@ def update_trtllm_mha_graph_metadata(
     PAGE_BLOCK = 512
     has_swa = swa_page_table is not None
     has_swa_out = swa_out_cache_loc is not None
+    has_causal_seqlens = causal_seqlens_kv_global is not None
 
     swa_out_len = swa_out_cache_loc.shape[0] if has_swa_out else 0
     if has_swa_out and out_cache_loc is not None:
@@ -197,6 +209,7 @@ def update_trtllm_mha_graph_metadata(
         swa_mapping,
         out_cache_loc,
         qlens,
+        causal_seqlens_kv_global,
         cache_seqlens,
         cu_seqlens_k,
         cu_seqlens_q,
@@ -207,6 +220,7 @@ def update_trtllm_mha_graph_metadata(
         seqlen_offset,
         max_seq_pages,
         q_stride,
+        causal_seqlen_offset,
         num_out_tokens,
         swa_out_len,
         req_to_token.stride(0),
@@ -218,6 +232,7 @@ def update_trtllm_mha_graph_metadata(
         HAS_SWA=has_swa,
         HAS_SWA_OUT=has_swa_out,
         Q_MODE=q_mode,
+        HAS_CAUSAL_SEQLENS=has_causal_seqlens,
         PAGE_BLOCK=PAGE_BLOCK,
         BS_BLOCK=triton.next_power_of_2(bs),
     )

--- a/python/sglang/kernels/ops/kvcache/trtllm_mha_page_table.py
+++ b/python/sglang/kernels/ops/kvcache/trtllm_mha_page_table.py
@@ -48,6 +48,8 @@ def create_trtllm_mha_kv_indices_triton(
     req_to_token_stride: tl.constexpr,
     page_table_stride: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    DCP_SIZE: tl.constexpr,
+    DCP_RANK: tl.constexpr,
     HAS_SWA: tl.constexpr,
 ):
     """Fill ``page_table_ptr`` (and ``swa_page_table_ptr`` when ``HAS_SWA``).
@@ -74,7 +76,10 @@ def create_trtllm_mha_kv_indices_triton(
 
     req_pool_index = tl.load(req_pool_indices_ptr + pid_req)
     page_idx = tl.arange(0, PAGES_PER_BLOCK) + pid_blk * PAGES_PER_BLOCK
-    token_pos = page_idx.to(tl.int64) * PAGE_SIZE
+    # DCP stores only the round-robin token positions owned by this rank.
+    # The scheduler allocates global slots in PAGE_SIZE * DCP_SIZE pages and
+    # the KV writer maps them to the local pool with slot // DCP_SIZE.
+    token_pos = page_idx.to(tl.int64) * PAGE_SIZE * DCP_SIZE + DCP_RANK
     mask = page_idx < num_pages
 
     slot = tl.load(
@@ -84,7 +89,12 @@ def create_trtllm_mha_kv_indices_triton(
         mask=mask,
     )
     out_off = pid_req * page_table_stride + page_idx
-    tl.store(page_table_ptr + out_off, (slot // PAGE_SIZE).to(tl.int32), mask=mask)
+    local_slot = slot // DCP_SIZE
+    tl.store(
+        page_table_ptr + out_off,
+        (local_slot // PAGE_SIZE).to(tl.int32),
+        mask=mask,
+    )
     if HAS_SWA:
         swa_index = tl.minimum(tl.maximum(slot, 0), full_to_swa_numel - 1)
         swa_slot = tl.load(full_to_swa_ptr + swa_index.to(tl.int64), mask=mask)
@@ -103,6 +113,8 @@ def build_trtllm_mha_page_table(
     page_size: int,
     swa_page_table: Optional[torch.Tensor] = None,
     full_to_swa: Optional[torch.Tensor] = None,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
 ) -> None:
     """Fill ``page_table`` (and ``swa_page_table`` when SWA) on-device, no D2H sync.
 
@@ -134,5 +146,7 @@ def build_trtllm_mha_page_table(
         req_to_token.stride(0),
         page_table.stride(0),
         PAGE_SIZE=page_size,
+        DCP_SIZE=dcp_size,
+        DCP_RANK=dcp_rank,
         HAS_SWA=has_swa,
     )

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -71,12 +71,12 @@ class HybridAttnBackend(AttentionBackend):
 
         Note:
             - decode_or_idle: Always uses decode backend
-            - target_verify: Uses decode backend if speculative_attention_mode is "decode", otherwise prefill backend
+            - target_verify/draft_extend_v2: Uses decode backend if speculative_attention_mode is "decode", otherwise prefill backend
             - prefill: Always uses prefill backend
         """
         if forward_mode.is_decode_or_idle():
             return self.decode_backend
-        elif forward_mode.is_target_verify():
+        elif forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2():
             return (
                 self.decode_backend
                 if self.spec_attn_is_decode

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -20,6 +20,9 @@ from sglang.kernels.ops.kvcache.trtllm_mha_graph_metadata import (
 from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
+from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    use_symmetric_memory,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.flashinfer_backend import (
     FlashInferAttnBackend,
@@ -27,6 +30,7 @@ from sglang.srt.layers.attention.flashinfer_backend import (
 )
 from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.layers.dcp import cp_lse_ag_out_rs_mha, get_dcp_lens
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     KVCacheAttentionAccessKind,
 )
@@ -34,7 +38,7 @@ from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_buffer, get_spec
+from sglang.srt.runtime_context import get_buffer, get_parallel, get_spec
 from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
@@ -133,6 +137,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # MHA-specific dimensions
         self.max_context_len = model_runner.model_config.context_len
         self.hidden_size = config.hidden_size
+        self.head_dim = config.head_dim
 
         # Runtime parameters
         self.data_type = model_runner.kv_cache_dtype
@@ -140,6 +145,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.page_size = model_runner.page_size
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.device = model_runner.device
+        parallel = get_parallel()
+        self.dcp_size = parallel.attn_dcp_size
+        self.dcp_rank = parallel.attn_dcp_rank
+        self.dcp_group = parallel.dcp_group if self.dcp_size > 1 else None
+        self.num_q_heads = config.num_attention_heads // parallel.attn_tp_size
+        self.dcp_max_context_len = (
+            self.max_context_len + self.dcp_size - 1
+        ) // self.dcp_size
 
         # Workspace allocation
         self.workspace_size = workspace_size_bytes
@@ -184,12 +197,21 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             self._swa_full_to_swa_mapping = None
 
+        if self.dcp_size > 1 and self._swa_kv_pool is not None:
+            raise NotImplementedError("TRTLLM MHA DCP does not support SWA KV pools")
+        if self.dcp_size > 1 and self.decode_uses_native_fp4:
+            raise NotImplementedError(
+                "TRTLLM MHA DCP does not support native FP4 KV cache"
+            )
+
         # Static page-table width (upper bound). The CUDA-graph path builds the
         # page table on-device sized to this constant, so it never reads a runtime
         # max. See _fill_page_table_device.
         self.max_num_pages = (
-            self.max_context_len + self.page_size - 1
+            self.dcp_max_context_len + self.page_size - 1
         ) // self.page_size
+        self.dcp_cuda_graph_out_buffer: Optional[torch.Tensor] = None
+        self.dcp_cuda_graph_lse_buffer: Optional[torch.Tensor] = None
 
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
@@ -203,6 +225,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         #   KV bf16: q_type = bf16, out_type=model_runner.dtype
         #   KV fp8: q_type = fp8, out_type=model_runner.dtype
         self.is_xqa_impl = is_sm90_supported() or is_sm120_supported()
+        if self.dcp_size > 1 and self.is_xqa_impl:
+            raise NotImplementedError(
+                "TRTLLM MHA DCP requires trtllm-gen return_lse support"
+            )
 
         # trtllm-gen serves page_size >= 128 only through its dynamic
         # tokens-per-page kernels, which exist solely for GQA with equal QK/V
@@ -211,8 +237,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # "Missing TRTLLM-GEN kernel" error during CUDA-graph capture.
         # XQA (SM90/SM120 decode) has native page-128 kernels; no check needed.
         if self.page_size >= 128 and not self.is_xqa_impl:
-            from sglang.srt.runtime_context import get_parallel
-
             attn_tp_size = get_parallel().attn_tp_size
             num_q_heads = config.num_attention_heads // attn_tp_size
             num_kv_heads = config.get_num_kv_heads(attn_tp_size)
@@ -304,6 +328,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             full_to_swa=(
                 self._swa_kv_pool.full_to_swa_index_mapping if has_swa else None
             ),
+            dcp_size=self.dcp_size,
+            dcp_rank=self.dcp_rank,
         )
 
     def _get_layer_cache_loc(
@@ -396,6 +422,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ),
             "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
         }
+        if self.dcp_size > 1:
+            self.dcp_cuda_graph_out_buffer = torch.empty(
+                max_num_tokens,
+                self.num_q_heads * self.dcp_size,
+                self.head_dim,
+                dtype=self.q_data_type,
+                device=self.device,
+            )
+            self.dcp_cuda_graph_lse_buffer = torch.empty(
+                max_num_tokens,
+                self.num_q_heads * self.dcp_size,
+                dtype=torch.float32,
+                device=self.device,
+            )
 
         # SWA write-target buffer; bound as a [:num_tokens] view in
         # _build_cuda_graph_metadata and refilled by the fused metadata kernel.
@@ -705,6 +745,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             qlens=qlens,
             q_stride=q_stride,
             q_mode=q_mode,
+            dcp_size=self.dcp_size,
+            dcp_rank=self.dcp_rank,
         )
 
         if self._needs_encoder_only_expand(forward_mode, metadata):
@@ -733,7 +775,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     ) -> bool:
         """Check if we should use the fused FP8 KV cache write path."""
         return (
-            not is_cp_v2_active(forward_batch)
+            self.dcp_size == 1
+            and not is_cp_v2_active(forward_batch)
             and save_kv_cache
             and k is not None
             and self.data_type == torch.float8_e4m3fn
@@ -866,7 +909,27 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         batch_size = forward_batch.batch_size
         device = seqlens_in_batch.device
 
-        if forward_batch.forward_mode.is_decode_or_idle():
+        if self.dcp_size > 1:
+            if (
+                not forward_batch.forward_mode.is_decode_or_idle()
+                or forward_batch.spec_info is not None
+            ):
+                raise NotImplementedError(
+                    "TRTLLM MHA DCP currently supports non-speculative decode only; "
+                    "use a separate Triton prefill backend"
+                )
+            metadata.cache_seqlens_int32 = get_dcp_lens(
+                seqlens_in_batch, self.dcp_size, self.dcp_rank
+            ).to(torch.int32)
+            metadata.cu_seqlens_q = torch.arange(
+                0, batch_size + 1, dtype=torch.int32, device=device
+            )
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32),
+                (1, 0),
+            )
+
+        elif forward_batch.forward_mode.is_decode_or_idle():
             if forward_batch.spec_info is not None:
                 # Draft Decode
                 # Here we only support topk = 1 for now.
@@ -1050,27 +1113,42 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             v = None
         else:
             if save_kv_cache and k is not None:
+                kv_write_kwargs = {}
+                if self.dcp_size > 1:
+                    cache_loc = cache_loc // self.dcp_size
+                    kv_write_kwargs["dcp_kv_mask"] = (
+                        forward_batch.positions % self.dcp_size == self.dcp_rank
+                    )
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
                     KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
                     k,
                     v,
                     *self._kv_write_scales(layer),
+                    **kv_write_kwargs,
                 )
 
         # For XQA, q_dtype should be bf16. For trtllm-gen,
         # q_dtype should be FP8 when KV is in FP8.
         q_scale = 1.0
-        if (
-            self.data_type == torch.float8_e4m3fn
-            and not self.is_xqa_impl
-            and not use_fused_qkv
-        ):
-            q = q.to(torch.float8_e4m3fn)
-        if self.is_xqa_impl:
-            q = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
-        else:
+        if self.dcp_size > 1:
             q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
+            with use_symmetric_memory(self.dcp_group):
+                q = q.contiguous()
+            q = self.dcp_group.all_gather(q, dim=1).contiguous()
+            if self.data_type == torch.float8_e4m3fn and not use_fused_qkv:
+                q = q.to(torch.float8_e4m3fn)
+        else:
+            if (
+                self.data_type == torch.float8_e4m3fn
+                and not self.is_xqa_impl
+                and not use_fused_qkv
+            ):
+                q = q.to(torch.float8_e4m3fn)
+            if self.is_xqa_impl:
+                q = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+            else:
+                q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
 
         if self.is_nvfp4_kvcache:
             kv_cache, kv_cache_block_scales = self._get_nvfp4_decode_kv_cache(layer)
@@ -1091,13 +1169,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         page_table = self._get_layer_page_table(layer, forward_batch)
 
-        o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+        dcp_kernel_kwargs = {}
+        if self.dcp_size > 1:
+            if self.dcp_cuda_graph_out_buffer is not None:
+                dcp_kernel_kwargs["out"] = self.dcp_cuda_graph_out_buffer[: q.shape[0]]
+                dcp_kernel_kwargs["lse"] = self.dcp_cuda_graph_lse_buffer[: q.shape[0]]
+            dcp_kernel_kwargs["return_lse"] = True
+
+        result = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
             query=q,
             kv_cache=kv_cache,
             workspace_buffer=self.workspace_buffer,
             block_tables=page_table,
             seq_lens=self.forward_metadata.cache_seqlens_int32,
-            max_seq_len=self.max_context_len,
+            max_seq_len=self.dcp_max_context_len,
             bmm1_scale=bmm1_scale,
             bmm2_scale=bmm2_scale,
             window_left=layer.sliding_window_size,
@@ -1105,9 +1190,16 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
             out_dtype=self.q_data_type,  # model_runner.dtype
             kv_cache_sf=kv_cache_block_scales,
+            **dcp_kernel_kwargs,
         )
-        if self.is_nvfp4_kvcache and o.dtype != self.q_data_type:
-            o = o.to(self.q_data_type)
+        if self.dcp_size > 1:
+            o, local_lse = result
+            # The DCP merge accumulates in float32.
+            o = cp_lse_ag_out_rs_mha(o, local_lse, self.dcp_group).to(self.q_data_type)
+        else:
+            o = result
+            if self.is_nvfp4_kvcache and o.dtype != self.q_data_type:
+                o = o.to(self.q_data_type)
 
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -80,6 +80,9 @@ DEFAULT_WORKSPACE_SIZE_MB = 512
 class TRTLLMMHAMetadata:
     # Sequence lengths for the forward batch
     cache_seqlens_int32: torch.Tensor = None
+    # Global KV prefix length before speculative query row 0. Cake DCP uses
+    # this to apply the per-row causal boundary without expanding requests.
+    causal_seqlens_kv_global: torch.Tensor = None
     # Maximum sequence length for query
     max_seq_len_q: int = 1
     # Cumulative sequence lengths for `query
@@ -232,6 +235,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         ) // self.page_size
         self.dcp_cuda_graph_out_buffer: Optional[torch.Tensor] = None
         self.dcp_cuda_graph_lse_buffer: Optional[torch.Tensor] = None
+        self.dcp_cuda_graph_q_gather_buffer: Optional[torch.Tensor] = None
+        self.dcp_cuda_graph_q_buffer: Optional[torch.Tensor] = None
 
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
@@ -500,19 +505,30 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
         }
         if self.dcp_size > 1:
-            self.dcp_cuda_graph_out_buffer = torch.empty(
-                max_num_tokens,
-                self.num_q_heads * self.dcp_size,
-                self.head_dim,
-                dtype=self.q_data_type,
-                device=self.device,
-            )
-            self.dcp_cuda_graph_lse_buffer = torch.empty(
-                max_num_tokens,
-                self.num_q_heads * self.dcp_size,
-                dtype=torch.float32,
-                device=self.device,
-            )
+            with use_symmetric_memory(self.dcp_group):
+                self.dcp_cuda_graph_q_gather_buffer = torch.empty(
+                    max_num_tokens * self.dcp_size,
+                    self.num_q_heads,
+                    self.head_dim,
+                    dtype=self.q_data_type,
+                    device=self.device,
+                )
+                self.dcp_cuda_graph_q_buffer = torch.empty(
+                    max_num_tokens,
+                    self.num_q_heads * self.dcp_size,
+                    self.head_dim,
+                    dtype=self.q_data_type,
+                    device=self.device,
+                )
+                self.dcp_cuda_graph_out_buffer = torch.empty_like(
+                    self.dcp_cuda_graph_q_buffer
+                )
+                self.dcp_cuda_graph_lse_buffer = torch.empty(
+                    max_num_tokens,
+                    self.num_q_heads * self.dcp_size,
+                    dtype=torch.float32,
+                    device=self.device,
+                )
 
         # SWA write-target buffer; bound as a [:num_tokens] view in
         # _build_cuda_graph_metadata and refilled by the fused metadata kernel.
@@ -568,6 +584,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
             }
+            if self.dcp_size > 1:
+                self.target_verify_metadata["causal_seqlens_kv_global"] = torch.zeros(
+                    max_bs, dtype=torch.int32, device=self.device
+                )
             if self.expand_encoder_only_verify:
                 max_verify_rows = max_bs * self.speculative_num_draft_tokens
                 self.target_verify_metadata["encoder_cache_seqlens"] = torch.zeros(
@@ -600,6 +620,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
             }
+            if self.dcp_size > 1:
+                self.draft_extend_metadata["causal_seqlens_kv_global"] = torch.zeros(
+                    max_bs, dtype=torch.int32, device=self.device
+                )
 
     def _build_cuda_graph_metadata(
         self,
@@ -675,6 +699,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 else num_tokens // bs
             )
             metadata.page_table = self.target_verify_metadata["page_table"][:bs, :]
+            if self.dcp_size > 1:
+                metadata.causal_seqlens_kv_global = self.target_verify_metadata[
+                    "causal_seqlens_kv_global"
+                ][:bs]
             self._bind_swa_page_table(
                 metadata,
                 self.target_verify_metadata,
@@ -705,6 +733,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata.cu_seqlens_k = self.draft_extend_metadata["cu_seqlens_k"][: bs + 1]
             metadata.max_seq_len_q = num_tokens_per_req
             metadata.page_table = self.draft_extend_metadata["page_table"][:bs, :]
+            if self.dcp_size > 1:
+                metadata.causal_seqlens_kv_global = self.draft_extend_metadata[
+                    "causal_seqlens_kv_global"
+                ][:bs]
             self._bind_swa_page_table(
                 metadata,
                 self.draft_extend_metadata,
@@ -763,6 +795,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         qlens = None
         q_stride = 0
         q_mode = Q_MODE_NONE
+        causal_seqlen_offset = 0
         if forward_mode.is_decode_or_idle():
             if spec_info is not None:
                 # Draft Decode
@@ -792,6 +825,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             cu_seqlens_q = metadata.cu_seqlens_q
             q_stride = num_tokens_per_req
             q_mode = Q_MODE_STRIDED
+            causal_seqlen_offset = -num_tokens_per_req
         else:
             raise ValueError(
                 "TRTLLM-MHA CUDA graph metadata build got an unsupported forward "
@@ -822,6 +856,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             qlens=qlens,
             q_stride=q_stride,
             q_mode=q_mode,
+            causal_seqlens_kv_global=metadata.causal_seqlens_kv_global,
+            causal_seqlen_offset=causal_seqlen_offset,
             dcp_size=self.dcp_size,
             dcp_rank=self.dcp_rank,
         )
@@ -929,6 +965,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             )
 
     def _assert_ragged_verify_supported(self) -> None:
+        if self.dcp_size > 1:
+            raise NotImplementedError(
+                "TRTLLM MHA DCP speculative decode requires uniform query lengths"
+            )
         if self.is_xqa_impl:
             raise NotImplementedError(
                 "Compact ragged verify (variable-length cum_seq_lens_q) "
@@ -994,19 +1034,42 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         device = seqlens_in_batch.device
 
         if self.dcp_size > 1:
-            if (
-                not forward_batch.forward_mode.is_decode_or_idle()
-                or forward_batch.spec_info is not None
-            ):
+            if forward_batch.forward_mode.is_decode_or_idle():
+                global_cache_seqlens = seqlens_in_batch
+                if forward_batch.spec_info is not None:
+                    global_cache_seqlens = global_cache_seqlens + (
+                        self.speculative_step_id + 1
+                    )
+                q_len_per_req = 1
+            elif forward_batch.forward_mode.is_target_verify():
+                if resolve_ragged_verify_layout(forward_batch) is not None:
+                    self._assert_ragged_verify_supported()
+                q_len_per_req = forward_batch.input_ids.shape[0] // batch_size
+                global_cache_seqlens = seqlens_in_batch + q_len_per_req
+                metadata.causal_seqlens_kv_global = seqlens_in_batch.to(
+                    torch.int32
+                ).contiguous()
+            elif forward_batch.forward_mode.is_draft_extend_v2():
+                q_len_per_req = forward_batch.spec_info.num_tokens_per_req
+                global_cache_seqlens = seqlens_in_batch
+                metadata.causal_seqlens_kv_global = torch.clamp(
+                    seqlens_in_batch - q_len_per_req, min=0
+                ).to(torch.int32)
+            else:
                 raise NotImplementedError(
-                    "TRTLLM MHA DCP currently supports non-speculative decode only; "
-                    "use a separate Triton prefill backend"
+                    "TRTLLM MHA DCP supports decode and uniform speculative "
+                    "decode only; use a separate prefill backend for prompt extend"
                 )
             metadata.cache_seqlens_int32 = get_dcp_lens(
-                seqlens_in_batch, self.dcp_size, self.dcp_rank
+                global_cache_seqlens, self.dcp_size, self.dcp_rank
             ).to(torch.int32)
+            metadata.max_seq_len_q = q_len_per_req
             metadata.cu_seqlens_q = torch.arange(
-                0, batch_size + 1, dtype=torch.int32, device=device
+                0,
+                batch_size * q_len_per_req + 1,
+                q_len_per_req,
+                dtype=torch.int32,
+                device=device,
             )
             metadata.cu_seqlens_k = torch.nn.functional.pad(
                 torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32),
@@ -1153,6 +1216,35 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         assert self.is_nvfp4_kvcache
         return self.kv_cache_quant_method.get_bmm_scales(layer.layer_id)
 
+    def _all_gather_dcp_spec_q(self, query: torch.Tensor) -> torch.Tensor:
+        """Gather DCP query heads into a CUDA-Graph-stable Cake input."""
+        query = query.contiguous()
+        if self.dcp_cuda_graph_q_buffer is None:
+            return self.dcp_group.all_gather(query, dim=1).contiguous()
+
+        num_rows, num_local_heads, head_dim = query.shape
+        if (
+            num_rows > self.dcp_cuda_graph_q_buffer.shape[0]
+            or num_local_heads != self.num_q_heads
+            or head_dim != self.head_dim
+        ):
+            raise RuntimeError(
+                "DCP speculative query exceeds the preallocated CUDA Graph buffer: "
+                f"got {tuple(query.shape)}, capacity "
+                f"{tuple(self.dcp_cuda_graph_q_buffer.shape)}"
+            )
+
+        gathered = self.dcp_cuda_graph_q_gather_buffer[: num_rows * self.dcp_size]
+        self.dcp_group.all_gather_into_tensor(gathered, query)
+        gathered = gathered.view(
+            self.dcp_size, num_rows, num_local_heads, head_dim
+        ).transpose(0, 1)
+        stable_query = self.dcp_cuda_graph_q_buffer[:num_rows]
+        stable_query.view(num_rows, self.dcp_size, num_local_heads, head_dim).copy_(
+            gathered
+        )
+        return stable_query
+
     def _run_fixed_q_len_decode(
         self,
         query: torch.Tensor,
@@ -1166,35 +1258,98 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         sinks: Optional[torch.Tensor],
         q_len_per_req: int = 1,
         kv_cache_sf=None,
+        causal_seqlens_kv_global: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Run decode, optionally sorting and splitting requests by KV length."""
 
-        def run_group(group_query, group_block_tables, group_seq_lens):
+        def run_group(
+            group_query,
+            group_block_tables,
+            group_seq_lens,
+            group_causal_seqlens_kv_global=None,
+        ):
             kwargs = {}
             if q_len_per_req != 1:
                 kwargs["q_len_per_req"] = q_len_per_req
-            return flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            if (
+                self.dcp_size > 1
+                and q_len_per_req > 1
+                and group_causal_seqlens_kv_global is None
+            ):
+                raise RuntimeError(
+                    "DCP speculative decode requires global KV prefix lengths"
+                )
+            dcp_spec_enabled = (
+                self.dcp_size > 1 and group_causal_seqlens_kv_global is not None
+            )
+            if dcp_spec_enabled:
+                if group_query.dtype != torch.bfloat16:
+                    raise NotImplementedError(
+                        "FlashInfer Cake DCP speculative decode requires BF16 query"
+                    )
+                kwargs.update(
+                    cp_world=self.dcp_size,
+                    cp_rank=self.dcp_rank,
+                    q_len_per_req=q_len_per_req,
+                    causal_seqlens_kv_global=group_causal_seqlens_kv_global,
+                )
+
+            if self.dcp_size > 1:
+                kwargs["return_lse"] = True
+                if self.dcp_cuda_graph_out_buffer is not None:
+                    num_rows = group_query.shape[0]
+                    kwargs["out"] = self.dcp_cuda_graph_out_buffer[:num_rows]
+                    kwargs["lse"] = self.dcp_cuda_graph_lse_buffer[:num_rows]
+
+            result = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=group_query,
                 kv_cache=kv_cache,
                 workspace_buffer=self.workspace_buffer,
                 block_tables=group_block_tables,
                 seq_lens=group_seq_lens,
-                max_seq_len=self.max_context_len,
+                max_seq_len=(
+                    self.dcp_max_context_len
+                    if self.dcp_size > 1
+                    else self.max_context_len
+                ),
                 bmm1_scale=bmm1_scale,
                 bmm2_scale=bmm2_scale,
                 window_left=window_left,
                 sinks=sinks,
-                skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
+                skip_softmax_threshold_scale_factor=(
+                    None
+                    if dcp_spec_enabled
+                    else envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get()
+                ),
                 out_dtype=self.q_data_type,
                 kv_cache_sf=kv_cache_sf,
                 multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
                 **kwargs,
             )
+            if self.dcp_size == 1:
+                return result
+
+            local_out, local_lse = result
+            return cp_lse_ag_out_rs_mha(
+                local_out,
+                local_lse,
+                self.dcp_group,
+                is_lse_base_on_e=False,
+            ).to(self.q_data_type)
 
         num_requests = seq_lens.shape[0]
-        num_splits = min(self.decode_seq_len_splits, num_requests)
+        # Keep DCP rows in their original order: Cake's causal prefix tensor and
+        # the caller-owned CUDA-graph buffers share this exact row layout.
+        num_splits = (
+            1 if self.dcp_size > 1 else min(self.decode_seq_len_splits, num_requests)
+        )
         if num_splits == 1:
-            return run_group(query, block_tables, seq_lens)
+            return run_group(
+                query,
+                block_tables,
+                seq_lens,
+                causal_seqlens_kv_global,
+            )
 
         order = torch.argsort(seq_lens)
         query_by_request = query.view(
@@ -1212,6 +1367,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
                 block_tables.index_select(0, indices),
                 seq_lens.index_select(0, indices),
+                None,
             )
             output_by_request.index_copy_(
                 0,
@@ -1373,7 +1529,27 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             v = None
         else:
             if save_kv_cache and k is not None:
-                if cp_v2_active:
+                if self.dcp_size > 1:
+                    cache_loc = cache_loc // self.dcp_size
+                    if (
+                        forward_batch.positions is not None
+                        and forward_batch.positions.numel() == cache_loc.numel()
+                    ):
+                        dcp_kv_mask = (
+                            forward_batch.positions % self.dcp_size == self.dcp_rank
+                        )
+                    else:
+                        dcp_kv_mask = forward_batch.dcp_kv_mask
+                    self.token_to_kv_pool.set_kv_buffer(
+                        layer,
+                        KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
+                        k,
+                        v,
+                        layer.k_scale,
+                        layer.v_scale,
+                        dcp_kv_mask=dcp_kv_mask,
+                    )
+                elif cp_v2_active:
                     cp_strategy = get_cp_strategy()
                     assert cp_strategy is not None
                     cp_strategy.materialize_full_kv(
@@ -1395,7 +1571,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         q_scale = 1.0
         if (
-            self.data_type == torch.float8_e4m3fn
+            self.dcp_size == 1
+            and self.data_type == torch.float8_e4m3fn
             and (
                 not self.is_xqa_impl
                 or not forward_batch.forward_mode.is_target_verify()
@@ -1404,7 +1581,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         ):
             q = q.to(torch.float8_e4m3fn)
 
-        if self.use_fmha_v2:
+        if self.dcp_size > 1:
+            q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
+            with use_symmetric_memory(self.dcp_group):
+                q = q.contiguous()
+            q = self._all_gather_dcp_spec_q(q)
+        elif self.use_fmha_v2:
             q = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
         else:
             q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
@@ -1442,6 +1624,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 forward_batch.forward_mode.is_target_verify()
                 and layer.attn_type == AttentionType.ENCODER_ONLY
             ):
+                if self.dcp_size > 1:
+                    raise NotImplementedError(
+                        "TRTLLM MHA DCP does not support ENCODER_ONLY target verify"
+                    )
                 # ENCODER_ONLY layers need bidirectional attention over the
                 # verify window; the spec-decode kernel is causal in-window, so
                 # run bs*L single-token rows over the full window instead (the
@@ -1471,6 +1657,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
                 )
             elif self.forward_metadata.is_ragged_verify:
+                if self.dcp_size > 1:
+                    self._assert_ragged_verify_supported()
                 o = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                     query=q,
                     kv_cache=kv_cache,
@@ -1500,6 +1688,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     window_left=layer.sliding_window_size,
                     sinks=attention_sink,
                     q_len_per_req=self.forward_metadata.max_seq_len_q,
+                    causal_seqlens_kv_global=(
+                        self.forward_metadata.causal_seqlens_kv_global
+                        if self.dcp_size > 1
+                        else None
+                    ),
                 )
         elif self.use_fmha_v2 and not cp_v2_active:
             # CP-v2 must go through cp_strategy.run_attention (per-shard

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -27,6 +27,9 @@ from sglang.kernels.ops.kvcache.trtllm_mha_graph_metadata import (
 from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
+from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+    use_symmetric_memory,
+)
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import SharedReadEnds
 from sglang.srt.layers.attention.flashinfer_backend import (
@@ -38,6 +41,7 @@ from sglang.srt.layers.attention.trtllm_mla_backend import (
 )
 from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.layers.dcp import cp_lse_ag_out_rs_mha, get_dcp_lens
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     KVCacheAttentionAccessKind,
 )
@@ -45,7 +49,7 @@ from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_buffer, get_spec
+from sglang.srt.runtime_context import get_buffer, get_parallel, get_spec
 from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
@@ -153,6 +157,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # MHA-specific dimensions
         self.max_context_len = model_runner.model_config.context_len
         self.hidden_size = config.hidden_size
+        self.head_dim = config.head_dim
 
         # Runtime parameters
         self.data_type = model_runner.kv_cache_dtype
@@ -160,6 +165,14 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         self.page_size = model_runner.page_size
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
         self.device = model_runner.device
+        parallel = get_parallel()
+        self.dcp_size = parallel.attn_dcp_size
+        self.dcp_rank = parallel.attn_dcp_rank
+        self.dcp_group = parallel.dcp_group if self.dcp_size > 1 else None
+        self.num_q_heads = config.num_attention_heads // parallel.attn_tp_size
+        self.dcp_max_context_len = (
+            self.max_context_len + self.dcp_size - 1
+        ) // self.dcp_size
 
         # Workspace allocation
         self.workspace_size = workspace_size_bytes
@@ -204,12 +217,21 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         else:
             self._swa_full_to_swa_mapping = None
 
+        if self.dcp_size > 1 and self._swa_kv_pool is not None:
+            raise NotImplementedError("TRTLLM MHA DCP does not support SWA KV pools")
+        if self.dcp_size > 1 and self.decode_uses_native_fp4:
+            raise NotImplementedError(
+                "TRTLLM MHA DCP does not support native FP4 KV cache"
+            )
+
         # Static page-table width (upper bound). The CUDA-graph path builds the
         # page table on-device sized to this constant, so it never reads a runtime
         # max. See _fill_page_table_device.
         self.max_num_pages = (
-            self.max_context_len + self.page_size - 1
+            self.dcp_max_context_len + self.page_size - 1
         ) // self.page_size
+        self.dcp_cuda_graph_out_buffer: Optional[torch.Tensor] = None
+        self.dcp_cuda_graph_lse_buffer: Optional[torch.Tensor] = None
 
         # Forward metadata
         self.forward_metadata: Optional[TRTLLMMHAMetadata] = None
@@ -223,6 +245,10 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         #   KV bf16: q_type = bf16, out_type=model_runner.dtype
         #   KV fp8: q_type = fp8, out_type=model_runner.dtype
         self.is_xqa_impl = is_sm90_supported() or is_sm120_supported()
+        if self.dcp_size > 1 and self.is_xqa_impl:
+            raise NotImplementedError(
+                "TRTLLM MHA DCP requires trtllm-gen return_lse support"
+            )
 
         # fmha_v2 prefill kernel supports SM90 and SM120
         self.use_fmha_v2 = is_sm90_supported() or is_sm120_supported()
@@ -234,8 +260,6 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         # "Missing TRTLLM-GEN kernel" error during CUDA-graph capture.
         # XQA (SM90/SM120 decode) has native page-128 kernels; no check needed.
         if self.page_size >= 128 and not self.is_xqa_impl:
-            from sglang.srt.runtime_context import get_parallel
-
             attn_tp_size = get_parallel().attn_tp_size
             num_q_heads = config.num_attention_heads // attn_tp_size
             num_kv_heads = config.get_num_kv_heads(attn_tp_size)
@@ -352,6 +376,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             full_to_swa=(
                 self._swa_kv_pool.full_to_swa_index_mapping if has_swa else None
             ),
+            dcp_size=self.dcp_size,
+            dcp_rank=self.dcp_rank,
         )
 
     def _get_layer_cache_loc(
@@ -473,6 +499,20 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ),
             "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
         }
+        if self.dcp_size > 1:
+            self.dcp_cuda_graph_out_buffer = torch.empty(
+                max_num_tokens,
+                self.num_q_heads * self.dcp_size,
+                self.head_dim,
+                dtype=self.q_data_type,
+                device=self.device,
+            )
+            self.dcp_cuda_graph_lse_buffer = torch.empty(
+                max_num_tokens,
+                self.num_q_heads * self.dcp_size,
+                dtype=torch.float32,
+                device=self.device,
+            )
 
         # SWA write-target buffer; bound as a [:num_tokens] view in
         # _build_cuda_graph_metadata and refilled by the fused metadata kernel.
@@ -782,6 +822,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             qlens=qlens,
             q_stride=q_stride,
             q_mode=q_mode,
+            dcp_size=self.dcp_size,
+            dcp_rank=self.dcp_rank,
         )
 
         if self._needs_encoder_only_expand(forward_mode, metadata):
@@ -810,7 +852,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     ) -> bool:
         """Check if we should use the fused FP8 KV cache write path."""
         return (
-            not is_cp_v2_active(forward_batch)
+            self.dcp_size == 1
+            and not is_cp_v2_active(forward_batch)
             and save_kv_cache
             and k is not None
             and self.data_type == torch.float8_e4m3fn
@@ -950,7 +993,27 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         batch_size = forward_batch.batch_size
         device = seqlens_in_batch.device
 
-        if forward_batch.forward_mode.is_decode_or_idle():
+        if self.dcp_size > 1:
+            if (
+                not forward_batch.forward_mode.is_decode_or_idle()
+                or forward_batch.spec_info is not None
+            ):
+                raise NotImplementedError(
+                    "TRTLLM MHA DCP currently supports non-speculative decode only; "
+                    "use a separate Triton prefill backend"
+                )
+            metadata.cache_seqlens_int32 = get_dcp_lens(
+                seqlens_in_batch, self.dcp_size, self.dcp_rank
+            ).to(torch.int32)
+            metadata.cu_seqlens_q = torch.arange(
+                0, batch_size + 1, dtype=torch.int32, device=device
+            )
+            metadata.cu_seqlens_k = torch.nn.functional.pad(
+                torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32),
+                (1, 0),
+            )
+
+        elif forward_batch.forward_mode.is_decode_or_idle():
             if forward_batch.spec_info is not None:
                 # Draft Decode
                 # Here we only support topk = 1 for now.
@@ -1202,27 +1265,42 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             v = None
         else:
             if save_kv_cache and k is not None:
+                kv_write_kwargs = {}
+                if self.dcp_size > 1:
+                    cache_loc = cache_loc // self.dcp_size
+                    kv_write_kwargs["dcp_kv_mask"] = (
+                        forward_batch.positions % self.dcp_size == self.dcp_rank
+                    )
                 self.token_to_kv_pool.set_kv_buffer(
                     layer,
                     KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
                     k,
                     v,
                     *self._kv_write_scales(layer),
+                    **kv_write_kwargs,
                 )
 
         # For XQA, q_dtype should be bf16. For trtllm-gen,
         # q_dtype should be FP8 when KV is in FP8.
         q_scale = 1.0
-        if (
-            self.data_type == torch.float8_e4m3fn
-            and not self.is_xqa_impl
-            and not use_fused_qkv
-        ):
-            q = q.to(torch.float8_e4m3fn)
-        if self.is_xqa_impl:
-            q = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
-        else:
+        if self.dcp_size > 1:
             q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
+            with use_symmetric_memory(self.dcp_group):
+                q = q.contiguous()
+            q = self.dcp_group.all_gather(q, dim=1).contiguous()
+            if self.data_type == torch.float8_e4m3fn and not use_fused_qkv:
+                q = q.to(torch.float8_e4m3fn)
+        else:
+            if (
+                self.data_type == torch.float8_e4m3fn
+                and not self.is_xqa_impl
+                and not use_fused_qkv
+            ):
+                q = q.to(torch.float8_e4m3fn)
+            if self.is_xqa_impl:
+                q = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+            else:
+                q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
 
         if self.is_nvfp4_kvcache:
             kv_cache, kv_cache_block_scales = self._get_nvfp4_decode_kv_cache(layer)

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -16,10 +16,11 @@
 
 The two LSE-merge variants kept separate (bodies are backend-forced, see
 PR #25090 vs #14194):
-  - cp_lse_ag_out_rs_mha: torch / natural-log logsumexp / all-reduce + head slice
+  - cp_lse_ag_out_rs_mha: torch / selectable LSE log base / all-reduce + head slice
   - cp_lse_ag_out_rs_mla: Triton (log2/exp2) correction / reduce-scatter
 """
 
+import math
 import warnings
 from typing import Optional
 
@@ -85,14 +86,19 @@ def cp_lse_ag_out_rs_mha(
     cp_attn_lse: torch.Tensor,
     cp_group: GroupCoordinator,
     return_lse: bool = False,
+    is_lse_base_on_e: bool = True,
 ):
     if cp_group.world_size == 1:
         return (cp_attn_out, cp_attn_lse) if return_lse else cp_attn_out
 
     cp_attn_lse = cp_attn_lse.contiguous()
     lses = _ag_lse(cp_attn_lse, cp_group)
-    global_lse = torch.logsumexp(lses, dim=0)
-    scale = torch.exp(cp_attn_lse - global_lse).unsqueeze(-1)
+    if is_lse_base_on_e:
+        global_lse = torch.logsumexp(lses, dim=0)
+        scale = torch.exp(cp_attn_lse - global_lse).unsqueeze(-1)
+    else:
+        global_lse = torch.logsumexp(lses * math.log(2.0), dim=0) * math.log2(math.e)
+        scale = torch.exp2(cp_attn_lse - global_lse).unsqueeze(-1)
     scale = torch.nan_to_num(scale, nan=0.0, posinf=0.0, neginf=0.0)
 
     out = cp_attn_out.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)

--- a/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
@@ -168,6 +168,21 @@ def resolve_attention_backend_strs(
     draft_attn_backend = model_runner.draft_attention_backend
     if is_draft_worker and draft_attn_backend:
         logger.warning(f"Overriding draft attention backend to {draft_attn_backend}.")
+        prefill_backend, _ = attention_backends()
+        # TRTLLM MHA's DCP kernel intentionally covers decode and uniform
+        # speculative rows, not ordinary prompt prefill.  Preserve the
+        # configured prefill backend for that one mode while keeping the
+        # operator-selected backend for draft decode/draft-extend.
+        if (
+            draft_attn_backend == "trtllm_mha"
+            and model_runner.server_args.dcp_size > 1
+            and prefill_backend != draft_attn_backend
+        ):
+            return ResolvedAttentionBackendStr(
+                prefill=prefill_backend,
+                decode=draft_attn_backend,
+                is_draft_override=True,
+            )
         # Single backend for all draft modes (no prefill/decode split).
         return ResolvedAttentionBackendStr(
             prefill=draft_attn_backend,
@@ -184,7 +199,7 @@ def _build_resolved_backend(
     resolved: ResolvedAttentionBackendStr,
     init_new_workspace: bool,
 ) -> AttentionBackend:
-    if resolved.is_draft_override:
+    if resolved.is_draft_override and resolved.decode == resolved.prefill:
         attn_backend = _build_backend_from_str(
             model_runner=model_runner,
             backend_str=resolved.prefill,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -344,7 +344,11 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         )
 
         self.draft_runner.draft_attn_backend = self.draft_attn_backend
-        if self.draft_extend_attn_backend is not None:
+        if (
+            self.draft_extend_attn_backend is not None
+            and self.draft_runner.prefill_attention_backend_str
+            == self.draft_runner.decode_attention_backend_str
+        ):
             self.draft_runner.attn_backend = self.draft_extend_attn_backend
         self.tree_mask_mode = default_tree_mask_mode()
 

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -39,6 +39,8 @@ def _make_backend_for_hook_test(speculative_num_draft_tokens=None):
     backend.use_sliding_window_kv_pool = False
     backend._swa_kv_pool = None
     backend._swa_full_to_swa_mapping = None
+    backend.dcp_size = 1
+    backend.dcp_rank = 0
     backend.speculative_step_id = 0
     backend.speculative_num_draft_tokens = speculative_num_draft_tokens
     backend.expand_encoder_only_verify = False
@@ -439,6 +441,64 @@ def test_bs_zero_noop():
         max_seq_pages=0,
         page_size=PAGE_SIZE,
     )
+
+
+def test_dcp_metadata_uses_local_lens_and_page_table():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    bs = 3
+    dcp_size = 4
+    dcp_rank = 2
+    global_lens = torch.tensor([1, 257, 1027], dtype=torch.int32, device=DEVICE)
+    max_local_len = (int(global_lens.max().item()) + dcp_size - 1) // dcp_size
+    max_seq_pages = (max_local_len + PAGE_SIZE - 1) // PAGE_SIZE
+    req_to_token = torch.arange(bs * 2048, dtype=torch.int32, device=DEVICE).reshape(
+        bs, 2048
+    )
+    req_pool_indices = torch.arange(bs, dtype=torch.int64, device=DEVICE)
+    cache_seqlens = torch.zeros(bs, dtype=torch.int32, device=DEVICE)
+    cu_seqlens_k = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
+    page_table = torch.full((bs, max_seq_pages), -1, dtype=torch.int32, device=DEVICE)
+
+    update_trtllm_mha_graph_metadata(
+        req_pool_indices=req_pool_indices,
+        seq_lens=global_lens,
+        req_to_token=req_to_token,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_k=cu_seqlens_k,
+        page_table=page_table,
+        bs=bs,
+        seqlen_offset=0,
+        max_seq_pages=max_seq_pages,
+        page_size=PAGE_SIZE,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
+    )
+    torch.cuda.synchronize()
+
+    local_lens = (global_lens // dcp_size + (dcp_rank < global_lens % dcp_size)).to(
+        torch.int32
+    )
+    torch.testing.assert_close(cache_seqlens, local_lens, rtol=0, atol=0)
+    torch.testing.assert_close(
+        cu_seqlens_k[1:],
+        torch.cumsum(local_lens, dim=0, dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    for req_idx in range(bs):
+        num_pages = (int(local_lens[req_idx].item()) + PAGE_SIZE - 1) // PAGE_SIZE
+        global_positions = (
+            torch.arange(num_pages, device=DEVICE, dtype=torch.int64)
+            * PAGE_SIZE
+            * dcp_size
+            + dcp_rank
+        )
+        expected = (req_to_token[req_idx, global_positions] // dcp_size) // PAGE_SIZE
+        torch.testing.assert_close(
+            page_table[req_idx, :num_pages], expected, rtol=0, atol=0
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -122,6 +122,159 @@ def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
     assert calls[0]["q_stride"] == 4
 
 
+@pytest.mark.parametrize(
+    ("forward_mode", "seq_lens", "q_len", "expected_prefix", "expected_total"),
+    [
+        (ForwardMode.TARGET_VERIFY, [9, 17], 4, [9, 17], [13, 21]),
+        (ForwardMode.DRAFT_EXTEND_V2, [13, 21], 4, [9, 17], [13, 21]),
+    ],
+)
+def test_dcp_spec_metadata_keeps_global_prefix_and_local_total(
+    forward_mode, seq_lens, q_len, expected_prefix, expected_total
+):
+    backend = TRTLLMHAAttnBackend.__new__(TRTLLMHAAttnBackend)
+    backend.dcp_size = 4
+    backend.dcp_rank = 2
+    backend.speculative_step_id = 0
+    backend.page_size = PAGE_SIZE
+    backend.max_num_pages = 2
+    backend._swa_kv_pool = None
+    backend.expand_encoder_only_verify = False
+    backend.use_sliding_window_kv_pool = False
+    backend._fill_page_table_device = lambda *_args, **_kwargs: None
+    backend._maybe_build_cp_zigzag_page_tables = lambda *_args, **_kwargs: None
+
+    batch_size = len(seq_lens)
+    spec_info = SimpleNamespace(
+        num_tokens_per_req=q_len,
+        ragged_verify_layout=None,
+    )
+    forward_batch = SimpleNamespace(
+        batch_size=batch_size,
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int32),
+        forward_mode=forward_mode,
+        spec_info=spec_info,
+        input_ids=torch.zeros(batch_size * q_len, dtype=torch.int64),
+        req_pool_indices=torch.arange(batch_size, dtype=torch.int64),
+        out_cache_loc=None,
+    )
+
+    backend.init_forward_metadata(forward_batch)
+    metadata = backend.forward_metadata
+    expected_total = torch.tensor(expected_total, dtype=torch.int32)
+    expected_local = expected_total // backend.dcp_size + (
+        backend.dcp_rank < expected_total % backend.dcp_size
+    )
+    torch.testing.assert_close(
+        metadata.causal_seqlens_kv_global,
+        torch.tensor(expected_prefix, dtype=torch.int32),
+    )
+    torch.testing.assert_close(metadata.cache_seqlens_int32, expected_local)
+    assert metadata.max_seq_len_q == q_len
+    torch.testing.assert_close(
+        metadata.cu_seqlens_q,
+        torch.arange(0, batch_size * q_len + 1, q_len, dtype=torch.int32),
+    )
+
+
+@pytest.mark.parametrize("q_len", [1, 4])
+def test_dcp_spec_decode_forwards_cake_contract_and_base2_lse(monkeypatch, q_len):
+    kernel_calls = []
+    merge_calls = []
+
+    def fake_decode(**kwargs):
+        kernel_calls.append(kwargs)
+        query = kwargs["query"]
+        return (
+            torch.zeros_like(query),
+            torch.zeros(query.shape[:2], dtype=torch.float32),
+        )
+
+    def fake_merge(out, lse, group, **kwargs):
+        merge_calls.append((lse, group, kwargs))
+        return out[:, : out.shape[1] // group.world_size]
+
+    monkeypatch.setattr(
+        trtllm_mha_backend,
+        "flashinfer",
+        SimpleNamespace(
+            decode=SimpleNamespace(trtllm_batch_decode_with_kv_cache=fake_decode)
+        ),
+    )
+    monkeypatch.setattr(trtllm_mha_backend, "cp_lse_ag_out_rs_mha", fake_merge)
+
+    backend = TRTLLMHAAttnBackend.__new__(TRTLLMHAAttnBackend)
+    backend.dcp_size = 4
+    backend.dcp_rank = 1
+    backend.dcp_group = SimpleNamespace(world_size=4)
+    backend.dcp_max_context_len = 32768
+    backend.max_context_len = 131072
+    backend.workspace_buffer = torch.empty(1, dtype=torch.uint8)
+    backend.q_data_type = torch.bfloat16
+    backend._multi_ctas_kv_counter_buffer = torch.zeros(1, dtype=torch.int32)
+    backend.decode_seq_len_splits = 8
+    backend.dcp_cuda_graph_out_buffer = None
+    backend.dcp_cuda_graph_lse_buffer = None
+
+    batch_size, num_heads, head_dim = 2, 16, 256
+    query = torch.zeros(batch_size * q_len, num_heads, head_dim, dtype=torch.bfloat16)
+    causal_prefix = torch.tensor([1024, 2048], dtype=torch.int32)
+    output = backend._run_fixed_q_len_decode(
+        query,
+        (torch.empty(0), torch.empty(0)),
+        torch.zeros(batch_size, 1, dtype=torch.int32),
+        torch.tensor([257, 513], dtype=torch.int32),
+        bmm1_scale=0.125,
+        bmm2_scale=1.0,
+        window_left=-1,
+        sinks=None,
+        q_len_per_req=q_len,
+        causal_seqlens_kv_global=causal_prefix,
+    )
+
+    assert output.shape == (batch_size * q_len, num_heads // 4, head_dim)
+    assert len(kernel_calls) == 1
+    call = kernel_calls[0]
+    assert call["cp_world"] == 4
+    assert call["cp_rank"] == 1
+    assert call["causal_seqlens_kv_global"] is causal_prefix
+    assert call["q_len_per_req"] == q_len
+    assert call["max_seq_len"] == backend.dcp_max_context_len
+    assert call["return_lse"] is True
+    assert call["skip_softmax_threshold_scale_factor"] is None
+    assert len(merge_calls) == 1
+    assert merge_calls[0][2] == {"is_lse_base_on_e": False}
+
+
+def test_dcp_spec_q_gather_reuses_graph_stable_buffer():
+    class FakeGroup:
+        def all_gather_into_tensor(self, output, query):
+            rows = query.shape[0]
+            for rank in range(4):
+                output[rank * rows : (rank + 1) * rows].copy_(query + rank * 100)
+
+    backend = TRTLLMHAAttnBackend.__new__(TRTLLMHAAttnBackend)
+    backend.dcp_size = 4
+    backend.dcp_group = FakeGroup()
+    backend.num_q_heads = 2
+    backend.head_dim = 3
+    backend.dcp_cuda_graph_q_gather_buffer = torch.empty(6 * 4, 2, 3)
+    backend.dcp_cuda_graph_q_buffer = torch.empty(6, 8, 3)
+
+    query = torch.arange(2 * 2 * 3, dtype=torch.float32).view(2, 2, 3)
+    stable_query = backend._all_gather_dcp_spec_q(query)
+    expected = torch.cat([query + rank * 100 for rank in range(4)], dim=1)
+    torch.testing.assert_close(stable_query, expected)
+
+    stable_ptr = stable_query.data_ptr()
+    stable_query = backend._all_gather_dcp_spec_q(query + 1)
+    assert stable_query.data_ptr() == stable_ptr
+    torch.testing.assert_close(
+        stable_query,
+        torch.cat([query + 1 + rank * 100 for rank in range(4)], dim=1),
+    )
+
+
 def test_hybrid_wrappers_forward_in_graph_hook():
     # The hybrid backend reads the mode from the published configuration.
     from sglang.srt.runtime_context import get_context
@@ -581,6 +734,7 @@ def test_dcp_metadata_uses_local_lens_and_page_table():
     )
     req_pool_indices = torch.arange(bs, dtype=torch.int64, device=DEVICE)
     cache_seqlens = torch.zeros(bs, dtype=torch.int32, device=DEVICE)
+    causal_seqlens_kv_global = torch.zeros(bs, dtype=torch.int32, device=DEVICE)
     cu_seqlens_k = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
     page_table = torch.full((bs, max_seq_pages), -1, dtype=torch.int32, device=DEVICE)
 
@@ -595,6 +749,8 @@ def test_dcp_metadata_uses_local_lens_and_page_table():
         seqlen_offset=0,
         max_seq_pages=max_seq_pages,
         page_size=PAGE_SIZE,
+        causal_seqlens_kv_global=causal_seqlens_kv_global,
+        causal_seqlen_offset=-1,
         dcp_size=dcp_size,
         dcp_rank=dcp_rank,
     )
@@ -604,6 +760,9 @@ def test_dcp_metadata_uses_local_lens_and_page_table():
         torch.int32
     )
     torch.testing.assert_close(cache_seqlens, local_lens, rtol=0, atol=0)
+    torch.testing.assert_close(
+        causal_seqlens_kv_global, global_lens - 1, rtol=0, atol=0
+    )
     torch.testing.assert_close(
         cu_seqlens_k[1:],
         torch.cumsum(local_lens, dim=0, dtype=torch.int32),

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -39,6 +39,8 @@ def _make_backend_for_hook_test(speculative_num_draft_tokens=None):
     backend.use_sliding_window_kv_pool = False
     backend._swa_kv_pool = None
     backend._swa_full_to_swa_mapping = None
+    backend.dcp_size = 1
+    backend.dcp_rank = 0
     backend.speculative_step_id = 0
     backend.speculative_num_draft_tokens = speculative_num_draft_tokens
     backend.expand_encoder_only_verify = False
@@ -562,6 +564,64 @@ def test_bs_zero_noop():
         max_seq_pages=0,
         page_size=PAGE_SIZE,
     )
+
+
+def test_dcp_metadata_uses_local_lens_and_page_table():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    bs = 3
+    dcp_size = 4
+    dcp_rank = 2
+    global_lens = torch.tensor([1, 257, 1027], dtype=torch.int32, device=DEVICE)
+    max_local_len = (int(global_lens.max().item()) + dcp_size - 1) // dcp_size
+    max_seq_pages = (max_local_len + PAGE_SIZE - 1) // PAGE_SIZE
+    req_to_token = torch.arange(bs * 2048, dtype=torch.int32, device=DEVICE).reshape(
+        bs, 2048
+    )
+    req_pool_indices = torch.arange(bs, dtype=torch.int64, device=DEVICE)
+    cache_seqlens = torch.zeros(bs, dtype=torch.int32, device=DEVICE)
+    cu_seqlens_k = torch.zeros(bs + 1, dtype=torch.int32, device=DEVICE)
+    page_table = torch.full((bs, max_seq_pages), -1, dtype=torch.int32, device=DEVICE)
+
+    update_trtllm_mha_graph_metadata(
+        req_pool_indices=req_pool_indices,
+        seq_lens=global_lens,
+        req_to_token=req_to_token,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_k=cu_seqlens_k,
+        page_table=page_table,
+        bs=bs,
+        seqlen_offset=0,
+        max_seq_pages=max_seq_pages,
+        page_size=PAGE_SIZE,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
+    )
+    torch.cuda.synchronize()
+
+    local_lens = (global_lens // dcp_size + (dcp_rank < global_lens % dcp_size)).to(
+        torch.int32
+    )
+    torch.testing.assert_close(cache_seqlens, local_lens, rtol=0, atol=0)
+    torch.testing.assert_close(
+        cu_seqlens_k[1:],
+        torch.cumsum(local_lens, dim=0, dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    for req_idx in range(bs):
+        num_pages = (int(local_lens[req_idx].item()) + PAGE_SIZE - 1) // PAGE_SIZE
+        global_positions = (
+            torch.arange(num_pages, device=DEVICE, dtype=torch.int64)
+            * PAGE_SIZE
+            * dcp_size
+            + dcp_rank
+        )
+        expected = (req_to_token[req_idx, global_positions] // dcp_size) // PAGE_SIZE
+        torch.testing.assert_close(
+            page_table[req_idx, :num_pages], expected, rtol=0, atol=0
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/attention/test_trtllm_mha_page_table.py
+++ b/test/registered/attention/test_trtllm_mha_page_table.py
@@ -62,6 +62,8 @@ def _build_page_table_kernel(
     page_size: int,
     max_num_pages: int,
     full_to_swa: Optional[torch.Tensor] = None,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
 ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
     """Device-side impl."""
     dev = req_to_token.device
@@ -80,6 +82,8 @@ def _build_page_table_kernel(
         page_size=page_size,
         swa_page_table=swa_page_table,
         full_to_swa=full_to_swa,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
     )
     return page_table, swa_page_table
 
@@ -148,6 +152,62 @@ class TestTrtllmMhaPageTable(CustomTestCase):
                     self._run_case(
                         max_ctx, page_size, num_reqs=max(64, bs), bs=bs, swa=True
                     )
+
+    def test_dcp_page_table_matches_round_robin_local_layout(self):
+        torch.manual_seed(0)
+        dev = "cuda"
+        dcp_size = 4
+        page_size = 64
+        max_context_len = 4096
+        num_reqs = 16
+        bs = 7
+        req_to_token = torch.randint(
+            0,
+            num_reqs * max_context_len,
+            (num_reqs, max_context_len),
+            dtype=torch.int32,
+            device=dev,
+        )
+        req_pool_indices = torch.randperm(num_reqs, device=dev)[:bs].to(torch.int32)
+        global_lens = torch.randint(
+            1, max_context_len + 1, (bs,), dtype=torch.int32, device=dev
+        )
+        max_local_pages = (
+            (max_context_len + dcp_size - 1) // dcp_size + page_size - 1
+        ) // page_size
+
+        for dcp_rank in range(dcp_size):
+            local_lens = (
+                global_lens // dcp_size + (dcp_rank < global_lens % dcp_size)
+            ).to(torch.int32)
+            page_table, _ = _build_page_table_kernel(
+                req_to_token,
+                req_pool_indices,
+                local_lens,
+                page_size,
+                max_local_pages,
+                dcp_size=dcp_size,
+                dcp_rank=dcp_rank,
+            )
+
+            local_page_starts = (
+                torch.arange(max_local_pages, device=dev, dtype=torch.int64)
+                * page_size
+                * dcp_size
+                + dcp_rank
+            )
+            slots = req_to_token[req_pool_indices[:, None], local_page_starts[None, :]]
+            reference = (slots // dcp_size) // page_size
+            for req_idx in range(bs):
+                num_pages = (
+                    int(local_lens[req_idx].item()) + page_size - 1
+                ) // page_size
+                torch.testing.assert_close(
+                    page_table[req_idx, :num_pages],
+                    reference[req_idx, :num_pages],
+                    rtol=0,
+                    atol=0,
+                )
 
     def _run_self_guard_case(self, max_context_len, page_size, bs, swa=False):
         """Short sequences against a full static buffer -- the GPU-only shape.

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -22,6 +22,7 @@ import torch
 from sglang.srt import runtime_context as rc
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
+from sglang.srt.layers.dcp.comm import cp_lse_ag_out_rs_mha
 from sglang.srt.layers.dcp.layout import (
     filter_dcp_local_chunk_kv_indices,
     get_dcp_lens,
@@ -142,6 +143,44 @@ class TestFilterDcpLocalChunkKvIndices(CustomTestCase):
 
 
 class TestGetDcpLens(CustomTestCase):
+    def test_mha_merge_supports_base2_lse(self):
+        rank_lses = [
+            torch.tensor([[1.0, 3.0]], dtype=torch.float32),
+            torch.tensor([[2.0, 1.0]], dtype=torch.float32),
+        ]
+        rank_outs = [
+            torch.tensor([[[2.0], [5.0]]], dtype=torch.float32),
+            torch.tensor([[[8.0], [1.0]]], dtype=torch.float32),
+        ]
+        global_lse = torch.logsumexp(
+            torch.stack(rank_lses) * math.log(2.0), dim=0
+        ) * math.log2(math.e)
+        weights = [torch.exp2(lse - global_lse) for lse in rank_lses]
+
+        class FakeGroup:
+            world_size = 2
+            rank_in_group = 0
+
+            def all_gather(self, tensor, dim):
+                self.assert_tensor = tensor
+                return torch.cat(rank_lses, dim=dim)
+
+            def all_reduce(self, tensor):
+                return tensor + rank_outs[1] * weights[1].unsqueeze(-1)
+
+        merged_out, merged_lse = cp_lse_ag_out_rs_mha(
+            rank_outs[0].clone(),
+            rank_lses[0],
+            FakeGroup(),
+            return_lse=True,
+            is_lse_base_on_e=False,
+        )
+        expected_out = sum(
+            out * weight.unsqueeze(-1) for out, weight in zip(rank_outs, weights)
+        )
+        torch.testing.assert_close(merged_out, expected_out[:, :1])
+        torch.testing.assert_close(merged_lse, global_lse[:, :1])
+
     def test_start_none_matches_owner_count(self):
         for n in DCP_SIZES:
             for rank in range(n):

--- a/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.model_runner_components import (
     attention_backend_setup,
 )
@@ -75,7 +76,55 @@ def test_split_full_attention_applies_model_wrapper_once():
         assert isinstance(split_backend, HybridAttnBackend)
         assert split_backend.decode_backend.name == "decode"
         assert split_backend.prefill_backend.name == "prefill"
+        assert split_backend._select_backend(ForwardMode.EXTEND).name == "prefill"
+        assert (
+            split_backend._select_backend(ForwardMode.DRAFT_EXTEND_V2).name == "prefill"
+        )
         assert runner.init_new_workspace is True
+    finally:
+        override.restore()
+
+
+def test_split_draft_override_builds_hybrid_backend():
+    from sglang.srt.runtime_context import get_context
+
+    override = get_context().override_server_args(speculative_attention_mode="decode")
+    override.install()
+    try:
+        runner = SimpleNamespace(
+            model_config=SimpleNamespace(context_len=2048),
+            kv_cache_dtype=None,
+            token_to_kv_pool=object(),
+            req_to_token_pool=object(),
+            init_new_workspace=None,
+        )
+        constructors = {
+            "decode-test": lambda model_runner: _FakeBackend("decode"),
+            "prefill-test": lambda model_runner: _FakeBackend("prefill"),
+        }
+        resolved = ResolvedAttentionBackendStr(
+            decode="decode-test",
+            prefill="prefill-test",
+            is_draft_override=True,
+        )
+
+        with (
+            patch.dict(attention_backend_setup.ATTENTION_BACKENDS, constructors),
+            patch.object(
+                attention_backend_setup,
+                "attn_backend_wrapper",
+                side_effect=lambda _runner, backend: backend,
+            ),
+        ):
+            result = attention_backend_setup._build_resolved_backend(
+                model_runner=runner,
+                resolved=resolved,
+                init_new_workspace=False,
+            )
+
+        assert isinstance(result, HybridAttnBackend)
+        assert result._select_backend(ForwardMode.EXTEND).name == "prefill"
+        assert result._select_backend(ForwardMode.DRAFT_EXTEND_V2).name == "decode"
     finally:
         override.restore()
 

--- a/test/registered/unit/spec/test_draft_per_runner_config.py
+++ b/test/registered/unit/spec/test_draft_per_runner_config.py
@@ -156,6 +156,23 @@ class TestDraftPerRunnerConfig(CustomTestCase):
         )
         self.assertEqual((draft.prefill, draft.decode), ("triton", "triton"))
 
+    def test_dcp_trtllm_draft_preserves_the_prompt_prefill_backend(self):
+        self._seed(
+            attention_backend="trtllm_mha",
+            prefill_attention_backend="triton",
+            decode_attention_backend="trtllm_mha",
+            dcp_size=4,
+        )
+
+        draft = resolve_attention_backend_strs(
+            model_runner=self._runner(
+                is_draft_worker=True, draft_attention_backend="trtllm_mha"
+            )
+        )
+
+        self.assertEqual((draft.prefill, draft.decode), ("triton", "trtllm_mha"))
+        self.assertTrue(draft.is_draft_override)
+
     def test_the_target_keeps_its_split_pair(self):
         self._seed(
             attention_backend="fa3",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The TRTLLM MHA decode backend does not support decode context parallelism (DCP). This PR adds the missing DCP decode path while keeping prefill on a supported backend. The common GQA KV-head mapping fix is split into #32858.

## Modifications

- Build DCP-local sequence lengths and token-indexed TRTLLM page tables.
- All-gather Q heads, request per-rank output/LSE, and merge partial attention results with the existing DCP collective.
- Add DCP metadata for target verify and draft extend, plus graph-stable Q gather and output/LSE buffers.
- Preserve the configured prefill backend for ordinary draft prompt prefill.
- Add targeted page-table, graph-metadata, LSE, Q-layout, and backend-routing tests.
- Reject unsupported DCP combinations: SWA KV pools, native FP4 KV cache, and XQA.

## Accuracy Tests

Qwen3.5-397B-A17B-NVFP4-V2 was evaluated on one GB300 node with TP4, 200 GSM8K examples, 8-shot prompting, temperature 0.6, `max_tokens=16384`, and full decode CUDA Graph through batch size 200. The DCP4 runs include #32858.

| Layout | Decode backend | GSM8K |
| --- | --- | ---: |
| TP4/DCP1 | Triton | 0.990 |
| TP4/DCP4 | Triton | 0.980 |
| TP4/DCP4 | TRTLLM MHA | 0.975 |

All runs completed 200/200 examples with no missing or unextractable answers. The TRTLLM MHA implementation also passed 154 targeted page-table and CUDA Graph metadata tests on ARM64/GB300 and x86/GB300, plus eager and full-graph DCP1/DCP4 serving smoke tests.

## Speculative Decode Validation

Validated against merged [FlashInfer #4518](https://github.com/flashinfer-ai/flashinfer/pull/4518).

| Test | Configuration | Result |
| --- | --- | --- |
| SGLang targeted tests | DCP metadata/page table, base-2 LSE merge, graph-stable Q gather, and draft prefill/decode routing | 10 passed |
| FlashInfer kernel tests | D256, FP8 KV, page size 64, Q/KV heads 16/1, CP4, `q_len` 1/2/4/7/8, CUDA Graph replay | 6 passed |
| End-to-end serving | TP16/DCP4, MTP4, Triton prompt prefill, TRTLLM MHA target/draft attention, full target-verify/draft-decode/draft-extend CUDA Graph, two deterministic 8192-input/8-output requests | Passed; identical output IDs and speculative acceptance metadata |

The end-to-end smoke used dummy weights, so it validates integration, shape routing, and CUDA Graph replay rather than model quality. This path requires the first stable FlashInfer release containing #4518; the current SGLang FlashInfer pin (0.6.17) does not contain it.

## Speed Tests and Profiling

End-to-end serving was measured on 16 GB300 GPUs with FP8 weights, FP8 E4M3 KV cache, TP16, ISL 8192, OSL 1024, concurrency 1024, 1,024 warmup requests, 5,120 measured requests, and full decode CUDA Graph through batch size 256.

| Layout | GQA prefill / decode | Output tok/s | Total tok/s | Total tok/s/GPU | Mean TTFT | Mean TPOT |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| TP16 | TRTLLM MHA / TRTLLM MHA | 1,326.19 | 11,935.67 | 745.98 | 502.17 s | 231.85 ms |
| TP16/DCP1 | Triton / TRTLLM MHA | 1,304.11 | 11,736.98 | 733.56 | 512.69 s | 233.69 ms |
| TP16/DCP4 | Triton / TRTLLM MHA | 1,822.46 | 16,402.15 | 1,025.13 | 168.89 s | 397.20 ms |

DCP1 and DCP4 differ only in `dcp_size`. At concurrency 1024, DCP4 improves output throughput by 39.75% over DCP1 and 37.42% over TP16, with a higher per-request TPOT. All 5,120 measured requests completed with exact 8K/1K lengths, zero request errors, zero empty outputs, and zero HTTP non-200 responses.

This CC1024 result was collected on a stacked validation branch containing this PR, #32858, #32800, and the high-concurrency output-buffer capacity guard found during the run; the last guard is not yet in this PR head.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change is required for this backend integration.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33147127468](https://github.com/sgl-project/sglang/actions/runs/33147127468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33147127407](https://github.com/sgl-project/sglang/actions/runs/33147127407)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33147127409](https://github.com/sgl-project/sglang/actions/runs/33147127409)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->