### PR TITLE
[Fix] Validate structural_tag mutual exclusivity in SamplingParams.verify()

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -196,9 +196,10 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
             self.json_schema,
             self.regex,
             self.ebnf,
+            self.structural_tag,
         ]  # since mutually exclusive, only one can be set
         if sum(x is not None for x in grammars) > 1:
-            raise ValueError("Only one of regex, json_schema, or ebnf can be set.")
+            raise ValueError("Only one of regex, json_schema, ebnf, or structural_tag can be set.")
 
     def normalize(self, tokenizer):
         # Process stop strings


### PR DESCRIPTION
## Summary

Fixes #31680

## Problem

SamplingParams.verify() rejects combining regex + json_schema + ebnf with each other, but never checks structural_tag against the other three. A request setting structural_tag together with regex/ebnf/json_schema is accepted without error, and structural_tag is silently dropped by the grammar-selection logic.

## Root Cause

structural_tag was added in #3566 after the grammars check was introduced in #2526. grammar_manager.py was updated but sampling_params.py was never updated.

## Fix

Added self.structural_tag to the grammars list in verify() and updated the error message to include "or structural_tag".

## File Changed

- python/sglang/srt/sampling/sampling_params.py

## Related

- Closes #31680

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30508584245](https://github.com/sgl-project/sglang/actions/runs/30508584245)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30508584147](https://github.com/sgl-project/sglang/actions/runs/30508584147)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->