### PR TITLE
[Spec] Bound FULL_MASK verify-mask reuse to the batch it was sized for

### DIFF
--- a/python/sglang/srt/layers/attention/verify_mask.py
+++ b/python/sglang/srt/layers/attention/verify_mask.py
@@ -41,19 +41,19 @@ class VerifyMask(msgspec.Struct):
 
     buffer: torch.Tensor
     mode: TreeMaskMode
+    max_context_len: int
     is_read: bool = True
 
     def fits(self, bs: int, num_draft_tokens: int) -> bool:
         """Whether this batch's writes stay inside the buffer.
 
-        Only the compact layout is checked. FULL_MASK keeps its pre-existing
-        unconditional reuse -- its bound needs a max_context_len that composite
-        backends do not carry -- so a batch past max_bs can still overflow it
-        when draft * sum(seq_len) exceeds the buffer, as it could before.
+        Sized with the formula the allocation used. Every sequence is capped by
+        ``max_context_len``, so that is an upper bound on the kernel's writes --
+        it holds while bs stays within the max_bs the buffer was sized for.
         """
-        if self.mode != TreeMaskMode.QLEN_ONLY:
-            return True
-        return self.buffer.numel() >= bs * num_draft_tokens * num_draft_tokens
+        return self.buffer.numel() >= tree_mask_numel(
+            self.mode, bs, num_draft_tokens, self.max_context_len
+        )
 
 
 def maybe_create_verify_mask(
@@ -78,5 +78,6 @@ def maybe_create_verify_mask(
             device=device,
         ),
         mode=mode,
+        max_context_len=max_context_len,
         is_read=is_read,
     )

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -74,12 +74,22 @@ class TestVerifyMaskCapacity(CustomTestCase):
         mask = _create(is_read=False)
         self.assertFalse(mask.fits(_MAX_BS + 1, _DRAFT))
 
-    def test_full_mask_always_fits(self):
-        """FULL_MASK is exempt from the check -- see fits()."""
+    def test_full_mask_does_not_fit_beyond_max_bs(self):
+        """The context dimension is sized for max_bs sequences, so a bigger batch
+        overflows it: with the hybrid-attn CI shape (--cuda-graph-max-bs-decode 8,
+        draft 4, ctx 4096) a 48-request verify writes 4 * (48 * 4096) + 4**2 * 48
+        cells into a 8 * 4 * (4096 + 4) buffer."""
         mask = VerifyMask(
-            buffer=torch.zeros(8, dtype=torch.bool), mode=TreeMaskMode.FULL_MASK
+            buffer=torch.zeros(
+                tree_mask_numel(TreeMaskMode.FULL_MASK, 8, 4, 4096), dtype=torch.bool
+            ),
+            mode=TreeMaskMode.FULL_MASK,
+            max_context_len=4096,
         )
-        self.assertTrue(mask.fits(_MAX_BS * 1000, _DRAFT))
+
+        self.assertTrue(mask.fits(8, 4))
+        self.assertFalse(mask.fits(48, 4))
+        self.assertLess(mask.buffer.numel(), 4 * (48 * 4096) + 4 * 4 * 48)
 
 
 class TestVerifyMaskGate(CustomTestCase):
@@ -107,6 +117,7 @@ def _mask(numel, **kwargs):
     return VerifyMask(
         buffer=torch.zeros(numel, dtype=torch.bool),
         mode=TreeMaskMode.QLEN_ONLY,
+        max_context_len=_MAX_CONTEXT_LEN,
         **kwargs,
     )
 
@@ -119,6 +130,7 @@ def _make_hybrid_backend(speculative_attention_mode, prefill_mask, decode_mask):
         server_args=SimpleNamespace(
             speculative_attention_mode=speculative_attention_mode
         ),
+        model_config=SimpleNamespace(context_len=_MAX_CONTEXT_LEN),
     )
     return HybridAttnBackend(
         model_runner,
@@ -145,8 +157,8 @@ class TestHybridAttnBackendHandsOutSelectedChildMask(CustomTestCase):
         self.assertIs(backend.verify_mask, prefill_mask)
 
     def test_capacity_check_needs_nothing_from_the_backend(self):
-        """A composite backend carries no max_context_len of its own: fits()
-        reaching back through the backend would raise AttributeError here."""
+        """fits() reads the max_context_len recorded on the mask -- the one that
+        sized the buffer -- so it never reaches back through the backend."""
         backend = _make_hybrid_backend("prefill", _mask(64, is_read=False), None)
 
         self.assertTrue(backend.verify_mask.fits(_MAX_BS, _DRAFT))


### PR DESCRIPTION
## Problem

`test_hybrid_attn_backend.py::TestHybridAttnBackendSpeculativeDecodingPrefillBackend::test_gsm8k` kills the scheduler (`exit code -6`; the CUDA coredump shows `CUDBG_EXCEPTION_WARP_ASSERT` in `at::native::index_elementwise_kernel<... OpaqueType<1> ...>`). Deterministic — both attempts of scheduled run [30628006576](https://github.com/sgl-project/sglang/actions/runs/30628006576) failed identically.

## Cause

#32920 gave `HybridAttnBackend` a `verify_mask` property, so the composite now reuses the selected child's preallocated buffer instead of allocating one per batch. But `VerifyMask.fits()` exempts `FULL_MASK` from its capacity check, and this config allocates the buffer for `--cuda-graph-max-bs-decode 8` while `max_running_requests` admits 48. `build_tree_kernel_efficient` writes `seq_lens_sum * draft + draft**2 * bs` cells, so a 48-request verify runs past the 8-request buffer and corrupts whatever follows it.

## Fix

Record `max_context_len` on the mask and bound both layouts with the same `tree_mask_numel` the allocation used — every sequence is capped by `max_context_len`, so that is a safe upper bound and the check reduces to "bs within the max_bs this buffer was sized for". Oversized batches fall back to allocating, as they did before #32920.

## Validation

1×H100, driving the real `build_tree_kernel_efficient` at the CI shape (max_bs 8, draft 4, ctx 4096; verify bs 48, seq_len 700 → 135,168 cells needed vs a 131,200-cell buffer) with a guard region after the buffer:

| | `fits(48, 4)` | mask numel | guard cells clobbered past end |
|---|---|---|---|
| control — fresh allocation | – | 135,168 | 0 |
| before | `True` → reuse | 131,200 | **17** |
| after | `False` → fresh alloc | 135,168 | 0 |

The control rules out the inputs themselves being at fault. Registered CPU test `test_verify_mask.py`: 12/12 pass.

## Note

Includes the one-line `model_config` fixture line from #33087 so this branch is green on current `main` (`HybridAttnBackend` reads `model_config.context_len` since #32690). Happy to drop it on rebase if #33087 lands first.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30667314834](https://github.com/sgl-project/sglang/actions/runs/30667314834)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30667314527](https://github.com/sgl-project/sglang/actions/runs/30667314527)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->