### PR TITLE
[Fix] [MLX] is_fully_idle: test any overlap loop, not the torch one

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3810,7 +3810,10 @@ class Scheduler(
             and self.chunked_req is None
             and not self.dllm_manager.any_staging_reqs()
             and (self.last_batch is None or self.last_batch.is_empty())
-            and (not self.enable_overlap or len(self.result_queue) == 0)
+            and (
+                not (self.enable_overlap or self.enable_overlap_mlx)
+                or len(self.result_queue) == 0
+            )
             and self._pp_microbatches_drained()
         )
 

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -198,6 +198,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         scheduler.last_batch = None
         scheduler.cur_batch_for_debug = None
         scheduler.enable_overlap = False
+        scheduler.enable_overlap_mlx = False
         scheduler.ps = ParallelState.trivial()
         scheduler.running_mbs = []
         scheduler.waiting_queue = []

--- a/test/registered/unit/managers/test_scheduler_idle_gate.py
+++ b/test/registered/unit/managers/test_scheduler_idle_gate.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestSchedulerIdleGate(unittest.TestCase):
+    def _new_scheduler(self, *, overlap: bool, overlap_mlx: bool, queued: int):
+        s = Scheduler.__new__(Scheduler)
+        s.running_batch = MagicMock(is_empty=MagicMock(return_value=True))
+        s.chunked_req = None
+        s.dllm_manager = MagicMock(any_staging_reqs=MagicMock(return_value=False))
+        s.last_batch = None
+        s.enable_overlap = overlap
+        s.enable_overlap_mlx = overlap_mlx
+        s.result_queue = [object()] * queued
+        s._pp_microbatches_drained = MagicMock(return_value=True)
+        s.waiting_queue = []
+        return s
+
+    def test_mlx_overlap_with_queued_result_is_not_idle(self):
+        s = self._new_scheduler(overlap=False, overlap_mlx=True, queued=1)
+        self.assertFalse(s.is_fully_idle(for_health_check=True))
+
+    def test_torch_overlap_unchanged(self):
+        s = self._new_scheduler(overlap=True, overlap_mlx=False, queued=1)
+        self.assertFalse(s.is_fully_idle(for_health_check=True))
+
+    def test_mlx_overlap_with_empty_queue_is_idle(self):
+        s = self._new_scheduler(overlap=False, overlap_mlx=True, queued=0)
+        self.assertTrue(s.is_fully_idle(for_health_check=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`is_fully_idle` checks `not self.enable_overlap or len(self.result_queue) == 0`. Since `enable_overlap` means overlap enabled and not MLX (`scheduler.py:383-384`), the first disjunct is unconditionally true on MLX and the queue is never inspected.

The predicate returns the right answer anyway: `running_batch` and `last_batch` are non empty whenever the queue is, and the MLX loop drains the queue before calling `on_idle`. Nothing enforces the coupling, and `release_memory_occupation` asserts on the predicate, while `flush_cache` resets both pools behind it. This makes the check correct by construction rather than by coincidence.

`batch_result_processor.py:769` already uses `(enable_overlap or enable_overlap_mlx)` for the same question.

Context: #32833.

## Modifications

The queue clause now tests either loop. Adds `test/registered/unit/managers/test_scheduler_idle_gate.py`, following the `Scheduler.__new__` fixture in `test_scheduler_flush_cache.py`. Also initializes `enable_overlap_mlx` in the fixture in `test/registered/unit/disaggregation/test_decode_queue_cleanup.py`, which builds a scheduler through `__new__` and set only the flags the old predicate read, so the new disjunction raised `AttributeError` there.

## Accuracy Tests

Three new cases: MLX overlap with a queued result is not idle, torch overlap unchanged, MLX overlap with an empty queue is idle. The third forces the fixture to satisfy every clause of the conjunction. The first fails on the parent commit and the other two pass; all three pass here, along with the existing disaggregation suite, for eight total.

This pins the predicate, not loop behavior. A CPU unit test cannot drive the MLX loop, so the masking argument above is reasoning rather than something this test verifies.

## Speed Tests and Profiling

Not applicable.

## AI Usage

An agent assisted with the enumeration that surfaced this. The tracing and every claim here are mine.

## CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30550186059](https://github.com/sgl-project/sglang/actions/runs/30550186059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30550185682](https://github.com/sgl-project/sglang/actions/runs/30550185682)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->