### PR TITLE
[AMD][DI][CI] MI355X disagg nightly: exclude mia1-p02-g53 and bound the server health wait

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -145,10 +145,15 @@ jobs:
           # Manual dispatch input wins; otherwise use the latest image resolved
           # by the setup job; otherwise the launcher falls back to the recipe default.
           IMAGE_OVERRIDE: ${{ inputs.image != '' && inputs.image || needs.setup.outputs.image }}
-          # Keep the scheduler off mia1-p01-g20: its ionic RDMA driver ABI
-          # mismatches the container, so MORI reports "no active RDMA device"
-          # and the disagg server dies on init. Remove once the node is fixed.
-          SLURM_EXCLUDE: mia1-p01-g20
+          # Keep the scheduler off known-bad nodes; drop each entry once the
+          # node is fixed.
+          #   mia1-p01-g20: its ionic RDMA driver ABI mismatches the container,
+          #     so MORI reports "no active RDMA device" and the disagg server
+          #     dies on init.
+          #   mia1-p02-g53: a server there comes up healthy but is unreachable
+          #     on its serving port from the peer compute node, so the PD path
+          #     never forms. Every leg scheduled onto it failed (0/7 in run 127).
+          SLURM_EXCLUDE: mia1-p01-g20,mia1-p02-g53
         run: bash scripts/ci/slurm/launch_mi355x.sh
 
       - name: Pack logs

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -543,8 +543,24 @@ docker run $DOCKER_COMMON --name mi355x_bench \
       export PYTHONPATH=/sgl-workspace/sglang/python:\${PYTHONPATH:-}
     fi
     bash \$CIDIR/install_checkout_router.sh
-    echo "[wait] prefill"; for i in \$(seq 1 600); do curl -sf http://\$PIP:$PPORT/health >/dev/null && break; sleep 5; done
-    echo "[wait] decode";  for i in \$(seq 1 600); do curl -sf http://\$DIP:$DPORT/health >/dev/null && break; sleep 5; done
+    # Two things matter in this wait. curl gets explicit timeouts so an
+    # unreachable host cannot stretch each attempt well past the sleep, and a
+    # wait that never succeeds aborts the leg instead of falling through to the
+    # router -- otherwise the router starts with zero healthy workers and an
+    # unreachable node is reported over an hour later as a confusing probe 503.
+    # 900s is ~3x the slowest healthy wait observed, which is the largest model.
+    wait_health() {
+      echo "[wait] \$1"
+      local start=\$SECONDS
+      while [ \$(( SECONDS - start )) -lt 900 ]; do
+        curl -sf --connect-timeout 2 --max-time 5 "\$2" >/dev/null && return 0
+        sleep 5
+      done
+      echo "[wait] \$1 never became healthy at \$2 after \$(( SECONDS - start ))s; aborting"
+      return 1
+    }
+    wait_health prefill http://\$PIP:$PPORT/health || exit 1
+    wait_health decode http://\$DIP:$DPORT/health || exit 1
     python3 -m sglang_router.launch_router \
       --pd-disaggregation \
       --prefill http://\$PIP:$PPORT $PBOOT \


### PR DESCRIPTION
## Motivation

Nightly run [30513562933](https://github.com/sgl-project/sglang/actions/runs/30513562933) (MI355X 2N 1P1D disagg) failed 13 of 18 legs and ran 14h before being cancelled. Two days earlier, [#125](https://github.com/sgl-project/sglang/actions/runs/30328553129) was 18/18 green. This PR fixes the two CI-side problems behind that; the remaining 8 failures are a container-image regression tracked separately (see below).

### 1. `mia1-p02-g53` is unreachable from its peer compute node

Slurm placed the decode server on `mia1-p02-g53` for 7 legs. All 7 failed and none passed, while 5 of the 11 legs that landed decode on `mia1-p02-g29` passed:

| decode node | legs | pass | fail |
|---|---|---|---|
| `mia1-p02-g29` | 11 | 5 | 6 (all `dsv4pro`, image regression) |
| `mia1-p02-g53` | 7 | 0 | 7 |

The server on g53 is itself fine: it loads the model, completes disaggregation warmup, and logs `The server is fired up and ready to roll!`. It simply never receives anything from outside. Across three g53 artifacts the decode log contains **zero** inbound `GET /health`, versus 11 in a passing g29 leg. So `curl http://<g53>:30026/health` from the prefill node never arrives, the router comes up with 0 healthy decode workers, and the probe fails:

```
Failed to select PD pair error=No decode workers available. Please check if decode servers are configured and healthy.
[probe] request failed -- PD path not serving; aborting before sweep
```

g53 was not allocated at all during the green #125 run (all 18 legs got g09 + g29), which is why this is newly visible. Excluding it alongside the existing `mia1-p01-g20` entry recovers 5 legs immediately.

### 2. The health wait could not fail, which cost ~7.5 of the 14 hours

```bash
echo "[wait] decode"; for i in $(seq 1 600); do curl -sf http://$DIP:$DPORT/health >/dev/null && break; sleep 5; done
```

`curl` had no `--connect-timeout`/`--max-time`, so each attempt against an unreachable host cost noticeably more than the 5s sleep, and nothing checked whether the loop ever succeeded — it fell straight through and launched the router regardless. Measured from the run, healthy and unhealthy waits are cleanly bimodal:

| | wait duration |
|---|---|
| 6 passing / reachable legs | 0.1 – 5.2 min (5.2 min is the largest model, Kimi-K2.6) |
| 5 g53 legs | 80.7 – 85.6 min |

Each g53 leg therefore burned ~80 min before failing at the probe, and reported an unreachable node as a confusing 503 rather than naming the endpoint that never answered.

## Modifications

- `.github/workflows/nightly-amd-mi355x-disagg.yml`: add `mia1-p02-g53` to `SLURM_EXCLUDE` (already comma-separated and passed through to `srun --exclude=`), and restructure the comment to document each excluded node and why, so entries can be dropped individually once fixed.
- `scripts/ci/slurm/launch_mi355x.sh`: replace the two fall-through wait loops with a `wait_health` helper that gives `curl` explicit `--connect-timeout 2 --max-time 5`, bounds the wait at 900s of wall clock (~3x the slowest healthy wait observed), and returns non-zero so the caller aborts the leg with a message naming the endpoint.

Behaviour on a healthy leg is unchanged — same `[wait] prefill` / `[wait] decode` log lines, same 5s poll interval, and 900s is ~3x headroom over the slowest real wait.

## Accuracy / performance

No runtime or model code touched; CI harness only.

## Checklist

- [x] Rendered `bench.sh` from the heredoc with representative values from the failing run and confirmed the escaping is right: runtime `$1`/`$2`/`$SECONDS` survive, launch-time ports interpolate (`http://$PIP:30025/health`).
- [x] `bash -n` clean on the generated `bench.sh`, on the extracted inner `bash -lc` payload, and on the full launcher.
- [x] Verified the payload contains no single quote, which would terminate the `bash -lc '...'` string.
- [x] Exercised `wait_health` directly: returns 0 in 0s against a live endpoint; returns 1 at the deadline against a closed port and against an unroutable host (the g53 case); caller `|| exit 1` aborts with exit 1 instead of falling through.
- [x] `check-yaml` parses the workflow and resolves `SLURM_EXCLUDE: mia1-p01-g20,mia1-p02-g53`.
- [x] `scripts/ci/check_workflow_job_names.py` and `codespell --config .codespellrc` pass; `git diff --check` clean.

## Not fixed here

The other 8 failures are all of the `dsv4pro` legs (fp4 and fp8 × plain/mtp/dp8ep8/dp8ep8-mtp), and they are a container-image regression rather than anything in this repo. Every one aborts on the same LLVM assertion inside the Triton AMD backend while compiling an aiter GEMM for gfx950:

```
llvm/ADT/ArrayRef.h:248: [with T = const mlir::dataflow::Lattice<mlir::triton::AxisInfo>*]:
  Assertion `Index < Length && "Invalid index!"' failed.

aiter/ops/triton/_triton_kernels/gemm/basic/gemm_a8w8_blockscale.py:232:0:
  error: Failures have been detected while processing an MLIR pass pipeline
  note: Pipeline failed while executing [`TritonAMDGPUConvertToBufferOps` on 'builtin.module']
```

which surfaces as `RuntimeError: PassManager::run failed` -> `Rank 0 scheduler died during initialization (exit code: -6/-3)`. Both `triton-custom` and `aiter` live in the image, and the workflow resolves the newest tag nightly: #125 ran `v0.5.16-rocm720-mi35x-20260727` and was green, this run used `v0.5.16-rocm720-mi35x-20260729`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30578745636](https://github.com/sgl-project/sglang/actions/runs/30578745636)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30578745352](https://github.com/sgl-project/sglang/actions/runs/30578745352)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->