### PR TITLE
docs: surface diffusion AR and PE guides

### DIFF
--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1327,6 +1327,8 @@
                 "pages": [
                   "docs/sglang-diffusion/api/cli",
                   "docs/sglang-diffusion/api/openai_api",
+                  "docs/sglang-diffusion/models_with_ar",
+                  "docs/sglang-diffusion/models_with_pe",
                   "docs/sglang-diffusion/api/post_processing"
                 ]
               },

--- a/docs_new/docs/sglang-diffusion/api/cli.mdx
+++ b/docs_new/docs/sglang-diffusion/api/cli.mdx
@@ -91,10 +91,10 @@ Use `sglang generate --help` and `sglang serve --help` for the full argument lis
 - `--attention-backend {BACKEND}`: attention backend for native SGLang and diffusers pipelines
 - `--component-attention-backends {MAP}`: per-component attention backend overrides, for example `text_encoder=torch_sdpa,transformer=fa`
 - `--attention-backend-config {CONFIG}`: attention backend configuration
-- `--srt-encoder-url {HTTPADDRESS}`: address of SGLang srt server with AR model for GLM-Image like models
+- `--srt-encoder-url {HTTPADDRESS}`: address of SGLang srt server with AR model for GLM-Image like models. See [Models with AR Stage](../models_with_ar).
 - `--srt-encoder-timeout {SECONDS}`: Timeout in seconds for HTTP requests to the SGLang encoder server
 - `--srt-encoder-connection-timeout {SECONDS}`: TCP connection timeout in seconds for SGLang encoder server
-- `--pe-server-url {HTTPADDRESS}`: url of SGLang server hosting the PE model (e.g., for ERNIE-Image)
+- `--pe-server-url {HTTPADDRESS}`: url of SGLang server hosting the PE model (e.g., for ERNIE-Image). See [Models with Prompt Enhancement](../models_with_pe).
 
 ### Sampling and output
 

--- a/docs_new/docs/sglang-diffusion/index.mdx
+++ b/docs_new/docs/sglang-diffusion/index.mdx
@@ -41,6 +41,8 @@ sglang serve --model-path Qwen/Qwen-Image --port 30010
 ## Additional Documentation
 
 - [Post-Processing](/docs/sglang-diffusion/api/post_processing): frame interpolation and upscaling
+- [Models with AR Stage](/docs/sglang-diffusion/models_with_ar): run hybrid diffusion pipelines like GLM-Image with a separate AR encoder server
+- [Models with Prompt Enhancement](/docs/sglang-diffusion/models_with_pe): run ERNIE-Image with either built-in PE or a separate PE server
 - [Deployment and Performance Modes](/docs/sglang-diffusion/deployment_cookbook): choose `--performance-mode`, offload, FSDP, CFG parallelism, SP, and TP
 - [Attention Backends](/docs/sglang-diffusion/attention_backends): choose the best backend for your model and hardware
 - [Sequence Parallelism](/docs/sglang-diffusion/ring_sp_performance): configure SP, Ulysses, and ring-based splitting for long sequences

--- a/docs_new/docs/sglang-diffusion/models_with_ar.mdx
+++ b/docs_new/docs/sglang-diffusion/models_with_ar.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Diffusion models with AR stage like GLM-Image"
+description: "Run diffusion pipelines that delegate an AR stage to a separate SGLang server, such as GLM-Image."
 ---
 
 ## Quick Start
@@ -27,7 +28,9 @@ sglang serve --model-path /path/to/zai-org/GLM-Image/vision_language_encoder/ \
 ```
 ```bash
 # Terminal 2 : launch server with Diffusion model
-sglang serve --model-path /path/to/zai-org/GLM-Image/ --srt-encoder-url "http://${HOST}:${AR_PORT}"
+sglang serve --model-path /path/to/zai-org/GLM-Image/ \
+  --srt-encoder-url "http://${HOST}:${AR_PORT}" \
+  --port ${PORT}
 ```
 ```bash
 # Terminal 3 : launch client

--- a/docs_new/docs/sglang-diffusion/models_with_pe.mdx
+++ b/docs_new/docs/sglang-diffusion/models_with_pe.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Diffusion Models with Prompt Enhancement (PE)"
+description: "Run ERNIE-Image with built-in prompt enhancement or a separate SGLang-served PE model."
 ---
 
 ## Quick Start
@@ -34,7 +35,9 @@ sglang serve --model-path /path/to/baidu/ERNIE-Image/pe/ --port ${PE_PORT}
 ```
 ```bash
 # Terminal 2: launch diffusion model server with PE server
-sglang serve --model-path /path/to/baidu/ERNIE-Image/ --pe-server-url "http://${HOST}:${PE_PORT}"
+sglang serve --model-path /path/to/baidu/ERNIE-Image/ \
+  --pe-server-url "http://${HOST}:${PE_PORT}" \
+  --port ${PORT}
 ```
 ```bash
 # Terminal 3: launch client
@@ -58,4 +61,4 @@ curl -X POST http://${HOST}:${PORT}/v1/images/generations \
 
 ## Ascend NPU Environment
 
-<a href="https://github.com/sgl-project/sglang/tree/main/docs_new/docs/sglang-diffusion/models_with_ar.mdx#ascend-npu-env">Check here.</a>
+See [Diffusion models with AR stage like GLM-Image](/docs/sglang-diffusion/models_with_ar#ascend-npu-env).


### PR DESCRIPTION
## What changed
- added the diffusion AR-stage and PE-server guides to the public SGLang Diffusion navigation
- linked both guides from the diffusion landing page and CLI reference
- fixed example commands in the AR/PE docs so the diffusion server examples include an explicit `--port`
- replaced the PE guide's GitHub source link with a docs-site internal link

## Why
The ERNIE-Image prompt-enhancement page had been added as a docs file but was not reachable from the public docs navigation or main diffusion entrypoints. That created public documentation drift and made the new `--pe-server-url` flow hard to discover.

## Impact
Users can now discover and follow the AR/PE deployment docs from the main diffusion docs surface without falling back to source-tree links.

## Validation
- `git diff --check`
- `python3` JSON parse check for `docs_new/docs.json`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30544008811](https://github.com/sgl-project/sglang/actions/runs/30544008811)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30544008585](https://github.com/sgl-project/sglang/actions/runs/30544008585)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->