### PR TITLE
[Kimi K3] Add tool-call parser

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -813,6 +813,8 @@ class OpenAIServingChat(OpenAIServingBase):
 
         # Apply chat template and its stop strings
         tools = None
+        tool_call_stop = None
+        required_parsed_natively = False
         if request.tools and request.tool_choice != "none":
             request.skip_special_tokens = False
             if not isinstance(request.tool_choice, str):
@@ -834,11 +836,18 @@ class OpenAIServingChat(OpenAIServingBase):
                     parallel_tool_calls=request.parallel_tool_calls,
                     thinking_mode=xgrammar_reasoning,
                 )
+                required_parsed_natively = parser.detector.parses_required_natively()
+                if self.chat_encoding_spec == "kimi_k3":
+                    tool_call_stop = parser.detector.eot_token
             # Fallback: use generic JSON schema for required/named tool choice
             # only when no parser-specific constraint was set
-            if tool_call_constraint is None and (
-                request.tool_choice == "required"
-                or isinstance(request.tool_choice, ToolChoice)
+            if (
+                tool_call_constraint is None
+                and not required_parsed_natively
+                and (
+                    request.tool_choice == "required"
+                    or isinstance(request.tool_choice, ToolChoice)
+                )
             ):
                 json_schema = get_json_schema_constraint(
                     request.tools,
@@ -863,6 +872,16 @@ class OpenAIServingChat(OpenAIServingBase):
             result = self._apply_jinja_template(request, tools, is_multimodal)
         else:
             result = self._apply_conversation_template(request, is_multimodal)
+
+        if tool_call_stop is not None:
+            if isinstance(result.stop, str):
+                result.stop = [result.stop]
+            elif result.stop is None:
+                result.stop = []
+            else:
+                result.stop = list(result.stop)
+            if tool_call_stop not in result.stop:
+                result.stop.append(tool_call_stop)
 
         result.tool_call_constraint = tool_call_constraint
         return result

--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -354,6 +354,11 @@ class BaseFormatDetector(ABC):
         """Return True if this detector supports structural tag format."""
         return True
 
+    def parses_required_natively(self) -> bool:
+        """Return True if ``tool_choice="required"`` must skip grammar
+        constraints and parse the model's native output format instead."""
+        return False
+
     @abstractmethod
     def structure_info(self) -> _GetInfoFunc:
         """

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -29,6 +29,7 @@ from sglang.srt.function_call.hunyuan_detector import HunyuanDetector
 from sglang.srt.function_call.inkling_detector import InklingDetector
 from sglang.srt.function_call.internlm_detector import InternlmDetector
 from sglang.srt.function_call.kimik2_detector import KimiK2Detector
+from sglang.srt.function_call.kimik3_detector import KimiK3Detector
 from sglang.srt.function_call.lfm2_detector import Lfm2Detector
 from sglang.srt.function_call.llama32_detector import Llama32Detector
 from sglang.srt.function_call.mimo_detector import MiMoDetector
@@ -71,6 +72,7 @@ class FunctionCallParser:
         "glm47": Glm47MoeDetector,
         "gpt-oss": GptOssDetector,
         "kimi_k2": KimiK2Detector,
+        "kimi_k3": KimiK3Detector,
         "lfm2": Lfm2Detector,
         "llama3": Llama32Detector,
         "mimo": MiMoDetector,
@@ -275,7 +277,9 @@ class FunctionCallParser:
                     tag = self.get_legacy_structural_tag(at_least_one=is_required)
                     return ("structural_tag", tag)
 
-            if tool_choice == "required" or isinstance(tool_choice, ToolChoice):
+            if (
+                tool_choice == "required" or isinstance(tool_choice, ToolChoice)
+            ) and not self.detector.parses_required_natively():
                 json_schema = get_json_schema_constraint(
                     self.tools, tool_choice, parallel_tool_calls=parallel_tool_calls
                 )

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -1,0 +1,197 @@
+import json
+import logging
+import re
+from typing import List
+
+from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+from sglang.srt.function_call.kimik3_format import (
+    MESSAGE_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
+    TOOLS_CLOSE,
+    TOOLS_OPEN,
+    partial_suffix_len,
+    strip_response_wrappers,
+)
+
+logger = logging.getLogger(__name__)
+
+_CALL_RE = re.compile(
+    r"<\|open\|>call\s+(?P<attrs>(?:(?!<\|sep\|>).)*?)<\|sep\|>"
+    r"(?P<body>.*?)<\|close\|>call<\|sep\|>",
+    re.DOTALL,
+)
+_ARG_RE = re.compile(
+    r"<\|open\|>argument\s+(?P<attrs>(?:(?!<\|sep\|>).)*?)<\|sep\|>"
+    r"(?P<val>.*?)<\|close\|>argument<\|sep\|>",
+    re.DOTALL,
+)
+_ATTR_RE = re.compile(r'(?P<k>\w+)="(?P<v>[^"]*)"')
+
+
+def _unescape_attr(value: str) -> str:
+    return value.replace("&quot;", '"').replace("&amp;", "&")
+
+
+def _parse_attrs(attrs: str) -> dict:
+    return {m["k"]: _unescape_attr(m["v"]) for m in _ATTR_RE.finditer(attrs)}
+
+
+class KimiK3Detector(BaseFormatDetector):
+    """Detector for the Kimi K3 XTML tool-call format.
+
+    K3 emits tool calls in a ``tools`` channel built from dedicated special
+    tokens; the plain reply lives in a preceding ``response`` channel:
+
+    ```
+    <|open|>response<|sep|>text<|close|>response<|sep|>
+    <|open|>tools<|sep|>
+      <|open|>call tool="name" index="1"<|sep|>
+        <|open|>argument key="k" type="string"<|sep|>raw text<|close|>argument<|sep|>
+      <|close|>call<|sep|>
+    <|close|>tools<|sep|>
+    ```
+
+    ``type="string"`` argument values are raw text; other types are
+    JSON-decoded. Attribute values reverse the template's ``&amp;``/``&quot;``
+    escaping. Constrained generation is unsupported: XTML per-argument
+    encoding cannot be expressed as a JSON-schema or structural-tag grammar,
+    so ``required`` tool choice is parsed natively without a constraint.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = TOOLS_OPEN
+        self.eot_token = TOOLS_CLOSE
+        self._sent_normal_idx = 0
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.bot_token in text
+
+    def supports_structural_tag(self) -> bool:
+        return False
+
+    def parses_required_natively(self) -> bool:
+        return True
+
+    def structure_info(self) -> _GetInfoFunc:
+        raise NotImplementedError(
+            "Kimi K3 XTML tool calls do not support constrained generation"
+        )
+
+    def _decode_call(self, attrs: str, body: str) -> dict | None:
+        call_attrs = _parse_attrs(attrs)
+        tool_name = call_attrs.get("tool", "")
+        if not tool_name:
+            return None
+        arguments = {}
+        for arg in _ARG_RE.finditer(body):
+            arg_attrs = _parse_attrs(arg["attrs"])
+            key = arg_attrs.get("key", "")
+            arg_type = arg_attrs.get("type", "string")
+            raw_value = arg["val"]
+            if arg_type == "string":
+                arguments[key] = raw_value
+            else:
+                try:
+                    arguments[key] = json.loads(raw_value)
+                except json.JSONDecodeError:
+                    arguments[key] = raw_value
+        return {
+            "name": tool_name,
+            "arguments": json.dumps(arguments, ensure_ascii=False),
+        }
+
+    def _parse_calls(self, section: str) -> List[dict]:
+        return [
+            call
+            for m in _CALL_RE.finditer(section)
+            if (call := self._decode_call(m["attrs"], m["body"])) is not None
+        ]
+
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
+        open_idx = text.find(self.bot_token)
+        if open_idx == -1:
+            return StreamingParseResult(normal_text=strip_response_wrappers(text))
+        try:
+            before = strip_response_wrappers(text[:open_idx])
+            section_start = open_idx + len(self.bot_token)
+            close_idx = text.find(self.eot_token, section_start)
+            section = (
+                text[section_start:]
+                if close_idx == -1
+                else text[section_start:close_idx]
+            )
+            calls = [
+                ToolCallItem(
+                    tool_index=i,
+                    name=call["name"],
+                    parameters=call["arguments"],
+                )
+                for i, call in enumerate(self._parse_calls(section))
+            ]
+            return StreamingParseResult(normal_text=before, calls=calls)
+        except Exception as e:
+            logger.error("Error in Kimi K3 detect_and_parse: %s", e, exc_info=True)
+            return StreamingParseResult(normal_text=text)
+
+    def parse_streaming_increment(
+        self, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        self._buffer += new_text
+        try:
+            open_idx = self._buffer.find(self.bot_token)
+            if open_idx == -1:
+                return StreamingParseResult(normal_text=self._emit_normal_text())
+
+            normal_text = self._emit_normal_text(limit=open_idx)
+            section = self._buffer[open_idx + len(self.bot_token) :]
+            calls = []
+            parsed = self._parse_calls(section)
+            for call in parsed[self.current_tool_id + 1 :]:
+                self.current_tool_id += 1
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": call["name"],
+                    "arguments": json.loads(call["arguments"]),
+                }
+                self.streamed_args_for_tool[self.current_tool_id] = call["arguments"]
+                calls.append(
+                    ToolCallItem(
+                        tool_index=self.current_tool_id,
+                        name=call["name"],
+                        parameters=call["arguments"],
+                    )
+                )
+            return StreamingParseResult(normal_text=normal_text, calls=calls)
+        except Exception as e:
+            logger.error(
+                "Error in Kimi K3 parse_streaming_increment: %s", e, exc_info=True
+            )
+            self._buffer = ""
+            return StreamingParseResult()
+
+    def _emit_normal_text(self, limit: int | None = None) -> str:
+        if limit is None:
+            holdback = partial_suffix_len(
+                self._buffer,
+                [self.bot_token, RESPONSE_OPEN, RESPONSE_CLOSE, MESSAGE_CLOSE],
+            )
+            limit = len(self._buffer) - holdback
+        if limit <= self._sent_normal_idx:
+            return ""
+        pending = self._buffer[self._sent_normal_idx : limit]
+        for marker in (RESPONSE_OPEN, RESPONSE_CLOSE, MESSAGE_CLOSE):
+            if marker in pending:
+                pending = pending.replace(marker, "")
+        self._sent_normal_idx = limit
+        return pending

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -1,0 +1,221 @@
+import json
+import sys
+
+import pytest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.core_types import ToolCallItem
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.function_call.kimik3_detector import KimiK3Detector
+from sglang.srt.function_call.kimik3_format import (
+    MESSAGE_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
+    TOOLS_CLOSE,
+    TOOLS_OPEN,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_tool(name: str) -> Tool:
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            description=f"{name} tool",
+            parameters={
+                "type": "object",
+                "properties": {"code": {"type": "string"}},
+            },
+        ),
+    )
+
+
+def _call_block(tool: str, index: int, args: dict[str, tuple[str, str]]) -> str:
+    parts = [f'<|open|>call tool="{tool}" index="{index}"<|sep|>']
+    for key, (arg_type, value) in args.items():
+        parts.append(
+            f'<|open|>argument key="{key}" type="{arg_type}"<|sep|>'
+            f"{value}<|close|>argument<|sep|>"
+        )
+    parts.append("<|close|>call<|sep|>")
+    return "".join(parts)
+
+
+def _chunks(text: str, size: int) -> list[str]:
+    return [text[index : index + size] for index in range(0, len(text), size)]
+
+
+def _stream(
+    detector: KimiK3Detector, chunks: list[str], tools: list[Tool]
+) -> tuple[str, list[ToolCallItem]]:
+    text = ""
+    calls = []
+    for chunk in chunks:
+        result = detector.parse_streaming_increment(chunk, tools)
+        text += result.normal_text
+        calls.extend(result.calls)
+    return text, calls
+
+
+def test_detect_and_parse_single_call() -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text = (
+        f"{RESPONSE_OPEN}Let me run it.{RESPONSE_CLOSE}{TOOLS_OPEN}"
+        + _call_block(
+            "python",
+            1,
+            {"code": ("string", "print(1)"), "opts": ("object", '{"a": 1}')},
+        )
+        + TOOLS_CLOSE
+    )
+    result = detector.detect_and_parse(text, tools)
+    assert result.normal_text == "Let me run it."
+    assert len(result.calls) == 1
+    assert result.calls[0].name == "python"
+    assert json.loads(result.calls[0].parameters) == {
+        "code": "print(1)",
+        "opts": {"a": 1},
+    }
+
+
+def test_detect_and_parse_no_tools_channel() -> None:
+    detector = KimiK3Detector()
+    result = detector.detect_and_parse(
+        f"{RESPONSE_OPEN}hi there{RESPONSE_CLOSE}{MESSAGE_CLOSE}",
+        [_make_tool("python")],
+    )
+    assert result.normal_text == "hi there"
+    assert result.calls == []
+
+
+def test_detect_and_parse_multiple_calls() -> None:
+    detector = KimiK3Detector()
+    text = (
+        TOOLS_OPEN
+        + _call_block("python", 1, {"code": ("string", "a")})
+        + _call_block("python", 2, {"code": ("string", "b")})
+        + TOOLS_CLOSE
+    )
+    result = detector.detect_and_parse(text, [_make_tool("python")])
+    assert [call.tool_index for call in result.calls] == [0, 1]
+    assert json.loads(result.calls[1].parameters) == {"code": "b"}
+
+
+def test_detect_and_parse_unclosed_tools_section() -> None:
+    detector = KimiK3Detector()
+    text = TOOLS_OPEN + _call_block("python", 1, {"code": ("string", "x")})
+    result = detector.detect_and_parse(text, [_make_tool("python")])
+    assert len(result.calls) == 1
+    assert json.loads(result.calls[0].parameters) == {"code": "x"}
+
+
+def test_attr_unescaping_and_raw_string_args() -> None:
+    detector = KimiK3Detector()
+    text = (
+        f"{TOOLS_OPEN}"
+        '<|open|>call tool="a&amp;b" index="1"<|sep|>'
+        '<|open|>argument key="q" type="string"<|sep|>'
+        "say &quot;hi&quot;<|close|>argument<|sep|>"
+        "<|close|>call<|sep|>"
+        f"{TOOLS_CLOSE}"
+    )
+    result = detector.detect_and_parse(text, [_make_tool("python")])
+    assert result.calls[0].name == "a&b"
+    assert json.loads(result.calls[0].parameters) == {"q": "say &quot;hi&quot;"}
+
+
+def test_non_string_arg_json_decoding() -> None:
+    detector = KimiK3Detector()
+    text = (
+        TOOLS_OPEN
+        + _call_block(
+            "python",
+            1,
+            {
+                "n": ("number", "42"),
+                "flag": ("boolean", "true"),
+                "bad": ("object", "{not json"),
+            },
+        )
+        + TOOLS_CLOSE
+    )
+    result = detector.detect_and_parse(text, [_make_tool("python")])
+    assert json.loads(result.calls[0].parameters) == {
+        "n": 42,
+        "flag": True,
+        "bad": "{not json",
+    }
+
+
+@pytest.mark.parametrize("chunk_size", [1, 7, 23])
+def test_streaming_split_markers(chunk_size: int) -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text = (
+        f"{RESPONSE_OPEN}Hello!{RESPONSE_CLOSE}{TOOLS_OPEN}"
+        + _call_block("python", 1, {"code": ("string", "print(2)")})
+        + TOOLS_CLOSE
+    )
+    normal_text, calls = _stream(detector, _chunks(text, chunk_size), tools)
+    assert normal_text == "Hello!"
+    assert len(calls) == 1
+    assert calls[0].name == "python"
+    assert json.loads(calls[0].parameters) == {"code": "print(2)"}
+
+
+def test_streaming_two_calls() -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text = (
+        TOOLS_OPEN
+        + _call_block("python", 1, {"code": ("string", "a")})
+        + _call_block("python", 2, {"code": ("string", "b")})
+        + TOOLS_CLOSE
+    )
+    _, calls = _stream(detector, _chunks(text, 7), tools)
+    assert [call.tool_index for call in calls] == [0, 1]
+    assert [json.loads(call.parameters) for call in calls] == [
+        {"code": "a"},
+        {"code": "b"},
+    ]
+
+
+def test_streaming_plain_text_only() -> None:
+    detector = KimiK3Detector()
+    text, calls = _stream(
+        detector, ["just a ", "plain ", "reply"], [_make_tool("python")]
+    )
+    assert text == "just a plain reply"
+    assert calls == []
+
+
+def test_streaming_bookkeeping_for_serving_layer() -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text = (
+        TOOLS_OPEN + _call_block("python", 1, {"code": ("string", "a")}) + TOOLS_CLOSE
+    )
+    _stream(detector, _chunks(text, 9), tools)
+    assert detector.current_tool_id == 0
+    assert detector.prev_tool_call_arr[0] == {
+        "name": "python",
+        "arguments": {"code": "a"},
+    }
+    assert json.loads(detector.streamed_args_for_tool[0]) == {"code": "a"}
+
+
+def test_detector_capabilities_and_registration() -> None:
+    detector = KimiK3Detector()
+    assert not detector.supports_structural_tag()
+    assert detector.parses_required_natively()
+    parser = FunctionCallParser([_make_tool("python")], "kimi_k3")
+    assert isinstance(parser.detector, KimiK3Detector)
+    assert parser.get_structure_constraint("required") is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -27,6 +27,7 @@ from sglang.srt.entrypoints.openai.serving_chat import (
     OpenAIServingChat,
     normalize_tool_content,
 )
+from sglang.srt.function_call.kimik3_format import TOOLS_CLOSE
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.template_detection import ReasoningToggleConfig
 from sglang.srt.utils import get_or_create_event_loop
@@ -563,6 +564,86 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertFalse(
                 parser.get_structure_constraint.call_args.kwargs["thinking_mode"]
             )
+
+    def test_kimi_k3_tool_call_stops_at_tools_close(self):
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.chat.tool_call_parser = "kimi_k3"
+        self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+                "strict": True,
+            },
+        }
+
+        cases = (
+            (None, [TOOLS_CLOSE]),
+            ("USER_STOP", ["USER_STOP", TOOLS_CLOSE]),
+            (["USER_STOP"], ["USER_STOP", TOOLS_CLOSE]),
+            ([TOOLS_CLOSE], [TOOLS_CLOSE]),
+        )
+        for request_stop, expected in cases:
+            with (
+                self.subTest(request_stop=request_stop),
+                patch(
+                    "sglang.srt.entrypoints.openai.serving_chat.FunctionCallParser"
+                ) as parser_cls,
+            ):
+                parser = parser_cls.return_value
+                parser.detector.eot_token = TOOLS_CLOSE
+                parser.detector.parses_required_natively.return_value = True
+                parser.get_structure_constraint.return_value = None
+                request = ChatCompletionRequest(
+                    model="x",
+                    messages=[{"role": "user", "content": "Weather in Paris?"}],
+                    tools=[tool],
+                    tool_choice="required",
+                    stop=request_stop,
+                )
+                original_stop = (
+                    list(request.stop)
+                    if isinstance(request.stop, list)
+                    else request.stop
+                )
+
+                result = self.chat._process_messages(request, is_multimodal=False)
+
+                self.assertEqual(result.stop, expected)
+                self.assertEqual(request.stop, original_stop)
+                self.assertIsNone(result.tool_call_constraint)
+
+    def test_kimi_k3_tool_call_stop_is_scoped_to_active_tools(self):
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.chat.tool_call_parser = "kimi_k3"
+        self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Weather in Paris?"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            tool_choice="none",
+        )
+
+        result = self.chat._process_messages(request, is_multimodal=False)
+
+        self.assertIsNone(result.stop)
 
     def test_jinja_rejects_non_object_tool_call_arguments(self):
         """History tool call arguments must parse to a JSON object."""


### PR DESCRIPTION
## Summary

- add streaming and non-streaming parsing for Kimi K3 XTML tool calls
- register `kimi_k3` with `FunctionCallParser`
- let model-native parsers bypass the incompatible JSON-only fallback for required tool choice
- stop Kimi K3 generation at the tools-channel close marker without mutating request stop lists
- add focused parser and serving-layer coverage

## Motivation

This extracts the base tool-call parser from #32541. Structural constrained decoding is intentionally left for the next PR so this layer remains focused on parsing and serving behavior.

## Validation

- `13 passed` in focused Kimi K3 tool-call parser tests
- `73 passed, 7 subtests passed` across registered function-call tests on the full stack
- `84 passed, 31 subtests passed` in `test_serving_chat.py` on the full stack
- changed-file pre-commit hooks and `git diff --check` pass

## Stack

- depends on #33017
- this PR contains one additional commit and targets the previous stack branch for a clean diff
- after #33017 lands, retarget this PR to `main`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608699594](https://github.com/sgl-project/sglang/actions/runs/30608699594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608699401](https://github.com/sgl-project/sglang/actions/runs/30608699401)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->