### PR TITLE
Fix three exception messages split across positional arguments

### DIFF
--- a/python/sglang/kernels/ops/attention/linear/lightning_attn.py
+++ b/python/sglang/kernels/ops/attention/linear/lightning_attn.py
@@ -405,8 +405,8 @@ class _attention(torch.autograd.Function):
         capability = torch.cuda.get_device_capability()
         if capability[0] < 8:
             raise RuntimeError(
-                "Flash attention currently only supported",
-                "for compute capability >= 80",
+                "Flash attention currently only supported "
+                "for compute capability >= 80"
             )
 
         # Get input dimensions

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -337,9 +337,9 @@ class CompressedTensorsConfig(QuantizationConfig):
             supported = capability >= min_capability
             if error and not supported:
                 raise RuntimeError(
-                    "Quantization scheme is not supported for ",
-                    f"the current GPU. Min capability: {min_capability}. ",
-                    f"Current capability: {capability}.",
+                    "Quantization scheme is not supported for "
+                    f"the current GPU. Min capability: {min_capability}. "
+                    f"Current capability: {capability}."
                 )
             return supported
         else:

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
@@ -86,10 +86,10 @@ class CompressedTensorsWNA16MoE(CompressedTensorsMoEScheme):
             and self.num_bits in WNA16_SUPPORTED_BITS
         ):
             raise ValueError(
-                "For Fused MoE layers, only ",
-                f"{CompressionFormat.pack_quantized.value} ",
-                "is supported for the following bits: ",
-                f"{WNA16_SUPPORTED_BITS}",
+                "For Fused MoE layers, only "
+                f"{CompressionFormat.pack_quantized.value} "
+                "is supported for the following bits: "
+                f"{WNA16_SUPPORTED_BITS}"
             )
         self.num_gpu_experts = num_gpu_experts
 


### PR DESCRIPTION
## Motivation

Three `raise` sites pass each clause of the message as a separate positional argument instead of one concatenated string. Python puts them all into `args`, so `str(e)` renders the tuple repr:

```python
raise RuntimeError(
    "Quantization scheme is not supported for ",
    f"the current GPU. Min capability: {min_capability}. ",
    f"Current capability: {capability}.",
)
```

```
('Quantization scheme is not supported for ', 'the current GPU. Min capability: 80. ', 'Current capability: 75.')
```

Both quantization messages exist to tell the user which compute capability their GPU has and which one the scheme needs, and both numbers arrive wrapped in quotes and parentheses.

| file | line | exception |
|---|---|---|
| `srt/layers/quantization/compressed_tensors/compressed_tensors.py` | 339 | `RuntimeError` |
| `srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py` | 88 | `ValueError` |
| `kernels/ops/attention/linear/lightning_attn.py` | 407 | `RuntimeError` |

The `lightning_attn` one also had a missing space — concatenating its two clauses as written gives `"supportedfor"`, so this PR adds it.

## Modifications

Joined the adjacent literals at each site. No control flow, exception types or wording changes beyond that one space.

An AST sweep over `python/sglang/` for raises of builtin exceptions with two or more string-constant/f-string arguments reports these three before the change and zero after.

## Accuracy Test

Not applicable — message-only change, no numerics touched.

## Benchmark and Profiling Results

Not applicable.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Update documentation as needed, including docstrings or example tutorials.

`ruff check --select=F401,F821,UP037` (the pre-commit selection) passes on all three files. `black` reports the same reformat requests on these files before and after my change — the hunks it wants are in untouched code and come from my local black 23.3.0 vs the pinned 26.1.0, and none of them overlap the lines in this diff.

These three raises are only reached on unsupported hardware, so I have no way to trigger them here — an H100/A100-class check isn't available to me. The change is a string concatenation with no behavioural component, and the tuple-vs-string rendering is reproducible standalone:

```python
>>> str(RuntimeError("a ", "b"))
"('a ', 'b')"
>>> str(RuntimeError("a " "b"))
'a b'
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30493531891](https://github.com/sgl-project/sglang/actions/runs/30493531891)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30493531678](https://github.com/sgl-project/sglang/actions/runs/30493531678)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->