### PR TITLE
[MLX] Disable multimodal on the MLX backend (text-only inference path)

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -310,6 +310,8 @@ class ModelConfig:
 
         # Set enable_multimodal
         if enable_multimodal is None:
+            from sglang.srt.utils.tensor_bridge import use_mlx
+
             mm_disabled_models = [
                 "Gemma3ForConditionalGeneration",
                 "Llama4ForConditionalGeneration",
@@ -333,6 +335,18 @@ class ModelConfig:
                     "Multimodal is disabled for this MiMoV2 checkpoint: "
                     "vision_config/audio_config not found in the model config "
                     "(likely a text-only MiMoV2 variant)."
+                )
+            elif use_mlx():
+                # The MLX backend is text-only (there is no vision/audio
+                # inference path). Do not attempt to build a multimodal
+                # processor on MLX; otherwise loading a checkpoint whose HF
+                # config carries a vision_config (e.g. a language-model-only
+                # MLX release of a multimodal arch) fails on the missing image
+                # processor. To force it, set --enable-multimodal.
+                enable_multimodal = False
+                logger.info(
+                    "Multimodal is disabled on the MLX backend (text-only "
+                    "inference path). To force it, set --enable-multimodal."
                 )
             else:
                 enable_multimodal = True


### PR DESCRIPTION
## Motivation

On the MLX backend there is no vision/audio inference path, but `ModelConfig` auto-resolve still enables multimodal when a checkpoint's HF config carries a `vision_config`. This crashes any **text-only MLX release of a multimodal architecture** (no `preprocessor_config.json`):

```
OSError: Can't load image processor for 'mlx-community/Qwen3.6-27B-OptiQ-4bit'.
... make sure ... preprocessor_config.json file
```

Reproduced with `Qwen3_5ForConditionalGeneration` (`mlx-community/Qwen3.6-27B-OptiQ-4bit`, a hybrid linear-attention model).

## Changes

`python/sglang/srt/configs/model_config.py`: when `enable_multimodal is None` (auto-resolve), force `enable_multimodal = False` if `use_mlx()`. This mirrors the existing precedents (`mm_disabled_models`, the MiMoV2 text-only check). Users can still force it with `--enable-multimodal`.

## Testing

`SGLANG_USE_MLX=1 python -m sglang.launch_server --model-path mlx-community/Qwen3.6-27B-OptiQ-4bit ...`
- before: `OSError` on the missing image processor (server never starts)
- after: tokenizer loads via `get_tokenizer`, server serves text

Part of enabling hybrid-SSM models on the MLX backend — companion to #32450 (which fixes the radix-cache crash, #32449). This patch is orthogonal: it only touches `model_config.py`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30481580193](https://github.com/sgl-project/sglang/actions/runs/30481580193)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30481584497](https://github.com/sgl-project/sglang/actions/runs/30481584497)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->