### PR TITLE
[Fix] Streaming logprobs: do not 500 on chunks without logprob fields

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1265,9 +1265,13 @@ class OpenAIServingChat(OpenAIServingBase):
                 choice_logprobs = None
                 if request.logprobs:
                     n_prev_token = n_prev_tokens.get(index, 0)
-                    total_output_logprobs = content["meta_info"][
-                        "output_token_logprobs_length"
-                    ]
+                    # An abort/finish chunk may carry no logprob fields (the
+                    # logprob accounting for this rid never started); default to
+                    # n_prev_token so the chunk skips logprob emission and still
+                    # reaches the finish/abort handling below instead of 500ing.
+                    total_output_logprobs = content["meta_info"].get(
+                        "output_token_logprobs_length", n_prev_token
+                    )
                     if n_prev_token < total_output_logprobs:
                         choice_logprobs = self._process_streaming_logprobs(
                             content, n_prev_token, total_output_logprobs

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -285,9 +285,13 @@ class OpenAIServingCompletion(OpenAIServingBase):
                         input_top_logprobs = None
 
                     n_prev_token = n_prev_tokens.get(index, 0)
-                    total_output_logprobs = content["meta_info"][
-                        "output_token_logprobs_length"
-                    ]
+                    # An abort/finish chunk may carry no logprob fields (the
+                    # logprob accounting for this rid never started); default to
+                    # n_prev_token so the chunk skips logprob emission and still
+                    # reaches the finish/abort handling below instead of 500ing.
+                    total_output_logprobs = content["meta_info"].get(
+                        "output_token_logprobs_length", n_prev_token
+                    )
                     if (
                         n_prev_token < total_output_logprobs
                         or input_token_logprobs is not None


### PR DESCRIPTION
## Motivation

When a streaming request sets `logprobs`, both `serving_chat.py` and `serving_completions.py` hard-read `content["meta_info"]["output_token_logprobs_length"]` on every chunk. An abort/finish chunk whose logprob accounting never started carries no logprob fields, so the read raises `KeyError` -> `Internal server error: 'output_token_logprobs_length'` (HTTP 500) **before** the abort-handling branch a few lines below can run.

Hit in production: replaying 24h of captured real traffic surfaced a `logprobs=true, top_logprobs=5` streaming request that 500'd this way on v0.5.13.post1; the identical unguarded read is present on current main in both files.

## Modification

Default the length read to `n_prev_token`: chunks without logprob fields skip logprob emission (`n_prev_token < total` is false, `n_prev_tokens` stays unchanged) and flow on to the finish/abort handling they were crashing in front of. Chunks that do carry logprobs are unaffected.

Two-line-per-file change, no behavior change for well-formed logprob chunks.

## Checklist

- [x] Format your code with pre-commit hooks (black clean on both files)
- [ ] Add unit tests (happy to add one if maintainers can point at the preferred harness for streaming abort chunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30615416980](https://github.com/sgl-project/sglang/actions/runs/30615416980)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30615416796](https://github.com/sgl-project/sglang/actions/runs/30615416796)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->