### PR TITLE
[Kimi-K3] Add direct-final NVLS Query publication

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -398,7 +398,13 @@ def _kimi_k3_overrides(server_args: Any, hf_config: Any) -> dict:
                 f"Decode attention backend for Kimi-K3 DCP must be 'cutedsl_mla' or 'tokenspeed_mla', got {decode_backend!r}."
             )
 
-        if server_args.dcp_replicate_q_proj is None:
+        if server_args.dcp_direct_q_gather:
+            logger.info(
+                "Kimi-K3 DCP enables direct-final NVLS Query publication and "
+                "disables replicated Q projection."
+            )
+            overrides["dcp_replicate_q_proj"] = False
+        elif server_args.dcp_replicate_q_proj is None:
             logger.info("Kimi-K3 DCP enables replicated Q projection by default.")
             overrides["dcp_replicate_q_proj"] = True
 

--- a/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
+++ b/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Symmetric-memory ``multimem.st`` all-gather along the hidden (last) dim.
+"""Symmetric-memory ``multimem.st`` all-gather into a final hidden layout.
 
 Each rank stores its ``[T, H/TP]`` shard into a multicast buffer in one NVLink
 pass instead of an NCCL ring; ``create_state`` rendezvous once so launches are
-CUDA-graph capturable.
+CUDA-graph capturable. The split-input variant writes strided ``q_nope`` and
+``q_rope`` tensors directly into a packed per-head Query layout.
 """
 
 import logging
@@ -287,6 +288,84 @@ def _all_gather_kernel_inner(
     _blockwise_barrier(signal_pad_ptr, RANK, WORLD_SIZE, sem="acq_rel")
 
 
+@triton.jit
+def _all_gather_split_kernel_inner(
+    nope_ptr,
+    rope_ptr,
+    multicast_ptr,
+    signal_pad_ptr,
+    total_tokens,
+    nope_stride_t,
+    nope_stride_h,
+    rope_stride_t,
+    rope_stride_h,
+    LOCAL_HEADS: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    TOTAL_HIDDEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    NUMEL_PER_THREAD: tl.constexpr,
+    RANK: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+) -> None:
+    """Publish split per-head Query inputs into one rank-major final row."""
+    _blockwise_barrier(signal_pad_ptr, RANK, WORLD_SIZE, sem="relaxed")
+    _sync_threads()
+
+    nope_chunks: tl.constexpr = NOPE_DIM // NUMEL_PER_THREAD
+    rope_chunks: tl.constexpr = ROPE_DIM // NUMEL_PER_THREAD
+    head_chunks: tl.constexpr = nope_chunks + rope_chunks
+    local_chunks: tl.constexpr = LOCAL_HEADS * head_chunks
+    total_hidden_chunks: tl.constexpr = TOTAL_HIDDEN // NUMEL_PER_THREAD
+    rank_offset_chunks: tl.constexpr = RANK * local_chunks
+    total_chunks = total_tokens * local_chunks
+
+    pid = tl.program_id(axis=0)
+    tid = _get_flat_tid()
+    block_start = pid * BLOCK_SIZE
+
+    while block_start < total_chunks:
+        chunk = block_start + tid
+        mask = chunk < total_chunks
+        token = chunk // local_chunks
+        local_col = chunk % local_chunks
+        head = local_col // head_chunks
+        head_col = local_col % head_chunks
+        is_nope = head_col < nope_chunks
+
+        nope_col = head_col * NUMEL_PER_THREAD
+        rope_col = (head_col - nope_chunks) * NUMEL_PER_THREAD
+        nope_addr = (
+            nope_ptr
+            + token * nope_stride_t
+            + head * nope_stride_h
+            + nope_col
+        )
+        rope_addr = (
+            rope_ptr
+            + token * rope_stride_t
+            + head * rope_stride_h
+            + rope_col
+        )
+        in_ptr = tl.where(is_nope, nope_addr, rope_addr).to(
+            tl.pointer_type(tl.uint64)
+        )
+
+        out_chunk = (
+            token * total_hidden_chunks + rank_offset_chunks + local_col
+        )
+        out_ptr = (
+            multicast_ptr.to(tl.int64).to(tl.pointer_type(tl.uint64))
+            + out_chunk * 2
+        )
+        x, y, z, w = _local_ld_128(in_ptr, mask)
+        _multimem_st_128(out_ptr, x, y, z, w, mask)
+        block_start += tl.num_programs(axis=0) * BLOCK_SIZE
+
+    _sync_threads()
+    _blockwise_barrier(signal_pad_ptr, RANK, WORLD_SIZE, sem="acq_rel")
+
+
 # ------------------------------------------------------------------------------
 # Public API
 # ------------------------------------------------------------------------------
@@ -411,6 +490,91 @@ def all_gather_inner(
     )
     output = state.comm_buff[:total_tokens, :tp_hidden_dim]
     return output.clone() if safe else output
+
+
+def all_gather_split_inner(
+    state: MultimemAllGatherState,
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+) -> torch.Tensor:
+    """Gather split ``[T,H,D]`` Query tensors directly into ``[T,H*P,Dn+Dr]``.
+
+    Unlike :func:`all_gather_inner`, this path accepts token/head-strided
+    inputs. It avoids first materializing a contiguous local Query concat.
+    """
+    assert q_nope.dtype == q_rope.dtype == torch.bfloat16, (
+        "Only bfloat16 is supported"
+    )
+    assert q_nope.ndim == q_rope.ndim == 3, (
+        "q_nope and q_rope must have shape [T,H,D]"
+    )
+    assert q_nope.shape[:2] == q_rope.shape[:2], (
+        "q_nope and q_rope must have matching token/head dimensions"
+    )
+    assert q_nope.device == q_rope.device == state.device, (
+        "q_nope, q_rope, and the symmetric workspace must share a device"
+    )
+    assert q_nope.stride(-1) == q_rope.stride(-1) == 1, (
+        "q_nope and q_rope must be contiguous in the last dimension"
+    )
+    assert q_nope.data_ptr() % 16 == q_rope.data_ptr() % 16 == 0, (
+        "q_nope and q_rope must have 16-byte-aligned base pointers"
+    )
+    assert all(
+        stride % _NUMEL_PER_THREAD == 0
+        for stride in (
+            q_nope.stride(0),
+            q_nope.stride(1),
+            q_rope.stride(0),
+            q_rope.stride(1),
+        )
+    ), "q_nope and q_rope token/head strides must preserve 16-byte alignment"
+
+    total_tokens, local_heads, nope_dim = q_nope.shape
+    rope_dim = q_rope.shape[-1]
+    head_dim = nope_dim + rope_dim
+    local_hidden = local_heads * head_dim
+    total_hidden = local_hidden * state.world_size
+    assert nope_dim % _NUMEL_PER_THREAD == 0, (
+        f"q_nope dim ({nope_dim}) must be a multiple of {_NUMEL_PER_THREAD}"
+    )
+    assert rope_dim % _NUMEL_PER_THREAD == 0, (
+        f"q_rope dim ({rope_dim}) must be a multiple of {_NUMEL_PER_THREAD}"
+    )
+    assert total_hidden <= state.hidden_dim, (
+        f"comm buffer too narrow: required={total_hidden} > "
+        f"state.hidden_dim={state.hidden_dim}"
+    )
+    assert 0 < total_tokens <= state.max_token_num, (
+        f"total_tokens={total_tokens} exceeds max_token_num={state.max_token_num}"
+    )
+
+    num_blocks, block_size, num_warps, numel_per_thread = _launch_config(
+        total_tokens * local_hidden
+    )
+    _all_gather_split_kernel_inner[(num_blocks, 1, 1)](
+        nope_ptr=q_nope,
+        rope_ptr=q_rope,
+        multicast_ptr=state.symm_mem_hdl.multicast_ptr,
+        signal_pad_ptr=state.symm_mem_hdl.signal_pad_ptrs_dev,
+        total_tokens=total_tokens,
+        nope_stride_t=q_nope.stride(0),
+        nope_stride_h=q_nope.stride(1),
+        rope_stride_t=q_rope.stride(0),
+        rope_stride_h=q_rope.stride(1),
+        LOCAL_HEADS=local_heads,
+        NOPE_DIM=nope_dim,
+        ROPE_DIM=rope_dim,
+        TOTAL_HIDDEN=state.hidden_dim,
+        BLOCK_SIZE=block_size,
+        NUMEL_PER_THREAD=numel_per_thread,
+        RANK=state.rank_in_group,
+        WORLD_SIZE=state.world_size,
+        num_warps=num_warps,
+    )
+    return state.comm_buff[:total_tokens, :total_hidden].view(
+        total_tokens, local_heads * state.world_size, head_dim
+    )
 
 
 # ------------------------------------------------------------------------------

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1499,23 +1499,24 @@ class Engine(EngineScoreMixin, EngineBase):
 
 def _set_envs_and_config(server_args: ServerArgs):
     # Set global environments
+    requires_nvls = server_args.enable_symm_mem or server_args.dcp_direct_q_gather
     # MNNVL fabric (GB200/GB300) multi-node: cross-node NVLink needs NCCL's
     # cuMem-based buffers and MNNVL transport. Default them on (user-set
     # values win; the symm-mem override below only fires when unset).
     if server_args.nnodes > 1 and is_mnnvl_fabric_device():
         os.environ.setdefault("NCCL_CUMEM_ENABLE", "1")
         os.environ.setdefault("NCCL_MNNVL_ENABLE", "1")
-    if "NCCL_CUMEM_ENABLE" not in os.environ or server_args.enable_symm_mem:
-        os.environ["NCCL_CUMEM_ENABLE"] = str(int(server_args.enable_symm_mem))
+    if "NCCL_CUMEM_ENABLE" not in os.environ or requires_nvls:
+        os.environ["NCCL_CUMEM_ENABLE"] = str(int(requires_nvls))
     if (
         "NCCL_NVLS_ENABLE" not in os.environ
         or server_args.enable_nccl_nvls
-        or server_args.enable_symm_mem
+        or requires_nvls
     ):
         os.environ["NCCL_NVLS_ENABLE"] = str(
-            int(server_args.enable_nccl_nvls or server_args.enable_symm_mem)
+            int(server_args.enable_nccl_nvls or requires_nvls)
         )
-    if "NCCL_GRAPH_MIXING_SUPPORT" not in os.environ or server_args.enable_symm_mem:
+    if "NCCL_GRAPH_MIXING_SUPPORT" not in os.environ or requires_nvls:
         # Note(wh): NCCL_GRAPH_MIXING_SUPPORT=0 can help improve performance for symmetric kernels.
         # details in https://github.com/NVIDIA/nccl-tests/issues/333#issuecomment-3103636985
         if server_args.dcp_size > 1:

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -21,7 +21,7 @@ PR #25090 vs #14194):
 """
 
 import warnings
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -36,6 +36,9 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.runtime_context import get_parallel
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.dcp.query import DCPDirectFinalQueryGatherer
 
 
 def _warn_deprecated_dcp_accessor(name: str, replacement: str) -> None:
@@ -239,7 +242,11 @@ def all_gather_kv_cache_for_mha_extend(
 def all_gather_q_for_mla_decode(
     q_nope_out: torch.Tensor,
     q_pe: torch.Tensor,
+    direct_gatherer: Optional["DCPDirectFinalQueryGatherer"] = None,
 ):
+    if direct_gatherer is not None:
+        return direct_gatherer(q_nope_out, q_pe)
+
     group = get_parallel().dcp_group
     with use_symmetric_memory(group):
         # transpose q_pe and q_nope_out from [B, H, L] to [H, B, L]

--- a/python/sglang/srt/layers/dcp/query.py
+++ b/python/sglang/srt/layers/dcp/query.py
@@ -1,0 +1,146 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Direct-to-final Query publication for decode context parallel MLA.
+
+Each DCP rank computes only its local Query heads and publishes the strided
+``q_nope`` and ``q_rope`` inputs through an NVLS multicast mapping directly
+into their offsets in the final complete Query buffer on every consumer. The
+attention kernels keep their existing local-input contract.
+
+The underlying multimem kernel has an entry barrier before it overwrites the
+shared buffer and an acquire-release exit barrier after publication. A single
+workspace can therefore be reused by sequential MLA layers: a rank cannot enter
+the next publication until its local attention consumer has finished, and the
+entry barrier prevents any producer from overwriting the previous Query until
+all ranks have reached that point.
+"""
+
+from __future__ import annotations
+
+import torch
+from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
+    MultimemAllGatherState,
+    all_gather_split_inner,
+    create_state,
+)
+from sglang.srt.distributed.parallel_state import GroupCoordinator
+
+
+class DCPDirectFinalQueryGatherer:
+    """Persistent DCP Query workspace backed by symmetric NVLS storage."""
+
+    def __init__(
+        self,
+        *,
+        group: GroupCoordinator,
+        max_tokens: int,
+        local_heads: int,
+        nope_dim: int,
+        rope_dim: int,
+        device: torch.device,
+    ) -> None:
+        if group.world_size <= 1:
+            raise ValueError("Direct-final DCP Query requires at least two ranks.")
+        if max_tokens <= 0:
+            raise ValueError(
+                f"Direct-final DCP Query max_tokens must be positive, got {max_tokens}."
+            )
+        if local_heads <= 0 or nope_dim <= 0 or rope_dim <= 0:
+            raise ValueError(
+                "Direct-final DCP Query dimensions must be positive, got "
+                f"local_heads={local_heads}, nope_dim={nope_dim}, rope_dim={rope_dim}."
+            )
+
+        self.group = group
+        self.max_tokens = int(max_tokens)
+        self.local_heads = int(local_heads)
+        self.global_heads = self.local_heads * group.world_size
+        self.nope_dim = int(nope_dim)
+        self.rope_dim = int(rope_dim)
+        self.head_dim = self.nope_dim + self.rope_dim
+        self.local_hidden = self.local_heads * self.head_dim
+        self.global_hidden = self.global_heads * self.head_dim
+
+        if self.local_hidden % 8 != 0:
+            raise ValueError(
+                "Direct-final DCP Query requires each BF16 shard row to contain "
+                f"a multiple of eight elements, got {self.local_hidden}."
+            )
+
+        self.state: MultimemAllGatherState = create_state(
+            group=group.device_group,
+            rank_in_group=group.rank_in_group,
+            max_tokens=self.max_tokens,
+            hidden_size=self.global_hidden,
+            device=device,
+        )
+        if self.state.symm_mem_hdl.multicast_ptr == 0:
+            raise RuntimeError(
+                "Direct-final DCP Query requires an NVLS multicast mapping for "
+                f"world_size={group.world_size}."
+            )
+
+    def __call__(
+        self,
+        q_nope: torch.Tensor,
+        q_rope: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self._validate_inputs(q_nope, q_rope)
+
+        final_query = all_gather_split_inner(self.state, q_nope, q_rope)
+        final_nope, final_rope = final_query.split(
+            (self.nope_dim, self.rope_dim), dim=-1
+        )
+        return final_nope, final_rope
+
+    def _validate_inputs(
+        self,
+        q_nope: torch.Tensor,
+        q_rope: torch.Tensor,
+    ) -> None:
+        expected_nope = (self.local_heads, self.nope_dim)
+        expected_rope = (self.local_heads, self.rope_dim)
+        if q_nope.ndim != 3 or tuple(q_nope.shape[1:]) != expected_nope:
+            raise ValueError(
+                "Direct-final DCP Query expected q_nope shape "
+                f"[T,{self.local_heads},{self.nope_dim}], got {tuple(q_nope.shape)}."
+            )
+        if q_rope.ndim != 3 or tuple(q_rope.shape[1:]) != expected_rope:
+            raise ValueError(
+                "Direct-final DCP Query expected q_rope shape "
+                f"[T,{self.local_heads},{self.rope_dim}], got {tuple(q_rope.shape)}."
+            )
+        if q_nope.shape[0] != q_rope.shape[0]:
+            raise ValueError(
+                "Direct-final DCP Query requires matching token counts, got "
+                f"{q_nope.shape[0]} and {q_rope.shape[0]}."
+            )
+        if not 0 < q_nope.shape[0] <= self.max_tokens:
+            raise ValueError(
+                "Direct-final DCP Query token count exceeds the persistent "
+                f"workspace: {q_nope.shape[0]} > {self.max_tokens}."
+            )
+        if q_nope.dtype != torch.bfloat16 or q_rope.dtype != torch.bfloat16:
+            raise TypeError(
+                "Direct-final DCP Query currently requires BF16 inputs, got "
+                f"{q_nope.dtype} and {q_rope.dtype}."
+            )
+        if not q_nope.is_cuda or not q_rope.is_cuda:
+            raise ValueError("Direct-final DCP Query inputs must be CUDA tensors.")
+        if q_nope.device != q_rope.device or q_nope.device != self.state.device:
+            raise ValueError(
+                "Direct-final DCP Query inputs and workspace must share a device, "
+                f"got {q_nope.device}, {q_rope.device}, and {self.state.device}."
+            )

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -874,8 +874,71 @@ class ModelRunner:
         self.prefill_attention_backend_str = backends.prefill_attention_backend_str
         self.decode_attention_backend_str = backends.decode_attention_backend_str
 
-        if self.server_args.dcp_size > 1 and self.server_args.dcp_replicate_q_proj:
-            self._prepare_replicated_q_proj()
+        if self.server_args.dcp_size > 1 and self.use_mla_backend:
+            if self.server_args.dcp_direct_q_gather:
+                self._prepare_direct_q_gather()
+            elif self.server_args.dcp_replicate_q_proj:
+                self._prepare_replicated_q_proj()
+
+    def _prepare_direct_q_gather(self) -> None:
+        """Allocate persistent direct-final Query storage before graph capture."""
+        from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
+            recommended_max_tokens,
+        )
+        from sglang.srt.layers.dcp.query import DCPDirectFinalQueryGatherer
+        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+
+        dcp_group = get_parallel().dcp_group
+        if dcp_group.world_size <= 1:
+            return
+
+        max_tokens = recommended_max_tokens(include_prefill=False, floor=1)
+        gatherers = {}
+        n_prepared = 0
+        for module in self.model.modules():
+            if not isinstance(module, DeepseekV2AttentionMLA):
+                continue
+            if module.w_kc is None:
+                continue
+
+            key = (
+                module.num_local_heads,
+                module.kv_lora_rank,
+                module.qk_rope_head_dim,
+                module.w_kc.device,
+            )
+            gatherer = gatherers.get(key)
+            if gatherer is None:
+                gatherer = DCPDirectFinalQueryGatherer(
+                    group=dcp_group,
+                    max_tokens=max_tokens,
+                    local_heads=module.num_local_heads,
+                    nope_dim=module.kv_lora_rank,
+                    rope_dim=module.qk_rope_head_dim,
+                    device=module.w_kc.device,
+                )
+                gatherers[key] = gatherer
+            module.dcp_direct_q_gatherer = gatherer
+            n_prepared += 1
+
+        if n_prepared == 0:
+            if self.ps.pp_size > 1:
+                logger.info(
+                    "dcp_direct_q_gather: this pipeline stage has no eligible "
+                    "MLA layers."
+                )
+                return
+            raise RuntimeError(
+                "--dcp-direct-q-gather was requested, but no eligible MLA layers "
+                "were found."
+            )
+        logger.info(
+            "dcp_direct_q_gather: prepared %d MLA layers with %d persistent "
+            "workspace layout(s), max_tokens=%d",
+            n_prepared,
+            len(gatherers),
+            max_tokens,
+        )
 
     def _prepare_replicated_q_proj(self) -> None:
         # --dcp-replicate-q-proj: gather each rank's attn_tp head-shard of

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -615,6 +615,7 @@ class DeepseekMLAForwardMixin:
                     q_nope_out, q_pe = all_gather_q_for_mla_decode(
                         q_nope_out=q_nope_out,
                         q_pe=q_pe,
+                        direct_gatherer=self.dcp_direct_q_gatherer,
                     )
             elif forward_batch.forward_mode.is_extend():
                 # for extend, gather kv

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1770,6 +1770,9 @@ class DeepseekV2AttentionMLA(
         # pre-CUDA-graph-capture by the model runner; None unless replicate is on.
         self.w_kc_qrep = None
         self.q_b_proj_qrep_weight = None
+        # Shared persistent direct-final Query workspace. The model runner
+        # installs it before CUDA-graph capture when explicitly requested.
+        self.dcp_direct_q_gatherer = None
 
         self.w_scale_k = None
         self.w_scale_v = None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1099,6 +1099,17 @@ class ServerArgs:
         ),
         NS("parallel"),
     ] = None
+    dcp_direct_q_gather: A[
+        bool,
+        Arg(
+            help="For MLA decode context parallelism, keep Query projection "
+            "weights and computation head-sharded, then publish each local BF16 "
+            "Query shard through NVLS multicast directly into the final complete "
+            "consumer-local Query buffer. This is an opt-in single-node NVIDIA "
+            "path and is mutually exclusive with replicated Q projection.",
+        ),
+        NS("parallel"),
+    ] = False
     enable_prefill_cp: A[
         bool,
         "Enable context parallelism for the prefill phase. Select the layout with --cp-strategy.",
@@ -3819,6 +3830,24 @@ class ServerArgs:
                     "--dcp-replicate-q-proj only applies to the a2a/fi_a2a DCP "
                     "communication backend (it removes the head-dim Q all-gather); "
                     f"got --dcp-comm-backend={self.dcp_comm_backend}."
+                )
+        if self.dcp_direct_q_gather:
+            if self.dcp_size <= 1:
+                raise ValueError("--dcp-direct-q-gather requires --dcp-size > 1.")
+            if self.nnodes != 1:
+                raise ValueError(
+                    "--dcp-direct-q-gather currently requires a single-node "
+                    "DCP group."
+                )
+            if not is_cuda():
+                raise ValueError(
+                    "--dcp-direct-q-gather requires an NVIDIA CUDA platform "
+                    "with NVLS multicast support."
+                )
+            if self.dcp_replicate_q_proj is True:
+                raise ValueError(
+                    "--dcp-direct-q-gather and --dcp-replicate-q-proj are "
+                    "mutually exclusive."
                 )
 
     def _handle_load_balance_method(self):

--- a/test/registered/kernels/benchmark/communication/bench_dcp_direct_final_query.py
+++ b/test/registered/kernels/benchmark/communication/bench_dcp_direct_final_query.py
@@ -1,0 +1,153 @@
+"""Benchmark Kimi-K3 DCP Query AllGather against direct-final NVLS.
+
+The benchmark isolates Query publication after local Q production. It covers:
+
+- ``source``: six local heads on DCP4, matching the prior vLLM Kimi-K3 study;
+- ``tp4``: 24 local heads on DCP4, matching this four-GPU SGLang target.
+
+Usage::
+
+    python test/registered/kernels/benchmark/communication/bench_dcp_direct_final_query.py \
+      --num-gpu 4
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import logging
+import os
+
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import (
+    get_benchmark_range,
+    multigpu_bench_main,
+)
+from sglang.srt.layers.dcp.query import DCPDirectFinalQueryGatherer
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=120,
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
+    disabled="requires four GPUs and self-skips in CI",
+)
+
+NOPE_DIM = 512
+ROPE_DIM = 64
+LOCAL_HEADS = get_benchmark_range([6, 24], [6, 24])
+NUM_TOKENS = get_benchmark_range([1, 2, 4, 8, 16, 17, 32, 128], [1, 17, 128])
+PROVIDERS = ["allgather", "direct_final"]
+MAX_TOKENS = max(NUM_TOKENS)
+
+
+@functools.cache
+def _init_world() -> ps.GroupCoordinator:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)),
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    torch.cuda.set_stream(torch.cuda.Stream())
+    assert ps._WORLD is not None
+    return ps._WORLD
+
+
+@functools.cache
+def _gatherer(local_heads: int) -> DCPDirectFinalQueryGatherer:
+    world = _init_world()
+    return DCPDirectFinalQueryGatherer(
+        group=world,
+        max_tokens=MAX_TOKENS,
+        local_heads=local_heads,
+        nope_dim=NOPE_DIM,
+        rope_dim=ROPE_DIM,
+        device=torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}"),
+    )
+
+
+def _allgather(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reproduce all_gather_q_for_mla_decode, including its local pack."""
+    world = _init_world()
+    combined = torch.cat((q_rope.transpose(0, 1), q_nope.transpose(0, 1)), dim=-1)
+    gathered = world.all_gather(combined, dim=0)
+    final_rope, final_nope = gathered.split((ROPE_DIM, NOPE_DIM), dim=-1)
+    return final_nope.transpose(0, 1), final_rope.transpose(0, 1)
+
+
+@marker.parametrize("local_heads", LOCAL_HEADS)
+@marker.parametrize("num_tokens", NUM_TOKENS)
+@marker.benchmark("provider", PROVIDERS)
+def benchmark(num_tokens: int, local_heads: int, provider: str):
+    world = _init_world()
+    if world.world_size != 4:
+        marker.skip("Kimi-K3 source and TP4/DCP4 geometries require four ranks.")
+
+    gatherer = _gatherer(local_heads)
+    if provider == "direct_final" and gatherer.state.symm_mem_hdl.multicast_ptr == 0:
+        marker.skip("NVLS multicast is unavailable.")
+
+    device = gatherer.state.device
+    q_nope_storage = torch.randn(
+        local_heads,
+        num_tokens,
+        NOPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    q_nope = q_nope_storage.transpose(0, 1)
+    q_rope_storage = torch.randn(
+        num_tokens,
+        local_heads,
+        128 + ROPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    q_rope = q_rope_storage[..., -ROPE_DIM:]
+
+    if provider == "allgather":
+
+        def fn(nope: torch.Tensor, rope: torch.Tensor):
+            return _allgather(nope, rope)
+
+    else:
+
+        def fn(nope: torch.Tensor, rope: torch.Tensor):
+            return gatherer(nope, rope)
+
+    return marker.do_bench(
+        fn,
+        input_args=(q_nope, q_rope),
+        graph_clone_args=(0, 1),
+        sync_multigpu_fn=lambda: dist.barrier(world.device_group),
+        memory_args=None,
+        memory_output=None,
+        extra_memory_footprint=(
+            num_tokens
+            * local_heads
+            * world.world_size
+            * (NOPE_DIM + ROPE_DIM)
+            * q_nope.element_size()
+        ),
+    )
+
+
+if __name__ == "__main__":
+    multigpu_bench_main(
+        name=__name__,
+        file=__file__,
+        num_gpus=(4,),
+        main_fn=benchmark.run,
+    )

--- a/test/registered/kernels/benchmark/communication/bench_kimi_k3_dcp_query_chain.py
+++ b/test/registered/kernels/benchmark/communication/bench_kimi_k3_dcp_query_chain.py
@@ -1,0 +1,196 @@
+"""Compare the three Kimi-K3 DCP Query production strategies on four GPUs.
+
+This benchmark covers the BF16 decode chain from normalized q_lora through
+q_b projection and the absorbed-q BMM. The sharded variants then use either
+the production Query AllGather or direct-final NVLS publication. Replicated-Q
+uses startup-gathered full-head weights and performs four times the per-rank
+projection/BMM work without a per-layer Query collective.
+
+RoPE and attention are deliberately excluded so this isolates the decision
+boundary changed by --dcp-direct-q-gather and --dcp-replicate-q-proj.
+
+Usage::
+
+    python test/registered/kernels/benchmark/communication/bench_kimi_k3_dcp_query_chain.py \
+      --num-gpu 4
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import logging
+import os
+
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import (
+    get_benchmark_range,
+    multigpu_bench_main,
+)
+from sglang.srt.layers.dcp.query import DCPDirectFinalQueryGatherer
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=180,
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
+    disabled="requires four GPUs and self-skips in CI",
+)
+
+WORLD_SIZE = 4
+GLOBAL_HEADS = 96
+LOCAL_HEADS = GLOBAL_HEADS // WORLD_SIZE
+Q_LORA_RANK = 1536
+QK_NOPE_DIM = 128
+ROPE_DIM = 64
+KV_LORA_RANK = 512
+QK_HEAD_DIM = QK_NOPE_DIM + ROPE_DIM
+NUM_TOKENS = get_benchmark_range([1, 2, 4, 8, 16, 17, 32, 64, 128], [1, 17, 128])
+PROVIDERS = ["allgather", "direct_final", "replicated_q"]
+MAX_TOKENS = max(NUM_TOKENS)
+
+
+@functools.cache
+def _init_world() -> ps.GroupCoordinator:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)),
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    torch.cuda.set_stream(torch.cuda.Stream())
+    assert ps._WORLD is not None
+    return ps._WORLD
+
+
+@functools.cache
+def _gatherer() -> DCPDirectFinalQueryGatherer:
+    world = _init_world()
+    return DCPDirectFinalQueryGatherer(
+        group=world,
+        max_tokens=MAX_TOKENS,
+        local_heads=LOCAL_HEADS,
+        nope_dim=KV_LORA_RANK,
+        rope_dim=ROPE_DIM,
+        device=torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}"),
+    )
+
+
+@functools.cache
+def _weights() -> tuple[torch.Tensor, ...]:
+    world = _init_world()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    generator = torch.Generator(device=device)
+    generator.manual_seed(32541 + world.rank_in_group)
+    local_q_b = torch.randn(
+        LOCAL_HEADS * QK_HEAD_DIM,
+        Q_LORA_RANK,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    local_w_kc = torch.randn(
+        LOCAL_HEADS,
+        QK_NOPE_DIM,
+        KV_LORA_RANK,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    full_q_b = world.all_gather(local_q_b, dim=0)
+    full_w_kc = world.all_gather(local_w_kc, dim=0)
+    return local_q_b, local_w_kc, full_q_b, full_w_kc
+
+
+def _produce_absorbed_query(
+    q_lora: torch.Tensor,
+    q_b_weight: torch.Tensor,
+    w_kc: torch.Tensor,
+    num_heads: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    query = F.linear(q_lora, q_b_weight).view(q_lora.shape[0], num_heads, QK_HEAD_DIM)
+    q_nope, q_rope = query.split((QK_NOPE_DIM, ROPE_DIM), dim=-1)
+    q_nope_absorbed = torch.bmm(q_nope.transpose(0, 1), w_kc).transpose(0, 1)
+    return q_nope_absorbed, q_rope
+
+
+def _production_allgather(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    world = _init_world()
+    combined = torch.cat((q_rope.transpose(0, 1), q_nope.transpose(0, 1)), dim=-1)
+    gathered = world.all_gather(combined, dim=0)
+    final_rope, final_nope = gathered.split((ROPE_DIM, KV_LORA_RANK), dim=-1)
+    return final_nope.transpose(0, 1), final_rope.transpose(0, 1)
+
+
+@marker.parametrize("num_tokens", NUM_TOKENS)
+@marker.benchmark("provider", PROVIDERS)
+def benchmark(num_tokens: int, provider: str):
+    world = _init_world()
+    if world.world_size != WORLD_SIZE:
+        marker.skip("The Kimi-K3 TP4/DCP4 comparison requires exactly four ranks.")
+
+    gatherer = _gatherer()
+    if provider == "direct_final" and gatherer.state.symm_mem_hdl.multicast_ptr == 0:
+        marker.skip("NVLS multicast is unavailable.")
+
+    device = gatherer.state.device
+    generator = torch.Generator(device=device)
+    generator.manual_seed(50484 + num_tokens)
+    q_lora = torch.randn(
+        num_tokens,
+        Q_LORA_RANK,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    local_q_b, local_w_kc, full_q_b, full_w_kc = _weights()
+
+    if provider == "replicated_q":
+
+        def fn(x: torch.Tensor):
+            return _produce_absorbed_query(x, full_q_b, full_w_kc, GLOBAL_HEADS)
+
+    elif provider == "allgather":
+
+        def fn(x: torch.Tensor):
+            q_nope, q_rope = _produce_absorbed_query(
+                x, local_q_b, local_w_kc, LOCAL_HEADS
+            )
+            return _production_allgather(q_nope, q_rope)
+
+    else:
+
+        def fn(x: torch.Tensor):
+            q_nope, q_rope = _produce_absorbed_query(
+                x, local_q_b, local_w_kc, LOCAL_HEADS
+            )
+            return gatherer(q_nope, q_rope)
+
+    return marker.do_bench(
+        fn,
+        input_args=(q_lora,),
+        graph_clone_args=(0,),
+        sync_multigpu_fn=lambda: dist.barrier(world.device_group),
+        disable_log_bandwidth=True,
+    )
+
+
+if __name__ == "__main__":
+    multigpu_bench_main(
+        name=__name__,
+        file=__file__,
+        num_gpus=(4,),
+        main_fn=benchmark.run,
+    )

--- a/test/registered/kernels/ops/communication/test_dcp_direct_final_query.py
+++ b/test/registered/kernels/ops/communication/test_dcp_direct_final_query.py
@@ -1,0 +1,210 @@
+"""Correctness and CUDA-graph tests for direct-final DCP Query publication.
+
+The source-reproduction geometry matches the vLLM Kimi-K3 Query experiment
+(six local heads on DCP4). The TP4/DCP4 geometry matches this repository's
+four-GPU Kimi-K3 development target (24 local heads, 96 gathered heads).
+
+Usage::
+
+    python test/registered/kernels/ops/communication/test_dcp_direct_final_query.py \
+      --num-gpu 4
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import logging
+import os
+
+import pytest
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+from sglang.kernels.jit.utils import get_ci_test_range
+from sglang.srt.layers.dcp.query import DCPDirectFinalQueryGatherer
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=180, stage="extra-b", runner_config="4-gpu-h200")
+
+NOPE_DIM = 512
+ROPE_DIM = 64
+MAX_TOKENS = 128
+TEST_TOKENS = get_ci_test_range([1, 8, 17, 32, 128], [1, 17, 128])
+TEST_LOCAL_HEADS = get_ci_test_range([6, 24], [6, 24])
+
+
+@functools.cache
+def _init_world() -> ps.GroupCoordinator:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)),
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    torch.cuda.set_stream(torch.cuda.Stream())
+    assert ps._WORLD is not None
+    return ps._WORLD
+
+
+@functools.cache
+def _gatherer(local_heads: int) -> DCPDirectFinalQueryGatherer:
+    world = _init_world()
+    return DCPDirectFinalQueryGatherer(
+        group=world,
+        max_tokens=MAX_TOKENS,
+        local_heads=local_heads,
+        nope_dim=NOPE_DIM,
+        rope_dim=ROPE_DIM,
+        device=torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}"),
+    )
+
+
+def _reference(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    group: dist.ProcessGroup,
+    world_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, local_heads, _ = q_nope.shape
+    local = torch.cat((q_nope, q_rope), dim=-1).reshape(num_tokens, -1)
+    gathered = torch.empty(
+        world_size * num_tokens,
+        local.shape[-1],
+        dtype=local.dtype,
+        device=local.device,
+    )
+    dist.all_gather_into_tensor(gathered, local, group=group)
+    final = (
+        gathered.view(world_size, num_tokens, local.shape[-1])
+        .movedim(0, 1)
+        .reshape(num_tokens, world_size * local_heads, NOPE_DIM + ROPE_DIM)
+    )
+    return final.split((NOPE_DIM, ROPE_DIM), dim=-1)
+
+
+def _assert_query_equal(
+    actual: tuple[torch.Tensor, torch.Tensor],
+    expected: tuple[torch.Tensor, torch.Tensor],
+) -> None:
+    torch.testing.assert_close(actual[0], expected[0], atol=0, rtol=0)
+    torch.testing.assert_close(actual[1], expected[1], atol=0, rtol=0)
+
+
+def _make_production_layout_inputs(
+    *,
+    num_tokens: int,
+    local_heads: int,
+    nope_value: int,
+    rope_value: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # The absorb BMM produces [H,T,512] and forward_mla transposes it without
+    # materializing. RoPE is a tail view of a packed [T,H,192] Query.
+    nope_storage = torch.full(
+        (local_heads, num_tokens, NOPE_DIM),
+        fill_value=nope_value,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    rope_storage = torch.full(
+        (num_tokens, local_heads, 128 + ROPE_DIM),
+        fill_value=rope_value,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    return nope_storage.transpose(0, 1), rope_storage[..., -ROPE_DIM:]
+
+
+@pytest.mark.parametrize("local_heads", TEST_LOCAL_HEADS)
+@pytest.mark.parametrize("num_tokens", TEST_TOKENS)
+@torch.inference_mode()
+def test_dcp_direct_final_query_eager_and_reuse(
+    local_heads: int,
+    num_tokens: int,
+) -> None:
+    world = _init_world()
+    if world.world_size != 4:
+        pytest.skip("Kimi-K3 source and TP4/DCP4 geometries require four ranks.")
+    gatherer = _gatherer(local_heads)
+    if gatherer.state.symm_mem_hdl.multicast_ptr == 0:
+        pytest.skip("NVLS multicast is unavailable.")
+
+    device = gatherer.state.device
+    for step in range(8):
+        dist.barrier(world.device_group)
+        q_nope, q_rope = _make_production_layout_inputs(
+            num_tokens=num_tokens,
+            local_heads=local_heads,
+            nope_value=step * world.world_size + world.rank_in_group,
+            rope_value=100 + step * world.world_size + world.rank_in_group,
+            device=device,
+        )
+        expected = _reference(q_nope, q_rope, world.device_group, world.world_size)
+        actual = gatherer(q_nope, q_rope)
+        _assert_query_equal(actual, expected)
+
+
+@pytest.mark.parametrize("local_heads", TEST_LOCAL_HEADS)
+@pytest.mark.parametrize("num_tokens", [1, 17])
+@torch.inference_mode()
+def test_dcp_direct_final_query_changing_input_cuda_graph(
+    local_heads: int,
+    num_tokens: int,
+) -> None:
+    world = _init_world()
+    if world.world_size != 4:
+        pytest.skip("Kimi-K3 source and TP4/DCP4 geometries require four ranks.")
+    gatherer = _gatherer(local_heads)
+    if gatherer.state.symm_mem_hdl.multicast_ptr == 0:
+        pytest.skip("NVLS multicast is unavailable.")
+
+    device = gatherer.state.device
+    static_nope_storage = torch.empty(
+        (local_heads, num_tokens, NOPE_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    static_rope_storage = torch.empty(
+        (num_tokens, local_heads, 128 + ROPE_DIM),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    static_nope = static_nope_storage.transpose(0, 1)
+    static_rope = static_rope_storage[..., -ROPE_DIM:]
+
+    # Compile Triton and initialize all lazy CUDA state outside capture.
+    static_nope.fill_(world.rank_in_group)
+    static_rope_storage.fill_(100 + world.rank_in_group)
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    dist.barrier(world.device_group)
+    with torch.cuda.stream(warmup_stream):
+        gatherer(static_nope, static_rope)
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    dist.barrier(world.device_group)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = gatherer(static_nope, static_rope)
+
+    for step in range(8):
+        static_nope.fill_(step * world.world_size + world.rank_in_group)
+        static_rope_storage.fill_(100 + step * world.world_size + world.rank_in_group)
+        dist.barrier(world.device_group)
+        graph.replay()
+        expected = _reference(
+            static_nope, static_rope, world.device_group, world.world_size
+        )
+        _assert_query_equal(graph_output, expected)
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(4,))

--- a/test/registered/unit/test_kimi_k3_dcp_query.py
+++ b/test/registered/unit/test_kimi_k3_dcp_query.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from sglang.srt.arg_groups.overrides import _kimi_k3_overrides
+from sglang.srt.layers.dcp.comm import all_gather_q_for_mla_decode
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_direct_query_dispatch_bypasses_collective():
+    q_nope = torch.randn(2, 3, 4)
+    q_rope = torch.randn(2, 3, 1)
+    expected = (q_nope + 1, q_rope + 2)
+    calls = []
+
+    def direct_gatherer(nope, rope):
+        calls.append((nope, rope))
+        return expected
+
+    actual = all_gather_q_for_mla_decode(
+        q_nope,
+        q_rope,
+        direct_gatherer=direct_gatherer,
+    )
+
+    assert actual == expected
+    assert calls == [(q_nope, q_rope)]
+
+
+def test_kimi_k3_direct_query_disables_replicated_projection():
+    args = SimpleNamespace(
+        dcp_size=4,
+        enable_symm_mem=False,
+        speculative_algorithm=None,
+        dcp_direct_q_gather=True,
+        dcp_replicate_q_proj=None,
+        dcp_comm_backend="ag_rs",
+    )
+    with (
+        patch(
+            "sglang.srt.arg_groups.overrides.attention_backends_of",
+            return_value=(None, None),
+        ),
+        patch(
+            "sglang.srt.arg_groups.overrides.get_device_name",
+            return_value="NVIDIA GB200",
+        ),
+        patch(
+            "sglang.srt.arg_groups.overrides.is_mnnvl_fabric_device",
+            return_value=False,
+        ),
+    ):
+        overrides = _kimi_k3_overrides(args, hf_config=None)
+
+    assert overrides["dcp_replicate_q_proj"] is False
+    assert overrides["dcp_comm_backend"] == "a2a"
+
+
+def test_direct_query_requires_dcp():
+    args = ServerArgs(
+        model_path="dummy",
+        dcp_size=1,
+        dcp_direct_q_gather=True,
+    )
+    with pytest.raises(ValueError, match="requires --dcp-size > 1"):
+        args._handle_dcp_validation()
+
+
+def test_direct_query_rejects_explicit_replication():
+    args = ServerArgs(
+        model_path="dummy",
+        dcp_size=4,
+        dcp_direct_q_gather=True,
+        dcp_replicate_q_proj=True,
+        dcp_comm_backend="a2a",
+    )
+    with (
+        patch("sglang.srt.server_args.is_cuda", return_value=True),
+        pytest.raises(ValueError, match="mutually exclusive"),
+    ):
+        args._handle_dcp_validation()
+
+
+def test_direct_query_rejects_multi_node():
+    args = ServerArgs(
+        model_path="dummy",
+        dcp_size=4,
+        nnodes=2,
+        dcp_direct_q_gather=True,
+        dcp_comm_backend="a2a",
+    )
+    with pytest.raises(ValueError, match="single-node"):
+        args._handle_dcp_validation()


### PR DESCRIPTION
## Summary

Add an opt-in direct-final Query publication path for single-node NVIDIA DCP decode.

Instead of packing a local Query shard, running an AllGather, and materializing the complete Query, each producer uses NVLS multicast stores to publish `q_nope` and `q_rope` directly into their final head offsets in a consumer-local symmetric buffer. Attention keeps one unchanged call over a complete local Query.

Replicated-Q remains the Kimi-K3 speed default. This PR is a weight/capacity-saving mode selected with `--dcp-direct-q-gather`.

## Performance and memory

Measured on four NVIDIA GB200 GPUs at Kimi-K3 TP4/DCP4 geometry:

| Tokens | Existing sharded AllGather | Direct-final | Improvement |
| ---: | ---: | ---: | ---: |
| 1 | 24.327 us | 17.237 us | 29.1% |
| 17 | 27.844 us | 17.963 us | 35.5% |
| 128 | 76.477 us | 36.912 us | 51.7% |

The isolated transport boundary improves by 40.5%-46.3% for 24 local heads.

Direct-final remains 1.97x-2.69x slower than replicated-Q on this host because the full-head replicated GEMM/BMM is substantially more efficient. Its value is memory: at a 128-token workspace it avoids about 1.534 GiB/rank versus the current K3 replicated-Q layout, or about 1.147 GiB/rank if the related replicated-Q storage-ownership PR also lands.

No request-level serving speedup is claimed.

## Validation

- 5 CPU dispatch and configuration tests passed.
- 14 four-GPU correctness and CUDA-graph tests passed.
- Covers 6 and 24 local heads; 1, 8, 17, 32, and 128 tokens; strided producer views; changing-input workspace reuse; and CUDA-graph replay.
- Bit-exact against the NCCL reference.
- `git diff --check` passed.

## Related PRs

- Parent Kimi-K3 integration: #32541
- Kimi-K3 follow-up tracker: #32607
- Replicated-Q storage ownership: #33070
- TP4 fused KDA decode: #33071
- KDA temporal-state copy-on-write: #33072
- Fused NVIDIA KDA prefill staging: #33073
- Generic lazy-compaction scheduler fix: #33060
- Related Shared-DCP work: #32851
- Related vLLM Kimi-K3 DCP integration: https://github.com/vllm-project/vllm/pull/50484
