### PR TITLE
Support PD disaggregation with DCP + DSPARK

### DIFF
--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -33,6 +33,23 @@ def handle_pd_disaggregation(server_args: ServerArgs) -> None:
             "overhead without improving prefill performance."
         )
 
+    if (
+        server_args.disaggregation_mode == "prefill"
+        and server_args.speculative_algorithm == "DSPARK"
+    ):
+        if server_args.enable_hierarchical_cache:
+            raise ValueError(
+                "PD prefill with DSPARK is incompatible with "
+                "--enable-hierarchical-cache: host-to-device prefix load-back "
+                "restores target KV only, leaving draft KV rows uninitialized."
+            )
+        if server_args.enable_prefill_context_parallel:
+            raise ValueError(
+                "PD prefill with DSPARK is incompatible with "
+                "--enable-prefill-context-parallel: each CP rank only writes "
+                "draft KV for its own token shard."
+            )
+
     if server_args.disaggregation_mode == "decode" and server_args.dcp_size > 1:
         if server_args.disaggregation_transfer_backend not in ("mooncake", "nixl"):
             raise ValueError(

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -24,6 +24,7 @@ class StateType(str, enum.Enum):
     SWA_RING = "swa_ring"
     # DeepSeek-V4 online C128 request-scoped state.
     C128_STATE = "c128_state"
+    DSPARK_DRAFT_KV = "dspark_draft_kv"
 
 
 @dataclasses.dataclass

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -447,7 +447,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_data_lens += device_kv_data_lens[c4_layer_num:]
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
             kv_data_mem_kinds += ["VRAM"] * len(device_kv_data_ptrs[c4_layer_num:])
-        if self.draft_token_to_kv_pool is not None:
+        dspark_draft_kv = self.scheduler.spec_algorithm.is_dspark()
+
+        if self.draft_token_to_kv_pool is not None and not dspark_draft_kv:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
@@ -463,7 +465,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args.kv_item_lens = kv_item_lens
         kv_args.kv_layer_ids = (
             self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
+            if (self.draft_token_to_kv_pool is None or dspark_draft_kv)
             and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
             else []
         )
@@ -481,6 +483,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             self.draft_token_to_kv_pool,
             total_kv_layers=self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=getattr(self, "req_to_token_pool", None),
+            dspark_draft_kv=dspark_draft_kv,
         )
 
         kv_args.ib_device = self.scheduler.server_args.disaggregation_ib_device
@@ -1200,9 +1203,21 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 )
                 if clear_c128_state is not None:
                     clear_c128_state(int(decode_req.req.req_pool_idx))
+
             # MINIMAX_INDEX_K reuses _dsa_payload: index rows live at the same loc
             # as main KV on the same page_size.
+            def _dspark_draft_kv_payload():
+                return (
+                    self.req_to_token_pool.req_to_token[
+                        decode_req.req.req_pool_idx, :seq_len
+                    ]
+                    .cpu()
+                    .numpy()
+                    .astype(np.int32)
+                )
+
             payloads = {
+                StateType.DSPARK_DRAFT_KV: _dspark_draft_kv_payload,
                 StateType.MAMBA: _mamba_payload,
                 StateType.SWA: _swa_payload,
                 StateType.DSA: _dsa_payload,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1233,6 +1233,36 @@ class MooncakeKVManager(CommonKVManager):
                         )
                         or rc
                     )
+            elif st == StateType.DSPARK_DRAFT_KV:
+                if (
+                    dst_item_lens and list(src_item_lens) != list(dst_item_lens)
+                ) or len(indices) != len(dst_indices):
+                    logger.error(
+                        "DSPARK draft KV mismatch for room %s: item_lens %s vs %s, "
+                        "indices %d vs %d",
+                        req.room,
+                        list(src_item_lens),
+                        list(dst_item_lens),
+                        len(indices),
+                        len(dst_indices),
+                    )
+                    rc = -1
+                else:
+                    rc = (
+                        self._send_kvcache_generic(
+                            mooncake_session_id=req.mooncake_session_id,
+                            src_data_ptrs=src_data_ptrs,
+                            dst_data_ptrs=dst_data_ptrs,
+                            item_lens=src_item_lens,
+                            prefill_data_indices=np.asarray(indices, dtype=np.int32),
+                            dst_data_indices=np.asarray(dst_indices, dtype=np.int32),
+                            executor=executor,
+                            state_type=st,
+                            src_layer_ids=src_state_layer_ids,
+                            dst_layer_ids=dst_state_layer_ids,
+                        )
+                        or rc
+                    )
             elif self._is_generic_kvcache_state_type(st):
                 if (
                     target_rank_registration_info is not None
@@ -1551,6 +1581,22 @@ class MooncakeKVManager(CommonKVManager):
                                 )
                                 break
 
+                        if req.mooncake_session_id not in self.decode_kv_args_table:
+                            self.record_failure(
+                                kv_chunk.room,
+                                f"KV args of remote mooncake session {req.mooncake_session_id} "
+                                f"are not registered",
+                            )
+                            self.update_status(kv_chunk.room, KVPoll.Failed)
+                            self.sync_status_to_decode_endpoint(
+                                req.endpoint,
+                                req.dst_port,
+                                req.room,
+                                KVPoll.Failed,
+                                prefill_unique_rank,
+                            )
+                            break
+
                         target_rank_registration_info: KVArgsRegisterInfo = (
                             self.decode_kv_args_table[req.mooncake_session_id]
                         )
@@ -1774,114 +1820,131 @@ class MooncakeKVManager(CommonKVManager):
                     f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
                 )
 
+    def _handle_bootstrap_message(self, waiting_req_bytes: List[bytes]):
+        room = waiting_req_bytes[0].decode("ascii")
+        # Staging: decode reports consumption watermark back to prefill
+        if room == "WATERMARK":
+            from sglang.srt.disaggregation.common.staging_handler import (
+                handle_watermark_msg,
+            )
+
+            handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
+            return
+        # Staging: decode replies with allocated staging offset
+        if room == "STAGING_RSP":
+            from sglang.srt.disaggregation.common.staging_handler import (
+                handle_staging_rsp,
+            )
+
+            handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
+            return
+        # Decode-side abort notification: mark room as failed and ACK
+        if room == "ABORT":
+            room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
+            decode_ip = waiting_req_bytes[2].decode("ascii")
+            decode_port = int(waiting_req_bytes[3].decode("ascii"))
+            # No need to abort the room if it has already succeeded
+            if (
+                room_to_be_aborted in self.request_status
+                and self.check_status(room_to_be_aborted) != KVPoll.Success
+            ):
+                self.update_status(room_to_be_aborted, KVPoll.Failed)
+                logger.debug(
+                    f"Received abort notification for room {room_to_be_aborted}, "
+                    f"marked as Failed"
+                )
+            else:
+                logger.debug(
+                    f"Received abort notification for room {room_to_be_aborted}, "
+                    f"ignoring (already completed or unknown)"
+                )
+            # Send ACK back to decode endpoint
+            try:
+                na = NetworkAddress(decode_ip, decode_port)
+                self._send_multipart_locked(
+                    na.to_tcp(),
+                    [
+                        b"ABORT_ACK",
+                        str(room_to_be_aborted).encode("ascii"),
+                    ],
+                    is_ipv6=na.is_ipv6,
+                )
+                logger.debug(
+                    f"Sent ABORT_ACK for room {room_to_be_aborted} to "
+                    f"{decode_ip}:{decode_port}"
+                )
+            except Exception as e:
+                logger.debug(
+                    f"Failed to send ABORT_ACK for room {room_to_be_aborted}: {e}"
+                )
+            return
+        mooncake_session_id = waiting_req_bytes[3].decode("ascii")
+        if room == "None":
+            decode_kv_args = KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
+            decode_kv_args.requires_dcp_relayout = self.requires_dcp_relayout(
+                decode_kv_args.dst_dcp_size,
+                decode_kv_args.dst_dcp_rank,
+            )
+            if decode_kv_args.requires_dcp_relayout:
+                decode_kv_args.dcp_token_item_lens = self.prepare_dcp_token_item_lens(
+                    [decode_kv_args.dst_kv_item_len] * len(self.kv_args.kv_item_lens)
+                )
+            self.decode_kv_args_table[mooncake_session_id] = decode_kv_args
+            with self.session_lock:
+                if mooncake_session_id in self.failed_sessions:
+                    self.failed_sessions.remove(mooncake_session_id)
+                if mooncake_session_id in self.session_failures:
+                    del self.session_failures[mooncake_session_id]
+            logger.debug(f"Register KVArgs from {mooncake_session_id} successfully")
+            return
+        else:
+            required_dst_info_num = int(waiting_req_bytes[7].decode("ascii"))
+            room = int(room)
+            if room not in self.transfer_infos:
+                self.transfer_infos[room] = {}
+
+            self.transfer_infos[room][mooncake_session_id] = TransferInfo.from_zmq(
+                waiting_req_bytes
+            )
+            # NOTE: after bootstrapping we can mark the req as waiting for input
+            if len(self.transfer_infos[room]) == required_dst_info_num:
+                self.resolve_kv_replica_factor(self.transfer_infos[room])
+                self.req_to_decode_prefix_len[room] = next(
+                    (
+                        info.decode_prefix_len
+                        for info in self.transfer_infos[room].values()
+                        if info.decode_prefix_len is not None
+                    ),
+                    0,
+                )
+                self.update_status(room, KVPoll.WaitingForInput)
+
+    def _fail_bootstrap_message(self, waiting_req_bytes: List[bytes]):
+        session_id = (
+            waiting_req_bytes[3].decode("ascii", errors="replace")
+            if len(waiting_req_bytes) > 3
+            else None
+        )
+        logger.exception(
+            f"Failed to handle bootstrap message (session={session_id}). "
+            f"Marking the session failed so pending rooms abort instead of hanging."
+        )
+        if session_id is None:
+            return
+        with self.session_lock:
+            self.session_failures[session_id] += 1
+            self.failed_sessions.add(session_id)
+
     def start_prefill_thread(self):
         def bootstrap_thread():
             """This thread recvs pre-alloc notification from the decode engine"""
             # KVPoll.Bootstrapping -> KVPoll.WaitingForInput
             while True:
                 waiting_req_bytes = self.server_socket.recv_multipart()
-                room = waiting_req_bytes[0].decode("ascii")
-                # Staging: decode reports consumption watermark back to prefill
-                if room == "WATERMARK":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_watermark_msg,
-                    )
-
-                    handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
-                    continue
-                # Staging: decode replies with allocated staging offset
-                if room == "STAGING_RSP":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_staging_rsp,
-                    )
-
-                    handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
-                    continue
-                # Decode-side abort notification: mark room as failed and ACK
-                if room == "ABORT":
-                    room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
-                    decode_ip = waiting_req_bytes[2].decode("ascii")
-                    decode_port = int(waiting_req_bytes[3].decode("ascii"))
-                    # No need to abort the room if it has already succeeded
-                    if (
-                        room_to_be_aborted in self.request_status
-                        and self.check_status(room_to_be_aborted) != KVPoll.Success
-                    ):
-                        self.update_status(room_to_be_aborted, KVPoll.Failed)
-                        logger.debug(
-                            f"Received abort notification for room {room_to_be_aborted}, "
-                            f"marked as Failed"
-                        )
-                    else:
-                        logger.debug(
-                            f"Received abort notification for room {room_to_be_aborted}, "
-                            f"ignoring (already completed or unknown)"
-                        )
-                    # Send ACK back to decode endpoint
-                    try:
-                        na = NetworkAddress(decode_ip, decode_port)
-                        self._send_multipart_locked(
-                            na.to_tcp(),
-                            [
-                                b"ABORT_ACK",
-                                str(room_to_be_aborted).encode("ascii"),
-                            ],
-                            is_ipv6=na.is_ipv6,
-                        )
-                        logger.debug(
-                            f"Sent ABORT_ACK for room {room_to_be_aborted} to "
-                            f"{decode_ip}:{decode_port}"
-                        )
-                    except Exception as e:
-                        logger.debug(
-                            f"Failed to send ABORT_ACK for room {room_to_be_aborted}: {e}"
-                        )
-                    continue
-                mooncake_session_id = waiting_req_bytes[3].decode("ascii")
-                if room == "None":
-                    decode_kv_args = KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
-                    decode_kv_args.requires_dcp_relayout = self.requires_dcp_relayout(
-                        decode_kv_args.dst_dcp_size,
-                        decode_kv_args.dst_dcp_rank,
-                    )
-                    if decode_kv_args.requires_dcp_relayout:
-                        decode_kv_args.dcp_token_item_lens = (
-                            self.prepare_dcp_token_item_lens(
-                                [decode_kv_args.dst_kv_item_len]
-                                * len(self.kv_args.kv_item_lens)
-                            )
-                        )
-                    self.decode_kv_args_table[mooncake_session_id] = decode_kv_args
-                    with self.session_lock:
-                        if mooncake_session_id in self.failed_sessions:
-                            self.failed_sessions.remove(mooncake_session_id)
-                        if mooncake_session_id in self.session_failures:
-                            del self.session_failures[mooncake_session_id]
-                    logger.debug(
-                        f"Register KVArgs from {mooncake_session_id} successfully"
-                    )
-                    continue
-                else:
-                    required_dst_info_num = int(waiting_req_bytes[7].decode("ascii"))
-                    room = int(room)
-                    if room not in self.transfer_infos:
-                        self.transfer_infos[room] = {}
-
-                    self.transfer_infos[room][mooncake_session_id] = (
-                        TransferInfo.from_zmq(waiting_req_bytes)
-                    )
-                    # NOTE: after bootstrapping we can mark the req as waiting for input
-                    if len(self.transfer_infos[room]) == required_dst_info_num:
-                        self.resolve_kv_replica_factor(self.transfer_infos[room])
-                        self.req_to_decode_prefix_len[room] = next(
-                            (
-                                info.decode_prefix_len
-                                for info in self.transfer_infos[room].values()
-                                if info.decode_prefix_len is not None
-                            ),
-                            0,
-                        )
-                        self.update_status(room, KVPoll.WaitingForInput)
+                try:
+                    self._handle_bootstrap_message(waiting_req_bytes)
+                except Exception:
+                    self._fail_bootstrap_message(waiting_req_bytes)
 
         threading.Thread(target=bootstrap_thread).start()
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -210,7 +210,15 @@ class PrefillBootstrapQueue:
             else getattr(self.token_to_kv_pool, "end_layer", None)
         )
 
-        if self.draft_token_to_kv_pool is not None and transfer_draft_cache:
+        dspark_draft_kv = (
+            self.scheduler.spec_algorithm.is_dspark() and transfer_draft_cache
+        )
+
+        if (
+            self.draft_token_to_kv_pool is not None
+            and transfer_draft_cache
+            and not dspark_draft_kv
+        ):
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
@@ -225,7 +233,7 @@ class PrefillBootstrapQueue:
         kv_args.kv_item_lens = kv_item_lens
         kv_args.kv_layer_ids = (
             self.token_to_kv_pool.get_kv_layer_ids()
-            if self.draft_token_to_kv_pool is None
+            if (self.draft_token_to_kv_pool is None or dspark_draft_kv)
             and hasattr(self.token_to_kv_pool, "get_kv_layer_ids")
             else []
         )
@@ -249,6 +257,7 @@ class PrefillBootstrapQueue:
             self.draft_token_to_kv_pool if transfer_draft_cache else None,
             self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=req_to_token_pool,
+            dspark_draft_kv=dspark_draft_kv,
         )
 
         if isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
@@ -1202,9 +1211,21 @@ class SchedulerDisaggregationPrefillMixin:
             state_types = (
                 self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
             )
+
             # MINIMAX_INDEX_K reuses _dsa_payload: index rows live at the same loc
             # as main KV on the same page_size.
+            def _dspark_draft_kv_payload():
+                return (
+                    self.req_to_token_pool.req_to_token[
+                        req.req_pool_idx, :transfer_input_len
+                    ]
+                    .cpu()
+                    .numpy()
+                    .astype(np.int32)
+                )
+
             payloads = {
+                StateType.DSPARK_DRAFT_KV: _dspark_draft_kv_payload,
                 StateType.MAMBA: _mamba_payload,
                 StateType.SWA: _swa_payload,
                 StateType.DSA: _dsa_payload,

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -988,6 +988,7 @@ def setup_state_kv_args(
     draft_token_to_kv_pool=None,
     total_kv_layers: int = None,
     req_to_token_pool=None,
+    dspark_draft_kv: bool = False,
 ) -> None:
     """Populate ``kv_args`` state-buffer fields from the given pool.
     Shared by prefill and decode bootstrap paths so the state_type dispatch
@@ -1000,6 +1001,7 @@ def setup_state_kv_args(
     from sglang.srt.mem_cache.memory_pool import (
         DSATokenToKVPool,
         HybridLinearKVPool,
+        MHATokenToKVPool,
         MiniMaxSparseKVPool,
     )
 
@@ -1231,6 +1233,32 @@ def setup_state_kv_args(
                 dim,
                 conv_shard_groups,
                 slice_outer_counts,
+            )
+
+    if dspark_draft_kv and draft_token_to_kv_pool is not None:
+        if not isinstance(draft_token_to_kv_pool, MHATokenToKVPool):
+            raise NotImplementedError(
+                "PD DSPARK draft KV transfer only supports MHATokenToKVPool drafts; "
+                f"got {type(draft_token_to_kv_pool).__name__}"
+            )
+        draft_ptrs, draft_lens, draft_page_item_lens = (
+            draft_token_to_kv_pool.get_contiguous_buf_infos()
+        )
+        if draft_ptrs:
+            draft_page_size = draft_token_to_kv_pool.page_size
+            if any(item_len % draft_page_size for item_len in draft_page_item_lens):
+                raise RuntimeError(
+                    "DSPARK draft KV page item length must be divisible by the "
+                    f"draft page size: item_lens={draft_page_item_lens}, "
+                    f"page_size={draft_page_size}"
+                )
+            append_state_component(
+                kv_args,
+                StateType.DSPARK_DRAFT_KV,
+                draft_ptrs,
+                draft_lens,
+                [item_len // draft_page_size for item_len in draft_page_item_lens],
+                layer_ids=list(range(len(draft_ptrs))),
             )
 
 


### PR DESCRIPTION
# **This PR needs to be reimplemented on main after Kimi K3 is merged into main.**

> **Merge note**: this targets `kimi-k3`. Once `kimi-k3` lands on `main`, this change must be rebased onto `main` and re-validated before it can be merged there — the disaggregation transfer paths it touches differ between the two branches.

PD disaggregation currently hangs when the decode side runs DCP and both sides run DSPARK. Each of the three works on its own; only the combination fails.

## Root cause

DSPARK appends the draft KV buffers to `kv_args.kv_item_lens`, so the draft shares `kv_indices` with the target. Under DCP the target indices are virtualized and `send_kvcache_dcp` relayouts them per token owner (`pos % dcp_size`, compacted to `pos // dcp_size`), but the draft pool is replicated and consumes those locs untranslated.

`prepare_dcp_token_item_lens` therefore fails its per-entry geometry check:

```
RuntimeError: PD DCP source/destination KV geometry differs:
  src=[1152 x24, 256, 256, ...]
```

(24 MLA target layers at 1152 B/page, followed by the draft entries.)

That raise happens inside `bootstrap_thread`, which had no exception handling, so the thread died and every later bootstrap/room/abort message went unprocessed. Requests hung silently until the client timed out.

## Change

Move the draft KV to its own `StateType.DSPARK_DRAFT_KV` state component, following the existing DSV4 NextN precedent. The state channel copies rows verbatim with per-token item lengths, so prefill (physical locs) and decode (virtual locs) stay aligned by position with no relayout, and the target KV channel goes back to being homogeneous.

Side effects:

- `kv_layer_ids` is restored for the speculative path. The draft entries used to force it empty, which silently disabled the PP x DCP layer-id pairing.
- Draft pools that are not `MHATokenToKVPool` (the DSV4 self-draft path, whose buffers and loc space differ) now fail at startup instead of transferring garbage.

Two robustness fixes are included because the combination is undiagnosable without them:

- `bootstrap_thread` no longer dies on a message-handling error; the mooncake session is marked failed so pending rooms abort through the existing path instead of hanging.
- The transfer worker skips rooms whose session never registered, instead of raising `KeyError` and killing the worker thread.

Prefill-side guards added for `--enable-hierarchical-cache` (load-back restores target KV only, leaving draft rows uninitialized) and `--enable-prefill-context-parallel` (each CP rank only writes its own token shard).

## Verification

2 nodes x 8 B300, Kimi-K3, prefill TP8/DCP1 + decode TP8/DCP8 (`a2a`, `--dcp-replicate-q-proj`), DSPARK block size 7, mooncake over RoCE.

| | result |
|---|---|
| GSM8K, 200 questions, parallel 64 | 0.995 |
| AIME26, 30 x 4 repeats, parallel 64, 867k completion tokens | 0.95 |
| KV transfer failures / CUDA asserts / dead threads | 0 |
| accept length | 8.00 on GSM8K, ~2.7 on AIME26 |

The accept-length split is the load-bearing signal: misplaced or truncated draft KV collapses it to ~1 in both cases.

## Not covered

- Decode-side radix cache stays disabled for this combination (`pd_disaggregation_hook.py`). Enabling it needs the draft payload to switch to `decode_prefix_len`-relative ranges, and depends on a separate unresolved decode-side radix corruption report. Tracked separately.
- nixl backend: `maybe_send_extra` has no branch for the new state type, so it fails at transfer time rather than at startup.
- Long-prompt TTFT: the state channel sends on the last chunk only.
