### PR TITLE
fix(dsv4): flatten OpenAI list content to string in encoder

### DIFF
--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -239,6 +239,34 @@ def attach_task_to_last_user_message(messages: List[Dict[str, Any]], task: str) 
     messages[idx]["task"] = task
 
 
+def _flatten_content(content: Any) -> str:
+    """Flatten OpenAI content (string or list of content parts) to a plain string.
+
+    OpenAI clients may send ``content`` as a list of typed parts
+    (e.g. ``[{"type": "text", "text": "hello"}]``) instead of a plain string.
+    The DSV4 encoder works exclusively with string content, so flatten the
+    list here — extracting text from text-type parts and joining with a
+    separator. Non-text parts (images, audio) are dropped since DSV4 is
+    text-only.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict) and part.get("type") == "text":
+                parts.append(part.get("text", ""))
+            # Non-text parts (images, audio, etc.) are silently dropped —
+            # DSV4 is text-only and has no way to represent them.
+        return "\n\n".join(parts)
+    # Unexpected type — coerce to string as a last resort.
+    return str(content)
+
+
 # ============================================================
 # Message Rendering
 # ============================================================
@@ -278,7 +306,7 @@ def render_message(
     last_user_idx = find_last_user_index(messages)
 
     role = msg.get("role")
-    content = msg.get("content")
+    content = _flatten_content(msg.get("content"))
     tools = msg.get("tools")
     response_format = msg.get("response_format")
     tool_calls = msg.get("tool_calls")
@@ -500,7 +528,7 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     }
                 )
         elif role == "user":
-            text_block = {"type": "text", "text": msg.get("content", "")}
+            text_block = {"type": "text", "text": _flatten_content(msg.get("content", ""))}
             if (
                 merged
                 and merged[-1].get("role") == "user"

--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -528,7 +528,10 @@ def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     }
                 )
         elif role == "user":
-            text_block = {"type": "text", "text": _flatten_content(msg.get("content", ""))}
+            text_block = {
+                "type": "text",
+                "text": _flatten_content(msg.get("content", "")),
+            }
             if (
                 merged
                 and merged[-1].get("role") == "user"


### PR DESCRIPTION
## Problem

The DeepSeek-V4 encoder crashes with `TypeError: sequence item 1: expected str instance, list found` when a message's `content` field is an OpenAI list of typed parts (e.g. `[{"type": "text", "text": "..."}]`) instead of a plain string.

The crash occurs in two places:
1. `render_message`: `prompt += content` — when `content` is a list, `str += list` raises `TypeError`
2. `merge_tool_messages`: `text_block = {"text": msg.get("content", "")}` — passes the list through as the `text` field, then `"\n\n".join(parts)` crashes in `render_message`

## Root cause

`serving_chat.py` flattens list content to string before calling the DSV4 encoder (line ~739), but direct callers of `encoding_dsv4.encode_messages` that bypass `serving_chat` hit the crash. In production, this was triggered by a Sference inference worker that calls `encode_messages` directly (the worker's `_build_prompt_dsv4` path), receiving OpenAI-format messages with list content from a client.

## Fix

Add a `_flatten_content()` helper that:
- Returns `""` for `None`
- Returns the string as-is for `str`
- Extracts text from text-type parts and joins with `"\n\n"` for `list`
- Drops non-text parts (images, audio) since DSV4 is text-only

Apply it at:
- `render_message`: where `content = msg.get("content")` → `content = _flatten_content(msg.get("content"))`
- `merge_tool_messages`: where the text block is built → `text_block = {"text": _flatten_content(msg.get("content", ""))}`

## Testing

```python
# User message with list content (the crash case)
encode_messages([{"role": "user", "content": [{"type": "text", "text": "hello"}]}], thinking_mode="chat")
# ✓ no crash, "hello" in prompt

# System + developer with list content
encode_messages([{"role": "system", "content": [{"type": "text", "text": "Be brief."}]}, ...])
# ✓ no crash

# Tool messages (merge_tool_messages path with list content)
encode_messages([..., {"role": "tool", "content": "4"}, {"role": "user", "content": [{"type": "text", "text": "Thanks!"}]}], ...)
# ✓ no crash

# Plain string content (regression check)
encode_messages([{"role": "user", "content": "hello"}], ...)
# ✓ still works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30547190932](https://github.com/sgl-project/sglang/actions/runs/30547190932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30547190478](https://github.com/sgl-project/sglang/actions/runs/30547190478)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->