### PR TITLE
[dLLM] Cut per-step host overhead in the dLLM extend path

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -504,6 +504,16 @@ class Envs:
     SGLANG_DISABLE_LAZY_COMPACTION = EnvBool(False)
     # Sort the multi-ended allocator's free list after a merge (perf A/B knob).
     SGLANG_SORT_FREE_LIST_AFTER_MERGE = EnvBool(False)
+    # Minimum dLLM FDFO reuse rows for fetching the retained KV blocks with one
+    # flat index op instead of a slice per row. The batched path trades one kernel
+    # launch per row for a fixed index build + H2D, so it wins on wide batches and
+    # loses on narrow ones; the row count gates it per round, so a small-batch
+    # latency deployment keeps the per-row path either way. Unset (default) takes
+    # the backend's measured break-even: 8 on Ascend (measured ~6; at 128 rows
+    # 5.7 ms per-row versus 0.3 ms batched), and never on backends where it has
+    # not been measured. Set it to the break-even you measure to override, or to
+    # -1 to disable the batched path outright (production A/B and quick rollback).
+    SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS = EnvInt(None)
     # Periodically log lazy-compaction stats per sub-pool (observability only).
     SGLANG_LOG_LAZY_COMPACTION_STATS = EnvBool(False)
     SGLANG_LOG_LAZY_COMPACTION_STATS_INTERVAL_SEC = EnvInt(30)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -504,15 +504,9 @@ class Envs:
     SGLANG_DISABLE_LAZY_COMPACTION = EnvBool(False)
     # Sort the multi-ended allocator's free list after a merge (perf A/B knob).
     SGLANG_SORT_FREE_LIST_AFTER_MERGE = EnvBool(False)
-    # Minimum dLLM FDFO reuse rows for fetching the retained KV blocks with one
-    # flat index op instead of a slice per row. The batched path trades one kernel
-    # launch per row for a fixed index build + H2D, so it wins on wide batches and
-    # loses on narrow ones; the row count gates it per round, so a small-batch
-    # latency deployment keeps the per-row path either way. Unset (default) takes
-    # the backend's measured break-even: 8 on Ascend (measured ~6; at 128 rows
-    # 5.7 ms per-row versus 0.3 ms batched), and never on backends where it has
-    # not been measured. Set it to the break-even you measure to override, or to
-    # -1 to disable the batched path outright (production A/B and quick rollback).
+    # Minimum dLLM FDFO reuse rows for gathering the retained KV blocks with one
+    # flat index op instead of a slice per row. Unset takes the backend default
+    # (Ascend only); -1 disables the batched path.
     SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS = EnvInt(None)
     # Periodically log lazy-compaction stats per sub-pool (observability only).
     SGLANG_LOG_LAZY_COMPACTION_STATS = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -343,6 +343,16 @@ class Envs:
     SGLANG_DISABLE_LAZY_COMPACTION = EnvBool(False)
     # Sort the multi-ended allocator's free list after a merge (perf A/B knob).
     SGLANG_SORT_FREE_LIST_AFTER_MERGE = EnvBool(False)
+    # Minimum dLLM FDFO reuse rows for fetching the retained KV blocks with one
+    # flat index op instead of a slice per row. The batched path trades one kernel
+    # launch per row for a fixed index build + H2D, so it wins on wide batches and
+    # loses on narrow ones; the row count gates it per round, so a small-batch
+    # latency deployment keeps the per-row path either way. Unset (default) takes
+    # the backend's measured break-even: 8 on Ascend (measured ~6; at 128 rows
+    # 5.7 ms per-row versus 0.3 ms batched), and never on backends where it has
+    # not been measured. Set it to the break-even you measure to override, or to
+    # -1 to disable the batched path outright (production A/B and quick rollback).
+    SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS = EnvInt(None)
     # Periodically log lazy-compaction stats per sub-pool (observability only).
     SGLANG_LOG_LAZY_COMPACTION_STATS = EnvBool(False)
     SGLANG_LOG_LAZY_COMPACTION_STATS_INTERVAL_SEC = EnvInt(30)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -443,7 +443,17 @@ class AscendAttnBackend(AttentionBackend):
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
         self.forward_metadata = ForwardMetadata()
-        seq_lens_max = forward_batch.seq_lens.max()
+        # dLLM runs one init per denoise step (overlap schedule is off), so its
+        # per-step host stalls are fully exposed as device idle. seq_lens_cpu and
+        # extend_seq_lens_cpu are the host mirrors the scheduler already holds, so
+        # take seq_lens_max and extend_seq_lens_cpu_int from them and skip the two
+        # D2H syncs (seq_lens.max() and extend_seq_lens.cpu()). Gated on dLLM to
+        # leave the decode/prefill path byte-identical.
+        is_dllm = forward_batch.forward_mode.is_dllm_extend()
+        if is_dllm:
+            seq_lens_max = int(forward_batch.seq_lens_cpu.max())
+        else:
+            seq_lens_max = forward_batch.seq_lens.max()
         if forward_batch.forward_mode.is_target_verify():
             spec_tokens_per_req = int(forward_batch.spec_info.draft_token_num)
             # Overlap scheduling can publish the CPU sequence length one step
@@ -480,9 +490,14 @@ class AscendAttnBackend(AttentionBackend):
             )
         if forward_batch.extend_seq_lens is not None:
             self.forward_metadata.extend_seq_lens = forward_batch.extend_seq_lens
-            self.forward_metadata.extend_seq_lens_cpu_int = (
-                forward_batch.extend_seq_lens.cpu().int()
-            )
+            if is_dllm and forward_batch.extend_seq_lens_cpu is not None:
+                self.forward_metadata.extend_seq_lens_cpu_int = torch.tensor(
+                    forward_batch.extend_seq_lens_cpu, dtype=torch.int32
+                )
+            else:
+                self.forward_metadata.extend_seq_lens_cpu_int = (
+                    forward_batch.extend_seq_lens.cpu().int()
+                )
         if forward_batch.seq_lens is not None:
             self.forward_metadata.seq_lens = forward_batch.seq_lens.int()
         else:

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -443,12 +443,9 @@ class AscendAttnBackend(AttentionBackend):
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
         self.forward_metadata = ForwardMetadata()
-        # dLLM runs one init per denoise step (overlap schedule is off), so its
-        # per-step host stalls are fully exposed as device idle. seq_lens_cpu and
-        # extend_seq_lens_cpu are the host mirrors the scheduler already holds, so
-        # take seq_lens_max and extend_seq_lens_cpu_int from them and skip the two
-        # D2H syncs (seq_lens.max() and extend_seq_lens.cpu()). Gated on dLLM to
-        # leave the decode/prefill path byte-identical.
+        # dLLM has no overlap schedule, so these two D2H syncs are exposed as
+        # device idle. Take them from the host mirrors instead. Gated on dLLM so
+        # the decode/prefill path stays byte-identical.
         is_dllm = forward_batch.forward_mode.is_dllm_extend()
         if is_dllm:
             seq_lens_max = int(forward_batch.seq_lens_cpu.max())

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_backend.py
@@ -440,7 +440,17 @@ class AscendAttnBackend(AttentionBackend):
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
         self.forward_metadata = ForwardMetadata()
-        seq_lens_max = forward_batch.seq_lens.max()
+        # dLLM runs one init per denoise step (overlap schedule is off), so its
+        # per-step host stalls are fully exposed as device idle. seq_lens_cpu and
+        # extend_seq_lens_cpu are the host mirrors the scheduler already holds, so
+        # take seq_lens_max and extend_seq_lens_cpu_int from them and skip the two
+        # D2H syncs (seq_lens.max() and extend_seq_lens.cpu()). Gated on dLLM to
+        # leave the decode/prefill path byte-identical.
+        is_dllm = forward_batch.forward_mode.is_dllm_extend()
+        if is_dllm:
+            seq_lens_max = int(forward_batch.seq_lens_cpu.max())
+        else:
+            seq_lens_max = forward_batch.seq_lens.max()
         if forward_batch.forward_mode.is_target_verify():
             seq_lens_max += self.speculative_num_draft_tokens
         elif (
@@ -469,9 +479,14 @@ class AscendAttnBackend(AttentionBackend):
             )
         if forward_batch.extend_seq_lens is not None:
             self.forward_metadata.extend_seq_lens = forward_batch.extend_seq_lens
-            self.forward_metadata.extend_seq_lens_cpu_int = (
-                forward_batch.extend_seq_lens.cpu().int()
-            )
+            if is_dllm and forward_batch.extend_seq_lens_cpu is not None:
+                self.forward_metadata.extend_seq_lens_cpu_int = torch.tensor(
+                    forward_batch.extend_seq_lens_cpu, dtype=torch.int32
+                )
+            else:
+                self.forward_metadata.extend_seq_lens_cpu_int = (
+                    forward_batch.extend_seq_lens.cpu().int()
+                )
         if forward_batch.seq_lens is not None:
             self.forward_metadata.seq_lens = forward_batch.seq_lens.int()
         else:

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -239,13 +239,23 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
             is_deepseek_dsa(self.model_runner.model_config.hf_config)
             or is_deepseek_v4(self.model_runner.model_config.hf_config)
         ):
+            # Prefer the host mirror kept by batch prep over re-reading the
+            # device tensor: .cpu() here is a blocking D2H behind whatever is
+            # already queued on the stream, once per replay.
+            #
+            # seq_lens_cpu is the authoritative host mirror on this path -- the
+            # ascend attention backend already derives its own seq_lens_cpu_int
+            # from it for every forward mode, and likewise adds the draft width
+            # on target-verify. Reading the device tensor here made the two
+            # disagree on their source; this aligns them.
+            seq_lens_cpu = (
+                forward_batch.seq_lens_cpu
+                if forward_batch.seq_lens_cpu is not None
+                else forward_batch.seq_lens.cpu()
+            )
             if forward_batch.forward_mode.is_target_verify():
-                seq_lens_cpu = forward_batch.seq_lens.cpu() + self.captured_req_width
-                seq_lens = seq_lens_cpu.tolist() + [0] * (self.bs - self.raw_bs)
-            else:
-                seq_lens = forward_batch.seq_lens.cpu().tolist() + [0] * (
-                    self.bs - self.raw_bs
-                )
+                seq_lens_cpu = seq_lens_cpu + self.captured_req_width
+            seq_lens = seq_lens_cpu.tolist() + [0] * (self.bs - self.raw_bs)
             output = self.backend.replay_with_input_update(
                 graph_key,
                 seq_lens=seq_lens,

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/npu_graph_runner.py
@@ -243,11 +243,6 @@ class NPUGraphRunner(DecodeCudaGraphRunner):
             # device tensor: .cpu() here is a blocking D2H behind whatever is
             # already queued on the stream, once per replay.
             #
-            # seq_lens_cpu is the authoritative host mirror on this path -- the
-            # ascend attention backend already derives its own seq_lens_cpu_int
-            # from it for every forward mode, and likewise adds the draft width
-            # on target-verify. Reading the device tensor here made the two
-            # disagree on their source; this aligns them.
             seq_lens_cpu = (
                 forward_batch.seq_lens_cpu
                 if forward_batch.seq_lens_cpu is not None

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from functools import lru_cache
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -13,6 +14,7 @@ from sglang.kernels.ops.memory.common import (
     get_last_loc_triton_safe,
     write_req_to_token_pool_triton,
 )
+from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_write_dsv4_decode,
     maybe_write_dsv4_extend,
@@ -403,6 +405,48 @@ def alloc_for_extend(
     return out_cache_loc, req_pool_indices_device, req_pool_indices_cpu
 
 
+# Break-even row count for the batched gather on Ascend, where it was measured
+# (~6 rows; 8 leaves margin). Other backends stay on the per-row path unless
+# SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS is set, since their break-even is unmeasured.
+_NPU_MIN_ROWS_FOR_BATCHED_GATHER = 8
+
+
+@lru_cache(maxsize=1)
+def _auto_min_rows_for_batched_gather() -> Optional[int]:
+    """Row count above which to batch the retained-block gather, or None to never
+    batch it. Cached so the decision -- and its log line -- happen once."""
+    if not _is_npu:
+        return None
+    logger.info(
+        "dLLM retained-block gather: batching enabled above %d reuse rows "
+        "(Ascend default). Override with SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS.",
+        _NPU_MIN_ROWS_FOR_BATCHED_GATHER,
+    )
+    return _NPU_MIN_ROWS_FOR_BATCHED_GATHER
+
+
+def _gather_reused_block_locs(
+    *,
+    req_to_token: torch.Tensor,
+    req_pool_indices: list[int],
+    prefix_lens: list[int],
+    block_len: int,
+    device: torch.device,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Re-read the retained KV block of every reuse row from ``req_to_token``
+    in one flat index op (rows share ``block_len``), instead of one slice +
+    cast kernel per row.
+    """
+    width = req_to_token.shape[1]
+    flat_cpu = torch.tensor(
+        [row * width + start for row, start in zip(req_pool_indices, prefix_lens)],
+        dtype=torch.int64,
+    ).unsqueeze(1) + torch.arange(block_len, dtype=torch.int64)
+    flat = flat_cpu.reshape(-1).to(device, non_blocking=True)
+    return req_to_token.reshape(-1)[flat].to(out_dtype).reshape(-1, block_len)
+
+
 def _alloc_extend_loc_with_kv_reuse(
     batch: ScheduleBatch,
     reuse_kv: list[bool],
@@ -415,11 +459,14 @@ def _alloc_extend_loc_with_kv_reuse(
     device = batch.device
     req_to_token = batch.req_to_token_pool.req_to_token
 
+    prefix_lens_list = prefix_lens_cpu.tolist()
+    extend_lens_list = extend_lens_cpu.tolist()
+
     for i, req in enumerate(batch.reqs):
         if not reuse_kv[i]:
             continue
-        prefix_len = int(prefix_lens_cpu[i])
-        extend_len = int(extend_lens_cpu[i])
+        prefix_len = prefix_lens_list[i]
+        extend_len = extend_lens_list[i]
         retained_len = len(req.dllm_incomplete_ids)
         if extend_len != retained_len:
             raise RuntimeError("dLLM FDFO retained KV must be reused as a full block.")
@@ -427,7 +474,7 @@ def _alloc_extend_loc_with_kv_reuse(
             raise RuntimeError("dLLM FDFO retained KV is missing.")
 
     alloc_extend_lens = [
-        0 if reuse_kv[i] else int(extend_lens_cpu[i]) for i in range(len(reuse_kv))
+        0 if reuse_kv[i] else extend_lens_list[i] for i in range(len(reuse_kv))
     ]
     alloc_extend_num_tokens = sum(alloc_extend_lens)
 
@@ -436,19 +483,17 @@ def _alloc_extend_loc_with_kv_reuse(
         if alloc_page_size == 1:
             fresh_slots = alloc_token_slots(batch.tree_cache, alloc_extend_num_tokens)
         else:
+            seq_lens_list = batch.seq_lens_cpu.tolist()
             alloc_seq_lens_cpu = torch.tensor(
                 [
-                    (
-                        int(prefix_lens_cpu[i])
-                        if reuse_kv[i]
-                        else int(batch.seq_lens_cpu[i])
-                    )
+                    prefix_lens_list[i] if reuse_kv[i] else seq_lens_list[i]
                     for i in range(len(reuse_kv))
                 ],
                 dtype=torch.int64,
             )
+            neg_one = torch.tensor([-1], device=device)
             last_loc = [
-                (t[-1:] if len(t) > 0 else torch.tensor([-1], device=device))
+                (t[-1:] if len(t) > 0 else neg_one)
                 for t in (r.prefix_indices for r in batch.reqs)
             ]
             fresh_slots = alloc_paged_token_slots_extend(
@@ -465,18 +510,52 @@ def _alloc_extend_loc_with_kv_reuse(
             )
 
     reuse_dtype = fresh_slots.dtype if fresh_slots is not None else torch.int64
+
+    reuse_rows = [i for i in range(len(reuse_kv)) if reuse_kv[i]]
+    req_pool_indices_list = req_pool_indices_cpu.tolist()
+    reuse_gathered = None
+    # The batched gather replaces one kernel launch per reuse row with a fixed
+    # index build + H2D, so it pays off on wide batches and loses on narrow ones.
+    # The row count is the gate: it is re-evaluated every round, so a batch that
+    # shrinks falls back on its own. The default comes from the backend; the env
+    # var overrides it (see SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS).
+    min_rows_for_batched_gather = envs.SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS.get()
+    if min_rows_for_batched_gather is None:
+        min_rows_for_batched_gather = _auto_min_rows_for_batched_gather()
+    if (
+        min_rows_for_batched_gather is not None
+        and min_rows_for_batched_gather >= 0  # negative disables outright
+        and len(reuse_rows) >= min_rows_for_batched_gather
+    ):
+        block_len = extend_lens_list[reuse_rows[0]]
+        # Rows of unequal length cannot share one flat index; fall back per row.
+        if all(extend_lens_list[i] == block_len for i in reuse_rows):
+            reuse_gathered = _gather_reused_block_locs(
+                req_to_token=req_to_token,
+                req_pool_indices=[req_pool_indices_list[i] for i in reuse_rows],
+                prefix_lens=[prefix_lens_list[i] for i in reuse_rows],
+                block_len=block_len,
+                device=device,
+                out_dtype=reuse_dtype,
+            )
+
     parts: list[torch.Tensor] = []
     fresh_ptr = 0
+    reuse_ptr = 0
     for i in range(len(reuse_kv)):
-        prefix_len = int(prefix_lens_cpu[i])
-        extend_len = int(extend_lens_cpu[i])
+        extend_len = extend_lens_list[i]
         if reuse_kv[i]:
-            req_idx = int(req_pool_indices_cpu[i])
-            parts.append(
-                req_to_token[req_idx, prefix_len : prefix_len + extend_len].to(
-                    reuse_dtype
+            if reuse_gathered is not None:
+                parts.append(reuse_gathered[reuse_ptr])
+                reuse_ptr += 1
+            else:
+                prefix_len = prefix_lens_list[i]
+                req_idx = req_pool_indices_list[i]
+                parts.append(
+                    req_to_token[req_idx, prefix_len : prefix_len + extend_len].to(
+                        reuse_dtype
+                    )
                 )
-            )
         else:
             parts.append(fresh_slots[fresh_ptr : fresh_ptr + extend_len])
             fresh_ptr += extend_len

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -382,9 +382,7 @@ def alloc_for_extend(
     return out_cache_loc, req_pool_indices_device, req_pool_indices_cpu
 
 
-# Break-even row count for the batched gather on Ascend, where it was measured
-# (~6 rows; 8 leaves margin). Other backends stay on the per-row path unless
-# SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS is set, since their break-even is unmeasured.
+# Ascend break-even for the batched gather (measured ~6; 8 leaves margin).
 _NPU_MIN_ROWS_FOR_BATCHED_GATHER = 8
 
 
@@ -412,8 +410,7 @@ def _gather_reused_block_locs(
     out_dtype: torch.dtype,
 ) -> torch.Tensor:
     """Re-read the retained KV block of every reuse row from ``req_to_token``
-    in one flat index op (rows share ``block_len``), instead of one slice +
-    cast kernel per row.
+    in one flat index op (rows share ``block_len``).
     """
     width = req_to_token.shape[1]
     flat_cpu = torch.tensor(
@@ -490,11 +487,6 @@ def _alloc_extend_loc_with_kv_reuse(
     reuse_rows = [i for i in range(len(reuse_kv)) if reuse_kv[i]]
     req_pool_indices_list = req_pool_indices_cpu.tolist()
     reuse_gathered = None
-    # The batched gather replaces one kernel launch per reuse row with a fixed
-    # index build + H2D, so it pays off on wide batches and loses on narrow ones.
-    # The row count is the gate: it is re-evaluated every round, so a batch that
-    # shrinks falls back on its own. The default comes from the backend; the env
-    # var overrides it (see SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS).
     min_rows_for_batched_gather = envs.SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS.get()
     if min_rows_for_batched_gather is None:
         min_rows_for_batched_gather = _auto_min_rows_for_batched_gather()

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
+from functools import lru_cache
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -13,6 +14,7 @@ from sglang.kernels.ops.memory.common import (
     get_last_loc_triton_safe,
     write_req_to_token_pool_triton,
 )
+from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_write_dsv4_decode,
     maybe_write_dsv4_extend,
@@ -380,6 +382,48 @@ def alloc_for_extend(
     return out_cache_loc, req_pool_indices_device, req_pool_indices_cpu
 
 
+# Break-even row count for the batched gather on Ascend, where it was measured
+# (~6 rows; 8 leaves margin). Other backends stay on the per-row path unless
+# SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS is set, since their break-even is unmeasured.
+_NPU_MIN_ROWS_FOR_BATCHED_GATHER = 8
+
+
+@lru_cache(maxsize=1)
+def _auto_min_rows_for_batched_gather() -> Optional[int]:
+    """Row count above which to batch the retained-block gather, or None to never
+    batch it. Cached so the decision -- and its log line -- happen once."""
+    if not _is_npu:
+        return None
+    logger.info(
+        "dLLM retained-block gather: batching enabled above %d reuse rows "
+        "(Ascend default). Override with SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS.",
+        _NPU_MIN_ROWS_FOR_BATCHED_GATHER,
+    )
+    return _NPU_MIN_ROWS_FOR_BATCHED_GATHER
+
+
+def _gather_reused_block_locs(
+    *,
+    req_to_token: torch.Tensor,
+    req_pool_indices: list[int],
+    prefix_lens: list[int],
+    block_len: int,
+    device: torch.device,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Re-read the retained KV block of every reuse row from ``req_to_token``
+    in one flat index op (rows share ``block_len``), instead of one slice +
+    cast kernel per row.
+    """
+    width = req_to_token.shape[1]
+    flat_cpu = torch.tensor(
+        [row * width + start for row, start in zip(req_pool_indices, prefix_lens)],
+        dtype=torch.int64,
+    ).unsqueeze(1) + torch.arange(block_len, dtype=torch.int64)
+    flat = flat_cpu.reshape(-1).to(device, non_blocking=True)
+    return req_to_token.reshape(-1)[flat].to(out_dtype).reshape(-1, block_len)
+
+
 def _alloc_extend_loc_with_kv_reuse(
     batch: ScheduleBatch,
     reuse_kv: list[bool],
@@ -392,11 +436,14 @@ def _alloc_extend_loc_with_kv_reuse(
     device = batch.device
     req_to_token = batch.req_to_token_pool.req_to_token
 
+    prefix_lens_list = prefix_lens_cpu.tolist()
+    extend_lens_list = extend_lens_cpu.tolist()
+
     for i, req in enumerate(batch.reqs):
         if not reuse_kv[i]:
             continue
-        prefix_len = int(prefix_lens_cpu[i])
-        extend_len = int(extend_lens_cpu[i])
+        prefix_len = prefix_lens_list[i]
+        extend_len = extend_lens_list[i]
         retained_len = len(req.dllm_incomplete_ids)
         if extend_len != retained_len:
             raise RuntimeError("dLLM FDFO retained KV must be reused as a full block.")
@@ -404,7 +451,7 @@ def _alloc_extend_loc_with_kv_reuse(
             raise RuntimeError("dLLM FDFO retained KV is missing.")
 
     alloc_extend_lens = [
-        0 if reuse_kv[i] else int(extend_lens_cpu[i]) for i in range(len(reuse_kv))
+        0 if reuse_kv[i] else extend_lens_list[i] for i in range(len(reuse_kv))
     ]
     alloc_extend_num_tokens = sum(alloc_extend_lens)
 
@@ -413,19 +460,17 @@ def _alloc_extend_loc_with_kv_reuse(
         if alloc_page_size == 1:
             fresh_slots = alloc_token_slots(batch.tree_cache, alloc_extend_num_tokens)
         else:
+            seq_lens_list = batch.seq_lens_cpu.tolist()
             alloc_seq_lens_cpu = torch.tensor(
                 [
-                    (
-                        int(prefix_lens_cpu[i])
-                        if reuse_kv[i]
-                        else int(batch.seq_lens_cpu[i])
-                    )
+                    prefix_lens_list[i] if reuse_kv[i] else seq_lens_list[i]
                     for i in range(len(reuse_kv))
                 ],
                 dtype=torch.int64,
             )
+            neg_one = torch.tensor([-1], device=device)
             last_loc = [
-                (t[-1:] if len(t) > 0 else torch.tensor([-1], device=device))
+                (t[-1:] if len(t) > 0 else neg_one)
                 for t in (r.prefix_indices for r in batch.reqs)
             ]
             fresh_slots = alloc_paged_token_slots_extend(
@@ -441,18 +486,52 @@ def _alloc_extend_loc_with_kv_reuse(
             )
 
     reuse_dtype = fresh_slots.dtype if fresh_slots is not None else torch.int64
+
+    reuse_rows = [i for i in range(len(reuse_kv)) if reuse_kv[i]]
+    req_pool_indices_list = req_pool_indices_cpu.tolist()
+    reuse_gathered = None
+    # The batched gather replaces one kernel launch per reuse row with a fixed
+    # index build + H2D, so it pays off on wide batches and loses on narrow ones.
+    # The row count is the gate: it is re-evaluated every round, so a batch that
+    # shrinks falls back on its own. The default comes from the backend; the env
+    # var overrides it (see SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS).
+    min_rows_for_batched_gather = envs.SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS.get()
+    if min_rows_for_batched_gather is None:
+        min_rows_for_batched_gather = _auto_min_rows_for_batched_gather()
+    if (
+        min_rows_for_batched_gather is not None
+        and min_rows_for_batched_gather >= 0  # negative disables outright
+        and len(reuse_rows) >= min_rows_for_batched_gather
+    ):
+        block_len = extend_lens_list[reuse_rows[0]]
+        # Rows of unequal length cannot share one flat index; fall back per row.
+        if all(extend_lens_list[i] == block_len for i in reuse_rows):
+            reuse_gathered = _gather_reused_block_locs(
+                req_to_token=req_to_token,
+                req_pool_indices=[req_pool_indices_list[i] for i in reuse_rows],
+                prefix_lens=[prefix_lens_list[i] for i in reuse_rows],
+                block_len=block_len,
+                device=device,
+                out_dtype=reuse_dtype,
+            )
+
     parts: list[torch.Tensor] = []
     fresh_ptr = 0
+    reuse_ptr = 0
     for i in range(len(reuse_kv)):
-        prefix_len = int(prefix_lens_cpu[i])
-        extend_len = int(extend_lens_cpu[i])
+        extend_len = extend_lens_list[i]
         if reuse_kv[i]:
-            req_idx = int(req_pool_indices_cpu[i])
-            parts.append(
-                req_to_token[req_idx, prefix_len : prefix_len + extend_len].to(
-                    reuse_dtype
+            if reuse_gathered is not None:
+                parts.append(reuse_gathered[reuse_ptr])
+                reuse_ptr += 1
+            else:
+                prefix_len = prefix_lens_list[i]
+                req_idx = req_pool_indices_list[i]
+                parts.append(
+                    req_to_token[req_idx, prefix_len : prefix_len + extend_len].to(
+                        reuse_dtype
+                    )
                 )
-            )
         else:
             parts.append(fresh_slots[fresh_ptr : fresh_ptr + extend_len])
             fresh_ptr += extend_len

--- a/test/registered/unit/mem_cache/test_dllm_reused_block_gather.py
+++ b/test/registered/unit/mem_cache/test_dllm_reused_block_gather.py
@@ -1,0 +1,84 @@
+"""Unit tests for the batched retained-block gather used by dLLM FDFO KV reuse.
+
+``_alloc_extend_loc_with_kv_reuse`` re-reads each reuse row's retained KV block
+out of ``req_to_token``. It used to do that one row at a time (a slice + cast
+kernel per row); the rows share a block length, so they are now fetched with a
+single flat index op. The index arithmetic (``row * width + start``, flattened
+and reshaped back) is what these tests pin down -- it is the part a
+"looks equivalent" rewrite silently gets wrong.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.mem_cache.allocation import _gather_reused_block_locs
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+ROWS, WIDTH = 8, 64
+
+
+def _fingerprint_pool() -> torch.Tensor:
+    # Slot at [row, col] is row*1000 + col, so a wrong row or a wrong start
+    # offset is visible in the value itself rather than only in the shape.
+    rows = torch.arange(ROWS, dtype=torch.int32).unsqueeze(1) * 1000
+    return rows + torch.arange(WIDTH, dtype=torch.int32)
+
+
+def _per_row_reference(req_to_token, req_pool_indices, prefix_lens, block_len, dtype):
+    return torch.stack(
+        [
+            req_to_token[idx, start : start + block_len].to(dtype)
+            for idx, start in zip(req_pool_indices, prefix_lens)
+        ]
+    )
+
+
+class TestGatherReusedBlockLocs(CustomTestCase):
+    def _gather(self, req_pool_indices, prefix_lens, block_len, dtype=torch.int64):
+        pool = _fingerprint_pool()
+        got = _gather_reused_block_locs(
+            req_to_token=pool,
+            req_pool_indices=req_pool_indices,
+            prefix_lens=prefix_lens,
+            block_len=block_len,
+            device=torch.device("cpu"),
+            out_dtype=dtype,
+        )
+        want = _per_row_reference(pool, req_pool_indices, prefix_lens, block_len, dtype)
+        return got, want
+
+    def test_matches_per_row_slicing_at_distinct_offsets(self):
+        # Rows are non-contiguous and each starts at a different offset: the
+        # flat index must combine the right row with the right start, not
+        # broadcast one row's offset across all of them.
+        got, want = self._gather([1, 3, 5], [4, 8, 0], 4)
+        self.assertTrue(torch.equal(got, want))
+        self.assertEqual(
+            got.tolist(),
+            [[1004, 1005, 1006, 1007], [3008, 3009, 3010, 3011], [5000, 5001, 5002, 5003]],
+        )
+
+    def test_preserves_row_order_when_pool_indices_are_unsorted(self):
+        # The gather feeds out_cache_loc positionally, so it must follow the
+        # caller's row order rather than the pool index order.
+        got, want = self._gather([5, 0, 3], [0, 12, 4], 4)
+        self.assertTrue(torch.equal(got, want))
+        self.assertEqual([row[0] for row in got.tolist()], [5000, 12, 3004])
+
+    def test_block_touching_the_row_end_does_not_bleed_into_the_next_row(self):
+        # A block ending exactly at WIDTH is the case a flat index gets wrong
+        # by reading past the row boundary.
+        got, want = self._gather([2], [WIDTH - 4], 4)
+        self.assertTrue(torch.equal(got, want))
+        self.assertEqual(got.tolist(), [[2060, 2061, 2062, 2063]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_dllm_reused_block_gather.py
+++ b/test/registered/unit/mem_cache/test_dllm_reused_block_gather.py
@@ -4,11 +4,20 @@
 out of ``req_to_token``. It used to do that one row at a time (a slice + cast
 kernel per row); the rows share a block length, so they are now fetched with a
 single flat index op. The index arithmetic (``row * width + start``, flattened
-and reshaped back) is what these tests pin down -- it is the part a
+and reshaped back) is what the first class pins down -- it is the part a
 "looks equivalent" rewrite silently gets wrong.
+
+The second class covers the caller instead of the helper. Batching splits the
+row loop into two independent cursors (``reuse_ptr`` over gathered rows,
+``fresh_ptr`` over freshly allocated tokens); if either advances on the wrong
+row the batch is silently mispaired, which no helper-level test can see. Every
+case therefore runs the same batch with batching forced off and forced on and
+requires the two ``out_cache_loc`` tensors to be identical -- the off path is
+the pre-existing behaviour, so agreement is the regression signal.
 """
 
 import unittest
+from types import SimpleNamespace
 
 import torch
 
@@ -17,7 +26,11 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.mem_cache.allocation import _gather_reused_block_locs
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache.allocation import (
+    _alloc_extend_loc_with_kv_reuse,
+    _gather_reused_block_locs,
+)
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -82,6 +95,133 @@ class TestGatherReusedBlockLocs(CustomTestCase):
         got, want = self._gather([2], [WIDTH - 4], 4)
         self.assertTrue(torch.equal(got, want))
         self.assertEqual(got.tolist(), [[2060, 2061, 2062, 2063]])
+
+
+class _FakeAllocator:
+    """Hands out consecutive slots so the same batch allocates identically with
+    batching on and off, making the two out_cache_loc tensors comparable."""
+
+    def __init__(self, base: int = 10_000):
+        self.base = base
+        self.cursor = 0
+
+    def alloc(self, num_tokens: int) -> torch.Tensor:
+        start = self.base + self.cursor
+        self.cursor += num_tokens
+        return torch.arange(start, start + num_tokens, dtype=torch.int64)
+
+
+class _FakeTreeCache:
+    # is_chunk_cache() short-circuits evict_from_tree_cache, so the allocator
+    # above is the only collaborator alloc_token_slots actually needs.
+    def __init__(self):
+        self.token_to_kv_pool_allocator = _FakeAllocator()
+
+    def is_chunk_cache(self) -> bool:
+        return True
+
+
+def _make_batch(*, reuse_kv, prefix_lens, extend_lens):
+    reqs = [
+        SimpleNamespace(
+            dllm_incomplete_ids=[0] * extend_lens[i] if reuse_kv[i] else [],
+            kv=SimpleNamespace(kv_allocated_len=prefix_lens[i] + extend_lens[i]),
+        )
+        for i in range(len(reuse_kv))
+    ]
+    return SimpleNamespace(
+        device=torch.device("cpu"),
+        req_to_token_pool=SimpleNamespace(req_to_token=_fingerprint_pool()),
+        reqs=reqs,
+        tree_cache=_FakeTreeCache(),
+    )
+
+
+class TestAllocExtendLocWithKvReuseBatching(CustomTestCase):
+    """The caller's reuse/fresh reassembly, with batching off vs on."""
+
+    def _run(self, *, reuse_kv, prefix_lens, extend_lens, min_rows):
+        # The env var is what we vary: _auto_min_rows_for_batched_gather is
+        # lru_cached and process-sticky, so the auto default must not be the
+        # knob under test. -1 disables outright; 0 batches every reuse row.
+        with envs.SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS.override(min_rows):
+            return _alloc_extend_loc_with_kv_reuse(
+                _make_batch(
+                    reuse_kv=reuse_kv,
+                    prefix_lens=prefix_lens,
+                    extend_lens=extend_lens,
+                ),
+                reuse_kv,
+                torch.tensor(list(range(len(reuse_kv))), dtype=torch.int64),
+                torch.tensor(prefix_lens, dtype=torch.int64),
+                torch.tensor(extend_lens, dtype=torch.int64),
+                torch.tensor(list(range(len(reuse_kv))), dtype=torch.int64),
+                1,
+            )
+
+    def _assert_batching_is_transparent(self, **kwargs):
+        off = self._run(min_rows=-1, **kwargs)
+        on = self._run(min_rows=0, **kwargs)
+        self.assertTrue(
+            torch.equal(off, on),
+            f"batching changed out_cache_loc:\n off={off.tolist()}\n on ={on.tolist()}",
+        )
+        return on
+
+    def test_interleaved_reuse_and_fresh_rows_keep_their_positions(self):
+        # The failure this guards: a cursor that advances on every row instead
+        # of only on its own kind silently shifts rows against each other.
+        # Fresh slots come from _FakeAllocator (10000+), reuse rows carry the
+        # pool fingerprint (row*1000 + col), so a swap is visible in the values.
+        out = self._assert_batching_is_transparent(
+            reuse_kv=[False, True, False, True],
+            prefix_lens=[0, 8, 0, 12],
+            extend_lens=[3, 4, 2, 4],
+        )
+        self.assertEqual(
+            out.tolist(),
+            # fmt: off
+            [
+                10000, 10001, 10002,          # row 0, fresh
+                1008, 1009, 1010, 1011,       # row 1, reuse @ pool row 1 off 8
+                10003, 10004,                 # row 2, fresh
+                3012, 3013, 3014, 3015,       # row 3, reuse @ pool row 3 off 12
+            ],
+            # fmt: on
+        )
+
+    def test_all_reuse_allocates_nothing_and_still_reassembles_in_order(self):
+        # No fresh slots at all: fresh_slots stays None and reuse_dtype falls
+        # back to int64. The gathered rows must still land in caller order.
+        out = self._assert_batching_is_transparent(
+            reuse_kv=[True, True, True],
+            prefix_lens=[4, 0, 16],
+            extend_lens=[4, 4, 4],
+        )
+        self.assertEqual(
+            out.tolist(),
+            [4, 5, 6, 7, 1000, 1001, 1002, 1003, 2016, 2017, 2018, 2019],
+        )
+
+    def test_reuse_rows_of_unequal_length_fall_back_per_row(self):
+        # Rows of different block_len cannot share one flat index, so the
+        # caller must decline to batch them. If that guard is dropped the
+        # gather reshapes against the wrong width and this diverges.
+        self._assert_batching_is_transparent(
+            reuse_kv=[True, False, True],
+            prefix_lens=[0, 0, 8],
+            extend_lens=[4, 3, 8],
+        )
+
+    def test_single_reuse_row_below_the_default_threshold(self):
+        # min_rows=0 forces batching on for a batch the Ascend default (8)
+        # would have left on the per-row path -- the gate must not be the only
+        # thing keeping the batched path correct on narrow batches.
+        self._assert_batching_is_transparent(
+            reuse_kv=[True, False],
+            prefix_lens=[12, 0],
+            extend_lens=[4, 5],
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_dllm_reused_block_gather.py
+++ b/test/registered/unit/mem_cache/test_dllm_reused_block_gather.py
@@ -62,7 +62,11 @@ class TestGatherReusedBlockLocs(CustomTestCase):
         self.assertTrue(torch.equal(got, want))
         self.assertEqual(
             got.tolist(),
-            [[1004, 1005, 1006, 1007], [3008, 3009, 3010, 3011], [5000, 5001, 5002, 5003]],
+            [
+                [1004, 1005, 1006, 1007],
+                [3008, 3009, 3010, 3011],
+                [5000, 5001, 5002, 5003],
+            ],
         )
 
     def test_preserves_row_order_when_pool_indices_are_unsorted(self):


### PR DESCRIPTION
## Motivation

dLLM inference disables the overlap scheduler (each denoise step has a hard input dependency on the previous step's result), so every bit of host time between steps is exposed directly as device idle. Profiling LLaDA2 at bs=128 on Ascend 910B3 showed three host-side costs on the per-step path, none of which needed to be there:

1. `AscendAttnBackend.init_forward_metadata` took two D2H syncs to obtain values the scheduler already holds on the host (`seq_lens_max`, `extend_seq_lens_cpu_int`).
2. `NPUGraphRunner` re-read `forward_batch.seq_lens.cpu()` before every replay, a blocking D2H behind whatever is queued on the stream, while the same host mirror was already available.
3. `_alloc_extend_loc_with_kv_reuse` (the dLLM FDFO retained-KV path) re-read each reuse row's retained block with its own slice + cast kernel, and pulled every scheduling scalar out of CPU tensors one element at a time. Both costs grow linearly with batch size.

## Modifications

**`hardware_backend/npu/attention/ascend_backend.py`** — take `seq_lens_max` from `seq_lens_cpu` and build `extend_seq_lens_cpu_int` from `extend_seq_lens_cpu`. Gated on `forward_mode.is_dllm_extend()`, so the decode/prefill path is byte-identical.

**`hardware_backend/npu/graph_runner/npu_graph_runner.py`** — use `forward_batch.seq_lens_cpu` when present, falling back to `.cpu()` when it is not. This one is **not** dLLM-gated and affects every non-DeepSeek-DSA/V4 model on this path, so it is worth stating why it is equivalent: `seq_lens_cpu` is already the authoritative host mirror here — the Ascend attention backend derives its own `seq_lens_cpu_int` from it for every forward mode, and likewise adds the draft width on target-verify. Reading the device tensor in the graph runner made the two components disagree on their source for the same forward; this aligns them. The `is_target_verify()` adjustment is unchanged, and the two former branches collapse into one because they now differ only by that addition.

**`mem_cache/allocation.py`** — three changes inside `_alloc_extend_loc_with_kv_reuse`, which is reached only via `if batch.is_dllm()` in `alloc_for_extend`, so non-dLLM requests never enter it:

- Add `_gather_reused_block_locs`: the retained blocks all share one length, so fetch them with a single flat index op instead of one slice + cast kernel per row. It replaces one kernel launch per row with a fixed index build + H2D, so it wins on wide batches and loses on narrow ones. The gate is the reuse-row count, re-evaluated every round, so a batch that shrinks falls back on its own — a small-batch latency deployment keeps the per-row path without configuring anything. The threshold defaults to the backend's measured break-even (8 on Ascend, where break-even is ~6) and is unset on backends where it has not been measured, so those keep today's behavior. `SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS` overrides it: a row count to retune, or `-1` to disable the batched path outright for A/B and rollback. Rows of non-uniform block length keep the per-row path regardless. The resolved default is logged once at INFO.
- Replace the per-element `int(cpu_tensor[i])` reads with one `.tolist()` per tensor. Unconditional: strictly less work at any batch size. At bs=128 the old code did roughly 770 of these, each allocating a temporary 0-dim tensor.
- Hoist the `torch.tensor([-1], device=...)` filler out of the `last_loc` comprehension. Unconditional for the same reason. Every empty-prefix row was allocating its own identical device tensor; the list is consumed by `torch.cat`, which copies, so one shared tensor is equivalent.

### Configuration

One new environment variable, `SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS` (`EnvInt(None)` in `environ.py`), the minimum number of dLLM FDFO reuse rows at which the retained blocks are gathered in one flat index op. Nothing needs to be set for the intended behavior on either an Ascend or a non-Ascend deployment:

| Value | Behavior | When to use |
| --- | --- | --- |
| unset (default) | Ascend: batch at 8+ reuse rows. Other backends: always per-row. | Normal serving, both latency and throughput. |
| `N` (>= 0) | Batch at `N`+ reuse rows. | Enabling it on a backend after measuring its break-even, or retuning Ascend. |
| `-1` | Never batch. | Production A/B and quick rollback. |

```bash
# enable on a non-Ascend backend after measuring its break-even
SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS=8 python3 -m sglang.launch_server ...

# roll back to the per-row path without redeploying
SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS=-1 python3 -m sglang.launch_server ...
```

The resolved default is logged once at INFO:

```
dLLM retained-block gather: batching enabled above 8 reuse rows (Ascend default).
Override with SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS.
```

## Accuracy Tests

No effect on model outputs — all three changes are host-side bookkeeping that produce the same values (the same slot indices, the same metadata) by different means. Verified with LLaDA2-mini on gsm8k (zero-shot, full 1319 samples): accuracy unchanged.

## Speed Tests and Profiling

Measured on Ascend 910B3 at bs=128 (LLaDA2-mini, 32-token dLLM blocks), microbenchmarking each site against the code it replaces:

| Site | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Retained-block gather (128 reuse rows x 32) | 5671 us | 309 us | **5.4 ms** |
| ~770 scheduling scalar reads | 3849 us | 54 us | **3.3 ms** |
| `init_forward_metadata` (idle stream) | 251 us | 83 us | 168 us |
| Graph replay `seq_lens` (idle stream) | 44 us | 6 us | 38 us |

The gather is the dominant one and the only part that changes complexity: the per-row path costs about 44 us per reuse row (one kernel launch each) and scales linearly, while the batched path is roughly constant at about 270 us. That constant is why it is row-gated rather than unconditional — below the break-even the per-row path is genuinely faster:

| reuse rows | per-row | batched | |
| ---: | ---: | ---: | --- |
| 1 | 120 us | 305 us | per-row path taken |
| 4 | 196 us | 269 us | per-row path taken |
| 6 | 279 us | 271 us | break-even |
| 8 | 362 us | 268 us | Ascend default threshold |
| 32 | 1449 us | 277 us | |
| 64 | 2762 us | 268 us | |
| 128 | 5671 us | 309 us | |
| 256 | 11466 us | 353 us | |

The `last_loc` hoist is not in the table because its benefit depends on how many requests have an empty prefix: each such row was allocating a device tensor at about 70 us, so it saves that times the number of empty-prefix rows in the batch (up to 8.9 ms at bs=128 when every row is fresh, and nothing when every row has a cached prefix).

On Ascend at bs=128 this removes about 8.7 ms per step out of the box, against a step time of about 98 ms. On a backend where the gather threshold is unset it removes about 3.5 ms (the scalar reads plus the two D2H syncs); the gather itself is one env var away once its break-even has been measured there.

## Unit Tests

`test/registered/unit/mem_cache/test_dllm_reused_block_gather.py` (CPU-only, no server) pins the flat index arithmetic in `_gather_reused_block_locs` against per-row slicing. Each case covers a way the gather can be heterogeneous across rows, which is where a "looks equivalent" rewrite goes wrong: distinct per-row start offsets, unsorted pool indices, and a block ending exactly at the row boundary. Changing `row * width` to `row * block_len` in the implementation fails all three.

These are deliberately not a re-test of the happy path. `test_dllm_fdfo_kv_reuse.py` covers that already in principle, but its reuse rows all share one prefix length and ascending pool indices, so an implementation that broadcast row 0's offset across every row would still pass it. (It is also module-level skipped today, and its fixtures no longer match `alloc_for_extend` — un-skipping it raises `SimpleNamespace has no attribute out_cache_loc_dsv4` — so it is not currently guarding anything either way.)

The two D2H changes have no new tests: they need an NPU, and their equivalence is structural (`seq_lens_cpu` is the mirror of `seq_lens`, which the same backend already relies on).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35510470444](https://github.com/sgl-project/sglang/actions/runs/35510470444)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35510470301](https://github.com/sgl-project/sglang/actions/runs/35510470301)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35510470420](https://github.com/sgl-project/sglang/actions/runs/35510470420)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->