### PR TITLE
[NPU] Add capability-based Gemma RMSNorm dispatch

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/device_capabilities.py
+++ b/python/sglang/srt/hardware_backend/npu/device_capabilities.py
@@ -8,26 +8,27 @@ logger = logging.getLogger(__name__)
 
 
 class NPUDeviceFamily(str, Enum):
-    A2 = "a2"
-    A3 = "a3"
-    A5 = "a5"
+    ASCEND_910B = "ascend_910b"
+    ASCEND_910C = "ascend_910c"
+    ASCEND_950 = "ascend_950"
     UNKNOWN = "unknown"
 
 
 class NPUFeature(str, Enum):
     NATIVE_GEMMA_RMS_NORM = "native_gemma_rms_norm"
+    TRITON_GEMMA_RMS_NORM = "triton_gemma_rms_norm"
 
 
 _DEVICE_FAMILY_RANGES = (
-    (220, 225, NPUDeviceFamily.A2),
-    (250, 255, NPUDeviceFamily.A3),
-    (260, 260, NPUDeviceFamily.A5),
+    (220, 225, NPUDeviceFamily.ASCEND_910B),
+    (250, 255, NPUDeviceFamily.ASCEND_910C),
+    (260, 260, NPUDeviceFamily.ASCEND_950),
 )
 
 _FEATURES_BY_DEVICE_FAMILY = {
-    NPUDeviceFamily.A2: frozenset({NPUFeature.NATIVE_GEMMA_RMS_NORM}),
-    NPUDeviceFamily.A3: frozenset({NPUFeature.NATIVE_GEMMA_RMS_NORM}),
-    NPUDeviceFamily.A5: frozenset(),
+    NPUDeviceFamily.ASCEND_910B: frozenset({NPUFeature.NATIVE_GEMMA_RMS_NORM}),
+    NPUDeviceFamily.ASCEND_910C: frozenset({NPUFeature.NATIVE_GEMMA_RMS_NORM}),
+    NPUDeviceFamily.ASCEND_950: frozenset({NPUFeature.TRITON_GEMMA_RMS_NORM}),
     NPUDeviceFamily.UNKNOWN: frozenset(),
 }
 

--- a/python/sglang/srt/hardware_backend/npu/device_capabilities.py
+++ b/python/sglang/srt/hardware_backend/npu/device_capabilities.py
@@ -1,0 +1,64 @@
+"""Semantic feature support for Ascend NPU device families."""
+
+import logging
+from enum import Enum
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+
+class NPUDeviceFamily(str, Enum):
+    A2 = "a2"
+    A3 = "a3"
+    A5 = "a5"
+    UNKNOWN = "unknown"
+
+
+class NPUFeature(str, Enum):
+    NATIVE_GEMMA_RMS_NORM = "native_gemma_rms_norm"
+
+
+_DEVICE_FAMILY_RANGES = (
+    (220, 225, NPUDeviceFamily.A2),
+    (250, 255, NPUDeviceFamily.A3),
+    (260, 260, NPUDeviceFamily.A5),
+)
+
+_FEATURES_BY_DEVICE_FAMILY = {
+    NPUDeviceFamily.A2: frozenset({NPUFeature.NATIVE_GEMMA_RMS_NORM}),
+    NPUDeviceFamily.A3: frozenset({NPUFeature.NATIVE_GEMMA_RMS_NORM}),
+    NPUDeviceFamily.A5: frozenset(),
+    NPUDeviceFamily.UNKNOWN: frozenset(),
+}
+
+
+@lru_cache(maxsize=1)
+def get_npu_device_family() -> NPUDeviceFamily:
+    """Resolve and cache the current process-wide Ascend device family."""
+    try:
+        import torch_npu
+
+        soc_version = int(torch_npu.npu.get_soc_version())
+    except (ImportError, AttributeError, RuntimeError, TypeError, ValueError) as e:
+        logger.warning(
+            "Unable to resolve the Ascend SoC version; optional NPU features "
+            "will use safe fallbacks: %s",
+            e,
+        )
+        return NPUDeviceFamily.UNKNOWN
+
+    for lower, upper, family in _DEVICE_FAMILY_RANGES:
+        if lower <= soc_version <= upper:
+            return family
+
+    logger.warning(
+        "Unknown Ascend SoC version %s; optional NPU features will use safe "
+        "fallbacks.",
+        soc_version,
+    )
+    return NPUDeviceFamily.UNKNOWN
+
+
+def supports_npu_feature(feature: NPUFeature) -> bool:
+    """Whether the current Ascend family supports a semantic NPU feature."""
+    return feature in _FEATURES_BY_DEVICE_FAMILY[get_npu_device_family()]

--- a/python/sglang/srt/hardware_backend/npu/device_operator.py
+++ b/python/sglang/srt/hardware_backend/npu/device_operator.py
@@ -1,0 +1,103 @@
+"""Device-aware operator facade for Ascend NPU kernels."""
+
+from typing import TYPE_CHECKING, Tuple
+
+from sglang.srt.hardware_backend.npu.device_capabilities import (
+    NPUFeature,
+    supports_npu_feature,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+
+def _triton_gemma_rms_norm(
+    input: "torch.Tensor",
+    weight: "torch.Tensor",
+    residual: "torch.Tensor | None",
+    eps: float,
+) -> Tuple["torch.Tensor", "torch.Tensor | None"]:
+    if input.numel() == 0:
+        residual_sum = None if residual is None else input + residual
+        return input.clone(), residual_sum
+
+    from sgl_kernel_npu.norm.add_rmsnorm_bias import add_gemma_rms_norm
+
+    original_shape = input.shape
+    input_2d = input.contiguous().view(-1, original_shape[-1])
+    residual_2d = None
+    if residual is not None:
+        residual_2d = residual.contiguous().view_as(input_2d)
+
+    norm_output, residual_sum = add_gemma_rms_norm(
+        input_2d,
+        weight.contiguous(),
+        residual_2d,
+        eps,
+    )
+    norm_output = norm_output.view(original_shape)
+    if residual is not None:
+        residual_sum = residual_sum.view(original_shape)
+    return norm_output, residual_sum
+
+
+class NPUDeviceOperator:
+    """Expose semantic operator APIs across Ascend device families."""
+
+    @staticmethod
+    def gemma_rms_norm(
+        input: "torch.Tensor",
+        weight: "torch.Tensor",
+        eps: float,
+    ) -> "torch.Tensor":
+        """Apply Gemma RMSNorm without exposing product checks to callers."""
+        if input.numel() == 0:
+            return input.clone()
+
+        input = input.contiguous()
+        weight = weight.contiguous()
+        if supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM):
+            import torch_npu
+
+            return torch_npu.npu_gemma_rms_norm(input, weight, eps)[0]
+
+        if supports_npu_feature(NPUFeature.TRITON_GEMMA_RMS_NORM):
+            return _triton_gemma_rms_norm(input, weight, None, eps)[0]
+
+        import torch_npu
+
+        return torch_npu.npu_rms_norm(input, 1.0 + weight, eps)[0]
+
+    @staticmethod
+    def add_gemma_rms_norm(
+        input: "torch.Tensor",
+        weight: "torch.Tensor",
+        residual: "torch.Tensor",
+        eps: float,
+    ) -> Tuple["torch.Tensor", "torch.Tensor"]:
+        """Add a residual and apply Gemma RMSNorm without mutating inputs."""
+        if input.numel() == 0:
+            return input.clone(), input + residual
+
+        input = input.contiguous()
+        weight = weight.contiguous()
+        residual = residual.contiguous()
+        if supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM):
+            import torch_npu
+
+            norm_output, _, residual_sum = torch_npu.npu_add_rms_norm(
+                residual, input, 1.0 + weight, eps
+            )
+            return norm_output, residual_sum
+
+        if supports_npu_feature(NPUFeature.TRITON_GEMMA_RMS_NORM):
+            norm_output, residual_sum = _triton_gemma_rms_norm(
+                input, weight, residual, eps
+            )
+            return norm_output, residual_sum
+
+        import torch_npu
+
+        residual_sum = input + residual
+        norm_output = torch_npu.npu_rms_norm(residual_sum, 1.0 + weight, eps)[0]
+        return norm_output, residual_sum

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -26,10 +26,7 @@ from sglang.srt.batch_invariant_ops import (
     rms_norm_batch_invariant,
 )
 from sglang.srt.environ import envs
-from sglang.srt.hardware_backend.npu.device_capabilities import (
-    NPUFeature,
-    supports_npu_feature,
-)
+from sglang.srt.hardware_backend.npu.device_operator import NPUDeviceOperator
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -163,7 +160,6 @@ logger = logging.getLogger(__name__)
 
 if _is_npu:
     import torch_npu
-    from sgl_kernel_npu.norm.add_rmsnorm_bias import add_gemma_rms_norm
 
 
 @lru_cache(maxsize=1)
@@ -999,19 +995,11 @@ class GemmaRMSNorm(MultiPlatformOp):
         if residual is not None:
             if post_residual_addition is not None:
                 residual = residual + post_residual_addition
-            norm_out, residual = add_gemma_rms_norm(
+            return NPUDeviceOperator.add_gemma_rms_norm(
                 x, self.weight, residual, self.variance_epsilon
             )
-            return norm_out, residual
 
-        if supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM):
-            x, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
-            return x
-
-        # Gemma RMSNorm == normalize(x) * (1 + weight). Ascend A5 does not
-        # provide the fused Gemma kernel, so use the equivalent RMSNorm path.
-        x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
-        return x
+        return NPUDeviceOperator.gemma_rms_norm(x, self.weight, self.variance_epsilon)
 
     def forward_xpu(
         self,
@@ -1103,10 +1091,13 @@ class Gemma3RMSNorm(MultiPlatformOp):
         return self.forward_native(x, residual)
 
     def forward_npu(self, x, residual: Optional[torch.Tensor] = None):
-        if residual is not None:
+        if envs.SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM.get():
             return self.forward_native(x, residual)
-        output, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.eps)
-        return output
+        if residual is not None:
+            return NPUDeviceOperator.add_gemma_rms_norm(
+                x, self.weight, residual, self.eps
+            )
+        return NPUDeviceOperator.gemma_rms_norm(x, self.weight, self.eps)
 
     def extra_repr(self):
         return f"{tuple(self.weight.shape)}, eps={self.eps}"

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -42,6 +42,7 @@ from sglang.srt.utils import (
     is_hip,
     is_musa,
     is_npu,
+    is_npu_a5,
     is_xpu,
 )
 
@@ -50,6 +51,7 @@ _is_flashinfer_available = is_flashinfer_available()
 _is_hip = is_hip()
 _is_musa = is_musa()
 _is_npu = is_npu()
+_is_npu_a5 = is_npu_a5()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
@@ -1000,11 +1002,15 @@ class GemmaRMSNorm(MultiPlatformOp):
             )
             return norm_out, residual
 
-        # npu_gemma_rms_norm has no kernel registered for Ascend A5 (socVersion
-        # ascend950). Gemma RMSNorm == normalize(x) * (1 + weight), which is
-        # equivalent to a plain rms_norm with gamma = 1 + weight; npu_rms_norm is
-        # implemented on A2/A3/A5, so this is a safe cross-SOC replacement.
-        x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
+        if _is_npu_a5:
+            # npu_gemma_rms_norm has no kernel registered for Ascend A5
+            # (socVersion ascend950). Gemma RMSNorm == normalize(x) * (1 + weight)
+            # equals a plain rms_norm with gamma = 1 + weight, so fall back to
+            # npu_rms_norm which is implemented on A5. A2/A3 keep the fused op.
+            x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
+            return x
+
+        x, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
         return x
 
     def forward_xpu(

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -42,7 +42,6 @@ from sglang.srt.utils import (
     is_hip,
     is_musa,
     is_npu,
-    is_npu_a5,
     is_xpu,
 )
 
@@ -51,7 +50,6 @@ _is_flashinfer_available = is_flashinfer_available()
 _is_hip = is_hip()
 _is_musa = is_musa()
 _is_npu = is_npu()
-_is_npu_a5 = is_npu_a5()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_cpu_amx_available = cpu_has_amx_support()
 _is_cpu = is_cpu()
@@ -1002,15 +1000,10 @@ class GemmaRMSNorm(MultiPlatformOp):
             )
             return norm_out, residual
 
-        if _is_npu_a5:
-            # npu_gemma_rms_norm has no kernel registered for Ascend A5
-            # (socVersion ascend950). Gemma RMSNorm == normalize(x) * (1 + weight)
-            # equals a plain rms_norm with gamma = 1 + weight, so fall back to
-            # npu_rms_norm which is implemented on A5. A2/A3 keep the fused op.
-            x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
-            return x
-
-        x, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
+        # Gemma RMSNorm == normalize(x) * (1 + weight). Use the equivalent
+        # npu_rms_norm path across NPU generations because npu_gemma_rms_norm
+        # has no kernel registered on Ascend A5.
+        x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
         return x
 
     def forward_xpu(

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -26,6 +26,10 @@ from sglang.srt.batch_invariant_ops import (
     rms_norm_batch_invariant,
 )
 from sglang.srt.environ import envs
+from sglang.srt.hardware_backend.npu.device_capabilities import (
+    NPUFeature,
+    supports_npu_feature,
+)
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -1000,9 +1004,12 @@ class GemmaRMSNorm(MultiPlatformOp):
             )
             return norm_out, residual
 
-        # Gemma RMSNorm == normalize(x) * (1 + weight). Use the equivalent
-        # npu_rms_norm path across NPU generations because npu_gemma_rms_norm
-        # has no kernel registered on Ascend A5.
+        if supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM):
+            x, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
+            return x
+
+        # Gemma RMSNorm == normalize(x) * (1 + weight). Ascend A5 does not
+        # provide the fused Gemma kernel, so use the equivalent RMSNorm path.
         x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
         return x
 

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1000,7 +1000,11 @@ class GemmaRMSNorm(MultiPlatformOp):
             )
             return norm_out, residual
 
-        x, _ = torch_npu.npu_gemma_rms_norm(x, self.weight, self.variance_epsilon)
+        # npu_gemma_rms_norm has no kernel registered for Ascend A5 (socVersion
+        # ascend950). Gemma RMSNorm == normalize(x) * (1 + weight), which is
+        # equivalent to a plain rms_norm with gamma = 1 + weight; npu_rms_norm is
+        # implemented on A2/A3/A5, so this is a safe cross-SOC replacement.
+        x, _ = torch_npu.npu_rms_norm(x, 1.0 + self.weight, self.variance_epsilon)
         return x
 
     def forward_xpu(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -185,6 +185,24 @@ def is_npu() -> bool:
     return True
 
 
+# torch_npu.npu.get_soc_version() code for the Ascend A5 (Ascend950) series.
+_ASCEND_A5_SOC_VERSION = 260
+
+
+@lru_cache(maxsize=1)
+def is_npu_a5() -> bool:
+    """Whether the current NPU is an Ascend A5 (Ascend950) device.
+
+    Some fused ops (e.g. npu_gemma_rms_norm) have no kernel registered for the
+    A5 soc and must fall back to an equivalent path, while A2/A3 keep the op.
+    """
+    if not is_npu():
+        return False
+    import torch_npu  # noqa: F401
+
+    return torch.npu.get_soc_version() == _ASCEND_A5_SOC_VERSION
+
+
 @lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -185,24 +185,6 @@ def is_npu() -> bool:
     return True
 
 
-# torch_npu.npu.get_soc_version() code for the Ascend A5 (Ascend950) series.
-_ASCEND_A5_SOC_VERSION = 260
-
-
-@lru_cache(maxsize=1)
-def is_npu_a5() -> bool:
-    """Whether the current NPU is an Ascend A5 (Ascend950) device.
-
-    Some fused ops (e.g. npu_gemma_rms_norm) have no kernel registered for the
-    A5 soc and must fall back to an equivalent path, while A2/A3 keep the op.
-    """
-    if not is_npu():
-        return False
-    import torch_npu  # noqa: F401
-
-    return torch.npu.get_soc_version() == _ASCEND_A5_SOC_VERSION
-
-
 @lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()

--- a/test/registered/unit/npu/test_device_capabilities.py
+++ b/test/registered/unit/npu/test_device_capabilities.py
@@ -1,0 +1,118 @@
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.hardware_backend.npu.device_capabilities import (
+    NPUDeviceFamily,
+    NPUFeature,
+    get_npu_device_family,
+    supports_npu_feature,
+)
+from sglang.srt.layers import layernorm as layernorm_module
+from sglang.srt.layers.layernorm import GemmaRMSNorm
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestNPUDeviceCapabilities(unittest.TestCase):
+    def setUp(self):
+        get_npu_device_family.cache_clear()
+
+    def tearDown(self):
+        get_npu_device_family.cache_clear()
+
+    def _torch_npu_for_soc(self, soc_version):
+        get_soc_version = MagicMock(return_value=soc_version)
+        torch_npu = SimpleNamespace(
+            npu=SimpleNamespace(get_soc_version=get_soc_version)
+        )
+        return torch_npu, get_soc_version
+
+    def test_native_gemma_rms_norm_feature_matrix(self):
+        cases = (
+            (220, NPUDeviceFamily.A2, True),
+            (225, NPUDeviceFamily.A2, True),
+            (250, NPUDeviceFamily.A3, True),
+            (255, NPUDeviceFamily.A3, True),
+            (260, NPUDeviceFamily.A5, False),
+            (999, NPUDeviceFamily.UNKNOWN, False),
+        )
+
+        for soc_version, expected_family, expected_support in cases:
+            with self.subTest(soc_version=soc_version):
+                get_npu_device_family.cache_clear()
+                torch_npu, _ = self._torch_npu_for_soc(soc_version)
+                with patch.dict(sys.modules, {"torch_npu": torch_npu}):
+                    self.assertEqual(get_npu_device_family(), expected_family)
+                    self.assertEqual(
+                        supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM),
+                        expected_support,
+                    )
+
+    def test_device_detection_is_cached(self):
+        torch_npu, get_soc_version = self._torch_npu_for_soc(220)
+        with patch.dict(sys.modules, {"torch_npu": torch_npu}):
+            self.assertTrue(supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM))
+            self.assertTrue(supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM))
+        get_soc_version.assert_called_once_with()
+
+    def test_detection_failure_uses_safe_fallback(self):
+        get_soc_version = MagicMock(side_effect=RuntimeError("not initialized"))
+        torch_npu = SimpleNamespace(
+            npu=SimpleNamespace(get_soc_version=get_soc_version)
+        )
+        with patch.dict(sys.modules, {"torch_npu": torch_npu}):
+            self.assertEqual(get_npu_device_family(), NPUDeviceFamily.UNKNOWN)
+            self.assertFalse(supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM))
+
+    def test_gemma_rms_norm_uses_native_kernel_when_supported(self):
+        layer = GemmaRMSNorm(4)
+        x = torch.randn(2, 4)
+        native_kernel = MagicMock(return_value=(x, None))
+        fallback_kernel = MagicMock()
+        torch_npu = SimpleNamespace(
+            npu_gemma_rms_norm=native_kernel,
+            npu_rms_norm=fallback_kernel,
+        )
+
+        with (
+            patch.object(layernorm_module, "torch_npu", torch_npu, create=True),
+            patch.object(layernorm_module, "supports_npu_feature", return_value=True),
+        ):
+            result = layer.forward_npu(x)
+
+        self.assertIs(result, x)
+        native_kernel.assert_called_once_with(x, layer.weight, layer.variance_epsilon)
+        fallback_kernel.assert_not_called()
+
+    def test_gemma_rms_norm_uses_equivalent_fallback_when_unsupported(self):
+        layer = GemmaRMSNorm(4)
+        x = torch.randn(2, 4)
+        fallback_kernel = MagicMock(return_value=(x, None))
+        native_kernel = MagicMock()
+        torch_npu = SimpleNamespace(
+            npu_gemma_rms_norm=native_kernel,
+            npu_rms_norm=fallback_kernel,
+        )
+
+        with (
+            patch.object(layernorm_module, "torch_npu", torch_npu, create=True),
+            patch.object(layernorm_module, "supports_npu_feature", return_value=False),
+        ):
+            result = layer.forward_npu(x)
+
+        self.assertIs(result, x)
+        fallback_kernel.assert_called_once()
+        args = fallback_kernel.call_args.args
+        self.assertIs(args[0], x)
+        torch.testing.assert_close(args[1], 1.0 + layer.weight)
+        self.assertEqual(args[2], layer.variance_epsilon)
+        native_kernel.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/npu/test_device_capabilities.py
+++ b/test/registered/unit/npu/test_device_capabilities.py
@@ -1,18 +1,20 @@
 import sys
 import unittest
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
 
+from sglang.srt.hardware_backend.npu import device_operator as device_operator_module
 from sglang.srt.hardware_backend.npu.device_capabilities import (
     NPUDeviceFamily,
     NPUFeature,
     get_npu_device_family,
     supports_npu_feature,
 )
+from sglang.srt.hardware_backend.npu.device_operator import NPUDeviceOperator
 from sglang.srt.layers import layernorm as layernorm_module
-from sglang.srt.layers.layernorm import GemmaRMSNorm
+from sglang.srt.layers.layernorm import Gemma3RMSNorm, GemmaRMSNorm
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -32,26 +34,61 @@ class TestNPUDeviceCapabilities(unittest.TestCase):
         )
         return torch_npu, get_soc_version
 
-    def test_native_gemma_rms_norm_feature_matrix(self):
+    @staticmethod
+    def _supports(*supported_features):
+        return lambda feature: feature in supported_features
+
+    @staticmethod
+    def _triton_module(kernel):
+        module = ModuleType("sgl_kernel_npu.norm.add_rmsnorm_bias")
+        module.add_gemma_rms_norm = kernel
+        return {
+            "sgl_kernel_npu": ModuleType("sgl_kernel_npu"),
+            "sgl_kernel_npu.norm": ModuleType("sgl_kernel_npu.norm"),
+            "sgl_kernel_npu.norm.add_rmsnorm_bias": module,
+        }
+
+    def test_gemma_rms_norm_feature_matrix(self):
         cases = (
-            (220, NPUDeviceFamily.A2, True),
-            (225, NPUDeviceFamily.A2, True),
-            (250, NPUDeviceFamily.A3, True),
-            (255, NPUDeviceFamily.A3, True),
-            (260, NPUDeviceFamily.A5, False),
-            (999, NPUDeviceFamily.UNKNOWN, False),
+            (
+                220,
+                NPUDeviceFamily.ASCEND_910B,
+                {NPUFeature.NATIVE_GEMMA_RMS_NORM},
+            ),
+            (
+                225,
+                NPUDeviceFamily.ASCEND_910B,
+                {NPUFeature.NATIVE_GEMMA_RMS_NORM},
+            ),
+            (
+                250,
+                NPUDeviceFamily.ASCEND_910C,
+                {NPUFeature.NATIVE_GEMMA_RMS_NORM},
+            ),
+            (
+                255,
+                NPUDeviceFamily.ASCEND_910C,
+                {NPUFeature.NATIVE_GEMMA_RMS_NORM},
+            ),
+            (
+                260,
+                NPUDeviceFamily.ASCEND_950,
+                {NPUFeature.TRITON_GEMMA_RMS_NORM},
+            ),
+            (999, NPUDeviceFamily.UNKNOWN, set()),
         )
 
-        for soc_version, expected_family, expected_support in cases:
+        for soc_version, expected_family, expected_features in cases:
             with self.subTest(soc_version=soc_version):
                 get_npu_device_family.cache_clear()
                 torch_npu, _ = self._torch_npu_for_soc(soc_version)
                 with patch.dict(sys.modules, {"torch_npu": torch_npu}):
                     self.assertEqual(get_npu_device_family(), expected_family)
-                    self.assertEqual(
-                        supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM),
-                        expected_support,
-                    )
+                    for feature in NPUFeature:
+                        self.assertEqual(
+                            supports_npu_feature(feature),
+                            feature in expected_features,
+                        )
 
     def test_device_detection_is_cached(self):
         torch_npu, get_soc_version = self._torch_npu_for_soc(220)
@@ -67,51 +104,216 @@ class TestNPUDeviceCapabilities(unittest.TestCase):
         )
         with patch.dict(sys.modules, {"torch_npu": torch_npu}):
             self.assertEqual(get_npu_device_family(), NPUDeviceFamily.UNKNOWN)
-            self.assertFalse(supports_npu_feature(NPUFeature.NATIVE_GEMMA_RMS_NORM))
+            for feature in NPUFeature:
+                self.assertFalse(supports_npu_feature(feature))
 
-    def test_gemma_rms_norm_uses_native_kernel_when_supported(self):
-        layer = GemmaRMSNorm(4)
-        x = torch.randn(2, 4)
-        native_kernel = MagicMock(return_value=(x, None))
-        fallback_kernel = MagicMock()
-        torch_npu = SimpleNamespace(
-            npu_gemma_rms_norm=native_kernel,
-            npu_rms_norm=fallback_kernel,
-        )
+    def test_gemma_rms_norm_uses_native_provider(self):
+        input = torch.randn(2, 4)
+        weight = torch.randn(4)
+        output = torch.randn_like(input)
+        native_kernel = MagicMock(return_value=(output, None))
+        torch_npu = SimpleNamespace(npu_gemma_rms_norm=native_kernel)
 
         with (
-            patch.object(layernorm_module, "torch_npu", torch_npu, create=True),
-            patch.object(layernorm_module, "supports_npu_feature", return_value=True),
+            patch.dict(sys.modules, {"torch_npu": torch_npu}),
+            patch.object(
+                device_operator_module,
+                "supports_npu_feature",
+                side_effect=self._supports(NPUFeature.NATIVE_GEMMA_RMS_NORM),
+            ),
         ):
-            result = layer.forward_npu(x)
+            result = NPUDeviceOperator.gemma_rms_norm(input, weight, 1e-6)
 
-        self.assertIs(result, x)
-        native_kernel.assert_called_once_with(x, layer.weight, layer.variance_epsilon)
-        fallback_kernel.assert_not_called()
+        self.assertIs(result, output)
+        native_kernel.assert_called_once_with(input, weight, 1e-6)
 
-    def test_gemma_rms_norm_uses_equivalent_fallback_when_unsupported(self):
-        layer = GemmaRMSNorm(4)
-        x = torch.randn(2, 4)
-        fallback_kernel = MagicMock(return_value=(x, None))
-        native_kernel = MagicMock()
-        torch_npu = SimpleNamespace(
-            npu_gemma_rms_norm=native_kernel,
-            npu_rms_norm=fallback_kernel,
-        )
+    def test_gemma_rms_norm_uses_triton_provider_and_restores_shape(self):
+        input = torch.randn(2, 4, 3).transpose(1, 2)
+        weight = torch.randn(4)
+        triton_kernel = MagicMock(side_effect=lambda x, *_: (x.clone(), None))
 
         with (
-            patch.object(layernorm_module, "torch_npu", torch_npu, create=True),
-            patch.object(layernorm_module, "supports_npu_feature", return_value=False),
+            patch.dict(sys.modules, self._triton_module(triton_kernel)),
+            patch.object(
+                device_operator_module,
+                "supports_npu_feature",
+                side_effect=self._supports(NPUFeature.TRITON_GEMMA_RMS_NORM),
+            ),
         ):
-            result = layer.forward_npu(x)
+            result = NPUDeviceOperator.gemma_rms_norm(input, weight, 1e-6)
 
-        self.assertIs(result, x)
-        fallback_kernel.assert_called_once()
+        self.assertEqual(result.shape, input.shape)
+        triton_input, triton_weight, triton_residual, eps = triton_kernel.call_args.args
+        self.assertEqual(triton_input.shape, (6, 4))
+        self.assertTrue(triton_input.is_contiguous())
+        self.assertTrue(triton_weight.is_contiguous())
+        self.assertIsNone(triton_residual)
+        self.assertEqual(eps, 1e-6)
+
+    def test_gemma_rms_norm_uses_decomposed_fallback(self):
+        input = torch.randn(2, 4)
+        weight = torch.randn(4)
+        output = torch.randn_like(input)
+        fallback_kernel = MagicMock(return_value=(output, None))
+        torch_npu = SimpleNamespace(npu_rms_norm=fallback_kernel)
+
+        with (
+            patch.dict(sys.modules, {"torch_npu": torch_npu}),
+            patch.object(
+                device_operator_module,
+                "supports_npu_feature",
+                side_effect=self._supports(),
+            ),
+        ):
+            result = NPUDeviceOperator.gemma_rms_norm(input, weight, 1e-6)
+
+        self.assertIs(result, output)
         args = fallback_kernel.call_args.args
-        self.assertIs(args[0], x)
-        torch.testing.assert_close(args[1], 1.0 + layer.weight)
-        self.assertEqual(args[2], layer.variance_epsilon)
-        native_kernel.assert_not_called()
+        self.assertIs(args[0], input)
+        torch.testing.assert_close(args[1], 1.0 + weight)
+        self.assertEqual(args[2], 1e-6)
+
+    def test_add_gemma_rms_norm_uses_native_provider(self):
+        input = torch.randn(2, 4)
+        residual = torch.randn_like(input)
+        weight = torch.randn(4)
+        output = torch.randn_like(input)
+        residual_sum = torch.randn_like(input)
+        native_kernel = MagicMock(return_value=(output, None, residual_sum))
+        torch_npu = SimpleNamespace(npu_add_rms_norm=native_kernel)
+
+        with (
+            patch.dict(sys.modules, {"torch_npu": torch_npu}),
+            patch.object(
+                device_operator_module,
+                "supports_npu_feature",
+                side_effect=self._supports(NPUFeature.NATIVE_GEMMA_RMS_NORM),
+            ),
+        ):
+            result = NPUDeviceOperator.add_gemma_rms_norm(input, weight, residual, 1e-6)
+
+        self.assertIs(result[0], output)
+        self.assertIs(result[1], residual_sum)
+        args = native_kernel.call_args.args
+        self.assertIs(args[0], residual)
+        self.assertIs(args[1], input)
+        torch.testing.assert_close(args[2], 1.0 + weight)
+        self.assertEqual(args[3], 1e-6)
+
+    def test_add_gemma_rms_norm_uses_triton_provider(self):
+        input = torch.randn(2, 3, 4)
+        residual = torch.randn_like(input)
+        weight = torch.randn(4)
+        triton_kernel = MagicMock(
+            side_effect=lambda x, _, r, __: (x.clone(), r.clone())
+        )
+
+        with (
+            patch.dict(sys.modules, self._triton_module(triton_kernel)),
+            patch.object(
+                device_operator_module,
+                "supports_npu_feature",
+                side_effect=self._supports(NPUFeature.TRITON_GEMMA_RMS_NORM),
+            ),
+        ):
+            output, residual_sum = NPUDeviceOperator.add_gemma_rms_norm(
+                input, weight, residual, 1e-6
+            )
+
+        self.assertEqual(output.shape, input.shape)
+        self.assertEqual(residual_sum.shape, residual.shape)
+        triton_input, _, triton_residual, _ = triton_kernel.call_args.args
+        self.assertEqual(triton_input.shape, (6, 4))
+        self.assertEqual(triton_residual.shape, (6, 4))
+
+    def test_add_gemma_rms_norm_uses_decomposed_fallback(self):
+        input = torch.randn(2, 4)
+        residual = torch.randn_like(input)
+        weight = torch.randn(4)
+        output = torch.randn_like(input)
+        fallback_kernel = MagicMock(return_value=(output, None))
+        torch_npu = SimpleNamespace(npu_rms_norm=fallback_kernel)
+
+        with (
+            patch.dict(sys.modules, {"torch_npu": torch_npu}),
+            patch.object(
+                device_operator_module,
+                "supports_npu_feature",
+                side_effect=self._supports(),
+            ),
+        ):
+            norm_output, residual_sum = NPUDeviceOperator.add_gemma_rms_norm(
+                input, weight, residual, 1e-6
+            )
+
+        self.assertIs(norm_output, output)
+        torch.testing.assert_close(residual_sum, input + residual)
+        args = fallback_kernel.call_args.args
+        torch.testing.assert_close(args[0], input + residual)
+        torch.testing.assert_close(args[1], 1.0 + weight)
+        self.assertEqual(args[2], 1e-6)
+
+    def test_empty_triton_inputs_do_not_launch_kernel(self):
+        input = torch.empty(0, 4)
+        residual = torch.empty_like(input)
+        weight = torch.randn(4)
+        triton_kernel = MagicMock()
+
+        with (
+            patch.dict(sys.modules, self._triton_module(triton_kernel)),
+            patch.object(
+                device_operator_module,
+                "supports_npu_feature",
+                side_effect=self._supports(NPUFeature.TRITON_GEMMA_RMS_NORM),
+            ),
+        ):
+            output = NPUDeviceOperator.gemma_rms_norm(input, weight, 1e-6)
+            fused_output, residual_sum = NPUDeviceOperator.add_gemma_rms_norm(
+                input, weight, residual, 1e-6
+            )
+
+        self.assertEqual(output.shape, input.shape)
+        self.assertEqual(fused_output.shape, input.shape)
+        self.assertEqual(residual_sum.shape, input.shape)
+        triton_kernel.assert_not_called()
+
+    def test_gemma_layers_delegate_normal_and_residual_paths(self):
+        input = torch.randn(2, 4)
+        residual = torch.randn_like(input)
+        norm_output = torch.randn_like(input)
+        residual_sum = torch.randn_like(input)
+
+        for layer in (GemmaRMSNorm(4), Gemma3RMSNorm(4)):
+            eps = (
+                layer.variance_epsilon if isinstance(layer, GemmaRMSNorm) else layer.eps
+            )
+            with self.subTest(layer=type(layer).__name__):
+                with (
+                    patch.object(
+                        layernorm_module.envs.SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM,
+                        "get",
+                        return_value=False,
+                    ),
+                    patch.object(
+                        layernorm_module.NPUDeviceOperator,
+                        "gemma_rms_norm",
+                        return_value=norm_output,
+                    ) as gemma_rms_norm,
+                    patch.object(
+                        layernorm_module.NPUDeviceOperator,
+                        "add_gemma_rms_norm",
+                        return_value=(norm_output, residual_sum),
+                    ) as add_gemma_rms_norm,
+                ):
+                    self.assertIs(layer.forward_npu(input), norm_output)
+                    fused_result = layer.forward_npu(input, residual)
+                    self.assertIs(fused_result[0], norm_output)
+                    self.assertIs(fused_result[1], residual_sum)
+
+                gemma_rms_norm.assert_called_once_with(input, layer.weight, eps)
+                add_gemma_rms_norm.assert_called_once_with(
+                    input, layer.weight, residual, eps
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> [!IMPORTANT]
> **WIP - please do not review this PR yet.**
>
> This PR is a concrete architecture-comparison branch. Please hold off on reviewing it until the WIP notice is removed.

## Purpose of this draft

This draft provides a functionally equivalent alternative to #32745 together with sgl-project/sgl-kernel-npu#638, so we can compare the ownership boundary without comparing different feature coverage.

Both alternatives now implement the same product behavior:

| Product family | Ordinary Gemma RMSNorm | Residual-add Gemma RMSNorm |
|---|---|---|
| Ascend 910B/910C | native ACLNN | native ACLNN |
| Ascend 950 | existing `sgl-kernel-npu` Triton kernel | existing `sgl-kernel-npu` Triton kernel |
| unknown/unsupported | decomposed `npu_rms_norm` fallback | add plus decomposed `npu_rms_norm` fallback |

Both `GemmaRMSNorm` and `Gemma3RMSNorm` delegate their ordinary and residual paths through the selected implementation.

The intended comparison is therefore only architectural:

- **This PR (#32908):** SGLang detects the Ascend product family, owns the semantic capability matrix, and selects the native, Triton, or fallback provider through `NPUDeviceOperator`.
- **PR #32745 + sgl-kernel-npu#638:** SGLang calls the unified logical kernel API, while `sgl-kernel-npu` owns product detection and provider selection.

The comparison should help determine the better long-term extension point for other operators with product-specific behavior, considering ownership, duplicated dispatch code, future Ascend products, dependency boundaries, and test surface.

## Summary

- use formal Ascend 910B, 910C, and 950 product-family names in the cached SGLang capability layer
- model native and Triton Gemma RMSNorm availability as semantic features instead of generation helpers such as `is_npu_a5()`
- add an SGLang-side `NPUDeviceOperator` facade for ordinary and residual-add Gemma RMSNorm
- select native providers on Ascend 910B/910C, the existing `sgl-kernel-npu` Triton kernel on Ascend 950, and conservative decomposed fallbacks for unknown products
- support multidimensional, non-contiguous, and empty inputs in the Triton path
- route both `GemmaRMSNorm` and `Gemma3RMSNorm` ordinary/residual NPU paths through the facade
- preserve `SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM` as a debugging switch

## Context

Qwen3.5 uses Gemma RMSNorm. The native `npu_gemma_rms_norm` operator is available on Ascend 910B/910C but has no registered kernel on Ascend 950, so directly calling it prevents Qwen3.5 from running on Ascend 950.

This PR intentionally keeps product detection and provider selection in SGLang. It depends only on the existing Triton Gemma kernel import path and does not require the new stable API proposed by sgl-project/sgl-kernel-npu#638.

## Validation

- Windows standalone torch provider probe passed for product mapping, native, Triton, decomposed fallback, multidimensional non-contiguous input, and empty input behavior
- AST delegation probe passed for `GemmaRMSNorm` and `Gemma3RMSNorm` ordinary/residual paths
- `py_compile`, Black, isort, and `git diff --check` passed
- the registered pytest file could not be collected in the local Windows environment because the full SRT import chain requires the Unix-only `resource` module; it remains available for normal Linux CI
- Ascend 950 Qwen3.5 Dense W8A8 load, warmup, and deterministic request: TODO
- Ascend 910B/910C Qwen3.5 smoke and native-provider confirmation: TODO

## Status

This remains a WIP comparison branch and is not proposed as a replacement for #32745 yet.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30529969847](https://github.com/sgl-project/sglang/actions/runs/30529969847)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30529969638](https://github.com/sgl-project/sglang/actions/runs/30529969638)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->