### PR TITLE
[Kimi-K3] Avoid temporal-state copies on prefix restore

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
+++ b/python/sglang/kernels/ops/attention/fla/chunk_delta_h.py
@@ -26,6 +26,56 @@ GDN_CHUNK_H_NUM_WARPS = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_WARPS", "4"))
 GDN_CHUNK_H_NUM_STAGES = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_STAGES", "2"))
 
 
+@triton.jit
+def _prepare_kda_state_io_indices_kernel(
+    cache_indices,
+    source_map,
+    output,
+    N: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < N
+    dst = tl.load(cache_indices + offsets, mask=mask, other=-1).to(tl.int64)
+    valid = mask & (dst >= 0)
+    src = tl.load(source_map + dst, mask=valid, other=-1).to(tl.int32)
+    packed = (src << 16) | dst.to(tl.int32)
+    tl.store(output + offsets, packed, mask=mask)
+    # Ownership is consumed into ``output``. Restore identity in the same
+    # launch so a later extend cannot observe stale COW state.
+    tl.store(source_map + dst, dst.to(tl.int32), mask=valid)
+
+
+def prepare_kda_state_io_indices(
+    cache_indices: torch.Tensor,
+    source_map: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """Pack 16-bit temporal read/write owners into one int32 kernel input."""
+    assert cache_indices.dtype == torch.int32 and cache_indices.ndim == 1
+    assert source_map.dtype == torch.int32 and source_map.ndim == 1
+    assert output.dtype == torch.int32 and output.ndim == 1
+    assert cache_indices.is_contiguous() and source_map.is_contiguous()
+    assert output.is_contiguous() and output.numel() >= cache_indices.numel()
+    assert cache_indices.device == source_map.device == output.device
+    assert source_map.numel() <= 65536, (
+        "KDA temporal COW packs source/destination state slots into 16 bits; "
+        f"got {source_map.numel()} slots"
+    )
+    n = cache_indices.numel()
+    if n == 0:
+        return output[:0]
+    block = min(triton.next_power_of_2(n), 256)
+    _prepare_kda_state_io_indices_kernel[(triton.cdiv(n, block),)](
+        cache_indices,
+        source_map,
+        output,
+        N=n,
+        BLOCK=block,
+    )
+    return output[:n]
+
+
 @triton.autotune(
     # Single hardcoded config. The kernel writes ht (final state) back into
     # initial_state in-place; with multiple configs, triton's autotune benchmark
@@ -46,7 +96,7 @@ GDN_CHUNK_H_NUM_STAGES = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_STAGES", "2"))
             num_stages=GDN_CHUNK_H_NUM_STAGES,
         )
     ],
-    key=["H", "K", "V", "BT", "USE_GK", "NT_BUCKET"],
+    key=["H", "K", "V", "BT", "USE_GK", "USE_IO_INDICES", "NT_BUCKET"],
     **autotune_cache_kwargs,
 )
 @triton.jit(do_not_specialize=["T"])
@@ -60,6 +110,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     h,
     initial_state,
     initial_state_indices,
+    initial_state_io_indices,
     stride_init_state,
     cu_seqlens,
     chunk_offsets,
@@ -73,6 +124,7 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     USE_G: tl.constexpr,
     USE_GK: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,
+    USE_IO_INDICES: tl.constexpr,
     INPLACE_UPDATE: tl.constexpr,
     SAVE_NEW_VALUE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
@@ -118,9 +170,15 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
     # may be an envelope-strided view (page-major / unified memory), where the
     # per-slot pitch spans ALL layers' state, not H*V*K. int64: envelope pitches
     # overflow an int32 index product.
-    index = tl.load(initial_state_indices + i_n).to(tl.int64)
-    h0 = initial_state + index * stride_init_state
-    ht = initial_state + index * stride_init_state
+    if USE_IO_INDICES:
+        packed_index = tl.load(initial_state_io_indices + i_n).to(tl.int32)
+        src_index = ((packed_index >> 16) & 0xFFFF).to(tl.int64)
+        dst_index = (packed_index & 0xFFFF).to(tl.int64)
+    else:
+        src_index = tl.load(initial_state_indices + i_n).to(tl.int64)
+        dst_index = src_index
+    h0 = initial_state + src_index * stride_init_state
+    ht = initial_state + dst_index * stride_init_state
     if USE_INITIAL_STATE:
         h0 = h0 + i_h * V * K
     if INPLACE_UPDATE:
@@ -322,6 +380,7 @@ def chunk_gated_delta_rule_fwd_h(
     cu_seqlens: Optional[torch.LongTensor] = None,
     chunk_indices: Optional[torch.LongTensor] = None,
     use_exp2: bool = False,
+    initial_state_io_indices: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     assert not (
         use_exp2 and g is not None
@@ -342,6 +401,13 @@ def chunk_gated_delta_rule_fwd_h(
             prepare_chunk_offsets(cu_seqlens, BT),
         )
     assert K <= 256, "current kernel does not support head dimension larger than 256."
+    if initial_state_io_indices is not None:
+        assert initial_state is not None and initial_state_indices is not None
+        assert initial_state_io_indices.dtype == torch.int32
+        assert initial_state_io_indices.ndim == 1
+        assert initial_state_io_indices.is_contiguous()
+        assert initial_state_io_indices.device == initial_state.device
+        assert initial_state_io_indices.numel() >= N
 
     h = k.new_empty(B, NT, H, V, K)
 
@@ -360,6 +426,7 @@ def chunk_gated_delta_rule_fwd_h(
         h=h,
         initial_state=initial_state,
         initial_state_indices=initial_state_indices,
+        initial_state_io_indices=initial_state_io_indices,
         # Envelope-strided state pools (page-major / unified memory) have a
         # per-slot pitch != H*V*K; contiguous pools pass exactly H*V*K.
         stride_init_state=(initial_state.stride(0) if initial_state is not None else 0),
@@ -374,6 +441,7 @@ def chunk_gated_delta_rule_fwd_h(
         USE_G=g is not None,
         USE_GK=gk is not None,
         USE_INITIAL_STATE=initial_state is not None,
+        USE_IO_INDICES=initial_state_io_indices is not None,
         INPLACE_UPDATE=True,
         SAVE_NEW_VALUE=v_new is not None,
         IS_VARLEN=cu_seqlens is not None,

--- a/python/sglang/kernels/ops/attention/fla/kda.py
+++ b/python/sglang/kernels/ops/attention/fla/kda.py
@@ -1095,6 +1095,7 @@ def chunk_kda_fwd(
     dt_bias: Optional[torch.Tensor] = None,
     lower_bound: Optional[float] = None,
     output_intermediate_states: bool = False,
+    initial_state_io_indices: Optional[torch.Tensor] = None,
 ):
     chunk_size = 64
     # Pre-compute chunk indices once and thread through all downstream kernels.
@@ -1166,6 +1167,7 @@ def chunk_kda_fwd(
         gk=g,
         initial_state=initial_state,
         initial_state_indices=initial_state_indices,
+        initial_state_io_indices=initial_state_io_indices,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
         use_exp2=True,
@@ -1210,6 +1212,7 @@ def chunk_kda(
     dt_bias: Optional[torch.Tensor] = None,
     lower_bound: Optional[float] = None,
     output_intermediate_states: bool = False,
+    initial_state_io_indices: torch.Tensor = None,
     **kwargs,
 ):
     if scale is None:
@@ -1229,6 +1232,7 @@ def chunk_kda(
         scale=scale,
         initial_state=initial_state,
         initial_state_indices=initial_state_indices,
+        initial_state_io_indices=initial_state_io_indices,
         cu_seqlens=cu_seqlens,
         A_log=A_log,
         dt_bias=dt_bias,

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -4,10 +4,14 @@ from typing import Optional, Tuple, Union
 import torch
 
 from sglang.kernels.ops.attention import kda_fused_decode
+from sglang.kernels.ops.attention.fla.chunk_delta_h import (
+    prepare_kda_state_io_indices,
+)
 from sglang.kernels.ops.mamba.causal_conv1d_triton import (
     causal_conv1d_fn,
     causal_conv1d_update,
 )
+from sglang.srt.configs.model_config import is_kimi_k3
 from sglang.srt.layers.attention.hybrid_linear_attn_backend import MambaAttnBackendBase
 from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
 from sglang.srt.layers.attention.linear.utils import (
@@ -362,6 +366,16 @@ class KDAAttnBackend(MambaAttnBackendBase):
         decode_backend = get_linear_attn_decode_backend()
         prefill_backend = get_linear_attn_prefill_backend()
         verify_backend = get_linear_attn_verify_backend()
+        self.temporal_cow_source_map = None
+        if (
+            is_cuda()
+            and getattr(model_runner.server_args, "enable_kda_temporal_cow", False)
+            and prefill_backend.is_triton()
+            and is_kimi_k3(model_runner.model_config.hf_config)
+        ):
+            self.temporal_cow_source_map = (
+                self.req_to_token_pool.mamba_pool.enable_temporal_cow()
+            )
         # KDA FlashInfer target_verify (recurrent_kda) is chain-only (no tree-ancestor
         # traversal). Reject EAGLE tree verify (topk > 1) early at setup, keyed on the
         # verify backend (not decode). The kernel keeps a per-call
@@ -391,6 +405,31 @@ class KDAAttnBackend(MambaAttnBackendBase):
                 model_runner.device,
             )
         )
+        self.temporal_state_io_indices = (
+            torch.empty(
+                self.verify_intermediate_state_indices.numel(),
+                dtype=torch.int32,
+                device=model_runner.device,
+            )
+            if self.temporal_cow_source_map is not None
+            else None
+        )
+        self._active_temporal_state_io_indices = None
+
+    def _refresh_temporal_state_io_indices(self, forward_batch: ForwardBatch):
+        self._active_temporal_state_io_indices = None
+        if (
+            self.temporal_state_io_indices is None
+            or not forward_batch.forward_mode.is_extend()
+            or forward_batch.forward_mode.is_target_verify()
+            or forward_batch.forward_mode.is_draft_extend_v2()
+        ):
+            return
+        self._active_temporal_state_io_indices = prepare_kda_state_io_indices(
+            self.forward_metadata.mamba_cache_indices,
+            self.temporal_cow_source_map,
+            self.temporal_state_io_indices,
+        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         super().init_forward_metadata(forward_batch)
@@ -403,6 +442,18 @@ class KDAAttnBackend(MambaAttnBackendBase):
                     self.forward_metadata.mamba_track_mask_indices
                 ]
             )
+        self._refresh_temporal_state_io_indices(forward_batch)
+
+    def init_forward_metadata_out_graph(
+        self,
+        forward_batch: ForwardBatch,
+        in_capture: bool = False,
+    ):
+        super().init_forward_metadata_out_graph(
+            forward_batch,
+            in_capture=in_capture,
+        )
+        self._refresh_temporal_state_io_indices(forward_batch)
 
     def forward_decode(
         self,
@@ -663,6 +714,7 @@ class KDAAttnBackend(MambaAttnBackendBase):
             beta=b,
             ssm_states=ssm_states,
             cache_indices=cache_indices,
+            initial_state_io_indices=self._active_temporal_state_io_indices,
             query_start_loc=query_start_loc,
             A_log=layer.A_log,
             dt_bias=layer.dt_bias,

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -225,6 +225,7 @@ class TritonKDAKernel(LinearAttnKernelBase):
         dt_bias: Optional[torch.Tensor] = None,
         lower_bound: Optional[float] = None,
         return_intermediate_states: bool = False,
+        initial_state_io_indices: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         return chunk_kda(
@@ -235,6 +236,7 @@ class TritonKDAKernel(LinearAttnKernelBase):
             beta=beta,
             initial_state=ssm_states,
             initial_state_indices=cache_indices,
+            initial_state_io_indices=initial_state_io_indices,
             use_qk_l2norm_in_kernel=True,
             cu_seqlens=query_start_loc,
             A_log=A_log,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -837,6 +837,7 @@ class MambaPool:
                 if enable_linear_replayssm_spec
                 else None
             )
+            self.temporal_cow_source_map = None
             mem_usage_bytes = self.mamba_cache.mem_usage_bytes()
             if isinstance(self.mamba_cache, self.SpeculativeState):
                 # `intermediate_conv_window` is an as_strided view whose logical
@@ -899,6 +900,21 @@ class MambaPool:
     def _should_fuse_slot_ops(self) -> bool:
         return self._conv_fuse_ok and not envs.SGLANG_DISABLE_FUSED_MAMBA_SLOT_OPS.get()
 
+    def enable_temporal_cow(self) -> torch.Tensor:
+        """Allocate the pool-stable KDA source map before CUDA graph capture."""
+        if self.temporal_cow_source_map is None:
+            temporal = self.mamba_cache.temporal
+            self.temporal_cow_source_map = torch.arange(
+                temporal.shape[1],
+                dtype=torch.int32,
+                device=temporal.device,
+            )
+            if hasattr(self, "mem_usage"):
+                self.mem_usage += (
+                    get_tensor_size_bytes(self.temporal_cow_source_map) / GB
+                )
+        return self.temporal_cow_source_map
+
     def clear_slots(self, indices: torch.Tensor):
         """Zero out mamba state at the given pool indices. Must run on forward stream."""
         if self._should_fuse_slot_ops():
@@ -908,6 +924,8 @@ class MambaPool:
             temporal = self.mamba_cache.temporal
             if temporal.numel() > 0:
                 temporal[:, indices] = 0
+            if self.temporal_cow_source_map is not None:
+                self.temporal_cow_source_map[indices] = indices.to(torch.int32)
             return
         if not _is_npu:
             need_size = len(indices)
@@ -928,6 +946,71 @@ class MambaPool:
                 t[:, indices] = 0
             t = self.mamba_cache.temporal
             t[:, indices] = 0
+        if self.temporal_cow_source_map is not None:
+            self.temporal_cow_source_map[indices] = indices.to(torch.int32)
+
+    def _validate_copy_source(
+        self, src_indices: torch.Tensor, dst_indices: torch.Tensor
+    ) -> None:
+        """Check the shared source invariants for full and copy-free COW."""
+        if self.replayssm_write_pos is not None and self.debug_memory_pool:
+            src_wp = self.replayssm_write_pos[src_indices]
+            assert bool((src_wp == 0).all().item()), (
+                "copy_from requires a fully-flushed ReplaySSM source "
+                f"(write_pos==0), got {src_wp.tolist()} for src "
+                f"{src_indices.tolist()}"
+            )
+        if envs.SGLANG_DEBUG_MEMORY_POOL.get():
+            overlap = set(src_indices.tolist()) & set(dst_indices.tolist())
+            assert not overlap, (
+                "mamba COW requires disjoint src/dst slots; "
+                f"overlap={sorted(overlap)}"
+            )
+
+    def _copy_conv_from(
+        self, src_indices: torch.Tensor, dst_indices: torch.Tensor
+    ) -> None:
+        if self._should_fuse_slot_ops():
+            from sglang.srt.mem_cache.mamba_slot_fused import fused_copy_conv_slots
+
+            fused_copy_conv_slots(self._conv_slot_desc, src_indices, dst_indices)
+        else:
+            for i in range(len(self.mamba_cache.conv)):
+                self.mamba_cache.conv[i][:, dst_indices] = self.mamba_cache.conv[i][
+                    :, src_indices
+                ]
+
+    def _reset_copied_slot_metadata(
+        self, dst_indices: torch.Tensor, *, reset_source_map: bool
+    ) -> None:
+        if self.replayssm_write_pos is not None:
+            self.replayssm_write_pos[dst_indices] = 0
+        # ReplaySSM spec-verify ring: a copied checkpoint has no pending ring
+        # entries, so its rolling origin + flush flag reset alongside write_pos.
+        if self.replayssm_cache_base is not None:
+            self.replayssm_cache_base[dst_indices] = 0
+        if self.replayssm_is_flush is not None:
+            self.replayssm_is_flush[dst_indices] = 0
+        if reset_source_map and self.temporal_cow_source_map is not None:
+            self.temporal_cow_source_map[dst_indices] = dst_indices.to(torch.int32)
+
+    def prepare_temporal_cow(
+        self, src_indices: torch.Tensor, dst_indices: torch.Tensor
+    ) -> None:
+        """Copy only the KDA convolution window and publish temporal sources.
+
+        The KDA backend resolves the persistent source map once per forward into
+        stable source/destination indices. Each layer then reads
+        ``temporal[src]`` and commits its final state directly to
+        ``temporal[dst]``. Source slots remain immutable and may be shared by
+        several restored requests.
+        """
+        if self.temporal_cow_source_map is None:
+            raise RuntimeError("copy-free temporal COW is not available for this pool")
+        self._validate_copy_source(src_indices, dst_indices)
+        self._copy_conv_from(src_indices, dst_indices)
+        self._reset_copied_slot_metadata(dst_indices, reset_source_map=False)
+        self.temporal_cow_source_map[dst_indices] = src_indices.to(torch.int32)
 
     def copy_from(self, src_indices: torch.Tensor, dst_indices: torch.Tensor):
         """Clone mamba state (conv + temporal) from src slots into dst slots.
@@ -940,43 +1023,12 @@ class MambaPool:
         caps the donate to the last flush boundary. The dst cursor is reset to 0
         (the copied checkpoint has no pending ring entries).
         """
-        if self.replayssm_write_pos is not None and self.debug_memory_pool:
-            # Debug-only (syncs): catch any copy of an active, un-flushed slot.
-            src_wp = self.replayssm_write_pos[src_indices]
-            assert bool((src_wp == 0).all().item()), (
-                "copy_from requires a fully-flushed ReplaySSM source "
-                f"(write_pos==0), got {src_wp.tolist()} for src "
-                f"{src_indices.tolist()}"
-            )
-        if self._should_fuse_slot_ops():
-            from sglang.srt.mem_cache.mamba_slot_fused import fused_copy_conv_slots
-
-            if envs.SGLANG_DEBUG_MEMORY_POOL.get():
-                overlap = set(src_indices.tolist()) & set(dst_indices.tolist())
-                assert not overlap, (
-                    "fused copy_from requires disjoint src/dst slots; "
-                    f"overlap={sorted(overlap)}"
-                )
-            fused_copy_conv_slots(self._conv_slot_desc, src_indices, dst_indices)
-            temporal = self.mamba_cache.temporal
-            if temporal.numel() > 0:
-                temporal[:, dst_indices] = temporal[:, src_indices]
-        else:
-            for i in range(len(self.mamba_cache.conv)):
-                self.mamba_cache.conv[i][:, dst_indices] = self.mamba_cache.conv[i][
-                    :, src_indices
-                ]
-            self.mamba_cache.temporal[:, dst_indices] = self.mamba_cache.temporal[
-                :, src_indices
-            ]
-        if self.replayssm_write_pos is not None:
-            self.replayssm_write_pos[dst_indices] = 0
-        # ReplaySSM spec-verify ring: a copied checkpoint has no pending ring
-        # entries, so its rolling origin + flush flag reset alongside write_pos.
-        if self.replayssm_cache_base is not None:
-            self.replayssm_cache_base[dst_indices] = 0
-        if self.replayssm_is_flush is not None:
-            self.replayssm_is_flush[dst_indices] = 0
+        self._validate_copy_source(src_indices, dst_indices)
+        self._copy_conv_from(src_indices, dst_indices)
+        temporal = self.mamba_cache.temporal
+        if temporal.numel() > 0:
+            temporal[:, dst_indices] = temporal[:, src_indices]
+        self._reset_copied_slot_metadata(dst_indices, reset_source_map=True)
 
     def get_cpu_copy(self, indices):
         current_platform.synchronize()

--- a/python/sglang/srt/mem_cache/unified_memory_pool.py
+++ b/python/sglang/srt/mem_cache/unified_memory_pool.py
@@ -720,6 +720,7 @@ class UnifiedMambaPool(MambaPool):
         self.enable_linear_replayssm_spec = False
         self.replayssm_cache_base = None
         self.replayssm_is_flush = None
+        self.temporal_cow_source_map = None
         self.debug_memory_pool = False
         self.conv_shard_groups = None
         self.conv_slice_axis = spec.conv_slice_axis

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -30,6 +30,7 @@ from sglang.srt.configs.model_config import (
     AttentionArch,
     ModelConfig,
     ModelImpl,
+    is_kimi_k3,
 )
 from sglang.srt.configs.update_config import adjust_config_with_unaligned_cpu_tp
 from sglang.srt.debug_utils.dumper import dumper
@@ -1485,11 +1486,30 @@ class ModelRunner:
                     forward_batch.mamba_cow_dst_indices,
                 )
             else:
-                # mamba_pool is a pure PHYSICAL store; translate both COW slot ids.
-                pool.mamba_pool.copy_from(
-                    pool.translate_mamba_indices(forward_batch.mamba_cow_src_indices),
-                    pool.translate_mamba_indices(forward_batch.mamba_cow_dst_indices),
+                # K3 Triton prefill can leave the FP32 temporal checkpoint at
+                # its immutable source. The KDA backend resolves source ownership
+                # once, then each layer reads src and writes its final state
+                # directly to dst; only the small BF16 convolution window is
+                # copied here. Other backends retain the proven full-copy path.
+                from sglang.srt.layers.attention.linear.utils import (
+                    get_linear_attn_prefill_backend,
                 )
+
+                src_indices = pool.translate_mamba_indices(
+                    forward_batch.mamba_cow_src_indices
+                )
+                dst_indices = pool.translate_mamba_indices(
+                    forward_batch.mamba_cow_dst_indices
+                )
+                use_temporal_cow = (
+                    is_kimi_k3(self.model_config.hf_config)
+                    and get_linear_attn_prefill_backend().is_triton()
+                    and pool.mamba_pool.temporal_cow_source_map is not None
+                )
+                if use_temporal_cow:
+                    pool.mamba_pool.prepare_temporal_cow(src_indices, dst_indices)
+                else:
+                    pool.mamba_pool.copy_from(src_indices, dst_indices)
         forward_batch.mamba_clear_indices = None
         forward_batch.mamba_cow_src_indices = None
         forward_batch.mamba_cow_dst_indices = None

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2527,6 +2527,15 @@ class ServerArgs:
         "Number of int8 mamba checkpoint slots (default: 2x the active mamba pool size).",
         NS("exec.mamba"),
     ] = None
+    enable_kda_temporal_cow: A[
+        bool,
+        "Enable copy-free KDA temporal-state restore for radix-prefix hits. "
+        "Kimi K3 with the Triton prefill backend copies only the BF16 convolution "
+        "window, reads the immutable FP32 temporal checkpoint in place, and writes "
+        "the updated state directly to the destination slot. This saves restore "
+        "bandwidth but adds a small KDA prefill indexing cost.",
+        NS("exec.mamba"),
+    ] = False
     linear_attn_backend: A[
         str,
         Arg(

--- a/test/registered/kernels/benchmark/attention/bench_kimi_k3_kda_temporal_cow.py
+++ b/test/registered/kernels/benchmark/attention/bench_kimi_k3_kda_temporal_cow.py
@@ -1,0 +1,499 @@
+"""Benchmark copy-free Kimi K3 KDA prefix restore at the TP4 state shape.
+
+The full-boundary comparison includes the exact 69-layer FP32 temporal state,
+the BF16 convolution window, and the first KDA update:
+
+    baseline:  copy checkpoint -> working slot, then update working slot
+    candidate: copy conv only, read temporal checkpoint, write working slot
+
+The packed-index overhead comparison measures ordinary KDA prefill with one
+ownership-resolution kernel against the pre-change int32 index path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from sglang.kernels.ops.attention.fla.chunk_delta_h import (
+    prepare_kda_state_io_indices,
+)
+from sglang.kernels.ops.attention.fla.kda import chunk_kda
+
+_LAYERS = 69
+_HEADS = 24
+_D = 128
+_CONV_ELEMENTS_PER_LAYER = 3 * 3 * _HEADS * _D
+
+
+@dataclass
+class Inputs:
+    q: torch.Tensor
+    k: torch.Tensor
+    baseline_v: torch.Tensor
+    candidate_v: torch.Tensor
+    g: torch.Tensor
+    beta: torch.Tensor
+    cu_seqlens: torch.Tensor
+    src: torch.Tensor
+    dst: torch.Tensor
+    source_map: torch.Tensor
+    baseline_state_io_indices: torch.Tensor
+    candidate_state_io_indices: torch.Tensor
+    baseline_temporal: torch.Tensor
+    candidate_temporal: torch.Tensor
+    baseline_conv: torch.Tensor
+    candidate_conv: torch.Tensor
+
+
+def make_inputs(batch: int, tokens: int, seed: int) -> Inputs:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    slots = 2 * batch
+    shape = (1, batch * tokens, _HEADS, _D)
+
+    def randn(*tensor_shape, dtype=torch.bfloat16, scale=0.1):
+        return (
+            torch.randn(
+                *tensor_shape,
+                dtype=dtype,
+                device="cuda",
+                generator=generator,
+            )
+            * scale
+        )
+
+    baseline_temporal = randn(
+        _LAYERS,
+        slots,
+        _HEADS,
+        _D,
+        _D,
+        dtype=torch.float32,
+        scale=0.01,
+    )
+    candidate_temporal = baseline_temporal.clone()
+    baseline_conv = randn(
+        _LAYERS,
+        slots,
+        _CONV_ELEMENTS_PER_LAYER,
+    )
+    candidate_conv = baseline_conv.clone()
+    baseline_v = randn(_LAYERS, *shape)
+    src = torch.arange(batch, device="cuda", dtype=torch.int32)
+    dst = torch.arange(batch, 2 * batch, device="cuda", dtype=torch.int32)
+    source_map = torch.arange(slots, device="cuda", dtype=torch.int32)
+    cu_seqlens = torch.arange(
+        0,
+        (batch + 1) * tokens,
+        tokens,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    return Inputs(
+        q=randn(*shape),
+        k=randn(*shape),
+        baseline_v=baseline_v,
+        candidate_v=baseline_v.clone(),
+        g=randn(*shape, dtype=torch.float32) - 1.0,
+        beta=torch.sigmoid(randn(1, batch * tokens, _HEADS, dtype=torch.float32)),
+        cu_seqlens=cu_seqlens,
+        src=src,
+        dst=dst,
+        source_map=source_map,
+        baseline_state_io_indices=torch.empty(
+            batch, device="cuda", dtype=torch.int32
+        ),
+        candidate_state_io_indices=torch.empty(
+            batch, device="cuda", dtype=torch.int32
+        ),
+        baseline_temporal=baseline_temporal,
+        candidate_temporal=candidate_temporal,
+        baseline_conv=baseline_conv,
+        candidate_conv=candidate_conv,
+    )
+
+
+def run_layers(
+    inputs: Inputs,
+    temporal: torch.Tensor,
+    values: torch.Tensor,
+    state_io_indices: torch.Tensor | None,
+) -> torch.Tensor:
+    output = None
+    for layer in range(_LAYERS):
+        output = chunk_kda(
+            q=inputs.q,
+            k=inputs.k,
+            v=values[layer],
+            g=inputs.g,
+            beta=inputs.beta,
+            initial_state=temporal[layer],
+            initial_state_indices=inputs.dst,
+            initial_state_io_indices=state_io_indices,
+            use_qk_l2norm_in_kernel=True,
+            cu_seqlens=inputs.cu_seqlens,
+        )
+    return output
+
+
+def baseline_prepare(inputs: Inputs) -> None:
+    src = inputs.src.long()
+    dst = inputs.dst.long()
+    inputs.baseline_conv[:, dst] = inputs.baseline_conv[:, src]
+    inputs.baseline_temporal[:, dst] = inputs.baseline_temporal[:, src]
+    inputs.source_map[dst] = inputs.dst
+    prepare_kda_state_io_indices(
+        inputs.dst,
+        inputs.source_map,
+        inputs.baseline_state_io_indices,
+    )
+
+
+def baseline_run(inputs: Inputs) -> torch.Tensor:
+    return run_layers(
+        inputs,
+        inputs.baseline_temporal,
+        inputs.baseline_v,
+        inputs.baseline_state_io_indices,
+    )
+
+
+def baseline(inputs: Inputs) -> torch.Tensor:
+    baseline_prepare(inputs)
+    return baseline_run(inputs)
+
+
+def candidate_prepare(inputs: Inputs) -> None:
+    src = inputs.src.long()
+    dst = inputs.dst.long()
+    inputs.candidate_conv[:, dst] = inputs.candidate_conv[:, src]
+    inputs.source_map[dst] = inputs.src
+    prepare_kda_state_io_indices(
+        inputs.dst,
+        inputs.source_map,
+        inputs.candidate_state_io_indices,
+    )
+
+
+def candidate_run(inputs: Inputs) -> torch.Tensor:
+    return run_layers(
+        inputs,
+        inputs.candidate_temporal,
+        inputs.candidate_v,
+        inputs.candidate_state_io_indices,
+    )
+
+
+def candidate(inputs: Inputs) -> torch.Tensor:
+    candidate_prepare(inputs)
+    return candidate_run(inputs)
+
+
+def no_map(inputs: Inputs) -> torch.Tensor:
+    return run_layers(inputs, inputs.baseline_temporal, inputs.baseline_v, None)
+
+
+def packed_indices_prepare(inputs: Inputs) -> None:
+    prepare_kda_state_io_indices(
+        inputs.dst,
+        inputs.source_map,
+        inputs.candidate_state_io_indices,
+    )
+
+
+def packed_indices_run(inputs: Inputs) -> torch.Tensor:
+    return run_layers(
+        inputs,
+        inputs.candidate_temporal,
+        inputs.candidate_v,
+        inputs.candidate_state_io_indices,
+    )
+
+
+def packed_indices(inputs: Inputs) -> torch.Tensor:
+    packed_indices_prepare(inputs)
+    return packed_indices_run(inputs)
+
+
+def correctness(inputs: Inputs) -> dict[str, float]:
+    expected = baseline(inputs)
+    actual = candidate(inputs)
+    torch.cuda.synchronize()
+    dst = inputs.dst.long()
+    src = inputs.src.long()
+    return {
+        "output_max_abs": float((expected.float() - actual.float()).abs().max()),
+        "destination_state_max_abs": float(
+            (inputs.baseline_temporal[:, dst] - inputs.candidate_temporal[:, dst])
+            .abs()
+            .max()
+        ),
+        "source_state_max_abs": float(
+            (inputs.baseline_temporal[:, src] - inputs.candidate_temporal[:, src])
+            .abs()
+            .max()
+        ),
+        "conv_max_abs": float(
+            (
+                inputs.baseline_conv[:, dst].float()
+                - inputs.candidate_conv[:, dst].float()
+            )
+            .abs()
+            .max()
+        ),
+    }
+
+
+def graph_replay(fn):
+    fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = fn()
+
+    def replay():
+        graph.replay()
+        return output
+
+    return replay
+
+
+def graph_replay_with_prepare(prepare, run):
+    prepare()
+    run()
+    torch.cuda.synchronize()
+    prepare()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = run()
+
+    def replay():
+        prepare()
+        graph.replay()
+        return output
+
+    return replay
+
+
+def time_sample(fn, iterations: int) -> dict[str, float]:
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    wall_start = time.perf_counter_ns()
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    wall_end = time.perf_counter_ns()
+    return {
+        "gpu_us": start.elapsed_time(end) * 1000.0 / iterations,
+        "wall_us": (wall_end - wall_start) / 1000.0 / iterations,
+    }
+
+
+def benchmark_pair(
+    functions: dict[str, object],
+    first: str,
+    samples: int,
+    iterations: int,
+) -> dict:
+    for _ in range(2):
+        for fn in functions.values():
+            fn()
+    torch.cuda.synchronize()
+
+    timings = {name: [] for name in functions}
+    names = tuple(functions)
+    initial_order = names if first == names[0] else names[::-1]
+    for sample in range(samples):
+        order = initial_order if sample % 2 == 0 else initial_order[::-1]
+        for provider in order:
+            timings[provider].append(time_sample(functions[provider], iterations))
+
+    def median(provider: str, metric: str) -> float:
+        return statistics.median(x[metric] for x in timings[provider])
+
+    before, after = names
+    before_gpu = median(before, "gpu_us")
+    after_gpu = median(after, "gpu_us")
+    return {
+        "raw": timings,
+        "median": {
+            "before": before,
+            "after": after,
+            "before_gpu_us": before_gpu,
+            "after_gpu_us": after_gpu,
+            "saved_gpu_us": before_gpu - after_gpu,
+            "saved_gpu_percent": 100.0 * (before_gpu - after_gpu) / before_gpu,
+            "before_wall_us": median(before, "wall_us"),
+            "after_wall_us": median(after, "wall_us"),
+        },
+    }
+
+
+def benchmark_cell(
+    batch: int,
+    tokens: int,
+    mode: str,
+    comparison: str,
+    first: str,
+    samples: int,
+    iterations: int,
+    seed: int,
+) -> dict:
+    inputs = make_inputs(batch, tokens, seed)
+    errors = correctness(inputs)
+    if comparison == "boundary":
+        if mode == "graph":
+            functions = {
+                "baseline": graph_replay_with_prepare(
+                    lambda: baseline_prepare(inputs),
+                    lambda: baseline_run(inputs),
+                ),
+                "candidate": graph_replay_with_prepare(
+                    lambda: candidate_prepare(inputs),
+                    lambda: candidate_run(inputs),
+                ),
+            }
+        else:
+            functions = {
+                "baseline": lambda: baseline(inputs),
+                "candidate": lambda: candidate(inputs),
+            }
+    else:
+        # Both pools hold identical destination state after correctness().
+        if mode == "graph":
+            functions = {
+                "no_map": graph_replay(lambda: no_map(inputs)),
+                "packed_indices": graph_replay_with_prepare(
+                    lambda: packed_indices_prepare(inputs),
+                    lambda: packed_indices_run(inputs),
+                ),
+            }
+        else:
+            functions = {
+                "no_map": lambda: no_map(inputs),
+                "packed_indices": lambda: packed_indices(inputs),
+            }
+
+    result = benchmark_pair(functions, first, samples, iterations)
+    return {
+        "batch": batch,
+        "tokens": tokens,
+        "mode": mode,
+        "comparison": comparison,
+        "first": first,
+        "samples": samples,
+        "iterations": iterations,
+        "state_bytes_per_request": {
+            "temporal": _LAYERS * _HEADS * _D * _D * 4,
+            "conv": _LAYERS * _CONV_ELEMENTS_PER_LAYER * 2,
+            "source_map": 4,
+            "packed_state_indices": 4,
+        },
+        "correctness": errors,
+        **result,
+    }
+
+
+def git_sha() -> str:
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batches", default="1,4,16,32")
+    parser.add_argument("--tokens", default="1,17")
+    parser.add_argument("--modes", default="eager,graph")
+    parser.add_argument(
+        "--comparison",
+        choices=("boundary", "map-overhead"),
+        default="boundary",
+    )
+    parser.add_argument(
+        "--first",
+        choices=("baseline", "candidate", "no_map", "packed_indices"),
+        required=True,
+    )
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=32541)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    expected_first = (
+        {"baseline", "candidate"}
+        if args.comparison == "boundary"
+        else {"no_map", "packed_indices"}
+    )
+    if args.first not in expected_first:
+        raise ValueError(
+            f"--first {args.first!r} is invalid for {args.comparison}; "
+            f"choose one of {sorted(expected_first)}"
+        )
+
+    result = {
+        "metadata": {
+            "git_sha": git_sha(),
+            "dirty": bool(
+                subprocess.check_output(
+                    ["git", "status", "--porcelain"], text=True
+                ).strip()
+            ),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "device": torch.cuda.get_device_name(),
+            "capability": torch.cuda.get_device_capability(),
+            "command": vars(args) | {"output": str(args.output)},
+        },
+        "cells": [],
+    }
+    for mode in args.modes.split(","):
+        for tokens in [int(value) for value in args.tokens.split(",")]:
+            for batch in [int(value) for value in args.batches.split(",")]:
+                cell = benchmark_cell(
+                    batch,
+                    tokens,
+                    mode,
+                    args.comparison,
+                    args.first,
+                    args.samples,
+                    args.iterations,
+                    args.seed + 1000 * tokens + batch,
+                )
+                result["cells"].append(cell)
+                median = cell["median"]
+                print(
+                    f"{args.comparison} B={batch} T={tokens} {mode}: "
+                    f"{median['before_gpu_us']:.3f} -> "
+                    f"{median['after_gpu_us']:.3f} us, "
+                    f"save {median['saved_gpu_us']:.3f} us "
+                    f"({median['saved_gpu_percent']:.2f}%)",
+                    flush=True,
+                )
+                torch.cuda.empty_cache()
+
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = args.output.with_suffix(args.output.suffix + ".tmp")
+        temporary.write_text(payload + "\n")
+        temporary.replace(args.output)
+    else:
+        print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/kernels/ops/attention/test_kimi_k3_kda_temporal_cow.py
+++ b/test/registered/kernels/ops/attention/test_kimi_k3_kda_temporal_cow.py
@@ -1,0 +1,371 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+from sglang.kernels.ops.attention.fla.chunk_delta_h import (
+    prepare_kda_state_io_indices,
+)
+from sglang.kernels.ops.attention.fla.kda import chunk_kda
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, MambaPool
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+class TestKimiK3KDATemporalCOW(unittest.TestCase):
+    H = 24
+    K = 128
+    V = 128
+    SLOTS = 12
+
+    @classmethod
+    def setUpClass(cls):
+        torch.manual_seed(20260731)
+        torch.cuda.set_device(0)
+
+    def _make_state(self, envelope_strided: bool) -> torch.Tensor:
+        elements_per_slot = self.H * self.V * self.K
+        if not envelope_strided:
+            return (
+                torch.randn(
+                    self.SLOTS,
+                    self.H,
+                    self.V,
+                    self.K,
+                    device="cuda",
+                    dtype=torch.float32,
+                )
+                * 0.01
+            )
+
+        slot_stride = elements_per_slot + 4096
+        storage = torch.randn(
+            self.SLOTS * slot_stride,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        return torch.as_strided(
+            storage,
+            size=(self.SLOTS, self.H, self.V, self.K),
+            stride=(slot_stride, self.V * self.K, self.K, 1),
+        )
+
+    def _make_inputs(self, lengths):
+        tokens = sum(lengths)
+        shape = (1, tokens, self.H, self.K)
+        q = torch.randn(shape, device="cuda", dtype=torch.bfloat16) * 0.1
+        k = torch.randn(shape, device="cuda", dtype=torch.bfloat16) * 0.1
+        v = torch.randn(shape, device="cuda", dtype=torch.bfloat16) * 0.1
+        g = torch.randn(shape, device="cuda", dtype=torch.float32) * 0.1 - 1.0
+        beta = torch.sigmoid(
+            torch.randn(1, tokens, self.H, device="cuda", dtype=torch.float32)
+        )
+        cu_seqlens = torch.tensor(
+            [0, *torch.tensor(lengths).cumsum(0).tolist()],
+            device="cuda",
+            dtype=torch.int32,
+        )
+        return q, k, v, g, beta, cu_seqlens
+
+    @staticmethod
+    def _clone_preserving_strides(state):
+        clone = torch.empty_strided(
+            state.shape,
+            state.stride(),
+            device=state.device,
+            dtype=state.dtype,
+        )
+        clone.copy_(state)
+        return clone
+
+    def _run_case(self, lengths, sources, envelope_strided):
+        destinations = list(range(6, 6 + len(sources)))
+        src = torch.tensor(sources, device="cuda", dtype=torch.int32)
+        dst = torch.tensor(destinations, device="cuda", dtype=torch.int32)
+        q, k, v, g, beta, cu_seqlens = self._make_inputs(lengths)
+        initial = self._make_state(envelope_strided)
+
+        baseline_state = self._clone_preserving_strides(initial)
+        baseline_state[dst.long()] = baseline_state[src.long()]
+        expected = chunk_kda(
+            q=q.clone(),
+            k=k.clone(),
+            v=v.clone(),
+            g=g.clone(),
+            beta=beta.clone(),
+            initial_state=baseline_state,
+            initial_state_indices=dst,
+            cu_seqlens=cu_seqlens,
+        )
+
+        candidate_state = self._clone_preserving_strides(initial)
+        source_before = candidate_state[src.long()].clone()
+        unrelated_before = candidate_state[5].clone()
+        source_map = torch.arange(self.SLOTS, device="cuda", dtype=torch.int32)
+        source_map[dst.long()] = src
+        state_io_indices = prepare_kda_state_io_indices(
+            dst,
+            source_map,
+            torch.empty(len(dst), device="cuda", dtype=torch.int32),
+        )
+        actual = chunk_kda(
+            q=q.clone(),
+            k=k.clone(),
+            v=v.clone(),
+            g=g.clone(),
+            beta=beta.clone(),
+            initial_state=candidate_state,
+            initial_state_indices=dst,
+            initial_state_io_indices=state_io_indices,
+            cu_seqlens=cu_seqlens,
+        )
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=2e-3)
+        torch.testing.assert_close(
+            candidate_state[dst.long()],
+            baseline_state[dst.long()],
+            rtol=1e-2,
+            atol=2e-3,
+        )
+        torch.testing.assert_close(
+            candidate_state[src.long()], source_before, rtol=0, atol=0
+        )
+        torch.testing.assert_close(candidate_state[5], unrelated_before, rtol=0, atol=0)
+        torch.testing.assert_close(source_map[dst.long()], dst, rtol=0, atol=0)
+
+    def test_dense_single_token_and_shared_branches(self):
+        self._run_case([1], [0], envelope_strided=False)
+        self._run_case([1, 1, 1, 1], [0, 0, 0, 0], envelope_strided=False)
+
+    def test_envelope_strided_variable_length(self):
+        self._run_case([1, 17], [0, 1], envelope_strided=True)
+
+    def test_packed_owner_resolution_spans_multiple_programs(self):
+        slots = 1024
+        count = 513
+        dst = torch.arange(count, device="cuda", dtype=torch.int32)
+        source_map = torch.arange(slots, device="cuda", dtype=torch.int32)
+        expected = (dst + 17) % slots
+        source_map[dst.long()] = expected
+        output = torch.empty(count, device="cuda", dtype=torch.int32)
+
+        actual = prepare_kda_state_io_indices(dst, source_map, output)
+        actual_src = torch.bitwise_and(
+            torch.bitwise_right_shift(actual, 16), 0xFFFF
+        )
+        actual_dst = torch.bitwise_and(actual, 0xFFFF)
+        torch.testing.assert_close(actual_src, expected, rtol=0, atol=0)
+        torch.testing.assert_close(actual_dst, dst, rtol=0, atol=0)
+        torch.testing.assert_close(source_map[dst.long()], dst, rtol=0, atol=0)
+
+    def test_pool_publish_reset_and_slot_reuse(self):
+        layers = 2
+        slots = 6
+        pool = object.__new__(MambaPool)
+        pool.mamba_cache = MambaPool.State(
+            conv=[
+                torch.randn(
+                    layers,
+                    slots,
+                    3,
+                    32,
+                    device="cuda",
+                    dtype=torch.bfloat16,
+                )
+            ],
+            temporal=torch.randn(
+                layers,
+                slots,
+                4,
+                8,
+                8,
+                device="cuda",
+                dtype=torch.float32,
+            ),
+        )
+        pool.temporal_cow_source_map = None
+        pool.replayssm_write_pos = torch.ones(slots, device="cuda", dtype=torch.int32)
+        pool.replayssm_cache_base = torch.ones(slots, device="cuda", dtype=torch.int32)
+        pool.replayssm_is_flush = torch.ones(slots, device="cuda", dtype=torch.int8)
+        pool.debug_memory_pool = False
+        pool.__dict__["_conv_fuse_ok"] = False
+
+        source_map = pool.enable_temporal_cow()
+        src = torch.tensor([1], device="cuda", dtype=torch.int32)
+        dst = torch.tensor([4], device="cuda", dtype=torch.int32)
+        temporal_dst_before = pool.mamba_cache.temporal[:, dst.long()].clone()
+
+        pool.prepare_temporal_cow(src, dst)
+        torch.testing.assert_close(
+            pool.mamba_cache.conv[0][:, dst.long()],
+            pool.mamba_cache.conv[0][:, src.long()],
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            pool.mamba_cache.temporal[:, dst.long()],
+            temporal_dst_before,
+            rtol=0,
+            atol=0,
+        )
+        self.assertEqual(int(source_map[dst].item()), int(src.item()))
+        self.assertEqual(int(pool.replayssm_write_pos[dst].item()), 0)
+        self.assertEqual(int(pool.replayssm_cache_base[dst].item()), 0)
+        self.assertEqual(int(pool.replayssm_is_flush[dst].item()), 0)
+
+        state_io_indices = prepare_kda_state_io_indices(
+            dst,
+            source_map,
+            torch.empty(len(dst), device="cuda", dtype=torch.int32),
+        )
+        packed = int(state_io_indices[0].item())
+        self.assertEqual((packed >> 16) & 0xFFFF, int(src.item()))
+        self.assertEqual(packed & 0xFFFF, int(dst.item()))
+        self.assertEqual(int(source_map[dst].item()), int(dst.item()))
+
+        pool.copy_from(src, dst)
+        torch.testing.assert_close(
+            pool.mamba_cache.temporal[:, dst.long()],
+            pool.mamba_cache.temporal[:, src.long()],
+            rtol=0,
+            atol=0,
+        )
+        self.assertEqual(int(source_map[dst].item()), int(dst.item()))
+
+        pool.clear_slots(dst)
+        self.assertEqual(
+            int(torch.count_nonzero(pool.mamba_cache.temporal[:, dst.long()])),
+            0,
+        )
+        self.assertEqual(
+            int(torch.count_nonzero(pool.mamba_cache.conv[0][:, dst.long()])),
+            0,
+        )
+        self.assertEqual(int(source_map[dst].item()), int(dst.item()))
+
+    def test_runner_uses_copy_free_for_triton_extend_and_split_prefill(self):
+        mamba_pool = SimpleNamespace(
+            temporal_cow_source_map=torch.arange(8, device="cuda", dtype=torch.int32),
+            prepare_temporal_cow=Mock(),
+            copy_from=Mock(),
+            clear_slots=Mock(),
+        )
+        req_pool = object.__new__(HybridReqToTokenPool)
+        req_pool.mamba_pool = mamba_pool
+        req_pool.mamba_ckpt_pool = None
+
+        runner = object.__new__(ModelRunner)
+        runner.req_to_token_pool = req_pool
+        runner.is_draft_worker = False
+        runner.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["KimiK3ForConditionalGeneration"])
+        )
+
+        def batch(mode):
+            return SimpleNamespace(
+                forward_mode=mode,
+                mamba_clear_indices=None,
+                mamba_cow_src_indices=torch.tensor(
+                    [1], device="cuda", dtype=torch.int32
+                ),
+                mamba_cow_dst_indices=torch.tensor(
+                    [5], device="cuda", dtype=torch.int32
+                ),
+            )
+
+        triton_backend = SimpleNamespace(is_triton=lambda: True)
+        with patch(
+            "sglang.srt.layers.attention.linear.utils.get_linear_attn_prefill_backend",
+            return_value=triton_backend,
+        ):
+            extend = batch(ForwardMode.EXTEND)
+            runner._maybe_execute_deferred_mamba_cow_and_clear(extend)
+            mamba_pool.prepare_temporal_cow.assert_called_once()
+            mamba_pool.copy_from.assert_not_called()
+
+            split = batch(ForwardMode.SPLIT_PREFILL)
+            runner._maybe_execute_deferred_mamba_cow_and_clear(split)
+            self.assertEqual(mamba_pool.prepare_temporal_cow.call_count, 2)
+            mamba_pool.copy_from.assert_not_called()
+
+    def test_changing_source_cuda_graph_replay(self):
+        dst = torch.tensor([6], device="cuda", dtype=torch.int32)
+        state_seed = self._make_state(envelope_strided=False)
+        state = state_seed.clone()
+        source_map = torch.arange(self.SLOTS, device="cuda", dtype=torch.int32)
+        state_io_indices = torch.empty(1, device="cuda", dtype=torch.int32)
+        prepare_kda_state_io_indices(dst, source_map, state_io_indices)
+        static_inputs = list(self._make_inputs([1]))
+
+        def candidate():
+            return chunk_kda(
+                q=static_inputs[0],
+                k=static_inputs[1],
+                v=static_inputs[2],
+                g=static_inputs[3],
+                beta=static_inputs[4],
+                initial_state=state,
+                initial_state_indices=dst,
+                initial_state_io_indices=state_io_indices,
+                cu_seqlens=static_inputs[5],
+            )
+
+        candidate()
+        torch.cuda.synchronize()
+        state.copy_(state_seed)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_output = candidate()
+
+        for source in (0, 1):
+            fresh_inputs = self._make_inputs([1])
+            for static, fresh in zip(static_inputs[:5], fresh_inputs[:5]):
+                static.copy_(fresh)
+            state.copy_(state_seed)
+            source_map.copy_(torch.arange(self.SLOTS, device="cuda", dtype=torch.int32))
+            source_map[dst.long()] = source
+            prepare_kda_state_io_indices(dst, source_map, state_io_indices)
+
+            baseline_state = state_seed.clone()
+            baseline_state[dst.long()] = baseline_state[source].clone()
+            expected = chunk_kda(
+                q=fresh_inputs[0].clone(),
+                k=fresh_inputs[1].clone(),
+                v=fresh_inputs[2].clone(),
+                g=fresh_inputs[3].clone(),
+                beta=fresh_inputs[4].clone(),
+                initial_state=baseline_state,
+                initial_state_indices=dst,
+                cu_seqlens=fresh_inputs[5],
+            )
+            graph.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(graph_output, expected, rtol=1e-2, atol=2e-3)
+            torch.testing.assert_close(
+                state[dst.long()],
+                baseline_state[dst.long()],
+                rtol=1e-2,
+                atol=2e-3,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add an opt-in copy-on-write path for KDA temporal state during prefix restoration.

The original restore boundary copies both the small BF16 convolution state and the complete FP32 temporal state before every layer consumes it. With `--enable-kda-temporal-cow`, the restored temporal source remains immutable and each KDA layer writes directly to the request's destination state. The 3.64 MiB convolution state is still copied; the 103.50 MiB temporal copy is removed per restored request slot.

The feature is opt-in because workloads without prefix restoration do not benefit and can pay a small enabled-path tax.

## Performance

Complete 69-layer CUDA-graph restore boundary on one NVIDIA GB200:

| Tokens | Batch 1 | Batch 4 | Batch 16 | Batch 32 |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 225 us | 995 us | 3.90 ms | 7.71 ms |
| 17 | 190 us | 992 us | 3.82 ms | 7.81 ms |

These values are time saved at the prefix-restore boundary. When no slot needs copy-on-write, graph measurements range from effectively neutral to a 2.62% regression, which is why the default remains off.

No request-level serving speedup is claimed.

## Validation

- 6 focused GPU tests passed on the exact split commit.
- Covers multiple requests sharing an immutable source, permuted ownership, dense and strided FP32 state, split prefill, CUDA-graph replay, source immutability, and exact destination commit.
- All focused benchmark processes reported zero output, destination-state, source-state, and convolution-state error.
- `git diff --check` passed.

## Related PRs

- Parent Kimi-K3 integration: #32541
- Kimi-K3 follow-up tracker: #32607
- Direct-final Query publication: #33069
- Replicated-Q storage ownership: #33070
- TP4 fused KDA decode: #33071
- Fused NVIDIA KDA prefill staging: #33073
- Generic lazy-compaction scheduler fix: #33060
