### PR TITLE
[ROCm] Add the AITER sparse-MLA kernel for DSA decode as option

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/aiter_sparse_mla.py
+++ b/python/sglang/kernels/ops/attention/dsa/aiter_sparse_mla.py
@@ -1,0 +1,276 @@
+"""aiter persistent sparse-MLA decode for ROCm (gfx950).
+
+This module owns the *calling convention* for aiter's persistent sparse MLA
+decode pair -- ``aiter::mla_a8w8_qh16_qseqlen1_gqaratio16_ps`` plus
+``kn_mla_reduce_v1_ps`` -- and nothing else. The kernels themselves live in
+aiter; what is hard to get right is how they are fed.
+
+The argument set below is a direct port of ATOM, which is the only caller of
+this kernel pair known to run correctly and at speed on GLM-5.2 / MI355X:
+
+  * ``atom/model_ops/attentions/aiter_mla.py``
+        ``AiterMLAMetadataBuilder.set_mla_persistent_worker_buffers``
+  * ``atom/model_ops/attention_mla.py``
+        ``MLAAttention._forward_decode``
+
+Two properties are load-bearing and easy to lose:
+
+1. **The metadata is built once per forward batch, not once per layer.**
+   ``get_mla_metadata_v1`` depends only on the batch's KV layout, which every
+   attention layer shares. Rebuilding it inside the per-layer attention call
+   costs ~5 extra kernel launches per layer (~22 us), which on a 92-layer model
+   is ~2 ms per decode iteration -- more than the kernel saves.
+
+2. **The metadata arguments must match the sparse KV layout.** DSA packs the
+   selected KV per query token at ``page_size=1``, so:
+
+   - ``kv_indptr`` must be the *sparse* (top-k) indptr, not the dense one.
+     With the dense indptr the asm kernel's ``kv_end`` runs past the written
+     region of the sparse index buffer once the context exceeds ``index_topk``,
+     giving an illegal KV-cache access.
+   - ``kv_last_page_lens`` must be all ones (one token per page). The dense
+     per-block value (1..block_size) makes ``get_mla_metadata_v1`` compute a KV
+     extent up to ``block_size - 1`` pages past the written sparse region.
+   - both must be sliced to ``[: bs + 1]`` / ``[: bs]``. aiter derives its
+     batch count from the *length* of ``kv_indptr``
+     (``get_mla_metadata_v1_0_device``: ``num_batches =
+     seqlens_kv_indptr.size(0) - 1``), so handing over a full-capacity buffer
+     makes it emit work items for every stale slot past ``bs``, with
+     ``qo_start`` running past the end of Q and O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from aiter.mla import mla_decode_fwd
+from aiter.ops.attention import get_mla_metadata_info_v1, get_mla_metadata_v1
+
+__all__ = [
+    "AiterSparseMLADecodeMetadata",
+    "aiter_sparse_mla_out_dtype",
+    "alloc_sparse_mla_decode_metadata",
+    "build_sparse_mla_decode_metadata",
+    "sparse_mla_decode",
+]
+
+
+# --- ATOM's tuned constants ------------------------------------------------
+#
+# Deliberately hardcoded rather than exposed: they are a matched set, and the
+# combination below is the one that has been measured end to end. Changing one
+# in isolation (notably fast_mode) silently selects a different metadata kernel
+# with different semantics -- see _METADATA_KERNEL_NOTE.
+#
+# _METADATA_KERNEL_NOTE: get_mla_metadata_v1 dispatches on (fast_mode,
+# intra_batch_mode):
+#     fast_mode=True                 -> v1_2_device, honors topk and page_size
+#     fast_mode=False, intra=True    -> v1_0_device, IGNORES topk
+#     fast_mode=False, intra=False   -> v1_1_device, honors topk
+# Sparse attention must not use the path that ignores topk.
+_FAST_MODE = True
+_IS_CAUSAL = True
+_KV_GRANULARITY = 16
+_MAX_SPLIT_PER_BATCH = 16
+_NHEAD_KV = 1
+# KV is packed one token per page for sparse decode.
+_PAGE_SIZE = 1
+# Passing an explicit num_kv_splits also pins aiter to persistent mode: its
+# non-persistent fallback cannot honor a top-k split scheme and would return
+# wrong results, so it never downgrades a caller that sets this.
+_NUM_KV_SPLITS = 16
+
+
+def aiter_sparse_mla_out_dtype(q_dtype: torch.dtype) -> torch.dtype:
+    """Output dtype for the decode call.
+
+    On the a8w8 path Q is fp8 while the attention output is not: aiter's reduce
+    kernels (``kn_mla_reduce_v1*``, ``csrc/kernels/mla/reduce.cu``) only
+    instantiate ``out_t`` for bf16 and fp16 and hard-fail on anything else. ATOM
+    sidesteps this by allocating its output in model dtype rather than Q dtype;
+    mapping fp8 to bf16 here is the same thing expressed locally.
+    """
+    return torch.bfloat16 if q_dtype.itemsize == 1 else q_dtype
+
+
+@dataclass
+class AiterSparseMLADecodeMetadata:
+    """Persistent work buffers plus the batch shape they were built for."""
+
+    work_meta_data: torch.Tensor
+    work_indptr: torch.Tensor
+    work_info_set: torch.Tensor
+    reduce_indptr: torch.Tensor
+    reduce_final_map: torch.Tensor
+    reduce_partial_map: torch.Tensor
+    # All-ones, [capacity]. One token per page; see the module docstring.
+    kv_last_page_lens: torch.Tensor
+
+    capacity: int
+    max_seqlen_q: int
+    num_heads_padded: int
+    q_dtype: torch.dtype
+    kv_dtype: torch.dtype
+
+    def matches(
+        self,
+        batch_size: int,
+        max_seqlen_q: int,
+        num_heads_padded: int,
+        q_dtype: torch.dtype,
+        kv_dtype: torch.dtype,
+    ) -> bool:
+        return (
+            batch_size <= self.capacity
+            and max_seqlen_q <= self.max_seqlen_q
+            and num_heads_padded == self.num_heads_padded
+            and q_dtype == self.q_dtype
+            and kv_dtype == self.kv_dtype
+        )
+
+    def kernel_kwargs(self) -> dict:
+        return {
+            "work_meta_data": self.work_meta_data,
+            "work_indptr": self.work_indptr,
+            "work_info_set": self.work_info_set,
+            "reduce_indptr": self.reduce_indptr,
+            "reduce_final_map": self.reduce_final_map,
+            "reduce_partial_map": self.reduce_partial_map,
+        }
+
+
+def alloc_sparse_mla_decode_metadata(
+    batch_size: int,
+    max_seqlen_q: int,
+    num_heads_padded: int,
+    q_dtype: torch.dtype,
+    kv_dtype: torch.dtype,
+    device: torch.device,
+) -> AiterSparseMLADecodeMetadata:
+    """Allocate the persistent work buffers for up to ``batch_size`` sequences.
+
+    Call this once per backend (and again only if the batch capacity or a dtype
+    changes), never inside CUDA graph capture: an allocation there would be
+    baked into the graph.
+    """
+    sizes = get_mla_metadata_info_v1(
+        batch_size,
+        max_seqlen_q,
+        num_heads_padded,
+        q_dtype,
+        kv_dtype,
+        is_sparse=True,
+        fast_mode=_FAST_MODE,
+    )
+    (
+        work_meta_data,
+        work_indptr,
+        work_info_set,
+        reduce_indptr,
+        reduce_final_map,
+        reduce_partial_map,
+    ) = (torch.empty(size, dtype=dtype, device=device) for size, dtype in sizes)
+
+    return AiterSparseMLADecodeMetadata(
+        work_meta_data=work_meta_data,
+        work_indptr=work_indptr,
+        work_info_set=work_info_set,
+        reduce_indptr=reduce_indptr,
+        reduce_final_map=reduce_final_map,
+        reduce_partial_map=reduce_partial_map,
+        kv_last_page_lens=torch.ones(batch_size, dtype=torch.int32, device=device),
+        capacity=batch_size,
+        max_seqlen_q=max_seqlen_q,
+        num_heads_padded=num_heads_padded,
+        q_dtype=q_dtype,
+        kv_dtype=kv_dtype,
+    )
+
+
+def build_sparse_mla_decode_metadata(
+    metadata: AiterSparseMLADecodeMetadata,
+    cu_seqlens_q: torch.Tensor,
+    sparse_kv_indptr: torch.Tensor,
+    bs: int,
+    max_seqlen_q: int,
+) -> None:
+    """Fill the work buffers in place. Call ONCE per forward batch.
+
+    ``cu_seqlens_q`` and ``sparse_kv_indptr`` must already be ``[: bs + 1]``
+    views; this function does not slice them, so that a caller inside CUDA graph
+    capture keeps stable tensor addresses.
+    """
+    get_mla_metadata_v1(
+        cu_seqlens_q,
+        sparse_kv_indptr,
+        metadata.kv_last_page_lens[:bs],
+        metadata.num_heads_padded,
+        _NHEAD_KV,
+        _IS_CAUSAL,
+        metadata.work_meta_data,
+        metadata.work_info_set,
+        metadata.work_indptr,
+        metadata.reduce_indptr,
+        metadata.reduce_final_map,
+        metadata.reduce_partial_map,
+        page_size=_PAGE_SIZE,
+        kv_granularity=_KV_GRANULARITY,
+        max_seqlen_qo=max_seqlen_q,
+        uni_seqlen_qo=max_seqlen_q,
+        fast_mode=_FAST_MODE,
+        max_split_per_batch=_MAX_SPLIT_PER_BATCH,
+        dtype_q=metadata.q_dtype,
+        dtype_kv=metadata.kv_dtype,
+    )
+
+
+def sparse_mla_decode(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    o: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    sparse_kv_indptr: torch.Tensor,
+    sparse_kv_indices: torch.Tensor,
+    metadata: AiterSparseMLADecodeMetadata,
+    bs: int,
+    max_seqlen_q: int,
+    sm_scale: float,
+    q_scale: Optional[torch.Tensor] = None,
+    kv_scale: Optional[torch.Tensor] = None,
+) -> None:
+    """Run the persistent sparse MLA decode, writing into ``o``.
+
+    Args:
+        q: ``[num_tokens, num_heads_padded, kv_lora_rank + qk_rope_head_dim]``.
+        kv_cache: flat MLA KV cache; viewed here as
+            ``[-1, 1, 1, head_dim]`` (one token per page).
+        o: ``[num_tokens, num_heads_padded, kv_lora_rank]``, dtype from
+            :func:`aiter_sparse_mla_out_dtype`.
+        cu_seqlens_q: ``[bs + 1]`` view.
+        sparse_kv_indptr: ``[bs + 1]`` view over the top-k selection.
+        sparse_kv_indices: the top-k index buffer (full capacity is fine; the
+            kernel only reads what ``sparse_kv_indptr`` delimits).
+        metadata: buffers already filled by
+            :func:`build_sparse_mla_decode_metadata` for this batch.
+        q_scale / kv_scale: required when Q is fp8 -- aiter's ``asm_mla.cu``
+            rejects fp8 Q with either missing.
+    """
+    mla_decode_fwd(
+        q,
+        kv_cache.view(-1, _PAGE_SIZE, 1, q.shape[-1]),
+        o,
+        cu_seqlens_q,
+        sparse_kv_indptr,
+        sparse_kv_indices,
+        metadata.kv_last_page_lens[:bs],
+        max_seqlen_q,
+        page_size=_PAGE_SIZE,
+        nhead_kv=_NHEAD_KV,
+        sm_scale=sm_scale,
+        num_kv_splits=_NUM_KV_SPLITS,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+        **metadata.kernel_kwargs(),
+    )

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -145,6 +145,14 @@ if _is_hip:
             paged_attention_ragged,
         )
         from aiter.mla import mla_decode_fwd, mla_prefill_fwd  # noqa: F401
+
+        from sglang.kernels.ops.attention.dsa.aiter_sparse_mla import (
+            AiterSparseMLADecodeMetadata,
+            aiter_sparse_mla_out_dtype,
+            alloc_sparse_mla_decode_metadata,
+            build_sparse_mla_decode_metadata,
+            sparse_mla_decode,
+        )
     except ImportError:
         print(
             "aiter is AMD specific kernel library. Please make sure aiter is installed on your AMD device."
@@ -248,6 +256,13 @@ class DSAMetadata:
     indexer_seq_lens: Optional[torch.Tensor] = None
     # batch index for each token.
     token_to_batch_idx: Optional[torch.Tensor] = None
+
+    # aiter's persistent sparse-MLA work plan. Depends only on the batch's
+    # sparse KV layout, which every attention layer shares, so it is built once
+    # per forward batch and read by all 90+ layers. Building it per layer costs
+    # ~5 extra kernel launches per layer, which is why the aiter decode path
+    # measured slower than tilelang before this was hoisted.
+    aiter_sparse_mla: Optional[AiterSparseMLADecodeMetadata] = None
 
 
 @torch.compile
@@ -453,6 +468,7 @@ class DeepseekSparseAttnBackend(
             self.aiter_dsa_metadata_kv_dtype = None
             self.aiter_dsa_kv_last_page_lens = None
             self.aiter_dsa_work_metadata = None
+            self.aiter_sparse_mla_metadata = None
 
             if (
                 self.dsa_prefill_impl == "aiter" or self.dsa_decode_impl == "aiter"
@@ -462,6 +478,23 @@ class DeepseekSparseAttnBackend(
                     batch_size=max_bs,
                     q_dtype=torch.bfloat16,
                     kv_dtype=fp8_dtype,
+                )
+
+            if (
+                self.dsa_decode_impl == "aiter"
+                and model_runner.kv_cache_dtype == fp8_dtype
+            ):
+                # Allocated once, outside any CUDA graph capture. q_dtype tracks
+                # kv_dtype because the a8w8 asm kernel is selected on that pair:
+                # the tilelang-fused rope path hands us fp8 Q whenever either DSA
+                # backend is tilelang, which is the configuration this targets.
+                self.aiter_sparse_mla_metadata = alloc_sparse_mla_decode_metadata(
+                    batch_size=max_bs,
+                    max_seqlen_q=1,
+                    num_heads_padded=self.num_head_padded,
+                    q_dtype=fp8_dtype,
+                    kv_dtype=fp8_dtype,
+                    device=self.device,
                 )
 
         # Speculative decoding
@@ -677,6 +710,31 @@ class DeepseekSparseAttnBackend(
         self.aiter_dsa_metadata_max_seqlen_q = max_seqlen_q
         self.aiter_dsa_metadata_q_dtype = q_dtype
         self.aiter_dsa_metadata_kv_dtype = kv_dtype
+
+    def _build_aiter_sparse_mla_metadata(
+        self,
+        dsa_cu_seqlens_q: torch.Tensor,
+        dsa_cu_seqlens_k: torch.Tensor,
+    ) -> Optional[AiterSparseMLADecodeMetadata]:
+        """Plan aiter's persistent sparse decode work for one forward batch.
+
+        Must run outside CUDA graph capture and replay: it fills the work buffers
+        that the captured decode kernels later read. ``dsa_cu_seqlens_k`` is
+        already the sparse (top-k clipped) indptr and ``dsa_cu_seqlens_q`` the
+        matching per-token arange, so deriving the inputs costs nothing here.
+        """
+        if self.aiter_sparse_mla_metadata is None:
+            return None
+
+        num_tokens = dsa_cu_seqlens_k.numel() - 1
+        build_sparse_mla_decode_metadata(
+            self.aiter_sparse_mla_metadata,
+            dsa_cu_seqlens_q[: num_tokens + 1],
+            dsa_cu_seqlens_k[: num_tokens + 1],
+            bs=num_tokens,
+            max_seqlen_q=1,
+        )
+        return self.aiter_sparse_mla_metadata
 
     def _prepare_aiter_dsa_decode_metadata(
         self,
@@ -1150,6 +1208,13 @@ class DeepseekSparseAttnBackend(
             indexer_seq_lens=indexer_seq_lens,
             token_to_batch_idx=token_to_batch_idx,
             topk_v2_plan=self._build_topk_v2_plan(seqlens_expanded),
+            aiter_sparse_mla=(
+                self._build_aiter_sparse_mla_metadata(
+                    dsa_cu_seqlens_q, dsa_cu_seqlens_k
+                )
+                if forward_batch.forward_mode.is_decode_or_idle()
+                else None
+            ),
         )
         self.forward_metadata = metadata
 
@@ -1478,6 +1543,9 @@ class DeepseekSparseAttnBackend(
             real_page_table=real_page_table,
             dsa_extend_seq_lens_list=dsa_extend_seq_lens_list,
             topk_v2_plan=self._build_topk_v2_plan(seqlens_expanded),
+            aiter_sparse_mla=self._build_aiter_sparse_mla_metadata(
+                dsa_cu_seqlens_q, dsa_cu_seqlens_k
+            ),
         )
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_metadata = metadata
@@ -1786,6 +1854,13 @@ class DeepseekSparseAttnBackend(
                 )
             )
 
+        # Re-plan aiter's work buffers for the new sequence lengths. The buffers
+        # are the same objects the captured graph reads, so this must stay a
+        # write into them and never a reallocation.
+        self._build_aiter_sparse_mla_metadata(
+            metadata.dsa_cu_seqlens_q, metadata.dsa_cu_seqlens_k
+        )
+
         self.forward_metadata = metadata
 
     def init_forward_metadata_replay_cuda_graph_from_precomputed(
@@ -1947,6 +2022,10 @@ class DeepseekSparseAttnBackend(
                 object.__setattr__(metadata, "paged_mqa_ctx_lens_2d", seqlens_32_2d)
             else:
                 metadata.paged_mqa_ctx_lens_2d.copy_(seqlens_32_2d)
+
+        self._build_aiter_sparse_mla_metadata(
+            metadata.dsa_cu_seqlens_q, metadata.dsa_cu_seqlens_k
+        )
 
         self.forward_metadata = metadata
 
@@ -3008,73 +3087,75 @@ class DeepseekSparseAttnBackend(
         metadata: DSAMetadata,
         bs: int,
     ) -> torch.Tensor:
-        q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
+        """Sparse MLA decode through aiter's persistent kernel pair.
 
-        if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
-        else:
-            o = torch.empty_like(q)
+        Everything batch-shaped was already planned by
+        :py:meth:`_build_aiter_sparse_mla_metadata`; the only per-layer work left
+        is gathering this layer's own top-k KV slots, since the *values* of the
+        selection differ per layer even though its per-request *lengths* do not.
+        """
+        assert (
+            metadata.aiter_sparse_mla is not None
+        ), "aiter sparse MLA decode metadata was not built for this batch"
+
+        q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
+        num_tokens = q.shape[0]
+
+        out_dtype = aiter_sparse_mla_out_dtype(q.dtype)
+        o = torch.empty(
+            (num_tokens, layer.tp_q_head_num * layer.v_head_dim),
+            dtype=out_dtype,
+            device=q.device,
+        )
 
         if self.need_pad_heads:
             q_kernel = q.view(
                 -1, layer.tp_q_head_num, layer.head_dim
             ).repeat_interleave(self.head_repeat_factor, dim=1)
-            o_kernel = q.new_empty(
-                (
-                    q.shape[0],
-                    layer.tp_q_head_num * self.head_repeat_factor,
-                    layer.v_head_dim,
-                )
+            o_kernel = torch.empty(
+                (num_tokens, self.num_head_padded, layer.v_head_dim),
+                dtype=out_dtype,
+                device=q.device,
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
             o_kernel = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
 
+        # asm_mla.cu rejects fp8 Q unless BOTH scales are given. The values are 1
+        # because the fused rope/cache path quantizes Q and KV against the same
+        # unit scale rather than a per-tensor one.
         q_scale = None
         kv_scale = None
-        aiter_persistent_kwargs = {}
+        if q_kernel.dtype.itemsize == 1:
+            q_scale = torch.ones((), dtype=torch.float32, device=q.device)
         if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q_kernel.device)
+            kv_scale = torch.ones((), dtype=torch.float32, device=q.device)
 
-        kv_indptr = self.kv_indptr
+        # dsa_cu_seqlens_k is seq_lens clamped to index_topk, cumulatively summed
+        # -- exactly the sparse indptr, and already up to date for this batch.
+        sparse_kv_indptr = metadata.dsa_cu_seqlens_k[: num_tokens + 1]
+        sparse_kv_indices = self.kv_indices
+        get_valid_kv_indices(
+            page_table_1, sparse_kv_indptr, sparse_kv_indices, num_tokens
+        )
 
-        non_minus1_mask = page_table_1 != -1
-        non_minus1_counts = non_minus1_mask.sum(dim=1)
-        kv_indptr[1 : bs + 1] = torch.cumsum(non_minus1_counts, dim=0)
-
-        kv_indices = self.kv_indices
-        get_valid_kv_indices(page_table_1, kv_indptr, kv_indices, bs)
-
-        kv_last_page_lens = metadata.cu_seqlens_q
-        if kv_cache.dtype == fp8_dtype:
-            aiter_persistent_kwargs = self._prepare_aiter_dsa_decode_metadata(
-                metadata.cu_seqlens_q,
-                kv_indptr,
-                bs,
-                metadata.max_seq_len_q,
-                q_kernel.dtype,
-                kv_cache.dtype,
-            )
-            kv_last_page_lens = aiter_persistent_kwargs.pop("kv_last_page_lens")
-
-        mla_decode_fwd(
+        sparse_mla_decode(
             q_kernel,
-            kv_cache.view(-1, 1, 1, layer.head_dim),
+            kv_cache,
             o_kernel,
-            metadata.cu_seqlens_q,
-            kv_indptr,
-            kv_indices,
-            kv_last_page_lens,
-            metadata.max_seq_len_q,
+            metadata.dsa_cu_seqlens_q[: num_tokens + 1],
+            sparse_kv_indptr,
+            sparse_kv_indices,
+            metadata.aiter_sparse_mla,
+            bs=num_tokens,
+            max_seqlen_q=1,
             sm_scale=layer.scaling,
-            logit_cap=layer.logit_cap,
             q_scale=q_scale,
             kv_scale=kv_scale,
-            **aiter_persistent_kwargs,
         )
 
         if self.need_pad_heads:
-            o = o_kernel[:, :: self.head_repeat_factor, :]
+            return o_kernel[:, :: self.head_repeat_factor, :]
 
         return o
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -496,6 +496,16 @@ class DeepseekSparseAttnBackend(
                     kv_dtype=fp8_dtype,
                     device=self.device,
                 )
+                # asm_mla.cu rejects fp8 Q unless BOTH scales are given, and the
+                # fused rope/cache path quantizes Q and KV against a unit scale,
+                # so the value is a constant 1.0. Allocating it per layer costs
+                # 2 fill launches x every layer x every forward, which measured
+                # +0.62 ms per decode iteration -- more than the aiter kernel
+                # itself saves. One tensor, allocated once, is shared by all
+                # layers; nothing ever writes to it.
+                self.aiter_sparse_mla_identity_scale = torch.ones(
+                    (), dtype=torch.float32, device=self.device
+                )
 
         # Speculative decoding
         self.topk = model_runner.server_args.speculative_eagle_topk or 0
@@ -3121,15 +3131,12 @@ class DeepseekSparseAttnBackend(
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
             o_kernel = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
 
-        # asm_mla.cu rejects fp8 Q unless BOTH scales are given. The values are 1
-        # because the fused rope/cache path quantizes Q and KV against the same
-        # unit scale rather than a per-tensor one.
-        q_scale = None
-        kv_scale = None
-        if q_kernel.dtype.itemsize == 1:
-            q_scale = torch.ones((), dtype=torch.float32, device=q.device)
-        if kv_cache.dtype == fp8_dtype:
-            kv_scale = torch.ones((), dtype=torch.float32, device=q.device)
+        # asm_mla.cu rejects fp8 Q unless BOTH scales are given. Both point at the
+        # same preallocated unit scalar -- see __init__ for why it is not built
+        # here.
+        identity_scale = self.aiter_sparse_mla_identity_scale
+        q_scale = identity_scale if q_kernel.dtype.itemsize == 1 else None
+        kv_scale = identity_scale if kv_cache.dtype == fp8_dtype else None
 
         # dsa_cu_seqlens_k is seq_lens clamped to index_topk, cumulatively summed
         # -- exactly the sparse indptr, and already up to date for this batch.


### PR DESCRIPTION

## Run it with

> ### **`--dsa-decode-backend aiter --dsa-prefill-backend tilelang`**
>
> **Both flags are required.** Passing only `--dsa-decode-backend aiter` will
> crash the server — see [How to run it](#how-to-run-it) below for why.

---

## One sentence

On ROCm, DSA decode attention already had an AITER code path, but nothing ever
reached it. This PR wires it up and fixes the three things that were wrong once
it did run. Decode attention gets ~14% faster; prefill is untouched.

## What was happening

- ROCm defaults both DSA backends to `tilelang`, so `--dsa-decode-backend aiter`
  was effectively dead code.
- TileLang runs the sparse-MLA decode as `main_kernel`, launched twice per
  decoder layer, every decode step.
- AITER ships a hand-written assembly kernel for exactly this shape
  (`mla_a8w8_qh16_qseqlen1_gqaratio16_ps` + `kn_mla_reduce_v1_ps`). It was
  simply not being called.

## The three fixes

1. **Plan the metadata once per batch, not once per layer.**
   `get_mla_metadata_v1` was being called inside the per-layer forward. It is
   batch-shaped, not layer-shaped, so it is now built once in the metadata
   step and reused by every layer.

2. **Call AITER with the parameters sparse attention actually needs.**
   `fast_mode=True` (the other dispatch paths silently ignore `topk`, which is
   the whole point of sparse attention), `kv_indptr` sliced per layer, and a
   bf16 output buffer.

3. **Hoist the FP8 identity scale out of the forward path.**
   `asm_mla.cu` rejects FP8 Q unless *both* `q_scale` and `kv_scale` are given.
   The fused rope/cache path quantizes against a unit scale, so the value is a
   constant `1.0` -- but allocating it with `torch.ones(())` inside the forward
   costs two `FillFunctor<float>` launches per layer per step. That measured
   **+0.62 ms per decode iteration**, more than the AITER kernel itself saved.
   It is now one tensor allocated in `__init__` and shared by all layers.
   (Also keeps the address stable for CUDA graph capture.)

Fix 3 is the interesting one: without it the PR is a wash. With it, it wins.

## Numbers

GLM-5.2 FP4, MI355X (gfx950), TP4, 8192 in / 1024 out, concurrency 64.
Same container, same image, back-to-back runs.

Decode attention, GPU time per decode iteration:

| | TileLang (before) | AITER (after) |
|---|---|---|
| `main_kernel` | 3.12 ms x 156 launches | -- |
| `aiter::mla_a8w8_...qseqlen1_ps` | -- | 1.83 ms x 78 |
| `kn_mla_reduce_v1_ps` | -- | 0.47 ms x 78 |
| `_get_valid_kv_indices_kernel` | -- | 0.31 ms x 78 |
| **sparse-MLA total** | **3.44 ms** | **2.97 ms (-14%)** |
| total decode GPU busy | 26.45 ms | 26.24 ms |

End to end:

| metric | before | after |
|---|---|---|
| output throughput | baseline | **+1.5%** |
| mean TPOT | 38.55 ms | 37.53 ms (**-2.6%**) |
| median ITL | 25.94 ms | 25.63 ms (-1.2%) |
| **P99 ITL** | 33.08 ms | **26.80 ms (-19%)** |

The P99 number is the one that matters most -- the latency tail tightened a lot.

## Accuracy

`python3 -m sglang.test.few_shot_gsm8k --num-questions 200`

```
Accuracy: 0.945
```

Unchanged versus the TileLang backend, so the `1.0` scale assumption below
holds for this configuration.

## Scope

Decode only, by design. Prefill GPU time is 728.36 -> 728.65 ms per window,
i.e. noise. Prefill still runs TileLang; porting that is follow-up work.

## How to run it

```
--dsa-prefill-backend tilelang --dsa-decode-backend aiter
```

Both flags are required. Passing only `--dsa-decode-backend aiter` breaks the
ROCm default guard in `arg_groups/overrides.py` (it applies only when *both*
backends are unset), falls through to the CUDA-only `flashmla_kv` prefill
default, and crashes with `ImportError: flashmla_ops`. That is pre-existing
behaviour, not introduced here -- worth a separate cleanup.

Confirm from the log:

```
Set DSA backends for fp8_e4m3 KV Cache: prefill=tilelang, decode=aiter
```

## Known limitation

`q_scale` / `kv_scale` are set to `1.0`, matching the fused rope/cache path.
gsm8k confirms this is correct today. If a future path quantizes Q against a
per-tensor scale, the real scale must be plumbed through instead.

## Files touched

`python/sglang/srt/layers/attention/dsa_backend.py` only.
No changes to prefill, scheduling, or any non-ROCm path.
