### PR TITLE
[PD] Fix false health-503 during decode retraction re-admission

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3799,6 +3799,9 @@ class Scheduler(
 
     def on_idle(self):
         """Idle housekeeping: guard, check, metrics, reset, sleep."""
+        # Flush any health-check signal deferred while the engine was busy.
+        self.maybe_send_health_check_signal()
+
         if not self.is_fully_idle():
             return
 
@@ -3857,6 +3860,14 @@ class Scheduler(
 
         # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode)
         idle &= len(self.waiting_queue) == 0
+
+        if (
+            for_health_check
+            and not self._engine_paused
+            and self.disaggregation_mode == DisaggregationMode.DECODE
+            and self.disagg_decode_prealloc_queue is not None
+        ):
+            idle &= len(self.disagg_decode_prealloc_queue.retracted_queue) == 0
 
         if not for_health_check:
             # Grammar queue and prefill inflight queue may not produce batch


### PR DESCRIPTION
## Motivation

A PD decode engine under KV pressure retracts running requests into `disagg_decode_prealloc_queue.retracted_queue`. `is_fully_idle(for_health_check=True)` did not count that queue, so once `running_batch`/`waiting_queue` drained, the engine looked idle to the health probe. The probe then issued a fake-bootstrap generate request that could not make progress until re-admission finished — timing out into a `/health_generate` 503 — even though the engine was actively self-healing. A router acting on that 503 can eject a healthy decode engine and fail requests with `no available engines`.

Non-PD is unaffected: retracted requests return to `waiting_queue`, which is already counted.

## Modifications

- `is_fully_idle(for_health_check=True)` now counts a non-empty decode `retracted_queue` as active (except while the engine is explicitly paused).
- `on_idle` flushes any health-check signal deferred while the engine was busy, so probes are answered promptly once the engine actually goes idle.

Verified on an internal PD setup: decode retraction under KV pressure no longer flips `/health_generate` to 503 during re-admission.

## Original commits

- `a0d5870ea`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30673255875](https://github.com/sgl-project/sglang/actions/runs/30673255875)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30673255786](https://github.com/sgl-project/sglang/actions/runs/30673255786)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->