### PR TITLE
[AMD] Enable A2A reduction for Triton DCP

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/pynccl.py
+++ b/python/sglang/srt/distributed/device_communicators/pynccl.py
@@ -335,8 +335,20 @@ class PyNcclCommunicator:
         )
         chunk_size = input_tensor.numel() // self.world_size
         dtype = ncclDataTypeEnum.from_torch(input_tensor.dtype)
+
+        # Keep the local chunk on-device instead of routing it through a
+        # grouped self-send/self-recv. RCCL can execute self P2P, but repeated
+        # CUDA-graph replay of grouped self P2P is not reliable on ROCm and can
+        # deadlock when the graph batch size changes. A stream-ordered D2D copy
+        # has identical all-to-all semantics and also removes two NCCL ops.
+        local_input = input_tensor.narrow(0, self.rank * chunk_size, chunk_size)
+        local_output = output_tensor.narrow(0, self.rank * chunk_size, chunk_size)
+        local_output.copy_(local_input)
+
         self.nccl.ncclGroupStart()
         for i in range(self.world_size):
+            if i == self.rank:
+                continue
             send_buf = input_tensor.narrow(0, i * chunk_size, chunk_size)
             self.nccl.ncclSend(
                 buffer_type(send_buf.data_ptr()),

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -24,6 +24,7 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.dcp import (
     cp_lse_ag_out_rs_mha,
     create_triton_kv_indices_for_dcp_triton,
+    dcp_a2a_lse_reduce,
     get_dcp_lens,
 )
 from sglang.srt.layers.radix_attention import AttentionType
@@ -67,6 +68,24 @@ if TYPE_CHECKING:
 
 
 _MLA_DECODE_MIN_BLOCK_KV = 32
+
+
+def _reduce_dcp_mha_output(
+    attn_output: torch.Tensor,
+    attn_lse: torch.Tensor,
+    group,
+    comm_backend: str,
+) -> torch.Tensor:
+    """Merge per-rank MHA partials with the configured DCP transport."""
+    if comm_backend in ("a2a", "fi_a2a"):
+        return dcp_a2a_lse_reduce(
+            attn_output,
+            attn_lse,
+            group,
+            is_lse_base_on_e=True,
+            comm_backend=comm_backend,
+        )
+    return cp_lse_ag_out_rs_mha(attn_output, attn_lse, group)
 
 
 def _mla_decode_kv_splits_cap(
@@ -177,6 +196,7 @@ class TritonAttnBackend(AttentionBackend):
         self.use_mla = model_runner.model_config.attention_arch == AttentionArch.MLA
         self.dcp_size = get_parallel().attn_dcp_size
         self.dcp_rank = get_parallel().attn_dcp_rank
+        self.dcp_comm_backend = model_runner.server_args.dcp_comm_backend
         self.num_head = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
         ) * self.dcp_size
@@ -1793,7 +1813,12 @@ class TritonAttnBackend(AttentionBackend):
                 ],
                 dim=-1,
             )
-            o = cp_lse_ag_out_rs_mha(o_for_decode, local_lse, group)
+            o = _reduce_dcp_mha_output(
+                o_for_decode,
+                local_lse,
+                group,
+                self.dcp_comm_backend,
+            )
             return o.reshape(-1, layer.tp_q_head_num * layer.v_head_dim).to(q.dtype)
 
         self.decode_attention_fwd(

--- a/test/registered/unit/test_triton_dcp_comm_backend.py
+++ b/test/registered/unit/test_triton_dcp_comm_backend.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sglang.srt.layers.attention.triton_backend import _reduce_dcp_mha_output
+
+
+@pytest.mark.parametrize("backend", ["a2a", "fi_a2a"])
+@patch("sglang.srt.layers.attention.triton_backend.cp_lse_ag_out_rs_mha")
+@patch("sglang.srt.layers.attention.triton_backend.dcp_a2a_lse_reduce")
+def test_dcp_mha_routes_a2a_backends(a2a_reduce, ag_rs_reduce, backend):
+    attn_output = MagicMock()
+    attn_lse = MagicMock()
+    group = MagicMock()
+    expected = MagicMock()
+    a2a_reduce.return_value = expected
+
+    result = _reduce_dcp_mha_output(attn_output, attn_lse, group, backend)
+
+    assert result is expected
+    a2a_reduce.assert_called_once_with(
+        attn_output,
+        attn_lse,
+        group,
+        is_lse_base_on_e=True,
+        comm_backend=backend,
+    )
+    ag_rs_reduce.assert_not_called()
+
+
+@patch("sglang.srt.layers.attention.triton_backend.cp_lse_ag_out_rs_mha")
+@patch("sglang.srt.layers.attention.triton_backend.dcp_a2a_lse_reduce")
+def test_dcp_mha_routes_ag_rs_by_default(a2a_reduce, ag_rs_reduce):
+    attn_output = MagicMock()
+    attn_lse = MagicMock()
+    group = MagicMock()
+    expected = MagicMock()
+    ag_rs_reduce.return_value = expected
+
+    result = _reduce_dcp_mha_output(attn_output, attn_lse, group, "ag_rs")
+
+    assert result is expected
+    ag_rs_reduce.assert_called_once_with(attn_output, attn_lse, group)
+    a2a_reduce.assert_not_called()


### PR DESCRIPTION
## Motivation

`--dcp-comm-backend a2a` was implemented for MLA decode, but Triton MHA decode ignored the setting and always used `cp_lse_ag_out_rs_mha`. As a result, enabling A2A for Qwen3.5 DCP was a silent no-op.

This PR makes Triton MHA honor the configured DCP reduction backend. During 8xMI355X validation, repeated CUDA-graph replay at high concurrency also exposed an RCCL deadlock in grouped self-send/self-recv. The local all-to-all chunk is now handled by a stream-ordered D2D copy, while remote chunks continue to use grouped RCCL P2P.

## Modifications

- Route Triton MHA DCP decode through:
  - `dcp_a2a_lse_reduce(..., is_lse_base_on_e=True)` for `a2a` and `fi_a2a`.
  - The existing `cp_lse_ag_out_rs_mha` path for the default `ag_rs` backend.
- Cache `dcp_comm_backend` in `TritonAttnBackend` during initialization.
- Skip RCCL self-send/self-recv in `PyNcclCommunicator.all_to_all_single` and copy the local chunk directly on the current stream.
- Add unit coverage verifying MHA routing for `ag_rs`, `a2a`, and `fi_a2a`.

The change is opt-in: the default remains `--dcp-comm-backend ag_rs`.

## Accuracy Tests

Hardware/model configuration:

- 8x AMD MI355X (gfx950)
- `Qwen/Qwen3.5-397B-A17B-FP8`
- TP8, DCP2, Triton attention
- GSM8K full 1,319 questions, 5-shot, concurrency 256

| DCP backend | Accuracy | Invalid rate | Result |
| --- | ---: | ---: | --- |
| `ag_rs` | 0.956 | 0.009 | PASS |
| `a2a` | 0.946 | 0.011 | PASS |

Both results exceed the existing Qwen3.5 Triton DCP accuracy threshold of 0.90.

Regression tests:

```bash
python3 -m pytest -q \
  test/registered/kernels/test_dcp_lse_combine.py \
  test/registered/unit/test_triton_dcp_comm_backend.py
```

Result: `24 passed`.

A concurrency-256 stress run (1,024 input / 16 output, 256 prompts) completed all 256 requests after the self-copy fix. Before the fix, the same high-concurrency path could deadlock during CUDA-graph replay.

## Speed Tests and Profiling

Single-request long-context benchmark, 1,000 output tokens, fresh server per backend. Positive throughput delta and negative TPOT delta favor A2A.

| Input | `ag_rs` total tok/s | `a2a` total tok/s | Throughput delta | `ag_rs` TPOT | `a2a` TPOT | TPOT delta |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 32k | 2,874.56 | 2,921.11 | +1.62% | 10.76 ms | 10.58 ms | -1.67% |
| 64k | 4,586.61 | 4,647.90 | +1.34% | 12.47 ms | 12.29 ms | -1.48% |
| 128k | 6,375.46 | 6,429.95 | +0.85% | 15.93 ms | 15.73 ms | -1.26% |
| 256k | 7,394.06 | 7,427.16 | +0.45% | 22.86 ms | 22.66 ms | -0.87% |

The 64k row is the mean of two counterbalanced fresh-server pairs. A shaped decode profile confirms one A2A reduction on each of Qwen3.5's 15 full-attention layers. The end-to-end gain decreases at longer input lengths because prefill increasingly dominates while this change targets decode reduction.

## Checklist

- [ ] Format code with pre-commit (CI lint pending).
- [x] Add unit tests.
- [x] Documentation is not required; this wires an existing public server argument into Triton MHA.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Get approvals from CODEOWNERS and other reviewers.
2. Trigger the relevant AMD/Qwen3.5 DCP CI after lint passes.
3. Merge after required checks and reviews are green.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30500810762](https://github.com/sgl-project/sglang/actions/runs/30500810762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30500996065](https://github.com/sgl-project/sglang/actions/runs/30500996065)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->