### PR TITLE
[Fix] Keep mrope cos/sin cache in fp32 like base RotaryEmbedding

### DIFF
--- a/python/sglang/kernels/ops/attention/rotary_triton.py
+++ b/python/sglang/kernels/ops/attention/rotary_triton.py
@@ -245,8 +245,11 @@ def triton_ernie45_rope_fused_inplace(
     section_h, section_w, section_t = mrope_section
     assert section_h == section_w, "Ernie4.5 layout assumes section_h == section_w"
     assert section_h + section_w + section_t == rd // 2
-    if cos_sin_cache.dtype != q.dtype or cos_sin_cache.device != q.device:
-        cos_sin_cache = cos_sin_cache.to(device=q.device, dtype=q.dtype)
+    # Do not downcast the cache to q's dtype: it is deliberately kept in fp32
+    # (see the NOTE in RotaryEmbedding.__init__). The kernel upcasts q/k to the
+    # cache dtype for the rotation and casts back on store.
+    if cos_sin_cache.device != q.device:
+        cos_sin_cache = cos_sin_cache.to(device=q.device)
     pad_n_qh = triton.next_power_of_2(n_qh)
     pad_n_kh = triton.next_power_of_2(n_kh)
     pad_hd = triton.next_power_of_2(head_size)

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -163,11 +163,16 @@ class MRotaryEmbedding(RotaryEmbedding):
         self.position_sin = sin.repeat(1, 2).view(-1, 1, 1, last_dim).contiguous()
 
     def _match_cos_sin_cache_dtype(self, query: torch.Tensor) -> None:
-        if (
-            self.cos_sin_cache.device != query.device
-            or self.cos_sin_cache.dtype != query.dtype
-        ):
-            self.cos_sin_cache = self.cos_sin_cache.to(query.device, dtype=query.dtype)
+        # Keep the cache in fp32 like the base RotaryEmbedding (see the NOTE in
+        # RotaryEmbedding.__init__): downcasting it to bf16/fp16 shifts the
+        # rotary phase enough to cause visible logit drift on long multimodal
+        # contexts. Only match the device here. XPU is the exception: its fused
+        # multimodal_rotary_embedding kernel requires the cache and query
+        # dtypes to match (see #31441).
+        if _is_xpu:
+            super()._match_cos_sin_cache_dtype(query)
+        elif self.cos_sin_cache.device != query.device:
+            self.cos_sin_cache = self.cos_sin_cache.to(query.device)
 
     def forward_native(
         self,

--- a/test/registered/unit/layers/rotary_embedding/test_mrope.py
+++ b/test/registered/unit/layers/rotary_embedding/test_mrope.py
@@ -1,0 +1,134 @@
+"""Unit tests for MRotaryEmbedding cos/sin cache dtype handling.
+
+The base RotaryEmbedding deliberately keeps ``cos_sin_cache`` in fp32 on CUDA
+for numerical stability (see the NOTE in ``RotaryEmbedding.__init__`` and
+``SGLANG_ROPE_CACHE_FP32``). MRotaryEmbedding must not silently downcast that
+cache to the query dtype: a bf16 cache shifts the rotary phase at the large
+position values multimodal models use.
+
+No server, no model loading. CPU-only: kernel launches are replaced with
+recorders, so only the Python-side dtype handling is exercised.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+maybe_stub_sgl_kernel()
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+import sglang.srt.layers.rotary_embedding.mrope as mrope_module
+from sglang.kernels.ops.attention import rotary_triton
+from sglang.srt.layers.rotary_embedding.mrope import MRotaryEmbedding
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+HEAD_SIZE = 64
+NUM_Q_HEADS = 4
+NUM_KV_HEADS = 1
+MROPE_SECTION = [16, 8, 8]  # sums to rotary_dim // 2
+
+
+def _make_mrope() -> MRotaryEmbedding:
+    mrope = MRotaryEmbedding(
+        head_size=HEAD_SIZE,
+        rotary_dim=HEAD_SIZE,
+        max_position_embeddings=4096,
+        base=10000,
+        is_neox_style=True,
+        dtype=torch.bfloat16,
+        mrope_section=MROPE_SECTION,
+    )
+    # On CUDA the constructor keeps the cache in fp32; on CPU it casts to the
+    # model dtype. Restore the CUDA-init state so the test reproduces what a
+    # CUDA host sees.
+    mrope.cos_sin_cache = mrope.cos_sin_cache.float()
+    return mrope
+
+
+class TestMRopeCacheDtype(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    def test_match_cos_sin_cache_dtype_keeps_fp32(self):
+        """The dtype-match helper must only move the cache across devices,
+        never downcast it to the (bf16) query dtype."""
+        mrope = _make_mrope()
+        query = torch.randn(4, NUM_Q_HEADS * HEAD_SIZE, dtype=torch.bfloat16)
+
+        mrope._match_cos_sin_cache_dtype(query)
+
+        self.assertEqual(
+            mrope.cos_sin_cache.dtype,
+            torch.float32,
+            "multimodal RoPE cache was downcast to the query dtype; it must "
+            "stay fp32 like the base RotaryEmbedding cache",
+        )
+
+    def test_forward_cuda_passes_fp32_cache_to_fused_kernel(self):
+        """forward_cuda with 2D (multimodal) positions must hand the fp32
+        cache to the fused mrope kernel and leave q/k dtypes untouched."""
+        mrope = _make_mrope()
+        num_tokens = 4
+        positions = torch.zeros(3, num_tokens, dtype=torch.int64)
+        query = torch.randn(num_tokens, NUM_Q_HEADS * HEAD_SIZE, dtype=torch.bfloat16)
+        key = torch.randn(num_tokens, NUM_KV_HEADS * HEAD_SIZE, dtype=torch.bfloat16)
+
+        seen = {}
+
+        def fake_triton_mrope_fused(q, k, cos_sin_cache, *args):
+            seen["cache_dtype"] = cos_sin_cache.dtype
+            seen["q_dtype"] = q.dtype
+            seen["k_dtype"] = k.dtype
+
+        with patch.object(mrope_module, "triton_mrope_fused", fake_triton_mrope_fused):
+            q_out, k_out = mrope.forward_cuda(positions, query, key)
+
+        self.assertEqual(seen["cache_dtype"], torch.float32)
+        self.assertEqual(seen["q_dtype"], torch.bfloat16)
+        self.assertEqual(seen["k_dtype"], torch.bfloat16)
+        # The fused kernel rotates q/k in place; output dtype is unchanged.
+        self.assertEqual(q_out.dtype, torch.bfloat16)
+        self.assertEqual(k_out.dtype, torch.bfloat16)
+
+    def test_ernie45_fused_wrapper_keeps_fp32_cache(self):
+        """The Ernie4.5 fused-rope wrapper must launch the kernel with the
+        fp32 cache as-is (no per-call downcast, no copy on a matching
+        device)."""
+        num_tokens = 4
+        q = torch.randn(num_tokens, NUM_Q_HEADS * HEAD_SIZE, dtype=torch.bfloat16)
+        k = torch.randn(num_tokens, NUM_KV_HEADS * HEAD_SIZE, dtype=torch.bfloat16)
+        cos_sin_cache = torch.randn(4096, HEAD_SIZE, dtype=torch.float32)
+        positions = torch.zeros(3, num_tokens, dtype=torch.int64)
+
+        with patch.object(
+            rotary_triton, "_triton_ernie45_rope_qk_fused", MagicMock()
+        ) as kernel:
+            rotary_triton.triton_ernie45_rope_fused_inplace(
+                q=q,
+                k=k,
+                cos_sin_cache=cos_sin_cache,
+                positions=positions,
+                mrope_section=[12, 12, 8],
+                head_size=HEAD_SIZE,
+                rotary_dim=HEAD_SIZE,
+                is_neox_style=True,
+            )
+
+        launch = kernel.__getitem__.return_value
+        launched_cache = launch.call_args.args[2]
+        self.assertEqual(
+            launched_cache.dtype,
+            torch.float32,
+            "Ernie4.5 fused rope downcast cos_sin_cache to the query dtype",
+        )
+        self.assertIs(launched_cache, cos_sin_cache)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [Fix] Keep mrope cos/sin cache in fp32 like base RotaryEmbedding

## Motivation

The base `RotaryEmbedding` keeps `cos_sin_cache` in fp32 on CUDA **by explicit design**:

```python
cache = self._compute_cos_sin_cache()
# NOTE(ByronHsu): cache needs to be in FP32 for numerical stability.
if not (_is_cuda or _is_xpu or envs.SGLANG_ROPE_CACHE_FP32.get()):
    cache = cache.to(dtype)
```

(`python/sglang/srt/layers/rotary_embedding/base.py`; see also the `SGLANG_ROPE_CACHE_FP32` knob from #29729 that extends this policy to other platforms, and #31140 which aligned XPU with it.) On the main CUDA path, the sgl-kernel rope op consumes this fp32 cache alongside bf16/fp16 q/k — mixed dtypes are the norm, and the op's docstring documents the cache as float32.

`MRotaryEmbedding` silently violates this policy. It inherits the fp32 cache at init, but its `forward_cuda` / `forward_triton` call `_match_cos_sin_cache_dtype(query)`, which downcasts the cache **in place to the query dtype on the first forward**. The Ernie4.5 fused-rope triton wrapper repeats the same downcast per call. Net effect: text models get the stability-mandated fp32 rope cache, while multimodal models (Qwen-VL, GLM-V, Ernie-VL, and every other bf16/fp16 mrope model) are the only models that don't.

This is not a perf tradeoff — the bandwidth/memory value of a bf16 cache is negligible — it is an accidental inconsistency. In production we observed the bf16 downcast shifting the rotary phase enough to cause visible logit drift on long-context multimodal inputs.

### Numeric impact

Max abs error of the cache's cos/sin values vs a float64 reference, bf16 cache and fp32 cache side by side (`rotary_dim=128`, `base=1e6`, the Qwen2.5-VL text-backbone config):

| position | cos bf16 | cos fp32 | cos bf16/fp32 | sin bf16 | sin fp32 | sin bf16/fp32 |
|---:|---:|---:|---:|---:|---:|---:|
| 1,000 | 1.83e-03 | 3.63e-05 | 50.2x | 1.95e-03 | 1.43e-05 | 136.2x |
| 10,000 | 1.94e-03 | 4.33e-04 | 4.5x | 1.96e-03 | 4.72e-04 | 4.1x |
| 32,768 | 1.95e-03 | 8.55e-04 | 2.3x | 2.05e-03 | 1.12e-03 | 1.8x |
| 131,072 | 1.95e-03 | 2.84e-03 | 0.7x | 6.26e-03 | 4.86e-03 | 1.3x |
| 262,144 | 1.07e-02 | 9.80e-03 | 1.1x | 7.57e-03 | 8.33e-03 | 0.9x |
| 524,288 | 2.10e-02 | 1.93e-02 | 1.1x | 1.34e-02 | 1.48e-02 | 0.9x |
| 1,000,000 | 6.19e-02 | 6.16e-02 | 1.0x | 2.70e-02 | 2.57e-02 | 1.1x |

The bf16 cache pins the phase error at bf16's quantization floor (~2e-3) at **every** position — 50–136× worse than the fp32 cache at short positions and 2–5× worse across the typical context range. (Past ~131k positions the fp32 cache-construction error grows and eventually dominates both columns, so the ratio approaches 1; that is a separate, pre-existing property of computing the cache in fp32 and is unchanged by this PR.) The per-token error looks small, but it is a systematic phase bias applied to every head at every layer, and it accumulates into measurable logit drift over long multimodal contexts.

## Modifications

- `MRotaryEmbedding._match_cos_sin_cache_dtype` now only moves the cache across devices and never casts its dtype, preserving whatever dtype the constructor's policy chose. Exception: on XPU it delegates to the base implementation (which still matches dtype), because the fused `multimodal_rotary_embedding` sycl kernel requires cache/query dtypes to match (#31441).
- `triton_ernie45_rope_fused_inplace` no longer downcasts the cache to `q.dtype` per call (this also removes a per-call full-cache cast).

### Kernel audit — every mrope consumer of `cos_sin_cache`, with fp32 cache + bf16/fp16 q/k

| Consumer | Path | fp32 cache OK? |
|---|---|---|
| `_triton_mrope_forward_fused` | `forward_cuda`/`forward_triton` (2D positions, CUDA/HIP) | ✅ loads q/k with `.to(sin_row.dtype)`, rotates in fp32, implicit downcast on `tl.store` back into the q/k buffers |
| `_triton_ernie45_rope_qk_fused` | Ernie4.5 `forward_cuda` (2D positions) | ✅ same pattern (`.to(cos.dtype)` + store back) |
| `apply_rotary_emb` (native) | `forward_cuda` 1D fallback / `forward_native` | ✅ casts cos/sin to `x.dtype` internally |
| `apply_rope_with_cos_sin_cache_inplace` | Ernie4.5 `forward_cuda` (1D positions) | ✅ docstring documents the cache as float32; same op the base class already feeds fp32 on the main path |
| XPU `multimodal_rotary_embedding` | `forward_xpu` | unchanged — still dtype-matched via the base helper (#31441) |
| NPU `npu_mrope`, CPU AMX op | `forward_npu` / `forward_cpu` | unchanged — these paths never called `_match_cos_sin_cache_dtype`, and the constructor keeps the cache in model dtype on those platforms |

Output dtypes of q/k are unchanged on every path (the triton kernels rotate in place and store back into the original bf16/fp16 buffers; the native path downcasts cos/sin before multiplying).

Behavior is also unchanged on HIP/MUSA by default (the constructor casts the cache to model dtype there, so device-move-only is a no-op) — and when `SGLANG_ROPE_CACHE_FP32` is set on those platforms, mrope now actually honors it instead of silently undoing it on the first forward.

**Why fix the helper rather than the call sites?** All four call sites (`forward_cuda`, `forward_triton`, `forward_xpu`, Ernie `forward_cuda`) share the helper, and the one platform exception (XPU) is expressed once. The base-class `_match_cos_sin_cache_dtype` is left untouched: it serves non-CUDA fallback paths where the cache legitimately is in model dtype.

## Accuracy Tests

New CPU unit test, `test/registered/unit/layers/rotary_embedding/test_mrope.py` (registered in `base-a-test-cpu`), fails before this change and passes after:

- `test_match_cos_sin_cache_dtype_keeps_fp32` — the helper must not downcast the fp32 cache to the bf16 query dtype.
- `test_forward_cuda_passes_fp32_cache_to_fused_kernel` — `forward_cuda` with 2D (multimodal) positions hands the fp32 cache to the fused mrope kernel and q/k dtypes are untouched (kernel launch replaced with a recorder).
- `test_ernie45_fused_wrapper_keeps_fp32_cache` — the Ernie4.5 wrapper launches the kernel with the fp32 cache as-is (no per-call downcast or copy).

```
3 failed (on main) → 3 passed (with this PR)
```

## Speed Tests and Profiling

No measurable impact expected: the triton kernels already upcast q/k to the cache dtype for the rotation, so the arithmetic is identical; the only change is reading fp32 instead of bf16 cos/sin rows (a few KB per step). The Ernie wrapper additionally stops re-casting the full cache on every call.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30665861833](https://github.com/sgl-project/sglang/actions/runs/30665861833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30665861878](https://github.com/sgl-project/sglang/actions/runs/30665861878)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->