### PR TITLE
[FIX] preserve embedding priority in batch slicing

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1121,6 +1121,7 @@ class EmbeddingReqInput:
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
                 http_worker_ipc=self.http_worker_ipc,
+                priority=self.priority,
                 return_pooled_hidden_states=self.return_pooled_hidden_states,
                 return_prompt_token_ids=self.return_prompt_token_ids,
                 multi_item_delimiter_indices=(
@@ -1148,6 +1149,7 @@ class EmbeddingReqInput:
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
                 http_worker_ipc=self.http_worker_ipc,
+                priority=self.priority,
                 dimensions=self.dimensions,
                 return_pooled_hidden_states=self.return_pooled_hidden_states,
                 return_prompt_token_ids=self.return_prompt_token_ids,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -634,6 +634,18 @@ class TestEmbeddingReqInputNormalization(CustomTestCase):
         self.assertEqual(req[0].priority, 7)
         self.assertEqual(req[1].priority, 7)
 
+    def test_getitem_preserves_priority_for_cross_encoder(self):
+        """Cross-encoder embedding subrequests must keep request priority."""
+        req = EmbeddingReqInput(
+            text=[["query 1", "document 1"], ["query 2", "document 2"]],
+            priority=7,
+            is_cross_encoder_request=True,
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].priority, 7)
+        self.assertEqual(req[1].priority, 7)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1,7 +1,7 @@
 import copy
 import unittest
 
-from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.test.ci.ci_register import (
     register_amd_ci,
     register_cpu_ci,
@@ -618,6 +618,21 @@ class TestGenerateReqInputNormalization(CustomTestCase):
                 text="Hello", input_ids=[1, 2, 3], input_embeds=[[0.1, 0.2]]
             )
             req.normalize_batch_and_arguments()
+
+
+class TestEmbeddingReqInputNormalization(CustomTestCase):
+    """Test the normalization of EmbeddingReqInput for batch processing."""
+
+    def test_getitem_preserves_priority(self):
+        """Batch embedding subrequests must keep request priority."""
+        req = EmbeddingReqInput(
+            text=["Hello", "World"],
+            priority=7,
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req[0].priority, 7)
+        self.assertEqual(req[1].priority, 7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Batched embedding requests currently lose their `priority` when
`EmbeddingReqInput.__getitem__` slices the batch into per-request objects.

The downstream embedding path already supports priority:

- `TokenizerManager._create_tokenized_object()` forwards `obj.priority` into
  `TokenizedEmbeddingReqInput`.
- `Scheduler.handle_embedding_request()` passes `recv_req.priority` into `Req`.

For batched requests, the tokenizer manager operates on `obj[i]`. Since
`EmbeddingReqInput.__getitem__` did not copy `priority`, batched embeddings were
silently scheduled with `priority=None`.

Fixes: https://github.com/sgl-project/sglang/issues/32844

## Modifications

- Preserve `EmbeddingReqInput.priority` in both `__getitem__` branches:
  normal embedding requests and cross-encoder embedding requests.
- Add unit regression coverage that verifies both normal and cross-encoder
  batched embedding subrequests keep the request priority.

## Accuracy Tests

Not applicable. This change only preserves request scheduling metadata for
batched embedding requests and does not change model computation or outputs.

## Speed Tests and Profiling

Not applicable. This adds no new work on the model execution path; it copies an
existing scalar field while constructing per-request objects.

## Tests

```text
pytest test/registered/unit/managers/test_io_struct.py::TestEmbeddingReqInputNormalization -q
2 passed

pre-commit run --files python/sglang/srt/managers/io_struct.py test/registered/unit/managers/test_io_struct.py
Passed
```

## Checklist

- [x] Format your code according to the SGLang pre-commit guidance.
- [x] Add unit tests according to the SGLang unit test guidance.
- [x] Update documentation if needed.
- [x] Provide accuracy and speed benchmark results where applicable.
- [x] Follow the SGLang code style guidance.