### PR TITLE
Add diffusion cookbook model tags

### DIFF
--- a/docs_new/cookbook/diffusion/Cosmos/Cosmos3.mdx
+++ b/docs_new/cookbook/diffusion/Cosmos/Cosmos3.mdx
@@ -4,6 +4,10 @@ metatags:
     description: "Serve NVIDIA Cosmos3 image, video, sound, and action generation with SGLang Diffusion."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["image", "video", "sound/action", "world model", "policy"]} />
+
 ## 1. Model Introduction
 
 [NVIDIA Cosmos3](https://huggingface.co/collections/nvidia/cosmos3) is an omnimodal world-model family for image, video, sound, and action generation. SGLang Diffusion serves the public checkpoints with the native `Cosmos3OmniDiffusersPipeline`.

--- a/docs_new/cookbook/diffusion/Ernie-Image/Ernie-Image.mdx
+++ b/docs_new/cookbook/diffusion/Ernie-Image/Ernie-Image.mdx
@@ -4,6 +4,10 @@ metatags:
     description: "Deploy ERNIE-Image and ERNIE-Image-Turbo with SGLang Diffusion."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["image", "text-to-image", "turbo"]} />
+
 ## 1. Model introduction
 
 [ERNIE-Image](https://huggingface.co/baidu/ERNIE-Image) is Baidu's text-to-image diffusion model family. SGLang Diffusion supports both the regular and Turbo checkpoints with the native `ErnieImagePipeline`.

--- a/docs_new/cookbook/diffusion/FLUX/FLUX.mdx
+++ b/docs_new/cookbook/diffusion/FLUX/FLUX.mdx
@@ -4,7 +4,10 @@ metatags:
     description: "Deploy FLUX diffusion models with SGLang - 12B/32B rectified flow transformers for high-quality text-to-image generation."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { FluxDeployment } from '/src/snippets/diffusion/flux-deployment.jsx';
+
+<DiffusionModelTags tags={["image", "text-to-image", "image editing", "multi-reference"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/Ideogram/Ideogram4.mdx
+++ b/docs_new/cookbook/diffusion/Ideogram/Ideogram4.mdx
@@ -4,6 +4,10 @@ metatags:
     description: "Deploy Ideogram 4 with SGLang Diffusion for high-aesthetic text-to-image generation."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["image", "text-to-image", "typography", "NF4/FP8/NVFP4"]} />
+
 ## 1. Model introduction
 
 [Ideogram 4](https://huggingface.co/ideogram-ai/ideogram-4-nf4) is Ideogram's text-to-image diffusion model. SGLang Diffusion supports the official NF4 and FP8 checkpoints, the Comfy-Org NVFP4 transformer checkpoint, and fal's single-branch Fast and Instant variants.

--- a/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
+++ b/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
@@ -5,6 +5,10 @@ metatags:
     description: "Deploy and use JoyAI-Echo long-form audio–video generation with SGLang Diffusion, including single-shot and multi-shot memory-bank workflows."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["video", "audio-video", "multi-shot", "memory bank"]} />
+
 ## 1. Model Introduction
 
 [JoyAI-Echo](https://huggingface.co/jdopensource/JoyAI-Echo) (JoyEcho) is a long-form audio–video generation model built on the LTX-2 backbone. Its core idea is a **paired audio–video memory bank**: each shot commits decoded frames and audio latents into a rolling bank, and subsequent shots condition on that memory prefix. This enables **multi-shot, minute-scale generation** with visual and audio continuity across prompts.

--- a/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
+++ b/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
@@ -7,7 +7,7 @@ metatags:
 
 import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 
-<DiffusionModelTags pullUp={true} tags={["video", "audio-video", "multi-shot", "memory bank"]} />
+<DiffusionModelTags tags={["video", "audio-video", "multi-shot", "memory bank"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
+++ b/docs_new/cookbook/diffusion/JoyEcho/JoyEcho.mdx
@@ -7,7 +7,7 @@ metatags:
 
 import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 
-<DiffusionModelTags tags={["video", "audio-video", "multi-shot", "memory bank"]} />
+<DiffusionModelTags pullUp={true} tags={["video", "audio-video", "multi-shot", "memory bank"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/Krea/Krea-2.mdx
+++ b/docs_new/cookbook/diffusion/Krea/Krea-2.mdx
@@ -4,6 +4,10 @@ metatags:
     description: "Deploy Krea-2 with SGLang - fast, high-quality text-to-image generation."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["image", "text-to-image", "turbo", "raw"]} />
+
 ## 1. Model Introduction
 
 [Krea-2](https://huggingface.co/krea/Krea-2-Turbo) is a high-quality text-to-image diffusion model from [Krea](https://www.krea.ai/). It ships in two variants that share the same backbone and differ only in their sampling recipe:

--- a/docs_new/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
+++ b/docs_new/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
@@ -5,7 +5,10 @@ metatags:
     description: "Deploy and use LTX-2 and LTX-2.3 video generation models with SGLang Diffusion, including one-stage, two-stage, HQ, TI2V, and LoRA examples."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { LTXDeployment } from '/src/snippets/diffusion/ltx-deployment.jsx';
+
+<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "two-stage"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
+++ b/docs_new/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
@@ -8,7 +8,7 @@ metatags:
 import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { LTXDeployment } from '/src/snippets/diffusion/ltx-deployment.jsx';
 
-<DiffusionModelTags pullUp={true} tags={["video", "text-to-video", "image-to-video", "two-stage"]} />
+<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "two-stage"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
+++ b/docs_new/cookbook/diffusion/LTX/LTX2 & LTX2.3.mdx
@@ -8,7 +8,7 @@ metatags:
 import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { LTXDeployment } from '/src/snippets/diffusion/ltx-deployment.jsx';
 
-<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "two-stage"]} />
+<DiffusionModelTags pullUp={true} tags={["video", "text-to-video", "image-to-video", "two-stage"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/LingBot-World/LingBot-World-2.0.mdx
+++ b/docs_new/cookbook/diffusion/LingBot-World/LingBot-World-2.0.mdx
@@ -5,11 +5,9 @@ metatags:
 tag: REALTIME
 ---
 
-<div className="not-prose" style={{display: "flex", flexWrap: "wrap", gap: "6px", margin: "8px 0 30px"}}>
-  <span style={{display: "inline-block", padding: "4px 9px", borderRadius: "999px", background: "#ecfeff", color: "#155e75", fontSize: "12px", fontWeight: 750}}>realtime</span>
-  <span style={{display: "inline-block", padding: "4px 9px", borderRadius: "999px", background: "#ecfeff", color: "#155e75", fontSize: "12px", fontWeight: 750}}>world model</span>
-  <span style={{display: "inline-block", padding: "4px 9px", borderRadius: "999px", background: "#ecfeff", color: "#155e75", fontSize: "12px", fontWeight: 750}}>causal DiT</span>
-</div>
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["realtime", "world model", "causal DiT", "camera control"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/LingBot-World/LingBot-World.mdx
+++ b/docs_new/cookbook/diffusion/LingBot-World/LingBot-World.mdx
@@ -5,11 +5,9 @@ metatags:
 tag: REALTIME
 ---
 
-<div className="not-prose" style={{display: "flex", flexWrap: "wrap", gap: "6px", margin: "8px 0 30px"}}>
-  <span style={{display: "inline-block", padding: "4px 9px", borderRadius: "999px", background: "#ecfeff", color: "#155e75", fontSize: "12px", fontWeight: 750}}>realtime</span>
-  <span style={{display: "inline-block", padding: "4px 9px", borderRadius: "999px", background: "#ecfeff", color: "#155e75", fontSize: "12px", fontWeight: 750}}>world model</span>
-  <span style={{display: "inline-block", padding: "4px 9px", borderRadius: "999px", background: "#ecfeff", color: "#155e75", fontSize: "12px", fontWeight: 750}}>causal DiT</span>
-</div>
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["realtime", "world model", "causal DiT", "camera control"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
+++ b/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
@@ -5,7 +5,7 @@ description: "Serve LongLive 2.0 distilled text-to-video and image-to-video mode
 
 import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 
-<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "few-step", "multi-shot"]} />
+<DiffusionModelTags pullUp={true} tags={["video", "text-to-video", "image-to-video", "few-step", "multi-shot"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
+++ b/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
@@ -1,7 +1,6 @@
 ---
 title: LongLive 2.0
 description: "Serve LongLive 2.0 distilled text-to-video and image-to-video models with SGLang-diffusion."
-tag: NEW
 ---
 
 import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';

--- a/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
+++ b/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
@@ -5,7 +5,7 @@ description: "Serve LongLive 2.0 distilled text-to-video and image-to-video mode
 
 import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 
-<DiffusionModelTags pullUp={true} tags={["video", "text-to-video", "image-to-video", "few-step", "multi-shot"]} />
+<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "few-step", "multi-shot"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
+++ b/docs_new/cookbook/diffusion/LongLive/LongLive-2.0.mdx
@@ -4,6 +4,10 @@ description: "Serve LongLive 2.0 distilled text-to-video and image-to-video mode
 tag: NEW
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "few-step", "multi-shot"]} />
+
 ## 1. Model Introduction
 
 [LongLive 2.0](https://nvlabs.github.io/LongLive/LongLive2/) is a distilled few-step text-to-video and image-to-video model from NVIDIA, built on Wan2.2-TI2V-5B. SGLang serves the Diffusers-format conversion for single-prompt and multi-shot video generation.

--- a/docs_new/cookbook/diffusion/MOVA/MOVA.mdx
+++ b/docs_new/cookbook/diffusion/MOVA/MOVA.mdx
@@ -4,6 +4,10 @@ metatags:
     description: "Deploy MOVA with SGLang - simultaneous video and audio generation with asymmetric dual-tower architecture, precise lip-sync, and environment-aware sound effects."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["video", "audio-video", "lip-sync", "environment audio"]} />
+
 ## 1. Model Introduction
 
 [MOVA](https://github.com/OpenMOSS/MOVA) (MOSS Video and Audio) is a foundation model developed by the SII-OpenMOSS Team, designed to break the "silent era" of open-source video generation. Unlike cascaded pipelines that generate sound as an afterthought, MOVA synthesizes video and audio simultaneously in a single inference pass for perfect alignment. It adopts an Asymmetric Dual-Tower Architecture, fusing pre-trained video and audio towers through a bidirectional cross-attention mechanism to maintain tight synchronization between video and audio during generation.

--- a/docs_new/cookbook/diffusion/Qwen-Image/Qwen-Image-Edit.mdx
+++ b/docs_new/cookbook/diffusion/Qwen-Image/Qwen-Image-Edit.mdx
@@ -4,7 +4,10 @@ metatags:
     description: "Deploy Qwen-Image-Edit-2511 with SGLang - 20B image editing model with text rendering, character consistency, and geometric reasoning."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { QwenImageEditDeployment } from '/src/snippets/diffusion/qwen-image-edit-deployment.jsx';
+
+<DiffusionModelTags tags={["image", "image editing", "text rendering", "character consistency"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/Qwen-Image/Qwen-Image.mdx
+++ b/docs_new/cookbook/diffusion/Qwen-Image/Qwen-Image.mdx
@@ -4,7 +4,10 @@ metatags:
     description: "Deploy Qwen-Image with SGLang - community contribution guide for Qwen's image generation model."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { QwenImageDeployment } from '/src/snippets/diffusion/qwen-image-deployment.jsx';
+
+<DiffusionModelTags tags={["image", "text-to-image", "text rendering", "NVFP4"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/SANA-WM/SANA-WM.mdx
+++ b/docs_new/cookbook/diffusion/SANA-WM/SANA-WM.mdx
@@ -4,6 +4,10 @@ metatags:
     description: "Deploy SANA-WM with SGLang - a camera-controlled text+image-to-video world model with WASD/IJKL 6-DoF camera control, served three ways: dense bidirectional and chunk-causal batch streaming over /v1/videos (SanaWMTwoStagePipeline), and live over a realtime WebSocket API (SanaWMRealtimePipeline, /v1/realtime_video/generate)."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
+
+<DiffusionModelTags tags={["video", "realtime", "world model", "camera control", "two-stage"]} />
+
 ## 1. Model Introduction
 
 [SANA-WM](https://huggingface.co/Efficient-Large-Model/SANA-WM_bidirectional) is an efficient open-source **world model** from NVLabs, trained natively for one-minute video generation. It is a **2.6B-parameter text+image-to-video (TI2V) diffusion transformer** that synthesizes **720p, minute-scale videos with precise 6-DoF camera control**, paired with an **LTX-2 refiner** for high-fidelity decoding. It builds on the [SANA](https://github.com/NVlabs/Sana) family — efficient high-resolution synthesis with a linear diffusion transformer.

--- a/docs_new/cookbook/diffusion/Wan/Wan2.1.mdx
+++ b/docs_new/cookbook/diffusion/Wan/Wan2.1.mdx
@@ -4,7 +4,10 @@ metatags:
     description: "Deploy Wan2.1 video generation models with SGLang - community contribution guide for Wan Video's diffusion models."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { Wan21Deployment } from '/src/snippets/diffusion/wan21-deployment.jsx';
+
+<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "LoRA", "text rendering"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/Wan/Wan2.2.mdx
+++ b/docs_new/cookbook/diffusion/Wan/Wan2.2.mdx
@@ -4,7 +4,10 @@ metatags:
     description: "Deploy Wan2.2 video generation models with SGLang - MoE architecture, cinematic aesthetics, and efficient 720P@24fps generation."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { Wan22Deployment } from '/src/snippets/diffusion/wan22-deployment.jsx';
+
+<DiffusionModelTags tags={["video", "text-to-video", "image-to-video", "TI2V", "MoE"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/cookbook/diffusion/Z-Image/Z-Image-Turbo.mdx
+++ b/docs_new/cookbook/diffusion/Z-Image/Z-Image-Turbo.mdx
@@ -4,7 +4,10 @@ metatags:
     description: "Deploy Z-Image-Turbo with SGLang - community contribution guide for Z-Image's fast image generation model."
 ---
 
+import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 import { ZImageTurboDeployment } from '/src/snippets/diffusion/zimage-turbo-deployment.jsx';
+
+<DiffusionModelTags tags={["image", "text-to-image", "turbo", "8-step"]} />
 
 ## 1. Model Introduction
 

--- a/docs_new/custom.css
+++ b/docs_new/custom.css
@@ -168,7 +168,11 @@ html.dark table tbody tr:nth-child(even) td,
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  margin: -2.75rem 0 0;
+  margin: 2px 0 0;
+}
+
+.sgd-model-tags--pull-up {
+  margin-top: -1.25rem;
 }
 
 .sgd-model-tags .sgd-chip {

--- a/docs_new/custom.css
+++ b/docs_new/custom.css
@@ -168,7 +168,7 @@ html.dark table tbody tr:nth-child(even) td,
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  margin: 2px 0 0;
+  margin: -2.75rem 0 0;
 }
 
 .sgd-model-tags .sgd-chip {

--- a/docs_new/custom.css
+++ b/docs_new/custom.css
@@ -180,7 +180,8 @@ html.dark table tbody tr:nth-child(even) td,
 }
 
 .prose:has(.sgd-model-tags) {
-  overflow-x: hidden;
+  overflow-x: clip;
+  overflow-y: visible;
 }
 
 .sgd-muted {

--- a/docs_new/custom.css
+++ b/docs_new/custom.css
@@ -179,6 +179,10 @@ html.dark table tbody tr:nth-child(even) td,
   margin-top: 0.75rem;
 }
 
+.prose:has(.sgd-model-tags) {
+  overflow-x: hidden;
+}
+
 .sgd-muted {
   color: rgb(107, 114, 128);
   font-size: 0.85rem;

--- a/docs_new/custom.css
+++ b/docs_new/custom.css
@@ -163,6 +163,17 @@ html.dark table tbody tr:nth-child(even) td,
   line-height: 1.45;
 }
 
+.sgd-model-tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 4px 0 8px;
+}
+
+.sgd-model-tags + h2 {
+  margin-top: 1.25rem;
+}
+
 .sgd-muted {
   color: rgb(107, 114, 128);
   font-size: 0.85rem;

--- a/docs_new/custom.css
+++ b/docs_new/custom.css
@@ -168,11 +168,7 @@ html.dark table tbody tr:nth-child(even) td,
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  margin: 2px 0 0;
-}
-
-.sgd-model-tags--pull-up {
-  margin-top: -1.25rem;
+  margin: -1.5rem 0 0;
 }
 
 .sgd-model-tags .sgd-chip {

--- a/docs_new/custom.css
+++ b/docs_new/custom.css
@@ -167,11 +167,16 @@ html.dark table tbody tr:nth-child(even) td,
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin: 4px 0 8px;
+  gap: 6px;
+  margin: 2px 0 0;
+}
+
+.sgd-model-tags .sgd-chip {
+  margin: 0;
 }
 
 .sgd-model-tags + h2 {
-  margin-top: 1.25rem;
+  margin-top: 0.75rem;
 }
 
 .sgd-muted {

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1188,7 +1188,6 @@
                   "cookbook/diffusion/intro",
                   {
                     "group": "Cosmos",
-                    "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/Cosmos/Cosmos3"
                     ]
@@ -1201,7 +1200,6 @@
                   },
                   {
                     "group": "Ideogram",
-                    "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/Ideogram/Ideogram4"
                     ]
@@ -1215,7 +1213,6 @@
                   },
                   {
                     "group": "LongLive",
-                    "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/LongLive/LongLive-2.0"
                     ]
@@ -1228,7 +1225,6 @@
                   },
                   {
                     "group": "JoyAI-Echo",
-                    "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/JoyEcho/JoyEcho"
                     ]
@@ -1248,7 +1244,6 @@
                   },
                   {
                     "group": "Krea",
-                    "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/Krea/Krea-2"
                     ]
@@ -1267,7 +1262,6 @@
                   },
                   {
                     "group": "LingBot World",
-                    "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/LingBot-World/LingBot-World",
                       "cookbook/diffusion/LingBot-World/LingBot-World-2.0"
@@ -1275,7 +1269,6 @@
                   },
                   {
                     "group": "SANA-WM",
-                    "tag": "NEW",
                     "pages": [
                       "cookbook/diffusion/SANA-WM/SANA-WM"
                     ]

--- a/docs_new/src/snippets/diffusion/model-tags.jsx
+++ b/docs_new/src/snippets/diffusion/model-tags.jsx
@@ -2,28 +2,9 @@ export const DiffusionModelTags = ({ tags = [] }) => {
   const normalizedTags = Array.isArray(tags) ? tags : [tags];
 
   return (
-    <div
-      className="not-prose"
-      style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: '6px',
-        margin: '8px 0 30px',
-      }}
-    >
+    <div className="not-prose sgd-model-tags">
       {normalizedTags.map((tag) => (
-        <span
-          key={tag}
-          style={{
-            display: 'inline-block',
-            padding: '4px 9px',
-            borderRadius: '999px',
-            background: '#ecfeff',
-            color: '#155e75',
-            fontSize: '12px',
-            fontWeight: 750,
-          }}
-        >
+        <span key={tag} className="sgd-chip">
           {tag}
         </span>
       ))}

--- a/docs_new/src/snippets/diffusion/model-tags.jsx
+++ b/docs_new/src/snippets/diffusion/model-tags.jsx
@@ -1,0 +1,32 @@
+export const DiffusionModelTags = ({ tags = [] }) => {
+  const normalizedTags = Array.isArray(tags) ? tags : [tags];
+
+  return (
+    <div
+      className="not-prose"
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '6px',
+        margin: '8px 0 30px',
+      }}
+    >
+      {normalizedTags.map((tag) => (
+        <span
+          key={tag}
+          style={{
+            display: 'inline-block',
+            padding: '4px 9px',
+            borderRadius: '999px',
+            background: '#ecfeff',
+            color: '#155e75',
+            fontSize: '12px',
+            fontWeight: 750,
+          }}
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/docs_new/src/snippets/diffusion/model-tags.jsx
+++ b/docs_new/src/snippets/diffusion/model-tags.jsx
@@ -1,9 +1,8 @@
-export const DiffusionModelTags = ({ tags = [], pullUp = false }) => {
+export const DiffusionModelTags = ({ tags = [] }) => {
   const normalizedTags = Array.isArray(tags) ? tags : [tags];
-  const className = `not-prose sgd-model-tags${pullUp ? ' sgd-model-tags--pull-up' : ''}`;
 
   return (
-    <div className={className}>
+    <div className="not-prose sgd-model-tags">
       {normalizedTags.map((tag) => (
         <span key={tag} className="sgd-chip">
           {tag}

--- a/docs_new/src/snippets/diffusion/model-tags.jsx
+++ b/docs_new/src/snippets/diffusion/model-tags.jsx
@@ -1,8 +1,9 @@
-export const DiffusionModelTags = ({ tags = [] }) => {
+export const DiffusionModelTags = ({ tags = [], pullUp = false }) => {
   const normalizedTags = Array.isArray(tags) ? tags : [tags];
+  const className = `not-prose sgd-model-tags${pullUp ? ' sgd-model-tags--pull-up' : ''}`;
 
   return (
-    <div className="not-prose sgd-model-tags">
+    <div className={className}>
       {normalizedTags.map((tag) => (
         <span key={tag} className="sgd-chip">
           {tag}


### PR DESCRIPTION
## Summary

- Add a shared `DiffusionModelTags` snippet for compact model metadata chips.
- Add top-of-page tags across SGLang-Diffusion cookbook model recipes.
- Replace LingBot World inline tag markup with the shared snippet.

## Notes

This keeps the cookbook overview and sidebar structure unchanged while making each model page surface modality and key capabilities more consistently.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30506089382](https://github.com/sgl-project/sglang/actions/runs/30506089382)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30506089224](https://github.com/sgl-project/sglang/actions/runs/30506089224)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->