### PR TITLE
fix(dspark): honor partial budgets in full-window fast path

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -429,11 +429,28 @@ class DSparkVerifyPlanner:
     ) -> Optional[RaggedVerifyLayout]:
         if self._ragged_verify_mode is RaggedVerifyMode.STATIC:
             return None
-        if self._is_verify_all and self._ragged_verify_mode is RaggedVerifyMode.COMPACT:
-            # Verify-all: the uniform layout (or None, past the captured grid)
-            # is constant per (bs, tier); serve it from cache instead of paying
-            # the per-step schedule and its host<->device round-trips.
-            key = (int(req_pool_indices.shape[0]), global_num_reqs)
+        bs = int(req_pool_indices.shape[0])
+        aligned_budget = self._budget_aligned_to_graph_tier(
+            req_pool_indices=req_pool_indices,
+            budget=budget,
+            global_num_reqs=global_num_reqs,
+            dp_tier_num_tokens=dp_tier_num_tokens,
+        )
+        if (
+            self._ragged_verify_mode is RaggedVerifyMode.COMPACT
+            and (self._is_verify_all or self._align_verify_tokens_to_graph_tier)
+            and verify_budget_covers_full_window(
+                budget=aligned_budget,
+                bs=bs,
+                verify_num_draft_tokens=self.verify_num_draft_tokens,
+                min_verify_len=self._schedule_cfg.min_verify_len,
+            )
+        ):
+            # A full verify window has a uniform layout (or None, past the
+            # captured grid) that is constant per (bs, tier). Serve it from
+            # cache instead of paying the per-step top-k schedule and its
+            # host<->device round-trips.
+            key = (bs, global_num_reqs)
             if key not in self._uniform_layout_cache:
                 self._uniform_layout_cache[key] = uniform_ragged_layout(
                     bs=key[0],
@@ -449,12 +466,7 @@ class DSparkVerifyPlanner:
             prefix_lens=prefix_lens,
             device=device,
             confidence=confidence,
-            budget=self._budget_aligned_to_graph_tier(
-                req_pool_indices=req_pool_indices,
-                budget=budget,
-                global_num_reqs=global_num_reqs,
-                dp_tier_num_tokens=dp_tier_num_tokens,
-            ),
+            budget=aligned_budget,
         )
         if verify_lens is None:
             assert dp_tier_num_tokens is None, (
@@ -678,6 +690,21 @@ def graph_tier_fill_budget(
     fill_total = min(graph_num_tokens, bs * verify_num_draft_tokens)
     floor_tokens = bs * max(min_verify_len, 1)
     return max(0, fill_total - floor_tokens)
+
+
+def verify_budget_covers_full_window(
+    *,
+    budget: Optional[int],
+    bs: int,
+    verify_num_draft_tokens: int,
+    min_verify_len: int,
+) -> bool:
+    """Whether the extra-token budget schedules every request's full window."""
+    if budget is None:
+        return False
+    floor_tokens = bs * max(min_verify_len, 1)
+    full_window_tokens = bs * verify_num_draft_tokens
+    return floor_tokens + budget >= full_window_tokens
 
 
 def dp_global_verify_tier_num_tokens(

--- a/test/registered/spec/dspark/test_dspark_scheduler.py
+++ b/test/registered/spec/dspark/test_dspark_scheduler.py
@@ -1,6 +1,7 @@
 import functools
 import types
 import unittest
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -9,6 +10,7 @@ from sglang.kernels.ops.speculative.dspark.dspark_schedule import (
 )
 from sglang.srt.speculative.dspark_components.dspark_planner import (
     DSparkScheduleConfig,
+    DSparkVerifyPlanner,
     HostConfidenceBudgetPlanner,
     VerifyBudgetDecision,
     compute_verify_token_budget,
@@ -18,7 +20,10 @@ from sglang.srt.speculative.dspark_components.dspark_sps import (
     SpsAdditiveCostTable,
     SpsCostTable,
 )
-from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    RaggedVerifyMode,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -471,6 +476,64 @@ class TestGraphTierFillBudget(CustomTestCase):
             self.assertEqual(total, min(graph_num_tokens, bs * cap))
 
 
+class TestFullWindowScheduling(CustomTestCase):
+    @staticmethod
+    def _planner(*, aligned_budget: int) -> DSparkVerifyPlanner:
+        planner = object.__new__(DSparkVerifyPlanner)
+        planner._ragged_verify_mode = RaggedVerifyMode.COMPACT
+        planner._is_verify_all = False
+        planner._align_verify_tokens_to_graph_tier = True
+        planner._schedule_cfg = DSparkScheduleConfig(gamma=5, min_verify_len=1)
+        planner._uniform_layout_cache = {}
+        planner.verify_num_draft_tokens = 6
+        planner.model_runner = object()
+        planner._budget_aligned_to_graph_tier = MagicMock(return_value=aligned_budget)
+        return planner
+
+    @staticmethod
+    def _schedule_kwargs() -> dict:
+        return dict(
+            req_pool_indices=torch.arange(8, dtype=torch.int32),
+            prefix_lens=torch.zeros(8, dtype=torch.int32),
+            device=torch.device("cpu"),
+            confidence=None,
+            budget=32,
+        )
+
+    def test_aligned_full_window_uses_cached_uniform_layout(self):
+        """A graph-aligned full window must bypass the per-step scheduler."""
+        planner = self._planner(aligned_budget=40)
+        planner._schedule_verify_lens = MagicMock(
+            side_effect=AssertionError("per-step scheduler should be bypassed")
+        )
+        expected_layout = object()
+
+        with patch(
+            "sglang.srt.speculative.dspark_components.dspark_planner."
+            "uniform_ragged_layout",
+            return_value=expected_layout,
+        ) as uniform_layout:
+            first = planner.schedule_layout(**self._schedule_kwargs())
+            second = planner.schedule_layout(**self._schedule_kwargs())
+
+        self.assertIs(first, expected_layout)
+        self.assertIs(second, expected_layout)
+        planner._schedule_verify_lens.assert_not_called()
+        uniform_layout.assert_called_once()
+
+    def test_partial_window_keeps_per_step_scheduler(self):
+        """A budget one token short of the full window must still schedule."""
+        planner = self._planner(aligned_budget=39)
+        planner._schedule_verify_lens = MagicMock(
+            side_effect=RuntimeError("per-step scheduler called")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "per-step scheduler called"):
+            planner.schedule_layout(**self._schedule_kwargs())
+
+        planner._schedule_verify_lens.assert_called_once()
+
+
 class _FakeRaggedRunner(types.SimpleNamespace):
     pass
 
@@ -489,7 +552,6 @@ class TestBudgetTierSelection(CustomTestCase):
         from sglang.srt.speculative.dspark_components.dspark_planner import (
             verify_layout_graph_num_tokens_floor,
         )
-        from sglang.srt.speculative.ragged_verify import RaggedVerifyMode
 
         model_runner = _fake_model_runner([8, 16, 1024], max_bs=128)
         floor = verify_layout_graph_num_tokens_floor(

--- a/test/registered/spec/dspark/test_dspark_scheduler.py
+++ b/test/registered/spec/dspark/test_dspark_scheduler.py
@@ -478,11 +478,16 @@ class TestGraphTierFillBudget(CustomTestCase):
 
 class TestFullWindowScheduling(CustomTestCase):
     @staticmethod
-    def _planner(*, aligned_budget: int) -> DSparkVerifyPlanner:
+    def _planner(
+        *,
+        aligned_budget: int,
+        is_verify_all: bool = False,
+        align_to_graph_tier: bool = True,
+    ) -> DSparkVerifyPlanner:
         planner = object.__new__(DSparkVerifyPlanner)
         planner._ragged_verify_mode = RaggedVerifyMode.COMPACT
-        planner._is_verify_all = False
-        planner._align_verify_tokens_to_graph_tier = True
+        planner._is_verify_all = is_verify_all
+        planner._align_verify_tokens_to_graph_tier = align_to_graph_tier
         planner._schedule_cfg = DSparkScheduleConfig(gamma=5, min_verify_len=1)
         planner._uniform_layout_cache = {}
         planner.verify_num_draft_tokens = 6
@@ -491,13 +496,13 @@ class TestFullWindowScheduling(CustomTestCase):
         return planner
 
     @staticmethod
-    def _schedule_kwargs() -> dict:
+    def _schedule_kwargs(*, bs: int = 8, budget: int = 32) -> dict:
         return dict(
-            req_pool_indices=torch.arange(8, dtype=torch.int32),
-            prefix_lens=torch.zeros(8, dtype=torch.int32),
+            req_pool_indices=torch.arange(bs, dtype=torch.int32),
+            prefix_lens=torch.zeros(bs, dtype=torch.int32),
             device=torch.device("cpu"),
             confidence=None,
-            budget=32,
+            budget=budget,
         )
 
     def test_aligned_full_window_uses_cached_uniform_layout(self):
@@ -521,17 +526,27 @@ class TestFullWindowScheduling(CustomTestCase):
         planner._schedule_verify_lens.assert_not_called()
         uniform_layout.assert_called_once()
 
-    def test_partial_window_keeps_per_step_scheduler(self):
-        """A budget one token short of the full window must still schedule."""
-        planner = self._planner(aligned_budget=39)
+    def test_sps_profiler_partial_budget_keeps_per_step_scheduler(self):
+        """A profiler budget must override verify-all and schedule its sample."""
+        planner = self._planner(
+            aligned_budget=168,
+            is_verify_all=True,
+            align_to_graph_tier=False,
+        )
         planner._schedule_verify_lens = MagicMock(
             side_effect=RuntimeError("per-step scheduler called")
         )
 
-        with self.assertRaisesRegex(RuntimeError, "per-step scheduler called"):
-            planner.schedule_layout(**self._schedule_kwargs())
+        with patch(
+            "sglang.srt.speculative.dspark_components.dspark_planner."
+            "uniform_ragged_layout",
+            return_value=object(),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "per-step scheduler called"):
+                planner.schedule_layout(**self._schedule_kwargs(bs=168, budget=168))
 
         planner._schedule_verify_lens.assert_called_once()
+        self.assertEqual(planner._schedule_verify_lens.call_args.kwargs["budget"], 168)
 
 
 class _FakeRaggedRunner(types.SimpleNamespace):


### PR DESCRIPTION
## Motivation

When no profiled SPS table is loaded, DSpark uses an uninitialized flat table and marks the planner as verify-all. The existing compact-layout fast path then returns a cached full-window layout without consulting the current verify budget.

SPS profiling deliberately injects partial budgets to measure step performance at different verify-token totals. Under the old fast path, those partial samples still execute the full verify window, so the recorded budget does not match the work performed and the generated SPS table contains inaccurate data.

Graph-tier alignment can also expand a normal runtime budget until it genuinely covers the full window. That case remains safe to serve from the cached uniform layout.

## Modifications

- Compute the graph-tier-aligned budget before selecting the scheduling path.
- Use the cached uniform layout only when the effective budget actually covers every request's full verify window.
- Route SPS profiler partial budgets through the per-step scheduler even when the planner is otherwise in verify-all mode.
- Preserve the cached fast path for true full-window budgets.
- Add behavior tests for the SPS profiler regression, the full-window bypass, and uniform-layout cache reuse.

## Accuracy Tests

The SPS profiler regression test uses the real failure condition: `_is_verify_all=True` with a forced partial budget.

- Pre-fix planner: the regression test fails because the scheduler is not called.
- Fixed planner: the same regression test passes and receives the requested partial budget.
- `test/registered/spec/dspark/test_dspark_scheduler.py`: 27 passed, 18 subtests passed.
- Pre-commit hooks for the changed files: passed.
- Full CI: pending.

## Speed Tests and Profiling

Not run. This PR fixes SPS profiling correctness and preserves the existing cached path for budgets that truly cover the full window; no numerical speedup is claimed.

## Checklist

- [x] Formatted with the repository pre-commit hooks.
- [x] Added a CPU behavior regression test for partial SPS profiling budgets.
- [x] Added behavior coverage for full-window bypass and cache reuse.
- [x] Documentation is not required for this internal scheduling fix.
- [ ] Performance benchmark not run.
- [x] Followed the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30544252576](https://github.com/sgl-project/sglang/actions/runs/30544252576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30544252238](https://github.com/sgl-project/sglang/actions/runs/30544252238)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->