### PR TITLE
[Fix] Validate structural_tag mutual exclusivity in SamplingParams.verify()

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -196,9 +196,10 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
             self.json_schema,
             self.regex,
             self.ebnf,
+            self.structural_tag,
         ]  # since mutually exclusive, only one can be set
         if sum(x is not None for x in grammars) > 1:
-            raise ValueError("Only one of regex, json_schema, or ebnf can be set.")
+            raise ValueError("Only one of regex, json_schema, ebnf, or structural_tag can be set.")
 
     def normalize(self, tokenizer):
         # Process stop strings


### PR DESCRIPTION
## Problem

Setting `structural_tag` together with `regex`/`ebnf`/`json_schema` passes validation silently. One constraint wins per the `elif` order in `grammar_manager.py` and the other is silently dropped — no error, no warning, no log.

## Root Cause

`structural_tag` was added in #3566 after the `grammars` mutual-exclusivity check was introduced in #2526. `grammar_manager.py` was updated but `sampling_params.py` was never updated.

## Fix

Added `self.structural_tag` to the `grammars` list and updated the error message.

**Before:** `regex + structural_tag` → passes verify() silently → structural_tag dropped
**After:** `regex + structural_tag` → `ValueError: Only one of regex, json_schema, ebnf, or structural_tag can be set.`

## Reproduction

```python
sp = SamplingParams(regex='a+', structural_tag='{...}')
sp.verify(vocab_size)  # Before: OK (bug), After: ValueError (correct)
```

Fixes #31680

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30598157454](https://github.com/sgl-project/sglang/actions/runs/30598157454)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30598157366](https://github.com/sgl-project/sglang/actions/runs/30598157366)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->