### PR TITLE
[Fix] Propagate priority in EmbeddingReqInput.__getitem__ for batched requests

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1107,6 +1107,7 @@ class EmbeddingReqInput:
                 text=[self.text[i]] if self.text is not None else None,
                 sampling_params=self.sampling_params[i],
                 is_cross_encoder_request=True,
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
@@ -1134,6 +1135,7 @@ class EmbeddingReqInput:
                     else None
                 ),
                 sampling_params=self.sampling_params[i],
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),


### PR DESCRIPTION
## Summary

Fixes #32844

## Problem

EmbeddingReqInput.__getitem__ does not preserve priority when a batched embedding request is split into per-request objects. Each subrequest falls back to None, so embedding batches submitted with a priority are scheduled as if no priority was provided.

This affects both normal embedding batches and cross-encoder embedding batches, because both branches in __getitem__ omit the field.

## Fix

Added priority=self.priority to both branches of __getitem__ (cross-encoder and normal).

## Reproduction

```python
req = EmbeddingReqInput(text=["hello", "world"], priority=7)
req.normalize_batch_and_arguments()
print(req[0].priority)  # Before: None, After: 7
print(req[1].priority)  # Before: None, After: 7
```

## File Changed

- python/sglang/srt/managers/io_struct.py

## Related

- Closes #32844

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30508687980](https://github.com/sgl-project/sglang/actions/runs/30508687980)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30508687787](https://github.com/sgl-project/sglang/actions/runs/30508687787)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->