### PR TITLE
[Kimi K3] Support parser auto-detection

### DIFF
--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -677,8 +677,11 @@ def _resolve_architecture_auto_parsers(server_args) -> None:
     )
     architectures = getattr(config, "architectures", None) or []
     arch = architectures[0] if architectures else ""
+    model_type = getattr(config, "model_type", "")
 
-    if "DeepseekV4" in arch:
+    if "KimiK3" in arch or model_type == "kimi_k3":
+        reasoning_parser, tool_call_parser = "kimi_k3", "kimi_k3"
+    elif "DeepseekV4" in arch:
         reasoning_parser, tool_call_parser = "deepseek-v4", "deepseekv4"
     elif "DeepseekV3" in arch:
         reasoning_parser, tool_call_parser = "deepseek-v3", "deepseekv32"

--- a/test/registered/unit/parser/test_template_manager.py
+++ b/test/registered/unit/parser/test_template_manager.py
@@ -15,7 +15,7 @@ from sglang.srt.parser.template_detection import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(2.0, "base-a-test-cpu")
+register_cpu_ci(est_time=2.0, suite="base-a-test-cpu")
 
 
 class _DummyTokenizer:
@@ -871,6 +871,34 @@ class TestResolveAutoParsers(unittest.TestCase):
 
         self.assertEqual(args.reasoning_parser, "deepseek-v4")
         self.assertEqual(args.tool_call_parser, "deepseekv4")
+
+    def test_kimi_k3_arch_without_chat_template_uses_custom_encoder(self):
+        args = self._make_server_args(reasoning_parser="auto", tool_call_parser="auto")
+        tokenizer = _DummyTokenizer([])
+        config = SimpleNamespace(
+            architectures=["KimiK3ForConditionalGeneration"], model_type="kimi_k3"
+        )
+
+        with _patch_hf_transformers_utils(
+            Mock(return_value=tokenizer), Mock(return_value=config)
+        ):
+            resolve_auto_parsers(args)
+
+        self.assertEqual(args.reasoning_parser, "kimi_k3")
+        self.assertEqual(args.tool_call_parser, "kimi_k3")
+
+    def test_kimi_k3_model_type_without_architecture_uses_custom_encoder(self):
+        args = self._make_server_args(reasoning_parser="auto", tool_call_parser="auto")
+        tokenizer = _DummyTokenizer([])
+        config = SimpleNamespace(architectures=None, model_type="kimi_k3")
+
+        with _patch_hf_transformers_utils(
+            Mock(return_value=tokenizer), Mock(return_value=config)
+        ):
+            resolve_auto_parsers(args)
+
+        self.assertEqual(args.reasoning_parser, "kimi_k3")
+        self.assertEqual(args.tool_call_parser, "kimi_k3")
 
     def test_deepseek_arch_fallback_runs_when_tokenizer_load_fails(self):
         args = self._make_server_args(reasoning_parser="auto", tool_call_parser="auto")


### PR DESCRIPTION
## Summary

- auto-select the Kimi K3 reasoning and tool-call parsers from either architecture or `model_type`
- cover configs with and without an architecture list

## Motivation

This preserves the small auto-detection change originally merged into #32541 through #32617 while keeping it out of the model-support PR. It is stacked last because both parser names must already be registered.

## Validation

- `2 passed` in focused Kimi K3 template-manager tests
- `143 passed, 55 subtests passed` across reasoning-parser and template-manager tests on the full stack
- changed-file pre-commit hooks and `git diff --check` pass

## Stack

- depends on #33019
- this PR contains one additional commit and targets the previous stack branch for a clean diff
- after #33019 lands, retarget this PR to `main`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30608713875](https://github.com/sgl-project/sglang/actions/runs/30608713875)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30608713518](https://github.com/sgl-project/sglang/actions/runs/30608713518)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->