### PR TITLE
[Rust Server] Return kv_events from /server_info like Python

### DIFF
--- a/rust/sglang-server/src/api_server/common.rs
+++ b/rust/sglang-server/src/api_server/common.rs
@@ -92,8 +92,6 @@ async fn model_info(State(state): State<AppState>) -> Response {
 /// `GET /server_info` — surface only an allowlist ([`INTERNAL_STATE_ALLOWLIST`] +
 /// curated [`ServerArgs`] accessors), never the raw server-args dump (embeds
 /// `api_key`/`admin_api_key`; see [`shape_server_info`]).
-///
-/// TODO(server_info): Python also includes `kv_events`; add once plumbed.
 async fn server_info(State(state): State<AppState>) -> Response {
     let bytes = match await_control_result(
         &state,
@@ -160,6 +158,7 @@ fn shape_server_info(msgpack: &[u8], server_args: &ServerArgs) -> Result<Vec<u8>
         "max_context_length": server_args.model_config.context_len,
         "max_total_num_tokens": server_args.max_total_num_tokens,
         "version": server_args.version,
+        "kv_events": server_args.describe_kv_events_publisher(),
         "internal_states": [serde_json::Value::Object(state_out)],
     });
     serde_json::to_vec(&response).map_err(|e| e.to_string())
@@ -169,6 +168,21 @@ fn shape_server_info(msgpack: &[u8], server_args: &ServerArgs) -> Result<Vec<u8>
 mod tests {
     use super::*;
 
+    fn msgpack_with_internal_state(entries: Vec<(rmpv::Value, rmpv::Value)>) -> Vec<u8> {
+        let internal = rmpv::Value::Map(entries);
+        let outer = rmpv::Value::Map(vec![(rmpv::Value::from("internal_state"), internal)]);
+        let mut msgpack = Vec::new();
+        rmpv::encode::write_value(&mut msgpack, &outer).unwrap();
+        msgpack
+    }
+
+    fn shape_for_args(args: serde_json::Value) -> serde_json::Value {
+        let msgpack = msgpack_with_internal_state(Vec::new());
+        let sa = ServerArgs::from_json(&args.to_string()).unwrap();
+        let out = shape_server_info(&msgpack, &sa).unwrap();
+        serde_json::from_slice(&out).unwrap()
+    }
+
     /// The scheduler's `internal_state` embeds the full server-args dump (incl.
     /// `api_key`/`admin_api_key`). `/server_info` must surface only the allowlisted
     /// runtime metrics + curated config — never the secrets — and must not re-nest
@@ -176,7 +190,8 @@ mod tests {
     #[test]
     fn shape_server_info_excludes_secrets_and_dump() {
         // GetInternalStateReqOutput.asdict → { "internal_state": { …dump+metrics… } }.
-        let internal = rmpv::Value::Map(vec![
+        let raw_kv_events_config = r#"{"publisher":"zmq","endpoint":"tcp://*:5557","topic":"kv","password":"nested-secret"}"#;
+        let msgpack = msgpack_with_internal_state(vec![
             (
                 rmpv::Value::from("api_key"),
                 rmpv::Value::from("secret-token"),
@@ -187,6 +202,10 @@ mod tests {
             ),
             (rmpv::Value::from("model_path"), rmpv::Value::from("/m")),
             (
+                rmpv::Value::from("kv_events_config"),
+                rmpv::Value::from(raw_kv_events_config),
+            ),
+            (
                 rmpv::Value::from("last_gen_throughput"),
                 rmpv::Value::from(1.5),
             ),
@@ -195,12 +214,18 @@ mod tests {
                 rmpv::Value::from(32),
             ),
         ]);
-        let outer = rmpv::Value::Map(vec![(rmpv::Value::from("internal_state"), internal)]);
-        let mut msgpack = Vec::new();
-        rmpv::encode::write_value(&mut msgpack, &outer).unwrap();
 
-        let sa =
-            ServerArgs::from_json(r#"{"model_path": "/m", "api_key": "secret-token"}"#).unwrap();
+        let sa = ServerArgs::from_json(
+            &serde_json::json!({
+                "model_path": "/m",
+                "api_key": "secret-token",
+                "kv_events_config": raw_kv_events_config,
+                "page_size": 64,
+                "dp_size": 1,
+            })
+            .to_string(),
+        )
+        .unwrap();
         let out = shape_server_info(&msgpack, &sa).unwrap();
         let text = String::from_utf8(out.clone()).unwrap();
         // No secret leaks anywhere in the serialized response.
@@ -208,6 +233,14 @@ mod tests {
         assert!(
             !text.contains("admin-token"),
             "admin_api_key leaked: {text}"
+        );
+        assert!(
+            !text.contains("nested-secret"),
+            "kv_events_config leaked: {text}"
+        );
+        assert!(
+            !text.contains("kv_events_config"),
+            "raw kv_events_config key leaked: {text}"
         );
 
         let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
@@ -222,5 +255,142 @@ mod tests {
         assert!(state0.get("api_key").is_none());
         // Curated top-level config comes from typed accessors, not the dump.
         assert_eq!(v["model_path"], "/m");
+        assert_eq!(v["kv_events"]["publisher"], "zmq");
+    }
+
+    #[test]
+    fn shape_server_info_includes_kv_events_descriptor_when_enabled() {
+        let v = shape_for_args(serde_json::json!({
+            "model_path": "/m",
+            "kv_events_config": r#"{"publisher":"zmq","endpoint":"tcp://*:5557","topic":"kv"}"#,
+            "page_size": 64,
+            "dp_size": 2,
+        }));
+
+        assert_eq!(
+            v["kv_events"],
+            serde_json::json!({
+                "publisher": "zmq",
+                "endpoint_host": "*",
+                "endpoint_port_base": 5557,
+                "topic": "kv",
+                "block_size": 64,
+                "dp_size": 2,
+            })
+        );
+    }
+
+    #[test]
+    fn shape_server_info_includes_kv_events_descriptor_with_explicit_host() {
+        let v = shape_for_args(serde_json::json!({
+            "model_path": "/m",
+            "kv_events_config": r#"{"publisher":"zmq","endpoint":"tcp://0.0.0.0:7777","topic":"kv"}"#,
+            "page_size": 128,
+            "dp_size": 1,
+        }));
+
+        assert_eq!(v["kv_events"]["endpoint_host"], "0.0.0.0");
+        assert_eq!(v["kv_events"]["endpoint_port_base"], 7777);
+        assert_eq!(v["kv_events"]["topic"], "kv");
+        assert_eq!(v["kv_events"]["block_size"], 128);
+        assert_eq!(v["kv_events"]["dp_size"], 1);
+    }
+
+    #[test]
+    fn shape_server_info_kv_events_null_for_disabled_or_invalid_config() {
+        let good_cfg = r#"{"publisher":"zmq","endpoint":"tcp://*:5557","topic":""}"#;
+        let cases = [
+            (
+                "no config",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "publisher null",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": r#"{"publisher":"null"}"#,
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "malformed json",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": "not-json",
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "non-tcp endpoint",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": r#"{"publisher":"zmq","endpoint":"inproc://cache","topic":""}"#,
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "missing port",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": r#"{"publisher":"zmq","endpoint":"tcp://0.0.0.0","topic":""}"#,
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "non-integer port",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": r#"{"publisher":"zmq","endpoint":"tcp://0.0.0.0:abc","topic":""}"#,
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "zero port",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": r#"{"publisher":"zmq","endpoint":"tcp://0.0.0.0:0","topic":""}"#,
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "port too large",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": r#"{"publisher":"zmq","endpoint":"tcp://0.0.0.0:65536","topic":""}"#,
+                    "page_size": 64,
+                }),
+            ),
+            (
+                "missing page size",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": good_cfg,
+                }),
+            ),
+            (
+                "zero page size",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": good_cfg,
+                    "page_size": 0,
+                }),
+            ),
+            (
+                "negative page size",
+                serde_json::json!({
+                    "model_path": "/m",
+                    "kv_events_config": good_cfg,
+                    "page_size": -1,
+                }),
+            ),
+        ];
+
+        for (name, args) in cases {
+            let v = shape_for_args(args);
+            assert!(v["kv_events"].is_null(), "{name}: {:?}", v["kv_events"]);
+        }
     }
 }

--- a/rust/sglang-server/src/runtime/config.rs
+++ b/rust/sglang-server/src/runtime/config.rs
@@ -124,6 +124,17 @@ pub struct ServerArgs {
     pub version: Option<String>,
     #[serde(default)]
     pub max_total_num_tokens: Option<u64>,
+    /// Raw Python `--kv-events-config`; parsed only into the safe `/server_info`
+    /// descriptor, never exposed verbatim.
+    #[serde(default)]
+    pub kv_events_config: Option<String>,
+    /// KV cache page size, advertised as the KV-events block size when the
+    /// scheduler-side publisher is enabled.
+    #[serde(default)]
+    pub page_size: Option<i64>,
+    /// Number of data-parallel KV-event publishers a consumer should subscribe to.
+    #[serde(default = "default_dp_size")]
+    pub dp_size: i64,
 }
 
 /// The slice of the resolved Python `ModelConfig` the rust server reads.
@@ -151,6 +162,25 @@ fn default_log_level() -> String {
 }
 fn default_worker_num() -> usize {
     1
+}
+fn default_dp_size() -> i64 {
+    1
+}
+fn default_kv_events_publisher() -> String {
+    "null".into()
+}
+fn default_kv_events_endpoint() -> String {
+    "tcp://*:5557".into()
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct KvEventsConfig {
+    #[serde(default = "default_kv_events_publisher")]
+    publisher: String,
+    #[serde(default = "default_kv_events_endpoint")]
+    endpoint: String,
+    #[serde(default)]
+    topic: String,
 }
 
 impl ServerArgs {
@@ -199,5 +229,37 @@ impl ServerArgs {
     pub fn api_worker_num(&self) -> usize {
         4.max(self.tokenizer_worker_num)
             .max(self.detokenizer_worker_num)
+    }
+
+    /// Structured KV-event publisher descriptor for `/server_info`.
+    ///
+    /// Mirrors Python `ServerArgs.describe_kv_events_publisher`: malformed or
+    /// non-routable configs are reported as `null` so `/server_info` remains
+    /// available, and raw config strings are never exposed.
+    pub fn describe_kv_events_publisher(&self) -> Option<serde_json::Value> {
+        let raw = self.kv_events_config.as_deref().filter(|s| !s.is_empty())?;
+        let page_size = self.page_size.filter(|page_size| *page_size > 0)?;
+
+        let cfg: KvEventsConfig = serde_json::from_str(raw).ok()?;
+        if cfg.publisher == "null" || cfg.endpoint.is_empty() {
+            return None;
+        }
+
+        let body = cfg.endpoint.strip_prefix("tcp://")?;
+        let last_colon = body.rfind(':')?;
+        let host = &body[..last_colon];
+        let port = body[last_colon + 1..].trim().parse::<i64>().ok()?;
+        if host.is_empty() || !(1..=65535).contains(&port) {
+            return None;
+        }
+
+        Some(serde_json::json!({
+            "publisher": cfg.publisher,
+            "endpoint_host": host,
+            "endpoint_port_base": port,
+            "topic": cfg.topic,
+            "block_size": page_size,
+            "dp_size": self.dp_size,
+        }))
     }
 }


### PR DESCRIPTION
## What changed

Rust server `/server_info` now returns the same `kv_events` discovery field that Python `/server_info` already returns (#25844).

Before this PR:

- Python workers exposed `kv_events` from `/server_info`
- Rust frontend workers did not expose that field
- KV-aware routers could not use the same discovery path for Rust workers

After this PR:

- Rust `/server_info` includes a structured `kv_events` descriptor when the configured publisher is safe to advertise
- Rust `/server_info` returns `"kv_events": null` when the config is disabled, malformed, non-TCP, has an invalid port, or lacks a positive page size
- Rust keeps its existing safe `/server_info` behavior: no raw `server_args`, no raw `kv_events_config`, and no secret fields are exposed

This is introspection-only. It does not implement KV-event publishing or move the scheduler-side publisher.

## Code changes

- `rust/sglang-server/src/runtime/config.rs`
  - add typed `ServerArgs` fields for `kv_events_config`, `page_size`, and `dp_size`
  - add `ServerArgs::describe_kv_events_publisher()`
  - parse ZMQ-style TCP endpoints into `endpoint_host` and `endpoint_port_base`
  - validate publisher state, TCP scheme, port range, and positive page size

- `rust/sglang-server/src/api_server/common.rs`
  - include `kv_events` in the shaped Rust `/server_info` response
  - keep the response allowlisted instead of dumping raw server args
  - add tests for valid descriptors, invalid configs, and secret redaction

## Example

Given these Rust server args:

```json
{
  "kv_events_config": "{\"publisher\":\"zmq\",\"endpoint\":\"tcp://*:5557\",\"topic\":\"kv\"}",
  "page_size": 64,
  "dp_size": 2
}
```

Rust `/server_info` now includes:

```json
{
  "kv_events": {
    "publisher": "zmq",
    "endpoint_host": "*",
    "endpoint_port_base": 5557,
    "topic": "kv",
    "block_size": 64,
    "dp_size": 2
  }
}
```

## Validation

Local macOS:

- `cargo fmt --manifest-path rust/Cargo.toml --package sglang-server --check`
- `cargo test --manifest-path rust/Cargo.toml -p sglang-server --lib api_server::common::tests::shape_server_info`
  - `4 passed`

Remote Linux/PyO3 validation on `root@134.199.199.149`, with heavy build paths on `/mnt/lmcache-build/sglang-rust-server-kv-events`:

- `cargo fmt --manifest-path rust/Cargo.toml --package sglang-server --check`
- `cargo test --manifest-path rust/Cargo.toml -p sglang-server --lib api_server::common::tests::shape_server_info`
  - `4 passed`
- `cargo test --manifest-path rust/Cargo.toml -p sglang-server`
  - branch `1702c0aff`: `135 passed; 3 failed`
  - base `fd28242b68`: `132 passed; 3 failed`
  - same pre-existing failures on both branch and base:
    - `api_server::frame::tests::cumulative_frame_json_matches_serde`
    - `api_server::frame::tests::cumulative_frame_json_matches_serde_with_logprobs`
    - `message::egress::tests::chunk_event_frame_stays_small`

Live Rust HTTP E2E:

- rebuilt the Rust server PyO3 extension from this branch
- started a real `sglang.srt.server._core.Server` with `skip_tokenizer_init=true`
- sent a real HTTP `GET /server_info` request to the Rust Axum listener
- decoded the ingress `GetInternalStateReq` and replied through `push_result`, simulating the scheduler control response
- verified HTTP 200
- verified the returned `kv_events` descriptor exactly matches the expected ZMQ host/port/topic/block-size/dp-size payload
- verified the serialized response does not contain `api_key`, `admin_api_key`, raw `kv_events_config`, or a nested test password

Result:

```text
LIVE_E2E_PASS
commit 1702c0aff
kv_events {"block_size":64,"dp_size":2,"endpoint_host":"*","endpoint_port_base":5557,"publisher":"zmq","topic":"kv"}
```

Fixes #33055.
Part of #23206.
Related to #29799.
Follow-up to #25844.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30622023649](https://github.com/sgl-project/sglang/actions/runs/30622023649)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30622023378](https://github.com/sgl-project/sglang/actions/runs/30622023378)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

