### PR TITLE
[Perf][LMCache] Skip redundant MP prefix lookups

### DIFF
--- a/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
+++ b/python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py
@@ -220,8 +220,18 @@ class LMCRadixCache(RadixCache):
         the held read locks and returns the radix-only result.
         """
         token_ids = key.raw_token_ids()
+        value_numel = int(value.numel())
+        chunk_size = self.lmcache_connector.chunk_size()
+        max_lmcache_match = len(token_ids) // chunk_size * chunk_size
+        # LMCache only returns complete chunks. If their aligned upper bound is
+        # already on device, LOOKUP cannot add any host-resident prefix.
+        if max_lmcache_match <= value_numel:
+            self._mp_load_back_markers.pop(req.rid, None)
+            self.lmcache_connector.release_pending(req.rid)
+            return base_res
+
         matched = self.lmcache_connector.lookup_kv(token_ids, req.rid)
-        if matched <= value.numel():
+        if matched <= value_numel:
             # Release the read locks; keep the pending session for end_session.
             self.lmcache_connector.release_pending(req.rid)
             return base_res
@@ -230,14 +240,14 @@ class LMCRadixCache(RadixCache):
             token_ids = token_ids[:]
         self._mp_load_back_markers[req.rid] = _LMCacheLoadBackMarker(
             key=RadixKey(token_ids, key.extra_key, key.is_bigram),
-            value_numel=int(value.numel()),
+            value_numel=value_numel,
         )
         return MatchResult(
             device_indices=value,
             last_device_node=last_node,
             last_host_node=last_node,
             best_match_node=last_node,
-            host_hit_length=matched - int(value.numel()),
+            host_hit_length=matched - value_numel,
         )
 
     def _ip_match_prefix(

--- a/test/registered/unit/mem_cache/test_lmc_radix_cache.py
+++ b/test/registered/unit/mem_cache/test_lmc_radix_cache.py
@@ -1,0 +1,161 @@
+"""CPU-only tests for the LMCache MP radix-cache fast path."""
+
+import importlib
+import sys
+import types
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import MatchResult
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _load_lmcache_radix_module():
+    """Import the integration without requiring LMCache in CPU CI."""
+    module_name = "sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    lmcache = types.ModuleType("lmcache")
+    lmcache.__path__ = []
+    integration = types.ModuleType("lmcache.integration")
+    integration.__path__ = []
+    sglang_integration = types.ModuleType("lmcache.integration.sglang")
+    sglang_integration.__path__ = []
+    mp_adapter = types.ModuleType("lmcache.integration.sglang.multi_process_adapter")
+    sglang_adapter = types.ModuleType("lmcache.integration.sglang.sglang_adapter")
+    utils = types.ModuleType("lmcache.integration.sglang.utils")
+
+    mp_adapter.LMCacheMPConnector = MagicMock
+    sglang_adapter.LMCacheLayerwiseConnector = MagicMock
+    sglang_adapter.LoadMetadata = MagicMock
+    sglang_adapter.StoreMetadata = MagicMock
+    utils.lmcache_get_config = MagicMock
+
+    lmcache.integration = integration
+    integration.sglang = sglang_integration
+    sglang_integration.multi_process_adapter = mp_adapter
+    sglang_integration.sglang_adapter = sglang_adapter
+    sglang_integration.utils = utils
+
+    stubs = {
+        "lmcache": lmcache,
+        "lmcache.integration": integration,
+        "lmcache.integration.sglang": sglang_integration,
+        "lmcache.integration.sglang.multi_process_adapter": mp_adapter,
+        "lmcache.integration.sglang.sglang_adapter": sglang_adapter,
+        "lmcache.integration.sglang.utils": utils,
+    }
+    with patch.dict(sys.modules, stubs):
+        return importlib.import_module(module_name)
+
+
+_lmc_radix_cache = _load_lmcache_radix_module()
+LMCRadixCache = _lmc_radix_cache.LMCRadixCache
+
+
+class TestLMCacheMPMatchPrefix(unittest.TestCase):
+    CHUNK_SIZE = 64
+    RID = "request-0"
+
+    def setUp(self):
+        self.connector = MagicMock()
+        self.connector.chunk_size.return_value = self.CHUNK_SIZE
+        self.cache = object.__new__(LMCRadixCache)
+        self.cache.lmcache_connector = self.connector
+        self.cache._mp_load_back_markers = {}
+        self.req = SimpleNamespace(rid=self.RID)
+        self.last_node = object()
+
+    def _match(
+        self, key: RadixKey, device_tokens: int
+    ) -> tuple[MatchResult, MatchResult]:
+        value = torch.arange(device_tokens, dtype=torch.int64)
+        base_result = MatchResult(
+            device_indices=value,
+            last_device_node=self.last_node,
+            last_host_node=self.last_node,
+            best_match_node=self.last_node,
+        )
+        result = self.cache._mp_match_prefix(
+            key,
+            base_result,
+            value,
+            self.last_node,
+            self.req,
+        )
+        return result, base_result
+
+    def test_skips_lookup_when_device_covers_aligned_maximum(self):
+        key = RadixKey(array("q", range(130)))
+        self.connector.lookup_kv.side_effect = AssertionError(
+            "blocking lookup must not run"
+        )
+
+        result, base_result = self._match(key, device_tokens=128)
+
+        self.assertIs(result, base_result)
+        self.connector.lookup_kv.assert_not_called()
+        self.connector.release_pending.assert_called_once_with(self.RID)
+        self.assertNotIn(self.RID, self.cache._mp_load_back_markers)
+
+    def test_lookup_runs_when_one_aligned_token_can_be_loaded(self):
+        key = RadixKey(array("q", range(128)))
+        self.connector.lookup_kv.return_value = 128
+
+        result, _ = self._match(key, device_tokens=127)
+
+        self.connector.lookup_kv.assert_called_once_with(key.raw_token_ids(), self.RID)
+        self.connector.release_pending.assert_not_called()
+        self.assertEqual(result.host_hit_length, 1)
+        self.assertEqual(
+            self.cache._mp_load_back_markers[self.RID].value_numel,
+            127,
+        )
+
+    def test_effective_capped_key_uses_no_lookup_for_sub_chunk_input(self):
+        key = RadixKey(array("q", range(130)), limit=63)
+        self.connector.lookup_kv.side_effect = AssertionError(
+            "sub-chunk lookup must not run"
+        )
+
+        result, base_result = self._match(key, device_tokens=0)
+
+        self.assertIs(result, base_result)
+        self.connector.lookup_kv.assert_not_called()
+        self.connector.release_pending.assert_called_once_with(self.RID)
+
+    def test_lookup_can_extend_across_multiple_chunks(self):
+        key = RadixKey(array("q", range(130)))
+        self.connector.lookup_kv.return_value = 128
+
+        result, _ = self._match(key, device_tokens=64)
+
+        self.connector.lookup_kv.assert_called_once_with(key.raw_token_ids(), self.RID)
+        self.connector.release_pending.assert_not_called()
+        self.assertEqual(result.host_hit_length, 64)
+
+    def test_skip_releases_stale_marker_without_second_lookup(self):
+        key = RadixKey(array("q", range(130)))
+        self.connector.lookup_kv.return_value = 128
+        first_result, _ = self._match(key, device_tokens=0)
+        self.assertEqual(first_result.host_hit_length, 128)
+        self.assertIn(self.RID, self.cache._mp_load_back_markers)
+
+        second_result, second_base_result = self._match(key, device_tokens=128)
+
+        self.assertIs(second_result, second_base_result)
+        self.connector.lookup_kv.assert_called_once()
+        self.connector.release_pending.assert_called_once_with(self.RID)
+        self.assertNotIn(self.RID, self.cache._mp_load_back_markers)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This PR removes a redundant blocking LMCache lookup from SGLang multi-process (MP) prefix matching.

When the GPU radix prefix already covers the largest chunk-aligned prefix LMCache could return, SGLang now clears any stale load-back marker, releases pending lookup state, and returns the existing radix result immediately. 
The normal LMCache lookup and retrieve path is unchanged whenever LMCache can still extend the prefix.

This is intentionally a small SGLang-only optimization. It adds no fused restore path, storage-backend-specific I/O, or LMCache protocol dependency. Non-MP behavior is unchanged and out of scope.

## End-to-end performance

The comparison uses `Qwen3-Coder-30B-A3B-Instruct` in TP1 with the same LMCache runtime and local-SSD configuration for parent and patch. Each launch ran three cycles of 16 serial requests per phase and discarded the first four requests per cycle. Results below are the median of the two independent launch-level p50s in ABBA order.

The reusable prefix was 768 tokens, followed by one uncached input token and eight generated tokens.

| Phase / metric | Parent | This PR | Change |
|:--|--:|--:|--:|
| GPU-covered TTFT p50 | 96.042 ms | 55.765 ms | **-41.94%** |
| GPU-covered end-to-end p50 | 148.387 ms | 108.008 ms | **-27.21%** |
| LMCache lookups per launch | 48 | 0 | **-100%** |
| Physical SSD reads per launch | 3,623,878,656 B | 0 B | **-100%** |
| Forced-L2 TTFT p50 control | 99.294 ms | 100.091 ms | +0.80% |

The forced-L2 control remains near parity because this PR does not change the storage restore path. The improvement comes from avoiding work when the requested prefix is already resident in the GPU radix cache.

### Page-cache and physical-read proof

The measurements were not page-cache hits:

- `mincore` reported zero resident pages before and after every measured storage phase;
- in the GPU-covered phase, daemon `/proc/<pid>/io` counters showed exactly 3,623,878,656 physical read bytes per parent launch and zero for this PR;
- in the forced-L2 control, both variants read exactly 3,623,878,656 physical bytes per launch;
- direct I/O remained enabled without a buffered-I/O fallback.

All storage-restored outputs matched the immediate GPU-cached reference, and daemon session state returned to zero after every cycle.

## Validation

- `python -m pytest -q test/registered/unit/mem_cache/test_lmc_radix_cache.py`: **5 passed**;
- all pre-commit hooks passed for both changed files;
- `git diff --check`: clean;
- focused tests cover exact aligned coverage, one-token extension, multi-chunk extension, effective capped keys, and stale-marker cleanup.

The performance runs used SGLang parent `5f9b0db18c` and patch `841a94fabb`. The PR was then rebased onto the next upstream `main` commit, which changes only model loading; the two benchmarked cache files are byte-identical in the published patch.