### PR TITLE
fix(hicache): complete Mamba sidecar backups after branch reconstruction

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -367,10 +367,18 @@ class HybridCacheController(BaseHiCacheController):
         priority: Optional[int] = None,
         node_id: int = -1,
         extra_pools: Optional[list[PoolTransfer]] = None,
+        host_indices: Optional[torch.Tensor] = None,
     ) -> Optional[torch.Tensor]:
-        host_indices = self.mem_pool_host.alloc(len(device_indices))
-        if host_indices is None:
-            return None
+        allocated_host_indices = host_indices is None
+        if allocated_host_indices:
+            host_indices = self.mem_pool_host.alloc(len(device_indices))
+            if host_indices is None:
+                return None
+        elif len(host_indices) != len(device_indices):
+            raise ValueError(
+                "Host/device index length mismatch for HiCache write: "
+                f"{len(host_indices)=}, {len(device_indices)=}"
+            )
         pool_transfers = self._resolve_pool_transfers_allocation(
             extra_pools,
             alloc_host=True,
@@ -378,7 +386,8 @@ class HybridCacheController(BaseHiCacheController):
             kv_host_indices=host_indices,
         )
         if pool_transfers is None and extra_pools:
-            self.mem_pool_host.free(host_indices)
+            if allocated_host_indices:
+                self.mem_pool_host.free(host_indices)
             return None
 
         self.write_queue.append(

--- a/python/sglang/srt/mem_cache/unified_cache/cache_action.py
+++ b/python/sglang/srt/mem_cache/unified_cache/cache_action.py
@@ -30,6 +30,15 @@ class ReplaceWriteThroughOnNodeSplit(msgspec.Struct, frozen=True):
     new_child_node_id: NodeId
 
 
+class ReplaceWriteThroughBatchOnNodeSplit(msgspec.Struct, frozen=True):
+    """Replace every pending write-through publication when a node splits."""
+
+    ack_ids: tuple[int, ...]
+    old_node_id: NodeId
+    new_node_id: NodeId
+    new_child_node_id: NodeId
+
+
 class FreeDeviceKV(msgspec.Struct, frozen=True):
     """Free unreferenced device KV slots (a SWA-aware combined free)."""
 
@@ -100,4 +109,9 @@ class SWARebuild(ComponentAction, frozen=True):
 
 
 # Cache-owned actions, applied by UnifiedRadixCache itself.
-CacheAction = ReplaceWriteThroughOnNodeSplit | FreeDeviceKV | BackupKV
+CacheAction = (
+    ReplaceWriteThroughOnNodeSplit
+    | ReplaceWriteThroughBatchOnNodeSplit
+    | FreeDeviceKV
+    | BackupKV
+)

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -107,6 +107,10 @@ class MambaComponent(TreeComponent):
             or node.component_data[ct].host_value is not None
         )
 
+    def needs_hicache_backup(self, node: UnifiedTreeNode) -> bool:
+        cd = node.component_data[self.component_type]
+        return cd.value is not None and cd.host_value is None
+
     def finalize_match_result_in_tree_core(
         self,
         result: MatchResult,
@@ -639,7 +643,7 @@ class MambaComponent(TreeComponent):
 
         if phase == CacheTransferPhase.BACKUP_HOST:
             cd = node.component_data[ct]
-            if cd.value is None:
+            if cd.value is None or cd.host_value is not None:
                 return None
             return [
                 PoolTransfer(

--- a/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
@@ -133,6 +133,14 @@ class TreeComponent(ABC):
         cd = node.component_data[self.component_type]
         return cd.value is None and cd.host_value is not None
 
+    def needs_hicache_backup(self, node: UnifiedTreeNode) -> bool:
+        """Whether this component has device data missing from the Host backup.
+
+        Components that are part of the node's reusable Host state override
+        this hook. Device-only auxiliary components keep the default ``False``.
+        """
+        return False
+
     def refresh_lru(
         self,
         phase: LRURefreshPhase,

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -47,6 +47,7 @@ from sglang.srt.mem_cache.unified_cache.cache_action import (
     CacheAction,
     ComponentAction,
     FreeDeviceKV,
+    ReplaceWriteThroughBatchOnNodeSplit,
     ReplaceWriteThroughOnNodeSplit,
 )
 from sglang.srt.mem_cache.unified_cache.components import (
@@ -122,7 +123,7 @@ class UnifiedTreeNode:
         )
         self.id = UnifiedTreeNode.counter
         UnifiedTreeNode.counter += 1
-        self.write_through_pending_id: Optional[int] = None
+        self.write_through_pending_ids: set[int] = set()
 
     def component(self, component_type: ComponentType) -> ComponentData:
         return self.component_data[component_type]
@@ -414,6 +415,10 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
     def is_backuped(self, node_id: NodeId) -> bool:
         """Whether the node's KV is already backed up to host."""
         return self._node_arena[node_id].backuped
+
+    def needs_hicache_backup(self, node_id: NodeId) -> bool:
+        """Whether the node is missing any policy-required Host state."""
+        return self._node_needs_hicache_backup(self._node_arena[node_id])
 
     def is_root(self, node_id: NodeId) -> bool:
         """Whether the node is the tree root."""
@@ -743,8 +748,23 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         node.hit_count += 1
         return (
             self.enable_hicache
-            and not node.backuped
+            and self._node_needs_hicache_backup(node)
             and node.hit_count >= self.write_through_threshold
+        )
+
+    def _node_needs_hicache_backup(self, node: UnifiedTreeNode) -> bool:
+        """Whether reusable device state is missing from the Host copy."""
+        if not self.enable_hicache:
+            return False
+        base = node.component_data[BASE_COMPONENT_TYPE]
+        if base.value is None:
+            return False
+        if base.host_value is None:
+            return True
+        return any(
+            component.needs_hicache_backup(node)
+            for component in self.components
+            if component.component_type != BASE_COMPONENT_TYPE
         )
 
     def begin_insert(self, params: InsertParams) -> InsertStepResult:
@@ -822,7 +842,14 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
     @staticmethod
     def _is_deferrable_action(action: CacheAction | ComponentAction) -> bool:
         """Fire-and-forget actions safe to batch until the next barrier."""
-        return isinstance(action, (FreeDeviceKV, ReplaceWriteThroughOnNodeSplit))
+        return isinstance(
+            action,
+            (
+                FreeDeviceKV,
+                ReplaceWriteThroughOnNodeSplit,
+                ReplaceWriteThroughBatchOnNodeSplit,
+            ),
+        )
 
     def _insert_walk_step(self, state: _InsertWalkState) -> None:
         """Process one walked node, appending its barrier actions to the state."""
@@ -903,6 +930,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         # All hooks run before their emitted actions execute; an action failure
         # fail-stops the process, so partial-commit state is never observed.
         state.result = InsertResult(prefix_len=state.total_prefix_length)
+        component_action_start = len(state.pending_actions)
         for component in self.components:
             component.commit_insert_component_data(
                 node=state.target_node,
@@ -910,6 +938,21 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 params=state.params,
                 result=state.result,
                 cache_actions=state.pending_actions,
+            )
+        if (
+            not state.is_new_leaf
+            and not state.params.chunked
+            and not self.is_write_back
+            and state.target_node.hit_count >= self.write_through_threshold
+            and self._node_needs_hicache_backup(state.target_node)
+        ):
+            # A branch checkpoint can attach Mamba state after this node's Full
+            # KV was already backed up. Complete that existing Host entry
+            # without incrementing the node's hit count a second time. Run the
+            # backup before component actions such as the Mamba path-cap walk.
+            state.pending_actions.insert(
+                component_action_start,
+                self._build_backup_kv_action(state.target_node),
             )
         state.phase = _InsertPhase.TAIL
 
@@ -954,11 +997,11 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
         # A split of a backuped node tells the cache to fix its publish list.
         action: Optional[CacheAction | ComponentAction] = None
-        if child.write_through_pending_id is not None:
-            ack_id = child.write_through_pending_id
-            new_node.write_through_pending_id = ack_id
-            action = ReplaceWriteThroughOnNodeSplit(
-                ack_id=ack_id,
+        if child.write_through_pending_ids:
+            ack_ids = tuple(sorted(child.write_through_pending_ids))
+            new_node.write_through_pending_ids.update(ack_ids)
+            action = ReplaceWriteThroughBatchOnNodeSplit(
+                ack_ids=ack_ids,
                 old_node_id=child.id,
                 new_node_id=new_node.id,
                 new_child_node_id=child.id,
@@ -1081,8 +1124,8 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         result = EvictDeviceLeafResult()
         node = self.node_by_id(node_id)
         assert self._is_device_leaf(node), f"node {node.id} is not a D-leaf"
-        if not node.backuped:
-            if is_write_back:
+        if self._node_needs_hicache_backup(node):
+            if is_write_back or node.backuped:
                 result.backup_kv = self._build_backup_kv_action(node, write_back=True)
                 return result
             # Write-through: node has no backup, delete entirely.
@@ -1109,9 +1152,13 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         result = DropSubtreeNoHostResult(is_dropped=False)
         node = self.node_by_id(node_id)
         assert self._is_device_leaf(node), f"node {node.id} is not a D-leaf"
+        if node.backuped:
+            # Full KV is already reusable on Host; only an auxiliary backup
+            # failed. Keep the device sidecar for a later retry.
+            return result
         # A failed backup never issues the D->H copy, so the subtree root has
         # no host state and no in-flight DMA reading its device slots.
-        assert not node.backuped and node.write_through_pending_id is None
+        assert not node.backuped and not node.write_through_pending_ids
         if any(cd.host_lock_ref > 0 for cd in node.component_data):
             return result
         descendants: list[UnifiedTreeNode] = []
@@ -1128,7 +1175,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             # Host-only by construction: a device descendant would contradict
             # this node being a D-leaf, and D-leaves evict before ancestors.
             assert desc.evicted and desc.backuped, f"node {desc.id} not host-only"
-            assert desc.write_through_pending_id is None
+            assert not desc.write_through_pending_ids
             self._release_all_component_layers(
                 desc,
                 StorageMedium.CPU,
@@ -1535,12 +1582,13 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         return result
 
     def build_backup_spec(self, node_id: NodeId):
-        """Read a node's device->host backup spec (device value + component transfers) now."""
+        """Read a node's current device/Host KV and component backup spec."""
         return self._build_backup_spec(self.node_by_id(node_id))
 
     def _build_backup_spec(self, node: UnifiedTreeNode):
         """Gather device value backup spec."""
-        device_value = node.component_data[BASE_COMPONENT_TYPE].value
+        base = node.component_data[BASE_COMPONENT_TYPE]
+        device_value = base.value
         comp_xfers: dict[ComponentType, list] = {}
         for comp in self.components:
             if comp.component_type == BASE_COMPONENT_TYPE:
@@ -1548,7 +1596,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             t = comp.build_hicache_transfers(node, CacheTransferPhase.BACKUP_HOST)
             if t:
                 comp_xfers[comp.component_type] = t
-        return device_value, comp_xfers
+        return device_value, base.host_value, comp_xfers
 
     def build_storage_backup_spec(
         self, node_id: NodeId, pass_prefix_keys: bool
@@ -1634,7 +1682,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             while (
                 ancestor is not None
                 and ancestor is not self.root_node
-                and not ancestor.backuped
+                and self._node_needs_hicache_backup(ancestor)
             ):
                 chain.append(ancestor)
                 ancestor = ancestor.parent
@@ -1720,18 +1768,17 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self._update_evictable_leaf_sets(node)
         return cache_actions
 
-    def mark_write_through_pending(self, node_id: NodeId) -> None:
+    def mark_write_through_pending(self, node_id: NodeId, ack_id: int) -> None:
         """Mark a node as having an in-flight write-through backup."""
         node = self.node_by_id(node_id)
-        node.write_through_pending_id = node_id
+        node.write_through_pending_ids.add(ack_id)
 
     def finish_write_through(self, node_ids: list[NodeId], ack_id: int) -> None:
         """Clear the write-through-pending mark (when it matches ack_id) and record the
         host store event for each acked node."""
         for node_id in node_ids:
             node = self.node_by_id(node_id)
-            if node.write_through_pending_id == ack_id:
-                node.write_through_pending_id = None
+            node.write_through_pending_ids.discard(ack_id)
             self._record_store_event(node, medium=StorageMedium.CPU)
 
     def set_component_device_value(

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -151,6 +151,11 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
         ...
 
     @abstractmethod
+    def needs_hicache_backup(self, node_id: NodeId) -> bool:
+        """Whether the node is missing any policy-required Host state."""
+        ...
+
+    @abstractmethod
     def is_root(self, node_id: NodeId) -> bool:
         """Whether the node is the tree root."""
         ...
@@ -364,10 +369,12 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
         ...
 
     @abstractmethod
-    def build_backup_spec(
-        self, node_id: NodeId
-    ) -> tuple[torch.Tensor, dict[ComponentType, list[PoolTransfer]]]:
-        """Read a node's device->host backup spec (device value + transfers) now."""
+    def build_backup_spec(self, node_id: NodeId) -> tuple[
+        torch.Tensor,
+        Optional[torch.Tensor],
+        dict[ComponentType, list[PoolTransfer]],
+    ]:
+        """Read current device/Host KV and component backup transfers."""
         ...
 
     @abstractmethod
@@ -440,7 +447,7 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
         ...
 
     @abstractmethod
-    def mark_write_through_pending(self, node_id: NodeId) -> None:
+    def mark_write_through_pending(self, node_id: NodeId, ack_id: int) -> None:
         """Mark a node as having an in-flight write-through backup."""
         ...
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -39,6 +39,7 @@ from sglang.srt.mem_cache.unified_cache.cache_action import (
     ComponentAction,
     FreeComponentDeviceSlot,
     FreeDeviceKV,
+    ReplaceWriteThroughBatchOnNodeSplit,
     ReplaceWriteThroughOnNodeSplit,
 )
 
@@ -280,6 +281,7 @@ class UnifiedRadixCache(BasePrefixCache):
         # Reset Controller.
         self.session.slots.clear()
         self.ongoing_write_through: dict[int, _OngoingWriteThrough] = {}
+        self._next_write_through_ack_id = -1
         self.ongoing_load_back: dict[int, _OngoingLoadBack] = {}
         self.enable_storage = False
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
@@ -816,6 +818,13 @@ class UnifiedRadixCache(BasePrefixCache):
                 action.old_node_id,
                 [action.new_node_id, action.new_child_node_id],
             )
+        elif isinstance(action, ReplaceWriteThroughBatchOnNodeSplit):
+            for ack_id in action.ack_ids:
+                self._replace_pending_write_through_node(
+                    ack_id,
+                    action.old_node_id,
+                    [action.new_node_id, action.new_child_node_id],
+                )
         elif isinstance(action, FreeDeviceKV):
             # tree values are page-aligned copies of a kv row: page-exact segments
             for indices in action.indices:
@@ -857,13 +866,22 @@ class UnifiedRadixCache(BasePrefixCache):
         """Run a backup action top-down, stopping at the first failed backup."""
         written = 0
         for node_id in action.node_ids:
-            # Overlapping chain actions: skip already-backed nodes.
-            if self.tree_core.is_backuped(node_id):
+            # Overlapping chain actions: skip complete Host entries. A node
+            # whose Full KV is backed up can still need a newly attached
+            # auxiliary state such as a branch-created Mamba checkpoint.
+            if not self.tree_core.needs_hicache_backup(node_id):
                 continue
-            device_value, comp_xfers = self.tree_core.build_backup_spec(node_id)
+            device_value, host_value, comp_xfers = self.tree_core.build_backup_spec(
+                node_id
+            )
             sidecar_xfers = self._build_backup_sidecar(device_value, comp_xfers)
+            ack_id = self._reserve_write_through_ack_id(node_id)
             host_indices = self._execute_kv_backup(
-                node_id, device_value, comp_xfers, sidecar_xfers
+                ack_id,
+                device_value,
+                comp_xfers,
+                sidecar_xfers,
+                host_indices=host_value,
             )
             if host_indices is None:
                 return 0
@@ -871,7 +889,7 @@ class UnifiedRadixCache(BasePrefixCache):
             lock_params = None
             if not write_back:
                 lock_params = self.inc_lock_ref(node_id).to_dec_params()
-            self._track_write_through_node(node_id, lock_params)
+            self._track_write_through_node(node_id, lock_params, ack_id)
             written = len(host_indices)
         return written
 
@@ -882,29 +900,51 @@ class UnifiedRadixCache(BasePrefixCache):
             CacheTransferPhase.BACKUP_HOST, kv_xfer, comp_xfers
         )
 
-    def _execute_kv_backup(self, node_id, device_value, comp_xfers, sidecar_xfers):
+    def _execute_kv_backup(
+        self,
+        ack_id,
+        device_value,
+        comp_xfers,
+        sidecar_xfers,
+        host_indices=None,
+    ):
         """Execute Backup action."""
-        kv_tokens = len(device_value)
-        host_avail = self.cache_controller.mem_pool_host.available_size()
-        if host_avail < kv_tokens:
-            needed = kv_tokens - host_avail
-            if self.evict_host(needed) < needed:
-                return None
+        if host_indices is None:
+            kv_tokens = len(device_value)
+            host_avail = self.cache_controller.mem_pool_host.available_size()
+            if host_avail < kv_tokens:
+                needed = kv_tokens - host_avail
+                if self.evict_host(needed) < needed:
+                    return None
         aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
         aux_xfers.extend(sidecar_xfers)
         return self.cache_controller.write(
-            device_value, node_id=node_id, extra_pools=aux_xfers or None
+            device_value,
+            node_id=ack_id,
+            extra_pools=aux_xfers or None,
+            host_indices=host_indices,
         )
 
     def _track_write_through_node(
         self,
         node_id: NodeId,
         lock_params: Optional[DecLockRefParams],
+        ack_id: int,
     ) -> None:
-        self.tree_core.mark_write_through_pending(node_id)
-        self.ongoing_write_through[node_id] = _OngoingWriteThrough(
+        self.tree_core.mark_write_through_pending(node_id, ack_id)
+        self.ongoing_write_through[ack_id] = _OngoingWriteThrough(
             node_id, lock_params, [node_id]
         )
+
+    def _reserve_write_through_ack_id(self, node_id: NodeId) -> int:
+        """Return an ack id that cannot overwrite another in-flight write."""
+        if node_id not in self.ongoing_write_through:
+            return node_id
+        ack_id = self._next_write_through_ack_id
+        while ack_id in self.ongoing_write_through:
+            ack_id -= 1
+        self._next_write_through_ack_id = ack_id - 1
+        return ack_id
 
     def _replace_pending_write_through_node(
         self, ack_id: int, old_node_id: NodeId, new_node_ids: list[NodeId]
@@ -941,9 +981,16 @@ class UnifiedRadixCache(BasePrefixCache):
             self.dec_lock_ref(lock_node_id, lock_params)
         if self.enable_storage:
             # Back up each fragment: after a split, lock_node only holds the
-            # suffix; the prefix fragment must be persisted as well.
+            # suffix; the prefix fragment must be persisted as well. Defer a
+            # fragment until its last overlapping Host write has completed.
+            still_pending = {
+                node_id
+                for pending in self.ongoing_write_through.values()
+                for node_id in pending.publish_node_ids
+            }
             for node_id in publish_node_ids:
-                self.write_backup_storage(node_id)
+                if node_id not in still_pending:
+                    self.write_backup_storage(node_id)
 
     def load_back(
         self,

--- a/test/registered/unit/mem_cache/test_mamba_path_state_cap.py
+++ b/test/registered/unit/mem_cache/test_mamba_path_state_cap.py
@@ -13,7 +13,14 @@ from unittest import mock
 import torch
 from test_unified_radix_cache_unittest import CacheConfig, UnifiedRadixCacheSuite
 
-from sglang.srt.mem_cache.unified_cache.cache_action import MambaEvictExcessPathStates
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    HybridCacheController,
+)
+from sglang.srt.mem_cache.unified_cache.cache_action import (
+    MambaEvictExcessPathStates,
+    ReplaceWriteThroughBatchOnNodeSplit,
+)
 from sglang.srt.mem_cache.unified_cache.components.mamba_component import (
     MambaComponent,
 )
@@ -21,7 +28,11 @@ from sglang.srt.mem_cache.unified_cache.components.tree_component import (
     ComponentType,
 )
 from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
-from sglang.srt.mem_cache.unified_radix_cache import UnifiedLRUList, UnifiedTreeNode
+from sglang.srt.mem_cache.unified_radix_cache import (
+    UnifiedLRUList,
+    UnifiedRadixCache,
+    UnifiedTreeNode,
+)
 from sglang.srt.server_args import ServerArgs
 from sglang.test.test_utils import CustomTestCase
 
@@ -180,6 +191,123 @@ class TestMambaPathStateCap(unittest.TestCase):
             )
         )
 
+    def test_hicache_completeness_includes_mamba_sidecar(self):
+        component, nodes, core, _ = _build_unified_chain(cap=-1, length=1)
+        node = nodes[0]
+        core.enable_hicache = True
+        core.components = (component,)
+
+        full_data = node.component_data[ComponentType.FULL]
+        mamba_data = node.component_data[ComponentType.MAMBA]
+        full_data.host_value = torch.tensor([200])
+
+        self.assertTrue(UnifiedTreeCore._node_needs_hicache_backup(core, node))
+
+        device_value, host_value, comp_xfers = UnifiedTreeCore._build_backup_spec(
+            core, node
+        )
+        self.assertIs(device_value, full_data.value)
+        self.assertIs(host_value, full_data.host_value)
+        self.assertEqual(
+            comp_xfers[ComponentType.MAMBA][0].name,
+            PoolName.MAMBA,
+        )
+        self.assertIs(
+            comp_xfers[ComponentType.MAMBA][0].device_indices,
+            mamba_data.value,
+        )
+
+        mamba_data.host_value = torch.tensor([300])
+        self.assertFalse(UnifiedTreeCore._node_needs_hicache_backup(core, node))
+        _, _, comp_xfers = UnifiedTreeCore._build_backup_spec(core, node)
+        self.assertNotIn(ComponentType.MAMBA, comp_xfers)
+
+    def test_supplemental_backup_reuses_existing_full_host_indices(self):
+        controller = object.__new__(HybridCacheController)
+        controller.mem_pool_host = mock.Mock()
+        controller.write_queue = []
+        controller.start_writing = mock.Mock()
+        controller._resolve_pool_transfers_allocation = mock.Mock(return_value=[])
+
+        device_indices = torch.tensor([1, 2])
+        host_indices = torch.tensor([10, 11])
+        result = HybridCacheController.write(
+            controller,
+            device_indices,
+            node_id=7,
+            host_indices=host_indices,
+        )
+
+        self.assertIs(result, host_indices)
+        controller.mem_pool_host.alloc.assert_not_called()
+        self.assertEqual(len(controller.write_queue), 1)
+        self.assertIs(controller.write_queue[0].host_indices, host_indices)
+
+        controller.write_queue.clear()
+        controller._resolve_pool_transfers_allocation.return_value = None
+        result = HybridCacheController.write(
+            controller,
+            device_indices,
+            node_id=7,
+            extra_pools=[
+                PoolTransfer(name=PoolName.MAMBA, device_indices=torch.tensor([3]))
+            ],
+            host_indices=host_indices,
+        )
+
+        self.assertIsNone(result)
+        controller.mem_pool_host.free.assert_not_called()
+        self.assertEqual(controller.write_queue, [])
+
+    def test_overlapping_supplemental_backup_uses_unique_ack_id(self):
+        cache = object.__new__(UnifiedRadixCache)
+        cache.tree_core = mock.Mock()
+        cache.ongoing_write_through = {}
+        cache._next_write_through_ack_id = -1
+
+        first_ack = cache._reserve_write_through_ack_id(7)
+        cache._track_write_through_node(7, None, first_ack)
+        second_ack = cache._reserve_write_through_ack_id(7)
+        cache._track_write_through_node(7, None, second_ack)
+
+        self.assertEqual(first_ack, 7)
+        self.assertEqual(second_ack, -1)
+        self.assertEqual(set(cache.ongoing_write_through), {7, -1})
+        self.assertEqual(
+            cache.tree_core.mark_write_through_pending.call_args_list,
+            [mock.call(7, 7), mock.call(7, -1)],
+        )
+
+    def test_storage_publish_waits_for_last_overlapping_backup(self):
+        cache = object.__new__(UnifiedRadixCache)
+        cache.tree_core = mock.Mock()
+        cache.ongoing_write_through = {}
+        cache.enable_storage = True
+        cache.write_backup_storage = mock.Mock()
+        cache._track_write_through_node(7, None, 7)
+        cache._track_write_through_node(7, None, -1)
+
+        cache._finish_write_through_ack(7)
+        cache.write_backup_storage.assert_not_called()
+
+        cache._finish_write_through_ack(-1)
+        cache.write_backup_storage.assert_called_once_with(7)
+
+    def test_split_relocates_every_overlapping_backup_ack(self):
+        cache = mock.MagicMock()
+        action = ReplaceWriteThroughBatchOnNodeSplit(
+            ack_ids=(7, -1),
+            old_node_id=2,
+            new_node_id=3,
+            new_child_node_id=2,
+        )
+
+        UnifiedRadixCache._apply_cache_action(cache, action)
+
+        cache._replace_pending_write_through_node.assert_has_calls(
+            [mock.call(7, 2, [3, 2]), mock.call(-1, 2, [3, 2])]
+        )
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "mamba pool fixtures need CUDA")
 class TestMambaPathCapWriteThroughOrdering(CustomTestCase):
@@ -286,9 +414,9 @@ class TestMambaPathCapWriteThroughOrdering(CustomTestCase):
         self.assertIsNotNone(leaf.component_data[ComponentType.MAMBA].host_value)
         cache.sanity_check()
 
-    def test_walk_backup_excludes_same_insert_restamped_mamba(self):
-        """The walked target's backup executes before commit hooks, so a mamba
-        value re-stamped by the same insert stays out of the host backup."""
+    def test_walk_backup_completes_same_insert_restamped_mamba(self):
+        """A checkpoint attached after the walk backup completes the same Host
+        entry with a follow-up Mamba sidecar transfer."""
         cache, allocator, req_to_token_pool = self._build_hicache_fixture()
         mamba_comp = cache.components[ComponentType.MAMBA]
 
@@ -302,7 +430,8 @@ class TestMambaPathCapWriteThroughOrdering(CustomTestCase):
         self.assertIsNone(ancestor.component_data[ComponentType.MAMBA].value)
 
         # Re-inserting [1, 2] crosses the threshold and re-stamps the tombstone
-        # in the same insert; the backup must not carry the fresh mamba state.
+        # in the same insert. The post-commit policy must complete the already
+        # backed-up Full KV entry with that fresh Mamba state.
         cache.write_through_threshold = ancestor.hit_count + 1
         self._insert(cache, allocator, req_to_token_pool, [1, 2])
         cache.writing_check(write_back=True)
@@ -310,7 +439,7 @@ class TestMambaPathCapWriteThroughOrdering(CustomTestCase):
         self.assertTrue(ancestor.backuped)
         ancestor_cd = ancestor.component_data[ComponentType.MAMBA]
         self.assertIsNotNone(ancestor_cd.value)
-        self.assertIsNone(ancestor_cd.host_value)
+        self.assertIsNotNone(ancestor_cd.host_value)
 
     def test_cap_walk_failure_still_drains_collected_frees(self):
         """A cap walk that raises mid-eviction must still free the tombstoned

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -56,6 +56,7 @@ from sglang.srt.mem_cache.unified_cache.cache_action import (
     FreeDeviceKV,
     RebuildFullToSWAMapping,
     RecoverSWAWithLockedFull,
+    ReplaceWriteThroughBatchOnNodeSplit,
     ReplaceWriteThroughOnNodeSplit,
     SWARebuild,
 )
@@ -5358,6 +5359,19 @@ class TestUnifiedRadixCacheActionRouting(CustomTestCase):
         UnifiedRadixCache._apply_cache_action(cache, action)
         cache._replace_pending_write_through_node.assert_called_once_with(7, 2, [3, 2])
 
+    def test_apply_cache_action_routes_overlapping_write_throughs(self):
+        cache = mock.MagicMock()
+        action = ReplaceWriteThroughBatchOnNodeSplit(
+            ack_ids=(7, -1),
+            old_node_id=2,
+            new_node_id=3,
+            new_child_node_id=2,
+        )
+        UnifiedRadixCache._apply_cache_action(cache, action)
+        cache._replace_pending_write_through_node.assert_has_calls(
+            [mock.call(7, 2, [3, 2]), mock.call(-1, 2, [3, 2])]
+        )
+
     def test_apply_cache_action_routes_free_device_kv(self):
         cache = mock.MagicMock()
         first, second = torch.tensor([4, 5]), torch.tensor([6])
@@ -5813,8 +5827,8 @@ class TestResumableInsertWalk(_InsertWalkSuite):
         cache.writing_check(write_back=True)
         parent = next(iter(cache.root_node.children.values()))
         (child,) = parent.children.values()
-        self.assertIsNone(parent.write_through_pending_id)
-        self.assertIsNone(child.write_through_pending_id)
+        self.assertFalse(parent.write_through_pending_ids)
+        self.assertFalse(child.write_through_pending_ids)
         cache.sanity_check()
 
 


### PR DESCRIPTION
## Motivation

PR #31181 made Mamba branch checkpoint reconstruction aware of HiCache, but one lifecycle gap remains:

1. a node's Full KV can already be backed up on Host;
2. a later branch reconstruction attaches a fresh Mamba checkpoint to that node;
3. `node.backuped` only reflects Full KV, so the new Mamba state is not copied to Host;
4. after device eviction, the Host entry is incomplete and the checkpoint must be reconstructed again.

## Changes

- Add component-aware HiCache backup completeness and let Mamba report device state that is missing on Host.
- Complete a late Mamba sidecar after insert commit for write-through policy.
- Complete a missing sidecar before device demotion for write-back policy.
- Reuse existing Full-KV Host indices instead of allocating a second Host KV slice.
- Avoid duplicate Mamba Host allocations.
- Preserve the device sidecar for retry if supplemental Host allocation fails.
- Give overlapping Full-KV/sidecar writes independent ack IDs and relocate every in-flight publication when a node splits.
- Delay storage publication until the final overlapping Host write completes.

## Scope

This is generic HiCache/Mamba policy code. It does not add Ascend/NPU-specific code, FIA integration, native transfer operators, or new kernel dependencies. It is intentionally independent of SGLang #32500 and `sgl-kernel-npu` #626.

## Validation

- `12 passed, 5 skipped` in `test_mamba_path_state_cap.py` (`5` existing CUDA-only fixture tests are skipped in the current non-CUDA environment).
- Python syntax compilation passed for all changed files.
- Black 26.1.0, isort 7.0.0, Ruff 0.15.1 (`F401,F821,UP037`), codespell, and `git diff --check` passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30519439519](https://github.com/sgl-project/sglang/actions/runs/30519439519)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30519439421](https://github.com/sgl-project/sglang/actions/runs/30519439421)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->