### PR TITLE
[Fix] Disable --enable-symm-mem under CUDA graphs on Kimi hybrid models

### DIFF
--- a/python/sglang/srt/arg_groups/kimi_k3_hook.py
+++ b/python/sglang/srt/arg_groups/kimi_k3_hook.py
@@ -44,27 +44,11 @@ def apply_kimi_k3_spec_backend_defaults(server_args: ServerArgs) -> None:
 def disable_kimi_k3_symm_mem(server_args: ServerArgs) -> None:
     """Turn `--enable-symm-mem` back off unless every phase runs eager.
 
-    The NCCL symmetric-memory pool hands out per-forward allocations, and an address
-    taken from it during capture is neither reserved for the graph's lifetime nor
-    guaranteed to sit at the same offset on every rank. Under capture that corrupts
-    speculative decoding, measured under TP8:
-
-      - with --enable-linear-replayssm-spec: accept collapses to 1.000 every run, so
-        spec dies and throughput falls below non-spec (81 vs 423 tok/s). Output stays
-        correct.
-      - without it: 4 of 7 server starts silently emit garbage ("Janet!!!!!!!...")
-        while reporting accept pinned at the 8.000 ceiling and a *higher* throughput
-        than a healthy run. Nothing errors. This is the dangerous one.
-
-    Only capture is affected, hence the all-eager escape hatch. The condition reads the
-    resolved cuda_graph_config rather than the deprecated disable_cuda_graph field,
-    which no longer covers --cuda-graph-backend-{decode,prefill}=disabled. Decode is the
-    measured path; prefill is included because the same per-forward allocation sits
-    inside any captured RowParallelLinear.
-
-    Nothing is lost by dropping the flag: the K3 fused all-reduce (auto-probed, and
-    skipped precisely when this flag is set) is both faster than the symmetric-memory
-    path and correct under capture.
+    Symm-mem allocations are per-forward, so an address captured into a graph is
+    neither reserved for its lifetime nor at the same offset on every rank. Under
+    capture that corrupts spec decode: accept collapses to 1.000, or the server
+    silently emits garbage with accept pinned at the ceiling. Prefill counts too --
+    the same allocation sits in any captured RowParallelLinear.
     """
     from sglang.srt.model_executor.cuda_graph_config import Backend
 

--- a/python/sglang/srt/arg_groups/kimi_k3_hook.py
+++ b/python/sglang/srt/arg_groups/kimi_k3_hook.py
@@ -49,10 +49,22 @@ def disable_kimi_k3_symm_mem(server_args: ServerArgs) -> None:
     capture that corrupts spec decode: accept collapses to 1.000, or the server
     silently emits garbage with accept pinned at the ceiling. Prefill counts too --
     the same allocation sits in any captured RowParallelLinear.
+
+    Gates on the arch itself: this runs from cuda-graph resolution, which is earlier
+    than the model-specific hook block.
     """
+    from sglang.srt.connector import ConnectorType
     from sglang.srt.model_executor.cuda_graph_config import Backend
+    from sglang.srt.utils import parse_connector_type
 
     if not server_args.enable_symm_mem:
+        return
+    if parse_connector_type(server_args.model_path) == ConnectorType.INSTANCE:
+        return
+    if server_args.get_model_config().hf_config.architectures[0] not in (
+        "KimiLinearForCausalLM",
+        "KimiK3ForConditionalGeneration",
+    ):
         return
     graph = server_args.cuda_graph_config
     if (

--- a/python/sglang/srt/arg_groups/kimi_k3_hook.py
+++ b/python/sglang/srt/arg_groups/kimi_k3_hook.py
@@ -41,6 +41,53 @@ def apply_kimi_k3_spec_backend_defaults(server_args: ServerArgs) -> None:
         )
 
 
+def disable_kimi_k3_symm_mem(server_args: ServerArgs) -> None:
+    """Turn `--enable-symm-mem` back off unless every phase runs eager.
+
+    The NCCL symmetric-memory pool hands out per-forward allocations, and an address
+    taken from it during capture is neither reserved for the graph's lifetime nor
+    guaranteed to sit at the same offset on every rank. Under capture that corrupts
+    speculative decoding, measured under TP8:
+
+      - with --enable-linear-replayssm-spec: accept collapses to 1.000 every run, so
+        spec dies and throughput falls below non-spec (81 vs 423 tok/s). Output stays
+        correct.
+      - without it: 4 of 7 server starts silently emit garbage ("Janet!!!!!!!...")
+        while reporting accept pinned at the 8.000 ceiling and a *higher* throughput
+        than a healthy run. Nothing errors. This is the dangerous one.
+
+    Only capture is affected, hence the all-eager escape hatch. The condition reads the
+    resolved cuda_graph_config rather than the deprecated disable_cuda_graph field,
+    which no longer covers --cuda-graph-backend-{decode,prefill}=disabled. Decode is the
+    measured path; prefill is included because the same per-forward allocation sits
+    inside any captured RowParallelLinear.
+
+    Nothing is lost by dropping the flag: the K3 fused all-reduce (auto-probed, and
+    skipped precisely when this flag is set) is both faster than the symmetric-memory
+    path and correct under capture.
+    """
+    from sglang.srt.model_executor.cuda_graph_config import Backend
+
+    if not server_args.enable_symm_mem:
+        return
+    graph = server_args.cuda_graph_config
+    if (
+        graph.decode.backend == Backend.DISABLED
+        and graph.prefill.backend == Backend.DISABLED
+    ):
+        return
+    server_args.enable_symm_mem = False
+    logger.warning(
+        "Kimi hybrid model: ignoring --enable-symm-mem because CUDA graphs are on. "
+        "The symmetric-memory pool's per-forward allocations are not valid for the "
+        "lifetime of a captured graph, which corrupts speculative decoding and can "
+        "silently produce wrong output. The auto-probed K3 fused all-reduce is faster "
+        "anyway. Disable capture on every phase "
+        "(--cuda-graph-backend-decode=disabled --cuda-graph-backend-prefill=disabled) "
+        "if you genuinely need symmetric memory."
+    )
+
+
 def apply_kimi_k3_linear_attn_defaults(server_args: ServerArgs) -> None:
     """KDA decode-fallback default for Kimi hybrid models (spec-independent)."""
     from sglang.srt.utils import is_sm100_supported

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4203,8 +4203,32 @@ class ServerArgs:
         ):
             self.cuda_graph_backend_prefill = Backend.FULL
 
+    def _apply_kimi_hybrid_symm_mem_guard(self):
+        """Kimi hybrid models drop --enable-symm-mem unless capture is off
+        everywhere. Called from _handle_cuda_graph_config once the per-phase
+        backends are resolved; see disable_kimi_k3_symm_mem for why."""
+        if (
+            not self.enable_symm_mem
+            or parse_connector_type(self.model_path) == ConnectorType.INSTANCE
+        ):
+            return
+        arch = self.get_model_config().hf_config.architectures[0]
+        if arch in (
+            "KimiLinearForCausalLM",
+            "KimiK3ForConditionalGeneration",
+        ):
+            from sglang.srt.arg_groups.kimi_k3_hook import disable_kimi_k3_symm_mem
+
+            disable_kimi_k3_symm_mem(self)
+
     def _handle_cuda_graph_config(self):
         self._parse_cuda_graph_config()
+        # Between parse and the compat cascade: the resolved per-phase backends
+        # are readable here, and enable_symm_mem is still the raw request. Both
+        # the tc_piecewise compat rules below and the symm-pool prealloc default
+        # in _handle_gpu_memory_settings key off enable_symm_mem, so a model hook
+        # that reverses it must land before them.
+        self._apply_kimi_hybrid_symm_mem_guard()
         self._apply_cuda_graph_compatibility()
         self._apply_cuda_graph_disaggregation_roles()
         self._validate_cuda_graph_config()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4204,9 +4204,7 @@ class ServerArgs:
             self.cuda_graph_backend_prefill = Backend.FULL
 
     def _apply_kimi_hybrid_symm_mem_guard(self):
-        """Kimi hybrid models drop --enable-symm-mem unless capture is off
-        everywhere. Called from _handle_cuda_graph_config once the per-phase
-        backends are resolved; see disable_kimi_k3_symm_mem for why."""
+        """Kimi hybrid archs drop --enable-symm-mem unless capture is off everywhere."""
         if (
             not self.enable_symm_mem
             or parse_connector_type(self.model_path) == ConnectorType.INSTANCE
@@ -4223,11 +4221,8 @@ class ServerArgs:
 
     def _handle_cuda_graph_config(self):
         self._parse_cuda_graph_config()
-        # Between parse and the compat cascade: the resolved per-phase backends
-        # are readable here, and enable_symm_mem is still the raw request. Both
-        # the tc_piecewise compat rules below and the symm-pool prealloc default
-        # in _handle_gpu_memory_settings key off enable_symm_mem, so a model hook
-        # that reverses it must land before them.
+        # Reads the resolved per-phase backends; must precede the compat rules
+        # below and _handle_gpu_memory_settings, which key off enable_symm_mem.
         self._apply_kimi_hybrid_symm_mem_guard()
         self._apply_cuda_graph_compatibility()
         self._apply_cuda_graph_disaggregation_roles()

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4203,27 +4203,13 @@ class ServerArgs:
         ):
             self.cuda_graph_backend_prefill = Backend.FULL
 
-    def _apply_kimi_hybrid_symm_mem_guard(self):
-        """Kimi hybrid archs drop --enable-symm-mem unless capture is off everywhere."""
-        if (
-            not self.enable_symm_mem
-            or parse_connector_type(self.model_path) == ConnectorType.INSTANCE
-        ):
-            return
-        arch = self.get_model_config().hf_config.architectures[0]
-        if arch in (
-            "KimiLinearForCausalLM",
-            "KimiK3ForConditionalGeneration",
-        ):
-            from sglang.srt.arg_groups.kimi_k3_hook import disable_kimi_k3_symm_mem
-
-            disable_kimi_k3_symm_mem(self)
-
     def _handle_cuda_graph_config(self):
+        from sglang.srt.arg_groups.kimi_k3_hook import disable_kimi_k3_symm_mem
+
         self._parse_cuda_graph_config()
         # Reads the resolved per-phase backends; must precede the compat rules
         # below and _handle_gpu_memory_settings, which key off enable_symm_mem.
-        self._apply_kimi_hybrid_symm_mem_guard()
+        disable_kimi_k3_symm_mem(self)
         self._apply_cuda_graph_compatibility()
         self._apply_cuda_graph_disaggregation_roles()
         self._validate_cuda_graph_config()


### PR DESCRIPTION
Symmetric-memory allocations are per-forward, so an address taken from that pool during graph capture is neither reserved for the graph's lifetime nor at the same offset on every rank. Under capture this corrupts DSPARK speculative decoding: accept collapses to 1.000, or (worse) the server silently emits garbage while reporting accept pinned at the ceiling, with no error. The flag is now forced off on Kimi hybrid archs unless every phase runs eager; the auto-probed K3 fused all-reduce is faster than the symm-mem path anyway.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30615097135](https://github.com/sgl-project/sglang/actions/runs/30615097135)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30615096976](https://github.com/sgl-project/sglang/actions/runs/30615096976)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->