### PR TITLE
[Kimi-K3] Avoid per-page D2H sync in large lazy-compaction batches

### DIFF
--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -60,6 +60,10 @@ _LAZY_COMPACTION_STATS_INTERVAL_SEC = float(
 # Signal handler emits each instance's final counters (atexit misses signal exits).
 _STATS_INSTANCES: weakref.WeakSet[MultiEndedAllocator] = weakref.WeakSet()
 _SIGNAL_HANDLERS_INSTALLED = False
+# A GPU gather plus async invariant check is cheaper than one D2H `.item()` per
+# survivor only once the move batch is moderately large. Small batches retain
+# the lower-launch-overhead host path.
+_DEVICE_V_MOVED_GATHER_THRESHOLD = 16
 
 
 def _emit_all_final_stats(reason: str) -> None:
@@ -1416,8 +1420,10 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             `_commit_move_batch` routes such srcs to `_pending_reuse`; urgent's
             settle makes them immediately reusable.
 
-        `_topmost_survivor` excludes all p2v=-1 pages, so a `v_moved < 0` in the
-        loop is a corrupt-state bug and raises.
+        `_topmost_survivor` excludes all p2v=-1 pages. `_commit_move_batch`
+        validates that invariant while choosing an adaptive remap path: small
+        move batches retain the low-launch-overhead host lookup, while large
+        batches gather every moved virtual id in one GPU operation.
         """
         if not self.lazy_compaction:
             return 0
@@ -1453,7 +1459,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
 
             srcs: List[int] = []
             dsts: List[int] = []
-            v_moveds: List[int] = []
 
             # Flush-scoped accumulator for event-FIRED srcs. `_commit_move_batch`
             # appends here instead of catting onto `_free_phys_pages`; the merge is
@@ -1498,12 +1503,11 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                         # Commit accumulated moves, then wait the forward so the
                         # rest of the walk is race-free.
                         self._commit_move_batch(
-                            srcs, dsts, v_moveds, latest_event, released_fired
+                            srcs, dsts, latest_event, released_fired
                         )
                         n_moves += len(srcs)
                         srcs.clear()
                         dsts.clear()
-                        v_moveds.clear()
                         inflight = self._inflight_forward
                         if inflight is not None:
                             torch.cuda.current_stream().wait_event(inflight[0])
@@ -1534,22 +1538,8 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                     dst_cursor -= 1
                 n_dst_consumed += 1
 
-                v_moved = int(self.physical_to_virtual[src].item())
-                if v_moved < 0:
-                    # `_topmost_survivor` excludes all p2v=-1 pages — corrupt state.
-                    raise AssertionError(
-                        f"MultiEndedAllocator({self.sub_pool_name!r})."
-                        f"_flush: topmost survivor p={src} has p2v=-1; "
-                        "this should be impossible (`_topmost_survivor` "
-                        "excludes `holes_cpu` and `_pending_reuse_pages_cpu`)."
-                        f" State: {self.allocator_state_str()}, "
-                        f"#holes={len(holes_cpu)}, "
-                        f"#pending_reuse={len(self._pending_reuse_pages_cpu)}"
-                    )
-
                 srcs.append(src)
                 dsts.append(dst)
-                v_moveds.append(v_moved)
 
                 # Advance cursor strictly past the picked src.
                 if self.grow_direction == "up":
@@ -1560,7 +1550,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                 if move_cap is not None and len(srcs) >= move_cap:
                     break
 
-            self._commit_move_batch(srcs, dsts, v_moveds, latest_event, released_fired)
+            self._commit_move_batch(srcs, dsts, latest_event, released_fired)
             n_moves += len(srcs)
 
             if single_pass_absorb:
@@ -1601,21 +1591,48 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         self,
         srcs: List[int],
         dsts: List[int],
-        v_moveds: List[int],
         latest_event: Optional[torch.cuda.Event],
         released_fired: List[torch.Tensor],
     ) -> None:
         """Issue ONE `move_kv_cache` + ONE bulk v2p/p2v remap for the accumulated
-        `(src, dst, v_moved)` triples. Fired srcs accumulate in `released_fired`
-        (merged by `_flush` AFTER its dst-slice, keeping the free list == holes_cpu);
-        event-pending srcs route to `_pending_reuse` (read-race gating).
+        `(src, dst)` pairs. Large batches gather every `v_moved` on-device from
+        p2v instead of synchronizing once per survivor; small batches retain the
+        lower-launch-overhead host path. Fired srcs accumulate in
+        `released_fired` (merged by `_flush` AFTER its dst-slice, keeping the
+        free list == holes_cpu); event-pending srcs route to `_pending_reuse`
+        (read-race gating).
         """
         if not srcs:
             return
         with record_function("MultiEndedAlloc._commit_move_batch"):
+            use_device_gather = (
+                torch.device(self.device).type != "cpu"
+                and len(srcs) >= _DEVICE_V_MOVED_GATHER_THRESHOLD
+            )
+            if not use_device_gather:
+                # Preserve the original small-batch ordering: read p2v before
+                # enqueueing the src/dst H2D tensors, so the first `.item()` does
+                # not synchronize behind those transfers.
+                v_moveds = [int(self.physical_to_virtual[src].item()) for src in srcs]
+                if any(v_moved < 0 for v_moved in v_moveds):
+                    raise AssertionError(
+                        "MultiEndedAllocator._commit_move_batch: selected a p2v=-1 "
+                        "source page"
+                    )
+
             src_pages_t = torch.tensor(srcs, dtype=torch.int64, device=self.device)
             dst_pages_t = torch.tensor(dsts, dtype=torch.int64, device=self.device)
-            v_moveds_t = torch.tensor(v_moveds, dtype=torch.int64, device=self.device)
+            if use_device_gather:
+                v_moveds_t = self.physical_to_virtual[src_pages_t].clone()
+                torch._assert_async(
+                    torch.all(v_moveds_t >= 0),
+                    "MultiEndedAllocator._commit_move_batch: selected a p2v=-1 "
+                    "source page",
+                )
+            else:
+                v_moveds_t = torch.tensor(
+                    v_moveds, dtype=torch.int64, device=self.device
+                )
             # Expand to token granularity (the move kernel is token-granular).
             if self.page_size == 1:
                 src_t, dst_t = src_pages_t, dst_pages_t

--- a/test/registered/kernels/test_multi_ended_allocator_cuda.py
+++ b/test/registered/kernels/test_multi_ended_allocator_cuda.py
@@ -1,0 +1,81 @@
+import torch
+from sglang.srt.mem_cache.multi_ended_allocator import MultiEndedAllocator
+from sglang.srt.mem_cache.unified_memory_pool import (
+    MambaSubPoolSpec,
+    MHASubPoolSpec,
+    UnifiedKVPool,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+class _MarkerKVCache:
+    def __init__(self, max_slots: int):
+        self.markers = torch.full((max_slots,), -1, dtype=torch.int64, device="cuda")
+
+    def move_kv_cache(self, dst_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        self.markers[dst_loc] = self.markers[src_loc]
+
+
+def test_large_lazy_compaction_device_remap_preserves_data():
+    full = MHASubPoolSpec(
+        name="full",
+        layer_num=1,
+        head_num=1,
+        head_dim=8,
+        store_dtype=torch.float16,
+        grow_direction="up",
+    )
+    mamba = MambaSubPoolSpec(
+        name="mamba",
+        layer_num=1,
+        conv_state_shapes=((4, 3),),
+        conv_dtype=torch.float32,
+        temporal_state_shape=(2, 2, 2),
+        temporal_dtype=torch.float32,
+        grow_direction="down",
+    )
+    total_bytes = full.entry_bytes() * 256 + mamba.entry_bytes() * 64
+    pool = UnifiedKVPool(
+        total_bytes=total_bytes,
+        sub_pool_specs=[full, mamba],
+        device="cuda",
+        enable_memory_saver=False,
+    )
+    full_cache = _MarkerKVCache(pool.max_slots("full"))
+    mamba_cache = _MarkerKVCache(pool.max_slots("mamba"))
+    full_alloc = MultiEndedAllocator(
+        kvcache=full_cache,
+        unified_buffer=pool,
+        sub_pool_name="full",
+        device="cuda",
+        is_id_owner=True,
+        lazy_compaction=True,
+    )
+    mamba_alloc = MultiEndedAllocator(
+        kvcache=mamba_cache,
+        unified_buffer=pool,
+        sub_pool_name="mamba",
+        device="cuda",
+        is_id_owner=True,
+        lazy_compaction=True,
+    )
+    full_alloc.bind_peer(mamba_alloc)
+    mamba_alloc.bind_peer(full_alloc)
+
+    virtual = full_alloc.alloc(64)
+    assert virtual is not None
+    physical = full_alloc.virtual_to_physical[virtual]
+    full_cache.markers[physical] = virtual
+
+    freed = virtual[:32:2]
+    full_alloc.free(freed)
+    moves = full_alloc._flush(urgent=True)
+    torch.cuda.synchronize()
+
+    assert moves == 16
+    live = virtual[~torch.isin(virtual, freed)]
+    live_physical = full_alloc.virtual_to_physical[live]
+    assert torch.equal(full_cache.markers[live_physical], live)
+    assert torch.equal(full_alloc.physical_to_virtual[live_physical], live)


### PR DESCRIPTION
## Summary

This PR removes a per-page device-to-host synchronization sequence from large lazy-compaction batches in `MultiEndedAllocator`.

- For fewer than 16 moved pages, retain the original host scalar lookup path.
- For at least 16 moved pages, gather all moved virtual page IDs on the GPU in one operation.
- Validate the gathered IDs with an asynchronous device assertion.
- Preserve the existing page selection, KV relocation, v2p/p2v update, event gating, and small-batch behavior.

## Motivation

The lazy-compaction path already batches KV movement and page-table updates, but its survivor walk reads one GPU scalar per moved page:

```python
physical_to_virtual[src].item()
```

Each `.item()` can synchronize the host scheduler with the CUDA stream. A long Kimi-K3 request has 64 MLA pages at 4096 tokens with page size 64, so one compaction flush can perform dozens of serial host synchronizations before submitting the already-batched relocation.

The issue is in the generic unified-pool allocator. Kimi-K3's large MLA pages and recurrent-state slots make it especially visible under long-request churn and high memory pressure.

## Before and after

```text
Before, N moved pages:
  N scalar GPU-to-CPU p2v reads
    -> one batched KV move
    -> one batched page-table update

After, N >= 16:
  one GPU p2v gather plus async validation
    -> the same batched KV move
    -> the same batched page-table update
```

The threshold is empirical. The extra GPU gather launch does not repay its cost for one-to-seven-page batches, so small compactions continue to use the original path.

## Performance

Measured on one NVIDIA GB200 using a deterministic Kimi-K3 unified-pool churn driver with real storage geometry:

- 24 MLA layers, BF16, 1,769,472 bytes per 64-token page.
- 69 KDA layers, 112,343,040 bytes per request state slot.
- Short, long, and alternating traffic at 50%-99% target pressure.
- Prefix reuse at 0%, 50%, and 90%, plus a 10% abort workload.

At 99% target pressure, for large long/alternating cells with 0% or 50% prefix reuse:

| Metric | Median improvement |
| --- | ---: |
| Compaction flush p99 | 23.6% |
| Scheduler-step p99 | 20.1% |

Large-cell scheduler-step p99 improvements ranged from 13.4% to 31.2%.

In a pessimistic flush-every-step guardrail across eight high-pressure cells:

| Metric | Absolute saving | Improvement |
| --- | ---: | ---: |
| Compaction flush p99 | 540.6 us | 17.7% |
| Scheduler-step p99 | 528.5 us | 10.1% |

Small-cell changes were noise-level: +0.8% nominal flush improvement and -0.4% nominal scheduler-step change.

For context, existing lazy compaction already reduced relocation traffic by 96.85% versus eager compaction in this matrix. That byte reduction is existing SGLang behavior, not a result of this PR. This PR targets the remaining host synchronization overhead.

No request-level serving speedup is claimed.

## Validation

- `65 passed`: `test/registered/unit/mem_cache/test_multi_ended_allocator.py`
- `1 passed`: focused CUDA large-remap test in `test/registered/kernels/test_multi_ended_allocator_cuda.py`
- `72/72` deterministic lazy-compaction matrix cells passed with zero allocation loss and exact relocation markers.
- `18/18` repeated 99%-pressure candidate cells passed.
- `8/8` flush-every-step guardrail cells improved.
- `git diff --check` and compile checks passed.

## Related PRs

- Parent Kimi-K3 integration: #32541
- Kimi-K3 follow-up tracker: #32607
- Direct-final Query publication: #33069
- Replicated-Q storage ownership: #33070
- TP4 fused KDA decode: #33071
- KDA temporal-state copy-on-write: #33072
- Fused NVIDIA KDA prefill staging: #33073
- Unified memory pool origin: #29678
- Lazy-compaction default/configuration: #31162
