### PR TITLE
[Feature] Support opt-in dp_rank-targeted health probes on /health and /health_generate

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -620,8 +620,14 @@ async def health_generate(request: Request) -> Response:
     """
     Check the health of the inference server by sending a special request to generate one token.
 
-    If the server is running something, this request will be ignored, so it creates zero overhead.
-    If the server is not running anything, this request will be run, so we know whether the server is healthy.
+    Without ``dp_rank``: if the server is running something, this request will be
+    ignored, so it creates zero overhead. If the server is not running anything,
+    this request will be run, so we know whether the server is healthy.
+
+    With an explicit ``dp_rank`` query parameter: the probe is routed to that
+    data-parallel rank and succeeds only when this exact probe request completes;
+    unrelated scheduler output cannot satisfy the check. This lets external
+    monitors detect a single wedged rank that the aggregate path cannot see.
     """
 
     if _global_state.tokenizer_manager.gracefully_exit:
@@ -631,8 +637,20 @@ async def health_generate(request: Request) -> Response:
     if _global_state.tokenizer_manager.server_status == ServerStatus.Starting:
         return Response(status_code=503)
 
+    routed_dp_rank = None
+    raw_dp_rank = request.query_params.get("dp_rank")
+    if raw_dp_rank is not None:
+        try:
+            routed_dp_rank = int(raw_dp_rank)
+        except ValueError:
+            return Response(status_code=400)
+        dp_size = _global_state.tokenizer_manager.elastic_worker_count
+        if routed_dp_rank < 0 or routed_dp_rank >= dp_size:
+            return Response(status_code=400)
+
     if (
-        not envs.SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION.get()
+        routed_dp_rank is None
+        and not envs.SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION.get()
         and request.url.path == "/health"
     ):
         return Response(status_code=200)
@@ -660,34 +678,87 @@ async def health_generate(request: Request) -> Response:
             rid=rid, input_ids=[0], sampling_params=sampling_params, log_metrics=False
         )
 
-    async def gen():
-        async for _ in _global_state.tokenizer_manager.generate_request(gri, request):
-            break
+    if routed_dp_rank is not None:
+        gri.routed_dp_rank = routed_dp_rank
+        gri.no_logs = True
 
-    task = asyncio.create_task(gen())
+    if routed_dp_rank is None:
+        # Aggregate probe: keep the long-standing semantics untouched. Any
+        # detokenizer output within the timeout marks the server healthy, so
+        # concurrent aggregate probes stay cheap and cannot starve each other.
+        async def gen():
+            async for _ in _global_state.tokenizer_manager.generate_request(
+                gri, request
+            ):
+                break
 
-    # As long as we receive any response from the detokenizer/scheduler, we consider the server is healthy.
+        task = asyncio.create_task(gen())
+
+        # As long as we receive any response from the detokenizer/scheduler, we consider the server is healthy.
+        tic = time.time()
+        while time.time() < tic + HEALTH_CHECK_TIMEOUT:
+            await asyncio.sleep(1)
+            if _global_state.tokenizer_manager.last_receive_tstamp > tic:
+                task.cancel()
+                _global_state.tokenizer_manager.rid_to_state.pop(rid, None)
+                _global_state.tokenizer_manager.server_status = ServerStatus.Up
+                return Response(status_code=200)
+
+        task.cancel()
+        tic_time = time.strftime("%H:%M:%S", time.localtime(tic))
+        last_receive_time = time.strftime(
+            "%H:%M:%S",
+            time.localtime(_global_state.tokenizer_manager.last_receive_tstamp),
+        )
+        logger.error(
+            f"Health check failed. Server couldn't get a response from detokenizer for last "
+            f"{HEALTH_CHECK_TIMEOUT} seconds. tic start time: {tic_time}. "
+            f"last_heartbeat time: {last_receive_time}"
+        )
+        _global_state.tokenizer_manager.rid_to_state.pop(rid, None)
+        _global_state.tokenizer_manager.server_status = ServerStatus.UnHealthy
+        return Response(status_code=503)
+
+    # Rank-targeted probe: wait for this exact rid so a wedged rank cannot be
+    # masked by output that other ranks produce.
     tic = time.time()
-    while time.time() < tic + HEALTH_CHECK_TIMEOUT:
-        await asyncio.sleep(1)
-        if _global_state.tokenizer_manager.last_receive_tstamp > tic:
-            task.cancel()
-            _global_state.tokenizer_manager.rid_to_state.pop(rid, None)
-            _global_state.tokenizer_manager.server_status = ServerStatus.Up
-            return Response(status_code=200)
 
-    task.cancel()
+    async def wait_for_exact_probe() -> bool:
+        async for result in _global_state.tokenizer_manager.generate_request(
+            gri, request
+        ):
+            meta_info = result.get("meta_info", {}) if isinstance(result, dict) else {}
+            if meta_info.get("id") == rid:
+                return True
+        return False
+
+    try:
+        completed = await asyncio.wait_for(
+            wait_for_exact_probe(), timeout=HEALTH_CHECK_TIMEOUT
+        )
+    except asyncio.TimeoutError:
+        completed = False
+    except Exception:
+        logger.exception("Health check generation failed for rid=%s", rid)
+        completed = False
+    finally:
+        # A timed-out probe may still be queued in a scheduler. Removing its
+        # local state prevents a leak; late health-check output is ignored by
+        # TokenizerManager using HEALTH_CHECK_RID_PREFIX.
+        _global_state.tokenizer_manager.rid_to_state.pop(rid, None)
+
+    if completed:
+        return Response(status_code=200)
+
     tic_time = time.strftime("%H:%M:%S", time.localtime(tic))
     last_receive_time = time.strftime(
         "%H:%M:%S", time.localtime(_global_state.tokenizer_manager.last_receive_tstamp)
     )
     logger.error(
-        f"Health check failed. Server couldn't get a response from detokenizer for last "
-        f"{HEALTH_CHECK_TIMEOUT} seconds. tic start time: {tic_time}. "
-        f"last_heartbeat time: {last_receive_time}"
+        f"Health check failed. Exact probe rid={rid} dp_rank={routed_dp_rank} "
+        f"did not complete within {HEALTH_CHECK_TIMEOUT} seconds. "
+        f"tic start time: {tic_time}. last_heartbeat time: {last_receive_time}"
     )
-    _global_state.tokenizer_manager.rid_to_state.pop(rid, None)
-    _global_state.tokenizer_manager.server_status = ServerStatus.UnHealthy
     return Response(status_code=503)
 
 

--- a/test/registered/unit/entrypoints/test_health_generate.py
+++ b/test/registered/unit/entrypoints/test_health_generate.py
@@ -1,0 +1,154 @@
+import asyncio
+import time
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.entrypoints import http_server
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.tokenizer_manager import ServerStatus
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeTokenizerManager:
+    def __init__(self, outputs):
+        self.outputs = outputs
+        self.requests = []
+        self.gracefully_exit = False
+        self.server_status = ServerStatus.Up
+        self.is_generation = True
+        self.elastic_worker_count = 4
+        self.rid_to_state = {}
+        self.last_receive_tstamp = time.time()
+        self.server_args = SimpleNamespace(
+            disaggregation_mode=DisaggregationMode.NULL.value
+        )
+
+    async def generate_request(self, request, raw_request):
+        del raw_request
+        self.requests.append(request)
+        for output in self.outputs(request):
+            yield output
+
+
+def _request(dp_rank=None, path="/health_generate"):
+    query_params = {} if dp_rank is None else {"dp_rank": str(dp_rank)}
+    return SimpleNamespace(
+        url=SimpleNamespace(path=path),
+        query_params=query_params,
+    )
+
+
+def _call_health_generate(manager, request):
+    prior_state = http_server.get_global_state()
+    http_server.set_global_state(SimpleNamespace(tokenizer_manager=manager))
+    try:
+        return asyncio.run(http_server.health_generate(request))
+    finally:
+        http_server._global_state = prior_state
+
+
+class TestHealthGenerate(unittest.TestCase):
+    def test_targets_requested_dp_rank_and_waits_for_exact_rid(self):
+        def outputs(request):
+            yield {
+                "meta_info": {
+                    "id": request.rid,
+                    "dp_rank": request.routed_dp_rank,
+                }
+            }
+
+        manager = _FakeTokenizerManager(outputs)
+        response = _call_health_generate(manager, _request(dp_rank=2))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(manager.requests), 1)
+        probe = manager.requests[0]
+        self.assertIsInstance(probe, GenerateReqInput)
+        self.assertEqual(probe.routed_dp_rank, 2)
+        self.assertFalse(probe.log_metrics)
+        self.assertTrue(probe.no_logs)
+
+    def test_rank_target_forces_generation_on_lightweight_health_path(self):
+        def outputs(request):
+            yield {"meta_info": {"id": request.rid, "dp_rank": 1}}
+
+        manager = _FakeTokenizerManager(outputs)
+        response = _call_health_generate(manager, _request(dp_rank=1, path="/health"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(manager.requests[0].routed_dp_rank, 1)
+
+    def test_unrelated_output_cannot_mask_failed_probe(self):
+        def outputs(request):
+            yield {"meta_info": {"id": f"other-{request.rid}", "dp_rank": 1}}
+
+        manager = _FakeTokenizerManager(outputs)
+        response = _call_health_generate(manager, _request(dp_rank=3))
+
+        self.assertEqual(response.status_code, 503)
+        # A rank-targeted probe must not flip the whole-server status:
+        # concurrent per-rank probes would race on the shared field.
+        self.assertEqual(manager.server_status, ServerStatus.Up)
+
+    def test_invalid_dp_rank_is_rejected_without_generation(self):
+        manager = _FakeTokenizerManager(lambda request: ())
+
+        for value in ("not-an-int", -1, 4):
+            with self.subTest(value=value):
+                response = _call_health_generate(manager, _request(dp_rank=value))
+                self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(manager.requests, [])
+
+    def test_default_path_keeps_heartbeat_semantics(self):
+        # Without dp_rank, any detokenizer activity within the timeout marks
+        # the server healthy, even if this probe's own rid never completes.
+        def outputs(request):
+            yield {"meta_info": {"id": f"other-{request.rid}"}}
+
+        manager = _FakeTokenizerManager(outputs)
+        manager.last_receive_tstamp = time.time() + 3600
+        response = _call_health_generate(manager, _request())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(manager.server_status, ServerStatus.Up)
+        probe = manager.requests[0]
+        self.assertIsNone(probe.routed_dp_rank)
+        self.assertFalse(probe.no_logs)
+
+    def test_concurrent_rank_probes_do_not_interfere(self):
+        def outputs(request):
+            yield {"meta_info": {"id": request.rid, "dp_rank": request.routed_dp_rank}}
+
+        manager = _FakeTokenizerManager(outputs)
+
+        async def run_all():
+            prior_state = http_server.get_global_state()
+            http_server.set_global_state(SimpleNamespace(tokenizer_manager=manager))
+            try:
+                return await asyncio.gather(
+                    *(
+                        http_server.health_generate(_request(dp_rank=rank % 4))
+                        for rank in range(8)
+                    )
+                )
+            finally:
+                http_server._global_state = prior_state
+
+        responses = asyncio.run(run_all())
+
+        self.assertEqual([r.status_code for r in responses], [200] * 8)
+        self.assertEqual(len(manager.requests), 8)
+        rids = {probe.rid for probe in manager.requests}
+        self.assertEqual(len(rids), 8)
+        self.assertEqual(
+            sorted(probe.routed_dp_rank for probe in manager.requests),
+            [0, 0, 1, 1, 2, 2, 3, 3],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `dp_size > 1`, the current `/health_generate` succeeds as soon as **any**
detokenizer output arrives within `HEALTH_CHECK_TIMEOUT`. That is the right
default for cheap aggregate probing, but it cannot detect a **single wedged
data-parallel rank**: as long as other ranks keep producing output, the probe
stays green while requests routed to the stuck rank hang until client timeout.

We hit exactly this in production (GLM-5.2, TP4/DP4 x 2 engines): one DP rank's
generation stalled, `/health` and `/health_generate` stayed 200, and the load
balancer kept sending traffic into the black hole. External monitors need a way
to ask "is rank N specifically able to generate a token?".

Related: #22877 reports the same failure shape (health check keeps passing
while requests fail), and the fault-tolerance RFC #22344 calls for per-rank
health state; this PR provides a minimal, opt-in pull-based building block for
that direction without touching the default probe semantics.

## What this PR does

`/health` and `/health_generate` accept an optional `dp_rank` query parameter:

- `GET /health_generate?dp_rank=2` routes the probe request to DP rank 2 via
  `routed_dp_rank` and returns 200 **only when this exact probe rid completes**;
  output produced by other ranks (or other requests) cannot satisfy the check.
- Invalid values (non-integer, out of `[0, dp_size)`) return 400 without
  spawning a generation request.
- `GET /health?dp_rank=N` performs the generation probe even when
  `SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION` is off (an explicit rank target is
  a deliberate request for a real probe).
- Rank-targeted probes set `no_logs` and are excluded from metrics like the
  existing health probes; on timeout the probe's `rid_to_state` entry is
  cleaned up, and late output is already dropped via `HEALTH_CHECK_RID_PREFIX`.
- Rank-targeted probes do **not** mutate the global `server_status`: concurrent
  per-rank probes would race on that shared field, and one wedged rank should
  not flip the whole-server status that other consumers read.

## What this PR deliberately does NOT change

The default no-`dp_rank` path keeps the long-standing semantics **unchanged**
(any detokenizer output within the timeout → 200, same `server_status`
transitions, same log lines). Routers and K8s commonly issue several aggregate
probes concurrently; keeping that path heartbeat-based means concurrent
aggregate probes stay cheap and cannot starve each other. (We first deployed a
variant that applied exact-rid waiting to the default path as well, and under
concurrent probing from the router it caused sustained false unhealthy
transitions — hence the strict opt-in split in this PR.)

## Tests

`test/registered/unit/entrypoints/test_health_generate.py` (CPU suite):

- rank-targeted probe routes `routed_dp_rank` and waits for the exact rid
- `?dp_rank` on `/health` forces a generation probe
- unrelated output cannot mask a failed rank probe (503), and the rank probe
  does not flip `server_status`
- invalid `dp_rank` → 400, no generation request spawned
- default path regression: heartbeat semantics preserved, `routed_dp_rank is
  None`, `no_logs` untouched
- 8 concurrent rank probes: unique rids, correct per-rank routing, all 200

## Follow-ups (out of scope here)

- Router-side integration (per-rank health fan-out or per-base-URL dedup) —
  needs its own design discussion.
- A GPU integration test that probes all ranks concurrently under load.

## Checklist

- [x] Format your code with pre-commit hooks (black/isort/ruff run on changed files)
- [x] Add unit tests (registered CPU suite)
- [ ] Update documentation as needed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->