### PR TITLE
[Diffusion] Add Lumina-Image-2.0 (NextDiT) support

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/lumina2.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/lumina2.py
@@ -16,10 +16,6 @@ from sglang.multimodal_gen.configs.models.fsdp import is_lumina2_layer
 
 @dataclass
 class Lumina2ArchConfig(DiTArchConfig):
-    # NOTE: these names must match the checkpoint's transformer/config.json keys.
-    # ArchConfig.__setattr__ routes any key it does not declare into
-    # `extra_attrs`, where nothing reads it, so a mismatched name means
-    # update_model_arch silently drops the checkpoint's value. Do not shorten.
     patch_size: int = 2
     in_channels: int = 16
     out_channels: int | None = None  # checkpoint stores null -> defaults to in_channels
@@ -39,7 +35,6 @@ class Lumina2ArchConfig(DiTArchConfig):
     sample_size: int = 128
     scaling_factor: float = 1.0  # present in config.json; unused by the model
 
-    # --- not checkpoint fields; fixed by the architecture ---
     qk_norm: bool = True
     # Absent from transformer/config.json; diffusers hardcodes theta=10000 at the
     # Lumina2RotaryPosEmbed construction site.
@@ -48,11 +43,6 @@ class Lumina2ArchConfig(DiTArchConfig):
     t_scale: float = 1000.0
 
     _fsdp_shard_conditions: list = field(default_factory=lambda: [is_lumina2_layer])
-
-    # NOTE: no stacked_params_mapping. That mechanism names the *checkpoint*
-    # shards feeding a fused runtime param, and param_names_mapping below
-    # already fuses (linear_1, linear_3) with explicit shard indices. An entry
-    # naming w1/w3 would match nothing: no Lumina key is ever named that.
 
     # diffusers Lumina2Transformer2DModel checkpoint keys -> runtime module
     # names. ffn_norm1 / ffn_norm2 / x_embedder / caption_embedder need no rule.
@@ -104,8 +94,6 @@ class Lumina2ArchConfig(DiTArchConfig):
 
     def __post_init__(self):
         super().__post_init__()
-        # NOTE: re-run by update_model_arch, so this must stay idempotent and
-        # must never overwrite a value the checkpoint supplied.
         self.out_channels = self.out_channels or self.in_channels
         self.num_channels_latents = self.in_channels
 

--- a/python/sglang/multimodal_gen/configs/models/dits/lumina2.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/lumina2.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Architecture and model configuration for Lumina-Image-2.0 DiT (NextDiT).
+#
+# Defaults correspond to Alpha-VLLM/Lumina-Image-2.0 (2B), read off the published
+# transformer/config.json and safetensors headers.
+#
+# Reference: https://arxiv.org/abs/2503.21758
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+from sglang.multimodal_gen.configs.models.dits.base import DiTArchConfig, DiTConfig
+from sglang.multimodal_gen.configs.models.fsdp import is_lumina2_layer
+
+
+@dataclass
+class Lumina2ArchConfig(DiTArchConfig):
+    # NOTE: these names must match the checkpoint's transformer/config.json keys.
+    # ArchConfig.__setattr__ routes any key it does not declare into
+    # `extra_attrs`, where nothing reads it, so a mismatched name means
+    # update_model_arch silently drops the checkpoint's value. Do not shorten.
+    patch_size: int = 2
+    in_channels: int = 16
+    out_channels: int | None = None  # checkpoint stores null -> defaults to in_channels
+    hidden_size: int = 2304
+    num_layers: int = 26
+    num_refiner_layers: int = 2
+    num_attention_heads: int = 24
+    num_kv_heads: int = 8  # GQA
+    norm_eps: float = 1e-5
+    cap_feat_dim: int = 2304  # Gemma-2-2B hidden size
+    # SwiGLU inner width = round_up(4 * hidden_size * (ffn_dim_multiplier or 1),
+    # multiple_of); a null multiplier gives 9216 = linear_1.weight.shape[0].
+    multiple_of: int = 256
+    ffn_dim_multiplier: float | None = None
+    axes_dim_rope: Tuple[int, int, int] = (32, 32, 32)
+    axes_lens: Tuple[int, int, int] = (300, 512, 512)
+    sample_size: int = 128
+    scaling_factor: float = 1.0  # present in config.json; unused by the model
+
+    # --- not checkpoint fields; fixed by the architecture ---
+    qk_norm: bool = True
+    # Absent from transformer/config.json; diffusers hardcodes theta=10000 at the
+    # Lumina2RotaryPosEmbed construction site.
+    rope_theta: float = 10000.0
+    # FlowMatchEuler num_train_timesteps; the DiT rescales timesteps by it.
+    t_scale: float = 1000.0
+
+    _fsdp_shard_conditions: list = field(default_factory=lambda: [is_lumina2_layer])
+
+    # NOTE: no stacked_params_mapping. That mechanism names the *checkpoint*
+    # shards feeding a fused runtime param, and param_names_mapping below
+    # already fuses (linear_1, linear_3) with explicit shard indices. An entry
+    # naming w1/w3 would match nothing: no Lumina key is ever named that.
+
+    # diffusers Lumina2Transformer2DModel checkpoint keys -> runtime module
+    # names. ffn_norm1 / ffn_norm2 / x_embedder / caption_embedder need no rule.
+    param_names_mapping: dict = field(
+        default_factory=lambda: {
+            r"(.*)\.attn\.to_q\.weight$": (r"\1.attention.to_qkv.weight", 0, 3),
+            r"(.*)\.attn\.to_k\.weight$": (r"\1.attention.to_qkv.weight", 1, 3),
+            r"(.*)\.attn\.to_v\.weight$": (r"\1.attention.to_qkv.weight", 2, 3),
+            # NOTE: these resolve, but the fused merge stacks shards into
+            # (N, out, r) and GQA makes them unequal, so an attention LoRA
+            # raises at load. Kept anyway: dropping them targets to_q/to_k/to_v,
+            # which the fused model lacks, and the adapter silently no-ops.
+            r"(.*)\.attn\.to_q\.(lora_A|lora_B)$": (r"\1.attention.to_qkv.\2", 0, 3),
+            r"(.*)\.attn\.to_k\.(lora_A|lora_B)$": (r"\1.attention.to_qkv.\2", 1, 3),
+            r"(.*)\.attn\.to_v\.(lora_A|lora_B)$": (r"\1.attention.to_qkv.\2", 2, 3),
+            r"(.*)\.attn\.(norm_q|norm_k|to_out)\.": r"\1.attention.\2.",
+            r"(.*)\.feed_forward\.linear_1\.weight$": (
+                r"\1.feed_forward.w13.weight",
+                0,
+                2,
+            ),
+            r"(.*)\.feed_forward\.linear_3\.weight$": (
+                r"\1.feed_forward.w13.weight",
+                1,
+                2,
+            ),
+            r"(.*)\.feed_forward\.linear_1\.(lora_A|lora_B)$": (
+                r"\1.feed_forward.w13.\2",
+                0,
+                2,
+            ),
+            r"(.*)\.feed_forward\.linear_3\.(lora_A|lora_B)$": (
+                r"\1.feed_forward.w13.\2",
+                1,
+                2,
+            ),
+            r"(.*)\.feed_forward\.linear_2\.": r"\1.feed_forward.w2.",
+            r"(.*)\.norm1\.linear\.": r"\1.adaLN_modulation.1.",
+            # norm1.weight (bare) is the context_refiner's unmodulated variant.
+            r"(.*)\.norm1\.norm\.": r"\1.attention_norm1.",
+            r"(.*)\.norm1\.weight$": r"\1.attention_norm1.weight",
+            r"(.*)\.norm2\.weight$": r"\1.attention_norm2.weight",
+            r"^time_caption_embed\.timestep_embedder\.linear_1\.": r"time_caption_embed.timestep_embedder.mlp.0.",
+            r"^time_caption_embed\.timestep_embedder\.linear_2\.": r"time_caption_embed.timestep_embedder.mlp.2.",
+            r"^norm_out\.linear_1\.": r"norm_out.adaLN_modulation.1.",
+            r"^norm_out\.linear_2\.": r"norm_out.linear.",
+        }
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        # NOTE: re-run by update_model_arch, so this must stay idempotent and
+        # must never overwrite a value the checkpoint supplied.
+        self.out_channels = self.out_channels or self.in_channels
+        self.num_channels_latents = self.in_channels
+
+        head_dim = self.hidden_size // self.num_attention_heads
+        if head_dim != sum(self.axes_dim_rope):
+            raise ValueError(
+                f"axes_dim_rope {self.axes_dim_rope} must sum to the attention head "
+                f"dim {head_dim} (hidden_size {self.hidden_size} / "
+                f"num_attention_heads {self.num_attention_heads})"
+            )
+
+
+@dataclass
+class Lumina2Config(DiTConfig):
+    arch_config: Lumina2ArchConfig = field(default_factory=Lumina2ArchConfig)
+    prefix: str = "Lumina2"

--- a/python/sglang/multimodal_gen/configs/models/fsdp.py
+++ b/python/sglang/multimodal_gen/configs/models/fsdp.py
@@ -48,6 +48,10 @@ def is_blocks_or_transformer_blocks(name: str, module: object) -> bool:
     return is_module_list_entry_in(name, ("blocks", "transformer_blocks"))
 
 
+def is_lumina2_layer(name: str, module: object) -> bool:
+    return is_module_list_entry_in(name, ("layers", "noise_refiner", "context_refiner"))
+
+
 def is_zimage_layer(name: str, module: object) -> bool:
     last_part = name.split(".")[-1]
     # Preserve Z-Image's finer historical FSDP granularity for perf.

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -249,11 +249,23 @@ class PipelineConfig:
     preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
         default_factory=lambda: (None,)
     )
+    # None falls back to the positive-branch preprocessors, which is what every
+    # model expected before this field existed.
+    negative_preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] | None = (
+        None
+    )
 
     # get prompt_embeds from encoder output
     postprocess_text_funcs: tuple[Callable[[BaseEncoderOutput], torch.tensor], ...] = (
         field(default_factory=lambda: (postprocess_text,))
     )
+
+    def get_preprocess_text_funcs(
+        self, *, is_negative: bool
+    ) -> tuple[Callable[[str], str] | None, ...]:
+        if is_negative and self.negative_preprocess_text_funcs is not None:
+            return self.negative_preprocess_text_funcs
+        return self.preprocess_text_funcs
 
     # STA (Sliding Tile Attention) parameters
     mask_strategy_file_path: str | None = None
@@ -1099,6 +1111,13 @@ class PipelineConfig:
         if len(self.text_encoder_configs) != len(self.preprocess_text_funcs):
             raise ValueError(
                 f"Length of text encoder configs ({len(self.text_encoder_configs)}) must be equal to length of text preprocessing functions ({len(self.preprocess_text_funcs)})"
+            )
+
+        if self.negative_preprocess_text_funcs is not None and len(
+            self.text_encoder_configs
+        ) != len(self.negative_preprocess_text_funcs):
+            raise ValueError(
+                f"Length of text encoder configs ({len(self.text_encoder_configs)}) must be equal to length of negative text preprocessing functions ({len(self.negative_preprocess_text_funcs)})"
             )
 
         if len(self.preprocess_text_funcs) != len(self.postprocess_text_funcs):

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/lumina2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/lumina2.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pipeline configuration for Lumina-Image-2.0 text-to-image generation.
+#
+# Lumina-2 produces 4D spatial latents (B, 16, H/8, W/8), so this inherits
+# SpatialImagePipelineConfig rather than a packed-token config. Conditioning
+# comes from Gemma-2 hidden_states[-2], not last_hidden_state.
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import torch
+
+from sglang.multimodal_gen.configs.models import DiTConfig, VAEConfig
+from sglang.multimodal_gen.configs.models.dits.lumina2 import Lumina2Config
+from sglang.multimodal_gen.configs.models.encoders import BaseEncoderOutput
+from sglang.multimodal_gen.configs.models.encoders.base import EncoderConfig
+from sglang.multimodal_gen.configs.models.encoders.gemma2 import (
+    Gemma2ArchConfig,
+    Gemma2Config,
+)
+from sglang.multimodal_gen.configs.models.vaes.flux import FluxVAEConfig
+from sglang.multimodal_gen.configs.pipeline_configs.base import (
+    ModelTaskType,
+    SpatialImagePipelineConfig,
+)
+from sglang.multimodal_gen.runtime.utils.condition_expansion import (
+    PromptToSampleBatchExpander,
+)
+
+# Prepended to the user prompt before Gemma-2 encoding, matching the
+# diffusers Lumina2Pipeline.
+LUMINA2_SYSTEM_PROMPT = (
+    "You are an assistant designed to generate superior images with the superior "
+    "degree of image-text alignment based on textual prompts or user prompts."
+)
+# NOTE: "<Prompt Start>" is part of the trained template -- diffusers
+# pipeline_lumina2.py:288, unchanged since v0.33.0. Dropping the marker
+# conditions the model on a template it never saw, with no error.
+LUMINA2_PROMPT_SEPARATOR = " <Prompt Start> "
+
+# Gemma-2 caption length Lumina-2 was trained with.
+LUMINA2_MAX_TEXT_LEN = 256
+
+
+@dataclass
+class Lumina2GemmaArchConfig(Gemma2ArchConfig):
+    text_len: int = LUMINA2_MAX_TEXT_LEN
+
+
+@dataclass
+class Lumina2GemmaConfig(Gemma2Config):
+    arch_config: Gemma2ArchConfig = field(default_factory=Lumina2GemmaArchConfig)
+
+
+def lumina2_preprocess_text(prompt: str) -> str:
+    """Prepend Lumina-2's system prompt to the positive caption.
+
+    Diffusers applies this template to the conditional branch only; Lumina's
+    ``negative_preprocess_text_funcs`` keeps negative prompts raw.
+    """
+    return LUMINA2_SYSTEM_PROMPT + LUMINA2_PROMPT_SEPARATOR + prompt
+
+
+def lumina2_postprocess_text(outputs: BaseEncoderOutput, _text_inputs) -> torch.Tensor:
+    # Second-to-last hidden state, padding intact: the DiT slices each caption to
+    # its true length via the attention mask, and unpadding here breaks that
+    # alignment. TextEncodingStage always requests output_hidden_states, so the
+    # stack is present regardless of the encoder arch config.
+    return outputs.hidden_states[-2]
+
+
+@dataclass
+class Lumina2PipelineConfig(SpatialImagePipelineConfig):
+    task_type: ModelTaskType = ModelTaskType.T2I
+
+    # Disables *embedded* guidance (a timestep-conditioned guidance token).
+    # Standard two-branch CFG via guidance_scale is still active.
+    should_use_guidance: bool = False
+    enable_autocast: bool = False
+    vae_tiling: bool = False
+    # NOTE: must be pinned alongside vae_tiling. check_pipeline_config() rejects
+    # vae_sp without vae_tiling, and the base defaults both to True, so leaving
+    # this inherited makes every `sglang generate` / `sglang serve` fail
+    # validation before a single weight loads.
+    vae_sp: bool = False
+    vae_precision: str = "bf16"
+
+    dit_config: DiTConfig = field(default_factory=Lumina2Config)
+    # Lumina-2 ships the FLUX.1-dev VAE verbatim (vae/config.json records
+    # _name_or_path: black-forest-labs/FLUX.1-dev). Its scaling/shift factors
+    # arrive from that config.json via vae_loader, so nothing to restate here.
+    vae_config: VAEConfig = field(default_factory=FluxVAEConfig)
+
+    text_encoder_configs: tuple[EncoderConfig, ...] = field(
+        default_factory=lambda: (Lumina2GemmaConfig(),)
+    )
+    text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("bf16",))
+
+    preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (lumina2_preprocess_text,)
+    )
+    negative_preprocess_text_funcs: tuple[Callable[[str], str] | None, ...] = field(
+        default_factory=lambda: (None,)
+    )
+    postprocess_text_funcs: tuple[Callable, ...] = field(
+        default_factory=lambda: (lumina2_postprocess_text,)
+    )
+
+    def tokenize_prompt(self, prompts: list[str], tokenizer, tok_kwargs) -> dict:
+        # A per-request max_sequence_length is honored but capped: caption
+        # positions index the DiT's axis-0 RoPE table, and the DiT parks every
+        # image token at axis-0 position cap_len -- hence one below the row count.
+        requested = tok_kwargs.pop("max_length", None) or LUMINA2_MAX_TEXT_LEN
+        max_rope_caption_len = self.dit_config.arch_config.axes_lens[0] - 1
+        effective_max_length = min(requested, max_rope_caption_len)
+        # Caption extents come from encoder_attention_mask.sum(), which only
+        # locates the real tokens under right padding. Lumina-2 inherits the
+        # "right" default, but a fine-tune repackaged from a generation setup
+        # can ship "left" and would mis-position every caption token without
+        # raising. diffusers pins it the same way (pipeline_lumina2.py:189).
+        tokenizer.padding_side = "right"
+        return tokenizer(
+            prompts,
+            padding="max_length",
+            max_length=effective_max_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+    def prepare_latent_shape(self, batch, batch_size, num_frames):
+        compression = self.vae_config.arch_config.spatial_compression_ratio
+        height = batch.height // compression
+        width = batch.width // compression
+        num_channels = self.dit_config.arch_config.num_channels_latents
+        return (batch_size, num_channels, height, width)
+
+    def expand_conditioning_to_sample_batch(self, batch):
+        # NOTE: this override is load-bearing. Req.batch_size scales latents by
+        # num_outputs_per_prompt but leaves conditioning at one row per prompt,
+        # and the DiT sizes its loops from encoder_attention_mask. The surplus
+        # samples would come back zeroed, in a prediction with fewer rows than
+        # the latents, which scheduler.step broadcasts rather than rejects.
+        expander = PromptToSampleBatchExpander.from_batch(batch)
+        if expander is None:
+            return batch
+
+        for field_name in (
+            "prompt_embeds",
+            "negative_prompt_embeds",
+            "prompt_attention_mask",
+            "negative_attention_mask",
+        ):
+            expander.expand_field(batch, field_name)
+        return batch
+
+    def get_pos_prompt_embeds(self, batch):
+        return batch.prompt_embeds[0]
+
+    def get_neg_prompt_embeds(self, batch):
+        return batch.negative_prompt_embeds[0]
+
+    def prepare_pos_cond_kwargs(self, batch, device, rotary_emb, dtype):
+        return {"encoder_attention_mask": _first_mask(batch.prompt_attention_mask)}
+
+    def prepare_neg_cond_kwargs(self, batch, device, rotary_emb, dtype):
+        return {"encoder_attention_mask": _first_mask(batch.negative_attention_mask)}
+
+    def postprocess_cfg_noise(
+        self,
+        batch,
+        noise_pred: torch.Tensor,
+        noise_pred_cond: torch.Tensor,
+    ) -> torch.Tensor:
+        """Lumina-2 renorm-CFG.
+
+        NOTE: deliberately not routed through the `cfg_normalization` sampling
+        param. That flag drives CFGPolicy._apply_cfg_normalization, a *global*
+        max-norm clip (one scalar norm over the whole tensor, applied only when
+        the guided norm exceeds the conditional one). Lumina rescales
+        unconditionally and per position along dim=-1. Enabling both applies two
+        different rescales; see configs/sample/lumina2.py.
+
+        No CFG guard is needed: CFGPolicy only reaches this hook after combining
+        two branches.
+        """
+        cond_norm = torch.norm(noise_pred_cond, dim=-1, keepdim=True)
+        noise_norm = torch.norm(noise_pred, dim=-1, keepdim=True).clamp_min(1e-12)
+        return noise_pred * (cond_norm / noise_norm)
+
+    def shard_latents_for_sp(self, batch, latents):
+        # NOTE: opts out of SpatialImagePipelineConfig's H'-dimension sharding.
+        # The Lumina-2 DiT has no sequence-parallel handling: _patchify_and_rope
+        # numbers image rows from whatever tensor it is given, so a rank holding
+        # rows H'/2..H' gets the wrong absolute RoPE positions, and every rank
+        # prepends its own full copy of the caption. Neither raises -- the image
+        # is just wrong. Real SP support needs both fixed first.
+        return latents, False
+
+    def gather_latents_for_sp(self, latents, batch=None):
+        return latents
+
+    def prepare_sigmas(self, sigmas, num_inference_steps):
+        return self._prepare_sigmas(sigmas, num_inference_steps)
+
+    def post_denoising_loop(self, latents, batch):
+        # Latents are already (B, C, H', W'); nothing to unpack.
+        return latents
+
+
+def _first_mask(mask):
+    # The batch stores per-encoder masks as a list; the DiT wants one tensor.
+    if isinstance(mask, (list, tuple)):
+        return mask[0] if mask else None
+    return mask

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/lumina2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/lumina2.py
@@ -34,9 +34,7 @@ LUMINA2_SYSTEM_PROMPT = (
     "You are an assistant designed to generate superior images with the superior "
     "degree of image-text alignment based on textual prompts or user prompts."
 )
-# NOTE: "<Prompt Start>" is part of the trained template -- diffusers
-# pipeline_lumina2.py:288, unchanged since v0.33.0. Dropping the marker
-# conditions the model on a template it never saw, with no error.
+# "<Prompt Start>" is part of Lumina's trained prompt template.
 LUMINA2_PROMPT_SEPARATOR = " <Prompt Start> "
 
 # Gemma-2 caption length Lumina-2 was trained with.
@@ -79,10 +77,7 @@ class Lumina2PipelineConfig(SpatialImagePipelineConfig):
     should_use_guidance: bool = False
     enable_autocast: bool = False
     vae_tiling: bool = False
-    # NOTE: must be pinned alongside vae_tiling. check_pipeline_config() rejects
-    # vae_sp without vae_tiling, and the base defaults both to True, so leaving
-    # this inherited makes every `sglang generate` / `sglang serve` fail
-    # validation before a single weight loads.
+    # VAE sequence parallelism requires tiling, which Lumina disables.
     vae_sp: bool = False
     vae_precision: str = "bf16"
 
@@ -114,11 +109,8 @@ class Lumina2PipelineConfig(SpatialImagePipelineConfig):
         requested = tok_kwargs.pop("max_length", None) or LUMINA2_MAX_TEXT_LEN
         max_rope_caption_len = self.dit_config.arch_config.axes_lens[0] - 1
         effective_max_length = min(requested, max_rope_caption_len)
-        # Caption extents come from encoder_attention_mask.sum(), which only
-        # locates the real tokens under right padding. Lumina-2 inherits the
-        # "right" default, but a fine-tune repackaged from a generation setup
-        # can ship "left" and would mis-position every caption token without
-        # raising. diffusers pins it the same way (pipeline_lumina2.py:189).
+        # Caption extents come from encoder_attention_mask.sum(), so real tokens
+        # must precede padding for RoPE positions to remain aligned.
         tokenizer.padding_side = "right"
         return tokenizer(
             prompts,
@@ -204,12 +196,10 @@ class Lumina2PipelineConfig(SpatialImagePipelineConfig):
         return self._prepare_sigmas(sigmas, num_inference_steps)
 
     def post_denoising_loop(self, latents, batch):
-        # Latents are already (B, C, H', W'); nothing to unpack.
         return latents
 
 
 def _first_mask(mask):
-    # The batch stores per-encoder masks as a list; the DiT wants one tensor.
     if isinstance(mask, (list, tuple)):
         return mask[0] if mask else None
     return mask

--- a/python/sglang/multimodal_gen/configs/sample/lumina2.py
+++ b/python/sglang/multimodal_gen/configs/sample/lumina2.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sampling parameters for Lumina-Image-2.0 (T2I)."""
+
+from dataclasses import dataclass
+
+from sglang.multimodal_gen.configs.sample.sampling_params import (
+    DataType,
+    SamplingParams,
+)
+
+
+@dataclass
+class Lumina2SamplingParams(SamplingParams):
+    """Defaults for Alpha-VLLM/Lumina-Image-2.0.
+
+    Matches the diffusers Lumina2Pipeline defaults: guidance_scale=4.0 with 30
+    FlowMatchEuler steps at 1024x1024.
+    """
+
+    data_type: DataType = DataType.IMAGE
+    num_frames: int = 1
+    guidance_scale: float = 4.0
+    num_inference_steps: int = 30
+    height: int = 1024
+    width: int = 1024
+    negative_prompt: str = ""
+    # NOTE: off deliberately, and pinned so a change to the base default cannot
+    # silently turn it on. Lumina's renorm-CFG is a different operation, and it
+    # already runs in Lumina2PipelineConfig.postprocess_cfg_noise.
+    cfg_normalization: float | bool = 0.0

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -75,6 +75,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import (
     LTX2PipelineConfig,
     LTX23PipelineConfig,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.lumina2 import Lumina2PipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.mova import (
     MOVA360PConfig,
     MOVA720PConfig,
@@ -142,6 +143,7 @@ from sglang.multimodal_gen.configs.sample.ltx_2 import (
     LTX23HQSamplingParams,
     LTX23SamplingParams,
 )
+from sglang.multimodal_gen.configs.sample.lumina2 import Lumina2SamplingParams
 from sglang.multimodal_gen.configs.sample.minimax_h3 import MiniMaxH3SamplingParams
 from sglang.multimodal_gen.configs.sample.mova import (
     MOVA_360P_SamplingParams,
@@ -1095,6 +1097,18 @@ def _register_configs():
                 "sana" in hf_id.lower()
                 and "sana-wm" not in hf_id.lower()
                 and "sana_wm" not in hf_id.lower()
+            )
+        ],
+    )
+
+    # Lumina-Image-2.0
+    register_configs(
+        sampling_param_cls=Lumina2SamplingParams,
+        pipeline_config_cls=Lumina2PipelineConfig,
+        hf_model_paths=["Alpha-VLLM/Lumina-Image-2.0"],
+        model_detectors=[
+            lambda hf_id: (
+                "lumina-image-2" in hf_id.lower() or "lumina2" in hf_id.lower()
             )
         ],
     )

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -76,13 +76,7 @@ _VARLEN_FA_ENABLED = os.environ.get("SGLANG_VARLEN_FA", "1") != "0"
 
 
 def _same_head_count(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> bool:
-    """True when Q/K/V share a head count (MHA), for ``[B, S, H, D]`` inputs.
-
-    The varlen FA fast path calls ``fused_pack_qkv``, which asserts Q/K/V share
-    a full shape, so GQA/MQA must not reach it. The surrounding gates compare
-    ``shape[:2]`` -- (batch, sequence) -- which is equal for GQA too, stopping
-    one index short of the dimension that actually differs.
-    """
+    """True when Q/K/V share a head count, for ``[B, S, H, D]`` inputs."""
     return q.shape[2] == k.shape[2] == v.shape[2]
 
 
@@ -91,9 +85,8 @@ def _expand_kv_for_gqa(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Repeat K/V heads up to Q's head count for kernels without native GQA.
 
-    ``scaled_dot_product_attention`` does not broadcast heads, so a GQA model
-    reaches it with mismatched head counts and raises. ``LocalAttention`` has
-    carried this expansion since it was written; ``USPAttention`` did not.
+    ``scaled_dot_product_attention`` does not broadcast heads, so K/V must be
+    expanded before using it for GQA.
 
     ``dim`` is the head axis: 1 for the ``[B, H, S, D]`` layout SDPA wants.
     Returns ``k, v`` unchanged -- the same objects -- when the counts already
@@ -755,7 +748,6 @@ class USPAttention(nn.Module):
                     and attn_mask.device == q.device
                     and q.dtype in (torch.float16, torch.bfloat16)
                     and q.shape[:2] == attn_mask.shape == k.shape[:2] == v.shape[:2]
-                    # shape[:2] stops before the head dimension.
                     and _same_head_count(q, k, v)
                 ):
                     bs, seq = q.shape[0], q.shape[1]
@@ -927,7 +919,6 @@ class USPAttention(nn.Module):
                 and gathered_mask.device == q.device
                 and q.dtype in (torch.float16, torch.bfloat16)
                 and q.shape[:2] == gathered_mask.shape == k.shape[:2] == v.shape[:2]
-                # shape[:2] stops before the head dimension.
                 and _same_head_count(q, k, v)
             ):
                 bs, seq = q.shape[0], q.shape[1]

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -75,6 +75,45 @@ _PYTORCH_DEFAULT_CUDA_SDP_BACKENDS = [
 _VARLEN_FA_ENABLED = os.environ.get("SGLANG_VARLEN_FA", "1") != "0"
 
 
+def _same_head_count(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> bool:
+    """True when Q/K/V share a head count (MHA), for ``[B, S, H, D]`` inputs.
+
+    The varlen FA fast path calls ``fused_pack_qkv``, which asserts Q/K/V share
+    a full shape, so GQA/MQA must not reach it. The surrounding gates compare
+    ``shape[:2]`` -- (batch, sequence) -- which is equal for GQA too, stopping
+    one index short of the dimension that actually differs.
+    """
+    return q.shape[2] == k.shape[2] == v.shape[2]
+
+
+def _expand_kv_for_gqa(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, dim: int = 1
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Repeat K/V heads up to Q's head count for kernels without native GQA.
+
+    ``scaled_dot_product_attention`` does not broadcast heads, so a GQA model
+    reaches it with mismatched head counts and raises. ``LocalAttention`` has
+    carried this expansion since it was written; ``USPAttention`` did not.
+
+    ``dim`` is the head axis: 1 for the ``[B, H, S, D]`` layout SDPA wants.
+    Returns ``k, v`` unchanged -- the same objects -- when the counts already
+    match, so MHA models (e.g. Z-Image) are bit-for-bit unaffected.
+    """
+    q_heads, kv_heads = q.shape[dim], k.shape[dim]
+    if q_heads == kv_heads:
+        return k, v
+    if kv_heads <= 0 or q_heads % kv_heads != 0:
+        raise ValueError(
+            f"query heads ({q_heads}) must be a positive multiple of "
+            f"kv heads ({kv_heads})"
+        )
+    repeat_factor = q_heads // kv_heads
+    return (
+        k.repeat_interleave(repeat_factor, dim=dim),
+        v.repeat_interleave(repeat_factor, dim=dim),
+    )
+
+
 def build_varlen_mask_meta(
     key_mask: torch.Tensor,
 ) -> dict:
@@ -505,10 +544,7 @@ class LocalAttention(nn.Module):
                     mask = mask[:, None, :, :]
                 mask = (mask - 1.0) * torch.finfo(q_.dtype).max
 
-            if q_.shape[1] != k_.shape[1]:
-                repeat_factor = q_.shape[1] // k_.shape[1]
-                k_ = k_.repeat_interleave(repeat_factor, dim=1)
-                v_ = v_.repeat_interleave(repeat_factor, dim=1)
+            k_, v_ = _expand_kv_for_gqa(q_, k_, v_)
 
             sdpa_context = (
                 sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
@@ -719,6 +755,8 @@ class USPAttention(nn.Module):
                     and attn_mask.device == q.device
                     and q.dtype in (torch.float16, torch.bfloat16)
                     and q.shape[:2] == attn_mask.shape == k.shape[:2] == v.shape[:2]
+                    # shape[:2] stops before the head dimension.
+                    and _same_head_count(q, k, v)
                 ):
                     bs, seq = q.shape[0], q.shape[1]
                     indices = attn_mask_meta["indices"]
@@ -753,6 +791,7 @@ class USPAttention(nn.Module):
                 q_ = q.transpose(1, 2)
                 k_ = k.transpose(1, 2)
                 v_ = v.transpose(1, 2)
+                k_, v_ = _expand_kv_for_gqa(q_, k_, v_)
                 mask = _prepare_sdpa_mask(attn_mask, dtype=q_.dtype, device=q_.device)
                 sdpa_context = (
                     sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)
@@ -888,6 +927,8 @@ class USPAttention(nn.Module):
                 and gathered_mask.device == q.device
                 and q.dtype in (torch.float16, torch.bfloat16)
                 and q.shape[:2] == gathered_mask.shape == k.shape[:2] == v.shape[:2]
+                # shape[:2] stops before the head dimension.
+                and _same_head_count(q, k, v)
             ):
                 bs, seq = q.shape[0], q.shape[1]
                 gathered_mask_meta = build_varlen_mask_meta(gathered_mask)
@@ -918,6 +959,7 @@ class USPAttention(nn.Module):
             q_ = q.transpose(1, 2)
             k_ = k.transpose(1, 2)
             v_ = v.transpose(1, 2)
+            k_, v_ = _expand_kv_for_gqa(q_, k_, v_)
             mask = _prepare_sdpa_mask(gathered_mask, dtype=q_.dtype, device=q_.device)
             sdpa_context = (
                 sdpa_kernel(_PYTORCH_DEFAULT_CUDA_SDP_BACKENDS)

--- a/python/sglang/multimodal_gen/runtime/models/dits/lumina2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/lumina2.py
@@ -1,0 +1,540 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Lumina-Image-2.0 DiT (NextDiT). The attention block, SwiGLU feed-forward,
+# timestep embedder, and axes-RoPE tables are imported from zimage.py rather
+# than forked; Lumina's precision differences are opt-in keyword arguments on
+# those shared classes.
+#
+# Reference: https://arxiv.org/abs/2503.21758
+# Ported from diffusers Lumina2Transformer2DModel.
+
+from typing import Any, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from sglang.multimodal_gen.configs.models.dits.lumina2 import Lumina2Config
+from sglang.multimodal_gen.runtime.layers.attention import (
+    build_varlen_mask_meta_from_lengths,
+)
+from sglang.multimodal_gen.runtime.layers.linear import (
+    ColumnParallelLinear,
+    ReplicatedLinear,
+)
+from sglang.multimodal_gen.runtime.layers.quantization.configs.base_config import (
+    QuantizationConfig,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
+    LayerwiseOffloadableModuleMixin,
+)
+from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
+
+# NOTE: deliberately not imported from zimage, whose value differs. Picking up
+# the wrong one builds a silently wrong adaLN width, with no shape error.
+from sglang.multimodal_gen.runtime.models.dits.zimage import (
+    FeedForward,
+    RopeEmbedder,
+    TimestepEmbedder,
+    ZImageAttention,
+)
+
+# diffusers LuminaRMSNormZero modulates from min(hidden_size, 1024).
+ADALN_EMBED_DIM = 1024
+
+# Only for the class-level weight-mapping attrs; instances use their own config.
+_DEFAULT_ARCH = Lumina2Config().arch_config
+
+
+class FP32SiluAndMul(nn.Module):
+    """SwiGLU activation with SiLU evaluated in fp32, matching Lumina.
+
+    Injected into the shared ``FeedForward`` via its ``activation`` argument;
+    Z-Image keeps the fused bf16 ``SiluAndMul``.
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate, value = x.chunk(2, dim=-1)
+        return F.silu(gate.float()).to(gate.dtype) * value
+
+
+class Lumina2RMSNorm(nn.Module):
+    """diffusers RMSNorm, cast boundary included (normalization.py:553-562).
+
+    NOTE: the affine multiply runs in the weight's dtype, not fp32. Hoisting it
+    into fp32 rounds once instead of twice and looks strictly more accurate, but
+    it is not what the checkpoint was matched against -- it drifts by up to
+    ~0.03 per element, in every norm of every block.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.variance_epsilon = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        variance = x.to(torch.float32).pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(variance + self.variance_epsilon)
+        if self.weight.dtype in (torch.float16, torch.bfloat16):
+            x = x.to(self.weight.dtype)
+        return x * self.weight
+
+
+def _ffn_hidden_dim(
+    dim: int, multiple_of: int, ffn_dim_multiplier: Optional[float]
+) -> int:
+    """diffusers LuminaFeedForward inner dim: 4*dim, optionally scaled, rounded up.
+
+    NOTE: a plain round-up, *not* the 8/3*dim SwiGLU rule Z-Image uses. dim=2304
+    with no multiplier gives 9216, matching the published checkpoint's
+    feed_forward.linear_1 = [9216, 2304].
+    """
+    inner = 4 * dim
+    if ffn_dim_multiplier is not None:
+        inner = int(ffn_dim_multiplier * inner)
+    return multiple_of * ((inner + multiple_of - 1) // multiple_of)
+
+
+class Lumina2TransformerBlock(nn.Module):
+    """Sandwich-norm NextDiT block. ``modulation=False`` is the caption/context
+    refiner variant (no adaLN). Structurally identical to ZImageTransformerBlock
+    except for the adaLN input dim and fp32 normalization/activation policies."""
+
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int,
+        n_kv_heads: int,
+        multiple_of: int,
+        ffn_dim_multiplier: Optional[float],
+        norm_eps: float,
+        qk_norm: bool,
+        modulation: bool = True,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.dim = dim
+        self.modulation = modulation
+
+        self.attention = ZImageAttention(
+            dim=dim,
+            num_heads=n_heads,
+            num_kv_heads=n_kv_heads,
+            qk_norm=qk_norm,
+            eps=norm_eps,
+            qk_norm_factory=Lumina2RMSNorm,
+            allow_fused_qk_norm_rope=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attention",
+        )
+        # Every SP rank holds the complete sequence, so USP collectives would
+        # treat replicated sequences as shards. See shard_latents_for_sp.
+        self.attention.attn.skip_sequence_parallel = True
+
+        self.feed_forward = FeedForward(
+            dim=dim,
+            hidden_dim=_ffn_hidden_dim(dim, multiple_of, ffn_dim_multiplier),
+            activation=FP32SiluAndMul(),
+            quant_config=quant_config,
+            prefix=f"{prefix}.feed_forward",
+        )
+
+        self.attention_norm1 = Lumina2RMSNorm(dim, eps=norm_eps)
+        self.attention_norm2 = Lumina2RMSNorm(dim, eps=norm_eps)
+        self.ffn_norm1 = Lumina2RMSNorm(dim, eps=norm_eps)
+        self.ffn_norm2 = Lumina2RMSNorm(dim, eps=norm_eps)
+
+        if modulation:
+            self.adaLN_modulation = nn.Sequential(
+                nn.SiLU(),
+                ReplicatedLinear(min(dim, ADALN_EMBED_DIM), 4 * dim, bias=True),
+            )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        freqs_cis: Tuple[torch.Tensor, torch.Tensor],
+        adaln_input: Optional[torch.Tensor] = None,
+        attn_mask: Optional[torch.Tensor] = None,
+        attn_mask_meta: Optional[dict] = None,
+    ):
+        attn_kwargs = dict(
+            freqs_cis=freqs_cis,
+            attn_mask=attn_mask,
+            attn_mask_meta=attn_mask_meta,
+        )
+
+        if self.modulation:
+            assert adaln_input is not None
+            mod, _ = self.adaLN_modulation[1](self.adaLN_modulation[0](adaln_input))
+            scale_msa, gate_msa, scale_mlp, gate_mlp = mod.unsqueeze(1).chunk(4, dim=-1)
+
+            attn_out = self.attention(
+                self.attention_norm1(x) * (1 + scale_msa), **attn_kwargs
+            )
+            x = x + torch.tanh(gate_msa) * self.attention_norm2(attn_out)
+
+            ffn_out = self.feed_forward(self.ffn_norm1(x) * (1 + scale_mlp))
+            x = x + torch.tanh(gate_mlp) * self.ffn_norm2(ffn_out)
+        else:
+            attn_out = self.attention(self.attention_norm1(x), **attn_kwargs)
+            x = x + self.attention_norm2(attn_out)
+            ffn_out = self.feed_forward(self.ffn_norm1(x))
+            x = x + self.ffn_norm2(ffn_out)
+
+        return x
+
+
+class Lumina2CombinedTimestepCaptionEmbedding(nn.Module):
+    """Timestep MLP (-> min(dim,1024)) + Gemma-2 caption projection (RMSNorm+Linear).
+
+    Mirrors diffusers Lumina2CombinedTimestepCaptionEmbedding.
+    """
+
+    def __init__(self, hidden_size: int, cap_feat_dim: int, norm_eps: float = 1e-5):
+        super().__init__()
+        self.timestep_embedder = TimestepEmbedder(
+            out_size=min(hidden_size, ADALN_EMBED_DIM)
+        )
+        self.caption_embedder = nn.Sequential(
+            Lumina2RMSNorm(cap_feat_dim, eps=norm_eps),
+            ReplicatedLinear(cap_feat_dim, hidden_size, bias=True),
+        )
+
+    def forward(self, timestep: torch.Tensor, encoder_hidden_states: torch.Tensor):
+        time_embed = self.timestep_embedder(timestep)
+        cap = self.caption_embedder[0](encoder_hidden_states)
+        cap, _ = self.caption_embedder[1](cap)
+        return time_embed, cap
+
+
+class Lumina2FinalLayer(nn.Module):
+    """adaLN-continuous final norm + projection to patch*patch*out_channels.
+
+    Mirrors diffusers LuminaLayerNormContinuous (adaLN input min(dim,1024)).
+    """
+
+    def __init__(self, hidden_size: int, patch_size: int, out_channels: int):
+        super().__init__()
+        self.norm_final = nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            ReplicatedLinear(min(hidden_size, ADALN_EMBED_DIM), hidden_size, bias=True),
+        )
+        self.linear = ColumnParallelLinear(
+            hidden_size,
+            patch_size * patch_size * out_channels,
+            bias=True,
+            gather_output=True,
+        )
+
+    def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        scale, _ = self.adaLN_modulation[1](self.adaLN_modulation[0](c))
+        x = self.norm_final(x) * (1 + scale.unsqueeze(1))
+        x, _ = self.linear(x)
+        return x
+
+
+class Lumina2Transformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
+    """Lumina-Image-2.0 NextDiT. Class name matches the diffusers ``_class_name``."""
+
+    # NOTE: no _supports_gradient_checkpointing. forward() has no such branch,
+    # so advertising it would let a caller enable a no-op.
+    _no_split_modules = ["Lumina2TransformerBlock"]
+    _fsdp_shard_conditions = _DEFAULT_ARCH._fsdp_shard_conditions
+    param_names_mapping = _DEFAULT_ARCH.param_names_mapping
+    reverse_param_names_mapping = _DEFAULT_ARCH.reverse_param_names_mapping
+    # Lets is_layer_skipped() resolve --quantization-ignored-layers entries,
+    # which name checkpoint weights. Both fusions are unconditional.
+    packed_modules_mapping = {
+        "to_qkv": ["to_q", "to_k", "to_v"],
+        "w13": ["linear_1", "linear_3"],
+    }
+
+    def __init__(
+        self,
+        config: Lumina2Config,
+        hf_config: dict[str, Any],
+        quant_config: Optional[QuantizationConfig] = None,
+    ) -> None:
+        super().__init__(config=config, hf_config=hf_config)
+        arch = config.arch_config
+        patch_size = arch.patch_size
+        self.patch_size = patch_size
+        self.in_channels = arch.in_channels
+        self.out_channels = arch.out_channels
+        dim = arch.hidden_size
+        self.hidden_size = dim
+        self.num_attention_heads = arch.num_attention_heads
+        self.num_channels_latents = arch.num_channels_latents
+        self.t_scale = arch.t_scale
+        # Rows per RoPE axis: (caption/time, patch row, patch column).
+        self.axes_lens = arch.axes_lens
+
+        self.x_embedder = ReplicatedLinear(
+            patch_size * patch_size * arch.in_channels, dim, bias=True
+        )
+        self.time_caption_embed = Lumina2CombinedTimestepCaptionEmbedding(
+            hidden_size=dim, cap_feat_dim=arch.cap_feat_dim, norm_eps=arch.norm_eps
+        )
+        self.rope_embedder = RopeEmbedder(
+            theta=arch.rope_theta,
+            axes_dims=arch.axes_dim_rope,
+            axes_lens=arch.axes_lens,
+            # diffusers builds the phase in fp64 (transformer_lumina2.py:245).
+            # It also rotates in complex128; GQA sends us to a bf16 fallback.
+            freqs_dtype=torch.float64,
+        )
+
+        def _blocks(name: str, count: int, modulation: bool) -> nn.ModuleList:
+            return nn.ModuleList(
+                [
+                    Lumina2TransformerBlock(
+                        dim=dim,
+                        n_heads=arch.num_attention_heads,
+                        n_kv_heads=arch.num_kv_heads,
+                        multiple_of=arch.multiple_of,
+                        ffn_dim_multiplier=arch.ffn_dim_multiplier,
+                        norm_eps=arch.norm_eps,
+                        qk_norm=arch.qk_norm,
+                        modulation=modulation,
+                        quant_config=quant_config,
+                        prefix=f"{name}.{i}",
+                    )
+                    for i in range(count)
+                ]
+            )
+
+        self.noise_refiner = _blocks(
+            "noise_refiner", arch.num_refiner_layers, modulation=True
+        )
+        self.context_refiner = _blocks(
+            "context_refiner", arch.num_refiner_layers, modulation=False
+        )
+        self.layers = _blocks("layers", arch.num_layers, modulation=True)
+        self.norm_out = Lumina2FinalLayer(dim, patch_size, arch.out_channels)
+        self.layer_names = ["layers"]
+
+    def _check_rope_axis(self, axis: int, max_index: int, what: str, knob: str) -> None:
+        """Reject a position that would index past RoPE table ``axis``."""
+        limit = self.axes_lens[axis]
+        if max_index >= limit:
+            raise ValueError(
+                f"Lumina-2 {what} needs axis-{axis} RoPE position {max_index}, "
+                f"but that table has only {limit} rows; lower {knob}."
+            )
+
+    def _patchify_and_rope(
+        self, hidden_states: torch.Tensor, encoder_attention_mask: torch.Tensor
+    ):
+        """Patchify latents and build the three RoPE tables Lumina needs.
+
+        Position ids are 3-axis: axis 0 is the caption/time axis, axes 1 and 2
+        are the image patch row/column. Caption tokens occupy ids 0..cap_len on
+        axis 0 with axes 1/2 pinned at 0; image tokens pin axis 0 at cap_len and
+        carry their row/col on axes 1/2. Mirrors diffusers Lumina2RotaryPosEmbed.
+
+        NOTE: captions must be right-padded. Caption extents come from
+        ``encoder_attention_mask.sum()``, which is only correct if the real
+        tokens come first; a left-padded mask would silently mis-assign every
+        caption position and RoPE frequency. Lumina2PipelineConfig.tokenize_prompt
+        pins padding_side to enforce this.
+        """
+        batch_size, channels, height, width = hidden_states.shape
+        p = self.patch_size
+        if height % p or width % p:
+            raise ValueError(
+                f"Lumina-2 latents must be divisible by patch_size {p}, got "
+                f"{height}x{width}. Requested image height/width must be a "
+                f"multiple of vae_scale_factor * patch_size (16 by default)."
+            )
+        post_patch_height, post_patch_width = height // p, width // p
+        image_seq_len = post_patch_height * post_patch_width
+        device = hidden_states.device
+
+        encoder_seq_len = encoder_attention_mask.shape[1]
+        cap_lens: List[int] = encoder_attention_mask.sum(dim=1).tolist()
+        # Unguarded, each of these is a device-side assert in the RoPE gather.
+        # Axis 0 needs cap_len itself: image tokens all sit at that position.
+        self._check_rope_axis(
+            0, encoder_seq_len, "caption length", "max_sequence_length"
+        )
+        self._check_rope_axis(
+            1, post_patch_height - 1, "latent patch rows", "image height"
+        )
+        self._check_rope_axis(
+            2, post_patch_width - 1, "latent patch columns", "image width"
+        )
+        seq_lens = [cap_len + image_seq_len for cap_len in cap_lens]
+        max_seq_len = max(seq_lens)
+
+        row_ids = (
+            torch.arange(post_patch_height, dtype=torch.long, device=device)
+            .view(-1, 1)
+            .repeat(1, post_patch_width)
+            .flatten()
+        )
+        col_ids = (
+            torch.arange(post_patch_width, dtype=torch.long, device=device)
+            .view(1, -1)
+            .repeat(post_patch_height, 1)
+            .flatten()
+        )
+
+        position_ids = torch.zeros(
+            batch_size, max_seq_len, 3, dtype=torch.long, device=device
+        )
+        for i, (cap_len, seq_len) in enumerate(zip(cap_lens, seq_lens)):
+            position_ids[i, :cap_len, 0] = torch.arange(
+                cap_len, dtype=torch.long, device=device
+            )
+            position_ids[i, cap_len:seq_len, 0] = cap_len
+            position_ids[i, cap_len:seq_len, 1] = row_ids
+            position_ids[i, cap_len:seq_len, 2] = col_ids
+
+        cos, sin = self.rope_embedder(position_ids.view(-1, 3))
+        joint_cos = cos.view(batch_size, max_seq_len, -1)
+        joint_sin = sin.view(batch_size, max_seq_len, -1)
+
+        rope_dim = joint_cos.shape[-1]
+        cap_cos = joint_cos.new_zeros(batch_size, encoder_seq_len, rope_dim)
+        cap_sin = joint_sin.new_zeros(batch_size, encoder_seq_len, rope_dim)
+        img_cos = joint_cos.new_zeros(batch_size, image_seq_len, rope_dim)
+        img_sin = joint_sin.new_zeros(batch_size, image_seq_len, rope_dim)
+        for i, (cap_len, seq_len) in enumerate(zip(cap_lens, seq_lens)):
+            cap_cos[i, :cap_len] = joint_cos[i, :cap_len]
+            cap_sin[i, :cap_len] = joint_sin[i, :cap_len]
+            img_cos[i] = joint_cos[i, cap_len:seq_len]
+            img_sin[i] = joint_sin[i, cap_len:seq_len]
+
+        # (B, C, H, W) -> (B, image_seq_len, p*p*C)
+        image_tokens = (
+            hidden_states.view(
+                batch_size, channels, post_patch_height, p, post_patch_width, p
+            )
+            .permute(0, 2, 4, 3, 5, 1)
+            .flatten(3)
+            .flatten(1, 2)
+        )
+
+        return (
+            image_tokens,
+            (cap_cos, cap_sin),
+            (img_cos, img_sin),
+            (joint_cos, joint_sin),
+            cap_lens,
+            seq_lens,
+        )
+
+    @staticmethod
+    def _padding_mask(
+        lengths: List[int], target_len: int, device: torch.device
+    ) -> Tuple[Optional[torch.Tensor], Optional[dict]]:
+        """Key-padding mask over a left-packed sequence, or (None, None).
+
+        Uniform lengths need no mask -- the common single-prompt case. diffusers
+        makes the same shortcut via ``use_mask``.
+        """
+        if all(length == target_len for length in lengths):
+            return None, None
+        length_key = tuple(int(length) for length in lengths)
+        positions = torch.arange(target_len, device=device).unsqueeze(0)
+        length_tensor = torch.as_tensor(
+            length_key, dtype=torch.long, device=device
+        ).unsqueeze(1)
+        mask = positions < length_tensor
+        meta = build_varlen_mask_meta_from_lengths(length_key, target_len, device)
+        return mask, meta
+
+    def _unpatchify(
+        self,
+        joint: torch.Tensor,
+        cap_lens: List[int],
+        seq_lens: List[int],
+        height: int,
+        width: int,
+    ) -> torch.Tensor:
+        p = self.patch_size
+        out = []
+        for i, (cap_len, seq_len) in enumerate(zip(cap_lens, seq_lens)):
+            out.append(
+                joint[i][cap_len:seq_len]
+                .view(height // p, width // p, p, p, self.out_channels)
+                .permute(4, 0, 2, 1, 3)
+                .flatten(3, 4)
+                .flatten(1, 2)
+            )
+        return torch.stack(out, dim=0)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_attention_mask: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        batch_size, _, height, width = hidden_states.shape
+        device = hidden_states.device
+
+        # Lumina treats t=0 as noise and t=1 as the image, the reverse of the
+        # FlowMatchEuler schedule the denoising stage hands us. diffusers
+        # reverses in the pipeline; here keeps it out of the pipeline config.
+        t = 1.0 - timestep.to(torch.float32) / self.t_scale
+        adaln_input, cap_feats = self.time_caption_embed(t, encoder_hidden_states)
+        adaln_input = adaln_input.to(hidden_states.dtype)
+
+        (
+            image_tokens,
+            cap_freqs_cis,
+            img_freqs_cis,
+            joint_freqs_cis,
+            cap_lens,
+            seq_lens,
+        ) = self._patchify_and_rope(hidden_states, encoder_attention_mask)
+
+        image_tokens, _ = self.x_embedder(image_tokens)
+
+        cap_mask, cap_mask_meta = self._padding_mask(
+            cap_lens, encoder_attention_mask.shape[1], device
+        )
+        for layer in self.context_refiner:
+            cap_feats = layer(
+                cap_feats,
+                cap_freqs_cis,
+                attn_mask=cap_mask,
+                attn_mask_meta=cap_mask_meta,
+            )
+
+        # Image tokens are dense: every sample has the same patch count, hence no mask.
+        for layer in self.noise_refiner:
+            image_tokens = layer(image_tokens, img_freqs_cis, adaln_input)
+
+        # Joint sequence, left-packed as [caption | image] per sample.
+        max_seq_len = max(seq_lens)
+        joint = image_tokens.new_zeros(batch_size, max_seq_len, self.hidden_size)
+        for i, (cap_len, seq_len) in enumerate(zip(cap_lens, seq_lens)):
+            joint[i, :cap_len] = cap_feats[i, :cap_len]
+            joint[i, cap_len:seq_len] = image_tokens[i]
+
+        joint_mask, joint_mask_meta = self._padding_mask(seq_lens, max_seq_len, device)
+        for layer in self.layers:
+            joint = layer(
+                joint,
+                joint_freqs_cis,
+                adaln_input,
+                attn_mask=joint_mask,
+                attn_mask_meta=joint_mask_meta,
+            )
+
+        joint = self.norm_out(joint, adaln_input)
+        output = self._unpatchify(joint, cap_lens, seq_lens, height, width)
+
+        # Lumina's velocity points the opposite way from the scheduler's
+        # convention. diffusers negates just before scheduler.step; doing it
+        # here is equivalent, since CFG and renorm are both odd.
+        return -output
+
+
+EntryClass = [Lumina2Transformer2DModel]

--- a/python/sglang/multimodal_gen/runtime/models/dits/lumina2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/lumina2.py
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Lumina-Image-2.0 DiT (NextDiT). The attention block, SwiGLU feed-forward,
-# timestep embedder, and axes-RoPE tables are imported from zimage.py rather
-# than forked; Lumina's precision differences are opt-in keyword arguments on
-# those shared classes.
+# Lumina-Image-2.0 DiT (NextDiT).
 #
 # Reference: https://arxiv.org/abs/2503.21758
 # Ported from diffusers Lumina2Transformer2DModel.
@@ -42,7 +39,6 @@ from sglang.multimodal_gen.runtime.models.dits.zimage import (
 # diffusers LuminaRMSNormZero modulates from min(hidden_size, 1024).
 ADALN_EMBED_DIM = 1024
 
-# Only for the class-level weight-mapping attrs; instances use their own config.
 _DEFAULT_ARCH = Lumina2Config().arch_config
 
 
@@ -59,13 +55,7 @@ class FP32SiluAndMul(nn.Module):
 
 
 class Lumina2RMSNorm(nn.Module):
-    """diffusers RMSNorm, cast boundary included (normalization.py:553-562).
-
-    NOTE: the affine multiply runs in the weight's dtype, not fp32. Hoisting it
-    into fp32 rounds once instead of twice and looks strictly more accurate, but
-    it is not what the checkpoint was matched against -- it drifts by up to
-    ~0.03 per element, in every norm of every block.
-    """
+    """RMSNorm with the affine multiply in the weight's dtype."""
 
     def __init__(self, dim: int, eps: float = 1e-5):
         super().__init__()
@@ -239,8 +229,6 @@ class Lumina2FinalLayer(nn.Module):
 class Lumina2Transformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
     """Lumina-Image-2.0 NextDiT. Class name matches the diffusers ``_class_name``."""
 
-    # NOTE: no _supports_gradient_checkpointing. forward() has no such branch,
-    # so advertising it would let a caller enable a no-op.
     _no_split_modules = ["Lumina2TransformerBlock"]
     _fsdp_shard_conditions = _DEFAULT_ARCH._fsdp_shard_conditions
     param_names_mapping = _DEFAULT_ARCH.param_names_mapping
@@ -282,8 +270,7 @@ class Lumina2Transformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             theta=arch.rope_theta,
             axes_dims=arch.axes_dim_rope,
             axes_lens=arch.axes_lens,
-            # diffusers builds the phase in fp64 (transformer_lumina2.py:245).
-            # It also rotates in complex128; GQA sends us to a bf16 fallback.
+            # Lumina evaluates RoPE phases in fp64 before storing fp32 tables.
             freqs_dtype=torch.float64,
         )
 
@@ -431,11 +418,7 @@ class Lumina2Transformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
     def _padding_mask(
         lengths: List[int], target_len: int, device: torch.device
     ) -> Tuple[Optional[torch.Tensor], Optional[dict]]:
-        """Key-padding mask over a left-packed sequence, or (None, None).
-
-        Uniform lengths need no mask -- the common single-prompt case. diffusers
-        makes the same shortcut via ``use_mask``.
-        """
+        """Key-padding mask over a left-packed sequence, or (None, None)."""
         if all(length == target_len for length in lengths):
             return None, None
         length_key = tuple(int(length) for length in lengths)

--- a/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
@@ -201,7 +201,6 @@ class FeedForward(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.w2",
         )
-        # None keeps the fused bf16 kernel; Lumina-2 injects FP32SiluAndMul.
         self.act = activation if activation is not None else SiluAndMul()
 
     def forward(self, x):
@@ -230,8 +229,7 @@ class ZImageAttention(nn.Module):
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads
         self.qk_norm = qk_norm
-        # False only ever disables. Lumina-2 passes it because the fused
-        # norm+RoPE kernel cannot reproduce its q/k norm's cast boundary.
+        # The fused norm+RoPE kernel cannot represent every injected norm policy.
         self.enable_zimage_qk_fusion = allow_fused_qk_norm_rope and quant_config is None
 
         tp_size = get_tp_world_size()
@@ -692,8 +690,7 @@ class RopeEmbedder:
         self.theta = theta
         self.axes_dims = axes_dims
         self.axes_lens = axes_lens
-        # Precision the phase is held at before cos/sin; the tables come back
-        # fp32 either way. Lumina-2 passes fp64 to match diffusers.
+        # Precision used to evaluate the phase before storing fp32 tables.
         self.freqs_dtype = freqs_dtype
         assert len(axes_dims) == len(
             axes_lens
@@ -718,8 +715,6 @@ class RopeEmbedder:
                     ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d)
                 )
                 timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
-                # Bit-identical to the old expression at the fp32 default, since
-                # the trailing .float() is then a no-op. Only fp64 changes.
                 freqs = torch.outer(timestep, freqs).to(freqs_dtype)
 
                 cos_list.append(torch.cos(freqs).float())

--- a/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/zimage.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -181,6 +181,7 @@ class FeedForward(nn.Module):
         hidden_dim: int,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        activation: Optional[nn.Module] = None,
     ):
         super().__init__()
         # Use MergedColumnParallelLinear for gate and up projection (fused)
@@ -200,7 +201,8 @@ class FeedForward(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.w2",
         )
-        self.act = SiluAndMul()
+        # None keeps the fused bf16 kernel; Lumina-2 injects FP32SiluAndMul.
+        self.act = activation if activation is not None else SiluAndMul()
 
     def forward(self, x):
         x13, _ = self.w13(x)
@@ -219,6 +221,8 @@ class ZImageAttention(nn.Module):
         eps: float = 1e-6,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        qk_norm_factory: Optional[Callable[..., nn.Module]] = None,
+        allow_fused_qk_norm_rope: bool = True,
     ) -> None:
         super().__init__()
         self.dim = dim
@@ -226,7 +230,9 @@ class ZImageAttention(nn.Module):
         self.num_heads = num_heads
         self.num_kv_heads = num_kv_heads
         self.qk_norm = qk_norm
-        self.enable_zimage_qk_fusion = quant_config is None
+        # False only ever disables. Lumina-2 passes it because the fused
+        # norm+RoPE kernel cannot reproduce its q/k norm's cast boundary.
+        self.enable_zimage_qk_fusion = allow_fused_qk_norm_rope and quant_config is None
 
         tp_size = get_tp_world_size()
         assert (
@@ -277,8 +283,9 @@ class ZImageAttention(nn.Module):
             )
 
         if self.qk_norm:
-            self.norm_q = ZImageRMSNorm(self.head_dim, eps=eps)
-            self.norm_k = ZImageRMSNorm(self.head_dim, eps=eps)
+            norm_cls = qk_norm_factory if qk_norm_factory is not None else ZImageRMSNorm
+            self.norm_q = norm_cls(self.head_dim, eps=eps)
+            self.norm_k = norm_cls(self.head_dim, eps=eps)
         else:
             self.norm_q = None
             self.norm_k = None
@@ -680,10 +687,14 @@ class RopeEmbedder:
         theta: float = 256.0,
         axes_dims: List[int] = (16, 56, 56),
         axes_lens: List[int] = (64, 128, 128),
+        freqs_dtype: torch.dtype = torch.float32,
     ):
         self.theta = theta
         self.axes_dims = axes_dims
         self.axes_lens = axes_lens
+        # Precision the phase is held at before cos/sin; the tables come back
+        # fp32 either way. Lumina-2 passes fp64 to match diffusers.
+        self.freqs_dtype = freqs_dtype
         assert len(axes_dims) == len(
             axes_lens
         ), "axes_dims and axes_lens must have the same length"
@@ -692,7 +703,12 @@ class RopeEmbedder:
         self.sin_cached = None
 
     @staticmethod
-    def precompute_freqs(dim: List[int], end: List[int], theta: float = 256.0):
+    def precompute_freqs(
+        dim: List[int],
+        end: List[int],
+        theta: float = 256.0,
+        freqs_dtype: torch.dtype = torch.float32,
+    ):
         with torch.device("cpu"):
             cos_list = []
             sin_list = []
@@ -702,10 +718,12 @@ class RopeEmbedder:
                     ** (torch.arange(0, d, 2, dtype=torch.float64, device="cpu") / d)
                 )
                 timestep = torch.arange(e, device=freqs.device, dtype=torch.float64)
-                freqs = torch.outer(timestep, freqs).float()
+                # Bit-identical to the old expression at the fp32 default, since
+                # the trailing .float() is then a no-op. Only fp64 changes.
+                freqs = torch.outer(timestep, freqs).to(freqs_dtype)
 
-                cos_list.append(torch.cos(freqs))
-                sin_list.append(torch.sin(freqs))
+                cos_list.append(torch.cos(freqs).float())
+                sin_list.append(torch.sin(freqs).float())
 
             return cos_list, sin_list
 
@@ -723,7 +741,10 @@ class RopeEmbedder:
 
         if self.cos_cached is None:
             self.cos_cached, self.sin_cached = self.precompute_freqs(
-                self.axes_dims, self.axes_lens, theta=self.theta
+                self.axes_dims,
+                self.axes_lens,
+                theta=self.theta,
+                freqs_dtype=self.freqs_dtype,
             )
             self.cos_cached = [c.to(device) for c in self.cos_cached]
             self.sin_cached = [s.to(device) for s in self.sin_cached]

--- a/python/sglang/multimodal_gen/runtime/pipelines/lumina2.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/lumina2.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Lumina-Image-2.0 text-to-image pipeline.
+#
+# Lumina-2 fits the standard modular T2I shape.
+# All model-specific behavior (system prompt, hidden_states[-2] conditioning,
+# renorm-CFG, 4D latents) lives in Lumina2PipelineConfig.
+#
+# pipeline_name must match _class_name in the HF model_index.json.
+
+from sglang.multimodal_gen.runtime.pipelines_core import LoRAPipeline
+from sglang.multimodal_gen.runtime.pipelines_core.composed_pipeline_base import (
+    ComposedPipelineBase,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages import (
+    InputValidationStage,
+    TextEncodingStage,
+)
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+
+class Lumina2Pipeline(LoRAPipeline, ComposedPipelineBase):
+    pipeline_name = "Lumina2Pipeline"
+
+    _required_config_modules = [
+        "text_encoder",
+        "tokenizer",
+        "vae",
+        "transformer",
+        "scheduler",
+    ]
+
+    def create_pipeline_stages(self, server_args: ServerArgs):
+        self.add_stage(InputValidationStage())
+
+        self.add_stage(
+            TextEncodingStage(
+                text_encoders=[self.get_module("text_encoder")],
+                tokenizers=[self.get_module("tokenizer")],
+            ),
+            "prompt_encoding_stage_primary",
+        )
+
+        self.add_standard_timestep_preparation_stage()
+        self.add_standard_latent_preparation_stage()
+        self.add_standard_denoising_stage()
+        self.add_standard_decoding_stage()
+
+
+EntryClass = Lumina2Pipeline

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora_pipeline.py
@@ -754,6 +754,15 @@ class LoRAPipeline(ComposedPipelineBase):
                         for i in range(num_params_to_merge)
                     ]
                     # Use stack instead of cat because it needs to be compatible with TP.
+                    shapes = {tuple(t.shape) for t in sorted_tensors}
+                    if len(shapes) > 1:
+                        raise ValueError(
+                            f"Cannot fuse LoRA shards for {target_name}: the stacked "
+                            f"(N, out, r) layout needs equal shards, got {sorted(shapes)}. "
+                            "GQA attention hits this because lora_B is wider for q "
+                            "than for k/v; such adapters need a block-diagonal fused "
+                            "form, which is not implemented."
+                        )
                     weight = torch.stack(sorted_tensors, dim=0)
                     del to_merge_params[target_name]
                 else:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
@@ -754,6 +754,7 @@ class SanaWMTextEncodingStage(TextEncodingStage):
                 max_length=max_length,
                 padding="max_length",
                 truncation=True,
+                is_negative=True,
             )
             neg_seq_lens_list = self._seq_lens_from_masks(neg_masks_list)
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -202,6 +202,11 @@ class TextEncodingStage(ConditionEncodingStage):
             server_args,
             encoder_index=all_indices,
             return_attention_mask=True,
+            is_negative=True,
+            # Must match the positive branch. _build_negative_text_cache_key
+            # already varies on this, so omitting it cached one length under a
+            # key that named another.
+            max_length=batch.max_sequence_length,
         )
         self._maybe_cache_negative_text_embedding(
             negative_cache_key, negative_text_outputs
@@ -575,6 +580,7 @@ class TextEncodingStage(ConditionEncodingStage):
         padding: bool | str | None = None,
         return_overflowing_tokens=None,
         return_length=None,
+        is_negative: bool = False,
     ):
         """
         Encode plain text using selected text encoder(s) and return embeddings.
@@ -595,6 +601,8 @@ class TextEncodingStage(ConditionEncodingStage):
             max_length: Optional per-call tokenizer override.
             truncation: Optional per-call tokenizer override.
             padding: Optional per-call tokenizer override.
+            is_negative: Select the pipeline's negative-branch text
+                preprocessors when configured.
 
         Returns:
             Depending on return_type and return_attention_mask:
@@ -643,7 +651,9 @@ class TextEncodingStage(ConditionEncodingStage):
         embeds_masks_list: list[torch.Tensor] = []
         seq_lens_list: list[list[int]] = []
 
-        preprocess_funcs = server_args.pipeline_config.preprocess_text_funcs
+        preprocess_funcs = server_args.pipeline_config.get_preprocess_text_funcs(
+            is_negative=is_negative
+        )
         postprocess_funcs = server_args.pipeline_config.postprocess_text_funcs
         text_encoder_extra_args = server_args.pipeline_config.text_encoder_extra_args
         encoder_cfgs = server_args.pipeline_config.text_encoder_configs

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -46,6 +46,7 @@ from sglang.multimodal_gen.test.test_utils import (
     DEFAULT_FLUX_2_KLEIN_4B_MODEL_NAME_FOR_TEST,
     DEFAULT_FLUX_2_KLEIN_BASE_4B_MODEL_NAME_FOR_TEST,
     DEFAULT_JOYAI_IMAGE_EDIT_MODEL_NAME_FOR_TEST,
+    DEFAULT_LUMINA_IMAGE_2_MODEL_NAME_FOR_TEST,
     DEFAULT_MOVA_360P_MODEL_NAME_FOR_TEST,
     DEFAULT_QWEN_IMAGE_EDIT_2509_MODEL_NAME_FOR_TEST,
     DEFAULT_QWEN_IMAGE_EDIT_2511_MODEL_NAME_FOR_TEST,
@@ -118,6 +119,10 @@ ONE_GPU_CASES: list[DiffusionTestCase] = [
     DiffusionTestCase(
         "flux_image_t2i",
         DiffusionServerArgs(model_path=DEFAULT_FLUX_1_DEV_MODEL_NAME_FOR_TEST),
+    ),
+    DiffusionTestCase(
+        "lumina_image_2_t2i",
+        DiffusionServerArgs(model_path=DEFAULT_LUMINA_IMAGE_2_MODEL_NAME_FOR_TEST),
     ),
     # TODO: modeling of flux different from official flux, so weights can't be loaded
     # consider opting for a different quantized hf-repo

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -182,6 +182,9 @@ DEFAULT_FLUX_2_KLEIN_BASE_4B_MODEL_NAME_FOR_TEST = (
     "black-forest-labs/FLUX.2-klein-base-4B"
 )
 
+# Lumina image generation models
+DEFAULT_LUMINA_IMAGE_2_MODEL_NAME_FOR_TEST = "Alpha-VLLM/Lumina-Image-2.0"
+
 # Wan video generation models
 DEFAULT_WAN_2_1_T2V_1_3B_MODEL_NAME_FOR_TEST = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
 DEFAULT_WAN_2_1_T2V_14B_MODEL_NAME_FOR_TEST = "Wan-AI/Wan2.1-T2V-14B-Diffusers"

--- a/python/sglang/multimodal_gen/test/unit/test_lumina2.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lumina2.py
@@ -1,14 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for Lumina-Image-2.0 config/weight plumbing.
-
-These run without a GPU or a checkpoint download. They cover the failure modes
-that are invisible until a real load: architecture fields silently not picked up
-from the checkpoint's config.json, and weight-name mappings that resolve to
-params the model does not have.
-
-LUMINA2_CHECKPOINT_CONFIG below is verbatim
-Alpha-VLLM/Lumina-Image-2.0 transformer/config.json.
-"""
+"""Unit tests for Lumina-Image-2.0 config and weight plumbing."""
 
 import copy
 import unittest
@@ -85,8 +76,6 @@ LUMINA2_CHECKPOINT_CONFIG = {
 
 
 def _global_server_args_or_none():
-    """The installed global, or None. conftest's fixture is a pytest mechanism,
-    so a direct ``python test_lumina2.py`` run has none and the getter raises."""
     try:
         return get_global_server_args()
     except ValueError:
@@ -95,9 +84,6 @@ def _global_server_args_or_none():
 
 def build_meta_model(config: Lumina2Config) -> Lumina2Transformer2DModel:
     """Instantiate the DiT on the meta device (no weights, no GPU)."""
-    # Under pytest, extend the conftest fixture's stub rather than replacing it,
-    # so a layer that starts reading some other ServerArgs field gets fixed once
-    # in the fixture instead of here.
     prev_args = _global_server_args_or_none()
     if prev_args is None:
         overridden = SimpleNamespace(attention_backend="torch_sdpa", comfyui_mode=False)
@@ -129,14 +115,6 @@ def build_meta_model(config: Lumina2Config) -> Lumina2Transformer2DModel:
 
 class TestSharedZImagePrimitives(CustomTestCase):
     def test_lumina_reuses_zimage_primitives_rather_than_forking_them(self):
-        """Lumina-2 and Z-Image are the same joint-DiT family, so the shared
-        blocks live in zimage.py -- the elder sibling -- matching this repo's
-        convention (causal_wanvideo <- wanvideo, longlive2 <- causal_wanvideo).
-
-        A local fork of any of these would drift from Z-Image silently, which
-        is how GQA support came to be missing from one of two copies of the
-        masked attention path.
-        """
         import sglang.multimodal_gen.runtime.models.dits.lumina2 as lumina2_mod
         import sglang.multimodal_gen.runtime.models.dits.zimage as zimage_mod
 
@@ -182,9 +160,7 @@ class TestSharedZImagePrimitives(CustomTestCase):
                 self.assertTrue(block.attention.attn.skip_sequence_parallel)
 
     def test_rope_phase_is_evaluated_in_fp64_for_lumina_only(self):
-        """diffusers transformer_lumina2.py:245 builds the phase in fp64 and
-        takes cos/sin there; rounding to fp32 first moves a few table entries by
-        a bf16 ulp. Z-Image shares this embedder and must keep fp32."""
+        """Lumina evaluates phases in fp64 while Z-Image retains fp32."""
         axes_dims, axes_lens = (32, 32, 32), (300, 512, 512)
         theta = 10000.0
 
@@ -198,17 +174,13 @@ class TestSharedZImagePrimitives(CustomTestCase):
             self.assertTrue(torch.equal(sin64[i], phase.sin().float()))
             self.assertEqual(cos64[i].dtype, torch.float32)
 
-        # If the two agreed, Lumina's opt-in would be untested and Z-Image's
-        # default unprotected.
         cos32, _ = ZImageRopeEmbedder.precompute_freqs(
             axes_dims, axes_lens, theta=theta
         )
         self.assertFalse(all(torch.equal(a, b) for a, b in zip(cos32, cos64)))
 
     def test_rms_norm_rounds_before_the_affine_multiply(self):
-        """diffusers normalization.py:553-562 casts to the weight dtype before
-        applying the weight. Hoisting that multiply into fp32 reads as a strict
-        accuracy win and silently drifts from the reference in every block."""
+        """The affine multiply runs after casting to the weight dtype."""
         torch.manual_seed(0)
         dim = 64
         norm = Lumina2RMSNorm(dim).to(torch.bfloat16)
@@ -224,7 +196,6 @@ class TestSharedZImagePrimitives(CustomTestCase):
         self.assertEqual(actual.dtype, torch.bfloat16)
         self.assertTrue(torch.equal(actual, expected))
 
-        # Keeps the assertion above honest: a revert cannot pass by coincidence.
         fp32_affine = (normalized * norm.weight.float()).to(torch.bfloat16)
         self.assertFalse(torch.equal(fp32_affine, expected))
 
@@ -373,19 +344,15 @@ class TestLumina2WeightMapping(CustomTestCase):
 
 class TestLumina2PipelineConfig(CustomTestCase):
     def test_registry_resolves_model_path(self):
-        # get_model_info would fetch model_index.json and, when that fails,
-        # still pass by falling back to these same classes. __wrapped__ skips
-        # lru_cache(maxsize=1) rather than evicting the entry other tests share.
-        # The patch is for the detector path, which pulls model_index.json
-        # before running detectors; the exact-path match returns before that.
+        # Bypass the shared cache while testing both exact and detected paths.
         resolve = _get_config_info.__wrapped__
         with patch(
             "sglang.multimodal_gen.registry.maybe_download_model_index",
             return_value={},
         ):
             for path in (
-                "Alpha-VLLM/Lumina-Image-2.0",  # exact hf_model_paths entry
-                "some-org/lumina2-finetune",  # model_detectors fallback
+                "Alpha-VLLM/Lumina-Image-2.0",
+                "some-org/lumina2-finetune",
             ):
                 info = resolve(path)
                 self.assertIsNotNone(info, path)
@@ -393,8 +360,6 @@ class TestLumina2PipelineConfig(CustomTestCase):
                 self.assertIs(info.sampling_param_cls, Lumina2SamplingParams)
 
     def test_pipeline_name_matches_hf_class_name(self):
-        """_class_name in model_index.json is how a checkpoint finds this
-        pipeline; renaming pipeline_name drops Lumina onto the generic path."""
         _discover_and_register_pipelines()
         self.assertIs(
             _PIPELINE_REGISTRY.get("Lumina2Pipeline"),
@@ -412,8 +377,6 @@ class TestLumina2PipelineConfig(CustomTestCase):
         self.assertIs(config.gather_latents_for_sp(latents), latents)
 
     def test_conditioning_expands_to_the_sample_batch(self):
-        """Conditioning must reach one row per sample, not per prompt; see
-        Lumina2PipelineConfig.expand_conditioning_to_sample_batch."""
         config = Lumina2PipelineConfig()
         batch = SimpleNamespace(
             prompt="a cat",
@@ -452,7 +415,6 @@ class TestLumina2PipelineConfig(CustomTestCase):
         self.assertIs(batch.prompt_embeds, embeds)
 
     def test_tokenizer_is_pinned_to_right_padding(self):
-        """A tokenizer arriving with left padding must be corrected in place."""
         config = Lumina2PipelineConfig()
 
         def fake_tokenizer(prompts, **kwargs):
@@ -483,11 +445,7 @@ class TestLumina2PipelineConfig(CustomTestCase):
         (preprocess,) = config.get_preprocess_text_funcs(is_negative=False)
         (negative_preprocess,) = config.get_preprocess_text_funcs(is_negative=True)
 
-        # Transcribed from diffusers pipeline_lumina2.py:288, identical in
-        # v0.33.0, v0.37.0 (the pinned one) and main:
-        #   prompt = [system_prompt + " <Prompt Start> " + p for p in prompt]
-        # Spelled out, not built from LUMINA2_PROMPT_SEPARATOR, so editing the
-        # separator turns this red instead of agreeing with itself.
+        # Keep the expected separator independent from the constant under test.
         self.assertEqual(
             preprocess("a cat"),
             LUMINA2_SYSTEM_PROMPT + " <Prompt Start> " + "a cat",
@@ -507,16 +465,7 @@ class TestLumina2PipelineConfig(CustomTestCase):
         )
 
     def test_renorm_matches_the_diffusers_formula_bitwise(self):
-        """Transcribed from diffusers pipeline_lumina2.py:750-758:
-
-            cond_norm  = torch.norm(noise_pred_cond, dim=-1, keepdim=True)
-            noise_norm = torch.norm(noise_pred,      dim=-1, keepdim=True)
-            noise_pred = noise_pred * (cond_norm / noise_norm)
-
-        The property test above only pins that the conditional norm is
-        restored; this pins the formula, so a different rescale that happens
-        to preserve the norm would still turn it red.
-        """
+        """Pin Lumina's per-position renormalization formula exactly."""
         config = Lumina2PipelineConfig()
         torch.manual_seed(0)
         cond = torch.randn(2, 1024, 16)
@@ -531,9 +480,6 @@ class TestLumina2PipelineConfig(CustomTestCase):
         torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     def test_renorm_survives_an_all_zero_prediction(self):
-        """clamp_min(1e-12) on the divisor. Bitwise identical to diffusers on
-        real input (verified above); it only differs where diffusers would
-        divide by zero."""
         config = Lumina2PipelineConfig()
         out = config.postprocess_cfg_noise(
             None, torch.zeros(1, 8, 16), torch.randn(1, 8, 16)
@@ -541,15 +487,7 @@ class TestLumina2PipelineConfig(CustomTestCase):
         self.assertTrue(torch.isfinite(out).all())
 
     def test_negating_before_cfg_equals_negating_after(self):
-        """The DiT returns ``-output`` (lumina2.py forward) while diffusers
-        negates in the pipeline *after* CFG and renorm
-        (pipeline_lumina2.py:761). That is only equivalent because both the CFG
-        combination and the renorm are odd in the prediction -- f(-x) = -f(x).
-
-        The equality is exact, not approximate: IEEE negation is exact and
-        round-to-nearest is symmetric under it, and ``torch.norm`` is unchanged
-        by sign. Asserted bitwise so a future non-odd postprocess turns it red.
-        """
+        """CFG and renormalization are odd, so negation may happen first."""
         config = Lumina2PipelineConfig()
         torch.manual_seed(0)
         cond = torch.randn(2, 4096, 16)
@@ -571,15 +509,7 @@ class TestLumina2PipelineConfig(CustomTestCase):
         torch.testing.assert_close(sgl, ref, rtol=0, atol=0)
 
     def test_sigma_grid_matches_the_diffusers_pipeline_linspace(self):
-        """diffusers' pipeline builds the grid itself (pipeline_lumina2.py:698)
-        and passes it into retrieve_timesteps:
-
-            sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
-
-        The scheduler's *own* default grid -- shift=6.0 applied to an internal
-        linspace -- is never used by the pipeline, so comparing against a bare
-        ``set_timesteps(steps)`` compares against code nothing calls.
-        """
+        """Lumina supplies an explicit linear sigma grid to the scheduler."""
         config = Lumina2PipelineConfig()
 
         for steps in (1, 2, 8, 30):
@@ -593,23 +523,17 @@ class TestLumina2PipelineConfig(CustomTestCase):
                 self.assertEqual(len(sigmas), steps)
                 self.assertEqual(list(sigmas), list(expected))
 
-        # An explicitly supplied grid must pass through untouched.
         given = [1.0, 0.7, 0.3]
         self.assertIs(config.prepare_sigmas(given, 3), given)
 
     def test_latent_geometry_derives_from_the_vae(self):
-        """FluxVAEArchConfig declares spatial_compression_ratio=1 and derives
-        the real value in post_init() from block_out_channels, falling back to
-        dim_mult. Reading it before post_init() reports 1 and makes the latent
-        look 8x too large -- that misread cost a false alarm during validation,
-        so both the pre and post values are pinned here."""
+        """The Flux VAE derives its spatial compression during post-init."""
         config = Lumina2PipelineConfig()
 
         self.assertEqual(config.vae_config.arch_config.spatial_compression_ratio, 1)
         config.vae_config.post_init()
         self.assertEqual(config.vae_config.arch_config.spatial_compression_ratio, 8)
 
-        # 16 latent channels, matching the FLUX.1-dev VAE Lumina-2 ships.
         self.assertEqual(config.dit_config.arch_config.num_channels_latents, 16)
 
         batch = SimpleNamespace(height=1024, width=1024)
@@ -622,14 +546,7 @@ class TestLumina2PipelineConfig(CustomTestCase):
         self.assertFalse(Lumina2SamplingParams().cfg_normalization)
 
     def test_pipeline_config_passes_its_own_validator(self):
-        """check_pipeline_config() rejects vae_sp without vae_tiling, and the
-        base class defaults both to True. Lumina sets vae_tiling=False, so
-        leaving vae_sp inherited fails validation before anything loads --
-        i.e. every `sglang generate` / `sglang serve` dies at startup.
-
-        The other Lumina tests build the config and assert on fields; none of
-        them ran it through its own validator, which is why that shipped.
-        """
+        """Lumina disables both VAE tiling and its dependent SP mode."""
         config = Lumina2PipelineConfig()
 
         self.assertFalse(config.vae_tiling)
@@ -637,19 +554,7 @@ class TestLumina2PipelineConfig(CustomTestCase):
         config.check_pipeline_config()
 
     def test_padding_mask_fires_when_the_tensor_is_wider_than_the_caption(self):
-        """Passes before and after the GQA fix; it pins *which path* an
-        ordinary request takes.
-
-        tokenize_prompt pads to max_length=256 while the attention mask carries
-        the caption's true length (~40 tokens with the system prompt). So
-        _padding_mask does not short-circuit, and the caption refiner runs the
-        masked attention path on a *single* prompt -- no batching required.
-        That is why the GQA defect in USPAttention's masked branch was a launch
-        blocker rather than a mixed-length-batch edge case.
-
-        The only case that legitimately skips the mask is a caption that fills
-        its tensor exactly.
-        """
+        """Ordinary padded captions exercise masked GQA attention."""
         device = torch.device("cpu")
 
         mask, meta = Lumina2Transformer2DModel._padding_mask(

--- a/python/sglang/multimodal_gen/test/unit/test_lumina2.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lumina2.py
@@ -1,0 +1,676 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for Lumina-Image-2.0 config/weight plumbing.
+
+These run without a GPU or a checkpoint download. They cover the failure modes
+that are invisible until a real load: architecture fields silently not picked up
+from the checkpoint's config.json, and weight-name mappings that resolve to
+params the model does not have.
+
+LUMINA2_CHECKPOINT_CONFIG below is verbatim
+Alpha-VLLM/Lumina-Image-2.0 transformer/config.json.
+"""
+
+import copy
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import torch
+
+from sglang.multimodal_gen.configs.models.dits.lumina2 import (
+    Lumina2ArchConfig,
+    Lumina2Config,
+)
+from sglang.multimodal_gen.configs.pipeline_configs.lumina2 import (
+    LUMINA2_MAX_TEXT_LEN,
+    LUMINA2_SYSTEM_PROMPT,
+    Lumina2PipelineConfig,
+)
+from sglang.multimodal_gen.configs.sample.lumina2 import Lumina2SamplingParams
+from sglang.multimodal_gen.registry import (
+    _PIPELINE_REGISTRY,
+    _discover_and_register_pipelines,
+    _get_config_info,
+)
+from sglang.multimodal_gen.runtime.loader.utils import (
+    get_param_names_mapping,
+    hf_to_custom_state_dict,
+)
+from sglang.multimodal_gen.runtime.models.dits.lumina2 import (
+    ADALN_EMBED_DIM,
+    FP32SiluAndMul,
+    Lumina2RMSNorm,
+    Lumina2Transformer2DModel,
+)
+from sglang.multimodal_gen.runtime.models.dits.zimage import (
+    FeedForward as ZImageFeedForward,
+)
+from sglang.multimodal_gen.runtime.models.dits.zimage import (
+    RopeEmbedder as ZImageRopeEmbedder,
+)
+from sglang.multimodal_gen.runtime.models.dits.zimage import (
+    TimestepEmbedder as ZImageTimestepEmbedder,
+)
+from sglang.multimodal_gen.runtime.models.dits.zimage import (
+    ZImageAttention,
+)
+from sglang.multimodal_gen.runtime.pipelines.lumina2 import Lumina2Pipeline
+from sglang.multimodal_gen.runtime.server_args import (
+    get_global_server_args,
+    set_global_server_args,
+)
+from sglang.test.test_utils import CustomTestCase
+
+LUMINA2_CHECKPOINT_CONFIG = {
+    "_class_name": "Lumina2Transformer2DModel",
+    "_diffusers_version": "0.33.0.dev0",
+    "axes_dim_rope": [32, 32, 32],
+    "axes_lens": [300, 512, 512],
+    "cap_feat_dim": 2304,
+    "ffn_dim_multiplier": None,
+    "hidden_size": 2304,
+    "in_channels": 16,
+    "multiple_of": 256,
+    "norm_eps": 1e-05,
+    "num_attention_heads": 24,
+    "num_kv_heads": 8,
+    "num_layers": 26,
+    "num_refiner_layers": 2,
+    "out_channels": None,
+    "patch_size": 2,
+    "sample_size": 128,
+    "scaling_factor": 1.0,
+}
+
+
+def _global_server_args_or_none():
+    """The installed global, or None. conftest's fixture is a pytest mechanism,
+    so a direct ``python test_lumina2.py`` run has none and the getter raises."""
+    try:
+        return get_global_server_args()
+    except ValueError:
+        return None
+
+
+def build_meta_model(config: Lumina2Config) -> Lumina2Transformer2DModel:
+    """Instantiate the DiT on the meta device (no weights, no GPU)."""
+    # Under pytest, extend the conftest fixture's stub rather than replacing it,
+    # so a layer that starts reading some other ServerArgs field gets fixed once
+    # in the fixture instead of here.
+    prev_args = _global_server_args_or_none()
+    if prev_args is None:
+        overridden = SimpleNamespace(attention_backend="torch_sdpa", comfyui_mode=False)
+    else:
+        overridden = copy.copy(prev_args)
+        overridden.attention_backend = "torch_sdpa"
+    fake_tp_group = SimpleNamespace(world_size=1, rank_in_group=0)
+    try:
+        set_global_server_args(overridden)
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.layers.attention.layer.get_ring_parallel_world_size",
+                return_value=1,
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.layers.linear.get_tp_group",
+                return_value=fake_tp_group,
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.models.dits.zimage.get_tp_world_size",
+                return_value=1,
+            ),
+        ):
+            with torch.device("meta"):
+                return Lumina2Transformer2DModel(config, {})
+    finally:
+        set_global_server_args(prev_args)
+
+
+class TestSharedZImagePrimitives(CustomTestCase):
+    def test_lumina_reuses_zimage_primitives_rather_than_forking_them(self):
+        """Lumina-2 and Z-Image are the same joint-DiT family, so the shared
+        blocks live in zimage.py -- the elder sibling -- matching this repo's
+        convention (causal_wanvideo <- wanvideo, longlive2 <- causal_wanvideo).
+
+        A local fork of any of these would drift from Z-Image silently, which
+        is how GQA support came to be missing from one of two copies of the
+        masked attention path.
+        """
+        import sglang.multimodal_gen.runtime.models.dits.lumina2 as lumina2_mod
+        import sglang.multimodal_gen.runtime.models.dits.zimage as zimage_mod
+
+        self.assertIs(lumina2_mod.ZImageAttention, ZImageAttention)
+        self.assertIs(lumina2_mod.FeedForward, ZImageFeedForward)
+        self.assertIs(lumina2_mod.RopeEmbedder, ZImageRopeEmbedder)
+        self.assertIs(lumina2_mod.TimestepEmbedder, ZImageTimestepEmbedder)
+
+        # Lumina's adaLN width is NOT Z-Image's. Importing zimage's
+        # ADALN_EMBED_DIM would build a silently wrong model -- no shape error
+        # at construction, just the wrong modulation width in three places.
+        self.assertEqual(ADALN_EMBED_DIM, 1024)
+        self.assertNotEqual(ADALN_EMBED_DIM, zimage_mod.ADALN_EMBED_DIM)
+
+    def test_fp32_silu_and_mul_matches_lumina_reference(self):
+        x = torch.linspace(-8, 8, 64, dtype=torch.float32).reshape(2, 32)
+        x = x.to(torch.bfloat16)
+        gate, value = x.chunk(2, dim=-1)
+        expected = torch.nn.functional.silu(gate.float()).to(gate.dtype) * value
+
+        actual = FP32SiluAndMul()(x)
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_lumina_model_selects_lumina_precision_policies(self):
+        model = build_meta_model(Lumina2Config())
+        block = model.layers[0]
+
+        self.assertIsInstance(block.attention, ZImageAttention)
+        self.assertIsInstance(block.attention.norm_q, Lumina2RMSNorm)
+        self.assertIsInstance(block.attention.norm_k, Lumina2RMSNorm)
+        self.assertFalse(block.attention.enable_zimage_qk_fusion)
+        self.assertIsInstance(block.feed_forward, ZImageFeedForward)
+        self.assertIsInstance(block.feed_forward.act, FP32SiluAndMul)
+        self.assertIsInstance(model.rope_embedder, ZImageRopeEmbedder)
+
+    def test_lumina_disables_usp_for_every_replicated_block_group(self):
+        model = build_meta_model(Lumina2Config())
+
+        for blocks in (model.context_refiner, model.noise_refiner, model.layers):
+            self.assertTrue(blocks)
+            for block in blocks:
+                self.assertTrue(block.attention.attn.skip_sequence_parallel)
+
+    def test_rope_phase_is_evaluated_in_fp64_for_lumina_only(self):
+        """diffusers transformer_lumina2.py:245 builds the phase in fp64 and
+        takes cos/sin there; rounding to fp32 first moves a few table entries by
+        a bf16 ulp. Z-Image shares this embedder and must keep fp32."""
+        axes_dims, axes_lens = (32, 32, 32), (300, 512, 512)
+        theta = 10000.0
+
+        cos64, sin64 = ZImageRopeEmbedder.precompute_freqs(
+            axes_dims, axes_lens, theta=theta, freqs_dtype=torch.float64
+        )
+        for i, (d, e) in enumerate(zip(axes_dims, axes_lens)):
+            freqs = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64) / d))
+            phase = torch.outer(torch.arange(e, dtype=torch.float64), freqs)
+            self.assertTrue(torch.equal(cos64[i], phase.cos().float()))
+            self.assertTrue(torch.equal(sin64[i], phase.sin().float()))
+            self.assertEqual(cos64[i].dtype, torch.float32)
+
+        # If the two agreed, Lumina's opt-in would be untested and Z-Image's
+        # default unprotected.
+        cos32, _ = ZImageRopeEmbedder.precompute_freqs(
+            axes_dims, axes_lens, theta=theta
+        )
+        self.assertFalse(all(torch.equal(a, b) for a, b in zip(cos32, cos64)))
+
+    def test_rms_norm_rounds_before_the_affine_multiply(self):
+        """diffusers normalization.py:553-562 casts to the weight dtype before
+        applying the weight. Hoisting that multiply into fp32 reads as a strict
+        accuracy win and silently drifts from the reference in every block."""
+        torch.manual_seed(0)
+        dim = 64
+        norm = Lumina2RMSNorm(dim).to(torch.bfloat16)
+        with torch.no_grad():
+            norm.weight.copy_(torch.randn(dim, dtype=torch.bfloat16))
+        x = torch.randn(4, 12, dim, dtype=torch.bfloat16)
+
+        variance = x.to(torch.float32).pow(2).mean(-1, keepdim=True)
+        normalized = x * torch.rsqrt(variance + norm.variance_epsilon)
+        expected = normalized.to(norm.weight.dtype) * norm.weight
+
+        actual = norm(x)
+        self.assertEqual(actual.dtype, torch.bfloat16)
+        self.assertTrue(torch.equal(actual, expected))
+
+        # Keeps the assertion above honest: a revert cannot pass by coincidence.
+        fp32_affine = (normalized * norm.weight.float()).to(torch.bfloat16)
+        self.assertFalse(torch.equal(fp32_affine, expected))
+
+
+class TestLumina2ArchConfig(CustomTestCase):
+    def test_every_checkpoint_config_key_is_a_declared_field(self):
+        """ArchConfig routes undeclared keys into extra_attrs, where nothing
+        reads them. A key landing there means update_model_arch silently drops
+        the checkpoint's value and the model is built from a stale default."""
+        declared = Lumina2ArchConfig.__dataclass_fields__
+        undeclared = sorted(
+            key
+            for key in LUMINA2_CHECKPOINT_CONFIG
+            if not key.startswith("_") and key not in declared
+        )
+        self.assertEqual(undeclared, [])
+
+    def test_update_model_arch_applies_checkpoint_values(self):
+        config = Lumina2Config()
+        config.update_model_arch(LUMINA2_CHECKPOINT_CONFIG)
+        arch = config.arch_config
+
+        self.assertEqual(arch.extra_attrs.get("num_kv_heads"), None)
+        self.assertEqual(arch.num_kv_heads, 8)
+        self.assertEqual(arch.num_refiner_layers, 2)
+        self.assertEqual(arch.patch_size, 2)
+        self.assertEqual(tuple(arch.axes_dim_rope), (32, 32, 32))
+        self.assertIsNone(arch.ffn_dim_multiplier)
+        # out_channels is null in the checkpoint and backfilled from in_channels.
+        self.assertEqual(arch.out_channels, 16)
+        self.assertEqual(arch.num_channels_latents, 16)
+
+    def test_non_default_checkpoint_values_reach_the_model(self):
+        """Guards the failure this whole file exists for: a variant checkpoint
+        whose values differ from our defaults must actually change the model."""
+        variant = dict(LUMINA2_CHECKPOINT_CONFIG, num_kv_heads=12, num_refiner_layers=3)
+        config = Lumina2Config()
+        config.update_model_arch(variant)
+        model = build_meta_model(config)
+
+        self.assertEqual(len(model.noise_refiner), 3)
+        self.assertEqual(len(model.context_refiner), 3)
+        # 24 heads * 96 head_dim + 2 * (12 kv heads * 96) = 2304 + 2304
+        self.assertEqual(
+            tuple(model.layers[0].attention.to_qkv.weight.shape), (4608, 2304)
+        )
+
+    def test_axes_dim_rope_must_sum_to_head_dim(self):
+        config = Lumina2Config()
+        with self.assertRaisesRegex(ValueError, "axes_dim_rope"):
+            config.update_model_arch(
+                dict(LUMINA2_CHECKPOINT_CONFIG, axes_dim_rope=[32, 32, 16])
+            )
+
+    def test_ffn_width_follows_the_checkpoint(self):
+        model = build_meta_model(Lumina2Config())
+        # round_up(4 * 2304, 256) = 9216, fused gate+up -> 18432 rows.
+        self.assertEqual(
+            tuple(model.layers[0].feed_forward.w13.weight.shape), (18432, 2304)
+        )
+        self.assertEqual(
+            tuple(model.layers[0].feed_forward.w2.weight.shape), (2304, 9216)
+        )
+
+    def test_fused_qkv_width_follows_the_checkpoint(self):
+        """The default-config counterpart to the GQA variant checked above. A
+        fusion can resolve by name and still be sized wrong, which surfaces much
+        later inside the loader's cat."""
+        model = build_meta_model(Lumina2Config())
+        # (24 q + 8 kv + 8 kv) * 96 head_dim.
+        self.assertEqual(
+            tuple(model.layers[0].attention.to_qkv.weight.shape), (3840, 2304)
+        )
+        # patch_size**2 * in_channels = 4 * 16.
+        self.assertEqual(tuple(model.x_embedder.weight.shape), (2304, 64))
+
+
+class TestLumina2WeightMapping(CustomTestCase):
+    def test_block_weights_map_onto_real_params(self):
+        mapping = get_param_names_mapping(Lumina2ArchConfig().param_names_mapping)
+        weights = [
+            ("layers.0.attn.to_q.weight", torch.full((2, 2), 1.0)),
+            ("layers.0.attn.to_k.weight", torch.full((2, 2), 2.0)),
+            ("layers.0.attn.to_v.weight", torch.full((2, 2), 3.0)),
+            ("layers.0.feed_forward.linear_1.weight", torch.full((2, 2), 4.0)),
+            ("layers.0.feed_forward.linear_3.weight", torch.full((2, 2), 5.0)),
+            ("layers.0.feed_forward.linear_2.weight", torch.full((2, 2), 6.0)),
+            ("layers.0.norm1.linear.weight", torch.full((2, 2), 7.0)),
+            ("layers.0.norm1.norm.weight", torch.full((2,), 8.0)),
+            ("layers.0.norm2.weight", torch.full((2,), 9.0)),
+            ("context_refiner.0.norm1.weight", torch.full((2,), 10.0)),
+            ("norm_out.linear_1.weight", torch.full((2, 2), 11.0)),
+            ("norm_out.linear_2.weight", torch.full((2, 2), 12.0)),
+            (
+                "time_caption_embed.timestep_embedder.linear_1.weight",
+                torch.full((2, 2), 13.0),
+            ),
+        ]
+        mapped, _ = hf_to_custom_state_dict(iter(weights), mapping)
+
+        # q/k/v fuse in order, gate/up fuse in order.
+        torch.testing.assert_close(
+            mapped["layers.0.attention.to_qkv.weight"],
+            torch.cat([w for _, w in weights[:3]], dim=0),
+        )
+        torch.testing.assert_close(
+            mapped["layers.0.feed_forward.w13.weight"],
+            torch.cat([w for _, w in weights[3:5]], dim=0),
+        )
+        for name in (
+            "layers.0.feed_forward.w2.weight",
+            "layers.0.adaLN_modulation.1.weight",
+            "layers.0.attention_norm1.weight",
+            "layers.0.attention_norm2.weight",
+            "context_refiner.0.attention_norm1.weight",
+            "norm_out.adaLN_modulation.1.weight",
+            "norm_out.linear.weight",
+            "time_caption_embed.timestep_embedder.mlp.0.weight",
+        ):
+            self.assertIn(name, mapped)
+
+        # A rule resolving to a name the model lacks is dropped at load time and
+        # leaves that layer at its initialized values, silently.
+        model = build_meta_model(Lumina2Config())
+        self.assertEqual(sorted(set(mapped) - set(model.state_dict())), [])
+
+    def test_packed_modules_mapping_covers_every_fusion(self):
+        """Omitting a fusion here silently quantizes a layer the user asked to
+        keep, since --quantization-ignored-layers names checkpoint weights."""
+        model = build_meta_model(Lumina2Config())
+        mapping = Lumina2Transformer2DModel.packed_modules_mapping
+        leaf_modules = {name.rsplit(".", 2)[-2] for name in model.state_dict()}
+
+        # Both fusions are unconditional for Lumina.
+        for fused in ("to_qkv", "w13"):
+            self.assertIn(fused, leaf_modules)
+            self.assertIn(fused, mapping)
+
+        # Shards must be names the checkpoint actually uses. Z-Image's w1/w3
+        # appear in no Lumina key and would resolve to nothing.
+        pattern_text = " ".join(Lumina2ArchConfig().param_names_mapping)
+        for shards in mapping.values():
+            for shard in shards:
+                self.assertIn(shard, pattern_text)
+
+
+class TestLumina2PipelineConfig(CustomTestCase):
+    def test_registry_resolves_model_path(self):
+        # get_model_info would fetch model_index.json and, when that fails,
+        # still pass by falling back to these same classes. __wrapped__ skips
+        # lru_cache(maxsize=1) rather than evicting the entry other tests share.
+        # The patch is for the detector path, which pulls model_index.json
+        # before running detectors; the exact-path match returns before that.
+        resolve = _get_config_info.__wrapped__
+        with patch(
+            "sglang.multimodal_gen.registry.maybe_download_model_index",
+            return_value={},
+        ):
+            for path in (
+                "Alpha-VLLM/Lumina-Image-2.0",  # exact hf_model_paths entry
+                "some-org/lumina2-finetune",  # model_detectors fallback
+            ):
+                info = resolve(path)
+                self.assertIsNotNone(info, path)
+                self.assertIs(info.pipeline_config_cls, Lumina2PipelineConfig)
+                self.assertIs(info.sampling_param_cls, Lumina2SamplingParams)
+
+    def test_pipeline_name_matches_hf_class_name(self):
+        """_class_name in model_index.json is how a checkpoint finds this
+        pipeline; renaming pipeline_name drops Lumina onto the generic path."""
+        _discover_and_register_pipelines()
+        self.assertIs(
+            _PIPELINE_REGISTRY.get("Lumina2Pipeline"),
+            Lumina2Pipeline,
+        )
+
+    def test_sequence_parallel_sharding_is_disabled(self):
+        """The DiT has no SP handling, so sharding latents across ranks would
+        silently produce a wrong image rather than fail."""
+        config = Lumina2PipelineConfig()
+        latents = torch.zeros(1, 16, 128, 128)
+        sharded, did_shard = config.shard_latents_for_sp(None, latents)
+        self.assertFalse(did_shard)
+        self.assertIs(sharded, latents)
+        self.assertIs(config.gather_latents_for_sp(latents), latents)
+
+    def test_conditioning_expands_to_the_sample_batch(self):
+        """Conditioning must reach one row per sample, not per prompt; see
+        Lumina2PipelineConfig.expand_conditioning_to_sample_batch."""
+        config = Lumina2PipelineConfig()
+        batch = SimpleNamespace(
+            prompt="a cat",
+            num_outputs_per_prompt=4,
+            prompt_embeds=[torch.zeros(1, 256, 2304)],
+            negative_prompt_embeds=[torch.zeros(1, 256, 2304)],
+            prompt_attention_mask=[torch.ones(1, 256, dtype=torch.long)],
+            negative_attention_mask=[torch.ones(1, 256, dtype=torch.long)],
+        )
+
+        config.expand_conditioning_to_sample_batch(batch)
+
+        for field in (
+            "prompt_embeds",
+            "negative_prompt_embeds",
+            "prompt_attention_mask",
+            "negative_attention_mask",
+        ):
+            (tensor,) = getattr(batch, field)
+            self.assertEqual(tensor.shape[0], 4, field)
+
+    def test_conditioning_expansion_is_a_no_op_for_a_single_output(self):
+        config = Lumina2PipelineConfig()
+        embeds = [torch.zeros(2, 256, 2304)]
+        batch = SimpleNamespace(
+            prompt=["a cat", "a dog"],
+            num_outputs_per_prompt=1,
+            prompt_embeds=embeds,
+            negative_prompt_embeds=None,
+            prompt_attention_mask=None,
+            negative_attention_mask=None,
+        )
+
+        config.expand_conditioning_to_sample_batch(batch)
+
+        self.assertIs(batch.prompt_embeds, embeds)
+
+    def test_tokenizer_is_pinned_to_right_padding(self):
+        """A tokenizer arriving with left padding must be corrected in place."""
+        config = Lumina2PipelineConfig()
+
+        def fake_tokenizer(prompts, **kwargs):
+            return SimpleNamespace(to=lambda _device: {})
+
+        fake_tokenizer.padding_side = "left"
+        config.tokenize_prompt(["a"], fake_tokenizer, {})
+        self.assertEqual(fake_tokenizer.padding_side, "right")
+
+    def test_caption_length_is_capped_to_the_rope_table(self):
+        config = Lumina2PipelineConfig()
+        captured = {}
+
+        def fake_tokenizer(prompts, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(to=lambda _device: {})
+
+        # One below the row count; see Lumina2PipelineConfig.tokenize_prompt.
+        axis0 = config.dit_config.arch_config.axes_lens[0]
+        config.tokenize_prompt(["a"], fake_tokenizer, {"max_length": 512})
+        self.assertEqual(captured["max_length"], axis0 - 1)
+
+        config.tokenize_prompt(["a"], fake_tokenizer, {})
+        self.assertEqual(captured["max_length"], LUMINA2_MAX_TEXT_LEN)
+
+    def test_prompt_preprocessing_matches_diffusers(self):
+        config = Lumina2PipelineConfig()
+        (preprocess,) = config.get_preprocess_text_funcs(is_negative=False)
+        (negative_preprocess,) = config.get_preprocess_text_funcs(is_negative=True)
+
+        # Transcribed from diffusers pipeline_lumina2.py:288, identical in
+        # v0.33.0, v0.37.0 (the pinned one) and main:
+        #   prompt = [system_prompt + " <Prompt Start> " + p for p in prompt]
+        # Spelled out, not built from LUMINA2_PROMPT_SEPARATOR, so editing the
+        # separator turns this red instead of agreeing with itself.
+        self.assertEqual(
+            preprocess("a cat"),
+            LUMINA2_SYSTEM_PROMPT + " <Prompt Start> " + "a cat",
+        )
+        self.assertEqual(preprocess(""), LUMINA2_SYSTEM_PROMPT + " <Prompt Start> ")
+        self.assertIsNone(negative_preprocess)
+
+    def test_renorm_cfg_matches_the_conditional_norm(self):
+        config = Lumina2PipelineConfig()
+        noise_pred_cond = torch.randn(1, 16, 8, 8)
+        noise_pred = noise_pred_cond * 3.0
+
+        out = config.postprocess_cfg_noise(None, noise_pred, noise_pred_cond)
+
+        torch.testing.assert_close(
+            torch.norm(out, dim=-1), torch.norm(noise_pred_cond, dim=-1)
+        )
+
+    def test_renorm_matches_the_diffusers_formula_bitwise(self):
+        """Transcribed from diffusers pipeline_lumina2.py:750-758:
+
+            cond_norm  = torch.norm(noise_pred_cond, dim=-1, keepdim=True)
+            noise_norm = torch.norm(noise_pred,      dim=-1, keepdim=True)
+            noise_pred = noise_pred * (cond_norm / noise_norm)
+
+        The property test above only pins that the conditional norm is
+        restored; this pins the formula, so a different rescale that happens
+        to preserve the norm would still turn it red.
+        """
+        config = Lumina2PipelineConfig()
+        torch.manual_seed(0)
+        cond = torch.randn(2, 1024, 16)
+        combined = torch.randn(2, 1024, 16)
+
+        expected = combined * (
+            torch.norm(cond, dim=-1, keepdim=True)
+            / torch.norm(combined, dim=-1, keepdim=True)
+        )
+        actual = config.postprocess_cfg_noise(None, combined, cond)
+
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_renorm_survives_an_all_zero_prediction(self):
+        """clamp_min(1e-12) on the divisor. Bitwise identical to diffusers on
+        real input (verified above); it only differs where diffusers would
+        divide by zero."""
+        config = Lumina2PipelineConfig()
+        out = config.postprocess_cfg_noise(
+            None, torch.zeros(1, 8, 16), torch.randn(1, 8, 16)
+        )
+        self.assertTrue(torch.isfinite(out).all())
+
+    def test_negating_before_cfg_equals_negating_after(self):
+        """The DiT returns ``-output`` (lumina2.py forward) while diffusers
+        negates in the pipeline *after* CFG and renorm
+        (pipeline_lumina2.py:761). That is only equivalent because both the CFG
+        combination and the renorm are odd in the prediction -- f(-x) = -f(x).
+
+        The equality is exact, not approximate: IEEE negation is exact and
+        round-to-nearest is symmetric under it, and ``torch.norm`` is unchanged
+        by sign. Asserted bitwise so a future non-odd postprocess turns it red.
+        """
+        config = Lumina2PipelineConfig()
+        torch.manual_seed(0)
+        cond = torch.randn(2, 4096, 16)
+        uncond = torch.randn(2, 4096, 16)
+        scale = 4.0
+
+        # diffusers: combine -> renorm -> negate.
+        ref = uncond + scale * (cond - uncond)
+        ref = ref * (
+            torch.norm(cond, dim=-1, keepdim=True)
+            / torch.norm(ref, dim=-1, keepdim=True)
+        )
+        ref = -ref
+
+        # SGLang: the DiT already negated, so CFG and renorm see -cond/-uncond.
+        sgl_combined = (-uncond) + scale * ((-cond) - (-uncond))
+        sgl = config.postprocess_cfg_noise(None, sgl_combined, -cond)
+
+        torch.testing.assert_close(sgl, ref, rtol=0, atol=0)
+
+    def test_sigma_grid_matches_the_diffusers_pipeline_linspace(self):
+        """diffusers' pipeline builds the grid itself (pipeline_lumina2.py:698)
+        and passes it into retrieve_timesteps:
+
+            sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+
+        The scheduler's *own* default grid -- shift=6.0 applied to an internal
+        linspace -- is never used by the pipeline, so comparing against a bare
+        ``set_timesteps(steps)`` compares against code nothing calls.
+        """
+        config = Lumina2PipelineConfig()
+
+        for steps in (1, 2, 8, 30):
+            with self.subTest(steps=steps):
+                sigmas = config.prepare_sigmas(None, steps)
+                # np.linspace, not torch.linspace: the implementation and
+                # diffusers both call this one, and the two can disagree in the
+                # last bit -- which would make an exact assert lie.
+                expected = np.linspace(1.0, 1 / steps, steps)
+
+                self.assertEqual(len(sigmas), steps)
+                self.assertEqual(list(sigmas), list(expected))
+
+        # An explicitly supplied grid must pass through untouched.
+        given = [1.0, 0.7, 0.3]
+        self.assertIs(config.prepare_sigmas(given, 3), given)
+
+    def test_latent_geometry_derives_from_the_vae(self):
+        """FluxVAEArchConfig declares spatial_compression_ratio=1 and derives
+        the real value in post_init() from block_out_channels, falling back to
+        dim_mult. Reading it before post_init() reports 1 and makes the latent
+        look 8x too large -- that misread cost a false alarm during validation,
+        so both the pre and post values are pinned here."""
+        config = Lumina2PipelineConfig()
+
+        self.assertEqual(config.vae_config.arch_config.spatial_compression_ratio, 1)
+        config.vae_config.post_init()
+        self.assertEqual(config.vae_config.arch_config.spatial_compression_ratio, 8)
+
+        # 16 latent channels, matching the FLUX.1-dev VAE Lumina-2 ships.
+        self.assertEqual(config.dit_config.arch_config.num_channels_latents, 16)
+
+        batch = SimpleNamespace(height=1024, width=1024)
+        self.assertEqual(
+            config.prepare_latent_shape(batch, 1, 1), (1, 16, 128, 128)
+        )
+
+    def test_cfg_normalization_stays_off(self):
+        """Lumina2SamplingParams pins this to 0.0 against a change to the base
+        default. Turning it on stacks CFGPolicy's global max-norm clip on top of
+        the per-position renorm above, which is a different operation."""
+        self.assertFalse(Lumina2SamplingParams().cfg_normalization)
+
+    def test_pipeline_config_passes_its_own_validator(self):
+        """check_pipeline_config() rejects vae_sp without vae_tiling, and the
+        base class defaults both to True. Lumina sets vae_tiling=False, so
+        leaving vae_sp inherited fails validation before anything loads --
+        i.e. every `sglang generate` / `sglang serve` dies at startup.
+
+        The other Lumina tests build the config and assert on fields; none of
+        them ran it through its own validator, which is why that shipped.
+        """
+        config = Lumina2PipelineConfig()
+
+        self.assertFalse(config.vae_tiling)
+        self.assertFalse(config.vae_sp)
+        config.check_pipeline_config()
+
+    def test_padding_mask_fires_when_the_tensor_is_wider_than_the_caption(self):
+        """Passes before and after the GQA fix; it pins *which path* an
+        ordinary request takes.
+
+        tokenize_prompt pads to max_length=256 while the attention mask carries
+        the caption's true length (~40 tokens with the system prompt). So
+        _padding_mask does not short-circuit, and the caption refiner runs the
+        masked attention path on a *single* prompt -- no batching required.
+        That is why the GQA defect in USPAttention's masked branch was a launch
+        blocker rather than a mixed-length-batch edge case.
+
+        The only case that legitimately skips the mask is a caption that fills
+        its tensor exactly.
+        """
+        device = torch.device("cpu")
+
+        mask, meta = Lumina2Transformer2DModel._padding_mask(
+            [37], LUMINA2_MAX_TEXT_LEN, device
+        )
+        self.assertIsNotNone(mask)
+        self.assertIsNotNone(meta)
+        self.assertEqual(tuple(mask.shape), (1, LUMINA2_MAX_TEXT_LEN))
+        self.assertEqual(int(mask.sum()), 37)
+        self.assertTrue(bool(mask[0, 36]))
+        self.assertFalse(bool(mask[0, 37]))
+
+        self.assertEqual(
+            Lumina2Transformer2DModel._padding_mask(
+                [LUMINA2_MAX_TEXT_LEN], LUMINA2_MAX_TEXT_LEN, device
+            ),
+            (None, None),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_lumina2.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lumina2.py
@@ -613,9 +613,7 @@ class TestLumina2PipelineConfig(CustomTestCase):
         self.assertEqual(config.dit_config.arch_config.num_channels_latents, 16)
 
         batch = SimpleNamespace(height=1024, width=1024)
-        self.assertEqual(
-            config.prepare_latent_shape(batch, 1, 1), (1, 16, 128, 128)
-        )
+        self.assertEqual(config.prepare_latent_shape(batch, 1, 1), (1, 16, 128, 128))
 
     def test_cfg_normalization_stays_off(self):
         """Lumina2SamplingParams pins this to 0.0 against a change to the base

--- a/python/sglang/multimodal_gen/test/unit/test_usp_attention_masked_gqa.py
+++ b/python/sglang/multimodal_gen/test/unit/test_usp_attention_masked_gqa.py
@@ -1,26 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Regression tests for USPAttention's masked path under GQA.
-
-``USPAttention``'s masked branch has two exits, and before this fix both assumed
-Q/K/V share a head count:
-
-* the varlen FA fast path calls ``fused_pack_qkv``, which asserts Q/K/V share a
-  full shape -- but the gate only compared ``shape[:2]``, i.e. (batch, sequence),
-  stopping one index short of the head dimension that GQA actually varies;
-* the SDPA fallback handed unexpanded K/V to
-  ``scaled_dot_product_attention``, which does not broadcast heads.
-
-``LocalAttention`` has carried the K/V expansion since it was written;
-``USPAttention`` did not, because its only consumer until Lumina-Image-2.0
-(24 query heads / 8 KV heads) was Z-Image, which is MHA.
-
-The masked branch is reached whenever a caption is shorter than its padded
-tensor -- ``tokenize_prompt`` pads to ``max_length`` while the attention mask
-carries the true length -- so this was not limited to mixed-length batches.
-
-MHA must be bit-for-bit unaffected; ``test_mha_masked_output_is_unchanged``
-asserts that by object identity, not by tolerance.
-"""
+"""Regression tests for masked GQA in USPAttention."""
 
 import unittest
 from types import SimpleNamespace
@@ -39,12 +18,7 @@ _LAYER = "sglang.multimodal_gen.runtime.layers.attention.layer"
 
 
 def _masked_forward(q, k, v, attn_mask):
-    """Drive USPAttention's masked non-SP branch on CPU.
-
-    ``__init__`` is bypassed (it needs a real backend + distributed setup), so
-    ``forward`` is called unbound -- ``nn.Module.__call__`` would go looking for
-    the state we skipped. Only the attributes that branch actually reads are set.
-    """
+    """Drive the masked non-SP branch without distributed initialization."""
     obj = USPAttention.__new__(USPAttention)
     obj.skip_sequence_parallel = True  # take the non-SP branch
     obj.softmax_scale = None
@@ -87,9 +61,6 @@ class TestUSPAttentionMaskedGQA(unittest.TestCase):
         self.mask = torch.tensor([[True, True, True, True, False, False]])
 
     def test_masked_attention_handles_gqa(self):
-        """4 query heads / 2 KV heads. Pre-fix this raised
-        ``RuntimeError: The size of tensor a (4) must match the size of
-        tensor b (2) at non-singleton dimension 1``."""
         q = torch.randn(1, 6, 4, 8)
         k = torch.randn(1, 6, 2, 8)
         v = torch.randn(1, 6, 2, 8)
@@ -100,7 +71,6 @@ class TestUSPAttentionMaskedGQA(unittest.TestCase):
         torch.testing.assert_close(out, _sdpa_reference(q, k, v, self.mask))
 
     def test_mha_masked_output_is_unchanged(self):
-        """Equal head counts must take exactly the pre-fix code path."""
         q = torch.randn(1, 6, 4, 8)
         k = torch.randn(1, 6, 4, 8)
         v = torch.randn(1, 6, 4, 8)

--- a/python/sglang/multimodal_gen/test/unit/test_usp_attention_masked_gqa.py
+++ b/python/sglang/multimodal_gen/test/unit/test_usp_attention_masked_gqa.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for USPAttention's masked path under GQA.
+
+``USPAttention``'s masked branch has two exits, and before this fix both assumed
+Q/K/V share a head count:
+
+* the varlen FA fast path calls ``fused_pack_qkv``, which asserts Q/K/V share a
+  full shape -- but the gate only compared ``shape[:2]``, i.e. (batch, sequence),
+  stopping one index short of the head dimension that GQA actually varies;
+* the SDPA fallback handed unexpanded K/V to
+  ``scaled_dot_product_attention``, which does not broadcast heads.
+
+``LocalAttention`` has carried the K/V expansion since it was written;
+``USPAttention`` did not, because its only consumer until Lumina-Image-2.0
+(24 query heads / 8 KV heads) was Z-Image, which is MHA.
+
+The masked branch is reached whenever a caption is shorter than its padded
+tensor -- ``tokenize_prompt`` pads to ``max_length`` while the attention mask
+carries the true length -- so this was not limited to mixed-length batches.
+
+MHA must be bit-for-bit unaffected; ``test_mha_masked_output_is_unchanged``
+asserts that by object identity, not by tolerance.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.multimodal_gen.runtime.layers.attention.layer import (
+    USPAttention,
+    _expand_kv_for_gqa,
+    _same_head_count,
+)
+
+_LAYER = "sglang.multimodal_gen.runtime.layers.attention.layer"
+
+
+def _masked_forward(q, k, v, attn_mask):
+    """Drive USPAttention's masked non-SP branch on CPU.
+
+    ``__init__`` is bypassed (it needs a real backend + distributed setup), so
+    ``forward`` is called unbound -- ``nn.Module.__call__`` would go looking for
+    the state we skipped. Only the attributes that branch actually reads are set.
+    """
+    obj = USPAttention.__new__(USPAttention)
+    obj.skip_sequence_parallel = True  # take the non-SP branch
+    obj.softmax_scale = None
+    obj.allow_cudnn_sdp = False  # plain SDPA, no kernel preference
+    obj.backend = None  # not FA -> varlen fast path is skipped
+    obj.attn_impl = None  # unmasked path only; must not be reached
+
+    with (
+        patch(
+            f"{_LAYER}.get_forward_context",
+            return_value=SimpleNamespace(attn_metadata=None),
+        ),
+        patch(f"{_LAYER}.get_sequence_parallel_world_size", return_value=1),
+    ):
+        return USPAttention.forward(obj, q, k, v, attn_mask=attn_mask)
+
+
+def _sdpa_reference(q, k, v, attn_mask):
+    """What the masked branch should compute, written independently.
+
+    Uses PyTorch's own ``enable_gqa`` rather than repeating the expansion under
+    test, so this cannot agree with the implementation by sharing its mistake.
+    """
+    additive = (attn_mask.to(q.dtype)[:, None, None, :] - 1.0) * torch.finfo(
+        q.dtype
+    ).max
+    out = F.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+        attn_mask=additive,
+        enable_gqa=q.shape[2] != k.shape[2],
+    )
+    return out.transpose(1, 2)
+
+
+class TestUSPAttentionMaskedGQA(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.mask = torch.tensor([[True, True, True, True, False, False]])
+
+    def test_masked_attention_handles_gqa(self):
+        """4 query heads / 2 KV heads. Pre-fix this raised
+        ``RuntimeError: The size of tensor a (4) must match the size of
+        tensor b (2) at non-singleton dimension 1``."""
+        q = torch.randn(1, 6, 4, 8)
+        k = torch.randn(1, 6, 2, 8)
+        v = torch.randn(1, 6, 2, 8)
+
+        out = _masked_forward(q, k, v, self.mask)
+
+        self.assertEqual(tuple(out.shape), (1, 6, 4, 8))
+        torch.testing.assert_close(out, _sdpa_reference(q, k, v, self.mask))
+
+    def test_mha_masked_output_is_unchanged(self):
+        """Equal head counts must take exactly the pre-fix code path."""
+        q = torch.randn(1, 6, 4, 8)
+        k = torch.randn(1, 6, 4, 8)
+        v = torch.randn(1, 6, 4, 8)
+
+        out = _masked_forward(q, k, v, self.mask)
+        torch.testing.assert_close(out, _sdpa_reference(q, k, v, self.mask))
+
+        # assertIs, not assert_close: MHA must get the same objects back, so
+        # nothing can perturb Z-Image's numerics.
+        kt, vt = k.transpose(1, 2), v.transpose(1, 2)
+        k_, v_ = _expand_kv_for_gqa(q.transpose(1, 2), kt, vt)
+        self.assertIs(k_, kt)
+        self.assertIs(v_, vt)
+
+    def test_varlen_fa_gate_rejects_gqa_and_accepts_mha(self):
+        """The gate the fast path needs. Reaching the real one requires CUDA +
+        FlashAttention + bf16, so the predicate is tested directly."""
+        gqa = (torch.empty(1, 4352, 24, 96), torch.empty(1, 4352, 8, 96))
+        self.assertFalse(_same_head_count(gqa[0], gqa[1], gqa[1]))
+
+        mha = torch.empty(1, 4352, 30, 96)
+        self.assertTrue(_same_head_count(mha, mha, mha))
+
+    def test_expand_kv_rejects_a_non_divisible_head_count(self):
+        q = torch.empty(1, 24, 4, 8)
+        bad = torch.empty(1, 5, 4, 8)
+        with self.assertRaises(ValueError) as ctx:
+            _expand_kv_for_gqa(q, bad, bad)
+        self.assertIn("positive multiple", str(ctx.exception))
+
+    def test_expanded_kv_repeats_each_group_contiguously(self):
+        """Query head i must see KV head i // repeat_factor. Getting the
+        interleave backwards (``repeat`` instead of ``repeat_interleave``)
+        still produces the right shape and silently wrong attention."""
+        q = torch.empty(1, 4, 6, 8)
+        k = torch.randn(1, 2, 6, 8)
+        k_, _ = _expand_kv_for_gqa(q, k, k)
+
+        for head in range(4):
+            self.assertTrue(torch.equal(k_[0, head], k[0, head // 2]))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "needs CUDA + FlashAttention")
+class TestUSPAttentionMaskedGQAOnGPU(unittest.TestCase):
+    def test_fused_varlen_path_is_still_taken_for_mha(self):
+        """The only test that exercises the real gate: MHA must keep the varlen
+        FA fast path, GQA must fall through to SDPA instead of reaching
+        ``fused_pack_qkv``'s equal-shape assert."""
+        from sglang.multimodal_gen.runtime.layers.attention.layer import (
+            build_varlen_mask_meta,
+        )
+        from sglang.multimodal_gen.runtime.layers.attention.layer import (
+            fused_pack_qkv as real_pack,
+        )
+        from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+
+        mask = torch.tensor([[True] * 4 + [False] * 2], device="cuda")
+        meta = build_varlen_mask_meta(mask)
+
+        def run(kv_heads):
+            q = torch.randn(1, 6, 4, 8, device="cuda", dtype=torch.bfloat16)
+            k = torch.randn(1, 6, kv_heads, 8, device="cuda", dtype=torch.bfloat16)
+            v = torch.randn(1, 6, kv_heads, 8, device="cuda", dtype=torch.bfloat16)
+            obj = USPAttention.__new__(USPAttention)
+            obj.skip_sequence_parallel = True
+            obj.softmax_scale = None
+            obj.allow_cudnn_sdp = False
+            obj.backend = AttentionBackendEnum.FA
+            obj.attn_impl = None
+            with (
+                patch(
+                    f"{_LAYER}.get_forward_context",
+                    return_value=SimpleNamespace(attn_metadata=None),
+                ),
+                patch(f"{_LAYER}.get_sequence_parallel_world_size", return_value=1),
+                patch(f"{_LAYER}.fused_pack_qkv", side_effect=real_pack) as spy,
+            ):
+                out = USPAttention.forward(
+                    obj, q, k, v, attn_mask=mask, attn_mask_meta=meta
+                )
+            return out, spy.called
+
+        _, mha_used_fa = run(kv_heads=4)
+        self.assertTrue(mha_used_fa, "MHA must keep the varlen FA fast path")
+
+        out, gqa_used_fa = run(kv_heads=2)
+        self.assertFalse(gqa_used_fa, "GQA must not reach fused_pack_qkv")
+        self.assertEqual(tuple(out.shape), (1, 6, 4, 8))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_zimage_pipeline_config.py
+++ b/python/sglang/multimodal_gen/test/unit/test_zimage_pipeline_config.py
@@ -18,9 +18,7 @@ from sglang.multimodal_gen.runtime.models.dits.zimage import (
 @contextmanager
 def _single_process_parallel():
     """Stub the TP / SP world so parallel-linear modules (ZImageAttention,
-    FeedForward) construct on the 'meta' device without an initialized
-    distributed group. Mirrors the patch set test_lumina2 uses for the same
-    purpose."""
+    FeedForward) construct on the 'meta' device."""
     fake_tp_group = SimpleNamespace(world_size=1, rank_in_group=0)
     with (
         patch(
@@ -40,16 +38,9 @@ def _single_process_parallel():
 
 
 class TestZImageSharedPrimitiveDefaults(unittest.TestCase):
-    """Lumina-2 reuses FeedForward / ZImageAttention / RopeEmbedder and opts into
-    its own precision policy through added keyword arguments. Every one of those
-    defaults to Z-Image's behavior; these pin that, so a future change to the
-    hooks cannot quietly move Z-Image."""
+    """Shared primitive defaults preserve Z-Image behavior."""
 
     def test_rope_default_reproduces_the_pre_hook_fp32_formula_bitwise(self) -> None:
-        """freqs_dtype defaults to fp32, and the .float() moved from before
-        cos()/sin() to after. For an fp32 phase both orderings are the same
-        computation. Written against the *old* expression so a regression
-        cannot pass by agreeing with the new code."""
         axes_dims, axes_lens, theta = (16, 56, 56), (64, 128, 128), 256.0
 
         cos_list, sin_list = RopeEmbedder.precompute_freqs(
@@ -63,7 +54,6 @@ class TestZImageSharedPrimitiveDefaults(unittest.TestCase):
             self.assertTrue(torch.equal(sin_list[i], torch.sin(phase)))
 
     def test_rope_fp64_phase_is_opt_in_and_actually_differs(self) -> None:
-        """The hook must do something, or Lumina silently gets Z-Image's fp32."""
         args = ((16, 56, 56), (64, 128, 128))
         cos32, _ = RopeEmbedder.precompute_freqs(*args)
         cos64, _ = RopeEmbedder.precompute_freqs(*args, freqs_dtype=torch.float64)
@@ -81,8 +71,6 @@ class TestZImageSharedPrimitiveDefaults(unittest.TestCase):
         self.assertTrue(attn.enable_zimage_qk_fusion)
 
     def test_allow_fused_qk_norm_rope_only_ever_disables(self) -> None:
-        """`allow_fused_qk_norm_rope and quant_config is None` must reduce to
-        the old `quant_config is None` whenever the flag is left alone."""
         with _single_process_parallel(), torch.device("meta"):
             off = ZImageAttention(
                 dim=64, num_heads=4, num_kv_heads=4, allow_fused_qk_norm_rope=False

--- a/python/sglang/multimodal_gen/test/unit/test_zimage_pipeline_config.py
+++ b/python/sglang/multimodal_gen/test/unit/test_zimage_pipeline_config.py
@@ -1,4 +1,5 @@
 import unittest
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -6,9 +7,95 @@ import torch
 
 from sglang.multimodal_gen.configs.pipeline_configs.zimage import ZImagePipelineConfig
 from sglang.multimodal_gen.runtime.models.dits.zimage import (
+    FeedForward,
+    RopeEmbedder,
+    ZImageAttention,
     ZImageRMSNorm,
     ZImageTransformer2DModel,
 )
+
+
+@contextmanager
+def _single_process_parallel():
+    """Stub the TP / SP world so parallel-linear modules (ZImageAttention,
+    FeedForward) construct on the 'meta' device without an initialized
+    distributed group. Mirrors the patch set test_lumina2 uses for the same
+    purpose."""
+    fake_tp_group = SimpleNamespace(world_size=1, rank_in_group=0)
+    with (
+        patch(
+            "sglang.multimodal_gen.runtime.layers.attention.layer.get_ring_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "sglang.multimodal_gen.runtime.layers.linear.get_tp_group",
+            return_value=fake_tp_group,
+        ),
+        patch(
+            "sglang.multimodal_gen.runtime.models.dits.zimage.get_tp_world_size",
+            return_value=1,
+        ),
+    ):
+        yield
+
+
+class TestZImageSharedPrimitiveDefaults(unittest.TestCase):
+    """Lumina-2 reuses FeedForward / ZImageAttention / RopeEmbedder and opts into
+    its own precision policy through added keyword arguments. Every one of those
+    defaults to Z-Image's behavior; these pin that, so a future change to the
+    hooks cannot quietly move Z-Image."""
+
+    def test_rope_default_reproduces_the_pre_hook_fp32_formula_bitwise(self) -> None:
+        """freqs_dtype defaults to fp32, and the .float() moved from before
+        cos()/sin() to after. For an fp32 phase both orderings are the same
+        computation. Written against the *old* expression so a regression
+        cannot pass by agreeing with the new code."""
+        axes_dims, axes_lens, theta = (16, 56, 56), (64, 128, 128), 256.0
+
+        cos_list, sin_list = RopeEmbedder.precompute_freqs(
+            axes_dims, axes_lens, theta=theta
+        )
+
+        for i, (d, e) in enumerate(zip(axes_dims, axes_lens)):
+            inv = 1.0 / (theta ** (torch.arange(0, d, 2, dtype=torch.float64) / d))
+            phase = torch.outer(torch.arange(e, dtype=torch.float64), inv).float()
+            self.assertTrue(torch.equal(cos_list[i], torch.cos(phase)))
+            self.assertTrue(torch.equal(sin_list[i], torch.sin(phase)))
+
+    def test_rope_fp64_phase_is_opt_in_and_actually_differs(self) -> None:
+        """The hook must do something, or Lumina silently gets Z-Image's fp32."""
+        args = ((16, 56, 56), (64, 128, 128))
+        cos32, _ = RopeEmbedder.precompute_freqs(*args)
+        cos64, _ = RopeEmbedder.precompute_freqs(*args, freqs_dtype=torch.float64)
+
+        self.assertEqual(cos32[0].dtype, torch.float32)
+        self.assertEqual(cos64[0].dtype, torch.float32)
+        self.assertFalse(all(torch.equal(a, b) for a, b in zip(cos32, cos64)))
+
+    def test_attention_defaults_keep_zimage_norm_and_fusion(self) -> None:
+        with _single_process_parallel(), torch.device("meta"):
+            attn = ZImageAttention(dim=64, num_heads=4, num_kv_heads=4)
+
+        self.assertIsInstance(attn.norm_q, ZImageRMSNorm)
+        self.assertIsInstance(attn.norm_k, ZImageRMSNorm)
+        self.assertTrue(attn.enable_zimage_qk_fusion)
+
+    def test_allow_fused_qk_norm_rope_only_ever_disables(self) -> None:
+        """`allow_fused_qk_norm_rope and quant_config is None` must reduce to
+        the old `quant_config is None` whenever the flag is left alone."""
+        with _single_process_parallel(), torch.device("meta"):
+            off = ZImageAttention(
+                dim=64, num_heads=4, num_kv_heads=4, allow_fused_qk_norm_rope=False
+            )
+        self.assertFalse(off.enable_zimage_qk_fusion)
+
+    def test_feed_forward_defaults_to_the_fused_silu(self) -> None:
+        from sglang.multimodal_gen.runtime.layers.activation import SiluAndMul
+
+        with _single_process_parallel(), torch.device("meta"):
+            ff = FeedForward(dim=64, hidden_dim=128)
+
+        self.assertIsInstance(ff.act, SiluAndMul)
 
 
 class TestZImagePipelineConfig(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Onboards [`Alpha-VLLM/Lumina-Image-2.0`](https://huggingface.co/Alpha-VLLM/Lumina-Image-2.0) as a text-to-image pipeline: a 2B flow-matching DiT (NextDiT) with a single Gemma-2 text encoder and the FLUX.1-dev VAE. 

Parent roadmap: #27214  
cc @mickqian 

## Modifications

**Model.** The DiT reuses `zimage.py`'s attention block, SwiGLU feed-forward, timestep embedder, and axes-RoPE tables instead of forking them. Lumina's precision differences are opt-in keyword arguments on those shared classes — `qk_norm_factory`, `allow_fused_qk_norm_rope`, `activation`, `freqs_dtype` — each defaulting to the existing behavior, so Z-Image stays bit-identical (verified end-to-end; see Accuracy Tests).

**Fixes for three issues this model was the first to hit:**
- **USPAttention masked path expanded no KV heads**, so any GQA model raised in `fused_pack_qkv` or SDPA. `LocalAttention` already had the expansion; this lifts it to a shared helper used by both.
- **The negative-prompt branch ignored the request's `max_sequence_length`** while its cache key already varied on it, so one length could be cached under a key naming another. Affects every CFG model that sets the flag.
- **Fusing LoRA shards of unequal width failed inside `torch.stack`**; it now reports the GQA cause. Block-diagonal fused LoRA remains unimplemented.

**Known deviation.** diffusers rotates RoPE in complex128. We build fp64 phases and store correctly-rounded fp32 tables, but GQA routes q/k to a PyTorch fallback that casts cos/sin to bf16 before multiplying. Closing that gap means changing a helper every GQA and non-CUDA model shares, so it is deliberately left out of this PR.

## Accuracy Tests

Verified against **diffusers 0.37.0** (the version pinned in `pyproject.toml`), `Lumina2Pipeline`, checkpoint snapshot `53504abd`, on an **A100 80GB**.

Bridged, then confirmed exact/within-threshold: the `<Prompt Start>` template, the RMSNorm cast boundary, fp64 RoPE phases, renorm-CFG, the timestep reversal, and the velocity negation. Weight-name mappings and fused widths are checked against the published checkpoint.

| Check | Result |
|---|---|
| Unit suite (targeted) | **50/50 pass** |
| Unit suite (full `multimodal_gen`) | 1051 pass / 8 pre-existing unrelated fails |
| Single-forward parity (1024², t=1000) | cos **0.99999** |
| 15-config matrix, `torch_sdpa` / `fa` | worst cos **0.99995** / **0.99994** |
| End-to-end, 8 cases (worst: 1024², 30 steps) | cos **0.9989 / 32.4 dB PSNR** |
| Determinism (two runs, same seed) | all 8 cases **bit-identical** |
| **Z-Image regression** (shared-hook inertness) | **bit-identical** before/after |

End-to-end parity, diffusers (left) vs SGLang (right) across all 8 cases:
<img width="738" height="2194" alt="e2e_contact_sheet" src="https://github.com/user-attachments/assets/09f538bd-a9b2-46c2-8633-d74501e6e0e2" />


### Distributed validation

Validated on **2× NVIDIA A100 80GB PCIe**:

- **TP=2:** 512×512 and non-square 768×512 generation matched TP=1 references at **36.15–37.42 dB PSNR**.
- **CFG parallel=2:** explicit and empty negative-prompt paths matched TP=1 at **35.28–40.22 dB PSNR**.
- **FSDP + CFG=2:** confirmed real sharding across 30 Lumina transformer submodules and matched TP=1 at **37.79 dB PSNR**.

## Speed Tests and Profiling
N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31042583402](https://github.com/sgl-project/sglang/actions/runs/31042583402)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31042582003](https://github.com/sgl-project/sglang/actions/runs/31042582003)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->