### PR TITLE
Fix RunAI streamer buffer race in DeepSeek weight loader

### DIFF
--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -206,9 +206,7 @@ class DeepseekV2WeightLoaderMixin:
             weight_names = []
 
             for name, loaded_weight in weights:
-                use_async_loading = should_async_load(
-                    loaded_weight
-                ) and not getattr(
+                use_async_loading = should_async_load(loaded_weight) and not getattr(
                     loaded_weight, RUNAI_STREAMER_TENSOR_ATTR, False
                 )
                 layer_id = get_layer_id(name)

--- a/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
+++ b/python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py
@@ -206,7 +206,11 @@ class DeepseekV2WeightLoaderMixin:
             weight_names = []
 
             for name, loaded_weight in weights:
-                use_async_loading = should_async_load(loaded_weight)
+                use_async_loading = should_async_load(
+                    loaded_weight
+                ) and not getattr(
+                    loaded_weight, RUNAI_STREAMER_TENSOR_ATTR, False
+                )
                 layer_id = get_layer_id(name)
                 if (
                     layer_id is not None


### PR DESCRIPTION
## Summary
- load RunAI-streamed tensors synchronously
- retain asynchronous loading for other CPU tensors
- prevent reuse of the streamer CPU buffer while a background copy is in progress

## Context
RunAI-streamed tensors are zero-copy views into a reusable CPU buffer. Advancing the iterator while SGLang asynchronously consumes the previous tensor can silently corrupt model weights.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30529854324](https://github.com/sgl-project/sglang/actions/runs/30529854324)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30529853840](https://github.com/sgl-project/sglang/actions/runs/30529853840)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->