### PR TITLE
[Responses API] Return error.code as a string, not the HTTP status int

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -496,7 +496,7 @@ async def validation_exception_handler(request: Request, exc: HTTPException):
     """Enrich HTTP exception with status code and other details.
 
     For /v1/responses, emit OpenAI-style nested error envelope:
-    {"error": {"message": "...", "type": "...", "param": null, "code": <status>}}
+    {"error": {"message": "...", "type": "...", "param": null, "code": "<status>"}}
     For /v1/messages, emit Anthropic-style envelope so SDK clients can parse it.
     """
     if request.url.path.startswith("/v1/messages"):
@@ -532,7 +532,8 @@ async def validation_exception_handler(request: Request, exc: HTTPException):
             "message": exc.detail,
             "type": HTTPStatus(exc.status_code).phrase,
             "param": None,
-            "code": exc.status_code,
+            # A string, per OpenAIServingResponses.create_error_response.
+            "code": str(exc.status_code),
         }
         return ORJSONResponse(
             content={"error": nested_error}, status_code=exc.status_code
@@ -578,7 +579,8 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
             "message": message,
             "type": HTTPStatus.BAD_REQUEST.phrase,
             "param": None,
-            "code": HTTPStatus.BAD_REQUEST.value,
+            # A string, per OpenAIServingResponses.create_error_response.
+            "code": str(HTTPStatus.BAD_REQUEST.value),
         }
         return ORJSONResponse(status_code=400, content={"error": nested_error})
 

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -153,7 +153,12 @@ class OpenAIServingResponses(OpenAIServingChat):
             "message": message,
             "type": err_type,
             "param": param,
-            "code": status_code,
+            # The OpenAI schema types `error.code` as a nullable *string* (a slug such
+            # as "context_length_exceeded"), not the HTTP status -- that is already
+            # carried by the response status. Strict clients reject a number here: the
+            # OpenAI Java SDK types ErrorObject.code() as Optional<String> and raises
+            # OpenAIInvalidDataException on access, hiding the real error.
+            "code": str(status_code),
         }
         return ORJSONResponse(content={"error": nested_error}, status_code=status_code)
 
@@ -169,7 +174,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                     "message": message,
                     "type": err_type,
                     "param": None,
-                    "code": status_code,
+                    # A string, per create_error_response above.
+                    "code": str(status_code),
                 }
             }
         )

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import unittest
 from unittest.mock import Mock, patch
 
@@ -523,6 +524,49 @@ class HarmonyResponsesTestCase(unittest.TestCase):
         ]
         msg = get_developer_message(instructions="be helpful", tools=tools)
         self.assertIsNotNone(msg)
+
+
+class ErrorEnvelopeSchemaTestCase(unittest.TestCase):
+    """`error.code` must be a string in the /v1/responses error envelope.
+
+    The OpenAI schema types `error.code` as a nullable string slug (e.g.
+    "context_length_exceeded"), never the HTTP status as a number -- the status is
+    already carried by the response status. Strict clients enforce this: the OpenAI
+    Java SDK types ErrorObject.code() as Optional<String> and raises
+    OpenAIInvalidDataException on access, which hides the real error from the caller.
+    """
+
+    def test_create_error_response_code_is_a_string(self):
+        serving = make_serving()
+        response = serving.create_error_response("boom", status_code=400)
+        error = json.loads(response.body)["error"]
+        self.assertIsInstance(error["code"], str)
+        self.assertEqual(error["code"], "400")
+
+    def test_create_error_response_code_is_a_string_for_non_400(self):
+        serving = make_serving()
+        response = serving.create_error_response("nope", status_code=404)
+        self.assertEqual(json.loads(response.body)["error"]["code"], "404")
+
+    def test_create_streaming_error_response_code_is_a_string(self):
+        serving = make_serving()
+        error = json.loads(serving.create_streaming_error_response("boom"))["error"]
+        self.assertIsInstance(error["code"], str)
+        self.assertEqual(error["code"], "400")
+
+    def test_request_error_path_emits_a_string_code(self):
+        """Same guarantee end-to-end through create_responses, not just the helper."""
+        serving = make_serving()
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            tool_choice="required",
+            tools=[{"type": "web_search"}, {"type": "mcp"}],
+            store=False,
+        )
+        result = asyncio.run(serving.create_responses(request, raw_request=None))
+        self.assertEqual(result.status_code, 400)
+        self.assertEqual(json.loads(result.body)["error"]["code"], "400")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The `/v1/responses` error envelope sets `code` to the HTTP status as an **integer**. In the OpenAI schema, `error.code` is a nullable **string** slug (e.g. `"context_length_exceeded"`) — never the HTTP status, which is already carried by the response status code. SGLang already gets this right elsewhere in `http_server.py` (`"code": "model_not_found"`).

This breaks strict OpenAI-compatible clients, and it breaks them in a particularly unhelpful way. The OpenAI **Java** SDK deserializes `body["error"]` into `ErrorObject`, whose `code()` is typed `Optional<String>`, so it raises `OpenAIInvalidDataException` **on access** rather than at parse time:

```java
// com.openai.models.ErrorObject
fun code(): Optional<String> = code.getOptional("code")   // throws on a JSON number
```

Callers typically read `code`/`type` while *reporting* a failure, so the exception fires inside their own error handler — the original server error gets masked and surfaces as a client-side deserialization bug. In our case every `/v1/responses` error (including context-length 400s) was reported as an SDK parse failure, with the real cause and the failure metrics lost.

Worth noting the blast radius: this only affects the OpenAI-style **nested** envelope (`{"error": {...}}`) that the Responses API uses. The flat legacy `ErrorResponse` returned by other endpoints has no `"error"` key, so SDK clients never parse it and never hit this — which is why it's specific to `/v1/responses`.

## Modifications

`code` is now a string at the four sites that build the nested `/v1/responses` envelope:

| File | Site |
|---|---|
| `openai/serving_responses.py` | `create_error_response` — all `/v1/responses` errors |
| `openai/serving_responses.py` | `create_streaming_error_response` |
| `entrypoints/http_server.py` | `HTTPException` handler, `/v1/responses` branch |
| `entrypoints/http_server.py` | `RequestValidationError` handler, `/v1/responses` branch |

`str(status_code)` keeps the existing information rather than dropping to `null`, so it's behavior-preserving for anything that reads the value as text, and only changes the JSON type. Also fixes the envelope shown in the `validation_exception_handler` docstring.

Adds `ErrorEnvelopeSchemaTestCase` to `test/registered/unit/entrypoints/openai/test_serving_responses.py` — both helpers plus the end-to-end `create_responses` error path (via the existing `tool_choice="required"` validation branch), so a regression to an int is caught at the helper *and* through the real request path.

**Two related things I left alone**, happy to fold in either if you'd prefer:

1. `type` in the two `http_server.py` handlers is `HTTPStatus(...).phrase` (`"Bad Request"`), which isn't an OpenAI error type (`"invalid_request_error"` etc.). It's a *string*, so it never throws — but it isn't schema-conformant either. Fixing it needs a status→type mapping like the one the `/v1/messages` branch already has, which felt like a separate change.
2. `http_server.py`'s `/generate` streaming handler emits `{"error": {..., "code": 400, "retryable": False}}` — also an int, but on the native endpoint with a bespoke field, so not part of the OpenAI-compat surface.

## Accuracy Tests

Not applicable — error-envelope serialization only, no model forward or kernel code touched.

## Speed Tests and Profiling

Not applicable — no inference path touched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

**One caveat in the interest of transparency:** my environment has no GPU and no network access to PyPI, so I could not execute `pre-commit` or the unit tests locally. I verified all three files compile, that no added line exceeds 88 chars (the file had none before), that `ruff`'s selected rules here (`F401,F821,UP037`) are satisfied, and that the new `json` import is used. I'm relying on CI for the authoritative format/test run and will fix anything it flags promptly.

The change has been running as a local patch against `v0.5.13-cu130` + #25881 in our deployment; unpatched, it reproduced on every `/v1/responses` error.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30486141914](https://github.com/sgl-project/sglang/actions/runs/30486141914)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30486144812](https://github.com/sgl-project/sglang/actions/runs/30486144812)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->