### PR TITLE
[DSA] Don't crash the MTP seed path when the indexer is inert

### DIFF
--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -84,7 +84,12 @@ def _forward_dsa_indexer_for_mha(
     if seed_buf is None:
         return
     if topk_indices is None:
-        raise RuntimeError("DSA MHA indexer did not produce the requested MTP seed")
+        # The attention backend exposes no indexer metadata (any non-DSA
+        # backend, e.g. an explicit --attention-backend flashinfer), so the
+        # indexer computes no top-k and attention runs dense. Publish the -1
+        # "no seed" sentinel instead of leaving the previous batch's seed.
+        seed_buf.fill_(-1)
+        return
 
     select = spec_info.dsa_seed_topk_select
     src = topk_indices if select is None else topk_indices[select]

--- a/test/registered/unit/models/test_deepseek_mha_mtp_seed.py
+++ b/test/registered/unit/models/test_deepseek_mha_mtp_seed.py
@@ -1,0 +1,85 @@
+"""Hermetic unit tests for the DSA MHA MTP-seed publish path.
+
+`_forward_dsa_indexer_for_mha` publishes the GLM-5.2 MTP IndexShare seed from
+the MHA prefill path. `Indexer.forward_cuda` returns None whenever the
+attention backend exposes no indexer metadata -- every non-DSA backend does,
+e.g. an explicit `--attention-backend flashinfer` on a DSA model -- so the seed
+publish has to degrade to the -1 "no seed" sentinel instead of killing the
+scheduler.
+
+Pure Python (no GPU, no model weights): only the attention-backend lookup is
+faked, `Indexer.forward_cuda` and `_forward_dsa_indexer_for_mha` are real.
+Runs on any PR-CI lane.
+"""
+
+import unittest
+from functools import partial
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.dsa import dsa_indexer
+from sglang.srt.layers.attention.dsa.dsa_indexer import Indexer
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha import (
+    _forward_dsa_indexer_for_mha,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+INDEX_TOPK = 4
+
+
+def _fake_forward_batch(seed_buf, select=None):
+    return SimpleNamespace(
+        spec_info=SimpleNamespace(
+            dsa_seed_topk_capture=seed_buf,
+            dsa_seed_topk_select=select,
+        )
+    )
+
+
+def _call(indexer, forward_batch):
+    _forward_dsa_indexer_for_mha(
+        indexer,
+        hidden_states=torch.zeros((2, 8)),
+        q_lora=torch.zeros((2, 8)),
+        positions=torch.zeros((2,), dtype=torch.int64),
+        forward_batch=forward_batch,
+        layer_id=0,
+    )
+
+
+class TestDsaMhaMtpSeed(CustomTestCase):
+    def test_seed_is_invalidated_without_indexer_metadata(self):
+        # A backend without indexer metadata (any non-DSA backend) makes the
+        # real Indexer.forward_cuda return None. The seed buffer must come back
+        # all -1, not keep the previous batch's values and not raise.
+        seed_buf = torch.full((2, INDEX_TOPK), 7, dtype=torch.int32)
+        # forward_cuda returns before it touches `self`, so None binds fine.
+        indexer = partial(Indexer.forward_cuda, None)
+        with mock.patch.object(
+            dsa_indexer, "get_attn_backend", return_value=AttentionBackend()
+        ):
+            _call(indexer, _fake_forward_batch(seed_buf))
+        self.assertTrue(torch.all(seed_buf == -1))
+
+    def test_seed_is_published_when_indexer_returns_indices(self):
+        topk_indices = torch.arange(3 * INDEX_TOPK, dtype=torch.int32).view(
+            3, INDEX_TOPK
+        )
+        seed_buf = torch.full((2, INDEX_TOPK), -1, dtype=torch.int32)
+        select = torch.tensor([0, 2])
+        _call(
+            lambda **kwargs: topk_indices,
+            _fake_forward_batch(seed_buf, select=select),
+        )
+        self.assertTrue(torch.equal(seed_buf, topk_indices[select]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #32893

`_forward_dsa_indexer_for_mha` raised whenever the indexer returned no
top-k for a requested MTP IndexShare seed. That happens for a legal
configuration: with an explicit `--attention-backend flashinfer` on a DSA
model, `_deepseek_family_overrides` does not swap in the `dsa` backend, the
EAGLE draft-extend backend is `FlashInferMLAAttnBackend`, and its inherited
`get_indexer_metadata()` returns `None`, so `Indexer.forward_cuda` returns
early with `None` even under `return_indices=True`. Every TP rank's scheduler
then died on the first request.

With a non-DSA backend the indexer is inert for the whole run and nothing
consumes the seed, so publish the `-1` "no seed" sentinel instead of raising.
`_get_dsa_extend_topk_buf` initializes the buffer with that value and the PD
path already decodes an all-negative seed back to "no seed". Filling matters
rather than just returning: the seed buffer is reused across batches, so a bare
return would hand the next draft loop the previous batch's seed.

Verified with a new hermetic unit test,
`test/registered/unit/models/test_deepseek_mha_mtp_seed.py`, that drives the
real `Indexer.forward_cuda` and the real `_forward_dsa_indexer_for_mha` against
a backend with no indexer metadata. It fails with the exact
`RuntimeError: DSA MHA indexer did not produce the requested MTP seed` from the
issue before the change and passes after. black/isort/ruff clean.

Not verified: I have no H20/H200-class GPU and no GLM-5.2-W4AFP8 weights, so I
did not run the reporter's 8-GPU launch command end to end. Please confirm it
serves requests. This patch stops the crash; it does not make DSA-model +
flashinfer a supported combination (the index-K cache is still never written
and attention runs dense there), and I did not measure output quality for it.

Thanks to @likyyyyyyy for the report with a full traceback and launch command.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30585299056](https://github.com/sgl-project/sglang/actions/runs/30585299056)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30585298867](https://github.com/sgl-project/sglang/actions/runs/30585298867)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->