### PR TITLE
fix(server_args): correct false "no_buffer is the default" claim for --enable-linear-replayssm

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2531,7 +2531,10 @@ class ServerArgs:
         "baseline (the per-K g_cache is K x larger and the reconstruction "
         "refolds the per-K decay every step), so it is not recommended for KDA "
         "models. Requires the Triton linear-attn decode backend and "
-        "--mamba-radix-cache-strategy no_buffer (the default).",
+        "--mamba-radix-cache-strategy no_buffer, which must be set "
+        "explicitly: the flag default 'auto' resolves to extra_buffer when "
+        "overlap scheduling is on (the common case), and the extra_buffer "
+        "donation path is not yet supported.",
         NS("exec.mamba"),
     ] = False
     linear_replayssm_cache_len: A[
@@ -5994,8 +5997,10 @@ class ServerArgs:
             if mamba_extra_buffer_of(resolved_view(self)):
                 raise ValueError(
                     "--enable-linear-replayssm requires --mamba-radix-cache-strategy "
-                    "no_buffer (the default); the extra_buffer ping-pong "
-                    "donation path is not yet supported (follow-up). Got "
+                    "no_buffer set explicitly; the flag default 'auto' resolves "
+                    "to extra_buffer when overlap scheduling is on, and the "
+                    "extra_buffer ping-pong donation path is not yet supported "
+                    "(follow-up). Got "
                     f"--mamba-radix-cache-strategy={self.mamba_radix_cache_strategy!r}."
                 )
             if self.disaggregation_mode != "null":


### PR DESCRIPTION
## Motivation

The `--enable-linear-replayssm` help text and the flag's own validation error both describe `--mamba-radix-cache-strategy no_buffer` as "the default". That is not correct. The default of `--mamba-radix-cache-strategy` is `auto`, and `auto` resolves to `extra_buffer` whenever overlap scheduling is enabled, which is the default. The `--enable-linear-replayssm` validation then rejects `extra_buffer` (the ping-pong donation path is a follow-up), so a user who reads the help, trusts that `no_buffer` is already the default, and leaves everything at defaults will hit the validation error. The error message they see repeats the same false "the default" claim, so it does not point them at the fix either.

## Modifications

Reword two user-facing strings in `python/sglang/srt/server_args.py`. The `--enable-linear-replayssm` help now says `no_buffer` must be set explicitly and explains that the `auto` default resolves to `extra_buffer` with overlap scheduling on. The validation error carries the same clarification instead of calling `no_buffer` the default. There is no behavior change; only the strings change.

## Accuracy Tests

Not applicable, this is a documentation and error-message wording fix with no behavior change. Confirmed the two strings were the only occurrences of the false phrasing and that no test pins them.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests. (N/A, wording-only change)
- [x] Update documentation as needed, including docstrings or example tutorials.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30506037162](https://github.com/sgl-project/sglang/actions/runs/30506037162)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30506037109](https://github.com/sgl-project/sglang/actions/runs/30506037109)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->