### PR TITLE
[Fix] Propagate priority in EmbeddingReqInput.__getitem__ for batched requests

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1117,6 +1117,7 @@ class EmbeddingReqInput:
                 text=[self.text[i]] if self.text is not None else None,
                 sampling_params=self.sampling_params[i],
                 is_cross_encoder_request=True,
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
@@ -1144,6 +1145,7 @@ class EmbeddingReqInput:
                     else None
                 ),
                 sampling_params=self.sampling_params[i],
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),


### PR DESCRIPTION
## Problem

`EmbeddingReqInput.__getitem__` splits batched embedding requests but drops the `priority` field entirely. Each subrequest gets `priority=None`, so embedding batches submitted with a priority are scheduled as if no priority was provided.

Both the cross-encoder and normal branches in `__getitem__` omit the field.

## Reproduction

```python
req = EmbeddingReqInput(text=["hello", "world"], priority=7)
req.normalize_batch_and_arguments()
print(req[0].priority)  # None (bug)
print(req[1].priority)  # None (bug)
```

## Fix

Added `priority=self.priority` to both branches of `__getitem__`.

**Before:** `req[0].priority` → `None` (priority silently dropped)
**After:** `req[0].priority` → `7` (priority correctly propagated)

Fixes #32844

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30598193644](https://github.com/sgl-project/sglang/actions/runs/30598193644)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30598193492](https://github.com/sgl-project/sglang/actions/runs/30598193492)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->