### PR TITLE
docs: fix non-existent `--optimistic-prefill-retries` server arg

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -3012,7 +3012,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-retries`</td>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--optimistic-prefill-attempts`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Number of optimistic prefill retries that will skip the bootstrap wait.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`0`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: int</td>


### PR DESCRIPTION
The server-arguments reference documents `--optimistic-prefill-retries`, but no such flag exists.

`python/sglang/srt/server_args.py:2989` defines the field:

```python
optimistic_prefill_attempts: A[int, "Number of optimistic prefill forward passes that skip the bootstrap wait.", NS("disagg")] = 0
```

which auto-derives the CLI flag **`--optimistic-prefill-attempts`** (used at `server_args.py:7846+` and `disaggregation/prefill.py`). There is no `optimistic_prefill_retries` anywhere in the code — a repo-wide search returns only this one doc line — so passing `--optimistic-prefill-retries` errors as an unrecognized argument. Same int type, same default `0`, same feature: just a misnamed doc row. This renames it to `--optimistic-prefill-attempts`. One-token docs fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30638827264](https://github.com/sgl-project/sglang/actions/runs/30638827264)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30638826870](https://github.com/sgl-project/sglang/actions/runs/30638826870)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->