### PR TITLE
Warn on risky serving-time Triton work

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -981,6 +981,12 @@ class Envs:
     SGLANG_PYSPY_DUMP_BEFORE_CRASH = EnvBool(True)
     SGLANG_CUDA_COREDUMP_BEFORE_CRASH = EnvBool(True)
     SGLANG_CUDA_COREDUMP_BEFORE_CRASH_WAIT_SECS = EnvFloat(60.0)
+    # Raise if Triton loads a kernel after the engine starts serving. This
+    # verifies that startup warmup covers every kernel specialization used at
+    # serving time.
+    SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY = EnvBool(False)
+    SGLANG_TRITON_SLOW_COMPILE_THRESHOLD_SECS = EnvFloat(1.0)
+    SGLANG_TRITON_LOAD_WARNING_THRESHOLD_GB = EnvFloat(1.0)
 
     # Encoder gRPC
     SGLANG_ENCODER_GRPC_TIMEOUT_SECS = EnvInt(60)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -296,6 +296,7 @@ from sglang.srt.utils import (
     set_gpu_proc_affinity,
     set_random_seed,
     suppress_other_loggers,
+    triton_load_watch,
 )
 from sglang.srt.utils.common import is_npu
 from sglang.srt.utils.hf_transformers_utils import (
@@ -1634,6 +1635,11 @@ class Scheduler(
         Sets up the schedule stream and dispatches to the appropriate event loop.
         The event loop blocks until shutdown.
         """
+        # Engine init (graph capture, warmups) is done; from here on any
+        # Triton kernel device-load is a lazy first-use at serving time.
+        triton_load_watch.install()
+        triton_load_watch.mark_serving_started()
+
         if use_mlx():
             # MLX overlap uses mx.async_eval for CPU/GPU overlap,
             # not PyTorch MPS streams.

--- a/python/sglang/srt/utils/triton_load_watch.py
+++ b/python/sglang/srt/utils/triton_load_watch.py
@@ -1,0 +1,113 @@
+"""Detect Triton kernel device-loads after the engine starts serving.
+
+Triton loads each kernel specialization's cubin onto the GPU at its first
+launch (``CompiledKernel._init_handles`` -> ``cuModuleLoadData``). That load
+needs free device memory *outside* the torch caching allocator. Engines size
+their pools to leave little post-init headroom, and the allocator's high-water
+mark consumes the rest during early serving — so a specialization first used
+mid-serving (e.g. a new adaptive speculative draft length, or a rare batch-size
+bucket) can die in ``cuModuleLoadData`` with CUDA OOM, minutes or hours in.
+
+Once ``mark_serving_started()`` has been called, this module warns when an
+uncached Triton compilation takes at least one second or a device-load starts
+with less than 1 GiB of free device memory. Set
+``SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY=1`` to raise on every late load
+instead — for CI recipes that assert full startup warmup coverage. The hooks
+only run for compilation and first-use loads, so steady-state cost is zero.
+
+Note: request-driven warmup (``--warmups``, the server warmup request) runs
+*after* ``mark_serving_started()`` and is subject to the same diagnostics;
+crash mode is only meant for deployments whose kernels are fully pre-loaded at
+engine init.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.utils.common import get_available_gpu_memory
+
+logger = logging.getLogger(__name__)
+
+_serving_started = False
+_prev_compile_listener = None
+_installed = False
+
+
+def install() -> None:
+    """Install the diagnostics (idempotent; chains pre-existing hooks)."""
+    global _installed, _prev_compile_listener
+    if _installed:
+        return
+    try:
+        import triton.knobs as knobs
+    except ImportError:
+        return
+    _prev_compile_listener = knobs.compilation.listener
+    knobs.runtime.kernel_load_start_hook.add(_on_kernel_load)
+    knobs.compilation.listener = _on_compilation
+    _installed = True
+
+
+def mark_serving_started() -> None:
+    """Arm diagnostics for subsequent Triton compilations and device-loads."""
+    global _serving_started
+    _serving_started = True
+
+
+def _on_compilation(*, src, metadata, metadata_group, times, cache_hit) -> None:
+    if _prev_compile_listener is not None:
+        _prev_compile_listener(
+            src=src,
+            metadata=metadata,
+            metadata_group=metadata_group,
+            times=times,
+            cache_hit=cache_hit,
+        )
+    if not _serving_started or cache_hit:
+        return
+
+    compile_time_secs = times.total / 1e6
+    if compile_time_secs < envs.SGLANG_TRITON_SLOW_COMPILE_THRESHOLD_SECS.get():
+        return
+
+    logger.warning(
+        "Triton kernel '%s' took %.2f s to compile after serving started. "
+        "Serving-time compilation can stall the engine; pre-compile it during "
+        "engine init.",
+        src.name,
+        compile_time_secs,
+    )
+
+
+def _on_kernel_load(module, function, name, metadata_group, hash) -> None:
+    if not _serving_started:
+        return
+
+    free_gb = None
+    if torch.cuda.is_available():
+        try:
+            free_gb = get_available_gpu_memory(
+                "cuda", torch.cuda.current_device(), empty_cache=False
+            )
+        except RuntimeError:
+            logger.debug("Unable to query free device memory", exc_info=True)
+
+    should_crash = envs.SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY.get()
+    if not should_crash and (
+        free_gb is None or free_gb >= envs.SGLANG_TRITON_LOAD_WARNING_THRESHOLD_GB.get()
+    ):
+        return
+
+    free_memory = f"{free_gb:.2f} GiB" if free_gb is not None else "unknown"
+    msg = (
+        f"Triton kernel '{name}' device-loaded after serving started "
+        f"(free device mem: {free_memory}). Pre-load it during engine init "
+        f"to avoid CUDA OOM."
+    )
+    if should_crash:
+        raise RuntimeError(msg)
+    logger.warning(msg)

--- a/test/registered/unit/utils/test_triton_load_watch.py
+++ b/test/registered/unit/utils/test_triton_load_watch.py
@@ -1,0 +1,62 @@
+"""Unit tests for triton_load_watch — no server, no model loading."""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+import unittest
+from unittest.mock import patch
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import triton_load_watch
+from sglang.test.test_utils import CustomTestCase
+
+
+@triton.jit
+def _probe_kernel(x_ptr, C: tl.constexpr):
+    # Each constexpr C is a distinct specialization -> a fresh device load.
+    tl.store(x_ptr + tl.program_id(0), C)
+
+
+class TestTritonLoadWatch(CustomTestCase):
+    def tearDown(self):
+        # The watch is process-global; disarm so later tests in the same
+        # pytest process don't warn on their own first-use kernel loads.
+        triton_load_watch._serving_started = False
+
+    def test_load_after_ready_warns_and_crashes(self):
+        triton_load_watch.install()
+        x = torch.zeros(4, device="cuda", dtype=torch.int32)
+
+        # Loads during init (before serving starts) are silent.
+        with self.assertNoLogs(triton_load_watch.logger, level="WARNING"):
+            _probe_kernel[(1,)](x, C=1)
+
+        triton_load_watch.mark_serving_started()
+
+        # First use of a new specialization after ready warns with the name.
+        with (
+            patch.object(
+                torch.cuda, "mem_get_info", return_value=(128 << 20, 80 << 30)
+            ),
+            self.assertLogs(triton_load_watch.logger, level="WARNING") as logs,
+        ):
+            _probe_kernel[(1,)](x, C=2)
+        self.assertTrue(any("free device mem" in line for line in logs.output))
+
+        # Already-loaded specializations stay silent.
+        with self.assertNoLogs(triton_load_watch.logger, level="WARNING"):
+            _probe_kernel[(1,)](x, C=2)
+
+        # Crash mode turns the next late load into a hard error.
+        with envs.SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY.override(True):
+            with self.assertRaises(RuntimeError):
+                _probe_kernel[(1,)](x, C=3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Triton can compile or device-load a kernel specialization after serving starts. Slow compilation stalls the engine, while a device load with little free memory can fail with CUDA OOM. The watcher should report only those risky events while retaining an opt-in crash mode for strict warmup coverage.

## Modifications

- Warn for uncached compilations slower than the configurable threshold.
- Warn for late device loads only when free device memory is below the configurable threshold.
- Keep `SGLANG_CRASH_ON_TRITON_LOAD_AFTER_READY` exhaustive for strict warmup coverage.
- Reuse the existing GPU memory helper without emptying the cache.

## Accuracy Tests

Not applicable; this changes diagnostics only and does not affect model outputs.

## Speed Tests and Profiling

Not run. The hooks execute only for compilation and first-use device loads, so steady-state serving is unchanged.

## Testing

- `uv run pre-commit run --from-ref origin/main --to-ref HEAD` — passed.
- `uv run python -m py_compile python/sglang/srt/environ.py python/sglang/srt/managers/scheduler.py python/sglang/srt/utils/triton_load_watch.py test/registered/unit/utils/test_triton_load_watch.py` — passed.
- GPU unit test not run locally because this host has no CUDA GPU; CI is requested below.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30947497946](https://github.com/sgl-project/sglang/actions/runs/30947497946)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30947498469](https://github.com/sgl-project/sglang/actions/runs/30947498469)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->