### PR TITLE
rocm: fix the aiter DSA MLA decode path for GLM5.2

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1332,7 +1332,15 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
 
     if not user_set_prefill and not user_set_decode and is_hip():
         declared["dsa_prefill_backend"] = "tilelang"
-        declared["dsa_decode_backend"] = "tilelang"
+        # ROCm decode default: aiter MLA. The aiter decode pair
+        # (aiter::mla_a8w8_qh16_qseqlen1_gqaratio16_ps + kn_mla_reduce_v1_ps)
+        # measures ~1.17 ms/iter faster at bs=64 on gfx950 than the tilelang
+        # sparse-MLA decode split/reduce pair. It needs an fp8_e4m3 KV cache
+        # (see DSABackend._prepare_aiter_dsa_decode_metadata), so every other
+        # KV dtype keeps tilelang. Override with --dsa-decode-backend tilelang.
+        declared["dsa_decode_backend"] = (
+            "aiter" if kv_cache_dtype == "fp8_e4m3" else "tilelang"
+        )
     elif kv_cache_dtype == "fp8_e4m3":
         # Blackwell FP8 defaults to trtllm; Hopper FP8 to flashmla_kv.
         default = "trtllm" if major >= 10 else "flashmla_kv"

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -2817,6 +2817,17 @@ class DeepseekSparseAttnBackend(
         kv_indices = self.kv_indices
         get_valid_kv_indices(page_table_1, kv_indptr, kv_indices, bs)
 
+        # aiter takes its batch count from kv_indptr's LENGTH, not from
+        # qo_indptr: get_mla_metadata_v1_0_device (aiter csrc/kernels/mla/
+        # metadata/v1_0_device.cuh) does `num_batches = seqlens_kv_indptr.size(0)
+        # - 1`. self.kv_indptr is a max_bs+1 capacity buffer, so handing it over
+        # whole makes the metadata kernel emit work items for every stale slot
+        # past bs, with qo_start = bid * uni_seqlen_qo running far past the end
+        # of q/o -- the persistent MLA kernel then reads and writes out of
+        # bounds (GPU memory access fault). cu_seqlens_q is already a [: bs + 1]
+        # view; kv_indptr has to match it.
+        kv_indptr = kv_indptr[: bs + 1]
+
         kv_last_page_lens = metadata.cu_seqlens_q
         if kv_cache.dtype == fp8_dtype:
             aiter_persistent_kwargs = self._prepare_aiter_dsa_decode_metadata(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -337,6 +337,7 @@ _DSA_IMPL_T: TypeAlias = Literal[
     "flashinfer_sparse_mla",
     "fa3",
     "tilelang",
+    "aiter",
     "trtllm",
 ]
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -23,6 +23,7 @@ from sglang.kernels.ops.attention.dsa.dequant_k_cache import (
     gather_dequant_requant_fp8_paged,
 )
 from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache
+from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 from sglang.kernels.ops.attention.dsa.transform_index import (
     transform_index_page_table_decode,
     transform_index_page_table_prefill,
@@ -133,6 +134,17 @@ else:
         flash_attn_varlen_func,
         flash_attn_with_kvcache,
     )
+
+
+def _aiter_mla_out_dtype(q_dtype: torch.dtype) -> torch.dtype:
+    """Output dtype for `aiter.mla.mla_decode_fwd`.
+
+    The callers below size their output buffer off q, but on the a8w8 path q is
+    fp8 while the attention output is not: aiter's reduce kernels
+    (`kn_mla_reduce_v1*`, aiter csrc/kernels/mla/reduce.cu) only instantiate
+    bf16 and fp16 `out_t` and hard-fail on anything else.
+    """
+    return torch.bfloat16 if q_dtype == fp8_dtype else q_dtype
 
 
 def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tensor:
@@ -437,10 +449,14 @@ class DeepseekSparseAttnBackend(
             if (
                 self.dsa_prefill_impl == "aiter" or self.dsa_decode_impl == "aiter"
             ) and model_runner.kv_cache_dtype == fp8_dtype:
+                # Warm the buffers with the dtype pair the forward will actually
+                # use, so no reallocation happens inside CUDA graph capture.
+                # With an fp8 KV cache the ROCm default routes q through
+                # `fused_qk_rope_cat_and_cache_mla`, which emits fp8 q.
                 self._ensure_aiter_dsa_decode_metadata_buffer(
                     max_seqlen_q=1,
                     batch_size=max_bs,
-                    q_dtype=torch.bfloat16,
+                    q_dtype=fp8_dtype,
                     kv_dtype=fp8_dtype,
                 )
 
@@ -585,6 +601,28 @@ class DeepseekSparseAttnBackend(
                 device=self.device,
             ),
         )
+
+    def _aiter_mla_scales(
+        self, q_dtype: torch.dtype, kv_dtype: torch.dtype
+    ) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+        """Scale pair for `aiter.mla.mla_decode_fwd`.
+
+        `mla_decode_stage1_asm_fwd` hard-requires BOTH scales once q is fp8 and
+        only kv_scale when q stays bf16 (aiter csrc/py_itfs_cu/asm_mla.cu). q is
+        fp8 whenever `fused_qk_rope_cat_and_cache_mla` produced it, which is the
+        default on ROCm with an fp8 KV cache -- that op already folds k_scale
+        into q, so q and kv share one fp8 domain and both scales are identity.
+        Same convention as the fp8 sparse-MLA prefill path
+        (`_forward_sparse_mla_q8kv8`, `_q8kv8_identity_scale`).
+        """
+        if q_dtype != fp8_dtype and kv_dtype != fp8_dtype:
+            return None, None
+        if self._q8kv8_identity_scale is None:
+            self._q8kv8_identity_scale = torch.tensor(
+                [1.0], dtype=torch.float32, device=self.device
+            )
+        identity = self._q8kv8_identity_scale
+        return (identity if q_dtype == fp8_dtype else None), identity
 
     def _ensure_aiter_dsa_decode_metadata_buffer(
         self,
@@ -2738,10 +2776,18 @@ class DeepseekSparseAttnBackend(
     ) -> torch.Tensor:
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
 
+        # The output buffer must not inherit q's dtype on the a8w8 path: aiter's
+        # reduce (kn_mla_reduce_v1*) only instantiates bf16/fp16 `out_t`
+        # (csrc/kernels/mla/reduce.cu), and an fp8 q carries its scale
+        # out-of-band anyway, so the attention output is never fp8.
+        out_dtype = _aiter_mla_out_dtype(q.dtype)
+
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+            o = q.new_empty(
+                (q.shape[0], layer.tp_q_head_num * layer.v_head_dim), dtype=out_dtype
+            )
         else:
-            o = torch.empty_like(q)
+            o = torch.empty_like(q, dtype=out_dtype)
 
         if self.need_pad_heads:
             q_kernel = q.view(
@@ -2752,17 +2798,15 @@ class DeepseekSparseAttnBackend(
                     q.shape[0],
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
+                dtype=out_dtype,
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
             o_kernel = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
 
-        q_scale = None
-        kv_scale = None
+        q_scale, kv_scale = self._aiter_mla_scales(q_kernel.dtype, kv_cache.dtype)
         aiter_persistent_kwargs = {}
-        if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
 
         kv_indptr = self.kv_indptr
 
@@ -2816,10 +2860,14 @@ class DeepseekSparseAttnBackend(
         num_tokens = q_all.shape[0]
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
 
+        out_dtype = _aiter_mla_out_dtype(q.dtype)
+
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((num_tokens, layer.tp_q_head_num * layer.v_head_dim))
+            o = q.new_empty(
+                (num_tokens, layer.tp_q_head_num * layer.v_head_dim), dtype=out_dtype
+            )
         else:
-            o = torch.empty_like(q)
+            o = torch.empty_like(q, dtype=out_dtype)
 
         if self.need_pad_heads:
             q_kernel = q.view(
@@ -2830,17 +2878,15 @@ class DeepseekSparseAttnBackend(
                     num_tokens,
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
+                dtype=out_dtype,
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
             o_kernel = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
 
-        q_scale = None
-        kv_scale = None
+        q_scale, kv_scale = self._aiter_mla_scales(q_kernel.dtype, kv_cache.dtype)
         aiter_persistent_kwargs = {}
-        if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
 
         non_minus1_mask = page_table_1 != -1
         non_minus1_counts = non_minus1_mask.sum(dim=1)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -23,7 +23,6 @@ from sglang.kernels.ops.attention.dsa.dequant_k_cache import (
     gather_dequant_requant_fp8_paged,
 )
 from sglang.kernels.ops.attention.dsa.quant_k_cache import quantize_k_cache
-from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 from sglang.kernels.ops.attention.dsa.transform_index import (
     transform_index_page_table_decode,
     transform_index_page_table_prefill,
@@ -34,6 +33,7 @@ from sglang.kernels.ops.attention.utils import (
     seqlens_expand_triton,
 )
 from sglang.kernels.ops.kvcache.cache_ops import concat_and_cast_q_fp8_pad
+from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.dsa.dsa_backend_mtp_precompute import (


### PR DESCRIPTION
The aiter option for --dsa-decode-backend has never been exercised on ROCm — the resolver in arg_groups/overrides.py forces both DSA backends to tilelang whenever the user doesn't set them explicitly, so DSABackend._forward_aiter was dead code. Selecting it manually crashes. This PR makes the path functional. Three defects, each of which aborts the server during init_cuda_graphs:

1. fp8 Q is never given its scale. On ROCm with an fp8 KV cache, _skip_rope_for_dsa_tilelang_fused() routes Q through fused_qk_rope_cat_and_cache_mla(..., q_out_dtype=fp8_dtype), so Q reaches the kernel as fp8. _forward_aiter hardcoded q_scale = None and populated only kv_scale, tripping aiter's contract in asm_mla.cu (fp8 Q requires q_scale and kv_scale). Replaced with a _aiter_mla_scales() helper that returns the correct pair for each (q_dtype, kv_dtype) combination, reusing the identity-scale tensor already established for the fp8 prefill path. Behaviour for bf16 Q is unchanged.

2. The output buffer inherits Q's dtype. o was allocated with q.new_empty(...), which yields an fp8 output tensor on the a8w8 path. aiter's reduce kernels (kn_mla_reduce_v1*, csrc/kernels/mla/reduce.cu) only instantiate out_t for bf16 and fp16 and hard-fail on anything else. Added _aiter_mla_out_dtype(), which maps fp8 to bf16 and passes every other dtype through. This matches ATOM's reference caller, which allocates its MLA output in model dtype rather than Q dtype.

3. kv_indptr is passed at full buffer capacity. aiter derives its batch count from the length of kv_indptr, not from qo_indptr — get_mla_metadata_v1_0_device does num_batches = seqlens_kv_indptr.size(0) - 1. _forward_aiter handed over self.kv_indptr, a max_bs + 1 capacity buffer, while cu_seqlens_q was already a [: bs + 1] view. The metadata kernel therefore emitted work items for every stale slot past bs, with qo_start = bid * uni_seqlen_qo running far past the end of Q and O, and the persistent kernel (mla_a8w8_qh16_qseqlen1_gqaratio16_ps) faulted with an out-of-bounds access on all TP ranks. Fixed by slicing to [: bs + 1]. _forward_aiter_extend allocates an exactly-sized kv_indptr and is unaffected.

Also warms the decode metadata buffers with the fp8 Q dtype so they aren't reallocated inside CUDA graph capture.

Scope. All changes are confined to _forward_aiter / _forward_aiter_extend and are no-ops unless a DSA backend is set to aiter. The tilelang, flashmla_*, trtllm, and fa3 paths call different functions and are untouched.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30581260509](https://github.com/sgl-project/sglang/actions/runs/30581260509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30581260212](https://github.com/sgl-project/sglang/actions/runs/30581260212)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->