### PR TITLE
[CI] Fix MoE compile and DSA indexer regressions

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_native.py
+++ b/python/sglang/srt/layers/moe/fused_moe_native.py
@@ -23,7 +23,8 @@ def fused_moe_forward_native(
     dispatch_output: StandardDispatchOutput,
 ) -> StandardCombineInput:
 
-    x, x_scale, topk_output = dispatch_output
+    x = dispatch_output.hidden_states
+    topk_output = dispatch_output.topk_output
     moe_runner_config = layer.moe_runner_config
 
     if moe_runner_config.apply_router_weight_on_input:

--- a/test/registered/kernels/ops/attention/test_dsa_indexer.py
+++ b/test/registered/kernels/ops/attention/test_dsa_indexer.py
@@ -262,6 +262,7 @@ class MockModelRunner:
                 "dsa_topk_backend": "sgl-kernel",
                 "dsa_paged_mqa_logits_backend": "auto",
                 "disaggregation_mode": "null",
+                "enable_two_batch_overlap": False,
             },
         )()
         self.hisparse_coordinator = None


### PR DESCRIPTION
## Summary

Fixes two regressions from #31888. Both actually failed in its final base CI run before the PR was force-merged:

- `test_torch_compile_moe.py` failed with `ValueError: too many values to unpack (expected 3)` after `StandardDispatchOutput` gained a fourth field. Read the required fields by name.
  CI: https://github.com/sgl-project/sglang/actions/runs/30411124003/job/90771215458

- `TestDSAIndexer.test_forward_decode_mode` failed with `AttributeError: 'ServerArgs' object has no attribute 'enable_two_batch_overlap'` after the backend added the setting. Add its default, `False`, to the mock.
  CI: https://github.com/sgl-project/sglang/actions/runs/30411124003/job/90771215506

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30546437100](https://github.com/sgl-project/sglang/actions/runs/30546437100)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30546436932](https://github.com/sgl-project/sglang/actions/runs/30546436932)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->