### PR TITLE
[HiCache] NIXL storage registration acquire/release (RFC #32841, stage 1)

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
@@ -1,11 +1,15 @@
-"""NIXL memory-registration helpers, exposed as context managers.
+"""NIXL memory-registration helpers.
 
 A ``NixlRegistry`` instance bundles the agent, the memory type, and
-(optionally) the file manager.  Its ``storage(...)`` method is a context
-manager that performs the entire register-and-build-descs sequence for
-the storage side of a transfer on entry, yields the ``xfer_descs`` (or
-None on failure), and unwinds ``agent.deregister_memory`` plus any
-``os.close(fd)`` on exit.
+(optionally) the file manager.  ``acquire_storage(...)`` performs the
+entire open-register-build-descs sequence for the storage side of a
+transfer and returns a live ``StorageRegistration`` (or None on failure,
+with any partially acquired resources released).  ``release_storage(...)``
+unwinds ``agent.deregister_memory`` plus any ``os.close(fd)``.  The
+``storage(...)`` context manager wraps the pair for callers whose
+registration lifetime matches one ``with`` block; an asynchronous caller
+can instead hold the ``StorageRegistration`` for the lifetime of its
+transfer handle and release on completion.
 
 The host side is pre-registered up front by ``HiCacheNixl`` and is not
 touched per transfer.
@@ -14,7 +18,9 @@ touched per transfer.
 import logging
 import threading
 from contextlib import contextmanager
-from typing import List, Optional
+from typing import Any, List, Optional
+
+import msgspec
 
 from .nixl_utils import NixlFileManager
 
@@ -28,9 +34,23 @@ def _buffer_sizes(buffers) -> Optional[List[int]]:
     return [b[1] for b in buffers]
 
 
+class StorageRegistration(msgspec.Struct):
+    """Live storage-side registration for one transfer.
+
+    Returned by ``NixlRegistry.acquire_storage``; release with
+    ``NixlRegistry.release_storage`` exactly once, after the last use of
+    ``descs``.  For fd-mode FILE registrations the fds backing ``descs``
+    stay open until release.
+    """
+
+    descs: Any
+    reg: Any = None
+    fds: List[int] = []
+
+
 class NixlRegistry:
-    """Owns the (agent, mem_type, file_manager) triple and provides a
-    context manager for the storage side of a transfer.
+    """Owns the (agent, mem_type, file_manager) triple and manages the
+    storage-side registration lifetime of transfers.
 
     A single instance is created once per HiCacheNixl in __init__ and
     reused for every transfer.
@@ -62,49 +82,6 @@ class NixlRegistry:
                 "fd registration."
             )
 
-    @contextmanager
-    def _open_files(self, paths: List[str], create: bool):
-        """Open fds for ``paths``; close all of them on exit.
-
-        Yields the list of fds, or None if any open fails (already-opened
-        fds are closed before returning by the same ``finally``).
-        """
-        fds: List[int] = []
-        try:
-            for path in paths:
-                fd = self.file_manager.open_file(path, create=create)
-                if fd is None:
-                    yield None
-                    return
-                fds.append(fd)
-            yield fds
-        finally:
-            for fd in fds:
-                self.file_manager.close_file(fd)
-
-    @contextmanager
-    def _registered(self, items: List[tuple], mem_type: str):
-        """Register ``items`` with NIXL; deregister on exit.
-
-        Yields the registration handle, or None if registration fails.
-        """
-        reg = None
-        if items:
-            reg_descs = self.agent.get_reg_descs(items, mem_type)
-            if reg_descs is not None:
-                try:
-                    reg = self.agent.register_memory(reg_descs)
-                except Exception as e:
-                    logger.error(f"Failed to register memory of type {mem_type}: {e}")
-        try:
-            yield reg
-        finally:
-            if reg is not None:
-                try:
-                    self.agent.deregister_memory(reg)
-                except Exception as e:
-                    logger.debug("deregister_memory skipped: %s", e)
-
     def _probe_path_mode(self) -> bool:
         """Probe whether NIXL honours path-mode metaInfo.
 
@@ -130,64 +107,128 @@ class NixlRegistry:
         except Exception:
             return True
 
-    @contextmanager
-    def storage(self, buffers, keys, direction):
-        """Open + register the storage side; deregister and close fds on exit.
+    def _register(self, items: List[tuple], mem_type: str):
+        """Register ``items`` with NIXL; returns the handle or None."""
+        if not items:
+            return None
+        reg_descs = self.agent.get_reg_descs(items, mem_type)
+        if reg_descs is None:
+            return None
+        try:
+            return self.agent.register_memory(reg_descs)
+        except Exception as e:
+            logger.error(f"Failed to register memory of type {mem_type}: {e}")
+            return None
 
-        Yields the storage xfer_descs, or None on failure.  For the FILE
-        backend, files are created (O_CREAT) when ``direction == "WRITE"``.
+    def _close_fds(self, fds: List[int]) -> None:
+        for fd in fds:
+            self.file_manager.close_file(fd)
+
+    def _acquire_file_path_mode(
+        self, *, keys: List[str], sizes: List[int], direction: str
+    ) -> Optional[StorageRegistration]:
+        parts = ["rw", "create"] if direction == "WRITE" else ["ro"]
+        if self.file_manager.use_direct_io:
+            parts.append("direct")
+        spec = ",".join(parts)
+        tuples = [(0, sizes[i], i + 1, f"{spec}:{keys[i]}") for i in range(len(keys))]
+        reg = self._register(tuples, "FILE")
+        if reg is None:
+            return None
+        return StorageRegistration(descs=reg.trim(), reg=reg)
+
+    def _acquire_file_fd_mode(
+        self, *, keys: List[str], sizes: List[int], direction: str
+    ) -> Optional[StorageRegistration]:
+        fds: List[int] = []
+        for path in keys:
+            fd = self.file_manager.open_file(path, create=(direction == "WRITE"))
+            if fd is None:
+                self._close_fds(fds)
+                return None
+            fds.append(fd)
+        tuples = [(0, sizes[i], fds[i], keys[i]) for i in range(len(keys))]
+        reg = self._register(tuples, "FILE")
+        if reg is None:
+            self._close_fds(fds)
+            return None
+        descs = self.agent.get_xfer_descs(
+            [(0, sizes[i], fds[i]) for i in range(len(fds))], "FILE"
+        )
+        return StorageRegistration(descs=descs, reg=reg, fds=fds)
+
+    def _acquire_obj(
+        self, *, keys: List[str], sizes: List[int]
+    ) -> Optional[StorageRegistration]:
+        # Reg tuple: (addr=0, size, devId, metaInfo=key).
+        # Xfer tuple: (addr=0, size, devId). devId links each xfer desc
+        # back to its registered object's metaInfo, so devIds must be
+        # unique within the list AND globally unique across concurrent
+        # acquire_storage() calls (the OBJ plugin's devIdToObjKey_ map is
+        # shared and unlocked). NIXL's pybind layer requires position 3 to
+        # be int, hence the key goes in metaInfo (position 4).
+        n = len(keys)
+        with self._obj_devid_lock:
+            base = self._obj_devid_next
+            self._obj_devid_next += n
+        dev_ids = list(range(base, base + n))
+        tuples = [(0, sizes[i], dev_ids[i], keys[i]) for i in range(n)]
+        reg = self._register(tuples, "OBJ")
+        if reg is None:
+            return None
+        descs = self.agent.get_xfer_descs(
+            [(0, sizes[i], dev_ids[i]) for i in range(n)],
+            self.mem_type,
+        )
+        return StorageRegistration(descs=descs, reg=reg)
+
+    def acquire_storage(
+        self, buffers, keys: List[str], direction: str
+    ) -> Optional[StorageRegistration]:
+        """Open + register the storage side of one transfer.
+
+        For the FILE backend, files are created (O_CREAT) when
+        ``direction == "WRITE"``.  Returns None on failure, with any
+        partially acquired resources (fds) released.  ``descs`` on the
+        returned registration may be None if descriptor construction
+        failed; the registration must still be released.
         """
         sizes = _buffer_sizes(buffers)
         if sizes is None:
-            yield None
-            return
+            return None
 
         if self.mem_type == "FILE":
             if self.path_mode:
-                parts = ["rw", "create"] if direction == "WRITE" else ["ro"]
-                if self.file_manager.use_direct_io:
-                    parts.append("direct")
-                spec = ",".join(parts)
-                tuples = [
-                    (0, sizes[i], i + 1, f"{spec}:{keys[i]}") for i in range(len(keys))
-                ]
-                with self._registered(tuples, "FILE") as reg:
-                    if reg is None:
-                        yield None
-                        return
-                    yield reg.trim()
-            else:
-                with self._open_files(keys, create=(direction == "WRITE")) as fds:
-                    if fds is None:
-                        yield None
-                        return
-                    tuples = [(0, sizes[i], fds[i], keys[i]) for i in range(len(keys))]
-                    with self._registered(tuples, "FILE") as reg:
-                        if reg is None:
-                            yield None
-                            return
-                        yield self.agent.get_xfer_descs(
-                            [(0, sizes[i], fds[i]) for i in range(len(fds))], "FILE"
-                        )
-        else:  # OBJ
-            # Reg tuple: (addr=0, size, devId, metaInfo=key).
-            # Xfer tuple: (addr=0, size, devId). devId links each xfer desc
-            # back to its registered object's metaInfo, so devIds must be
-            # unique within the list AND globally unique across concurrent
-            # storage() calls (the OBJ plugin's devIdToObjKey_ map is shared
-            # and unlocked). NIXL's pybind layer requires position 3 to be
-            # int, hence the key goes in metaInfo (position 4).
-            n = len(keys)
-            with self._obj_devid_lock:
-                base = self._obj_devid_next
-                self._obj_devid_next += n
-            dev_ids = list(range(base, base + n))
-            tuples = [(0, sizes[i], dev_ids[i], keys[i]) for i in range(n)]
-            with self._registered(tuples, "OBJ") as reg:
-                if reg is None:
-                    yield None
-                    return
-                yield self.agent.get_xfer_descs(
-                    [(0, sizes[i], dev_ids[i]) for i in range(n)],
-                    self.mem_type,
+                return self._acquire_file_path_mode(
+                    keys=keys, sizes=sizes, direction=direction
                 )
+            return self._acquire_file_fd_mode(
+                keys=keys, sizes=sizes, direction=direction
+            )
+        return self._acquire_obj(keys=keys, sizes=sizes)
+
+    def release_storage(self, registration: StorageRegistration) -> None:
+        """Deregister and close any fds. Exception-safe; call exactly once,
+        after the last use of ``registration.descs`` (fds must outlive the
+        registration, so deregister happens before the fds close)."""
+        if registration.reg is not None:
+            try:
+                self.agent.deregister_memory(registration.reg)
+            except Exception as e:
+                logger.debug("deregister_memory skipped: %s", e)
+        self._close_fds(registration.fds)
+
+    @contextmanager
+    def storage(self, buffers, keys: List[str], direction: str):
+        """Acquire + release around one ``with`` block.
+
+        Yields the storage xfer_descs, or None on failure.  Kept for
+        callers whose registration lifetime matches the block; async
+        callers should use acquire_storage/release_storage directly.
+        """
+        registration = self.acquire_storage(buffers, keys, direction)
+        try:
+            yield registration.descs if registration is not None else None
+        finally:
+            if registration is not None:
+                self.release_storage(registration)

--- a/test/registered/unit/mem_cache/test_hicache_nixl_registry.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_registry.py
@@ -1,0 +1,191 @@
+"""Unit tests for NixlRegistry acquire/release -- mocked agent, no NIXL."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.mem_cache.storage.nixl.nixl_registry import (
+    NixlRegistry,
+)
+from sglang.test.test_utils import CustomTestCase
+
+BUFFERS = [(0x1000, 4096), (0x2000, 4096)]
+KEYS = ["/base/aa/key1", "/base/bb/key2"]
+
+
+def make_agent(*, path_mode: bool) -> MagicMock:
+    """Agent mock whose path-mode probe answers ``path_mode``.
+
+    The probe registers a nonexistent path: a path-mode NIXL raises from
+    register_memory, a pre-path-mode NIXL returns a handle. Calls after
+    the probe succeed.
+    """
+    agent = MagicMock()
+    probe_seen = {"done": False}
+
+    def register_memory(reg_descs):
+        if not probe_seen["done"]:
+            probe_seen["done"] = True
+            if path_mode:
+                raise RuntimeError("path-mode probe: open failed")
+            return MagicMock(name="probe_reg")
+        return MagicMock(name="reg")
+
+    agent.register_memory.side_effect = register_memory
+    return agent
+
+
+class TestPathModeLifecycle(CustomTestCase):
+    """Acquire must register path-mode tuples and release must deregister
+    the same handle. Guards the register/deregister pairing the async
+    backend (RFC #32841) will rely on across a transfer's lifetime."""
+
+    def setUp(self):
+        self.agent = make_agent(path_mode=True)
+        self.file_manager = MagicMock(use_direct_io=False)
+        self.registry = NixlRegistry(self.agent, "FILE", self.file_manager)
+        self.assertTrue(self.registry.path_mode)
+
+    def test_acquire_release_pairs_registration(self):
+        registration = self.registry.acquire_storage(BUFFERS, KEYS, "WRITE")
+
+        self.assertIsNotNone(registration)
+        # Registration tuples carry the path-mode spec, one devId per key.
+        items, mem_type = self.agent.get_reg_descs.call_args_list[-1][0]
+        self.assertEqual(mem_type, "FILE")
+        self.assertEqual(
+            items,
+            [
+                (0, 4096, 1, "rw,create:/base/aa/key1"),
+                (0, 4096, 2, "rw,create:/base/bb/key2"),
+            ],
+        )
+        # descs come from trimming the registration handle.
+        self.assertIs(registration.descs, registration.reg.trim.return_value)
+        # No fd path involved in path mode.
+        self.file_manager.open_file.assert_not_called()
+
+        self.registry.release_storage(registration)
+        self.agent.deregister_memory.assert_called_once_with(registration.reg)
+
+    def test_read_direction_uses_ro_spec_without_create(self):
+        self.registry.acquire_storage(BUFFERS, KEYS, "READ")
+        items, _ = self.agent.get_reg_descs.call_args_list[-1][0]
+        self.assertEqual(items[0][3], "ro:/base/aa/key1")
+
+    def test_register_failure_returns_none(self):
+        self.agent.register_memory.side_effect = RuntimeError("no space")
+        self.assertIsNone(self.registry.acquire_storage(BUFFERS, KEYS, "WRITE"))
+        self.agent.deregister_memory.assert_not_called()
+
+
+class TestFdModeLifecycle(CustomTestCase):
+    """fd-mode ordering contract: fds must outlive the registration.
+
+    Acquire opens fds before registering; release deregisters before
+    closing. Breaking either order hands NIXL dead fds."""
+
+    def setUp(self):
+        self.agent = make_agent(path_mode=False)
+        self.calls: list[str] = []
+        self.agent.deregister_memory.side_effect = lambda reg: self.calls.append(
+            "deregister"
+        )
+        self.file_manager = MagicMock(use_direct_io=False)
+        fd_iter = iter([10, 11])
+        self.file_manager.open_file.side_effect = lambda path, create: (
+            self.calls.append(f"open:{path}"),
+            next(fd_iter),
+        )[1]
+        self.file_manager.close_file.side_effect = lambda fd: self.calls.append(
+            f"close:{fd}"
+        )
+        self.registry = NixlRegistry(self.agent, "FILE", self.file_manager)
+        self.assertFalse(self.registry.path_mode)
+        # The path-mode probe registers and deregisters once during
+        # construction; drop it so tests assert on transfer calls only.
+        self.calls.clear()
+
+    def test_release_deregisters_before_closing_fds(self):
+        registration = self.registry.acquire_storage(BUFFERS, KEYS, "WRITE")
+
+        self.assertIsNotNone(registration)
+        self.assertEqual(registration.fds, [10, 11])
+        items, _ = self.agent.get_reg_descs.call_args_list[-1][0]
+        self.assertEqual(items[0], (0, 4096, 10, "/base/aa/key1"))
+
+        self.registry.release_storage(registration)
+        self.assertEqual(
+            self.calls,
+            [
+                "open:/base/aa/key1",
+                "open:/base/bb/key2",
+                "deregister",
+                "close:10",
+                "close:11",
+            ],
+        )
+
+    def test_open_failure_closes_already_opened_fds(self):
+        self.file_manager.open_file.side_effect = [10, None]
+        self.assertIsNone(self.registry.acquire_storage(BUFFERS, KEYS, "WRITE"))
+        self.file_manager.close_file.assert_called_once_with(10)
+
+    def test_register_failure_closes_fds(self):
+        self.agent.register_memory.side_effect = RuntimeError("no space")
+        self.assertIsNone(self.registry.acquire_storage(BUFFERS, KEYS, "WRITE"))
+        # Both fds closed and nothing deregistered after construction
+        # (the probe's own register/deregister pair was cleared in setUp).
+        self.assertEqual(
+            self.calls,
+            ["open:/base/aa/key1", "open:/base/bb/key2", "close:10", "close:11"],
+        )
+
+
+class TestObjDevIds(CustomTestCase):
+    """Consecutive acquires must use disjoint devId ranges: the OBJ
+    plugin's devIdToObjKey_ map is process-wide and unlocked, so reusing
+    a devId across in-flight registrations corrupts the key mapping."""
+
+    def test_devid_ranges_are_disjoint_across_acquires(self):
+        agent = MagicMock()
+        registry = NixlRegistry(agent, "OBJ", None)
+
+        registry.acquire_storage(BUFFERS, KEYS, "WRITE")
+        first_items, _ = agent.get_reg_descs.call_args_list[-1][0]
+        registry.acquire_storage(BUFFERS, KEYS, "WRITE")
+        second_items, _ = agent.get_reg_descs.call_args_list[-1][0]
+
+        first_ids = {item[2] for item in first_items}
+        second_ids = {item[2] for item in second_items}
+        self.assertEqual(len(first_ids & second_ids), 0)
+
+
+class TestStorageContextManager(CustomTestCase):
+    """storage() is a thin acquire/release wrapper and must keep its
+    original contract: yield descs (or None) and always release."""
+
+    def test_yields_descs_and_releases_on_exit(self):
+        agent = make_agent(path_mode=True)
+        registry = NixlRegistry(agent, "FILE", MagicMock(use_direct_io=False))
+
+        with registry.storage(BUFFERS, KEYS, "WRITE") as descs:
+            self.assertIsNotNone(descs)
+            agent.deregister_memory.assert_not_called()
+        agent.deregister_memory.assert_called_once()
+
+    def test_yields_none_without_release_when_acquire_fails(self):
+        agent = make_agent(path_mode=True)
+        registry = NixlRegistry(agent, "FILE", MagicMock(use_direct_io=False))
+        agent.register_memory.side_effect = RuntimeError("no space")
+
+        with registry.storage(BUFFERS, KEYS, "WRITE") as descs:
+            self.assertIsNone(descs)
+        agent.deregister_memory.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Stage 1 of the async completion redesign proposed in RFC #32841 (roadmap item on #26693). The RFC's staged plan starts with a mechanical, behavior-neutral refactor: expose the storage-side registration lifetime as an explicit acquire/release pair so a future asynchronous caller can hold a registration for the lifetime of its transfer handle and release on completion, instead of being forced to complete the transfer inside one `with` block. The same primitive is the prerequisite for runtime storage-backend detach (drain outstanding handles, then release).

Rebased onto current main (no conflicts; main did not touch this directory in the interim). Design semantics for the later stages are pinned down on the RFC, latest in https://github.com/sgl-project/sglang/issues/32841#issuecomment-5187150516.

## Modifications

- `NixlRegistry.acquire_storage(buffers, keys, direction)` performs the open-register-build-descs sequence and returns a `StorageRegistration` (msgspec.Struct holding descs, the registration handle and any fds), or None on failure with partial resources released.
- `NixlRegistry.release_storage(registration)` deregisters then closes fds, preserving the original ordering (fds must outlive the registration).
- The `storage()` context manager is reimplemented as a thin wrapper over the pair, so the single existing call site (`hicache_nixl._xfer_pre_registered`) is untouched and behavior is identical: same registration tuples for path-mode/fd-mode/OBJ, same failure cleanup, same OBJ devId allocation under the lock.
- No behavior change intended anywhere; this PR deliberately does not switch any caller to the new API.

New CPU-CI unit tests (`test_hicache_nixl_registry.py`, mocked agent, no NIXL install needed): path-mode and fd-mode lifecycles, deregister-before-fd-close ordering, failure cleanup on partial open and on register failure, OBJ devId range disjointness across acquires and the context manager contract.

## Accuracy Tests

Not applicable: no change to inference outputs.

## Speed Tests and Profiling

Not applicable: structural refactor, identical call sequence per transfer.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30972211745](https://github.com/sgl-project/sglang/actions/runs/30972211745)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30972211618](https://github.com/sgl-project/sglang/actions/runs/30972211618)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
