### PR TITLE
[diffusion][docs] Fix Cosmos3 model sizes

### DIFF
--- a/docs_new/cookbook/diffusion/Cosmos/Cosmos3.mdx
+++ b/docs_new/cookbook/diffusion/Cosmos/Cosmos3.mdx
@@ -15,7 +15,7 @@ import { DiffusionModelTags } from '/src/snippets/diffusion/model-tags.jsx';
 | Model | Status | Notes |
 | --- | --- | --- |
 | `nvidia/Cosmos3-Nano` | Supported | T2I, T2V, I2V, V2V, joint sound, and action |
-| `nvidia/Cosmos3-Super` | Supported | T2I, T2V, I2V, and V2V; use multi-GPU for the 32B checkpoint |
+| `nvidia/Cosmos3-Super` | Supported | T2I, T2V, I2V, and V2V; use multi-GPU for the 64B checkpoint |
 | `nvidia/Cosmos3-Super-Text2Image` | Supported | T2I-specialized checkpoint |
 | `nvidia/Cosmos3-Super-Image2Video` | Supported | I2V-specialized checkpoint |
 | `nvidia/Cosmos3-Nano-Policy-DROID` | Supported | DROID policy action generation |

--- a/docs_new/docs/sglang-diffusion/compatibility_matrix.mdx
+++ b/docs_new/docs/sglang-diffusion/compatibility_matrix.mdx
@@ -612,8 +612,8 @@ Optimization columns are abbreviated to keep the matrix readable:
    - `resident` usually provides the best latency/throughput but uses much more VRAM.
    - Default is auto: `resident` on H200/high-memory CUDA GPUs, otherwise `original`.
    - Deprecated compatibility: `snapshot` is accepted as an alias for `original` and may be removed after two release cycles.
-5. Cosmos3 ships in two sizes — `nvidia/Cosmos3-Nano` (8B) and
-   `nvidia/Cosmos3-Super` (32B). Both share the same pipeline; the only
+5. Cosmos3 ships in two sizes — `nvidia/Cosmos3-Nano` (16B) and
+   `nvidia/Cosmos3-Super` (64B). Both share the same pipeline; the only
    difference is transformer depth and width, picked up from
    `transformer/config.json` at load time. A single checkpoint serves T2V,
    I2V (`--image-path`), and T2I (`--num-frames 1`).

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -1035,7 +1035,7 @@ def _register_configs():
 
     # Cosmos3 — single checkpoint serves T2V, I2V, and T2I. Mode is dispatched
     # per-request inside the pipeline from ``num_frames`` and ``image_path``.
-    # Both Nano (8B) and Super (32B) share the same pipeline; arch dimensions
+    # Both Nano (16B) and Super (64B) share the same pipeline; arch dimensions
     # come from ``transformer/config.json`` via ``update_model_arch``.
     register_configs(
         sampling_param_cls=Cosmos3SamplingParams,


### PR DESCRIPTION
## Summary

- correct Cosmos3 Nano from 8B to 16B in the diffusion compatibility matrix
- correct Cosmos3 Super from 32B to 64B in the compatibility matrix and cookbook
- keep the registry comment consistent with the public documentation

NVIDIA's official model card lists Cosmos3-Nano as 16B and Cosmos3-Super (including the I2V and T2I variants) as 64B:
https://huggingface.co/nvidia/Cosmos3-Super#model-architecture

## Testing

- `ruff check python/sglang/multimodal_gen/registry.py`
- `ruff format --check python/sglang/multimodal_gen/registry.py`
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30530362595](https://github.com/sgl-project/sglang/actions/runs/30530362595)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #30536649429](https://github.com/sgl-project/sglang/actions/runs/30536649429)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->