### PR TITLE
[AMD] Enable MiniMax-M3-MXFP4 (Quark) on ROCm

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -174,9 +174,21 @@ class AiterRunnerCore(MoeRunnerCore):
             # `SGLANG_USE_AITER_MOE_GU_ITLV=0` to switch to SEPARATED, which
             # matches the layout produced by `Mxfp4MoEMethod` (gpt-oss
             # MXFP4) and the gptoss_fp4 tuned FlyDSL kernels.
+            # Choose gate/up layout from the model's actual weight layout, not
+            # only the env default. Models whose experts are NOT gate/up-
+            # interleaved (e.g. MiniMax-M3, MoeRunnerConfig.gate_up_interleaved
+            # =False) require SEPARATED; interleaved models (e.g. gpt-oss, whose
+            # Mxfp4MoEMethod also preshuffles into the interleaved layout) require
+            # INTERLEAVE. The env var still lets users override the interleaved
+            # default. Using INTERLEAVE on a separated checkpoint reads gate/up
+            # transposed and produces incoherent output.
+            use_interleave = (
+                self.config.gate_up_interleaved
+                and envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
+            )
             extra["gate_mode"] = (
                 GateMode.INTERLEAVE.value
-                if envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
+                if use_interleave
                 else GateMode.SEPARATED.value
             )
             extra["swiglu_limit"] = quant_info.swiglu_limit

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -605,7 +605,13 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+            from dataclasses import replace
+
+            # MXFP4 hard-codes Swiglu in the AITER kernel path (mirror Mxfp4MoEMethod):
+            # aiter.fused_moe only applies clamped SwiGLU-OAI when activation==Swiglu.
+            self.runner = MoeRunner(
+                moe_runner_backend, replace(moe_runner_config, activation="swiglu")
+            )
         else:
             # TODO(cwan): refactor other backends
             pass
@@ -638,5 +644,10 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
             expert_mask=layer.dispatcher.expert_mask_gpu,
+            swiglu_limit=(
+                self.moe_runner_config.gemm1_clamp_limit
+                or self.moe_runner_config.swiglu_limit
+                or 0.0
+            ),
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -58,24 +58,16 @@ def should_ignore_layer(
             for shard_proj_name in shard_proj_names
         ]
 
-        # Layer should be ignored if shards are ignored.
-        should_ignore_layer = None
-        for shard_name in shard_names:
-            should_ignore_shard = check_equal_or_regex_match(
-                layer_name=shard_name, targets=ignore
-            )
-
-            # If shard_idx=0, set layer ignore to match shard.
-            if should_ignore_layer is None:
-                should_ignore_layer = should_ignore_shard
-
-            # If shard_idx=1+ confirm scheme matches prior shards.
-            elif should_ignore_shard != should_ignore_layer:
-                raise ValueError(
-                    f"Found different quantization schemes for "
-                    f"{shard_proj_names} in {layer_name}. SGLang "
-                    "requires all to use the same scheme."
-                )
+        # A fused layer is ignored (left unquantized) if ANY of its shards is
+        # listed in `ignore`. Requiring every shard to agree breaks models whose
+        # fused module legitimately has fewer shards on disk than the mapping
+        # lists: MiniMax-M3's DSA disables the index-value projection on layers
+        # 3+, so `index_v_proj` does not exist there while `index_q_proj` and
+        # `index_k_proj` are both excluded, which raised on an absent shard.
+        should_ignore_layer = any(
+            check_equal_or_regex_match(layer_name=shard_name, targets=ignore)
+            for shard_name in shard_names
+        )
 
     # Unfused layers like down_proj and o_proj will match
     # the safetensors checkpoint already.


### PR DESCRIPTION
## Motivation

`amd/MiniMax-M3-MXFP4` (AMD Quark MXFP4: MoE experts in MXFP4, attention/dense left BF16) does not serve correctly on ROCm. On MI355X it fails to load, and once loading is fixed it generates incoherent output. This PR contains the three changes needed to make it load **and** generate correctly.

> **Rebased on #31989.** An earlier revision of this PR also added a fallback `packed_modules_mapping` for Quark configs, because `MiniMaxM3SparseForConditionalGeneration` did not declare one and the loader's Quark default only covers `gate_up_proj` / `fused_qkv_a_proj_with_mqa` — so `qkv_proj` never expanded and excluded attention layers were treated as quantized. #31989 (`feat: Support nvidia/MiniMax-M3-NVFP4`) added `packed_modules_mapping` to the model class, which resolves that independently. **That part has been dropped**; what remains is the three items below.

## Changes

**1. `quark/utils.py` — a fused layer is ignored if *any* shard is ignored**

`should_ignore_layer()` required every shard of a fused module to agree, and raised otherwise. MiniMax-M3's DSA disables the index-value projection on layers 3+, so `index_v_proj` does not exist there while `index_q_proj` and `index_k_proj` are both in the config's `exclude` list. Expanding `index_qkv_proj` therefore produced a 2-of-3 match and hit:

```
ValueError: Found different quantization schemes for
  ['index_q_proj', 'index_k_proj', 'index_v_proj'] in
  language_model.model.layers.5.self_attn.index_qkv_proj
```

Verified against the real checkpoint on current `main` (mapping supplied by the model class per #31989):

| layer | `index_q` | `index_k` | `index_v` | strict loop | `any()` |
|---|---|---|---|---|---|
| 1 (dense) | — | — | — | `False` | `False` |
| 5 (DSA) | excluded | excluded | *absent* | **raises** | `True` |

`qkv_proj` and `gate_up_proj` are unaffected (all shards present and in agreement), so behaviour for existing checkpoints is unchanged.

**2. `quark_w4a4_mxfp4_moe.py` — dispatch clamped SwiGLU-OAI**

`aiter.fused_moe` applies the clamped SwiGLU-OAI activation (`gate.clamp(max=limit) * sigmoid(alpha*gate) * (up+1)`) only when `activation == Swiglu`; with `Silu` it computes plain `silu(gate)*up`. The model is built with `activation="silu"` plus `gemm1_alpha` / `gemm1_clamp_limit`, so every expert silently computed the wrong function. This mirrors what `Mxfp4MoEMethod` already does for gpt-oss, and forwards the clamp via `swiglu_limit`.

Measured on one expert against a reference implementation of the intended activation: `Silu` (before) cos **0.833**; `Swiglu` + `swiglu_limit` (after) cos **1.0000**, rerr 0.003 — the FP4 precision floor.

**3. `moe_runner/aiter.py` — layout-aware `gate_mode`**

`gate_mode` was selected from `SGLANG_USE_AITER_MOE_GU_ITLV` alone, defaulting to INTERLEAVE. MiniMax-M3 builds its experts with `gate_up_interleaved=False`, so INTERLEAVE reads gate/up transposed. Now derived from `MoeRunnerConfig.gate_up_interleaved` **and** the env var: separated-layout checkpoints get SEPARATED, while gpt-oss (interleaved, and preshuffled by `Mxfp4MoEMethod` to match) keeps INTERLEAVE. The env var still overrides the interleaved case.

Only models that explicitly set `gate_up_interleaved=False` change behaviour — today that is MiniMax-M3 alone.

## Validation

Offline on **MI355X (gfx950), TP=4**, container `rocm/sgl-dev:v0.5.15.post1-rocm720-mi35x-20260723`:

- Weight load: all 59 shards, no asserts.
- `"What is 84*3/2?"` → `126` with coherent reasoning (previously token soup, e.g. `"sputut\n\nut..."`).
- **GSM8K 0.830** (200 questions, 0 invalid).
- Bisected: fixes 1+2 without 3 still produce incoherent output; fix 2 alone is not sufficient. All three are required.

```bash
SGLANG_USE_AITER=1 python3 -m sglang.launch_server \
  --model-path amd/MiniMax-M3-MXFP4 --trust-remote-code --tp 4 \
  --attention-backend aiter --moe-runner-backend aiter \
  --chunked-prefill-size 8192 --mem-fraction-static 0.90 \
  --context-length 32768 --disable-radix-cache
```

## Notes

- GSM8K 0.830 vs ATOM's published 0.9363 for the same checkpoint. Suspected to be harness truncation of M3's long `<mm:think>` reasoning rather than a numerics gap — **not yet isolated**.
- MXFP4 alpha/beta come from aiter's built-in `swiglu()` defaults (`alpha=1.702`, `limit=7.0`), which match MiniMax-M3. A model with a different `swiglu_alpha` would need those plumbed through `aiter.fused_moe`, which does not expose them today.
- `--moe-runner-backend triton` remains unsupported for this scheme (`QuarkW4A4MXFp4MoE` has no `.runner`); use the aiter runner. Out of scope here.

cc @fxmarty-amd @ch-wan

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30610374932](https://github.com/sgl-project/sglang/actions/runs/30610374932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30610374854](https://github.com/sgl-project/sglang/actions/runs/30610374854)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->