### PR TITLE
[Kimi K3] Add reasoning parser

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -363,6 +363,9 @@ class OpenAIServingResponses(OpenAIServingChat):
                         session_id=request.session_id,
                         extra_key=self._compute_extra_key(request),
                         background=request.background,
+                        require_reasoning=self._is_thinking_enabled_for_request(
+                            request
+                        ),
                     )
 
                     generator = self._generate_with_builtin_tools(
@@ -2386,6 +2389,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 return_text_in_logprobs=adapted_request.return_text_in_logprobs,
                 return_hidden_states=adapted_request.return_hidden_states,
                 background=adapted_request.background,
+                require_reasoning=adapted_request.require_reasoning,
             )
 
             # Update sampling params with reduced max_tokens

--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -1,0 +1,35 @@
+from typing import List
+
+THINK_OPEN = "<|open|>think<|sep|>"
+THINK_CLOSE = "<|close|>think<|sep|>"
+RESPONSE_OPEN = "<|open|>response<|sep|>"
+RESPONSE_CLOSE = "<|close|>response<|sep|>"
+TOOLS_OPEN = "<|open|>tools<|sep|>"
+TOOLS_CLOSE = "<|close|>tools<|sep|>"
+MESSAGE_CLOSE = "<|close|>message<|sep|>"
+CALL_OPEN = "<|open|>call"
+CALL_CLOSE = "<|close|>call<|sep|>"
+ARGUMENT_CLOSE = "<|close|>argument<|sep|>"
+
+
+def partial_suffix_len(text: str, markers: List[str]) -> int:
+    best = 0
+    for marker in markers:
+        for length in range(min(len(marker) - 1, len(text)), best, -1):
+            if text.endswith(marker[:length]):
+                best = length
+                break
+    return best
+
+
+def strip_response_wrappers(text: str) -> str:
+    open_idx = text.find(RESPONSE_OPEN)
+    if open_idx != -1:
+        close_idx = text.find(RESPONSE_CLOSE, open_idx + len(RESPONSE_OPEN))
+        if close_idx != -1:
+            text = text[open_idx + len(RESPONSE_OPEN) : close_idx]
+        else:
+            text = text[open_idx + len(RESPONSE_OPEN) :]
+    else:
+        text = text.replace(RESPONSE_CLOSE, "")
+    return text.replace(MESSAGE_CLOSE, "")

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -12,6 +12,16 @@ from sglang.srt.entrypoints.openai.encoding_dsv4 import (
 )
 from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest
 from sglang.srt.function_call.hunyuan_detector import resolve_hunyuan_tokens
+from sglang.srt.function_call.kimik3_format import (
+    MESSAGE_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
+    THINK_CLOSE,
+    THINK_OPEN,
+    TOOLS_OPEN,
+    partial_suffix_len,
+    strip_response_wrappers,
+)
 from sglang.srt.parser.harmony_parser import HarmonyParser
 from sglang.srt.parser.inkling_tokenizer import (
     CONTENT_INVOKE_TOOL_JSON,
@@ -417,6 +427,185 @@ class KimiK2Detector(BaseReasoningFormatDetector):
             reasoning_default="thinking",
             force_nonempty_content=force_nonempty_content,
         )
+
+
+_THINK_CLOSE_WITHOUT_SEP = THINK_CLOSE.split("<|sep|>")[0]
+
+
+class KimiK3Detector(BaseReasoningFormatDetector):
+    """Detector for the Kimi K3 XTML think channel.
+
+    K3 wraps reasoning as ``<|open|>think<|sep|>...<|close|>think<|sep|>``
+    where each marker is a multi-token special sequence, so partial markers
+    can straddle streaming chunks and must be held back. In thinking mode
+    the serving layer may feed the open marker as the generation prefix, so
+    output can begin inside the think channel with no open marker
+    (``force_reasoning=True`` covers this).
+
+    Post-reasoning content is unwrapped from the XTML ``response`` /
+    ``message`` markers; a ``tools`` channel is passed through raw for the
+    kimi_k3 tool-call detector.
+    """
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = True,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+    ):
+        think_excluded_tokens = [
+            "response",
+            "message",
+            "<|end_of_msg|>",
+            "[EOS]",
+            "[EOT]",
+        ]
+        super().__init__(
+            THINK_OPEN,
+            THINK_CLOSE,
+            think_excluded_tokens=think_excluded_tokens,
+            force_reasoning=force_reasoning,
+            stream_reasoning=stream_reasoning,
+            tool_start_token=TOOLS_OPEN,
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+            reasoning_default="thinking",
+        )
+        self._reasoning_done = False
+        self._tools_passthrough = False
+
+    def _clean_content(self, text: str) -> str:
+        tools_idx = text.find(TOOLS_OPEN)
+        if tools_idx != -1:
+            return strip_response_wrappers(text[:tools_idx]) + text[tools_idx:]
+        return strip_response_wrappers(text)
+
+    def _next_channel_idx(self, text: str, start: int = 0) -> int:
+        found = [
+            idx
+            for token in (RESPONSE_OPEN, self.tool_start_token)
+            if (idx := text.find(token, start)) != -1
+        ]
+        return min(found) if found else -1
+
+    @staticmethod
+    def _strip_dangling_think_close(text: str) -> str:
+        return text.removesuffix(_THINK_CLOSE_WITHOUT_SEP)
+
+    def detect_and_parse(self, text: str) -> StreamingParseResult:
+        in_reasoning = self._in_reasoning or self.think_start_token in text
+        if not in_reasoning and self.think_end_token not in text:
+            return StreamingParseResult(normal_text=self._clean_content(text))
+
+        open_idx = text.find(self.think_start_token)
+        start = open_idx + len(self.think_start_token) if open_idx != -1 else 0
+        close_idx = text.find(self.think_end_token, start)
+        if close_idx == -1:
+            channel_idx = self._next_channel_idx(text, start)
+            if channel_idx != -1:
+                return StreamingParseResult(
+                    reasoning_text=self._strip_dangling_think_close(
+                        text[start:channel_idx]
+                    ),
+                    normal_text=self._clean_content(text[channel_idx:]),
+                )
+            return StreamingParseResult(
+                reasoning_text=self._strip_dangling_think_close(text[start:])
+            )
+
+        reasoning_text = text[start:close_idx]
+        rest = text[close_idx + len(self.think_end_token) :]
+        return StreamingParseResult(
+            reasoning_text=reasoning_text, normal_text=self._clean_content(rest)
+        )
+
+    def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
+        self._buffer += new_text
+
+        if not self._in_reasoning and not self._reasoning_done:
+            open_idx = self._buffer.find(self.think_start_token)
+            if open_idx != -1:
+                self._buffer = self._buffer[open_idx + len(self.think_start_token) :]
+                self._in_reasoning = True
+                self.stripped_think_start = True
+            elif self.think_start_token.startswith(self._buffer):
+                return StreamingParseResult()
+            else:
+                self._reasoning_done = True
+
+        if self._in_reasoning:
+            buf = self._buffer
+            if not self.stripped_think_start:
+                open_idx = buf.find(self.think_start_token)
+                if open_idx != -1:
+                    buf = buf[open_idx + len(self.think_start_token) :]
+                    self._buffer = buf
+                    self.stripped_think_start = True
+
+            close_idx = buf.find(self.think_end_token)
+            if close_idx != -1:
+                reasoning_text = buf[:close_idx]
+                self._buffer = buf[close_idx + len(self.think_end_token) :]
+                self._in_reasoning = False
+                self._reasoning_done = True
+                return StreamingParseResult(
+                    reasoning_text=reasoning_text or None,
+                    normal_text=self._drain_content() or None,
+                )
+
+            channel_idx = self._next_channel_idx(buf)
+            if channel_idx != -1:
+                reasoning_text = self._strip_dangling_think_close(buf[:channel_idx])
+                self._buffer = buf[channel_idx:]
+                self._in_reasoning = False
+                self._reasoning_done = True
+                self._tools_passthrough = buf.startswith(
+                    self.tool_start_token, channel_idx
+                )
+                return StreamingParseResult(
+                    reasoning_text=reasoning_text or None,
+                    normal_text=self._drain_content() or None,
+                )
+
+            if not self.stream_reasoning:
+                return StreamingParseResult()
+            markers = [self.think_end_token, self.tool_start_token, RESPONSE_OPEN]
+            if not self.stripped_think_start:
+                markers.append(self.think_start_token)
+            holdback = partial_suffix_len(buf, markers)
+            emit = buf[: len(buf) - holdback] if holdback else buf
+            emit = self._strip_dangling_think_close(emit)
+            self._buffer = buf[len(emit) :]
+            return StreamingParseResult(reasoning_text=emit)
+
+        return StreamingParseResult(normal_text=self._drain_content())
+
+    def _drain_content(self) -> str:
+        buf = self._buffer
+        if not buf:
+            return ""
+        if self._tools_passthrough:
+            self._buffer = ""
+            return buf
+
+        tools_idx = buf.find(TOOLS_OPEN)
+        if tools_idx != -1:
+            head = buf[:tools_idx]
+            for marker in (RESPONSE_OPEN, RESPONSE_CLOSE, MESSAGE_CLOSE):
+                head = head.replace(marker, "")
+            self._tools_passthrough = True
+            self._buffer = ""
+            return head + buf[tools_idx:]
+
+        holdback = partial_suffix_len(
+            buf, [RESPONSE_OPEN, RESPONSE_CLOSE, MESSAGE_CLOSE, TOOLS_OPEN]
+        )
+        emit = buf[: len(buf) - holdback] if holdback else buf
+        self._buffer = buf[len(emit) :]
+        for marker in (RESPONSE_OPEN, RESPONSE_CLOSE, MESSAGE_CLOSE):
+            emit = emit.replace(marker, "")
+        return emit
 
 
 class Glm45Detector(BaseReasoningFormatDetector):
@@ -1448,6 +1637,7 @@ class ReasoningParser:
         "gpt-oss": GptOssDetector,
         "kimi": KimiDetector,
         "kimi_k2": KimiK2Detector,
+        "kimi_k3": KimiK3Detector,
         "mimo": _MimoDetector,
         "poolside_v1": _PoolsideV1Detector,
         "qwen3": Qwen3Detector,

--- a/test/registered/unit/parser/test_kimik3_reasoning_parser.py
+++ b/test/registered/unit/parser/test_kimik3_reasoning_parser.py
@@ -1,0 +1,128 @@
+import sys
+
+import pytest
+
+from sglang.srt.function_call.kimik3_format import (
+    MESSAGE_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
+    THINK_CLOSE,
+    THINK_OPEN,
+    TOOLS_CLOSE,
+    TOOLS_OPEN,
+)
+from sglang.srt.parser.reasoning_parser import KimiK3Detector, ReasoningParser
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _stream(detector: KimiK3Detector, chunks: list[str]) -> tuple[str, str]:
+    reasoning = ""
+    content = ""
+    for chunk in chunks:
+        result = detector.parse_streaming_increment(chunk)
+        reasoning += result.reasoning_text
+        content += result.normal_text
+    return reasoning, content
+
+
+def _chunks(text: str, size: int) -> list[str]:
+    return [text[index : index + size] for index in range(0, len(text), size)]
+
+
+@pytest.mark.parametrize(
+    ("text", "reasoning", "content"),
+    [
+        (
+            f"{THINK_OPEN}deep thought{THINK_CLOSE}"
+            f"{RESPONSE_OPEN}the answer{RESPONSE_CLOSE}{MESSAGE_CLOSE}",
+            "deep thought",
+            "the answer",
+        ),
+        (
+            f"thinking...{THINK_CLOSE}{RESPONSE_OPEN}done{RESPONSE_CLOSE}",
+            "thinking...",
+            "done",
+        ),
+        (
+            f"{RESPONSE_OPEN}plain reply{RESPONSE_CLOSE}{MESSAGE_CLOSE}",
+            "",
+            "plain reply",
+        ),
+        ("still going", "still going", ""),
+    ],
+)
+def test_non_stream_reasoning_channels(text: str, reasoning: str, content: str) -> None:
+    detector = KimiK3Detector(force_reasoning=True)
+    result = detector.detect_and_parse(text)
+    assert result.reasoning_text == reasoning
+    assert result.normal_text == content
+
+
+def test_non_stream_tools_channel_passthrough() -> None:
+    tools_channel = (
+        f'{TOOLS_OPEN}<|open|>call tool="python" index="1"<|sep|>'
+        "<|close|>call<|sep|>"
+        f"{TOOLS_CLOSE}"
+    )
+    detector = KimiK3Detector(force_reasoning=True)
+    result = detector.detect_and_parse(
+        f"thought{THINK_CLOSE}{RESPONSE_OPEN}reply{RESPONSE_CLOSE}{tools_channel}"
+    )
+    assert result.reasoning_text == "thought"
+    assert result.normal_text == f"reply{tools_channel}"
+
+
+def test_non_stream_recovers_missing_think_separator() -> None:
+    detector = KimiK3Detector(force_reasoning=True)
+    result = detector.detect_and_parse(
+        f"thought{THINK_CLOSE.removesuffix('<|sep|>')}{RESPONSE_OPEN}"
+        f"reply{RESPONSE_CLOSE}"
+    )
+    assert result.reasoning_text == "thought"
+    assert result.normal_text == "reply"
+
+
+@pytest.mark.parametrize("chunk_size", [1, 4, 13])
+def test_streaming_split_markers(chunk_size: int) -> None:
+    detector = KimiK3Detector(force_reasoning=True)
+    text = (
+        f"{THINK_OPEN}deep thought{THINK_CLOSE}"
+        f"{RESPONSE_OPEN}the answer{RESPONSE_CLOSE}{MESSAGE_CLOSE}"
+    )
+    reasoning, content = _stream(detector, _chunks(text, chunk_size))
+    assert reasoning == "deep thought"
+    assert content == "the answer"
+
+
+def test_streaming_tools_channel_passthrough() -> None:
+    tools_channel = (
+        f'{TOOLS_OPEN}<|open|>call tool="python" index="1"<|sep|>'
+        "<|close|>call<|sep|>"
+        f"{TOOLS_CLOSE}"
+    )
+    detector = KimiK3Detector(force_reasoning=True)
+    text = f"thought{THINK_CLOSE}{RESPONSE_OPEN}reply{RESPONSE_CLOSE}{tools_channel}"
+    reasoning, content = _stream(detector, _chunks(text, 5))
+    assert reasoning == "thought"
+    assert content == f"reply{tools_channel}"
+
+
+def test_streaming_recovers_missing_think_separator() -> None:
+    detector = KimiK3Detector(force_reasoning=True)
+    text = (
+        f"thought{THINK_CLOSE.removesuffix('<|sep|>')}{RESPONSE_OPEN}"
+        f"reply{RESPONSE_CLOSE}"
+    )
+    reasoning, content = _stream(detector, _chunks(text, 3))
+    assert reasoning == "thought"
+    assert content == "reply"
+
+
+def test_reasoning_parser_registration() -> None:
+    assert isinstance(ReasoningParser("kimi_k3").detector, KimiK3Detector)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

- add a Kimi K3 XTML reasoning detector for streaming and non-streaming responses
- share Kimi K3 channel markers and boundary helpers
- propagate `require_reasoning` through Responses API generation and builtin-tool continuations
- add focused coverage for split markers, missing think separators, response unwrapping, and tools-channel passthrough

## Motivation

This extracts the reasoning-parser portion of #32541 so the Kimi K3 model-support PR can be reviewed and merged in smaller pieces. The parser is independent of the model runtime and can land first.

## Validation

- `12 passed` in the focused Kimi K3 reasoning-parser tests
- `143 passed, 55 subtests passed` across reasoning-parser and template-manager tests on the full stack
- changed-file pre-commit hooks and `git diff --check` pass

## Stack

This is the first PR in the parser split and targets `main` directly.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608682070](https://github.com/sgl-project/sglang/actions/runs/30608682070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608681921](https://github.com/sgl-project/sglang/actions/runs/30608681921)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->