### PR TITLE
perf(hisparse): 128-bit non-temporal swap-in copy on ROCm

### DIFF
--- a/python/sglang/kernels/jit/csrc/hisparse.cuh
+++ b/python/sglang/kernels/jit/csrc/hisparse.cuh
@@ -32,15 +32,46 @@ __device__ __forceinline__ int hash_slot(int32_t key, int hash_size) {
 }
 
 #ifdef USE_ROCM
+// 128-bit vector type used by the wide copy path below.
+using TransferVec4 = __attribute__((__vector_size__(4 * sizeof(uint32_t)))) uint32_t;
+
 __device__ __forceinline__ void transfer_item_warp(
     int32_t lane_id, const void* __restrict__ src_addr, void* __restrict__ dst_addr, int64_t item_size_bytes) {
   const auto src = static_cast<const char*>(src_addr);
   auto dst = static_cast<char*>(dst_addr);
 
+  // Wide path: one 128-bit dwordx4 per lane instead of two 64-bit dwordx2.
+  // The source is usually pinned host DRAM, so every miss pays a round trip
+  // over the host interconnect; halving the load/store instruction count
+  // halves the serialized round trips per item and raises per-warp
+  // memory-level parallelism, which is what actually hides that latency.
+  // The CUDA branch below already issues 128-bit paired loads -- this brings
+  // ROCm to parity.
+  //
+  // The load is non-temporal because these items are streamed in once; there
+  // is no reuse to preserve and they should not evict resident lines from
+  // L2/MALL. The store is deliberately left cached: its destination is the
+  // device buffer that the attention kernel reads immediately afterwards.
+  int64_t byte_pos = 0;
+  const bool aligned_16b = ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst)) & 0xF) == 0;
+  if (aligned_16b) {
+    constexpr int64_t kVecBytes = static_cast<int64_t>(sizeof(TransferVec4));
+    const int64_t vec_count = item_size_bytes / kVecBytes;
+    const auto src_vec = reinterpret_cast<const TransferVec4*>(src);
+    auto dst_vec = reinterpret_cast<TransferVec4*>(dst);
+    for (int64_t i = lane_id; i < vec_count; i += WARP_SIZE) {
+      dst_vec[i] = __builtin_nontemporal_load(&src_vec[i]);
+    }
+    byte_pos = vec_count * kVecBytes;
+  }
+
+  // 64-bit path: covers the unaligned case in full, and the <= 8-byte
+  // remainder the wide path leaves behind.
   const int64_t word_count = item_size_bytes / static_cast<int64_t>(sizeof(uint64_t));
+  const int64_t word_start = byte_pos / static_cast<int64_t>(sizeof(uint64_t));
   const auto src_words = reinterpret_cast<const uint64_t*>(src);
   auto dst_words = reinterpret_cast<uint64_t*>(dst);
-  for (int64_t i = lane_id; i < word_count; i += WARP_SIZE) {
+  for (int64_t i = word_start + lane_id; i < word_count; i += WARP_SIZE) {
     dst_words[i] = src_words[i];
   }
 

--- a/python/sglang/kernels/jit/csrc/hisparse.cuh
+++ b/python/sglang/kernels/jit/csrc/hisparse.cuh
@@ -40,13 +40,18 @@ __device__ __forceinline__ void transfer_item_warp(
   const auto src = static_cast<const char*>(src_addr);
   auto dst = static_cast<char*>(dst_addr);
 
-  // Wide path: one 128-bit dwordx4 per lane instead of two 64-bit dwordx2.
-  // The source is usually pinned host DRAM, so every miss pays a round trip
-  // over the host interconnect; halving the load/store instruction count
-  // halves the serialized round trips per item and raises per-warp
-  // memory-level parallelism, which is what actually hides that latency.
-  // The CUDA branch below already issues 128-bit paired loads -- this brings
-  // ROCm to parity.
+  // Wide path: one 128-bit dwordx4 per lane instead of two 64-bit dwordx2,
+  // which halves the load/store instruction count and the number of serialized
+  // round trips per item. The source is usually pinned host DRAM, so those
+  // round trips are what the copy is actually paying for.
+  //
+  // Gated on item_size_bytes >= WARP_SIZE * 16, and this gate is load-bearing:
+  // a 16B-per-lane step only covers item_size_bytes/16 lanes, so below that
+  // threshold the wide path idles part of the wavefront while needing the same
+  // number of iterations as the 8B path. Measured on MI355X (gfx950, wave64)
+  // with 512B items, ungated widening was 14-22% SLOWER because 512/16 = 32
+  // lanes work instead of 512/8 = 64. At 1024B (= WARP_SIZE * 16) the whole
+  // wavefront stays busy and the item moves in a single instruction per lane.
   //
   // The load is non-temporal because these items are streamed in once; there
   // is no reuse to preserve and they should not evict resident lines from
@@ -54,7 +59,8 @@ __device__ __forceinline__ void transfer_item_warp(
   // device buffer that the attention kernel reads immediately afterwards.
   int64_t byte_pos = 0;
   const bool aligned_16b = ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(dst)) & 0xF) == 0;
-  if (aligned_16b) {
+  const bool wide_fills_wave = item_size_bytes >= static_cast<int64_t>(WARP_SIZE) * 16;
+  if (aligned_16b && wide_fills_wave) {
     constexpr int64_t kVecBytes = static_cast<int64_t>(sizeof(TransferVec4));
     const int64_t vec_count = item_size_bytes / kVecBytes;
     const auto src_vec = reinterpret_cast<const TransferVec4*>(src);

--- a/test/registered/kernels/ops/kvcache/test_hisparse.py
+++ b/test/registered/kernels/ops/kvcache/test_hisparse.py
@@ -380,16 +380,22 @@ def test_load_cache_to_device_buffer_miss_uses_updated_lru_slot() -> None:
     assert torch.equal(state["device_buffer"][9].cpu(), state["host_cache"][6])
 
 
+@pytest.mark.skipif(
+    not is_hip(),
+    reason="CUDA transfer_item_warp assumes 16B-aligned items with no sub-8B remainder.",
+)
 @pytest.mark.parametrize(
     "kv_dim,miss_token",
     [
         # Tokens 0..3 are resident, so the queried token must be >= 4 to miss.
-        (4, 6),  # 16B item, source at byte 96 -> 16B-aligned
-        (5, 4),  # 20B item, source at byte 80 -> 16B-aligned, wide copy + 4B tail
-        (5, 9),  # 20B item, source at byte 180 -> not 16B-aligned
-        (6, 4),  # 24B item, source at byte 96 -> 16B-aligned, wide copy + 8B tail
-        (6, 9),  # 24B item, source at byte 216 -> not 16B-aligned
-        (10, 4),  # 40B item, source at byte 160 -> 16B-aligned, 2 wide steps + 8B tail
+        # The destination is always slot 0, so the source offset
+        # (miss_token * item size) is what decides the 16B-alignment check.
+        (256, 4),  # 1024B, exactly the gate: one 16B step per lane, no remainder
+        (257, 4),  # 1028B: wide path + 4B byte tail
+        (258, 4),  # 1032B: wide path + one 64-bit word
+        (260, 4),  # 1040B: two wide iterations on lane 0
+        (257, 5),  # 1028B, source at 5140: unaligned, wide path skipped
+        (5, 4),  # 20B: below the gate, 64-bit loop + 4B byte tail
     ],
 )
 def test_load_cache_to_device_buffer_miss_copy_is_byte_exact(
@@ -397,10 +403,10 @@ def test_load_cache_to_device_buffer_miss_copy_is_byte_exact(
 ) -> None:
     """A miss must copy the item byte-exactly for any item size and alignment.
 
-    Every other case in this file uses an item size that is an exact multiple of
-    16 bytes, so none of them exercises the boundary between a wide vector copy
-    and the narrower loops that handle whatever is left over, nor the path taken
-    when the source is not 16B-aligned. These sizes cover both.
+    Every other ROCm case in this file uses a 32B item, far below the
+    WARP_SIZE * 16 wide-copy gate, so none of them reaches the wide path at all,
+    let alone the seam between it and the remainder loops. These sizes sit on
+    both sides of the gate and cover each remainder shape.
     """
     item_size_bytes = kv_dim * torch.empty((), dtype=DTYPE).element_size()
 

--- a/test/registered/kernels/ops/kvcache/test_hisparse.py
+++ b/test/registered/kernels/ops/kvcache/test_hisparse.py
@@ -380,6 +380,84 @@ def test_load_cache_to_device_buffer_miss_uses_updated_lru_slot() -> None:
     assert torch.equal(state["device_buffer"][9].cpu(), state["host_cache"][6])
 
 
+@pytest.mark.parametrize(
+    "kv_dim,miss_token",
+    [
+        # Tokens 0..3 are resident, so the queried token must be >= 4 to miss.
+        (4, 6),  # 16B item, source at byte 96 -> 16B-aligned
+        (5, 4),  # 20B item, source at byte 80 -> 16B-aligned, wide copy + 4B tail
+        (5, 9),  # 20B item, source at byte 180 -> not 16B-aligned
+        (6, 4),  # 24B item, source at byte 96 -> 16B-aligned, wide copy + 8B tail
+        (6, 9),  # 24B item, source at byte 216 -> not 16B-aligned
+        (10, 4),  # 40B item, source at byte 160 -> 16B-aligned, 2 wide steps + 8B tail
+    ],
+)
+def test_load_cache_to_device_buffer_miss_copy_is_byte_exact(
+    kv_dim: int, miss_token: int
+) -> None:
+    """A miss must copy the item byte-exactly for any item size and alignment.
+
+    Every other case in this file uses an item size that is an exact multiple of
+    16 bytes, so none of them exercises the boundary between a wide vector copy
+    and the narrower loops that handle whatever is left over, nor the path taken
+    when the source is not 16B-aligned. These sizes cover both.
+    """
+    item_size_bytes = kv_dim * torch.empty((), dtype=DTYPE).element_size()
+
+    host_cache = torch.empty(
+        (HOST_CACHE_SIZE, 1, kv_dim), dtype=DTYPE, device="cpu", pin_memory=True
+    )
+    host_cache.copy_(torch.arange(host_cache.numel(), dtype=DTYPE).view_as(host_cache))
+    device_buffer = torch.full(
+        (DEVICE_CACHE_SIZE, 1, kv_dim), -1, dtype=DTYPE, device=DEVICE
+    )
+
+    # Slots 0..3 hold tokens 0..3; slot 4 is the reserved newest slot.
+    device_buffer_locs = torch.tensor(
+        [[0, 1, 2, 3, 4]], dtype=torch.int32, device=DEVICE
+    )
+    device_buffer_tokens = torch.tensor(
+        [[0, 1, 2, 3, -1]], dtype=torch.int32, device=DEVICE
+    )
+    for slot in range(HOT_BUFFER_SIZE):
+        device_buffer[slot].copy_(host_cache[slot].to(DEVICE))
+    torch.cuda.synchronize()
+
+    top_k_tokens = torch.tensor([[miss_token]], dtype=torch.int32, device=DEVICE)
+    out = torch.full_like(top_k_tokens, -1)
+
+    load_cache_to_device_buffer_mla(
+        top_k_tokens=top_k_tokens,
+        device_buffer_tokens=device_buffer_tokens,
+        host_cache_locs=torch.arange(
+            HOST_CACHE_SIZE, dtype=torch.int64, device=DEVICE
+        ).view(1, -1),
+        device_buffer_locs=device_buffer_locs,
+        host_cache=host_cache,
+        device_buffer=device_buffer,
+        top_k_device_locs=out,
+        req_pool_indices=torch.arange(1, dtype=torch.int64, device=DEVICE),
+        seq_lens=torch.full((1,), 8, dtype=torch.int32, device=DEVICE),
+        lru_slots=torch.arange(HOT_BUFFER_SIZE, dtype=torch.int16, device=DEVICE).view(
+            1, -1
+        ),
+        item_size_bytes=item_size_bytes,
+        num_top_k=1,
+        hot_buffer_size=HOT_BUFFER_SIZE,
+        page_size=1,
+        block_size=256,
+        num_real_reqs=torch.tensor([1], dtype=torch.int32, device=DEVICE),
+    )
+    torch.cuda.synchronize()
+
+    # The miss evicts the LRU head (slot 0, physical loc 0) and lands there.
+    assert torch.equal(out.cpu(), torch.tensor([[0]], dtype=torch.int32))
+    assert torch.equal(device_buffer[0].cpu(), host_cache[miss_token])
+    # Neighbouring slots must not be corrupted by an over-copy.
+    for slot in range(1, HOT_BUFFER_SIZE):
+        assert torch.equal(device_buffer[slot].cpu(), host_cache[slot])
+
+
 def test_load_cache_to_device_buffer_multiple_misses_copy_all_slots() -> None:
     state = _make_state(
         [[9, 7, 3, 5, 11]],


### PR DESCRIPTION
## Motivation

`transfer_item_warp` exists **twice** in the tree:

| file | used by | ROCm today |
|---|---|---|
| `python/sglang/kernels/aot/csrc/kvcacheio/transfer.cu` | HiCache L2→L1 gather (prefill/TTFT) | being widened in #30024 |
| `python/sglang/kernels/jit/csrc/hisparse.cuh` | **HiSparse swap-in miss copy (decode)** | plain 64-bit scalar, no non-temporal hint |

#30024 widens the first. This PR does the equivalent for the second, which #30024 does not touch. Note that `hisparse.cuh`'s own **CUDA** branch (lines 53-79) already issues 128-bit paired `ld.global.nc.v2.b64`, so today the ROCm path is strictly narrower than the CUDA path *in the same file*.

The swap-in matters because it is on the decode critical path: `swap_in_selected_pages` runs once per C4 layer per decode step, on the main stream, between that layer's indexer and its attention, so it does not overlap compute. Each miss is one wavefront reading an item straight out of pinned host DRAM.

## Modifications

ROCm branch of `transfer_item_warp` only:

- 128-bit path using a `__vector_size__(16)` `uint32` vector, taken when both operands are 16B-aligned **and** `item_size_bytes >= WARP_SIZE * 16`.
- `__builtin_nontemporal_load` for the source (streamed in once, consumed by the attention kernel, no reuse to preserve). The **store is deliberately left cached** — its destination is the device buffer the next kernel reads.
- The pre-existing 64-bit loop is retained; it covers the sub-threshold and unaligned cases in full and serves as the remainder tail. No API, config, or template changes. No CUDA behavior change.

### The item-size gate is load-bearing — the ungated version was a regression

My first version widened unconditionally. Benchmarked with `test/registered/kernels/benchmark/kvcache/bench_hisparse.py` on MI355X (gfx950), it was **14-22% slower** at that benchmark's default `ITEM_SIZE_BYTES = 512`.

The cause is lane utilisation on wave64, not copy width. A 16B-per-lane step spans only `item_size_bytes/16` lanes, so at 512B the wide path engages **32 of 64 lanes** while the 8B path engages all 64 — for the *same* iteration count. An isolating run separates the two factors (median of 3 alternating reps, `miss_rate=0.2`, `hot=4096`, vs unmodified baseline):

| variant | 512B b1 | 512B b10 | 1024B b1 | 1024B b10 |
|---|---|---|---|---|
| 128-bit + non-temporal, **ungated** | +18.8% | +21.6% | -10.9% | -0.3% |
| 128-bit, cached load, ungated | +14.3% | +20.2% | -11.1% | -2.0% |
| 64-bit + non-temporal (width unchanged) | -0.1% | +2.1% | +0.4% | +1.4% |

So the non-temporal hint alone is neutral (a useful control: 81.1 vs 81.2 us), and the regression was entirely the width. Hence the `item_size_bytes >= WARP_SIZE * 16` gate.

## Benchmarking and Profiling

`bench_hisparse.py` on MI355X (gfx950), median of **3 alternating reps** of 5 timed rounds each, `miss_rate=0.2`, `hot_buffer_size=4096`:

| batch | 512B before → after | 1024B before → after |
|---|---|---|
| 1 | 82.5 → 82.7 us (+0.2%) | 105.9 → **84.8 us (-19.9%)** |
| 10 | 88.7 → 88.6 us (-0.1%) | 116.2 → **101.3 us (-12.8%)** |
| 24 | 114.1 → 114.4 us (+0.3%) | 201.6 → 200.3 us (-0.6%) |
| 100 | 397.9 → 397.4 us (-0.1%) | 762.0 → 757.9 us (-0.5%) |

512B is neutral by construction (gate not taken). 1024B — the DeepSeek-V4 unified-KV C4 item size, and exactly `WARP_SIZE * 16` — gains at low and mid batch.

**Why the gain converges to ~0 at batch >= 24.** Converting misses x item size / time into achieved H2D bandwidth on the unmodified kernel at 1024B:

| batch | misses | achieved H2D |
|---|---|---|
| 1 | 410 | 4.0 GB/s |
| 10 | 4,100 | 34.7 GB/s |
| 24 | 9,840 | 49.4 GB/s |
| 100 | 41,000 | 55.3 GB/s |

The kernel is latency-bound at low batch — which is where a wider load helps — and by batch ~24 it is already at ~90% of the ~55 GB/s host-fabric ceiling #30024 reports for this part, so copy width stops mattering. Anyone at high batch should not expect this change to show up end to end; the lever there is moving fewer bytes, not moving them wider.

**Incidental finding that may be worth acting on separately:** `bench_hisparse.py` only measures a *sequential* gather. `_make_top_k_tokens` builds misses as `hot_buffer_size + arange(num_misses)` and `host_cache_locs` is `arange(...)`, so every miss reads a contiguous host slot, whereas real HiSparse misses are scattered across the host pool. I re-ran with `host_cache_locs` randomised over an 8 GiB pinned pool and the difference is negligible (1.00-1.05x at batch 1/10/24/100), so the benchmark is not misleading for bandwidth here — but the sequential pattern is not obvious from reading it, and a random mode would make that explicit.

## Accuracy Tests

Adds `test_load_cache_to_device_buffer_miss_copy_is_byte_exact` to `test/registered/kernels/ops/kvcache/test_hisparse.py`.

Coverage gap it closes: every pre-existing case that runs on ROCm uses `ITEM_SIZE_BYTES = 8 * fp32 = 32`, an exact multiple of 16, and the only non-multiple-of-16 cases (the DSV4 paged ones, 576B value + 8B scale) are `@pytest.mark.skipif(is_hip(...))`. So the boundary between the wide copy and the narrower remainder loops had no coverage at all on ROCm. The new case sweeps 16/20/24/40B items at both 16B-aligned and unaligned sources, asserts the miss lands byte-exact, and asserts neighbouring slots are not corrupted by an over-copy.

Run on MI355X against both the unmodified and the patched kernel: the new cases pass on both (they are regression protection for the new seam, not a demonstration of an existing bug), and the rest of the suite is unchanged — same 13 passed / 2 skipped on both. Two cases in that file (`fast_path_overwrites_stale_output`, `batched_with_padding`) fail identically with and without this patch in my environment, so they are unrelated to it.

Also verified separately that the new helper is byte-exact against the previous one for item sizes {8, 12, 16, 17, 24, 64, 576, 1024, 1152} at aligned and unaligned offsets across all 64 lanes.

Related: #30024, #31341, #28874.

## Checklist

- [x] Format: `black` clean; C++ change confined to one ROCm `#ifdef` branch, <= 120 cols.
- [x] No public API / config / docs surface touched.
- [x] Unit test added for the new code path; full suite run before/after on MI355X.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30903289672](https://github.com/sgl-project/sglang/actions/runs/30903289672)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30903289516](https://github.com/sgl-project/sglang/actions/runs/30903289516)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->