### PR TITLE
Fix stop-condition priority at the max token boundary

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1325,18 +1325,23 @@ class Req(ReqDllmMixin):
 
         return self.surr_and_decode_ids, self.read_offset - self.surr_offset
 
-    def _stop_match_tail_len(self, new_accepted_len: int) -> int:
+    def _stop_match_tail_len(
+        self, new_accepted_len: int, output_len: Optional[int] = None
+    ) -> int:
+        if output_len is None:
+            output_len = len(self.output_ids)
+
         max_len_tail_str = max(
             self.sampling_params.stop_str_max_len + 1,
             self.sampling_params.stop_regex_max_len + 1,
         )
         # Cover all newly accepted tokens so an early stop string is not missed
         # when speculative decoding accepts multiple tokens per step.
-        return min(
-            max_len_tail_str + max(new_accepted_len - 1, 0), len(self.output_ids)
-        )
+        return min(max_len_tail_str + max(new_accepted_len - 1, 0), output_len)
 
-    def tail_str(self, new_accepted_len: int = 1) -> str:
+    def tail_str(
+        self, new_accepted_len: int = 1, output_len: Optional[int] = None
+    ) -> str:
         # Check stop strings and stop regex patterns together
         if (
             len(self.sampling_params.stop_strs) == 0
@@ -1344,8 +1349,12 @@ class Req(ReqDllmMixin):
         ):
             return ""
 
-        tail_len = self._stop_match_tail_len(new_accepted_len)
-        return self.tokenizer.decode(self.output_ids[-tail_len:])
+        if output_len is None:
+            output_len = len(self.output_ids)
+        tail_len = self._stop_match_tail_len(new_accepted_len, output_len)
+        return self.tokenizer.decode(
+            self.output_ids[output_len - tail_len : output_len]
+        )
 
     def check_match_stop_str_prefix(self) -> bool:
         """
@@ -1376,9 +1385,16 @@ class Req(ReqDllmMixin):
 
         return False
 
-    def _check_token_based_finish(self, new_accepted_tokens: List[int]) -> bool:
+    def _check_token_based_finish(
+        self,
+        new_accepted_tokens: List[int],
+        accepted_start: Optional[int] = None,
+    ) -> bool:
         if self.sampling_params.ignore_eos:
             return False
+
+        if accepted_start is None:
+            accepted_start = len(self.output_ids) - len(new_accepted_tokens)
 
         # Check stop token ids
         matched_eos = False
@@ -1394,7 +1410,7 @@ class Req(ReqDllmMixin):
                     matched_eos |= token_id in self.tokenizer.additional_stop_token_ids
             if matched_eos:
                 self.finished_reason = FINISH_MATCHED_TOKEN(matched=token_id)
-                matched_pos = len(self.output_ids) - len(new_accepted_tokens) + i
+                matched_pos = accepted_start + i
                 self.finished_len = matched_pos + 1
                 return True
 
@@ -1406,6 +1422,7 @@ class Req(ReqDllmMixin):
         *,
         stop_str: Optional[str] = None,
         stop_regex: Optional[str] = None,
+        output_len: Optional[int] = None,
     ) -> int:
         """Map a matched stop string/regex to output_ids length (stop included)."""
 
@@ -1414,9 +1431,11 @@ class Req(ReqDllmMixin):
                 return stop_str in text
             return re.search(stop_regex, text) is not None
 
-        tail_len = self._stop_match_tail_len(new_accepted_len)
-        start = len(self.output_ids) - tail_len
-        token_window = self.output_ids[start:]
+        if output_len is None:
+            output_len = len(self.output_ids)
+        tail_len = self._stop_match_tail_len(new_accepted_len, output_len)
+        start = output_len - tail_len
+        token_window = self.output_ids[start:output_len]
 
         # Old prefixes were checked in the previous step.
         for token_count in range(
@@ -1426,14 +1445,16 @@ class Req(ReqDllmMixin):
                 return start + token_count
 
         # The full tail window is already known to match by the caller.
-        return len(self.output_ids)
+        return output_len
 
-    def _check_str_based_finish(self, new_accepted_len: int = 1):
+    def _check_str_based_finish(
+        self, new_accepted_len: int = 1, output_len: Optional[int] = None
+    ):
         if (
             len(self.sampling_params.stop_strs) > 0
             or len(self.sampling_params.stop_regex_strs) > 0
         ):
-            tail_str = self.tail_str(new_accepted_len)
+            tail_str = self.tail_str(new_accepted_len, output_len)
 
             # Check stop strings
             if len(self.sampling_params.stop_strs) > 0:
@@ -1443,7 +1464,9 @@ class Req(ReqDllmMixin):
                         self.finished_reason = FINISH_MATCHED_STR(matched=stop_str)
                         if stop_str_in_tail:
                             self.finished_len = self._locate_str_stop_finished_len(
-                                new_accepted_len, stop_str=stop_str
+                                new_accepted_len,
+                                stop_str=stop_str,
+                                output_len=output_len,
                             )
                         return True
 
@@ -1455,7 +1478,9 @@ class Req(ReqDllmMixin):
                             matched=stop_regex_str
                         )
                         self.finished_len = self._locate_str_stop_finished_len(
-                            new_accepted_len, stop_regex=stop_regex_str
+                            new_accepted_len,
+                            stop_regex=stop_regex_str,
+                            output_len=output_len,
                         )
                         return True
 
@@ -1486,30 +1511,59 @@ class Req(ReqDllmMixin):
             self.to_finish = None
             return
 
-        if len(self.output_ids) >= self.sampling_params.max_new_tokens:
-            self.finished_reason = FINISH_LENGTH(
-                length=self.sampling_params.max_new_tokens
-            )
-            self.finished_len = self.sampling_params.max_new_tokens
-            return
+        output_len = len(self.output_ids)
+        max_new_tokens = self.sampling_params.max_new_tokens
+        reached_length = output_len >= max_new_tokens
 
-        new_accepted_tokens = self.output_ids[-new_accepted_len:]
+        accepted_start = max(0, output_len - new_accepted_len)
+        finish_check_end = min(output_len, max_new_tokens)
+        bounded_accepted_len = max(0, finish_check_end - accepted_start)
+        new_accepted_tokens = self.output_ids[accepted_start:finish_check_end]
+
+        # Preserve the existing length result for invalid tokens at the length
+        # boundary, and never decode an invalid in-budget token as text.
+        invalid_token_at_length = (
+            reached_length
+            and self.vocab_size is not None
+            and any(
+                token_id < 0 or token_id >= self.vocab_size
+                for token_id in new_accepted_tokens
+            )
+        )
 
         # Sanitize out-of-range / NaN token ids before any decode.
-        if self._check_vocab_boundary_finish(new_accepted_tokens):
+        if not reached_length and self._check_vocab_boundary_finish(
+            new_accepted_tokens
+        ):
             return
 
-        # Stop string beats EOS/stop-token matched in the same step (speculative
-        # decoding can accept >1 token): token-based would trim only the last
-        # token and leak the stop string.
-        if self._check_str_based_finish(new_accepted_len):
-            return
+        if bounded_accepted_len > 0 and not invalid_token_at_length:
+            # Stop string beats EOS/stop-token matched in the same step
+            # (speculative decoding can accept >1 token): token-based would trim
+            # only the last token and leak the stop string.
+            if self._check_str_based_finish(
+                bounded_accepted_len, output_len=finish_check_end
+            ):
+                return
 
-        if self._check_token_based_finish(new_accepted_tokens):
-            return
+            if self._check_token_based_finish(
+                new_accepted_tokens, accepted_start=accepted_start
+            ):
+                return
 
-        if self.grammar is not None and self.grammar.is_terminated():
-            self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
+            # Speculative grammar handling truncates the accepted run at the
+            # terminating token, so an overshoot means termination was out of budget.
+            if (
+                finish_check_end == output_len
+                and self.grammar is not None
+                and self.grammar.is_terminated()
+            ):
+                self.finished_reason = FINISH_MATCHED_TOKEN(matched=self.output_ids[-1])
+                return
+
+        if reached_length:
+            self.finished_reason = FINISH_LENGTH(length=max_new_tokens)
+            self.finished_len = max_new_tokens
             return
 
     def reset_for_retract(self):

--- a/test/registered/unit/managers/test_finish_state_stop_priority.py
+++ b/test/registered/unit/managers/test_finish_state_stop_priority.py
@@ -1,0 +1,230 @@
+"""Regression tests for stop conditions at the max-new-tokens boundary."""
+
+import unittest
+from array import array
+
+from sglang.srt.managers.schedule_batch import (
+    FINISH_LENGTH,
+    FINISH_MATCHED_STR,
+    FINISH_MATCHED_TOKEN,
+    FINISHED_MATCHED_REGEX,
+    Req,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+STOP_ID = 1
+EOS_ID = 2
+VOCAB_SIZE = 100
+
+
+class _FakeTokenizer:
+    eos_token_id = EOS_ID
+    additional_stop_token_ids = None
+
+    def encode(self, text, add_special_tokens=False):
+        return list(range(len(text)))
+
+    def decode(self, token_ids):
+        return "".join(
+            {
+                STOP_ID: "STOP",
+                EOS_ID: "<EOS>",
+                10: " blue",
+                11: " sky",
+                12: ".",
+                60: "a",
+                61: ".",
+                99: " extra",
+            }.get(int(token_id), "?")
+            for token_id in token_ids
+        )
+
+
+class _TerminatedGrammar:
+    @staticmethod
+    def is_terminated():
+        return True
+
+
+def _make_req(
+    output_ids,
+    *,
+    max_new_tokens,
+    grammar=None,
+    vocab_size=VOCAB_SIZE,
+    **sampling_kwargs,
+):
+    tokenizer = _FakeTokenizer()
+    sampling_params = SamplingParams(
+        max_new_tokens=max_new_tokens,
+        **sampling_kwargs,
+    )
+    sampling_params.normalize(tokenizer=tokenizer)
+    req = Req(
+        rid="finish-priority",
+        origin_input_text="",
+        origin_input_ids=array("q", [0]),
+        sampling_params=sampling_params,
+        eos_token_ids=frozenset(),
+        vocab_size=vocab_size,
+    )
+    req.tokenizer = tokenizer
+    req.grammar = grammar
+    req.output_ids = array("q", output_ids)
+    return req
+
+
+class TestFinishStateStopPriority(CustomTestCase):
+    def test_eos_at_max_token_boundary_finishes_as_stop(self):
+        for output_ids in ([10, EOS_ID], [10, 11, EOS_ID]):
+            with self.subTest(max_new_tokens=len(output_ids)):
+                req = _make_req(output_ids, max_new_tokens=len(output_ids))
+
+                req.update_finish_state()
+
+                self.assertIsInstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+                self.assertEqual(req.finished_reason.matched, EOS_ID)
+                self.assertEqual(req.finished_len, len(output_ids))
+
+    def test_explicit_stop_token_at_boundary_finishes_as_stop(self):
+        req = _make_req([10, 11], max_new_tokens=2, stop_token_ids=[11])
+
+        req.update_finish_state()
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+        self.assertEqual(req.finished_reason.matched, 11)
+        self.assertEqual(req.finished_len, 2)
+
+    def test_stop_string_at_boundary_finishes_as_stop(self):
+        req = _make_req([10, STOP_ID], max_new_tokens=2, stop=["STOP"])
+
+        req.update_finish_state(new_accepted_len=2)
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_STR)
+        self.assertEqual(req.finished_reason.matched, "STOP")
+        self.assertEqual(req.finished_len, 2)
+
+    def test_stop_regex_at_boundary_finishes_as_stop(self):
+        req = _make_req([60, 61], max_new_tokens=2, stop_regex=[r"\.$"])
+
+        req.update_finish_state(new_accepted_len=2)
+
+        self.assertIsInstance(req.finished_reason, FINISHED_MATCHED_REGEX)
+        self.assertEqual(req.finished_reason.matched, r"\.$")
+        self.assertEqual(req.finished_len, 2)
+
+    def test_stop_string_wins_over_eos_at_boundary(self):
+        req = _make_req([10, STOP_ID, EOS_ID], max_new_tokens=3, stop=["STOP"])
+
+        req.update_finish_state(new_accepted_len=3)
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_STR)
+        self.assertEqual(req.finished_reason.matched, "STOP")
+        self.assertEqual(req.finished_len, 2)
+        self.assertEqual(list(req.output_ids), [10, STOP_ID, EOS_ID])
+        self.assertEqual(list(req.output_ids_through_stop), [10, STOP_ID])
+
+    def test_speculative_eos_within_budget_finishes_as_stop(self):
+        req = _make_req([10, EOS_ID, 99, 99], max_new_tokens=3)
+
+        req.update_finish_state(new_accepted_len=3)
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+        self.assertEqual(req.finished_reason.matched, EOS_ID)
+        self.assertEqual(req.finished_len, 2)
+        self.assertEqual(list(req.output_ids), [10, EOS_ID, 99, 99])
+        self.assertEqual(list(req.output_ids_through_stop), [10, EOS_ID])
+
+    def test_speculative_eos_beyond_budget_finishes_as_length(self):
+        req = _make_req([10, 11, 12, EOS_ID], max_new_tokens=3)
+
+        req.update_finish_state(new_accepted_len=3)
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 3)
+        self.assertEqual(list(req.output_ids), [10, 11, 12, EOS_ID])
+        self.assertEqual(list(req.output_ids_through_stop), [10, 11, 12])
+
+    def test_speculative_stop_string_beyond_budget_finishes_as_length(self):
+        req = _make_req([10, 11, 12, STOP_ID], max_new_tokens=3, stop=["STOP"])
+
+        req.update_finish_state(new_accepted_len=3)
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 3)
+
+    def test_speculative_stop_string_within_budget_finishes_as_stop(self):
+        req = _make_req([10, STOP_ID, 99, 99], max_new_tokens=3, stop=["STOP"])
+
+        req.update_finish_state(new_accepted_len=3)
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_STR)
+        self.assertEqual(req.finished_reason.matched, "STOP")
+        self.assertEqual(req.finished_len, 2)
+        self.assertEqual(list(req.output_ids_through_stop), [10, STOP_ID])
+
+    def test_grammar_at_boundary_finishes_as_stop(self):
+        req = _make_req([10, 11], max_new_tokens=2, grammar=_TerminatedGrammar())
+
+        req.update_finish_state()
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+        self.assertEqual(req.finished_reason.matched, 11)
+
+    def test_grammar_beyond_budget_finishes_as_length(self):
+        req = _make_req([10, 11, 12], max_new_tokens=2, grammar=_TerminatedGrammar())
+
+        req.update_finish_state(new_accepted_len=2)
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 2)
+
+    def test_ignore_eos_preserves_length_finish(self):
+        req = _make_req([10, EOS_ID], max_new_tokens=2, ignore_eos=True)
+
+        req.update_finish_state()
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 2)
+
+    def test_non_stop_token_at_boundary_finishes_as_length(self):
+        req = _make_req([10, 11], max_new_tokens=2)
+
+        req.update_finish_state()
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 2)
+
+    def test_zero_token_budget_finishes_as_length(self):
+        req = _make_req([], max_new_tokens=0)
+
+        req.update_finish_state()
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 0)
+
+    def test_invalid_token_at_boundary_preserves_length_finish(self):
+        req = _make_req([10, VOCAB_SIZE], max_new_tokens=2)
+
+        req.update_finish_state()
+
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_len, 2)
+        self.assertEqual(list(req.output_ids), [10, VOCAB_SIZE])
+
+    def test_invalid_token_before_boundary_preserves_nan_finish(self):
+        req = _make_req([10, VOCAB_SIZE], max_new_tokens=3)
+
+        req.update_finish_state()
+
+        self.assertIsInstance(req.finished_reason, FINISH_MATCHED_STR)
+        self.assertEqual(req.finished_reason.matched, "NaN happened")
+        self.assertEqual(req.finished_len, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When a stop condition and `max_new_tokens` are reached in the same decode step, the request currently finishes with a length reason before checking the stop condition. Under speculative decoding, a single accepted chunk may also extend beyond the token budget, so finish checks must not inspect out-of-budget tokens.

## Modifications

- Restrict stop-condition checks to the accepted-token prefix within `max_new_tokens`.
- Check stop strings and regexes, EOS and stop token IDs, and grammar termination before falling back to the length finish reason.
- Preserve stop-string priority and accurate `finished_len` when a speculative chunk accepts multiple tokens.
- Preserve existing invalid-token handling.
- Add CPU regression tests for boundary, speculative overshoot, grammar, ignore-EOS, zero-budget, and invalid-token cases.

## Accuracy Tests

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/managers/test_finish_state_stop_priority.py \
  test/registered/unit/managers/test_stop_str_speculative.py \
  test/registered/unit/managers/test_grammar_stop_speculative.py
```

Result: `27 passed`.

## Speed Tests and Profiling

Not applicable. This change does not modify model forward code or kernels. Finish checks remain bounded to the newly accepted tokens and configured stop-pattern tail.

## Checklist

- [x] Format code according to the pre-commit configuration.
- [x] Add unit tests.
- [x] Documentation is not required for this behavior fix.
- [x] Accuracy and speed benchmarks are not applicable to model computation.
- [x] Follow the SGLang code style guidance.

The modified files pass all pre-commit hooks. The full-repository non-Rust hooks also pass; Rust hooks were not run locally because the Rust toolchain is unavailable, and this PR does not modify Rust files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30619820950](https://github.com/sgl-project/sglang/actions/runs/30619820950)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30619820913](https://github.com/sgl-project/sglang/actions/runs/30619820913)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->