### PR TITLE
Fix duplicated words in one error message and five comments

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/linear.py
+++ b/python/sglang/multimodal_gen/runtime/layers/linear.py
@@ -953,7 +953,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             if not is_sharded_weight:
                 loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
 
-        # Special case for for AQLM codebooks.
+        # Special case for AQLM codebooks.
         elif is_metadata:
             # metadata indicates fixed size concatenated along dim 0
             shard_size = loaded_weight.shape[0]

--- a/python/sglang/srt/configs/internvl.py
+++ b/python/sglang/srt/configs/internvl.py
@@ -140,7 +140,7 @@ class InternLM2Config(PretrainedConfig):
 
         if not isinstance(self.rope_scaling, dict) or len(self.rope_scaling) != 2:
             raise ValueError(
-                "`rope_scaling` must be a dictionary with with two fields, `type` and `factor`, "
+                "`rope_scaling` must be a dictionary with two fields, `type` and `factor`, "
                 f"got {self.rope_scaling}"
             )
         rope_scaling_type = self.rope_scaling.get("type", None)

--- a/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/utils.py
@@ -98,7 +98,7 @@ def find_matched_target(
     config that a layer corresponds to.
 
     Recall that a compressed-tensors configs has a concept of
-    config_groups, where each layer can be quantized with with a different
+    config_groups, where each layer can be quantized with a different
     scheme.
 
     targets in each config_group will be a list of either layer names

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -175,7 +175,7 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
 
     def _determine_chunk_size(self, forward_batch: ForwardBatch) -> int:
         """
-        Heuristically determine the chunk size based on token token number in a batch.
+        Heuristically determine the chunk size based on token number in a batch.
 
         Args:
             forward_batch (ForwardBatch): The batch information containing sequence lengths.

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -379,7 +379,7 @@ class MultiHttpWorkerDetokenizerMixin:
             self.socket_mapping.clear_all_sockets()
 
     def multi_http_worker_event_loop(self: DetokenizerManager):
-        """The event loop that handles requests, for multi multi-http-worker mode"""
+        """The event loop that handles requests, for multi-http-worker mode"""
         self.socket_mapping = SocketMapping()
         # Watchdog wiring mirrors DetokenizerManager.event_loop: the watchdog is
         # paused while waiting for input and fed once per processed message.

--- a/python/sglang/srt/models/minicpmo.py
+++ b/python/sglang/srt/models/minicpmo.py
@@ -1186,7 +1186,7 @@ class MiniCPMWhisperEncoderLayer(nn.Module):
         return outputs
 
 
-# Copied from from transformers.models.whisper.modeling_whisper.WhisperEncoder and add use_cache for streaming inference
+# Copied from transformers.models.whisper.modeling_whisper.WhisperEncoder and add use_cache for streaming inference
 class MiniCPMWhisperEncoder(WhisperEncoder):
 
     def __init__(self, config: WhisperConfig):


### PR DESCRIPTION
## Motivation

`InternVLChatConfig` raises this when `rope_scaling` is malformed:

```
`rope_scaling` must be a dictionary with with two fields, `type` and `factor`, got {'type': 'linear'}
```

Triggered the branch directly to confirm:

```
before: `rope_scaling` must be a dictionary with with two fields, `type` and `factor`, got {'type': 'linear'}
after : `rope_scaling` must be a dictionary with two fields, `type` and `factor`, got {'type': 'linear'}
```

Five comments/docstrings repeat a word the same way:

| file | line | |
|---|---|---|
| `srt/managers/multi_tokenizer_mixin.py` | 382 | `for multi multi-http-worker mode` |
| `srt/lora/backend/chunked_backend.py` | 178 | `based on token token number` |
| `srt/models/minicpmo.py` | 1189 | `# Copied from from transformers.models.whisper...` |
| `srt/layers/quantization/compressed_tensors/utils.py` | 101 | `quantized with with a different` |
| `multimodal_gen/runtime/layers/linear.py` | 956 | `# Special case for for AQLM codebooks.` |

The `minicpmo.py` one is a `# Copied from` marker — the doubled `from` would break a consistency checker that parses those markers, if one is ever pointed at that file.

## Modifications

One word removed per site. No behaviour change.

Found with a regex sweep for repeated adjacent words over `python/sglang`, skipping URLs, CLI flags and markup. Four remaining hits are deliberate and left alone: `unified_kv unified_kv:` used as a label, `two-stage stage 2`, `and and/or` inside a help string, and `head head-encoded`.

## Accuracy Test

Not applicable — one message string and five comments.

## Benchmark and Profiling Results

Not applicable.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Update documentation as needed, including docstrings or example tutorials.

`ruff check --select=F401,F821,UP037` (the pre-commit selection) passes. `black` reports the same two files as needing reformatting before and after this change — the hunks it wants are in untouched code and come from my local black 23.3.0 vs the pinned 26.1.0; none overlap these lines.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30497260115](https://github.com/sgl-project/sglang/actions/runs/30497260115)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30497259976](https://github.com/sgl-project/sglang/actions/runs/30497259976)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->