### PR TITLE
[Fix] Clear stale FlashInfer BF16 MoE index cache

### DIFF
--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -374,6 +374,11 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
+            # The cached indices are GPU tensors. Colocated weight offloading
+            # can release their backing memory between reloads, so rebuild them
+            # once per post-processing cycle.
+            self._cache_permute_indices.clear()
+
             from flashinfer.fused_moe.core import (
                 _maybe_get_cached_w3_w1_permute_indices,
                 convert_to_block_layout,


### PR DESCRIPTION
## Motivation

@humansand

Colocated RL weight updates pause and offload the rollout model before loading new weights. `UnquantizedFusedMoEMethod` caches FlashInfer permutation-index tensors on the GPU, so those tensors can point to released memory after the model resumes. Reusing them during post-load processing can corrupt the shuffled BF16 expert weights.

[sgl-project/sglang#28676](https://github.com/sgl-project/sglang/pull/28676) fixed the equivalent MXFP8 cache, but mixed-precision checkpoints with BF16 experts use this separate cache in `UnquantizedFusedMoEMethod`.

ModelOpt NVFP4 quantized experts do not need the same clear: `prepare_static_weights_for_trtllm_fp4_moe()` creates its permutation-index dictionary locally for each post-load call. The BF16 experts in the first/last layers, plus the BF16 shared experts, use `UnquantizedFusedMoEMethod`, whose persistent instance cache is what this PR clears.

## Modifications

Clear the FlashInfer TRT-LLM BF16 permutation-index cache once at the start of each post-load processing cycle. The rebuilt indices are still reused across experts within that cycle.

## Accuracy Tests

- Targeted external regression test for two consecutive BF16 FlashInfer post-load cycles: `1 passed`.
- DeepSeek V3.2 5-layer MXFP8 Miles E2E on 8x B200 with 8-GPU training and 8-GPU colocated rollout:
  - dense FP8 GEMM backend: `flashinfer_cutlass`
  - MoE backend: `flashinfer_trtllm_routed`
  - 3/3 rollouts and 24/24 training steps completed
  - the one injected rollout-engine failure was detected and one engine was recovered
  - weight-checker lifecycle completed and the Ray job succeeded
- GLM-5.2 5-layer ModelOpt NVFP4 Miles E2E on 8x B200 with 8-GPU training and 8-GPU colocated rollout:
  - environment: FlashInfer `0.6.15.post1`; image-pinned SGLang commit `3fe50eddf881b4f33c60c1867af84eeb1626d91d` with only this PR's patch applied
  - rollout: four TP2/DP2/EP2 engines with `flashinfer_trtllm_routed`
  - 2/2 rollouts, 2/2 training steps, and 3/3 weight-update/resume cycles completed
  - Ray job succeeded without a crash or hang
- `pre-commit run --all-files`: passed.

No test file is included in this PR.

## Speed Tests and Profiling

Not applicable. The cache clear runs only during weight post-processing, not in the model forward path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
