### PR TITLE
[MLX] Guard GDNAttnBackend init when the mamba cache is not allocated

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -336,13 +336,21 @@ class GDNAttnBackend(MambaAttnBackendBase):
 
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
-        self.conv_states_shape = (
-            model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape
+        _mamba_cache = (
+            model_runner.req_to_token_pool.mamba_pool.mamba_cache
         )
-        if not is_cpu() and not is_npu():
-            assert (
-                self.conv_states_shape[-1] < FLA_CHUNK_SIZE
-            ), f"{self.conv_states_shape[-1]=} should be less than {FLA_CHUNK_SIZE}"
+        if _mamba_cache is not None:
+            self.conv_states_shape = _mamba_cache.conv[0].shape
+            if not is_cpu() and not is_npu():
+                assert (
+                    self.conv_states_shape[-1] < FLA_CHUNK_SIZE
+                ), f"{self.conv_states_shape[-1]=} should be less than {FLA_CHUNK_SIZE}"
+        else:
+            # Non-CUDA backends (e.g. MLX) do not allocate the mamba conv
+            # cache: the forward pass runs through the native backend
+            # (mlx_lm), not this Triton/CUDA linear-attention kernel, so
+            # there is no conv-state shape to read here.
+            self.conv_states_shape = None
 
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()


### PR DESCRIPTION
## Motivation

`GDNAttnBackend.__init__` reads `req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape` unconditionally. On the MLX backend, `MlxAuxiliaryStatePool.mamba_cache` is `None` (the MLX runner owns the auxiliary / linear-attention state natively through `mlx_lm`, and the Triton/CUDA GDN kernel is **not** used for compute there), so constructing the attention backend raises:

```
AttributeError: 'NoneType' object has no attribute 'conv'
```

…during attention-backend setup, before the server starts. Hit while serving a hybrid linear-attention model (`Qwen3_5ForConditionalGeneration`, `mlx-community/Qwen3.6-27B-OptiQ-4bit`) on the MLX backend.

## Changes

`python/sglang/srt/layers/attention/linear/gdn_backend.py`: when `mamba_cache is None`, set `conv_states_shape = None` and skip the `FLA_CHUNK_SIZE` assert. `conv_states_shape` is referenced only inside `__init__` (the GDN kernel is never invoked on the MLX forward path — `MlxModelRunner` runs the forward via `mlx_lm`), so `None` is safe.

## Testing

Tested end-to-end as part of the MLX hybrid-SSM enablement stack (together with #32801 and #32450): the 27B hybrid model serves on the MLX backend. Without this guard, server startup fails at attention-backend construction.

Companion to #32449 / #32450.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30481610462](https://github.com/sgl-project/sglang/actions/runs/30481610462)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30481610317](https://github.com/sgl-project/sglang/actions/runs/30481610317)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->