### PR TITLE
[AMD] Accept row-strided views in RMSNorm aiter path

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -519,14 +519,17 @@ class RMSNorm(MultiPlatformOp):
             # AITER's ROCm rmsnorm2d_fwd requires weight/activation dtypes to match;
             # FP32 weight + BF16 activation yields finite-but-corrupted output on gfx950.
             return self.forward_native(x, residual, post_residual_addition)
-        # Aiter's RMSNorm kernels expect 2D contiguous inputs. Keep the
-        # already-safe layout as a zero-copy path, and only normalize strided or
-        # higher-rank views such as Q/K slices from packed QKV projections.
+        # Aiter's rmsnorm2d_fwd is row-wise, so a 2D view whose last dim is
+        # unit-stride (contiguous rows, possibly strided row pitch — e.g. Q/KV
+        # slices split from a packed QKV projection) is consumed correctly as
+        # is. Only clone when the last dim itself is strided, or the view is
+        # higher-rank and must be densely reshaped first. This avoids a
+        # contiguous copy of the row-strided Q/KV slices on the MLA prefill path.
         needs_reshape = x.dim() != 2 and residual is None
         if needs_reshape:
             original_shape = x.shape
             x = x.contiguous().reshape(-1, original_shape[-1])
-        elif not x.is_contiguous():
+        elif not x.is_contiguous() and x.stride(-1) != 1:
             x = x.contiguous()
         if is_batch_invariant_mode_enabled():
             if (

--- a/test/registered/layers/test_rmsnorm_aiter_row_strided.py
+++ b/test/registered/layers/test_rmsnorm_aiter_row_strided.py
@@ -1,0 +1,68 @@
+"""Guard for the aiter RMSNorm row-strided fast path.
+
+RMSNorm.forward_aiter (ROCm/aiter) skips the `.contiguous()` clone for a 2D view
+whose last dim is unit-stride but whose row pitch is strided -- e.g. a q_lora / kv_a
+slice split from a packed QKV-a projection on the DeepSeek MLA prefill path. This
+test asserts the no-clone path is bit-identical to feeding a contiguous copy, i.e.
+aiter's row-wise rmsnorm2d_fwd consumes the row-strided view correctly.
+"""
+
+from __future__ import annotations
+
+from sglang.test.ci.ci_register import register_amd_ci
+
+# ROCm/aiter-only guard; register for the AMD 1-GPU small suite.
+register_amd_ci(est_time=20, suite="stage-b-test-1-gpu-small-amd")
+
+import pytest
+import torch
+
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.utils import is_hip
+
+pytestmark = pytest.mark.skipif(
+    not is_hip(), reason="aiter RMSNorm path is ROCm/HIP-only"
+)
+
+
+def _rmsnorm(hidden: int, dtype: torch.dtype) -> RMSNorm:
+    norm = RMSNorm(hidden, eps=1e-6).to(device="cuda", dtype=dtype)
+    with torch.no_grad():
+        norm.weight.normal_(mean=1.0, std=0.02)  # non-trivial weights
+    return norm
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("hidden", [512, 1536])  # kv_a (512), q_lora (1536)
+def test_forward_aiter_row_strided_matches_contiguous(dtype, hidden):
+    torch.manual_seed(0)
+    M = 128
+    norm = _rmsnorm(hidden, dtype)
+    fm = getattr(norm, "_forward_method", None)
+    if fm is None or getattr(fm, "__func__", None) is not RMSNorm.forward_aiter:
+        pytest.skip("aiter RMSNorm path not selected (SGLANG_USE_AITER off)")
+
+    # Row-strided view with UNIT last-dim stride: take the first `hidden` columns
+    # of a wider [M, 2*hidden] buffer -> stride (2*hidden, 1): contiguous rows,
+    # strided row pitch. Mirrors a slice split from a packed QKV-a projection.
+    wide = torch.randn(M, 2 * hidden, dtype=dtype, device="cuda")
+    strided = wide[:, :hidden]
+    assert not strided.is_contiguous()
+    assert strided.stride(-1) == 1
+
+    contig = strided.contiguous()
+    assert torch.equal(strided, contig)  # identical values, different layout
+
+    out_strided = norm.forward_aiter(strided)  # P1: fed to kernel without clone
+    out_contig = norm.forward_aiter(contig)
+
+    # Bit-identical: the row-strided fast path must match the contiguous path.
+    assert torch.equal(out_strided, out_contig), (
+        f"row-strided aiter RMSNorm output differs from contiguous "
+        f"(dtype={dtype}, hidden={hidden}, "
+        f"max_abs_diff={(out_strided.float() - out_contig.float()).abs().max().item()})"
+    )
+
+    # Sanity: it is actually an RMSNorm (matches the reference within dtype tol).
+    ref = norm.forward_native(contig)
+    torch.testing.assert_close(out_contig.float(), ref.float(), rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
# [AMD] Accept row-strided views in RMSNorm aiter path

## Motivation

`RMSNorm.forward_aiter` clones any non-contiguous input to contiguous before calling
aiter's `rmsnorm2d_fwd`. But `rmsnorm2d_fwd` is row-wise and only requires the last
dim to be unit-stride; a 2D view with contiguous rows but a strided row pitch — e.g. a
q_lora / kv_a slice split from a packed QKV-a projection — is already valid input. The
clone is a wasted per-layer `contiguous()` copy on the DeepSeek MLA prefill path.

## Modifications

Relax the guard to only clone when the last dim itself is strided (`stride(-1) != 1`)
or the view is higher-rank:

```python
elif not x.is_contiguous() and x.stride(-1) != 1:
    x = x.contiguous()
```

Output is bit-identical for the unit-last-dim case (aiter `rmsnorm2d_fwd` is row-wise
and reads row-strided input correctly).

## Accuracy Tests

GSM8K, 500 questions, 5-shot, greedy (temp 0), DeepSeek-R1 fp8, MI355X TP8+DP+MoRI.
Invalid = 0.000.

| build | GSM8K acc |
|---|---|
| baseline | 0.968 |
| + this change | 0.964 |

Within the ~±1% stack nondeterminism floor (see note below). No accuracy change —
consistent with the bit-identical claim for row-strided/unit-last-dim inputs.

> Noise floor: a numerically-identical control change (caching a constant scale)
> measured 0.958 vs 0.968 baseline in the same harness, i.e. run-to-run
> nondeterminism of the fp8/DP/MoRI stack is ~±1% at 500 questions.

## Profiling

before:
<img width="3330" height="794" alt="image" src="https://github.com/user-attachments/assets/7405b66a-f389-4141-a1dc-684724eb946d" />
after:
<img width="3588" height="673" alt="image" src="https://github.com/user-attachments/assets/c3d4bb35-730a-4881-895d-3bfa91f5c290" />

## Checklist / notes

- **Broad blast radius:** `forward_aiter` is the aiter RMSNorm dispatch for *all*
  models, not just DeepSeek. To guard the no-clone path, this PR adds
  `test/registered/layers/test_rmsnorm_aiter_row_strided.py`, asserting bit-identical
  output (`torch.equal`) for a row-strided (unit-last-dim) 2D view vs a contiguous copy
  across {bf16, fp16} × hidden {512 (kv_a), 1536 (q_lora)}, plus a native-reference
  sanity check. It is registered for AMD CI
  (`register_amd_ci(est_time=20, suite="stage-b-test-1-gpu-small-amd")`) and skips off
  ROCm/HIP or when the aiter path is not selected. Verified 4/4 passing on MI355X.
- Unconditional change, no new flags.


