### PR TITLE
fix: honor weight-check skips for quantized entries

### DIFF
--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -319,7 +319,11 @@ def _build_check_entries(
             continue  # compared via its weight's comparable
         if name in quantized_set:
             qw = quantized_set[name]
-            yield CheckEntry(name, True, qw.comparable_cls(tensor, raw[qw.scale_name]))
+            yield CheckEntry(
+                name,
+                name not in skip_compare_names,
+                qw.comparable_cls(tensor, raw[qw.scale_name]),
+            )
         else:
             should_compare = name not in skip_compare_names and (
                 not _is_non_persistent_buffer_name(name)

--- a/test/registered/rl/test_weight_checker_e2e.py
+++ b/test/registered/rl/test_weight_checker_e2e.py
@@ -160,7 +160,12 @@ class TestWeightCheckerE2E(CustomTestCase):
         self.assertIn("checksums", first)
         self.assertIn("parallelism_info", first)
 
-        info = first["parallelism_info"]
+        parallelism_info = first["parallelism_info"]
+        self.assertIsInstance(parallelism_info, list)
+        self.assertGreaterEqual(len(parallelism_info), 1)
+
+        info = parallelism_info[0]
+        self.assertEqual(info["role"], "target")
         for key in (
             "tp_rank",
             "tp_size",

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -267,6 +267,18 @@ class TestPostprocessTensors(CustomTestCase):
             [("weird.cos_sin_cache.foo.bar", False, RawComparable(t))],
         )
 
+    def test_skip_set_marks_quantized_entry_not_compared(self):
+        qweight, sf_fp32, _ = _build_fp8_quant_pair()
+        raw = {"x.weight": qweight, "x.weight_scale_inv": sf_fp32}
+        quantized_set = {
+            "x.weight": QuantizedWeight(Fp8BlockComparable, "x.weight_scale_inv")
+        }
+        ref = Fp8BlockComparable(qweight, sf_fp32)
+        _assert_entries_close(
+            _build_check_entries(raw, {"x.weight"}, quantized_set),
+            [("x.weight", False, ref)],
+        )
+
     # --- fp8 quant pair (real dequant on real fp8 tensors) ---
 
     def test_fp8_quant_pair_yields_lazy_pair(self):


### PR DESCRIPTION
## Summary
Restore weight-check skip semantics and per-role checksum assertions after the v0.5.16 rebase.

## Symptom & Reproduction
- **Symptom:** A quantized weight matched by `skip_tensor_list` was still compared.
- **Reproduction:** `test_skip_set_marks_quantized_entry_not_compared` observed `should_compare=True` before the fix.

## Root Cause
1. `_build_check_entries` hard-coded `True` for quantized entries.
2. `test_weight_checker_e2e.py` retained the pre-list `parallelism_info` assertion.

## Fix
Use `name not in skip_compare_names` for quantized entries and restore the omitted CUDA and E2E assertions.

## Verification
- **New test:** `test_skip_set_marks_quantized_entry_not_compared` verifies a skipped quantized entry has `should_compare=False`.
- **Existing suite:** `test_weight_checker.py` passes all 60 tests.
- **Lint:** `ruff` passes.
- **Formatting:** `black` and `isort` pass.
- **Whitespace:** `git diff --check` passes.
- **E2E collection:** The checksum E2E collects successfully.
- **E2E runtime:** Server startup stops before the assertion because installed `sglang-kernel==0.4.4` is below required `0.4.5`.

## Review Focus
- Scrutinize `_build_check_entries` to confirm the raw non-persistent-buffer behavior remains unchanged.
- Scrutinize `test_e_checksum_returns_ranks_with_hashes` against the current `List[ParallelismInfo]` wire shape.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30487047856](https://github.com/sgl-project/sglang/actions/runs/30487047856)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30487047560](https://github.com/sgl-project/sglang/actions/runs/30487047560)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->