### PR TITLE
[dLLM] Cap and capacity-gate the dLLM staging token budget

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -929,10 +929,15 @@ class PrefillAdder:
             # rem_total_tokens charges max_new_tokens upfront per staging row
             # every round, so it goes negative long before the KV pool is
             # actually full; letting staging through anyway avoids stalling
-            # in-flight denoise blocks. It must still be capped at one block:
-            # a larger grant produces a variable-length row, and the denoise
-            # algorithms reshape the batch as uniform block_size rows.
-            _rem_tokens = min(self.rem_dllm_tokens, self.dllm_block_size)
+            # in-flight denoise blocks. Grant exactly one whole block or
+            # nothing: the denoise algorithms reshape the batch with
+            # `view(B, block_size)`, which admits neither a larger grant
+            # (variable-length row) nor a partial one (ragged row).
+            _rem_tokens = (
+                self.dllm_block_size
+                if self.rem_dllm_tokens >= self.dllm_block_size
+                else 0
+            )
 
         return _rem_tokens
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -926,7 +926,13 @@ class PrefillAdder:
             int(self.rem_total_tokens),
         )
         if _rem_tokens <= 0:
-            _rem_tokens = self.rem_dllm_tokens
+            # rem_total_tokens charges max_new_tokens upfront per staging row
+            # every round, so it goes negative long before the KV pool is
+            # actually full; letting staging through anyway avoids stalling
+            # in-flight denoise blocks. It must still be capped at one block:
+            # a larger grant produces a variable-length row, and the denoise
+            # algorithms reshape the batch as uniform block_size rows.
+            _rem_tokens = min(self.rem_dllm_tokens, self.dllm_block_size)
 
         return _rem_tokens
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -935,6 +935,14 @@ class PrefillAdder:
                 if self.rem_dllm_tokens >= self.dllm_block_size
                 else 0
             )
+        else:
+            # A positive sub-block budget rounds down to 0, it does NOT take
+            # the whole-block fallback: the fallback only overrides a
+            # rem_total_tokens driven negative by the upfront max_new_tokens
+            # charge, while a small positive budget is genuine and a full
+            # block would overshoot it. The min above caps at block_size, so
+            # this yields exactly one block or nothing.
+            _rem_tokens = _rem_tokens // self.dllm_block_size * self.dllm_block_size
 
         return _rem_tokens
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -926,13 +926,10 @@ class PrefillAdder:
             int(self.rem_total_tokens),
         )
         if _rem_tokens <= 0:
-            # rem_total_tokens charges max_new_tokens upfront per staging row
-            # every round, so it goes negative long before the KV pool is
-            # actually full; letting staging through anyway avoids stalling
-            # in-flight denoise blocks. Grant exactly one whole block or
-            # nothing: the denoise algorithms reshape the batch with
-            # `view(B, block_size)`, which admits neither a larger grant
-            # (variable-length row) nor a partial one (ragged row).
+            # rem_total_tokens charges max_new_tokens upfront per staging row,
+            # so it goes negative long before the KV pool is full. Grant one
+            # whole block or nothing: the denoise algorithms reshape with
+            # view(B, block_size), which admits neither a larger nor a ragged row.
             _rem_tokens = (
                 self.dllm_block_size
                 if self.rem_dllm_tokens >= self.dllm_block_size

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -792,7 +792,13 @@ class PrefillAdder:
             int(self.rem_total_tokens),
         )
         if _rem_tokens <= 0:
-            _rem_tokens = self.rem_dllm_tokens
+            # rem_total_tokens charges max_new_tokens upfront per staging row
+            # every round, so it goes negative long before the KV pool is
+            # actually full; letting staging through anyway avoids stalling
+            # in-flight denoise blocks. It must still be capped at one block:
+            # a larger grant produces a variable-length row, and the denoise
+            # algorithms reshape the batch as uniform block_size rows.
+            _rem_tokens = min(self.rem_dllm_tokens, self.dllm_block_size)
 
         return _rem_tokens
 

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -475,8 +475,11 @@ class RadixCache(BasePrefixCache):
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:kv_len_to_handle]
+        # Slice by the kv length, not len(token_ids): a dLLM FDFO request can
+        # hold committed KV beyond origin+output (its unresolved block lives in
+        # dllm_incomplete_ids only), and the tail free below must reclaim it.
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, : len(token_ids)
+            req.req_pool_idx, :kv_len_to_handle
         ]
 
         radix_key = RadixKey(

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -453,8 +453,11 @@ class RadixCache(SessionRadixCacheMixin, KVCacheEventMixin, BasePrefixCache):
             return
 
         token_ids = (req.origin_input_ids + req.output_ids)[:kv_len_to_handle]
+        # Slice by the kv length, not len(token_ids): a dLLM FDFO request can
+        # hold committed KV beyond origin+output (its unresolved block lives in
+        # dllm_incomplete_ids only), and the tail free below must reclaim it.
         kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, : len(token_ids)
+            req.req_pool_idx, :kv_len_to_handle
         ]
 
         radix_key = RadixKey(

--- a/test/registered/unit/managers/test_dllm_staging_token_budget.py
+++ b/test/registered/unit/managers/test_dllm_staging_token_budget.py
@@ -1,0 +1,83 @@
+"""Regression tests for the dLLM staging token-budget fallback cap.
+
+Bug: ``PrefillAdder._get_dllm_remain_tokens`` falls back to ``rem_dllm_tokens``
+when ``rem_total_tokens`` is exhausted (it charges ``max_new_tokens`` upfront
+per staging row every round, so long-output workloads drive it negative long
+before the KV pool fills). Uncapped, the fallback can grant a staging row more
+than ``block_size`` tokens, producing a variable-length row that crashes the
+denoise algorithms' uniform-block reshape (``view(B, block_size)``).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_policy import PrefillAdder
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_adder(
+    *, rem_dllm_tokens: int, dllm_block_size: int, available_tokens: int
+) -> PrefillAdder:
+    """Build a PrefillAdder with only the state `_get_dllm_remain_tokens` reads.
+
+    `rem_total_tokens` is a property over the allocator/tree-cache sizes minus
+    `rem_total_token_offset`; drive it via `available_tokens`.
+    """
+    adder = PrefillAdder.__new__(PrefillAdder)
+    adder.rem_dllm_tokens = rem_dllm_tokens
+    adder.dllm_block_size = dllm_block_size
+    adder.is_all_swa = False
+    adder.is_hybrid_swa = False
+    adder.is_hybrid_ssm_cache = False
+    adder.token_to_kv_pool_allocator = SimpleNamespace(
+        available_size=lambda: available_tokens
+    )
+    adder.tree_cache = SimpleNamespace(evictable_size=lambda: 0)
+    adder.rem_total_token_offset = 0
+    return adder
+
+
+class TestDllmStagingTokenBudgetFallbackCap(CustomTestCase):
+    BLOCK_SIZE = 32
+
+    def test_exhausted_budget_fallback_is_capped_at_one_block(self):
+        # rem_total_tokens <= 0 takes the fallback branch. The grant must be
+        # capped at one block: anything larger produces a variable-length
+        # staging row and breaks the uniform view(B, block_size) reshape.
+        adder = _make_adder(
+            rem_dllm_tokens=4096,
+            dllm_block_size=self.BLOCK_SIZE,
+            available_tokens=-100,
+        )
+        self.assertEqual(adder._get_dllm_remain_tokens(), self.BLOCK_SIZE)
+
+    def test_fallback_cap_does_not_inflate_a_smaller_dllm_budget(self):
+        # The cap is min(rem_dllm_tokens, block_size), not a blanket
+        # block_size: when the dLLM budget itself is below one block, the
+        # fallback must not grant more than that budget.
+        adder = _make_adder(
+            rem_dllm_tokens=16,
+            dllm_block_size=self.BLOCK_SIZE,
+            available_tokens=-100,
+        )
+        self.assertEqual(adder._get_dllm_remain_tokens(), 16)
+
+    def test_normal_budget_path_is_unaffected(self):
+        # With rem_total_tokens still positive the pre-existing
+        # min(rem_dllm, block, total) result must be unchanged by the cap.
+        adder = _make_adder(
+            rem_dllm_tokens=4096,
+            dllm_block_size=self.BLOCK_SIZE,
+            available_tokens=20,
+        )
+        self.assertEqual(adder._get_dllm_remain_tokens(), 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_dllm_staging_token_budget.py
+++ b/test/registered/unit/managers/test_dllm_staging_token_budget.py
@@ -85,15 +85,28 @@ class TestDllmStagingTokenBudgetFallbackCap(CustomTestCase):
         )
         self.assertEqual(adder._get_dllm_remain_tokens(), self.BLOCK_SIZE)
 
-    def test_normal_budget_path_is_unaffected(self):
-        # Positive rem_total_tokens: min(rem_dllm, block, total), unchanged
-        # by the cap.
+    def test_normal_path_rounds_sub_block_budget_to_zero(self):
+        # Positive rem_total_tokens below one block: round to 0 (NO_TOKEN),
+        # not to a ragged 20-token row — and not to the whole-block fallback,
+        # since a small positive budget is genuine and a full block would
+        # overshoot it.
         adder = _make_adder(
             rem_dllm_tokens=4096,
             dllm_block_size=self.BLOCK_SIZE,
             available_tokens=20,
         )
-        self.assertEqual(adder._get_dllm_remain_tokens(), 20)
+        self.assertEqual(adder._get_dllm_remain_tokens(), 0)
+
+    def test_normal_path_grants_one_full_block(self):
+        # Positive rem_total_tokens at or above one block: grant exactly one
+        # block (the min already caps at block_size).
+        for available in (self.BLOCK_SIZE, 100):
+            adder = _make_adder(
+                rem_dllm_tokens=4096,
+                dllm_block_size=self.BLOCK_SIZE,
+                available_tokens=available,
+            )
+            self.assertEqual(adder._get_dllm_remain_tokens(), self.BLOCK_SIZE)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_dllm_staging_token_budget.py
+++ b/test/registered/unit/managers/test_dllm_staging_token_budget.py
@@ -6,9 +6,6 @@ per staging row every round, so long-output workloads drive it negative long
 before the KV pool fills). Uncapped, the fallback can grant a staging row more
 than ``block_size`` tokens, producing a variable-length row that crashes the
 denoise algorithms' uniform-block reshape (``view(B, block_size)``).
-
-The fallback must grant a whole block or nothing: a sub-block grant is just as
-unusable as an oversized one, since ``view(B, block_size)`` admits neither.
 """
 
 import unittest
@@ -72,7 +69,6 @@ class TestDllmStagingTokenBudgetFallbackCap(CustomTestCase):
         self.assertEqual(adder._get_dllm_remain_tokens(), 0)
 
     def test_fallback_refuses_a_zero_dllm_budget(self):
-        # Nothing left to grant at all.
         adder = _make_adder(
             rem_dllm_tokens=0,
             dllm_block_size=self.BLOCK_SIZE,
@@ -90,8 +86,8 @@ class TestDllmStagingTokenBudgetFallbackCap(CustomTestCase):
         self.assertEqual(adder._get_dllm_remain_tokens(), self.BLOCK_SIZE)
 
     def test_normal_budget_path_is_unaffected(self):
-        # With rem_total_tokens still positive the pre-existing
-        # min(rem_dllm, block, total) result must be unchanged by the cap.
+        # Positive rem_total_tokens: min(rem_dllm, block, total), unchanged
+        # by the cap.
         adder = _make_adder(
             rem_dllm_tokens=4096,
             dllm_block_size=self.BLOCK_SIZE,

--- a/test/registered/unit/managers/test_dllm_staging_token_budget.py
+++ b/test/registered/unit/managers/test_dllm_staging_token_budget.py
@@ -6,6 +6,9 @@ per staging row every round, so long-output workloads drive it negative long
 before the KV pool fills). Uncapped, the fallback can grant a staging row more
 than ``block_size`` tokens, producing a variable-length row that crashes the
 denoise algorithms' uniform-block reshape (``view(B, block_size)``).
+
+The fallback must grant a whole block or nothing: a sub-block grant is just as
+unusable as an oversized one, since ``view(B, block_size)`` admits neither.
 """
 
 import unittest
@@ -57,16 +60,34 @@ class TestDllmStagingTokenBudgetFallbackCap(CustomTestCase):
         )
         self.assertEqual(adder._get_dllm_remain_tokens(), self.BLOCK_SIZE)
 
-    def test_fallback_cap_does_not_inflate_a_smaller_dllm_budget(self):
-        # The cap is min(rem_dllm_tokens, block_size), not a blanket
-        # block_size: when the dLLM budget itself is below one block, the
-        # fallback must not grant more than that budget.
+    def test_fallback_refuses_a_sub_block_dllm_budget(self):
+        # A partial grant is as unusable as an oversized one: the denoise
+        # reshape needs whole block_size rows, so a budget below one block
+        # must yield 0 (NO_TOKEN) rather than a ragged row.
         adder = _make_adder(
             rem_dllm_tokens=16,
             dllm_block_size=self.BLOCK_SIZE,
             available_tokens=-100,
         )
-        self.assertEqual(adder._get_dllm_remain_tokens(), 16)
+        self.assertEqual(adder._get_dllm_remain_tokens(), 0)
+
+    def test_fallback_refuses_a_zero_dllm_budget(self):
+        # Nothing left to grant at all.
+        adder = _make_adder(
+            rem_dllm_tokens=0,
+            dllm_block_size=self.BLOCK_SIZE,
+            available_tokens=-100,
+        )
+        self.assertEqual(adder._get_dllm_remain_tokens(), 0)
+
+    def test_fallback_grants_exactly_one_block_at_the_boundary(self):
+        # Exactly one block is available: grant it whole, don't round down.
+        adder = _make_adder(
+            rem_dllm_tokens=self.BLOCK_SIZE,
+            dllm_block_size=self.BLOCK_SIZE,
+            available_tokens=-100,
+        )
+        self.assertEqual(adder._get_dllm_remain_tokens(), self.BLOCK_SIZE)
 
     def test_normal_budget_path_is_unaffected(self):
         # With rem_total_tokens still positive the pre-existing

--- a/test/registered/unit/mem_cache/test_radix_cache_dllm_abort_free.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_dllm_abort_free.py
@@ -1,0 +1,115 @@
+"""Regression tests for KV reclaim in RadixCache.cache_finished_req.
+
+Bug: ``cache_finished_req`` sliced the request's ``req_to_token`` row by
+``len(origin_input_ids + output_ids)``. A dLLM FDFO request aborted with an
+unresolved denoise block holds committed KV beyond that length (the block's
+tokens live only in ``dllm_incomplete_ids``), so the tail free never saw those
+slots and every such abort leaked one block of KV -- the idle invariant check
+then fails with ``pool memory leak detected``. The row must be sliced by
+``kv_len_to_handle`` (the KV length) instead.
+"""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.radix_cache import RadixCache
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_KV_BASE = 100  # req_to_token row fingerprint: kv slot for position i is 100+i
+
+
+class _RecordingAllocator:
+    """Records every KV slot freed through the segment APIs."""
+
+    def __init__(self):
+        self.device = "cpu"
+        self.freed = []
+
+    def free_segments(self, segments):
+        for free_index, _start_pos in segments:
+            self.freed.extend(free_index.tolist())
+
+    def free_segment(self, free_index, *, start_pos):
+        self.freed.extend(free_index.tolist())
+
+
+def _make_cache(allocator, max_context: int = 64):
+    pool = SimpleNamespace(
+        req_to_token=(
+            torch.arange(_KV_BASE, _KV_BASE + max_context, dtype=torch.int32)
+            .unsqueeze(0)
+            .repeat(4, 1)
+        )
+    )
+    return RadixCache(
+        CacheInitParams(
+            disable=False,
+            req_to_token_pool=pool,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+        )
+    )
+
+
+def _make_req(*, num_prompt: int, num_output: int):
+    return SimpleNamespace(
+        rid="test-req",
+        origin_input_ids=array("q", range(num_prompt)),
+        output_ids=array("q", range(1000, 1000 + num_output)),
+        req_pool_idx=1,
+        cache_protected_len=0,
+        extra_key=None,
+        priority=0,
+        last_node=None,
+        session=None,
+    )
+
+
+class TestCacheFinishedReqFreesByKvLen(CustomTestCase):
+    def test_aborted_fdfo_req_frees_kv_beyond_token_ids(self):
+        # Abort with an unresolved denoise block: 8 tokens in origin+output,
+        # but 12 KV slots committed (the last 4 belong to the unresolved
+        # block). Every committed slot must end up either freed or held by the
+        # radix tree -- the pre-fix slicing left the 4 tail slots unaccounted.
+        allocator = _RecordingAllocator()
+        cache = _make_cache(allocator)
+        req = _make_req(num_prompt=6, num_output=2)
+        kv_len = 12
+
+        cache.cache_finished_req(req, kv_len_to_handle=kv_len)
+
+        self.assertEqual(
+            sorted(allocator.freed),
+            [_KV_BASE + 8, _KV_BASE + 9, _KV_BASE + 10, _KV_BASE + 11],
+        )
+        self.assertEqual(cache.evictable_size(), 8)
+        self.assertEqual(len(allocator.freed) + cache.evictable_size(), kv_len)
+
+    def test_ar_finished_req_reclaim_is_unchanged(self):
+        # AR invariance: an autoregressive request finishes with
+        # kv_len_to_handle < len(origin+output) (the last output token's KV is
+        # never committed), where the kv-length slice and the old
+        # len(token_ids) slice are identical -- nothing extra may be freed.
+        allocator = _RecordingAllocator()
+        cache = _make_cache(allocator)
+        req = _make_req(num_prompt=6, num_output=2)
+        kv_len = 7
+
+        cache.cache_finished_req(req, kv_len_to_handle=kv_len)
+
+        self.assertEqual(allocator.freed, [])
+        self.assertEqual(cache.evictable_size(), kv_len)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_radix_cache_dllm_abort_free.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_dllm_abort_free.py
@@ -69,6 +69,7 @@ def _make_req(*, num_prompt: int, num_output: int):
         req_pool_idx=1,
         cache_protected_len=0,
         extra_key=None,
+        cache_salt=None,
         priority=0,
         last_node=None,
         session=None,


### PR DESCRIPTION
## Motivation

One device-agnostic dLLM scheduling-budget fix found while running LLaDA2 FDFO at large batch sizes, plus regression tests pinning an abort-path KV reclaim that upstream has since fixed independently. Reproduces on any backend (no device-specific branches involved).

### Bug 1: KV leak when aborting FDFO requests with unresolved blocks

`RadixCache.cache_finished_req` slices `req_to_token` by `len(origin_input_ids + output_ids)`, but an FDFO request's unresolved denoise block exists only in `dllm_incomplete_ids` — its committed KV slots lie **beyond** that length. The tail free never sees those slots, so every aborted incomplete request orphans one block of KV, and the pool never recovers.

**How to reproduce** (radix cache on, i.e. default):

```bash
# 1. Launch a dLLM server; strict idle check turns the leak warning into a hard error.
#    --dllm-algorithm is the only required dLLM flag (FDFO and radix cache are on by
#    default; the attention backend is auto-resolved per platform).
SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE=1 \
python3 -m sglang.launch_server --model inclusionAI/LLaDA2.0-mini --trust-remote-code \
  --dllm-algorithm LowConfidence

# 2. Send concurrent long generations and hard-disconnect the clients mid-generation
#    (client-side timeout closes the connection -> server aborts the request while
#    its current denoise block is still unresolved)
python3 - <<'EOF'
import concurrent.futures, requests
def hit(i):
    try:
        requests.post("http://127.0.0.1:30000/generate",
            json={"text": "Write a very long story.",
                  "sampling_params": {"max_new_tokens": 2048}},
            timeout=5)
    except requests.exceptions.ReadTimeout:
        pass
with concurrent.futures.ThreadPoolExecutor(128) as ex:
    list(ex.map(hit, range(128)))
EOF

# 3. Wait for the server to go idle
```

Before this PR: once the server goes idle, the invariant check fails (crash under strict mode, repeated warnings otherwise):

```
File ".../sglang/srt/managers/scheduler.py", line 3662, in on_idle
  self.invariant_checker._report_leak("pool", "\n".join(messages))
File ".../sglang/srt/managers/scheduler_components/invariant_checker.py", line 428, in _report_leak
  raise_error_or_warn(
ValueError: pool memory leak detected! [full] total=635008, available=32, evictable=634944, protected=0, session_held=0, uncached=0
```

The accounting pins it down: `available + evictable + protected + session_held + uncached = 634976`, which is short of `total = 635008` by exactly **32 tokens = one denoise block** — this trace had one aborted incomplete request. The pool shrinks by one block per aborted incomplete request and never recovers (bisected with per-abort allocator accounting).

With the fix (now upstream's `owned_kv_len` slicing in `cache_finished_req`): the idle check passes; the pool returns to full size after every abort wave.

**Resolution note**: upstream's `cache_finished_req` refactor now slices by `owned_kv_len`, which contains exactly this fix, so this PR no longer carries a code change here. It keeps two unit tests (`test_radix_cache_dllm_abort_free.py`) pinning the reclaim behavior — they fail on the pre-refactor code and guard against regression.

### Bug 2: uncapped staging token-budget fallback crashes the denoise reshape

`PrefillAdder._get_dllm_remain_tokens` falls back to `rem_dllm_tokens` when `rem_total_tokens` is exhausted. `rem_total_tokens` charges `max_new_tokens` upfront for every staging row on every scheduling round, so long-output workloads drive it negative long before the KV pool actually fills — the fallback is then the common path, and it is uncapped: a staging row can be granted more than `block_size` tokens (e.g. a mid-prompt prefill row's whole remaining prompt). That produces a variable-length row, which crashes the denoise algorithms' uniform-block reshape (`view(B, block_size)`).

**How to reproduce**:

```bash
# 1. Launch as above (strict-mode env not needed)
python3 -m sglang.launch_server --model inclusionAI/LLaDA2.0-mini --trust-remote-code \
  --dllm-algorithm LowConfidence

# 2. Long-output workload at full batch (bench_serving defaults to port 30000,
#    matching the server default)
python3 -m sglang.bench_serving --backend sglang --dataset-name random \
  --num-prompts 512 --random-input-len 512 --random-output-len 2048 --random-range-ratio 1
```

Before this PR: once `rem_total_tokens` goes negative (reliably within the run), the scheduler admits an over-sized staging row and the server crashes in the denoise step with `RuntimeError: shape '[B, 32]' is invalid for input of size N`.

After this PR: a single staging grant is capped at one block, every row stays uniform, and the run completes.

## Modifications

- `managers/schedule_policy.py` — the staging token budget in `_get_dllm_remain_tokens`, in three layers:
  - The exhausted-budget fallback grants exactly one block or nothing (never a ragged or oversized row — the denoise algorithms reshape with `view(B, block_size)`), and only when `cur_rem_tokens` covers the full admission charge (`ceil_paged(block_size) + page_size + mamba gap reserve`, the same amount `PrefillBudget.reserve()` debits): `rem_total_tokens` goes negative from upfront `max_new_tokens` accounting long before the pool fills, but real exhaustion must still refuse.
  - Positive budgets round down to whole blocks (a sub-block budget is a refusal, not a ragged row).
  - Rows reusing retained FDFO KV allocate zero fresh tokens and are exempt from both gates; the exemption mirrors `alloc_for_extend`'s `reuse_kv` predicate verbatim (`req.kv.holds_kv and dllm_incomplete_ids`).
- `dllm/mixin/scheduler.py` — `process_dllm_staging_reqs` treats NO_TOKEN as a per-row refusal instead of returning, so a refused fresh row cannot starve zero-cost reuse rows queued behind it; any refusal still reports NO_TOKEN so incoming requests don't jump ahead.
- AR is unaffected: `_get_dllm_remain_tokens` is only reachable on `dllm_config is not None` paths.

## Unit Tests

Two CPU-only test files (`base-a-test-cpu`, no GPU/server):

- `test/registered/unit/managers/test_dllm_staging_token_budget.py` (19 cases) — the one-block cap, sub-block refusals, the capacity-gate boundary (`charge-1 -> 0`, `charge -> block`, incl. `page_size > 1`, an unaligned block, and the mamba extra charge), the reuse-exemption predicate quadrants driven through `add_dllm_staging_req`, and the staging loop's per-row refusal in both queue orderings.
- `test/registered/unit/mem_cache/test_radix_cache_dllm_abort_free.py` (2 cases) — pins upstream's abort-path KV reclaim (the aborted-FDFO case with an unresolved block, plus an AR-invariance case).

## Accuracy Tests

No effect on model outputs by construction (memory-reclaim / scheduling-budget only). Verified with LLaDA2-mini on gsm8k (zero-shot, full 1319 samples): accuracy unchanged before/after.

## Speed Tests and Profiling

No measurable throughput change; both fixes are off the hot path (abort cleanup, and a clamp on an already-taken fallback branch). The repros above are the before/after evidence: the abort wave now passes the idle pool invariant check, and the 512-in/2048-out full-batch run completes instead of crashing.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35508977564](https://github.com/sgl-project/sglang/actions/runs/35508977564)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35508977496](https://github.com/sgl-project/sglang/actions/runs/35508977496)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35508977654](https://github.com/sgl-project/sglang/actions/runs/35508977654)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->