### PR TITLE
[Kimi-K3] Share replicated-Q weight storage

### DIFF
--- a/python/sglang/srt/layers/dcp/query_weights.py
+++ b/python/sglang/srt/layers/dcp/query_weights.py
@@ -1,0 +1,120 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Storage helpers for replicated DCP Query projection weights."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import torch
+
+
+class _AllGatherGroup(Protocol):
+    world_size: int
+    rank_in_group: int
+
+    def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor: ...
+
+
+def replicated_rank_slice(
+    replicated_weight: torch.Tensor,
+    *,
+    local_shape: torch.Size | tuple[int, ...],
+    rank: int,
+    world_size: int,
+) -> torch.Tensor:
+    """Return the rank-local row slice of a full replicated weight."""
+
+    if world_size <= 1:
+        raise ValueError(f"world_size must be greater than one, got {world_size}.")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"rank must be in [0, {world_size}), got {rank}.")
+    if len(local_shape) == 0 or replicated_weight.ndim == 0:
+        raise ValueError("DCP replicated Query weights must have at least one axis.")
+
+    expected_shape = (local_shape[0] * world_size, *local_shape[1:])
+    if tuple(replicated_weight.shape) != expected_shape:
+        raise ValueError(
+            "Replicated Query weight shape does not match the local row shard: "
+            f"expected {expected_shape}, got {tuple(replicated_weight.shape)}."
+        )
+    return replicated_weight.narrow(0, rank * local_shape[0], local_shape[0])
+
+
+def bind_parameter_to_replicated_rank_slice_(
+    parameter: torch.nn.Parameter,
+    replicated_weight: torch.Tensor,
+    *,
+    rank: int,
+    world_size: int,
+) -> torch.Tensor:
+    """Make a local row-sharded parameter own a view of replicated storage.
+
+    The full replicated tensor remains the decode weight. The original
+    Parameter object is retained so model loaders and parameter-name based
+    update APIs continue to write the local shard in place.
+    """
+
+    if parameter.dtype != replicated_weight.dtype:
+        raise TypeError(
+            "Local and replicated Query weights must have the same dtype, got "
+            f"{parameter.dtype} and {replicated_weight.dtype}."
+        )
+    if parameter.device != replicated_weight.device:
+        raise ValueError(
+            "Local and replicated Query weights must share a device, got "
+            f"{parameter.device} and {replicated_weight.device}."
+        )
+
+    local_weight = replicated_rank_slice(
+        replicated_weight,
+        local_shape=parameter.shape,
+        rank=rank,
+        world_size=world_size,
+    )
+    if tuple(local_weight.stride()) != tuple(parameter.stride()):
+        raise ValueError(
+            "Replicated Query rank slice must preserve the local weight layout: "
+            f"expected stride {tuple(parameter.stride())}, got "
+            f"{tuple(local_weight.stride())}."
+        )
+
+    with torch.no_grad():
+        parameter.data = local_weight
+    return local_weight
+
+
+def refresh_replicated_weight_(
+    local_weight: torch.Tensor,
+    replicated_weight: torch.Tensor,
+    *,
+    group: _AllGatherGroup,
+) -> None:
+    """Refresh graph-stable replicated storage after an online weight update."""
+
+    gathered = group.all_gather(local_weight.contiguous(), dim=0)
+    if (
+        gathered.shape != replicated_weight.shape
+        or gathered.dtype != replicated_weight.dtype
+        or gathered.device != replicated_weight.device
+    ):
+        raise ValueError(
+            "Refreshed replicated Query weight does not match its persistent "
+            f"buffer: got shape={tuple(gathered.shape)}, dtype={gathered.dtype}, "
+            f"device={gathered.device}; expected "
+            f"shape={tuple(replicated_weight.shape)}, "
+            f"dtype={replicated_weight.dtype}, device={replicated_weight.device}."
+        )
+    replicated_weight.copy_(gathered)

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -478,6 +478,7 @@ class ModelRunner:
             update_model_fields=self.update_model_fields,
             recapture_cuda_graph=self.init_decode_cuda_graph,
             get_model_runner=lambda: self,
+            post_update_weights=self._refresh_replicated_q_proj_weights,
         )
 
     def init_spec_aux_hidden_state(self):
@@ -881,6 +882,10 @@ class ModelRunner:
         # --dcp-replicate-q-proj: gather each rank's attn_tp head-shard of
         # q_b_proj / w_kc into full-head buffers once here (pre-capture) so the
         # MLA decode path can skip the per-layer Q all-gather. bf16/fp16 only.
+        from sglang.srt.layers.dcp.query_weights import (
+            bind_parameter_to_replicated_rank_slice_,
+            replicated_rank_slice,
+        )
         from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
         from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
 
@@ -907,15 +912,81 @@ class ModelRunner:
                     "(bf16/fp16 only); this layer keeps the Q all-gather."
                 )
                 continue
+            local_w_kc_shape = m.w_kc.shape
             m.w_kc_qrep = dcp_group.all_gather(m.w_kc.contiguous(), dim=0)
+            # Decode keeps the existing standard-contiguous full-head layout.
+            # In qrep mode the local tensor is used only by prefill/extend, so
+            # make it a rank slice of the full storage instead of retaining a
+            # second K-contiguous allocation.
+            m.w_kc = replicated_rank_slice(
+                m.w_kc_qrep,
+                local_shape=local_w_kc_shape,
+                rank=dcp_group.rank_in_group,
+                world_size=dcp_group.world_size,
+            )
             m.q_b_proj_qrep_weight = dcp_group.all_gather(
                 qp.weight.data.contiguous(), dim=0
             )
+            bind_parameter_to_replicated_rank_slice_(
+                qp.weight,
+                m.q_b_proj_qrep_weight,
+                rank=dcp_group.rank_in_group,
+                world_size=dcp_group.world_size,
+            )
             n_prepared += 1
         logger.info(
-            "dcp_replicate_q_proj: prepared full-head Q weights for %d MLA layers",
+            "dcp_replicate_q_proj: prepared full-head Q weights for %d MLA "
+            "layers; local q-proj parameters share the replicated storage",
             n_prepared,
         )
+
+    def _refresh_replicated_q_proj_weights(self) -> None:
+        """Refresh graph-stable qrep buffers after online weight updates."""
+        from sglang.srt.layers.dcp.query_weights import (
+            refresh_replicated_weight_,
+            replicated_rank_slice,
+        )
+        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+
+        dcp_group = get_parallel().dcp_group
+        if dcp_group.world_size <= 1:
+            return
+
+        n_refreshed = 0
+        for m in self.model.modules():
+            if not isinstance(m, DeepseekV2AttentionMLA):
+                continue
+            if m.q_b_proj_qrep_weight is None or m.w_kc_qrep is None:
+                continue
+
+            qp = m.q_b_proj if m.has_q_b_proj else m.q_proj
+            refresh_replicated_weight_(
+                qp.weight.data,
+                m.q_b_proj_qrep_weight,
+                group=dcp_group,
+            )
+            refresh_replicated_weight_(
+                m.w_kc,
+                m.w_kc_qrep,
+                group=dcp_group,
+            )
+            # Kimi-K3 post_load_weights reconstructs a temporary local w_kc.
+            # Rebind it after refreshing the persistent full-head buffer so an
+            # online reload preserves the startup storage saving.
+            m.w_kc = replicated_rank_slice(
+                m.w_kc_qrep,
+                local_shape=m.w_kc.shape,
+                rank=dcp_group.rank_in_group,
+                world_size=dcp_group.world_size,
+            )
+            n_refreshed += 1
+
+        if n_refreshed:
+            logger.info(
+                "dcp_replicate_q_proj: refreshed graph-stable full-head Q "
+                "weights for %d MLA layers after online weight update",
+                n_refreshed,
+            )
 
     def init_cuda_graphs(self, capture_decode_cuda_graph: bool = True):
         capture = capture_cuda_graphs(

--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -62,7 +62,12 @@ class WeightUpdater:
     update_model_fields: Callable[..., None]
     recapture_cuda_graph: Callable[[], None]
     get_model_runner: Callable[[], ModelRunner]
+    post_update_weights: Optional[Callable[[], None]] = None
     _model_update_group: dict = field(default_factory=dict)
+
+    def _run_post_update_weights(self) -> None:
+        if self.post_update_weights is not None:
+            self.post_update_weights()
 
     def init_weights_update_group(
         self,
@@ -205,6 +210,7 @@ class WeightUpdater:
             load_format=load_format,
             load_config=load_config,
         )
+        self._run_post_update_weights()
 
         if recapture_cuda_graph and (
             self.device == "cuda"
@@ -271,6 +277,7 @@ class WeightUpdater:
                 handle.wait()
 
             self.get_model().load_weights(weights)
+            self._run_post_update_weights()
             return True, "Succeeded to update parameter online."
 
         except Exception as e:
@@ -306,6 +313,7 @@ class WeightUpdater:
             )
             reconstructed_tensors = bucket.reconstruct_tensors()
             self.get_model().load_weights(reconstructed_tensors)
+            self._run_post_update_weights()
             return True, f"Succeeded to update parameter online."
         except Exception as e:
             error_msg = (
@@ -350,6 +358,7 @@ class WeightUpdater:
             self.get_model().load_weights(named_tensors)
         else:
             raise NotImplementedError(f"Unknown load_format={load_format}")
+        self._run_post_update_weights()
         return True, "Success"
 
     def _update_weights_from_flattened_bucket(
@@ -381,6 +390,7 @@ class WeightUpdater:
 
         # Load the reconstructed tensors using the standard method
         self.get_model().load_weights(reconstructed_tensors)
+        self._run_post_update_weights()
 
         return True, "Success"
 
@@ -399,6 +409,7 @@ class WeightUpdater:
             # Create a worker extension that integrates with SGLang's model
             worker = SGLangCheckpointEngineWorkerExtensionImpl(self.get_model_runner())
             worker.update_weights_from_ipc(recv_req.zmq_handles)
+            self._run_post_update_weights()
             return True, "IPC weight update completed successfully"
         except ImportError as e:
             return False, f"IPC weight update failed: ImportError {e}"

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -452,11 +452,12 @@ class DeepseekMLAForwardMixin:
         _kvb_q = None
         if q_replicate_active:
             # full-head absorb with the pre-gathered w_kc (q_nope already full-head)
-            q_nope_out = (
-                torch.bmm(q_nope.transpose(0, 1), self.w_kc_qrep)
-                .transpose(0, 1)
-                .contiguous()
-            )
+            # Keep the [T,H,V] transpose view. K3's FP8 MLA prologue accepts
+            # explicit token/head strides, so materializing a contiguous copy
+            # here only adds an HBM round trip before every decode layer.
+            q_nope_out = torch.bmm(
+                q_nope.transpose(0, 1), self.w_kc_qrep
+            ).transpose(0, 1)
         elif fusion_plan is not None:
             # The composite split op fills q_nope_out_buf and attention reads
             # this transposed alias directly.

--- a/test/registered/kernels/benchmark/attention/bench_kimi_k3_qrep_query_layout.py
+++ b/test/registered/kernels/benchmark/attention/bench_kimi_k3_qrep_query_layout.py
@@ -1,0 +1,112 @@
+"""Benchmark removal of the replicated-Q post-BMM contiguous copy."""
+
+from __future__ import annotations
+
+import os
+
+import flashinfer
+import torch
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import get_benchmark_range
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=60,
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
+)
+
+NUM_HEADS = 96
+QK_NOPE_DIM = 512
+QK_ROPE_DIM = 64
+NUM_TOKENS = get_benchmark_range([1, 17, 128], [1, 17, 128])
+PROVIDERS = ["copy_then_pack", "strided_view_pack"]
+if os.environ.get("SGLANG_QREP_BENCH_REVERSE") == "1":
+    PROVIDERS.reverse()
+
+
+@marker.parametrize("num_tokens", NUM_TOKENS)
+@marker.benchmark("provider", PROVIDERS)
+def benchmark(num_tokens: int, provider: str):
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device)
+    generator.manual_seed(32541 + num_tokens)
+    q_nope_storage = torch.randn(
+        NUM_HEADS,
+        num_tokens,
+        QK_NOPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    q_nope_view = q_nope_storage.transpose(0, 1)
+    q_rope = torch.randn(
+        num_tokens,
+        NUM_HEADS,
+        QK_ROPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    k_nope = torch.randn(
+        num_tokens,
+        QK_NOPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    k_rope = torch.randn(
+        num_tokens,
+        QK_ROPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    cos_sin_cache = torch.randn(
+        2048,
+        QK_ROPE_DIM,
+        dtype=torch.float32,
+        device=device,
+        generator=generator,
+    )
+    positions = torch.arange(num_tokens, dtype=torch.int32, device=device)
+    q_fp8 = torch.empty(
+        (num_tokens, NUM_HEADS, QK_NOPE_DIM + QK_ROPE_DIM),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+    k_fp8 = torch.empty(
+        (num_tokens, QK_NOPE_DIM + QK_ROPE_DIM),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+
+    def fn(q_nope: torch.Tensor):
+        if provider == "copy_then_pack":
+            q_nope = q_nope.contiguous()
+        return flashinfer.rope.mla_rope_quantize_fp8(
+            q_rope=q_rope,
+            k_rope=k_rope,
+            q_nope=q_nope,
+            k_nope=k_nope,
+            cos_sin_cache=cos_sin_cache,
+            pos_ids=positions,
+            is_neox=False,
+            quantize_dtype=torch.float8_e4m3fn,
+            q_rope_out=q_fp8[..., QK_NOPE_DIM:],
+            k_rope_out=k_fp8[..., QK_NOPE_DIM:],
+            q_nope_out=q_fp8[..., :QK_NOPE_DIM],
+            k_nope_out=k_fp8[..., :QK_NOPE_DIM],
+            enable_pdl=True,
+        )
+
+    return marker.do_bench(
+        fn,
+        input_args=(q_nope_view,),
+        graph_clone_args=(0,),
+        disable_log_bandwidth=True,
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/benchmark/communication/bench_kimi_k3_qrep_local_view.py
+++ b/test/registered/kernels/benchmark/communication/bench_kimi_k3_qrep_local_view.py
@@ -1,0 +1,155 @@
+"""Measure Kimi-K3 local Query production before and after q_b storage sharing.
+
+The shared provider uses a contiguous rank slice of the full replicated q_b
+buffer, matching the optimized prefill/extend path. Decode consumes the same
+full replicated tensor in both designs and therefore has no runtime difference.
+
+Usage::
+
+    python \
+      test/registered/kernels/benchmark/communication/bench_kimi_k3_qrep_local_view.py \
+      --num-gpu 4
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import logging
+import os
+
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import (
+    get_benchmark_range,
+    multigpu_bench_main,
+)
+from sglang.srt.layers.dcp.query_weights import (
+    bind_parameter_to_replicated_rank_slice_,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=120,
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
+    disabled="requires four GPUs and self-skips in CI",
+)
+
+WORLD_SIZE = 4
+GLOBAL_HEADS = 96
+LOCAL_HEADS = GLOBAL_HEADS // WORLD_SIZE
+Q_LORA_RANK = 1536
+QK_NOPE_DIM = 128
+ROPE_DIM = 64
+KV_LORA_RANK = 512
+QK_HEAD_DIM = QK_NOPE_DIM + ROPE_DIM
+NUM_TOKENS = get_benchmark_range([1, 17, 128], [1, 17, 128])
+PROVIDERS = ["separate_local_q_b", "shared_local_q_b"]
+if os.environ.get("SGLANG_QREP_BENCH_REVERSE") == "1":
+    PROVIDERS.reverse()
+
+
+@functools.cache
+def _init_world() -> ps.GroupCoordinator:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)),
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    torch.cuda.set_stream(torch.cuda.Stream())
+    assert ps._WORLD is not None
+    return ps._WORLD
+
+
+@functools.cache
+def _weights() -> tuple[torch.Tensor, ...]:
+    world = _init_world()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    generator = torch.Generator(device=device)
+    generator.manual_seed(32541 + world.rank_in_group)
+    separate_q_b = torch.nn.Parameter(
+        torch.randn(
+            LOCAL_HEADS * QK_HEAD_DIM,
+            Q_LORA_RANK,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        ),
+        requires_grad=False,
+    )
+    full_q_b = world.all_gather(separate_q_b.data, dim=0)
+    shared_q_b = torch.nn.Parameter(separate_q_b.detach().clone(), requires_grad=False)
+    bind_parameter_to_replicated_rank_slice_(
+        shared_q_b,
+        full_q_b,
+        rank=world.rank_in_group,
+        world_size=world.world_size,
+    )
+    w_kc = torch.randn(
+        LOCAL_HEADS,
+        QK_NOPE_DIM,
+        KV_LORA_RANK,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    return separate_q_b, shared_q_b, w_kc
+
+
+def _produce_local_query(
+    q_lora: torch.Tensor,
+    q_b_weight: torch.Tensor,
+    w_kc: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    query = F.linear(q_lora, q_b_weight).view(q_lora.shape[0], LOCAL_HEADS, QK_HEAD_DIM)
+    q_nope, q_rope = query.split((QK_NOPE_DIM, ROPE_DIM), dim=-1)
+    q_nope = torch.bmm(q_nope.transpose(0, 1), w_kc).transpose(0, 1)
+    return q_nope, q_rope
+
+
+@marker.parametrize("num_tokens", NUM_TOKENS)
+@marker.benchmark("provider", PROVIDERS)
+def benchmark(num_tokens: int, provider: str):
+    world = _init_world()
+    if world.world_size != WORLD_SIZE:
+        marker.skip("The Kimi-K3 TP4/DCP4 comparison requires exactly four ranks.")
+
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    generator = torch.Generator(device=device)
+    generator.manual_seed(50484 + num_tokens)
+    q_lora = torch.randn(
+        num_tokens,
+        Q_LORA_RANK,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    separate_q_b, shared_q_b, w_kc = _weights()
+    q_b_weight = separate_q_b if provider == "separate_local_q_b" else shared_q_b
+
+    return marker.do_bench(
+        _produce_local_query,
+        input_args=(q_lora, q_b_weight, w_kc),
+        graph_clone_args=(0,),
+        sync_multigpu_fn=lambda: dist.barrier(world.device_group),
+        disable_log_bandwidth=True,
+    )
+
+
+if __name__ == "__main__":
+    multigpu_bench_main(
+        name=__name__,
+        file=__file__,
+        num_gpus=(4,),
+        main_fn=benchmark.run,
+    )

--- a/test/registered/kernels/benchmark/communication/bench_kimi_k3_qrep_wkc_layout.py
+++ b/test/registered/kernels/benchmark/communication/bench_kimi_k3_qrep_wkc_layout.py
@@ -1,0 +1,151 @@
+"""Compare Kimi-K3 w_kc BMM layouts for local and replicated-Q heads.
+
+The current local Kimi-K3 layout makes the reduction (K) axis contiguous.
+Replicated-Q currently materializes a standard contiguous full-head tensor.
+This benchmark tests whether one K-contiguous full-head storage can serve both
+decode and rank-local prefill/extend views.
+
+Usage::
+
+    python \
+      test/registered/kernels/benchmark/communication/bench_kimi_k3_qrep_wkc_layout.py \
+      --num-gpu 4
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import logging
+import os
+
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import (
+    get_benchmark_range,
+    multigpu_bench_main,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=120,
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
+    disabled="requires four GPUs and self-skips in CI",
+)
+
+WORLD_SIZE = 4
+GLOBAL_HEADS = 96
+LOCAL_HEADS = GLOBAL_HEADS // WORLD_SIZE
+QK_NOPE_DIM = 128
+KV_LORA_RANK = 512
+NUM_TOKENS = get_benchmark_range([1, 17, 128], [1, 17, 128])
+WEIGHT_NAMES = [
+    "local_standard",
+    "local_k_contiguous",
+    "full_standard",
+    "full_k_contiguous",
+]
+PROVIDERS = list(WEIGHT_NAMES)
+if os.environ.get("SGLANG_QREP_BENCH_REVERSE") == "1":
+    PROVIDERS.reverse()
+
+
+@functools.cache
+def _init_world() -> ps.GroupCoordinator:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)),
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    torch.cuda.set_stream(torch.cuda.Stream())
+    assert ps._WORLD is not None
+    return ps._WORLD
+
+
+def _k_contiguous(weight: torch.Tensor) -> torch.Tensor:
+    return weight.transpose(1, 2).contiguous().transpose(1, 2)
+
+
+@functools.cache
+def _weights() -> tuple[torch.Tensor, ...]:
+    world = _init_world()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    generator = torch.Generator(device=device)
+    generator.manual_seed(32541 + world.rank_in_group)
+    local_standard = torch.randn(
+        LOCAL_HEADS,
+        QK_NOPE_DIM,
+        KV_LORA_RANK,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    local_k_contiguous = _k_contiguous(local_standard)
+    full_standard = world.all_gather(local_standard, dim=0)
+    # Gather the physical [H, V, K] backing so both the full tensor and its
+    # local head slices retain K-contiguous [H, K, V] strides.
+    full_k_contiguous = world.all_gather(
+        local_k_contiguous.transpose(1, 2).contiguous(), dim=0
+    ).transpose(1, 2)
+
+    torch.testing.assert_close(local_standard, local_k_contiguous, atol=0, rtol=0)
+    torch.testing.assert_close(full_standard, full_k_contiguous, atol=0, rtol=0)
+    assert local_standard.stride() == (65536, 512, 1)
+    assert local_k_contiguous.stride() == (65536, 1, 128)
+    assert full_standard.stride() == (65536, 512, 1)
+    assert full_k_contiguous.stride() == (65536, 1, 128)
+    return (
+        local_standard,
+        local_k_contiguous,
+        full_standard,
+        full_k_contiguous,
+    )
+
+
+@marker.parametrize("num_tokens", NUM_TOKENS)
+@marker.benchmark("provider", PROVIDERS)
+def benchmark(num_tokens: int, provider: str):
+    world = _init_world()
+    if world.world_size != WORLD_SIZE:
+        marker.skip("The Kimi-K3 TP4/DCP4 comparison requires exactly four ranks.")
+
+    weights = dict(zip(WEIGHT_NAMES, _weights(), strict=True))
+    weight = weights[provider]
+    num_heads = weight.shape[0]
+    device = weight.device
+    generator = torch.Generator(device=device)
+    generator.manual_seed(50484 + num_tokens)
+    q_nope = torch.randn(
+        num_heads,
+        num_tokens,
+        QK_NOPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+
+    return marker.do_bench(
+        torch.bmm,
+        input_args=(q_nope, weight),
+        graph_clone_args=(0,),
+        sync_multigpu_fn=lambda: dist.barrier(world.device_group),
+        disable_log_bandwidth=True,
+    )
+
+
+if __name__ == "__main__":
+    multigpu_bench_main(
+        name=__name__,
+        file=__file__,
+        num_gpus=(4,),
+        main_fn=benchmark.run,
+    )

--- a/test/registered/kernels/ops/attention/test_kimi_k3_qrep_query_layout.py
+++ b/test/registered/kernels/ops/attention/test_kimi_k3_qrep_query_layout.py
@@ -1,0 +1,213 @@
+"""Validate the strided replicated-Q output consumed by the K3 FP8 prologue."""
+
+from __future__ import annotations
+
+import flashinfer
+import pytest
+import torch
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-large")
+
+NUM_HEADS = 96
+QK_NOPE_DIM = 512
+QK_ROPE_DIM = 64
+
+
+def _inputs(num_tokens: int):
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device)
+    generator.manual_seed(32541 + num_tokens)
+
+    # torch.bmm(q_nope.transpose(0, 1), w_kc) produces [H,T,V].
+    q_nope_storage = torch.randn(
+        NUM_HEADS,
+        num_tokens,
+        QK_NOPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    q_nope_view = q_nope_storage.transpose(0, 1)
+    q_rope = torch.randn(
+        num_tokens,
+        NUM_HEADS,
+        QK_ROPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    k_nope = torch.randn(
+        num_tokens,
+        QK_NOPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    k_rope = torch.randn(
+        num_tokens,
+        QK_ROPE_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    cos_sin_cache = torch.randn(
+        2048,
+        QK_ROPE_DIM,
+        dtype=torch.float32,
+        device=device,
+        generator=generator,
+    )
+    positions = torch.arange(num_tokens, dtype=torch.int32, device=device)
+    return (
+        q_nope_storage,
+        q_nope_view,
+        q_rope,
+        k_nope,
+        k_rope,
+        cos_sin_cache,
+        positions,
+    )
+
+
+def _pack_query(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    enable_pdl: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q_fp8 = torch.empty(
+        (*q_nope.shape[:2], QK_NOPE_DIM + QK_ROPE_DIM),
+        dtype=torch.float8_e4m3fn,
+        device=q_nope.device,
+    )
+    k_fp8 = torch.empty(
+        (q_nope.shape[0], QK_NOPE_DIM + QK_ROPE_DIM),
+        dtype=torch.float8_e4m3fn,
+        device=q_nope.device,
+    )
+    flashinfer.rope.mla_rope_quantize_fp8(
+        q_rope=q_rope,
+        k_rope=k_rope,
+        q_nope=q_nope,
+        k_nope=k_nope,
+        cos_sin_cache=cos_sin_cache,
+        pos_ids=positions,
+        is_neox=False,
+        quantize_dtype=torch.float8_e4m3fn,
+        q_rope_out=q_fp8[..., QK_NOPE_DIM:],
+        k_rope_out=k_fp8[..., QK_NOPE_DIM:],
+        q_nope_out=q_fp8[..., :QK_NOPE_DIM],
+        k_nope_out=k_fp8[..., :QK_NOPE_DIM],
+        enable_pdl=enable_pdl,
+    )
+    return q_fp8, k_fp8
+
+
+@pytest.mark.parametrize("num_tokens", [1, 17, 128])
+@torch.inference_mode()
+def test_qrep_strided_query_matches_contiguous_fp8_prologue(num_tokens: int) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required.")
+    (
+        _,
+        q_nope_view,
+        q_rope,
+        k_nope,
+        k_rope,
+        cos_sin_cache,
+        positions,
+    ) = _inputs(num_tokens)
+    assert not q_nope_view.is_contiguous() or num_tokens == 1
+    assert q_nope_view.stride() == (
+        QK_NOPE_DIM,
+        num_tokens * QK_NOPE_DIM,
+        1,
+    )
+
+    expected = _pack_query(
+        q_nope_view.contiguous(),
+        q_rope,
+        k_nope,
+        k_rope,
+        cos_sin_cache,
+        positions,
+        enable_pdl=True,
+    )
+    actual = _pack_query(
+        q_nope_view,
+        q_rope,
+        k_nope,
+        k_rope,
+        cos_sin_cache,
+        positions,
+        enable_pdl=True,
+    )
+
+    assert torch.equal(expected[0].view(torch.uint8), actual[0].view(torch.uint8))
+    assert torch.equal(expected[1].view(torch.uint8), actual[1].view(torch.uint8))
+
+
+@torch.inference_mode()
+def test_qrep_strided_query_fp8_prologue_cuda_graph_replay() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required.")
+    (
+        q_nope_storage,
+        q_nope_view,
+        q_rope,
+        k_nope,
+        k_rope,
+        cos_sin_cache,
+        positions,
+    ) = _inputs(17)
+
+    # Warm all lazy FlashInfer state before capture.
+    _pack_query(
+        q_nope_view,
+        q_rope,
+        k_nope,
+        k_rope,
+        cos_sin_cache,
+        positions,
+        enable_pdl=True,
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = _pack_query(
+            q_nope_view,
+            q_rope,
+            k_nope,
+            k_rope,
+            cos_sin_cache,
+            positions,
+            enable_pdl=True,
+        )
+
+    for step in range(3):
+        q_nope_storage.add_(step + 1)
+        q_rope.add_(step + 1)
+        k_nope.add_(step + 1)
+        k_rope.add_(step + 1)
+        graph.replay()
+        expected = _pack_query(
+            q_nope_view.contiguous(),
+            q_rope,
+            k_nope,
+            k_rope,
+            cos_sin_cache,
+            positions,
+            enable_pdl=True,
+        )
+        assert torch.equal(
+            expected[0].view(torch.uint8), graph_output[0].view(torch.uint8)
+        )
+        assert torch.equal(
+            expected[1].view(torch.uint8), graph_output[1].view(torch.uint8)
+        )

--- a/test/registered/kernels/ops/communication/test_dcp_replicated_query_weights.py
+++ b/test/registered/kernels/ops/communication/test_dcp_replicated_query_weights.py
@@ -1,0 +1,212 @@
+"""Four-GPU checks for shared replicated-Q projection weight storage.
+
+Usage::
+
+    python \
+      test/registered/kernels/ops/communication/test_dcp_replicated_query_weights.py \
+      --num-gpu 4
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import gc
+import json
+import logging
+import os
+
+import pytest
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+from sglang.srt.layers.dcp.query_weights import (
+    bind_parameter_to_replicated_rank_slice_,
+    refresh_replicated_weight_,
+    replicated_rank_slice,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=60, stage="extra-b", runner_config="4-gpu-h200")
+
+WORLD_SIZE = 4
+LOCAL_HEADS = 24
+QK_HEAD_DIM = 192
+Q_LORA_RANK = 1536
+LOCAL_ROWS = LOCAL_HEADS * QK_HEAD_DIM
+LOCAL_WEIGHT_BYTES = LOCAL_ROWS * Q_LORA_RANK * torch.bfloat16.itemsize
+LOCAL_W_KC_BYTES = LOCAL_HEADS * 128 * 512 * torch.bfloat16.itemsize
+
+
+@functools.cache
+def _init_world() -> ps.GroupCoordinator:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)),
+        local_rank=local_rank,
+        backend="nccl",
+    )
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    assert ps._WORLD is not None
+    return ps._WORLD
+
+
+@torch.inference_mode()
+def test_dcp_replicated_query_storage_alias_refresh_and_memory() -> None:
+    world = _init_world()
+    if world.world_size != WORLD_SIZE:
+        pytest.skip("The Kimi-K3 TP4/DCP4 storage test requires four ranks.")
+
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device)
+
+    local = torch.nn.Parameter(
+        torch.full(
+            (LOCAL_ROWS, Q_LORA_RANK),
+            world.rank_in_group,
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        requires_grad=False,
+    )
+    after_local = torch.cuda.memory_allocated(device)
+    replicated = world.all_gather(local.data.contiguous(), dim=0)
+    torch.cuda.synchronize(device)
+    after_gather = torch.cuda.memory_allocated(device)
+    replicated_ptr = replicated.data_ptr()
+
+    bind_parameter_to_replicated_rank_slice_(
+        local,
+        replicated,
+        rank=world.rank_in_group,
+        world_size=world.world_size,
+    )
+    gc.collect()
+    torch.cuda.synchronize(device)
+    after_alias = torch.cuda.memory_allocated(device)
+
+    assert local.is_contiguous()
+    assert local.untyped_storage().data_ptr() == replicated.untyped_storage().data_ptr()
+    assert local.storage_offset() == world.rank_in_group * local.numel()
+    # The local 13.5 MiB q_b allocation is released; tolerate one allocator page.
+    assert after_gather - after_alias >= LOCAL_WEIGHT_BYTES - (2 << 20)
+    assert after_gather - after_local >= replicated.nbytes
+    if world.rank_in_group == 0:
+        print(
+            "QREP_STORAGE_RESULT "
+            + json.dumps(
+                {
+                    "local_weight_bytes": LOCAL_WEIGHT_BYTES,
+                    "allocated_after_local": after_local,
+                    "allocated_after_gather": after_gather,
+                    "allocated_after_alias": after_alias,
+                    "released_bytes": after_gather - after_alias,
+                },
+                sort_keys=True,
+            )
+        )
+
+    expected = torch.arange(
+        WORLD_SIZE, dtype=torch.bfloat16, device=device
+    ).repeat_interleave(LOCAL_ROWS * Q_LORA_RANK)
+    torch.testing.assert_close(replicated.flatten(), expected, atol=0, rtol=0)
+
+    local_w_kc = (
+        torch.full(
+            (LOCAL_HEADS, 128, 512),
+            world.rank_in_group,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        .transpose(1, 2)
+        .contiguous()
+        .transpose(1, 2)
+    )
+    assert local_w_kc.stride() == (65536, 1, 128)
+    w_kc_after_local = torch.cuda.memory_allocated(device)
+    full_w_kc = world.all_gather(local_w_kc.contiguous(), dim=0)
+    torch.cuda.synchronize(device)
+    w_kc_after_gather = torch.cuda.memory_allocated(device)
+    full_w_kc_ptr = full_w_kc.data_ptr()
+    local_w_kc = replicated_rank_slice(
+        full_w_kc,
+        local_shape=local_w_kc.shape,
+        rank=world.rank_in_group,
+        world_size=world.world_size,
+    )
+    gc.collect()
+    torch.cuda.synchronize(device)
+    w_kc_after_alias = torch.cuda.memory_allocated(device)
+
+    assert full_w_kc.stride() == (65536, 512, 1)
+    assert local_w_kc.stride() == (65536, 512, 1)
+    assert (
+        local_w_kc.untyped_storage().data_ptr()
+        == full_w_kc.untyped_storage().data_ptr()
+    )
+    assert w_kc_after_gather - w_kc_after_alias >= LOCAL_W_KC_BYTES
+
+    # Simulate Kimi-K3 post_load_weights reconstructing an independent
+    # K-contiguous local tensor during an online reload.
+    reloaded_local_w_kc = (
+        torch.full_like(local_w_kc, 20 + world.rank_in_group)
+        .transpose(1, 2)
+        .contiguous()
+        .transpose(1, 2)
+    )
+    assert reloaded_local_w_kc.stride() == (65536, 1, 128)
+    refresh_replicated_weight_(reloaded_local_w_kc, full_w_kc, group=world)
+    local_w_kc = replicated_rank_slice(
+        full_w_kc,
+        local_shape=reloaded_local_w_kc.shape,
+        rank=world.rank_in_group,
+        world_size=world.world_size,
+    )
+    torch.cuda.synchronize(device)
+    assert full_w_kc.data_ptr() == full_w_kc_ptr
+    assert (
+        local_w_kc.untyped_storage().data_ptr()
+        == full_w_kc.untyped_storage().data_ptr()
+    )
+    for rank in range(WORLD_SIZE):
+        torch.testing.assert_close(
+            full_w_kc[rank * LOCAL_HEADS : (rank + 1) * LOCAL_HEADS],
+            torch.full_like(local_w_kc, 20 + rank),
+            atol=0,
+            rtol=0,
+        )
+
+    if world.rank_in_group == 0:
+        print(
+            "QREP_W_KC_STORAGE_RESULT "
+            + json.dumps(
+                {
+                    "local_weight_bytes": LOCAL_W_KC_BYTES,
+                    "allocated_after_local": w_kc_after_local,
+                    "allocated_after_gather": w_kc_after_gather,
+                    "allocated_after_alias": w_kc_after_alias,
+                    "released_bytes": w_kc_after_gather - w_kc_after_alias,
+                },
+                sort_keys=True,
+            )
+        )
+
+    local.fill_(10 + world.rank_in_group)
+    refresh_replicated_weight_(local, replicated, group=world)
+    torch.cuda.synchronize(device)
+    assert replicated.data_ptr() == replicated_ptr
+    expected = torch.arange(
+        10, 10 + WORLD_SIZE, dtype=torch.bfloat16, device=device
+    ).repeat_interleave(LOCAL_ROWS * Q_LORA_RANK)
+    torch.testing.assert_close(replicated.flatten(), expected, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(4,))

--- a/test/registered/unit/test_kimi_k3_replicated_query_weights.py
+++ b/test/registered/unit/test_kimi_k3_replicated_query_weights.py
@@ -1,0 +1,86 @@
+"""CPU tests for replicated DCP Query projection weight storage."""
+
+import torch
+
+from sglang.srt.layers.dcp.query_weights import (
+    bind_parameter_to_replicated_rank_slice_,
+    refresh_replicated_weight_,
+    replicated_rank_slice,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeAllGatherGroup:
+    def __init__(self, shards, rank):
+        self.shards = shards
+        self.world_size = len(shards)
+        self.rank_in_group = rank
+
+    def all_gather(self, input_, dim=-1):
+        shards = list(self.shards)
+        shards[self.rank_in_group] = input_
+        return torch.cat(shards, dim=dim)
+
+
+def test_replicated_query_weight_owns_local_parameter_storage():
+    local = torch.nn.Parameter(torch.arange(12, dtype=torch.float32).view(3, 4))
+    local.weight_loader = object()
+    replicated = torch.cat((local.detach(), local.detach() + 100), dim=0)
+
+    local_view = bind_parameter_to_replicated_rank_slice_(
+        local,
+        replicated,
+        rank=1,
+        world_size=2,
+    )
+
+    assert local.weight_loader is not None
+    assert local.data_ptr() == local_view.data_ptr()
+    assert local.untyped_storage().data_ptr() == replicated.untyped_storage().data_ptr()
+    assert local.storage_offset() == 12
+    torch.testing.assert_close(local, replicated[3:])
+
+    local.data.fill_(7)
+    torch.testing.assert_close(replicated[3:], torch.full((3, 4), 7.0))
+    torch.testing.assert_close(
+        replicated[:3],
+        torch.arange(12, dtype=torch.float32).view(3, 4),
+    )
+
+
+def test_refresh_replicated_query_weight_preserves_buffer_pointer():
+    shards = [torch.full((2, 3), float(rank), dtype=torch.float32) for rank in range(4)]
+    replicated = torch.cat(shards, dim=0)
+    local = replicated[4:6]
+    local.fill_(20)
+    original_ptr = replicated.data_ptr()
+
+    refresh_replicated_weight_(
+        local,
+        replicated,
+        group=_FakeAllGatherGroup(shards, rank=2),
+    )
+
+    assert replicated.data_ptr() == original_ptr
+    expected_shards = list(shards)
+    expected_shards[2] = torch.full((2, 3), 20.0)
+    torch.testing.assert_close(replicated, torch.cat(expected_shards, dim=0))
+
+
+def test_replicated_query_tensor_rank_slice_can_change_local_layout():
+    local_shape = (2, 3, 4)
+    replicated = torch.arange(48, dtype=torch.float32).view(4, 3, 4)
+
+    local = replicated_rank_slice(
+        replicated,
+        local_shape=local_shape,
+        rank=1,
+        world_size=2,
+    )
+
+    assert local.shape == local_shape
+    assert local.stride() == replicated.stride()
+    assert local.storage_offset() == 24
+    assert local.untyped_storage().data_ptr() == replicated.untyped_storage().data_ptr()


### PR DESCRIPTION
## Summary

Remove duplicate rank-local Query projection weight allocations from Kimi-K3's default replicated-Q path.

The startup AllGather now owns the only persistent full `q_b` and `w_kc` buffers. Rank-local parameters become contiguous views into their rank slice of that storage, preserving weight-loader metadata and the local prefill/extend layout. Online weight updates refresh the existing full buffers in place, keeping CUDA-graph addresses stable.

This PR changes storage ownership, not the replicated-Q execution policy. Replicated-Q remains the speed default and still performs no per-layer Query AllGather during decode.

## Memory and performance

Measured at TP4/DCP4 with 24 MLA layers:

| Saving | Per rank | Four-GPU node |
| --- | ---: | ---: |
| Tensor payload | 396 MiB | 1,584 MiB |
| PyTorch allocator memory | 408 MiB | 1,632 MiB |

After the change, replicated-Q owns 66 MiB/layer instead of 82.5 MiB/layer. Its persistent premium over purely sharded weights becomes 49.5 MiB/layer, or 1.160 GiB/rank across 24 layers.

The local `q_b` view changes measured Query production by -0.028% to +0.018%, which is noise-level.

No request-level serving speedup is claimed.

## Validation

- 3 CPU storage/view/refresh tests passed.
- 4 one-GPU Query-layout tests passed.
- 1 four-GPU allocation, aliasing, rank-order, refresh, and pointer-stability test passed.
- `git diff --check` passed.

## Related PRs

- Parent Kimi-K3 integration: #32541
- Kimi-K3 follow-up tracker: #32607
- Direct-final Query publication: #33069
- TP4 fused KDA decode: #33071
- KDA temporal-state copy-on-write: #33072
- Fused NVIDIA KDA prefill staging: #33073
- Generic lazy-compaction scheduler fix: #33060
