### PR TITLE
Add native gRPC reflection

### DIFF
--- a/rust/sglang-grpc/Cargo.toml
+++ b/rust/sglang-grpc/Cargo.toml
@@ -31,6 +31,7 @@ uuid = { workspace = true }
 prost = "0.13"
 tokenizers = { version = "0.21", default-features = false, features = ["onig"] }
 tonic = { version = "0.12", features = ["gzip", "transport"] }
+tonic-reflection = "0.12.3"
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/rust/sglang-grpc/src/lib.rs
+++ b/rust/sglang-grpc/src/lib.rs
@@ -5,6 +5,9 @@ pub(crate) mod utils;
 
 pub mod proto {
     tonic::include_proto!("sglang.runtime.v1");
+
+    pub const FILE_DESCRIPTOR_SET: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/sglang_descriptor.bin"));
 }
 
 use pyo3::prelude::*;

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -18,6 +18,17 @@ use crate::utils::{
     build_text_generate_dict, extract_model_path,
 };
 
+fn reflection_service() -> Result<
+    tonic_reflection::server::v1::ServerReflectionServer<
+        impl tonic_reflection::server::v1::ServerReflection,
+    >,
+    tonic_reflection::server::Error,
+> {
+    tonic_reflection::server::Builder::configure()
+        .register_encoded_file_descriptor_set(proto::FILE_DESCRIPTOR_SET)
+        .build_v1()
+}
+
 pub struct SglangServiceImpl {
     pub bridge: Arc<PyBridge>,
     pub response_timeout: Duration,
@@ -993,11 +1004,13 @@ pub async fn run_grpc_server(
     let svc = proto::sglang_service_server::SglangServiceServer::new(service)
         .max_decoding_message_size(max_message_size)
         .max_encoding_message_size(max_message_size);
+    let reflection = reflection_service()?;
 
     tracing::info!("gRPC server listening on {}", addr);
 
     tonic::transport::Server::builder()
         .add_service(svc)
+        .add_service(reflection)
         .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
             shutdown.notified().await;
             tracing::info!("gRPC server shutting down");

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -1,10 +1,18 @@
 use super::{
-    DEFAULT_GRPC_MAX_MESSAGE_SIZE, openai_status_code, resolve_max_message_size,
-    terminal_error_status,
+    DEFAULT_GRPC_MAX_MESSAGE_SIZE, openai_status_code, reflection_service,
+    resolve_max_message_size, terminal_error_status,
 };
 use crate::bridge::TerminalError;
-use std::collections::HashMap;
-use tonic::Code;
+use std::collections::{BTreeSet, HashMap};
+use std::net::SocketAddr;
+use tokio::sync::oneshot;
+use tokio_stream::{StreamExt, wrappers::TcpListenerStream};
+use tonic::transport::{Endpoint, Server};
+use tonic::{Code, Request};
+use tonic_reflection::pb::v1::{
+    ServerReflectionRequest, ServiceResponse, server_reflection_client::ServerReflectionClient,
+    server_reflection_request::MessageRequest, server_reflection_response::MessageResponse,
+};
 
 #[test]
 fn openai_status_code_uses_forwarded_status_when_present() {
@@ -72,4 +80,82 @@ fn resolve_max_message_size_honors_env_var() {
     unsafe {
         std::env::remove_var(VAR);
     }
+}
+
+#[tokio::test]
+async fn reflection_service_advertises_sglang_service() {
+    let services = make_reflection_request(ServerReflectionRequest {
+        host: String::new(),
+        message_request: Some(MessageRequest::ListServices(String::new())),
+    })
+    .await;
+
+    let MessageResponse::ListServicesResponse(services) = services else {
+        panic!("expected ListServicesResponse");
+    };
+    let names = service_names(services.service);
+
+    assert!(names.contains("grpc.reflection.v1.ServerReflection"));
+    assert!(names.contains("sglang.runtime.v1.SglangService"));
+
+    let descriptor = make_reflection_request(ServerReflectionRequest {
+        host: String::new(),
+        message_request: Some(MessageRequest::FileContainingSymbol(String::from(
+            "sglang.runtime.v1.SglangService",
+        ))),
+    })
+    .await;
+
+    let MessageResponse::FileDescriptorResponse(descriptor) = descriptor else {
+        panic!("expected FileDescriptorResponse");
+    };
+    assert!(!descriptor.file_descriptor_proto.is_empty());
+}
+
+fn service_names(services: Vec<ServiceResponse>) -> BTreeSet<String> {
+    services.into_iter().map(|service| service.name).collect()
+}
+
+async fn make_reflection_request(request: ServerReflectionRequest) -> MessageResponse {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let addr: SocketAddr = "127.0.0.1:0".parse().expect("parse reflection bind addr");
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("bind reflection test listener");
+    let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(reflection_service().expect("build reflection service"))
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                drop(shutdown_rx.await);
+            })
+            .await
+            .expect("serve reflection test");
+    });
+
+    let channel = Endpoint::from_shared(endpoint)
+        .expect("reflection endpoint")
+        .connect()
+        .await
+        .expect("connect reflection client");
+    let mut client = ServerReflectionClient::new(channel);
+    let request = Request::new(tokio_stream::once(request));
+    let mut response = client
+        .server_reflection_info(request)
+        .await
+        .expect("reflection request")
+        .into_inner();
+    let message = response
+        .next()
+        .await
+        .expect("reflection response")
+        .expect("successful reflection response")
+        .message_response
+        .expect("reflection message response");
+
+    shutdown_tx.send(()).expect("send reflection shutdown");
+    server.await.expect("join reflection test server");
+
+    message
 }


### PR DESCRIPTION
## Summary

Refs #22558.

This PR implements the gRPC reflection item listed in RFC #22558 Phase 1 remaining tasks.

It reuses the descriptor set already generated by `rust/sglang-grpc/build.rs` and registers `tonic-reflection` on the native Rust gRPC server, enabling `grpcurl` / `grpc_cli` service discovery without local proto files.

cc @alexnails

## Changes

- Add `tonic-reflection = "0.12.3"` to `rust/sglang-grpc`, matching the existing `tonic = 0.12` stack.
- Expose the generated encoded file descriptor set from the `proto` module.
- Register a v1 gRPC reflection service on the same Tonic server as `SglangService`.
- Add an async Rust test that verifies:
  - `ListServices` includes `grpc.reflection.v1.ServerReflection` and `sglang.runtime.v1.SglangService`
  - `FileContainingSymbol("sglang.runtime.v1.SglangService")` returns descriptor bytes

## Validation

Local macOS:

```bash
$HOME/.cargo/bin/cargo fmt --all --manifest-path rust/Cargo.toml -- --check
$HOME/.cargo/bin/cargo test -p sglang-grpc --manifest-path rust/Cargo.toml
$HOME/.cargo/bin/cargo check -p sglang-grpc --manifest-path rust/Cargo.toml
git diff --check
```

Remote ROCm MI300X (`root@134.199.199.149`), directory `/root/codex-validation/sglang-grpc-reflection`, commit `cd5943818963`:

```bash
/root/.cargo/bin/cargo fmt --all --manifest-path rust/Cargo.toml -- --check
/root/.cargo/bin/cargo test -p sglang-grpc --manifest-path rust/Cargo.toml
/root/.cargo/bin/cargo check -p sglang-grpc --manifest-path rust/Cargo.toml
git diff --check
```

Packaging/runtime validation:

- Built and installed the native gRPC PyO3 extension with `SGLANG_BUILD_RUST_EXTS=grpc`.
- Imported `sglang.srt.grpc._core` successfully and verified `start_server` is exported.

Full end-to-end validation with a live SGLang server on ROCm:

- Built ROCm `sgl_kernel` from `python/sglang/kernels/aot/pyproject_rocm.toml` with `AMDGPU_TARGET=gfx942` for the validation env.
- Started `python -m sglang.launch_server` with local `Qwen3Guard-Gen-0.6B`, real weight loading, HTTP `31382`, gRPC `31383`.
- Server log confirmed real model load and native gRPC startup:

```text
Load weight end ... type=Qwen3ForCausalLM
Native gRPC server started on 127.0.0.1:31383
```

Manual grpcurl reflection:

```bash
.bin/grpcurl -plaintext 127.0.0.1:31383 list
```

returned:

```text
grpc.reflection.v1.ServerReflection
sglang.runtime.v1.SglangService
```

```bash
.bin/grpcurl -plaintext 127.0.0.1:31383 describe sglang.runtime.v1.SglangService
```

returned the full SGLang service and RPC list.

Dynamic RPC call using reflection-discovered schema:

```bash
.bin/grpcurl -plaintext -d "{}" 127.0.0.1:31385 \
  sglang.runtime.v1.SglangService/HealthCheck
```

returned:

```json
{
  "healthy": true
}
```

## Scope

This PR only enables server reflection. It does not change auth, TLS/mTLS, keepalive tuning, message-size configuration, request semantics, or Python/CLI/env options.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30611660551](https://github.com/sgl-project/sglang/actions/runs/30611660551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30611660739](https://github.com/sgl-project/sglang/actions/runs/30611660739)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
