### PR TITLE
[diffusion] feat: add --encode-only serving mode returning encoder outputs via POST /encode

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -23,6 +23,7 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.realtime import (
 )
 from sglang.multimodal_gen.runtime.entrypoints.openai.utils import build_sampling_params
 from sglang.multimodal_gen.runtime.entrypoints.post_training import (
+    encode_api,
     rollout_api,
     weights_api,
 )
@@ -409,6 +410,7 @@ def create_app(server_args: ServerArgs):
     app.include_router(mesh_api.router)
     app.include_router(weights_api.router)
     app.include_router(rollout_api.router)
+    app.include_router(encode_api.router)
 
     app.state.server_args = server_args
     return app

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/encode_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/encode_api.py
@@ -1,0 +1,99 @@
+"""Encode-only HTTP API (``POST /encode``), served with --encode-only."""
+
+from __future__ import annotations
+
+import msgspec
+from fastapi import APIRouter, HTTPException, Response
+
+from sglang.multimodal_gen.configs.sample.sampling_params import generate_request_id
+from sglang.multimodal_gen.runtime.entrypoints.openai.utils import build_sampling_params
+from sglang.multimodal_gen.runtime.entrypoints.post_training.io_struct import (
+    EncodeRequest,
+    EncodeResponse,
+)
+from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
+    _maybe_serialize,
+)
+from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
+from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
+from sglang.multimodal_gen.runtime.server_args import get_global_server_args
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+router = APIRouter(tags=["encode"])
+
+
+def _build_sampling_kwargs(request: EncodeRequest) -> dict:
+    sampling_kwargs: dict = dict(
+        prompt=request.prompt,
+        negative_prompt=request.negative_prompt,
+        seed=request.seed,
+        generator_device=request.generator_device,
+        width=request.width,
+        height=request.height,
+        num_frames=request.num_frames,
+        fps=request.fps,
+        image_path=request.image_path,
+        video_path=request.video_path,
+        suppress_logs=request.suppress_logs,
+        save_output=False,
+    )
+    if request.extra_sampling_params:
+        sampling_kwargs.update(request.extra_sampling_params)
+    return {k: v for k, v in sampling_kwargs.items() if v is not None}
+
+
+@router.post(
+    "/encode",
+    response_class=Response,
+    responses={
+        200: {
+            "model": EncodeResponse,
+            "content": {"application/msgpack": {}},
+        }
+    },
+)
+async def encode(request: EncodeRequest):
+    request_id = generate_request_id()
+    server_args = get_global_server_args()
+    if not server_args.encode_only:
+        raise HTTPException(
+            status_code=400, detail="Server was not launched with --encode-only"
+        )
+    sampling_kwargs = _build_sampling_kwargs(request)
+    try:
+        sampling_params = build_sampling_params(request_id, **sampling_kwargs)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid sampling params: {exc}"
+        ) from exc
+    pipeline_request = prepare_request(
+        server_args=server_args, sampling_params=sampling_params
+    )
+    try:
+        output_batch: OutputBatch = await async_scheduler_client.forward(
+            pipeline_request
+        )
+    except Exception as exc:
+        logger.error("Encode failed: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Encode failed: {exc}") from exc
+    if output_batch.error:
+        raise HTTPException(status_code=500, detail=output_batch.error)
+    if output_batch.encoder_output is None:
+        raise HTTPException(status_code=500, detail="No encoder output produced")
+    inference_time_s = (
+        output_batch.metrics.total_duration_s
+        if output_batch.metrics and output_batch.metrics.total_duration_s > 0
+        else None
+    )
+    response = EncodeResponse(
+        request_id=request_id,
+        prompt=request.prompt,
+        encoder_output=_maybe_serialize(output_batch.encoder_output),
+        inference_time_s=inference_time_s,
+    )
+    return Response(
+        content=msgspec.msgpack.encode(response.model_dump()),
+        media_type="application/msgpack",
+    )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/io_struct.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/io_struct.py
@@ -111,3 +111,34 @@ class RolloutResponse(BaseModel):
 
     inference_time_s: Optional[float] = None
     peak_memory_mb: Optional[float] = None
+
+
+class EncodeRequest(BaseModel):
+    prompt: str
+    negative_prompt: Optional[str] = None
+    seed: Optional[int] = None
+    generator_device: str = "cuda"
+
+    width: Optional[int] = None
+    height: Optional[int] = None
+    num_frames: Optional[int] = None
+    fps: Optional[int] = None
+
+    image_path: Optional[list[str]] = None
+    # ground-truth video to VAE-encode into latents (e.g. SFT targets)
+    video_path: Optional[str] = None
+
+    suppress_logs: bool = False
+
+    extra_sampling_params: Optional[dict[str, Any]] = None
+
+
+class EncodeResponse(BaseModel):
+    request_id: str
+    prompt: str
+
+    # serialized tensors: prompt_embeds, negative_prompt_embeds, attention
+    # masks, pooled embeds, image_latent, video_latents
+    encoder_output: dict[str, Any]
+
+    inference_time_s: Optional[float] = None

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -733,6 +733,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             rollout_trajectory_data=getattr(result, "rollout_trajectory_data", None),
             noise_pred=getattr(result, "noise_pred", None),
             trajectory_decoded=getattr(result, "trajectory_decoded", None),
+            encoder_output=result.encoder_output,
         )
 
     @staticmethod

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -40,6 +40,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBa
 from sglang.multimodal_gen.runtime.pipelines_core.stages import (
     DecodingStage,
     DenoisingStage,
+    EncoderOutputStage,
     ImageEncodingStage,
     ImageVAEEncodingStage,
     InputValidationStage,
@@ -102,8 +103,10 @@ class ComposedPipelineBase(ABC):
         use. The pipeline should be stateless and not hold any batch state.
         """
         self.server_args = server_args
-        self._disagg_role = server_args.disagg_role
-        self.validate_disagg_role(self._disagg_role)
+        self._role = (
+            RoleType.ENCODER if server_args.encode_only else server_args.disagg_role
+        )
+        self.validate_disagg_role(self._role)
 
         self.model_path: str = model_path
         self._stages: list[PipelineStage] = []
@@ -122,22 +125,26 @@ class ComposedPipelineBase(ABC):
         self._required_config_modules = list(base_required_config_modules)
         self._extra_config_module_map = dict(self._extra_config_module_map)
 
-        # Filter modules based on disaggregation role
-        if self._disagg_role != RoleType.MONOLITHIC:
+        # Filter modules based on pipeline role
+        if self._role != RoleType.MONOLITHIC:
             original_modules = list(self._required_config_modules)
             task_name = self.server_args.pipeline_config.task_type.name.lower()
+            extra_allowed_modules = self._get_extra_allowed_modules_for_role(
+                self._role, task_name
+            )
+            if server_args.encode_only:
+                extra_allowed_modules.add("vae")
+                server_args.pipeline_config.vae_config.load_encoder = True
             self._required_config_modules = filter_modules_for_role(
                 self._required_config_modules,
-                self._disagg_role,
-                extra_allowed_modules=self._get_extra_allowed_modules_for_role(
-                    self._disagg_role, task_name
-                ),
+                self._role,
+                extra_allowed_modules=extra_allowed_modules,
             )
             skipped = set(original_modules) - set(self._required_config_modules)
             if skipped:
                 logger.info(
-                    "Disagg role=%s: skipping modules %s",
-                    self._disagg_role.value,
+                    "Role=%s: skipping modules %s",
+                    self._role.value,
                     sorted(skipped),
                 )
 
@@ -164,6 +171,8 @@ class ComposedPipelineBase(ABC):
 
         logger.info("Creating pipeline stages...")
         self.create_pipeline_stages(self.server_args)
+        if self.server_args.encode_only:
+            self.add_stage(EncoderOutputStage(vae=self.get_module("vae")))
 
     def get_module(self, module_name: str, default_value: Any = None) -> Any:
         return self.modules.get(module_name, default_value)
@@ -299,9 +308,9 @@ class ComposedPipelineBase(ABC):
                 if hasattr(pipeline_cfg, "post_init"):
                     pipeline_cfg.post_init()
                 logger.info(
-                    "Disagg role=%s: initialized %s config from HF JSON "
+                    "Role=%s: initialized %s config from HF JSON "
                     "(spatial_compression_ratio=%s)",
-                    self._disagg_role.value,
+                    self._role.value,
                     module_name,
                     getattr(
                         getattr(pipeline_cfg, "arch_config", None),
@@ -311,9 +320,9 @@ class ComposedPipelineBase(ABC):
                 )
             except Exception as e:
                 logger.warning(
-                    "Disagg role=%s: failed to read HF config for skipped "
+                    "Role=%s: failed to read HF config for skipped "
                     "component %s: %s",
-                    self._disagg_role.value,
+                    self._role.value,
                     module_name,
                     e,
                 )
@@ -371,15 +380,15 @@ class ComposedPipelineBase(ABC):
 
                     module_role = get_module_role("transformer_2")
                     if (
-                        self._disagg_role == RoleType.MONOLITHIC
+                        self._role == RoleType.MONOLITHIC
                         or module_role is None
-                        or module_role == self._disagg_role
+                        or module_role == self._role
                     ):
                         self.required_config_modules.append("transformer_2")
                     else:
                         logger.info(
-                            "Disagg role=%s: skipping dynamically added module transformer_2",
-                            self._disagg_role.value,
+                            "Role=%s: skipping dynamically added module transformer_2",
+                            self._role.value,
                         )
             else:
                 logger.info(
@@ -403,9 +412,9 @@ class ComposedPipelineBase(ABC):
             len(model_index) > 1
         ), "model_index.json must contain at least one pipeline module"
 
-        # In disagg mode, read HF config for skipped components (e.g., VAE)
+        # For partial roles, read HF config for skipped components (e.g., VAE)
         # so that update_model_arch + post_init can derive pipeline_config.
-        if self._disagg_role != RoleType.MONOLITHIC:
+        if self._role != RoleType.MONOLITHIC:
             self._init_skipped_component_configs(model_index, server_args)
 
         model_index = {
@@ -575,14 +584,14 @@ class ComposedPipelineBase(ABC):
         role_affinity: RoleType,
         stage_name: str,
     ) -> bool:
-        if self._disagg_role == RoleType.MONOLITHIC:
+        if self._role == RoleType.MONOLITHIC:
             return True
-        if role_affinity == self._disagg_role:
+        if role_affinity == self._role:
             return True
 
         logger.info(
-            "Disagg role=%s: skipping stage %s (affinity=%s)",
-            self._disagg_role.value,
+            "Role=%s: skipping stage %s (affinity=%s)",
+            self._role.value,
             stage_name,
             role_affinity.value,
         )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -230,6 +230,8 @@ class Req:
     output: torch.Tensor | None = None
     audio: torch.Tensor | None = None
     audio_sample_rate: int | None = None
+    # encoder tensors collected by EncoderOutputStage (encode-only serving)
+    encoder_output: dict[str, Any] | None = None
 
     def __init__(self, **kwargs):
         # Initialize dataclass fields
@@ -455,6 +457,7 @@ class OutputBatch:
     trajectory_latents: torch.Tensor | None = None
     rollout_trajectory_data: RolloutTrajectoryData | None = None
     trajectory_decoded: list[torch.Tensor] | None = None
+    encoder_output: dict[str, Any] | None = None
     error: str | None = None
     output_file_paths: list[str] | None = None
 
@@ -472,6 +475,7 @@ class OutputBatch:
         self.trajectory_timesteps = None
         self.trajectory_latents = None
         self.rollout_trajectory_data = None
+        self.encoder_output = None
         self.trajectory_decoded = None
         self.output_file_paths = None
         self.raw_frame_batches = None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/__init__.py
@@ -26,6 +26,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising_dmd import (
 )
 from sglang.multimodal_gen.runtime.pipelines_core.stages.encoding import EncodingStage
 from sglang.multimodal_gen.runtime.pipelines_core.stages.image_encoding import (
+    EncoderOutputStage,
     ImageEncodingStage,
     ImageVAEEncodingStage,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "ConditionEncodingStage",
     "AuxiliaryConditionEncodingStage",
     "DecodingStage",
+    "EncoderOutputStage",
     "ImageEncodingStage",
     "ImageVAEEncodingStage",
     "TextEncodingStage",

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/image_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/image_encoding.py
@@ -36,6 +36,9 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
     VerificationResult,
 )
+from sglang.multimodal_gen.runtime.post_training.rollout_denoising_mixin import (
+    _kwargs_to_cpu,
+)
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.precision import (
@@ -46,6 +49,7 @@ from sglang.multimodal_gen.runtime.utils.precision import (
     temporary_module_dtype,
 )
 from sglang.multimodal_gen.runtime.utils.vision import (
+    load_video,
     normalize,
     numpy_to_pt,
     pil_to_numpy,
@@ -1092,3 +1096,92 @@ class ImageVAEEncodingStage(PipelineStage):
         #     "image_latent", batch.image_latent, [V.is_tensor, V.with_dims(5)]
         # )
         return result
+
+
+class EncoderOutputStage(ImageVAEEncodingStage):
+    """Terminal stage for encode-only serving: collects encoder tensors on CPU."""
+
+    def __init__(self, vae: ParallelTiledVAE | None = None) -> None:
+        super().__init__(vae=vae)
+
+    def forward(self, batch: Req, server_args: ServerArgs) -> Req:
+        video_latents = None
+        if batch.video_path is not None:
+            if self.vae is None:
+                raise ValueError("video_path requires a VAE, but none is loaded")
+            video_latents = self._encode_video(batch, server_args)
+        batch.encoder_output = _kwargs_to_cpu(
+            {
+                "prompt_embeds": batch.prompt_embeds,
+                "negative_prompt_embeds": batch.negative_prompt_embeds,
+                "prompt_attention_mask": batch.prompt_attention_mask,
+                "negative_attention_mask": batch.negative_attention_mask,
+                "pooled_embeds": batch.pooled_embeds,
+                "neg_pooled_embeds": batch.neg_pooled_embeds,
+                "image_latent": batch.image_latent,
+                "video_latents": video_latents,
+            }
+        )
+        return batch
+
+    def _encode_video(self, batch: Req, server_args: ServerArgs) -> torch.Tensor:
+        frames = load_video(batch.video_path)
+        if batch.num_frames is not None:
+            frames = frames[: batch.num_frames]
+        frames = [
+            frame.resize((batch.width, batch.height), PIL.Image.LANCZOS)
+            for frame in frames
+        ]
+        # T frames of (1, C, H, W) stacked to (1, C, T, H, W)
+        video = torch.stack([self.preprocess(frame) for frame in frames], dim=2)
+        video = video.to(get_local_torch_device(), dtype=torch.float32)
+
+        vae_dtype = resolve_precision(
+            server_args, self.component_name, precision_attr="vae_precision"
+        )
+        vae_autocast_enabled = autocast_enabled(vae_dtype, server_args.disable_autocast)
+        with self.use_declared_component(
+            component_name=self.component_name,
+            module=self.vae,
+        ) as vae:
+            assert vae is not None
+            self.vae = vae
+            with autocast_context(vae_dtype, server_args.disable_autocast):
+                if server_args.pipeline_config.vae_tiling:
+                    self.vae.enable_tiling()
+                if not vae_autocast_enabled:
+                    video = video.to(vae_dtype)
+                video = server_args.pipeline_config.preprocess_vae_encode(
+                    video, self.vae
+                )
+                with temporary_module_dtype(
+                    self.vae, vae_dtype, enabled=not vae_autocast_enabled
+                ) as vae:
+                    latent_dist = vae.encode(video)
+                if isinstance(latent_dist, AutoencoderKLOutput):
+                    latent_dist = latent_dist.latent_dist
+
+            sample_mode = server_args.pipeline_config.vae_config.encode_sample_mode()
+            latents = self.retrieve_latents(
+                latent_dist, batch.generator, sample_mode=sample_mode
+            )
+            latents = server_args.pipeline_config.postprocess_vae_encode(
+                latents, self.vae
+            )
+            normalized = server_args.pipeline_config.normalize_vae_encode(
+                latents, self.vae
+            )
+            if normalized is not None:
+                return normalized
+            scaling_factor, shift_factor = (
+                server_args.pipeline_config.get_decode_scale_and_shift(
+                    device=latents.device, dtype=latents.dtype, vae=self.vae
+                )
+            )
+            return self.scale_and_shift_encode_latents(
+                latents, scaling_factor, shift_factor
+            )
+
+    def build_dedup_fingerprint(self, batch: Req, server_args: ServerArgs) -> int:
+        # Output depends on the prompt as well, so never share across requests.
+        return id(batch)

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -386,6 +386,9 @@ class ServerArgs(DisaggServerArgsMixin):
     # MoE parameters used by Wan2.2
     boundary_ratio: float | None = None
 
+    # Serve only encoder-side components (text encoders, VAE); no denoising/decoding
+    encode_only: bool = False
+
     # Disaggregation (pool mode only — launched via launch_pool_disagg_server())
     disagg_role: RoleType = RoleType.MONOLITHIC
     disagg_timeout: int = 3600
@@ -496,6 +499,8 @@ class ServerArgs(DisaggServerArgsMixin):
 
     def _validate_parameters(self):
         """check consistency and raise errors for invalid configs"""
+        if self.encode_only and self.disagg_role != RoleType.MONOLITHIC:
+            raise ValueError("--encode-only cannot be combined with --disagg-role")
         self._validate_pipeline()
         self._validate_offload()
         if not current_platform.is_cpu():
@@ -1811,6 +1816,12 @@ class ServerArgs(DisaggServerArgsMixin):
             action="store_true",
             default=ServerArgs.enable_batching_metrics,
             help="Log periodic batch efficiency metrics such as realized batch size and queue wait time.",
+        )
+        parser.add_argument(
+            "--encode-only",
+            action="store_true",
+            default=ServerArgs.encode_only,
+            help="Serve only encoder-side components (text encoders, VAE); requests return encoder outputs instead of generated media.",
         )
         parser.add_argument(
             "--host",

--- a/python/sglang/multimodal_gen/test/unit/test_disagg_roles.py
+++ b/python/sglang/multimodal_gen/test/unit/test_disagg_roles.py
@@ -222,7 +222,7 @@ def _make_pipeline(role: RoleType) -> _FakePipeline:
     pipeline.modules = {}
     pipeline._stages = []
     pipeline._stage_name_mapping = {}
-    pipeline._disagg_role = role
+    pipeline._role = role
     return pipeline
 
 
@@ -504,7 +504,7 @@ class TestStageAffinityAndValidation(_GlobalStageArgsMixin, unittest.TestCase):
         pipeline.server_args = self._install_stage_server_args(
             pipeline_config=Hunyuan3D2PipelineConfig(paint_enable=paint_enable)
         )
-        pipeline._disagg_role = role
+        pipeline._role = role
         pipeline.modules = {
             "hy3dshape_image_processor": object(),
             "hy3dshape_conditioner": object(),


### PR DESCRIPTION
## Motivation

Post-training frameworks (RL / SFT on diffusion models) need text-encoder embeddings and VAE latents for offline datasets, without loading the DiT. Disaggregation already provides role-based component filtering, but a standalone encoder role only speaks the ZMQ pool protocol back to a DiffusionServer head node and cannot serve HTTP, and its output is always forwarded to a denoiser.

## Modifications

- Add `--encode-only`: launches a normal monolithic server (HTTP server, scheduler, and launch topology unchanged) whose pipeline resolves its role to `ENCODER`, reusing the existing role-based module/stage filtering. `vae` is force-allowed for the role and its encoder submodule is loaded (`load_encoder=True`, T2V configs default it to False).
- Rename the pipeline attribute `_disagg_role` to `_role` since it is now derived from more than the disagg config. Scheduler/orchestrator attributes are untouched; `--disagg-role` semantics are unchanged.
- Add `EncoderOutputStage`, appended automatically in encode-only mode: optionally VAE-encodes an input video (`video_path`, e.g. SFT ground truth) into normalized latents via the pipeline-config encode hooks, and collects prompt embeds / attention masks / pooled embeds / `image_latent` / `video_latents` into `Req.encoder_output` on CPU.
- Add `POST /encode` under `entrypoints/post_training`, returning the collected tensors with the existing safetensors + msgpack serialization.
- Reject `--encode-only` combined with `--disagg-role` at args validation.

## Testing

- Wan2.1-T2V-1.3B, `sglang serve --encode-only`: loads only text_encoder/tokenizer/vae (`Role=encoder: skipping modules ['transformer']`, denoising/decoding stages skipped). `POST /encode` with a 9-frame 256x256 video returns `prompt_embeds (1, 512, 4096)`, attention masks, and `video_latents (1, 16, 3, 32, 32)` matching the Wan VAE compression ratios; two identical requests return bit-identical tensors.
- Monolithic regression: 256x256, 9-frame, 2-step T2V generation through DiffGenerator succeeds after the rename.
- `test_disagg_roles.py` 47 passed; `test_server_args.py` 117 passed (1 pre-existing environment-dependent failure also present on clean main).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30597234012](https://github.com/sgl-project/sglang/actions/runs/30597234012)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30597233942](https://github.com/sgl-project/sglang/actions/runs/30597233942)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->