### PR TITLE
[Kimi-K3] Fuse NVIDIA KDA prefill staging

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/kda_nvidia.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_nvidia.py
@@ -6,11 +6,11 @@ Wraps the vendored ``kda_nvidia_prefill`` package through its FLA-compatible
 V-major ``[B,H,V,K]`` cache to the vendor's K-major ``[B,H,K,V]`` state and
 back; the vendored split kernels keep their original internal layouts.
 
-The serving wrapper repacks ordinary packed prefill batches into bounded
+The serving wrapper repacks sufficiently large ordinary prefills into bounded
 equal-length groups (B <= 8) and pads every sequence to one of
-2k/4k/8k/16k. This makes short multi-sequence prefill use the same NVIDIA KDA
-pipeline while bounding compile variants and transient workspaces. Everything
-that is not an ordinary state-committing prefill stays on its dedicated path:
+2k/4k/8k/16k. A measured crossover gate retains Triton for short groups where
+padding and staging outweigh the faster persistent kernel. Everything that is
+not an ordinary state-committing prefill stays on its dedicated path:
 
 - single-sequence prefill, including chunks of one long request, where Triton
   retains the neutral BS=1 performance;
@@ -30,10 +30,14 @@ loud log (attempt-and-verify, same stance as the fused decode kernel).
 """
 
 import logging
-from typing import Optional
 
 import torch
-
+from sglang.srt.layers.attention.linear.kernels.kda_nvidia_staging import (
+    gather_nvidia_kda_state,
+    pack_nvidia_kda_inputs,
+    scatter_nvidia_kda_state,
+    unpack_nvidia_kda_output,
+)
 from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
@@ -43,6 +47,23 @@ logger = logging.getLogger(__name__)
 
 _BUCKETS = (2048, 4096, 8192, 16384)
 _MAX_NVIDIA_KDA_BATCH = 8
+_MIN_NVIDIA_KDA_SEQ_LEN = 1024
+_MIN_NVIDIA_KDA_GROUP_TOKENS = 4096
+
+
+def _nvidia_kda_wins_staging_gate(seq_lens: list[int]) -> bool:
+    """Conservative GB200 crossover after charging the complete wrapper."""
+    for start in range(0, len(seq_lens), _MAX_NVIDIA_KDA_BATCH):
+        group = seq_lens[start : start + _MAX_NVIDIA_KDA_BATCH]
+        max_length = max(group)
+        # At least four real 1K tokens, or the equivalent ragged payload in a
+        # larger bucket, repays the complete staging boundary on GB200.
+        if (
+            max_length < _MIN_NVIDIA_KDA_SEQ_LEN
+            or sum(group) < _MIN_NVIDIA_KDA_GROUP_TOKENS
+        ):
+            return False
+    return True
 
 
 def _to_nvidia_kda_state_layout(
@@ -147,7 +168,7 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
             **kwargs,
         )
 
-    def _flat_param(self, t: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    def _flat_param(self, t: torch.Tensor | None) -> torch.Tensor | None:
         if t is None:
             return None
         key = (t.data_ptr(), t.dtype, tuple(t.shape))
@@ -229,9 +250,9 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
         ssm_states: torch.Tensor,
         cache_indices: torch.Tensor,
         query_start_loc: torch.Tensor,
-        A_log: Optional[torch.Tensor] = None,
-        dt_bias: Optional[torch.Tensor] = None,
-        lower_bound: Optional[float] = None,
+        A_log: torch.Tensor | None = None,
+        dt_bias: torch.Tensor | None = None,
+        lower_bound: float | None = None,
         return_intermediate_states: bool = False,
         **kwargs,
     ) -> torch.Tensor:
@@ -316,8 +337,6 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
                 kwargs,
             )
 
-        self._ensure_loaded()
-
         seq_lens = [int(length) for length in seq_lens_cpu]
         if (
             any(length <= 0 or length > _BUCKETS[-1] for length in seq_lens)
@@ -346,6 +365,25 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
                 kwargs,
             )
 
+        if not _nvidia_kda_wins_staging_gate(seq_lens):
+            return self._triton_extend(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                ssm_states,
+                cache_indices,
+                query_start_loc,
+                A_log,
+                dt_bias,
+                lower_bound,
+                return_intermediate_states,
+                kwargs,
+            )
+
+        self._ensure_loaded()
+
         num_heads = q.shape[2]
         head_k_dim = q.shape[-1]
         head_v_dim = v.shape[-1]
@@ -356,8 +394,19 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
         all_slot_indices = torch.where(
             cache_indices >= 0, cache_indices, ssm_states.shape[0] - 1
         ).to(torch.int64)
-        state_backup = ssm_states.index_select(0, all_slot_indices).clone()
+        # A single group does not mutate the pool until its final scatter, so
+        # there is nothing to restore if staging or the vendor kernel fails.
+        # Multi-group batches can commit earlier groups before a later failure;
+        # retain the rollback copy only for that uncommon case.
+        state_backup = (
+            ssm_states.index_select(0, all_slot_indices).clone()
+            if len(seq_lens) > _MAX_NVIDIA_KDA_BATCH
+            else None
+        )
         packed_output = torch.empty_like(v)
+        use_fused_staging = (
+            q.is_cuda and num_heads > 0 and head_k_dim == 128 and head_v_dim == 128
+        )
 
         try:
             seq_start = 0
@@ -387,39 +436,59 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
                     head_v_dim,
                     q.device,
                 )
-                st["q"].zero_()
-                st["k"].zero_()
-                st["v"].zero_()
-                st["g"].fill_(-1000.0)
-                st["beta"].zero_()
+                if use_fused_staging:
+                    pack_nvidia_kda_inputs(
+                        q=q,
+                        k=k,
+                        v=v,
+                        g=g,
+                        beta=beta,
+                        cu_seqlens=query_start_loc,
+                        seq_start=seq_start,
+                        group_size=group_size,
+                        staging=st,
+                    )
+                else:
+                    st["q"].zero_()
+                    st["k"].zero_()
+                    st["v"].zero_()
+                    st["g"].fill_(-1000.0)
+                    st["beta"].zero_()
 
-                row_token_start = token_start
-                for row, length in enumerate(group_lens):
-                    row_token_end = row_token_start + length
-                    st["q"][row, :length].copy_(
-                        self._l2norm(q[0, row_token_start:row_token_end].contiguous())
-                    )
-                    st["k"][row, :length].copy_(
-                        self._l2norm(k[0, row_token_start:row_token_end].contiguous())
-                    )
-                    st["v"][row, :length].copy_(v[0, row_token_start:row_token_end])
-                    g_in = g[0, row_token_start:row_token_end]
-                    if g_in.dim() == 2:
-                        g_in = g_in.view(length, num_heads, head_k_dim)
-                    st["g"][row, :length].copy_(g_in)
-                    st["beta"][row, :length].copy_(
-                        beta[0, row_token_start:row_token_end]
-                    )
-                    row_token_start = row_token_end
+                    row_token_start = token_start
+                    for row, length in enumerate(group_lens):
+                        row_token_end = row_token_start + length
+                        st["q"][row, :length].copy_(
+                            self._l2norm(
+                                q[0, row_token_start:row_token_end].contiguous()
+                            )
+                        )
+                        st["k"][row, :length].copy_(
+                            self._l2norm(
+                                k[0, row_token_start:row_token_end].contiguous()
+                            )
+                        )
+                        st["v"][row, :length].copy_(v[0, row_token_start:row_token_end])
+                        g_in = g[0, row_token_start:row_token_end]
+                        if g_in.dim() == 2:
+                            g_in = g_in.view(length, num_heads, head_k_dim)
+                        st["g"][row, :length].copy_(g_in)
+                        st["beta"][row, :length].copy_(
+                            beta[0, row_token_start:row_token_end]
+                        )
+                        row_token_start = row_token_end
 
                 group_slots = all_slot_indices[seq_start : seq_start + group_size]
-                st["s0"].copy_(
-                    _to_nvidia_kda_state_layout(
-                        ssm_states.index_select(0, group_slots),
-                        head_k_dim=head_k_dim,
-                        head_v_dim=head_v_dim,
+                if use_fused_staging:
+                    gather_nvidia_kda_state(ssm_states, group_slots, st["s0"])
+                else:
+                    st["s0"].copy_(
+                        _to_nvidia_kda_state_layout(
+                            ssm_states.index_select(0, group_slots),
+                            head_k_dim=head_k_dim,
+                            head_v_dim=head_v_dim,
+                        )
                     )
-                )
                 res = self._fwd(
                     st["q"],
                     st["k"],
@@ -438,28 +507,42 @@ class NvidiaKDAKernel(LinearAttnKernelBase):
                 )
                 group_output, final_state = res[0], res[1]
 
-                row_token_start = token_start
-                for row, length in enumerate(group_lens):
-                    row_token_end = row_token_start + length
-                    packed_output[0, row_token_start:row_token_end].copy_(
-                        group_output[row, :length]
+                if use_fused_staging:
+                    unpack_nvidia_kda_output(
+                        group_output,
+                        packed_output,
+                        query_start_loc,
+                        seq_start=seq_start,
                     )
-                    row_token_start = row_token_end
-
-                ssm_states.index_copy_(
-                    0,
-                    group_slots,
-                    _from_nvidia_kda_state_layout(
+                    scatter_nvidia_kda_state(
                         final_state,
-                        head_k_dim=head_k_dim,
-                        head_v_dim=head_v_dim,
-                        dtype=ssm_states.dtype,
-                    ),
-                )
+                        group_slots,
+                        ssm_states,
+                    )
+                else:
+                    row_token_start = token_start
+                    for row, length in enumerate(group_lens):
+                        row_token_end = row_token_start + length
+                        packed_output[0, row_token_start:row_token_end].copy_(
+                            group_output[row, :length]
+                        )
+                        row_token_start = row_token_end
+
+                    ssm_states.index_copy_(
+                        0,
+                        group_slots,
+                        _from_nvidia_kda_state_layout(
+                            final_state,
+                            head_k_dim=head_k_dim,
+                            head_v_dim=head_v_dim,
+                            dtype=ssm_states.dtype,
+                        ),
+                    )
                 seq_start += group_size
                 token_start += group_tokens
         except Exception:
-            ssm_states.index_copy_(0, all_slot_indices, state_backup)
+            if state_backup is not None:
+                ssm_states.index_copy_(0, all_slot_indices, state_backup)
             logger.warning(
                 "NVIDIA KDA prefill failed (T=%d sequences=%d); restored states "
                 "and fell back to Triton for this batch",

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_nvidia_staging.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_nvidia_staging.py
@@ -1,0 +1,309 @@
+"""Fused staging kernels for the NVIDIA KDA prefill backend."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _pack_inputs_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    cu_seqlens,
+    q_out,
+    k_out,
+    v_out,
+    g_out,
+    beta_out,
+    seq_start,
+    bucket,
+    q_stride_t,
+    q_stride_h,
+    q_stride_d,
+    k_stride_t,
+    k_stride_h,
+    k_stride_d,
+    v_stride_t,
+    v_stride_h,
+    v_stride_d,
+    g_stride_t,
+    g_stride_h,
+    g_stride_d,
+    beta_stride_t,
+    beta_stride_h,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    row = tl.program_id(0)
+    tile = tl.program_id(1)
+    head = tl.program_id(2)
+    token_offsets = tile * BLOCK_T + tl.arange(0, BLOCK_T)
+    dim_offsets = tl.arange(0, D)
+
+    source_start = tl.load(cu_seqlens + seq_start + row)
+    source_end = tl.load(cu_seqlens + seq_start + row + 1)
+    valid_token = token_offsets < (source_end - source_start)
+    bucket_token = token_offsets < bucket
+    source_tokens = source_start + token_offsets
+
+    q_offsets = (
+        source_tokens[:, None] * q_stride_t
+        + head * q_stride_h
+        + dim_offsets[None, :] * q_stride_d
+    )
+    k_offsets = (
+        source_tokens[:, None] * k_stride_t
+        + head * k_stride_h
+        + dim_offsets[None, :] * k_stride_d
+    )
+    mask = valid_token[:, None]
+    q_values = tl.load(q + q_offsets, mask=mask, other=0.0).to(tl.float32)
+    k_values = tl.load(k + k_offsets, mask=mask, other=0.0).to(tl.float32)
+    q_values /= tl.sqrt(tl.sum(q_values * q_values, axis=1)[:, None] + 1e-6)
+    k_values /= tl.sqrt(tl.sum(k_values * k_values, axis=1)[:, None] + 1e-6)
+
+    output_offsets = (
+        (row * bucket + token_offsets[:, None]) * H * D
+        + head * D
+        + dim_offsets[None, :]
+    )
+    output_mask = bucket_token[:, None]
+    tl.store(q_out + output_offsets, q_values, mask=output_mask)
+    tl.store(k_out + output_offsets, k_values, mask=output_mask)
+
+    v_offsets = (
+        source_tokens[:, None] * v_stride_t
+        + head * v_stride_h
+        + dim_offsets[None, :] * v_stride_d
+    )
+    g_offsets = (
+        source_tokens[:, None] * g_stride_t
+        + head * g_stride_h
+        + dim_offsets[None, :] * g_stride_d
+    )
+    v_values = tl.load(v + v_offsets, mask=mask, other=0.0)
+    g_values = tl.load(g + g_offsets, mask=mask, other=-1000.0)
+    tl.store(v_out + output_offsets, v_values, mask=output_mask)
+    tl.store(g_out + output_offsets, g_values, mask=output_mask)
+
+    beta_offsets = source_tokens * beta_stride_t + head * beta_stride_h
+    beta_values = tl.load(beta + beta_offsets, mask=valid_token, other=0.0)
+    tl.store(
+        beta_out + (row * bucket + token_offsets) * H + head,
+        beta_values,
+        mask=bucket_token,
+    )
+
+
+def pack_nvidia_kda_inputs(
+    *,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    seq_start: int,
+    group_size: int,
+    staging: dict[str, torch.Tensor],
+) -> None:
+    """Normalize and repack one packed-varlen group into its padded bucket."""
+    q_view = q[0]
+    k_view = k[0]
+    v_view = v[0]
+    g_view = g[0].view(q.shape[1], q.shape[2], q.shape[3])
+    beta_view = beta[0]
+    bucket = staging["q"].shape[1]
+    heads = q.shape[2]
+    dim = q.shape[3]
+    assert dim == 128 and v.shape[-1] == dim
+    assert staging["q"].shape[0] == group_size
+
+    block_t = 8
+    _pack_inputs_kernel[(group_size, triton.cdiv(bucket, block_t), heads)](
+        q_view,
+        k_view,
+        v_view,
+        g_view,
+        beta_view,
+        cu_seqlens,
+        staging["q"],
+        staging["k"],
+        staging["v"],
+        staging["g"],
+        staging["beta"],
+        seq_start,
+        bucket,
+        *q_view.stride(),
+        *k_view.stride(),
+        *v_view.stride(),
+        *g_view.stride(),
+        *beta_view.stride(),
+        H=heads,
+        D=dim,
+        BLOCK_T=block_t,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+@triton.jit
+def _unpack_output_kernel(
+    source,
+    output,
+    cu_seqlens,
+    seq_start,
+    bucket,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+):
+    row = tl.program_id(0)
+    tile = tl.program_id(1)
+    head = tl.program_id(2)
+    token_offsets = tile * BLOCK_T + tl.arange(0, BLOCK_T)
+    dim_offsets = tl.arange(0, D)
+    destination_start = tl.load(cu_seqlens + seq_start + row)
+    destination_end = tl.load(cu_seqlens + seq_start + row + 1)
+    valid = token_offsets < (destination_end - destination_start)
+    source_offsets = (
+        (row * bucket + token_offsets[:, None]) * H * D
+        + head * D
+        + dim_offsets[None, :]
+    )
+    destination_offsets = (
+        (destination_start + token_offsets)[:, None] * H * D
+        + head * D
+        + dim_offsets[None, :]
+    )
+    values = tl.load(source + source_offsets, mask=valid[:, None])
+    tl.store(output + destination_offsets, values, mask=valid[:, None])
+
+
+def unpack_nvidia_kda_output(
+    source: torch.Tensor,
+    output: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    seq_start: int,
+) -> None:
+    group_size, bucket, heads, dim = source.shape
+    block_t = 8
+    _unpack_output_kernel[(group_size, triton.cdiv(bucket, block_t), heads)](
+        source,
+        output[0],
+        cu_seqlens,
+        seq_start,
+        bucket,
+        H=heads,
+        D=dim,
+        BLOCK_T=block_t,
+        num_warps=8,
+        num_stages=2,
+    )
+
+
+@triton.jit
+def _gather_state_kernel(
+    pool,
+    slots,
+    output,
+    pool_stride_slot,
+    pool_stride_head,
+    pool_stride_v,
+    pool_stride_k,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    offsets = tl.program_id(2) * BLOCK + tl.arange(0, BLOCK)
+    valid = offsets < D * D
+    k_offsets = offsets // D
+    v_offsets = offsets % D
+    slot = tl.load(slots + row).to(tl.int64)
+    source_offsets = (
+        slot * pool_stride_slot
+        + head * pool_stride_head
+        + v_offsets * pool_stride_v
+        + k_offsets * pool_stride_k
+    )
+    destination_offsets = ((row * H + head) * D + k_offsets) * D + v_offsets
+    values = tl.load(pool + source_offsets, mask=valid)
+    tl.store(output + destination_offsets, values, mask=valid)
+
+
+def gather_nvidia_kda_state(
+    pool: torch.Tensor,
+    slots: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    rows, heads, dim_k, dim_v = output.shape
+    assert dim_k == dim_v == 128 and slots.numel() == rows
+    block = 256
+    _gather_state_kernel[(rows, heads, triton.cdiv(dim_k * dim_v, block))](
+        pool,
+        slots,
+        output,
+        *pool.stride(),
+        H=heads,
+        D=dim_k,
+        BLOCK=block,
+        num_warps=8,
+    )
+
+
+@triton.jit
+def _scatter_state_kernel(
+    source,
+    slots,
+    pool,
+    pool_stride_slot,
+    pool_stride_head,
+    pool_stride_v,
+    pool_stride_k,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    offsets = tl.program_id(2) * BLOCK + tl.arange(0, BLOCK)
+    valid = offsets < D * D
+    k_offsets = offsets // D
+    v_offsets = offsets % D
+    slot = tl.load(slots + row).to(tl.int64)
+    source_offsets = ((row * H + head) * D + k_offsets) * D + v_offsets
+    destination_offsets = (
+        slot * pool_stride_slot
+        + head * pool_stride_head
+        + v_offsets * pool_stride_v
+        + k_offsets * pool_stride_k
+    )
+    values = tl.load(source + source_offsets, mask=valid)
+    tl.store(pool + destination_offsets, values, mask=valid)
+
+
+def scatter_nvidia_kda_state(
+    source: torch.Tensor,
+    slots: torch.Tensor,
+    pool: torch.Tensor,
+) -> None:
+    rows, heads, dim_k, dim_v = source.shape
+    assert dim_k == dim_v == 128 and slots.numel() == rows
+    block = 256
+    _scatter_state_kernel[(rows, heads, triton.cdiv(dim_k * dim_v, block))](
+        source,
+        slots,
+        pool,
+        *pool.stride(),
+        H=heads,
+        D=dim_k,
+        BLOCK=block,
+        num_warps=8,
+    )

--- a/test/registered/kernels/benchmark/attention/bench_kimi_k3_kda_nvidia_staging.py
+++ b/test/registered/kernels/benchmark/attention/bench_kimi_k3_kda_nvidia_staging.py
@@ -1,0 +1,384 @@
+"""Benchmark the complete Kimi K3 NVIDIA KDA prefill boundary.
+
+This benchmark charges all boundary work around the persistent vendor kernel:
+
+    input normalization/repack + state gather/transpose + vendor kernel
+    + output unpack + state scatter/transpose
+
+It compares that forced path with Triton and with the production crossover
+selection. Both uniform and ragged request batches are supported. Example:
+
+    python bench_kimi_k3_kda_nvidia_staging.py \
+        --cells 2x128,4x1024,8x2048,4096+1 \
+        --first triton --output /tmp/kda-prefill.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from sglang.srt.layers.attention.linear.kernels import kda_nvidia
+from sglang.srt.layers.attention.linear.kernels.kda_nvidia import NvidiaKDAKernel
+from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
+
+_HEADS = 24
+_D = 128
+_LOWER_BOUND = -5.0
+
+
+@dataclass
+class Inputs:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    g: torch.Tensor
+    beta: torch.Tensor
+    state: torch.Tensor
+    slots: torch.Tensor
+    cu_seqlens: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    lengths: list[int]
+
+
+def make_inputs(lengths: list[int], seed: int) -> Inputs:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    batch = len(lengths)
+    total = sum(lengths)
+    slots_count = batch + 4
+
+    def randn(*shape, dtype=torch.bfloat16, scale=0.1):
+        return (
+            torch.randn(
+                *shape,
+                dtype=dtype,
+                device="cuda",
+                generator=generator,
+            )
+            * scale
+        )
+
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(lengths).cumsum(0).tolist()],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    return Inputs(
+        q=randn(1, total, _HEADS, _D),
+        k=randn(1, total, _HEADS, _D),
+        v=randn(1, total, _HEADS, _D),
+        g=randn(1, total, _HEADS, _D),
+        beta=torch.sigmoid(randn(1, total, _HEADS, dtype=torch.float32)),
+        state=randn(
+            slots_count,
+            _HEADS,
+            _D,
+            _D,
+            dtype=torch.float32,
+            scale=0.01,
+        ),
+        slots=torch.randperm(slots_count, device="cuda", generator=generator)[:batch]
+        .to(torch.int32)
+        .contiguous(),
+        cu_seqlens=cu_seqlens,
+        a_log=randn(1, 1, _HEADS, 1, dtype=torch.float32, scale=0.5) - 1.5,
+        dt_bias=randn(_HEADS * _D, dtype=torch.float32),
+        lengths=lengths,
+    )
+
+
+def clone_inputs(source: Inputs) -> Inputs:
+    return Inputs(
+        q=source.q.clone(),
+        k=source.k.clone(),
+        v=source.v.clone(),
+        g=source.g.clone(),
+        beta=source.beta.clone(),
+        state=source.state.clone(),
+        slots=source.slots,
+        cu_seqlens=source.cu_seqlens,
+        a_log=source.a_log,
+        dt_bias=source.dt_bias,
+        lengths=source.lengths,
+    )
+
+
+def common_kwargs(inputs: Inputs) -> dict:
+    return {
+        "ssm_states": inputs.state,
+        "cache_indices": inputs.slots,
+        "query_start_loc": inputs.cu_seqlens,
+        "A_log": inputs.a_log,
+        "dt_bias": inputs.dt_bias,
+        "lower_bound": _LOWER_BOUND,
+        "extend_seq_lens_cpu": inputs.lengths,
+        "is_spec_decode": False,
+        "return_intermediate_states": False,
+    }
+
+
+def triton(kernel: TritonKDAKernel, inputs: Inputs) -> torch.Tensor:
+    return kernel.extend(
+        inputs.q,
+        inputs.k,
+        inputs.v,
+        inputs.g,
+        inputs.beta,
+        **common_kwargs(inputs),
+    )
+
+
+def nvidia(kernel: NvidiaKDAKernel, inputs: Inputs) -> torch.Tensor:
+    return kernel.extend(
+        inputs.q,
+        inputs.k,
+        inputs.v,
+        inputs.g,
+        inputs.beta,
+        **common_kwargs(inputs),
+    )
+
+
+@contextmanager
+def forced_nvidia_gate(enabled: bool):
+    original = kda_nvidia._nvidia_kda_wins_staging_gate
+    if enabled:
+        kda_nvidia._nvidia_kda_wins_staging_gate = lambda _lengths: True
+    try:
+        yield
+    finally:
+        kda_nvidia._nvidia_kda_wins_staging_gate = original
+
+
+def correctness(source: Inputs) -> dict[str, float]:
+    triton_inputs = clone_inputs(source)
+    nvidia_inputs = clone_inputs(source)
+    expected = triton(TritonKDAKernel(), triton_inputs)
+    with forced_nvidia_gate(True):
+        actual = nvidia(NvidiaKDAKernel(), nvidia_inputs)
+    torch.cuda.synchronize()
+
+    expected_state = triton_inputs.state[triton_inputs.slots.long()]
+    actual_state = nvidia_inputs.state[nvidia_inputs.slots.long()]
+    output_cos = torch.nn.functional.cosine_similarity(
+        expected.float().flatten(),
+        actual.float().flatten(),
+        dim=0,
+    )
+    state_cos = torch.nn.functional.cosine_similarity(
+        expected_state.flatten(),
+        actual_state.flatten(),
+        dim=0,
+    )
+    return {
+        "output_cosine": float(output_cos),
+        "output_max_abs": float((expected.float() - actual.float()).abs().max()),
+        "state_cosine": float(state_cos),
+        "state_max_abs": float((expected_state - actual_state).abs().max()),
+    }
+
+
+def time_sample(fn, iterations: int) -> dict[str, float]:
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    wall_start = time.perf_counter_ns()
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    wall_end = time.perf_counter_ns()
+    return {
+        "gpu_us": start.elapsed_time(end) * 1000.0 / iterations,
+        "wall_us": (wall_end - wall_start) / 1000.0 / iterations,
+    }
+
+
+def percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def benchmark_cell(
+    lengths: list[int],
+    first: str,
+    samples: int,
+    iterations: int,
+    seed: int,
+) -> dict:
+    source = make_inputs(lengths, seed)
+    errors = correctness(source)
+    inputs = {
+        name: clone_inputs(source) for name in ("triton", "forced_nvidia", "selected")
+    }
+    triton_kernel = TritonKDAKernel()
+    forced_kernel = NvidiaKDAKernel()
+    selected_kernel = NvidiaKDAKernel()
+
+    def run_triton():
+        return triton(triton_kernel, inputs["triton"])
+
+    def run_forced_nvidia():
+        with forced_nvidia_gate(True):
+            return nvidia(forced_kernel, inputs["forced_nvidia"])
+
+    def run_selected():
+        return nvidia(selected_kernel, inputs["selected"])
+
+    functions = {
+        "triton": run_triton,
+        "forced_nvidia": run_forced_nvidia,
+        "selected": run_selected,
+    }
+    for _ in range(3):
+        for fn in functions.values():
+            fn()
+    torch.cuda.synchronize()
+
+    names = list(functions)
+    first_index = names.index(first)
+    initial_order = names[first_index:] + names[:first_index]
+    timings = {name: [] for name in names}
+    for sample in range(samples):
+        order = initial_order if sample % 2 == 0 else list(reversed(initial_order))
+        for provider in order:
+            timings[provider].append(time_sample(functions[provider], iterations))
+
+    def summary(provider: str) -> dict[str, float]:
+        gpu = [item["gpu_us"] for item in timings[provider]]
+        wall = [item["wall_us"] for item in timings[provider]]
+        return {
+            "gpu_p50_us": statistics.median(gpu),
+            "gpu_p95_us": percentile(gpu, 0.95),
+            "wall_p50_us": statistics.median(wall),
+            "wall_p95_us": percentile(wall, 0.95),
+        }
+
+    medians = {name: summary(name) for name in names}
+    baseline = medians["triton"]["gpu_p50_us"]
+    for provider in ("forced_nvidia", "selected"):
+        candidate = medians[provider]["gpu_p50_us"]
+        medians[provider]["saved_vs_triton_us"] = baseline - candidate
+        medians[provider]["saved_vs_triton_percent"] = (
+            100.0 * (baseline - candidate) / baseline
+        )
+
+    bucket = next(value for value in kda_nvidia._BUCKETS if value >= max(lengths))
+    return {
+        "lengths": lengths,
+        "batch": len(lengths),
+        "tokens": sum(lengths),
+        "bucket": bucket,
+        "padding_tokens": len(lengths) * bucket - sum(lengths),
+        "padding_fraction": 1.0 - sum(lengths) / (len(lengths) * bucket),
+        "production_selects_nvidia": (
+            kda_nvidia._nvidia_kda_wins_staging_gate(lengths)
+        ),
+        "samples": samples,
+        "iterations": iterations,
+        "correctness": errors,
+        "raw": timings,
+        "median": medians,
+    }
+
+
+def parse_cell(value: str) -> list[int]:
+    if "x" in value:
+        batch, length = value.split("x", maxsplit=1)
+        return [int(length)] * int(batch)
+    return [int(length) for length in value.split("+")]
+
+
+def git_sha() -> str:
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cells",
+        default=(
+            "2x128,2x512,2x1024,2x2048,"
+            "4x128,4x512,4x1024,4x2048,"
+            "8x128,8x512,8x1024,8x2048,"
+            "4096+1,4096+1024,2048+128+128+128"
+        ),
+    )
+    parser.add_argument(
+        "--first",
+        choices=("triton", "forced_nvidia", "selected"),
+        required=True,
+    )
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=32541)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if torch.cuda.get_device_capability()[0] != 10:
+        raise RuntimeError("NVIDIA KDA prefill requires datacenter Blackwell")
+
+    cells = [parse_cell(value) for value in args.cells.split(",")]
+    result = {
+        "metadata": {
+            "git_sha": git_sha(),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "device": torch.cuda.get_device_name(),
+            "capability": torch.cuda.get_device_capability(),
+            "command": vars(args) | {"output": str(args.output)},
+        },
+        "cells": [],
+    }
+    for index, lengths in enumerate(cells):
+        cell = benchmark_cell(
+            lengths,
+            args.first,
+            args.samples,
+            args.iterations,
+            args.seed + index,
+        )
+        result["cells"].append(cell)
+        forced = cell["median"]["forced_nvidia"]
+        selected = cell["median"]["selected"]
+        print(
+            f"lengths={lengths}: Triton "
+            f"{cell['median']['triton']['gpu_p50_us']:.3f} us, "
+            f"NVIDIA {forced['gpu_p50_us']:.3f} us "
+            f"({forced['saved_vs_triton_percent']:+.2f}%), "
+            f"selected {selected['gpu_p50_us']:.3f} us "
+            f"({selected['saved_vs_triton_percent']:+.2f}%)",
+            flush=True,
+        )
+        del cell
+        torch.cuda.empty_cache()
+
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = args.output.with_suffix(args.output.suffix + ".tmp")
+        temporary.write_text(payload + "\n")
+        temporary.replace(args.output)
+    print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/kernels/ops/attention/test_kda_nvidia_staging.py
+++ b/test/registered/kernels/ops/attention/test_kda_nvidia_staging.py
@@ -1,0 +1,187 @@
+import pytest
+import torch
+from sglang.kernels.ops.attention.fla.l2norm import l2norm_fwd
+from sglang.srt.layers.attention.linear.kernels.kda_nvidia import NvidiaKDAKernel
+from sglang.srt.layers.attention.linear.kernels.kda_nvidia_staging import (
+    gather_nvidia_kda_state,
+    pack_nvidia_kda_inputs,
+    scatter_nvidia_kda_state,
+    unpack_nvidia_kda_output,
+)
+from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10),
+    reason="NVIDIA KDA prefill requires datacenter Blackwell",
+)
+
+
+def _staging(rows: int, bucket: int, heads: int, dim: int):
+    return {
+        "q": torch.empty(rows, bucket, heads, dim, device="cuda", dtype=torch.bfloat16),
+        "k": torch.empty(rows, bucket, heads, dim, device="cuda", dtype=torch.bfloat16),
+        "v": torch.empty(rows, bucket, heads, dim, device="cuda", dtype=torch.bfloat16),
+        "g": torch.empty(rows, bucket, heads, dim, device="cuda", dtype=torch.bfloat16),
+        "beta": torch.empty(rows, bucket, heads, device="cuda", dtype=torch.bfloat16),
+    }
+
+
+def test_fused_input_and_output_staging_matches_reference():
+    torch.manual_seed(32541)
+    lengths = [1, 17, 128]
+    rows, bucket, heads, dim = len(lengths), 256, 2, 128
+    total = sum(lengths)
+    q = torch.randn(1, total, heads, dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    g = torch.randn_like(q)
+    beta = torch.rand(1, total, heads, device="cuda", dtype=torch.float32)
+    cu = torch.tensor(
+        [0, *torch.tensor(lengths).cumsum(0).tolist()],
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    expected = _staging(rows, bucket, heads, dim)
+    for tensor in expected.values():
+        tensor.zero_()
+    expected["g"].fill_(-1000.0)
+    start = 0
+    for row, length in enumerate(lengths):
+        end = start + length
+        expected["q"][row, :length] = l2norm_fwd(q[0, start:end].contiguous())
+        expected["k"][row, :length] = l2norm_fwd(k[0, start:end].contiguous())
+        expected["v"][row, :length] = v[0, start:end]
+        expected["g"][row, :length] = g[0, start:end]
+        expected["beta"][row, :length] = beta[0, start:end]
+        start = end
+
+    actual = _staging(rows, bucket, heads, dim)
+    pack_nvidia_kda_inputs(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        cu_seqlens=cu,
+        seq_start=0,
+        group_size=rows,
+        staging=actual,
+    )
+    torch.cuda.synchronize()
+    for name in expected:
+        torch.testing.assert_close(actual[name], expected[name], rtol=0, atol=1e-3)
+
+    source = torch.randn_like(actual["v"])
+    output = torch.zeros_like(v)
+    unpack_nvidia_kda_output(source, output, cu, seq_start=0)
+    expected_output = torch.cat(
+        [source[row, :length] for row, length in enumerate(lengths)], dim=0
+    ).unsqueeze(0)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(output, expected_output, rtol=0, atol=0)
+
+
+def test_fused_state_staging_supports_envelope_strides():
+    torch.manual_seed(32542)
+    slots, rows, heads, dim = 7, 3, 2, 128
+    elements_per_slot = heads * dim * dim
+    storage = torch.randn(
+        slots * (elements_per_slot + 1024), device="cuda", dtype=torch.float32
+    )
+    pool = torch.as_strided(
+        storage,
+        size=(slots, heads, dim, dim),
+        stride=(elements_per_slot + 1024, dim * dim, dim, 1),
+    )
+    pool_before = pool.clone()
+    selected = torch.tensor([5, 1, 3], device="cuda", dtype=torch.int64)
+    vendor_state = torch.empty(
+        rows, heads, dim, dim, device="cuda", dtype=torch.float32
+    )
+
+    gather_nvidia_kda_state(pool, selected, vendor_state)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        vendor_state, pool[selected].transpose(-1, -2), rtol=0, atol=0
+    )
+
+    vendor_state.add_(1.0)
+    scatter_nvidia_kda_state(vendor_state, selected, pool)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        pool[selected].transpose(-1, -2), vendor_state, rtol=0, atol=0
+    )
+    untouched = torch.ones(slots, device="cuda", dtype=torch.bool)
+    untouched[selected] = False
+    torch.testing.assert_close(pool[untouched], pool_before[untouched], rtol=0, atol=0)
+
+
+def test_real_nvidia_kda_prefill_matches_triton_tp4():
+    torch.manual_seed(32543)
+    batch, length, heads, dim = 4, 1024, 24, 128
+    total = batch * length
+    q = torch.randn(1, total, heads, dim, device="cuda", dtype=torch.bfloat16) * 0.1
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    g = torch.randn_like(q) * 0.1
+    beta = torch.sigmoid(
+        torch.randn(1, total, heads, device="cuda", dtype=torch.float32)
+    )
+    a_log = torch.randn(1, 1, heads, 1, device="cuda", dtype=torch.float32) * 0.5 - 1.5
+    dt_bias = torch.randn(heads * dim, device="cuda", dtype=torch.float32) * 0.1
+    cu = torch.arange(0, total + 1, length, device="cuda", dtype=torch.int32)
+    slots = torch.tensor([5, 1, 7, 3], device="cuda", dtype=torch.int32)
+    state_seed = (
+        torch.randn(9, heads, dim, dim, device="cuda", dtype=torch.float32) * 0.01
+    )
+    common = {
+        "cache_indices": slots,
+        "query_start_loc": cu,
+        "A_log": a_log,
+        "dt_bias": dt_bias,
+        "lower_bound": -5.0,
+        "extend_seq_lens_cpu": [length] * batch,
+        "is_spec_decode": False,
+        "return_intermediate_states": False,
+    }
+
+    ref_state = state_seed.clone()
+    ref = TritonKDAKernel().extend(
+        q.clone(),
+        k.clone(),
+        v.clone(),
+        g.clone(),
+        beta.clone(),
+        ssm_states=ref_state,
+        **common,
+    )
+    actual_state = state_seed.clone()
+    actual = NvidiaKDAKernel().extend(
+        q.clone(),
+        k.clone(),
+        v.clone(),
+        g.clone(),
+        beta.clone(),
+        ssm_states=actual_state,
+        **common,
+    )
+    torch.cuda.synchronize()
+
+    output_cos = torch.nn.functional.cosine_similarity(
+        ref.float().flatten(), actual.float().flatten(), dim=0
+    )
+    state_cos = torch.nn.functional.cosine_similarity(
+        ref_state[slots.long()].flatten(),
+        actual_state[slots.long()].flatten(),
+        dim=0,
+    )
+    assert output_cos > 0.999
+    assert state_cos > 0.9999
+    assert torch.equal(
+        ref_state[torch.tensor([0, 2, 4, 6, 8], device="cuda", dtype=torch.long)],
+        actual_state[torch.tensor([0, 2, 4, 6, 8], device="cuda", dtype=torch.long)],
+    )

--- a/test/registered/unit/layers/attention/linear/kernels/test_kda_nvidia.py
+++ b/test/registered/unit/layers/attention/linear/kernels/test_kda_nvidia.py
@@ -4,10 +4,10 @@ import unittest
 from unittest.mock import Mock, patch
 
 import torch
-
 from sglang.srt.layers.attention.linear.kernels.kda_nvidia import (
     NvidiaKDAKernel,
     _from_nvidia_kda_state_layout,
+    _nvidia_kda_wins_staging_gate,
     _to_nvidia_kda_state_layout,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -51,6 +51,16 @@ class TestNvidiaKDAAllPrefillWrapper(CustomTestCase):
                 head_k_dim=7,
                 head_v_dim=5,
             )
+
+    def test_measured_staging_crossover_gate(self):
+        self.assertFalse(_nvidia_kda_wins_staging_gate([128, 128]))
+        self.assertFalse(_nvidia_kda_wins_staging_gate([512] * 8))
+        self.assertFalse(_nvidia_kda_wins_staging_gate([1024, 1024]))
+        self.assertTrue(_nvidia_kda_wins_staging_gate([1024] * 4))
+        self.assertTrue(_nvidia_kda_wins_staging_gate([2048, 2048]))
+        self.assertTrue(_nvidia_kda_wins_staging_gate([1024] * 8))
+        self.assertTrue(_nvidia_kda_wins_staging_gate([4096, 1]))
+        self.assertFalse(_nvidia_kda_wins_staging_gate([2048, 2048] + [512] * 8))
 
     def _make_kernel(self):
         calls = []
@@ -125,18 +135,23 @@ class TestNvidiaKDAAllPrefillWrapper(CustomTestCase):
         states_before = states.clone()
         slots = torch.tensor([2, 0, 4], dtype=torch.int32)
 
-        output = kernel.extend(
-            x["q"],
-            x["k"],
-            x["v"],
-            x["g"],
-            x["beta"],
-            ssm_states=states,
-            cache_indices=slots,
-            query_start_loc=x["query_start_loc"],
-            extend_seq_lens_cpu=seq_lens,
-            A_log=torch.zeros(128, dtype=torch.float32),
-        )
+        with patch(
+            "sglang.srt.layers.attention.linear.kernels.kda_nvidia."
+            "_nvidia_kda_wins_staging_gate",
+            return_value=True,
+        ):
+            output = kernel.extend(
+                x["q"],
+                x["k"],
+                x["v"],
+                x["g"],
+                x["beta"],
+                ssm_states=states,
+                cache_indices=slots,
+                query_start_loc=x["query_start_loc"],
+                extend_seq_lens_cpu=seq_lens,
+                A_log=torch.zeros(128, dtype=torch.float32),
+            )
 
         self.assertEqual(len(calls), 1)
         call = calls[0]
@@ -183,6 +198,77 @@ class TestNvidiaKDAAllPrefillWrapper(CustomTestCase):
                 A_log=torch.zeros(128, dtype=torch.float32),
             )
         self.assertEqual(calls, [])
+
+    def test_single_group_failure_does_not_mutate_state_before_fallback(self):
+        kernel, _ = self._make_kernel()
+        kernel._fwd = Mock(side_effect=RuntimeError("injected"))
+        kernel._triton = Mock()
+        kernel._triton.extend.return_value = "triton"
+        seq_lens = [2, 3]
+        x = self._inputs(seq_lens)
+        states = torch.randn(4, 1, 128, 128, dtype=torch.bfloat16)
+        states_before = states.clone()
+
+        with patch(
+            "sglang.srt.layers.attention.linear.kernels.kda_nvidia."
+            "_nvidia_kda_wins_staging_gate",
+            return_value=True,
+        ):
+            output = kernel.extend(
+                x["q"],
+                x["k"],
+                x["v"],
+                x["g"],
+                x["beta"],
+                ssm_states=states,
+                cache_indices=torch.tensor([1, 3], dtype=torch.int32),
+                query_start_loc=x["query_start_loc"],
+                extend_seq_lens_cpu=seq_lens,
+                A_log=torch.zeros(128, dtype=torch.float32),
+            )
+
+        self.assertEqual(output, "triton")
+        self.assertTrue(torch.equal(states, states_before))
+        kernel._triton.extend.assert_called_once()
+
+    def test_multi_group_failure_rolls_back_committed_state(self):
+        kernel, calls = self._make_kernel()
+        original_fwd = kernel._fwd
+
+        def fail_second_group(*args, **kwargs):
+            if calls:
+                raise RuntimeError("injected")
+            return original_fwd(*args, **kwargs)
+
+        kernel._fwd = fail_second_group
+        kernel._triton = Mock()
+        kernel._triton.extend.return_value = "triton"
+        seq_lens = [1] * 9
+        x = self._inputs(seq_lens)
+        states = torch.randn(12, 1, 128, 128, dtype=torch.bfloat16)
+        states_before = states.clone()
+
+        with patch(
+            "sglang.srt.layers.attention.linear.kernels.kda_nvidia."
+            "_nvidia_kda_wins_staging_gate",
+            return_value=True,
+        ):
+            output = kernel.extend(
+                x["q"],
+                x["k"],
+                x["v"],
+                x["g"],
+                x["beta"],
+                ssm_states=states,
+                cache_indices=torch.arange(1, 10, dtype=torch.int32),
+                query_start_loc=x["query_start_loc"],
+                extend_seq_lens_cpu=seq_lens,
+                A_log=torch.zeros(128, dtype=torch.float32),
+            )
+
+        self.assertEqual(output, "triton")
+        self.assertTrue(torch.equal(states, states_before))
+        kernel._triton.extend.assert_called_once()
 
     def test_supports_only_datacenter_blackwell(self):
         with (


### PR DESCRIPTION
## Summary

Fuse the staging boundary around the opt-in NVIDIA KDA prefill backend and route losing short shapes to Triton.

This is not a CuTeDSL implementation. The recurrent math remains NVIDIA's persistent KDA kernel. New Triton kernels fuse q/k normalization, input packing and padding, recurrent-state gather/layout conversion, output restore, and final-state scatter/layout conversion.

CuTeDSL is excluded from the same-semantics comparison because its current KDA prefill path does not implement Kimi-K3's bounded gate.

## Performance

Measured on one NVIDIA GB200 with BF16 q/k/v/g, FP32 beta and recurrent state, H=24, K=V=128, and safe gate lower bound -5:

| Selected shape | Before | After | Saving |
| --- | ---: | ---: | ---: |
| B4 x 1024 | 459.50 us | 381.03 us | 78.47 us, 17.08% |
| B2 x 2048 | 489.11 us | 372.55 us | 116.56 us, 23.83% |
| Ragged [4096, 1] | 565.10 us | 414.80 us | 150.30 us, 26.60% |

A forced B8 x 2048 cell improves by 935.37 us, or 58.87%. Short cells lose, so the production selector requires a maximum sequence length of at least 1024 and at least 4096 real tokens per group. Rejected cells run Triton.

This PR improves only the opt-in `nvidia_kda` backend; it does not make NVIDIA KDA the default. No request-level serving speedup is claimed.

## Validation

- 12 focused CPU/GPU tests passed on the exact split commit.
- Complete NVIDIA wrapper versus Triton: output cosine about 0.999989 and state cosine about 0.999995.
- Covers ragged batches, permuted cache slots, non-zero FP32 state, state rollback on failure, and Triton fallback.
- `git diff --check` passed.

## Related PRs

- Parent Kimi-K3 integration: #32541
- Kimi-K3 follow-up tracker: #32607
- Direct-final Query publication: #33069
- Replicated-Q storage ownership: #33070
- TP4 fused KDA decode: #33071
- KDA temporal-state copy-on-write: #33072
- Generic lazy-compaction scheduler fix: #33060
