### PR TITLE
fix(attention): align unified xai temperature scaling

### DIFF
--- a/python/sglang/kernels/ops/attention/extend_attention.py
+++ b/python/sglang/kernels/ops/attention/extend_attention.py
@@ -939,10 +939,11 @@ def _fwd_kernel_unified(
     # XAI temperature handling
     if xai_temperature_len > 0:
         offs_qidx = cur_seq_prefix_len + cur_block_m * BLOCK_M + offs_m
+        xai_temperature_scale = 1.0 / tl.log2(float(xai_temperature_len))
         xai_temperature_reg = tl.where(
-            offs_qidx < xai_temperature_len,
+            offs_qidx > xai_temperature_len,
+            tl.log2(offs_qidx.to(tl.float32)) * xai_temperature_scale,
             1.0,
-            xai_temperature_len / (offs_qidx + 1.0),
         )
 
     # Load Q

--- a/test/registered/attention/test_triton_attention_kernels.py
+++ b/test/registered/attention/test_triton_attention_kernels.py
@@ -732,7 +732,9 @@ class TestTritonAttention(CustomTestCase):
 
         self.assertTrue(torch.isfinite(o).all())
 
-    def _test_extend_attention_unified_vs_regular_once(self, B, N_CTX, H_Q, H_KV, D):
+    def _test_extend_attention_unified_vs_regular_once(
+        self, B, N_CTX, H_Q, H_KV, D, xai_temperature_len=-1
+    ):
         """Test that unified kernel produces same results as 2-stage kernel."""
         dtype = torch.bfloat16
         device = get_device()
@@ -813,6 +815,7 @@ class TestTritonAttention(CustomTestCase):
             max_len_extend=max_len_extend,
             k_scale=1.0,
             v_scale=1.0,
+            xai_temperature_len=xai_temperature_len,
         )
 
         # Build unified KV indices
@@ -853,6 +856,7 @@ class TestTritonAttention(CustomTestCase):
             sm_scale=None,
             logit_cap=0.0,
             is_causal=True,
+            xai_temperature_len=xai_temperature_len,
         )
 
         # Compare results
@@ -872,15 +876,23 @@ class TestTritonAttention(CustomTestCase):
     def test_extend_attention_unified_vs_regular(self):
         """Test unified kernel matches 2-stage kernel across different configs."""
         configs = [
-            (4, 512, 32, 8, 128),  # Standard config
-            (2, 2048, 32, 8, 128),  # Long sequence (test 2048 specifically)
-            (8, 256, 64, 8, 80),  # Non-standard head dim
+            (4, 512, 32, 8, 128, -1),  # Standard config
+            (2, 2048, 32, 8, 128, -1),  # Long sequence (test 2048 specifically)
+            (8, 256, 64, 8, 80, -1),  # Non-standard head dim
+            (2, 512, 32, 8, 128, 4),  # Grok/xAI temperature scaling
         ]
 
-        for B, N_CTX, H_Q, H_KV, D in configs:
-            with self.subTest(B=B, N_CTX=N_CTX, H_Q=H_Q, H_KV=H_KV, D=D):
+        for B, N_CTX, H_Q, H_KV, D, xai_temperature_len in configs:
+            with self.subTest(
+                B=B,
+                N_CTX=N_CTX,
+                H_Q=H_Q,
+                H_KV=H_KV,
+                D=D,
+                xai_temperature_len=xai_temperature_len,
+            ):
                 self._test_extend_attention_unified_vs_regular_once(
-                    B, N_CTX, H_Q, H_KV, D
+                    B, N_CTX, H_Q, H_KV, D, xai_temperature_len=xai_temperature_len
                 )
 
     def test_build_unified_kv_indices(self):


### PR DESCRIPTION
## Motivation

Fixes #32942

The unified deterministic extend attention kernel used a different
`xai_temperature_len` formula from the regular Triton extend/decode attention
paths.

For Grok/xAI models, `config.attn_temperature_len` is wired into
`xai_temperature_len`. The regular extend and decode kernels use logarithmic
scaling after the configured threshold, while the unified deterministic extend
kernel used a reciprocal scale. That made the deterministic unified prefill path
change attention logits compared with the regular Triton path when xAI
temperature scaling was enabled.

## Modifications

- Updated the unified deterministic extend attention kernel to use the same
  logarithmic `xai_temperature_len` scaling as regular extend/decode attention.
- Extended the existing unified-vs-regular Triton attention test with an
  `xai_temperature_len=4` case.

## Accuracy Tests

No full model accuracy eval was run locally. The change is limited to matching
the unified deterministic kernel's xAI temperature scaling to the existing
regular extend/decode kernel semantics.

## Speed Tests and Profiling

Not run. No performance impact is expected outside the existing
`xai_temperature_len > 0` path.

## Tests

```bash
PYTHONPATH=/home/rohan/Projects/sglang/python /tmp/sglang/.venv/bin/python /tmp/verify_unified_xai_temperature.py
```

Result:

```text
NVIDIA GeForce RTX 5060 Ti
xai_temperature_len=-1 max_diff=0.001953 allclose=True
xai_temperature_len=4 max_diff=0.001953 allclose=True
```

```bash
uv tool run ruff check --select=F401,F821,UP037 python/sglang/kernels/ops/attention/extend_attention.py test/registered/attention/test_triton_attention_kernels.py
uv tool run black --check python/sglang/kernels/ops/attention/extend_attention.py test/registered/attention/test_triton_attention_kernels.py
git diff --check
```

Results:

```text
All checks passed!
2 files would be left unchanged.
git diff --check: passed
```

I also attempted to run the registered pytest directly:

```bash
PYTHONPATH=/home/rohan/Projects/sglang/python /tmp/sglang/.venv/bin/python -m pytest /home/rohan/Projects/sglang/test/registered/attention/test_triton_attention_kernels.py::TestTritonAttention::test_extend_attention_unified_vs_regular -q
```

Collection was blocked by the local `sglang-kernel` wheel on RTX 5060 Ti
SM120:

```text
[sgl_kernel] CRITICAL: Could not load any common_ops library
common_ops.abi3.so: undefined symbol: _ZNK2at10TensorBase14const_data_ptrIiLi0EEEPKT_v
```

## Checklist

- [x] Format your code according to the SGLang pre-commit guidance.
- [x] Add unit tests according to the SGLang unit test guidance.
- [x] Update documentation if needed.
- [x] Provide accuracy and speed benchmark results where applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30554866716](https://github.com/sgl-project/sglang/actions/runs/30554866716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30554866038](https://github.com/sgl-project/sglang/actions/runs/30554866038)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
