### PR TITLE
fix(kimi-k3): support canonical DCP decode offload to Mooncake L3

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -33,6 +33,24 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
             "overhead without improving prefill performance."
         )
 
+    if (
+        server_args.disaggregation_mode == "decode"
+        and server_args.enable_hierarchical_cache
+        and not server_args.disaggregation_decode_enable_radix_cache
+        and server_args.hicache_storage_backend is not None
+    ):
+        # PD Decode defaults to ChunkCache. Its L3 integration is the
+        # request-lifecycle offload path: Decode archives newly generated pages
+        # for a later Prefill request instead of matching prefixes locally.
+        # Normalize the legacy/generated HiCache recipe onto that path.
+        server_args.enable_hierarchical_cache = False
+        server_args.disaggregation_decode_enable_offload_kvcache = True
+        logger.warning(
+            "PD Decode uses chunk cache; treating "
+            "--enable-hierarchical-cache with --hicache-storage-backend as "
+            "--disaggregation-decode-enable-offload-kvcache."
+        )
+
     if server_args.disaggregation_mode == "decode" and server_args.dcp_size > 1:
         if server_args.disaggregation_transfer_backend not in ("mooncake", "nixl"):
             raise ValueError(

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -50,6 +50,7 @@ from sglang.srt.disaggregation.utils import (
     ReqToMetadataIdxAllocator,
     TransferBackend,
     _is_fake_transfer,
+    build_kv_transfer_layer_ids,
     get_dsv4_c128_state_indices,
     get_kv_class,
     is_dsv4_c128_online_enabled,
@@ -431,6 +432,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             transfer_kv_pool.get_contiguous_buf_infos()
         )
+        target_kv_entry_count = len(kv_data_ptrs)
+        draft_kv_entry_count = 0
         kv_data_mem_kinds = (
             ["DRAM"] * len(kv_data_ptrs)
             if self.scheduler.enable_hisparse
@@ -453,6 +456,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
+            draft_kv_entry_count = len(draft_kv_data_ptrs)
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
@@ -461,11 +465,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
+        kv_args.kv_layer_ids = build_kv_transfer_layer_ids(
+            self.token_to_kv_pool,
+            self.draft_token_to_kv_pool,
+            target_kv_entry_count,
+            draft_kv_entry_count,
         )
         if self.transfer_backend == TransferBackend.NIXL:
             kv_args.kv_data_mem_kinds = kv_data_mem_kinds

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1142,13 +1142,33 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             seq_len = origin_input_len
 
             def _mamba_payload():
-                return [
-                    self.req_to_token_pool.req_index_to_mamba_index_mapping[
-                        decode_req.req.req_pool_idx
-                    ]
-                    .cpu()
-                    .numpy()
+                req = decode_req.req
+                indices = [
+                    int(
+                        self.req_to_token_pool.req_index_to_mamba_index_mapping[
+                            req.req_pool_idx
+                        ].item()
+                    )
                 ]
+                decode_offload_enabled = (
+                    self.scheduler.server_args
+                    .disaggregation_decode_enable_offload_kvcache
+                )
+                if (
+                    decode_offload_enabled
+                    and req.mamba_ping_pong_track_buffer is not None
+                ):
+                    interval = self.scheduler.server_args.mamba_track_interval
+                    checkpoint_len = seq_len // interval * interval
+                    if checkpoint_len > 0:
+                        keep_idx = (
+                            self.req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
+                        )
+                        indices.append(
+                            int(req.mamba_ping_pong_track_buffer[keep_idx].item())
+                        )
+                        req.mamba_last_track_seqlen = checkpoint_len
+                return indices
 
             def _swa_payload():
                 window_size = self.scheduler.sliding_window_size

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -13,14 +13,25 @@ from sglang.srt.environ import envs
 from sglang.srt.managers.cache_controller import HiCacheController
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.hicache_storage import (
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+)
+from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
+    build_hybrid_mamba_stack,
+    build_kv_host_pool,
+)
 from sglang.srt.mem_cache.memory_pool import (
+    HybridLinearKVPool,
     MHATokenToKVPool,
     MLATokenToKVPool,
     ReqToTokenPool,
 )
 from sglang.srt.mem_cache.pool_host.common import get_allocator_type
 from sglang.srt.mem_cache.pool_host.mha import get_mha_host_pool_cls
-from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import ceil_align
 
@@ -43,7 +54,12 @@ class DecodeKVCacheOffloadManager:
     ) -> None:
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
-        self.page_size = server_args.page_size
+        parallel = get_parallel()
+        self.page_size = (
+            token_to_kv_pool_allocator.page_size
+            if parallel.dcp_enabled
+            else server_args.page_size
+        )
         self.server_args = server_args
         self.request_counter = 0
         self.tree_cache = tree_cache
@@ -54,33 +70,6 @@ class DecodeKVCacheOffloadManager:
             self.offload_stride = max(
                 self.page_size, (env_stride // self.page_size) * self.page_size
             )
-        kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
-        allocator_type = get_allocator_type(server_args)
-
-        if isinstance(kv_cache, MHATokenToKVPool):
-            self.decode_host_mem_pool = get_mha_host_pool_cls(kv_cache)(
-                kv_cache,
-                server_args.hicache_ratio,
-                server_args.hicache_size,
-                self.page_size,
-                server_args.hicache_mem_layout,
-                allocator_type=allocator_type,
-            )
-        elif isinstance(kv_cache, MLATokenToKVPool):
-            self.decode_host_mem_pool = MLATokenToKVPoolHost(
-                kv_cache,
-                server_args.hicache_ratio,
-                server_args.hicache_size,
-                self.page_size,
-                server_args.hicache_mem_layout,
-                allocator_type=allocator_type,
-            )
-        else:
-            raise ValueError("Unsupported KV cache type for decode offload")
-
-        self.tp_group = tp_group
-        self.tp_world_size = torch.distributed.get_world_size(group=self.tp_group)
-
         hicache_storage_backend_extra_config = {}
         if server_args.hicache_storage_backend_extra_config:
             try:
@@ -92,17 +81,77 @@ class DecodeKVCacheOffloadManager:
                     f"Invalid hicache storage backend extra config JSON: {e}"
                 )
 
-        self.cache_controller = HiCacheController(
-            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-            mem_pool_host=self.decode_host_mem_pool,
-            page_size=self.page_size,
-            tp_group=tp_group,
-            io_backend=server_args.hicache_io_backend,
-            load_cache_event=threading.Event(),
-            storage_backend=server_args.hicache_storage_backend,
-            model_name=server_args.served_model_name,
-            storage_backend_extra_config=hicache_storage_backend_extra_config,
-        )
+        kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
+        allocator_type = get_allocator_type(server_args)
+        self.is_hybrid_mamba = isinstance(kv_cache, HybridLinearKVPool)
+
+        if self.is_hybrid_mamba:
+            params = CacheInitParams(
+                disable=True,
+                req_to_token_pool=req_to_token_pool,
+                token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+                page_size=self.page_size,
+                tp_cache_group=tp_group,
+            )
+            (
+                self.decode_host_mem_pool,
+                self.cache_controller,
+            ) = build_hybrid_mamba_stack(
+                params=params,
+                server_args=server_args,
+                kv_pool=kv_cache.full_kv_pool,
+                mamba_pool=req_to_token_pool.mamba_pool,
+                full_layer_mapping=dict(kv_cache.full_attention_layer_id_mapping),
+                mamba_layer_mapping=dict(req_to_token_pool.mamba_map),
+                load_cache_event=threading.Event(),
+                storage_backend=server_args.hicache_storage_backend,
+                use_mla=kv_cache.use_mla,
+                model_name=server_args.served_model_name,
+                storage_backend_extra_config=hicache_storage_backend_extra_config,
+            )
+            self.decode_mamba_host_pool = self.decode_host_mem_pool.get_pool(
+                PoolName.MAMBA
+            )
+            req_to_token_pool.register_layer_transfer_counter(
+                self.cache_controller.layer_done_counter
+            )
+            kv_cache.register_layer_transfer_counter(
+                self.cache_controller.layer_done_counter
+            )
+        elif isinstance(kv_cache, MHATokenToKVPool):
+            self.decode_host_mem_pool = get_mha_host_pool_cls(kv_cache)(
+                kv_cache,
+                server_args.hicache_ratio,
+                server_args.hicache_size,
+                self.page_size,
+                server_args.hicache_mem_layout,
+                allocator_type=allocator_type,
+            )
+        elif isinstance(kv_cache, MLATokenToKVPool):
+            self.decode_host_mem_pool = build_kv_host_pool(
+                kv_pool=kv_cache,
+                page_size=self.page_size,
+                server_args=server_args,
+                use_mla=True,
+            )
+        else:
+            raise ValueError("Unsupported KV cache type for decode offload")
+
+        self.tp_group = tp_group
+        self.tp_world_size = torch.distributed.get_world_size(group=self.tp_group)
+
+        if not self.is_hybrid_mamba:
+            self.cache_controller = HiCacheController(
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                mem_pool_host=self.decode_host_mem_pool,
+                page_size=self.page_size,
+                tp_group=tp_group,
+                io_backend=server_args.hicache_io_backend,
+                load_cache_event=threading.Event(),
+                storage_backend=server_args.hicache_storage_backend,
+                model_name=server_args.served_model_name,
+                storage_backend_extra_config=hicache_storage_backend_extra_config,
+            )
 
         self.ongoing_offload = {}
         self.ongoing_backup = {}
@@ -182,9 +231,18 @@ class DecodeKVCacheOffloadManager:
         # Asynchronously offload incremental KV cache from device to host
         self.request_counter += 1
         ack_id = self.request_counter
+        extra_pools = self._build_extra_pool_transfers(req)
+        if self.is_hybrid_mamba and extra_pools is None:
+            logger.error("Missing KDA state for request %s", req.rid)
+            return False
+
+        write_kwargs = {}
+        if extra_pools is not None:
+            write_kwargs["extra_pools"] = extra_pools
         host_indices = self.cache_controller.write(
             device_indices=incremental_indices.long(),
             node_id=ack_id,
+            **write_kwargs,
         )
         if host_indices is None:
             logger.error(f"Not enough host memory for request {req.rid}")
@@ -198,6 +256,7 @@ class DecodeKVCacheOffloadManager:
             time.time(),
             start,
             end,
+            extra_pools,
         )
         state.inc_len += incremental_aligned_len
         return True
@@ -235,6 +294,7 @@ class DecodeKVCacheOffloadManager:
                     start_time,
                     start,
                     end,
+                    extra_pools,
                 ) = self.ongoing_offload.pop(ack_id)
 
                 self._mark_offload_finished(req.rid)
@@ -244,7 +304,12 @@ class DecodeKVCacheOffloadManager:
                     else None
                 )
                 last_hash = self._trigger_backup(
-                    req, host_indices, incremental_tokens, start_time, prior_hash
+                    req,
+                    host_indices,
+                    incremental_tokens,
+                    start_time,
+                    prior_hash,
+                    extra_pools,
                 )
                 if req.rid in self.offloaded_state:
                     self.offloaded_state[req.rid].last_hash = last_hash
@@ -293,6 +358,12 @@ class DecodeKVCacheOffloadManager:
             ]
             self.token_to_kv_pool_allocator.free(overalloc_indices)
 
+        # Hybrid requests own a separate Mamba/KDA state slot. The regular
+        # release_kv_cache path frees it before releasing req_to_token, but
+        # decode offload bypasses that helper and must mirror the lifecycle
+        # here after the device-to-host copy has completed.
+        if self.is_hybrid_mamba and req.mamba_pool_idx is not None:
+            self.req_to_token_pool.free_mamba_cache(req)
         self.req_to_token_pool.free(req)
         req.kv = None
         self.tree_cache.protected_size_ -= len(req.prefix_indices)
@@ -304,27 +375,79 @@ class DecodeKVCacheOffloadManager:
         for _ in range(finish_count):
             storage_operation = self.cache_controller.ack_backup_queue.get()
             ack_id = storage_operation.id
-            req_id, host_indices, start_time = self.ongoing_backup.pop(ack_id)
+            req_id, host_indices, extra_pools, start_time = self.ongoing_backup.pop(
+                ack_id
+            )
 
             # Release host memory
             self.decode_host_mem_pool.free(host_indices)
+            self._free_extra_host_indices(extra_pools)
 
             logger.debug(
                 f"Finished backup request {req_id}, free host memory, len:{len(host_indices)}, cost time:{time.time() - start_time:.2f} seconds."
             )
 
     def _trigger_backup(
-        self, req, host_indices, incremental_tokens, start_time, prior_hash
+        self,
+        req,
+        host_indices,
+        incremental_tokens,
+        start_time,
+        prior_hash,
+        extra_pools=None,
     ):
         """Trigger async backup from host to storage."""
         page_hashes = self._compute_prefix_hash(incremental_tokens, prior_hash)
+        for transfer in extra_pools or []:
+            if transfer.name == PoolName.MAMBA:
+                transfer.keys = [page_hashes[-1]]
+                transfer.hit_policy = PoolHitPolicy.TRAILING_PAGES
+        storage_kwargs = {}
+        if extra_pools is not None:
+            storage_kwargs["extra_pools"] = extra_pools
         ack_id = self.cache_controller.write_storage(
             host_indices,
             incremental_tokens,
             hash_value=page_hashes,
+            **storage_kwargs,
         )
-        self.ongoing_backup[ack_id] = (req.rid, host_indices, start_time)
+        self.ongoing_backup[ack_id] = (
+            req.rid,
+            host_indices,
+            extra_pools,
+            start_time,
+        )
         return page_hashes[-1] if len(page_hashes) > 0 else prior_hash
+
+    def _build_extra_pool_transfers(self, req):
+        if not self.is_hybrid_mamba:
+            return None
+        mamba_pool_idx = getattr(req, "mamba_pool_idx", None)
+        if mamba_pool_idx is None:
+            return None
+        if not isinstance(mamba_pool_idx, torch.Tensor):
+            mamba_pool_idx = torch.tensor(
+                mamba_pool_idx,
+                dtype=torch.int64,
+                device=self.token_to_kv_pool_allocator.device,
+            )
+        return [
+            PoolTransfer(
+                name=PoolName.MAMBA,
+                device_indices=mamba_pool_idx.reshape(1),
+                hit_policy=PoolHitPolicy.TRAILING_PAGES,
+            )
+        ]
+
+    def _free_extra_host_indices(self, extra_pools) -> None:
+        if not extra_pools or not self.is_hybrid_mamba:
+            return
+        for transfer in extra_pools:
+            if transfer.host_indices is None:
+                continue
+            entry = self.decode_host_mem_pool.entry_map.get(transfer.name)
+            if entry is not None:
+                entry.host_pool.free(transfer.host_indices)
 
     def _compute_prefix_hash(self, tokens, prior_hash=""):
         page_hashes = []

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -152,6 +152,9 @@ class DecodeKVCacheOffloadManager:
                 model_name=server_args.served_model_name,
                 storage_backend_extra_config=hicache_storage_backend_extra_config,
             )
+        self.canonical_storage_layout = bool(
+            hicache_storage_backend_extra_config.get("canonical_dcp_size", 0)
+        )
 
         self.ongoing_offload = {}
         self.ongoing_backup = {}
@@ -188,23 +191,38 @@ class DecodeKVCacheOffloadManager:
         if token_indices.dim() == 0 or token_indices.numel() == 0:
             return False
 
-        # Prefill side offloads page-aligned origin_input_ids, decode side offloads the incremental part
+        # In the ordinary layout, Prefill owns the page-aligned prompt and
+        # Decode only appends incremental pages. A canonical cross-DCP chain
+        # cannot make that assumption: PD Prefill inserts intermediate chunks
+        # with chunked=True, which deliberately suppresses HiCache write-
+        # through. Decode therefore publishes the complete chain from offset
+        # zero, beginning with the transferred prompt checkpoint.
         all_tokens = req.origin_input_ids + req.output_ids[:-1]
         prefill_offloaded_len = (
             len(req.origin_input_ids) // self.page_size * self.page_size
         )
+        offload_start = (
+            0 if self.canonical_storage_layout else prefill_offloaded_len
+        )
         state = self.offloaded_state.get(req.rid)
         if state is None:
-            prefill_hashes = self._compute_prefix_hash(
-                req.origin_input_ids[:prefill_offloaded_len]
+            prefill_tokens = req.origin_input_ids[:offload_start]
+            prefill_hashes = self._compute_prefix_hash(prefill_tokens)
+            storage_prefill_hashes = self._compute_prefix_hash(
+                prefill_tokens,
+                page_size=self.cache_controller.storage_page_size,
             )
             last_prefill_hash = (
-                prefill_hashes[-1] if prefill_offloaded_len > 0 else None
+                prefill_hashes[-1] if offload_start > 0 else None
+            )
+            storage_last_prefill_hash = (
+                storage_prefill_hashes[-1] if offload_start > 0 else None
             )
             state = OffloadedState(
-                prefill_len=prefill_offloaded_len,
+                prefill_len=offload_start,
                 inc_len=0,
                 last_hash=last_prefill_hash,
+                storage_last_hash=storage_last_prefill_hash,
             )
             self.offloaded_state[req.rid] = state
         incremental_total = len(all_tokens) - state.prefill_len
@@ -231,7 +249,7 @@ class DecodeKVCacheOffloadManager:
         # Asynchronously offload incremental KV cache from device to host
         self.request_counter += 1
         ack_id = self.request_counter
-        extra_pools = self._build_extra_pool_transfers(req)
+        extra_pools = self._build_extra_pool_transfers(req, checkpoint_len=end)
         if self.is_hybrid_mamba and extra_pools is None:
             logger.error("Missing KDA state for request %s", req.rid)
             return False
@@ -303,16 +321,25 @@ class DecodeKVCacheOffloadManager:
                     if req.rid in self.offloaded_state
                     else None
                 )
-                last_hash = self._trigger_backup(
+                storage_prior_hash = (
+                    self.offloaded_state[req.rid].storage_last_hash
+                    if req.rid in self.offloaded_state
+                    else None
+                )
+                last_hash, storage_last_hash = self._trigger_backup(
                     req,
                     host_indices,
                     incremental_tokens,
                     start_time,
                     prior_hash,
+                    storage_prior_hash,
                     extra_pools,
                 )
                 if req.rid in self.offloaded_state:
                     self.offloaded_state[req.rid].last_hash = last_hash
+                    self.offloaded_state[req.rid].storage_last_hash = (
+                        storage_last_hash
+                    )
 
                 if req.finished() and not self._has_inflight_offload(req.rid):
                     state = self.offloaded_state.get(req.rid)
@@ -394,15 +421,22 @@ class DecodeKVCacheOffloadManager:
         incremental_tokens,
         start_time,
         prior_hash,
+        storage_prior_hash,
         extra_pools=None,
     ):
         """Trigger async backup from host to storage."""
         page_hashes = self._compute_prefix_hash(incremental_tokens, prior_hash)
+        storage_page_hashes = self._compute_prefix_hash(
+            incremental_tokens,
+            storage_prior_hash,
+            page_size=self.cache_controller.storage_page_size,
+        )
         for transfer in extra_pools or []:
             if transfer.name == PoolName.MAMBA:
-                transfer.keys = [page_hashes[-1]]
+                transfer.keys = [storage_page_hashes[-1]]
                 transfer.hit_policy = PoolHitPolicy.TRAILING_PAGES
         storage_kwargs = {}
+        storage_kwargs["storage_hash_value"] = storage_page_hashes
         if extra_pools is not None:
             storage_kwargs["extra_pools"] = extra_pools
         ack_id = self.cache_controller.write_storage(
@@ -417,12 +451,33 @@ class DecodeKVCacheOffloadManager:
             extra_pools,
             start_time,
         )
-        return page_hashes[-1] if len(page_hashes) > 0 else prior_hash
+        return (
+            page_hashes[-1] if page_hashes else prior_hash,
+            storage_page_hashes[-1]
+            if storage_page_hashes
+            else storage_prior_hash,
+        )
 
-    def _build_extra_pool_transfers(self, req):
+    def _build_extra_pool_transfers(self, req, checkpoint_len=None):
         if not self.is_hybrid_mamba:
             return None
         mamba_pool_idx = getattr(req, "mamba_pool_idx", None)
+        if self.canonical_storage_layout:
+            tracked_len = getattr(req, "mamba_last_track_seqlen", None)
+            if tracked_len != checkpoint_len:
+                logger.warning(
+                    "Skip Decode-origin L3 publication for request %s: "
+                    "KDA checkpoint is at %s, storage boundary is %s.",
+                    req.rid,
+                    tracked_len,
+                    checkpoint_len,
+                )
+                return None
+            ping_pong = getattr(req, "mamba_ping_pong_track_buffer", None)
+            if ping_pong is None:
+                return None
+            keep_idx = self.req_to_token_pool.get_mamba_ping_pong_keep_idx(req)
+            mamba_pool_idx = ping_pong[keep_idx]
         if mamba_pool_idx is None:
             return None
         if not isinstance(mamba_pool_idx, torch.Tensor):
@@ -449,11 +504,12 @@ class DecodeKVCacheOffloadManager:
             if entry is not None:
                 entry.host_pool.free(transfer.host_indices)
 
-    def _compute_prefix_hash(self, tokens, prior_hash=""):
+    def _compute_prefix_hash(self, tokens, prior_hash="", page_size=None):
+        page_size = page_size or self.page_size
         page_hashes = []
         last_hash = prior_hash
-        for offset in range(0, len(tokens), self.page_size):
-            page_tokens = tokens[offset : offset + self.page_size]
+        for offset in range(0, len(tokens), page_size):
+            page_tokens = tokens[offset : offset + page_size]
             last_hash = self.cache_controller.get_hash_str(page_tokens, last_hash)
             page_hashes.append(last_hash)
         return page_hashes

--- a/python/sglang/srt/disaggregation/kv_events.py
+++ b/python/sglang/srt/disaggregation/kv_events.py
@@ -92,15 +92,22 @@ class OffloadedState:
 
     - prefill_len (int): The length of the prefill part of the KV cache block.
     - inc_len (int): The length of the incremental part of the KV cache block.
-    - last_hash (Optional[str]): The hash of the last token in the KV cache block.
+    - last_hash (Optional[str]): The runtime-page hash at the end of the block.
+    - storage_last_hash (Optional[str]): The storage-page hash at the end of the
+      block. This can differ from last_hash when L3 uses a canonical layout.
     """
 
     def __init__(
-        self, prefill_len: int, inc_len: int = 0, last_hash: Optional[str] = None
+        self,
+        prefill_len: int,
+        inc_len: int = 0,
+        last_hash: Optional[str] = None,
+        storage_last_hash: Optional[str] = None,
     ):
         self.prefill_len = prefill_len
         self.inc_len = inc_len
         self.last_hash = last_hash
+        self.storage_last_hash = storage_last_hash
 
 
 class BlockStored(KVCacheEvent):

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1329,7 +1329,13 @@ class MooncakeKVManager(CommonKVManager):
         src_layer_ids: Optional[List[int]] = None,
         dst_layer_ids: Optional[List[int]] = None,
     ):
-        assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
+        if len(prefill_mamba_index) != len(dst_mamba_index):
+            raise ValueError(
+                "Mamba state index count mismatch between Prefill and Decode: "
+                f"prefill={len(prefill_mamba_index)}, "
+                f"decode={len(dst_mamba_index)}."
+            )
+        state_pairs = list(zip(prefill_mamba_index, dst_mamba_index))
 
         transfer_blocks = []
         pairs = build_transfer_entry_pairs(
@@ -1339,12 +1345,15 @@ class MooncakeKVManager(CommonKVManager):
             len(dst_state_data_ptrs),
             allow_positional_fallback=self.pp_size == 1,
         )
-        for i, j in pairs:
-            dst_state_ptr = dst_state_data_ptrs[j]
-            length = src_state_item_lens[i]
-            src_addr = src_state_data_ptrs[i] + length * int(prefill_mamba_index[0])
-            dst_addr = dst_state_ptr + length * int(dst_mamba_index[0])
-            transfer_blocks.append((src_addr, dst_addr, length))
+        for src_state_index, dst_state_index in state_pairs:
+            for i, j in pairs:
+                dst_state_ptr = dst_state_data_ptrs[j]
+                length = src_state_item_lens[i]
+                src_addr = (
+                    src_state_data_ptrs[i] + length * int(src_state_index)
+                )
+                dst_addr = dst_state_ptr + length * int(dst_state_index)
+                transfer_blocks.append((src_addr, dst_addr, length))
 
         return self._transfer_data(req.mooncake_session_id, transfer_blocks)
 
@@ -1383,7 +1392,13 @@ class MooncakeKVManager(CommonKVManager):
             f"Prefill attn_tp_size={self.attn_tp_size}, Decode attn_tp_size={dst_attn_tp_size}. "
             "Performance may be affected."
         )
-        assert len(prefill_mamba_index) == 1, "Mamba should have single state index"
+        if len(prefill_mamba_index) != len(dst_mamba_index):
+            raise ValueError(
+                "Mamba state index count mismatch between Prefill and Decode: "
+                f"prefill={len(prefill_mamba_index)}, "
+                f"decode={len(dst_mamba_index)}."
+            )
+        state_pairs = list(zip(prefill_mamba_index, dst_mamba_index))
 
         # If no dimension info available, fall back to regular transfer
         if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
@@ -1409,49 +1424,53 @@ class MooncakeKVManager(CommonKVManager):
             len(dst_state_data_ptrs),
             allow_positional_fallback=self.pp_size == 1,
         )
-        for i, j in pairs:
-            dst_state_ptr = dst_state_data_ptrs[j]
-            src_item_len = src_state_item_lens[i]
-            dst_item_len = dst_state_item_lens[j]
-            src_dim = src_state_dim_per_tensor[i]
-            dst_dim = dst_state_dim_per_tensor[j]
+        for src_state_index, dst_state_index in state_pairs:
+            for i, j in pairs:
+                dst_state_ptr = dst_state_data_ptrs[j]
+                src_item_len = src_state_item_lens[i]
+                dst_item_len = dst_state_item_lens[j]
+                src_dim = src_state_dim_per_tensor[i]
+                dst_dim = dst_state_dim_per_tensor[j]
 
-            conv_shard_groups = (
-                src_state_conv_shard_groups[i]
-                if src_state_conv_shard_groups and i < len(src_state_conv_shard_groups)
-                else None
-            )
-            outer_count = (
-                src_state_slice_outer_counts[i]
-                if src_state_slice_outer_counts
-                and i < len(src_state_slice_outer_counts)
-                else 1
-            )
-            for (
-                src_offset,
-                dst_offset,
-                bytes_to_send,
-            ) in compute_mamba_state_slice_byte_blocks(
-                src_item_len=src_item_len,
-                dst_item_len=dst_item_len,
-                src_dim=src_dim,
-                dst_dim=dst_dim,
-                outer_count=outer_count,
-                src_attn_tp_size=self.attn_tp_size,
-                dst_attn_tp_size=dst_attn_tp_size,
-                dst_tp_rank_in_group=dst_tp_rank_in_group,
-                local_tp_rank_in_group=local_tp_rank_in_group,
-                conv_shard_groups=conv_shard_groups,
-            ):
-                src_addr = (
-                    src_state_data_ptrs[i]
-                    + src_item_len * int(prefill_mamba_index[0])
-                    + src_offset
+                conv_shard_groups = (
+                    src_state_conv_shard_groups[i]
+                    if src_state_conv_shard_groups
+                    and i < len(src_state_conv_shard_groups)
+                    else None
                 )
-                dst_addr = (
-                    dst_state_ptr + dst_item_len * int(dst_mamba_index[0]) + dst_offset
+                outer_count = (
+                    src_state_slice_outer_counts[i]
+                    if src_state_slice_outer_counts
+                    and i < len(src_state_slice_outer_counts)
+                    else 1
                 )
-                transfer_blocks.append((src_addr, dst_addr, bytes_to_send))
+                for (
+                    src_offset,
+                    dst_offset,
+                    bytes_to_send,
+                ) in compute_mamba_state_slice_byte_blocks(
+                    src_item_len=src_item_len,
+                    dst_item_len=dst_item_len,
+                    src_dim=src_dim,
+                    dst_dim=dst_dim,
+                    outer_count=outer_count,
+                    src_attn_tp_size=self.attn_tp_size,
+                    dst_attn_tp_size=dst_attn_tp_size,
+                    dst_tp_rank_in_group=dst_tp_rank_in_group,
+                    local_tp_rank_in_group=local_tp_rank_in_group,
+                    conv_shard_groups=conv_shard_groups,
+                ):
+                    src_addr = (
+                        src_state_data_ptrs[i]
+                        + src_item_len * int(src_state_index)
+                        + src_offset
+                    )
+                    dst_addr = (
+                        dst_state_ptr
+                        + dst_item_len * int(dst_state_index)
+                        + dst_offset
+                    )
+                    transfer_blocks.append((src_addr, dst_addr, bytes_to_send))
 
         return self._transfer_data(req.mooncake_session_id, transfer_blocks)
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2023,10 +2023,13 @@ class NixlKVManager(CommonKVManager):
         dst_layer_ids: list[int] = None,
     ):
         """Transfer Mamba states via RDMA."""
-        assert len(prefill_state_indices) == 1, "Mamba should have single state index"
-        assert len(dst_state_indices) == len(
-            prefill_state_indices
-        ), "State indices count mismatch between Prefill and Decode"
+        if len(prefill_state_indices) != len(dst_state_indices):
+            raise ValueError(
+                "Mamba state index count mismatch between Prefill and Decode: "
+                f"prefill={len(prefill_state_indices)}, "
+                f"decode={len(dst_state_indices)}."
+            )
+        state_pairs = list(zip(prefill_state_indices, dst_state_indices))
 
         src_addrs = []
         dst_addrs = []
@@ -2038,15 +2041,18 @@ class NixlKVManager(CommonKVManager):
             len(dst_state_data_ptrs),
             allow_positional_fallback=self.pp_size == 1,
         )
-        for i, j in pairs:
-            dst_state_ptr = dst_state_data_ptrs[j]
-            length = src_state_item_lens[i]
-            if length == 0 or src_state_data_ptrs[i] == 0 or dst_state_ptr == 0:
-                continue
-            src_addr = src_state_data_ptrs[i] + length * int(prefill_state_indices[0])
-            dst_addr = dst_state_ptr + length * int(dst_state_indices[0])
-            src_addrs.append((src_addr, length, self.kv_args.gpu_id))
-            dst_addrs.append((dst_addr, length, dst_gpu_id))
+        for src_state_index, dst_state_index in state_pairs:
+            for i, j in pairs:
+                dst_state_ptr = dst_state_data_ptrs[j]
+                length = src_state_item_lens[i]
+                if length == 0 or src_state_data_ptrs[i] == 0 or dst_state_ptr == 0:
+                    continue
+                src_addr = (
+                    src_state_data_ptrs[i] + length * int(src_state_index)
+                )
+                dst_addr = dst_state_ptr + length * int(dst_state_index)
+                src_addrs.append((src_addr, length, self.kv_args.gpu_id))
+                dst_addrs.append((dst_addr, length, dst_gpu_id))
 
         src_descs = self.agent.get_xfer_descs(src_addrs, "VRAM")
         dst_descs = self.agent.get_xfer_descs(dst_addrs, "VRAM")
@@ -2099,7 +2105,13 @@ class NixlKVManager(CommonKVManager):
             f"Prefill attn_tp_size={self.attn_tp_size}, "
             f"Decode attn_tp_size={decode_tp_size}."
         )
-        assert len(prefill_state_indices) == 1, "Mamba should have single state index"
+        if len(prefill_state_indices) != len(dst_state_indices):
+            raise ValueError(
+                "Mamba state index count mismatch between Prefill and Decode: "
+                f"prefill={len(prefill_state_indices)}, "
+                f"decode={len(dst_state_indices)}."
+            )
+        state_pairs = list(zip(prefill_state_indices, dst_state_indices))
 
         if not src_state_dim_per_tensor or not dst_state_dim_per_tensor:
             return self._send_mamba_state(
@@ -2128,54 +2140,62 @@ class NixlKVManager(CommonKVManager):
             len(dst_state_data_ptrs),
             allow_positional_fallback=self.pp_size == 1,
         )
-        for i, j in pairs:
-            dst_state_ptr = dst_state_data_ptrs[j]
-            src_item_len = src_state_item_lens[i]
-            dst_item_len = dst_state_item_lens[j]
-            if src_item_len == 0 or src_state_data_ptrs[i] == 0 or dst_state_ptr == 0:
-                continue
-            src_dim = src_state_dim_per_tensor[i]
-            dst_dim = dst_state_dim_per_tensor[j]
+        for src_state_index, dst_state_index in state_pairs:
+            for i, j in pairs:
+                dst_state_ptr = dst_state_data_ptrs[j]
+                src_item_len = src_state_item_lens[i]
+                dst_item_len = dst_state_item_lens[j]
+                if (
+                    src_item_len == 0
+                    or src_state_data_ptrs[i] == 0
+                    or dst_state_ptr == 0
+                ):
+                    continue
+                src_dim = src_state_dim_per_tensor[i]
+                dst_dim = dst_state_dim_per_tensor[j]
 
-            conv_shard_groups = (
-                src_state_conv_shard_groups[i]
-                if src_state_conv_shard_groups and i < len(src_state_conv_shard_groups)
-                else None
-            )
-            outer_count = (
-                src_state_slice_outer_counts[i]
-                if src_state_slice_outer_counts
-                and i < len(src_state_slice_outer_counts)
-                else 1
-            )
-            for (
-                src_offset,
-                dst_offset,
-                bytes_to_send,
-            ) in compute_mamba_state_slice_byte_blocks(
-                src_item_len=src_item_len,
-                dst_item_len=dst_item_len,
-                src_dim=src_dim,
-                dst_dim=dst_dim,
-                outer_count=outer_count,
-                src_attn_tp_size=self.attn_tp_size,
-                dst_attn_tp_size=decode_tp_size,
-                dst_tp_rank_in_group=dst_tp_rank_in_group,
-                local_tp_rank_in_group=local_tp_rank_in_group,
-                conv_shard_groups=conv_shard_groups,
-            ):
-                src_addr = (
-                    src_state_data_ptrs[i]
-                    + src_item_len * int(prefill_state_indices[0])
-                    + src_offset
+                conv_shard_groups = (
+                    src_state_conv_shard_groups[i]
+                    if src_state_conv_shard_groups
+                    and i < len(src_state_conv_shard_groups)
+                    else None
                 )
-                dst_addr = (
-                    dst_state_ptr
-                    + dst_item_len * int(dst_state_indices[0])
-                    + dst_offset
+                outer_count = (
+                    src_state_slice_outer_counts[i]
+                    if src_state_slice_outer_counts
+                    and i < len(src_state_slice_outer_counts)
+                    else 1
                 )
-                src_addrs.append((src_addr, bytes_to_send, self.kv_args.gpu_id))
-                dst_addrs.append((dst_addr, bytes_to_send, dst_gpu_id))
+                for (
+                    src_offset,
+                    dst_offset,
+                    bytes_to_send,
+                ) in compute_mamba_state_slice_byte_blocks(
+                    src_item_len=src_item_len,
+                    dst_item_len=dst_item_len,
+                    src_dim=src_dim,
+                    dst_dim=dst_dim,
+                    outer_count=outer_count,
+                    src_attn_tp_size=self.attn_tp_size,
+                    dst_attn_tp_size=decode_tp_size,
+                    dst_tp_rank_in_group=dst_tp_rank_in_group,
+                    local_tp_rank_in_group=local_tp_rank_in_group,
+                    conv_shard_groups=conv_shard_groups,
+                ):
+                    src_addr = (
+                        src_state_data_ptrs[i]
+                        + src_item_len * int(src_state_index)
+                        + src_offset
+                    )
+                    dst_addr = (
+                        dst_state_ptr
+                        + dst_item_len * int(dst_state_index)
+                        + dst_offset
+                    )
+                    src_addrs.append(
+                        (src_addr, bytes_to_send, self.kv_args.gpu_id)
+                    )
+                    dst_addrs.append((dst_addr, bytes_to_send, dst_gpu_id))
 
         src_descs = self.agent.get_xfer_descs(src_addrs, "VRAM")
         dst_descs = self.agent.get_xfer_descs(dst_addrs, "VRAM")

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -20,6 +20,7 @@ Life cycle of a request in the prefill server
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 from array import array
 from collections import deque
@@ -1142,13 +1143,48 @@ class SchedulerDisaggregationPrefillMixin:
             c128_seq_len = transfer_input_len
 
             def _mamba_payload():
-                return [
-                    self.req_to_token_pool.req_index_to_mamba_index_mapping[
-                        req.req_pool_idx
-                    ]
-                    .cpu()
-                    .numpy()
+                indices = [
+                    int(
+                        self.req_to_token_pool.req_index_to_mamba_index_mapping[
+                            req.req_pool_idx
+                        ].item()
+                    )
                 ]
+                # Canonical Decode-origin L3 publication needs the historical
+                # KDA state at the widened DCP page boundary, in addition to
+                # the active post-prefill state used for normal decoding.
+                extra_config = json.loads(
+                    self.server_args.hicache_storage_backend_extra_config or "{}"
+                )
+                checkpoint_len = (
+                    seq_len // self.server_args.mamba_track_interval
+                ) * self.server_args.mamba_track_interval
+                if (
+                    int(extra_config.get("canonical_dcp_size", 0)) > 0
+                    and checkpoint_len > 0
+                ):
+                    # ``cache_unfinished_req`` runs before this final PD send.
+                    # It donates the tracked ping-pong slot to the newly inserted
+                    # radix node and clears ``mamba_last_track_seqlen``.  The
+                    # request lock keeps that node (and its Mamba component)
+                    # alive until the transfer poll succeeds and release_kv_cache
+                    # drops the lock.
+                    if req.cache_protected_len != checkpoint_len:
+                        raise RuntimeError(
+                            "Canonical Mooncake KDA checkpoint mismatch before "
+                            f"PD transfer: cached={req.cache_protected_len}, "
+                            f"expected={checkpoint_len}, rid={req.rid}."
+                        )
+                    checkpoint = self.tree_cache.get_mamba_device_value(
+                        req.last_node
+                    )
+                    if checkpoint is None or checkpoint.numel() != 1:
+                        raise RuntimeError(
+                            "Canonical Mooncake KDA checkpoint is not device "
+                            f"resident on the protected radix node for rid={req.rid}."
+                        )
+                    indices.append(int(checkpoint.item()))
+                return indices
 
             def _swa_payload():
                 window_size = self.sliding_window_size

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -40,6 +40,7 @@ from sglang.srt.disaggregation.utils import (
     MetadataBuffers,
     ReqToMetadataIdxAllocator,
     TransferBackend,
+    build_kv_transfer_layer_ids,
     get_dsv4_c128_state_indices,
     get_kv_class,
     is_aborted,
@@ -205,6 +206,8 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
+        target_kv_entry_count = len(kv_data_ptrs)
+        draft_kv_entry_count = 0
         kv_args.prefill_end_layer = (
             kv_args.prefill_start_layer + len(kv_data_ptrs)
             if layer_shard_enabled
@@ -217,6 +220,7 @@ class PrefillBootstrapQueue:
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
+            draft_kv_entry_count = len(draft_kv_data_ptrs)
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
@@ -224,11 +228,11 @@ class PrefillBootstrapQueue:
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
-        kv_args.kv_layer_ids = (
-            self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
-            and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
-            else []
+        kv_args.kv_layer_ids = build_kv_transfer_layer_ids(
+            self.token_to_kv_pool,
+            self.draft_token_to_kv_pool,
+            target_kv_entry_count,
+            draft_kv_entry_count,
         )
         if not self.is_mla_backend:
             kv_args.kv_head_num = self.token_to_kv_pool.head_num

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -46,6 +46,7 @@ if is_npu():
 #########################
 FAKE_BOOTSTRAP_HOST = "2.2.2.2"
 _IS_HIP = is_hip()
+_DRAFT_KV_LAYER_ID_BASE = 1 << 31
 
 
 def poll_and_all_reduce_pp(
@@ -956,6 +957,46 @@ def resolve_dcp_dst_entry_indices(
         for _, j in build_transfer_entry_pairs(
             src_layer_ids, dst_layer_ids, n_src, n_dst
         )
+    ]
+
+
+def build_kv_transfer_layer_ids(
+    token_to_kv_pool,
+    draft_token_to_kv_pool,
+    target_entry_count: int,
+    draft_entry_count: int,
+) -> List[int]:
+    """Build metadata aligned with the target and optional draft KV buffers.
+
+    Hybrid target pools expose global model-layer ids, which are required to
+    pair PP-local Prefill entries with Decode entries. Speculative Decode also
+    appends draft-model buffers. Those entries are not present on a target-only
+    Prefill peer, but the metadata still has to describe every registered
+    destination entry. Give draft entries a separate positional namespace so
+    target ids remain matchable without confusing target and draft layers that
+    happen to use the same model-layer numbers.
+    """
+    if not hasattr(token_to_kv_pool, "get_kv_layer_ids"):
+        return []
+
+    target_layer_ids = list(token_to_kv_pool.get_kv_layer_ids())
+    if len(target_layer_ids) != target_entry_count:
+        raise RuntimeError(
+            "Target KV layer metadata length must match registered entries: "
+            f"metadata={len(target_layer_ids)}, entries={target_entry_count}"
+        )
+
+    if draft_token_to_kv_pool is None:
+        if draft_entry_count != 0:
+            raise RuntimeError(
+                "Draft KV entries were registered without a draft KV pool"
+            )
+        return target_layer_ids
+
+    if draft_entry_count >= _DRAFT_KV_LAYER_ID_BASE:
+        raise RuntimeError(f"Too many draft KV entries: {draft_entry_count}")
+    return target_layer_ids + [
+        _DRAFT_KV_LAYER_ID_BASE + i for i in range(draft_entry_count)
     ]
 
 

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -77,14 +77,15 @@ def should_enable_multimem_logits_all_gather(
     do_tensor_parallel_all_gather: bool,
     use_attn_tp_group: bool,
     dcp_enabled: bool,
+    disaggregation_mode: str,
 ) -> bool:
     """Return whether the logits TP gather can use torch symmetric memory.
 
     Kimi-K3 DCP already disables ``--enable-symm-mem`` because its decode
-    CUDA-graph path is not compatible with symmetric memory.  The logits
-    gatherer allocates torch symmetric memory independently of that flag, so
-    it must observe the same restriction or the first real forward can hang in
-    ``torch.distributed._symmetric_memory.rendezvous``.
+    CUDA-graph path is not compatible with symmetric memory.  A disaggregated
+    Kimi prefill worker can hit the same rendezvous hang even with DCP=1.
+    The logits gatherer allocates torch symmetric memory independently of that
+    flag, so it must observe both restrictions.
     """
     architectures = getattr(config, "architectures", None) or ()
     is_kimi_k3 = (
@@ -95,7 +96,10 @@ def should_enable_multimem_logits_all_gather(
     return (
         do_tensor_parallel_all_gather
         and not use_attn_tp_group
-        and not (is_kimi_k3 and dcp_enabled)
+        and not (
+            is_kimi_k3
+            and (dcp_enabled or disaggregation_mode == "prefill")
+        )
     )
 
 
@@ -413,6 +417,7 @@ class LogitsProcessor(nn.Module):
             # already being published. ServerArgs is authoritative while
             # model layers are being constructed.
             dcp_enabled=get_server_args().dcp_size > 1,
+            disaggregation_mode=get_server_args().disaggregation_mode,
         )
         if (
             self.do_tensor_parallel_all_gather
@@ -420,7 +425,7 @@ class LogitsProcessor(nn.Module):
             and not enable_multimem_logits_gather
         ):
             logger.info(
-                "Kimi-K3 DCP disables multimem logits all-gather; "
+                "Kimi-K3 DCP/disaggregation disables multimem logits all-gather; "
                 "falling back to NCCL."
             )
 

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -71,6 +71,34 @@ _UNQUANTIZED_LM_HEAD_METHODS = {
 }
 
 
+def should_enable_multimem_logits_all_gather(
+    config,
+    *,
+    do_tensor_parallel_all_gather: bool,
+    use_attn_tp_group: bool,
+    dcp_enabled: bool,
+) -> bool:
+    """Return whether the logits TP gather can use torch symmetric memory.
+
+    Kimi-K3 DCP already disables ``--enable-symm-mem`` because its decode
+    CUDA-graph path is not compatible with symmetric memory.  The logits
+    gatherer allocates torch symmetric memory independently of that flag, so
+    it must observe the same restriction or the first real forward can hang in
+    ``torch.distributed._symmetric_memory.rendezvous``.
+    """
+    architectures = getattr(config, "architectures", None) or ()
+    is_kimi_k3 = (
+        getattr(config, "model_type", None) in ("kimi_k3", "kimi_linear")
+        or "KimiK3ForConditionalGeneration" in architectures
+        or "KimiLinearForCausalLM" in architectures
+    )
+    return (
+        do_tensor_parallel_all_gather
+        and not use_attn_tp_group
+        and not (is_kimi_k3 and dcp_enabled)
+    )
+
+
 def _has_lm_head_runtime_attrs(lm_head, attr_names: Tuple[str, ...]) -> bool:
     return all(hasattr(lm_head, attr_name) for attr_name in attr_names)
 
@@ -377,11 +405,30 @@ class LogitsProcessor(nn.Module):
         self.enable_mis = get_server_args().enable_mis
         self.rl_on_policy_target = get_server_args().rl_on_policy_target
 
+        enable_multimem_logits_gather = should_enable_multimem_logits_all_gather(
+            self.config,
+            do_tensor_parallel_all_gather=self.do_tensor_parallel_all_gather,
+            use_attn_tp_group=self.use_attn_tp_group,
+            # RuntimeContext.dcp_enabled depends on the DCP process group
+            # already being published. ServerArgs is authoritative while
+            # model layers are being constructed.
+            dcp_enabled=get_server_args().dcp_size > 1,
+        )
+        if (
+            self.do_tensor_parallel_all_gather
+            and not self.use_attn_tp_group
+            and not enable_multimem_logits_gather
+        ):
+            logger.info(
+                "Kimi-K3 DCP disables multimem logits all-gather; "
+                "falling back to NCCL."
+            )
+
         self._logits_gatherer = triton_symm_mem_ag.MultimemAllGatherer(
             max_tokens=triton_symm_mem_ag.recommended_max_tokens(
                 include_prefill=False, floor=128
             ),
-            enabled=self.do_tensor_parallel_all_gather and not self.use_attn_tp_group,
+            enabled=enable_multimem_logits_gather,
             skip_entry_sync=True,
         )
 

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -175,12 +175,18 @@ class StorageOperation:
         last_hash: Optional[str] = None,
         hash_value: Optional[List[str]] = None,
         prefix_keys: Optional[List[str]] = None,
+        storage_hash_value: Optional[List[str]] = None,
+        storage_last_hash: Optional[str] = None,
     ):
         self.host_indices = host_indices
         self.token_ids = token_ids
         self.last_hash = last_hash
         self.completed_tokens = 0
         self.hash_value = hash_value if hash_value is not None else []
+        self.storage_hash_value = (
+            storage_hash_value if storage_hash_value is not None else []
+        )
+        self.storage_last_hash = storage_last_hash
         self.prefix_keys = prefix_keys
 
         self.id = StorageOperation.counter
@@ -471,6 +477,66 @@ class HiCacheController:
         self.storage_config = self._generate_storage_config(
             model_name, storage_backend_extra_config
         )
+        extra_config = self.storage_config.extra_config or {}
+        has_canonical_page_size = "canonical_page_size" in extra_config
+        has_canonical_dcp_size = "canonical_dcp_size" in extra_config
+        if has_canonical_page_size != has_canonical_dcp_size:
+            raise ValueError(
+                "canonical_page_size and canonical_dcp_size must be configured "
+                "together."
+            )
+        canonical_page_size = int(
+            extra_config.get("canonical_page_size", self.page_size)
+        )
+        canonical_dcp_size = int(extra_config.get("canonical_dcp_size", 0))
+        if has_canonical_dcp_size and canonical_dcp_size <= 0:
+            raise ValueError(
+                "canonical_dcp_size must be a positive integer, got "
+                f"{canonical_dcp_size}."
+            )
+        if canonical_dcp_size and storage_backend != "mooncake":
+            raise ValueError(
+                "canonical_dcp_size is currently supported only by the Mooncake "
+                f"HiCache backend, got {storage_backend!r}."
+            )
+        if canonical_dcp_size and not self.storage_config.is_mla_model:
+            raise ValueError(
+                "canonical_dcp_size currently supports only MLA KV pools."
+            )
+        if canonical_page_size <= 0 or self.page_size % canonical_page_size != 0:
+            raise ValueError(
+                "canonical_page_size must be a positive divisor of the HiCache "
+                f"logical page size ({self.page_size}), got {canonical_page_size}."
+            )
+        if canonical_dcp_size and canonical_page_size % canonical_dcp_size != 0:
+            raise ValueError(
+                "canonical_page_size must be divisible by canonical_dcp_size: "
+                f"{canonical_page_size} % {canonical_dcp_size} != 0."
+            )
+        if canonical_dcp_size and self.storage_config.attn_cp_size != 1:
+            raise ValueError(
+                "Mooncake canonical DCP layout does not support context "
+                "parallelism yet; expected attn_cp_size=1, got "
+                f"{self.storage_config.attn_cp_size}."
+            )
+        if canonical_dcp_size and self.mem_pool_host.layout != "page_first":
+            raise ValueError(
+                "Mooncake canonical DCP layout requires "
+                "--hicache-mem-layout page_first, got "
+                f"{self.mem_pool_host.layout!r}."
+            )
+        if canonical_dcp_size and self.storage_config.attn_dcp_size not in (
+            1,
+            canonical_dcp_size,
+        ):
+            raise ValueError(
+                "Mooncake canonical DCP layout currently supports only DCP1 "
+                "or the canonical DCP size itself: "
+                f"local={self.storage_config.attn_dcp_size}, "
+                f"canonical={canonical_dcp_size}."
+            )
+        self.storage_page_size = canonical_page_size
+        self.storage_hashes_per_page = self.page_size // canonical_page_size
         # for MLA models, only one rank needs to backup the KV cache
         self.backup_skip = (
             self.storage_config.is_mla_model
@@ -996,7 +1062,19 @@ class HiCacheController:
 
             prev_completed_tokens = operation.completed_tokens
             # Get one batch token, and update the completed_tokens if succeed
-            extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
+            storage_start = i * self.storage_hashes_per_page
+            storage_end = (i + len(batch_hashes)) * self.storage_hashes_per_page
+            canonical_hashes = operation.storage_hash_value[
+                storage_start:storage_end
+            ]
+            extra_info = HiCacheStorageExtraInfo(
+                prefix_keys=prefix_keys,
+                extra_info=(
+                    {"canonical_hashes": canonical_hashes}
+                    if canonical_hashes
+                    else None
+                ),
+            )
             self.page_get_func(operation, batch_hashes, batch_host_indices, extra_info)
             # Check termination
             if (
@@ -1209,7 +1287,19 @@ class HiCacheController:
             ]
             # Set one batch token, and record if success.
             # todo: allow partial success
-            extra_info = HiCacheStorageExtraInfo(prefix_keys=prefix_keys)
+            storage_start = i * self.storage_hashes_per_page
+            storage_end = (i + len(batch_hashes)) * self.storage_hashes_per_page
+            canonical_hashes = operation.storage_hash_value[
+                storage_start:storage_end
+            ]
+            extra_info = HiCacheStorageExtraInfo(
+                prefix_keys=prefix_keys,
+                extra_info=(
+                    {"canonical_hashes": canonical_hashes}
+                    if canonical_hashes
+                    else None
+                ),
+            )
             success = self.page_set_func(batch_hashes, batch_host_indices, extra_info)
             if not success:
                 logger.warning(

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -326,6 +326,7 @@ class HiCacheController:
 
         self.prefetch_sync_groups = []
         seen_rank_sets = set()
+        world_size = torch.distributed.get_world_size()
 
         if self.attn_cp_group is not None or self.attn_tp_group is not None:
             base_groups = [self.attn_cp_group, self.attn_tp_group]
@@ -339,11 +340,20 @@ class HiCacheController:
             if group_ranks in seen_rank_sets:
                 continue
             seen_rank_sets.add(group_ranks)
-            self.prefetch_sync_groups.append(
-                create_custom_parallel_group(
+            if group_ranks == tuple(range(world_size)):
+                # Avoid the object all-gather in create_custom_parallel_group
+                # when every world rank participates. Decode-side cache
+                # offloading attaches storage late in scheduler startup, where
+                # an extra default-group collective can race with other rank
+                # initialization and deadlock before the Gloo group is created.
+                sync_group = torch.distributed.new_group(
+                    ranks=list(group_ranks), backend="gloo"
+                )
+            else:
+                sync_group = create_custom_parallel_group(
                     group_ranks=list(group_ranks), backend="gloo"
                 )
-            )
+            self.prefetch_sync_groups.append(sync_group)
 
     def _destroy_prefetch_sync_groups(self) -> None:
         for group in self.prefetch_sync_groups:
@@ -466,6 +476,9 @@ class HiCacheController:
             self.storage_config.is_mla_model
             # todo: load balancing
             and self.storage_config.tp_rank != 0
+            # MLA KV is TP-replicated in the ordinary layout, but each DCP
+            # rank owns a distinct interleaved token shard.
+            and self.storage_config.attn_dcp_size == 1
         )
 
         # Use storage backend factory for dynamic backend creation
@@ -622,6 +635,7 @@ class HiCacheController:
             )
 
         attn_cp_rank, attn_cp_size = self.get_attn_cp_rank_and_size()
+        parallel = get_parallel()
 
         return HiCacheStorageConfig(
             tp_rank=self.tp_rank,
@@ -635,6 +649,8 @@ class HiCacheController:
             enable_storage_metrics=self.enable_storage_metrics,
             is_page_first_layout=self.mem_pool_host.layout == "page_first",
             model_name=model_name,
+            attn_dcp_rank=parallel.attn_dcp_rank,
+            attn_dcp_size=parallel.attn_dcp_size,
             tp_lcm_size=tp_lcm_size,
             should_split_heads=should_split_heads,
             extra_config=storage_backend_extra_config,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2473,6 +2473,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     ) -> _MambaRadixCacheV2TrackEntry:
         server_args = get_server_args()
         mamba_cache_chunk_size = server_args.mamba_cache_chunk_size
+        mamba_checkpoint_interval = getattr(
+            server_args,
+            "mamba_radix_checkpoint_interval",
+            mamba_cache_chunk_size,
+        )
+        assert mamba_checkpoint_interval % mamba_cache_chunk_size == 0, (
+            "mamba radix checkpoint interval must be a multiple of the kernel "
+            f"state stride, got {mamba_checkpoint_interval=} and "
+            f"{mamba_cache_chunk_size=}"
+        )
 
         def _force_track_h(i: int) -> int:
             assert i % mamba_cache_chunk_size == 0
@@ -2485,7 +2495,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # to force the math calculation to retrieve the correct mamba state from h.
             return i + 1
 
-        mask = req.extend_range.length >= mamba_cache_chunk_size
+        mask = req.extend_range.length >= mamba_checkpoint_interval
         track_index = req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx].item()
         mamba_track_seqlen = -1
         if mask:
@@ -2502,22 +2512,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # mamba radix cache to track which seqlen this mamba state should store at.
             mamba_track_seqlen_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_range.length // mamba_cache_chunk_size)
-                * mamba_cache_chunk_size
+                + (req.extend_range.length // mamba_checkpoint_interval)
+                * mamba_checkpoint_interval
             )
 
-            # mamba_track_fla_chunk_aligned is the aligned seqlen based on mamba_cache_chunk_size
-            # If mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned, which can be true when
-            # page_size > mamba_cache_chunk_size, we need to force the math calculation to retrieve the correct mamba state from h
-            # by _force_track_h()
-            mamba_track_fla_chunk_aligned = (
-                len(req.prefix_indices)
-                + (req.extend_range.length // mamba_cache_chunk_size)
-                * mamba_cache_chunk_size
-            )
-            if mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned:
-                # We want to track mamba_track_seqlen_aligned, and it's not the last position,
-                # so we need to add 1 to the seqlen to retrieve the correct mamba state from h.
+            # An aligned checkpoint can use ``last_recurrent_state`` only when
+            # it is also the final position of this extend.  For an interior
+            # boundary, encode boundary + 1 so the attention backend selects
+            # the corresponding intermediate ``h`` state while
+            # ``mamba_last_track_seqlen`` retains the true cache position.
+            if mamba_track_seqlen_aligned != mamba_track_seqlen:
                 mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)
 
             # In lazy mode, skip the swap — the second ping-pong slot is not
@@ -2534,7 +2538,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # is within the current extend batch.
                 branching_seqlen_aligned_mask = (
                     req.mamba_branching_seqlen - len(req.prefix_indices)
-                ) % mamba_cache_chunk_size == 0
+                ) % mamba_checkpoint_interval == 0
                 if (
                     req.mamba_branching_seqlen > len(req.prefix_indices)
                     and req.mamba_branching_seqlen < mamba_track_seqlen

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -385,6 +385,10 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def supports_mamba(self) -> bool:
         return False
 
+    def get_mamba_device_value(self, node: Any) -> Optional[torch.Tensor]:
+        """Return the device-resident Mamba checkpoint attached to ``node``."""
+        return None
+
     def supports_streaming_session(self) -> bool:
         return False
 

--- a/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/hi_mamba_radix_cache.py
@@ -110,6 +110,7 @@ class HiMambaRadixCache(MambaRadixCache):
                 )
 
         self.page_size = params.page_size
+        self.storage_page_size = self.page_size
         self.hybrid_kv_cache = params.token_to_kv_pool_allocator.get_kvcache()
         if not isinstance(self.hybrid_kv_cache, HybridLinearKVPool):
             raise ValueError(
@@ -154,6 +155,8 @@ class HiMambaRadixCache(MambaRadixCache):
             load_cache_event=self.load_cache_event,
             enable_storage_metrics=self.enable_storage_metrics,
         )
+        if self.enable_storage:
+            self.storage_page_size = self.cache_controller.storage_page_size
         self._apply_storage_runtime_config(
             storage_backend=server_args.hicache_storage_backend,
             prefetch_threshold=prefetch_threshold,
@@ -950,6 +953,12 @@ class HiMambaRadixCache(MambaRadixCache):
         self.mamba_evictable_size_ += len(mamba_value)
         if self.enable_storage or self.enable_kv_cache_events:
             new_node.hash_value = compute_node_hash_values(new_node, self.page_size)
+        if self.enable_storage:
+            new_node.storage_hash_value = compute_node_hash_values(
+                new_node,
+                self.storage_page_size,
+                hash_attr="storage_hash_value",
+            )
         self._record_store_event(new_node, medium=StorageMedium.GPU)
         self._update_full_device_leaf_status(new_node)
         self._update_full_device_leaf_status(parent)
@@ -1105,8 +1114,13 @@ class HiMambaRadixCache(MambaRadixCache):
             return self._split_evicted_node(key, child, split_len)
 
         self.evictable_full_device_leaves.discard(child)
+        storage_parent_hashes, storage_child_hashes = split_node_hash_value(
+            child.storage_hash_value, split_len, self.storage_page_size
+        )
 
         new_node = super()._split_node(key, child, split_len)
+        new_node.storage_hash_value = storage_parent_hashes
+        child.storage_hash_value = storage_child_hashes
 
         if child.backuped:
             new_node.host_value = child.host_value[:split_len].clone()
@@ -1137,6 +1151,9 @@ class HiMambaRadixCache(MambaRadixCache):
 
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
+        )
+        new_node.storage_hash_value, child.storage_hash_value = split_node_hash_value(
+            child.storage_hash_value, split_len, self.storage_page_size
         )
 
         child.last_access_time = get_last_access_time()
@@ -1382,6 +1399,7 @@ class HiMambaRadixCache(MambaRadixCache):
                 storage_backend_extra_config=extra_config,
                 host_pools=self.host_pool_group.entries,
             )
+            self.storage_page_size = self.cache_controller.storage_page_size
         except Exception as e:
             logger.exception(
                 f"Failed to attach storage backend '{storage_backend}': {e}"
@@ -1790,6 +1808,7 @@ class HiMambaRadixCache(MambaRadixCache):
             node.key,
             node.hash_value,
             prefix_keys,
+            storage_hash_value=node.storage_hash_value,
             extra_pools=extra_pools,
         )
         mamba_host_protected = extra_pools is not None
@@ -1833,6 +1852,11 @@ class HiMambaRadixCache(MambaRadixCache):
             new_input_tokens,
             last_hash,
             prefix_keys,
+            storage_last_hash=(
+                last_host_node.storage_hash_value[-1]
+                if last_host_node.storage_hash_value
+                else None
+            ),
             extra_pools=extra_pools,
         )
         self.ongoing_prefetch[req_id] = (
@@ -1901,6 +1925,10 @@ class HiMambaRadixCache(MambaRadixCache):
             ),
             written_indices,
             hash_value[: min_completed_tokens // self.page_size],
+            operation.storage_hash_value[
+                : (min_completed_tokens // self.page_size)
+                * self.cache_controller.storage_hashes_per_page
+            ],
             mamba_host_indices,
             mamba_loaded,
         )
@@ -1942,6 +1970,7 @@ class HiMambaRadixCache(MambaRadixCache):
         key: RadixKey,
         host_value,
         hash_value,
+        storage_hash_value,
         mamba_host_value: Optional[torch.Tensor] = None,
         mamba_loaded: bool = False,
     ):
@@ -1962,6 +1991,9 @@ class HiMambaRadixCache(MambaRadixCache):
             key = key[prefix_len:]
             host_value = host_value[prefix_len:]
             hash_value = hash_value[prefix_len // self.page_size :]
+            storage_hash_value = storage_hash_value[
+                prefix_len // self.storage_page_size :
+            ]
             matched_length += prefix_len
 
             if prefix_len < len(node.key):
@@ -1980,6 +2012,7 @@ class HiMambaRadixCache(MambaRadixCache):
             new_node.mamba_value = None
             new_node.host_value = host_value.clone()
             new_node.hash_value = hash_value
+            new_node.storage_hash_value = storage_hash_value
             node.children[child_key] = new_node
             leaf_node = new_node
             self._update_full_host_leaf_status(new_node)

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -35,6 +35,8 @@ class HiCacheStorageConfig:
     enable_storage_metrics: bool
     is_page_first_layout: bool
     model_name: Optional[str]
+    attn_dcp_rank: int = 0
+    attn_dcp_size: int = 1
     tp_lcm_size: Optional[int] = None
     should_split_heads: bool = False
     extra_config: Optional[dict] = None

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -111,9 +111,19 @@ class StorageOperation(BaseStorageOperation):
         last_hash: Optional[str] = None,
         hash_value: Optional[List[str]] = None,
         prefix_keys: Optional[List[str]] = None,
+        storage_hash_value: Optional[List[str]] = None,
+        storage_last_hash: Optional[str] = None,
         pool_transfers: Optional[list[PoolTransfer]] = None,
     ):
-        super().__init__(host_indices, token_ids, last_hash, hash_value, prefix_keys)
+        super().__init__(
+            host_indices,
+            token_ids,
+            last_hash,
+            hash_value,
+            prefix_keys,
+            storage_hash_value,
+            storage_last_hash,
+        )
         self.pool_transfers = pool_transfers
         self.pool_storage_result = PoolTransferResult.empty()
 
@@ -125,6 +135,7 @@ class PrefetchOperation(StorageOperation):
         token_ids: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        storage_last_hash: Optional[str] = None,
         pool_transfers: Optional[list[PoolTransfer]] = None,
     ):
         self.request_id = request_id
@@ -136,6 +147,7 @@ class PrefetchOperation(StorageOperation):
             None,
             token_ids,
             last_hash,
+            storage_last_hash=storage_last_hash,
             prefix_keys=prefix_keys,
             pool_transfers=pool_transfers,
         )
@@ -562,12 +574,14 @@ class HybridCacheController(BaseHiCacheController):
         new_input_tokens: List[int],
         last_hash: Optional[str] = None,
         prefix_keys: Optional[List[str]] = None,
+        storage_last_hash: Optional[str] = None,
         extra_pools: Optional[list[PoolTransfer]] = None,
     ) -> PrefetchOperation:
         operation = PrefetchOperation(
             request_id,
             new_input_tokens,
             last_hash,
+            storage_last_hash=storage_last_hash,
             prefix_keys=prefix_keys,
             pool_transfers=extra_pools,
         )
@@ -580,12 +594,14 @@ class HybridCacheController(BaseHiCacheController):
         token_ids: List[int],
         hash_value: Optional[List[str]] = None,
         prefix_keys: Optional[List[str]] = None,
+        storage_hash_value: Optional[List[str]] = None,
         extra_pools: Optional[list[PoolTransfer]] = None,
     ) -> int:
         operation = StorageOperation(
             host_indices,
             token_ids,
             hash_value=hash_value,
+            storage_hash_value=storage_hash_value,
             prefix_keys=prefix_keys,
             pool_transfers=extra_pools,
         )
@@ -596,9 +612,15 @@ class HybridCacheController(BaseHiCacheController):
         hash_value = self.get_hash_str(
             operation.token_ids, operation.last_hash, page_size=self.page_size
         )
+        storage_hash_value = self.get_hash_str(
+            operation.token_ids,
+            operation.storage_last_hash,
+            page_size=self.storage_page_size,
+        )
 
         extra_info = HiCacheStorageExtraInfo(
-            prefix_keys=operation.prefix_keys.copy() if operation.prefix_keys else None
+            prefix_keys=operation.prefix_keys.copy() if operation.prefix_keys else None,
+            extra_info={"canonical_hashes": storage_hash_value},
         )
         if operation.pool_transfers:
             hit_result = self.storage_backend.batch_exists_v2(
@@ -612,6 +634,9 @@ class HybridCacheController(BaseHiCacheController):
 
         kv_hit_pages = hit_result.kv_hit_pages
         operation.pool_storage_result.update_kv_hit_pages(kv_hit_pages)
+        operation.storage_hash_value = storage_hash_value[
+            : kv_hit_pages * self.storage_hashes_per_page
+        ]
 
         return (
             hash_value[:kv_hit_pages],
@@ -659,8 +684,18 @@ class HybridCacheController(BaseHiCacheController):
             and not operation.is_terminated()
             and kv_completed_pages == len(operation.hash_value)
         ):
+            storage_hashes = operation.storage_hash_value or operation.hash_value
+            hashes_per_page = (
+                self.storage_hashes_per_page
+                if operation.storage_hash_value
+                else 1
+            )
+            storage_page_hashes = [
+                storage_hashes[(page + 1) * hashes_per_page - 1]
+                for page in range(kv_completed_pages)
+            ]
             self._sync_trailing_keys(
-                operation.pool_transfers, operation.hash_value, kv_completed_pages
+                operation.pool_transfers, storage_page_hashes, kv_completed_pages
             )
             self._resolve_sidecar_derived_pool_transfers(operation)
             results = self.storage_backend.batch_get_v2(operation.pool_transfers)
@@ -681,6 +716,19 @@ class HybridCacheController(BaseHiCacheController):
             ]
 
         if backup_transfers:
+            storage_hashes = operation.storage_hash_value or operation.hash_value
+            hashes_per_page = (
+                self.storage_hashes_per_page
+                if operation.storage_hash_value
+                else 1
+            )
+            storage_page_hashes = [
+                storage_hashes[(page + 1) * hashes_per_page - 1]
+                for page in range(len(operation.hash_value))
+            ]
+            self._sync_trailing_keys(
+                backup_transfers, storage_page_hashes, len(operation.hash_value)
+            )
             self._resolve_sidecar_derived_pool_transfers(operation)
             results = self.storage_backend.batch_set_v2(backup_transfers)
             operation.pool_storage_result.update_extra_pool_hit_pages(results)

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -27,7 +27,7 @@ from sglang.srt.mem_cache.pool_host.mha import (
     get_mha_host_pool_cls,
 )
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
-from sglang.srt.mem_cache.unified_cache_components import ComponentType
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
 from sglang.srt.runtime_context import get_parallel
 
 if TYPE_CHECKING:

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -102,6 +102,8 @@ class TreeNode:
         self.host_value = None
         # store hash values of each pages
         self.hash_value: Optional[List[str]] = None
+        # L3 may use a canonical page geometry independent of the DCP layout.
+        self.storage_hash_value: Optional[List[str]] = None
 
         # for lru list, invariant:
         # 1. prev has greater last_access_time
@@ -479,11 +481,15 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
     def supports_mamba(self) -> bool:
         return True
 
+    def get_mamba_device_value(self, node: TreeNode) -> Optional[torch.Tensor]:
+        return node.mamba_value
+
     def reset(self) -> None:
         self.root_node = TreeNode()
         self.root_node.key = RadixKey(array("q"), None)
         self.root_node.value = []
         self.root_node.hash_value = []
+        self.root_node.storage_hash_value = []
         self.root_node.full_lock_ref = 1
         self.root_node.mamba_lock_ref = 1
         self.full_evictable_size_ = 0

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1526,6 +1526,15 @@ class HostPoolGroup:
 
         self.layout = self.anchor_entry.host_pool.layout
         self.page_size = self.anchor_entry.host_pool.page_size
+        # The primary pool exposes a widened logical page under DCP while its
+        # backing buffer uses the per-rank physical page. Storage backends see
+        # HostPoolGroup rather than the primary pool directly, so preserve both
+        # units at this wrapper boundary.
+        self.logical_page_size = getattr(
+            self.anchor_entry.host_pool,
+            "logical_page_size",
+            self.page_size,
+        )
         self.device = self.anchor_entry.host_pool.device
         self.size = self.anchor_entry.host_pool.size
         self.can_use_write_back_jit = all(

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -322,14 +322,16 @@ class HostKVCache(abc.ABC):
         rank keeps exactly 1/dcp_size of the slots, covering its full
         physical pages.
         """
-        if self.dcp_size == 1:
+        dcp_size = getattr(self, "dcp_size", 1)
+        dcp_rank = getattr(self, "dcp_rank", 0)
+        if dcp_size == 1:
             return indices
-        owned = indices[indices % self.dcp_size == self.dcp_rank] // self.dcp_size
-        assert owned.numel() * self.dcp_size == indices.numel(), (
+        owned = indices[indices % dcp_size == dcp_rank] // dcp_size
+        assert owned.numel() * dcp_size == indices.numel(), (
             "HiCache DCP translation expects runs of whole widened pages "
             f"(every residue class equally represented); got {indices.numel()} "
             f"logical slots -> {owned.numel()} owned rows with dcp_size="
-            f"{self.dcp_size}."
+            f"{dcp_size}."
         )
         return owned
 

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -468,11 +468,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
             raise ValueError(f"Unsupported IO backend: {io_backend}")
 
     def get_data_page(self, index, flat: bool = True) -> torch.Tensor:
-        assert self.dcp_size == 1, (
-            "HiCache L3 storage paths are not yet DCP-aware (per-rank shards "
-            "need dcp_rank-scoped keys); --hicache-storage-backend with "
-            "--dcp-size > 1 should have been rejected at server start."
-        )
+        index = self._storage_physical_page_start(index)
         if self.layout == "layer_first":
             data_page = self.kv_buffer[:, index : index + self.page_size, :, :]
         elif self.layout == "page_first":
@@ -500,6 +496,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         ).flatten()
 
     def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:
+        index = self._storage_physical_page_start(index)
         if self.layout == "layer_first":
             self.kv_buffer[:, index : index + self.page_size, :, :] = data_page.reshape(
                 self.layer_num,
@@ -530,10 +527,11 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         """
         meta data for zero copy
         """
-        assert len(indices) % self.page_size == 0
+        assert len(indices) % self.logical_page_size == 0
         ptr_list = []
         kv_buffer_data_ptr = self.kv_buffer.data_ptr()
-        indices = indices.tolist()
+        indices = self.dcp_kernel_indices(indices).tolist()
+        assert len(indices) % self.page_size == 0
         if self.layout == "layer_first":
             for index in range(0, len(indices), self.page_size):
                 for layer_id in range(self.layer_num):
@@ -565,6 +563,15 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")
         return ptr_list, element_size_list
+
+    def _storage_physical_page_start(self, logical_index: int) -> int:
+        """Map a logical L3 page start to this DCP rank's physical host row."""
+        logical_index = int(logical_index)
+        assert logical_index % self.logical_page_size == 0, (
+            "HiCache storage operations must start on a logical page boundary: "
+            f"index={logical_index}, logical_page_size={self.logical_page_size}."
+        )
+        return logical_index // self.dcp_size
 
     def is_stride_page_aligned(self, page_size_bytes: int = 4096) -> bool:
         """Return True if per-page strides are multiples of *page_size_bytes*.

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -586,6 +586,35 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 )
 
             self.storage_config = storage_config
+            extra_config = storage_config.extra_config or {}
+            self.canonical_dcp_size = int(extra_config.get("canonical_dcp_size", 0))
+            self.canonical_page_size = int(extra_config.get("canonical_page_size", 0))
+            if self.canonical_dcp_size:
+                if self.canonical_page_size <= 0:
+                    raise ValueError(
+                        "canonical_page_size is required when canonical_dcp_size "
+                        "is enabled."
+                    )
+                if self.attn_dcp_size not in (1, self.canonical_dcp_size):
+                    raise ValueError(
+                        "Mooncake canonical DCP layout currently supports only "
+                        "DCP1 or the canonical DCP size itself: "
+                        f"local={self.attn_dcp_size}, "
+                        f"canonical={self.canonical_dcp_size}."
+                    )
+                self.canonical_mla_scope = (
+                    f"canonv1_tp{storage_config.tp_size}_"
+                    f"pp{self.pp_rank}of{self.pp_size}"
+                )
+                # Hybrid sidecars (Mamba/KDA state) must use the same
+                # cross-DCP namespace on both DCP1 and DCP-N.  The legacy
+                # mha_suffix does not encode the canonical geometry, so it can
+                # collide with non-canonical objects or another canonical N.
+                self.canonical_hybrid_scope = (
+                    f"{self.canonical_mla_scope}_"
+                    f"dcp{self.canonical_dcp_size}_"
+                    f"page{self.canonical_page_size}"
+                )
             self.should_split_heads = storage_config.should_split_heads
             self.split_factor = 0
             if self.should_split_heads:
@@ -764,9 +793,14 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             # object (mooncake rejects 0-size puts). get_page_buffer_meta drops
             # its temporal pointer under the same condition to stay aligned.
             conv_num = len(getattr(host_pool, "conv_buffer", None) or [])
-            suffixes = [f"_{self.mha_suffix}_conv_{i}" for i in range(conv_num)]
+            mamba_scope = (
+                f"{self.canonical_hybrid_scope}_rank{self.mha_suffix}"
+                if self.canonical_dcp_size
+                else self.mha_suffix
+            )
+            suffixes = [f"_{mamba_scope}_conv_{i}" for i in range(conv_num)]
             if getattr(host_pool, "temporal_state_elem_size", 1) > 0:
-                suffixes = [f"_{self.mha_suffix}_temporal"] + suffixes
+                suffixes = [f"_{mamba_scope}_temporal"] + suffixes
         elif pool_name == PoolName.DRAFT:
             # Draft pool's MLA/MHA layout is independent from the target
             # (e.g. EAGLE-MHA draft on top of an MLA target), so pick the
@@ -829,12 +863,20 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
 
         hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
         final_pages = kv_pages
+        sidecar_keys = keys
+        canonical_hashes = self._canonical_hashes(extra_info)
+        if canonical_hashes:
+            hashes_per_page = len(canonical_hashes) // len(keys)
+            sidecar_keys = [
+                canonical_hashes[(page + 1) * hashes_per_page - 1]
+                for page in range(len(keys))
+            ]
 
         for transfer in pool_transfers or []:
             if final_pages == 0:
                 break
             component_keys, key_multiplier = self._get_hybrid_page_component_keys(
-                keys, transfer
+                sidecar_keys, transfer
             )
             component_keys = self._tag_keys(component_keys)
             ex = self._batch_exist(component_keys)
@@ -994,6 +1036,112 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         assert len(key_list) == len(ptr_list)
         return key_list, ptr_list, element_size_list
 
+    def _canonical_hashes(
+        self, extra_info: Optional[HiCacheStorageExtraInfo]
+    ) -> Optional[List[str]]:
+        if not self.canonical_dcp_size or extra_info is None:
+            return None
+        return (extra_info.extra_info or {}).get("canonical_hashes")
+
+    def _canonical_mla_keys(self, canonical_hashes: List[str]) -> List[str]:
+        if self.attn_dcp_size == 1:
+            return [
+                (
+                    f"{page_hash}_{self.canonical_mla_scope}_"
+                    f"dcp{shard}of{self.canonical_dcp_size}_k"
+                )
+                for page_hash in canonical_hashes
+                for shard in range(self.canonical_dcp_size)
+            ]
+        return [
+            (
+                f"{page_hash}_{self.canonical_mla_scope}_"
+                f"dcp{self.attn_dcp_rank}of{self.canonical_dcp_size}_k"
+            )
+            for page_hash in canonical_hashes
+        ]
+
+    def _get_canonical_mla_buffer_meta(
+        self, canonical_hashes: List[str], host_indices: torch.Tensor
+    ):
+        """Map DCP1/DCP-N host pages to canonical N-way token-shard objects.
+
+        A canonical page is split by token position modulo N.  DCP-N owns one
+        contiguous component per rank; DCP1 exposes the same object as a
+        multi-buffer made of N-strided token rows.  Mooncake concatenates or
+        scatters those rows without an intermediate copy.
+        """
+        pool_group = self.mem_pool_host
+        host_pool = getattr(
+            getattr(pool_group, "anchor_entry", None),
+            "host_pool",
+            pool_group,
+        )
+        if pool_group.layout != "page_first":
+            raise ValueError(
+                "Mooncake canonical DCP layout currently requires "
+                "--hicache-mem-layout page_first."
+            )
+        logical_page_size = pool_group.logical_page_size
+        logical_pages = len(host_indices) // logical_page_size
+        hashes_per_page = logical_page_size // self.canonical_page_size
+        if len(canonical_hashes) != logical_pages * hashes_per_page:
+            raise ValueError(
+                "Canonical hash/page mismatch: "
+                f"hashes={len(canonical_hashes)}, logical_pages={logical_pages}, "
+                f"hashes_per_page={hashes_per_page}."
+            )
+        tokens_per_shard = self.canonical_page_size // self.canonical_dcp_size
+        if tokens_per_shard <= 0:
+            raise ValueError(
+                "canonical_page_size must be at least canonical_dcp_size."
+            )
+
+        indices = host_indices.tolist()
+        base_ptr = host_pool.kv_buffer.data_ptr()
+        row_bytes = (
+            host_pool.layer_num
+            * host_pool.kv_cache_dim
+            * host_pool.dtype.itemsize
+        )
+        ptrs = []
+        sizes = []
+        for logical_page in range(logical_pages):
+            logical_start = int(indices[logical_page * logical_page_size])
+            physical_start = host_pool._storage_physical_page_start(logical_start)
+            if self.attn_dcp_size == 1:
+                for _canonical_page in range(hashes_per_page):
+                    canonical_start = physical_start + (
+                        _canonical_page * self.canonical_page_size
+                    )
+                    for shard in range(self.canonical_dcp_size):
+                        shard_ptrs = [
+                            base_ptr
+                            + (
+                                canonical_start
+                                + shard
+                                + token_idx * self.canonical_dcp_size
+                            )
+                            * row_bytes
+                            for token_idx in range(tokens_per_shard)
+                        ]
+                        ptrs.append(shard_ptrs)
+                        sizes.append([row_bytes] * tokens_per_shard)
+            else:
+                for canonical_page in range(hashes_per_page):
+                    component_start = (
+                        physical_start + canonical_page * tokens_per_shard
+                    )
+                    ptrs.append(base_ptr + component_start * row_bytes)
+                    sizes.append(tokens_per_shard * row_bytes)
+
+        keys = self._canonical_mla_keys(canonical_hashes)
+        if len(keys) != len(ptrs):
+            raise RuntimeError(
+                f"Canonical Mooncake key/buffer mismatch: {len(keys)} != {len(ptrs)}"
+            )
+        return keys, ptrs, sizes
+
     def _batch_preprocess(self, keys, host_indices):
         assert len(keys) > 0
         logical_page_size = getattr(
@@ -1054,7 +1202,18 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         # Apply config prefix if available.
         keys = self._tag_keys(keys)
 
-        key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(keys, host_indices)
+        canonical_hashes = self._canonical_hashes(extra_info)
+        if self.is_mla_backend and canonical_hashes:
+            canonical_hashes = self._tag_keys(canonical_hashes)
+            key_strs, buffer_ptrs, buffer_sizes = (
+                self._get_canonical_mla_buffer_meta(canonical_hashes, host_indices)
+            )
+            key_multiplier = self.canonical_dcp_size
+        else:
+            key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(
+                keys, host_indices
+            )
+            key_multiplier = None
 
         start_time = time.perf_counter()
         get_results = self._get_batch_zero_copy_impl(
@@ -1068,7 +1227,11 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 len(keys) / (end_time - start_time) * self.gb_per_page
             )
 
-        return self._batch_postprocess(get_results, is_set_operate=False)
+        return self._batch_postprocess(
+            get_results,
+            is_set_operate=False,
+            key_multiplier=key_multiplier,
+        )
 
     def batch_set_v1(
         self,
@@ -1083,8 +1246,18 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         # Apply config prefix if available.
         keys = self._tag_keys(keys)
 
-        key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(keys, host_indices)
-        key_multiplier = len(key_strs) // len(keys)
+        canonical_hashes = self._canonical_hashes(extra_info)
+        if self.is_mla_backend and canonical_hashes:
+            canonical_hashes = self._tag_keys(canonical_hashes)
+            key_strs, buffer_ptrs, buffer_sizes = (
+                self._get_canonical_mla_buffer_meta(canonical_hashes, host_indices)
+            )
+            key_multiplier = self.canonical_dcp_size
+        else:
+            key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(
+                keys, host_indices
+            )
+            key_multiplier = len(key_strs) // len(keys)
         group_ids = (
             self._expand_group_ids(keys, key_multiplier)
             if self._can_use_group_semantics()
@@ -1126,7 +1299,11 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             for i in range(len(set_indices)):
                 set_results[set_indices[i]] = put_results[i]
 
-        return self._batch_postprocess(set_results, is_set_operate=True)
+        return self._batch_postprocess(
+            set_results,
+            is_set_operate=True,
+            key_multiplier=key_multiplier,
+        )
 
     def set(
         self,
@@ -1257,7 +1434,12 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         # Apply config prefix if available.
         keys = self._tag_keys(keys)
 
-        if self.is_mla_backend:
+        canonical_hashes = self._canonical_hashes(extra_info)
+        if self.is_mla_backend and canonical_hashes:
+            canonical_hashes = self._tag_keys(canonical_hashes)
+            query_keys = self._canonical_mla_keys(canonical_hashes)
+            key_multiplier = self.canonical_dcp_size
+        elif self.is_mla_backend:
             query_keys = [f"{key}_{self.mla_suffix}_k" for key in keys]
             key_multiplier = 1
         else:

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -559,6 +559,8 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 self.pp_size = storage_config.pp_size
                 self.attn_cp_rank = storage_config.attn_cp_rank
                 self.attn_cp_size = storage_config.attn_cp_size
+                self.attn_dcp_rank = storage_config.attn_dcp_rank
+                self.attn_dcp_size = storage_config.attn_dcp_size
                 self.enable_storage_metrics = storage_config.enable_storage_metrics
             else:
                 self.is_mla_backend = False
@@ -567,6 +569,8 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 self.pp_size = 1
                 self.attn_cp_rank = 0
                 self.attn_cp_size = 1
+                self.attn_dcp_rank = 0
+                self.attn_dcp_size = 1
 
             self.enable_pp = self.pp_size > 1
             if self.enable_pp:
@@ -575,6 +579,11 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             else:
                 self.mha_suffix = f"{self.local_rank}"
                 self.mla_suffix = ""
+            if self.attn_dcp_size > 1:
+                dcp_suffix = f"dcp{self.attn_dcp_rank}of{self.attn_dcp_size}"
+                self.mla_suffix = (
+                    f"{self.mla_suffix}_{dcp_suffix}" if self.mla_suffix else dcp_suffix
+                )
 
             self.storage_config = storage_config
             self.should_split_heads = storage_config.should_split_heads
@@ -987,7 +996,12 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
 
     def _batch_preprocess(self, keys, host_indices):
         assert len(keys) > 0
-        assert len(keys) == len(host_indices) // self.mem_pool_host.page_size
+        logical_page_size = getattr(
+            self.mem_pool_host,
+            "logical_page_size",
+            self.mem_pool_host.page_size,
+        )
+        assert len(keys) == len(host_indices) // logical_page_size
         if self.is_mla_backend:
             return self._get_mla_buffer_meta(keys, host_indices)
         else:

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -91,6 +91,7 @@ class StorageBackupSpec(NamedTuple):
     host_value: torch.Tensor
     token_ids: array
     hash_value: list[str]
+    storage_hash_value: list[str]
     prefix_keys: Optional[list[str]]
     comp_xfers: dict[ComponentType, list[PoolTransfer]]
 
@@ -112,6 +113,7 @@ class UnifiedTreeNode:
         self.last_access_time = get_and_increase_time_counter()
         self.creation_time = get_and_increase_time_counter()
         self.hash_value = None
+        self.storage_hash_value = None
         self.hit_count = 0
         self.priority = priority
         self.lru_prev: list[UnifiedTreeNode | None] = [None] * (
@@ -147,6 +149,11 @@ class UnifiedTreeNode:
         if self.hash_value is None or len(self.hash_value) == 0:
             return None
         return self.hash_value[-1]
+
+    def get_last_storage_hash_value(self) -> Optional[str]:
+        if not self.storage_hash_value:
+            return None
+        return self.storage_hash_value[-1]
 
     def get_prefix_hash_values(self, node: UnifiedTreeNode) -> list[str]:
         if node is None or node.hash_value is None:
@@ -328,6 +335,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         components: dict[ComponentType, TreeComponent],
     ):
         self.page_size = params.page_size
+        self.storage_page_size = self.page_size
         self.is_eagle = params.is_eagle and ComponentType.MAMBA not in components
         self.enable_hicache = False
         self.enable_storage = False
@@ -375,6 +383,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self.root_node.key = RadixKey(array("q"), None)
         self.root_node.component_data[BASE_COMPONENT_TYPE].value = []
         self.root_node.hash_value = []
+        self.root_node.storage_hash_value = []
         for ct in self.component_types:
             self.root_node.component_data[ct].lock_ref = 1
 
@@ -947,6 +956,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
         )
+        new_node.storage_hash_value, child.storage_hash_value = split_node_hash_value(
+            child.storage_hash_value, split_len, self.storage_page_size
+        )
 
         for component in self.components:
             component.redistribute_on_node_split(new_parent=new_node, child=child)
@@ -991,6 +1003,11 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self.component_evictable_size_[BASE_COMPONENT_TYPE] += len(value)
         if self.enable_storage:
             new_node.hash_value = compute_node_hash_values(new_node, self.page_size)
+            new_node.storage_hash_value = compute_node_hash_values(
+                new_node,
+                self.storage_page_size,
+                hash_attr="storage_hash_value",
+            )
 
         self._update_evictable_leaf_sets(new_node)
         self._update_evictable_leaf_sets(parent)
@@ -1471,6 +1488,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         key: RadixKey,
         host_value: torch.Tensor,
         hash_value: list[str],
+        storage_hash_value: Optional[list[str]] = None,
     ) -> InsertResult:
         """Insert a host-side (backuped) tree path descending from the given node."""
         node = self.node_by_id(node_id)
@@ -1490,6 +1508,10 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             key = key[prefix_len:]
             host_value = host_value[prefix_len:]
             hash_value = hash_value[prefix_len // self.page_size :]
+            if storage_hash_value is not None:
+                storage_hash_value = storage_hash_value[
+                    prefix_len // self.storage_page_size :
+                ]
             matched_length += prefix_len
 
             if prefix_len < len(node.key):
@@ -1527,6 +1549,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         new_node.parent = node
         new_node.key = key
         new_node.hash_value = hash_value
+        new_node.storage_hash_value = storage_hash_value
         new_node.component_data[BASE_COMPONENT_TYPE].host_value = host_value.clone()
         node.children[child_key] = new_node
         self._update_evictable_leaf_sets(new_node)
@@ -1573,6 +1596,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             host_value=node.component_data[BASE_COMPONENT_TYPE].host_value,
             token_ids=node.key.token_ids,
             hash_value=node.hash_value,
+            storage_hash_value=node.storage_hash_value or node.hash_value,
             prefix_keys=prefix_keys,
             comp_xfers=comp_xfers,
         )

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -120,6 +120,7 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
 
     # ==== Tree-owned state the Controller reads (or, via its facade setters, writes) ====
     page_size: int
+    storage_page_size: int
     is_eagle: bool
     device: torch.device
     enable_hicache: bool
@@ -359,6 +360,7 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
         key: RadixKey,
         host_value: torch.Tensor,
         hash_value: list[str],
+        storage_hash_value: Optional[list[str]] = None,
     ) -> InsertResult:
         """Insert a host-side (backuped) tree path descending from the given node."""
         ...

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -344,6 +344,9 @@ class UnifiedRadixCache(BasePrefixCache):
         # Tag HiCache enablement on the TreeCore.
         if self.cache_controller is not None:
             self.tree_core.set_hicache_enabled()
+            self.tree_core.storage_page_size = (
+                self.cache_controller.storage_page_size
+            )
             if self.supports_swa():
                 swa = self.components[ComponentType.SWA]
                 self.tree_core.has_swa_host_pool = swa._swa_kv_pool_host is not None
@@ -1126,6 +1129,7 @@ class UnifiedRadixCache(BasePrefixCache):
             spec.token_ids,
             spec.hash_value,
             spec.prefix_keys,
+            storage_hash_value=spec.storage_hash_value,
             extra_pools=aux_xfers or None,
         )
         self.ongoing_backup[operation_id] = (
@@ -1213,6 +1217,9 @@ class UnifiedRadixCache(BasePrefixCache):
             prefetch_key,
             last_hash,
             prefix_keys,
+            storage_last_hash=self.tree_core.node_by_id(
+                last_host_node_id
+            ).get_last_storage_hash_value(),
             extra_pools=aux_xfers or None,
         )
         self.ongoing_prefetch[req_id] = _OngoingPrefetch(
@@ -1311,6 +1318,10 @@ class UnifiedRadixCache(BasePrefixCache):
             fetched_key,
             host_indices[:min_completed_tokens],
             hash_value[: min_completed_tokens // self.page_size],
+            operation.storage_hash_value[
+                : min_completed_tokens
+                // self.cache_controller.storage_page_size
+            ],
         )
 
         # Apply the host-insert walk's actions before the transfer commit.
@@ -1997,6 +2008,11 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def supports_mamba(self) -> bool:
         return self.is_mamba_enabled
+
+    def get_mamba_device_value(self, node: NodeId) -> Optional[torch.Tensor]:
+        if not self.is_mamba_enabled:
+            return None
+        return self.tree_core.get_component_device_value(node, ComponentType.MAMBA)
 
     # ---- Streaming session API (delegates to composed StreamingSession) ----
 

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -123,12 +123,15 @@ def hash_str_to_int64(hash_str: str) -> int:
     return uint64_val
 
 
-def compute_node_hash_values(node: Any, page_size: int) -> List[str]:
+def compute_node_hash_values(
+    node: Any, page_size: int, hash_attr: str = "hash_value"
+) -> List[str]:
     """Compute SHA256-based hash values for position-aware KV block IDs."""
     parent_hash = None
-    if node.parent is not None and node.parent.hash_value is not None:
-        if len(node.parent.key) > 0 and len(node.parent.hash_value) > 0:
-            parent_hash = node.parent.hash_value[-1]
+    if node.parent is not None:
+        parent_hash_values = getattr(node.parent, hash_attr, None)
+        if len(node.parent.key) > 0 and parent_hash_values:
+            parent_hash = parent_hash_values[-1]
 
     hash_values = get_hash_str(node.key, parent_hash, page_size=page_size)
     assert isinstance(hash_values, list)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7066,15 +7066,40 @@ class ServerArgs:
         self._resolve_hicache_dcp_compatibility()
 
     def _resolve_hicache_dcp_compatibility(self):
-        if self.dcp_size <= 1 or not self.enable_hierarchical_cache:
+        if self.dcp_size <= 1:
+            return
+
+        def is_supported_kimi_hybrid() -> tuple[bool, list[str]]:
+            model_arches = self.get_model_config().hf_config.architectures
+            supported = {"KimiLinearForCausalLM", "KimiK3ForConditionalGeneration"}
+            return bool(supported.intersection(model_arches)), model_arches
+
+        if self.disaggregation_decode_enable_offload_kvcache:
+            supported, model_arches = is_supported_kimi_hybrid()
+            if not supported:
+                raise ValueError(
+                    "Decode KV offload with --dcp-size > 1 is only supported "
+                    "for the Kimi MLA+KDA hybrid models, got "
+                    f"{model_arches}."
+                )
+            logger.info(
+                "PD Decode ChunkCache + DCP L3 offload enabled: every DCP "
+                "rank archives its MLA shard and KDA state."
+            )
+            return
+        if not self.enable_hierarchical_cache:
             return
         if self.hicache_storage_backend is not None:
-            raise NotImplementedError(
-                "--hicache-storage-backend (L3) with --dcp-size > 1 is not "
-                "supported yet: under DCP each rank holds a distinct "
-                "interleaved MLA KV shard, so the rank-0-only replicated-MLA "
-                "backup and the storage keys must become dcp_rank-aware "
-                "first. Run HiCache+DCP with L1/L2 only."
+            supported, model_arches = is_supported_kimi_hybrid()
+            if not supported:
+                raise NotImplementedError(
+                    "--hicache-storage-backend (L3) with --dcp-size > 1 is "
+                    "only supported for the Kimi MLA+KDA hybrid models, got "
+                    f"{model_arches}."
+                )
+            logger.info(
+                "Kimi HiCache + DCP L3 enabled: every DCP rank stores its "
+                "MLA shard and rank-local KDA state."
             )
         if self.speculative_algorithm is not None:
             raise NotImplementedError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7065,6 +7065,61 @@ class ServerArgs:
         # pool boundary; only the validated MLA-hybrid (Kimi) path is wired.
         self._resolve_hicache_dcp_compatibility()
 
+        # Step 4: A Decode-origin hybrid checkpoint must describe the exact
+        # token boundary used by the canonical DCP storage page.  Prefill keeps
+        # that historical KDA state in an extra buffer; Decode receives it and
+        # continues tracking the same boundaries even though its request cache
+        # remains ChunkCache.
+        self._resolve_canonical_hybrid_checkpointing()
+
+    def _resolve_canonical_hybrid_checkpointing(self):
+        if self.hicache_storage_backend != "mooncake":
+            return
+        try:
+            extra_config = json.loads(
+                self.hicache_storage_backend_extra_config or "{}"
+            )
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Invalid hicache storage backend extra config JSON: {e}"
+            ) from e
+        canonical_dcp_size = int(extra_config.get("canonical_dcp_size", 0))
+        if canonical_dcp_size <= 0:
+            return
+        canonical_page_size = int(extra_config.get("canonical_page_size", 0))
+        if canonical_page_size <= 0:
+            # HiCacheController emits the full paired-option diagnostic. Avoid
+            # deriving a bogus checkpoint interval here first.
+            return
+
+        model_arches = self.get_model_config().hf_config.architectures
+        supported = {"KimiLinearForCausalLM", "KimiK3ForConditionalGeneration"}
+        if not supported.intersection(model_arches):
+            return
+
+        checkpoint_interval = canonical_page_size * canonical_dcp_size
+        # Keep this separate from ``mamba_cache_chunk_size``.  KDA kernels
+        # materialize intermediate recurrent states at their native chunk
+        # stride (64 for Kimi KDA), while a canonical DCP object may only be
+        # publishable at a wider boundary (for example 64 * DCP8 = 512).
+        self._canonical_hybrid_checkpoint_interval = checkpoint_interval
+        if self.mamba_track_interval != checkpoint_interval:
+            logger.warning(
+                "Canonical Mooncake DCP hybrid checkpoints require "
+                "mamba_track_interval=%d; overriding %d.",
+                checkpoint_interval,
+                self.mamba_track_interval,
+            )
+            self.mamba_track_interval = checkpoint_interval
+
+        if (
+            self.disaggregation_mode == "decode"
+            and self.disaggregation_decode_enable_offload_kvcache
+        ):
+            # ChunkCache still needs a historical KDA checkpoint slot for L3
+            # publication. This does not enable Decode RadixCache.
+            self.mamba_radix_cache_strategy = "extra_buffer"
+
     def _resolve_hicache_dcp_compatibility(self):
         if self.dcp_size <= 1:
             return
@@ -8565,8 +8620,12 @@ class ServerArgs:
         )
 
     def enable_mamba_extra_buffer(self) -> bool:
+        checkpoint_only_decode = (
+            self.disaggregation_mode == "decode"
+            and self.disaggregation_decode_enable_offload_kvcache
+        )
         return (
-            self.disable_radix_cache is False
+            (self.disable_radix_cache is False or checkpoint_only_decode)
             and self.mamba_radix_cache_strategy in ("extra_buffer", "extra_buffer_lazy")
         )
 
@@ -8611,6 +8670,21 @@ class ServerArgs:
             ), f"For SSM models, either chunk_size or page_size must be divisible by the other, got {chunk_size=}, {page_size=}"
             self._mamba_cache_chunk_size = max(chunk_size, page_size)
         return self._mamba_cache_chunk_size
+
+    @property
+    def mamba_radix_checkpoint_interval(self) -> int:
+        """Token interval represented by a tracked Radix Mamba checkpoint.
+
+        Normally this is the native cache chunk stride. Canonical Mooncake DCP
+        objects use a wider interval without changing the kernel's intermediate
+        state stride.
+        """
+        canonical_interval = getattr(
+            self, "_canonical_hybrid_checkpoint_interval", None
+        )
+        if canonical_interval is not None:
+            return canonical_interval
+        return self.mamba_cache_chunk_size
 
     def _check_two_batch_overlap(self):
         # With no EP a2a backend, two-batch-overlap is only valid on the non-EP


### PR DESCRIPTION
# Support Kimi-K3 PD+DCP L3 hicache with Mooncake 

## Summary

> TLDR: This PR addresses a core limitation in the existing Mooncake L3 storage/offload path: it does not support Kimi-K3 DCP Decode. It cannot correctly persist the per-rank MLA shards together with the Mamba/KDA state, nor can Prefill and Decode instances with heterogeneous DCP layouts share the same L3 cache. With DSPARK enabled, inconsistent target/draft KV metadata also causes the first real PD request to fail.

The target version only supported Kimi+DCP with HiCache L1/L2. MLA KV could move between the L1 GPU cache and the L2 Host cache through widened logical slots and per-rank physical index translation, but that path was not connected to external Mooncake storage. Adding `--hicache-storage-backend mooncake` to standard HiCache failed during initialization with `NotImplementedError: --hicache-storage-backend (L3) with --dcp-size > 1 is not supported yet`, because Mooncake still used the ordinary-TP rank-0-only replicated MLA layout, non-DCP-aware keys, and physical-page semantics.

Besides, the target deployment encountered one or more of the following failures:

1. PD Decode uses ChunkCache by default, while `--enable-hierarchical-cache` was interpreted as Radix HiCache. The two cache policies conflicted during argument validation: `ValueError: PD decode DCP currently requires chunk cache; --enable-hierarchical-cache is not supported.`
2. The dedicated Decode offload manager did not understand Kimi's `HybridLinearKVPool`, so it could not manage MLA KV and Mamba/KDA state together: `ValueError: Unsupported KV cache type for decode offload`.
3. Mooncake still used ordinary TP keys, rank-0-only writes, and physical-page semantics for DCP MLA, so it could not preserve the distinct token shard owned by every DCP rank.
4. DCP1 and DCP8 generated different L3 object layouts. A heterogeneous P/D deployment could only miss L3 and fall back to recomputation.
5. KDA produces an intermediate state every 64 tokens, while canonical DCP8 L3 can publish a checkpoint only at a complete 512-token boundary. The previous logic could associate the final forward state with an earlier L3 key.
6. DSPARK Decode registers target+draft KV, while Prefill provides target-layer metadata only. The first real P→D request failed with `RuntimeError: Layer metadata must be provided by both PD peers or neither`.

After the fix, PD Decode continues to use ChunkCache; Complete cache pages produced by Decode are written to Mooncake using a canonical DCP layout. On a later request, Prefill performs prefix matching and L3 restoration through Radix/HiCache. DCP1 and DCP8 can share the same L3 objects, and the path is compatible with DSPARK Decode.

This PR contains four groups of fixes:

1. **DCP8↔DCP8 Decode Mooncake L3 support.** Normalize Decode's `--enable-hierarchical-cache` configuration into ChunkCache dedicated offload, manage MLA KV and Mamba/KDA state together for `HybridLinearKVPool`, let every DCP rank write its own token shard, and complete the Host-slot, storage-ACK, and Mamba-state lifecycles.
2. **DCP1↔DCP8 heterogeneous L3 layout conversion.** Introduce a canonical object layout, key namespace, and logical-to-physical page mapping that are independent of the local DCP layout. DCP1 and DCP8 readers/writers can access the same MLA KV and Mamba/KDA L3 objects instead of missing because their local layouts differ.
3. **KDA checkpoint-boundary correctness.** Separate the 64-token kernel state stride from the 512-token canonical DCP8 checkpoint interval. Publish checkpoints only when all shards form a complete page, and select the corresponding intermediate recurrent state instead of associating the final forward state with an earlier L3 key.
4. **DSPARK compatibility with DCP PD transfer.** Preserve Decode target-layer metadata and describe target KV and draft KV separately, allowing Prefill to provide target-only metadata while Decode completes the first and subsequent real P→D requests correctly.

Corresponding commits:

- `1503dcddc fix(kimi-k3): support DCP decode L3 offload`: adapts Decode ChunkCache to the HiCache arguments, supports combined MLA KV and Mamba/KDA-state offload for `HybridLinearKVPool`, and completes the Host-cache and Mooncake-publication lifecycles for DCP Decode.
- `1878c611e fix(hicache): canonicalize Mooncake DCP layouts`: introduces canonical DCP keys and object layouts, implements DCP8↔DCP8 and DCP1↔DCP8 Mooncake L3 conversion, and fixes the KDA checkpoint boundary and P→D checkpoint metadata.
- `0af3efcc0 fix(disagg): preserve layer metadata with draft KV`: fixes the mismatch between DSPARK target/draft KV metadata and Prefill target-only metadata that caused the first P→D request to fail.

## Motivation

The existing Mooncake L3 implementation assumes an ordinary TP/replicated MLA layout. It does not provide the all-rank shard writes, rank-aware object keys, logical-to-physical page mapping, or Mamba/KDA checkpoint lifecycle required by DCP Decode. Consequently, even if DCP Decode can finish the current request, it cannot safely publish the resulting hybrid cache to shared L3.

Kimi-K3 Decode uses both MLA KV and Mamba/KDA recurrent state. With DCP enabled, one logical context is sharded across ranks along the token dimension, increasing KV capacity for long-context and high-concurrency workloads. DSPARK also adds draft KV buffers on Decode. DCP and DSPARK therefore need compatibility beyond the compute kernels: PD transfer metadata, the Decode offload lifecycle, and the Mooncake storage layout must all agree.

In a multi-turn conversation, the previous assistant output is generated by Decode and becomes part of the prompt history in the next request. If Decode cannot write that cache to shared L3, Prefill must recompute the entire assistant history. The primary purpose of Decode L3 is therefore not to let Decode match its own prefixes, but to let a later Prefill request reuse the history generated by Decode.

Deployments may also use heterogeneous layouts, for example DCP1 on Prefill and DCP8 on Decode. The real-time P→D path can relayout data for the current request, but cross-request L3 storage needs a canonical format independent of the local DCP layout. Otherwise, DCP1 and DCP8 use different keys and object layouts and cannot read each other's cache.

## Implementation

### 1. Connect Decode ChunkCache to Mooncake L3 offload

- `arg_groups/pd_disaggregation_hook.py` now recognizes the combination of PD Decode, ChunkCache, and Mooncake HiCache. It disables Decode Radix HiCache and enables request-lifecycle dedicated KV offload instead. The documented launch arguments no longer trigger a cache-policy conflict, while Decode continues to use ChunkCache.
- `server_args.py` adds capability checks and argument validation for the Kimi hybrid cache. Only models backed by a supported `HybridLinearKVPool` may enter this path; unsupported backend, layout, and DCP combinations fail during initialization.
- `disaggregation/decode_kvcache_offload_manager.py` assembles both an MLA Host pool and a Mamba/KDA Host pool for `HybridLinearKVPool`. Every publication includes an MLA KV transfer and a recurrent-state transfer, avoiding attention-only cache entries that cannot restore the model state.
- Decode performs incremental D2H only for newly generated tokens that form complete logical pages. Host slots remain owned until the Mooncake storage ACK arrives; failure paths release allocated Host slots, and the corresponding Mamba device slot is released when the request finishes.
- `managers/cache_controller.py`, `mem_cache/memory_pool_host.py`, and `mem_cache/pool_host/mla.py` distinguish logical pages from the physical pages held by each DCP rank. The Decode offload manager, Host pool, and storage backend therefore use consistent index units for the same token range.

### 2. Add a canonical DCP object layout to Mooncake

`server_args.py`, `cache_controller.py`, and `mooncake_store.py` add the following storage configuration:

```json
{
  "canonical_dcp_size": 8,
  "canonical_page_size": 64
}
```

Each 64-token canonical page is divided into eight token shards, with eight tokens per shard:

```text
64-token canonical page
├── shard 0: token 0, 8, ..., 56
├── shard 1: token 1, 9, ..., 57
├── ...
└── shard 7: token 7, 15, ..., 63
```

- `cache_controller.py` derives canonical page hashes from the logical token hash and passes the same hashes to MLA KV and hybrid-sidecar storage operations. L3 object counts are no longer inferred from the number of local physical pages.
- `mooncake_store.py` generates stable object keys from the canonical geometry. DCP1 and DCP8 produce the same namespace and hash chain for the same tokens. DCP1 scatters/gathers a contiguous local page into eight canonical shards, while each DCP8 rank reads or writes only its own shard.
- MLA KV and Mamba/KDA sidecars use a namespace that includes the canonical geometry, preventing collisions with legacy TP objects or objects using a different canonical DCP size.
- `pool_host/mla.py` maps logical indices to physical buffer addresses. Mooncake batch put/get derives pointers and sizes for every canonical shard instead of using ordinary TP's rank-0-only buffer semantics.
- Initialization validates `canonical_page_size`, `canonical_dcp_size`, local DCP size, Host-pool layout, and attention-CP configuration. Unsupported combinations fail fast instead of reading objects whose shapes match but whose semantics do not.

### 3. Correct KDA checkpoint publication and P→D transfer

- `server_args.py` separates KDA's 64-token kernel state stride from the 512-token canonical DCP8 checkpoint interval. The former indexes intermediate states; the latter determines which boundaries may be published to L3.
- The Mamba radix/hybrid cache controllers track complete checkpoint boundaries and create storage operations only for complete canonical pages. A request tail shorter than 512 tokens is not published as an incorrect checkpoint; it is recomputed after restoration.
- The Prefill scheduler retrieves the historical state for the checkpoint boundary from the ping-pong state buffer instead of associating the final active state of the complete forward pass with an earlier L3 key.
- `disaggregation/prefill.py`, `decode.py`, and the Mooncake/NIXL connections extend the state-transfer descriptor. P→D carries both the active state needed to continue the current Decode and the historical checkpoint state that may later be published to L3.
- Decode submits the received historical state and its corresponding MLA canonical page to the dedicated offload manager together, ensuring that the L3 key, MLA KV, and Mamba/KDA checkpoint refer to the same token boundary.

### 4. Fix DSPARK target/draft KV metadata

- `disaggregation/utils.py` adds shared transfer-layer-ID construction. Target KV entries retain their real model layer IDs, while draft KV entries use a separate 32-bit positional namespace, preventing ID collisions.
- Prefill and Decode use the same logic when registering Mooncake/NIXL transfer buffers and validate that the number of layer IDs matches the actual number of target+draft buffers.
- Prefill continues to send target-layer metadata when it only has target KV. Decode no longer clears target metadata when it also registers target+draft KV. Both peers can establish the P→D mapping through their common target layer IDs, while draft buffers remain local to Decode.
- Missing metadata or a mismatched buffer count now produces an explicit error instead of falling back to unsafe registration-order matching.

## Data Flow After the Fix

```mermaid
flowchart LR
    U1[Current request] --> P1[Prefill Radix/HiCache]
    P1 -->|PD transfer| D1[Decode DCP ChunkCache]
    D1 --> C1[Incremental MLA KV]
    D1 --> C2[Mamba/KDA checkpoint]
    C1 --> L3[Mooncake canonical L3]
    C2 --> L3
    U2[Next request] --> P2[Prefill prefix match]
    L3 -->|restore| P2
    P2 -->|compute unmatched suffix only| D2[Decode]
```

Decode does not need a local Radix tree. L3 objects use a token hash chain and the canonical layout; Prefill performs prefix matching on the next request.

## Reproduction Environment

Two nodes with eight GPUs each are required:

| Node | Role | Topology |
|---|---|---|
| Prefill node | Prefill, Router | TP8 / DCP1 |
| Decode node | Decode, Mooncake master | TP8 / DCP8 |

Prepare the following paths:

```text
<sglang-source>       SGLang source under test
<model-path>          Kimi-K3 model weights
<draft-model-path>    Kimi-K3 DSPARK draft weights
<prefill-mooncake>    Mooncake config on the Prefill node
<decode-mooncake>     Mooncake config on the Decode node
```

Every service must explicitly load the source under test instead of the SGLang package preinstalled in the image:

```bash
export PYTHONPATH=<sglang-source>/python
```

### 1. Start Mooncake master

Run on the Decode node:

```bash
mooncake_master \
  --port 50051 \
  --enable_http_metadata_server=true \
  --http_metadata_server_port=8080 \
  --eviction_high_watermark_ratio=0.90
```

This validation used Mooncake TCP transport to exclude differences in RDMA fabric configuration. Mooncake storage put/query/get, object keys, and canonical buffer conversion all used the real storage path.

### 2. Start Prefill

Run on the Prefill node:

```bash
export PYTHONPATH=<sglang-source>/python
export GLOO_SOCKET_IFNAME=<network-interface>
export NCCL_SOCKET_IFNAME=<network-interface>
export UCX_NET_DEVICES=<network-interface>
export SGLANG_HOST_IP=<prefill-ip>
export SGLANG_HICACHE_MOONCAKE_CONFIG_PATH=<prefill-mooncake>

python3 -m sglang.launch_server \
  --trust-remote-code \
  --model-path <model-path> \
  --served-model-name kimi-k3 \
  --tp-size 8 \
  --pp-size 1 \
  --dcp-size 1 \
  --disable-custom-all-reduce \
  --weight-loader-prefetch-checkpoints \
  --mem-fraction-static 0.90 \
  --chunked-prefill-size 16384 \
  --max-prefill-tokens 16384 \
  --disable-flashinfer-autotune \
  --reasoning-parser kimi_k3 \
  --tool-call-parser kimi_k3 \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend mooncake_tcp \
  --disaggregation-bootstrap-port 8998 \
  --mamba-full-memory-ratio 5.77 \
  --host 0.0.0.0 \
  --port 30000 \
  --enable-hierarchical-cache \
  --hicache-storage-backend mooncake \
  --hicache-write-policy write_through_selective \
  --hicache-mem-layout page_first \
  --hicache-storage-backend-extra-config \
    '{"canonical_dcp_size":8,"canonical_page_size":64}' \
  --skip-server-warmup
```

### 3. Start Decode

Run on the Decode node:

```bash
export PYTHONPATH=<sglang-source>/python
export GLOO_SOCKET_IFNAME=<network-interface>
export NCCL_SOCKET_IFNAME=<network-interface>
export UCX_NET_DEVICES=<network-interface>
export SGLANG_HOST_IP=<decode-ip>
export SGLANG_RAGGED_VERIFY_MODE=static
export SGLANG_HICACHE_MOONCAKE_CONFIG_PATH=<decode-mooncake>

python3 -m sglang.launch_server \
  --trust-remote-code \
  --model-path <model-path> \
  --served-model-name kimi-k3 \
  --tp-size 8 \
  --dcp-size 8 \
  --disable-custom-all-reduce \
  --weight-loader-prefetch-checkpoints \
  --mem-fraction-static 0.85 \
  --disaggregation-decode-extra-slots 16 \
  --reasoning-parser kimi_k3 \
  --tool-call-parser kimi_k3 \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake_tcp \
  --mamba-full-memory-ratio 0.18 \
  --host 0.0.0.0 \
  --port 30100 \
  --enable-hierarchical-cache \
  --hicache-storage-backend mooncake \
  --hicache-mem-layout page_first \
  --hicache-storage-backend-extra-config \
    '{"canonical_dcp_size":8,"canonical_page_size":64}' \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path <draft-model-path> \
  --speculative-dspark-block-size 7 \
  --enable-linear-replayssm-spec
```

### 4. Start Router

Run on the Router node:

```bash
python3 -m sglang_router.launch_router \
  --pd-disaggregation \
  --prefill http://<prefill-ip>:30000 8998 \
  --decode http://<decode-ip>:30100 \
  --host 0.0.0.0 \
  --port 8000 \
  --prometheus-port 29037 \
  --policy round_robin \
  --disable-circuit-breaker \
  --worker-startup-timeout-secs 1800 \
  --worker-startup-check-interval 5 \
  --request-timeout-secs 1800 \
  --model-path kimi-k3 \
  --tokenizer-path <model-path>
```

## Validation Method

Each input length was tested through three isolated paths:

1. Flush the Prefill cache, send a request, and record the cold cached-token count.
2. Send the identical request again without flushing Prefill to verify an L1 hit.
3. Wait for Decode to finish Mooncake publication, flush Prefill L1/L2, and send the identical request again to verify a Decode-origin L3 hit.

Pseudocode:

```python
flush_prefill_cache()
cold = completion(prompt)

l1_hit = completion(prompt)

wait_for_decode_publication()
flush_prefill_cache()
l3_hit = completion(prompt)
```

In addition to cached-token geometry, the validation checks:

- Whether Decode actually enters a DSPARK batch.
- Whether Mooncake L3 objects remain restorable after the Prefill flush.
- Whether P/D transfer workers remain alive.
- Whether metadata, checkpoint, sidecar, or publication errors occur.

## Results

### Canonical L1/L3 Hits

| Input tokens | Cold cached | L1 cached | L3 cached after Prefill flush | Canonical boundary |
|---:|---:|---:|---:|---:|
| 520 | 0 | 512 | 512 | 512 |
| 1030 | 0 | 1024 | 1024 | 1024 |
| 1671 | 0 | 1536 | 1536 | 1536 |

These results show that canonical objects written by DCP8 Decode can be restored by DCP1 Prefill on the next request. A tail shorter than the 512-token checkpoint interval is recomputed and is not incorrectly counted as a cache hit.

### DSPARK Runtime Results

| Check | Result |
|---|---|
| DSPARK Decode batch | Pass |
| CUDA Graph Decode | Pass |
| Target/draft metadata transfer | Pass |
| P/D transfer workers remain alive | Pass |
| Layer metadata errors | 0 |
| Checkpoint/sidecar errors | 0 |
| L3 publication errors | 0 |

Observed DSPARK acceptance:

| Sample | Accept length | Accept rate |
|---:|---:|---:|
| 1 | 2.27 | 0.18 |
| 2 | 2.48 | 0.21 |
| 3 | 3.02 | 0.29 |

These values only confirm that the DSPARK path executed; they are not presented as performance conclusions for this PR.

### KDA Checkpoint Correctness

| Validation | Result |
|---|---|
| 520-token full tail vs. tail restored from `h[8]` / token 512 | Exact |
| Maximum absolute error | 0 |
| Full convolution tail vs. tail restored from raw-input window 509..511 | Exact |
| Maximum absolute error | 0 |

## Compatibility and Limitations

| Combination | Status |
|---|---|
| DCP1 local layout + canonical DCP8 L3 | Supported |
| DCP8 local layout + canonical DCP8 L3 | Supported |
| DCP8 Decode + DSPARK + Mooncake L3 | Supported |
| DCP9 local layout + canonical DCP8 L3 | Fail-fast |
| Decode RadixCache + DCP | Unsupported, non-goal |
| Decode RadixCache + DSPARK | Unsupported, non-goal |

Known limitations:

- DCP8 creates eight canonical MLA shard objects, increasing the total object count.
- Decode write-back adds D2H, Host staging, and Mooncake put overhead.
- Mamba/KDA state is reusable only at complete 512-token boundaries.
- A tail shorter than one checkpoint interval must be recomputed.
- The current converter supports DCP1 and the canonical DCP size, not arbitrary DCP-N layouts.
- This validation used Mooncake TCP; RDMA performance requires separate evaluation.

Unsupported layouts fail during initialization instead of risking silent corruption.

## Checklist

- [x] Preserve PD Decode ChunkCache semantics.
- [x] Support Kimi hybrid MLA+Mamba/KDA offload.
- [x] Support DCP-aware Mooncake storage.
- [x] Support canonical DCP1/DCP8 L3 objects.
- [x] Fix KDA interior checkpoints.
- [x] Validate DCP1 Prefill → DCP8 Decode PD relayout.
- [x] Validate DCP8 Decode → Mooncake → DCP1 Prefill cross-request restoration.
- [x] Fix DSPARK target/draft metadata mapping.
- [x] Complete cold/L1/L3 validation at 520, 1030, and 1671 tokens.
- [x] Fail fast on unsupported DCP layouts.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30614431080](https://github.com/sgl-project/sglang/actions/runs/30614431080)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30614430844](https://github.com/sgl-project/sglang/actions/runs/30614430844)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->