### PR TITLE
fix(kimi-k3): neutralize a literal image placeholder in user text

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1022,7 +1022,12 @@ class OpenAIServingChat(OpenAIServingBase):
             template_kwargs = dict(request.chat_template_kwargs or {})
             template_kwargs.pop("tokenize", None)
             template_kwargs.pop("return_dict", None)
-            template_kwargs["image_prompts"] = ["<|media_pad|>"] * len(image_data)
+            # `None`, not `[]`: an empty list makes the encoder treat a literal
+            # "<|kimi_image_placeholder|>" in message text as a real placeholder
+            # and reject the request.
+            template_kwargs["image_prompts"] = (
+                ["<|media_pad|>"] * len(image_data) if image_data else None
+            )
             # encoding_k3 accepts thinking_effort in {low, high, max} and
             # asserts on anything else; "none" is handled at the protocol
             # level by disabling thinking.

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -161,6 +161,17 @@ def _extract_max_dynamic_patch(request: ChatCompletionRequest):
     return img_max_dynamic_patch, vid_max_dynamic_patch
 
 
+# K3 images reach the encoder out of band, as structured `image_url` parts, so an
+# occurrence of this token in text is ordinary user content. Left as-is it would
+# additionally consume an image slot and make the encoder reject the request.
+KIMI_K3_IMAGE_PLACEHOLDER = "<|kimi_image_placeholder|>"
+KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED = "<| kimi_image_placeholder |>"
+
+
+def neutralize_kimi_k3_image_placeholder(text: str) -> str:
+    return text.replace(KIMI_K3_IMAGE_PLACEHOLDER, KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED)
+
+
 class OpenAIServingChat(OpenAIServingBase):
     """Handler for /v1/chat/completions requests"""
 
@@ -333,11 +344,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 continue
             chunk_type = chunk.get("type")
             if chunk_type in ("text", "input_text"):
-                text = chunk["text"]
-                if "<|kimi_image_placeholder|>" in text:
-                    raise ValueError(
-                        "<|kimi_image_placeholder|> is reserved for Kimi-K3 image input"
-                    )
+                text = neutralize_kimi_k3_image_placeholder(chunk["text"])
                 parts.append({"type": "text", "text": text})
             elif chunk_type in ("image_url", "input_image"):
                 image_obj = chunk.get("image_url") or {}
@@ -1010,6 +1017,12 @@ class OpenAIServingChat(OpenAIServingBase):
                     )
                 elif msg.get("content") is None:
                     msg["content"] = ""
+                elif isinstance(msg.get("content"), str):
+                    # String content (tool results, folded system turns) never
+                    # reaches _flatten_kimi_k3_content, so neutralize here too.
+                    msg["content"] = neutralize_kimi_k3_image_placeholder(
+                        msg["content"]
+                    )
 
             for msg in messages:
                 if msg.get("role") == "developer":
@@ -1022,12 +1035,7 @@ class OpenAIServingChat(OpenAIServingBase):
             template_kwargs = dict(request.chat_template_kwargs or {})
             template_kwargs.pop("tokenize", None)
             template_kwargs.pop("return_dict", None)
-            # `None`, not `[]`: an empty list makes the encoder treat a literal
-            # "<|kimi_image_placeholder|>" in message text as a real placeholder
-            # and reject the request.
-            template_kwargs["image_prompts"] = (
-                ["<|media_pad|>"] * len(image_data) if image_data else None
-            )
+            template_kwargs["image_prompts"] = ["<|media_pad|>"] * len(image_data)
             # encoding_k3 accepts thinking_effort in {low, high, max} and
             # asserts on anything else; "none" is handled at the protocol
             # level by disabling thinking.


### PR DESCRIPTION
A text-only conversation that merely *mentions* `<|kimi_image_placeholder|>` is rejected. Reaching the encoder as a string it surfaces as

```
400 More image placeholders than image prompts.
```

and since the text stays in history, every later request in that conversation fails the same way. The token shows up in ordinary content: `python/sglang/srt/configs/kimi_k3.py` on this branch defines `image_placeholder: str = "<|kimi_image_placeholder|>"`, so simply discussing a model config triggers it.

## Why it happens

K3 images reach the encoder **out of band**: `_flatten_kimi_k3_content` keeps them as structured `image_url` parts, and `_render_content_segments` turns each part into one `image_state.next_prompt()`. sglang never passes an image through the text channel.

The encoder additionally supports an **in-band** form -- a literal placeholder inside text also consumes an image prompt (`_append_text` splits on it). sglang doesn't use that form, but user text containing the literal falls into it anyway, consuming a slot that no image asked for, so the count check fails.

`_flatten_kimi_k3_content` already tried to prevent this by rejecting such text outright, but that guard only ran for list-form `content`. String-form content -- tool results, folded system turns -- bypassed it entirely and hit the encoder's much less obvious error instead. Before this change, all four combinations failed:

| literal in | images | before |
|---|---|---|
| list-form text block | 0 | `ValueError: ... is reserved for Kimi-K3 image input` |
| list-form text block | 1 | same |
| string-form content | 0 | `400 More image placeholders than image prompts.` |
| string-form content | 1 | same |

## Change

Neutralize the literal (`<|kimi_image_placeholder|>` -> `<| kimi_image_placeholder |>`) on both paths instead of rejecting it. A user asking about the token is a legitimate request, and out-of-band image binding is unaffected.

`image_prompts` keeps its exact-count semantics: `["<|media_pad|>"] * len(image_data)` is left as is, so if any future path forgets to neutralize, the encoder still fails loudly rather than silently turning user text into an image token.

## Verification

Driving the real K3 encoder, all four combinations plus the no-literal regression:

```
                                          images  media_pad  literal-as-special
list: text w/ literal, no image                0          0                   0
list: text w/ literal + 1 image                1          1                   0
str:  text w/ literal, no image                0          0                   0
str:  literal + earlier turn w/ image          1          1                   0
regression: 2 images, no literal               2          2                   0
```

`media_pad` always equals the image count, the literal is never promoted to a special token, and it appears in the rendered text as ordinary escaped text.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30610248564](https://github.com/sgl-project/sglang/actions/runs/30610248564)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30610248403](https://github.com/sgl-project/sglang/actions/runs/30610248403)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->