### PR TITLE
Remove template note from documentation guide

### DIFF
--- a/docs_new/CONTRIBUTING.md
+++ b/docs_new/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-> **Customize this file**: Tailor this template to your project by noting specific contribution types you're looking for, adding a Code of Conduct, or adjusting the writing guidelines to match your style.
-
 # Contribute to the documentation
 
 Thank you for your interest in contributing to our documentation! This guide will help you get started.


### PR DESCRIPTION
## Motivation

The documentation contribution guide still begins with the Mintlify template instruction to customize the file. This note is intended for maintainers preparing a template, not for contributors reading the finished guide.

## Modifications

Remove the template note so the page starts with the documentation contribution heading.

## Accuracy Tests

Not applicable; documentation only. Verified that the guide starts with its H1 and no longer contains the template instruction. `git diff --check` passes.

## Speed Tests and Profiling

Not applicable; documentation only.

## Checklist

- [x] Update documentation
- [x] Follow the documentation writing guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30505626767](https://github.com/sgl-project/sglang/actions/runs/30505626767)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30505626680](https://github.com/sgl-project/sglang/actions/runs/30505626680)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->