### PR TITLE
feat: add configurable memory saver hook mode

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -824,7 +824,8 @@ class Engine(EngineScoreMixin, EngineBase):
         if not use_dp_controller:
             # Launch tensor parallel scheduler processes
             memory_saver_adapter = TorchMemorySaverAdapter.create(
-                enable=server_args.enable_memory_saver
+                enable=server_args.enable_memory_saver,
+                hook_mode=server_args.memory_saver_hook_mode,
             )
             scheduler_pipe_readers = []
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -48,6 +48,7 @@ from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
 from sglang.srt.observability.req_time_stats import DPControllerReqTimeStats
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
+from sglang.srt.plugins import load_plugins
 from sglang.srt.server_args import (
     DP_ATTENTION_HANDSHAKE_PORT_DELTA,
     PortArgs,
@@ -601,7 +602,8 @@ class DataParallelController:
             logger.info(f"Launch DP{dp_rank} starting at GPU #{base_gpu_id}.")
 
         memory_saver_adapter = TorchMemorySaverAdapter.create(
-            enable=server_args.enable_memory_saver
+            enable=server_args.enable_memory_saver,
+            hook_mode=server_args.memory_saver_hook_mode,
         )
 
         scheduler_pipe_readers = []
@@ -813,6 +815,7 @@ def run_data_parallel_controller_process(
     setproctitle.setproctitle("sglang::data_parallel_controller")
     faulthandler.enable()
     kill_itself_when_parent_died()
+    load_plugins()
     parent_process = psutil.Process().parent()
 
     configure_logger(server_args)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -607,7 +607,8 @@ class ModelRunner:
 
     def init_memory_saver_adapter(self):
         self.memory_saver_adapter = TorchMemorySaverAdapter.create(
-            enable=self.server_args.enable_memory_saver
+            enable=self.server_args.enable_memory_saver,
+            hook_mode=self.server_args.memory_saver_hook_mode,
         )
 
     def maybe_init_remote_instance_transfer_engine(self):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3288,6 +3288,11 @@ class ServerArgs:
         "Allow saving memory using release_memory_occupation and resume_memory_occupation",
         NS("exec.features"),
     ] = False
+    memory_saver_hook_mode: A[
+        str,
+        "Select the torch_memory_saver hook mode or registered backend.",
+        NS("exec.features"),
+    ] = "preload"
     enable_weights_cpu_backup: A[
         bool,
         "Save model weights (both main model and draft model, if any) to CPU memory during release_weights_occupation and resume_weights_occupation",

--- a/python/sglang/srt/utils/torch_memory_saver_adapter.py
+++ b/python/sglang/srt/utils/torch_memory_saver_adapter.py
@@ -13,10 +13,14 @@ except ImportError as e:
 
 logger = logging.getLogger(__name__)
 
+_configured_hook_mode = None
+
 
 class TorchMemorySaverAdapter(ABC):
     @staticmethod
-    def create(enable: bool):
+    def create(enable: bool, hook_mode=None):
+        global _configured_hook_mode
+
         if enable and import_error is not None:
             logger.warning(
                 "enable_memory_saver is enabled, but "
@@ -24,6 +28,18 @@ class TorchMemorySaverAdapter(ABC):
                 "via `pip3 install torch-memory-saver`. "
             )
             raise import_error
+
+        if enable and hook_mode is not None:
+            if _configured_hook_mode is None:
+                _memory_saver.hook_mode = hook_mode
+                _configured_hook_mode = hook_mode
+            elif _configured_hook_mode != hook_mode:
+                raise RuntimeError(
+                    "torch_memory_saver hook mode is already configured as "
+                    f"{_configured_hook_mode!r}; cannot reconfigure it as "
+                    f"{hook_mode!r} in the same process"
+                )
+
         return (
             _TorchMemorySaverAdapterReal() if enable else _TorchMemorySaverAdapterNoop()
         )


### PR DESCRIPTION
## Motivation

SGLang currently assumes the `torch_memory_saver` preload hook, which prevents registered allocator backends from selecting a different hook mode and unnecessarily configures `LD_PRELOAD` for those backends.


## Related work

- SGLang RFC: #27310 (ask 4.1)
- `torch_memory_saver` RFC: [fzyzcjy/torch_memory_saver#77](https://github.com/fzyzcjy/torch_memory_saver/issues/77)
- `torch_memory_saver` implementation: [fzyzcjy/torch_memory_saver#79](https://github.com/fzyzcjy/torch_memory_saver/pull/79)

## Modifications

- Add `--memory-saver-hook-mode`, defaulting to `preload`.
- Select the registered hook mode in the direct launcher, data-parallel controller, and scheduler process before first use.
- Load plugins in the data-parallel controller so process-local backend registration is available before it launches schedulers.
- Delegate subprocess configuration to `torch_memory_saver`, which decides whether the selected backend uses `LD_PRELOAD`.
- Preserve existing behavior for callers that do not specify a hook mode.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30594749717](https://github.com/sgl-project/sglang/actions/runs/30594749717)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30594749618](https://github.com/sgl-project/sglang/actions/runs/30594749618)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

