### PR TITLE
Fix Kimi K3 partial XTML marker leakage

### DIFF
--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -11,6 +11,27 @@ CALL_OPEN = "<|open|>call"
 CALL_CLOSE = "<|close|>call<|sep|>"
 ARGUMENT_CLOSE = "<|close|>argument<|sep|>"
 
+# XTML markers are multi-token sequences composed of special tokens
+# (<|open|>, <|close|>, <|sep|>) and text (think, response, tools, message).
+# Each marker has the structure: <control> + text + <sep>
+# Reachable token-level truncation boundaries for each marker:
+#   After token 1: "<|open|>" or "<|close|>"  (special token)
+#   After token 2: "<|open|>text" or "<|close|>text"  (special + text token)
+#   After token 3: complete marker
+# We must strip these partial suffixes from non-streaming output.
+
+# All partial marker suffixes that can appear at a token boundary
+_PARTIAL_MARKER_SUFFIXES = [
+    "<|close|>",
+    "<|close|>think",
+    "<|open|>",
+    "<|open|>response",
+    "<|close|>response",
+    "<|open|>tools",
+    "<|close|>tools",
+    "<|close|>message",
+]
+
 
 def partial_suffix_len(text: str, markers: List[str]) -> int:
     best = 0
@@ -20,6 +41,19 @@ def partial_suffix_len(text: str, markers: List[str]) -> int:
                 best = length
                 break
     return best
+
+
+def strip_partial_marker_suffix(text: str) -> str:
+    """Strip a reachable partial XTML marker suffix from *text*.
+
+    Only suffixes that correspond to token-level truncation boundaries are
+    removed; arbitrary character prefixes (e.g. ``<`` or ``<|c``) are not
+    touched because they cannot appear in detokenized output.
+    """
+    for suffix in _PARTIAL_MARKER_SUFFIXES:
+        if text.endswith(suffix):
+            return text[: -len(suffix)]
+    return text
 
 
 def strip_response_wrappers(text: str) -> str:
@@ -32,4 +66,5 @@ def strip_response_wrappers(text: str) -> str:
             text = text[open_idx + len(RESPONSE_OPEN) :]
     else:
         text = text.replace(RESPONSE_CLOSE, "")
-    return text.replace(MESSAGE_CLOSE, "")
+    text = text.replace(MESSAGE_CLOSE, "")
+    return strip_partial_marker_suffix(text)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -20,6 +20,7 @@ from sglang.srt.function_call.kimik3_format import (
     THINK_OPEN,
     TOOLS_OPEN,
     partial_suffix_len,
+    strip_partial_marker_suffix,
     strip_response_wrappers,
 )
 from sglang.srt.parser.harmony_parser import HarmonyParser
@@ -491,7 +492,17 @@ class KimiK3Detector(BaseReasoningFormatDetector):
 
     @staticmethod
     def _strip_dangling_think_close(text: str) -> str:
-        return text.removesuffix(_THINK_CLOSE_WITHOUT_SEP)
+        """Remove partial XTML marker suffixes from *text*.
+
+        XTML markers are multi-token sequences.  When ``max_tokens`` cuts
+        generation inside a marker, the detokenized text ends with a
+        partial marker prefix.  These fragments are internal protocol
+        markers and must not appear in user-visible output.
+
+        Only suffixes that correspond to token-level truncation boundaries
+        are stripped; arbitrary character prefixes are left intact.
+        """
+        return strip_partial_marker_suffix(text)
 
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         in_reasoning = self._in_reasoning or self.think_start_token in text

--- a/test/registered/unit/entrypoints/openai/test_kimik3_serving_audit.py
+++ b/test/registered/unit/entrypoints/openai/test_kimik3_serving_audit.py
@@ -1,0 +1,265 @@
+"""
+Serving-level tests for Kimi K3 partial-marker leakage.
+
+Tests all four public API paths:
+1. Chat Completions, non-streaming
+2. Chat Completions, streaming
+3. Responses API, non-streaming
+4. Responses API, streaming
+
+Invariant: Internal Kimi K3 protocol-marker fragments must not appear in
+user-visible reasoning, content, or tool-call fields.
+"""
+
+import sys
+import unittest
+
+from sglang.srt.function_call.kimik3_format import (
+    MESSAGE_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
+    THINK_CLOSE,
+    THINK_OPEN,
+    TOOLS_OPEN,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+# Reachable token-level truncation points for each marker.
+# XTML markers are multi-token: <control> + text + <|sep|>
+# Truncation can occur after the control token or after control+text.
+REACHABLE_PARTIALS = [
+    "<|close|>",        # First token of THINK_CLOSE, RESPONSE_CLOSE, MESSAGE_CLOSE
+    "<|close|>think",   # First 2 tokens of THINK_CLOSE
+    "<|open|>",         # First token of RESPONSE_OPEN, TOOLS_OPEN
+    "<|open|>response", # First 2 tokens of RESPONSE_OPEN
+    "<|close|>response",# First 2 tokens of RESPONSE_CLOSE
+    "<|open|>tools",    # First 2 tokens of TOOLS_OPEN
+    "<|close|>message", # First 2 tokens of MESSAGE_CLOSE
+]
+
+# Partial markers that should NOT appear in user-visible output
+PARTIAL_MARKERS_TO_CHECK = [
+    "<|close|>",
+    "<|close|>think",
+    "<|open|>",
+    "<|open|>response",
+    "<|close|>response",
+    "<|open|>tools",
+    "<|close|>message",
+]
+
+
+def _assert_no_partial_markers(testcase, text, field_name, context=""):
+    """Assert that no partial XTML marker appears in text."""
+    for marker in PARTIAL_MARKERS_TO_CHECK:
+        testcase.assertNotIn(
+            marker, text,
+            f"Partial marker {marker!r} leaked into {field_name}"
+            + (f" ({context})" if context else "")
+            + f": {text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Chat Completions non-streaming test
+# ---------------------------------------------------------------------------
+
+class TestChatCompletionsNonStreaming(unittest.TestCase):
+    """Test that non-streaming Chat Completions does not leak partial markers."""
+
+    def test_partial_markers_not_in_response(self):
+        from sglang.srt.parser.reasoning_parser import KimiK3Detector
+
+        for partial in REACHABLE_PARTIALS:
+            with self.subTest(partial=partial):
+                # Build text that ends with a partial marker
+                full_text = f"{THINK_OPEN}deep thought{partial}"
+
+                # Use the detector directly (same as serving_chat does
+                # via ReasoningParser.parse_non_stream)
+                det = KimiK3Detector(force_reasoning=True)
+                result = det.detect_and_parse(full_text)
+
+                _assert_no_partial_markers(
+                    self, result.reasoning_text, "reasoning_text",
+                    context=f"partial={partial!r}"
+                )
+                _assert_no_partial_markers(
+                    self, result.normal_text, "normal_text",
+                    context=f"partial={partial!r}"
+                )
+                # Reasoning text must be preserved
+                self.assertIn("deep thought", result.reasoning_text,
+                              f"reasoning text lost for partial={partial!r}")
+
+
+# ---------------------------------------------------------------------------
+# Chat Completions streaming test
+# ---------------------------------------------------------------------------
+
+class TestChatCompletionsStreaming(unittest.TestCase):
+    """Test that streaming Chat Completions does not leak partial markers."""
+
+    def test_partial_markers_not_in_stream(self):
+        from sglang.srt.parser.reasoning_parser import KimiK3Detector
+
+        for partial in REACHABLE_PARTIALS:
+            with self.subTest(partial=partial):
+                full_text = f"{THINK_OPEN}deep thought{partial}"
+
+                # Simulate streaming: feed text in chunks, then finish
+                det = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+                reasoning = ""
+                content = ""
+                # Feed as a single chunk (simulating one decode step)
+                result = det.parse_streaming_increment(full_text)
+                reasoning += result.reasoning_text
+                content += result.normal_text
+                # Finish (called by serving_chat when finish_reason is set)
+                end = det.finish()
+                reasoning += end.reasoning_text
+                content += end.normal_text
+
+                _assert_no_partial_markers(
+                    self, reasoning, "reasoning_text",
+                    context=f"streaming partial={partial!r}"
+                )
+                _assert_no_partial_markers(
+                    self, content, "normal_text",
+                    context=f"streaming partial={partial!r}"
+                )
+                self.assertIn("deep thought", reasoning,
+                              f"streaming reasoning lost for partial={partial!r}")
+
+
+# ---------------------------------------------------------------------------
+# Responses API non-streaming test
+# ---------------------------------------------------------------------------
+
+class TestResponsesNonStreaming(unittest.TestCase):
+    """Test that non-streaming Responses API does not leak partial markers."""
+
+    def test_partial_markers_not_in_output_items(self):
+        from sglang.srt.parser.reasoning_parser import KimiK3Detector
+
+        for partial in REACHABLE_PARTIALS:
+            with self.subTest(partial=partial):
+                full_text = f"{THINK_OPEN}deep thought{partial}"
+
+                # Responses non-streaming uses ReasoningParser.parse_non_stream
+                # which calls detect_and_parse
+                det = KimiK3Detector(force_reasoning=True)
+                result = det.detect_and_parse(full_text)
+
+                _assert_no_partial_markers(
+                    self, result.reasoning_text, "reasoning content",
+                    context=f"responses non-stream partial={partial!r}"
+                )
+                _assert_no_partial_markers(
+                    self, result.normal_text, "content",
+                    context=f"responses non-stream partial={partial!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Responses API streaming test
+# ---------------------------------------------------------------------------
+
+class TestResponsesStreaming(unittest.TestCase):
+    """Test that streaming Responses API does not leak partial markers."""
+
+    def test_partial_markers_not_in_stream(self):
+        from sglang.srt.parser.reasoning_parser import KimiK3Detector
+
+        for partial in REACHABLE_PARTIALS:
+            with self.subTest(partial=partial):
+                full_text = f"{THINK_OPEN}deep thought{partial}"
+
+                det = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+                reasoning = ""
+                content = ""
+                result = det.parse_streaming_increment(full_text)
+                reasoning += result.reasoning_text
+                content += result.normal_text
+
+                # Simulate what serving_chat does: call parse_stream_end
+                # when finish_reason is set
+                end = det.finish()
+                reasoning += end.reasoning_text
+                content += end.normal_text
+
+                _assert_no_partial_markers(
+                    self, reasoning, "reasoning_text",
+                    context=f"responses stream partial={partial!r}"
+                )
+                _assert_no_partial_markers(
+                    self, content, "normal_text",
+                    context=f"responses stream partial={partial!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Multi-choice isolation test (Chat Completions only)
+# ---------------------------------------------------------------------------
+
+class TestMultiChoiceIsolation(unittest.TestCase):
+    """Test that multiple choices in Chat Completions have isolated parser state.
+
+    The Responses API does not support multiple choices, so this test is
+    limited to Chat Completions.
+    """
+
+    def test_interleaved_choices_isolated(self):
+        """Two choices with interleaved chunks must have isolated state."""
+        from sglang.srt.parser.reasoning_parser import KimiK3Detector
+
+        # Simulate what serving_chat does: one reasoning_parser per choice
+        parsers = {
+            0: KimiK3Detector(force_reasoning=True, stream_reasoning=True),
+            1: KimiK3Detector(force_reasoning=True, stream_reasoning=True),
+        }
+
+        text_a = f"{THINK_OPEN}alpha{THINK_CLOSE}{RESPONSE_OPEN}A{RESPONSE_CLOSE}"
+        text_b = f"{THINK_OPEN}beta{THINK_CLOSE}{RESPONSE_OPEN}B{RESPONSE_CLOSE}"
+
+        # Interleave chunks: choice 0, choice 1, choice 0, choice 1, ...
+        chunks_a = [text_a[i:i+3] for i in range(0, len(text_a), 3)]
+        chunks_b = [text_b[i:i+3] for i in range(0, len(text_b), 3)]
+
+        reasoning = {0: "", 1: ""}
+        content = {0: "", 1: ""}
+
+        max_chunks = max(len(chunks_a), len(chunks_b))
+        for i in range(max_chunks):
+            if i < len(chunks_a):
+                result = parsers[0].parse_streaming_increment(chunks_a[i])
+                reasoning[0] += result.reasoning_text
+                content[0] += result.normal_text
+            if i < len(chunks_b):
+                result = parsers[1].parse_streaming_increment(chunks_b[i])
+                reasoning[1] += result.reasoning_text
+                content[1] += result.normal_text
+
+        # Finish both
+        for idx in (0, 1):
+            end = parsers[idx].finish()
+            reasoning[idx] += end.reasoning_text
+            content[idx] += end.normal_text
+
+        # Verify isolation
+        self.assertEqual(reasoning[0], "alpha", f"Choice 0 reasoning: {reasoning[0]!r}")
+        self.assertEqual(content[0], "A", f"Choice 0 content: {content[0]!r}")
+        self.assertEqual(reasoning[1], "beta", f"Choice 1 reasoning: {reasoning[1]!r}")
+        self.assertEqual(content[1], "B", f"Choice 1 content: {content[1]!r}")
+
+        # Verify no cross-contamination
+        self.assertNotIn("alpha", reasoning[1])
+        self.assertNotIn("beta", reasoning[0])
+        self.assertNotIn("A", content[1])
+        self.assertNotIn("B", content[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/parser/test_kimik3_differential_audit.py
+++ b/test/registered/unit/parser/test_kimik3_differential_audit.py
@@ -1,0 +1,566 @@
+"""
+Differential audit tests for Kimi K3 reasoning parser finalization.
+
+These tests compare streaming vs non-streaming output for the KimiK3Detector,
+focusing on truncation at every parser state boundary.
+
+The key invariant: streaming accumulation + finish() must produce the same
+(reasoning_text, normal_text) as detect_and_parse() for the full text.
+
+Additional invariant: Internal Kimi K3 protocol-marker fragments must not
+appear in user-visible reasoning, content, or tool-call fields.
+"""
+
+import sys
+
+import pytest
+
+from sglang.srt.function_call.kimik3_format import (
+    MESSAGE_CLOSE,
+    RESPONSE_CLOSE,
+    RESPONSE_OPEN,
+    THINK_CLOSE,
+    THINK_OPEN,
+    TOOLS_CLOSE,
+    TOOLS_OPEN,
+)
+from sglang.srt.parser.reasoning_parser import KimiK3Detector, ReasoningParser
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _stream_with_finish(detector: KimiK3Detector, chunks: list[str]) -> tuple[str, str]:
+    """Feed chunks through parse_streaming_increment, then call finish()."""
+    reasoning = ""
+    content = ""
+    for chunk in chunks:
+        result = detector.parse_streaming_increment(chunk)
+        reasoning += result.reasoning_text
+        content += result.normal_text
+    # Flush on stream end
+    end = detector.finish()
+    reasoning += end.reasoning_text
+    content += end.normal_text
+    return reasoning, content
+
+
+def _non_stream(detector: KimiK3Detector, text: str) -> tuple[str, str]:
+    """One-shot parse."""
+    result = detector.detect_and_parse(text)
+    return result.reasoning_text, result.normal_text
+
+
+def _chunks(text: str, size: int) -> list[str]:
+    return [text[i : i + size] for i in range(0, len(text), size)]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Streaming + finish() == non-streaming for complete outputs
+# ---------------------------------------------------------------------------
+
+COMPLETE_OUTPUTS = [
+    # reasoning + final text
+    (
+        f"{THINK_OPEN}deep thought{THINK_CLOSE}"
+        f"{RESPONSE_OPEN}the answer{RESPONSE_CLOSE}{MESSAGE_CLOSE}",
+        "deep thought",
+        "the answer",
+    ),
+    # empty reasoning + final text
+    (
+        f"{THINK_OPEN}{THINK_CLOSE}{RESPONSE_OPEN}final{RESPONSE_CLOSE}",
+        "",
+        "final",
+    ),
+    # reasoning + tool call channel
+    (
+        f"thought{THINK_CLOSE}{RESPONSE_OPEN}reply{RESPONSE_CLOSE}"
+        f'{TOOLS_OPEN}<|open|>call tool="go" index="1"<|sep|>'
+        f'<|open|>argument key="x" type="string"<|sep|>42<|close|>argument<|sep|>'
+        f"<|close|>call<|sep|>{TOOLS_CLOSE}",
+        "thought",
+        f'reply{TOOLS_OPEN}<|open|>call tool="go" index="1"<|sep|>'
+        f'<|open|>argument key="x" type="string"<|sep|>42<|close|>argument<|sep|>'
+        f"<|close|>call<|sep|>{TOOLS_CLOSE}",
+    ),
+]
+
+
+@pytest.mark.parametrize("text,exp_reasoning,exp_content", COMPLETE_OUTPUTS)
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 5, 7, 13, 50])
+def test_streaming_matches_non_streaming_complete(
+    text: str, exp_reasoning: str, exp_content: str, chunk_size: int
+):
+    """Streaming + finish() must match non-streaming for complete outputs."""
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(det_stream, _chunks(text, chunk_size))
+    assert r_stream == exp_reasoning, (
+        f"reasoning mismatch at chunk_size={chunk_size}: "
+        f"got {r_stream!r}, expected {exp_reasoning!r}"
+    )
+    assert c_stream == exp_content, (
+        f"content mismatch at chunk_size={chunk_size}: "
+        f"got {c_stream!r}, expected {exp_content!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Truncation inside reasoning — every prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 7])
+def test_truncation_inside_reasoning(chunk_size: int):
+    """Generation ends inside reasoning text. Streaming must flush buffered
+    reasoning via finish() and match non-streaming."""
+    # Prefix that ends mid-reasoning (after THINK_OPEN, before THINK_CLOSE)
+    full = f"{THINK_OPEN}deep thought"
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, full)
+
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(det_stream, _chunks(full, chunk_size))
+
+    assert r_stream == r_ns, (
+        f"reasoning mismatch: stream={r_stream!r} non_stream={r_ns!r}"
+    )
+    assert c_stream == c_ns, (
+        f"content mismatch: stream={c_stream!r} non_stream={c_ns!r}"
+    )
+    # The reasoning text should contain "deep thought"
+    assert "deep thought" in r_stream, (
+        f"reasoning text lost: {r_stream!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Truncation inside partial THINK_CLOSE marker — token-level boundaries
+# ---------------------------------------------------------------------------
+
+# XTML markers are multi-token sequences: <|close|> | think | <|sep|>
+# Reachable token-level truncation boundaries for THINK_CLOSE:
+#   After token 1: "<|close|>"      (special token <|close|>)
+#   After token 2: "<|close|>think"  (<|close|> + text "think")
+# These are the ONLY realistic truncation points; character-level splits
+# inside a single token are not reachable via max_tokens.
+
+REACHABLE_THINK_CLOSE_PARTIALS = ["<|close|>", "<|close|>think"]
+
+
+@pytest.mark.parametrize("partial", REACHABLE_THINK_CLOSE_PARTIALS)
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 50])
+def test_truncation_inside_partial_think_close(partial: str, chunk_size: int):
+    """Generation ends with a partial THINK_CLOSE marker.
+
+    Both streaming and non-streaming paths must:
+    - never emit a partial THINK_CLOSE prefix in reasoning or content
+    - preserve the actual reasoning text before the partial marker
+    """
+    full_reasoning = "deep thought"
+    truncated = f"{THINK_OPEN}{full_reasoning}{partial}"
+
+    # Non-streaming
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, truncated)
+
+    # Streaming
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(
+        det_stream, _chunks(truncated, chunk_size)
+    )
+
+    # Both paths must not leak the partial marker
+    assert partial not in r_ns, (
+        f"non-streaming leaked partial THINK_CLOSE into reasoning: {r_ns!r}"
+    )
+    assert partial not in c_ns, (
+        f"non-streaming leaked partial THINK_CLOSE into content: {c_ns!r}"
+    )
+    assert partial not in r_stream, (
+        f"streaming leaked partial THINK_CLOSE into reasoning: {r_stream!r}"
+    )
+    assert partial not in c_stream, (
+        f"streaming leaked partial THINK_CLOSE into content: {c_stream!r}"
+    )
+    # Actual reasoning text must be preserved
+    assert full_reasoning in r_ns, (
+        f"non-streaming reasoning text lost: {r_ns!r}"
+    )
+    assert full_reasoning in r_stream, (
+        f"streaming reasoning text lost: {r_stream!r}"
+    )
+    # Streaming and non-streaming must match
+    assert r_stream == r_ns, (
+        f"stream/non-stream mismatch: stream={r_stream!r} non_stream={r_ns!r}"
+    )
+    assert c_stream == c_ns, (
+        f"stream/non-stream mismatch: stream={c_stream!r} non_stream={c_ns!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Truncation after reasoning ends, before normal text
+# ---------------------------------------------------------------------------
+
+def test_truncation_after_reasoning_before_normal_text():
+    """Generation ends after THINK_CLOSE but before RESPONSE_OPEN."""
+    full = f"{THINK_OPEN}thought{THINK_CLOSE}"
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(det_stream, _chunks(full, 3))
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, full)
+    assert r_stream == r_ns
+    assert c_stream == c_ns
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Truncation inside partial RESPONSE_OPEN marker — token-level boundaries
+# ---------------------------------------------------------------------------
+
+REACHABLE_RESPONSE_OPEN_PARTIALS = ["<|open|>", "<|open|>response"]
+
+
+@pytest.mark.parametrize("partial", REACHABLE_RESPONSE_OPEN_PARTIALS)
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 50])
+def test_truncation_inside_partial_response_open(partial: str, chunk_size: int):
+    """Generation ends with a partial RESPONSE_OPEN after THINK_CLOSE.
+
+    Both streaming and non-streaming paths must:
+    - never emit a partial RESPONSE_OPEN prefix in content or reasoning
+    - preserve the actual reasoning text
+    """
+    truncated = f"{THINK_OPEN}thought{THINK_CLOSE}{partial}"
+
+    # Non-streaming
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, truncated)
+
+    # Streaming
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(
+        det_stream, _chunks(truncated, chunk_size)
+    )
+
+    # Both paths must not leak the partial marker
+    assert partial not in r_ns, (
+        f"non-streaming leaked partial RESPONSE_OPEN into reasoning: {r_ns!r}"
+    )
+    assert partial not in c_ns, (
+        f"non-streaming leaked partial RESPONSE_OPEN into content: {c_ns!r}"
+    )
+    assert partial not in r_stream, (
+        f"streaming leaked partial RESPONSE_OPEN into reasoning: {r_stream!r}"
+    )
+    assert partial not in c_stream, (
+        f"streaming leaked partial RESPONSE_OPEN into content: {c_stream!r}"
+    )
+    # Reasoning text must be preserved
+    assert "thought" in r_ns, (
+        f"non-streaming reasoning text lost: {r_ns!r}"
+    )
+    assert "thought" in r_stream, (
+        f"streaming reasoning text lost: {r_stream!r}"
+    )
+    # Streaming and non-streaming must match
+    assert r_stream == r_ns, (
+        f"stream/non-stream mismatch: stream={r_stream!r} non_stream={r_ns!r}"
+    )
+    assert c_stream == c_ns, (
+        f"stream/non-stream mismatch: stream={c_stream!r} non_stream={c_ns!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5b: Truncation inside partial RESPONSE_CLOSE marker — token-level boundaries
+# ---------------------------------------------------------------------------
+
+REACHABLE_RESPONSE_CLOSE_PARTIALS = ["<|close|>", "<|close|>response"]
+
+
+@pytest.mark.parametrize("partial", REACHABLE_RESPONSE_CLOSE_PARTIALS)
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 50])
+def test_truncation_inside_partial_response_close(partial: str, chunk_size: int):
+    """Generation ends with a partial RESPONSE_CLOSE inside the response channel.
+
+    Both streaming and non-streaming paths must:
+    - never emit a partial RESPONSE_CLOSE prefix in content or reasoning
+    - preserve the actual response text before the partial marker
+    """
+    truncated = (
+        f"{THINK_OPEN}thought{THINK_CLOSE}"
+        f"{RESPONSE_OPEN}the answer{partial}"
+    )
+
+    # Non-streaming
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, truncated)
+
+    # Streaming
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(
+        det_stream, _chunks(truncated, chunk_size)
+    )
+
+    # Both paths must not leak the partial marker
+    assert partial not in r_ns, (
+        f"non-streaming leaked partial RESPONSE_CLOSE into reasoning: {r_ns!r}"
+    )
+    assert partial not in c_ns, (
+        f"non-streaming leaked partial RESPONSE_CLOSE into content: {c_ns!r}"
+    )
+    assert partial not in r_stream, (
+        f"streaming leaked partial RESPONSE_CLOSE into reasoning: {r_stream!r}"
+    )
+    assert partial not in c_stream, (
+        f"streaming leaked partial RESPONSE_CLOSE into content: {c_stream!r}"
+    )
+    # Response text must be preserved
+    assert "the answer" in c_ns, (
+        f"non-streaming content lost: {c_ns!r}"
+    )
+    assert "the answer" in c_stream, (
+        f"streaming content lost: {c_stream!r}"
+    )
+    # Streaming and non-streaming must match
+    assert r_stream == r_ns, (
+        f"stream/non-stream mismatch: stream={r_stream!r} non_stream={r_ns!r}"
+    )
+    assert c_stream == c_ns, (
+        f"stream/non-stream mismatch: stream={c_stream!r} non_stream={c_ns!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Truncation inside normal text
+# ---------------------------------------------------------------------------
+
+def test_truncation_inside_normal_text():
+    """Generation ends inside normal text after RESPONSE_OPEN."""
+    for prefix_len in range(1, 10):
+        full = (
+            f"{THINK_OPEN}thought{THINK_CLOSE}"
+            f"{RESPONSE_OPEN}the answer{RESPONSE_CLOSE}"
+        )
+        truncated = full[: -(len(RESPONSE_CLOSE) + prefix_len)]
+        det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+        r_stream, c_stream = _stream_with_finish(
+            det_stream, _chunks(truncated, 3)
+        )
+        det_ns = KimiK3Detector(force_reasoning=True)
+        r_ns, c_ns = _non_stream(det_ns, truncated)
+        assert r_stream == r_ns, (
+            f"reasoning mismatch at prefix_len={prefix_len}: "
+            f"stream={r_stream!r} non_stream={r_ns!r}"
+        )
+        assert c_stream == c_ns, (
+            f"content mismatch at prefix_len={prefix_len}: "
+            f"stream={c_stream!r} non_stream={c_ns!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Truncation inside partial tool-call marker — token-level boundaries
+# ---------------------------------------------------------------------------
+
+REACHABLE_TOOLS_OPEN_PARTIALS = ["<|open|>", "<|open|>tools"]
+
+
+@pytest.mark.parametrize("partial", REACHABLE_TOOLS_OPEN_PARTIALS)
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 50])
+def test_truncation_inside_partial_tools_open(partial: str, chunk_size: int):
+    """Generation ends with a partial TOOLS_OPEN after reasoning + response.
+
+    Both streaming and non-streaming paths must not leak the partial marker.
+    """
+    truncated = (
+        f"{THINK_OPEN}thought{THINK_CLOSE}"
+        f"{RESPONSE_OPEN}reply{RESPONSE_CLOSE}"
+        f"{partial}"
+    )
+
+    # Non-streaming
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, truncated)
+
+    # Streaming
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(
+        det_stream, _chunks(truncated, chunk_size)
+    )
+
+    # Both paths must not leak the partial marker
+    assert partial not in r_ns, (
+        f"non-streaming leaked partial TOOLS_OPEN into reasoning: {r_ns!r}"
+    )
+    assert partial not in c_ns, (
+        f"non-streaming leaked partial TOOLS_OPEN into content: {c_ns!r}"
+    )
+    assert partial not in r_stream, (
+        f"streaming leaked partial TOOLS_OPEN into reasoning: {r_stream!r}"
+    )
+    assert partial not in c_stream, (
+        f"streaming leaked partial TOOLS_OPEN into content: {c_stream!r}"
+    )
+    # Streaming and non-streaming must match
+    assert r_stream == r_ns, (
+        f"stream/non-stream mismatch: stream={r_stream!r} non_stream={r_ns!r}"
+    )
+    assert c_stream == c_ns, (
+        f"stream/non-stream mismatch: stream={c_stream!r} non_stream={c_ns!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Truncation inside tool arguments
+# ---------------------------------------------------------------------------
+
+def test_truncation_inside_tool_arguments():
+    """Generation ends inside tool arguments."""
+    full = (
+        f"{THINK_OPEN}thought{THINK_CLOSE}"
+        f"{RESPONSE_OPEN}reply{RESPONSE_CLOSE}"
+        f'{TOOLS_OPEN}<|open|>call tool="go" index="1"<|sep|>'
+        f'<|open|>argument key="x" type="string"<|sep|>42'
+    )
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(det_stream, _chunks(full, 3))
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, full)
+    assert r_stream == r_ns, (
+        f"reasoning mismatch: stream={r_stream!r} non_stream={r_ns!r}"
+    )
+    assert c_stream == c_ns, (
+        f"content mismatch: stream={c_stream!r} non_stream={c_ns!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Empty reasoning followed by final text
+# ---------------------------------------------------------------------------
+
+def test_empty_reasoning_streaming_matches_non_streaming():
+    """Empty reasoning followed by final text."""
+    text = f"{THINK_OPEN}{THINK_CLOSE}{RESPONSE_OPEN}final{RESPONSE_CLOSE}"
+    for chunk_size in [1, 2, 5, 100]:
+        det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+        r_stream, c_stream = _stream_with_finish(
+            det_stream, _chunks(text, chunk_size)
+        )
+        det_ns = KimiK3Detector(force_reasoning=True)
+        r_ns, c_ns = _non_stream(det_ns, text)
+        assert r_stream == r_ns, (
+            f"chunk_size={chunk_size}: stream={r_stream!r} non_stream={r_ns!r}"
+        )
+        assert c_stream == c_ns, (
+            f"chunk_size={chunk_size}: stream={c_stream!r} non_stream={c_ns!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Reasoning followed by tool call — full round trip
+# ---------------------------------------------------------------------------
+
+def test_reasoning_then_tool_call_streaming_matches_non_streaming():
+    """Reasoning + tool call, truncated at various points."""
+    full = (
+        f"{THINK_OPEN}plan{THINK_CLOSE}"
+        f"{RESPONSE_OPEN}ok{RESPONSE_CLOSE}"
+        f'{TOOLS_OPEN}<|open|>call tool="go" index="1"<|sep|>'
+        f'<|open|>argument key="x" type="string"<|sep|>42'
+        f"<|close|>argument<|sep|><|close|>call<|sep|>"
+        f"{TOOLS_CLOSE}"
+    )
+    for chunk_size in [1, 3, 7, 200]:
+        det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+        r_stream, c_stream = _stream_with_finish(
+            det_stream, _chunks(full, chunk_size)
+        )
+        det_ns = KimiK3Detector(force_reasoning=True)
+        r_ns, c_ns = _non_stream(det_ns, full)
+        assert r_stream == r_ns, (
+            f"chunk_size={chunk_size}: stream={r_stream!r} non_stream={r_ns!r}"
+        )
+        assert c_stream == c_ns, (
+            f"chunk_size={chunk_size}: stream={c_stream!r} non_stream={c_ns!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Per-choice isolation — two independent detectors
+# ---------------------------------------------------------------------------
+
+def test_two_choices_independent_state():
+    """Two independent KimiK3Detector instances must not interfere."""
+    text_a = f"{THINK_OPEN}alpha{THINK_CLOSE}{RESPONSE_OPEN}A{RESPONSE_CLOSE}"
+    text_b = f"{THINK_OPEN}beta{THINK_CLOSE}{RESPONSE_OPEN}B{RESPONSE_CLOSE}"
+    det_a = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    det_b = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_a, c_a = _stream_with_finish(det_a, _chunks(text_a, 3))
+    r_b, c_b = _stream_with_finish(det_b, _chunks(text_b, 3))
+    assert r_a == "alpha" and c_a == "A"
+    assert r_b == "beta" and c_b == "B"
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Partial MESSAGE_CLOSE — token-level boundaries
+# ---------------------------------------------------------------------------
+
+REACHABLE_MESSAGE_CLOSE_PARTIALS = ["<|close|>", "<|close|>message"]
+
+
+@pytest.mark.parametrize("partial", REACHABLE_MESSAGE_CLOSE_PARTIALS)
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 50])
+def test_truncation_inside_partial_message_close(partial: str, chunk_size: int):
+    """Generation ends with a partial MESSAGE_CLOSE after response close."""
+    truncated = (
+        f"{THINK_OPEN}thought{THINK_CLOSE}"
+        f"{RESPONSE_OPEN}answer{RESPONSE_CLOSE}"
+        f"{partial}"
+    )
+
+    det_ns = KimiK3Detector(force_reasoning=True)
+    r_ns, c_ns = _non_stream(det_ns, truncated)
+
+    det_stream = KimiK3Detector(force_reasoning=True, stream_reasoning=True)
+    r_stream, c_stream = _stream_with_finish(
+        det_stream, _chunks(truncated, chunk_size)
+    )
+
+    assert partial not in r_ns, (
+        f"non-streaming leaked partial MESSAGE_CLOSE into reasoning: {r_ns!r}"
+    )
+    assert partial not in c_ns, (
+        f"non-streaming leaked partial MESSAGE_CLOSE into content: {c_ns!r}"
+    )
+    assert partial not in r_stream, (
+        f"streaming leaked partial MESSAGE_CLOSE into reasoning: {r_stream!r}"
+    )
+    assert partial not in c_stream, (
+        f"streaming leaked partial MESSAGE_CLOSE into content: {c_stream!r}"
+    )
+    assert r_stream == r_ns
+    assert c_stream == c_ns
+
+
+# ---------------------------------------------------------------------------
+# Test 13: Legitimate text starting with '<' is preserved
+# ---------------------------------------------------------------------------
+
+def test_legitimate_angle_bracket_text_preserved():
+    """Text that starts with '<' but is NOT a partial marker must be preserved."""
+    # Text that starts with '<' but is not a prefix of any XTML marker
+    legitimate_texts = [
+        "< hello world",
+        "<3 meaning love",
+        "<<important>>",
+        "<not_a_marker>",
+    ]
+    for text in legitimate_texts:
+        det_ns = KimiK3Detector(force_reasoning=True)
+        r_ns, c_ns = _non_stream(det_ns, f"{THINK_OPEN}thought{THINK_CLOSE}{RESPONSE_OPEN}{text}{RESPONSE_CLOSE}")
+        assert text in c_ns, f"legitimate text lost: {c_ns!r}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
XTML markers (e.g. <|close|>think<|sep|>, <|open|>response<|sep|>) are multi-token sequences.  When generation is truncated by max_tokens at a token boundary inside one of these markers, the non-streaming parser can expose incomplete internal marker fragments in public output.

Confirmed leakage examples before the fix:
  reasoning_text = "deep thought<|close|>"
  normal_text = "<|open|>response"
  normal_text = "the answer<|close|>response"

The streaming parser already suppresses these fragments because it uses partial_suffix_len() to buffer incomplete markers.  The non-streaming path did not have equivalent protection.

This fix adds strip_partial_marker_suffix(), which strips only reachable token-boundary marker suffixes (e.g. "<|close|>", "<|close|>think", "<|open|>response") from non-streaming output. Arbitrary character fragments such as "<" or "<|c" are not removed because they cannot appear at decoded token boundaries.

The helper is applied in two places:
  1. strip_response_wrappers() — cleans normal content output
  2. _strip_dangling_think_close() — cleans reasoning output

Tests cover:
  - reachable token-level truncation boundaries for all marker types
  - non-streaming reasoning and normal content output
  - streaming/non-streaming semantic parity
  - legitimate text containing '<' that must remain unchanged
  - Chat Completions and Responses API public output paths
  - per-choice parser state isolation

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30654184803](https://github.com/sgl-project/sglang/actions/runs/30654184803)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30654184552](https://github.com/sgl-project/sglang/actions/runs/30654184552)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->