### PR TITLE
perf: compact sparse logit bias storage

### DIFF
--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -24,6 +24,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+LOGIT_BIAS_SPARSE_ENTRY_FACTOR = 16
+
+
+def _use_sparse_logit_bias(num_entries: int, batch_size: int, vocab_size: int) -> bool:
+    return 0 < num_entries * LOGIT_BIAS_SPARSE_ENTRY_FACTOR <= batch_size * vocab_size
+
+
+def _materialize_logit_bias(
+    bias: Optional[torch.Tensor],
+    rows: Optional[torch.Tensor],
+    token_ids: Optional[torch.Tensor],
+    batch_size: int,
+    vocab_size: int,
+    device: str,
+) -> Optional[torch.Tensor]:
+    if bias is None or rows is None:
+        return bias
+    dense = torch.zeros(batch_size, vocab_size, dtype=bias.dtype, device=device)
+    dense[rows, token_ids] = bias
+    return dense
+
 
 @dataclasses.dataclass
 class SamplingBatchInfo:
@@ -82,6 +103,9 @@ class SamplingBatchInfo:
 
     # Handle logit bias
     logit_bias: Optional[torch.Tensor] = None
+    logit_bias_rows: Optional[torch.Tensor] = None
+    logit_bias_token_ids: Optional[torch.Tensor] = None
+    logit_bias_rows_cpu: Optional[List[int]] = None
 
     @classmethod
     def from_schedule_batch(cls, batch: ScheduleBatch, vocab_size: int):
@@ -132,13 +156,41 @@ class SamplingBatchInfo:
             else None
         )
 
+        num_bias_entries = sum(
+            len(req.sampling_params.logit_bias or {}) for req in reqs
+        )
         logit_bias = None
-        if any(r.sampling_params.logit_bias is not None for r in reqs):
+        logit_bias_rows = None
+        logit_bias_token_ids = None
+        logit_bias_rows_cpu = None
+        use_sparse_logit_bias = getattr(
+            global_server_args, "speculative_algorithm", None
+        ) is None and _use_sparse_logit_bias(num_bias_entries, len(reqs), vocab_size)
+        if use_sparse_logit_bias:
+            logit_bias_rows_cpu = []
+            token_ids = []
+            values = []
+            for row, req in enumerate(reqs):
+                if req.sampling_params.logit_bias is not None:
+                    for token_id, value in req.sampling_params.logit_bias.items():
+                        logit_bias_rows_cpu.append(row)
+                        token_ids.append(int(token_id))
+                        values.append(value)
+            logit_bias = torch.tensor(values, dtype=torch.float, pin_memory=_pin).to(
+                device, non_blocking=True
+            )
+            logit_bias_rows = torch.tensor(
+                logit_bias_rows_cpu, dtype=torch.long, pin_memory=_pin
+            ).to(device, non_blocking=True)
+            logit_bias_token_ids = torch.tensor(
+                token_ids, dtype=torch.long, pin_memory=_pin
+            ).to(device, non_blocking=True)
+        elif num_bias_entries:
             logit_bias = torch.zeros(len(reqs), vocab_size, device=device)
-            for i, r in enumerate(reqs):
-                if r.sampling_params.logit_bias is not None:
-                    for key, value in r.sampling_params.logit_bias.items():
-                        logit_bias[i, int(key)] = value
+            for row, req in enumerate(reqs):
+                if req.sampling_params.logit_bias is not None:
+                    for token_id, value in req.sampling_params.logit_bias.items():
+                        logit_bias[row, int(token_id)] = value
 
         # Check if any request has custom logit processor
         has_custom_logit_processor = (
@@ -214,6 +266,9 @@ class SamplingBatchInfo:
             custom_logit_processor=merged_custom_logit_processor,
             device=device,
             logit_bias=logit_bias,
+            logit_bias_rows=logit_bias_rows,
+            logit_bias_token_ids=logit_bias_token_ids,
+            logit_bias_rows_cpu=logit_bias_rows_cpu,
             return_sampling_masks=return_sampling_masks,
             sampling_mask_max_top_k=sampling_mask_max_top_k,
         )
@@ -298,7 +353,12 @@ class SamplingBatchInfo:
             self.grammar_mask.apply(logits)
 
         if self.logit_bias is not None:
-            logits.add_(self.logit_bias)
+            if self.logit_bias_rows is None:
+                logits.add_(self.logit_bias)
+            else:
+                logits[
+                    self.logit_bias_rows, self.logit_bias_token_ids
+                ] += self.logit_bias
 
     def filter_batch(self, keep_indices: List[int], keep_indices_device: torch.Tensor):
         self.penalizer_orchestrator.filter(keep_indices_device)
@@ -318,7 +378,50 @@ class SamplingBatchInfo:
                 setattr(self, item, value[keep_indices_device])
 
         if self.logit_bias is not None:
-            self.logit_bias = self.logit_bias[keep_indices_device]
+            if self.logit_bias_rows_cpu is None:
+                self.logit_bias = self.logit_bias[keep_indices_device]
+            else:
+                entries_by_row = {}
+                for entry, row in enumerate(self.logit_bias_rows_cpu):
+                    entries_by_row.setdefault(row, []).append(entry)
+                entry_indices = []
+                new_rows = []
+                for new_row, old_row in enumerate(keep_indices):
+                    selected = entries_by_row.get(old_row, [])
+                    entry_indices.extend(selected)
+                    new_rows.extend([new_row] * len(selected))
+
+                if not entry_indices:
+                    self.logit_bias = None
+                    self.logit_bias_rows = None
+                    self.logit_bias_token_ids = None
+                    self.logit_bias_rows_cpu = None
+                else:
+                    entry_indices_device = torch.tensor(
+                        entry_indices, dtype=torch.long, device=self.logit_bias.device
+                    )
+                    self.logit_bias = self.logit_bias[entry_indices_device]
+                    self.logit_bias_token_ids = self.logit_bias_token_ids[
+                        entry_indices_device
+                    ]
+                    self.logit_bias_rows_cpu = new_rows
+                    self.logit_bias_rows = torch.tensor(
+                        new_rows, dtype=torch.long, device=self.logit_bias.device
+                    )
+                    if not _use_sparse_logit_bias(
+                        len(new_rows), len(keep_indices), self.vocab_size
+                    ):
+                        self.logit_bias = _materialize_logit_bias(
+                            self.logit_bias,
+                            self.logit_bias_rows,
+                            self.logit_bias_token_ids,
+                            len(keep_indices),
+                            self.vocab_size,
+                            self.device,
+                        )
+                        self.logit_bias_rows = None
+                        self.logit_bias_token_ids = None
+                        self.logit_bias_rows_cpu = None
         if self.return_sampling_masks is not None:
             self.return_sampling_masks = [
                 self.return_sampling_masks[i] for i in keep_indices
@@ -412,11 +515,76 @@ class SamplingBatchInfo:
         self_len = len(self)
         other_len = len(other)
 
-        # Merge logit bias - note this has to come before the temperatures tensor update! Otherwise will cause crashes.
-        # See note below on len(self) and len(other).
-        self.logit_bias = merge_bias_tensor(
-            self.logit_bias, other.logit_bias, self_len, other_len, self.device, 0.0
-        )
+        # Merge logit bias before temperatures, because __len__ uses temperatures.
+        self_sparse = self.logit_bias_rows_cpu is not None
+        other_sparse = other.logit_bias_rows_cpu is not None
+        if (self.logit_bias is None or self_sparse) and (
+            other.logit_bias is None or other_sparse
+        ):
+            biases = []
+            token_ids = []
+            rows_cpu = []
+            if self_sparse:
+                biases.append(self.logit_bias)
+                token_ids.append(self.logit_bias_token_ids)
+                rows_cpu.extend(self.logit_bias_rows_cpu)
+            if other_sparse:
+                biases.append(other.logit_bias)
+                token_ids.append(other.logit_bias_token_ids)
+                rows_cpu.extend([row + self_len for row in other.logit_bias_rows_cpu])
+
+            if not biases:
+                self.logit_bias = None
+                self.logit_bias_rows = None
+                self.logit_bias_token_ids = None
+                self.logit_bias_rows_cpu = None
+            else:
+                self.logit_bias = torch.cat(biases)
+                self.logit_bias_token_ids = torch.cat(token_ids)
+                self.logit_bias_rows_cpu = rows_cpu
+                self.logit_bias_rows = torch.tensor(
+                    rows_cpu, dtype=torch.long, device=self.logit_bias.device
+                )
+                if not _use_sparse_logit_bias(
+                    len(rows_cpu), self_len + other_len, self.vocab_size
+                ):
+                    self.logit_bias = _materialize_logit_bias(
+                        self.logit_bias,
+                        self.logit_bias_rows,
+                        self.logit_bias_token_ids,
+                        self_len + other_len,
+                        self.vocab_size,
+                        self.device,
+                    )
+                    self.logit_bias_rows = None
+                    self.logit_bias_token_ids = None
+                    self.logit_bias_rows_cpu = None
+        else:
+            self.logit_bias = merge_bias_tensor(
+                _materialize_logit_bias(
+                    self.logit_bias,
+                    self.logit_bias_rows,
+                    self.logit_bias_token_ids,
+                    self_len,
+                    self.vocab_size,
+                    self.device,
+                ),
+                _materialize_logit_bias(
+                    other.logit_bias,
+                    other.logit_bias_rows,
+                    other.logit_bias_token_ids,
+                    other_len,
+                    other.vocab_size,
+                    other.device,
+                ),
+                self_len,
+                other_len,
+                self.device,
+                0.0,
+            )
+            self.logit_bias_rows = None
+            self.logit_bias_token_ids = None
+            self.logit_bias_rows_cpu = None
         if (
             self.return_sampling_masks is not None
             or other.return_sampling_masks is not None

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -43,6 +43,17 @@ def _make_info(batch_size=2, **overrides):
     return SamplingBatchInfo(**defaults)
 
 
+def _make_sparse_info(batch_size, entries):
+    rows = [row for row, _token, _value in entries]
+    return _make_info(
+        batch_size=batch_size,
+        logit_bias=torch.tensor([value for _row, _token, value in entries]),
+        logit_bias_rows=torch.tensor(rows),
+        logit_bias_token_ids=torch.tensor([token for _row, token, _value in entries]),
+        logit_bias_rows_cpu=rows,
+    )
+
+
 def _serial_batched_fill(entries, vocab_mask):
     for entry in entries:
         entry.grammar.fill_vocab_mask(vocab_mask, entry.row)
@@ -168,6 +179,20 @@ class TestApplyLogitsBias(CustomTestCase):
         info.apply_logits_bias(logits)
         self.assertAlmostEqual(logits[0, 5].item(), 10.0, places=5)
         self.assertAlmostEqual(logits[0, 0].item(), 0.0, places=5)
+
+    def test_sparse_apply_matches_dense_reference_across_dtypes(self):
+        entries = [(1, 5, 0.125), (4, 7, -1.75)]
+        for dtype in (torch.float32, torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                info = _make_sparse_info(6, entries)
+                actual = torch.zeros(6, VOCAB_SIZE, dtype=dtype)
+                dense = torch.zeros(6, VOCAB_SIZE)
+                dense[1, 5] = 0.125
+                dense[4, 7] = -1.75
+                expected = actual.clone()
+                expected.add_(dense)
+                info.apply_logits_bias(actual)
+                self.assertTrue(torch.equal(actual, expected))
 
     def test_applies_vocab_mask(self):
         """Test that a grammar_mask gets applied to the logits."""
@@ -359,6 +384,31 @@ class TestFilterBatch(CustomTestCase):
         info.filter_batch([1], keep)
         self.assertIsNone(info.sampling_seed)
 
+    def test_filter_reorders_and_drops_sparse_entries(self):
+        info = _make_sparse_info(4, [(1, 3, 1.0), (3, 9, 2.0)])
+        info.filter_batch([3, 0, 1], torch.tensor([3, 0, 1]))
+        self.assertEqual(info.logit_bias_rows_cpu, [0, 2])
+        self.assertTrue(torch.equal(info.logit_bias_rows, torch.tensor([0, 2])))
+        self.assertTrue(torch.equal(info.logit_bias_token_ids, torch.tensor([9, 3])))
+        self.assertTrue(torch.equal(info.logit_bias, torch.tensor([2.0, 1.0])))
+
+    def test_filter_preserves_duplicate_keep_indices(self):
+        info = _make_sparse_info(4, [(1, 3, 1.0), (3, 9, 2.0)])
+        info.filter_batch([1, 1, 0], torch.tensor([1, 1, 0]))
+        self.assertEqual(info.logit_bias_rows_cpu, [0, 1])
+        self.assertTrue(torch.equal(info.logit_bias, torch.tensor([1.0, 1.0])))
+
+    def test_filter_densifies_above_entry_threshold(self):
+        info = _make_sparse_info(16, [(2, 1, 1.0), (2, 2, 2.0), (2, 3, 3.0)])
+        info.filter_batch([2], torch.tensor([2]))
+        self.assertEqual(info.logit_bias.shape, (1, VOCAB_SIZE))
+        self.assertIsNone(info.logit_bias_rows)
+        self.assertIsNone(info.logit_bias_token_ids)
+        self.assertIsNone(info.logit_bias_rows_cpu)
+        self.assertTrue(
+            torch.equal(info.logit_bias[0, 1:4], torch.tensor([1.0, 2.0, 3.0]))
+        )
+
 
 # merge_batch
 class TestMergeBatch(CustomTestCase):
@@ -401,6 +451,27 @@ class TestMergeBatch(CustomTestCase):
         info2.logit_bias = None
         info1.merge_batch(info2)
         self.assertEqual(info1.logit_bias.shape, (2, VOCAB_SIZE))
+
+    def test_merge_sparse_entries_offsets_rhs_rows(self):
+        info1 = _make_sparse_info(16, [(2, 1, 1.0)])
+        info2 = _make_sparse_info(16, [(0, 2, 2.0), (3, 3, 3.0)])
+        info1.merge_batch(info2)
+        self.assertEqual(info1.logit_bias_rows_cpu, [2, 16, 19])
+        self.assertTrue(
+            torch.equal(info1.logit_bias_token_ids, torch.tensor([1, 2, 3]))
+        )
+        self.assertTrue(torch.equal(info1.logit_bias, torch.tensor([1.0, 2.0, 3.0])))
+
+    def test_merge_densifies_above_entry_threshold(self):
+        info1 = _make_sparse_info(1, [(0, 1, 1.0), (0, 2, 2.0), (0, 3, 3.0)])
+        info2 = _make_sparse_info(1, [(0, 4, 4.0), (0, 5, 5.0), (0, 6, 6.0)])
+        info1.merge_batch(info2)
+        self.assertEqual(info1.logit_bias.shape, (2, VOCAB_SIZE))
+        self.assertIsNone(info1.logit_bias_rows)
+        self.assertIsNone(info1.logit_bias_token_ids)
+        self.assertIsNone(info1.logit_bias_rows_cpu)
+        self.assertEqual(info1.logit_bias[0, 3].item(), 3.0)
+        self.assertEqual(info1.logit_bias[1, 6].item(), 6.0)
 
     def test_merge_with_custom_logit_processor(self):
         """Test that merge combines processors when only one side has them."""
@@ -518,19 +589,48 @@ class TestFromScheduleBatch(CustomTestCase):
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_server_args")
     def test_logit_bias_construction(self, mock_server_args):
-        """Test that logit_bias dict is converted to a tensor with correct values."""
+        """Sparse dictionaries retain only their token entries."""
         mock_server_args.return_value.enable_deterministic_inference = False
         mock_server_args.return_value.enable_custom_logit_processor = False
+        mock_server_args.return_value.speculative_algorithm = None
 
-        reqs = [self._make_req(logit_bias={"5": 2.0, "10": -1.0})]
+        reqs = [
+            self._make_req(logit_bias={"5": 2.0, "10": -1.0}),
+            self._make_req(),
+        ]
         batch = MagicMock()
         batch.reqs = reqs
         batch.device = DEVICE
         info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
-        self.assertIsNotNone(info.logit_bias)
-        self.assertAlmostEqual(info.logit_bias[0, 5].item(), 2.0)
-        self.assertAlmostEqual(info.logit_bias[0, 10].item(), -1.0)
-        self.assertAlmostEqual(info.logit_bias[0, 0].item(), 0.0)
+        self.assertTrue(torch.equal(info.logit_bias, torch.tensor([2.0, -1.0])))
+        self.assertEqual(info.logit_bias_rows_cpu, [0, 0])
+        self.assertTrue(torch.equal(info.logit_bias_rows, torch.tensor([0, 0])))
+        self.assertTrue(torch.equal(info.logit_bias_token_ids, torch.tensor([5, 10])))
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_server_args")
+    def test_logit_bias_dense_fallback_for_high_entry_density(self, mock_server_args):
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = False
+        mock_server_args.return_value.speculative_algorithm = None
+        reqs = [self._make_req(logit_bias={"1": 1.0, "2": 2.0, "3": 3.0})]
+        batch = MagicMock(reqs=reqs, device=DEVICE)
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertEqual(info.logit_bias.shape, (1, VOCAB_SIZE))
+        self.assertIsNone(info.logit_bias_rows)
+        self.assertIsNone(info.logit_bias_token_ids)
+
+    @patch("sglang.srt.sampling.sampling_batch_info.get_server_args")
+    def test_logit_bias_dense_fallback_for_speculative_decoding(self, mock_server_args):
+        mock_server_args.return_value.enable_deterministic_inference = False
+        mock_server_args.return_value.enable_custom_logit_processor = False
+        mock_server_args.return_value.speculative_algorithm = "EAGLE"
+        reqs = [self._make_req(logit_bias={"5": 2.0}), self._make_req()]
+        batch = MagicMock(reqs=reqs, device=DEVICE)
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertEqual(info.logit_bias.shape, (2, VOCAB_SIZE))
+        self.assertEqual(info.logit_bias[0, 5].item(), 2.0)
+        self.assertIsNone(info.logit_bias_rows)
+        self.assertIsNone(info.logit_bias_token_ids)
 
     @patch("sglang.srt.sampling.sampling_batch_info.get_server_args")
     def test_deterministic_seed(self, mock_server_args):


### PR DESCRIPTION
## Motivation

`logit_bias` arrives as a sparse per-request dictionary, but one biased request
currently materializes a float32 `[batch_size, vocab_size]` tensor and adds that
entire tensor to logits on every sampling step. For a batch of 64 with a 128,256
token vocabulary, one bias entry therefore retains 32,833,536 bytes to represent
20 bytes of entry data.

This change keeps ordinary sparse requests compact while preserving the existing
dense representation whenever compact indexed updates stop being the better
resource tradeoff.

## Modifications

- Store ordinary sparse logit bias as parallel value, row-index, and token-index
  tensors, and apply only those entries.
- Use a GPU-derived entry-density gate: compact storage is admitted through
  `entries <= batch_size * vocab_size / 16`; denser inputs retain the existing
  dense tensor.
- Preserve the original dense form for speculative decoding because its consumers
  directly assume `[batch_size, vocab_size]` shape.
- Teach batch filtering and merging to remap compact rows and materialize dense
  state if a lifecycle transition crosses the gate.
- Add focused coverage for construction, exact application across float32/float16/
  bfloat16, filter reorder/drop/duplication, merge row offsets, densification,
  high-density fallback, and speculative fallback.

The production change is confined to `sampling_batch_info.py`; the only other
changed file is its registered unit test.

## Accuracy Tests

On the parent commit, the final focused selector fails 11 new lifecycle and
representation assertions (4 existing controls pass). On this commit, all 12
focused tests pass, including three dtype subtests.

The adjacent registered sampling suite also passes:

```text
python -m pytest \
  test/registered/unit/sampling/test_sampling_batch_info.py \
  test/registered/unit/sampling/test_sampling_params.py

119 passed, plus 3 dtype subtests
```

Additional parity checks:

- exact float32, float16, and bfloat16 output parity;
- exact eager/CUDA-graph output parity with one capture and no recapture;
- identical dense tensors and GPU peaks for threshold+1, fully dense, and EAGLE
  controls;
- identical generated text SHA-256, completion-token counts, and finish reasons
  in the paired public endpoint run.

## Speed Tests and Profiling

Hardware: NVIDIA RTX 4070 Laptop GPU (`sm_89`, 8,188 MiB), driver 595.79,
PyTorch 2.11.0+cu130. Component measurements use five warmups and 30 alternating
groups of 50 operations.

At `B=64`, `V=128256`, and one bias entry:

| Metric | Current main | This change |
|---|---:|---:|
| Persistent logit-bias storage | 32,833,536 B | 20 B |
| Measured indexed-apply temporary | 0 B | 512 B |
| Apply median [p10, p90] | 424.17 us [420.90, 453.95] | 32.78 us [30.03, 39.79] |
| Construction median | 0.315 ms | 0.200 ms |

The fixed six-cell sparse matrix showed 1.23x-14.14x apply speedups with exact
parity. CUDA-graph replay was 426.31 to 8.02 us at `B=64,V=128256,E=1`, with
identical 1,024-byte capture memory.

The density boundary was measured independently at `B=64,V=65536`. At 6.25%
entries, compact persistent storage plus measured apply workspace was 6,291,456
bytes versus 16,777,216 dense bytes (62.5% less), while apply was 46.51 versus
67.49 us. At the next 12.5% point, the footprint reduction fell to 25% and compact
apply was 72.05 versus 64.72 us, which is why denser requests fall back to the
unchanged representation.

PyTorch profiling shows existing ATen index/add/index-put kernels replacing the
full vector add; this patch adds no kernel, binary, or JIT compilation. The paired
SmolLM-135M public endpoint run was statistically flat (0.48845 versus 0.49001 s
median; 65.24 versus 64.96 completion tok/s), so this PR does **not** claim an
end-to-end server speedup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

cc @b8zhong
cc @0xymoro

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30604249177](https://github.com/sgl-project/sglang/actions/runs/30604249177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30604249051](https://github.com/sgl-project/sglang/actions/runs/30604249051)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->