### PR TITLE
[Fix] Restore and batch sparse embedding responses

### DIFF
--- a/python/sglang/srt/layers/sparse_pooler.py
+++ b/python/sglang/srt/layers/sparse_pooler.py
@@ -11,6 +11,7 @@ from sglang.srt.model_executor.model_runner import ForwardBatch
 @dataclass
 class SparseEmbeddingOutput:
     embeddings: torch.Tensor  # [batch_size, vocab_size]
+    pooled_hidden_states: torch.Tensor | None = None
 
 
 class SparsePooler(nn.Module):

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -60,6 +60,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_SPARSE_EMBEDDING_CONVERSION_CHUNK_SIZE = 512
+
+
+def _sparse_embeddings_to_python(
+    embeddings: torch.Tensor,
+) -> list[dict[int, float]]:
+    """Convert sparse tensor output with bounded tensor-to-Python transfers."""
+    output = [{} for _ in range(embeddings.size(0))]
+    indices = embeddings.indices()
+    values = embeddings.values()
+
+    for start in range(0, values.shape[0], _SPARSE_EMBEDDING_CONVERSION_CHUNK_SIZE):
+        end = start + _SPARSE_EMBEDDING_CONVERSION_CHUNK_SIZE
+        batch_ids, token_ids = indices[:, start:end].tolist()
+        chunk_values = values[start:end].tolist()
+        for batch_id, token_id, value in zip(batch_ids, token_ids, chunk_values):
+            output[batch_id][token_id] = value
+    return output
+
 
 @dataclass(kw_only=True, slots=True, frozen=True)
 class SchedulerBatchResultProcessor:
@@ -355,12 +374,7 @@ class SchedulerBatchResultProcessor:
         embeddings = result.embeddings
 
         if is_sparse:
-            batch_ids, token_ids = embeddings.indices()
-            values = embeddings.values()
-
-            embeddings = [{} for _ in range(embeddings.size(0))]
-            for i in range(batch_ids.shape[0]):
-                embeddings[batch_ids[i].item()][token_ids[i].item()] = values[i].item()
+            embeddings = _sparse_embeddings_to_python(embeddings)
         else:
             if isinstance(embeddings, torch.Tensor):
                 embeddings = embeddings.tolist()

--- a/test/registered/unit/managers/test_sparse_embedding_response.py
+++ b/test/registered/unit/managers/test_sparse_embedding_response.py
@@ -1,0 +1,116 @@
+"""Contract tests for sparse embedding output and response conversion."""
+
+import math
+import unittest
+
+import torch
+
+from sglang.srt.layers.sparse_pooler import SparseEmbeddingOutput
+from sglang.srt.managers.scheduler_components import batch_result_processor
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _scalar_reference(tensor: torch.Tensor) -> list[dict[int, float]]:
+    batch_ids, token_ids = tensor.indices()
+    values = tensor.values()
+    output = [{} for _ in range(tensor.size(0))]
+    for index in range(values.shape[0]):
+        output[batch_ids[index].item()][token_ids[index].item()] = values[index].item()
+    return output
+
+
+def _bulk(tensor: torch.Tensor) -> list[dict[int, float]]:
+    return batch_result_processor._sparse_embeddings_to_python(tensor)
+
+
+def _linear_sparse(batch: int, nnz: int) -> torch.Tensor:
+    linear = torch.arange(nnz, dtype=torch.int64)
+    indices = torch.stack((linear % batch, linear // batch))
+    return torch.sparse_coo_tensor(
+        indices,
+        linear.to(torch.float32),
+        size=(batch, math.ceil(nnz / batch)),
+    ).coalesce()
+
+
+class TestSparseEmbeddingResponse(CustomTestCase):
+    def test_sparse_output_satisfies_scheduler_contract(self):
+        output = SparseEmbeddingOutput(embeddings=torch.tensor([[1.0]]))
+        self.assertIsNone(output.pooled_hidden_states)
+
+    def test_empty_preserves_batch_rows(self):
+        tensor = torch.sparse_coo_tensor(
+            torch.empty((2, 0), dtype=torch.int64),
+            torch.empty((0,), dtype=torch.float32),
+            size=(5, 128),
+        ).coalesce()
+        self.assertEqual(_bulk(tensor), [{}, {}, {}, {}, {}])
+
+    def test_singleton(self):
+        tensor = torch.sparse_coo_tensor(
+            torch.tensor([[0], [2]]), torch.tensor([1.25]), size=(1, 4)
+        ).coalesce()
+        self.assertEqual(_bulk(tensor), [{2: 1.25}])
+
+    def test_exact_dictionary_parity_across_value_dtypes(self):
+        indices = torch.tensor([[0, 0, 2, 3], [1, 7, 4, 9]])
+        for dtype in (torch.float32, torch.float16, torch.bfloat16):
+            with self.subTest(dtype=dtype):
+                tensor = torch.sparse_coo_tensor(
+                    indices,
+                    torch.tensor([0.5, -2.0, 3.25, 8.0], dtype=dtype),
+                    size=(4, 16),
+                ).coalesce()
+                self.assertEqual(_bulk(tensor), _scalar_reference(tensor))
+
+    def test_signed_zero_is_preserved(self):
+        tensor = torch.sparse_coo_tensor(
+            torch.tensor([[0, 0], [2, 3]]),
+            torch.tensor([-0.0, 0.0]),
+            size=(1, 8),
+        ).coalesce()
+        result = _bulk(tensor)[0]
+        self.assertTrue(torch.signbit(torch.tensor(result[2])).item())
+        self.assertFalse(torch.signbit(torch.tensor(result[3])).item())
+
+    def test_coalesced_duplicate_semantics(self):
+        tensor = torch.sparse_coo_tensor(
+            torch.tensor([[1, 1], [3, 3]]),
+            torch.tensor([1.25, 2.75]),
+            size=(2, 8),
+        ).coalesce()
+        self.assertEqual(_bulk(tensor), [{}, {3: 4.0}])
+
+    def test_chunk_boundary(self):
+        tensor = _linear_sparse(batch=3, nnz=515)
+        self.assertEqual(_bulk(tensor), _scalar_reference(tensor))
+
+    def test_large_nnz(self):
+        tensor = _linear_sparse(batch=32, nnz=8192)
+        result = _bulk(tensor)
+        self.assertEqual(result, _scalar_reference(tensor))
+        self.assertEqual(sum(map(len, result)), 8192)
+
+    def test_input_metadata_is_not_mutated(self):
+        tensor = _linear_sparse(batch=4, nnz=37)
+        indices_before = tensor.indices().clone()
+        values_before = tensor.values().clone()
+        _bulk(tensor)
+        self.assertTrue(torch.equal(tensor.indices(), indices_before))
+        self.assertTrue(torch.equal(tensor.values(), values_before))
+
+    def test_uncoalesced_error_is_preserved(self):
+        tensor = torch.sparse_coo_tensor(
+            torch.tensor([[0, 0], [1, 1]]),
+            torch.tensor([1.0, 2.0]),
+            size=(1, 8),
+        )
+        with self.assertRaises(RuntimeError):
+            _bulk(tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Sparse embedding requests currently fail before response serialization because
`SparseEmbeddingOutput` does not expose the optional `pooled_hidden_states` field consumed by
the scheduler. Once that contract is restored, the sparse response path converts every COO
entry with three scalar `.item()` calls, causing one device synchronization per scalar.

## Modifications

- Add the scheduler's optional pooled-state field to `SparseEmbeddingOutput`.
- Convert sparse indices and values to Python in bounded 512-entry chunks, then build the same
  per-request dictionaries.
- Add focused tests for the output contract, exact dtype/value parity, boundary shapes,
  metadata immutability, and the existing uncoalesced-input error.

The production change is confined to the sparse pooler output contract and the existing sparse
branch in `batch_result_processor.py`; the only other changed file is its registered unit test.

The 512-entry chunk is the measured low-allocation Pareto point: larger chunks saved at most
about 1.8 ms at 8,192 nnz but increased temporary Python allocation.

## Accuracy Tests

```text
pytest -q test/registered/unit/managers/test_sparse_embedding_response.py
..........                                                            [100%]
10 passed, 16 warnings, 3 subtests passed in 31.66s
```

The same test file produced 12 failures on the unmodified base. It verifies exact dictionary
parity against an independent scalar reference for float16, float32, and bfloat16, including
empty/singleton inputs, signed zero, coalesced duplicates, the 512-entry boundary, 8,192 nnz,
input immutability, and the pre-existing uncoalesced-input exception.

Two adjacent unit files also pass: 10 tests in 33.19s. The correctness-only and full-patch
native `/encode` runs returned the same 256-nnz response digest at concurrency 1, 8, and 32.
The OpenAI-compatible response schema's existing rejection of sparse dictionaries is unchanged.

## Speed Tests and Profiling

Hardware: NVIDIA RTX 4070 Laptop GPU (`sm_89`, 8,188 MiB), driver 595.79,
PyTorch 2.11.0+cu130. Component measurements use float16 values, five warmups, and 20
CUDA-synchronized samples per shape, with scalar/patched order alternated each sample:

| nnz | scalar median [p10, p90] ms | patched median [p10, p90] ms | speedup |
|---:|---:|---:|---:|
| 16 | 1.4292 [1.3430, 1.5595] | 0.0901 [0.0717, 0.1440] | 15.9x |
| 256 | 22.8581 [22.2263, 24.3800] | 0.1945 [0.0924, 0.3956] | 117.5x |
| 2,048 | 184.5454 [182.4708, 197.5460] | 0.7399 [0.5001, 0.8752] | 249.4x |
| 4,096 | 383.4719 [376.8144, 392.7776] | 1.3085 [1.0233, 1.6382] | 293.1x |
| 8,192 | 761.0318 [752.4783, 791.2167] | 2.7057 [2.0180, 3.0870] | 281.3x |

The 1-nnz cell was 0.0946 ms versus 0.0779 ms, within the measured spread, so no material win
is claimed there. Every shape produced the same response digest. At 2,048 nnz, profiling reduced
6,144 `aten::item` plus 6,144 `_local_scalar_dense` calls to eight bounded transfers. Across all
shapes, the maximum patched-minus-reference deltas were 15,112 bytes of Python allocation and
8,192 bytes of CUDA allocation, with zero RSS delta.

For an end-to-end denominator, I added only the missing output field to current main and retained
the original scalar conversion. Unmodified main remains the correctness fail-before because it
cannot serve a response. Both serving runs used the same tiny XLM-RoBERTa validation fixture,
deterministic shape-matched sparse head, 256 distinct input IDs, five warmup batches, and 20
measured batches per concurrency:

| concurrency | correctness-only median [p10, p90] ms | full patch median [p10, p90] ms | latency reduction | throughput |
|---:|---:|---:|---:|---:|
| 1 | 28.629 [26.274, 30.616] | 7.352 [6.758, 8.573] | 74.3% | 35.07 → 129.22 req/s (3.68x) |
| 8 | 191.023 [32.544, 202.755] | 17.164 [7.505, 19.440] | 91.0% | 41.09 → 433.63 req/s (10.55x) |
| 32 | 739.359 [697.251, 799.219] | 32.990 [23.034, 38.499] | 95.5% | 42.48 → 807.34 req/s (19.00x) |

An independent full-patch repeat measured 7.800/20.837/40.842 ms and
125.22/362.99/689.82 requests/s, still a 72.8%–94.5% latency reduction and
3.57x–16.24x throughput gain against the correctness-only run. Responses were identical. Peak
process-tree RSS changed from 3,780,214,784 to 3,809,566,720 bytes (+0.74% of the fixed WSL
ceiling), while peak device memory was identical at 1,504,399,360 bytes. These end-to-end claims
are limited to the disclosed 256-nnz `/encode` workload; they are not retrieval-quality claims.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (All applicable exact-file hooks pass.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

cc @asm2amqp @fzyzcjy

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30660689846](https://github.com/sgl-project/sglang/actions/runs/30660689846)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30660689509](https://github.com/sgl-project/sglang/actions/runs/30660689509)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->