### PR TITLE
[Bug Fix] Guard host-list token_ids_logprobs normalization

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -388,8 +388,11 @@ class SchedulerBatchResultProcessor:
                     x.tolist() for x in logits_output.next_token_top_logprobs_idx
                 ]
             if logits_output.next_token_token_ids_logprobs_val:
+                # Same contract as the D2H relay in managers/utils.py: entries
+                # may be host lists already (delayed-copy prefill-only reqs).
                 logits_output.next_token_token_ids_logprobs_val = [
-                    v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
+                    v.tolist() if torch.is_tensor(v) else v
+                    for v in logits_output.next_token_token_ids_logprobs_val
                 ]
 
     def _apply_prefill_logprobs(
@@ -793,8 +796,11 @@ class SchedulerBatchResultProcessor:
                 ]
 
             if logits_output.next_token_token_ids_logprobs_val:
+                # Same contract as the D2H relay in managers/utils.py: entries
+                # may be host lists already (delayed-copy prefill-only reqs).
                 logits_output.next_token_token_ids_logprobs_val = [
-                    v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
+                    v.tolist() if torch.is_tensor(v) else v
+                    for v in logits_output.next_token_token_ids_logprobs_val
                 ]
         return next_token_ids, next_token_logprobs
 

--- a/test/registered/unit/managers/test_batch_result_processor_token_ids_logprobs.py
+++ b/test/registered/unit/managers/test_batch_result_processor_token_ids_logprobs.py
@@ -1,0 +1,97 @@
+"""Unit tests for mixed host-list/tensor token_ids_logprobs normalization.
+
+``LogitsProcessorOutput.next_token_token_ids_logprobs_val`` is declared as
+``List[Union[List[float], torch.Tensor]]``: prefill-only requests can leave
+already-copied host lists in the field (delayed-copy optimization). Both
+normalization sites must tolerate the mix instead of crashing the scheduler
+event loop.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _SpecNone:
+    def is_none(self) -> bool:
+        return True
+
+
+def _make_processor() -> SchedulerBatchResultProcessor:
+    return SchedulerBatchResultProcessor(
+        is_generation=True,
+        disaggregation_mode=None,
+        enable_overlap=False,
+        enable_overlap_mlx=False,
+        server_args=SimpleNamespace(enable_metrics=False),
+        model_config=SimpleNamespace(think_end_id=None),
+        token_to_kv_pool_allocator=None,
+        tree_cache=None,
+        hisparse_coordinator=None,
+        req_to_token_pool=None,
+        decode_offload_manager=None,
+        metrics_collector=None,
+        metrics_reporter=SimpleNamespace(),
+        draft_worker=None,
+        model_worker=SimpleNamespace(on_verify_complete_cpu=lambda *a, **k: None),
+        logprob_result_processor=None,
+        output_streamer=SimpleNamespace(),
+        abort_request=lambda *a, **k: None,
+    )
+
+
+def _logits_output() -> SimpleNamespace:
+    return SimpleNamespace(
+        next_token_logprobs=torch.tensor([-0.5, -1.0]),
+        input_token_logprobs=None,
+        next_token_top_logprobs_val=[],
+        next_token_top_logprobs_idx=[],
+        next_token_token_ids_logprobs_val=[[-0.25, -2.0], torch.tensor([-0.75])],
+        next_token_token_ids_logprobs_idx=[[7, 11], [3]],
+    )
+
+
+class TestTokenIdsLogprobsHostLists(CustomTestCase):
+    def test_move_logprobs_to_cpu_tolerates_host_lists(self):
+        processor = _make_processor()
+        logits_output = _logits_output()
+        batch = SimpleNamespace(return_logprob=True)
+
+        processor.move_logprobs_to_cpu(batch=batch, logits_output=logits_output)
+
+        self.assertEqual(
+            logits_output.next_token_token_ids_logprobs_val,
+            [[-0.25, -2.0], [-0.75]],
+        )
+
+    def test_normalize_decode_outputs_tolerates_host_lists(self):
+        processor = _make_processor()
+        logits_output = _logits_output()
+        batch = SimpleNamespace(return_logprob=True, spec_algorithm=_SpecNone())
+
+        next_token_ids, next_token_logprobs = processor._normalize_decode_outputs(
+            batch=batch,
+            result=SimpleNamespace(),
+            logits_output=logits_output,
+            next_token_ids=torch.tensor([5, 9]),
+        )
+
+        self.assertEqual(next_token_ids, [[5], [9]])
+        self.assertEqual(next_token_logprobs, [-0.5, -1.0])
+        self.assertEqual(
+            logits_output.next_token_token_ids_logprobs_val,
+            [[-0.25, -2.0], [-0.75]],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang's `token_ids_logprob` path can produce mixed result rows: some are already Python host lists, while others remain tensors for asynchronous device-to-host copying. The result normalizer incorrectly assumed every row was a tensor and called `.tolist()` unconditionally.

We encountered this while validating the `only-teacher` Top-K path in [radixark/miles#1969](https://github.com/radixark/miles/pull/1969). After the teacher returns its Top-K candidates, Miles asks the student SGLang server to rescore those IDs with a prefill-only request (`return_logprob=true`, `max_new_tokens=0`, and `token_ids_logprob` populated). A valid host-list row then reaches the unconditional `.tolist()` call, raising `AttributeError: 'list' object has no attribute 'tolist'` and terminating the scheduler before it returns the requested scores.

The fix makes the final response boundary accept both valid representations: convert tensor rows with `.tolist()` and preserve rows that are already host lists. Since these values are already host-bound, converting lists back into tensors would only add a redundant list-to-tensor-to-list round trip.

## What's in this PR

- Convert tensor entries with `.tolist()`.
- Preserve entries that are already host lists.
- Apply the same normalization contract in the prefill and decode result paths.
- Add registered CPU regression coverage for mixed list/tensor values at both call sites.

This does not change requested scores, response schemas, device-copy policy, or requests that do not use `token_ids_logprob`.

## Validation

- Reproduced the scheduler failure with prefill-only arbitrary token-ID scoring requests on an NVIDIA H200 GPU cluster.
- Before the guard, the first affected rescore request consistently terminated the scheduler with `AttributeError: 'list' object has no attribute 'tolist'` across legacy/blocked and short/long request patterns.
- With the guard, both short-response downstream cells completed 6/6 training steps and the blocked long-response cell completed 2/2 test steps with no engine exceptions. The legacy long-response cell reached the external scorer's deadline instead of crashing the scheduler.
- SGLang pre-commit passed on both changed files.
- Registered-test registry validation passed.
