### PR TITLE
fix(transformers): support ByteDance/Ouro-1.4B via Transformers backend fallback

### DIFF
--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -1018,7 +1018,7 @@ class TransformersBase(nn.Module):
             )
             hf_input_ids = None
 
-        return self.model(
+        hidden_states = self.model(
             input_ids=hf_input_ids,
             inputs_embeds=hf_input_embeds,
             use_cache=False,
@@ -1027,7 +1027,14 @@ class TransformersBase(nn.Module):
             forward_batch=forward_batch,
             attention_instances=self.attention_instances,
             **kwargs,
-        )[0][0, ...]
+        )[0]
+        # Some remote model code (e.g. ByteDance/Ouro's looped/early-exit
+        # architecture) doesn't fully honor `return_dict=False` and still
+        # wraps the first tuple element in a ModelOutput instead of a plain
+        # tensor. Unwrap one more level in that case.
+        if not isinstance(hidden_states, torch.Tensor):
+            hidden_states = hidden_states[0]
+        return hidden_states[0, ...]
 
     def _forward_hidden_states(
         self,

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -311,6 +311,12 @@ def _patch_text_config(parent_config: PretrainedConfig, text_config):
     parent directly to the language model, others pass the text sub-config),
     so we propagate in both directions when an attribute is missing.
     (See https://github.com/huggingface/transformers/pull/41541)
+
+    Some trust_remote_code configs (e.g. ByteDance/Ouro's OuroConfig) never
+    set these attributes at all, on either side, so there's nothing to
+    propagate. Their remote modeling code still accesses them directly
+    (e.g. `config.pad_token_id`), which raises AttributeError instead of
+    returning None, so default to None when both sides are missing.
     """
     _ATTRS_TO_PROPAGATE = [
         "pad_token_id",
@@ -325,6 +331,10 @@ def _patch_text_config(parent_config: PretrainedConfig, text_config):
             setattr(text_config, attr, getattr(parent_config, attr))
         elif text_has and not parent_has:
             setattr(parent_config, attr, getattr(text_config, attr))
+        elif not parent_has and not text_has:
+            setattr(parent_config, attr, None)
+            if text_config is not parent_config:
+                setattr(text_config, attr, None)
     return text_config
 
 
@@ -394,7 +404,7 @@ def get_hf_text_config(config: PretrainedConfig):
 
     if text_config is not None:
         return _patch_text_config(config, text_config)
-    return config
+    return _patch_text_config(config, config)
 
 
 # ---------------------------------------------------------------------------

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -60,6 +60,8 @@ def apply_all():
     _patch_image_processor_kwargs()
     _patch_image_process_cuda_tensor()
     _patch_nemotron_h_pattern()
+    _patch_default_rope_init_function()
+    _patch_mask_function_input_embeds_kwarg()
 
     # v5 general patches
     _ensure_clean_up_tokenization_compat()
@@ -159,6 +161,139 @@ def _patch_rope_parameters_validation():
             return _orig_standardize(self)
 
         PretrainedConfig.standardize_rope_params = _safe_standardize
+
+
+def _compute_default_rope_parameters(
+    config=None, device=None, seq_len=None, layer_type=None, **rope_kwargs
+):
+    """Pre-refactor "default" (non-scaling) RoPE init formula.
+
+    Newer transformers versions moved this case into
+    ``RotaryEmbeddingConfigMixin`` and dropped it from the
+    ``ROPE_INIT_FUNCTIONS`` dispatch dict / off legacy ``RotaryEmbedding``
+    modules entirely, since they no longer need to compute it themselves.
+    Legacy remote model code (e.g. ByteDance/Ouro) predates this and still
+    expects it to be reachable both ways -- see the two call sites patched
+    by ``_patch_default_rope_init_function`` below.
+    """
+    import torch
+
+    if config is not None and len(rope_kwargs) > 0:
+        raise ValueError(
+            "Unexpected arguments: `**rope_kwargs` and `config` are mutually "
+            "exclusive in `_compute_default_rope_parameters`, got "
+            f"`rope_kwargs`={rope_kwargs} and `config`={config}"
+        )
+    if len(rope_kwargs) > 0:
+        base = rope_kwargs["base"]
+        dim = rope_kwargs["dim"]
+    else:
+        base = config.rope_theta
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // config.num_attention_heads
+        )
+        dim = int(head_dim * partial_rotary_factor)
+
+    attention_factor = 1.0  # Unused in this type of RoPE
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, dim, 2, dtype=torch.int64).to(
+                device=device, dtype=torch.float
+            )
+            / dim
+        )
+    )
+    return inv_freq, attention_factor
+
+
+def _patch_default_rope_init_function():
+    """Restore the ``"default"`` RoPE case for legacy remote model code.
+
+    Two independent transformers-internal spots special-case
+    ``rope_type == "default"`` and no longer resolve it the way legacy
+    ``trust_remote_code`` models expect:
+
+    1. ``ROPE_INIT_FUNCTIONS`` (a dispatch dict) dropped its ``"default"``
+       entry, keeping only the scaling strategies (linear, dynamic, yarn,
+       ...). Legacy code doing ``ROPE_INIT_FUNCTIONS[self.rope_type]`` with
+       ``rope_type == "default"`` gets ``KeyError``.
+    2. ``PreTrainedModel._init_weights``'s RotaryEmbedding branch resolves
+       the "default" case via ``module.compute_default_rope_parameters`` --
+       a method only the new ``RotaryEmbeddingConfigMixin``-based modules
+       define -- instead of consulting ``ROPE_INIT_FUNCTIONS``. Legacy
+       ``RotaryEmbedding`` modules (which only set ``rope_init_fn``) get
+       ``AttributeError`` during ``post_init()``.
+
+    Both are fixed with the same pre-refactor formula
+    (``_compute_default_rope_parameters``), since the underlying math for
+    the non-scaling case hasn't changed.
+    """
+    from transformers import modeling_rope_utils
+    from transformers.modeling_utils import PreTrainedModel
+
+    rope_init_functions = getattr(modeling_rope_utils, "ROPE_INIT_FUNCTIONS", None)
+    if rope_init_functions is not None and "default" not in rope_init_functions:
+        rope_init_functions["default"] = _compute_default_rope_parameters
+
+    _orig_init_weights = PreTrainedModel._init_weights
+
+    def _init_weights_with_legacy_rope_fallback(self, module):
+        if (
+            "RotaryEmbedding" in module.__class__.__name__
+            and hasattr(module, "original_inv_freq")
+            and getattr(module, "rope_type", None) == "default"
+            and not hasattr(module, "compute_default_rope_parameters")
+        ):
+            module.compute_default_rope_parameters = _compute_default_rope_parameters
+        return _orig_init_weights(self, module)
+
+    PreTrainedModel._init_weights = _init_weights_with_legacy_rope_fallback
+
+
+def _patch_mask_function_input_embeds_kwarg():
+    """Accept pre-refactor kwargs on mask-creation helpers.
+
+    ``transformers.masking_utils.create_causal_mask`` (and its
+    sliding-window/chunked/bidirectional siblings) dropped some legacy
+    kwargs. Some remote model code (e.g. ByteDance/Ouro) still calls them
+    the old way:
+
+    - ``input_embeds`` (singular) instead of the current ``inputs_embeds``.
+    - ``cache_position``, which the current docstring explicitly documents
+      as "Deprecated and unused" -- safe to drop rather than rename.
+
+    Wrap each to remap/drop these before forwarding, rather than reactively
+    special-casing every legacy kwarg one at a time: anything not accepted
+    by the *current* signature is filtered out, since passing it through
+    unfiltered would just raise ``TypeError`` anyway.
+    """
+    import inspect
+
+    from transformers import masking_utils
+
+    for name in (
+        "create_causal_mask",
+        "create_sliding_window_causal_mask",
+        "create_chunked_causal_mask",
+        "create_bidirectional_sliding_window_mask",
+    ):
+        orig_fn = getattr(masking_utils, name, None)
+        if orig_fn is None:
+            continue
+        accepted_params = set(inspect.signature(orig_fn).parameters)
+
+        def _make_wrapper(fn, accepted_params):
+            def _wrapper(*args, **kwargs):
+                if "input_embeds" in kwargs:
+                    kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+                kwargs = {k: v for k, v in kwargs.items() if k in accepted_params}
+                return fn(*args, **kwargs)
+
+            return _wrapper
+
+        setattr(masking_utils, name, _make_wrapper(orig_fn, accepted_params))
 
 
 def _patch_flash_attn_availability():


### PR DESCRIPTION
## Motivation

`ByteDance/Ouro-1.4B` has no native SGLang model implementation (looped/early-exit "Universal Transformer"-style architecture), so it falls back to the generic Transformers backend (`TransformersForCausalLM`). Its `trust_remote_code` modeling code predates several transformers v5 API changes, and fails at server startup with:

```
AttributeError: 'OuroConfig' object has no attribute 'pad_token_id'. Did you mean: 'bos_token_id'?
```

Fixing just that surfaced a chain of further, distinct transformers-v5-vs-legacy-remote-code incompatibilities one at a time; all four are fixed here so the model actually serves and generates.

## Modifications

- `sglang/srt/utils/hf_transformers/common.py`: `_patch_text_config`/`get_hf_text_config` already exists to re-propagate `pad_token_id`/`bos_token_id`/`eos_token_id`/`tie_word_embeddings` between a parent config and its text sub-config after transformers v5's "untangle config" refactor (huggingface/transformers#41541) stopped auto-inheriting them. It only handled the case where *one side* has the attribute. `OuroConfig` (pure text model, no sub-config) never sets any of them on *either* side, so there was nothing to propagate and direct attribute access in the remote code raised `AttributeError`. Now defaults to `None` when both sides are missing, and runs even for pure-text configs (previously a no-op).
- `sglang/srt/utils/hf_transformers_patches.py`: two new compat patches, following the existing pattern in this module (`_patch_rope_parameters_validation`, `_patch_flash_attn_availability`, etc. — "fixes for remote-model-code that hasn't been updated for v5 yet"):
  - `_patch_default_rope_init_function`: restores the `"default"` (non-scaling) entry in `ROPE_INIT_FUNCTIONS`, which newer transformers dropped in favor of `RotaryEmbeddingConfigMixin`, and patches `PreTrainedModel._init_weights`'s RotaryEmbedding branch to fall back to the same formula when a legacy `RotaryEmbedding` module doesn't define the new `compute_default_rope_parameters` method.
  - `_patch_mask_function_input_embeds_kwarg`: wraps `create_causal_mask` and its sliding-window/chunked/bidirectional siblings to accept legacy kwargs (`input_embeds` -> `inputs_embeds` rename, `cache_position` now unused/deprecated per the current docstring) by filtering to whatever the *current* signature actually accepts, instead of hardcoding each renamed/removed kwarg.
- `sglang/srt/models/transformers.py` (`TransformersBase._run_hf_backbone`): some remote model code (Ouro included) doesn't fully honor `return_dict=False` and still wraps the first output element in a `ModelOutput` instead of a plain tensor. The generic wrapper did `self.model(...)[0][0, ...]`, which crashed with `TypeError: tuple indices must be integers or slices, not tuple` when `[0]` was itself a `ModelOutput`. Now unwraps one more level when the first element isn't a `torch.Tensor`.

All four fixes are scoped to genuinely-missing/legacy-API cases (`hasattr` guards, dict-key-presence checks, signature introspection) so they no-op for any model whose config/remote code is already up to date.

## Accuracy Tests

Verified locally end-to-end in a docker container (XPU backend) with the patched sglang installed in place of the image's baked-in copy:

- `ByteDance/Ouro-1.4B`: `sglang serve --model-path ByteDance/Ouro-1.4B --device xpu --tp-size 1 --trust-remote-code --attention-backend intel_xpu` now boots successfully ("The server is fired up and ready to roll!") and `/generate` returns coherent text, e.g.:
  - `"The capital of France is"` -> `" Paris."`
  - `"Once upon a time,"` -> `" there was a boy named Vasya. Vasya had many friends. ..."`
- Regression check that the shared code paths touched here don't affect other models:
  - `openai-community/gpt2` (native SGLang model, i.e. does **not** go through the Transformers-backend fallback at all) served and generated normally with the same patched build — confirms the `common.py` config-normalization change (the only patch applied universally, native or fallback) is a no-op for well-formed configs.
  - Fixes 2-4 above are structurally isolated to `TransformersBase`/`transformers.masking_utils`/`ROPE_INIT_FUNCTIONS`/generic `PreTrainedModel._init_weights`, none of which native SGLang model implementations (Llama, Qwen, DeepSeek, GPT-2, etc.) call into — they implement attention/rope/masking via SGLang's own layers.

## Speed Tests and Profiling

Not applicable — these are correctness/compatibility fixes for a fallback code path with no native kernel or scheduling changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30521880375](https://github.com/sgl-project/sglang/actions/runs/30521880375)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30521880189](https://github.com/sgl-project/sglang/actions/runs/30521880189)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->