### PR TITLE
Use supported FP8 attention output GEMM on SM120 instead of forcing it off

### DIFF
--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -68,6 +68,14 @@ def _validate_dsa_tbo_index_sharing(server_args: Any, hf_config: Any) -> None:
         )
 
 
+def _apply_sm120_fp8_wo_a_gemm_default() -> None:
+    """Keep an explicit setting or the global default on capable builds."""
+    from sglang.srt.layers.deep_gemm_wrapper.configurer import DEEPGEMM_SCALE_UE8M0
+
+    if not DEEPGEMM_SCALE_UE8M0:
+        envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+
+
 def _rocm_fp8_wo_a_supported() -> bool:
     """True when ROCm can run the DeepSeek-V4 fp8 wo_a GEMM (gfx950 + aiter)."""
     try:
@@ -368,9 +376,8 @@ def handle_model_specific_adjustments(server_args: Any):
         validate_deepseek_v4_mega_moe_token_budget(server_args)
 
         if get_platform().is_sm120:
-            # SM120 lacks tcgen05/TMEM: disable features that depend on
-            # DeepGEMM or require >99KB SMEM (topk_v2).
-            envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+            # Preserve the FP8 W_o_A default only on capable DeepGEMM builds.
+            _apply_sm120_fp8_wo_a_gemm_default()
             envs.SGLANG_OPT_USE_TOPK_V2.set(False)
             if not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.is_set():
                 envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -409,6 +409,20 @@ def add_linear_attn_kernel_backend_choices(choices):
     LINEAR_ATTN_KERNEL_BACKEND_CHOICES.extend(choices)
 
 
+def _apply_sm120_fp8_wo_a_gemm_default() -> None:
+    """Gate the SM120 FP8 W_o_A GEMM override on the DeepGEMM ue8m0 capability.
+
+    Builds that cannot run the GEMM (DEEPGEMM_SCALE_UE8M0 false) get
+    SGLANG_OPT_FP8_WO_A_GEMM forced off. Capable builds are left untouched, so
+    they keep the global default or an explicit setting. The capability check in
+    `_handle_environment_variables` stays authoritative.
+    """
+    from sglang.srt.layers.deep_gemm_wrapper.configurer import DEEPGEMM_SCALE_UE8M0
+
+    if not DEEPGEMM_SCALE_UE8M0:
+        envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+
+
 @dataclasses.dataclass
 class ServerArgs:
     """Server-wide configuration for SGLang.
@@ -5176,9 +5190,10 @@ class ServerArgs:
 
             run_post_process_pass(self, _deepseek_v4_sm120_moe)
             if is_sm120_supported():
-                # SM120 lacks tcgen05/TMEM: disable features that depend on
-                # DeepGEMM or require >99KB SMEM (topk_v2).
-                envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+                # Keep the W_o_A DeepGEMM default only when the installed build
+                # supports SM120; disable features that require >99KB SMEM
+                # (topk_v2).
+                _apply_sm120_fp8_wo_a_gemm_default()
                 envs.SGLANG_OPT_USE_TOPK_V2.set(False)
                 envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
                 envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1685,6 +1685,34 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             "flashinfer_trtllm_routed",
         )
 
+    def test_sm120_fp8_wo_a_gemm_default_gates_on_deepgemm_capability(self):
+        """The SM120 FP8 W_o_A GEMM override is capability-gated, not a force.
+
+        Only a build without the DeepGEMM ue8m0 capability gets the GEMM turned
+        off; a capable build must be left untouched so the global default or an
+        explicit setting survives to the later DeepGEMM capability check.
+        """
+        from sglang.srt.arg_groups.model_hook import _apply_sm120_fp8_wo_a_gemm_default
+        from sglang.srt.environ import envs
+        from sglang.srt.layers.deep_gemm_wrapper import configurer
+
+        field = envs.SGLANG_OPT_FP8_WO_A_GEMM
+
+        def _run(capable):
+            """Call the helper with a stubbed capability; return recorded set()."""
+            with (
+                patch.object(configurer, "DEEPGEMM_SCALE_UE8M0", capable),
+                patch.object(field, "set") as mock_set,
+            ):
+                _apply_sm120_fp8_wo_a_gemm_default()
+                return mock_set
+
+        # Incapable build: forced off.
+        _run(capable=False).assert_called_once_with(False)
+
+        # Capable build: untouched, keeping the default or explicit setting.
+        _run(capable=True).assert_not_called()
+
     def test_nemotron_h_overrides_at_callable_level(self):
         from sglang.srt.arg_groups.model_overrides.nemotron_h import (
             _nemotron_h_overrides,

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -837,6 +837,34 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         with patch.object(overrides_module, "is_sm120_supported", return_value=False):
             self.assertEqual(_deepseek_v4_sm120_moe(_view()), {})
 
+    def test_sm120_fp8_wo_a_gemm_default_gates_on_deepgemm_capability(self):
+        """The SM120 FP8 W_o_A GEMM override is capability-gated, not a force.
+
+        Only a build without the DeepGEMM ue8m0 capability gets the GEMM turned
+        off; a capable build must be left untouched so the global default or an
+        explicit setting survives to the later DeepGEMM capability check.
+        """
+        from sglang.srt.environ import envs
+        from sglang.srt.layers.deep_gemm_wrapper import configurer
+        from sglang.srt.server_args import _apply_sm120_fp8_wo_a_gemm_default
+
+        field = envs.SGLANG_OPT_FP8_WO_A_GEMM
+
+        def _run(capable):
+            """Call the helper with a stubbed capability; return recorded set()."""
+            with (
+                patch.object(configurer, "DEEPGEMM_SCALE_UE8M0", capable),
+                patch.object(field, "set") as mock_set,
+            ):
+                _apply_sm120_fp8_wo_a_gemm_default()
+                return mock_set
+
+        # Incapable build: forced off.
+        _run(capable=False).assert_called_once_with(False)
+
+        # Capable build: untouched, keeping the default or explicit setting.
+        _run(capable=True).assert_not_called()
+
     def test_nemotron_h_overrides_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _nemotron_h_overrides
 


### PR DESCRIPTION
## Motivation

On DeepSeek-V4 SM120 the model override currently forces `SGLANG_OPT_FP8_WO_A_GEMM` off. #29927 is now merged; that override bypasses a supported path on capable builds. The global default is true, and the later DeepGEMM capability check already disables builds that cannot run the GEMM.

## Modifications

- Gate the DeepSeek-V4 SM120 override on `DEEPGEMM_SCALE_UE8M0`.
- Leave capable builds at the global default while preserving an explicit false setting.
- Add unit coverage for capable and incapable builds.

Default behavior changes only for DeepSeek-V4 on capable SM120 builds.

## Accuracy Tests

Rebased on main `2c05ed4e77`. [Author test logs and source bindings](https://github.com/ormandj/sglang-glm53-flash-sm120/blob/main/evidence/v0.3.2/pr-maintenance/README.md) record the tested snapshots. The subsequent main refresh changes only unrelated ROCm/NPU files; each repaired patch is byte-identical across that refresh. Author CPU validation passed 91 tests and 29 subtests with one skip. The helper now lives in `arg_groups/model_hook.py`.

The following accuracy and speed results are retained author reports from the original source identified below, not new measurements of this rebase.

DeepSeek-V4-Flash, TP=2, 2x RTX PRO 6000, temperature 0, no MTP, and no DSpark. The source was current main `ffd4705baa39` + #29927 `41ee852a6eb6` + this PR `1dbf09f6e015`, with no other SGLang PRs or runtime source overlays.

The paired 1,319-question GSM8K run scored 1,250 correct with the flag off and 1,246 correct with the default enabled. There were 14 candidate-only and 18 control-only successes; McNemar p = 0.5966 and the paired bootstrap 95% interval was -1.14 to +0.53 percentage points. All 2,638 responses stopped cleanly with zero invalid or failed responses.

## Speed Tests and Profiling

The control set `SGLANG_OPT_FP8_WO_A_GEMM=0`; the candidate left the variable unset. The source, image, dependencies, arguments, and hardware were otherwise identical. Sustained decode used zero-token contexts, 30-second cells, and a maximum of 8,192 output tokens. Each value is the median of five runs.

| Concurrency | Off (tok/s) | Default (tok/s) | Change |
|---:|---:|---:|---:|
| 1 | 97.90 | 99.46 | +1.60% |
| 2 | 167.26 | 179.86 | +7.53% |
| 4 | 289.05 | 308.80 | +6.83% |
| 8 | 470.66 | 493.86 | +4.93% |
| 16 | 710.93 | 737.59 | +3.75% |
| 32 | 1004.43 | 1041.03 | +3.64% |

| Exact cold prefill | Off (tok/s) | Default (tok/s) | Change |
|---:|---:|---:|---:|
| 8K | 7,911 | 8,409 | +6.30% |
| 64K | 8,685 | 8,847 | +1.87% |
| 128K | 8,047 | 8,160 | +1.40% |

The five-run coding median changed from 97.68 to 99.64 tok/s (+2.00%). KV-cache token capacity changed from 1,723,648 to 1,823,488 (+5.79%).

The focused unit test and pre-commit checks pass. In the candidate container, the runtime source HEAD/tree matched `62d35aaa5e82`/`d0961aec18dd`, the environment variable was absent, the DeepGEMM capability reported true, and the effective default remained true.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34058833439](https://github.com/sgl-project/sglang/actions/runs/34058833439)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34058833395](https://github.com/sgl-project/sglang/actions/runs/34058833395)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34058833636](https://github.com/sgl-project/sglang/actions/runs/34058833636)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->