### PR TITLE
[Do not merge] Build the miles ROCm 7.2 nightly image from the mooncake python layer branch

### DIFF
--- a/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
@@ -25,13 +25,13 @@ jobs:
       - name: Checkout miles repository
         uses: actions/checkout@v4
         with:
-          repository: radixark/miles
-          ref: main
+          repository: XinyuJiangCMU/miles
+          ref: pr/dockerfile-rm-dead-aiter-args-20260627
           fetch-depth: 0
           persist-credentials: false
 
       - name: Record miles commit
-        run: echo "Building from miles main @ $(git rev-parse HEAD)"
+        run: echo "Building from miles pr/dockerfile-rm-dead-aiter-args-20260627 @ $(git rev-parse HEAD)"
 
       - name: Set date
         run: echo "DATE=$(date +%Y%m%d)" >> $GITHUB_ENV


### PR DESCRIPTION
Not for merge. This points the miles ROCm 7.2 nightly image build at a miles branch instead of
`radixark/miles@main`, so the image build can be exercised against that branch before the change lands
in miles.

The miles branch adds mooncake's pure Python layer to the ROCm image and moves `rocm720-mi35x` to the
`v0.5.16` 20260730 base. Neither is visible to this workflow today, because the checkout step is pinned
to `radixark/miles@main`.

What a run exercises:

- `docker/build.py --variant rocm720-mi35x` resolves and pulls the newer base
- `docker/Dockerfile.rocm` builds end to end on that base, including the TE wheel install and the
  tile_kernels and tilelang patches, which are the parts most likely to break on a base bump
- the mooncake Python layer lands next to the native modules built into the base

The push steps are left as they are. A run will publish `rocm/sgl-dev:miles-rocm720-mi35x-<date>` from
this branch rather than from miles main, so that tag should be removed or rebuilt afterwards.

Revert the checkout step to `radixark/miles@main` before this branch is used for anything else.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30609057101](https://github.com/sgl-project/sglang/actions/runs/30609057101)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30609056967](https://github.com/sgl-project/sglang/actions/runs/30609056967)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->