### PR TITLE
[GDN] Align FlashInfer BF16-state gate inputs

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -38,6 +38,15 @@ _flashinfer_gated_delta_rule_decode = None
 _flashinfer_gated_delta_rule_mtp_bf16 = None
 
 
+def _ensure_32_byte_aligned(tensor: torch.Tensor) -> torch.Tensor:
+    """Meet the BF16-state CuTe kernel's ``assumed_align=32`` contract.
+
+    A logically contiguous view may retain a non-zero storage offset, so
+    ``contiguous()`` alone does not guarantee an aligned data pointer.
+    """
+    return tensor if tensor.data_ptr() % 32 == 0 else tensor.clone()
+
+
 def maybe_build_flashinfer_checkpoint_plan(
     forward_batch: ForwardBatch,
     forward_metadata: ForwardMetadata,
@@ -232,6 +241,9 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         value_fi = v.view(batch_size, 1, num_v_heads, head_v_dim)
         a_fi = a.view(batch_size, 1, num_v_heads)
         b_fi = b.view(batch_size, 1, num_v_heads)
+        if self.use_state_pool:
+            a_fi = _ensure_32_byte_aligned(a_fi)
+            b_fi = _ensure_32_byte_aligned(b_fi)
 
         if self.use_state_pool:
             output_fi, _ = self._decode_fn(
@@ -406,6 +418,9 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
 
         a_mtp = a.view(batch_size, draft_token_num, num_v_heads)
         b_mtp = b.view(batch_size, draft_token_num, num_v_heads)
+        if self.use_state_pool:
+            a_mtp = _ensure_32_byte_aligned(a_mtp)
+            b_mtp = _ensure_32_byte_aligned(b_mtp)
 
         intermediate_states_buffer_mtp = intermediate_states_buffer
         if self.use_state_pool and intermediate_states_buffer is not None:

--- a/test/registered/attention/unittests/gdn/test_flashinfer.py
+++ b/test/registered/attention/unittests/gdn/test_flashinfer.py
@@ -10,6 +10,9 @@ from sglang.test.test_utils import CustomTestCase
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
+    FlashInferGDNKernel,
+)
 from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKernel
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.gdn_attention import (
@@ -230,6 +233,62 @@ class TestFlashInferGDNBackendCorrectness(CustomTestCase):
                     head_k_dim=self.HEAD_K_DIM,
                     head_v_dim=self.HEAD_V_DIM,
                 )
+
+    def test_bf16_state_decode_aligns_gate_views(self):
+        num_heads = 2
+        num_v_heads = 8
+        head_dim = 128
+
+        projected_ba = torch.randn(
+            1, 2 * num_v_heads, dtype=torch.bfloat16, device="cuda"
+        )
+        b, a = projected_ba.split([num_v_heads, num_v_heads], dim=-1)
+        b = b.contiguous()
+        a = a.contiguous()
+        self.assertEqual(b.data_ptr() % 32, 0)
+        self.assertEqual(a.data_ptr() % 32, 16)
+
+        captured_gates = {}
+
+        def decode_fn(**kwargs):
+            captured_gates["a"] = kwargs["a"]
+            captured_gates["b"] = kwargs["b"]
+            return torch.zeros_like(kwargs["v"]), None
+
+        kernel = object.__new__(FlashInferGDNKernel)
+        kernel.use_state_pool = True
+        kernel._decode_fn = decode_fn
+
+        q = torch.randn(1, 1, num_heads, head_dim, dtype=torch.bfloat16, device="cuda")
+        k = torch.randn_like(q)
+        v = torch.randn(
+            1, 1, num_v_heads, head_dim, dtype=torch.bfloat16, device="cuda"
+        )
+        output = kernel.decode(
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log=torch.randn(num_v_heads, dtype=torch.float32, device="cuda"),
+            dt_bias=torch.randn(num_v_heads, dtype=torch.float32, device="cuda"),
+            ssm_states=torch.zeros(
+                1,
+                num_v_heads,
+                head_dim,
+                head_dim,
+                dtype=torch.bfloat16,
+                device="cuda",
+            ),
+            cache_indices=torch.zeros(1, dtype=torch.int32, device="cuda"),
+            query_start_loc=torch.tensor([0, 1], dtype=torch.int32, device="cuda"),
+        )
+
+        self.assertEqual(captured_gates["a"].data_ptr() % 32, 0)
+        self.assertEqual(captured_gates["b"].data_ptr() % 32, 0)
+        torch.testing.assert_close(captured_gates["a"].view_as(a), a)
+        torch.testing.assert_close(captured_gates["b"].view_as(b), b)
+        self.assertEqual(output.shape, (1, 1, num_v_heads, head_dim))
 
     # Layout-robustness. See dense/test_triton.py for the rationale.
     LAYOUT_ROBUSTNESS_CASES = (


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

FlashInfer 0.6.15.post1 compiles the BF16-state CuTe GDN gate inputs with `assumed_align=32`, but a logically contiguous PyTorch view is not necessarily backed by a 32-byte-aligned data pointer.

The failing layout starts from one fused `[b | a]` projection buffer. After tensor-parallel sharding, each local gate can contain eight BF16 values. `b` starts at the aligned base address, while `a` starts eight BF16 values later, which is a 16-byte offset. For a single-row decode tensor, PyTorch considers both views contiguous, so `contiguous()` returns the original views without moving `a` to an aligned address. Passing that `a` view to the FlashInfer BF16-state decode kernel fails with:

```text
RuntimeError: Tensor data pointer is not aligned to 32 bytes
```

Before this change, the first decode fails when a gate view begins at that 16-byte offset. After this change, the backend materializes only an unaligned gate view before invoking FlashInfer; both gate inputs then satisfy the kernel contract and real prefill/decode completes successfully.

PR #32706 documents the same 16-byte-offset condition, but intentionally enables its view fast path only for Triton because FlashInfer rejects the unaligned pointer. It does not add alignment handling to the FlashInfer backend.

## Modifications

- Add a small helper at the FlashInfer GDN backend boundary that returns an already aligned tensor unchanged and clones only a tensor whose data pointer is not 32-byte aligned.
- Apply the alignment guard to BF16-state single-token decode and multi-token verification.
- Add a regression test that constructs the problematic fused gate layout, verifies that `a` initially begins at a 16-byte offset, and confirms that the backend passes aligned, value-identical gates to FlashInfer.

## Accuracy Tests

The regression test verifies that materialization changes only the storage address: both `a` and `b` remain value-identical after alignment.

An SM100 serving A/B was also completed with the same conditional materialization. The control loaded all ranks but failed on its first real decode with the alignment error above. The fixed run completed real prefill and decode successfully.

## Speed Tests and Profiling

This is a correctness fix for a path that previously crashed before serving the first token. No end-to-end speed comparison is meaningful for the failing case. Inputs that already satisfy the 32-byte contract remain on the existing zero-copy path; only an unaligned gate view is materialized.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change is required for this internal backend fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Correctness A/B is provided above; performance is not applicable to the crashing control.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
