### PR TITLE
fix: import IPython lazily in print_highlight

### DIFF
--- a/python/sglang/utils.py
+++ b/python/sglang/utils.py
@@ -23,7 +23,6 @@ from typing import Any, Callable, List, Optional, Tuple, Type, Union
 import numpy as np
 import pybase64
 import requests
-from IPython.display import HTML, display
 from pydantic import BaseModel
 from tqdm import tqdm
 
@@ -459,6 +458,8 @@ def is_in_ci() -> bool:
 
 def print_highlight(html_content: str):
     if is_in_ci():
+        from IPython.display import HTML, display
+
         html_content = str(html_content).replace("\n", "<br>")
         display(HTML(f"<strong style='color: #00008B;'>{html_content}</strong>"))
     else:


### PR DESCRIPTION
## Motivation

`python/sglang/utils.py` imports `IPython.display` at module scope, but the only
consumer is `print_highlight()`, which calls `display()` solely when
`SGLANG_IS_IN_CI` is set. Every server start therefore imports IPython for a
branch that never executes in a production deployment.

This is not only unnecessary overhead — it can prevent the server from starting.
`sglang.utils` is on the `launch_server` import path
(`launch_server` → `srt.server_args` → `srt.configs.__init__` →
`srt.configs.qwen3_asr` → `srt.configs.qwen3_omni` → `sglang.utils`), and
IPython pulls in `sqlite3` and its native dependencies. On a machine where those
don't line up, startup fails with an error that names neither IPython nor SGLang:

```
$ python -m sglang. launch_server \
--model-path Qwen/Qwen2.5-0.5B-Instruct \
--host 127.0.0.1 --port 30000
Traceback (most recent call last):
File "<frozen runpy>"
• line 198, in _run_module_as_main
File "<frozen runpy>"
File Throe/S vyap/sgtang/python/glang/Caunch server, py", Line 8, in modules
from sglang.srt.server_args import prepare_server_args
File "/home/jovyan/sglang/python/sglang/srt/server_args-py", line 44, in ‹module> from sglang.srt.configs.linear_attn_model_registry import get_linear_attn_spec_by_arch
File "/home/jovyan/sglang/python/sglang/srt/configs/.
init_-py", line 46, in <module>
from sglang.srt.configs.qwen3_asr import Qwen3ASRConfig
File "/home/jovyan/sglang/python/sglang/srt/configs/qwen3_asr.py", line 10, in module> from sglang.srt.configs.qwen3_omni import Qwen30mniMoeAudioEncoderConfig
File "/home/jovyan/sglang/python/sglang/srt/configs/qwen3_omni.py", line 4, in <module> from sglang.utils import logger
File "/home/jovyan/sglang/python/sglang/utils-py", line 26, in <module> from IPython.display import HTML, display
File "/home/jovyan/11m2/lib/python3.11/site-packages/IPython/_init_-py", line 56, in <module> from. terminal. embed import embed
File "/home/jovyan/11m2/lib/python3.11/site-packages/IPython/terminal/embed.py", line 15, in <module> from IPython.core.interactiveshell import InteractiveShell, make_main_module_type
File "/home/jovyan/llm2/lib/python3.11/site-packages/IPython/core/interactiveshell.py", line 72, in <module> from IPython.core.displayhook import DisplayHook
File "/home/jovyan/11m2/lib/python3.11/site-packages/IPython/core/displayhook-py", line 19, in <module> from history import HistoryOutput
File "/home/jovyan/11m2/lib/python3.11/site-packages/IPython/core/history-py", line 53, in <module> from sqlite3 import DatabaseError, OperationalError
File "/home/jovyan/11m2/lib/python3.11/sqlite3/_init_-py", line 57, in <module> from sqlite3.dbapi2 import *
File "/home/jovyan/11m2/lib/python3.11/sqlite3/dbapi2.py", line 27, in <module> from _sqlite3 import *
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version 'CXXABI_1.3.15' not found (required by /home/jovyan/11m2/lib/python3.11/1ib-dynload/../.././libicui18n.so.78)
```

## Modifications

Moved `from IPython.display import HTML, display` from module scope into the
`if is_in_ci():` branch of `print_highlight()`. One file, one deletion, one
insertion. No behavior change.

IPython is no longer on the server import path:

```
$ python -X importtime -c "import sglang.srt.server_args" 2>&1 | grep -ci ipython
0
```

Both branches still work:

```
$ python -c "import sglang.utils; print('import ok')"
import ok

$ python -c "from sglang.utils import print_highlight; print_highlight('hello')"
hello

$ SGLANG_IS_IN_CI=1 python -c "from sglang.utils import print_highlight; print_highlight('hello')"
<IPython.core.display.HTML object>
```

(The last line is `display()` falling back to `repr` outside a notebook —
unchanged from before this patch.)

## Accuracy Tests

N/A — no changes to kernels, model code, or any output path.

## Speed Tests and Profiling

N/A for inference speed. Startup only: `import IPython.display` measures ~250 ms
on this machine, which is small relative to total import time. The motivation
here is dependency isolation rather than latency.
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---
Question for maintainers: `IPython` is currently in `[project] dependencies` in
`python/pyproject.toml`. Given it is used in exactly one CI-only branch, would
you prefer it moved to an optional extra? Happy to open a separate PR — leaving
it untouched here to keep this diff minimal.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30572815236](https://github.com/sgl-project/sglang/actions/runs/30572815236)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30572814903](https://github.com/sgl-project/sglang/actions/runs/30572814903)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->