### PR TITLE
[Kimi K3] Add structural tool constraints

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -382,6 +382,7 @@ class BaseFormatDetector(ABC):
         tools: Union[List[Tool], None] = None,
         tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
         thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
     ) -> Optional[StructuralTag]:
         """
         Return a model-native XGrammar structural tag when supported.
@@ -394,6 +395,11 @@ class BaseFormatDetector(ABC):
                 ReasonerGrammarBackend will own the <think>...</think> prefix
                 (the typical case when --reasoning-parser is configured) so
                 only one layer constrains the reasoning section.
+            parallel_tool_calls: Whether multiple tool calls may appear in one
+                assistant response. xgrammar's get_model_structural_tag does
+                not expose this knob, so this base implementation ignores it;
+                only detectors that build their own tags (e.g. Kimi K3)
+                honor it.
 
         Returns:
             StructuralTag if this detector supports model-native tags, otherwise None
@@ -416,7 +422,10 @@ class BaseFormatDetector(ABC):
         )
 
     def get_auto_tool_call_structural_tag(
-        self, tools: Union[List[Tool], None] = None
+        self,
+        tools: Union[List[Tool], None] = None,
+        thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
     ) -> Optional[StructuralTag]:
         """Return an always-on structural tag for automatic tool choice.
 

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -254,16 +254,31 @@ class FunctionCallParser:
         try:
             if tool_choice == "auto" and not should_constrain_auto:
                 structural_tag = self.detector.get_auto_tool_call_structural_tag(
-                    tools=self.tools
+                    tools=self.tools,
+                    thinking_mode=thinking_mode,
+                    parallel_tool_calls=parallel_tool_calls,
                 )
                 if structural_tag is not None:
                     return ("structural_tag", structural_tag)
 
             if is_required or should_constrain_auto:
+                structural_tag_tools = self.tools
+                if self.tool_strict_level >= ToolStrictLevel.PARAMETER:
+                    structural_tag_tools = [
+                        tool.model_copy(
+                            update={
+                                "function": tool.function.model_copy(
+                                    update={"strict": True}
+                                )
+                            }
+                        )
+                        for tool in self.tools
+                    ]
                 structural_tag = self.detector.get_structural_tag(
-                    tools=self.tools,
+                    tools=structural_tag_tools,
                     thinking_mode=thinking_mode,
                     tool_choice=tool_choice,
+                    parallel_tool_calls=parallel_tool_calls,
                 )
                 if structural_tag is not None:
                     return ("structural_tag", structural_tag)

--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -822,11 +822,15 @@ class Glm47MoeDetector(BaseFormatDetector):
         tools: Union[List[Tool], None] = None,
         tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
         thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
     ) -> Optional[StructuralTag]:
         if not self.supports_structural_tag():
             return None
         return super().get_structural_tag(
-            tools=tools, tool_choice=tool_choice, thinking_mode=thinking_mode
+            tools=tools,
+            tool_choice=tool_choice,
+            thinking_mode=thinking_mode,
+            parallel_tool_calls=parallel_tool_calls,
         )
 
     def structure_info(self) -> _GetInfoFunc:

--- a/python/sglang/srt/function_call/inkling_detector.py
+++ b/python/sglang/srt/function_call/inkling_detector.py
@@ -238,7 +238,10 @@ class InklingDetector(BaseFormatDetector):
         return info
 
     def get_auto_tool_call_structural_tag(
-        self, tools: Optional[List[Tool]] = None
+        self,
+        tools: Optional[List[Tool]] = None,
+        thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
     ) -> StructuralTag:
         """Constrain JSON after Inkling's tool-payload trigger token.
 
@@ -248,7 +251,7 @@ class InklingDetector(BaseFormatDetector):
         ``END_MESSAGE``. This mirrors the TML sampling default used by the OAI
         API and intentionally does not restrict names to the request's tools.
         """
-        del tools
+        del tools, thinking_mode, parallel_tool_calls
         return StructuralTag.model_validate(
             {
                 "type": "structural_tag",

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -430,12 +430,16 @@ class KimiK2Detector(BaseFormatDetector):
         tools: Union[List[Tool], None] = None,
         tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
         thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
     ) -> Optional[StructuralTag]:
         if not (
             tools and (tool_choice == "required" or isinstance(tool_choice, ToolChoice))
         ):
             return super().get_structural_tag(
-                tools=tools, tool_choice=tool_choice, thinking_mode=thinking_mode
+                tools=tools,
+                tool_choice=tool_choice,
+                thinking_mode=thinking_mode,
+                parallel_tool_calls=parallel_tool_calls,
             )
         if get_model_structural_tag is None:
             return None

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import re
-from typing import List
+from typing import List, Literal, Optional, Union
 
-from sglang.srt.entrypoints.openai.protocol import Tool
+from xgrammar import StructuralTag
+
+from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
     StreamingParseResult,
@@ -18,6 +20,10 @@ from sglang.srt.function_call.kimik3_format import (
     TOOLS_OPEN,
     partial_suffix_len,
     strip_response_wrappers,
+)
+from sglang.srt.function_call.kimik3_structural_tag import (
+    get_kimik3_auto_tool_call_structural_tag,
+    get_kimik3_structural_tag,
 )
 
 logger = logging.getLogger(__name__)
@@ -60,9 +66,7 @@ class KimiK3Detector(BaseFormatDetector):
 
     ``type="string"`` argument values are raw text; other types are
     JSON-decoded. Attribute values reverse the template's ``&amp;``/``&quot;``
-    escaping. Constrained generation is unsupported: XTML per-argument
-    encoding cannot be expressed as a JSON-schema or structural-tag grammar,
-    so ``required`` tool choice is parsed natively without a constraint.
+    escaping.
     """
 
     def __init__(self):
@@ -75,14 +79,40 @@ class KimiK3Detector(BaseFormatDetector):
         return self.bot_token in text
 
     def supports_structural_tag(self) -> bool:
-        return False
+        return True
 
     def parses_required_natively(self) -> bool:
-        return True
+        return False
 
     def structure_info(self) -> _GetInfoFunc:
         raise NotImplementedError(
-            "Kimi K3 XTML tool calls do not support constrained generation"
+            "Kimi K3 uses its model-native structural tag implementation"
+        )
+
+    def get_auto_tool_call_structural_tag(
+        self,
+        tools: Union[List[Tool], None] = None,
+        thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
+    ) -> Optional[StructuralTag]:
+        return get_kimik3_auto_tool_call_structural_tag(
+            tools or [],
+            thinking_mode=thinking_mode,
+            parallel_tool_calls=parallel_tool_calls,
+        )
+
+    def get_structural_tag(
+        self,
+        tools: Union[List[Tool], None] = None,
+        tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
+        thinking_mode: bool = False,
+        parallel_tool_calls: bool = True,
+    ) -> StructuralTag:
+        return get_kimik3_structural_tag(
+            tools=tools or [],
+            tool_choice=tool_choice,
+            thinking_mode=thinking_mode,
+            parallel_tool_calls=parallel_tool_calls,
         )
 
     def _decode_call(self, attrs: str, body: str) -> dict | None:

--- a/python/sglang/srt/function_call/kimik3_structural_tag.py
+++ b/python/sglang/srt/function_call/kimik3_structural_tag.py
@@ -1,0 +1,598 @@
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
+
+from xgrammar import StructuralTag
+from xgrammar.structural_tag import (
+    AnyTextFormat,
+    AnyTokensFormat,
+    ConstStringFormat,
+    ExcludeTokenFormat,
+    Format,
+    JSONSchemaFormat,
+    OptionalFormat,
+    OrFormat,
+    RegexFormat,
+    SequenceFormat,
+    StarFormat,
+    TagFormat,
+    TagsWithSeparatorFormat,
+    TokenFormat,
+    TriggeredTagsFormat,
+)
+
+from sglang.srt.entrypoints.openai.protocol import Tool, ToolChoice
+from sglang.srt.function_call.kimik3_format import (
+    ARGUMENT_CLOSE,
+    CALL_CLOSE,
+    CALL_OPEN,
+    THINK_CLOSE,
+    THINK_OPEN,
+    TOOLS_CLOSE,
+    TOOLS_OPEN,
+)
+
+_JSON_TYPES = (
+    "string",
+    "number",
+    "integer",
+    "boolean",
+    "array",
+    "object",
+    "null",
+)
+_CLOSE_TOKEN = "<|close|>"
+_ARGUMENT_CLOSE_SUFFIX = ARGUMENT_CLOSE.removeprefix(_CLOSE_TOKEN)
+_JSON_TO_XTML_TYPE = {
+    "string": "string",
+    "number": "number",
+    "integer": "number",
+    "boolean": "boolean",
+    "array": "array",
+    "object": "object",
+    "null": "null",
+}
+_STRING_KEYWORDS = {"format", "maxLength", "minLength", "pattern"}
+_NUMBER_KEYWORDS = {
+    "exclusiveMaximum",
+    "exclusiveMinimum",
+    "maximum",
+    "minimum",
+    "multipleOf",
+}
+_ARRAY_KEYWORDS = {
+    "contains",
+    "items",
+    "maxContains",
+    "maxItems",
+    "minContains",
+    "minItems",
+    "prefixItems",
+    "uniqueItems",
+}
+_OBJECT_KEYWORDS = {
+    "additionalProperties",
+    "dependentRequired",
+    "dependentSchemas",
+    "maxProperties",
+    "minProperties",
+    "patternProperties",
+    "properties",
+    "propertyNames",
+    "required",
+}
+
+
+def _escape_attr(value: str) -> str:
+    return value.replace("&", "&amp;").replace('"', "&quot;")
+
+
+def _json_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    return "object"
+
+
+def _matches_json_type(value: Any, json_type: str) -> bool:
+    value_type = _json_type(value)
+    return value_type == json_type or (
+        json_type == "number" and value_type == "integer"
+    )
+
+
+def _resolve_local_ref(
+    ref: str, root_schema: Dict[str, Any]
+) -> Optional[Union[bool, Dict[str, Any]]]:
+    if not ref.startswith("#/"):
+        return None
+    value: Any = root_schema
+    for part in ref[2:].split("/"):
+        key = part.replace("~1", "/").replace("~0", "~")
+        if not isinstance(value, dict) or key not in value:
+            return None
+        value = value[key]
+    if isinstance(value, (bool, dict)):
+        return value
+    return None
+
+
+def _schema_types(
+    schema: Union[bool, Dict[str, Any]],
+    root_schema: Dict[str, Any],
+    seen_refs: Optional[Set[str]] = None,
+) -> List[str]:
+    if schema is False:
+        return []
+    if schema is True:
+        return list(_JSON_TYPES)
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        seen_refs = set() if seen_refs is None else set(seen_refs)
+        if ref not in seen_refs:
+            target = _resolve_local_ref(ref, root_schema)
+            if target is not None:
+                seen_refs.add(ref)
+                return _schema_types(target, root_schema, seen_refs)
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str):
+        return [schema_type] if schema_type in _JSON_TYPES else list(_JSON_TYPES)
+    if isinstance(schema_type, list):
+        return [item for item in _JSON_TYPES if item in schema_type]
+
+    for keyword in ("anyOf", "oneOf"):
+        options = schema.get(keyword)
+        if isinstance(options, list):
+            option_types = {
+                item
+                for option in options
+                if isinstance(option, (bool, dict))
+                for item in _schema_types(option, root_schema, seen_refs)
+            }
+            return [item for item in _JSON_TYPES if item in option_types]
+
+    options = schema.get("allOf")
+    if isinstance(options, list):
+        type_sets = [
+            set(_schema_types(option, root_schema, seen_refs))
+            for option in options
+            if isinstance(option, (bool, dict))
+        ]
+        constrained = [types for types in type_sets if types != set(_JSON_TYPES)]
+        if constrained:
+            result = constrained[0] | (
+                {"integer"} if "number" in constrained[0] else set()
+            )
+            for types in constrained[1:]:
+                result &= types | ({"integer"} if "number" in types else set())
+            # number survives the intersection only if every branch allows it,
+            # making the widened integer redundant rather than the other way.
+            if "number" in result and "integer" in result:
+                result.remove("integer")
+            return [item for item in _JSON_TYPES if item in result]
+
+    if "const" in schema:
+        return [_json_type(schema["const"])]
+    enum = schema.get("enum")
+    if isinstance(enum, list):
+        enum_types = {_json_type(value) for value in enum}
+        return [item for item in _JSON_TYPES if item in enum_types]
+    if _OBJECT_KEYWORDS.intersection(schema):
+        return ["object"]
+    if _ARRAY_KEYWORDS.intersection(schema):
+        return ["array"]
+    if _STRING_KEYWORDS.intersection(schema):
+        return ["string"]
+    if _NUMBER_KEYWORDS.intersection(schema):
+        return ["number"]
+    return list(_JSON_TYPES)
+
+
+def _with_root_definitions(
+    schema: Union[bool, Dict[str, Any]], root_schema: Dict[str, Any]
+) -> Union[bool, Dict[str, Any]]:
+    if not isinstance(schema, dict):
+        return schema
+    result = dict(schema)
+    for key in ("$defs", "definitions"):
+        if key in root_schema and key not in result:
+            result[key] = root_schema[key]
+    return result
+
+
+def _restrict_schema_type(
+    schema: Union[bool, Dict[str, Any]],
+    json_type: str,
+    root_schema: Dict[str, Any],
+) -> Union[bool, Dict[str, Any]]:
+    if not isinstance(schema, dict):
+        return {"type": json_type} if schema else False
+
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        target = _resolve_local_ref(ref, root_schema)
+        if target is not None:
+            return _with_root_definitions(
+                _restrict_schema_type(target, json_type, root_schema), root_schema
+            )
+
+    result = dict(schema)
+    schema_type = result.get("type")
+    if isinstance(schema_type, list):
+        if json_type not in schema_type:
+            return False
+        result["type"] = json_type
+    elif isinstance(schema_type, str):
+        if schema_type != json_type:
+            return False
+    else:
+        result["type"] = json_type
+
+    for keyword in ("anyOf", "oneOf"):
+        options = result.get(keyword)
+        if not isinstance(options, list):
+            continue
+        restricted = [
+            _restrict_schema_type(option, json_type, root_schema)
+            for option in options
+            if isinstance(option, (bool, dict))
+            and json_type in _schema_types(option, root_schema)
+        ]
+        if not restricted:
+            return False
+        if len(restricted) == 1 and isinstance(restricted[0], dict):
+            result.pop(keyword)
+            result.update(restricted[0])
+        else:
+            result[keyword] = restricted
+
+    enum = result.get("enum")
+    if isinstance(enum, list):
+        result["enum"] = [
+            value for value in enum if _matches_json_type(value, json_type)
+        ]
+        if not result["enum"]:
+            return False
+    if "const" in result and not _matches_json_type(result["const"], json_type):
+        return False
+    return _with_root_definitions(result, root_schema)
+
+
+def _value_format(
+    schema: Union[bool, Dict[str, Any]],
+    json_type: str,
+    loose_string: bool = False,
+) -> Format:
+    if loose_string and json_type == "string":
+        return AnyTextFormat()
+    return JSONSchemaFormat(
+        json_schema=schema,
+        style="qwen_xml" if json_type == "string" else "json",
+    )
+
+
+def _argument_value_variants(
+    schema: Union[bool, Dict[str, Any]],
+    root_schema: Dict[str, Any],
+    loose_strings: bool = False,
+) -> List[Tuple[str, Format]]:
+    return [
+        (
+            json_type,
+            _value_format(restricted, json_type, loose_string=loose_strings),
+        )
+        for json_type in _schema_types(schema, root_schema)
+        if (restricted := _restrict_schema_type(schema, json_type, root_schema))
+        is not False
+    ]
+
+
+def _known_argument_format(
+    key: str,
+    schema: Union[bool, Dict[str, Any]],
+    root_schema: Dict[str, Any],
+) -> Optional[Format]:
+    escaped_key = _escape_attr(key)
+    variants = [
+        TagFormat(
+            begin=(
+                f'<|open|>argument key="{escaped_key}" '
+                f'type="{_JSON_TO_XTML_TYPE[json_type]}"<|sep|>'
+            ),
+            content=value_format,
+            end=ARGUMENT_CLOSE,
+        )
+        for json_type, value_format in _argument_value_variants(schema, root_schema)
+    ]
+    if not variants:
+        return None
+    if len(variants) == 1:
+        return variants[0]
+    return OrFormat(elements=variants)
+
+
+def _dynamic_argument_format(
+    schema: Union[bool, Dict[str, Any]],
+    root_schema: Dict[str, Any],
+    loose_strings: bool = False,
+) -> Format:
+    variants = [
+        SequenceFormat(
+            elements=[
+                RegexFormat(pattern=r'[^"& \t\r\n\f\v=<>]+'),
+                ConstStringFormat(
+                    value=(f'" type="{_JSON_TO_XTML_TYPE[json_type]}"<|sep|>')
+                ),
+                value_format,
+            ]
+        )
+        for json_type, value_format in _argument_value_variants(
+            schema, root_schema, loose_strings=loose_strings
+        )
+    ]
+    if not variants:
+        raise ValueError("Kimi K3 additional parameter schema accepts no values")
+    content = variants[0] if len(variants) == 1 else OrFormat(elements=variants)
+    return TagFormat(
+        begin='<|open|>argument key="',
+        content=content,
+        end=ARGUMENT_CLOSE,
+    )
+
+
+def _strict_arguments_format(parameters: Dict[str, Any]) -> Format:
+    properties = parameters.get("properties", {})
+    if not isinstance(properties, dict):
+        raise ValueError("Kimi K3 tool parameters 'properties' must be an object")
+    required = parameters.get("required", [])
+    if not isinstance(required, list) or not all(
+        isinstance(item, str) for item in required
+    ):
+        raise ValueError("Kimi K3 tool parameters 'required' must be a string list")
+
+    required_set = set(required)
+    missing = required_set.difference(properties)
+    if missing:
+        raise ValueError(
+            f"Kimi K3 required parameters are missing schemas: {sorted(missing)!r}"
+        )
+
+    elements: List[Format] = []
+    for key, schema in properties.items():
+        if not isinstance(key, str) or not isinstance(schema, (bool, dict)):
+            raise ValueError("Kimi K3 tool property schemas must be JSON schemas")
+        argument = _known_argument_format(key, schema, parameters)
+        if argument is None:
+            if key in required_set:
+                raise ValueError(
+                    f"Kimi K3 required parameter {key!r} accepts no values"
+                )
+            continue
+        elements.append(
+            argument if key in required_set else OptionalFormat(content=argument)
+        )
+
+    additional = parameters.get("additionalProperties", True)
+    if additional is True:
+        elements.append(StarFormat(content=_dynamic_argument_format(True, parameters)))
+    elif isinstance(additional, dict):
+        elements.append(
+            StarFormat(content=_dynamic_argument_format(additional, parameters))
+        )
+    elif additional is not False:
+        raise ValueError(
+            "Kimi K3 tool parameters 'additionalProperties' must be a schema"
+        )
+    if not elements:
+        return ConstStringFormat(value="")
+    return SequenceFormat(elements=elements)
+
+
+def _tool_arguments_format(tool: Tool) -> Format:
+    parameters = tool.function.parameters
+    if not tool.function.strict:
+        root_schema = parameters if isinstance(parameters, dict) else {}
+        return StarFormat(
+            content=_dynamic_argument_format(True, root_schema, loose_strings=True)
+        )
+    if parameters is None:
+        # Server-side strict levels mark tools without parameters strict too;
+        # they take no arguments rather than failing the whole constraint.
+        return ConstStringFormat(value="")
+    if not isinstance(parameters, dict):
+        raise ValueError(
+            f"Kimi K3 strict tool {tool.function.name!r} must define parameters"
+        )
+    schema_types = _schema_types(parameters, parameters)
+    if "object" not in schema_types:
+        raise ValueError(
+            f"Kimi K3 tool {tool.function.name!r} parameters must be an object schema"
+        )
+    return _strict_arguments_format(parameters)
+
+
+def _tool_call_tag(tool: Tool, arguments_format: Optional[Format] = None) -> TagFormat:
+    name = _escape_attr(tool.function.name)
+    if arguments_format is None:
+        arguments_format = _tool_arguments_format(tool)
+    return TagFormat(
+        begin=f'{CALL_OPEN} tool="{name}" index="',
+        content=SequenceFormat(
+            elements=[
+                RegexFormat(pattern=r"[1-9][0-9]*"),
+                ConstStringFormat(value='"<|sep|>'),
+                arguments_format,
+            ]
+        ),
+        end=CALL_CLOSE,
+    )
+
+
+def _tool_calls_tag(call_tags: List[TagFormat], parallel_tool_calls: bool) -> TagFormat:
+    if parallel_tool_calls:
+        content: Format = TagsWithSeparatorFormat(
+            tags=call_tags, separator="", at_least_one=True
+        )
+    elif len(call_tags) == 1:
+        content = call_tags[0]
+    else:
+        content = OrFormat(elements=call_tags)
+    return TagFormat(begin=TOOLS_OPEN, content=content, end=TOOLS_CLOSE)
+
+
+def _auto_suffix(
+    tools_tag: TagFormat, parallel_tool_calls: bool
+) -> TriggeredTagsFormat:
+    # A retriggered second tools section would evade the single-call limit.
+    return TriggeredTagsFormat(
+        triggers=[TOOLS_OPEN],
+        tags=[tools_tag],
+        excludes=[THINK_OPEN, THINK_CLOSE, CALL_OPEN],
+        stop_after_first=not parallel_tool_calls,
+    )
+
+
+def _with_reasoning(suffix: Format, thinking_mode: bool) -> Format:
+    if not thinking_mode:
+        return suffix
+    return SequenceFormat(
+        elements=[
+            TagFormat(begin="", content=AnyTextFormat(), end=THINK_CLOSE),
+            suffix,
+        ]
+    )
+
+
+def _single_xtml_type(
+    schema: Union[bool, Dict[str, Any]], root_schema: Dict[str, Any]
+) -> Optional[str]:
+    schema_types = _schema_types(schema, root_schema)
+    if len(schema_types) != 1:
+        return None
+    return _JSON_TO_XTML_TYPE[schema_types[0]]
+
+
+def _nonempty_argument_format(key: str, xtml_type: str) -> Format:
+    # A token-based end keeps the first close token out of both content formats.
+    argument = TagFormat(
+        begin=(
+            f'<|open|>argument key="{_escape_attr(key)}" ' f'type="{xtml_type}"<|sep|>'
+        ),
+        content=SequenceFormat(elements=[ExcludeTokenFormat(), AnyTokensFormat()]),
+        end=TokenFormat(token=_CLOSE_TOKEN),
+    )
+    return SequenceFormat(
+        elements=[
+            argument,
+            ConstStringFormat(value=_ARGUMENT_CLOSE_SUFFIX),
+        ]
+    )
+
+
+def _auto_tool_arguments_format(tool: Tool) -> Format:
+    parameters = tool.function.parameters
+    if not isinstance(parameters, dict):
+        return AnyTextFormat()
+    properties = parameters.get("properties", {})
+    required = parameters.get("required", [])
+    if not isinstance(properties, dict) or not isinstance(required, list):
+        return AnyTextFormat()
+
+    required_tags: List[Format] = []
+    for key in required:
+        schema = properties.get(key)
+        if not isinstance(key, str) or not isinstance(schema, (bool, dict)):
+            return AnyTextFormat()
+        xtml_type = _single_xtml_type(schema, parameters)
+        if xtml_type is None:
+            return AnyTextFormat()
+        required_tags.append(_nonempty_argument_format(key, xtml_type))
+
+    if required_tags:
+        elements = required_tags
+    else:
+        alternatives = [
+            _nonempty_argument_format(key, xtml_type)
+            for key, schema in properties.items()
+            if isinstance(key, str)
+            and isinstance(schema, (bool, dict))
+            and (xtml_type := _single_xtml_type(schema, parameters)) is not None
+        ]
+        if not alternatives:
+            return AnyTextFormat()
+        elements = [
+            (
+                alternatives[0]
+                if len(alternatives) == 1
+                else OrFormat(elements=alternatives)
+            )
+        ]
+
+    return SequenceFormat(
+        elements=[*elements, AnyTextFormat(excludes=[CALL_OPEN, CALL_CLOSE])]
+    )
+
+
+def get_kimik3_auto_tool_call_structural_tag(
+    tools: List[Tool],
+    thinking_mode: bool = False,
+    parallel_tool_calls: bool = True,
+) -> Optional[StructuralTag]:
+    if not tools:
+        return None
+
+    call_tags = [
+        _tool_call_tag(tool, _auto_tool_arguments_format(tool)) for tool in tools
+    ]
+    suffix = _auto_suffix(
+        _tool_calls_tag(call_tags, parallel_tool_calls), parallel_tool_calls
+    )
+    return StructuralTag(format=_with_reasoning(suffix, thinking_mode))
+
+
+def _select_tools(
+    tools: List[Tool],
+    tool_choice: Union[ToolChoice, Literal["auto", "required"]],
+) -> Tuple[List[Tool], bool]:
+    if not isinstance(tool_choice, ToolChoice):
+        return tools, tool_choice == "required"
+    name = tool_choice.function.name
+    selected = [tool for tool in tools if tool.function.name == name]
+    if not selected:
+        raise ValueError(f"Kimi K3 tool choice {name!r} is not in the tools list")
+    return selected, True
+
+
+def get_kimik3_structural_tag(
+    tools: List[Tool],
+    tool_choice: Union[ToolChoice, Literal["auto", "required"]] = "auto",
+    thinking_mode: bool = False,
+    parallel_tool_calls: bool = True,
+) -> StructuralTag:
+    selected_tools, at_least_one = _select_tools(tools, tool_choice)
+    if not selected_tools:
+        raise ValueError("Kimi K3 structural tags require at least one tool")
+
+    call_tags = [_tool_call_tag(tool) for tool in selected_tools]
+    tools_tag = _tool_calls_tag(call_tags, parallel_tool_calls)
+    if at_least_one:
+        suffix: Format = SequenceFormat(
+            elements=[
+                AnyTextFormat(
+                    excludes=[TOOLS_OPEN, THINK_OPEN, THINK_CLOSE, CALL_OPEN]
+                ),
+                tools_tag,
+            ]
+        )
+    else:
+        suffix = _auto_suffix(tools_tag, parallel_tool_calls)
+    return StructuralTag(format=_with_reasoning(suffix, thinking_mode))

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -210,11 +210,11 @@ def test_streaming_bookkeeping_for_serving_layer() -> None:
 
 def test_detector_capabilities_and_registration() -> None:
     detector = KimiK3Detector()
-    assert not detector.supports_structural_tag()
-    assert detector.parses_required_natively()
+    assert detector.supports_structural_tag()
+    assert not detector.parses_required_natively()
     parser = FunctionCallParser([_make_tool("python")], "kimi_k3")
     assert isinstance(parser.detector, KimiK3Detector)
-    assert parser.get_structure_constraint("required") is None
+    assert parser.get_structure_constraint("required") is not None
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/function_call/test_kimik3_structural_tag.py
+++ b/test/registered/unit/function_call/test_kimik3_structural_tag.py
@@ -1,0 +1,818 @@
+import json
+import sys
+
+import pytest
+import xgrammar as xgr
+from xgrammar.testing import _is_grammar_accept_string
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    Function,
+    Tool,
+    ToolChoice,
+    ToolChoiceFuncName,
+)
+from sglang.srt.environ import ToolStrictLevel, envs
+from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.function_call.kimik3_detector import KimiK3Detector
+from sglang.srt.function_call.kimik3_format import (
+    ARGUMENT_CLOSE,
+    CALL_CLOSE,
+    THINK_CLOSE,
+    TOOLS_CLOSE,
+    TOOLS_OPEN,
+)
+from sglang.srt.function_call.kimik3_structural_tag import (
+    get_kimik3_auto_tool_call_structural_tag,
+    get_kimik3_structural_tag,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+_CLOSE_TOKEN = "<|close|>"
+_CLOSE_TOKEN_ID = 256
+_TOKENIZER_INFO = xgr.TokenizerInfo(
+    [bytes([token_id]) for token_id in range(256)] + [_CLOSE_TOKEN.encode()]
+)
+_TOKEN_COMPILER = xgr.GrammarCompiler(_TOKENIZER_INFO, cache_enabled=True)
+
+
+def _tool(name="weather", strict=True):
+    return Tool(
+        type="function",
+        function=Function(
+            name=name,
+            strict=strict,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string",
+                        "pattern": "[A-Z][A-Za-z ]+",
+                    },
+                    "days": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                    },
+                    "unit": {
+                        "type": ["string", "null"],
+                        "enum": ["celsius", "fahrenheit", None],
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "properties": {"source": {"type": "string"}},
+                        "required": ["source"],
+                        "additionalProperties": False,
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["city", "days"],
+                "additionalProperties": False,
+            },
+        ),
+    )
+
+
+def _argument(key, argument_type, value):
+    return (
+        f'<|open|>argument key="{key}" type="{argument_type}"<|sep|>'
+        f"{value}{ARGUMENT_CLOSE}"
+    )
+
+
+def _call(name, index, *arguments):
+    return (
+        f'<|open|>call tool="{name}" index="{index}"<|sep|>'
+        + "".join(arguments)
+        + CALL_CLOSE
+    )
+
+
+def _tools_section(*calls):
+    return TOOLS_OPEN + "".join(calls) + TOOLS_CLOSE
+
+
+def _grammar(tools, tool_choice="auto", thinking_mode=False, parallel_tool_calls=True):
+    structural_tag = get_kimik3_structural_tag(
+        tools,
+        tool_choice=tool_choice,
+        thinking_mode=thinking_mode,
+        parallel_tool_calls=parallel_tool_calls,
+    )
+    return xgr.Grammar.from_structural_tag(structural_tag)
+
+
+def _accepts(grammar, value):
+    return _is_grammar_accept_string(grammar, value)
+
+
+def _encode_with_close_token(value):
+    token_ids = []
+    start = 0
+    while (index := value.find(_CLOSE_TOKEN, start)) != -1:
+        token_ids.extend(value[start:index].encode())
+        token_ids.append(_CLOSE_TOKEN_ID)
+        start = index + len(_CLOSE_TOKEN)
+    token_ids.extend(value[start:].encode())
+    return token_ids
+
+
+def _token_accepts(structural_tag, value):
+    compiled = _TOKEN_COMPILER.compile_structural_tag(structural_tag)
+    matcher = xgr.GrammarMatcher(compiled)
+    for token_id in _encode_with_close_token(value):
+        if not matcher.accept_token(token_id):
+            return False
+    return matcher.is_completed()
+
+
+def _valid_weather_call(index=1):
+    return _call(
+        "weather",
+        index,
+        _argument("city", "string", "San Francisco"),
+        _argument("days", "number", "3"),
+        _argument("unit", "string", "celsius"),
+        _argument("metadata", "object", '{"source":"forecast"}'),
+        _argument("tags", "array", '["coastal","windy"]'),
+    )
+
+
+def test_detector_advertises_model_native_structural_tag():
+    detector = KimiK3Detector()
+
+    assert detector.supports_structural_tag()
+    assert not detector.parses_required_natively()
+    assert isinstance(detector.get_structural_tag([_tool()]), xgr.StructuralTag)
+
+
+def test_strict_schema_accepts_native_xtml_values():
+    grammar = _grammar([_tool()], tool_choice="required")
+
+    assert _accepts(grammar, _tools_section(_valid_weather_call()))
+    assert _accepts(
+        grammar,
+        _tools_section(
+            _call(
+                "weather",
+                1,
+                _argument("city", "string", "Paris"),
+                _argument("days", "number", "1"),
+            )
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        (_argument("city", "string", "paris"), _argument("days", "number", "3")),
+        (
+            _argument("city", "string", "Paris"),
+            _argument("days", "number", "11"),
+        ),
+        (
+            _argument("city", "number", "3"),
+            _argument("days", "number", "3"),
+        ),
+        (
+            _argument("city", "string", "Paris"),
+            _argument("days", "number", "3"),
+            _argument("unit", "string", "kelvin"),
+        ),
+        (
+            _argument("city", "string", "Paris"),
+            _argument("days", "number", "3"),
+            _argument("tags", "array", "[coastal]"),
+        ),
+        (
+            _argument("city", "string", "Paris"),
+            _argument("days", "number", "3"),
+            _argument("unknown", "string", "value"),
+        ),
+    ],
+)
+def test_strict_schema_rejects_invalid_parameters(arguments):
+    grammar = _grammar([_tool()], tool_choice="required")
+
+    assert not _accepts(grammar, _tools_section(_call("weather", 1, *arguments)))
+
+
+def test_required_allows_response_prefix_but_requires_tools():
+    grammar = _grammar([_tool()], tool_choice="required")
+    response = "<|open|>response<|sep|>Checking." "<|close|>response<|sep|>"
+
+    assert _accepts(grammar, response + _tools_section(_valid_weather_call()))
+    assert not _accepts(grammar, response)
+
+
+def test_auto_allows_plain_response_or_multiple_tool_calls():
+    grammar = _grammar([_tool(), _tool("forecast")])
+    plain = (
+        "<|open|>response<|sep|>No tool needed."
+        "<|close|>response<|sep|><|close|>message<|sep|>"
+    )
+    calls = _tools_section(
+        _valid_weather_call(),
+        _call(
+            "forecast",
+            2,
+            _argument("city", "string", "London"),
+            _argument("days", "number", "2"),
+        ),
+    )
+
+    assert _accepts(grammar, plain)
+    assert _accepts(grammar, calls)
+
+
+def test_named_tool_choice_forces_only_the_selected_tool():
+    grammar = _grammar(
+        [_tool(), _tool("forecast")],
+        tool_choice=ToolChoice(function=ToolChoiceFuncName(name="forecast")),
+    )
+    forecast_call = _call(
+        "forecast",
+        1,
+        _argument("city", "string", "London"),
+        _argument("days", "number", "2"),
+    )
+
+    assert _accepts(grammar, _tools_section(forecast_call))
+    assert not _accepts(grammar, _tools_section(_valid_weather_call()))
+
+
+def test_function_call_parser_uses_native_tag_for_named_tool_choice():
+    tool_choice = ToolChoice(function=ToolChoiceFuncName(name="forecast"))
+    constraint = FunctionCallParser(
+        [_tool(), _tool("forecast")], "kimi_k3"
+    ).get_structure_constraint(tool_choice)
+    assert constraint is not None
+    grammar = xgr.Grammar.from_structural_tag(constraint[1])
+    forecast_call = _call(
+        "forecast",
+        1,
+        _argument("city", "string", "London"),
+        _argument("days", "number", "2"),
+    )
+
+    assert _accepts(grammar, _tools_section(forecast_call))
+    assert not _accepts(grammar, _tools_section(_valid_weather_call()))
+
+
+def test_non_strict_tool_keeps_xtml_structure_and_loose_parameters():
+    grammar = _grammar([_tool(strict=False)], tool_choice="required")
+    call = _call(
+        "weather",
+        1,
+        _argument("custom", "array", '["x",1]'),
+        _argument("other", "string", "raw text"),
+    )
+
+    assert _accepts(grammar, _tools_section(call))
+    assert not _accepts(grammar, _tools_section("unstructured"))
+
+
+def test_strict_schema_supports_refs_and_mixed_unions():
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="convert",
+            strict=True,
+            parameters={
+                "type": "object",
+                "$defs": {
+                    "mode": {
+                        "type": "string",
+                        "enum": ["fast", "safe"],
+                    }
+                },
+                "properties": {
+                    "mode": {"$ref": "#/$defs/mode"},
+                    "value": {
+                        "anyOf": [
+                            {"type": "string", "enum": ["auto"]},
+                            {
+                                "type": "integer",
+                                "minimum": 2,
+                                "maximum": 3,
+                            },
+                        ]
+                    },
+                },
+                "required": ["mode", "value"],
+                "additionalProperties": False,
+            },
+        ),
+    )
+    grammar = _grammar([tool], tool_choice="required")
+
+    assert _accepts(
+        grammar,
+        _tools_section(
+            _call(
+                "convert",
+                1,
+                _argument("mode", "string", "fast"),
+                _argument("value", "number", "2"),
+            )
+        ),
+    )
+    assert not _accepts(
+        grammar,
+        _tools_section(
+            _call(
+                "convert",
+                1,
+                _argument("mode", "string", "unsafe"),
+                _argument("value", "number", "1"),
+            )
+        ),
+    )
+
+
+def test_strict_schema_handles_number_enums_and_all_of_integer_constraints():
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="score",
+            strict=True,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "number",
+                        "enum": [1, 1.5],
+                    },
+                    "count": {
+                        "allOf": [
+                            {"type": "number"},
+                            {"type": "integer", "minimum": 1},
+                        ]
+                    },
+                },
+                "required": ["value", "count"],
+                "additionalProperties": False,
+            },
+        ),
+    )
+    grammar = _grammar([tool], tool_choice="required")
+
+    assert _accepts(
+        grammar,
+        _tools_section(
+            _call(
+                "score",
+                1,
+                _argument("value", "number", "1"),
+                _argument("count", "number", "2"),
+            )
+        ),
+    )
+    assert not _accepts(
+        grammar,
+        _tools_section(
+            _call(
+                "score",
+                1,
+                _argument("value", "number", "2"),
+                _argument("count", "number", "1.5"),
+            )
+        ),
+    )
+
+
+def test_strict_schema_preserves_additional_properties_default():
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="annotate",
+            strict=True,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "label": {"type": "string"},
+                },
+                "required": ["label"],
+            },
+        ),
+    )
+    grammar = _grammar([tool], tool_choice="required")
+
+    assert _accepts(
+        grammar,
+        _tools_section(
+            _call(
+                "annotate",
+                1,
+                _argument("label", "string", "sample"),
+                _argument("confidence", "number", "0.9"),
+            )
+        ),
+    )
+
+
+def test_dynamic_argument_key_compiles_without_xgrammar_unicode_warning(capfd):
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="annotate",
+            strict=True,
+            parameters={
+                "type": "object",
+                "properties": {},
+            },
+        ),
+    )
+    grammar = _grammar([tool], tool_choice="required")
+
+    assert _accepts(
+        grammar,
+        _tools_section(_call("annotate", 1, _argument("置信度", "number", "0.9"))),
+    )
+    assert "Negative Character class" not in capfd.readouterr().err
+
+
+def test_strict_empty_object_accepts_no_arguments_only():
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="ping",
+            strict=True,
+            parameters={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        ),
+    )
+    grammar = _grammar([tool], tool_choice="required")
+
+    assert _accepts(grammar, _tools_section(_call("ping", 1)))
+    assert not _accepts(
+        grammar,
+        _tools_section(_call("ping", 1, _argument("unexpected", "string", "value"))),
+    )
+
+
+def test_tool_strict_level_controls_native_tag_parameter_schema():
+    invalid_call = _tools_section(
+        _call(
+            "weather",
+            264,
+            _argument("city", "string", "paris"),
+            _argument("days", "number", "99"),
+        )
+    )
+    empty_call = _tools_section(_call("weather", 264))
+
+    with envs.SGLANG_TOOL_STRICT_LEVEL.override(ToolStrictLevel.OFF):
+        constraint = FunctionCallParser(
+            [_tool(strict=False)], "kimi_k3"
+        ).get_structure_constraint("auto")
+        assert constraint is not None
+        assert _token_accepts(constraint[1], invalid_call)
+        assert not _token_accepts(constraint[1], empty_call)
+
+    with envs.SGLANG_TOOL_STRICT_LEVEL.override(ToolStrictLevel.FUNCTION):
+        constraint = FunctionCallParser(
+            [_tool(strict=False)], "kimi_k3"
+        ).get_structure_constraint("auto")
+        assert constraint is not None
+        grammar = xgr.Grammar.from_structural_tag(constraint[1])
+        assert _accepts(grammar, invalid_call)
+        assert _accepts(grammar, empty_call)
+
+    with envs.SGLANG_TOOL_STRICT_LEVEL.override(ToolStrictLevel.PARAMETER):
+        constraint = FunctionCallParser(
+            [_tool(strict=False)], "kimi_k3"
+        ).get_structure_constraint("auto")
+        assert constraint is not None
+        assert not _accepts(
+            xgr.Grammar.from_structural_tag(constraint[1]), invalid_call
+        )
+
+
+def test_auto_hook_constrains_all_calls_and_requires_nonempty_values():
+    structural_tag = get_kimik3_auto_tool_call_structural_tag([_tool(strict=False)])
+    assert structural_tag is not None
+    first = _call(
+        "weather",
+        3,
+        _argument("city", "string", "Paris"),
+        _argument("days", "number", "3"),
+    )
+    second = _call(
+        "weather",
+        264,
+        _argument("city", "string", "London"),
+        _argument("days", "number", "2"),
+    )
+
+    assert _token_accepts(structural_tag, _tools_section(first, second))
+    assert not _token_accepts(
+        structural_tag,
+        _tools_section(first, _call("weather", 264)),
+    )
+    assert not _token_accepts(
+        structural_tag,
+        _tools_section(
+            _call(
+                "weather",
+                3,
+                _argument("city", "string", ""),
+                _argument("days", "number", "3"),
+            )
+        ),
+    )
+    assert not _token_accepts(structural_tag, _tools_section(_call("weather", 3)))
+
+
+def test_auto_hook_rejects_unknown_or_unclosed_calls():
+    structural_tag = get_kimik3_auto_tool_call_structural_tag([_tool(strict=False)])
+    assert structural_tag is not None
+    call = _call(
+        "weather",
+        49,
+        _argument("city", "string", "Paris"),
+        _argument("days", "number", "3"),
+    )
+    unknown = _call(
+        "forecast",
+        49,
+        _argument("city", "string", "Paris"),
+        _argument("days", "number", "3"),
+    )
+
+    assert not _token_accepts(structural_tag, _tools_section(unknown))
+    assert not _token_accepts(
+        structural_tag, TOOLS_OPEN + call.removesuffix(CALL_CLOSE)
+    )
+    assert not _token_accepts(structural_tag, TOOLS_OPEN + call)
+
+
+def test_auto_hook_does_not_swallow_parser_visible_closes():
+    structural_tag = get_kimik3_auto_tool_call_structural_tag([_tool(strict=False)])
+    assert structural_tag is not None
+    output = (
+        TOOLS_OPEN
+        + '<|open|>call tool="weather" index="23"<|sep|>'
+        + _argument("city", "string", "Paris")
+        + '<|open|>argument key="days" type="number"<|sep|>'
+        + ARGUMENT_CLOSE
+        + CALL_CLOSE
+        + "3"
+        + ARGUMENT_CLOSE
+        + CALL_CLOSE
+        + TOOLS_CLOSE
+    )
+
+    parsed = KimiK3Detector().detect_and_parse(output, [_tool(strict=False)])
+
+    assert json.loads(parsed.calls[0].parameters) == {"city": "Paris", "days": ""}
+    assert not _token_accepts(structural_tag, output)
+
+
+@pytest.mark.parametrize(
+    "tool_strict_level",
+    [
+        ToolStrictLevel.OFF,
+        ToolStrictLevel.FUNCTION,
+        ToolStrictLevel.PARAMETER,
+    ],
+)
+def test_parallel_tool_calls_false_rejects_second_call(tool_strict_level):
+    with envs.SGLANG_TOOL_STRICT_LEVEL.override(tool_strict_level):
+        constraint = FunctionCallParser(
+            [_tool(strict=False)], "kimi_k3"
+        ).get_structure_constraint("auto", parallel_tool_calls=False)
+    assert constraint is not None
+    first = _call(
+        "weather",
+        165,
+        _argument("city", "string", "Paris"),
+        _argument("days", "number", "3"),
+    )
+    second = _call(
+        "weather",
+        166,
+        _argument("city", "string", "London"),
+        _argument("days", "number", "2"),
+    )
+
+    assert _token_accepts(constraint[1], _tools_section(first))
+    assert not _token_accepts(constraint[1], _tools_section(first, second))
+    assert not _token_accepts(
+        constraint[1], _tools_section(first) + _tools_section(second)
+    )
+
+
+def test_parallel_tool_calls_true_constrains_every_call():
+    grammar = _grammar(
+        [_tool(strict=False)],
+        parallel_tool_calls=True,
+    )
+    first = _call(
+        "weather",
+        7,
+        _argument("city", "string", "Paris"),
+    )
+    second = _call(
+        "weather",
+        19,
+        _argument("other", "array", '["loose"]'),
+    )
+
+    assert _accepts(grammar, _tools_section(first, second))
+
+
+def test_parameter_level_constrains_every_parallel_call():
+    with envs.SGLANG_TOOL_STRICT_LEVEL.override(ToolStrictLevel.PARAMETER):
+        constraint = FunctionCallParser(
+            [_tool(strict=False)], "kimi_k3"
+        ).get_structure_constraint("auto")
+    assert constraint is not None
+    grammar = xgr.Grammar.from_structural_tag(constraint[1])
+    first = _valid_weather_call(index=3)
+    valid_second = _call(
+        "weather",
+        49,
+        _argument("city", "string", "London"),
+        _argument("days", "number", "2"),
+    )
+    invalid_second = _call(
+        "weather",
+        49,
+        _argument("city", "string", "london"),
+        _argument("days", "number", "99"),
+    )
+
+    assert _accepts(grammar, _tools_section(first, valid_second))
+    assert not _accepts(grammar, _tools_section(first, invalid_second))
+
+
+def test_strict_tool_without_parameters_compiles_to_empty_arguments():
+    """SGLANG_TOOL_STRICT_LEVEL=2 marks every tool strict, including tools
+    that declare no parameters; the grammar build must not fail for them."""
+    tool = Tool(type="function", function=Function(name="ping", strict=True))
+    grammar = _grammar([tool], tool_choice="required")
+
+    assert _accepts(grammar, _tools_section(_call("ping", 1)))
+    assert not _accepts(
+        grammar,
+        _tools_section(_call("ping", 1, _argument("x", "string", "y"))),
+    )
+
+
+def test_parameter_level_keeps_constraint_with_no_parameter_tool():
+    """A single no-parameter tool must not poison the whole request: a build
+    error here was swallowed and required fell back to a JSON-only grammar
+    the K3 parser cannot read."""
+    tools = [
+        _tool(strict=False),
+        Tool(type="function", function=Function(name="ping")),
+    ]
+    with envs.SGLANG_TOOL_STRICT_LEVEL.override(ToolStrictLevel.PARAMETER):
+        constraint = FunctionCallParser(tools, "kimi_k3").get_structure_constraint(
+            "required"
+        )
+
+    assert constraint is not None
+    assert constraint[0] == "structural_tag"
+
+
+def test_all_of_number_branches_do_not_narrow_to_integer():
+    """allOf with only number branches was intersected down to integer,
+    silently dropping non-integer enum values."""
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="scale",
+            strict=True,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "factor": {"allOf": [{"type": "number"}], "enum": [1.5, 2]},
+                },
+                "required": ["factor"],
+                "additionalProperties": False,
+            },
+        ),
+    )
+    grammar = _grammar([tool], tool_choice="required")
+
+    assert _accepts(
+        grammar,
+        _tools_section(_call("scale", 1, _argument("factor", "number", "1.5"))),
+    )
+    assert not _accepts(
+        grammar,
+        _tools_section(_call("scale", 1, _argument("factor", "number", "3"))),
+    )
+
+
+def test_auto_hook_serializes_into_sampling_parameters():
+    constraint = FunctionCallParser(
+        [_tool(strict=False)], "kimi_k3"
+    ).get_structure_constraint("auto")
+    assert constraint is not None
+    request = ChatCompletionRequest(
+        model="test",
+        messages=[{"role": "user", "content": "Weather?"}],
+        max_completion_tokens=16,
+    )
+
+    sampling_params = request.to_sampling_params(
+        stop=[],
+        model_generation_config={},
+        tool_call_constraint=constraint,
+    )
+
+    serialized = json.loads(sampling_params["structural_tag"])
+    assert serialized["type"] == "structural_tag"
+    assert serialized["format"]["type"] == "triggered_tags"
+
+
+def test_auto_hook_forces_one_typed_property_when_none_are_required():
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="search",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+            },
+        ),
+    )
+    structural_tag = get_kimik3_auto_tool_call_structural_tag([tool])
+    assert structural_tag is not None
+
+    assert _token_accepts(
+        structural_tag,
+        _tools_section(_call("search", 1, _argument("limit", "number", "3"))),
+    )
+    assert not _token_accepts(structural_tag, _tools_section(_call("search", 1)))
+
+
+def test_auto_hook_keeps_structure_for_ambiguous_required_argument_type():
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="lookup",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "key": {"type": ["string", "integer"]},
+                },
+                "required": ["key"],
+            },
+        ),
+    )
+
+    structural_tag = get_kimik3_auto_tool_call_structural_tag([tool])
+    assert structural_tag is not None
+    grammar = xgr.Grammar.from_structural_tag(structural_tag)
+
+    assert _accepts(
+        grammar,
+        _tools_section(_call("lookup", 9254, _argument("key", "number", "3"))),
+    )
+    assert not _accepts(
+        grammar,
+        TOOLS_OPEN + _call("lookup", 9254, _argument("key", "number", "3")),
+    )
+
+
+def test_parameter_level_applies_to_other_model_native_tags():
+    with envs.SGLANG_TOOL_STRICT_LEVEL.override(ToolStrictLevel.PARAMETER):
+        constraint = FunctionCallParser(
+            [_tool(strict=False)], "kimi_k2"
+        ).get_structure_constraint("auto")
+
+    assert constraint is not None
+    serialized = constraint[1].model_dump_json()
+    assert '"properties"' in serialized
+    assert '"city"' in serialized
+
+
+def test_reasoning_prefix_is_owned_by_exactly_one_layer():
+    tool = _tool()
+    wrapped_by_xgrammar = _grammar([tool], tool_choice="required", thinking_mode=True)
+    post_reasoning_only = _grammar([tool], tool_choice="required", thinking_mode=False)
+    output = "reasoning" + THINK_CLOSE + _tools_section(_valid_weather_call())
+
+    assert _accepts(wrapped_by_xgrammar, output)
+    assert not _accepts(post_reasoning_only, output)
+    assert _accepts(post_reasoning_only, _tools_section(_valid_weather_call()))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

- build Kimi K3's complete XTML tool section with XGrammar structural-tag formats
- support automatic, required, and named tool choice
- honor `parallel_tool_calls`, per-tool strict schemas, and `SGLANG_TOOL_STRICT_LEVEL`
- preserve Kimi K3's native per-argument encoding while enforcing JSON Schema constraints
- prevent argument content from consuming parser-visible XTML close delimiters

## Motivation

This extracts the structural constrained-decoding layer from #32541 and keeps it separate from the base tool-call parser. The grammar is cohesive but test-heavy, so isolating it makes both review surfaces materially smaller.

The previous automatic constraint only covered a narrow first-call shape. Continued conversations use global call indices, and malformed calls could bypass the grammar or consume close delimiters that the parser treats as structural boundaries.

## Validation

- `35 passed` in focused Kimi K3 structural-tag tests
- `436 passed, 14 subtests passed` across registered unit function-call tests on the full stack
- all changed-file pre-commit hooks and `git diff --check` pass
- prior Kimi K3 validation from the extracted implementation covered all 165 KVV schemas at strict levels 0/1/2 and zero max-token runaways in fixed benchmark runs

## Stack

- depends on #33018
- this PR contains one additional commit and targets the previous stack branch for a clean diff
- after #33018 lands, retarget this PR to `main`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608708441](https://github.com/sgl-project/sglang/actions/runs/30608708441)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608708331](https://github.com/sgl-project/sglang/actions/runs/30608708331)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->