### PR TITLE
Fix Kimi-K3 FP8 DSPARK verification performance

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -275,6 +275,33 @@ def _target_checkpoint_bundles_dspark_draft(server_args: ServerArgs) -> bool:
     return checkpoint_bundles_dspark_draft(server_args.get_model_config().hf_config)
 
 
+def _route_kimi_k3_fp8_dspark_verify_to_decode(server_args: ServerArgs) -> None:
+    """Avoid materializing the full FP8 KV cache as BF16 for every verify step."""
+    from sglang.srt.arg_groups.overrides import (
+        attention_backends_of,
+        resolved_view,
+    )
+
+    view = resolved_view(server_args)
+    prefill_backend, decode_backend = attention_backends_of(view)
+    architectures = getattr(
+        server_args.get_model_config().hf_config, "architectures", ()
+    )
+    if (
+        "KimiK3ForConditionalGeneration" in architectures
+        and view.kv_cache_dtype == "fp8_e4m3"
+        and view.speculative_attention_mode == "prefill"
+        and prefill_backend == "fa3"
+        and decode_backend == "flashmla"
+    ):
+        server_args.speculative_attention_mode = "decode"
+        logger.warning(
+            "Kimi-K3 DSPARK with an FP8 KV cache routes target verification "
+            "to FlashMLA decode attention. FA3 prefill attention otherwise "
+            "converts the full KV cache to BF16 on every verify step."
+        )
+
+
 def _handle_dspark(server_args: ServerArgs) -> None:
     if not server_args.device.startswith("cuda"):
         raise ValueError("DSpark speculative decoding only supports CUDA device.")
@@ -430,6 +457,8 @@ def _handle_dspark(server_args: ServerArgs) -> None:
             "scheduler, which is off under SGLANG_RAGGED_VERIFY_MODE=static; it "
             "will be a no-op."
         )
+
+    _route_kimi_k3_fp8_dspark_verify_to_decode(server_args)
 
 
 def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:

--- a/test/registered/spec/dspark/test_dspark_draft_path_default.py
+++ b/test/registered/spec/dspark/test_dspark_draft_path_default.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from sglang.srt.arg_groups.speculative_hook import (
     _handle_dspark,
+    _route_kimi_k3_fp8_dspark_verify_to_decode,
     _target_checkpoint_bundles_dspark_draft,
 )
 from sglang.srt.server_args import ServerArgs
@@ -39,6 +40,27 @@ def _make_dspark_server_args(
     server_args.speculative_draft_model_path = None
     server_args.speculative_dspark_block_size = 5
     server_args.model_config = SimpleNamespace(hf_config=hf_config)
+    return server_args
+
+
+def _make_verify_routing_args(
+    *,
+    architecture: str = "KimiK3ForConditionalGeneration",
+    kv_cache_dtype: str = "fp8_e4m3",
+    speculative_attention_mode: str = "prefill",
+    prefill_attention_backend: str = "fa3",
+    decode_attention_backend: str = "flashmla",
+) -> SimpleNamespace:
+    hf_config = SimpleNamespace(architectures=[architecture])
+    server_args = SimpleNamespace(
+        _resolved_overrides=[],
+        attention_backend=prefill_attention_backend,
+        prefill_attention_backend=None,
+        decode_attention_backend=decode_attention_backend,
+        kv_cache_dtype=kv_cache_dtype,
+        speculative_attention_mode=speculative_attention_mode,
+    )
+    server_args.get_model_config = lambda: SimpleNamespace(hf_config=hf_config)
     return server_args
 
 
@@ -82,6 +104,43 @@ class TestDsparkDraftPathDefaulting(CustomTestCase):
             server_args.speculative_draft_model_path,
             "deepseek-ai/some-other-dspark-draft",
         )
+
+
+class TestKimiK3Fp8VerifyRouting(CustomTestCase):
+    def test_routes_fp8_fa3_verify_to_flashmla_decode(self):
+        server_args = _make_verify_routing_args()
+
+        _route_kimi_k3_fp8_dspark_verify_to_decode(server_args)
+
+        self.assertEqual(server_args.speculative_attention_mode, "decode")
+
+    def test_keeps_bf16_verify_on_prefill(self):
+        server_args = _make_verify_routing_args(kv_cache_dtype="auto")
+
+        _route_kimi_k3_fp8_dspark_verify_to_decode(server_args)
+
+        self.assertEqual(server_args.speculative_attention_mode, "prefill")
+
+    def test_keeps_other_models_on_prefill(self):
+        server_args = _make_verify_routing_args(architecture="DeepseekV4ForCausalLM")
+
+        _route_kimi_k3_fp8_dspark_verify_to_decode(server_args)
+
+        self.assertEqual(server_args.speculative_attention_mode, "prefill")
+
+    def test_keeps_non_flashmla_decode_backend_on_prefill(self):
+        server_args = _make_verify_routing_args(decode_attention_backend="triton")
+
+        _route_kimi_k3_fp8_dspark_verify_to_decode(server_args)
+
+        self.assertEqual(server_args.speculative_attention_mode, "prefill")
+
+    def test_keeps_explicit_decode_mode(self):
+        server_args = _make_verify_routing_args(speculative_attention_mode="decode")
+
+        _route_kimi_k3_fp8_dspark_verify_to_decode(server_args)
+
+        self.assertEqual(server_args.speculative_attention_mode, "decode")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- route Kimi-K3 DSPARK target verification through FlashMLA decode attention when the KV cache is FP8 E4M3 and the hybrid backends are FA3 prefill / FlashMLA decode
- preserve the existing behavior for BF16 KV, other models, and other decode backends
- add focused routing tests

## Root cause

The default speculative attention mode sends target verification to the prefill backend. For Kimi-K3 with an FP8 KV cache, FA3 converts the full cache to BF16 on every DSPARK verification step. A b8 trace showed 96 large conversion/copy kernels per step—24 full-attention layers times four cache chunks—adding about 168 ms per step.

Routing target verification to FlashMLA uses its native FP8 KV path and removes those full-cache conversions.

## H200 validation

Kimi-K3, TP32/EP32 on 32 H200 GPUs, DSPARK block size 7, 8K input / 1K output, b8:

| Configuration | Output tok/s | Accept length |
|---|---:|---:|
| FP8 KV, prefill verify | 173.32 | 6.03 |
| FP8 KV, decode verify | 668.79 | 5.96 |
| BF16 KV control | 674.94 | 6.08 |

The fixed FP8 path is 3.86× faster and within 0.9% of BF16. A corrected 10-step GPU trace has no copy kernel above 1 ms.

Quality gate: the fixed FP8 path and BF16 control both scored 99.0% on the same deterministic 200-example, five-shot GSM8K evaluation.

## Tests

- `python3 test/registered/spec/dspark/test_dspark_draft_path_default.py` — 10 passed
- `ruff format --check` — passed
- `ruff check` for the changed test — passed

Fixes #32938

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30551137947](https://github.com/sgl-project/sglang/actions/runs/30551137947)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #30551137374](https://github.com/sgl-project/sglang/actions/runs/30551137374)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->