### PR TITLE
Add Rust server Prometheus metrics

### DIFF
--- a/rust/sglang-server/src/api_server.rs
+++ b/rust/sglang-server/src/api_server.rs
@@ -7,6 +7,7 @@ mod common;
 mod frame;
 mod guard;
 mod log;
+mod metrics_endpoint;
 mod native_api;
 mod openai;
 mod submit;
@@ -15,6 +16,7 @@ use std::sync::Arc;
 
 use axum::Router;
 
+use crate::metrics::MetricsState;
 use crate::runtime::ServerArgs;
 use crate::tokenizer_manager::ActivityCounter;
 use crate::tokenizer_manager::Senders;
@@ -26,6 +28,7 @@ struct AppState {
     senders: Senders,
     egress_buf: usize,
     server_args: Arc<ServerArgs>,
+    metrics: Arc<MetricsState>,
     /// Egress heartbeat (bumped per drained ring frame).
     egress_activity: ActivityCounter,
 }
@@ -36,6 +39,7 @@ pub async fn serve(
     egress_buf: usize,
     server_args: Arc<ServerArgs>,
     egress_activity: ActivityCounter,
+    metrics: Arc<MetricsState>,
     // The SAME set ingress releases from — see `Ingress::on_abort`. Constructing a
     // local one here would leave the api server admitting rids that nothing ever
     // releases.
@@ -45,13 +49,18 @@ pub async fn serve(
         senders,
         egress_buf,
         server_args: server_args.clone(),
+        metrics: metrics.clone(),
         egress_activity,
     };
     // Each endpoint module registers its own routes and merges here.
-    let app = Router::new()
+    let mut app = Router::new()
         .merge(common::routes())
         .merge(native_api::routes())
-        .merge(openai::routes())
+        .merge(openai::routes());
+    if server_args.enable_metrics {
+        app = app.merge(metrics_endpoint::routes());
+    }
+    let app = app
         // TODO(auth): no API-key boundary yet. Python gates every route (except
         // /health*, /metrics*, OPTIONS) via `add_api_key_middleware`; until ported,
         // a configured `api_key` does NOT protect these routes.
@@ -59,6 +68,11 @@ pub async fn serve(
         // No body limit, matching the Python server.
         .layer(axum::extract::DefaultBodyLimit::disable())
         .with_state(state);
+    let app = if server_args.enable_metrics {
+        metrics_endpoint::apply_http_metrics(app, metrics)
+    } else {
+        app
+    };
     let app = log::apply(app, &server_args);
 
     // The listener was already bound synchronously in `runtime::start` (so a port

--- a/rust/sglang-server/src/api_server/common.rs
+++ b/rust/sglang-server/src/api_server/common.rs
@@ -17,6 +17,7 @@ use super::AppState;
 use super::guard::AbortGuard;
 use super::submit::submit;
 use crate::message::{ControlRequest, EgressItem, GetInternalStateReq, RequestKind};
+use crate::metrics::{InputSourceLabel, RequestKindLabel};
 use crate::runtime::ServerArgs;
 
 /// The routes this module owns, mounted by `api_server::serve`.
@@ -38,6 +39,9 @@ async fn await_control_result(
     state: &AppState,
     control: ControlRequest,
 ) -> Result<bytes::Bytes, Response> {
+    state
+        .metrics
+        .request_received(RequestKindLabel::Control, InputSourceLabel::Control, false);
     let (rid, mut rx) = submit(state, RequestKind::Control(Box::new(control)), false).await?;
     // Control requests register a detok entry like any other, and only
     // `handle_result` removes it — so a request that never produces one (a stalled

--- a/rust/sglang-server/src/api_server/metrics_endpoint.rs
+++ b/rust/sglang-server/src/api_server/metrics_endpoint.rs
@@ -1,0 +1,128 @@
+//! Prometheus endpoint and HTTP request metrics middleware for the Rust server.
+
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+
+use super::AppState;
+use crate::metrics::{HttpEndpointLabel, HttpMethodLabel, MetricsState};
+
+const PROMETHEUS_TEXT_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+pub(super) fn routes() -> Router<AppState> {
+    Router::new().route("/metrics", get(metrics))
+}
+
+pub(super) fn apply_http_metrics(app: Router, metrics: Arc<MetricsState>) -> Router {
+    app.layer(axum::middleware::from_fn_with_state(
+        metrics,
+        track_http_metrics,
+    ))
+}
+
+async fn metrics(State(state): State<AppState>) -> Response {
+    (
+        StatusCode::OK,
+        [("content-type", PROMETHEUS_TEXT_CONTENT_TYPE)],
+        state.metrics.render_prometheus(),
+    )
+        .into_response()
+}
+
+async fn track_http_metrics(
+    State(metrics): State<Arc<MetricsState>>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let Some(endpoint) = HttpEndpointLabel::from_path(req.uri().path()) else {
+        return next.run(req).await;
+    };
+    let method = HttpMethodLabel::from_method(req.method());
+    metrics.http_request_started(endpoint, method);
+    let res = next.run(req).await;
+    metrics.http_request_finished(endpoint, method, res.status().as_u16());
+    res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{RuntimeConfig, RustServerServerArgs, ServerArgs};
+    use std::io::{Read, Write};
+
+    const TEST_SERVER_ARGS: &str = r#"{
+        "skip_tokenizer_init": true,
+        "served_model_name": "test-model",
+        "model_config": {"context_len": 2048, "vocab_size": 1000}
+    }"#;
+    const TEST_SERVER_ARGS_WITH_METRICS: &str = r#"{
+        "skip_tokenizer_init": true,
+        "served_model_name": "test-model",
+        "enable_metrics": true,
+        "model_config": {"context_len": 2048, "vocab_size": 1000}
+    }"#;
+
+    fn get(path: &str, addr: std::net::SocketAddr) -> String {
+        let mut conn = std::net::TcpStream::connect(addr).expect("connect");
+        let req = format!("GET {path} HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n");
+        conn.write_all(req.as_bytes()).unwrap();
+        conn.flush().unwrap();
+        let mut response = String::new();
+        conn.read_to_string(&mut response).unwrap();
+        response
+    }
+
+    fn status_code(response: &str) -> u16 {
+        response
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|code| code.parse().ok())
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn metrics_route_is_gated_by_enable_metrics() {
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = probe.local_addr().unwrap();
+        drop(probe);
+
+        let server_args = ServerArgs::from_json(TEST_SERVER_ARGS).unwrap();
+        let cfg = RuntimeConfig {
+            rust_server_args: RustServerServerArgs {
+                http_addr: addr,
+                api_worker_num: 1,
+                ..Default::default()
+            },
+            server_args: Arc::new(server_args),
+        };
+        let rt = crate::runtime::start(cfg).expect("start runtime");
+        assert_eq!(status_code(&get("/metrics", addr)), 404);
+        rt.request_shutdown();
+
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = probe.local_addr().unwrap();
+        drop(probe);
+        let server_args = ServerArgs::from_json(TEST_SERVER_ARGS_WITH_METRICS).unwrap();
+        let cfg = RuntimeConfig {
+            rust_server_args: RustServerServerArgs {
+                http_addr: addr,
+                api_worker_num: 1,
+                ..Default::default()
+            },
+            server_args: Arc::new(server_args),
+        };
+        let rt = crate::runtime::start(cfg).expect("start runtime");
+        let response = get("/metrics", addr);
+        assert_eq!(status_code(&response), 200);
+        assert!(response.contains("content-type: text/plain; version=0.0.4; charset=utf-8"));
+        assert!(response.contains("sglang:rust_server_ring_capacity{ring=\"ingress\"}"));
+        rt.request_shutdown();
+    }
+}

--- a/rust/sglang-server/src/api_server/native_api.rs
+++ b/rust/sglang-server/src/api_server/native_api.rs
@@ -30,8 +30,10 @@ use super::frame::{
 use super::guard::AbortGuard;
 use super::submit::{pre_submit_error, submit};
 use crate::environ::env_bool;
+use crate::ids::HEALTH_CHECK_RID_PREFIX;
 use crate::ids::Rid;
 use crate::message::{EgressItem, GenerateBody, GenerateRequest, RequestKind, SamplingParams};
+use crate::metrics::{InputSourceLabel, RequestKindLabel, RequestStageLabel};
 
 /// The routes this module owns, mounted by `api_server::serve`.
 pub(super) fn routes() -> Router<AppState> {
@@ -93,6 +95,11 @@ async fn health_generate(State(state): State<AppState>, timeout: std::time::Dura
         stream: false,
         ..Default::default()
     };
+    state.metrics.request_received(
+        RequestKindLabel::HealthGenerate,
+        InputSourceLabel::InputIds,
+        false,
+    );
     let (rid, _keepalive) =
         match submit(&state, RequestKind::Generate(Box::new(probe)), false).await {
             // Hold the receiver so the probe's sink stays open until it completes.
@@ -138,6 +145,7 @@ async fn generate(
         // can only answer unary — as Python's does (FastAPI rejects before its
         // handler runs).
         Err(rejection) => {
+            state.metrics.request_error(RequestStageLabel::Parse, 400);
             return pre_submit_error(StatusCode::BAD_REQUEST, &rejection.body_text(), false);
         }
     };
@@ -149,9 +157,19 @@ async fn generate(
         // The error carries its own status (a bad batch is `Validation` → 400).
         Err(e) => {
             let code = StatusCode::from_u16(e.http_status()).unwrap_or(StatusCode::BAD_REQUEST);
+            state
+                .metrics
+                .request_error(RequestStageLabel::Validate, code.as_u16());
             return pre_submit_error(code, &e.to_string(), stream);
         }
     };
+    for payload in &payloads {
+        state.metrics.request_received(
+            request_kind_label(payload),
+            input_source_label(payload),
+            stream,
+        );
+    }
     if !is_batch {
         // `into_requests` guarantees exactly one payload for a non-batch body.
         let payload = payloads
@@ -161,6 +179,22 @@ async fn generate(
         generate_single(&state, payload, stream).await
     } else {
         generate_batch(&state, payloads, stream).await
+    }
+}
+
+fn request_kind_label(req: &GenerateRequest) -> RequestKindLabel {
+    if req.rid.as_str().starts_with(HEALTH_CHECK_RID_PREFIX) {
+        RequestKindLabel::HealthGenerate
+    } else {
+        RequestKindLabel::Generate
+    }
+}
+
+fn input_source_label(req: &GenerateRequest) -> InputSourceLabel {
+    if req.already_tokenized() {
+        InputSourceLabel::InputIds
+    } else {
+        InputSourceLabel::Text
     }
 }
 

--- a/rust/sglang-server/src/api_server/submit.rs
+++ b/rust/sglang-server/src/api_server/submit.rs
@@ -19,6 +19,7 @@ use super::frame::error_value;
 use crate::fsm::RequestState;
 use crate::ids::Rid;
 use crate::message::{EgressItem, EgressSink, Request, RequestKind};
+use crate::metrics::RequestStageLabel;
 use crate::tokenizer_manager::TmEvent;
 
 /// Submit one request; returns the rid, its hashed routing key, and the egress
@@ -58,6 +59,10 @@ pub(super) async fn submit(
         // `SendError` has a single meaning — the channel is disconnected.
         Err(_) => {
             tracing::error!(%rid, "tm inbox closed; request rejected");
+            state.metrics.request_error(
+                RequestStageLabel::Submit,
+                StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+            );
             // Return 503 so the client can retry.
             Err(pre_submit_error(
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/rust/sglang-server/src/detokenizer.rs
+++ b/rust/sglang-server/src/detokenizer.rs
@@ -22,12 +22,14 @@
 //!   ChunkEvent{finish:Some}  -> step ids -> delta -> final frame
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::error::Error;
 use crate::fsm::{Event, RequestState};
 use crate::ids::Rid;
 use crate::message::DetokMsg;
 use crate::message::{ChunkEvent, EgressItem, EgressSink, Matched, SinkError, TokenIds};
+use crate::metrics::{MetricsState, RequestKindLabel, RequestStageLabel, TerminalOutcomeLabel};
 use crate::runtime::Runnable;
 use crate::tokenizer_manager::AbortSource;
 
@@ -112,6 +114,7 @@ impl DetokenizerBackend {
 
 struct DetokState {
     sink: EgressSink,
+    kind: RequestKindLabel,
     /// `return_text_in_logprobs`: whether to decode this request's logprob token
     /// ids to text (in this shard) for the `[logprob, token_id, text]` tuples.
     decode_logprob_text: bool,
@@ -141,6 +144,7 @@ pub struct DetokenizerWorker {
     /// Unbounded abort lane, used to abort a request the shard had to drop
     /// (client backpressure) so the scheduler stops generating for it.
     abort: flume::Sender<AbortSource>,
+    metrics: Arc<MetricsState>,
 }
 
 impl DetokenizerWorker {
@@ -149,12 +153,14 @@ impl DetokenizerWorker {
         rx: flume::Receiver<DetokMsg>,
         backend: DetokenizerBackend,
         abort: flume::Sender<AbortSource>,
+        metrics: Arc<MetricsState>,
     ) -> Self {
         Self {
             shard,
             rx,
             backend,
             abort,
+            metrics,
         }
     }
 }
@@ -172,34 +178,46 @@ impl Runnable for DetokenizerWorker {
             match msg {
                 DetokMsg::Register {
                     rid,
+                    kind,
                     sink,
                     decode_logprob_text,
                     no_stop_trim,
                 } => {
-                    table.insert(
+                    if let Some(old) = table.insert(
                         rid.clone(),
                         DetokState {
                             sink,
+                            kind,
                             decode_logprob_text,
                             no_stop_trim,
                             decoder: self.backend.new_decoder(),
                             // Registered == handed to the scheduler == Queued.
                             fsm: RequestState::Queued,
                         },
-                    );
+                    ) {
+                        self.metrics.inflight_dec(old.kind);
+                    }
+                    self.metrics.inflight_inc(kind);
                 }
                 // One decode step's chunks for this shard, batched by tm-egress.
                 DetokMsg::Chunks(evs) => {
                     for ev in evs {
-                        handle_chunk(&mut table, ev, &self.backend, &self.abort);
+                        handle_chunk(&mut table, ev, &self.backend, &self.abort, &self.metrics);
                     }
                 }
-                DetokMsg::Result { rid, payload } => handle_result(&mut table, &rid, payload),
-                DetokMsg::Fail { rid, message } => {
-                    handle_fail(&mut table, &rid, message, &self.abort)
+                DetokMsg::Result { rid, payload } => {
+                    handle_result(&mut table, &rid, payload, &self.metrics)
                 }
-                DetokMsg::Deregister { rid } => {
-                    table.remove(&rid);
+                DetokMsg::Fail { rid, message } => {
+                    handle_fail(&mut table, &rid, message, &self.abort, &self.metrics)
+                }
+                DetokMsg::Deregister { rid, outcome } => {
+                    if let Some(st) = table.remove(&rid) {
+                        self.metrics.inflight_dec(st.kind);
+                        if let Some(outcome) = outcome {
+                            self.metrics.request_terminal(st.kind, outcome);
+                        }
+                    }
                 }
             }
         }
@@ -208,12 +226,19 @@ impl Runnable for DetokenizerWorker {
 
 /// Control-request result: deliver the JSON payload to the sink verbatim as a
 /// single `Done` frame — no detokenization, no streaming.
-fn handle_result(table: &mut HashMap<Rid, DetokState>, rid: &Rid, payload: bytes::Bytes) {
+fn handle_result(
+    table: &mut HashMap<Rid, DetokState>,
+    rid: &Rid,
+    payload: bytes::Bytes,
+    metrics: &MetricsState,
+) {
     if let Some(mut st) = table.remove(rid) {
         let _ = st.sink.try_send(EgressItem::Control(payload));
         // Egress FSM: a control request goes straight to Completed (no Streaming
         // / Finalizing states — single response, never streamed).
         st.fsm = RequestState::Completed;
+        metrics.inflight_dec(st.kind);
+        metrics.request_terminal(st.kind, TerminalOutcomeLabel::ControlResult);
     }
 }
 
@@ -228,6 +253,7 @@ fn handle_fail(
     rid: &Rid,
     message: String,
     abort: &flume::Sender<AbortSource>,
+    metrics: &MetricsState,
 ) {
     if let Some(mut st) = table.remove(rid) {
         // Abort first: `try_send` on the sink can release the handler, which frees
@@ -237,6 +263,9 @@ fn handle_fail(
             .sink
             .try_send(EgressItem::Error(Error::Internal(message)));
         st.fsm = RequestState::Completed;
+        metrics.inflight_dec(st.kind);
+        metrics.request_error(RequestStageLabel::Egress, 500);
+        metrics.request_terminal(st.kind, TerminalOutcomeLabel::Error);
     }
 }
 
@@ -245,6 +274,7 @@ fn handle_chunk(
     mut ev: ChunkEvent,
     backend: &DetokenizerBackend,
     abort: &flume::Sender<AbortSource>,
+    metrics: &MetricsState,
 ) {
     // Copied once: `ev` is moved into the sink below, but the rid is still
     // needed to look the request up and to remove it.
@@ -290,7 +320,11 @@ fn handle_chunk(
                 let _ = st.fsm.apply(Event::Error(e.clone()));
                 let _ = abort.send(AbortSource::Detok(rid.clone()));
                 let _ = st.sink.try_send(EgressItem::Error(e));
+                let kind = st.kind;
                 table.remove(&rid);
+                metrics.inflight_dec(kind);
+                metrics.request_error(RequestStageLabel::Detokenize, 500);
+                metrics.request_terminal(kind, TerminalOutcomeLabel::Error);
                 return;
             }
         },
@@ -332,7 +366,17 @@ fn handle_chunk(
         } else {
             Event::Disconnect
         });
+        let kind = st.kind;
         table.remove(&rid);
+        metrics.inflight_dec(kind);
+        metrics.request_terminal(
+            kind,
+            if sent {
+                TerminalOutcomeLabel::Success
+            } else {
+                TerminalOutcomeLabel::Disconnect
+            },
+        );
     } else {
         // Every intermediate chunk emits its delta frame. A failed send means the
         // client can't receive it — `Closed` (gone) or `Full` (backpressure: not
@@ -363,7 +407,16 @@ fn handle_chunk(
             if matches!(e, SinkError::Full) {
                 let _ = abort.send(AbortSource::Detok(rid.clone()));
             }
+            let kind = st.kind;
             table.remove(&rid);
+            metrics.inflight_dec(kind);
+            metrics.request_terminal(
+                kind,
+                match e {
+                    SinkError::Full => TerminalOutcomeLabel::ClientBackpressure,
+                    SinkError::Closed => TerminalOutcomeLabel::Disconnect,
+                },
+            );
         }
     }
 }
@@ -394,7 +447,75 @@ fn trim_stop_str(text: &mut String, stop: &str, no_stop_trim: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
     use tokio::sync::mpsc;
+
+    fn metrics() -> Arc<MetricsState> {
+        Arc::new(MetricsState::new())
+    }
+
+    fn eventually(mut predicate: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if predicate() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(predicate(), "condition was not met before timeout");
+    }
+
+    fn state(tx: mpsc::Sender<EgressItem>) -> DetokState {
+        DetokState {
+            sink: EgressSink::Local(tx),
+            kind: RequestKindLabel::Generate,
+            decode_logprob_text: false,
+            no_stop_trim: false,
+            decoder: None,
+            fsm: RequestState::Queued,
+        }
+    }
+
+    #[test]
+    fn register_and_deregister_keep_inflight_exact() {
+        let (detok_tx, detok_rx) = flume::unbounded::<DetokMsg>();
+        let (abort_tx, _abort_rx) = flume::unbounded::<AbortSource>();
+        let metrics = metrics();
+        let worker = DetokenizerWorker::new(
+            0,
+            detok_rx,
+            DetokenizerBackend::Skip,
+            abort_tx,
+            metrics.clone(),
+        );
+        let handle = std::thread::spawn(move || worker.run());
+        let (sink_tx, _sink_rx) = mpsc::channel::<EgressItem>(1);
+
+        detok_tx
+            .send(DetokMsg::Register {
+                rid: Rid::from("1"),
+                kind: RequestKindLabel::Generate,
+                sink: EgressSink::Local(sink_tx),
+                decode_logprob_text: false,
+                no_stop_trim: false,
+            })
+            .unwrap();
+        eventually(|| metrics.inflight_requests(RequestKindLabel::Generate) == 1);
+
+        detok_tx
+            .send(DetokMsg::Deregister {
+                rid: Rid::from("1"),
+                outcome: Some(TerminalOutcomeLabel::Success),
+            })
+            .unwrap();
+        eventually(|| {
+            metrics.inflight_requests(RequestKindLabel::Generate) == 0
+                && metrics.terminal_total(RequestKindLabel::Generate, TerminalOutcomeLabel::Success)
+                    == 1
+        });
+        drop(detok_tx);
+        handle.join().unwrap();
+    }
 
     /// A non-terminal chunk that can't be delivered (sink full → client
     /// backpressure) drops the request AND aborts scheduler work — it does not
@@ -407,24 +528,17 @@ mod tests {
             .unwrap();
 
         let mut table = HashMap::new();
-        table.insert(
-            Rid::from("1"),
-            DetokState {
-                sink: EgressSink::Local(tx),
-                decode_logprob_text: false,
-                no_stop_trim: false,
-                decoder: None,
-                fsm: RequestState::Queued,
-            },
-        );
+        table.insert(Rid::from("1"), state(tx));
 
         let (tm_tx, tm_rx) = flume::unbounded::<AbortSource>();
+        let metrics = metrics();
         let ev = ChunkEvent {
             rid: Rid::from("1"),
             token_ids: vec![5],
             ..Default::default() // finish_reason None → non-terminal
         };
-        handle_chunk(&mut table, ev, &DetokenizerBackend::Skip, &tm_tx);
+        metrics.inflight_inc(RequestKindLabel::Generate);
+        handle_chunk(&mut table, ev, &DetokenizerBackend::Skip, &tm_tx, &metrics);
 
         // Request removed (no lingering state to be mistaken for success)...
         assert!(!table.contains_key(&Rid::from("1")));
@@ -433,6 +547,14 @@ mod tests {
             tm_rx.try_recv(),
             Ok(AbortSource::Detok(rid)) if rid == Rid::from("1")
         ));
+        assert_eq!(metrics.inflight_requests(RequestKindLabel::Generate), 0);
+        assert_eq!(
+            metrics.terminal_total(
+                RequestKindLabel::Generate,
+                TerminalOutcomeLabel::ClientBackpressure
+            ),
+            1
+        );
     }
 
     /// `trim_stop_str` reproduces the base's stop-string semantics: `stop: "3"` on
@@ -474,16 +596,10 @@ mod tests {
         let (tx_a, mut rx_a) = mpsc::channel::<EgressItem>(4);
         let (tx_b, mut rx_b) = mpsc::channel::<EgressItem>(4);
         let mut table = HashMap::new();
-        let state = |tx| DetokState {
-            sink: EgressSink::Local(tx),
-            decode_logprob_text: false,
-            no_stop_trim: false,
-            decoder: None,
-            fsm: RequestState::Queued,
-        };
         table.insert(Rid::from("alice"), state(tx_a));
         table.insert(Rid::from("bob"), state(tx_b));
         let (tm_tx, _tm_rx) = flume::unbounded::<AbortSource>();
+        let metrics = metrics();
 
         let chunk = |rid: &str, id: i32| ChunkEvent {
             rid: Rid::from(rid.to_string()),
@@ -495,12 +611,14 @@ mod tests {
             chunk("alice", 11),
             &DetokenizerBackend::Skip,
             &tm_tx,
+            &metrics,
         );
         handle_chunk(
             &mut table,
             chunk("bob", 22),
             &DetokenizerBackend::Skip,
             &tm_tx,
+            &metrics,
         );
 
         let ids = |rx: &mut mpsc::Receiver<EgressItem>| match rx.try_recv() {
@@ -532,14 +650,12 @@ mod tests {
         table.insert(
             Rid::from("1"),
             DetokState {
-                sink: EgressSink::Local(tx),
-                decode_logprob_text: false,
                 no_stop_trim,
-                decoder: None, // skip mode → output_ids passthrough
-                fsm: RequestState::Queued,
+                ..state(tx)
             },
         );
         let (tm_tx, _tm_rx) = flume::unbounded::<AbortSource>();
+        let metrics = metrics();
         let ev = ChunkEvent {
             rid: Rid::from("1"),
             token_ids: ids,
@@ -550,7 +666,7 @@ mod tests {
             ),
             ..Default::default()
         };
-        handle_chunk(&mut table, ev, &DetokenizerBackend::Skip, &tm_tx);
+        handle_chunk(&mut table, ev, &DetokenizerBackend::Skip, &tm_tx, &metrics);
         match rx.try_recv() {
             Ok(EgressItem::Done(out)) => out,
             other => panic!("expected Done, got {other:?}"),

--- a/rust/sglang-server/src/lib.rs
+++ b/rust/sglang-server/src/lib.rs
@@ -17,6 +17,7 @@ mod error;
 mod fsm;
 mod ids;
 mod message;
+mod metrics;
 mod ring;
 mod runtime;
 mod tokenizer;
@@ -185,19 +186,31 @@ impl Server {
     /// committed to. It essentially never fires — measured headroom is ~100×.
     fn push_batch(&self, py: Python<'_>, header: &[u8], data_cols: Vec<PyBackedBytes>) -> bool {
         let cols: Vec<&[u8]> = data_cols.iter().map(|d| d.as_ref()).collect();
-        self.push_frame(py, crate::message::frame_egress_batch_cols(header, &cols))
+        self.push_frame(
+            py,
+            crate::message::frame_egress_batch_cols(header, &cols),
+            crate::metrics::EgressFrameLabel::Batch,
+        )
     }
 
     /// Push a control-request result. Blocks for backpressure; `False` only on
     /// shutdown.
     fn push_result(&self, py: Python<'_>, rid: &str, payload: &[u8]) -> bool {
-        self.push_frame(py, crate::message::frame_egress_result(rid, payload))
+        self.push_frame(
+            py,
+            crate::message::frame_egress_result(rid, payload),
+            crate::metrics::EgressFrameLabel::Result,
+        )
     }
 
     /// Route a terminal failure back to request `rid`. Blocks for backpressure;
     /// `False` only on shutdown.
     fn push_error(&self, py: Python<'_>, rid: &str, message: &str) -> bool {
-        self.push_frame(py, crate::message::frame_egress_error(rid, message))
+        self.push_frame(
+            py,
+            crate::message::frame_egress_error(rid, message),
+            crate::metrics::EgressFrameLabel::Error,
+        )
     }
 
     /// Signal all threads to stop (best effort).
@@ -211,14 +224,29 @@ impl Server {
     /// detaching only to park on a full ring. Shared by every push path — they
     /// differ solely in how the frame is built. `false` only on shutdown.
     #[inline]
-    fn push_frame(&self, py: Python<'_>, frame: bytes::Bytes) -> bool {
+    fn push_frame(
+        &self,
+        py: Python<'_>,
+        frame: bytes::Bytes,
+        frame_label: crate::metrics::EgressFrameLabel,
+    ) -> bool {
         match self.rt.egress.try_push(frame) {
-            Ok(()) => true,
+            Ok(()) => {
+                self.rt.metrics.egress_ring_push(frame_label);
+                true
+            }
             // Consumer gone (shutdown): the frame is unavoidably lost.
             Err(None) => false,
             // Full: the scheduler must block here so backpressure reaches it, and
             // blocking is exactly when releasing the GIL pays for itself.
-            Err(Some(frame)) => py.detach(|| self.rt.egress.push(frame)),
+            Err(Some(frame)) => {
+                self.rt.metrics.egress_ring_backpressure(frame_label);
+                let ok = py.detach(|| self.rt.egress.push(frame));
+                if ok {
+                    self.rt.metrics.egress_ring_push(frame_label);
+                }
+                ok
+            }
         }
     }
 }

--- a/rust/sglang-server/src/message.rs
+++ b/rust/sglang-server/src/message.rs
@@ -30,6 +30,7 @@ use bytes::Bytes;
 
 use crate::fsm::RequestState;
 use crate::ids::Rid;
+use crate::metrics::{RequestKindLabel, TerminalOutcomeLabel};
 
 /// The owned request as it travels ingress stages (single owner, so `state` is
 /// mutated lock-free). Common fields here; variant data in [`RequestKind`].
@@ -65,6 +66,8 @@ pub enum DetokMsg {
         /// Client-visible rid string — kept in `DetokState` so the shard can
         /// emit `TmEvent::Abort(rid)` (the wire needs the string, not the hash).
         rid: Rid,
+        /// Low-cardinality request kind, used only for metrics.
+        kind: RequestKindLabel,
         sink: EgressSink,
         /// Decode logprob token ids to text here (CPU-bound) not on the api threads.
         decode_logprob_text: bool,
@@ -81,5 +84,8 @@ pub enum DetokMsg {
     /// Drop the `rid -> sink` entry for a request rejected before the scheduler
     /// (the rejecting stage already answered the client); else `Register` leaks one
     /// entry.
-    Deregister { rid: Rid },
+    Deregister {
+        rid: Rid,
+        outcome: Option<TerminalOutcomeLabel>,
+    },
 }

--- a/rust/sglang-server/src/metrics.rs
+++ b/rust/sglang-server/src/metrics.rs
@@ -1,0 +1,925 @@
+//! Low-cardinality Prometheus metrics for the embedded Rust frontend.
+//!
+//! The Python scheduler owns the GPU/runtime metrics. This module only tracks the
+//! Rust api-server/tokenizer-manager boundary with cheap atomics, then renders a
+//! fixed Prometheus text exposition for `/metrics`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum HttpEndpointLabel {
+    Generate = 0,
+    Health,
+    HealthGenerate,
+    ServerInfo,
+    GetModelInfo,
+    ModelInfo,
+    V1Models,
+    Other,
+}
+
+impl HttpEndpointLabel {
+    const COUNT: usize = 8;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Generate,
+        Self::Health,
+        Self::HealthGenerate,
+        Self::ServerInfo,
+        Self::GetModelInfo,
+        Self::ModelInfo,
+        Self::V1Models,
+        Self::Other,
+    ];
+
+    pub fn from_path(path: &str) -> Option<Self> {
+        match path {
+            "/generate" => Some(Self::Generate),
+            "/health" => Some(Self::Health),
+            "/health_generate" => Some(Self::HealthGenerate),
+            "/server_info" => Some(Self::ServerInfo),
+            "/get_model_info" => Some(Self::GetModelInfo),
+            "/model_info" => Some(Self::ModelInfo),
+            "/v1/models" => Some(Self::V1Models),
+            // Do not let a scrape perturb the values it is reading.
+            "/metrics" => None,
+            _ => Some(Self::Other),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Generate => "/generate",
+            Self::Health => "/health",
+            Self::HealthGenerate => "/health_generate",
+            Self::ServerInfo => "/server_info",
+            Self::GetModelInfo => "/get_model_info",
+            Self::ModelInfo => "/model_info",
+            Self::V1Models => "/v1/models",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum HttpMethodLabel {
+    Get = 0,
+    Post,
+    Other,
+}
+
+impl HttpMethodLabel {
+    const COUNT: usize = 3;
+    const ALL: [Self; Self::COUNT] = [Self::Get, Self::Post, Self::Other];
+
+    pub fn from_method(method: &axum::http::Method) -> Self {
+        match *method {
+            axum::http::Method::GET => Self::Get,
+            axum::http::Method::POST => Self::Post,
+            _ => Self::Other,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Other => "OTHER",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+enum HttpStatusLabel {
+    Ok = 0,
+    BadRequest,
+    NotFound,
+    MethodNotAllowed,
+    ClientClosed,
+    InternalServerError,
+    ServiceUnavailable,
+    Other,
+}
+
+impl HttpStatusLabel {
+    const COUNT: usize = 8;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Ok,
+        Self::BadRequest,
+        Self::NotFound,
+        Self::MethodNotAllowed,
+        Self::ClientClosed,
+        Self::InternalServerError,
+        Self::ServiceUnavailable,
+        Self::Other,
+    ];
+
+    fn from_u16(code: u16) -> Self {
+        match code {
+            200 => Self::Ok,
+            400 => Self::BadRequest,
+            404 => Self::NotFound,
+            405 => Self::MethodNotAllowed,
+            499 => Self::ClientClosed,
+            500 => Self::InternalServerError,
+            503 => Self::ServiceUnavailable,
+            _ => Self::Other,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ok => "200",
+            Self::BadRequest => "400",
+            Self::NotFound => "404",
+            Self::MethodNotAllowed => "405",
+            Self::ClientClosed => "499",
+            Self::InternalServerError => "500",
+            Self::ServiceUnavailable => "503",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum RequestKindLabel {
+    Generate = 0,
+    HealthGenerate,
+    Control,
+}
+
+impl RequestKindLabel {
+    const COUNT: usize = 3;
+    const ALL: [Self; Self::COUNT] = [Self::Generate, Self::HealthGenerate, Self::Control];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Generate => "generate",
+            Self::HealthGenerate => "health_generate",
+            Self::Control => "control",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum InputSourceLabel {
+    Text = 0,
+    InputIds,
+    Control,
+}
+
+impl InputSourceLabel {
+    const COUNT: usize = 3;
+    const ALL: [Self; Self::COUNT] = [Self::Text, Self::InputIds, Self::Control];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::InputIds => "input_ids",
+            Self::Control => "control",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum RequestStageLabel {
+    Parse = 0,
+    Validate,
+    Normalize,
+    Tokenize,
+    PreSend,
+    Queue,
+    Submit,
+    Egress,
+    Detokenize,
+}
+
+impl RequestStageLabel {
+    const COUNT: usize = 9;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Parse,
+        Self::Validate,
+        Self::Normalize,
+        Self::Tokenize,
+        Self::PreSend,
+        Self::Queue,
+        Self::Submit,
+        Self::Egress,
+        Self::Detokenize,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Parse => "parse",
+            Self::Validate => "validate",
+            Self::Normalize => "normalize",
+            Self::Tokenize => "tokenize",
+            Self::PreSend => "pre_send",
+            Self::Queue => "queue",
+            Self::Submit => "submit",
+            Self::Egress => "egress",
+            Self::Detokenize => "detokenize",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum TerminalOutcomeLabel {
+    Success = 0,
+    Error,
+    Disconnect,
+    ClientBackpressure,
+    ControlResult,
+}
+
+impl TerminalOutcomeLabel {
+    const COUNT: usize = 5;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Success,
+        Self::Error,
+        Self::Disconnect,
+        Self::ClientBackpressure,
+        Self::ControlResult,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Error => "error",
+            Self::Disconnect => "disconnect",
+            Self::ClientBackpressure => "client_backpressure",
+            Self::ControlResult => "control_result",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum EgressFrameLabel {
+    Batch = 0,
+    Result,
+    Error,
+    BadBatch,
+    Unknown,
+}
+
+impl EgressFrameLabel {
+    const COUNT: usize = 5;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Batch,
+        Self::Result,
+        Self::Error,
+        Self::BadBatch,
+        Self::Unknown,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Batch => "batch",
+            Self::Result => "result",
+            Self::Error => "error",
+            Self::BadBatch => "bad_batch",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum RingLabel {
+    Ingress = 0,
+    Egress,
+    Channel,
+}
+
+impl RingLabel {
+    const COUNT: usize = 3;
+    const ALL: [Self; Self::COUNT] = [Self::Ingress, Self::Egress, Self::Channel];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Ingress => "ingress",
+            Self::Egress => "egress",
+            Self::Channel => "channel",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum ThreadPoolLabel {
+    Api = 0,
+    Tokenizer,
+    Detokenizer,
+    TmIngress,
+    TmEgress,
+}
+
+impl ThreadPoolLabel {
+    const COUNT: usize = 5;
+    const ALL: [Self; Self::COUNT] = [
+        Self::Api,
+        Self::Tokenizer,
+        Self::Detokenizer,
+        Self::TmIngress,
+        Self::TmEgress,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Api => "api",
+            Self::Tokenizer => "tokenizer",
+            Self::Detokenizer => "detokenizer",
+            Self::TmIngress => "tm_ingress",
+            Self::TmEgress => "tm_egress",
+        }
+    }
+}
+
+const HTTP_REQUEST_CARDINALITY: usize = HttpEndpointLabel::COUNT * HttpMethodLabel::COUNT;
+const HTTP_RESPONSE_CARDINALITY: usize =
+    HttpEndpointLabel::COUNT * HttpMethodLabel::COUNT * HttpStatusLabel::COUNT;
+const RUST_REQUEST_CARDINALITY: usize = RequestKindLabel::COUNT * InputSourceLabel::COUNT * 2;
+const REQUEST_ERROR_CARDINALITY: usize = RequestStageLabel::COUNT * HttpStatusLabel::COUNT;
+const TERMINAL_CARDINALITY: usize = RequestKindLabel::COUNT * TerminalOutcomeLabel::COUNT;
+
+pub struct MetricsState {
+    http_requests_total: [AtomicU64; HTTP_REQUEST_CARDINALITY],
+    http_responses_total: [AtomicU64; HTTP_RESPONSE_CARDINALITY],
+    http_requests_active: [AtomicU64; HTTP_REQUEST_CARDINALITY],
+    rust_server_requests_total: [AtomicU64; RUST_REQUEST_CARDINALITY],
+    request_errors_total: [AtomicU64; REQUEST_ERROR_CARDINALITY],
+    request_terminal_total: [AtomicU64; TERMINAL_CARDINALITY],
+    inflight_requests: [AtomicU64; RequestKindLabel::COUNT],
+    ingress_ring_push_total: [AtomicU64; RequestKindLabel::COUNT],
+    ingress_ring_backpressure_total: [AtomicU64; RequestKindLabel::COUNT],
+    ingress_ring_depth: AtomicU64,
+    egress_ring_push_total: [AtomicU64; EgressFrameLabel::COUNT],
+    egress_ring_backpressure_total: [AtomicU64; EgressFrameLabel::COUNT],
+    egress_ring_depth: AtomicU64,
+    egress_frames_total: [AtomicU64; EgressFrameLabel::COUNT],
+    ring_capacity: [AtomicU64; RingLabel::COUNT],
+    threads: [AtomicU64; ThreadPoolLabel::COUNT],
+}
+
+impl Default for MetricsState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricsState {
+    pub fn new() -> Self {
+        Self {
+            http_requests_total: atomic_array(),
+            http_responses_total: atomic_array(),
+            http_requests_active: atomic_array(),
+            rust_server_requests_total: atomic_array(),
+            request_errors_total: atomic_array(),
+            request_terminal_total: atomic_array(),
+            inflight_requests: atomic_array(),
+            ingress_ring_push_total: atomic_array(),
+            ingress_ring_backpressure_total: atomic_array(),
+            ingress_ring_depth: AtomicU64::new(0),
+            egress_ring_push_total: atomic_array(),
+            egress_ring_backpressure_total: atomic_array(),
+            egress_ring_depth: AtomicU64::new(0),
+            egress_frames_total: atomic_array(),
+            ring_capacity: atomic_array(),
+            threads: atomic_array(),
+        }
+    }
+
+    #[inline]
+    pub fn http_request_started(&self, endpoint: HttpEndpointLabel, method: HttpMethodLabel) {
+        self.http_requests_total[http_idx(endpoint, method)].fetch_add(1, Ordering::Relaxed);
+        self.http_requests_active[http_idx(endpoint, method)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn http_request_finished(
+        &self,
+        endpoint: HttpEndpointLabel,
+        method: HttpMethodLabel,
+        status_code: u16,
+    ) {
+        let status = HttpStatusLabel::from_u16(status_code);
+        self.http_responses_total[http_response_idx(endpoint, method, status)]
+            .fetch_add(1, Ordering::Relaxed);
+        saturating_sub(&self.http_requests_active[http_idx(endpoint, method)], 1);
+    }
+
+    #[inline]
+    pub fn request_received(
+        &self,
+        kind: RequestKindLabel,
+        input_source: InputSourceLabel,
+        stream: bool,
+    ) {
+        self.rust_server_requests_total[request_idx(kind, input_source, stream)]
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn request_error(&self, stage: RequestStageLabel, status_code: u16) {
+        let status = HttpStatusLabel::from_u16(status_code);
+        self.request_errors_total[request_error_idx(stage, status)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn request_terminal(&self, kind: RequestKindLabel, outcome: TerminalOutcomeLabel) {
+        self.request_terminal_total[terminal_idx(kind, outcome)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn inflight_inc(&self, kind: RequestKindLabel) {
+        self.inflight_requests[kind as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn inflight_dec(&self, kind: RequestKindLabel) {
+        saturating_sub(&self.inflight_requests[kind as usize], 1);
+    }
+
+    #[inline]
+    pub fn ingress_ring_push(&self, kind: RequestKindLabel) {
+        self.ingress_ring_push_total[kind as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn ingress_ring_backpressure(&self, kind: RequestKindLabel) {
+        self.ingress_ring_backpressure_total[kind as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn ingress_depth_inc(&self) {
+        self.ingress_ring_depth.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn ingress_depth_dec(&self, n: u64) {
+        saturating_sub(&self.ingress_ring_depth, n);
+    }
+
+    #[inline]
+    pub fn egress_ring_push(&self, frame: EgressFrameLabel) {
+        self.egress_ring_push_total[frame as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn egress_ring_backpressure(&self, frame: EgressFrameLabel) {
+        self.egress_ring_backpressure_total[frame as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn egress_depth_inc(&self) {
+        self.egress_ring_depth.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn egress_depth_dec(&self, n: u64) {
+        saturating_sub(&self.egress_ring_depth, n);
+    }
+
+    #[inline]
+    pub fn egress_frame(&self, frame: EgressFrameLabel) {
+        self.egress_frames_total[frame as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn set_ring_capacity(&self, ring: RingLabel, value: u64) {
+        self.ring_capacity[ring as usize].store(value, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn set_threads(&self, pool: ThreadPoolLabel, value: u64) {
+        self.threads[pool as usize].store(value, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub fn ingress_depth(&self) -> u64 {
+        self.ingress_ring_depth.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub fn egress_depth(&self) -> u64 {
+        self.egress_ring_depth.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub fn inflight_requests(&self, kind: RequestKindLabel) -> u64 {
+        self.inflight_requests[kind as usize].load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub fn terminal_total(&self, kind: RequestKindLabel, outcome: TerminalOutcomeLabel) -> u64 {
+        self.request_terminal_total[terminal_idx(kind, outcome)].load(Ordering::Relaxed)
+    }
+
+    pub fn render_prometheus(&self) -> String {
+        let mut out = String::with_capacity(8192);
+        append_header(
+            &mut out,
+            "sglang:http_requests_total",
+            "Total number of HTTP requests by endpoint and method.",
+            "counter",
+        );
+        for endpoint in HttpEndpointLabel::ALL {
+            for method in HttpMethodLabel::ALL {
+                append_counter_sample(
+                    &mut out,
+                    "sglang:http_requests_total",
+                    &[("endpoint", endpoint.label()), ("method", method.label())],
+                    self.http_requests_total[http_idx(endpoint, method)].load(Ordering::Relaxed),
+                );
+            }
+        }
+
+        append_header(
+            &mut out,
+            "sglang:http_responses_total",
+            "Total number of HTTP responses by endpoint, status code, and method.",
+            "counter",
+        );
+        for endpoint in HttpEndpointLabel::ALL {
+            for method in HttpMethodLabel::ALL {
+                for status in HttpStatusLabel::ALL {
+                    append_counter_sample(
+                        &mut out,
+                        "sglang:http_responses_total",
+                        &[
+                            ("endpoint", endpoint.label()),
+                            ("status_code", status.label()),
+                            ("method", method.label()),
+                        ],
+                        self.http_responses_total[http_response_idx(endpoint, method, status)]
+                            .load(Ordering::Relaxed),
+                    );
+                }
+            }
+        }
+
+        append_header(
+            &mut out,
+            "sglang:http_requests_active",
+            "Number of currently active HTTP requests.",
+            "gauge",
+        );
+        for endpoint in HttpEndpointLabel::ALL {
+            for method in HttpMethodLabel::ALL {
+                append_sample(
+                    &mut out,
+                    "sglang:http_requests_active",
+                    &[("endpoint", endpoint.label()), ("method", method.label())],
+                    self.http_requests_active[http_idx(endpoint, method)].load(Ordering::Relaxed),
+                );
+            }
+        }
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_requests_total",
+            "Total number of Rust frontend logical requests.",
+            "counter",
+        );
+        for kind in RequestKindLabel::ALL {
+            for source in InputSourceLabel::ALL {
+                for stream in [false, true] {
+                    append_counter_sample(
+                        &mut out,
+                        "sglang:rust_server_requests_total",
+                        &[
+                            ("kind", kind.label()),
+                            ("input_source", source.label()),
+                            ("stream", if stream { "true" } else { "false" }),
+                        ],
+                        self.rust_server_requests_total[request_idx(kind, source, stream)]
+                            .load(Ordering::Relaxed),
+                    );
+                }
+            }
+        }
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_request_errors_total",
+            "Total number of Rust frontend request errors by stage and status code.",
+            "counter",
+        );
+        for stage in RequestStageLabel::ALL {
+            for status in HttpStatusLabel::ALL {
+                append_counter_sample(
+                    &mut out,
+                    "sglang:rust_server_request_errors_total",
+                    &[("stage", stage.label()), ("status_code", status.label())],
+                    self.request_errors_total[request_error_idx(stage, status)]
+                        .load(Ordering::Relaxed),
+                );
+            }
+        }
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_request_terminal_total",
+            "Total number of Rust frontend terminal request outcomes.",
+            "counter",
+        );
+        for kind in RequestKindLabel::ALL {
+            for outcome in TerminalOutcomeLabel::ALL {
+                append_counter_sample(
+                    &mut out,
+                    "sglang:rust_server_request_terminal_total",
+                    &[("kind", kind.label()), ("outcome", outcome.label())],
+                    self.request_terminal_total[terminal_idx(kind, outcome)]
+                        .load(Ordering::Relaxed),
+                );
+            }
+        }
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_inflight_requests",
+            "Number of Rust frontend requests registered with detokenizer shards.",
+            "gauge",
+        );
+        for kind in RequestKindLabel::ALL {
+            append_sample(
+                &mut out,
+                "sglang:rust_server_inflight_requests",
+                &[("kind", kind.label())],
+                self.inflight_requests[kind as usize].load(Ordering::Relaxed),
+            );
+        }
+
+        append_by_kind_counter(
+            &mut out,
+            "sglang:rust_server_ingress_ring_push_total",
+            "Total number of successful pushes into the Rust ingress ring.",
+            &self.ingress_ring_push_total,
+        );
+        append_by_kind_counter(
+            &mut out,
+            "sglang:rust_server_ingress_ring_backpressure_total",
+            "Total number of ingress ring backpressure events.",
+            &self.ingress_ring_backpressure_total,
+        );
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_ingress_ring_depth",
+            "Current number of messages queued in the Rust ingress ring.",
+            "gauge",
+        );
+        append_sample(
+            &mut out,
+            "sglang:rust_server_ingress_ring_depth",
+            &[],
+            self.ingress_ring_depth.load(Ordering::Relaxed),
+        );
+
+        append_by_frame_counter(
+            &mut out,
+            "sglang:rust_server_egress_ring_push_total",
+            "Total number of successful pushes into the Rust egress ring.",
+            &self.egress_ring_push_total,
+        );
+        append_by_frame_counter(
+            &mut out,
+            "sglang:rust_server_egress_ring_backpressure_total",
+            "Total number of egress ring backpressure events.",
+            &self.egress_ring_backpressure_total,
+        );
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_egress_ring_depth",
+            "Current number of messages queued in the Rust egress ring.",
+            "gauge",
+        );
+        append_sample(
+            &mut out,
+            "sglang:rust_server_egress_ring_depth",
+            &[],
+            self.egress_ring_depth.load(Ordering::Relaxed),
+        );
+
+        append_by_frame_counter(
+            &mut out,
+            "sglang:rust_server_egress_frames_total",
+            "Total number of Rust egress frames drained by frame type.",
+            &self.egress_frames_total,
+        );
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_ring_capacity",
+            "Configured Rust server ring or channel capacity.",
+            "gauge",
+        );
+        for ring in RingLabel::ALL {
+            append_sample(
+                &mut out,
+                "sglang:rust_server_ring_capacity",
+                &[("ring", ring.label())],
+                self.ring_capacity[ring as usize].load(Ordering::Relaxed),
+            );
+        }
+
+        append_header(
+            &mut out,
+            "sglang:rust_server_threads",
+            "Configured Rust server worker threads by pool.",
+            "gauge",
+        );
+        for pool in ThreadPoolLabel::ALL {
+            append_sample(
+                &mut out,
+                "sglang:rust_server_threads",
+                &[("pool", pool.label())],
+                self.threads[pool as usize].load(Ordering::Relaxed),
+            );
+        }
+
+        out
+    }
+}
+
+fn atomic_array<const N: usize>() -> [AtomicU64; N] {
+    std::array::from_fn(|_| AtomicU64::new(0))
+}
+
+#[inline]
+fn saturating_sub(value: &AtomicU64, delta: u64) {
+    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(delta))
+    });
+}
+
+#[inline]
+const fn http_idx(endpoint: HttpEndpointLabel, method: HttpMethodLabel) -> usize {
+    (endpoint as usize) * HttpMethodLabel::COUNT + method as usize
+}
+
+#[inline]
+const fn http_response_idx(
+    endpoint: HttpEndpointLabel,
+    method: HttpMethodLabel,
+    status: HttpStatusLabel,
+) -> usize {
+    ((endpoint as usize) * HttpMethodLabel::COUNT + method as usize) * HttpStatusLabel::COUNT
+        + status as usize
+}
+
+#[inline]
+const fn request_idx(
+    kind: RequestKindLabel,
+    input_source: InputSourceLabel,
+    stream: bool,
+) -> usize {
+    ((kind as usize) * InputSourceLabel::COUNT + input_source as usize) * 2 + stream as usize
+}
+
+#[inline]
+const fn request_error_idx(stage: RequestStageLabel, status: HttpStatusLabel) -> usize {
+    (stage as usize) * HttpStatusLabel::COUNT + status as usize
+}
+
+#[inline]
+const fn terminal_idx(kind: RequestKindLabel, outcome: TerminalOutcomeLabel) -> usize {
+    (kind as usize) * TerminalOutcomeLabel::COUNT + outcome as usize
+}
+
+fn append_by_kind_counter(
+    out: &mut String,
+    name: &'static str,
+    help: &'static str,
+    values: &[AtomicU64; RequestKindLabel::COUNT],
+) {
+    append_header(out, name, help, "counter");
+    for kind in RequestKindLabel::ALL {
+        append_counter_sample(
+            out,
+            name,
+            &[("kind", kind.label())],
+            values[kind as usize].load(Ordering::Relaxed),
+        );
+    }
+}
+
+fn append_by_frame_counter(
+    out: &mut String,
+    name: &'static str,
+    help: &'static str,
+    values: &[AtomicU64; EgressFrameLabel::COUNT],
+) {
+    append_header(out, name, help, "counter");
+    for frame in EgressFrameLabel::ALL {
+        append_counter_sample(
+            out,
+            name,
+            &[("frame", frame.label())],
+            values[frame as usize].load(Ordering::Relaxed),
+        );
+    }
+}
+
+fn append_header(out: &mut String, name: &str, help: &str, metric_type: &str) {
+    out.push_str("# HELP ");
+    out.push_str(name);
+    out.push(' ');
+    out.push_str(help);
+    out.push('\n');
+    out.push_str("# TYPE ");
+    out.push_str(name);
+    out.push(' ');
+    out.push_str(metric_type);
+    out.push('\n');
+}
+
+fn append_counter_sample(out: &mut String, name: &str, labels: &[(&str, &str)], value: u64) {
+    if value > 0 {
+        append_sample(out, name, labels, value);
+    }
+}
+
+fn append_sample(out: &mut String, name: &str, labels: &[(&str, &str)], value: u64) {
+    out.push_str(name);
+    if !labels.is_empty() {
+        out.push('{');
+        for (i, (k, v)) in labels.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            out.push_str(k);
+            out.push_str("=\"");
+            append_escaped_label_value(out, v);
+            out.push('"');
+        }
+        out.push('}');
+    }
+    out.push(' ');
+    out.push_str(&value.to_string());
+    out.push('\n');
+}
+
+fn append_escaped_label_value(out: &mut String, value: &str) {
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(ch),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_values_are_escaped() {
+        let mut out = String::new();
+        append_sample(&mut out, "m", &[("label", "quote\" slash\\ newline\n")], 1);
+        assert_eq!(out, "m{label=\"quote\\\" slash\\\\ newline\\n\"} 1\n");
+    }
+
+    #[test]
+    fn counters_and_gauges_render_prometheus_text() {
+        let metrics = MetricsState::new();
+        metrics.request_received(RequestKindLabel::Generate, InputSourceLabel::Text, false);
+        metrics.request_error(RequestStageLabel::Validate, 400);
+        metrics.inflight_inc(RequestKindLabel::Generate);
+        metrics.set_ring_capacity(RingLabel::Ingress, 7);
+        metrics.set_threads(ThreadPoolLabel::Api, 2);
+
+        let text = metrics.render_prometheus();
+        assert!(text.contains("# HELP sglang:rust_server_requests_total"));
+        assert!(text.contains(
+            "sglang:rust_server_requests_total{kind=\"generate\",input_source=\"text\",stream=\"false\"} 1"
+        ));
+        assert!(text.contains(
+            "sglang:rust_server_request_errors_total{stage=\"validate\",status_code=\"400\"} 1"
+        ));
+        assert!(text.contains("sglang:rust_server_inflight_requests{kind=\"generate\"} 1"));
+        assert!(text.contains("sglang:rust_server_ring_capacity{ring=\"ingress\"} 7"));
+        assert!(text.contains("sglang:rust_server_threads{pool=\"api\"} 2"));
+    }
+
+    #[test]
+    fn gauges_saturate_at_zero() {
+        let metrics = MetricsState::new();
+        metrics.inflight_dec(RequestKindLabel::Generate);
+        metrics.ingress_depth_dec(1);
+        metrics.egress_depth_dec(1);
+        assert_eq!(metrics.inflight_requests(RequestKindLabel::Generate), 0);
+        assert_eq!(metrics.ingress_depth(), 0);
+        assert_eq!(metrics.egress_depth(), 0);
+    }
+}

--- a/rust/sglang-server/src/ring.rs
+++ b/rust/sglang-server/src/ring.rs
@@ -10,12 +10,13 @@
 //! ever push/drain raw `Bytes` — neither side touches a `PyObject` off-thread,
 //! so the producer threads never need the GIL.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bytes::Bytes;
 
 use crate::message::IngressMsg;
+use crate::metrics::MetricsState;
 
 /// Ingress: TokenizerManager → scheduler `recv_requests`.
 /// Producers are Rust TM workers; the single consumer is the Python thread.
@@ -24,10 +25,12 @@ use crate::message::IngressMsg;
 #[derive(Clone)]
 pub struct IngressProducer {
     tx: flume::Sender<IngressMsg>,
+    metrics: Arc<MetricsState>,
 }
 
 pub struct IngressConsumer {
     rx: flume::Receiver<IngressMsg>,
+    metrics: Arc<MetricsState>,
     /// One-slot buffer holding a message consumed by a blocking [`wait`] so the
     /// scheduler can park on idle without losing it — the next [`drain`] returns
     /// it first. Only ever touched by the single consumer (the Python thread),
@@ -60,7 +63,11 @@ impl IngressProducer {
     /// caller can fail the request rather than block a worker thread.
     #[inline]
     pub fn try_push(&self, msg: IngressMsg) -> bool {
-        self.tx.try_send(msg).is_ok()
+        let ok = self.tx.try_send(msg).is_ok();
+        if ok {
+            self.metrics.ingress_depth_inc();
+        }
+        ok
     }
 }
 
@@ -81,7 +88,10 @@ impl IngressConsumer {
         }
         while batch.headers.len() < max {
             match self.rx.try_recv() {
-                Ok(m) => push_msg(&mut batch, m),
+                Ok(m) => {
+                    self.metrics.ingress_depth_dec(1);
+                    push_msg(&mut batch, m);
+                }
                 Err(_) => break, // Empty or Disconnected -> stop now
             }
         }
@@ -100,6 +110,7 @@ impl IngressConsumer {
         }
         match self.rx.recv_timeout(timeout) {
             Ok(m) => {
+                self.metrics.ingress_depth_dec(1);
                 *self.stash.lock().unwrap() = Some(m);
                 true
             }
@@ -122,6 +133,7 @@ fn push_msg(batch: &mut IngressColumns, m: IngressMsg) {
 #[derive(Clone)]
 pub struct EgressProducer {
     tx: flume::Sender<Bytes>,
+    metrics: Arc<MetricsState>,
 }
 
 pub struct EgressConsumer {
@@ -136,7 +148,11 @@ impl EgressProducer {
     /// `false` only when the consumer is gone (runtime shutdown), where the frame
     /// is unavoidably lost.
     pub fn push(&self, msg: Bytes) -> bool {
-        self.tx.send(msg).is_ok()
+        let ok = self.tx.send(msg).is_ok();
+        if ok {
+            self.metrics.egress_depth_inc();
+        }
+        ok
     }
 
     /// Non-blocking push, so the pyo3 boundary can try to hand the frame over
@@ -151,7 +167,10 @@ impl EgressProducer {
     #[inline]
     pub fn try_push(&self, msg: Bytes) -> Result<(), Option<Bytes>> {
         match self.tx.try_send(msg) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                self.metrics.egress_depth_inc();
+                Ok(())
+            }
             Err(flume::TrySendError::Full(msg)) => Err(Some(msg)),
             Err(flume::TrySendError::Disconnected(_)) => Err(None),
         }
@@ -167,25 +186,34 @@ impl EgressConsumer {
 }
 
 /// Build both halves of a bounded ring.
-pub fn ingress_ring(cap: usize) -> (IngressProducer, IngressConsumer) {
+pub fn ingress_ring(cap: usize, metrics: Arc<MetricsState>) -> (IngressProducer, IngressConsumer) {
     let (tx, rx) = flume::bounded(cap);
     (
-        IngressProducer { tx },
+        IngressProducer {
+            tx,
+            metrics: metrics.clone(),
+        },
         IngressConsumer {
             rx,
+            metrics,
             stash: Mutex::new(None),
         },
     )
 }
 
-pub fn egress_ring(cap: usize) -> (EgressProducer, EgressConsumer) {
+pub fn egress_ring(cap: usize, metrics: Arc<MetricsState>) -> (EgressProducer, EgressConsumer) {
     let (tx, rx) = flume::bounded(cap);
-    (EgressProducer { tx }, EgressConsumer { rx })
+    (EgressProducer { tx, metrics }, EgressConsumer { rx })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metrics::MetricsState;
+
+    fn metrics() -> Arc<MetricsState> {
+        Arc::new(MetricsState::new())
+    }
 
     fn msg(h: &'static [u8]) -> IngressMsg {
         IngressMsg {
@@ -198,12 +226,15 @@ mod tests {
     /// non-destructively, and the next `drain` returns it.
     #[test]
     fn wait_stashes_then_drain_returns_it() {
-        let (tx, rx) = ingress_ring(8);
+        let metrics = metrics();
+        let (tx, rx) = ingress_ring(8, metrics.clone());
         // Empty ring → times out, nothing stashed.
         assert!(!rx.wait(Duration::from_millis(1)));
         // Push one, then wait stashes it (returns true).
         assert!(tx.try_push(msg(b"a")));
+        assert_eq!(metrics.ingress_depth(), 1);
         assert!(rx.wait(Duration::from_millis(200)));
+        assert_eq!(metrics.ingress_depth(), 0);
         // Idempotent: already stashed, returns true without touching the ring.
         assert!(rx.wait(Duration::from_millis(1)));
         // Drain yields the stashed message, then the ring is empty.
@@ -214,7 +245,7 @@ mod tests {
     /// A blocked `wait` is woken the instant a producer pushes (no polling).
     #[test]
     fn wait_wakes_on_push() {
-        let (tx, rx) = ingress_ring(8);
+        let (tx, rx) = ingress_ring(8, metrics());
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_millis(20));
             let _ = tx.try_push(msg(b"a"));
@@ -229,22 +260,28 @@ mod tests {
     /// committed frame is delivered in order, never dropped.
     #[test]
     fn egress_push_blocks_until_drained() {
-        let (tx, rx) = egress_ring(1);
+        let metrics = metrics();
+        let (tx, rx) = egress_ring(1, metrics.clone());
         assert!(tx.push(Bytes::from_static(b"a"))); // fits; ring now full
+        assert_eq!(metrics.egress_depth(), 1);
         let t = std::thread::spawn(move || tx.push(Bytes::from_static(b"b")));
         // The parked push can't have completed while the ring is full.
         std::thread::sleep(Duration::from_millis(20));
         // Drain one → frees a slot → the parked push lands.
         assert_eq!(rx.receiver().recv().unwrap(), Bytes::from_static(b"a"));
+        metrics.egress_depth_dec(1);
         assert!(t.join().unwrap(), "push should succeed once space frees");
+        assert_eq!(metrics.egress_depth(), 1);
         assert_eq!(rx.receiver().recv().unwrap(), Bytes::from_static(b"b"));
+        metrics.egress_depth_dec(1);
+        assert_eq!(metrics.egress_depth(), 0);
     }
 
     /// A closed ring (consumer gone → shutdown) returns `false` instead of
     /// parking forever, so a scheduler blocked in `push` unblocks on teardown.
     #[test]
     fn egress_push_returns_false_when_closed() {
-        let (tx, rx) = egress_ring(1);
+        let (tx, rx) = egress_ring(1, metrics());
         drop(rx);
         assert!(!tx.push(Bytes::from_static(b"x")));
     }

--- a/rust/sglang-server/src/runtime.rs
+++ b/rust/sglang-server/src/runtime.rs
@@ -22,6 +22,7 @@ mod threads;
 pub use config::{RuntimeConfig, RustServerServerArgs, ServerArgs};
 
 use crate::message::DetokMsg;
+use crate::metrics::{MetricsState, RingLabel, ThreadPoolLabel};
 use crate::ring::{
     EgressConsumer, EgressProducer, IngressConsumer, IngressProducer, egress_ring, ingress_ring,
 };
@@ -37,6 +38,7 @@ pub use runnable::Runnable;
 pub struct Runtime {
     pub ingress: IngressConsumer,
     pub egress: EgressProducer,
+    pub metrics: Arc<MetricsState>,
     /// Worker join handles, joined by `request_shutdown` / `Drop`.
     threads: Mutex<Vec<JoinHandle<()>>>,
     /// The single shutdown sender.
@@ -103,12 +105,32 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
     let (shutdown_tx, shutdown_rx) = flume::unbounded::<()>();
     let mut threads = Vec::new();
     let plan = plan_cores(&cfg);
+    let metrics = Arc::new(MetricsState::new());
+    metrics.set_ring_capacity(
+        RingLabel::Ingress,
+        cfg.rust_server_args.ingress_ring_cap as u64,
+    );
+    metrics.set_ring_capacity(
+        RingLabel::Egress,
+        cfg.rust_server_args.egress_ring_cap as u64,
+    );
+    metrics.set_ring_capacity(RingLabel::Channel, cfg.rust_server_args.channel_cap as u64);
+    metrics.set_threads(
+        ThreadPoolLabel::Api,
+        cfg.rust_server_args.api_worker_num as u64,
+    );
+    metrics.set_threads(
+        ThreadPoolLabel::Detokenizer,
+        cfg.server_args.detokenizer_worker_num as u64,
+    );
+    metrics.set_threads(ThreadPoolLabel::TmIngress, 1);
+    metrics.set_threads(ThreadPoolLabel::TmEgress, 1);
 
     // --- rings (Rust ↔ Python) ---
     let (ingress_tx, ingress_rx): (IngressProducer, IngressConsumer) =
-        ingress_ring(cfg.rust_server_args.ingress_ring_cap);
+        ingress_ring(cfg.rust_server_args.ingress_ring_cap, metrics.clone());
     let (egress_tx, egress_rx): (EgressProducer, EgressConsumer) =
-        egress_ring(cfg.rust_server_args.egress_ring_cap);
+        egress_ring(cfg.rust_server_args.egress_ring_cap, metrics.clone());
 
     // --- inter-stage channels ---
     let (tm_tx, tm_rx) = flume::bounded::<TmEvent>(cfg.rust_server_args.channel_cap);
@@ -147,6 +169,14 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
         cfg.server_args.revision.as_deref(),
         skip_tokenizer_init,
     )?;
+    metrics.set_threads(
+        ThreadPoolLabel::Tokenizer,
+        if dyn_tokenizer.is_some() {
+            cfg.server_args.tokenizer_worker_num as u64
+        } else {
+            0
+        },
+    );
 
     // --- Detokenizer shards (pinned, CPU bound) ---
     {
@@ -162,12 +192,14 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
         // owned `detok_rx` Vec is moved out element-by-element via the iterator.
         let count = detok_rx.len();
         let mut rxs = detok_rx.into_iter();
+        let metrics = metrics.clone();
         spawn_pool("detokenizer", detok_cores, count, &mut threads, |i| {
             detokenizer::DetokenizerWorker::new(
                 i,
                 rxs.next().unwrap(),
                 backend.clone(),
                 abort_tx.clone(),
+                metrics.clone(),
             )
         });
     }
@@ -206,12 +238,14 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
             .map(|c| vec![c]);
         let mut egress_rx = Some(egress_rx); // moved into the single worker
         let activity = egress_activity.clone();
+        let metrics = metrics.clone();
         let shutdown_rx = shutdown_rx.clone();
         spawn_pool("tm-egress", cores, 1, &mut threads, |_| {
             tokenizer_manager::Egress::new(
                 egress_rx.take().unwrap(),
                 senders.clone(),
                 activity.clone(),
+                metrics.clone(),
                 shutdown_rx.clone(),
             )
         });
@@ -228,6 +262,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
         let limits = tokenizer_manager::Limits::try_from(&*cfg.server_args)
             .map_err(|e| format!("ingress limits: {e}"))?;
         let mut parts = Some((tm_rx, ingress_tx)); // moved into the single worker
+        let metrics = metrics.clone();
         let shutdown_rx = shutdown_rx.clone();
         spawn_pool("tm-ingress", cores, 1, &mut threads, |_| {
             let (tm_rx, ingress_tx) = parts.take().unwrap();
@@ -237,6 +272,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
                 senders.clone(),
                 ingress_tx,
                 limits.clone(),
+                metrics.clone(),
                 shutdown_rx.clone(),
             )
         });
@@ -248,6 +284,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
         let api_cores = plan.as_ref().map(|p| p.api.clone());
         let senders = senders.clone();
         let api_activity = egress_activity.clone();
+        let api_metrics = metrics.clone();
         let shutdown_rx = shutdown_rx.clone();
         let handle = std::thread::Builder::new()
             .name("api-runtime".into())
@@ -273,6 +310,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
                     cfg.server_args.clone(),
                     // Egress heartbeat watched by `/health_generate`.
                     api_activity,
+                    api_metrics,
                     shutdown_rx,
                 ))
             })
@@ -283,6 +321,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
     Ok(Runtime {
         ingress: ingress_rx,
         egress: egress_tx,
+        metrics,
         threads: Mutex::new(threads),
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
     })

--- a/rust/sglang-server/src/runtime/config.rs
+++ b/rust/sglang-server/src/runtime/config.rs
@@ -83,6 +83,9 @@ pub struct ServerArgs {
     pub log_level: String,
     #[serde(default)]
     pub log_level_http: Option<String>,
+    /// Enable the Rust `/metrics` endpoint and frontend metrics exposition.
+    #[serde(default)]
+    pub enable_metrics: bool,
     /// Pinned tokenizer threads / detok shards (Python asserts both ≥ 1).
     #[serde(default = "default_worker_num")]
     pub tokenizer_worker_num: usize,

--- a/rust/sglang-server/src/tokenizer_manager/egress.rs
+++ b/rust/sglang-server/src/tokenizer_manager/egress.rs
@@ -18,6 +18,7 @@ use crate::message::DetokMsg;
 use crate::message::{
     ChunkEvent, EGRESS_TAG_BATCH, EGRESS_TAG_ERROR, EGRESS_TAG_RESULT, for_each_chunk,
 };
+use crate::metrics::{EgressFrameLabel, MetricsState, RequestStageLabel};
 use crate::ring::EgressConsumer;
 use crate::runtime::Runnable;
 use crate::tokenizer_manager::{Senders, recv};
@@ -34,6 +35,7 @@ pub struct Egress {
     egress: EgressConsumer,
     senders: Senders,
     activity: ActivityCounter,
+    metrics: Arc<MetricsState>,
     shutdown: flume::Receiver<()>,
 }
 
@@ -42,12 +44,14 @@ impl Egress {
         egress: EgressConsumer,
         senders: Senders,
         activity: ActivityCounter,
+        metrics: Arc<MetricsState>,
         shutdown: flume::Receiver<()>,
     ) -> Self {
         Self {
             egress,
             senders,
             activity,
+            metrics,
             shutdown,
         }
     }
@@ -60,13 +64,16 @@ impl Runnable for Egress {
         let mut buckets: Vec<Vec<ChunkEvent>> = (0..shards).map(|_| Vec::new()).collect();
 
         while let Some(bytes) = recv(self.egress.receiver(), &self.shutdown) {
+            self.metrics.egress_depth_dec(1);
             let Some((&tag, body)) = bytes.split_first() else {
+                self.metrics.egress_frame(EgressFrameLabel::Unknown);
                 continue;
             };
             match tag {
                 // A whole decode batch: bucket each request by the shard owning its
                 // rid, then hand each shard its chunks in one send.
                 EGRESS_TAG_BATCH => {
+                    self.metrics.egress_frame(EgressFrameLabel::Batch);
                     for b in buckets.iter_mut() {
                         b.clear();
                     }
@@ -82,6 +89,7 @@ impl Runnable for Egress {
                     // logprobs — the corruption the decoder's bounds checks exist to
                     // prevent. Better a lost frame than a silently wrong one.
                     if !decoded.ok {
+                        self.metrics.egress_frame(EgressFrameLabel::BadBatch);
                         // Dropping the frame keeps wrong data off the wire, but a
                         // request whose chunk was in it would otherwise wait forever:
                         // mid-stream it gets a hole, and if its FINAL chunk was here
@@ -126,6 +134,7 @@ impl Runnable for Egress {
                         }
                         let chunks = DetokMsg::Chunks(std::mem::take(b));
                         if self.senders.detok[i].send(chunks).is_err() {
+                            self.metrics.request_error(RequestStageLabel::Egress, 500);
                             tracing::error!("egress: detok shard closed");
                         }
                     }
@@ -133,16 +142,25 @@ impl Runnable for Egress {
                     self.activity.fetch_add(1, Ordering::Relaxed);
                 }
                 EGRESS_TAG_RESULT => {
+                    self.metrics.egress_frame(EgressFrameLabel::Result);
                     if let Some((rid, msg)) = decode_result(body) {
                         self.route(&rid, msg);
+                    } else {
+                        self.metrics.egress_frame(EgressFrameLabel::Unknown);
                     }
                 }
                 EGRESS_TAG_ERROR => {
+                    self.metrics.egress_frame(EgressFrameLabel::Error);
                     if let Some((rid, msg)) = decode_error(body) {
                         self.route(&rid, msg);
+                    } else {
+                        self.metrics.egress_frame(EgressFrameLabel::Unknown);
                     }
                 }
-                other => tracing::warn!(tag = other, "egress: unknown frame tag"),
+                other => {
+                    self.metrics.egress_frame(EgressFrameLabel::Unknown);
+                    tracing::warn!(tag = other, "egress: unknown frame tag");
+                }
             }
         }
     }
@@ -154,6 +172,7 @@ impl Egress {
     #[inline]
     fn route(&self, rid: &Rid, msg: DetokMsg) {
         if self.senders.detok_for(rid).send(msg).is_err() {
+            self.metrics.request_error(RequestStageLabel::Egress, 500);
             tracing::error!("egress: detok shard closed");
         }
     }

--- a/rust/sglang-server/src/tokenizer_manager/ingress.rs
+++ b/rust/sglang-server/src/tokenizer_manager/ingress.rs
@@ -17,6 +17,8 @@
 //! The egress edges (Streaming/Finalizing/Completed) are driven on the egress
 //! side (see `egress` + `detokenizer`).
 
+use std::sync::Arc;
+
 use bytes::Bytes;
 
 use crate::error::Error;
@@ -26,6 +28,7 @@ use crate::message::{
     AbortReq, ControlRequest, DetokMsg, EgressItem, GenerateRequest, IngressMsg, Request,
     RequestKind,
 };
+use crate::metrics::{MetricsState, RequestKindLabel, RequestStageLabel, TerminalOutcomeLabel};
 use crate::ring::IngressProducer;
 use crate::runtime::{Runnable, ServerArgs};
 use crate::tokenizer_manager::{AbortSource, Senders, TmEvent};
@@ -41,6 +44,7 @@ pub struct Ingress {
     senders: Senders,
     ingress: IngressProducer,
     limits: Limits,
+    metrics: Arc<MetricsState>,
     shutdown: flume::Receiver<()>,
 }
 
@@ -104,6 +108,7 @@ impl Ingress {
         senders: Senders,
         ingress: IngressProducer,
         limits: Limits,
+        metrics: Arc<MetricsState>,
         shutdown: flume::Receiver<()>,
     ) -> Self {
         Self {
@@ -112,6 +117,7 @@ impl Ingress {
             senders,
             ingress,
             limits,
+            metrics,
             shutdown,
         }
     }
@@ -163,16 +169,18 @@ impl Ingress {
     /// holds that key — a concurrent request's sink — leaving that client with no
     /// terminal frame and a hung connection. Python cannot hit this because it
     /// validates before `rid_to_state[obj.rid] = state`.
-    fn fail(&self, req: &mut Request, err: Error, registered: bool) {
+    fn fail(&self, req: &mut Request, err: Error, registered: bool, stage: RequestStageLabel) {
         // Log only server faults (500); 4xx/499/503 are expected and would spam.
         if err.http_status() == 500 {
             tracing::error!(rid = %req.rid, error = %err, "ingress rejected request");
         }
+        self.metrics.request_error(stage, err.http_status());
         let _ = req.state.apply(Event::Error(err.clone()));
         let _ = req.sink.try_send(EgressItem::Error(err)); // client may be gone
         if registered {
             let _ = self.senders.detok_for(&req.rid).send(DetokMsg::Deregister {
                 rid: req.rid.clone(),
+                outcome: Some(TerminalOutcomeLabel::Error),
             });
         }
     }
@@ -192,14 +200,17 @@ impl Ingress {
                 // Failures move to `Failed` and fall through to the reject arm.
                 RequestState::Received => {
                     if let Err(e) = validate(&mut req, &self.limits) {
-                        let _ = req.state.apply(Event::Error(e)); // → Failed
-                        continue;
+                        self.fail(&mut req, e, registered, RequestStageLabel::Validate);
+                        return;
                     }
                     if !self.register_detok(&req) {
-                        let _ = req
-                            .state
-                            .apply(Event::Error(Error::Internal("detok shard gone".into())));
-                        continue;
+                        self.fail(
+                            &mut req,
+                            Error::Internal("detok shard gone".into()),
+                            registered,
+                            RequestStageLabel::Submit,
+                        );
+                        return;
                     }
                     registered = true;
                     // `validate` advanced Received → Validating; keep driving.
@@ -227,6 +238,7 @@ impl Ingress {
                                 &mut req,
                                 Error::Internal("non-generate request in Normalizing".into()),
                                 registered,
+                                RequestStageLabel::Normalize,
                             );
                             return;
                         };
@@ -244,7 +256,8 @@ impl Ingress {
                     };
                     match outcome {
                         Err(e) => {
-                            let _ = req.state.apply(Event::Error(e)); // → Failed
+                            self.fail(&mut req, e, registered, RequestStageLabel::Normalize);
+                            return;
                         }
                         Ok(o) => {
                             // AlreadyTokenized → Queued, NeedsTokenize → Tokenizing.
@@ -264,6 +277,7 @@ impl Ingress {
                             &mut req,
                             Error::Internal("tokenizer pool gone".into()),
                             true,
+                            RequestStageLabel::Tokenize,
                         );
                     }
                     return;
@@ -277,8 +291,8 @@ impl Ingress {
                     if let RequestKind::Generate(g) = &mut req.kind
                         && let Err(e) = check_total_tokens(g, &self.limits)
                     {
-                        let _ = req.state.apply(Event::Error(e)); // → Failed
-                        continue;
+                        self.fail(&mut req, e, registered, RequestStageLabel::PreSend);
+                        return;
                     }
                     let _ = req.state.apply(Event::PreSendValidated); // → Queued
                 }
@@ -295,7 +309,13 @@ impl Ingress {
                 }
                 // The single reject path for every post-register failure.
                 RequestState::Failed(e) => {
-                    self.fail(&mut req, e, registered);
+                    let stage = match &e {
+                        Error::Tokenize(_) => RequestStageLabel::Tokenize,
+                        Error::QueueFull => RequestStageLabel::Queue,
+                        Error::Detokenize(_) => RequestStageLabel::Detokenize,
+                        _ => RequestStageLabel::Validate,
+                    };
+                    self.fail(&mut req, e, registered, stage);
                     return;
                 }
                 // Unreachable (egress states never reach here). Reject via `fail`/
@@ -305,6 +325,7 @@ impl Ingress {
                         &mut req,
                         Error::Internal(format!("unexpected ingress state: {other:?}")),
                         registered,
+                        RequestStageLabel::Validate,
                     );
                     return;
                 }
@@ -329,6 +350,7 @@ impl Ingress {
             .detok_for(&req.rid)
             .send(DetokMsg::Register {
                 rid: req.rid.clone(),
+                kind: request_kind_label(&req.kind),
                 sink: req.sink.clone(),
                 decode_logprob_text,
                 no_stop_trim,
@@ -349,16 +371,20 @@ impl Ingress {
         let header = match encode {
             Ok(b) => b,
             Err(e) => {
-                self.fail(&mut req, e, true); // on the push path: registered
+                self.fail(&mut req, e, true, RequestStageLabel::Queue); // on the push path: registered
                 return;
             }
         };
         // Control requests carry no tensor cell — empty `ids`.
-        if !self.ingress.try_push(IngressMsg {
+        if self.ingress.try_push(IngressMsg {
             header,
             ids: Bytes::new(),
         }) {
-            self.fail(&mut req, Error::QueueFull, true); // registered
+            self.metrics.ingress_ring_push(RequestKindLabel::Control);
+        } else {
+            self.metrics
+                .ingress_ring_backpressure(RequestKindLabel::Control);
+            self.fail(&mut req, Error::QueueFull, true, RequestStageLabel::Queue); // registered
         }
     }
 
@@ -372,19 +398,27 @@ impl Ingress {
     /// ([`Rid::from_client`]), so no later request can ever answer to it.
     fn on_abort(&self, source: AbortSource) {
         let rid = source.rid().clone();
-        let _ = self
-            .senders
-            .detok_for(&rid)
-            .send(DetokMsg::Deregister { rid: rid.clone() });
+        let outcome = match &source {
+            AbortSource::Guard(_) => Some(TerminalOutcomeLabel::Disconnect),
+            AbortSource::Detok(_) => None,
+        };
+        let _ = self.senders.detok_for(&rid).send(DetokMsg::Deregister {
+            rid: rid.clone(),
+            outcome,
+        });
 
         // The ring is BOUNDED and drops pushes under exactly the load this matters
         // for, so report the miss rather than assuming the scheduler was told.
         match ControlRequest::AbortReq(AbortReq::new(rid.as_str().to_string(), false)).encode() {
             Ok(header) => {
-                if !self.ingress.try_push(IngressMsg {
+                if self.ingress.try_push(IngressMsg {
                     header,
                     ids: Bytes::new(),
                 }) {
+                    self.metrics.ingress_ring_push(RequestKindLabel::Control);
+                } else {
+                    self.metrics
+                        .ingress_ring_backpressure(RequestKindLabel::Control);
                     tracing::error!(
                         rid = %rid,
                         "abort dropped: ingress ring full; the scheduler keeps generating \
@@ -414,16 +448,34 @@ impl Ingress {
         let (header, ids) = match serialized {
             Ok(v) => v,
             Err(e) => {
-                self.fail(&mut req, e, true); // on the push path: registered
+                self.fail(&mut req, e, true, RequestStageLabel::Queue); // on the push path: registered
                 return;
             }
         };
 
-        if !self.ingress.try_push(IngressMsg { header, ids }) {
-            self.fail(&mut req, Error::QueueFull, true); // registered
+        let kind = request_kind_label(&req.kind);
+        if self.ingress.try_push(IngressMsg { header, ids }) {
+            self.metrics.ingress_ring_push(kind);
+        } else {
+            self.metrics.ingress_ring_backpressure(kind);
+            self.fail(&mut req, Error::QueueFull, true, RequestStageLabel::Queue); // registered
         }
         // On success the scheduler owns the request (egress arrives by rid); we
         // drop our `Request` here — the detok shard holds the sink.
+    }
+}
+
+fn request_kind_label(kind: &RequestKind) -> RequestKindLabel {
+    match kind {
+        RequestKind::Generate(g)
+            if g.rid
+                .as_str()
+                .starts_with(crate::ids::HEALTH_CHECK_RID_PREFIX) =>
+        {
+            RequestKindLabel::HealthGenerate
+        }
+        RequestKind::Generate(_) => RequestKindLabel::Generate,
+        RequestKind::Control(_) => RequestKindLabel::Control,
     }
 }
 
@@ -570,8 +622,13 @@ mod tests {
     use super::*;
     use crate::fsm::RequestState;
     use crate::message::{EgressSink, GenerateRequest, SamplingParams};
+    use crate::metrics::MetricsState;
     use crate::ring::{IngressConsumer, ingress_ring};
     use tokio::sync::mpsc;
+
+    fn metrics() -> Arc<MetricsState> {
+        Arc::new(MetricsState::new())
+    }
 
     /// An `Ingress` plus its detok-shard receiver, ring consumer (keep alive —
     /// dropping it closes the ring → false QueueFull), and tm inbox sender.
@@ -625,13 +682,21 @@ mod tests {
             tok: tok_tx,
             detok: vec![detok_tx],
         };
-        let (ingress_producer, consumer) = ingress_ring(16);
+        let (ingress_producer, consumer) = ingress_ring(16, metrics());
         let (tm_tx, tm_rx) = flume::unbounded();
         // Keep the shutdown sender alive (leak) so its branch never fires — tests
         // end `run` by dropping `tm_tx`, not by shutdown.
         let (sd_tx, sd_rx) = flume::unbounded::<()>();
         std::mem::forget(sd_tx);
-        let ingress = Ingress::new(tm_rx, abort_rx, senders, ingress_producer, limits, sd_rx);
+        let ingress = Ingress::new(
+            tm_rx,
+            abort_rx,
+            senders,
+            ingress_producer,
+            limits,
+            metrics(),
+            sd_rx,
+        );
         (ingress, detok_rx, consumer, tm_tx)
     }
 
@@ -651,7 +716,7 @@ mod tests {
             AbortSource::Detok("x".into()),
         ] {
             let (detok_tx, detok_rx) = flume::unbounded::<DetokMsg>();
-            let (ingress_producer, consumer) = ingress_ring(16);
+            let (ingress_producer, consumer) = ingress_ring(16, metrics());
             let (sd_tx, sd_rx) = flume::unbounded::<()>();
             std::mem::forget(sd_tx);
             let ingress = Ingress::new(
@@ -665,13 +730,14 @@ mod tests {
                 },
                 ingress_producer,
                 test_limits(),
+                metrics(),
                 sd_rx,
             );
 
             ingress.on_abort(source.clone());
 
             assert!(
-                matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid }) if rid.as_str() == "x"),
+                matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid, .. }) if rid.as_str() == "x"),
                 "{source:?} must drop the detok entry",
             );
             assert_eq!(
@@ -934,7 +1000,7 @@ mod tests {
             "registered before the check",
         );
         assert!(
-            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid }) if rid.as_str() == "33"),
+            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid, .. }) if rid.as_str() == "33"),
             "must deregister on reject",
         );
         assert!(
@@ -963,11 +1029,19 @@ mod tests {
             tok: tok_tx,
             detok: vec![detok_tx],
         };
-        let (producer, _consumer) = ingress_ring(1);
+        let (producer, _consumer) = ingress_ring(1, metrics());
         let (_tm_tx, tm_rx) = flume::unbounded();
         let (sd_tx, sd_rx) = flume::unbounded::<()>();
         std::mem::forget(sd_tx);
-        let ingress = Ingress::new(tm_rx, abort_rx, senders, producer, test_limits(), sd_rx);
+        let ingress = Ingress::new(
+            tm_rx,
+            abort_rx,
+            senders,
+            producer,
+            test_limits(),
+            metrics(),
+            sd_rx,
+        );
 
         ingress.on_abort(AbortSource::Guard("pushed".into()));
         ingress.on_abort(AbortSource::Guard("dropped".into()));
@@ -975,7 +1049,7 @@ mod tests {
         // Both deregisters land regardless of whether the ring accepted the push.
         for expected in ["pushed", "dropped"] {
             assert!(
-                matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid }) if rid.as_str() == expected),
+                matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid, .. }) if rid.as_str() == expected),
                 "{expected}: the detok entry must be dropped even when the ring is full",
             );
         }
@@ -1049,7 +1123,7 @@ mod tests {
             "expected Register for rid 7",
         );
         assert!(
-            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid }) if rid.as_str() == "7"),
+            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid, .. }) if rid.as_str() == "7"),
             "expected Deregister for rid 7 (leak fix)",
         );
         assert!(
@@ -1137,7 +1211,7 @@ mod tests {
         ingress.run();
 
         assert!(
-            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid }) if rid.as_str() == "11"),
+            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid, .. }) if rid.as_str() == "11"),
             "tokenize failure must deregister rid 11",
         );
         assert!(detok_rx.try_recv().is_err(), "no further shard messages");
@@ -1156,7 +1230,7 @@ mod tests {
         ingress.run();
 
         assert!(
-            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid }) if rid.as_str() == "rid-13"),
+            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid, .. }) if rid.as_str() == "rid-13"),
             "abort must deregister by rid",
         );
         assert!(detok_rx.try_recv().is_err(), "no further shard messages");
@@ -1202,7 +1276,7 @@ mod tests {
             "expected Register for rid 21",
         );
         assert!(
-            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid }) if rid.as_str() == "21"),
+            matches!(detok_rx.try_recv(), Ok(DetokMsg::Deregister { rid, .. }) if rid.as_str() == "21"),
             "pool-gone hand-off must deregister rid 21",
         );
         assert!(detok_rx.try_recv().is_err(), "no further shard messages");

--- a/test/registered/observability/test_rust_server_metrics.py
+++ b/test/registered/observability/test_rust_server_metrics.py
@@ -1,0 +1,195 @@
+"""Integration test: embedded Rust server exports frontend Prometheus metrics."""
+
+import json
+import time
+import unittest
+from typing import Dict, List
+
+import requests
+from prometheus_client.parser import text_string_to_metric_families
+from prometheus_client.samples import Sample
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_rust_server_built,
+    popen_launch_server,
+)
+
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=120, suite="stage-b-test-1-gpu-small-amd")
+
+
+def _parse_prometheus_metrics(metrics_text: str) -> Dict[str, List[Sample]]:
+    result: Dict[str, List[Sample]] = {}
+    for family in text_string_to_metric_families(metrics_text):
+        for sample in family.samples:
+            result.setdefault(sample.name, []).append(sample)
+    return result
+
+
+def _sum_samples(
+    metrics: Dict[str, List[Sample]], name: str, labels: Dict[str, str]
+) -> float:
+    return sum(
+        sample.value
+        for sample in metrics.get(name, [])
+        if all(sample.labels.get(k) == v for k, v in labels.items())
+    )
+
+
+def _all_samples_zero(metrics: Dict[str, List[Sample]], name: str) -> bool:
+    return all(sample.value == 0 for sample in metrics.get(name, []))
+
+
+@unittest.skipUnless(
+    is_rust_server_built(),
+    "embedded rust server extension not built",
+)
+class TestRustServerMetrics(CustomTestCase):
+    def test_rust_server_metrics_exported(self):
+        process = popen_launch_server(
+            DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+            DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            env={
+                "SGLANG_RUST_SERVER": "1",
+                "SGLANG_USE_PICKLE_IPC": "0",
+                "SGLANG_USE_AITER": "0",
+            },
+            other_args=[
+                "--enable-metrics",
+                "--attention-backend",
+                "torch_native",
+                "--sampling-backend",
+                "pytorch",
+                "--grammar-backend",
+                "none",
+                "--cuda-graph-backend-decode",
+                "disabled",
+                "--cuda-graph-backend-prefill",
+                "disabled",
+                "--skip-server-warmup",
+                "--mem-fraction-static",
+                "0.2",
+                "--dtype",
+                "bfloat16",
+            ],
+        )
+        self.addCleanup(kill_process_tree, process.pid)
+
+        health = requests.get(f"{DEFAULT_URL_FOR_TEST}/health_generate")
+        self.assertEqual(health.status_code, 200, health.text)
+
+        unary = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "The capital of France is",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 4},
+            },
+        )
+        self.assertEqual(unary.status_code, 200, unary.text)
+
+        stream = requests.post(
+            f"{DEFAULT_URL_FOR_TEST}/generate",
+            json={
+                "text": "Today I learned",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 4},
+                "stream": True,
+            },
+            stream=True,
+        )
+        self.assertEqual(stream.status_code, 200)
+        for line in stream.iter_lines():
+            if line.startswith(b"data: ") and line[6:] != b"[DONE]":
+                json.loads(line[6:])
+
+        deadline = time.time() + 10
+        metrics_text = ""
+        metrics: Dict[str, List[Sample]] = {}
+        while True:
+            metrics_response = requests.get(f"{DEFAULT_URL_FOR_TEST}/metrics")
+            self.assertEqual(metrics_response.status_code, 200)
+            self.assertIn("text/plain", metrics_response.headers["content-type"])
+            metrics_text = metrics_response.text
+            metrics = _parse_prometheus_metrics(metrics_text)
+            if _all_samples_zero(
+                metrics, "sglang:http_requests_active"
+            ) and _all_samples_zero(metrics, "sglang:rust_server_inflight_requests"):
+                break
+            if time.time() >= deadline:
+                break
+            time.sleep(0.2)
+
+        for name in [
+            "sglang:http_requests_total",
+            "sglang:http_responses_total",
+            "sglang:http_requests_active",
+            "sglang:rust_server_requests_total",
+            "sglang:rust_server_inflight_requests",
+            "sglang:rust_server_ingress_ring_push_total",
+            "sglang:rust_server_egress_frames_total",
+            "sglang:rust_server_ring_capacity",
+            "sglang:rust_server_threads",
+        ]:
+            self.assertIn(name, metrics_text, f"Missing metric: {name}")
+
+        self.assertGreaterEqual(
+            _sum_samples(
+                metrics,
+                "sglang:rust_server_requests_total",
+                {
+                    "kind": "generate",
+                    "input_source": "text",
+                    "stream": "false",
+                },
+            ),
+            1,
+        )
+        self.assertGreaterEqual(
+            _sum_samples(
+                metrics,
+                "sglang:rust_server_requests_total",
+                {
+                    "kind": "generate",
+                    "input_source": "text",
+                    "stream": "true",
+                },
+            ),
+            1,
+        )
+        self.assertGreaterEqual(
+            _sum_samples(
+                metrics,
+                "sglang:rust_server_requests_total",
+                {
+                    "kind": "health_generate",
+                    "input_source": "input_ids",
+                    "stream": "false",
+                },
+            ),
+            1,
+        )
+        self.assertGreaterEqual(
+            _sum_samples(
+                metrics,
+                "sglang:http_requests_total",
+                {"endpoint": "/generate", "method": "POST"},
+            ),
+            2,
+        )
+
+        for sample in metrics.get("sglang:http_requests_active", []):
+            self.assertEqual(sample.value, 0, sample)
+        for sample in metrics.get("sglang:rust_server_inflight_requests", []):
+            self.assertEqual(sample.value, 0, sample)
+
+        self.assertNotIn('rid="', metrics_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a low-cardinality Prometheus `/metrics` endpoint for the embedded Rust server frontend.

The first slice intentionally stays Rust-frontend only: it does not merge Python scheduler multiprocess metrics, does not add a Rust Prometheus exporter dependency, and does not change auth behavior.

Part of the Rust server observability work tracked in #23206.

## Changes

- Add `MetricsState` backed by atomics and manual Prometheus text exposition.
- Gate Rust `/metrics` on `--enable-metrics` / `ServerArgs.enable_metrics`.
- Reuse existing HTTP metric names for request, response, and active gauges.
- Add Rust frontend counters/gauges for logical requests, request errors, terminal outcomes, inflight requests, ingress/egress ring depth, ring push/backpressure, egress frame tags, ring capacity, and worker thread counts.
- Instrument API submit paths, tokenizer ingress, ingress/egress rings, and detokenizer register/terminal/remove paths.
- Add Rust unit coverage for rendering, label escaping, counters/gauges, ring depth saturation, detokenizer inflight accounting, and `/metrics` gating.
- Add registered observability coverage for Rust server `/metrics`.

## Validation

Local macOS:

- `cd rust && cargo fmt --check`
- `cd rust && cargo check -p sglang-server`
- `cd rust && RUSTFLAGS='-C link-arg=-undefined -C link-arg=dynamic_lookup' cargo test --workspace`
- `python3 -m py_compile test/registered/observability/test_rust_server_metrics.py`
- `git diff --check`

Remote Linux / ROCm MI300X (`root@134.199.199.149`, `/root/codex-validation/sglang-rust-server-metrics`, commit `2a0cb5d898`):

- `cd rust && cargo fmt --check`
- `cd rust && cargo test -p sglang-server`
- `cd rust && cargo test --workspace`
- Rust metrics E2E with local `Qwen3Guard-Gen-0.6B`: launched `SGLANG_RUST_SERVER=1 --enable-metrics`, exercised `/health`, `/health_generate`, unary `/generate`, streaming `/generate`, scraped `/metrics`, checked counters increased, inflight/active gauges returned to zero, and verified no high-cardinality `rid` labels.
- Existing Rust endpoint smoke: `TestRustServerEndpoint.test_get_server_info` with the same local ROCm model and AMD-safe backend args.

Note: the full `TestRustServerEndpoint` suite was not run against the local Qwen model because several tests encode default-Llama token/logprob assumptions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30613756322](https://github.com/sgl-project/sglang/actions/runs/30613756322)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30613756243](https://github.com/sgl-project/sglang/actions/runs/30613756243)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->