### PR TITLE
Throttle decode-side /query_dp_ranks bootstrap query

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -345,6 +345,8 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self._max_ensure_retries: int = 15  # scheduling cycles
         self._ensure_last_attempt_time: Dict[str, float] = {}
         self._ensure_retry_interval: float = 1.0  # seconds
+        self._dp_rank_query_last_attempt_time: Dict[str, float] = {}
+        self._dp_rank_query_interval: float = 0.01  # seconds
         # Retracted requests staged for rebootstrap while generation is paused.
         # Enqueued into ``self.queue`` only on ``continue_generation`` so the
         # prefix KV is recomputed under the post-retract (updated) weights.
@@ -868,8 +870,21 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 else:
                     need_query.append(decode_req)
 
-            # Pass 2: resolve dp rank for addrs whose info is available
+            # Pass 2: resolve dp rank for addrs whose info is available.
+            # Throttled per addr like pass 1: the prefill registers a room's
+            # dp_rank only once it picks the request up, so an unthrottled
+            # query opens one bootstrap connection per scheduling cycle
+            # (thousands per second while the decode is otherwise idle).
             if need_query:
+                now = time.monotonic()
+                last_attempt = self._dp_rank_query_last_attempt_time.get(bootstrap_addr)
+                if last_attempt is not None and (
+                    now - last_attempt < self._dp_rank_query_interval
+                ):
+                    remaining.extend(need_query)
+                    continue
+                self._dp_rank_query_last_attempt_time[bootstrap_addr] = now
+
                 rooms = [decode_req.req.bootstrap_room for decode_req in need_query]
                 room_to_rank = CommonKVReceiver.query_prefill_dp_ranks(
                     bootstrap_addr, rooms

--- a/test/registered/unit/disaggregation/test_decode_dp_rank_query_throttle.py
+++ b/test/registered/unit/disaggregation/test_decode_dp_rank_query_throttle.py
@@ -1,0 +1,93 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.common.conn import PrefillServerInfo
+from sglang.srt.disaggregation.decode import DecodePreallocQueue
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+BOOTSTRAP_HOST = "127.0.0.1"
+BOOTSTRAP_PORT = 8998
+BOOTSTRAP_ADDR = f"{BOOTSTRAP_HOST}:{BOOTSTRAP_PORT}"
+
+
+def _make_queue(num_reqs, dp_rank_query_interval):
+    queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+    queue.pending_reqs = [
+        SimpleNamespace(
+            req=SimpleNamespace(
+                rid=f"r{room}",
+                bootstrap_room=room,
+                bootstrap_host=BOOTSTRAP_HOST,
+                bootstrap_port=BOOTSTRAP_PORT,
+                disagg_prefill_dp_rank=None,
+            ),
+            kv_receiver=MagicMock(),
+        )
+        for room in range(num_reqs)
+    ]
+    queue._ensure_retry_count = {}
+    queue._max_ensure_retries = 15
+    queue._ensure_last_attempt_time = {}
+    queue._ensure_retry_interval = 1.0
+    queue._dp_rank_query_last_attempt_time = {}
+    queue._dp_rank_query_interval = dp_rank_query_interval
+
+    # Prefill topology is already cached, and the prefill does not use
+    # follow_bootstrap_room, so every request has to resolve its dp_rank
+    # through the bootstrap server.
+    info = PrefillServerInfo(
+        attn_tp_size=8,
+        attn_cp_size=1,
+        dp_size=8,
+        pp_size=1,
+        page_size=1,
+        kv_cache_dtype="auto",
+        follow_bootstrap_room=False,
+        enable_dsa_cache_layer_split=False,
+    )
+    queue.kv_manager = SimpleNamespace(
+        prefill_info_table={BOOTSTRAP_ADDR: info},
+        try_ensure_parallel_info=lambda bootstrap_addr: True,
+    )
+    return queue
+
+
+class TestDecodeDpRankQueryThrottle(CustomTestCase):
+    def test_unresolved_reqs_query_bootstrap_once_per_interval(self):
+        # The prefill registers a room's dp_rank only once it picks the request
+        # up. Until then the query returns nothing, and the scheduling loop must
+        # not open one bootstrap connection per cycle (issue #33088).
+        queue = _make_queue(num_reqs=8, dp_rank_query_interval=10.0)
+
+        with patch(
+            "sglang.srt.disaggregation.decode.CommonKVReceiver.query_prefill_dp_ranks",
+            return_value={},
+        ) as query:
+            for _ in range(100):
+                queue._resolve_pending_reqs()
+
+        self.assertEqual(query.call_count, 1)
+        self.assertEqual(len(queue.pending_reqs), 8)
+
+    def test_first_query_is_not_delayed_and_resolves_reqs(self):
+        queue = _make_queue(num_reqs=2, dp_rank_query_interval=10.0)
+        decode_reqs = list(queue.pending_reqs)
+
+        with patch(
+            "sglang.srt.disaggregation.decode.CommonKVReceiver.query_prefill_dp_ranks",
+            return_value={"0": 3, "1": 5},
+        ) as query:
+            queue._resolve_pending_reqs()
+
+        self.assertEqual(query.call_count, 1)
+        self.assertEqual(queue.pending_reqs, [])
+        decode_reqs[0].kv_receiver.init.assert_called_once_with(3)
+        decode_reqs[1].kv_receiver.init.assert_called_once_with(5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #33088

`DecodePreallocQueue._resolve_pending_reqs` runs once per scheduler cycle, and its
pass 2 issues a `POST /query_dp_ranks` for every still-unresolved request with no
rate limit, while pass 1 right above it is throttled to one attempt per second per
bootstrap address. The prefill registers a room's `dp_rank` only when it picks the
request up, so until then (or forever, if the bootstrap is unreachable) the decode
opens one bootstrap connection per event-loop iteration. On an otherwise idle decode
node that is thousands of connections per second per DP rank, which is the
`/query_dp_ranks` connect storm and the ~1.36M `Error querying dp_ranks from
bootstrap` log lines in the issue.

This throttles the dp-rank query per bootstrap address, mirroring the pass-1
throttle. The interval is 10ms, well under any realistic prefill scheduling latency,
so the first query for a new request is never delayed and the happy path is
unaffected.

Verified on CPU only (8x A40 box, no ROCm and no second node, so the reporter's
1P+1D MI355X run was not reproducible here). Driving the real
`_resolve_pending_reqs` against a bootstrap address that does not answer, with a
counter on `socket.create_connection`:

- before: 862 scheduler iterations in 1.0s, 862 TCP connect attempts
- after: 16204 iterations in 1.0s, 88 TCP connect attempts

New unit test `test_decode_dp_rank_query_throttle.py` fails before the change
(`100 != 1`) and passes after. `test/registered/unit/disaggregation/` is green
(83 passed, 11 skipped).

Not verified: the reporter's `[Errno 99] Cannot assign requested address` itself.
Failed connects come back `ECONNREFUSED` here and never exhausted the ephemeral port
range, so the claim is that the storm causes their `[Errno 99]`, not that I observed
it. If their bootstrap was unreachable for an independent reason, this removes the
storm and the log flood but not the handshake failure. Also not fixed here: a
request whose `dp_rank` is never registered still waits in `pending_reqs` forever
instead of failing with a clear error, because `query_prefill_dp_ranks` returns `{}`
for both "transport error" and "not registered yet". That is a separate change.

Thanks to @ChangLiu0709 for the report, the log volume count and the reproduction
steps.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30664766727](https://github.com/sgl-project/sglang/actions/runs/30664766727)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30664766308](https://github.com/sgl-project/sglang/actions/runs/30664766308)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->