### PR TITLE
[diffusion] fuse Wan VAE DupUp3D shortcut add

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/wanvae.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/wanvae.py
@@ -180,6 +180,77 @@ class DupUp3D(nn.Module):
             x = x[:, :, self.factor_t - 1 :, :, :]
         return x
 
+    def can_fuse_add(
+        self, x_main: torch.Tensor, x: torch.Tensor, first_chunk: bool
+    ) -> bool:
+        """Return whether `add_into_` can replace `x_main + self(x)`."""
+        if x.ndim != 5 or x_main.ndim != 5:
+            return False
+        if torch.is_grad_enabled() and (x.requires_grad or x_main.requires_grad):
+            return False
+        if self.repeats <= 0 or self.factor % self.repeats != 0:
+            return False
+        if x.shape[1] != self.in_channels:
+            return False
+
+        batch, _, frames, height, width = x.shape
+        output_frames = frames * self.factor_t
+        if first_chunk:
+            output_frames -= self.factor_t - 1
+
+        return (
+            x_main.dtype == x.dtype
+            and x_main.device == x.device
+            and tuple(x_main.shape)
+            == (
+                batch,
+                self.out_channels,
+                output_frames,
+                height * self.factor_s,
+                width * self.factor_s,
+            )
+        )
+
+    def add_into_(
+        self, x_main: torch.Tensor, x: torch.Tensor, first_chunk: bool = False
+    ) -> torch.Tensor:
+        """Add the duplicated shortcut directly into `x_main`.
+
+        `forward` only copies input values into an expanded tensor. This
+        method adds those values to their strided destinations instead, avoiding
+        the expanded shortcut allocation and its layout conversion.
+        """
+        temporal_factor = self.factor_t
+        spatial_factor = self.factor_s
+        input_channel_stride = self.factor // self.repeats
+        dropped_frames = temporal_factor - 1 if first_chunk else 0
+
+        for temporal_offset in range(temporal_factor):
+            input_frame_start = 1 if temporal_offset < dropped_frames else 0
+            output_frame_start = (
+                input_frame_start * temporal_factor + temporal_offset - dropped_frames
+            )
+            for height_offset in range(spatial_factor):
+                for width_offset in range(spatial_factor):
+                    flattened_offset = (
+                        temporal_offset * spatial_factor + height_offset
+                    ) * spatial_factor + width_offset
+                    input_channel_start = flattened_offset // self.repeats
+                    x_main[
+                        :,
+                        :,
+                        output_frame_start::temporal_factor,
+                        height_offset::spatial_factor,
+                        width_offset::spatial_factor,
+                    ].add_(
+                        x[
+                            :,
+                            input_channel_start::input_channel_stride,
+                            input_frame_start:,
+                        ]
+                    )
+        return x_main
+
 
 class WanCausalConv3d(nn.Conv3d):
     r"""
@@ -478,7 +549,11 @@ def residual_up_block_forward(self, x):
         x = self.upsampler(x)
 
     if self.avg_shortcut is not None:
-        x = x + self.avg_shortcut(x_copy)
+        is_first_chunk = bool(first_chunk.get())
+        if self.avg_shortcut.can_fuse_add(x, x_copy, is_first_chunk):
+            x = self.avg_shortcut.add_into_(x, x_copy, is_first_chunk)
+        else:
+            x = x + self.avg_shortcut(x_copy)
 
     return x
 

--- a/python/sglang/multimodal_gen/test/unit/test_wan_vae_dupup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_wan_vae_dupup.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.models.vaes.wanvae import (
+    DupUp3D,
+    forward_context,
+    residual_up_block_forward,
+)
+
+_DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+@pytest.mark.parametrize(
+    ("in_channels", "out_channels", "factor_t", "first_chunk", "channels_last"),
+    (
+        (1024, 1024, 2, False, False),
+        (1024, 1024, 2, True, True),
+        (1024, 512, 2, False, False),
+        (512, 256, 1, False, False),
+    ),
+)
+def test_add_into_matches_materialized_shortcut(
+    in_channels: int,
+    out_channels: int,
+    factor_t: int,
+    first_chunk: bool,
+    channels_last: bool,
+):
+    torch.manual_seed(0)
+    dup = DupUp3D(in_channels, out_channels, factor_t=factor_t, factor_s=2)
+    frames = 1 if first_chunk else 3
+    x = torch.randn(
+        1,
+        in_channels,
+        frames,
+        2,
+        3,
+        dtype=torch.bfloat16,
+        device=_DEVICE,
+    )
+    with forward_context(first_chunk_arg=first_chunk):
+        shortcut = dup(x)
+    x_main = torch.randn_like(shortcut)
+    if channels_last:
+        x_main = x_main.contiguous(memory_format=torch.channels_last_3d)
+    expected = x_main + shortcut
+    destination = x_main.clone(memory_format=torch.preserve_format)
+
+    assert dup.can_fuse_add(destination, x, first_chunk)
+    actual = dup.add_into_(destination, x, first_chunk)
+
+    assert actual is destination
+    assert torch.equal(actual, expected)
+    if channels_last:
+        assert actual.stride() == x_main.stride()
+        assert actual.is_contiguous(memory_format=torch.channels_last_3d)
+
+
+def test_residual_up_block_uses_fused_shortcut():
+    torch.manual_seed(0)
+    dup = DupUp3D(64, 32, factor_t=2, factor_s=2)
+    x = torch.randn(1, 64, 1, 2, 3, device=_DEVICE)
+    with forward_context(first_chunk_arg=True):
+        shortcut = dup(x)
+    x_main = torch.randn_like(shortcut)
+    expected = x_main + shortcut
+    block = SimpleNamespace(
+        avg_shortcut=dup,
+        resnets=(),
+        upsampler=lambda _: x_main.clone(memory_format=torch.preserve_format),
+    )
+
+    with (
+        patch.object(
+            dup,
+            "forward",
+            side_effect=AssertionError("materialized shortcut path was used"),
+        ),
+        forward_context(first_chunk_arg=True),
+    ):
+        actual = residual_up_block_forward(block, x)
+
+    assert torch.equal(actual, expected)


### PR DESCRIPTION
## Motivation

`DupUp3D` currently materializes its upsample shortcut with `repeat_interleave`, reshape/permute, and `contiguous()` before adding it to the decoder's main branch. Every shortcut element is only a copied input value, so the full shortcut allocation and layout conversion are avoidable.

## Modifications

- Add `DupUp3D.add_into_` to add source values directly into their strided destinations in the main branch.
- Use the in-place path for supported channel mappings and matching shapes/dtypes/devices.
- Preserve the materialized fallback for unsupported inputs and autograd execution.
- Add focused parity and integration coverage for the three Wan decoder stage mappings, first-chunk trimming, and `channels_last_3d` output.

## Accuracy Tests

- The focused unit suite passes all 5 cases.
- The fused result is bitwise equal to `x_main + DupUp3D.forward(x)` for BF16 production mappings, including the single-frame first chunk.
- A full public `WanDecoder3d` forward also produced bitwise-identical output (`max_abs_diff = 0`).
- The test pins the `channels_last_3d` destination layout and verifies that `WanResidualUpBlock` selects the fused path.
- All pre-commit hooks pass.

## Speed Tests and Profiling

Benchmarked commit `b83a1677fbc98cb6990180168743a998d9ce642c` on one NVIDIA GB300 Max-Q with PyTorch 2.9.1+cu130, CUDA 13.0, BF16, and `channels_last_3d`. The baseline forces the unchanged upstream materialized path; the comparison enables this PR's fused path on the same model and inputs.

### Full public decoder forward

Public `WanDecoder3d` with Wan 2.2 residual-decoder dimensions (`decoder_base_dim=256`, `z_dim=48`, `dim_mult=(1,2,4,4)`, two residual blocks), input `1×48×37×54×30`, output `1×3×148×432×240`. Random weights make the run checkpoint-independent without changing kernel shapes. Results are medians of 7 alternating trials after 2 warmup pairs.

| Path | Latency | Relative | Peak allocated during forward |
| --- | ---: | ---: | ---: |
| Materialized shortcut | 2235.1 ms | 1.000× | 60,342 MiB |
| Strided in-place add | 2182.8 ms | **1.024×** | 60,342 MiB |

The full-decoder peak is unchanged because larger convolution activations dominate it.

### Isolated shortcut operation

The baseline is `x_main + DupUp3D.forward(x)`; the fused path is `add_into_` with the same preallocated destination. Results are medians of 7 trials of 100 calls after 20 warmups. A second complete run reproduced every timing within 0.01 ms, and every case was bitwise equal.

| Case (C×T×H×W, batch 1) | Baseline | Fused | Speedup | Extra peak allocation (baseline → fused) |
| --- | ---: | ---: | ---: | ---: |
| Stage 1, first: `1024×1×54×30 → 1024×1×108×60` | 0.1111 ms | 0.0972 ms | 1.14× | 52 → 0 MiB |
| Stage 1, steady: `1024×1×54×30 → 1024×2×108×60` | 0.1349 ms | 0.1210 ms | 1.12× | 52 → 0 MiB |
| Stage 2: `1024×2×108×60 → 512×4×216×120` | 0.5669 ms | 0.1617 ms | 3.51× | 204 → 0 MiB |
| Stage 3: `512×4×216×120 → 256×4×432×240` | 1.2358 ms | 0.2805 ms | 4.41× | 405 → 0 MiB |

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Documentation is not required for this internal optimization.
- [x] Provide accuracy results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30511050480](https://github.com/sgl-project/sglang/actions/runs/30511050480)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30511050254](https://github.com/sgl-project/sglang/actions/runs/30511050254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->