### PR TITLE
[Fix] Repair verify mask test fixture

### DIFF
--- a/python/sglang/srt/layers/attention/verify_mask.py
+++ b/python/sglang/srt/layers/attention/verify_mask.py
@@ -46,10 +46,8 @@ class VerifyMask(msgspec.Struct):
     def fits(self, bs: int, num_draft_tokens: int) -> bool:
         """Whether this batch's writes stay inside the buffer.
 
-        Only the compact layout is checked. FULL_MASK keeps its pre-existing
-        unconditional reuse -- its bound needs a max_context_len that composite
-        backends do not carry -- so a batch past max_bs can still overflow it
-        when draft * sum(seq_len) exceeds the buffer, as it could before.
+        Only the compact layout is checked. FULL_MASK keeps unconditional reuse
+        because its runtime bound depends on sequence lengths not passed to fits().
         """
         if self.mode != TreeMaskMode.QLEN_ONLY:
             return True

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -119,6 +119,7 @@ def _make_hybrid_backend(speculative_attention_mode, prefill_mask, decode_mask):
         server_args=SimpleNamespace(
             speculative_attention_mode=speculative_attention_mode
         ),
+        model_config=SimpleNamespace(context_len=_MAX_CONTEXT_LEN),
     )
     return HybridAttnBackend(
         model_runner,
@@ -145,8 +146,6 @@ class TestHybridAttnBackendHandsOutSelectedChildMask(CustomTestCase):
         self.assertIs(backend.verify_mask, prefill_mask)
 
     def test_capacity_check_needs_nothing_from_the_backend(self):
-        """A composite backend carries no max_context_len of its own: fits()
-        reaching back through the backend would raise AttributeError here."""
         backend = _make_hybrid_backend("prefill", _mask(64, is_read=False), None)
 
         self.assertTrue(backend.verify_mask.fits(_MAX_BS, _DRAFT))


### PR DESCRIPTION
## Summary

- fix the current-main Base CPU CI failure by adding the missing `model_config.context_len` contract to the verify-mask hybrid backend fixture
- remove a stale test description and correct the `FULL_MASK` capacity documentation

## Root cause

This fixes a deterministic Base CI failure present on current `main`, reproduced by [`base-a-test-cpu (1)` in run #30633567943](https://github.com/sgl-project/sglang/actions/runs/30633567943/job/91165643750).

`HybridAttnBackend.__init__` now reads `model_runner.model_config.context_len`, but the lightweight fixture in `test_verify_mask.py` did not provide `model_config`. The registered Base CPU test therefore failed during backend construction before reaching its assertions.

## Regression timeline

- **06:13 UTC — [#32920](https://github.com/sgl-project/sglang/pull/32920) merged.** It introduced the lightweight `_make_hybrid_backend` fixture. At that point `HybridAttnBackend` did not read `model_runner.model_config`, so the fixture still matched the constructor contract.
- **11:43 UTC — [#32690](https://github.com/sgl-project/sglang/pull/32690) merged.** It added the unconditional `model_runner.model_config.context_len` read and updated other lightweight fixtures, but missed `test_verify_mask.py`. From this point, current `main` contained the deterministic regression.
- **13:21 UTC — [#33074](https://github.com/sgl-project/sglang/pull/33074) reproduced the failure after incorporating `main`.** Its own diff touches neither `HybridAttnBackend` nor `test_verify_mask.py`; [`base-a-test-cpu (1)`](https://github.com/sgl-project/sglang/actions/runs/30633567943/job/91165643750) failed with the missing-`model_config` `AttributeError`. Therefore #33074 is an affected PR, while #32690 is the direct regression trigger.

## Impact

This restores the registered verify-mask CPU test and prevents the deterministic fixture failure from cascading into unrelated PR checks.

## Validation

- `python3 -m py_compile python/sglang/srt/layers/attention/verify_mask.py test/registered/unit/layers/attention/test_verify_mask.py`
- `pre-commit run --files python/sglang/srt/layers/attention/verify_mask.py test/registered/unit/layers/attention/test_verify_mask.py`
- `git diff --check`
- isolated fixture/constructor contract smoke covering prefill and decode mask selection

The complete test file was not run locally because the workspace interpreter does not have `torch` installed; the registered CI job will exercise it in the normal test environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30640019579](https://github.com/sgl-project/sglang/actions/runs/30640019579)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30640020074](https://github.com/sgl-project/sglang/actions/runs/30640020074)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->