### PR TITLE
[MLX] Fix device mismatch in forward token relay (enables batched decode)

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -510,7 +510,7 @@ class FutureMap:
             self._lazy_init_forward_buf(payload)
         self._maybe_init_dsa_topk_indices_buf(payload)
         self.output_tokens_buf[indices] = payload.bonus_tokens.to(
-            self.output_tokens_buf.dtype
+            self.output_tokens_buf
         )
 
         if self.need_topk:


### PR DESCRIPTION
## Motivation

On the MLX backend, any **batched/concurrent decode (≥2 running requests)** crashes the scheduler:

```
File ".../srt/managers/overlap_utils.py", line 512, in stash
    self.output_tokens_buf[indices] = payload.bonus_tokens.to(
        self.output_tokens_buf.dtype
    )
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
```

Root cause: `FutureMapRelay.stash` writes `payload.bonus_tokens` into `output_tokens_buf` using `.to(buf.dtype)`, which aligns **dtype but not device**. On MLX the tp_worker produces `next_token_ids` on the host (`hardware_backend/mlx/tp_worker.py`, `device="cpu"`), while `output_tokens_buf` lives on the model device (MPS). Single-request decode happened not to trip it, but a 2-request decode batch does.

This effectively disables SGLang's main serving advantage (request batching) on the MLX backend.

## Changes

`python/sglang/srt/managers/overlap_utils.py`: write with `.to(self.output_tokens_buf)` instead of `.to(self.output_tokens_buf.dtype)`, so the source tensor is aligned to the buffer's **device as well as dtype**. Robust for any backend whose sampled tokens arrive host-resident; a no-op when devices already match.

## Testing

`Qwen3_6ForConditionalGeneration` hybrid model (`mlx-community/Qwen3.6-27B-OptiQ-4bit`, 4-bit) on Apple Silicon, with `SGLANG_USE_MLX=1`. Before: 2+ concurrent `/v1/chat/completions` crash the server. After:

| concurrent N | aggregate tok/s | per-req tok/s |
|---|---|---|
| 1 | 14.1 | 14.1 |
| 2 | 25.6 | 12.8 |
| 4 | 44.1 | 11.0 |

Correctness verified under concurrency (e.g. `"What is 7+8?"` → `15`, `"capital of France?"` → `Paris`, issued simultaneously, both correct).

Companion to #32449 / #32450 (hybrid-SSM on MLX); this patch is in generic relay code.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30482484381](https://github.com/sgl-project/sglang/actions/runs/30482484381)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30482498427](https://github.com/sgl-project/sglang/actions/runs/30482498427)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->