### PR TITLE
Fix clearing transferred Mamba state in disaggregated decode

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1822,6 +1822,12 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             return
 
         self._commit_hicache_local_restore_to_req(decode_req)
+        if (
+            not _is_fake_transfer(decode_req.req, self.scheduler.server_args)
+            and StateType.MAMBA in decode_req.kv_receiver.kv_mgr.kv_args.state_types
+        ):
+            # The transfer initialized the slot; clearing it would discard the state.
+            decode_req.req.mamba_needs_clear = False
 
         # Case 3: Success - commit the transfer
         # PD true-retraction rebootstrap: the prefill recomputed the prefix KV


### PR DESCRIPTION
## Motivation

A successful disaggregated transfer initializes the destination Mamba cache slot, but the request can remain marked for clearing. The next initialization step may therefore discard the transferred recurrent state before decoding.

## Modifications

- Clear `mamba_needs_clear` after committing a real transfer containing Mamba state.
- Preserve existing behavior for fake transfers and transfers without Mamba state.

## Accuracy Tests

- Verified exact monolithic/disaggregated output parity for BF16, W4A16, and W4A4 configurations.
- `ruff` checks passed.
- `black --check` passed.

## Speed Tests and Profiling

Not applicable; the change adds one state update after transfer completion.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30599240903](https://github.com/sgl-project/sglang/actions/runs/30599240903)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30599240742](https://github.com/sgl-project/sglang/actions/runs/30599240742)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->