### PR TITLE
[AMD] Cache constant one-scale for fp8 MLA prefill attention

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -205,6 +205,14 @@ class AiterAttnBackend(AttentionBackend):
             (max_bs + 1,), dtype=torch.int64, device=model_runner.device
         )
         self._kv_indices_scratch: Optional[torch.Tensor] = None
+        # Constant fp32 1.0 descale reused by the fp8 MLA prefill kernel: with
+        # BF16 absorb the real scales are folded into the weights, so q/k/v
+        # descale are all 1.0. Cache it once here to avoid a per-call
+        # torch.ones((), ...) allocation + FillFunctor launch on the attention
+        # critical path.
+        self._one_scale = torch.ones(
+            (), dtype=torch.float32, device=model_runner.device
+        )
 
         # Create prefill indices updater
         if not skip_prefill:
@@ -789,7 +797,7 @@ class AiterAttnBackend(AttentionBackend):
             k = k.to(fp8_dtype)
         if v.dtype != fp8_dtype:
             v = v.to(fp8_dtype)
-        one_scale = torch.ones((), dtype=torch.float32, device=q.device)
+        one_scale = self._one_scale
 
         tile_q = 256
         reduce_indptr = self.forward_metadata.reduce_indptr


### PR DESCRIPTION
# [AMD] Cache constant one-scale for fp8 MLA prefill attention

Branch: `rbrugaro/mla-prefill-cache-one-scale`  ·  File: `python/sglang/srt/layers/attention/aiter_backend.py`

## Motivation

The fp8 MLA prefill attention kernel (`mla_fp8_prefill_attn`) takes q/k/v descale
scalars. With BF16 absorb the real scales are folded into the weights, so all three
are a constant `1.0`. Today this scalar is re-allocated with `torch.ones((), ...)` on
**every** call, adding a device allocation and a `FillFunctor` kernel launch to the
attention critical path on every prefill forward, for every layer.

These are launch-latency-bound: tiny kernels whose fixed launch cost is a meaningful
fraction of end-to-end time at small batch / short sequence.

## Modifications

Allocate the constant `1.0` fp32 scale once in `AiterAttnBackend.__init__`
(`self._one_scale`) and reuse it in `mla_fp8_prefill_attn`. No numerical change
(identical constant).

## Accuracy Tests

GSM8K, 500 questions, 5-shot, greedy (temp 0), DeepSeek-R1 fp8 (kv_cache=fp8_e4m3),
MI355X TP8 + DP-attention + MoRI EP. Invalid = 0.000 in all runs.

| build | GSM8K acc |
|---|---|
| baseline | 0.968 |
| + this change | 0.958 |

The 1.0-point delta is **within the run-to-run nondeterminism of the fp8/DP/MoRI
stack** (this change is numerically identical, so it defines the noise floor at
~±1% = ~5/500 questions). No accuracy change.

## Profiling
before:
<img width="2583" height="83" alt="image" src="https://github.com/user-attachments/assets/a8cf6393-23ba-4fa4-9233-db4828acf398" />
after:
<img width="3219" height="76" alt="image" src="https://github.com/user-attachments/assets/02920b8c-f68d-483f-8457-5d199bb03f9f" />

**Profiling (torch profiler, DeepSeek-R1 TP-0 EXTEND trace, this change isolated on the
same image via file-swap):** the per-call `FillFunctor` scalar-fill launches drop from
**992 → 504** (−488 = 8 steps × 61 layers), with an identical −488 drop in host-side
`hipLaunchKernel`. No other kernel changes vs baseline. Trace files: `trace_baseline/`
vs `trace_P0/` (`...TP-0-...-EXTEND.trace.json.gz`).


## Checklist / notes

- fp8 prefill-attn path is `is_gfx95_supported()`-gated; validated on MI355X (gfx950).
  Upstream CI likely cannot exercise it — AMD reviewer validation needed.
- Unconditional change, no new flags.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30647760972](https://github.com/sgl-project/sglang/actions/runs/30647760972)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30647760849](https://github.com/sgl-project/sglang/actions/runs/30647760849)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->