### PR TITLE
[NPU] Support Jet-Nemotron-2B on Ascend

### DIFF
--- a/docs_new/docs/hardware-platforms/ascend-npus/ascend_npu_support_models.mdx
+++ b/docs_new/docs/hardware-platforms/ascend-npus/ascend_npu_support_models.mdx
@@ -332,6 +332,12 @@ You are welcome to enable various models based on your business requirements.
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>jet-ai/Jet-Nemotron-2B</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Jet-Nemotron</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Eco-Tech/Kimi-K2.6-w4a8</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Kimi</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅</td>

--- a/python/sglang/srt/models/jet_nemotron.py
+++ b/python/sglang/srt/models/jet_nemotron.py
@@ -5,9 +5,6 @@ import einops
 import torch
 import torch.nn as nn
 
-from sglang.kernels.ops.attention.fla.fused_recurrent import (
-    fused_recurrent_gated_delta_rule_update,
-)
 from sglang.kernels.ops.attention.fla.layernorm_gated import RMSNorm as RMSNormGated
 from sglang.srt.configs.jet_nemotron import JetBlockConfig, JetNemotronConfig
 from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
@@ -31,7 +28,19 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen2 import Qwen2MLP, Qwen2Model
-from sglang.srt.utils import add_prefix
+from sglang.srt.utils import add_prefix, is_npu
+from sglang.srt.utils.hf_transformers_utils import get_rope_config
+
+_is_npu = is_npu()
+
+if _is_npu:
+    from sgl_kernel_npu.fla.fused_sigmoid_gating_recurrent import (
+        fused_sigmoid_gating_delta_rule_update_npu,
+    )
+else:
+    from sglang.kernels.ops.attention.fla.fused_recurrent import (
+        fused_recurrent_gated_delta_rule_update,
+    )
 
 
 class DynamicShortConvolutionKernelGenerator(nn.Module):
@@ -286,13 +295,18 @@ class JetBlock(nn.Module):
         k = nn.functional.silu(k)
         k = einops.rearrange(k, "l (h d) -> l h d", h=self.num_heads, d=self.head_k_dim)
 
-        conv_cache = layer_cache.conv
+        conv_cache = layer_cache.conv[0]
         assert isinstance(conv_cache, torch.Tensor)
+        conv_state = conv_cache[
+            forward_metadata.mamba_cache_indices, :, -self.total_v_dim :
+        ].transpose(1, 2)
+        assert conv_state.shape[1:] == (
+            self.total_v_dim,
+            self.conv_size - 1,
+        ), (conv_cache.shape, conv_state.shape)
         v, new_conv_state = self.dynamic_conv1d(
             v,
-            conv_state=conv_cache[
-                forward_metadata.mamba_cache_indices, -self.total_v_dim :, :
-            ],
+            conv_state=conv_state,
             generator_input=hidden_states,
             seq_lens=(
                 forward_batch.extend_seq_lens
@@ -303,30 +317,52 @@ class JetBlock(nn.Module):
                 )
             ),
         )
-        conv_cache[forward_metadata.mamba_cache_indices, -self.total_v_dim :, :] = (
-            new_conv_state
+        conv_cache[forward_metadata.mamba_cache_indices, :, -self.total_v_dim :] = (
+            new_conv_state.transpose(1, 2)
         )
         v = einops.rearrange(v, "l (h d) -> l h d", h=self.num_heads, d=self.head_v_dim)
 
-        g = -self.A_log.float().exp() * nn.functional.softplus(a.float() + self.dt_bias)
+        if _is_npu:
+            o = fused_sigmoid_gating_delta_rule_update_npu(
+                A_log=self.A_log,
+                a=a,
+                dt_bias=self.dt_bias,
+                softplus_beta=1.0,
+                softplus_threshold=20.0,
+                q=q.unsqueeze(0),
+                k=k.unsqueeze(0),
+                v=v.unsqueeze(0),
+                b=beta,
+                initial_state_source=layer_cache.temporal,
+                initial_state_indices=forward_metadata.mamba_cache_indices,
+                cu_seqlens=cast(torch.LongTensor, forward_metadata.query_start_loc),
+                use_qk_l2norm_in_kernel=True,
+            ).squeeze(0)
+        else:
+            g = -self.A_log.float().exp() * nn.functional.softplus(
+                a.float() + self.dt_bias
+            )
+            beta = nn.functional.sigmoid(beta)
 
-        beta = nn.functional.sigmoid(beta)
-
-        o = fused_recurrent_gated_delta_rule_update(
-            q=q.unsqueeze(0),
-            k=k.unsqueeze(0),
-            v=v.unsqueeze(0),
-            g=g.unsqueeze(0),
-            beta=beta.unsqueeze(0),
-            initial_state_source=layer_cache.temporal,
-            initial_state_indices=forward_metadata.mamba_cache_indices,
-            cu_seqlens=cast(torch.LongTensor, forward_metadata.query_start_loc),
-            use_qk_l2norm_in_kernel=True,
-        ).squeeze(0)
+            o = fused_recurrent_gated_delta_rule_update(
+                q=q.unsqueeze(0),
+                k=k.unsqueeze(0),
+                v=v.unsqueeze(0),
+                g=g.unsqueeze(0),
+                beta=beta.unsqueeze(0),
+                initial_state_source=layer_cache.temporal,
+                initial_state_indices=forward_metadata.mamba_cache_indices,
+                cu_seqlens=cast(torch.LongTensor, forward_metadata.query_start_loc),
+                use_qk_l2norm_in_kernel=True,
+            ).squeeze(0)
 
         z = einops.rearrange(z, "l (h d) -> l h d", h=self.num_heads)
 
-        o = self.o_norm(o, z)
+        if _is_npu:
+            o, _ = torch.ops.npu.npu_rms_norm(o, self.o_norm.weight, self.o_norm.eps)
+            o = o * nn.functional.silu(z)
+        else:
+            o = self.o_norm(o, z)
 
         o = einops.rearrange(o, "l h d -> l (h d)")
 
@@ -369,12 +405,13 @@ class JetNemotronAttention(nn.Module):
             prefix=add_prefix("o_proj", prefix),
         )
 
+        rope_theta, rope_scaling = get_rope_config(self.config)
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=self.head_dim,
             max_position=self.config.max_position_embeddings,
-            base=int(self.config.rope_parameters["rope_theta"]),
-            rope_scaling=self.config.rope_parameters,
+            base=int(rope_theta),
+            rope_scaling=rope_scaling,
         )
 
         match self.config.layer_types[layer_id]:
@@ -420,10 +457,12 @@ class JetNemotronDecoderLayer(nn.Module):
         config: JetNemotronConfig,
         alt_stream: torch.cuda.Stream | None = None,
         layer_id: int = 0,
+        start_layer: int = 0,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
+        self.start_layer = start_layer
 
         match config.layer_types[layer_id]:
             case "attn" | "swa":

--- a/python/sglang/test/ascend/test_ascend_utils.py
+++ b/python/sglang/test/ascend/test_ascend_utils.py
@@ -111,6 +111,7 @@ GROK_2_WEIGHTS_TOKENIZER_PATH = os.path.join(
 INTERNLM2_7B_WEIGHTS_PATH = os.path.join(
     MODEL_WEIGHTS_DIR, "Shanghai_AI_Laboratory/internlm2-7b"
 )
+JET_NEMOTRON_2B_WEIGHTS_PATH = os.path.join(MODEL_WEIGHTS_DIR, "jet-ai/Jet-Nemotron-2B")
 KIMI_K2_THINKING_WEIGHTS_PATH = os.path.join(MODEL_WEIGHTS_DIR, "Kimi/Kimi-K2-Thinking")
 KIMI_K2_5_W4A8_MODEL_PATH = os.path.join(MODEL_WEIGHTS_DIR, "Eco-Tech/Kimi-K2.5-w4a8")
 KIMI_K2_5_EAGLE3_MODEL_PATH = os.path.join(

--- a/test/registered/ascend/llm_models/test_npu_jet_nemotron_2b.py
+++ b/test/registered/ascend/llm_models/test_npu_jet_nemotron_2b.py
@@ -1,0 +1,32 @@
+import unittest
+
+from sglang.test.ascend.gsm8k_ascend_mixin import GSM8KAscendMixin
+from sglang.test.ascend.test_ascend_utils import JET_NEMOTRON_2B_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+
+class TestJetNemotron2B(GSM8KAscendMixin, CustomTestCase):
+    """Testcase: Verify that the inference accuracy of the jet-ai/Jet-Nemotron-2B model on the GSM8K dataset is no less than 0.752.
+
+    [Test Category] Model
+    [Test Target] jet-ai/Jet-Nemotron-2B
+    """
+
+    model = JET_NEMOTRON_2B_WEIGHTS_PATH
+    accuracy = 0.752
+    other_args = [
+        "--trust-remote-code",
+        "--mem-fraction-static",
+        "0.8",
+        "--attention-backend",
+        "ascend",
+        "--disable-cuda-graph",
+        "--disable-radix-cache",
+    ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add Ascend NPU inference support for `jet-ai/Jet-Nemotron-2B` and address [Ascend/sglang#531](https://github.com/Ascend/sglang/issues/531).

Without the NPU-specific dispatch, server warmup reaches the CUDA recurrent path and fails in `fused_recurrent_gated_delta_rule_update` because the NPU execution metadata does not provide `intermediate_state_indices`.

## Modifications

- Dispatch Jet-Nemotron's recurrent update to `fused_sigmoid_gating_delta_rule_update_npu` on Ascend while preserving the existing CUDA path.
- Use the native NPU RMSNorm op for the per-head gated RMSNorm, avoiding the current Triton-NPU kernel's UB overflow for this shape.
- Align the model with current SGLang interfaces: Qwen2 decoder `start_layer`, Hugging Face RoPE config access, and the current Mamba convolution-cache layout.
- Add an A3 nightly registered GSM8K test with an accuracy floor of `0.752` (official `0.762` reference minus 0.010 absolute).
- Add Jet-Nemotron-2B to the Ascend supported-model table.

## Accuracy

Tested with the official `jet-ai/Jet-Nemotron-2B` BF16 checkpoint, 200 GSM8K questions, 5-shot, temperature 0, and 128 client threads.

| Metric | Result |
| --- | ---: |
| Official model-card GSM8K reference | 0.762 |
| Ascend A3 measured score | **0.785** |
| Registered-test floor | 0.752 |

The registered test passed twice. The measured 200-question subset is above both the official reference and the acceptance floor; there is no accuracy degradation.

## Performance

Single logical Ascend A3 device, eager execution (`--disable-cuda-graph`):

| Metric | Result |
| --- | ---: |
| Output throughput | **190.589 token/s** |
| Evaluation latency | **126.062 s** |

There is no official performance baseline for this issue, so this is reported as an informational measurement.

## Test environment

- Image: `quay.io/ascend/sglang:main-cann9.0.0-a3`
- Device: Ascend A3 (`Ascend910_9382`), TP=1
- CANN: 9.0.0
- PyTorch / torch-npu: 2.10 / 2.10

## Tests

```bash
pytest -s -v test/registered/ascend/llm_models/test_npu_jet_nemotron_2b.py
python3 scripts/ci/check_registered_tests.py
python3 -m compileall -q python/sglang/srt/models/jet_nemotron.py python/sglang/test/ascend/test_ascend_utils.py test/registered/ascend/llm_models/test_npu_jet_nemotron_2b.py
uvx black==26.1.0 --check python/sglang/srt/models/jet_nemotron.py python/sglang/test/ascend/test_ascend_utils.py test/registered/ascend/llm_models/test_npu_jet_nemotron_2b.py
uvx isort==7.0.0 --check-only python/sglang/srt/models/jet_nemotron.py python/sglang/test/ascend/test_ascend_utils.py test/registered/ascend/llm_models/test_npu_jet_nemotron_2b.py
uvx ruff==0.15.1 check --select=F401,F821,UP037 python/sglang/srt/models/jet_nemotron.py python/sglang/test/ascend/test_ascend_utils.py test/registered/ascend/llm_models/test_npu_jet_nemotron_2b.py
```

All passed locally. This is intentionally opened as a draft for maintainer review and CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30483665873](https://github.com/sgl-project/sglang/actions/runs/30483665873)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30483670016](https://github.com/sgl-project/sglang/actions/runs/30483670016)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->