### PR TITLE
fix(moe): make MoeRunner's unsupported-a2a-backend error actionable

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -138,6 +138,15 @@ class FusedOpPool:
         fused_func = cls._fused_funcs.get(key)
         return fused_func
 
+    @classmethod
+    def a2a_backends_for(cls, runner_name: str) -> list[str]:
+        """The a2a backend names that have a fused func registered for
+        ``runner_name`` (sorted). Used to build an actionable error when a
+        fused-only runner is paired with an unsupported a2a backend."""
+        return sorted(
+            a2a for (a2a, runner) in cls._fused_funcs if runner == runner_name
+        )
+
 
 class PermuteMethodPool:
     _pre_permute_methods: dict[

--- a/python/sglang/srt/layers/moe/moe_runner/runner.py
+++ b/python/sglang/srt/layers/moe/moe_runner/runner.py
@@ -123,9 +123,18 @@ class MoeRunner:
             )
 
             if self.runner_core is None and self.fused_func is None:
+                supported = FusedOpPool.a2a_backends_for(runner_backend_name)
+                if supported:
+                    raise NotImplementedError(
+                        f"MoE runner backend {runner_backend_name!r} has no fused "
+                        f"func for a2a backend {a2a_backend_name!r}. Supported a2a "
+                        f"backend(s) for this runner: {supported}. Set "
+                        f"--moe-a2a-backend to one of them."
+                    )
                 raise NotImplementedError(
-                    f"Runner backend {runner_backend} requires a fused func for a2a backend "
-                    f"{a2a_backend_name}, but none is registered."
+                    f"MoE runner backend {runner_backend_name!r} has no fused func "
+                    f"for a2a backend {a2a_backend_name!r}, and none is registered "
+                    f"for any a2a backend, so it cannot run on the fused-only path."
                 )
 
         self.down_gemm_overlap_args: Optional[DownGemmOverlapArgs] = None


### PR DESCRIPTION
## Motivation

A fused-only MoE runner backend (marlin, hpc_ops) sets `runner_core = None`, so a fused func is its only execution route. When the resolved all-to-all backend has no fused func registered for that runner, `MoeRunner.__init__` raised a `NotImplementedError` that named neither the a2a backends the runner does support nor how to change the configuration:

```
NotImplementedError: Runner backend MoeRunnerBackend.MARLIN requires a fused func for a2a backend deepep, but none is registered.
```

This is reachable on SM90 (Hopper) with an MXFP4 MoE model under expert parallelism, where marlin is the available runner but the a2a backend resolves to `deepep`, while marlin only has a fused func for a2a `none`. The operator sees the crash deep inside runner construction with no hint about what to do.

This is another instance of the pattern described in #31774: an unsupported backend combination validated case by case, failing late and with an inconsistent, unactionable response. Here the axis is runner backend against a2a backend rather than backend against KV dtype or platform, which is why it is a small standalone message fix rather than part of the DSA table slice, but it moves this instance toward the response contract that RFC argues for, a raise that names the working alternatives.

## Modifications

Add `FusedOpPool.a2a_backends_for(runner_name)`, which returns the sorted a2a backend names that have a fused func registered for a given runner. Use it in `MoeRunner.__init__` to list the supported a2a backends in the error and point the user at `--moe-a2a-backend`. When nothing is registered for the runner at all, the message says so instead of implying a fix exists. No behavior change: the same runner and a2a combinations still fail, only the message improves.

## Accuracy Tests

Not applicable, this is an error-message and diagnostics change with no behavior change. The existing MoE runner tests under `test/manual/layers/moe/` require GPUs; there is no CPU-registered runner test home, so no unit test is added. The new helper is a pure filter over the fused-func registry.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests. (N/A, message-only change; runner tests are GPU-only)
- [x] Update documentation as needed, including docstrings or example tutorials.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30506039589](https://github.com/sgl-project/sglang/actions/runs/30506039589)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30506039450](https://github.com/sgl-project/sglang/actions/runs/30506039450)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->