### PR TITLE
[Kernel][Hardware][AMD] Add opt-in fail-closed DeepSeek-R1 FP8 M32 fused-MoE fast path for MI355X

### DIFF
--- a/python/sglang/__init__.py
+++ b/python/sglang/__init__.py
@@ -26,6 +26,16 @@ if _sys.platform == "darwin" and _platform.machine() == "arm64":
 del _platform
 del _sys
 
+# Triton 3.7 removed a few public compatibility names still referenced during
+# SGLang imports. Install only those missing names before runtime modules load.
+# This is a safe no-op when Triton is unavailable.
+from sglang.srt.artemis_kernels.compat import (
+    install_triton_compat_shims as _install_artemis_triton_compat_shims,
+)
+
+_install_artemis_triton_compat_shims()
+del _install_artemis_triton_compat_shims
+
 from sglang.srt.utils.hf_transformers_patches import apply_all as _apply_hf_patches
 
 _apply_hf_patches()

--- a/python/sglang/srt/artemis_kernels/__init__.py
+++ b/python/sglang/srt/artemis_kernels/__init__.py
@@ -1,0 +1,1 @@
+"""Optional Artemis-optimized kernels."""

--- a/python/sglang/srt/artemis_kernels/compat.py
+++ b/python/sglang/srt/artemis_kernels/compat.py
@@ -1,0 +1,78 @@
+"""Compatibility checks for the Triton APIs used by Artemis."""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
+
+QUALIFIED_TRITON_VERSION = "3.7.0+git5f3f125e"
+QUALIFIED_TRITON_COMMIT = "5f3f125e8f63c24613f1f73b937442864f263f94"
+MINIMUM_TRITON_VERSION = (3, 7, 0)
+
+
+def _release_tuple(version: str) -> tuple[int, int, int] | None:
+    match = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?", version)
+    if match is None:
+        return None
+    major, minor, patch = match.groups(default="0")
+    return int(major), int(minor), int(patch)
+
+
+@lru_cache(maxsize=1)
+def install_triton_compat_shims() -> bool:
+    """Install narrow compatibility shims, or return false without Triton."""
+    try:
+        import triton
+        import triton.language as tl
+        from triton.compiler.compiler import CompiledKernel
+    except ImportError:
+        return False
+
+    if not hasattr(tl, "constexpr_function"):
+        constexpr_function = getattr(triton, "constexpr_function", None)
+        if constexpr_function is None:
+            return False
+        tl.constexpr_function = constexpr_function
+    if not hasattr(CompiledKernel, "num_ctas"):
+        CompiledKernel.num_ctas = property(lambda kernel: kernel.metadata.num_ctas)
+    if not hasattr(CompiledKernel, "cluster_dims"):
+        CompiledKernel.cluster_dims = property(lambda kernel: (kernel.metadata.num_ctas, 1, 1))
+    return True
+
+
+@lru_cache(maxsize=1)
+def ensure_triton_compat() -> str:
+    """Validate Triton and ensure the required compatibility shims exist."""
+    if not install_triton_compat_shims():
+        raise RuntimeError(
+            "ARTEMIS_KERNELS requires Triton with constexpr_function support; "
+            f"qualified build={QUALIFIED_TRITON_VERSION!r}"
+        )
+
+    import triton
+
+    module_version = str(getattr(triton, "__version__", "unknown"))
+    try:
+        version = distribution_version("triton")
+    except PackageNotFoundError:
+        version = module_version
+    release = _release_tuple(version)
+    if release is None or release < MINIMUM_TRITON_VERSION:
+        raise RuntimeError(
+            "ARTEMIS_KERNELS requires Triton >= 3.7.0; "
+            f"found distribution={version!r} module={module_version!r}, "
+            f"qualified build={QUALIFIED_TRITON_VERSION!r}"
+        )
+
+    return version
+
+
+__all__ = [
+    "MINIMUM_TRITON_VERSION",
+    "QUALIFIED_TRITON_COMMIT",
+    "QUALIFIED_TRITON_VERSION",
+    "ensure_triton_compat",
+    "install_triton_compat_shims",
+]

--- a/python/sglang/srt/artemis_kernels/mi355x/__init__.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/__init__.py
@@ -1,0 +1,1 @@
+"""Artemis kernels specialized for AMD Instinct MI355X."""

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/__init__.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/__init__.py
@@ -1,0 +1,1 @@
+"""DeepSeek-R1 FP8 kernels for MI355X."""

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/__init__.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/__init__.py
@@ -1,0 +1,1 @@
+"""Fused-MoE kernels for the MI355X DeepSeek-R1 FP8 path."""

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/dispatcher.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/dispatcher.py
@@ -1,0 +1,244 @@
+"""Fail-closed dispatcher for the registered Artemis fused-MoE shapes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+import torch
+from sglang.srt.environ import envs
+
+from .registry import FusedMoeKernelSpec, find_kernel_spec
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.moe_runner.aiter import (
+        AiterMoeQuantInfo,
+        AiterRunnerInput,
+    )
+    from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+
+_MARKER = "[artemis-dsr1-fp8-fused-moe]"
+_SEEN_DISPATCH: set[str] = set()
+
+
+def is_artemis_fused_moe_enabled() -> bool:
+    """Return whether the opt-in Artemis kernel dispatcher is enabled."""
+    return envs.ARTEMIS_KERNELS.get()
+
+
+def _device_arch(tensor: torch.Tensor) -> str:
+    index = tensor.device.index
+    if index is None:
+        index = torch.cuda.current_device()
+    return str(torch.cuda.get_device_properties(index).gcnArchName).split(":", 1)[0]
+
+
+def _shape_spec(
+    runner_input: AiterRunnerInput,
+    runner_config: MoeRunnerConfig,
+) -> FusedMoeKernelSpec | None:
+    hidden = runner_input.hidden_states
+    topk_ids = runner_input.topk_ids
+    topk_weights = runner_input.topk_weights
+    if hidden.ndim != 2 or topk_ids.ndim != 2 or topk_weights.ndim != 2:
+        return None
+    return find_kernel_spec(
+        tokens=hidden.shape[0],
+        hidden_size=runner_config.hidden_size,
+        intermediate_size_per_partition=runner_config.intermediate_size_per_partition,
+        experts=runner_config.num_local_experts,
+        top_k=runner_config.top_k,
+    )
+
+
+def _contract_mismatch(
+    spec: FusedMoeKernelSpec,
+    runner_input: AiterRunnerInput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> str | None:
+    hidden = runner_input.hidden_states
+    topk_ids = runner_input.topk_ids
+    topk_weights = runner_input.topk_weights
+    w1 = quant_info.w13_weight
+    w2 = quant_info.w2_weight
+    w1_scale = quant_info.w13_scale
+    w2_scale = quant_info.w2_scale
+
+    if hidden.shape != spec.hidden_shape or hidden.dtype is not torch.bfloat16:
+        return "hidden"
+    if w1.shape != spec.w13_shape or w1.dtype is not torch.float8_e4m3fn:
+        return "w1"
+    if w2.shape != spec.w2_shape or w2.dtype is not torch.float8_e4m3fn:
+        return "w2"
+    if w1_scale is None or w1_scale.dtype is not torch.float32:
+        return "w1_scale_dtype"
+    if w2_scale is None or w2_scale.dtype is not torch.float32:
+        return "w2_scale_dtype"
+    if w1_scale.shape != spec.w13_scale_shape or not w1_scale.is_contiguous():
+        return "w1_scale_layout"
+    if w2_scale.shape != spec.w2_scale_shape or not w2_scale.is_contiguous():
+        return "w2_scale_layout"
+    if topk_ids.shape != spec.topk_shape or topk_ids.dtype is not torch.int32:
+        return "topk_ids"
+    if topk_weights.shape != spec.topk_shape or topk_weights.dtype is not torch.float32:
+        return "topk_weights"
+    if getattr(quant_info.quant_type, "value", None) != "per_128x128":
+        return "quant_type"
+    if quant_info.expert_mask is not None:
+        return "expert_mask"
+    if quant_info.a13_scale is not None or quant_info.a2_scale is not None:
+        return "prequantized_activation"
+    if quant_info.b13 is not None or quant_info.b2 is not None:
+        return "bias"
+    if quant_info.doweight_stage1 or quant_info.hidden_pad or quant_info.intermediate_pad:
+        return "quant_flags"
+    if (
+        runner_config.num_experts != spec.experts
+        or runner_config.num_local_experts != spec.experts
+        or runner_config.num_fused_shared_experts != 1
+        or runner_config.params_dtype is not torch.bfloat16
+        or runner_config.activation != "silu"
+        or not runner_config.is_gated
+    ):
+        return "runner_config"
+    if runner_config.apply_router_weight_on_input or runner_config.no_combine:
+        return "runner_flags"
+    tensors = (hidden, w1, w2, w1_scale, w2_scale, topk_ids, topk_weights)
+    if any(tensor.device.type != "cuda" or not tensor.is_contiguous() for tensor in tensors):
+        return "layout"
+    if len({tensor.device for tensor in tensors}) != 1:
+        return "device"
+    if _device_arch(hidden) != spec.architecture:
+        return "arch"
+    return None
+
+
+def _allocate_preparation(
+    hidden: torch.Tensor,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return (
+        torch.empty_like(hidden, dtype=torch.float8_e4m3fn),
+        torch.empty(
+            (hidden.shape[0], hidden.shape[1] // block_size),
+            dtype=torch.float32,
+            device=hidden.device,
+        ),
+        torch.empty_like(hidden),
+    )
+
+
+def launch_fused_moe(
+    spec: FusedMoeKernelSpec,
+    output: torch.Tensor,
+    hidden: torch.Tensor,
+    quantized: torch.Tensor,
+    scales: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Compose the preparation, W1, and W2 stages selected by the registry."""
+    from sglang.srt.artemis_kernels.compat import ensure_triton_compat
+
+    from .kernels.moe_workspaces import get_route_workspaces
+
+    ensure_triton_compat()
+    if spec.tokens != 32:  # The registry is closed; this protects future edits.
+        raise ValueError(f"unregistered fused-MoE specialization: {spec.name}")
+    from .kernels.moe_prep_gluon_m32 import moe_prep_gluon_m32 as prep
+    from .kernels.moe_w1_gluon_m32 import moe_w1_gluon_m32 as w1_stage
+    from .kernels.moe_w2_gluon_m32 import moe_w2_gluon_m32 as w2_stage
+
+    route_tokens, route_weights, route_counts, route_slots, contribution = get_route_workspaces(
+        hidden.device, spec.tokens
+    )
+    prep(
+        hidden,
+        quantized,
+        scales,
+        output,
+        topk_ids,
+        topk_weights,
+        route_tokens,
+        route_weights,
+        route_counts,
+        route_slots,
+    )
+    intermediate, intermediate_scale = w1_stage(
+        quantized,
+        w1,
+        scales,
+        w1_scale,
+        route_tokens,
+        route_counts,
+    )
+    return w2_stage(
+        output,
+        contribution,
+        w2,
+        w2_scale,
+        intermediate,
+        intermediate_scale,
+        route_tokens,
+        route_weights,
+        route_counts,
+        route_slots,
+    )
+
+
+def _emit_dispatch(spec: FusedMoeKernelSpec) -> None:
+    if spec.name in _SEEN_DISPATCH:
+        return
+    _SEEN_DISPATCH.add(spec.name)
+    print(
+        f"{_MARKER} event=dispatch pid={os.getpid()} kernel={spec.name} "
+        f"shape={spec.tokens}x{spec.hidden_size} experts={spec.experts} topk={spec.top_k}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def dispatch_fused_moe(
+    runner_input: AiterRunnerInput,
+    quant_info: AiterMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> torch.Tensor | None:
+    """Dispatch a registered specialization, or return ``None`` for stock."""
+    if not is_artemis_fused_moe_enabled():
+        return None
+    spec = _shape_spec(runner_input, runner_config)
+    if spec is None or _contract_mismatch(spec, runner_input, quant_info, runner_config):
+        return None
+
+    hidden = runner_input.hidden_states
+    topk_ids = runner_input.topk_ids
+    topk_weights = runner_input.topk_weights
+    quantized, scales, output = _allocate_preparation(hidden, spec.block_size)
+    result = launch_fused_moe(
+        spec,
+        output,
+        hidden,
+        quantized,
+        scales,
+        quant_info.w13_weight,
+        quant_info.w2_weight,
+        topk_ids,
+        topk_weights,
+        quant_info.w13_scale,
+        quant_info.w2_scale,
+    )
+    _emit_dispatch(spec)
+    return result
+
+
+__all__ = [
+    "dispatch_fused_moe",
+    "is_artemis_fused_moe_enabled",
+    "launch_fused_moe",
+]

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/__init__.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/__init__.py
@@ -1,0 +1,1 @@
+"""Kernel implementations for the MI355X fused-MoE path."""

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_prep_gluon_m32.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_prep_gluon_m32.py
@@ -9,9 +9,8 @@ the shared expert records slot 8, and unused compact rows record -1.
 from __future__ import annotations
 
 import torch
-
-import triton.experimental.gluon as gluon
 import triton.experimental.gluon.language as gl
+from triton.experimental import gluon
 
 M = gl.constexpr(32)
 H = gl.constexpr(7168)

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_prep_gluon_m32.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_prep_gluon_m32.py
@@ -1,0 +1,320 @@
+"""Exact M32 prep with compact-row-aligned route slots for deterministic W2.
+
+This is the selected grid-512, two-band stride-2 M32 preparation schedule.
+It preserves every legacy quantization, clear, and route-metadata store while
+also writing ``route_slots[257, 32]``. Routed rows record slots 0 through 7,
+the shared expert records slot 8, and unused compact rows record -1.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import triton.experimental.gluon as gluon
+import triton.experimental.gluon.language as gl
+
+M = gl.constexpr(32)
+H = gl.constexpr(7168)
+TOPK = gl.constexpr(9)
+EXPERTS = gl.constexpr(257)
+ROUTED_EXPERTS = gl.constexpr(256)
+GROUP_K = gl.constexpr(128)
+GROUPS_PER_TOKEN = gl.constexpr(56)
+QUANT_GROUPS = gl.constexpr(4)
+QUANT_CTAS = gl.constexpr(448)
+FP8_MAX_RECIPROCAL = gl.constexpr(0.0022321429569274187)
+
+@gluon.jit
+def _compact_route_m32_exact_slots(
+    topk_ids_ptr,
+    topk_weights_ptr,
+    route_tokens_ptr,
+    route_weights_ptr,
+    route_counts_ptr,
+    route_slots_ptr,
+    expert_id,
+):
+    route_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1],
+        threads_per_warp=[64],
+        warps_per_cta=[1],
+        order=[0],
+    )
+    rows = gl.arange(0, M, layout=route_layout)
+    if expert_id == ROUTED_EXPERTS:
+        shared_weights = gl.amd.cdna4.buffer_load(
+            topk_weights_ptr,
+            rows * TOPK + (TOPK - 1),
+        )
+        shared_base: gl.constexpr = ROUTED_EXPERTS * M
+        gl.amd.cdna4.buffer_store(rows, route_tokens_ptr, shared_base + rows)
+        gl.amd.cdna4.buffer_store(
+            shared_weights,
+            route_weights_ptr,
+            shared_base + rows,
+        )
+        gl.amd.cdna4.buffer_store(
+            gl.full((M,), TOPK - 1, gl.int32, layout=route_layout),
+            route_slots_ptr,
+            shared_base + rows,
+        )
+        gl.store(route_counts_ptr + ROUTED_EXPERTS, M)
+    else:
+        route_matrix_layout: gl.constexpr = gl.BlockedLayout(
+            size_per_thread=[1, 4],
+            threads_per_warp=[32, 2],
+            warps_per_cta=[1, 1],
+            order=[1, 0],
+        )
+        matrix_rows = gl.arange(
+            0,
+            M,
+            layout=gl.SliceLayout(1, route_matrix_layout),
+        )
+        matrix_slots = gl.arange(
+            0,
+            TOPK - 1,
+            layout=gl.SliceLayout(0, route_matrix_layout),
+        )
+        matrix_offsets = matrix_rows[:, None] * TOPK + matrix_slots[None, :]
+        matrix_ids = gl.amd.cdna4.buffer_load(topk_ids_ptr, matrix_offsets)
+        matrix_matches = matrix_ids == expert_id
+        match = gl.convert_layout(
+            gl.max(matrix_matches.to(gl.int32), axis=1).to(gl.int1),
+            route_layout,
+        )
+        selected_slot = gl.convert_layout(
+            gl.max(
+                gl.where(matrix_matches, matrix_slots[None, :], 0),
+                axis=1,
+            ),
+            route_layout,
+        )
+        selected_weight = gl.amd.cdna4.buffer_load(
+            topk_weights_ptr,
+            rows * TOPK + selected_slot,
+            mask=match,
+        )
+        match_i32 = match.to(gl.int32)
+        row_bits = match_i32.to(gl.uint32) << rows
+        match_bits = gl.reduce_or(row_bits, axis=0)
+        lower_mask = gl.full(
+            (M,),
+            0xFFFFFFFF,
+            gl.uint32,
+            layout=route_layout,
+        ) >> (31 - rows)
+        prefix_bits = match_bits & lower_mask
+        positions = gl.inline_asm_elementwise(
+            "v_bcnt_u32_b32 $0, $1, 0",
+            "=v,v",
+            [prefix_bits],
+            dtype=gl.uint32,
+            is_pure=True,
+            pack=1,
+        ).to(gl.int32)
+        route_base = expert_id * M
+        gl.amd.cdna4.buffer_store(
+            gl.full((M,), M, gl.int32, layout=route_layout),
+            route_tokens_ptr,
+            route_base + rows,
+        )
+        gl.amd.cdna4.buffer_store(
+            gl.zeros((M,), gl.float32, layout=route_layout),
+            route_weights_ptr,
+            route_base + rows,
+        )
+        gl.amd.cdna4.buffer_store(
+            gl.full((M,), -1, gl.int32, layout=route_layout),
+            route_slots_ptr,
+            route_base + rows,
+        )
+        destination = route_base + positions - 1
+        gl.amd.cdna4.buffer_store(
+            rows,
+            route_tokens_ptr,
+            destination,
+            mask=match,
+        )
+        gl.amd.cdna4.buffer_store(
+            selected_weight,
+            route_weights_ptr,
+            destination,
+            mask=match,
+        )
+        gl.amd.cdna4.buffer_store(
+            selected_slot,
+            route_slots_ptr,
+            destination,
+            mask=match,
+        )
+        gl.store(route_counts_ptr + expert_id, gl.sum(match_i32, axis=0))
+
+
+@gluon.jit
+def _moe_prep_m32_exact_slots_kernel(
+    hidden_ptr,
+    quantized_ptr,
+    scales_ptr,
+    output_ptr,
+    topk_ids_ptr,
+    topk_weights_ptr,
+    route_tokens_ptr,
+    route_weights_ptr,
+    route_counts_ptr,
+    route_slots_ptr,
+):
+    program_id = gl.program_id(0)
+
+    # Preserve the selected prep's reversed physical quant-tile issue order.
+    quant_valid = program_id < QUANT_CTAS
+    quant_program = QUANT_CTAS - 1 - program_id
+    quant_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 8],
+        threads_per_warp=[4, 16],
+        warps_per_cta=[1, 1],
+        order=[1, 0],
+    )
+    quant_rows = gl.arange(
+        0,
+        QUANT_GROUPS,
+        layout=gl.SliceLayout(1, quant_layout),
+    )
+    quant_cols = gl.arange(
+        0,
+        GROUP_K,
+        layout=gl.SliceLayout(0, quant_layout),
+    )
+    global_group = quant_program * QUANT_GROUPS + quant_rows
+    quant_offsets = global_group[:, None] * GROUP_K + quant_cols[None, :]
+    quant_group_valid = quant_valid & (global_group < M * GROUPS_PER_TOKEN)
+    quant_element_valid = quant_group_valid[:, None]
+    values = gl.amd.cdna4.buffer_load(
+        hidden_ptr,
+        quant_offsets,
+        mask=quant_element_valid,
+    ).to(gl.float32)
+    absmax = gl.maximum(
+        gl.max(gl.abs(values), axis=1, keep_dims=True),
+        1.0e-10,
+    )
+    group_scales = absmax * FP8_MAX_RECIPROCAL
+    quantized = (values * (1.0 / group_scales)).to(quantized_ptr.type.element_ty)
+    gl.amd.cdna4.buffer_store(
+        quantized,
+        quantized_ptr,
+        quant_offsets,
+        mask=quant_element_valid,
+    )
+    token = global_group // GROUPS_PER_TOKEN
+    k_group = global_group - token * GROUPS_PER_TOKEN
+    scale_offsets = k_group * M + token
+    scale_values = gl.convert_layout(
+        gl.reshape(group_scales, (QUANT_GROUPS,)),
+        gl.SliceLayout(1, quant_layout),
+    )
+    gl.amd.cdna4.buffer_store(
+        scale_values,
+        scales_ptr,
+        scale_offsets,
+        mask=quant_group_valid,
+    )
+    gl.amd.cdna4.buffer_store(
+        gl.zeros(
+            (QUANT_GROUPS, GROUP_K),
+            output_ptr.type.element_ty,
+            layout=quant_layout,
+        ),
+        output_ptr,
+        quant_offsets,
+        mask=quant_element_valid,
+    )
+
+    routed = ((program_id & 1) == 0) & (program_id < 512)
+    shared = program_id == 511
+    if routed | shared:
+        expert_id = gl.where(
+            routed,
+            (program_id // 2 + 128) & 255,
+            ROUTED_EXPERTS,
+        )
+        _compact_route_m32_exact_slots(
+            topk_ids_ptr,
+            topk_weights_ptr,
+            route_tokens_ptr,
+            route_weights_ptr,
+            route_counts_ptr,
+            route_slots_ptr,
+            expert_id,
+        )
+
+
+def moe_prep_gluon_m32(
+    hidden: torch.Tensor,
+    quantized: torch.Tensor,
+    scales: torch.Tensor,
+    output: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    route_tokens: torch.Tensor,
+    route_weights: torch.Tensor,
+    route_counts: torch.Tensor,
+    route_slots: torch.Tensor,
+) -> None:
+    """Run selected M32 prep and emit aligned compact-row route slots."""
+    if hidden.shape != (int(M), int(H)) or hidden.dtype is not torch.bfloat16:
+        raise ValueError("hidden must be contiguous BF16 [32,7168]")
+    if quantized.shape != hidden.shape or quantized.dtype is not torch.float8_e4m3fn:
+        raise ValueError("quantized must be contiguous FP8 E4M3FN [32,7168]")
+    if scales.shape != (int(M), int(GROUPS_PER_TOKEN)) or scales.dtype is not torch.float32:
+        raise ValueError("scales must be contiguous FP32 [32,56]")
+    if output.shape != hidden.shape or output.dtype is not torch.bfloat16:
+        raise ValueError("output must be contiguous BF16 [32,7168]")
+    if topk_ids.shape != (int(M), int(TOPK)) or topk_ids.dtype is not torch.int32:
+        raise ValueError("topk_ids must be contiguous INT32 [32,9]")
+    if topk_weights.shape != (int(M), int(TOPK)) or topk_weights.dtype is not torch.float32:
+        raise ValueError("topk_weights must be contiguous FP32 [32,9]")
+    if route_tokens.shape != (int(EXPERTS), int(M)) or route_tokens.dtype is not torch.int32:
+        raise ValueError("route_tokens must be contiguous INT32 [257,32]")
+    if route_weights.shape != (int(EXPERTS), int(M)) or route_weights.dtype is not torch.float32:
+        raise ValueError("route_weights must be contiguous FP32 [257,32]")
+    if route_counts.shape != (int(EXPERTS),) or route_counts.dtype is not torch.int32:
+        raise ValueError("route_counts must be contiguous INT32 [257]")
+    if route_slots.shape != (int(EXPERTS), int(M)) or route_slots.dtype is not torch.int32:
+        raise ValueError("route_slots must be contiguous INT32 [257,32]")
+    tensors = (
+        hidden,
+        quantized,
+        scales,
+        output,
+        topk_ids,
+        topk_weights,
+        route_tokens,
+        route_weights,
+        route_counts,
+        route_slots,
+    )
+    if not all(tensor.is_cuda and tensor.is_contiguous() for tensor in tensors):
+        raise ValueError("all tensors must be contiguous on GPU")
+    if len({tensor.device for tensor in tensors}) != 1:
+        raise ValueError("all tensors must be on one GPU")
+    if route_slots.data_ptr() % 16:
+        raise ValueError("route_slots must be at least 16-byte aligned")
+
+    _moe_prep_m32_exact_slots_kernel[(512,)](
+        hidden,
+        quantized,
+        scales,
+        output,
+        topk_ids,
+        topk_weights,
+        route_tokens,
+        route_weights,
+        route_counts,
+        route_slots,
+        num_warps=1,
+        waves_per_eu=1,
+    )
+
+
+__all__ = ["moe_prep_gluon_m32"]

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w1_gluon_m32.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w1_gluon_m32.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import torch
-
-import triton.experimental.gluon as gluon
 import triton.experimental.gluon.language as gl
+from triton.experimental import gluon
 
 M = gl.constexpr(32)
 H = gl.constexpr(7168)

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w1_gluon_m32.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w1_gluon_m32.py
@@ -1,0 +1,498 @@
+"""Expert-indexed W1 consuming route metadata prepared before the launch."""
+
+from __future__ import annotations
+
+import torch
+
+import triton.experimental.gluon as gluon
+import triton.experimental.gluon.language as gl
+
+M = gl.constexpr(32)
+H = gl.constexpr(7168)
+I = gl.constexpr(256)
+E = gl.constexpr(257)
+BLOCK_M = gl.constexpr(32)
+BLOCK_N = gl.constexpr(256)
+BLOCK_K = gl.constexpr(128)
+K_UNROLL = gl.constexpr(8)
+NUM_WARPS = gl.constexpr(8)
+
+
+@gluon.jit
+def _load_preshuffled_w1_128x256(
+    weight_ptr,
+    expert_id,
+    n_group_base,
+    k_block,
+    packed_layout: gl.constexpr,
+    dot_b_layout: gl.constexpr,
+):
+    packed_k = gl.arange(0, BLOCK_K * 16, layout=gl.SliceLayout(0, packed_layout))
+    packed_n = gl.arange(0, BLOCK_N // 16, layout=gl.SliceLayout(1, packed_layout))
+    offsets = (
+        expert_id * (2 * I * H)
+        + (n_group_base + packed_n[:, None]) * (H * 16)
+        + k_block * (BLOCK_K * 16)
+        + packed_k[None, :]
+    )
+    packed = gl.amd.cdna4.buffer_load(weight_ptr, offsets, cache=".cg")
+    logical = (
+        packed.reshape(1, BLOCK_N // 16, BLOCK_K // 32, 2, 16, 16)
+        .permute(0, 1, 4, 2, 3, 5)
+        .reshape(BLOCK_N, BLOCK_K)
+        .trans(1, 0)
+    )
+    return gl.convert_layout(logical, dot_b_layout, assert_trivial=True)
+
+
+@gluon.jit
+def _load_w1_group(
+    x_ptr,
+    w1_ptr,
+    x_scale_ptr,
+    w1_scale_ptr,
+    token_ids,
+    valid_rows,
+    x_shared,
+    x_scale_shared,
+    expert_id,
+    k_block,
+    x_load_layout: gl.constexpr,
+    mfma_layout: gl.constexpr,
+    dot_a_layout: gl.constexpr,
+    dot_b_layout: gl.constexpr,
+    packed_weight_layout: gl.constexpr,
+):
+    row_mfma_layout: gl.constexpr = gl.SliceLayout(1, mfma_layout)
+    k_offsets = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, x_load_layout))
+    output_n = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))
+    x_offsets = token_ids[:, None] * H + k_block * BLOCK_K + k_offsets[None, :]
+    x = gl.amd.cdna4.buffer_load(x_ptr, x_offsets, mask=valid_rows[:, None])
+    x_scales = gl.amd.cdna4.buffer_load(
+        x_scale_ptr,
+        k_block * M + token_ids,
+        mask=valid_rows,
+    )
+    x_shared.store(x)
+    x_scale_shared.store(x_scales)
+    x_dot = x_shared.load(layout=dot_a_layout)
+    x_scale = x_scale_shared.load(layout=row_mfma_layout)
+    gate = _load_preshuffled_w1_128x256(
+        w1_ptr,
+        expert_id,
+        0,
+        k_block,
+        packed_layout=packed_weight_layout,
+        dot_b_layout=dot_b_layout,
+    )
+    up = _load_preshuffled_w1_128x256(
+        w1_ptr,
+        expert_id,
+        I // 16,
+        k_block,
+        packed_layout=packed_weight_layout,
+        dot_b_layout=dot_b_layout,
+    )
+    gate_scale = gl.load(w1_scale_ptr + expert_id * 4 * 56 + (output_n // BLOCK_K) * 56 + k_block)
+    up_scale = gl.load(w1_scale_ptr + expert_id * 4 * 56 + (2 + output_n // BLOCK_K) * 56 + k_block)
+    return x_dot, x_scale, gate, up, gate_scale, up_scale
+
+
+@gluon.jit
+def _accumulate_w1_group(operands, gate_acc, up_acc, zero):
+    x_dot, x_scale, gate, up, gate_scale, up_scale = operands
+    gate_group = gl.amd.cdna4.mfma_scaled(
+        x_dot,
+        None,
+        "e4m3",
+        gate,
+        None,
+        "e4m3",
+        zero,
+    )
+    up_group = gl.amd.cdna4.mfma_scaled(
+        x_dot,
+        None,
+        "e4m3",
+        up,
+        None,
+        "e4m3",
+        zero,
+    )
+    gate_acc += gate_group * x_scale[:, None] * gate_scale[None, :]
+    up_acc += up_group * x_scale[:, None] * up_scale[None, :]
+    return gate_acc, up_acc
+
+
+@gluon.jit
+def _compute_w1_k8(
+    x_ptr,
+    w1_ptr,
+    x_scale_ptr,
+    w1_scale_ptr,
+    token_shared,
+    x_shared,
+    x_scale_shared,
+    activation_shared,
+    expert_id,
+    x_load_layout: gl.constexpr,
+    mfma_layout: gl.constexpr,
+    dot_a_layout: gl.constexpr,
+    dot_b_layout: gl.constexpr,
+    packed_weight_layout: gl.constexpr,
+):
+    """Compute and quantize the selected load-first K-unroll-8 W1 body."""
+    row_load_layout: gl.constexpr = gl.SliceLayout(1, x_load_layout)
+    token_ids = token_shared.load(layout=row_load_layout)
+    valid_rows = token_ids < M
+    gate_acc = gl.zeros((BLOCK_M, BLOCK_N), gl.float32, layout=mfma_layout)
+    up_acc = gl.zeros((BLOCK_M, BLOCK_N), gl.float32, layout=mfma_layout)
+    zero = gl.zeros((BLOCK_M, BLOCK_N), gl.float32, layout=mfma_layout)
+
+    for k_base in range(0, H // BLOCK_K, K_UNROLL):
+        operands0 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        operands1 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base + 1,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        operands2 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base + 2,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        operands3 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base + 3,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        operands4 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base + 4,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        operands5 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base + 5,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        operands6 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base + 6,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        operands7 = _load_w1_group(
+            x_ptr,
+            w1_ptr,
+            x_scale_ptr,
+            w1_scale_ptr,
+            token_ids,
+            valid_rows,
+            x_shared,
+            x_scale_shared,
+            expert_id,
+            k_base + 7,
+            x_load_layout=x_load_layout,
+            mfma_layout=mfma_layout,
+            dot_a_layout=dot_a_layout,
+            dot_b_layout=dot_b_layout,
+            packed_weight_layout=packed_weight_layout,
+        )
+        gate_acc, up_acc = _accumulate_w1_group(operands0, gate_acc, up_acc, zero)
+        gate_acc, up_acc = _accumulate_w1_group(operands1, gate_acc, up_acc, zero)
+        gate_acc, up_acc = _accumulate_w1_group(operands2, gate_acc, up_acc, zero)
+        gate_acc, up_acc = _accumulate_w1_group(operands3, gate_acc, up_acc, zero)
+        gate_acc, up_acc = _accumulate_w1_group(operands4, gate_acc, up_acc, zero)
+        gate_acc, up_acc = _accumulate_w1_group(operands5, gate_acc, up_acc, zero)
+        gate_acc, up_acc = _accumulate_w1_group(operands6, gate_acc, up_acc, zero)
+        gate_acc, up_acc = _accumulate_w1_group(operands7, gate_acc, up_acc, zero)
+
+    activated = gate_acc * (1.0 / (1.0 + gl.exp(-gate_acc))) * up_acc
+    activation_shared.store(activated)
+    activated0 = activation_shared.slice(0, BLOCK_K, dim=1).load(layout=x_load_layout)
+    activated1 = activation_shared.slice(BLOCK_K, BLOCK_K, dim=1).load(layout=x_load_layout)
+    row_amax0 = gl.maximum(
+        gl.max(gl.abs(activated0), axis=1, keep_dims=True),
+        1.0e-10,
+    )
+    row_amax1 = gl.maximum(
+        gl.max(gl.abs(activated1), axis=1, keep_dims=True),
+        1.0e-10,
+    )
+    row_scale0 = row_amax0.to(gl.float32) * (1.0 / 448.0)
+    row_scale1 = row_amax1.to(gl.float32) * (1.0 / 448.0)
+    quantized0 = activated0 * (1.0 / row_scale0)
+    quantized1 = activated1 * (1.0 / row_scale1)
+    quantized0 = gl.minimum(gl.maximum(quantized0, -448.0), 448.0)
+    quantized1 = gl.minimum(gl.maximum(quantized1, -448.0), 448.0)
+    return (
+        quantized0.to(x_ptr.type.element_ty),
+        quantized1.to(x_ptr.type.element_ty),
+        gl.reshape(row_scale0, (BLOCK_M,)),
+        gl.reshape(row_scale1, (BLOCK_M,)),
+    )
+
+
+_WORKSPACES: dict[tuple[torch.device, int], tuple[torch.Tensor, torch.Tensor]] = {}
+
+
+def _get_moe_workspaces_m32(
+    x: torch.Tensor,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return cached FP8 activation and FP32 scale workspaces.
+
+    The buffers are keyed by device and expert count so their addresses remain
+    stable across CUDA graph replays.  The selected M32 path stores two K128
+    activation groups per expert.
+    """
+    key = (x.device, num_experts)
+    workspaces = _WORKSPACES.get(key)
+    if workspaces is None:
+        workspaces = (
+            torch.empty(
+                (num_experts, 2, int(BLOCK_M), int(BLOCK_K)),
+                dtype=x.dtype,
+                device=x.device,
+            ),
+            torch.empty(
+                (num_experts, 2, int(BLOCK_M)),
+                dtype=torch.float32,
+                device=x.device,
+            ),
+        )
+        _WORKSPACES[key] = workspaces
+    return workspaces
+
+
+@gluon.jit
+def _w1_precompacted_kernel(
+    x_ptr,
+    w1_ptr,
+    x_scale_ptr,
+    w1_scale_ptr,
+    intermediate_workspace_ptr,
+    intermediate_scale_workspace_ptr,
+    route_tokens_ptr,
+    route_counts_ptr,
+):
+    expert_id = gl.program_id(0)
+    if gl.load(route_counts_ptr + expert_id) == 0:
+        return
+
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4,
+        instr_shape=[32, 32, 64],
+        transposed=True,
+        warps_per_cta=[1, NUM_WARPS],
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(0, mfma_layout, 16)
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(1, mfma_layout, 16)
+    x_load_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 8],
+        threads_per_warp=[8, 8],
+        warps_per_cta=[4, 2],
+        order=[1, 0],
+    )
+    packed_weight_layout: gl.constexpr = gl.DistributedLinearLayout(
+        reg_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 512], [0, 1024]],
+        lane_bases=[[0, 16], [0, 32], [0, 64], [0, 128], [1, 0], [0, 256]],
+        warp_bases=[[2, 0], [4, 0], [8, 0]],
+        block_bases=[],
+        shape=[BLOCK_N // 16, BLOCK_K * 16],
+    )
+    tile_shared_layout: gl.constexpr = gl.SwizzledSharedLayout(
+        vec=16,
+        per_phase=2,
+        max_phase=8,
+        order=[1, 0],
+    )
+    row_shared_layout: gl.constexpr = gl.SwizzledSharedLayout(
+        vec=1,
+        per_phase=1,
+        max_phase=1,
+        order=[0],
+    )
+    x_shared = gl.allocate_shared_memory(
+        x_ptr.type.element_ty,
+        [BLOCK_M, BLOCK_K],
+        layout=tile_shared_layout,
+    )
+    x_scale_shared = gl.allocate_shared_memory(
+        gl.float32,
+        [BLOCK_M],
+        layout=row_shared_layout,
+    )
+    activation_shared = gl.allocate_shared_memory(
+        gl.float32,
+        [BLOCK_M, BLOCK_N],
+        layout=tile_shared_layout,
+    )
+    token_shared = gl.allocate_shared_memory(
+        gl.int32,
+        [BLOCK_M],
+        layout=row_shared_layout,
+    )
+    row_load_layout: gl.constexpr = gl.SliceLayout(1, x_load_layout)
+    rows = gl.arange(0, BLOCK_M, layout=row_load_layout)
+    route_base = expert_id * BLOCK_M
+    token_shared.store(gl.amd.cdna4.buffer_load(route_tokens_ptr, route_base + rows))
+
+    inter0, inter1, scale0, scale1 = _compute_w1_k8(
+        x_ptr,
+        w1_ptr,
+        x_scale_ptr,
+        w1_scale_ptr,
+        token_shared,
+        x_shared,
+        x_scale_shared,
+        activation_shared,
+        expert_id,
+        x_load_layout=x_load_layout,
+        mfma_layout=mfma_layout,
+        dot_a_layout=dot_a_layout,
+        dot_b_layout=dot_b_layout,
+        packed_weight_layout=packed_weight_layout,
+    )
+    cols = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, x_load_layout))
+    workspace_base = expert_id * 2 * BLOCK_M * BLOCK_K
+    workspace_offsets = rows[:, None] * BLOCK_K + cols[None, :]
+    gl.amd.cdna4.buffer_store(
+        inter0,
+        intermediate_workspace_ptr,
+        workspace_base + workspace_offsets,
+    )
+    gl.amd.cdna4.buffer_store(
+        inter1,
+        intermediate_workspace_ptr,
+        workspace_base + BLOCK_M * BLOCK_K + workspace_offsets,
+    )
+    scale0 = gl.convert_layout(scale0, row_load_layout)
+    scale1 = gl.convert_layout(scale1, row_load_layout)
+    scale_base = expert_id * 2 * BLOCK_M
+    gl.amd.cdna4.buffer_store(
+        scale0,
+        intermediate_scale_workspace_ptr,
+        scale_base + rows,
+    )
+    gl.amd.cdna4.buffer_store(
+        scale1,
+        intermediate_scale_workspace_ptr,
+        scale_base + BLOCK_M + rows,
+    )
+
+
+def moe_w1_gluon_m32(
+    x: torch.Tensor,
+    w1: torch.Tensor,
+    x_scale: torch.Tensor,
+    w1_scale: torch.Tensor,
+    route_tokens: torch.Tensor,
+    route_counts: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run exact K8 W1 using precomputed stable expert-indexed routes."""
+    intermediate, intermediate_scale = _get_moe_workspaces_m32(x, int(E))
+    _w1_precompacted_kernel[(int(E),)](
+        x,
+        w1,
+        x_scale,
+        w1_scale,
+        intermediate,
+        intermediate_scale,
+        route_tokens,
+        route_counts,
+        num_warps=8,
+        waves_per_eu=1,
+    )
+    return intermediate, intermediate_scale
+
+
+__all__ = ["moe_w1_gluon_m32"]

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w2_gluon_m32.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w2_gluon_m32.py
@@ -1,0 +1,438 @@
+"""Bit-exact no-atomic MI355X DSR1 TP8 FP8 W2 for concurrency 32.
+
+The selected native-M16 producer writes each expert result to its unique
+``contribution[token, route_slot, hidden]`` location. A fixed M8xN128 reducer
+then adds slots 0 through 8 in order, rounding to BF16 after every add. Under
+the DSR1 contract of eight unique routed experts plus shared expert 256, every
+contribution element is overwritten and the workspace needs no clear launch.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import triton.experimental.gluon as gluon
+import triton.experimental.gluon.language as gl
+
+M = gl.constexpr(32)
+H = gl.constexpr(7168)
+I = gl.constexpr(256)
+E = gl.constexpr(257)
+TOPK = gl.constexpr(9)
+M16 = gl.constexpr(16)
+BLOCK_N = gl.constexpr(128)
+BLOCK_K = gl.constexpr(128)
+OUTPUT_SPLITS = gl.constexpr(28)
+NUM_WARPS = gl.constexpr(4)
+REDUCE_M = gl.constexpr(8)
+REDUCE_N = gl.constexpr(128)
+
+@gluon.jit
+def _load_preshuffled_w2(
+    w2_ptr,
+    expert_id,
+    output_tile,
+    k_block,
+    packed_layout: gl.constexpr,
+    dot_b_layout: gl.constexpr,
+):
+    packed_k = gl.arange(0, BLOCK_K * 16, layout=gl.SliceLayout(0, packed_layout))
+    packed_n = gl.arange(
+        0,
+        BLOCK_N // 16,
+        layout=gl.SliceLayout(1, packed_layout),
+    )
+    offsets = (
+        expert_id * (H * I)
+        + (output_tile * (BLOCK_N // 16) + packed_n[:, None]) * (I * 16)
+        + k_block * (BLOCK_K * 16)
+        + packed_k[None, :]
+    )
+    packed = gl.amd.cdna4.buffer_load(w2_ptr, offsets, cache=".cg")
+    logical = (
+        packed.reshape(1, BLOCK_N // 16, BLOCK_K // 32, 2, 16, 16)
+        .permute(0, 1, 4, 2, 3, 5)
+        .reshape(BLOCK_N, BLOCK_K)
+        .trans(1, 0)
+    )
+    return gl.convert_layout(logical, dot_b_layout, assert_trivial=True)
+
+
+@gluon.jit
+def _load_w2_pair(
+    w2_ptr,
+    w2_scale_ptr,
+    expert_id,
+    output_tile,
+    packed_layout: gl.constexpr,
+    dot_b_layout: gl.constexpr,
+):
+    weights0 = _load_preshuffled_w2(
+        w2_ptr,
+        expert_id,
+        output_tile,
+        0,
+        packed_layout,
+        dot_b_layout,
+    )
+    weights1 = _load_preshuffled_w2(
+        w2_ptr,
+        expert_id,
+        output_tile,
+        1,
+        packed_layout,
+        dot_b_layout,
+    )
+    scale_base = expert_id * 56 * 2 + output_tile * 2
+    scale0 = gl.load(w2_scale_ptr + scale_base)
+    scale1 = gl.load(w2_scale_ptr + scale_base + 1)
+    return weights0, weights1, scale0, scale1
+
+
+@gluon.jit
+def _load_m16_chunk(
+    intermediate_ptr,
+    intermediate_scale_ptr,
+    route_tokens_ptr,
+    route_weights_ptr,
+    expert_id,
+    route_count,
+    row_base,
+    dot_a_layout: gl.constexpr,
+    row_layout: gl.constexpr,
+):
+    a_rows = gl.arange(0, M16, layout=gl.SliceLayout(1, dot_a_layout))
+    a_cols = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))
+    logical_a_rows = row_base + a_rows
+    valid_a = logical_a_rows[:, None] < route_count
+    workspace_base = expert_id * 2 * M * BLOCK_K
+    offsets = logical_a_rows[:, None] * BLOCK_K + a_cols[None, :]
+    inter0 = gl.amd.cdna4.buffer_load(
+        intermediate_ptr,
+        workspace_base + offsets,
+        mask=valid_a,
+        other=0.0,
+    )
+    inter1 = gl.amd.cdna4.buffer_load(
+        intermediate_ptr,
+        workspace_base + M * BLOCK_K + offsets,
+        mask=valid_a,
+        other=0.0,
+    )
+    rows = gl.arange(0, M16, layout=row_layout)
+    logical_rows = row_base + rows
+    valid_rows = logical_rows < route_count
+    route_base = expert_id * M
+    tokens = gl.amd.cdna4.buffer_load(
+        route_tokens_ptr,
+        route_base + logical_rows,
+        mask=valid_rows,
+        other=M,
+    )
+    route_weights = gl.amd.cdna4.buffer_load(
+        route_weights_ptr,
+        route_base + logical_rows,
+        mask=valid_rows,
+        other=0.0,
+    )
+    scale_base = expert_id * 2 * M
+    scale0 = gl.amd.cdna4.buffer_load(
+        intermediate_scale_ptr,
+        scale_base + logical_rows,
+        mask=valid_rows,
+        other=0.0,
+    )
+    scale1 = gl.amd.cdna4.buffer_load(
+        intermediate_scale_ptr,
+        scale_base + M + logical_rows,
+        mask=valid_rows,
+        other=0.0,
+    )
+    return inter0, inter1, scale0, scale1, route_weights, tokens, valid_rows
+
+
+@gluon.jit
+def _load_route_slots_m32_exact(
+    route_slots_ptr,
+    expert_id,
+    route_count,
+    row_base,
+    row_layout: gl.constexpr,
+):
+    rows = gl.arange(0, M16, layout=row_layout)
+    logical_rows = row_base + rows
+    return gl.amd.cdna4.buffer_load(
+        route_slots_ptr,
+        expert_id * M + logical_rows,
+        mask=logical_rows < route_count,
+        other=TOPK,
+    )
+
+
+@gluon.jit
+def _store_contribution_m32_exact(
+    contribution_ptr,
+    weights,
+    inputs,
+    slots,
+    output_tile,
+    output_n,
+    zero,
+):
+    weights0, weights1, weight_scale0, weight_scale1 = weights
+    (
+        inter0,
+        inter1,
+        inter_scale0,
+        inter_scale1,
+        route_weights,
+        tokens,
+        valid_rows,
+    ) = inputs
+    down0 = gl.amd.cdna4.mfma_scaled(
+        inter0,
+        None,
+        "e4m3",
+        weights0,
+        None,
+        "e4m3",
+        zero,
+    )
+    down1 = gl.amd.cdna4.mfma_scaled(
+        inter1,
+        None,
+        "e4m3",
+        weights1,
+        None,
+        "e4m3",
+        zero,
+    )
+    down = down0 * inter_scale0[:, None] * weight_scale0
+    down += down1 * inter_scale1[:, None] * weight_scale1
+    down *= route_weights[:, None]
+    matched = valid_rows & (slots >= 0) & (slots < TOPK)
+    offsets = (
+        (tokens[:, None] * TOPK + slots[:, None]) * H + output_tile * BLOCK_N + output_n[None, :]
+    )
+    gl.amd.cdna4.buffer_store(
+        down.to(contribution_ptr.type.element_ty),
+        contribution_ptr,
+        offsets,
+        mask=matched[:, None],
+    )
+
+
+@gluon.jit
+def _store_two_contributions_m32_exact(
+    contribution_ptr,
+    weight0,
+    weight1,
+    inputs,
+    slots,
+    output_base,
+    output_n,
+    zero,
+):
+    _store_contribution_m32_exact(
+        contribution_ptr,
+        weight0,
+        inputs,
+        slots,
+        output_base,
+        output_n,
+        zero,
+    )
+    _store_contribution_m32_exact(
+        contribution_ptr,
+        weight1,
+        inputs,
+        slots,
+        output_base + 1,
+        output_n,
+        zero,
+    )
+
+
+@gluon.jit
+def _moe_w2_m32_exact_contribution_kernel(
+    contribution_ptr,
+    route_slots_ptr,
+    w2_ptr,
+    w2_scale_ptr,
+    intermediate_ptr,
+    intermediate_scale_ptr,
+    route_tokens_ptr,
+    route_weights_ptr,
+    route_counts_ptr,
+):
+    pid = gl.program_id(0)
+    expert_index = pid // OUTPUT_SPLITS
+    raw_split = pid % OUTPUT_SPLITS
+    output_split = (raw_split * 9) % OUTPUT_SPLITS
+    expert_id = gl.where(expert_index == 0, E - 1, expert_index - 1)
+    route_count = gl.load(route_counts_ptr + expert_id)
+    if route_count == 0:
+        return
+
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4,
+        instr_shape=[16, 16, 128],
+        transposed=True,
+        warps_per_cta=[1, NUM_WARPS],
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(0, mfma_layout, 16)
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(1, mfma_layout, 16)
+    row_layout: gl.constexpr = gl.SliceLayout(1, mfma_layout)
+    packed_layout: gl.constexpr = gl.DistributedLinearLayout(
+        reg_bases=[[0, 1], [0, 2], [0, 4], [0, 8], [0, 1024], [4, 0]],
+        lane_bases=[[0, 16], [0, 32], [0, 64], [0, 128], [0, 256], [0, 512]],
+        warp_bases=[[1, 0], [2, 0]],
+        block_bases=[],
+        shape=[BLOCK_N // 16, BLOCK_K * 16],
+    )
+    output_base = output_split * 2
+    output_n = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))
+    zero = gl.zeros((M16, BLOCK_N), gl.float32, layout=mfma_layout)
+    weight0 = _load_w2_pair(
+        w2_ptr,
+        w2_scale_ptr,
+        expert_id,
+        output_base,
+        packed_layout,
+        dot_b_layout,
+    )
+    weight1 = _load_w2_pair(
+        w2_ptr,
+        w2_scale_ptr,
+        expert_id,
+        output_base + 1,
+        packed_layout,
+        dot_b_layout,
+    )
+    inputs0 = _load_m16_chunk(
+        intermediate_ptr,
+        intermediate_scale_ptr,
+        route_tokens_ptr,
+        route_weights_ptr,
+        expert_id,
+        route_count,
+        0,
+        dot_a_layout,
+        row_layout,
+    )
+    slots0 = _load_route_slots_m32_exact(
+        route_slots_ptr,
+        expert_id,
+        route_count,
+        0,
+        row_layout=row_layout,
+    )
+    _store_two_contributions_m32_exact(
+        contribution_ptr,
+        weight0,
+        weight1,
+        inputs0,
+        slots0,
+        output_base,
+        output_n,
+        zero,
+    )
+    if route_count > M16:
+        inputs1 = _load_m16_chunk(
+            intermediate_ptr,
+            intermediate_scale_ptr,
+            route_tokens_ptr,
+            route_weights_ptr,
+            expert_id,
+            route_count,
+            M16,
+            dot_a_layout,
+            row_layout,
+        )
+        slots1 = _load_route_slots_m32_exact(
+            route_slots_ptr,
+            expert_id,
+            route_count,
+            M16,
+            row_layout=row_layout,
+        )
+        _store_two_contributions_m32_exact(
+            contribution_ptr,
+            weight0,
+            weight1,
+            inputs1,
+            slots1,
+            output_base,
+            output_n,
+            zero,
+        )
+
+
+@gluon.jit
+def _moe_w2_m32_exact_reduce_kernel(out_ptr, contribution_ptr):
+    layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 4],
+        threads_per_warp=[8, 8],
+        warps_per_cta=[1, 4],
+        order=[1, 0],
+    )
+    rows = gl.arange(0, REDUCE_M, layout=gl.SliceLayout(1, layout))
+    cols = gl.arange(0, REDUCE_N, layout=gl.SliceLayout(0, layout))
+    pid = gl.program_id(0)
+    token_base = (pid // (H // REDUCE_N)) * REDUCE_M
+    output_base = (pid % (H // REDUCE_N)) * REDUCE_N
+    tokens = token_base + rows
+    output_cols = output_base + cols
+
+    accumulator = gl.zeros((REDUCE_M, REDUCE_N), gl.float32, layout=layout)
+    for route_slot in gl.static_range(TOPK):
+        offsets = (tokens[:, None] * TOPK + route_slot) * H + output_cols[None, :]
+        contribution = gl.amd.cdna4.buffer_load(contribution_ptr, offsets)
+        accumulator = (accumulator + contribution.to(gl.float32)).to(gl.bfloat16).to(gl.float32)
+
+    output_offsets = tokens[:, None] * H + output_cols[None, :]
+    gl.amd.cdna4.buffer_store(
+        accumulator.to(out_ptr.type.element_ty),
+        out_ptr,
+        output_offsets,
+    )
+
+
+def moe_w2_gluon_m32(
+    out: torch.Tensor,
+    contribution: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    intermediate: torch.Tensor,
+    intermediate_scale: torch.Tensor,
+    route_tokens: torch.Tensor,
+    route_weights: torch.Tensor,
+    route_counts: torch.Tensor,
+    route_slots: torch.Tensor,
+) -> torch.Tensor:
+    """Run direct contribution stores and fixed slot-order BF16 reduction."""
+    _moe_w2_m32_exact_contribution_kernel[(int(E) * int(OUTPUT_SPLITS),)](
+        contribution,
+        route_slots,
+        w2,
+        w2_scale,
+        intermediate,
+        intermediate_scale,
+        route_tokens,
+        route_weights,
+        route_counts,
+        num_warps=4,
+        waves_per_eu=2,
+    )
+    _moe_w2_m32_exact_reduce_kernel[
+        ((int(M) // int(REDUCE_M)) * (int(H) // int(REDUCE_N)),)
+    ](
+        out,
+        contribution,
+        num_warps=4,
+        waves_per_eu=3,
+    )
+    return out
+
+
+__all__ = ["moe_w2_gluon_m32"]

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w2_gluon_m32.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_w2_gluon_m32.py
@@ -10,9 +10,8 @@ contribution element is overwritten and the workspace needs no clear launch.
 from __future__ import annotations
 
 import torch
-
-import triton.experimental.gluon as gluon
 import triton.experimental.gluon.language as gl
+from triton.experimental import gluon
 
 M = gl.constexpr(32)
 H = gl.constexpr(7168)

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_workspaces.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/kernels/moe_workspaces.py
@@ -1,0 +1,57 @@
+"""Graph-stable route-slot and contribution buffers for exact DSR1 W2."""
+
+from __future__ import annotations
+
+import torch
+
+EXPERTS = 257
+TOPK = 9
+HIDDEN_SIZE = 7168
+SUPPORTED_M = (32,)
+
+_WORKSPACES: dict[
+    tuple[torch.device, int],
+    tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+] = {}
+
+
+def get_route_workspaces(
+    device: torch.device,
+    m: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Return all graph-stable route metadata and exact-W2 contribution storage.
+
+    The contribution tensor is intentionally not cleared. Under the fail-closed
+    DSR1 contract, every token has eight unique routed experts plus shared
+    expert 256, so prep records one route for every slot and the producer
+    overwrites every ``[token, slot, hidden]`` element exactly once.
+    """
+    if m not in SUPPORTED_M:
+        raise ValueError(f"exact W2 supports M={SUPPORTED_M}, got M={m}")
+    key = (device, m)
+    workspaces = _WORKSPACES.get(key)
+    if workspaces is None:
+        workspaces = (
+            torch.empty((EXPERTS, m), dtype=torch.int32, device=device),
+            torch.empty((EXPERTS, m), dtype=torch.float32, device=device),
+            torch.empty((EXPERTS,), dtype=torch.int32, device=device),
+            torch.empty((EXPERTS, m), dtype=torch.int32, device=device),
+            torch.empty((m, TOPK, HIDDEN_SIZE), dtype=torch.bfloat16, device=device),
+        )
+        _WORKSPACES[key] = workspaces
+    return workspaces
+
+
+__all__ = ["get_route_workspaces"]

--- a/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/registry.py
+++ b/python/sglang/srt/artemis_kernels/mi355x/dsr1_fp8/fused_moe/registry.py
@@ -1,0 +1,84 @@
+"""Registry of exact fused-MoE shapes qualified by Artemis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FusedMoeKernelSpec:
+    """One fail-closed fused-MoE specialization."""
+
+    name: str
+    tokens: int
+    hidden_size: int = 7168
+    intermediate_size_per_partition: int = 256
+    experts: int = 257
+    top_k: int = 9
+    block_size: int = 128
+    architecture: str = "gfx950"
+
+    @property
+    def hidden_shape(self) -> tuple[int, int]:
+        return (self.tokens, self.hidden_size)
+
+    @property
+    def w13_shape(self) -> tuple[int, int, int]:
+        return (self.experts, 2 * self.intermediate_size_per_partition, self.hidden_size)
+
+    @property
+    def w2_shape(self) -> tuple[int, int, int]:
+        return (self.experts, self.hidden_size, self.intermediate_size_per_partition)
+
+    @property
+    def topk_shape(self) -> tuple[int, int]:
+        return (self.tokens, self.top_k)
+
+    @property
+    def w13_scale_shape(self) -> tuple[int, int, int]:
+        return (
+            self.experts,
+            2 * self.intermediate_size_per_partition // self.block_size,
+            self.hidden_size // self.block_size,
+        )
+
+    @property
+    def w2_scale_shape(self) -> tuple[int, int, int]:
+        return (
+            self.experts,
+            self.hidden_size // self.block_size,
+            self.intermediate_size_per_partition // self.block_size,
+        )
+
+
+FUSED_MOE_KERNELS = (
+    FusedMoeKernelSpec(name="dsr1_fp8_tp8_m32", tokens=32),
+)
+
+_KERNELS_BY_SHAPE = {
+    (
+        spec.tokens,
+        spec.hidden_size,
+        spec.intermediate_size_per_partition,
+        spec.experts,
+        spec.top_k,
+    ): spec
+    for spec in FUSED_MOE_KERNELS
+}
+
+
+def find_kernel_spec(
+    *,
+    tokens: int,
+    hidden_size: int,
+    intermediate_size_per_partition: int,
+    experts: int,
+    top_k: int,
+) -> FusedMoeKernelSpec | None:
+    """Return the exact registered shape, or ``None`` for stock fallback."""
+    return _KERNELS_BY_SHAPE.get(
+        (tokens, hidden_size, intermediate_size_per_partition, experts, top_k)
+    )
+
+
+__all__ = ["FUSED_MOE_KERNELS", "FusedMoeKernelSpec", "find_kernel_spec"]

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -741,6 +741,7 @@ class Envs:
     SGLANG_USE_SGL_FA3_KERNEL = EnvBool(True)
 
     # Kernels
+    ARTEMIS_KERNELS = EnvBool(False)
     # Force every sglang.kernels BaseFusedOp onto one backend (a KernelBackend
     # value, e.g. "torch" / "torch_compile" / "triton" / "aot"); unset =
     # auto-select by priority. "torch" flips all fused ops to their pure-torch

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -145,6 +145,18 @@ class AiterRunnerCore(MoeRunnerCore):
                 )
             return AiterRunnerOutput(hidden_states=runner_input.hidden_states)
 
+        from sglang.srt.artemis_kernels.mi355x.dsr1_fp8.fused_moe.dispatcher import (
+            dispatch_fused_moe,
+        )
+
+        artemis_output = dispatch_fused_moe(
+            runner_input,
+            quant_info,
+            self.config,
+        )
+        if artemis_output is not None:
+            return AiterRunnerOutput(hidden_states=artemis_output)
+
         from aiter.fused_moe import fused_moe
 
         from sglang.srt.environ import envs

--- a/test/registered/unit/layers/moe/test_aiter_runner.py
+++ b/test/registered/unit/layers/moe/test_aiter_runner.py
@@ -5,6 +5,9 @@ import pytest
 import torch
 
 import sglang.srt.layers.moe.moe_runner.aiter as aiter_runner
+from sglang.srt.artemis_kernels.mi355x.dsr1_fp8.fused_moe import (
+    dispatcher as artemis_dispatcher,
+)
 from sglang.srt.layers.moe.moe_runner.aiter import (
     AiterMoeQuantInfo,
     AiterQuantType,
@@ -113,6 +116,59 @@ def test_aiter_runner_preserves_no_combine_rank_for_empty_input(monkeypatch):
     output = runner.run(runner_input, _quant_info(), running_state={})
 
     assert output.hidden_states.shape == (0, 2, 4)
+
+
+def test_aiter_runner_short_circuits_stock_path_for_artemis_output(monkeypatch):
+    expected = torch.full((1, 4), 7, dtype=torch.bfloat16)
+    monkeypatch.setattr(
+        artemis_dispatcher,
+        "dispatch_fused_moe",
+        lambda runner_input, quant_info, runner_config: expected,
+    )
+
+    runner = AiterRunnerCore(MoeRunnerConfig(activation="silu"))
+    output = runner.run(_runner_input(), _quant_info(), running_state={})
+
+    assert output.hidden_states is expected
+
+
+def test_aiter_runner_falls_back_when_artemis_declines(monkeypatch):
+    captured = {}
+
+    def fused_moe(**kwargs):
+        captured.update(kwargs)
+        return kwargs["hidden_states"]
+
+    _install_fake_aiter(monkeypatch, fused_moe)
+    monkeypatch.setattr(
+        artemis_dispatcher,
+        "dispatch_fused_moe",
+        lambda runner_input, quant_info, runner_config: None,
+    )
+
+    runner_input = _runner_input()
+    runner = AiterRunnerCore(MoeRunnerConfig(activation="silu"))
+    output = runner.run(runner_input, _quant_info(), running_state={})
+
+    assert output.hidden_states is runner_input.hidden_states
+    assert captured["hidden_states"] is runner_input.hidden_states
+
+
+def test_artemis_dispatcher_is_fail_closed_when_disabled(monkeypatch):
+    monkeypatch.setattr(
+        artemis_dispatcher,
+        "is_artemis_fused_moe_enabled",
+        lambda: False,
+    )
+
+    assert (
+        artemis_dispatcher.dispatch_fused_moe(
+            _runner_input(),
+            _quant_info(),
+            MoeRunnerConfig(activation="silu"),
+        )
+        is None
+    )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/moe/test_aiter_runner.py
+++ b/test/registered/unit/layers/moe/test_aiter_runner.py
@@ -2,9 +2,8 @@ import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
-import torch
-
 import sglang.srt.layers.moe.moe_runner.aiter as aiter_runner
+import torch
 from sglang.srt.artemis_kernels.mi355x.dsr1_fp8.fused_moe import (
     dispatcher as artemis_dispatcher,
 )


### PR DESCRIPTION
## Motivation

DeepSeek-R1 decode on MI355X commonly reaches the fused-MoE path with `M=32`.
This PR adds an opt-in Artemis implementation specialized for that contract while
keeping the existing AITER path as the default and fail-closed fallback.

## What this changes

- Add gfx950/M32 FP8 fused-MoE kernels and dispatch helpers.
- Integrate the fast path into the current `AiterRunnerCore` execution flow.
- Add narrow Triton compatibility shims needed by the imported kernels.
- Gate the feature behind `ARTEMIS_KERNELS`; it remains disabled by default.
- Fall back to the stock AITER implementation when the feature is disabled,
  the input does not match the supported contract, imports fail, or dispatch
  rejects the input.
- Add CPU unit coverage for fast-path short-circuiting, disabled behavior, and
  stock-AITER fallback.

## Supported fast-path contract

The optimized path is intentionally narrow: gfx950, FP8 DeepSeek-R1-style
fused MoE, and `M=32`. Unsupported inputs do not enter the Artemis kernels.

## Validation

Validation completed on the rebased branch:

- `git diff --check`
- Python bytecode compilation for the changed MoE/quantization modules and tests
- Ruff critical-error checks (`E9`, `F63`, `F7`, `F821`)
- CPU fallback tests were added, but were not executed in the local preparation
  environment because its Python installation does not contain `numpy`/`pytest`.

Results recorded for the original MI355X implementation before this upstream
rebase:

- Complete pipeline: 1.1471x speedup / 12.82% latency reduction
- Output throughput: 1946.988 vs 1718.433 tok/s (+13.2996%)
- Total throughput: 3887.817 vs 3431.430 tok/s (+13.2996%)
- GSM8K smoke comparison: 32/32 semantic matches, with completion markers from
  all ranks

The benchmark and GSM8K runs still need to be repeated on this exact rebased
commit before the PR is marked ready. The final report will include the ROCm,
Triton, AITER, model, launch configuration, and absolute latency details.

## Follow-up

A second, stacked branch adds the MI355X M32 block-scaled GEMM and padded AITER
TopK router work:

https://github.com/haofrank/sglang/tree/codex/artemis-mi355x-router-block-mm

It will be submitted separately after this base PR lands (or after maintainers
select a preferred stacking strategy).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30491447155](https://github.com/sgl-project/sglang/actions/runs/30491447155)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30491445646](https://github.com/sgl-project/sglang/actions/runs/30491445646)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->