### PR TITLE
[GPU] enable pdmux on SM100 and SM120 GPUs

### DIFF
--- a/python/sglang/srt/multiplex/pdmux_context.py
+++ b/python/sglang/srt/multiplex/pdmux_context.py
@@ -63,6 +63,10 @@ def get_arch_constraints(compute_capability):
         return 4, 2
     elif major == 9 and minor >= 0:
         return 8, 8
+    elif major == 10 and minor >= 0:
+        return 8, 8
+    elif major == 12 and minor >= 0:
+        return 8, 8
     else:
         raise ValueError(f"Unsupported compute capability: {major}.{minor}")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
PD-Multiplexing (PDMux) is a critical serving optimization that uses CUDA Green Contexts to physically partition a GPU's SMs into isolated prefill and decode groups, which significantly improves throughput under mixed workloads. Blackwell (SM100/SM103) and SM120 GPUs are increasingly deployed in production serving environments. 

However, SGLang's `Scheduler` crashes immediately on these GPUs when `--enable-pdmux` is set because `get_arch_constraints()` does not recognize compute capability 10.x or 12.0. This blocks users on newer hardware from benefiting from PD-Multiplexing entirely.

## Problem
https://github.com/sgl-project/sglang/issues/32933

## Modifications

`srt/multiplex/pdmux_context.py`Add CC 10.x and 12.0 branches returning `(8, 8)`

```python
elif major == 10 and minor >= 0:
    return 8, 8
elif major == 12 and minor >= 0:
    return 8, 8
```

## Accuracy Tests
<img width="860" height="108" alt="image" src="https://github.com/user-attachments/assets/7243964a-b833-4a94-a66a-4a35b069961c" />


<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30543563896](https://github.com/sgl-project/sglang/actions/runs/30543563896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30543563710](https://github.com/sgl-project/sglang/actions/runs/30543563710)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->