### PR TITLE
Fuse GDN decode projection unpack with Conv1D

### DIFF
--- a/python/sglang/kernels/ops/attention/triton_gdn_fused_proj.py
+++ b/python/sglang/kernels/ops/attention/triton_gdn_fused_proj.py
@@ -310,6 +310,323 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     return mixed_qkv, z, b, a
 
 
+# =============================================================================
+# Decode-only Qwen3.5 contiguous projection unpack + causal Conv1D update.
+#
+# This deliberately leaves the quantized projection GEMMs unchanged. The safe
+# fusion boundary begins at their activation outputs:
+#   qkvz = [all_q | all_k | all_v | all_z]
+#   ba   = [all_b | all_a]
+# =============================================================================
+
+
+@triton.jit
+def _fused_qkvzba_causal_conv1d_update_contiguous_kernel(
+    mixed_qkv,
+    z,
+    b,
+    a,
+    mixed_qkvz,
+    mixed_ba,
+    conv_state,
+    conv_weight,
+    conv_bias,
+    conv_state_indices,
+    stride_qkvz_batch: tl.constexpr,
+    stride_qkvz_dim: tl.constexpr,
+    stride_ba_batch: tl.constexpr,
+    stride_ba_dim: tl.constexpr,
+    stride_state_batch: tl.constexpr,
+    stride_state_dim: tl.constexpr,
+    stride_state_pos: tl.constexpr,
+    stride_weight_dim: tl.constexpr,
+    stride_weight_width: tl.constexpr,
+    stride_state_indices: tl.constexpr,
+    QKV_DIM: tl.constexpr,
+    V_DIM: tl.constexpr,
+    NUM_V_HEADS: tl.constexpr,
+    STATE_LEN: tl.constexpr,
+    KERNEL_WIDTH: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    SILU_ACTIVATION: tl.constexpr,
+    PAD_SLOT_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    dim_idx = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    qkv_mask = dim_idx < QKV_DIM
+
+    x = tl.load(
+        mixed_qkvz
+        + batch_idx * stride_qkvz_batch
+        + dim_idx * stride_qkvz_dim,
+        mask=qkv_mask,
+        other=0.0,
+    )
+
+    state_slot = tl.load(
+        conv_state_indices + batch_idx * stride_state_indices
+    ).to(tl.int64)
+    valid_slot = state_slot != PAD_SLOT_ID
+    state_base = (
+        conv_state
+        + state_slot * stride_state_batch
+        + dim_idx * stride_state_dim
+    )
+
+    acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    if HAS_BIAS:
+        acc += tl.load(conv_bias + dim_idx, mask=qkv_mask, other=0.0).to(
+            tl.float32
+        )
+
+    # Match the deployed direct-Triton update exactly. Its effective decode
+    # state length is width-1 even when the physical cache tensor is wider.
+    for pos in tl.static_range(KERNEL_WIDTH - 1):
+        state_value = tl.load(
+            state_base
+            + pos * stride_state_pos,
+            mask=qkv_mask & valid_slot,
+            other=0.0,
+        )
+        weight_value = tl.load(
+            conv_weight
+            + dim_idx * stride_weight_dim
+            + pos * stride_weight_width,
+            mask=qkv_mask,
+            other=0.0,
+        )
+        # Do not force an FP32 multiply here. This expression deliberately
+        # retains the operand types/order of causal_conv1d_triton.py.
+        acc += state_value * weight_value
+
+    last_weight = tl.load(
+        conv_weight
+        + dim_idx * stride_weight_dim
+        + (KERNEL_WIDTH - 1) * stride_weight_width,
+        mask=qkv_mask,
+        other=0.0,
+    )
+    acc += x * last_weight
+    if SILU_ACTIVATION:
+        conv_out = acc / (1.0 + tl.exp(-acc))
+    else:
+        conv_out = acc
+
+    # The legacy kernel leaves padded rows' input unchanged.
+    conv_out = tl.where(valid_slot, conv_out, x)
+    tl.store(
+        mixed_qkv + batch_idx * QKV_DIM + dim_idx,
+        conv_out,
+        mask=qkv_mask,
+    )
+
+    # The direct-Triton wrapper sets effective state_len=width-1 for decode.
+    for pos in tl.static_range(KERNEL_WIDTH - 2):
+        next_value = tl.load(
+            state_base + (pos + 1) * stride_state_pos,
+            mask=qkv_mask & valid_slot,
+            other=0.0,
+        )
+        tl.store(
+            state_base + pos * stride_state_pos,
+            next_value,
+            mask=qkv_mask & valid_slot,
+        )
+    tl.store(
+        state_base + (KERNEL_WIDTH - 2) * stride_state_pos,
+        x,
+        mask=qkv_mask & valid_slot,
+    )
+
+    # The first feature lanes also materialize the smaller downstream tensors.
+    z_mask = dim_idx < V_DIM
+    z_value = tl.load(
+        mixed_qkvz
+        + batch_idx * stride_qkvz_batch
+        + (QKV_DIM + dim_idx) * stride_qkvz_dim,
+        mask=z_mask,
+        other=0.0,
+    )
+    tl.store(z + batch_idx * V_DIM + dim_idx, z_value, mask=z_mask)
+
+    gate_mask = dim_idx < NUM_V_HEADS
+    b_value = tl.load(
+        mixed_ba
+        + batch_idx * stride_ba_batch
+        + dim_idx * stride_ba_dim,
+        mask=gate_mask,
+        other=0.0,
+    )
+    a_value = tl.load(
+        mixed_ba
+        + batch_idx * stride_ba_batch
+        + (NUM_V_HEADS + dim_idx) * stride_ba_dim,
+        mask=gate_mask,
+        other=0.0,
+    )
+    tl.store(b + batch_idx * NUM_V_HEADS + dim_idx, b_value, mask=gate_mask)
+    tl.store(a + batch_idx * NUM_V_HEADS + dim_idx, a_value, mask=gate_mask)
+
+
+def can_use_fused_qkvzba_causal_conv1d_update_contiguous(
+    mixed_qkvz: torch.Tensor,
+    mixed_ba: torch.Tensor,
+    conv_state: torch.Tensor,
+    conv_weight: torch.Tensor,
+    conv_bias: torch.Tensor | None,
+    conv_state_indices: torch.Tensor,
+    *,
+    qkv_dim: int,
+    v_dim: int,
+    num_v_heads: int,
+    activation: str | None,
+) -> tuple[bool, str]:
+    """Return an explicit eligibility decision for the decode fusion."""
+    tensors = (mixed_qkvz, mixed_ba, conv_state, conv_weight, conv_state_indices)
+    if not all(isinstance(tensor, torch.Tensor) for tensor in tensors):
+        return False, "all inputs must be torch.Tensor instances"
+    if not all(tensor.is_cuda for tensor in tensors):
+        return False, "CUDA tensors are required"
+    if mixed_qkvz.ndim != 2 or mixed_ba.ndim != 2:
+        return False, "projection outputs must be rank-2"
+    if conv_state.ndim != 3 or conv_weight.ndim != 2:
+        return False, "Conv1D state/weight ranks must be 3/2"
+    if conv_state_indices.ndim != 1:
+        return False, "conv_state_indices must be rank-1"
+    batch = mixed_qkvz.shape[0]
+    if mixed_ba.shape[0] != batch or conv_state_indices.shape[0] != batch:
+        return False, "batch dimensions must match"
+    if qkv_dim <= 0 or v_dim <= 0 or num_v_heads <= 0:
+        return False, "TP-local dimensions must be positive"
+    if mixed_qkvz.shape[1] != qkv_dim + v_dim:
+        return False, "qkvz layout is not contiguous [Q|K|V|Z]"
+    if mixed_ba.shape[1] != 2 * num_v_heads:
+        return False, "ba layout is not contiguous [B|A]"
+    if conv_state.shape[1] != qkv_dim or conv_weight.shape[0] != qkv_dim:
+        return False, "Conv1D feature dimension does not match packed QKV"
+    width = conv_weight.shape[1]
+    if width < 2 or width > 4:
+        return False, "only Conv1D widths 2 through 4 are supported"
+    if conv_state.shape[2] < width - 1:
+        return False, "Conv1D state is shorter than width - 1"
+    supported_dtypes = (torch.float16, torch.bfloat16, torch.float32)
+    if mixed_qkvz.dtype not in supported_dtypes:
+        return False, "QKVZ activation dtype must be FP16, BF16, or FP32"
+    if conv_state.dtype != mixed_qkvz.dtype or conv_weight.dtype != mixed_qkvz.dtype:
+        return False, "QKVZ, Conv1D state, and weight dtypes must match"
+    if mixed_ba.dtype not in supported_dtypes:
+        return False, "BA activation dtype must be FP16, BF16, or FP32"
+    if conv_bias is not None:
+        if (
+            not isinstance(conv_bias, torch.Tensor)
+            or not conv_bias.is_cuda
+            or conv_bias.ndim != 1
+            or conv_bias.shape[0] != qkv_dim
+            or conv_bias.dtype != mixed_qkvz.dtype
+        ):
+            return False, "Conv1D bias contract is incompatible"
+    if activation not in (None, "silu", "swish"):
+        return False, "activation must be None, silu, or swish"
+    if mixed_qkvz.stride(1) != 1 or mixed_ba.stride(1) != 1:
+        return False, "projection feature dimensions must be contiguous"
+    if conv_weight.stride(1) != 1:
+        return False, "Conv1D weight width dimension must be contiguous"
+    if conv_state_indices.dtype not in (torch.int32, torch.int64):
+        return False, "conv_state_indices must be int32 or int64"
+    return True, "eligible"
+
+
+def fused_qkvzba_causal_conv1d_update_contiguous(
+    mixed_qkvz: torch.Tensor,
+    mixed_ba: torch.Tensor,
+    conv_state: torch.Tensor,
+    conv_weight: torch.Tensor,
+    conv_bias: torch.Tensor | None,
+    conv_state_indices: torch.Tensor,
+    *,
+    qkv_dim: int,
+    v_dim: int,
+    num_v_heads: int,
+    head_v_dim: int,
+    activation: str | None,
+    pad_slot_id: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Decode-only fused Qwen3.5 projection unpack and Conv1D state update."""
+    eligible, reason = can_use_fused_qkvzba_causal_conv1d_update_contiguous(
+        mixed_qkvz,
+        mixed_ba,
+        conv_state,
+        conv_weight,
+        conv_bias,
+        conv_state_indices,
+        qkv_dim=qkv_dim,
+        v_dim=v_dim,
+        num_v_heads=num_v_heads,
+        activation=activation,
+    )
+    if not eligible:
+        raise ValueError(f"Ineligible fused GDN decode projection/Conv1D: {reason}")
+    if v_dim != num_v_heads * head_v_dim:
+        raise ValueError(
+            "Ineligible fused GDN decode projection/Conv1D: "
+            "v_dim must equal num_v_heads * head_v_dim"
+        )
+
+    batch = mixed_qkvz.shape[0]
+    mixed_qkv = torch.empty(
+        (batch, qkv_dim), dtype=mixed_qkvz.dtype, device=mixed_qkvz.device
+    )
+    z = torch.empty(
+        (batch, num_v_heads, head_v_dim),
+        dtype=mixed_qkvz.dtype,
+        device=mixed_qkvz.device,
+    )
+    b = torch.empty(
+        (batch, num_v_heads),
+        dtype=mixed_ba.dtype,
+        device=mixed_ba.device,
+    )
+    a = torch.empty_like(b)
+
+    block_size = 256
+    grid = (batch, triton.cdiv(qkv_dim, block_size))
+    _fused_qkvzba_causal_conv1d_update_contiguous_kernel[grid](
+        mixed_qkv,
+        z,
+        b,
+        a,
+        mixed_qkvz,
+        mixed_ba,
+        conv_state,
+        conv_weight,
+        conv_bias,
+        conv_state_indices,
+        mixed_qkvz.stride(0),
+        mixed_qkvz.stride(1),
+        mixed_ba.stride(0),
+        mixed_ba.stride(1),
+        conv_state.stride(0),
+        conv_state.stride(1),
+        conv_state.stride(2),
+        conv_weight.stride(0),
+        conv_weight.stride(1),
+        conv_state_indices.stride(0),
+        QKV_DIM=qkv_dim,
+        V_DIM=v_dim,
+        NUM_V_HEADS=num_v_heads,
+        STATE_LEN=conv_state.shape[2],
+        KERNEL_WIDTH=conv_weight.shape[1],
+        HAS_BIAS=conv_bias is not None,
+        SILU_ACTIVATION=activation in ("silu", "swish"),
+        PAD_SLOT_ID=pad_slot_id,
+        BLOCK_SIZE=block_size,
+        num_warps=8,
+        num_stages=2,
+    )
+    return mixed_qkv, z, b, a
+
+
 @triton.jit
 def fused_qkv_split_gdn_prefill_kernel(
     q,

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Tuple, Union
 
 import torch
@@ -29,10 +30,23 @@ if not is_cpu():
 
 if is_cuda() or is_hip():
     from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+        can_use_fused_qkvzba_causal_conv1d_update_contiguous,
+        fused_qkvzba_causal_conv1d_update_contiguous,
+        fused_qkvzba_split_reshape_cat_contiguous,
         fused_qkv_split_gdn_prefill,
     )
 
 MAX_FUSED_QKV_SPLIT_DIM = 8192
+_fused_decode_proj_conv_logged = False
+_fused_decode_proj_conv_fallback_logged = False
+_fused_decode_proj_conv_layers_logged: set[int] = set()
+_fused_decode_real_tensor_verified_layers: set[int] = set()
+_fused_decode_log_layer_hits = (
+    os.environ.get("SGLANG_GDN_DECODE_FUSION_LOG_LAYER_HITS", "0") == "1"
+)
+_fused_decode_verify_real_tensors = (
+    os.environ.get("SGLANG_GDN_DECODE_FUSION_VERIFY_REAL_TENSORS", "0") == "1"
+)
 
 if is_cuda():
     from sglang.srt.layers.attention.mamba.causal_conv1d import (
@@ -372,6 +386,11 @@ class GDNAttnBackend(MambaAttnBackendBase):
         b: torch.Tensor,
         **kwargs,
     ):
+        global _fused_decode_proj_conv_fallback_logged
+        global _fused_decode_proj_conv_logged
+        global _fused_decode_proj_conv_layers_logged
+        global _fused_decode_real_tensor_verified_layers
+
         layer_cache = self.req_to_token_pool.mamba2_layer_cache(layer.layer_id)
         conv_states = layer_cache.conv[0]
         ssm_states = layer_cache.temporal
@@ -389,15 +408,177 @@ class GDNAttnBackend(MambaAttnBackendBase):
         replayssm_k = layer_cache.replayssm_k
         replayssm_g = layer_cache.replayssm_g
 
-        assert isinstance(mixed_qkv, torch.Tensor)
-        mixed_qkv = causal_conv1d_update(
-            mixed_qkv,
-            conv_states,
-            layer.conv_weights,
-            layer.bias,
-            layer.activation,
-            conv_state_indices=cache_indices,
-        )
+        return_z = False
+        conv_already_applied = False
+        if isinstance(mixed_qkv, tuple):
+            if len(mixed_qkv) != 2:
+                raise ValueError(
+                    "Fused GDN decode projection input must be "
+                    "(projected_qkvz, projected_ba)"
+                )
+            projected_qkvz, projected_ba = mixed_qkv
+            eligible, eligibility_reason = (
+                can_use_fused_qkvzba_causal_conv1d_update_contiguous(
+                    projected_qkvz,
+                    projected_ba,
+                    conv_states,
+                    layer.conv_weights,
+                    layer.bias,
+                    cache_indices,
+                    qkv_dim=layer.q_dim + layer.k_dim + layer.v_dim,
+                    v_dim=layer.v_dim,
+                    num_v_heads=layer.num_v_heads,
+                    activation=layer.activation,
+                )
+            )
+            if eligible:
+                qkv_dim = layer.q_dim + layer.k_dim + layer.v_dim
+                fused_backend = "triton_direct_oracle_exact"
+                if not _fused_decode_proj_conv_logged:
+                    rank0_log(
+                        "Using fused GDN decode QKVZ/BA unpack + indexed Conv1D."
+                    )
+                    _fused_decode_proj_conv_logged = True
+                if (
+                    (
+                        _fused_decode_log_layer_hits
+                        or _fused_decode_verify_real_tensors
+                    )
+                    and layer.layer_id not in _fused_decode_proj_conv_layers_logged
+                ):
+                    rank0_log(
+                        "GDN_FUSED_DECODE_BACKEND "
+                        f"layer_id={layer.layer_id} backend={fused_backend} "
+                        f"batch={projected_qkvz.shape[0]} "
+                        f"qkv_dim={qkv_dim} state_shape={tuple(conv_states.shape)} "
+                        f"state_indices_dtype={cache_indices.dtype}"
+                    )
+                    _fused_decode_proj_conv_layers_logged.add(layer.layer_id)
+
+                # Diagnostic-only real-tensor oracle. It consumes the actual
+                # projection activations and selected pre-update cache rows,
+                # but runs the deployed direct-Triton update on a compact
+                # state copy so the live cache is mutated only by the
+                # candidate. Any mismatch aborts at the first GDN layer.
+                verify_real_tensors = (
+                    _fused_decode_verify_real_tensors
+                    and layer.layer_id
+                    not in _fused_decode_real_tensor_verified_layers
+                )
+                if verify_real_tensors:
+                    if bool(torch.any(cache_indices < 0).item()):
+                        raise AssertionError(
+                            "Real-tensor GDN fusion verification requires "
+                            "non-padding cache indices"
+                        )
+                    ref_indices = torch.arange(
+                        cache_indices.numel(),
+                        device=cache_indices.device,
+                        dtype=torch.int32,
+                    )
+                    ref_state = torch.index_select(
+                        conv_states, 0, cache_indices.to(torch.int64)
+                    )
+                    ref_mixed_qkv, ref_z, ref_b, ref_a = (
+                        fused_qkvzba_split_reshape_cat_contiguous(
+                            projected_qkvz,
+                            projected_ba,
+                            layer.num_q_heads,
+                            layer.num_v_heads,
+                            layer.head_q_dim,
+                            layer.head_v_dim,
+                        )
+                    )
+                    ref_mixed_qkv = causal_conv1d_update(
+                        ref_mixed_qkv,
+                        ref_state,
+                        layer.conv_weights,
+                        layer.bias,
+                        layer.activation,
+                        conv_state_indices=ref_indices,
+                    )
+
+                mixed_qkv, z, b, a = (
+                    fused_qkvzba_causal_conv1d_update_contiguous(
+                        projected_qkvz,
+                        projected_ba,
+                        conv_states,
+                        layer.conv_weights,
+                        layer.bias,
+                        cache_indices,
+                        qkv_dim=qkv_dim,
+                        v_dim=layer.v_dim,
+                        num_v_heads=layer.num_v_heads,
+                        head_v_dim=layer.head_v_dim,
+                        activation=layer.activation,
+                    )
+                )
+                if verify_real_tensors:
+                    candidate_state = torch.index_select(
+                        conv_states, 0, cache_indices.to(torch.int64)
+                    )
+                    named_pairs = (
+                        ("qkv", mixed_qkv, ref_mixed_qkv),
+                        ("z", z, ref_z),
+                        ("b", b, ref_b),
+                        ("a", a, ref_a),
+                        ("state", candidate_state, ref_state),
+                    )
+                    report = []
+                    mismatch = False
+                    for tensor_name, candidate, reference in named_pairs:
+                        diff = (candidate.float() - reference.float()).abs()
+                        nonzero = int(torch.count_nonzero(diff).item())
+                        mismatch |= nonzero != 0
+                        report.append(
+                            f"{tensor_name}_nonzero={nonzero}/"
+                            f"{diff.numel()} {tensor_name}_max="
+                            f"{diff.max().item()}"
+                        )
+                    rank0_log(
+                        "GDN_FUSED_REAL_TENSOR_PARITY "
+                        f"layer_id={layer.layer_id} backend={fused_backend} "
+                        + " ".join(report)
+                    )
+                    _fused_decode_real_tensor_verified_layers.add(layer.layer_id)
+                    if mismatch:
+                        raise AssertionError(
+                            "GDN fused real-tensor parity failed at "
+                            f"layer_id={layer.layer_id}; " + " ".join(report)
+                        )
+                conv_already_applied = True
+            else:
+                # Explicit correctness fallback for an unexpected runtime
+                # tensor/state contract. This still returns Z to the model.
+                if not _fused_decode_proj_conv_fallback_logged:
+                    rank0_log(
+                        "Falling back from fused GDN decode projection/Conv1D: "
+                        f"{eligibility_reason}"
+                    )
+                    _fused_decode_proj_conv_fallback_logged = True
+                mixed_qkv, z, b, a = (
+                    fused_qkvzba_split_reshape_cat_contiguous(
+                        projected_qkvz,
+                        projected_ba,
+                        layer.num_q_heads,
+                        layer.num_v_heads,
+                        layer.head_q_dim,
+                        layer.head_v_dim,
+                    )
+                )
+            return_z = True
+        else:
+            assert isinstance(mixed_qkv, torch.Tensor)
+
+        if not conv_already_applied:
+            mixed_qkv = causal_conv1d_update(
+                mixed_qkv,
+                conv_states,
+                layer.conv_weights,
+                layer.bias,
+                layer.activation,
+                conv_state_indices=cache_indices,
+            )
 
         # Skip split + reshape + separate gating kernel by consuming
         # the packed mixed_qkv directly in a single fused Triton kernel.
@@ -422,7 +603,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
             self._track_mamba_state_decode(
                 forward_batch, conv_states, ssm_states, cache_indices
             )
-            return core_attn_out
+            return (core_attn_out, z) if return_z else core_attn_out
 
         query, key, value = torch.split(
             mixed_qkv,
@@ -452,7 +633,7 @@ class GDNAttnBackend(MambaAttnBackendBase):
             forward_batch, conv_states, ssm_states, cache_indices
         )
 
-        return core_attn_out
+        return (core_attn_out, z) if return_z else core_attn_out
 
     def forward_extend(
         self,

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -21,6 +21,30 @@ from sglang.srt.utils import is_cuda
 
 logger = logging.getLogger(__name__)
 
+_FLASHINFER_GDN_ALIGNMENT = 32
+
+
+def _empty_aligned_like(
+    tensor: torch.Tensor, alignment: int = _FLASHINFER_GDN_ALIGNMENT
+) -> torch.Tensor:
+    """Return an uninitialized contiguous tensor with an aligned data pointer."""
+    element_size = tensor.dtype.itemsize
+    alignment_elements = max(1, alignment // element_size)
+    storage = torch.empty(
+        tensor.numel() + alignment_elements - 1,
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    start_bytes = (-storage.data_ptr()) % alignment
+    if start_bytes % element_size:
+        raise RuntimeError(
+            f"Cannot align {tensor.dtype} storage at {storage.data_ptr()} "
+            f"to {alignment} bytes"
+        )
+    start = start_bytes // element_size
+    return storage[start : start + tensor.numel()].view(tensor.shape)
+
+
 # ---------------------------------------------------------------------------
 # Lazy import for FlashInfer GDN kernels
 # ---------------------------------------------------------------------------
@@ -112,6 +136,19 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         sm_major = torch.cuda.get_device_capability()[0]
         self.use_state_pool = sm_major >= 10
         self.supports_target_verify = sm_major in (9, 10)
+        self._aligned_input_buffers: dict[tuple, torch.Tensor] = {}
+        self._aligned_parameter_cache: dict[
+            tuple, tuple[torch.Tensor, torch.Tensor]
+        ] = {}
+        self._alignment_fallback_warned = False
+        # Mutable state/workspace cannot be repaired with a temporary copy:
+        # FlashInfer writes through those pointers. Triton has no 32-byte ABI
+        # requirement and is therefore the semantics-preserving fallback.
+        from sglang.srt.layers.attention.linear.kernels.gdn_triton import (
+            TritonGDNKernel,
+        )
+
+        self._alignment_fallback_kernel = TritonGDNKernel()
 
         if sm_major == 9 and self._prefill_fn is None:
             raise RuntimeError("FlashInfer GDN prefill kernel is unavailable.")
@@ -154,6 +191,104 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
 
         logger.info("Using FlashInfer GDN kernels")
 
+    def _prepare_dynamic_input(self, name: str, tensor: torch.Tensor) -> torch.Tensor:
+        """Repair an under-aligned read-only input using reusable scratch.
+
+        The normal producer path returns aligned tensors and takes the zero-cost
+        branch. The scratch path is a safety net for other models or view
+        layouts. A buffer is allocated once per argument/shape/stream and then
+        reused, avoiding allocator churn in eager decode and providing stable
+        addresses for CUDA Graph capture.
+        """
+        if tensor.data_ptr() % _FLASHINFER_GDN_ALIGNMENT == 0:
+            return tensor
+
+        stream_key = (
+            torch.cuda.current_stream(tensor.device).cuda_stream
+            if tensor.device.type == "cuda"
+            else None
+        )
+        key = (
+            name,
+            tensor.device,
+            tensor.dtype,
+            tuple(tensor.shape),
+            stream_key,
+        )
+        aligned = self._aligned_input_buffers.get(key)
+        if aligned is None:
+            aligned = _empty_aligned_like(tensor)
+            self._aligned_input_buffers[key] = aligned
+        aligned.copy_(tensor)
+        return aligned
+
+    def _prepare_parameter(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        *,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        """Return a stable aligned view/copy of an immutable kernel parameter."""
+        key = (
+            name,
+            id(tensor),
+            dtype,
+        )
+        cached_entry = self._aligned_parameter_cache.get(key)
+        if cached_entry is not None and cached_entry[0] is tensor:
+            return cached_entry[1]
+
+        prepared = tensor.detach().reshape(-1)
+        if dtype is not None:
+            prepared = prepared.to(dtype=dtype, copy=False)
+        if (
+            not prepared.is_contiguous()
+            or prepared.data_ptr() % _FLASHINFER_GDN_ALIGNMENT
+        ):
+            aligned = _empty_aligned_like(prepared)
+            aligned.copy_(prepared)
+            prepared = aligned
+        # Retaining the source also prevents a recycled Python id from
+        # colliding with an older cache entry.
+        self._aligned_parameter_cache[key] = (tensor, prepared)
+        return prepared
+
+    def _prepare_gate_parameters(
+        self,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        *,
+        A_log_dtype: Optional[torch.dtype] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return (
+            self._prepare_parameter("A_log", A_log, dtype=A_log_dtype),
+            self._prepare_parameter("dt_bias", dt_bias),
+        )
+
+    def _mutable_inputs_are_aligned(
+        self, *named_tensors: tuple[str, Optional[torch.Tensor]]
+    ) -> bool:
+        """Return whether mutable buffers satisfy FlashInfer's ABI.
+
+        Copying a state or workspace into temporary storage would lose kernel
+        writeback. The caller falls back to Triton instead.
+        """
+        for name, tensor in named_tensors:
+            if tensor is None or tensor.data_ptr() % _FLASHINFER_GDN_ALIGNMENT == 0:
+                continue
+            if not self._alignment_fallback_warned:
+                logger.warning(
+                    "FlashInfer GDN mutable buffer %r has data_ptr %d "
+                    "(mod 32 = %d); falling back to Triton for this call.",
+                    name,
+                    tensor.data_ptr(),
+                    tensor.data_ptr() % _FLASHINFER_GDN_ALIGNMENT,
+                )
+                self._alignment_fallback_warned = True
+            return False
+        return True
+
     # ---- decode ----
 
     def decode(
@@ -171,6 +306,21 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         query_start_loc: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
+        if not self._mutable_inputs_are_aligned(("ssm_states", ssm_states)):
+            return self._alignment_fallback_kernel.decode(
+                q,
+                k,
+                v,
+                a,
+                b,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                **kwargs,
+            )
+
         batch_size = cache_indices.shape[0]
         num_heads = q.shape[2]
         head_k_dim = q.shape[3]
@@ -182,20 +332,35 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         value_fi = v.view(batch_size, 1, num_v_heads, head_v_dim)
         a_fi = a.view(batch_size, 1, num_v_heads)
         b_fi = b.view(batch_size, 1, num_v_heads)
+        query_fi = self._prepare_dynamic_input("decode_q", query_fi)
+        key_fi = self._prepare_dynamic_input("decode_k", key_fi)
+        value_fi = self._prepare_dynamic_input("decode_v", value_fi)
+        a_fi = self._prepare_dynamic_input("decode_a", a_fi)
+        b_fi = self._prepare_dynamic_input("decode_b", b_fi)
+        A_log_fi, dt_bias_fi = self._prepare_gate_parameters(
+            A_log,
+            dt_bias,
+            # Preserve the original backend contract: the SM100 state-pool
+            # kernel consumes float32 A_log, while SM90 uses the source dtype.
+            A_log_dtype=torch.float32 if self.use_state_pool else None,
+        )
 
         if self.use_state_pool:
+            cache_indices_fi = self._prepare_dynamic_input(
+                "decode_cache_indices", cache_indices
+            )
             output_fi, _ = self._decode_fn(
                 q=query_fi,
                 k=key_fi,
                 v=value_fi,
                 state=None,
-                A_log=A_log.detach().float(),
+                A_log=A_log_fi,
                 a=a_fi,
-                dt_bias=dt_bias.detach(),
+                dt_bias=dt_bias_fi,
                 b=b_fi,
                 use_qk_l2norm=True,
                 initial_state=ssm_states,
-                initial_state_indices=cache_indices,
+                initial_state_indices=cache_indices_fi,
             )
         else:
             # TODO: Once FlashInfer PR#2521 is merged for SM90, gather/scatter
@@ -206,9 +371,9 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
                 k=key_fi,
                 v=value_fi,
                 state=state_batch,
-                A_log=A_log.detach(),
+                A_log=A_log_fi,
                 a=a_fi,
-                dt_bias=dt_bias.detach(),
+                dt_bias=dt_bias_fi,
                 b=b_fi,
                 scale=None,
                 output=None,
@@ -343,17 +508,10 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
         num_v_heads = v.shape[2]
         head_v_dim = v.shape[3]
 
-        query_mtp = q.view(batch_size, draft_token_num, num_heads, head_k_dim)
-        key_mtp = k.view(batch_size, draft_token_num, num_heads, head_k_dim)
-        value_mtp = v.view(batch_size, draft_token_num, num_v_heads, head_v_dim)
-
         if a is None or b is None or A_log is None or dt_bias is None:
             raise RuntimeError(
                 "FlashInfer GDN MTP kernel requires a, b, A_log, dt_bias."
             )
-
-        a_mtp = a.view(batch_size, draft_token_num, num_v_heads)
-        b_mtp = b.view(batch_size, draft_token_num, num_v_heads)
 
         intermediate_states_buffer_mtp = intermediate_states_buffer
         if self.use_state_pool and intermediate_states_buffer is not None:
@@ -361,16 +519,61 @@ class FlashInferGDNKernel(LinearAttnKernelBase):
             # per-call batch id, while SGLang's speculative state cache is
             # pool-scoped and may include an extra dummy slot.
             intermediate_states_buffer_mtp = intermediate_states_buffer[:batch_size]
+        if not self._mutable_inputs_are_aligned(
+            ("ssm_states", ssm_states),
+            ("intermediate_states_buffer", intermediate_states_buffer_mtp),
+        ):
+            return self._alignment_fallback_kernel.target_verify(
+                A_log=A_log,
+                dt_bias=dt_bias,
+                q=q,
+                k=k,
+                v=v,
+                a=a,
+                b=b,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                intermediate_states_buffer=intermediate_states_buffer,
+                intermediate_state_indices=intermediate_state_indices,
+                cache_steps=cache_steps,
+                retrieve_parent_token=retrieve_parent_token,
+                **kwargs,
+            )
+
+        query_mtp = self._prepare_dynamic_input(
+            "verify_q",
+            q.view(batch_size, draft_token_num, num_heads, head_k_dim),
+        )
+        key_mtp = self._prepare_dynamic_input(
+            "verify_k",
+            k.view(batch_size, draft_token_num, num_heads, head_k_dim),
+        )
+        value_mtp = self._prepare_dynamic_input(
+            "verify_v",
+            v.view(batch_size, draft_token_num, num_v_heads, head_v_dim),
+        )
+
+        a_mtp = self._prepare_dynamic_input(
+            "verify_a", a.view(batch_size, draft_token_num, num_v_heads)
+        )
+        b_mtp = self._prepare_dynamic_input(
+            "verify_b", b.view(batch_size, draft_token_num, num_v_heads)
+        )
+        A_log_fi, dt_bias_fi = self._prepare_gate_parameters(A_log, dt_bias)
+        cache_indices_fi = self._prepare_dynamic_input(
+            "verify_cache_indices", cache_indices
+        )
 
         output_fi, _ = self._mtp_fn(
             q=query_mtp,
             k=key_mtp,
             v=value_mtp,
             initial_state=ssm_states,
-            initial_state_indices=cache_indices,
-            A_log=A_log.detach(),
+            initial_state_indices=cache_indices_fi,
+            A_log=A_log_fi,
             a=a_mtp,
-            dt_bias=dt_bias.detach(),
+            dt_bias=dt_bias_fi,
             b=b_mtp,
             scale=None,
             output=None,

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -641,7 +641,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             and isinstance(projected_states_ba, torch.Tensor)
         )
         value_to_key_head_ratio = self.num_v_heads // self.num_k_heads
-        use_fused_contiguous_unpack = value_to_key_head_ratio in [1, 2, 4]
+        use_fused_contiguous_unpack = value_to_key_head_ratio in [1, 2, 4, 8]
         if use_fused_decode_proj_conv:
             # The GDN backend owns the indexed Conv1D state and therefore owns
             # the safe unpack+Conv fusion boundary. B/A are passed as temporary
@@ -671,17 +671,6 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             )
             b = b.contiguous()
             a = a.contiguous()
-            if _is_cuda and forward_batch.forward_mode.is_decode():
-                # FlashInfer GDN requires each gate tensor to start at a
-                # 32-byte-aligned address. For TP-local configurations with
-                # eight value heads, ``a`` can be a view at a 16-byte offset,
-                # so contiguous() is a no-op despite the invalid address.
-                # Preserve the original generic split path and materialize
-                # only a view that actually violates the backend contract.
-                if b.data_ptr() % 32 != 0:
-                    b = b.clone(memory_format=torch.contiguous_format)
-                if a.data_ptr() % 32 != 0:
-                    a = a.clone(memory_format=torch.contiguous_format)
 
             query, key, value = map(
                 lambda x: x.reshape(x.shape[0], -1), (query, key, value)

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -130,6 +130,9 @@ _gdn_use_alt_stream = _is_cuda or (
 _qknorm_use_alt_stream = _is_cuda or (
     get_bool_env_var("SGLANG_QK_NORM_ALT_STREAM", "False") and _hip_use_alt_stream
 )
+_gdn_decode_fused_proj_conv = _is_cuda and get_bool_env_var(
+    "SGLANG_ENABLE_GDN_DECODE_FUSED_PROJ_CONV", "True"
+)
 _is_amx_available = cpu_has_amx_support()
 
 cached_get_processor = lru_cache(get_processor)
@@ -631,7 +634,23 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             hidden_states
         )
 
-        if self.num_v_heads // self.num_k_heads in [1, 2, 4] and not _is_npu:
+        use_fused_decode_proj_conv = (
+            _gdn_decode_fused_proj_conv
+            and forward_batch.forward_mode.is_decode()
+            and isinstance(projected_states_qkvz, torch.Tensor)
+            and isinstance(projected_states_ba, torch.Tensor)
+        )
+        value_to_key_head_ratio = self.num_v_heads // self.num_k_heads
+        use_fused_contiguous_unpack = value_to_key_head_ratio in [1, 2, 4]
+        if use_fused_decode_proj_conv:
+            # The GDN backend owns the indexed Conv1D state and therefore owns
+            # the safe unpack+Conv fusion boundary. B/A are passed as temporary
+            # placeholders and replaced by the backend before recurrent GDN.
+            mixed_qkv = (projected_states_qkvz, projected_states_ba)
+            z = None
+            b = projected_states_ba
+            a = projected_states_ba
+        elif use_fused_contiguous_unpack and not _is_npu:
             if _is_cpu:
                 num_k_heads_tp = self.num_k_heads // self.attn_tp_size
                 num_v_heads_tp = self.num_v_heads // self.attn_tp_size
@@ -652,18 +671,39 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             )
             b = b.contiguous()
             a = a.contiguous()
+            if _is_cuda and forward_batch.forward_mode.is_decode():
+                # FlashInfer GDN requires each gate tensor to start at a
+                # 32-byte-aligned address. For TP-local configurations with
+                # eight value heads, ``a`` can be a view at a 16-byte offset,
+                # so contiguous() is a no-op despite the invalid address.
+                # Preserve the original generic split path and materialize
+                # only a view that actually violates the backend contract.
+                if b.data_ptr() % 32 != 0:
+                    b = b.clone(memory_format=torch.contiguous_format)
+                if a.data_ptr() % 32 != 0:
+                    a = a.clone(memory_format=torch.contiguous_format)
 
             query, key, value = map(
                 lambda x: x.reshape(x.shape[0], -1), (query, key, value)
             )
             mixed_qkv = torch.cat((query, key, value), dim=-1)
 
-        core_attn_out = self.attn(
+        attn_result = self.attn(
             forward_batch,
             mixed_qkv=mixed_qkv,
             a=a,
             b=b,
         )
+        if use_fused_decode_proj_conv:
+            if not isinstance(attn_result, tuple) or len(attn_result) != 2:
+                raise RuntimeError(
+                    "Fused GDN decode projection/Conv1D backend must return "
+                    "(core_attn_out, z)"
+                )
+            core_attn_out, z = attn_result
+        else:
+            core_attn_out = attn_result
+        assert z is not None
 
         z_shape_og = z.shape
         # reshape input data into 2D tensor

--- a/test/registered/kernels/ops/attention/test_gdn_decode_fused_proj_conv.py
+++ b/test/registered/kernels/ops/attention/test_gdn_decode_fused_proj_conv.py
@@ -1,0 +1,360 @@
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
+    can_use_fused_qkvzba_causal_conv1d_update_contiguous,
+    fused_qkvzba_causal_conv1d_update_contiguous,
+    fused_qkvzba_split_reshape_cat_contiguous,
+)
+from sglang.kernels.ops.mamba.causal_conv1d_triton import causal_conv1d_update
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-large")
+
+
+def _reference(
+    qkvz,
+    ba,
+    state,
+    weight,
+    bias,
+    indices,
+    *,
+    qkv_dim,
+    v_dim,
+    num_v_heads,
+    head_v_dim,
+    activation,
+):
+    qkv = qkvz[:, :qkv_dim]
+    out = torch.empty_like(qkv)
+    state_out = state.clone()
+    width = weight.shape[1]
+    for row, slot_tensor in enumerate(indices.cpu()):
+        slot = int(slot_tensor)
+        if slot == -1:
+            out[row].copy_(qkv[row])
+            continue
+        # The deployed direct-Triton decode wrapper uses an effective
+        # state_len=width-1 even if the physical cache envelope is wider.
+        history = state[slot, :, : width - 1].float()
+        values = torch.cat((history, qkv[row, :, None].float()), dim=-1)
+        acc = (values * weight.float()).sum(dim=-1)
+        if bias is not None:
+            acc = acc + bias.float()
+        if activation in ("silu", "swish"):
+            acc = torch.nn.functional.silu(acc)
+        out[row].copy_(acc.to(qkv.dtype))
+        if width > 2:
+            state_out[slot, :, : width - 2].copy_(
+                state[slot, :, 1 : width - 1]
+            )
+        state_out[slot, :, width - 2].copy_(qkv[row])
+
+    z = qkvz[:, qkv_dim:].reshape(-1, num_v_heads, head_v_dim).contiguous()
+    b, a = ba.split([num_v_heads, num_v_heads], dim=-1)
+    return out, z, b.contiguous(), a.contiguous(), state_out
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+class TestGDNDecodeFusedProjectionConv1D(unittest.TestCase):
+    def test_contiguous_unpack_ratio8_microbenchmark_baseline(self):
+        batch = 9
+        num_qk_heads = 1
+        num_v_heads = 8
+        head_dim = 128
+        qkv_dim = (2 * num_qk_heads + num_v_heads) * head_dim
+        v_dim = num_v_heads * head_dim
+        qkvz = torch.randn(
+            batch,
+            qkv_dim + v_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        ba = torch.randn(
+            batch,
+            2 * num_v_heads,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat_contiguous(
+            qkvz,
+            ba,
+            num_qk_heads,
+            num_v_heads,
+            head_dim,
+            head_dim,
+        )
+        torch.testing.assert_close(mixed_qkv, qkvz[:, :qkv_dim])
+        torch.testing.assert_close(
+            z, qkvz[:, qkv_dim:].reshape(batch, num_v_heads, head_dim)
+        )
+        torch.testing.assert_close(b, ba[:, :num_v_heads])
+        torch.testing.assert_close(a, ba[:, num_v_heads:])
+
+    def _run_case(
+        self,
+        *,
+        batch,
+        q_dim,
+        k_dim,
+        v_dim,
+        num_v_heads,
+        head_v_dim,
+        width,
+        state_len,
+        dtype,
+        with_bias,
+        activation,
+        strided_state=False,
+        with_padding=False,
+    ):
+        torch.manual_seed(17)
+        device = "cuda"
+        qkv_dim = q_dim + k_dim + v_dim
+        qkvz = torch.randn(
+            batch, qkv_dim + v_dim, device=device, dtype=dtype
+        )
+        ba = torch.randn(batch, 2 * num_v_heads, device=device, dtype=dtype)
+        weight = torch.randn(qkv_dim, width, device=device, dtype=dtype) * 0.1
+        bias = (
+            torch.randn(qkv_dim, device=device, dtype=dtype) * 0.1
+            if with_bias
+            else None
+        )
+        slots = batch + 3
+        if strided_state:
+            backing = torch.randn(
+                slots,
+                state_len,
+                qkv_dim * 2,
+                device=device,
+                dtype=dtype,
+            )
+            state = backing[:, :, ::2].transpose(1, 2)
+            self.assertFalse(state.is_contiguous())
+        else:
+            state = torch.randn(
+                slots, qkv_dim, state_len, device=device, dtype=dtype
+            )
+        indices = torch.randperm(slots, device=device, dtype=torch.int64)[:batch]
+        if with_padding:
+            indices[-1] = -1
+        indices = indices.to(torch.int32)
+
+        ref = _reference(
+            qkvz,
+            ba,
+            state,
+            weight,
+            bias,
+            indices,
+            qkv_dim=qkv_dim,
+            v_dim=v_dim,
+            num_v_heads=num_v_heads,
+            head_v_dim=head_v_dim,
+            activation=activation,
+        )
+        state_test = state.clone(memory_format=torch.preserve_format)
+        out, z, b, a = fused_qkvzba_causal_conv1d_update_contiguous(
+            qkvz,
+            ba,
+            state_test,
+            weight,
+            bias,
+            indices,
+            qkv_dim=qkv_dim,
+            v_dim=v_dim,
+            num_v_heads=num_v_heads,
+            head_v_dim=head_v_dim,
+            activation=activation,
+        )
+        torch.cuda.synchronize()
+
+        atol = 2e-2 if dtype == torch.bfloat16 else 3e-3
+        output_max_diff = (out.float() - ref[0].float()).abs().max().item()
+        state_max_diff = (
+            (state_test.float() - ref[4].float()).abs().max().item()
+        )
+        print(
+            "case "
+            f"B={batch} QKV={qkv_dim} V={v_dim} W={width} "
+            f"dtype={dtype} output_max_diff={output_max_diff:.8g} "
+            f"state_max_diff={state_max_diff:.8g}",
+            flush=True,
+        )
+        torch.testing.assert_close(out, ref[0], rtol=0, atol=atol)
+        torch.testing.assert_close(z, ref[1], rtol=0, atol=0)
+        torch.testing.assert_close(b, ref[2], rtol=0, atol=0)
+        torch.testing.assert_close(a, ref[3], rtol=0, atol=0)
+        torch.testing.assert_close(state_test, ref[4], rtol=0, atol=0)
+        self.assertEqual(b.data_ptr() % 32, 0)
+        self.assertEqual(a.data_ptr() % 32, 0)
+
+    def test_random_shapes_widths_dtypes_and_state_updates(self):
+        cases = (
+            # Small boundary shapes.
+            dict(
+                batch=1,
+                q_dim=16,
+                k_dim=16,
+                v_dim=32,
+                num_v_heads=2,
+                head_v_dim=16,
+                width=2,
+                state_len=1,
+                dtype=torch.float16,
+                with_bias=False,
+                activation=None,
+            ),
+            dict(
+                batch=17,
+                q_dim=32,
+                k_dim=32,
+                v_dim=64,
+                num_v_heads=4,
+                head_v_dim=16,
+                width=3,
+                state_len=5,
+                dtype=torch.bfloat16,
+                with_bias=True,
+                activation="silu",
+                strided_state=True,
+                with_padding=True,
+            ),
+            # Qwen3.5-35B TP16 local GDN dimensions.
+            dict(
+                batch=32,
+                q_dim=128,
+                k_dim=128,
+                v_dim=256,
+                num_v_heads=2,
+                head_v_dim=128,
+                width=4,
+                state_len=3,
+                dtype=torch.bfloat16,
+                with_bias=False,
+                activation="silu",
+            ),
+            # Large TP-local GDN dimensions with an 8:1 value/key head ratio.
+            dict(
+                batch=8,
+                q_dim=128,
+                k_dim=128,
+                v_dim=1024,
+                num_v_heads=8,
+                head_v_dim=128,
+                width=4,
+                state_len=3,
+                dtype=torch.bfloat16,
+                with_bias=False,
+                activation="silu",
+            ),
+        )
+        for case in cases:
+            with self.subTest(case=case):
+                self._run_case(**case)
+
+    def test_cuda_graph_replay(self):
+        batch = 4
+        qkv_dim, v_dim, num_v_heads, head_v_dim = 128, 64, 2, 32
+        qkvz = torch.randn(
+            batch, qkv_dim + v_dim, device="cuda", dtype=torch.bfloat16
+        )
+        ba = torch.randn(
+            batch, 2 * num_v_heads, device="cuda", dtype=torch.bfloat16
+        )
+        weight = torch.randn(
+            qkv_dim, 4, device="cuda", dtype=torch.bfloat16
+        )
+        state = torch.randn(
+            batch + 1, qkv_dim, 3, device="cuda", dtype=torch.bfloat16
+        )
+        initial_state = state.clone()
+        indices = torch.arange(batch, device="cuda", dtype=torch.int32)
+        # Compile before capture; Triton compilation itself is not graph-safe.
+        fused_qkvzba_causal_conv1d_update_contiguous(
+            qkvz,
+            ba,
+            state,
+            weight,
+            None,
+            indices,
+            qkv_dim=qkv_dim,
+            v_dim=v_dim,
+            num_v_heads=num_v_heads,
+            head_v_dim=head_v_dim,
+            activation="silu",
+        )
+        state.copy_(initial_state)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured = fused_qkvzba_causal_conv1d_update_contiguous(
+                qkvz,
+                ba,
+                state,
+                weight,
+                None,
+                indices,
+                qkv_dim=qkv_dim,
+                v_dim=v_dim,
+                num_v_heads=num_v_heads,
+                head_v_dim=head_v_dim,
+                activation="silu",
+            )
+        state.copy_(initial_state)
+        graph.replay()
+        ref_state = initial_state.clone()
+        ref_qkv, ref_z, ref_b, ref_a = (
+            fused_qkvzba_split_reshape_cat_contiguous(
+                qkvz,
+                ba,
+                1,
+                num_v_heads,
+                32,
+                head_v_dim,
+            )
+        )
+        ref_qkv = causal_conv1d_update(
+            ref_qkv,
+            ref_state,
+            weight,
+            None,
+            "silu",
+            conv_state_indices=indices,
+        )
+        torch.testing.assert_close(captured[0], ref_qkv, rtol=0, atol=0)
+        torch.testing.assert_close(captured[1], ref_z, rtol=0, atol=0)
+        torch.testing.assert_close(captured[2], ref_b, rtol=0, atol=0)
+        torch.testing.assert_close(captured[3], ref_a, rtol=0, atol=0)
+        torch.testing.assert_close(state, ref_state, rtol=0, atol=0)
+
+    def test_fp8_activation_is_an_explicit_fallback(self):
+        if not hasattr(torch, "float8_e4m3fn"):
+            self.skipTest("PyTorch has no FP8 dtype")
+        qkvz = torch.empty(1, 96, device="cuda", dtype=torch.float8_e4m3fn)
+        ba = torch.empty(1, 4, device="cuda", dtype=torch.bfloat16)
+        state = torch.empty(2, 64, 3, device="cuda", dtype=torch.bfloat16)
+        weight = torch.empty(64, 4, device="cuda", dtype=torch.bfloat16)
+        indices = torch.zeros(1, device="cuda", dtype=torch.int32)
+        eligible, reason = (
+            can_use_fused_qkvzba_causal_conv1d_update_contiguous(
+                qkvz,
+                ba,
+                state,
+                weight,
+                None,
+                indices,
+                qkv_dim=64,
+                v_dim=32,
+                num_v_heads=2,
+                activation="silu",
+            )
+        )
+        self.assertFalse(eligible)
+        self.assertIn("FP16, BF16, or FP32", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_gdn_flashinfer_alignment.py
+++ b/test/registered/unit/layers/attention/test_gdn_flashinfer_alignment.py
@@ -1,0 +1,222 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
+    FlashInferGDNKernel,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _view_with_pointer_mod(
+    shape: tuple[int, ...], dtype: torch.dtype, pointer_mod: int
+) -> torch.Tensor:
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    element_size = dtype.itemsize
+    base = torch.empty(numel + 32 // element_size, dtype=dtype)
+    for offset in range(32 // element_size):
+        view = base[offset : offset + numel]
+        if view.data_ptr() % 32 == pointer_mod:
+            return view.view(shape)
+    raise AssertionError(f"Could not construct a pointer with mod32={pointer_mod}")
+
+
+def _make_kernel_without_flashinfer() -> FlashInferGDNKernel:
+    kernel = object.__new__(FlashInferGDNKernel)
+    kernel._aligned_input_buffers = {}
+    kernel._aligned_parameter_cache = {}
+    kernel._alignment_fallback_warned = False
+    return kernel
+
+
+class TestFlashInferGDNAlignment(unittest.TestCase):
+    def test_dynamic_repair_buffer_is_reused_without_allocator_churn(self):
+        kernel = _make_kernel_without_flashinfer()
+        source = _view_with_pointer_mod((1, 1, 8), torch.bfloat16, 16)
+        source.fill_(1)
+
+        first = kernel._prepare_dynamic_input("decode_a", source)
+        first_ptr = first.data_ptr()
+        self.assertEqual(first_ptr % 32, 0)
+        torch.testing.assert_close(first, source)
+        self.assertEqual(len(kernel._aligned_input_buffers), 1)
+
+        source.fill_(2)
+        second = kernel._prepare_dynamic_input("decode_a", source)
+        self.assertIs(second, first)
+        self.assertEqual(second.data_ptr(), first_ptr)
+        torch.testing.assert_close(second, source)
+        self.assertEqual(len(kernel._aligned_input_buffers), 1)
+
+        # Distinct kernel arguments cannot alias because both are live at the
+        # FlashInfer call boundary.
+        other = kernel._prepare_dynamic_input("decode_b", source)
+        self.assertNotEqual(other.data_ptr(), first_ptr)
+        self.assertEqual(len(kernel._aligned_input_buffers), 2)
+
+    def test_decode_repairs_read_only_arguments_before_flashinfer(self):
+        kernel = _make_kernel_without_flashinfer()
+        kernel.use_state_pool = True
+        captured = {}
+
+        def fake_decode(**kwargs):
+            captured.update(kwargs)
+            v = kwargs["v"]
+            return (
+                torch.zeros(
+                    v.shape[0],
+                    1,
+                    v.shape[2],
+                    v.shape[3],
+                    dtype=v.dtype,
+                ),
+                None,
+            )
+
+        kernel._decode_fn = fake_decode
+
+        q = torch.empty(1, 1, 1, 128, dtype=torch.bfloat16)
+        k = torch.empty_like(q)
+        v = torch.empty(1, 1, 8, 128, dtype=torch.bfloat16)
+        a = _view_with_pointer_mod((1, 1, 8), torch.bfloat16, 16)
+        b = _view_with_pointer_mod((1, 1, 8), torch.bfloat16, 16)
+        A_log = _view_with_pointer_mod((8,), torch.float32, 4)
+        dt_bias = _view_with_pointer_mod((8,), torch.bfloat16, 2)
+        state = torch.zeros(2, 8, 128, 128, dtype=torch.bfloat16)
+        cache_indices = _view_with_pointer_mod((1,), torch.int32, 4)
+
+        result = kernel.decode(
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            ssm_states=state,
+            cache_indices=cache_indices,
+            query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        )
+
+        self.assertEqual(result.shape, (1, 1, 8, 128))
+        for name in (
+            "q",
+            "k",
+            "v",
+            "A_log",
+            "a",
+            "dt_bias",
+            "b",
+            "initial_state",
+            "initial_state_indices",
+        ):
+            with self.subTest(name=name):
+                self.assertEqual(captured[name].data_ptr() % 32, 0)
+        torch.testing.assert_close(captured["a"], a)
+        torch.testing.assert_close(captured["b"], b)
+
+    def test_gate_parameter_cache_preserves_backend_dtype_contract(self):
+        kernel = _make_kernel_without_flashinfer()
+        A_log = torch.empty(8, dtype=torch.bfloat16)
+        dt_bias = torch.empty(8, dtype=torch.bfloat16)
+
+        A_log_sm90, _ = kernel._prepare_gate_parameters(A_log, dt_bias)
+        A_log_sm100, _ = kernel._prepare_gate_parameters(
+            A_log, dt_bias, A_log_dtype=torch.float32
+        )
+
+        self.assertEqual(A_log_sm90.dtype, torch.bfloat16)
+        self.assertEqual(A_log_sm100.dtype, torch.float32)
+        self.assertEqual(A_log_sm90.data_ptr() % 32, 0)
+        self.assertEqual(A_log_sm100.data_ptr() % 32, 0)
+        self.assertIs(
+            kernel._prepare_gate_parameters(A_log, dt_bias)[0],
+            A_log_sm90,
+        )
+
+    def test_mutable_state_falls_back_without_losing_writeback(self):
+        kernel = _make_kernel_without_flashinfer()
+        captured = {}
+        expected = torch.empty(1)
+
+        class FakeFallback:
+            def decode(self, *args, **kwargs):
+                captured["args"] = args
+                captured["kwargs"] = kwargs
+                return expected
+
+        kernel._alignment_fallback_kernel = FakeFallback()
+        state = _view_with_pointer_mod((2, 8, 4, 4), torch.bfloat16, 16)
+        q = torch.empty(1, 1, 1, 4, dtype=torch.bfloat16)
+        k = torch.empty_like(q)
+        v = torch.empty(1, 1, 8, 4, dtype=torch.bfloat16)
+        a = torch.empty(1, 1, 8, dtype=torch.bfloat16)
+        b = torch.empty_like(a)
+        cache_indices = torch.zeros(1, dtype=torch.int32)
+        query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+
+        result = kernel.decode(
+            q,
+            k,
+            v,
+            a,
+            b,
+            A_log=torch.zeros(8),
+            dt_bias=torch.zeros(8, dtype=torch.bfloat16),
+            ssm_states=state,
+            cache_indices=cache_indices,
+            query_start_loc=query_start_loc,
+        )
+
+        self.assertIs(result, expected)
+        self.assertIs(captured["kwargs"]["ssm_states"], state)
+        self.assertEqual(len(kernel._aligned_input_buffers), 0)
+
+    def test_mutable_mtp_workspace_falls_back_without_copying(self):
+        kernel = _make_kernel_without_flashinfer()
+        kernel.use_state_pool = True
+        captured = {}
+        expected = torch.empty(1)
+
+        class FakeFallback:
+            def target_verify(self, **kwargs):
+                captured.update(kwargs)
+                return expected
+
+        kernel._alignment_fallback_kernel = FakeFallback()
+        q = torch.empty(1, 2, 1, 4, dtype=torch.bfloat16)
+        k = torch.empty_like(q)
+        v = torch.empty(1, 2, 8, 4, dtype=torch.bfloat16)
+        a = torch.empty(1, 2, 8, dtype=torch.bfloat16)
+        b = torch.empty_like(a)
+        state = torch.empty(2, 8, 4, 4, dtype=torch.bfloat16)
+        workspace = _view_with_pointer_mod((2, 2, 8, 4, 4), torch.bfloat16, 16)
+
+        result = kernel.target_verify(
+            torch.zeros(8),
+            torch.zeros(8, dtype=torch.bfloat16),
+            q,
+            k,
+            v,
+            a,
+            b,
+            ssm_states=state,
+            cache_indices=torch.zeros(1, dtype=torch.int32),
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            intermediate_states_buffer=workspace,
+            intermediate_state_indices=torch.zeros(1, 2, dtype=torch.int32),
+            cache_steps=2,
+            retrieve_parent_token=None,
+        )
+
+        self.assertIs(result, expected)
+        self.assertIs(captured["intermediate_states_buffer"], workspace)
+        self.assertEqual(len(kernel._aligned_input_buffers), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_gdn_flashinfer_alignment.py
+++ b/test/registered/unit/layers/attention/test_gdn_flashinfer_alignment.py
@@ -34,6 +34,28 @@ def _make_kernel_without_flashinfer() -> FlashInferGDNKernel:
 
 
 class TestFlashInferGDNAlignment(unittest.TestCase):
+    def test_oakhaven_bs1_split_view_reproduces_under_alignment(self):
+        # Oakhaven TP16's generic projection packs [b_local(8) | a_local(8)]
+        # in BF16. The a view begins 16 bytes after the storage base. At BS=1
+        # PyTorch considers the strided view contiguous, so contiguous() is a
+        # no-op and cannot satisfy FlashInfer's stricter 32-byte ABI.
+        projected_ba = torch.empty((2, 16), dtype=torch.bfloat16)
+        _, a = projected_ba.split((8, 8), dim=-1)
+
+        a_bs1 = a[:1]
+        self.assertEqual(a_bs1.stride(), (16, 1))
+        self.assertTrue(a_bs1.is_contiguous())
+        self.assertEqual(a_bs1.data_ptr() % 32, 16)
+        self.assertEqual(a_bs1.contiguous().data_ptr(), a_bs1.data_ptr())
+
+        # BS>1 exposes the row gap, so contiguous() does allocate a rebased,
+        # allocator-aligned tensor. This explains why only BS=1 failed.
+        a_bs2 = a[:2]
+        self.assertFalse(a_bs2.is_contiguous())
+        repaired = a_bs2.contiguous()
+        self.assertNotEqual(repaired.data_ptr(), a_bs2.data_ptr())
+        self.assertEqual(repaired.data_ptr() % 32, 0)
+
     def test_dynamic_repair_buffer_is_reused_without_allocator_churn(self):
         kernel = _make_kernel_without_flashinfer()
         source = _view_with_pointer_mod((1, 1, 8), torch.bfloat16, 16)


### PR DESCRIPTION
Fuse GDN decode projection unpack with Conv1D

## Accuracy Tests

| Effective examples | Score | Acceptance floor | Same-model baseline | Eval latency (s) | Output throughput (token/s) |
|---:|---:|---:|---:|---:|---:|
| 1311/1311 | 0.9801678108 | 0.95 | 0.9771167048 | 449.805 | 904.156 |

## Speed Tests and Profiling
Kernel
QKV=1280, V=1024
| Batch | Baseline (us) | Fused (us) | Saved (us) | Speedup |
|---:|---:|---:|---:|---:|
| 1 | 80.58 | 46.02 | 34.57 | 1.75x |
| 2 | 82.69 | 46.79 | 35.90 | 1.77x |
| 4 | 81.73 | 46.07 | 35.67 | 1.77x |
| 8 | 80.51 | 45.10 | 35.41 | 1.79x |
| 16 | 81.24 | 45.95 | 35.29 | 1.77x |
| 32 | 84.23 | 46.02 | 38.21 | 1.83x |
| 64 | 81.84 | 45.52 | 36.32 | 1.80x |
| 128 | 80.08 | 44.42 | 35.66 | 1.80x |

E2E
| CC | Control output tok/s | Fused output tok/s | Output delta | Control TPOT (ms) | Fused TPOT (ms) | TPOT delta |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 119.00 | 121.56 | +2.16% | 8.056 | 7.896 | -1.99% |
| 2 | 211.89 | 226.91 | +7.09% | 8.830 | 8.213 | -6.98% |
| 4 | 380.24 | 402.15 | +5.76% | 9.541 | 8.967 | -6.01% |
| 8 | 612.91 | 644.17 | +5.10% | 11.437 | 10.809 | -5.49% |
| 16 | 867.67 | 896.18 | +3.29% | 15.607 | 15.025 | -3.73% |
| 32 | 1184.16 | 1218.13 | +2.87% | 21.794 | 21.041 | -3.45% |
| 64 | 1481.28 | 1509.98 | +1.94% | 33.107 | 32.285 | -2.48% |
| 128 | 1800.27 | 1819.32 | +1.06% | 49.476 | 48.862 | -1.24% |

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30688506653](https://github.com/sgl-project/sglang/actions/runs/30688506653)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30688506563](https://github.com/sgl-project/sglang/actions/runs/30688506563)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->