### PR TITLE
fix(distributed): use cpu group for custom parallel config exchange

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2435,7 +2435,12 @@ def create_custom_parallel_group(
     local_config = sorted(list(set(group_ranks)))
     gathered_configs = [None for _ in range(world_size)]
 
-    torch.distributed.all_gather_object(gathered_configs, local_config)
+    # Use the CPU-backed world group explicitly so object exchange does not
+    # depend on the backend-selection fallback in torch.distributed.
+    world_cpu_group = get_world_group().cpu_group
+    torch.distributed.all_gather_object(
+        gathered_configs, local_config, group=world_cpu_group
+    )
 
     unique_groups = []
     seen_signatures = set()

--- a/test/registered/unit/distributed/test_parallel_state.py
+++ b/test/registered/unit/distributed/test_parallel_state.py
@@ -268,6 +268,36 @@ def test_parallel_group_construction_tp8_moe_ep4_cp2():
             parallel_state.destroy_model_parallel()
 
 
+def test_create_custom_parallel_group_uses_cpu_group_for_config_exchange():
+    mock_cpu_group = object()
+    mock_world_group = Mock()
+    mock_world_group.cpu_group = mock_cpu_group
+
+    def fake_all_gather_object(gathered_configs, local_config, group=None):
+        assert group is mock_cpu_group
+        gathered_configs[:] = [[1, 3], [0, 2]]
+
+    with (
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=2),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch.object(
+            parallel_state,
+            "get_world_group",
+            return_value=mock_world_group,
+        ),
+        patch(
+            "torch.distributed.all_gather_object",
+            side_effect=fake_all_gather_object,
+        ),
+        patch("torch.distributed.new_group", return_value=Mock()) as mock_new_group,
+    ):
+        group = parallel_state.create_custom_parallel_group([1, 3], backend="gloo")
+
+    assert group is not None
+    assert mock_new_group.call_count == 2
+
+
 if __name__ == "__main__":
     # Run tests without requiring GPUs
     import sys


### PR DESCRIPTION
## Motivation
Fixes #32751. create_custom_parallel_group() was calling 	orch.distributed.all_gather_object() without an explicit group, which could fall back to nondeterministic backend selection on non-NVIDIA backends and lead to initialization failures during custom parallel-group setup. This patch makes the exchange explicitly use the CPU-backed world group.

## Modifications
- Explicitly pass the CPU-backed world group to ll_gather_object() in create_custom_parallel_group()
- Add a regression unit test covering this custom-group config exchange path

## Accuracy Tests
- Added a regression test for the custom parallel-group config exchange path

## Speed Tests and Profiling
- No performance change is expected; this is a correctness fix for distributed initialization and only affects the custom group setup path