### PR TITLE
[Diffusion] Bind accelerator before distributed initialization

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -536,6 +536,12 @@ def maybe_init_distributed_environment_and_model_parallel(
     world_size = int(os.environ.get("WORLD_SIZE", 1))
     rank = int(os.environ.get("RANK", 0))
     device = get_local_torch_device()
+
+    # Bind the process before creating any process groups or communicators.
+    # CPU and MPS do not expose per-rank accelerator device selection.
+    if device.type not in ("cpu", "mps"):
+        torch.get_device_module(device).set_device(local_rank)
+
     logger.info(
         "Initializing distributed environment with world_size=%d, device=%s, timeout=%s",
         world_size,
@@ -561,14 +567,6 @@ def maybe_init_distributed_environment_and_model_parallel(
         ring_degree=ring_degree,
         sequence_parallel_degree=sp_size,
     )
-
-    # Only set CUDA device if we're on a CUDA platform
-    if current_platform.is_cuda_alike():
-        device = torch.device(f"cuda:{local_rank}")
-        torch.cuda.set_device(device)
-    elif current_platform.is_npu():
-        device = torch.device(f"npu:{local_rank}")
-        torch.npu.set_device(device)
 
 
 def model_parallel_is_initialized() -> bool:

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -194,7 +194,6 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
 
     def init_device_and_model(self) -> None:
         """Initialize the device and load the model."""
-        torch.get_device_module().set_device(self.local_rank)
         # Set environment variables for distributed initialization
         os.environ["MASTER_ADDR"] = "localhost"
         os.environ["MASTER_PORT"] = str(self.master_port)

--- a/python/sglang/multimodal_gen/test/unit/test_distributed_device_binding.py
+++ b/python/sglang/multimodal_gen/test/unit/test_distributed_device_binding.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for per-rank accelerator device binding."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from sglang.multimodal_gen.runtime import platforms
+from sglang.multimodal_gen.runtime.distributed import parallel_state
+from sglang.multimodal_gen.runtime.managers import gpu_worker
+
+
+class _FakePlatform:
+    def __init__(self, *, cuda_alike: bool):
+        self._cuda_alike = cuda_alike
+
+    def get_torch_distributed_backend_str(self) -> str:
+        return "nccl" if self._cuda_alike else "xccl"
+
+    def is_cuda_alike(self) -> bool:
+        return self._cuda_alike
+
+    def is_npu(self) -> bool:
+        return False
+
+
+@pytest.mark.parametrize(
+    ("device_type", "cuda_alike"),
+    (("cuda", True), ("xpu", False), ("musa", True)),
+)
+def test_distributed_init_binds_rank_before_creating_groups(
+    monkeypatch, device_type, cuda_alike
+):
+    """A rank must be bound before communicator setup on every accelerator."""
+    calls = []
+    device = SimpleNamespace(type=device_type)
+    device_module = SimpleNamespace(
+        set_device=lambda local_rank: calls.append(("set_device", local_rank))
+    )
+
+    monkeypatch.setattr(
+        platforms, "current_platform", _FakePlatform(cuda_alike=cuda_alike)
+    )
+    monkeypatch.setattr(parallel_state, "_WORLD", None)
+    monkeypatch.setattr(parallel_state, "get_local_torch_device", lambda: device)
+    monkeypatch.setattr(
+        parallel_state.torch,
+        "get_device_module",
+        lambda selected_device: device_module,
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.cuda,
+        "set_device",
+        lambda selected_device: calls.append(("set_device", selected_device)),
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "init_distributed_environment",
+        lambda **kwargs: calls.append(("init_distributed", kwargs["local_rank"])),
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "initialize_model_parallel",
+        lambda **kwargs: calls.append(("init_model_parallel", None)),
+    )
+    monkeypatch.setenv("LOCAL_RANK", "3")
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("WORLD_SIZE", "4")
+
+    parallel_state.maybe_init_distributed_environment_and_model_parallel(
+        tp_size=1,
+        sp_size=1,
+    )
+
+    assert calls == [
+        ("set_device", 3),
+        ("init_distributed", 3),
+        ("init_model_parallel", None),
+    ]
+
+
+def test_gpu_worker_allows_device_modules_without_set_device(monkeypatch):
+    """MPS workers must reach distributed init although torch.mps has no set_device."""
+    worker = object.__new__(gpu_worker.GPUWorker)
+    worker.local_rank = 0
+    worker.rank = 0
+    worker.master_port = 30000
+    worker.server_args = SimpleNamespace(
+        cfg_parallel_degree=None,
+        dist_timeout=None,
+        dp_size=1,
+        layerwise_offload_components=[],
+        num_gpus=1,
+        ring_degree=1,
+        sp_degree=1,
+        tp_size=1,
+        ulysses_degree=1,
+    )
+    worker._configure_persistent_torch_compile_cache = Mock()
+    distributed_init = Mock()
+    pipeline = object()
+
+    monkeypatch.setattr(
+        gpu_worker.torch, "get_device_module", lambda: SimpleNamespace()
+    )
+    monkeypatch.setattr(
+        gpu_worker,
+        "maybe_init_distributed_environment_and_model_parallel",
+        distributed_init,
+    )
+    monkeypatch.setattr(gpu_worker, "model_parallel_is_initialized", lambda: False)
+    monkeypatch.setattr(gpu_worker, "setproctitle", lambda title: None)
+    monkeypatch.setattr(gpu_worker, "build_pipeline", lambda server_args: pipeline)
+    for name in ("MASTER_ADDR", "MASTER_PORT", "LOCAL_RANK", "RANK", "WORLD_SIZE"):
+        monkeypatch.setenv(name, "original")
+
+    worker.init_device_and_model()
+
+    distributed_init.assert_called_once()
+    assert worker.pipeline is pipeline


### PR DESCRIPTION
## Motivation

Fixes #33031.

Distributed initialization selected each rank's device only after process groups and device communicators had already been created. The late binding was also limited to CUDA/NPU-specific branches, leaving XPU and MUSA ranks on device 0. Separately, `GPUWorker` unconditionally called `set_device` on the active device module, which fails on MPS because `torch.mps` does not provide that API.

## Modifications

- Bind the local accelerator through `torch.get_device_module(device).set_device(local_rank)` before any process group or communicator initialization.
- Skip per-rank binding for CPU and MPS, which do not use indexed accelerator selection.
- Remove the earlier unconditional binding from `GPUWorker` and centralize it in the distributed initialization path, after rank environment variables are set.
- Add regression coverage for CUDA ordering, XPU/MUSA binding, and MPS modules without `set_device`.

## Accuracy Tests

Not applicable. This changes initialization order and device selection only; model computation and outputs are unchanged.

## Speed Tests and Profiling

Not applicable. The change affects one-time process initialization and prevents unintended cross-device allocation/communication.

## Validation

- `ruff`, `black-jupyter`, `isort`, `codespell`, Python AST, Chinese-character, and CI-registration checks passed for all changed files.
- `python -m py_compile` passed for all changed Python files.
- A source-level regression harness reproduces the missing/late binding on the pre-fix sources and verifies `set_device -> init_distributed_environment -> initialize_model_parallel` after the fix.
- `pytest python/sglang/multimodal_gen/test/unit/test_distributed_device_binding.py -q` could not be collected in the local Windows environment because importing SGLang requires the POSIX-only `resource` module. The added test is CPU/mock based and is intended to run in the repository's Linux CI environment.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation changes are needed for this internal initialization fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable to initialization-only behavior.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30621319535](https://github.com/sgl-project/sglang/actions/runs/30621319535)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30621319126](https://github.com/sgl-project/sglang/actions/runs/30621319126)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->