### PR TITLE
feat(dgx-spark): add inkling-small MoE support for sm_121

### DIFF
--- a/python/sglang/kernels/ops/moe/inkling_moe.py
+++ b/python/sglang/kernels/ops/moe/inkling_moe.py
@@ -11,6 +11,7 @@ from sglang.srt.layers.moe.moe_runner.triton_utils.helion_utils import (
     get_model_depths,
     helion_aot_autotune,
 )
+from sglang.srt.utils.common import is_dgx_spark
 
 DEFAULT_BLOCK_SIZE = 4096
 BLOCK_SIZE_M = 128
@@ -896,6 +897,11 @@ def grouped_gemm_triton(
             "num_warps": 8,
             "num_stages": 3,
         }
+
+    # sm_121 (GB10 / DGX Spark) has less shared memory headroom; drop one stage.
+    if is_dgx_spark():
+        config["num_stages"] -= 1
+
     # Set grid_m to the max number of M blocks and skip padding-only blocks
     # in the kernel based on expert_block_offs[-1]
     grid_m = expert_block_schedule.numel()

--- a/python/sglang/kernels/ops/moe/inkling_moe.py
+++ b/python/sglang/kernels/ops/moe/inkling_moe.py
@@ -11,7 +11,7 @@ from sglang.srt.layers.moe.moe_runner.triton_utils.helion_utils import (
     get_model_depths,
     helion_aot_autotune,
 )
-from sglang.srt.utils.common import is_dgx_spark
+from sglang.srt.utils.common import is_sm121
 
 DEFAULT_BLOCK_SIZE = 4096
 BLOCK_SIZE_M = 128
@@ -885,7 +885,10 @@ def grouped_gemm_triton(
             "BLOCK_SIZE_K": 128,
             "GROUP_SIZE_M": 8,
             "num_warps": 4,
-            "num_stages": 4,
+            # sm_121 (GB10 / DGX Spark) caps shared memory at 99 KB per block;
+            # num_stages=4 needs 108 KB and fails to launch. The BLOCK_SIZE_M=128
+            # branch below fits at its default 3 stages (96 KB), so it is left alone.
+            "num_stages": 3 if is_sm121() else 4,
         }
     else:
         assert block_size_m == BLOCK_SIZE_M, f"{block_size_m=}"
@@ -897,10 +900,6 @@ def grouped_gemm_triton(
             "num_warps": 8,
             "num_stages": 3,
         }
-
-    # sm_121 (GB10 / DGX Spark) has less shared memory headroom; drop one stage.
-    if is_dgx_spark():
-        config["num_stages"] -= 1
 
     # Set grid_m to the max number of M blocks and skip padding-only blocks
     # in the kernel based on expert_block_offs[-1]

--- a/python/sglang/kernels/ops/moe/inkling_moe.py
+++ b/python/sglang/kernels/ops/moe/inkling_moe.py
@@ -885,9 +885,9 @@ def grouped_gemm_triton(
             "BLOCK_SIZE_K": 128,
             "GROUP_SIZE_M": 8,
             "num_warps": 4,
-            # sm_121 (GB10 / DGX Spark) caps shared memory at 99 KB per block;
-            # num_stages=4 needs 108 KB and fails to launch. The BLOCK_SIZE_M=128
-            # branch below fits at its default 3 stages (96 KB), so it is left alone.
+            # sm_121 (GB10 / DGX Spark) caps shared memory at 99 KB per block and
+            # num_stages=4 needs 108 KB. The BLOCK_SIZE_M=128 branch below fits at
+            # its default 3 (96 KB) and needs no gate.
             "num_stages": 3 if is_sm121() else 4,
         }
     else:

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/silu_and_mul_interleaved_sm_121.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/silu_and_mul_interleaved_sm_121.json
@@ -1,0 +1,39 @@
+{
+  "useful_configs": {
+    "0": "helion.Config(block_sizes=[2, 512], indexing=['tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor', 'tensor_descriptor'], l2_groupings=[1], load_eviction_policies=['last', '', ''], loop_orders=[[1, 0]], num_stages=3, num_warps=1, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[None])",
+    "1": "helion.Config(block_sizes=[1, 1024], indexing=['tensor_descriptor', 'tensor_descriptor', 'pointer', 'pointer'], l2_groupings=[1], load_eviction_policies=['last', 'first', 'last'], loop_orders=[[1, 0]], num_stages=5, num_warps=1, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[None])",
+    "4": "helion.Config(block_sizes=[2, 512], indexing=['pointer', 'tensor_descriptor', 'pointer'], l2_groupings=[2], load_eviction_policies=['last', ''], loop_orders=[[0, 1]], num_stages=2, num_warps=1, pid_type='flat', range_flattens=[None], range_multi_buffers=[None], range_num_stages=[0], range_unroll_factors=[0], range_warp_specializes=[None])"
+  },
+  "hash_configs": {
+    "(512, (2,), (False,))": 0,
+    "(512, (2,), (True,))": 1,
+    "(1024, (2,), (False,))": 0,
+    "(1024, (2,), (True,))": 0,
+    "(1536, (2,), (False,))": 1,
+    "(1536, (2,), (True,))": 1,
+    "(2048, (2,), (False,))": 4,
+    "(2048, (2,), (True,))": 1,
+    "(3072, (2,), (False,))": 0,
+    "(3072, (2,), (True,))": 0,
+    "(4096, (2,), (False,))": 4,
+    "(4096, (2,), (True,))": 1,
+    "(4608, (2,), (False,))": 0,
+    "(4608, (2,), (True,))": 0,
+    "(6144, (2,), (False,))": 0,
+    "(6144, (2,), (True,))": 1,
+    "(7680, (2,), (False,))": 1,
+    "(7680, (2,), (True,))": 1,
+    "(8192, (2,), (False,))": 4,
+    "(8192, (2,), (True,))": 1,
+    "(9216, (2,), (False,))": 0,
+    "(9216, (2,), (True,))": 0,
+    "(10240, (2,), (False,))": 0,
+    "(10240, (2,), (True,))": 1,
+    "(12288, (2,), (False,))": 0,
+    "(12288, (2,), (True,))": 1,
+    "(14336, (2,), (False,))": 0,
+    "(14336, (2,), (True,))": 1,
+    "(16384, (2,), (False,))": 4,
+    "(16384, (2,), (True,))": 1
+  }
+}

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -186,6 +186,11 @@ def is_npu() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_dgx_spark() -> bool:
+    return is_cuda() and torch.cuda.get_device_capability() == (12, 1)
+
+
+@lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()
     return (

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -309,9 +309,8 @@ is_sm90_supported = lru_cache(maxsize=1)(
 )
 
 
-# GB10 (DGX Spark and OEM equivalents): consumer-Blackwell shared memory capacity
-# (99 KB per block) on a cc 12.1 device, vs datacenter Blackwell's 228 KB. Not
-# expressible via _check_cuda_device_version, which only matches on the major.
+# GB10 (DGX Spark and OEM equivalents). Not expressible via
+# _check_cuda_device_version, which only matches on the major.
 @lru_cache(maxsize=1)
 def is_sm121() -> bool:
     return is_cuda() and torch.cuda.get_device_capability() == (12, 1)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -186,11 +186,6 @@ def is_npu() -> bool:
 
 
 @lru_cache(maxsize=1)
-def is_dgx_spark() -> bool:
-    return is_cuda() and torch.cuda.get_device_capability() == (12, 1)
-
-
-@lru_cache(maxsize=1)
 def is_host_cpu_x86() -> bool:
     machine = platform.machine().lower()
     return (
@@ -312,6 +307,14 @@ is_sm90_supported = lru_cache(maxsize=1)(
         _check_cuda_device_version, device_capability_majors=[9], cuda_version=(12, 3)
     )
 )
+
+
+# GB10 (DGX Spark and OEM equivalents): consumer-Blackwell shared memory capacity
+# (99 KB per block) on a cc 12.1 device, vs datacenter Blackwell's 228 KB. Not
+# expressible via _check_cuda_device_version, which only matches on the major.
+@lru_cache(maxsize=1)
+def is_sm121() -> bool:
+    return is_cuda() and torch.cuda.get_device_capability() == (12, 1)
 
 
 try:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Enable Inkling-small MoE kernels on DGX Spark (GB10, sm_121). The existing Triton configs and grouped-GEMM staging assumptions target larger GPUs; sm_121 has less shared-memory headroom, so default configs can fail or underperform without platform-specific tuning.

## Modifications

- Add `is_dgx_spark()` in `common.py` (CUDA + compute capability `(12, 1)`), cached via `lru_cache`.
- In `inkling_moe.grouped_gemm_triton`, reduce `num_stages` by 1 on DGX Spark to fit shared-memory limits.
- Add Helion autotune config `silu_and_mul_interleaved_sm_121.json` for the silu-and-mul interleaved MoE path on sm_121 (copied from sm_100).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

N/A. Config and `num_stages` tuning for sm_121 only; no intentional change to numerics beyond kernel launch parameters. This is an enablement PR. Model outputs normal language after tested on DGX Spark.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Speed tests are based on the following command (NCCL==2.30.7 to avoid NCCL hang, credit to [drowzeys/keys-64TKS-Inkling-Small-NVFP4-Dspark-SGlang-SM121-optimized-on-Two-DGX-Sparks](https://github.com/drowzeys/keys-64TKS-Inkling-Small-NVFP4-Dspark-SGlang-SM121-optimized-on-Two-DGX-Sparks) instructions):

```shell
SGLANG_ENABLE_UNIFIED_RADIX_TREE=1 \
sglang serve \
  --trust-remote-code \
  --model-path thinkingmachines/Inkling-Small-NVFP4 \
  --tp 2 \
  --nnodes 2 \
  --node-rank <rank> \
  --dist-init-addr 192.168.100.10:5000 \
  --quantization modelopt_fp4 \
  --attention-backend triton \
  --page-size 128 \
  --fp4-gemm-backend marlin \
  --moe-runner-backend marlin \
  --mamba-radix-cache-strategy extra_buffer \
  --mem-fraction-static 0.85 \
  --swa-full-tokens-ratio 0.1 \
  --mamba-full-memory-ratio 0.1 \
  --enable-multimodal \
  --disable-prefill-cuda-graph \
  --reasoning-parser inkling \
  --tool-call-parser inkling \
  --host 0.0.0.0 \
  --port 30000
```

Concurrency=1:

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 1         
Successful requests:                     8         
Benchmark duration (s):                  112.62    
Total input tokens:                      2572      
Total input text tokens:                 2572      
Total generated tokens:                  2670      
Total generated tokens (retokenized):    2664      
Request throughput (req/s):              0.07      
Input token throughput (tok/s):          22.84     
Output token throughput (tok/s):         23.71     
Peak output token throughput (tok/s):    25.00     
Peak concurrent requests:                2         
Total token throughput (tok/s):          46.55     
Concurrency:                             1.00      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   14068.34  
Median E2E Latency (ms):                 14415.05  
P90 E2E Latency (ms):                    21522.79  
P95 E2E Latency (ms):                    23406.92  
P99 E2E Latency (ms):                    24914.23  
---------------Time to First Token----------------
Mean TTFT (ms):                          549.05    
Median TTFT (ms):                        435.87    
P90 TTFT (ms):                           1013.92   
P95 TTFT (ms):                           1220.82   
P99 TTFT (ms):                           1386.34   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          40.65     
Median TPOT (ms):                        40.63     
P90 TPOT (ms):                           40.86     
P95 TPOT (ms):                           40.89     
P99 TPOT (ms):                           40.92     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           40.63     
Median ITL (ms):                         40.52     
P90 ITL (ms):                            42.09     
P95 ITL (ms):                            50.11     
P99 ITL (ms):                            51.24     
Max ITL (ms):                            57.93     
==================================================
```

Concurrency=4:

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 4         
Successful requests:                     32        
Benchmark duration (s):                  289.93    
Total input tokens:                      12778     
Total input text tokens:                 12778     
Total generated tokens:                  18225     
Total generated tokens (retokenized):    18167     
Request throughput (req/s):              0.11      
Input token throughput (tok/s):          44.07     
Output token throughput (tok/s):         62.86     
Peak output token throughput (tok/s):    76.00     
Peak concurrent requests:                5         
Total token throughput (tok/s):          106.93    
Concurrency:                             3.71      
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   33656.65  
Median E2E Latency (ms):                 33559.75  
P90 E2E Latency (ms):                    56060.61  
P95 E2E Latency (ms):                    57295.94  
P99 E2E Latency (ms):                    59795.16  
---------------Time to First Token----------------
Mean TTFT (ms):                          756.09    
Median TTFT (ms):                        607.40    
P90 TTFT (ms):                           1977.74   
P95 TTFT (ms):                           2123.49   
P99 TTFT (ms):                           2123.65   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          57.73     
Median TPOT (ms):                        58.44     
P90 TPOT (ms):                           59.24     
P95 TPOT (ms):                           59.53     
P99 TPOT (ms):                           59.78     
---------------Inter-Token Latency----------------
Mean ITL (ms):                           57.87     
Median ITL (ms):                         56.00     
P90 ITL (ms):                            59.39     
P95 ITL (ms):                            66.66     
P99 ITL (ms):                            81.93     
Max ITL (ms):                            1121.03   
==================================================
```

Concurrency=16:

```
============ Serving Benchmark Result ============
Backend:                                 sglang    
Traffic request rate:                    inf       
Max request concurrency:                 16        
Successful requests:                     48        
Benchmark duration (s):                  225.04    
Total input tokens:                      21679     
Total input text tokens:                 21679     
Total generated tokens:                  24852     
Total generated tokens (retokenized):    24805     
Request throughput (req/s):              0.21      
Input token throughput (tok/s):          96.33     
Output token throughput (tok/s):         110.43    
Peak output token throughput (tok/s):    160.00    
Peak concurrent requests:                18        
Total token throughput (tok/s):          206.77    
Concurrency:                             13.69     
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   64164.82  
Median E2E Latency (ms):                 63418.31  
P90 E2E Latency (ms):                    114054.66 
P95 E2E Latency (ms):                    121558.86 
P99 E2E Latency (ms):                    127461.44 
---------------Time to First Token----------------
Mean TTFT (ms):                          1316.18   
Median TTFT (ms):                        596.45    
P90 TTFT (ms):                           3066.20   
P95 TTFT (ms):                           3066.30   
P99 TTFT (ms):                           3066.39   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          123.07    
Median TPOT (ms):                        123.96    
P90 TPOT (ms):                           134.29    
P95 TPOT (ms):                           134.88    
P99 TPOT (ms):                           136.23    
---------------Inter-Token Latency----------------
Mean ITL (ms):                           121.62    
Median ITL (ms):                         116.66    
P90 ITL (ms):                            130.54    
P95 ITL (ms):                            172.99    
P99 ITL (ms):                            337.44    
Max ITL (ms):                            1238.88   
==================================================
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A it seems)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A it seems)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31050454897](https://github.com/sgl-project/sglang/actions/runs/31050454897)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31050454696](https://github.com/sgl-project/sglang/actions/runs/31050454696)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->