### PR TITLE
[Docs] Add DeepSeek-V4 Flash Official (0731) recipe

### DIFF
--- a/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs_new/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -1,6 +1,6 @@
 ---
 title: DeepSeek-V4
-description: "Deploy DeepSeek-V4 with SGLang — verified launch commands, benchmarks, and tuning for the Flash (284B) and Pro (1.6T) Mixture-of-Experts models."
+description: "Deploy DeepSeek-V4 with SGLang — verified launch commands, benchmarks, and tuning for Flash Official (0731), Flash, and Pro."
 tag: NEW
 ---
 
@@ -127,7 +127,7 @@ import { Playground } from "/src/snippets/_playground.jsx";
 
 ## 1. Model Introduction
 
-**DeepSeek-V4** is the next-generation Mixture-of-Experts model from DeepSeek, released 2026-04-24 under an **MIT License**. It ships as two Instruct repos (one per variant) plus matching Base repos:
+**DeepSeek-V4** is the next-generation Mixture-of-Experts model from DeepSeek, released 2026-04-24 under an **MIT License**. The 0731 Flash refresh adds a checkpoint with a bundled DSpark draft head:
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
   <colgroup>
@@ -152,6 +152,12 @@ import { Playground } from "/src/snippets/_playground.jsx";
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>single-node serving on B200 / B300 / GB200 / GB300 / H200 (TP=4); RTX PRO 6000 (TP=2); H100 (TP=8)</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><strong><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731">DeepSeek-V4-Flash-0731</a></strong></td>
+      <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>284B</strong></td>
+      <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.02)"}}>13B</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Flash Official (0731), with a bundled DSpark draft head; verified for low-latency serving on 4×GB300</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><strong><a href="https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro">DeepSeek-V4-Pro</a></strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.05)"}}><strong>1.6T</strong></td>
       <td style={{padding: "9px 12px", textAlign: "right", backgroundColor: "rgba(255,255,255,0.02)"}}>49B</td>
@@ -160,13 +166,13 @@ import { Playground } from "/src/snippets/_playground.jsx";
   </tbody>
 </table>
 
-Both Instruct repos ship as **FP4 MoE experts + FP8 attention / dense** (one mixed-precision checkpoint covers every FP4-capable GPU). Matching `*-Base` repos ship pure FP8 mixed and are for further pre-training only — not for chat or tool calling.
+The Instruct checkpoints ship as **FP4 MoE experts + FP8 attention / dense** (one mixed-precision checkpoint covers every FP4-capable GPU). Matching `*-Base` repos ship pure FP8 mixed and are for further pre-training only — not for chat or tool calling.
 
 **Highlights:** hybrid CSA + HCA attention (~27% inference FLOPs / ~10% KV cache vs DSv3.2 at 1M context), manifold-constrained hyper-connections (mHC), Muon optimizer, **1M-token context** (32T+ pre-training tokens), three reasoning modes (*Non-think* / *Think High* / *Think Max* — use ≥ 384K context for Think Max), and a dedicated `encoding_dsv4.encode_messages` Python encoder + DSML tool-call grammar.
 
 **Recommended generation:** `temperature=1.0`, `top_p=1.0`.
 
-**Resources:** HuggingFace · [Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash) · [Pro](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro)  ·  ModelScope · [Flash](https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Flash) · [Pro](https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Pro).
+**Resources:** HuggingFace · [Flash Official (0731)](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731) · [Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash) · [Pro](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro)  ·  ModelScope · [Flash](https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Flash) · [Pro](https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Pro).
 
 ## 2. Configuration Tips
 
@@ -178,7 +184,11 @@ Must hold: `max-running-requests × MTP_draft_tokens ≤ SGLANG_DEEPEP_NUM_MAX_D
 
 The generator currently picks values on the **conservative** side (mirroring an internal stress-test matrix). They run safely out of the box but likely leave throughput on the table — please tune them up toward your actual workload's peak concurrency and report findings back so the defaults can be revised.
 
-**MTP (Multi-Token Prediction, EAGLE)**
+**Speculative decoding**
+
+The original Flash and Pro recipes use EAGLE. Flash Official (0731) uses the bundled DSpark draft head; see [DSpark](#34-dspark-speculative-decoding) for its launch and tuning notes.
+
+For the original Flash and Pro checkpoints:
 
 - `low-latency`: steps=3, draft-tokens=4 → largest win at bs=1.
 - `balanced`: steps=1, draft-tokens=2 → gentler MTP, reduces throughput hit at higher batch.
@@ -549,3 +559,35 @@ For AMD devices,
 The Write policy knob defaults to `write_through` (the upstream default); switch to `write_back` / `write_through_selective` to trade durability for write speed when the storage tier is slow.
 
 For more details, see the [HiCache documentation](../../../docs/advanced_features/hicache).
+
+### 3.4 DSpark (Speculative Decoding)
+
+Flash Official (0731) bundles a DSpark draft head in `deepseek-ai/DeepSeek-V4-Flash-0731`. The target and draft weights therefore come from the same checkpoint: enable DSpark with `--speculative-algorithm DSPARK` and do not set a separate `--speculative-draft-model-path`.
+
+Unlike the EAGLE recipes for the original Flash and Pro checkpoints, this recipe omits `--speculative-num-steps`, `--speculative-eagle-topk`, and `--speculative-num-draft-tokens`. SGLang reads the DSpark shape from the checkpoint.
+
+The verified 4×GB300 FP4 low-latency command is:
+
+```bash Command
+sglang serve \
+  --trust-remote-code \
+  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
+  --tp 4 \
+  --moe-runner-backend flashinfer_mxfp4 \
+  --speculative-algorithm DSPARK \
+  --mem-fraction-static 0.90 \
+  --chunked-prefill-size 4096 \
+  --swa-full-tokens-ratio 0.1 \
+  --host 0.0.0.0 \
+  --port 30000
+```
+
+Keep `--mem-fraction-static 0.90` on this topology to leave enough headroom for the batch-256 verify graph. The first cold start can take 10–15 minutes while FlashInfer autotunes and SGLang captures the draft and verify graphs; later starts reuse the cache. This path is verified end-to-end on 4×GB300 with SGLang v0.5.16.
+
+**Tune proposed draft tokens.** `--speculative-dspark-block-size N` asks DSpark to propose `N` tokens per step; the target verifies a window of `N + 1`. If the flag is omitted, SGLang reads the value from the checkpoint. The current 0731 checkpoint resolves to five proposed tokens, which is the verified default. Use the **DSpark Proposed Draft Tokens** slider in the [Playground](#advanced-features-playground) to sweep one through five.
+
+Larger blocks can improve decode latency when acceptance stays high, but they also increase verification work and graph memory. Start from the checkpoint default, then sweep downward under the real prompt-length and concurrency distribution. The gain is usually largest for short interactive traffic and narrows as prefill dominates. Track P50/P99 TTFT and TPOT, total throughput, accepted length, GPU memory, and stop rate rather than choosing from acceptance alone.
+
+For every candidate, compare with the same recipe without `--speculative-algorithm DSPARK`. Restart the server between the DSpark and non-speculative legs, keep the request corpus, sampling, concurrency, and warmup identical, and give each `bench_serving` leg its own `--flush-cache`. Leave `--speculative-draft-attention-backend` unset unless a separate profiling run justifies an override.
+
+DSpark currently requires CUDA and `pp_size == 1`. If a larger draft block or concurrency causes graph-capture OOM, lower `--mem-fraction-static`, the draft block size, or the configured maximum running requests, then rerun both performance and accuracy gates.

--- a/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4-benchmarks.jsx
@@ -1,6 +1,6 @@
 // DeepSeek-V4 per-cell benchmark numbers, keyed by the same `match` tuple as
 // deepseek-v4.jsx cells. See _deployment.jsx for the speed/accuracy schema.
-// Measured on sglang v0.5.15 / v0.5.15.post1 (per-cell sglang_version).
+// Measured on sglang v0.5.15 / v0.5.15.post1 / v0.5.16 (per-cell sglang_version).
 // tokens_per_sec_per_gpu is total (input+output) tok/s/GPU = output/GPU × (isl+osl)/osl.
 export const benchmarks = [
   // ====================================================================
@@ -236,6 +236,17 @@ export const benchmarks = [
   // ====================================================================
   // GB300 + FP4
   // ====================================================================
+  {
+    match: { hw: "gb300", variant: "flash-official", quant: "fp4", strategy: "low-latency", nodes: "single" },
+    sglang_version: "0.5.16",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 468.93, tpot_ms: 1.31, tokens_per_sec_per_gpu: 930 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 726.81, tpot_ms: 8.84, tokens_per_sec_per_gpu: 2711 },
+    ],
+    accuracy: { gsm8k_pct: 97.04 },
+  },
   {
     match: { hw: "gb300", variant: "flash", quant: "fp4", strategy: "low-latency", nodes: "single" },
     sglang_version: "0.5.15.post1",

--- a/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs_new/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -22,6 +22,7 @@ export const config = {
 
   variants: [
     { id: "flash", label: "Flash", subtitle: "284B" },
+    { id: "flash-official", label: "Flash Official", subtitle: "284B · 0731" },
     { id: "pro",   label: "Pro",   subtitle: "1.6T" },
   ],
   quantizations: [
@@ -44,6 +45,7 @@ export const config = {
     "flash|fp4": "deepseek-ai/DeepSeek-V4-Flash",
     "flash|fp8": "deepseek-ai/DeepSeek-V4-Flash",
     "flash|nvfp4": "nvidia/DeepSeek-V4-Flash-NVFP4",
+    "flash-official|fp4": "deepseek-ai/DeepSeek-V4-Flash-0731",
     "pro|fp4":   "deepseek-ai/DeepSeek-V4-Pro",
     "pro|fp8":   "deepseek-ai/DeepSeek-V4-Pro",
     "pro|nvfp4": "nvidia/DeepSeek-V4-Pro-NVFP4",
@@ -96,6 +98,14 @@ sgl-eval run gpqa \\
   --temperature 1.0 --top-p 1.0 --thinking \\
   --out-dir /sgl-workspace/logs \\
   --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1`,
+        "flash-official":
+`# To install sgl-eval: pip install git+https://github.com/sgl-project/sgl-eval
+sgl-eval run gpqa \\
+  --model {{MODEL_NAME}} --api-key <api-key> \\
+  --n-repeats 16 --max-tokens 200000 \\
+  --temperature 1.0 --top-p 1.0 --thinking \\
+  --out-dir /sgl-workspace/logs \\
+  --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1`,
         pro:
 `# To install sgl-eval: pip install git+https://github.com/sgl-project/sgl-eval
 sgl-eval run gpqa \\
@@ -106,6 +116,14 @@ sgl-eval run gpqa \\
   --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1`,
       },
       aime25_pct: {
+        "flash-official":
+`# To install sgl-eval: pip install git+https://github.com/sgl-project/sgl-eval
+sgl-eval run aime25 \\
+  --model {{MODEL_NAME}} --api-key <api-key> \\
+  --n-repeats 16 --max-tokens 200000 \\
+  --temperature 1.0 --top-p 1.0 --thinking \\
+  --out-dir /sgl-workspace/logs \\
+  --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1`,
         flash:
 `# To install sgl-eval: pip install git+https://github.com/sgl-project/sgl-eval
 sgl-eval run aime25 \\
@@ -268,10 +286,15 @@ sgl-eval run aime25 \\
         { id: "off",        label: "Off (greedy)" },
         { id: "mtp-314",    label: "EAGLE / MTP 3-1-4",
           flags: ["--speculative-algorithm EAGLE", "--speculative-num-steps 3",
-                  "--speculative-eagle-topk 1", "--speculative-num-draft-tokens 4"] },
+                  "--speculative-eagle-topk 1", "--speculative-num-draft-tokens 4"],
+          hide: { variant: ["flash-official"] } },
         { id: "mtp-112",    label: "EAGLE / MTP 1-1-2",
           flags: ["--speculative-algorithm EAGLE", "--speculative-num-steps 1",
-                  "--speculative-eagle-topk 1", "--speculative-num-draft-tokens 2"] },
+                  "--speculative-eagle-topk 1", "--speculative-num-draft-tokens 2"],
+          hide: { variant: ["flash-official"] } },
+        { id: "dspark",     label: "DSpark",
+          flags: ["--speculative-algorithm DSPARK"],
+          hide: { variant: ["flash", "pro"] } },
         { id: "ngram",      label: "NGRAM",
           flags: ["--speculative-algorithm NGRAM",
                   "--speculative-num-draft-tokens 16",
@@ -383,6 +406,24 @@ sgl-eval run aime25 \\
       ],
       defaultHostRatio: 10,
     },
+
+    flagSelects: [
+      {
+        id: "dsparkDraftTokens",
+        title: "DSpark Proposed Draft Tokens",
+        showWhen: (base) => base.variant === "flash-official",
+        control: "slider",
+        stripPrefixes: ["--speculative-dspark-block-size"],
+        options: [
+          { id: "auto", label: "Checkpoint default" },
+          { id: "1", label: "1", flags: ["--speculative-dspark-block-size 1"] },
+          { id: "2", label: "2", flags: ["--speculative-dspark-block-size 2"] },
+          { id: "3", label: "3", flags: ["--speculative-dspark-block-size 3"] },
+          { id: "4", label: "4", flags: ["--speculative-dspark-block-size 4"] },
+          { id: "5", label: "5", flags: ["--speculative-dspark-block-size 5"] },
+        ],
+      },
+    ],
   },
 
   cells: [
@@ -914,6 +955,23 @@ sgl-eval run aime25 \\
     // ====================================================================
     // GB300 + FP4
     // ====================================================================
+    {
+      match: { hw: "gb300", variant: "flash-official", quant: "fp4", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      env: [],
+      flags: [
+        "--trust-remote-code",
+        "--model-path {{MODEL_NAME}}",
+        "--tp 4",
+        "--moe-runner-backend flashinfer_mxfp4",
+        "--speculative-algorithm DSPARK",
+        "--mem-fraction-static 0.90",
+        "--chunked-prefill-size 4096",
+        "--swa-full-tokens-ratio 0.1",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
     {
       match: { hw: "gb300", variant: "flash", quant: "fp4", strategy: "low-latency", nodes: "single" },
       verified: true,


### PR DESCRIPTION
## Summary

- add a separate **Flash Official** option for `deepseek-ai/DeepSeek-V4-Flash-0731`
- add the verified 4×GB300 FP4 low-latency DSpark recipe without pinning a revision in the generated command
- add a dedicated DSpark section and Playground draft-block-size tuning control, following the Kimi-K3 and Inkling cookbook structure
- publish the completed serving and GSM8K benchmark results

## Verified recipe

The checkpoint bundles its DSpark draft head, so the recipe uses `--speculative-algorithm DSPARK` without a separate draft model or EAGLE controls. `--mem-fraction-static 0.90` leaves enough headroom for the batch-256 verify graph on 4×GB300.

Test environment: SGLang v0.5.16 (`fdebc938f7f4d16fe6b9f55dcd9a767cf0899ea1`), model revision `9e165c30e2704aec5d9d593cce3eebd58bbef1cb`, 4×GB300.

## Results

| Workload | P50 TTFT | P50 TPOT | Total tok/s/GPU |
|---|---:|---:|---:|
| Random, input cap 8192 / output cap 1024, concurrency 1 | 468.93 ms | 1.31 ms | 930 |
| Random, input cap 8192 / output cap 1024, concurrency 16 | 726.81 ms | 8.84 ms | 2711 |

Each serving benchmark ran 64 warmup requests and its own `--flush-cache` before 32 measured requests.

GSM8K completed all 1,319 examples at 97.04% accuracy, 100% stop rate, 0% truncation rate, and 0% error rate.

Compared directionally with the previous GB300 Flash FP4 low-latency cookbook cell, total tokens/s/GPU is +81.3% at concurrency 1 and +10.0% at concurrency 16; P50 TPOT is 64.8% and 11.2% lower. This is not a strict A/B because the checkpoint, speculative algorithm, and SGLang version changed.

AIME25×16 and GPQA Diamond×16 are running after the PR is opened and will be added in a follow-up commit.

## Validation

- `pre-commit run --files ...`
- `npx mint validate`
- `npx mint broken-links`
- local Mint preview returned HTTP 200 and rendered the model, DSpark section, and tuning control
- streaming completion smoke, 5-request serving smoke, GSM8K, and both serving workloads passed without server-side CUDA or traceback errors

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30638395625](https://github.com/sgl-project/sglang/actions/runs/30638395625)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30638395168](https://github.com/sgl-project/sglang/actions/runs/30638395168)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->