### PR TITLE
perf(startup): skip unused PyTorch headers for KV VMM allocator stub

### DIFF
--- a/python/sglang/srt/mem_cache/kv_vmm_backing.py
+++ b/python/sglang/srt/mem_cache/kv_vmm_backing.py
@@ -178,6 +178,7 @@ class KvVmmArena:
             is_python_module=False,
             verbose=False,
             build_directory=out_dir,
+            no_implicit_headers=True,
         )
         self._so_path = f"{out_dir}/{libname}.so"
         lib = ctypes.CDLL(self._so_path)


### PR DESCRIPTION
## Summary

`KvVmmArena` builds a small allocator stub for each KV arena. `load_inline` adds `torch/extension.h` by default.

The stub does not use PyTorch APIs. This change disables implicit headers and keeps the allocator ABI unchanged.

The standalone reproduction in the commit message produced these results:

| Mode | Time | Library size |
| --- | ---: | ---: |
| Implicit headers | 12.191s | 1246.5 KiB |
| No implicit headers | 0.232s | 69.9 KiB |

## Test plan

- `python3 -m py_compile python/sglang/srt/mem_cache/kv_vmm_backing.py`
- `uvx pre-commit run --files python/sglang/srt/mem_cache/kv_vmm_backing.py`

## Original commits

- `90f2de01d`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30669511332](https://github.com/sgl-project/sglang/actions/runs/30669511332)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30669510964](https://github.com/sgl-project/sglang/actions/runs/30669510964)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->