### PR TITLE
[Fix] Count multi-layer draft-extend replays in the fwd-occupancy device timer

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1543,8 +1543,7 @@ class ModelRunner:
                 and self.prefill_cuda_graph_runner.can_run_graph(forward_batch)
                 and get_cp_strategy() is None
             ):
-                # Prefill cuda graph (piecewise). Timing lives inside the
-                # runner's execute, wrapped around the model forward only.
+                # Prefill cuda graph (piecewise). Timed inside the runner's execute.
                 kwargs = self._extend_forward_kwargs(forward_batch, pp_proxy_tensors)
                 ret = self.prefill_cuda_graph_runner.execute(forward_batch, **kwargs)
                 can_run_graph = True

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1543,9 +1543,20 @@ class ModelRunner:
                 and self.prefill_cuda_graph_runner.can_run_graph(forward_batch)
                 and get_cp_strategy() is None
             ):
-                # Prefill cuda graph (piecewise). Timed inside the runner's execute.
+                # Prefill cuda graph (piecewise).
                 kwargs = self._extend_forward_kwargs(forward_batch, pp_proxy_tensors)
-                ret = self.prefill_cuda_graph_runner.execute(forward_batch, **kwargs)
+                category = (
+                    "target_verify"
+                    if forward_batch.forward_mode.is_target_verify()
+                    else "extend"
+                )
+                # TODO: the timing here is too broad -- it also includes
+                # load_batch time. Move it into the prefill cuda graph runner
+                # to capture only the model.forward part.
+                with device_timer_ctx(self.device_timer, category):
+                    ret = self.prefill_cuda_graph_runner.execute(
+                        forward_batch, **kwargs
+                    )
                 can_run_graph = True
             else:
                 # Eager: decode / extend / idle dispatched inside the runner.

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -201,6 +201,7 @@ from sglang.srt.utils import (
     set_cuda_arch,
     slow_rank_detector,
 )
+from sglang.srt.utils.device_timer import device_timer_ctx
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.srt.utils.nvtx_utils import profile_range
 from sglang.srt.utils.offloader import (
@@ -1319,12 +1320,7 @@ class ModelRunner:
             forward_batch.split_index + forward_count,
             self.model_config.num_hidden_layers,
         )
-        ctx = (
-            self.device_timer.wrap(metadata={"category": "split_prefill"})
-            if self.device_timer
-            else contextlib.nullcontext()
-        )
-        with ctx:
+        with device_timer_ctx(self.device_timer, "split_prefill"):
             ret = self.model.forward_split_prefill(
                 forward_batch.input_ids,
                 forward_batch.positions,
@@ -1547,25 +1543,10 @@ class ModelRunner:
                 and self.prefill_cuda_graph_runner.can_run_graph(forward_batch)
                 and get_cp_strategy() is None
             ):
-                category = (
-                    "target_verify"
-                    if forward_batch.forward_mode.is_target_verify()
-                    else "extend"
-                )
-                # Prefill cuda graph (piecewise).
+                # Prefill cuda graph (piecewise). Timing lives inside the
+                # runner's execute, wrapped around the model forward only.
                 kwargs = self._extend_forward_kwargs(forward_batch, pp_proxy_tensors)
-                # TODO: device_timer.wrap is too broad here — it also includes
-                # load_batch time. Move timing into the prefill cuda graph runner
-                # to capture only the model.forward part.
-                ctx = (
-                    self.device_timer.wrap(metadata={"category": category})
-                    if self.device_timer
-                    else contextlib.nullcontext()
-                )
-                with ctx:
-                    ret = self.prefill_cuda_graph_runner.execute(
-                        forward_batch, **kwargs
-                    )
+                ret = self.prefill_cuda_graph_runner.execute(forward_batch, **kwargs)
                 can_run_graph = True
             else:
                 # Eager: decode / extend / idle dispatched inside the runner.

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -99,6 +99,7 @@ from sglang.srt.utils import (
     require_attn_tp_gather,
     require_mlp_tp_gather,
 )
+from sglang.srt.utils.device_timer import device_timer_ctx
 from sglang.srt.utils.profile_utils import export_cuda_graph_capture_trace
 
 try:
@@ -1212,12 +1213,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         forward_batch: ForwardBatch,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> Union[LogitsProcessorOutput, PPProxyTensors]:
-        timer_ctx = (
-            self.model_runner.device_timer.wrap(
-                metadata={"category": forward_batch.forward_mode.name.lower()}
-            )
-            if self.model_runner.device_timer
-            else contextlib.nullcontext()
+        timer_ctx = device_timer_ctx(
+            self.model_runner.device_timer, forward_batch.forward_mode.name.lower()
         )
         # Publish a read-done event for the WAR barrier: a cuda-graph forward
         # finishes its shared req_to_token / SWA reads at this pre-replay

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -55,6 +55,7 @@ from sglang.srt.utils.common import (
     get_eager_max_batch_size,
     require_mlp_sync,
 )
+from sglang.srt.utils.device_timer import device_timer_ctx
 
 logger = logging.getLogger(__name__)
 
@@ -237,11 +238,7 @@ class EagerRunner(BaseRunner):
         # FIXME: add pp_proxy_tensors arg to all models
         kwargs = model_runner._pp_kwargs(pp_proxy_tensors)
 
-        ctx = (
-            model_runner.device_timer.wrap(metadata={"category": "decode"})
-            if model_runner.device_timer
-            else contextlib.nullcontext()
-        )
+        ctx = device_timer_ctx(model_runner.device_timer, "decode")
 
         with ctx, pdmux_ctx:
             return model_runner.model.forward(

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -294,12 +294,7 @@ class EagerRunner(BaseRunner):
             if forward_batch.forward_mode.is_target_verify()
             else "extend"
         )
-        ctx = (
-            model_runner.device_timer.wrap(metadata={"category": category})
-            if model_runner.device_timer
-            else contextlib.nullcontext()
-        )
-        with ctx:
+        with device_timer_ctx(model_runner.device_timer, category):
             pcg_runner = model_runner.prefill_cuda_graph_runner
             if (
                 _is_hip
@@ -398,12 +393,7 @@ class EagerRunner(BaseRunner):
             model_runner.attn_backend.forward_metadata = None
 
         kwargs = model_runner._pp_kwargs(pp_proxy_tensors)
-        ctx = (
-            model_runner.device_timer.wrap(metadata={"category": "idle"})
-            if model_runner.device_timer
-            else contextlib.nullcontext()
-        )
-        with ctx:
+        with device_timer_ctx(model_runner.device_timer, "idle"):
             return model_runner.model.forward(
                 forward_batch.input_ids,
                 forward_batch.positions,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1609,8 +1609,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             if shape_key.variant_label is not None:
                 self._prepare_chunked_prefix_replay(shape_key, forward_batch)
 
-            # Timed here (not in ModelRunner.forward) so load_batch stays out
-            # of the fwd-occupancy numerator.
+            # Timed around the forward only: load_batch and the chunked-prefix
+            # refresh above stay out of the fwd-occupancy numerator.
             timer_ctx = device_timer_ctx(
                 self.model_runner.device_timer,
                 (

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -112,7 +112,6 @@ from sglang.srt.utils import (
     require_mlp_tp_gather,
 )
 from sglang.srt.utils.aiter import maybe_pre_warm_aiter_chip_info
-from sglang.srt.utils.device_timer import device_timer_ctx
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -1609,32 +1608,20 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             if shape_key.variant_label is not None:
                 self._prepare_chunked_prefix_replay(shape_key, forward_batch)
 
-            # Timed around the forward only: load_batch and the chunked-prefix
-            # refresh above stay out of the fwd-occupancy numerator.
-            timer_ctx = device_timer_ctx(
-                self.model_runner.device_timer,
-                (
-                    "target_verify"
-                    if forward_batch.forward_mode.is_target_verify()
-                    else "extend"
-                ),
-            )
             if self._uses_eager_prefill_tail():
-                with timer_ctx:
-                    output = self._execute_body_capture(
-                        forward_batch,
-                        static_forward_batch,
-                        static_num_tokens,
-                        raw_num_tokens,
-                        shape_key,
-                        **kwargs,
-                    )
+                output = self._execute_body_capture(
+                    forward_batch,
+                    static_forward_batch,
+                    static_num_tokens,
+                    raw_num_tokens,
+                    shape_key,
+                    **kwargs,
+                )
             else:
-                with timer_ctx:
-                    output = self._execute_tc_piecewise(
-                        static_forward_batch,
-                        static_num_tokens,
-                        raw_num_tokens,
-                        **kwargs,
-                    )
+                output = self._execute_tc_piecewise(
+                    static_forward_batch,
+                    static_num_tokens,
+                    raw_num_tokens,
+                    **kwargs,
+                )
             return self._finalize_execute_output(output)

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -112,6 +112,7 @@ from sglang.srt.utils import (
     require_mlp_tp_gather,
 )
 from sglang.srt.utils.aiter import maybe_pre_warm_aiter_chip_info
+from sglang.srt.utils.device_timer import device_timer_ctx
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -1608,20 +1609,32 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             if shape_key.variant_label is not None:
                 self._prepare_chunked_prefix_replay(shape_key, forward_batch)
 
+            # Timed here (not in ModelRunner.forward) so load_batch stays out
+            # of the fwd-occupancy numerator.
+            timer_ctx = device_timer_ctx(
+                self.model_runner.device_timer,
+                (
+                    "target_verify"
+                    if forward_batch.forward_mode.is_target_verify()
+                    else "extend"
+                ),
+            )
             if self._uses_eager_prefill_tail():
-                output = self._execute_body_capture(
-                    forward_batch,
-                    static_forward_batch,
-                    static_num_tokens,
-                    raw_num_tokens,
-                    shape_key,
-                    **kwargs,
-                )
+                with timer_ctx:
+                    output = self._execute_body_capture(
+                        forward_batch,
+                        static_forward_batch,
+                        static_num_tokens,
+                        raw_num_tokens,
+                        shape_key,
+                        **kwargs,
+                    )
             else:
-                output = self._execute_tc_piecewise(
-                    static_forward_batch,
-                    static_num_tokens,
-                    raw_num_tokens,
-                    **kwargs,
-                )
+                with timer_ctx:
+                    output = self._execute_tc_piecewise(
+                        static_forward_batch,
+                        static_num_tokens,
+                        raw_num_tokens,
+                        **kwargs,
+                    )
             return self._finalize_execute_output(output)

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional
 
@@ -47,6 +46,7 @@ from sglang.srt.utils import (
     require_mlp_tp_gather,
 )
 from sglang.srt.utils.async_probe import maybe_detect_nan, maybe_detect_oob
+from sglang.srt.utils.device_timer import device_timer_ctx
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
@@ -653,12 +653,7 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
 
         # Replay via backend
         shape_key = self._make_graph_key(bs)
-        timer_ctx = (
-            self.model_runner.device_timer.wrap(metadata={"category": "eagle_draft"})
-            if self.model_runner.device_timer
-            else contextlib.nullcontext()
-        )
-        with timer_ctx:
+        with device_timer_ctx(self.model_runner.device_timer, "eagle_draft"):
             out = self._replay_graph(shape_key, forward_batch)
         if self.buffers.dsa_seed_topk is not None:
             forward_batch.spec_info.dsa_topk_indices = None

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -49,6 +49,7 @@ from sglang.srt.utils import (
     require_mlp_sync,
     require_mlp_tp_gather,
 )
+from sglang.srt.utils.device_timer import device_timer_ctx
 
 _is_hip = is_hip()
 
@@ -615,14 +616,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         self.raw_bs = raw_bs
         self.bs = bs
         shape_key = self._make_graph_key(bs)
-        timer_ctx = (
-            self.model_runner.device_timer.wrap(
-                metadata={"category": "eagle_draft_extend"}
-            )
-            if self.model_runner.device_timer
-            else contextlib.nullcontext()
-        )
-        with timer_ctx:
+        with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
             out = self._replay_graph(shape_key, forward_batch)
 
         out = LogitsProcessorOutput(

--- a/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
@@ -447,12 +447,11 @@ class FrozenKVMTPCudaGraphRunner(DecodeCudaGraphRunner):
         shape_key = self._make_graph_key(bs)
         # NVTX span: the graph bypasses `model_runner.forward`'s record_function.
         span_name = f"step[DRAFT_LOOP raw_bs={raw_bs} bs={bs} topk={self.topk}]"
-        timer_ctx = device_timer_ctx(self.model_runner.device_timer, "frozen_kv_draft")
-        if torch.autograd._profiler_enabled():
-            with timer_ctx, torch.profiler.record_function(span_name):
-                out = self._replay_graph(shape_key, forward_batch)
-        else:
-            with timer_ctx:
+        with device_timer_ctx(self.model_runner.device_timer, "frozen_kv_draft"):
+            if torch.autograd._profiler_enabled():
+                with torch.profiler.record_function(span_name):
+                    out = self._replay_graph(shape_key, forward_batch)
+            else:
                 out = self._replay_graph(shape_key, forward_batch)
 
         if bs != raw_bs:

--- a/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_cuda_graph_runner.py
@@ -41,6 +41,7 @@ from sglang.srt.utils import (
     require_mlp_sync,
     require_mlp_tp_gather,
 )
+from sglang.srt.utils.device_timer import device_timer_ctx
 
 if TYPE_CHECKING:
     from sglang.srt.speculative.frozen_kv_mtp_worker_v2 import FrozenKVMTPDraftWorker
@@ -446,11 +447,13 @@ class FrozenKVMTPCudaGraphRunner(DecodeCudaGraphRunner):
         shape_key = self._make_graph_key(bs)
         # NVTX span: the graph bypasses `model_runner.forward`'s record_function.
         span_name = f"step[DRAFT_LOOP raw_bs={raw_bs} bs={bs} topk={self.topk}]"
+        timer_ctx = device_timer_ctx(self.model_runner.device_timer, "frozen_kv_draft")
         if torch.autograd._profiler_enabled():
-            with torch.profiler.record_function(span_name):
+            with timer_ctx, torch.profiler.record_function(span_name):
                 out = self._replay_graph(shape_key, forward_batch)
         else:
-            out = self._replay_graph(shape_key, forward_batch)
+            with timer_ctx:
+                out = self._replay_graph(shape_key, forward_batch)
 
         if bs != raw_bs:
             out = self._postprocess_output_to_raw_bs(out, raw_bs)

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -499,7 +499,6 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
         self.bs = bs
         shape_key = self._make_graph_key(bs)
-        # Same fwd-occupancy accounting as the single-layer draft runners.
         with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
             return self._replay_graph(shape_key, fb_view)
 

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -82,6 +82,7 @@ from sglang.srt.utils import (
     require_mlp_sync,
     require_mlp_tp_gather,
 )
+from sglang.srt.utils.device_timer import device_timer_ctx
 
 if is_npu():
     from sglang.srt.speculative.multi_layer_eagle_utils import (
@@ -498,17 +499,8 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
         self.bs = bs
         shape_key = self._make_graph_key(bs)
-        # Same fwd-occupancy accounting as the single-layer draft runners:
-        # without the wrap the draft replay's GPU time lands in the metric's
-        # denominator only.
-        timer_ctx = (
-            self.model_runner.device_timer.wrap(
-                metadata={"category": "eagle_draft_extend"}
-            )
-            if self.model_runner.device_timer
-            else contextlib.nullcontext()
-        )
-        with timer_ctx:
+        # Same fwd-occupancy accounting as the single-layer draft runners.
+        with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
             return self._replay_graph(shape_key, fb_view)
 
 
@@ -984,14 +976,9 @@ class OneGraphMultiLayerEagleMultiStepDraftExtendCudaGraphRunner(
                 if r is not None:
                     r.deepep_adapter.replay()
             shape_key = first._make_graph_key(self.bs)
-            timer_ctx = (
-                first.model_runner.device_timer.wrap(
-                    metadata={"category": "eagle_draft_extend"}
-                )
-                if first.model_runner.device_timer
-                else contextlib.nullcontext()
-            )
-            with timer_ctx:
+            with device_timer_ctx(
+                first.model_runner.device_timer, "eagle_draft_extend"
+            ):
                 outs = first.backend.replay(shape_key, self._replay_spec_info)
             raw_bs = self.raw_bs
             self._cached = {}

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -498,7 +498,18 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
 
         self.bs = bs
         shape_key = self._make_graph_key(bs)
-        return self._replay_graph(shape_key, fb_view)
+        # Same fwd-occupancy accounting as the single-layer draft runners:
+        # without the wrap the draft replay's GPU time lands in the metric's
+        # denominator only.
+        timer_ctx = (
+            self.model_runner.device_timer.wrap(
+                metadata={"category": "eagle_draft_extend"}
+            )
+            if self.model_runner.device_timer
+            else contextlib.nullcontext()
+        )
+        with timer_ctx:
+            return self._replay_graph(shape_key, fb_view)
 
 
 class MultiLayerEagleMultiStepDraftExtendCudaGraphRunner:
@@ -973,7 +984,15 @@ class OneGraphMultiLayerEagleMultiStepDraftExtendCudaGraphRunner(
                 if r is not None:
                     r.deepep_adapter.replay()
             shape_key = first._make_graph_key(self.bs)
-            outs = first.backend.replay(shape_key, self._replay_spec_info)
+            timer_ctx = (
+                first.model_runner.device_timer.wrap(
+                    metadata={"category": "eagle_draft_extend"}
+                )
+                if first.model_runner.device_timer
+                else contextlib.nullcontext()
+            )
+            with timer_ctx:
+                outs = first.backend.replay(shape_key, self._replay_spec_info)
             raw_bs = self.raw_bs
             self._cached = {}
             non_null = [r for r in self.runners if r is not None]

--- a/python/sglang/srt/utils/device_timer.py
+++ b/python/sglang/srt/utils/device_timer.py
@@ -21,17 +21,24 @@ class DeviceTimer:
     def __init__(self, reporter: Callable):
         self._intervals: Deque[_TimingInterval] = deque()
         self._reporters: List[Callable] = [reporter]
+        self._in_wrap = False
 
     def add_reporter(self, reporter: Callable):
         self._reporters.append(reporter)
 
     @contextmanager
     def wrap(self, metadata: Dict):
-        self._intervals.append(_TimingInterval.create())
+        # Not re-entrant: a nested wrap would end the wrong interval and leave
+        # an un-ended one at the head of the queue for _report() to trip over.
+        assert not self._in_wrap, "DeviceTimer.wrap is not re-entrant"
+        interval = _TimingInterval.create()
+        self._intervals.append(interval)
+        self._in_wrap = True
         try:
             yield
         finally:
-            self._intervals[-1].end(metadata=metadata)
+            self._in_wrap = False
+            interval.end(metadata=metadata)
             self._report()
 
     def _report(self):

--- a/python/sglang/srt/utils/device_timer.py
+++ b/python/sglang/srt/utils/device_timer.py
@@ -1,9 +1,21 @@
 from collections import deque
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from typing import Callable, Deque, Dict, List, Optional
 
 import torch
+
+
+def device_timer_ctx(timer: Optional["DeviceTimer"], category: str):
+    """Timing context for one forward segment; no-op when the timer is absent.
+
+    Every runner wraps its graph replay / forward execution with this so the
+    segment's device time enters fwd_occupancy (and the metrics riding the
+    same timer).
+    """
+    if timer is None:
+        return nullcontext()
+    return timer.wrap(metadata={"category": category})
 
 
 class DeviceTimer:

--- a/python/sglang/srt/utils/device_timer.py
+++ b/python/sglang/srt/utils/device_timer.py
@@ -9,9 +9,8 @@ import torch
 def device_timer_ctx(timer: Optional["DeviceTimer"], category: str):
     """Timing context for one forward segment; no-op when the timer is absent.
 
-    Every runner wraps its graph replay / forward execution with this so the
-    segment's device time enters fwd_occupancy (and the metrics riding the
-    same timer).
+    A segment that skips this stays out of the fwd_occupancy numerator while
+    still counting in its wall-clock denominator, i.e. reads as GPU idle.
     """
     if timer is None:
         return nullcontext()


### PR DESCRIPTION
`sglang:fwd_occupancy` divides forward-pass device time by wall clock, with the numerator collected by `DeviceTimer.wrap()` around each forward segment. The single-layer EAGLE draft runners wrap their replays (`eagle_draft_cuda_graph_runner`, `eagle_draft_extend_cuda_graph_runner`, categories `eagle_draft` / `eagle_draft_extend`), and the metrics reporter installs the timer on `draft_runner_list` specifically for the multi-layer worker -- but neither multi-layer draft-extend runner ever wraps, so the draft replays' GPU time lands in the metric's denominator only. On multi-layer EAGLE the gauge under-reports GPU utilization by the draft phase's share and misreads as idle. The frozen-KV MTP draft loop has the same gap.

## Changes

- Wrap both multi-layer draft-extend replay paths -- the per-step runner and the single-CG variant -- with the same `eagle_draft_extend` category the single-layer runner uses. The NPU subclasses only override `_replay_graph` / `_create_runner`, so they inherit the wrap.
- Wrap the frozen-KV MTP draft replay under a new `frozen_kv_draft` category.
- Collapse the `wrap(...) if device_timer else nullcontext()` boilerplate into `device_timer_ctx(timer, category)` at every call site.
- Have `DeviceTimer.wrap` hold its own interval instead of reading `self._intervals[-1]`, and assert it is not entered re-entrantly: a nested wrap would end the wrong interval and leave an un-ended one for `_report()` to trip over.

## Result

A/B on a 1T-class MoE target with 3-step multi-layer EAGLE, tp=8, bs=1 decode, three 4096-token rounds each (only the draft-extend wrap differs):

| | fwd_occupancy | tok/s | accept_length |
| --- | --- | --- | --- |
| before | 89.19% | 248.9 | 2.68 |
| after | 96.63% | 248.8 | 2.68 |

Throughput and accept length are unchanged (the wrap is two cuda events per replay); the corrected gauge matches the merged GPU-busy share measured independently from a torch profiler trace (96.4%).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30513243368](https://github.com/sgl-project/sglang/actions/runs/30513243368)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30513243247](https://github.com/sgl-project/sglang/actions/runs/30513243247)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
