### PR TITLE
[Perf] Fast-path chain-style draft token organization in multi-layer EAGLE

### DIFF
--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -15,8 +15,7 @@ if TYPE_CHECKING:
 
 
 class EagleDraftWorkerBase(ABC):
-    # Chain (topk=1) constants shared by every draft worker's draft_forward
-    # fast path; stay None when topk > 1. See _rebuild_topk1_chain_buffers.
+    # topk=1 chain constants for draft_forward's fast path; None when topk > 1.
     _topk1_parents_prealloc: Optional[torch.Tensor] = None
     _topk1_score_indices_prealloc: Optional[torch.Tensor] = None
 

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
+import torch
+
 if TYPE_CHECKING:
     from sglang.srt.managers.io_struct import (
         UpdateWeightFromDiskReqInput,
@@ -13,6 +15,11 @@ if TYPE_CHECKING:
 
 
 class EagleDraftWorkerBase(ABC):
+    # Chain (topk=1) constants shared by every draft worker's draft_forward
+    # fast path; stay None when topk > 1. See _rebuild_topk1_chain_buffers.
+    _topk1_parents_prealloc: Optional[torch.Tensor] = None
+    _topk1_score_indices_prealloc: Optional[torch.Tensor] = None
+
     @abstractmethod
     def draft():
         pass
@@ -40,6 +47,40 @@ class EagleDraftWorkerBase(ABC):
         """Capture draft graphs (decode disabled on the draft TpModelWorker)."""
         self.draft_worker.init_cuda_graphs(capture_decode_cuda_graph=False)
         self._capture_cuda_graphs()
+
+    def _rebuild_topk1_chain_buffers(self) -> None:
+        # For topk=1 the draft tree degenerates to a chain, so parent_list and
+        # top_scores_index are runtime-invariant. Must be rebuilt after any
+        # change to speculative_num_steps / speculative_num_draft_tokens.
+        if self.topk != 1:
+            return
+        # _override_worker_state can set both directly, bypassing the hook that
+        # pins this relation; the fast path is only valid when it holds.
+        assert self.speculative_num_draft_tokens == self.speculative_num_steps + 1, (
+            "topk=1 requires speculative_num_draft_tokens == speculative_num_steps + 1, "
+            f"got {self.speculative_num_draft_tokens} and {self.speculative_num_steps}"
+        )
+        num_steps = self.speculative_num_steps
+        sa = self.server_args
+        decode_max_bs = (
+            sa.cuda_graph_config.decode.max_bs
+            if sa.cuda_graph_config is not None
+            else None
+        )
+        max_bs = max(
+            decode_max_bs or 0,
+            sa.max_running_requests or 0,
+            1,
+        )
+        # A single-step chain has no parent entries (slow path drops the last
+        # step). repeat (not expand): the kernel reads these as contiguous.
+        parent_width = num_steps if num_steps > 1 else 0
+        self._topk1_parents_prealloc = torch.arange(
+            -1, parent_width - 1, dtype=torch.long, device=self.device
+        ).repeat(max_bs, 1)
+        self._topk1_score_indices_prealloc = torch.arange(
+            num_steps, dtype=torch.long, device=self.device
+        ).repeat(max_bs, 1)
 
 
 class BaseSpecWorker(ABC):

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -103,7 +103,9 @@ def organize_draft_results(
     parents_list: List[torch.Tensor],
     num_draft_token: int,
 ):
+    # b, n, topk; n = 1 + (num_steps-1) * topk
     score_list = torch.cat(score_list, dim=1).flatten(1)
+    # b, (topk + (num_steps-1) * topk)
     ss_token_list = torch.cat(token_list, dim=1)
     top_scores = torch.topk(score_list, num_draft_token - 1, dim=-1)
     top_scores_index = top_scores.indices

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -144,7 +144,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             server_args.speculative_algorithm
         )
 
-        # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
         self._rebuild_topk1_chain_buffers()
 
         # Load draft model weights only.

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -145,8 +145,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         )
 
         # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
-        self._topk1_parents_prealloc = None
-        self._topk1_score_indices_prealloc = None
         self._rebuild_topk1_chain_buffers()
 
         # Load draft model weights only.
@@ -250,40 +248,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.seed_dsa_topk_from_draft_extend = (
             self.index_share_for_mtp_iteration and self.dsa_index_topk is not None
         )
-
-    def _rebuild_topk1_chain_buffers(self) -> None:
-        # For topk=1 the draft tree degenerates to a chain, so parent_list and
-        # top_scores_index are runtime-invariant. Must be rebuilt after any
-        # change to speculative_num_steps / speculative_num_draft_tokens.
-        if self.topk != 1:
-            return
-        # _override_worker_state can set both directly, bypassing the hook that
-        # pins this relation; the fast path is only valid when it holds.
-        assert self.speculative_num_draft_tokens == self.speculative_num_steps + 1, (
-            "topk=1 requires speculative_num_draft_tokens == speculative_num_steps + 1, "
-            f"got {self.speculative_num_draft_tokens} and {self.speculative_num_steps}"
-        )
-        num_steps = self.speculative_num_steps
-        sa = self.server_args
-        decode_max_bs = (
-            sa.cuda_graph_config.decode.max_bs
-            if sa.cuda_graph_config is not None
-            else None
-        )
-        max_bs = max(
-            decode_max_bs or 0,
-            sa.max_running_requests or 0,
-            1,
-        )
-        # A single-step chain has no parent entries (slow path drops the last
-        # step). repeat (not expand): the kernel reads these as contiguous.
-        parent_width = num_steps if num_steps > 1 else 0
-        self._topk1_parents_prealloc = torch.arange(
-            -1, parent_width - 1, dtype=torch.long, device=self.device
-        ).repeat(max_bs, 1)
-        self._topk1_score_indices_prealloc = torch.arange(
-            num_steps, dtype=torch.long, device=self.device
-        ).repeat(max_bs, 1)
 
     def init_token_map(self):
         # Load hot token ids

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING, List
 
 import torch
 
@@ -50,6 +50,7 @@ from sglang.srt.speculative.eagle_info import (
 from sglang.srt.speculative.eagle_utils import (
     default_tree_mask_mode,
     get_draft_recurrent_hidden_state_spec,
+    organize_draft_results,
 )
 from sglang.srt.speculative.eagle_worker_common import (
     build_eagle_verify_input,
@@ -119,10 +120,6 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
-        # (bs, k) -> cached [0, .., k-1] rows for draft_forward's identity path.
-        self._selected_index_cache: Dict[Tuple[int, int], torch.Tensor] = {}
-        # bs -> cached [-1, 0, .., S-2] parent rows for the chain fast path.
-        self._chain_parent_cache: Dict[int, torch.Tensor] = {}
         # Leviathan/Chen rejection sampling (temp>0): the draft samples X ~ q and
         # provides q so the verify accepts iff coin*q < p and resamples the residual.
         # Single-CG runner samples in-graph (_sample_draft_proposal); per-step
@@ -136,6 +133,9 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
+
+        # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
+        self._rebuild_topk1_chain_buffers()
 
         # Set constant
         EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
@@ -449,25 +449,28 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         # Chain-style (topk=1, one token per draft step, all of them selected):
         # the slice/cat organization in _draft_forward_organize is the identity
         # on topk_index, and parent_list is the constant [-1, 0, .., S-2] per
-        # row. Return cached constants and skip every kernel launch here.
-        num_steps = self.speculative_num_steps
+        # row. Return the prealloc'd constants and skip every kernel launch here.
+        parents_prealloc = self._topk1_parents_prealloc
         if (
-            self.topk == 1
-            and num_steps > 1
-            and self.speculative_num_draft_tokens - 1 == num_steps
-            and topk_index.shape[1] == num_steps
+            parents_prealloc is not None
+            and topk_index.shape[1] == self.speculative_num_steps
+            and topk_index.shape[0] <= parents_prealloc.shape[0]
         ):
             bs = topk_index.shape[0]
-            device = topk_index.device
             return (
-                self._chain_parent_list(bs, device),
-                self._identity_selected_index(bs, num_steps, device),
+                parents_prealloc[:bs],
+                self._topk1_score_indices_prealloc[:bs],
                 topk_index,
             )
 
         return self._draft_forward_organize(topk_p, topk_index, hidden_states)
 
-    def _draft_forward_organize(self, topk_p, topk_index, hidden_states):
+    def _draft_forward_organize(
+        self,
+        topk_p: torch.Tensor,
+        topk_index: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ):
         # Return values
         score_list: List[torch.Tensor] = []
         token_list: List[torch.Tensor] = []
@@ -500,64 +503,9 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
                     )
 
         # Organize the results
-        score_list = torch.cat(score_list, dim=1).flatten(
-            1
-        )  # b, n, topk; n= 1 + (num_steps-1) * self.topk
-        ss_token_list = torch.cat(
-            token_list, dim=1
-        )  # b, (self.topk + (num_steps-1) * self.topk)
-        num_selected = self.speculative_num_draft_tokens - 1
-        if num_selected == score_list.shape[-1]:
-            # topk takes every candidate, so sorting its indices yields
-            # [0, .., k-1] and the gather is the identity. Chain-style EAGLE
-            # (topk=1, num_draft_tokens=num_steps+1) always lands here.
-            top_scores_index = self._identity_selected_index(
-                score_list.shape[0], num_selected, score_list.device
-            )
-            draft_tokens = ss_token_list
-        else:
-            top_scores = torch.topk(score_list, num_selected, dim=-1)
-            top_scores_index = top_scores.indices
-            top_scores_index = torch.sort(top_scores_index).values
-            maybe_detect_oob(
-                top_scores_index,
-                0,
-                ss_token_list.shape[1],
-                "draft_forward: top_scores_index OOB for gather on ss_token_list",
-            )
-            draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
-
-        if len(parents_list) > 1:
-            parent_list = torch.cat(parents_list[:-1], dim=1)
-        else:
-            batch_size = parents_list[0].shape[0]
-            parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
-
-        return parent_list, top_scores_index, draft_tokens
-
-    def _identity_selected_index(
-        self, bs: int, k: int, device: torch.device
-    ) -> torch.Tensor:
-        key = (bs, k)
-        cached = self._selected_index_cache.get(key)
-        if cached is None:
-            cached = (
-                torch.arange(k, dtype=torch.long, device=device)
-                .expand(bs, k)
-                .contiguous()
-            )
-            self._selected_index_cache[key] = cached
-        return cached
-
-    def _chain_parent_list(self, bs: int, device: torch.device) -> torch.Tensor:
-        cached = self._chain_parent_cache.get(bs)
-        if cached is None:
-            row = torch.arange(
-                -1, self.speculative_num_steps - 1, dtype=torch.long, device=device
-            )
-            cached = row.expand(bs, -1).contiguous()
-            self._chain_parent_cache[bs] = cached
-        return cached
+        return organize_draft_results(
+            score_list, token_list, parents_list, self.speculative_num_draft_tokens
+        )
 
     def draft_extend(self):
         pass

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -134,7 +134,6 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
             server_args.speculative_algorithm
         )
 
-        # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
         self._rebuild_topk1_chain_buffers()
 
         # Set constant
@@ -447,9 +446,8 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         maybe_detect_nan(topk_p, "draft_forward: NaN in initial topk_p from spec_info")
 
         # Chain-style (topk=1, one token per draft step, all of them selected):
-        # the slice/cat organization in _draft_forward_organize is the identity
-        # on topk_index, and parent_list is the constant [-1, 0, .., S-2] per
-        # row. Return the prealloc'd constants and skip every kernel launch here.
+        # _draft_forward_organize's slice/cat/topk/sort/gather is the identity on
+        # topk_index, and parent_list is the constant [-1, 0, .., S-2] per row.
         parents_prealloc = self._topk1_parents_prealloc
         if (
             parents_prealloc is not None
@@ -502,7 +500,6 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
                         )
                     )
 
-        # Organize the results
         return organize_draft_results(
             score_list, token_list, parents_list, self.speculative_num_draft_tokens
         )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import replace
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 import torch
 
@@ -119,6 +119,10 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        # (bs, k) -> cached [0, .., k-1] rows for draft_forward's identity path.
+        self._selected_index_cache: Dict[Tuple[int, int], torch.Tensor] = {}
+        # bs -> cached [-1, 0, .., S-2] parent rows for the chain fast path.
+        self._chain_parent_cache: Dict[int, torch.Tensor] = {}
         # Leviathan/Chen rejection sampling (temp>0): the draft samples X ~ q and
         # provides q so the verify accepts iff coin*q < p and resamples the residual.
         # Single-CG runner samples in-graph (_sample_draft_proposal); per-step
@@ -442,6 +446,28 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
 
         maybe_detect_nan(topk_p, "draft_forward: NaN in initial topk_p from spec_info")
 
+        # Chain-style (topk=1, one token per draft step, all of them selected):
+        # the slice/cat organization in _draft_forward_organize is the identity
+        # on topk_index, and parent_list is the constant [-1, 0, .., S-2] per
+        # row. Return cached constants and skip every kernel launch here.
+        num_steps = self.speculative_num_steps
+        if (
+            self.topk == 1
+            and num_steps > 1
+            and self.speculative_num_draft_tokens - 1 == num_steps
+            and topk_index.shape[1] == num_steps
+        ):
+            bs = topk_index.shape[0]
+            device = topk_index.device
+            return (
+                self._chain_parent_list(bs, device),
+                self._identity_selected_index(bs, num_steps, device),
+                topk_index,
+            )
+
+        return self._draft_forward_organize(topk_p, topk_index, hidden_states)
+
+    def _draft_forward_organize(self, topk_p, topk_index, hidden_states):
         # Return values
         score_list: List[torch.Tensor] = []
         token_list: List[torch.Tensor] = []
@@ -480,18 +506,26 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         ss_token_list = torch.cat(
             token_list, dim=1
         )  # b, (self.topk + (num_steps-1) * self.topk)
-        top_scores = torch.topk(
-            score_list, self.speculative_num_draft_tokens - 1, dim=-1
-        )
-        top_scores_index = top_scores.indices
-        top_scores_index = torch.sort(top_scores_index).values
-        maybe_detect_oob(
-            top_scores_index,
-            0,
-            ss_token_list.shape[1],
-            "draft_forward: top_scores_index OOB for gather on ss_token_list",
-        )
-        draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
+        num_selected = self.speculative_num_draft_tokens - 1
+        if num_selected == score_list.shape[-1]:
+            # topk takes every candidate, so sorting its indices yields
+            # [0, .., k-1] and the gather is the identity. Chain-style EAGLE
+            # (topk=1, num_draft_tokens=num_steps+1) always lands here.
+            top_scores_index = self._identity_selected_index(
+                score_list.shape[0], num_selected, score_list.device
+            )
+            draft_tokens = ss_token_list
+        else:
+            top_scores = torch.topk(score_list, num_selected, dim=-1)
+            top_scores_index = top_scores.indices
+            top_scores_index = torch.sort(top_scores_index).values
+            maybe_detect_oob(
+                top_scores_index,
+                0,
+                ss_token_list.shape[1],
+                "draft_forward: top_scores_index OOB for gather on ss_token_list",
+            )
+            draft_tokens = torch.gather(ss_token_list, index=top_scores_index, dim=1)
 
         if len(parents_list) > 1:
             parent_list = torch.cat(parents_list[:-1], dim=1)
@@ -500,6 +534,30 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
             parent_list = torch.empty(batch_size, 0, device=parents_list[0].device)
 
         return parent_list, top_scores_index, draft_tokens
+
+    def _identity_selected_index(
+        self, bs: int, k: int, device: torch.device
+    ) -> torch.Tensor:
+        key = (bs, k)
+        cached = self._selected_index_cache.get(key)
+        if cached is None:
+            cached = (
+                torch.arange(k, dtype=torch.long, device=device)
+                .expand(bs, k)
+                .contiguous()
+            )
+            self._selected_index_cache[key] = cached
+        return cached
+
+    def _chain_parent_list(self, bs: int, device: torch.device) -> torch.Tensor:
+        cached = self._chain_parent_cache.get(bs)
+        if cached is None:
+            row = torch.arange(
+                -1, self.speculative_num_steps - 1, dtype=torch.long, device=device
+            )
+            cached = row.expand(bs, -1).contiguous()
+            self._chain_parent_cache[bs] = cached
+        return cached
 
     def draft_extend(self):
         pass

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -51,9 +51,6 @@ class StandaloneDraftWorker(EagleDraftWorker):
             server_args.speculative_algorithm
         )
 
-        # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
-        self._topk1_parents_prealloc = None
-        self._topk1_score_indices_prealloc = None
         self._rebuild_topk1_chain_buffers()
 
         # Set constant


### PR DESCRIPTION
For chain-style drafts (topk=1, num_draft_tokens == num_steps + 1), the slice/topk/sort/gather/cat organization in `draft_forward` reduces to the identity on `topk_index`, and `parent_list` is a constant `[-1, 0, .., S-2]` row — return cached constants instead of launching those kernels every decode step. The general tree path is kept as `_draft_forward_organize`, with an identity shortcut when top-k selects every candidate.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30529615116](https://github.com/sgl-project/sglang/actions/runs/30529615116)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30529614854](https://github.com/sgl-project/sglang/actions/runs/30529614854)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->