### PR TITLE
[Fix] Bound FULL_MASK verify-mask reuse by the captured max_bs

### DIFF
--- a/python/sglang/srt/layers/attention/verify_mask.py
+++ b/python/sglang/srt/layers/attention/verify_mask.py
@@ -26,14 +26,16 @@ def tree_mask_numel(
     return bs * per_req
 
 
-class VerifyMask(msgspec.Struct):
+class VerifyMask(msgspec.Struct, frozen=True):
     """The target-verify mask.
 
     ``build_tree_kernel_efficient`` writes the buffer in place after draft, which
-    is what lets the worker skip the ``seq_lens_sum`` D2H sync. Keep the three
+    is what lets the worker skip the ``seq_lens_sum`` D2H sync. Keep them
     together: taking the buffer without its layout has the kernel write a shape
-    the reader does not expect. The kernel writes every cell even when unread, so
-    the buffer is always allocated.
+    the reader does not expect, and without its ``max_bs`` there is nothing left
+    to bound reuse by. The kernel writes every cell even when unread, so the
+    buffer is always allocated. Frozen so the fields cannot drift apart -- swap
+    the whole struct to resize.
 
     Temporary home -- a phase-level buffer with no owner today (``spec_info`` is a
     per-phase union the graph registry cannot slot).
@@ -41,14 +43,16 @@ class VerifyMask(msgspec.Struct):
 
     buffer: torch.Tensor
     mode: TreeMaskMode
-    max_context_len: int
+    max_bs: int
     is_read: bool = True
 
-    def fits(self, bs: int, num_draft_tokens: int) -> bool:
-        """Whether this batch's writes stay inside the buffer."""
-        return self.buffer.numel() >= tree_mask_numel(
-            self.mode, bs, num_draft_tokens, self.max_context_len
-        )
+    def fits(self, bs: int) -> bool:
+        """Whether this batch's writes stay inside the buffer.
+
+        Every layout is sized per request off worst-case per-request bounds
+        (FULL_MASK's spans max_context_len), so max_bs bounds them all.
+        """
+        return bs <= self.max_bs
 
 
 def maybe_create_verify_mask(
@@ -73,6 +77,6 @@ def maybe_create_verify_mask(
             device=device,
         ),
         mode=mode,
-        max_context_len=max_context_len,
+        max_bs=max_bs,
         is_read=is_read,
     )

--- a/python/sglang/srt/layers/attention/verify_mask.py
+++ b/python/sglang/srt/layers/attention/verify_mask.py
@@ -32,10 +32,9 @@ class VerifyMask(msgspec.Struct, frozen=True):
     ``build_tree_kernel_efficient`` writes the buffer in place after draft, which
     is what lets the worker skip the ``seq_lens_sum`` D2H sync. Keep them
     together: taking the buffer without its layout has the kernel write a shape
-    the reader does not expect, and without its ``max_bs`` there is nothing left
-    to bound reuse by. The kernel writes every cell even when unread, so the
-    buffer is always allocated. Frozen so the fields cannot drift apart -- swap
-    the whole struct to resize.
+    the reader does not expect. The kernel writes every cell even when unread, so
+    the buffer is always allocated. Frozen -- resize by swapping the whole struct,
+    never a field, so ``max_bs`` cannot go stale against ``buffer``.
 
     Temporary home -- a phase-level buffer with no owner today (``spec_info`` is a
     per-phase union the graph registry cannot slot).
@@ -49,8 +48,8 @@ class VerifyMask(msgspec.Struct, frozen=True):
     def fits(self, bs: int) -> bool:
         """Whether this batch's writes stay inside the buffer.
 
-        Every layout is sized per request off worst-case per-request bounds
-        (FULL_MASK's spans max_context_len), so max_bs bounds them all.
+        ``tree_mask_numel`` is ``bs * per_req`` and per_req is fixed at
+        allocation (FULL_MASK's spans max_context_len), so max_bs bounds it.
         """
         return bs <= self.max_bs
 

--- a/python/sglang/srt/layers/attention/verify_mask.py
+++ b/python/sglang/srt/layers/attention/verify_mask.py
@@ -41,17 +41,14 @@ class VerifyMask(msgspec.Struct):
 
     buffer: torch.Tensor
     mode: TreeMaskMode
-    max_bs: int
+    max_context_len: int
     is_read: bool = True
 
-    def fits(self, bs: int) -> bool:
-        """Whether this batch's writes stay inside the buffer.
-
-        Both layouts are sized per request off worst-case per-request bounds, so
-        the allocation's own max_bs covers either one: FULL_MASK writes
-        draft * (seq_len + draft) per request and seq_len <= max_context_len.
-        """
-        return bs <= self.max_bs
+    def fits(self, bs: int, num_draft_tokens: int) -> bool:
+        """Whether this batch's writes stay inside the buffer."""
+        return self.buffer.numel() >= tree_mask_numel(
+            self.mode, bs, num_draft_tokens, self.max_context_len
+        )
 
 
 def maybe_create_verify_mask(
@@ -76,6 +73,6 @@ def maybe_create_verify_mask(
             device=device,
         ),
         mode=mode,
-        max_bs=max_bs,
+        max_context_len=max_context_len,
         is_read=is_read,
     )

--- a/python/sglang/srt/layers/attention/verify_mask.py
+++ b/python/sglang/srt/layers/attention/verify_mask.py
@@ -41,17 +41,17 @@ class VerifyMask(msgspec.Struct):
 
     buffer: torch.Tensor
     mode: TreeMaskMode
+    max_bs: int
     is_read: bool = True
 
-    def fits(self, bs: int, num_draft_tokens: int) -> bool:
+    def fits(self, bs: int) -> bool:
         """Whether this batch's writes stay inside the buffer.
 
-        Only the compact layout is checked. FULL_MASK keeps unconditional reuse
-        because its runtime bound depends on sequence lengths not passed to fits().
+        Both layouts are sized per request off worst-case per-request bounds, so
+        the allocation's own max_bs covers either one: FULL_MASK writes
+        draft * (seq_len + draft) per request and seq_len <= max_context_len.
         """
-        if self.mode != TreeMaskMode.QLEN_ONLY:
-            return True
-        return self.buffer.numel() >= bs * num_draft_tokens * num_draft_tokens
+        return bs <= self.max_bs
 
 
 def maybe_create_verify_mask(
@@ -76,5 +76,6 @@ def maybe_create_verify_mask(
             device=device,
         ),
         mode=mode,
+        max_bs=max_bs,
         is_read=is_read,
     )

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -351,9 +351,7 @@ def build_eagle_verify_input(
         tree_mask_buf, mask_mode, fill_mask = None, tree_mask_mode, True
     else:
         mask_mode, fill_mask = verify_mask.mode, verify_mask.is_read
-        tree_mask_buf = (
-            verify_mask.buffer if verify_mask.fits(bs, num_draft_tokens) else None
-        )
+        tree_mask_buf = verify_mask.buffer if verify_mask.fits(bs) else None
 
     # build_tree_kernel uses seq_lens_sum only to size the (non-preallocated)
     # FULL_MASK tree mask; over-size is safe. Skip per-iter .sum().item() D2H via UB.

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -351,7 +351,9 @@ def build_eagle_verify_input(
         tree_mask_buf, mask_mode, fill_mask = None, tree_mask_mode, True
     else:
         mask_mode, fill_mask = verify_mask.mode, verify_mask.is_read
-        tree_mask_buf = verify_mask.buffer if verify_mask.fits(bs) else None
+        tree_mask_buf = (
+            verify_mask.buffer if verify_mask.fits(bs, num_draft_tokens) else None
+        )
 
     # build_tree_kernel uses seq_lens_sum only to size the (non-preallocated)
     # FULL_MASK tree mask; over-size is safe. Skip per-iter .sum().item() D2H via UB.

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1210,7 +1210,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         verify_mask = attn_backend.verify_mask
         # Every position in a 1-node tree is visible, so an all-True fill is
         # correct under either layout.
-        if verify_mask is not None and verify_mask.fits(bs, 1):
+        if verify_mask is not None and verify_mask.fits(bs):
             custom_mask = verify_mask.buffer
             custom_mask.fill_(True)
         else:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -1210,7 +1210,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         verify_mask = attn_backend.verify_mask
         # Every position in a 1-node tree is visible, so an all-True fill is
         # correct under either layout.
-        if verify_mask is not None and verify_mask.fits(bs):
+        if verify_mask is not None and verify_mask.fits(bs, 1):
             custom_mask = verify_mask.buffer
             custom_mask.fill_(True)
         else:

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -67,12 +67,12 @@ class TestVerifyMaskCapacity(CustomTestCase):
     def test_compact_layout_fits_up_to_max_bs(self):
         # is_read=False pins QLEN_ONLY; the read layout is build-dependent.
         mask = _create(is_read=False)
-        self.assertTrue(mask.fits(_MAX_BS, _DRAFT))
-        self.assertTrue(mask.fits(1, _DRAFT))
+        self.assertTrue(mask.fits(_MAX_BS))
+        self.assertTrue(mask.fits(1))
 
     def test_compact_layout_does_not_fit_beyond_max_bs(self):
         mask = _create(is_read=False)
-        self.assertFalse(mask.fits(_MAX_BS + 1, _DRAFT))
+        self.assertFalse(mask.fits(_MAX_BS + 1))
 
     def test_full_mask_does_not_fit_beyond_max_bs(self):
         """The context dimension is per-request slack, not spare room for extra
@@ -86,11 +86,11 @@ class TestVerifyMaskCapacity(CustomTestCase):
                 dtype=torch.bool,
             ),
             mode=TreeMaskMode.FULL_MASK,
-            max_context_len=_MAX_CONTEXT_LEN,
+            max_bs=_MAX_BS,
         )
 
-        self.assertTrue(mask.fits(_MAX_BS, _DRAFT))
-        self.assertFalse(mask.fits(_MAX_BS + 1, _DRAFT))
+        self.assertTrue(mask.fits(_MAX_BS))
+        self.assertFalse(mask.fits(_MAX_BS + 1))
 
 
 class TestVerifyMaskGate(CustomTestCase):
@@ -118,7 +118,7 @@ def _mask(numel, **kwargs):
     return VerifyMask(
         buffer=torch.zeros(numel, dtype=torch.bool),
         mode=TreeMaskMode.QLEN_ONLY,
-        max_context_len=_MAX_CONTEXT_LEN,
+        max_bs=_MAX_BS,
         **kwargs,
     )
 
@@ -160,7 +160,7 @@ class TestHybridAttnBackendHandsOutSelectedChildMask(CustomTestCase):
     def test_capacity_check_needs_nothing_from_the_backend(self):
         backend = _make_hybrid_backend("prefill", _mask(64, is_read=False), None)
 
-        self.assertTrue(backend.verify_mask.fits(_MAX_BS, _DRAFT))
+        self.assertTrue(backend.verify_mask.fits(_MAX_BS))
 
 
 class TestTreeMaskNumel(CustomTestCase):

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -61,25 +61,36 @@ class TestVerifyMaskSizing(CustomTestCase):
 
 
 class TestVerifyMaskCapacity(CustomTestCase):
-    """A batch past the captured max_bs must not silently reuse the compact
-    layout -- it has no context-dimension slack to absorb the overflow."""
+    """A batch past the captured max_bs must not silently reuse the buffer --
+    every layout is sized per request, so none has slack for extra ones."""
 
     def test_compact_layout_fits_up_to_max_bs(self):
         # is_read=False pins QLEN_ONLY; the read layout is build-dependent.
         mask = _create(is_read=False)
-        self.assertTrue(mask.fits(_MAX_BS, _DRAFT))
-        self.assertTrue(mask.fits(1, _DRAFT))
+        self.assertTrue(mask.fits(_MAX_BS))
+        self.assertTrue(mask.fits(1))
 
     def test_compact_layout_does_not_fit_beyond_max_bs(self):
         mask = _create(is_read=False)
-        self.assertFalse(mask.fits(_MAX_BS + 1, _DRAFT))
+        self.assertFalse(mask.fits(_MAX_BS + 1))
 
-    def test_full_mask_always_fits(self):
-        """FULL_MASK is exempt from the check -- see fits()."""
+    def test_full_mask_does_not_fit_beyond_max_bs(self):
+        """The context dimension is per-request slack, not spare room for extra
+        requests: reusing FULL_MASK past max_bs reads off the end of the buffer.
+        Built explicitly because default_tree_mask_mode() is host-dependent."""
         mask = VerifyMask(
-            buffer=torch.zeros(8, dtype=torch.bool), mode=TreeMaskMode.FULL_MASK
+            buffer=torch.zeros(
+                tree_mask_numel(
+                    TreeMaskMode.FULL_MASK, _MAX_BS, _DRAFT, _MAX_CONTEXT_LEN
+                ),
+                dtype=torch.bool,
+            ),
+            mode=TreeMaskMode.FULL_MASK,
+            max_bs=_MAX_BS,
         )
-        self.assertTrue(mask.fits(_MAX_BS * 1000, _DRAFT))
+
+        self.assertTrue(mask.fits(_MAX_BS))
+        self.assertFalse(mask.fits(_MAX_BS + 1))
 
 
 class TestVerifyMaskGate(CustomTestCase):
@@ -103,10 +114,11 @@ class _FakeAttnBackend:
         self.verify_mask = verify_mask
 
 
-def _mask(numel, **kwargs):
+def _mask(numel, *, max_bs=_MAX_BS, **kwargs):
     return VerifyMask(
         buffer=torch.zeros(numel, dtype=torch.bool),
         mode=TreeMaskMode.QLEN_ONLY,
+        max_bs=max_bs,
         **kwargs,
     )
 
@@ -148,7 +160,7 @@ class TestHybridAttnBackendHandsOutSelectedChildMask(CustomTestCase):
     def test_capacity_check_needs_nothing_from_the_backend(self):
         backend = _make_hybrid_backend("prefill", _mask(64, is_read=False), None)
 
-        self.assertTrue(backend.verify_mask.fits(_MAX_BS, _DRAFT))
+        self.assertTrue(backend.verify_mask.fits(_MAX_BS))
 
 
 class TestTreeMaskNumel(CustomTestCase):

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -67,16 +67,16 @@ class TestVerifyMaskCapacity(CustomTestCase):
     def test_compact_layout_fits_up_to_max_bs(self):
         # is_read=False pins QLEN_ONLY; the read layout is build-dependent.
         mask = _create(is_read=False)
-        self.assertTrue(mask.fits(_MAX_BS))
-        self.assertTrue(mask.fits(1))
+        self.assertTrue(mask.fits(_MAX_BS, _DRAFT))
+        self.assertTrue(mask.fits(1, _DRAFT))
 
     def test_compact_layout_does_not_fit_beyond_max_bs(self):
         mask = _create(is_read=False)
-        self.assertFalse(mask.fits(_MAX_BS + 1))
+        self.assertFalse(mask.fits(_MAX_BS + 1, _DRAFT))
 
     def test_full_mask_does_not_fit_beyond_max_bs(self):
         """The context dimension is per-request slack, not spare room for extra
-        requests: reusing FULL_MASK past max_bs reads off the end of the buffer.
+        requests: reusing FULL_MASK past max_bs runs off the end of the buffer.
         Built explicitly because default_tree_mask_mode() is host-dependent."""
         mask = VerifyMask(
             buffer=torch.zeros(
@@ -86,11 +86,11 @@ class TestVerifyMaskCapacity(CustomTestCase):
                 dtype=torch.bool,
             ),
             mode=TreeMaskMode.FULL_MASK,
-            max_bs=_MAX_BS,
+            max_context_len=_MAX_CONTEXT_LEN,
         )
 
-        self.assertTrue(mask.fits(_MAX_BS))
-        self.assertFalse(mask.fits(_MAX_BS + 1))
+        self.assertTrue(mask.fits(_MAX_BS, _DRAFT))
+        self.assertFalse(mask.fits(_MAX_BS + 1, _DRAFT))
 
 
 class TestVerifyMaskGate(CustomTestCase):
@@ -114,11 +114,11 @@ class _FakeAttnBackend:
         self.verify_mask = verify_mask
 
 
-def _mask(numel, *, max_bs=_MAX_BS, **kwargs):
+def _mask(numel, **kwargs):
     return VerifyMask(
         buffer=torch.zeros(numel, dtype=torch.bool),
         mode=TreeMaskMode.QLEN_ONLY,
-        max_bs=max_bs,
+        max_context_len=_MAX_CONTEXT_LEN,
         **kwargs,
     )
 
@@ -160,7 +160,7 @@ class TestHybridAttnBackendHandsOutSelectedChildMask(CustomTestCase):
     def test_capacity_check_needs_nothing_from_the_backend(self):
         backend = _make_hybrid_backend("prefill", _mask(64, is_read=False), None)
 
-        self.assertTrue(backend.verify_mask.fits(_MAX_BS))
+        self.assertTrue(backend.verify_mask.fits(_MAX_BS, _DRAFT))
 
 
 class TestTreeMaskNumel(CustomTestCase):

--- a/test/registered/unit/layers/attention/test_verify_mask.py
+++ b/test/registered/unit/layers/attention/test_verify_mask.py
@@ -61,8 +61,7 @@ class TestVerifyMaskSizing(CustomTestCase):
 
 
 class TestVerifyMaskCapacity(CustomTestCase):
-    """A batch past the captured max_bs must not silently reuse the buffer --
-    every layout is sized per request, so none has slack for extra ones."""
+    """A batch past the captured max_bs must not silently reuse the buffer."""
 
     def test_compact_layout_fits_up_to_max_bs(self):
         # is_read=False pins QLEN_ONLY; the read layout is build-dependent.
@@ -75,9 +74,9 @@ class TestVerifyMaskCapacity(CustomTestCase):
         self.assertFalse(mask.fits(_MAX_BS + 1))
 
     def test_full_mask_does_not_fit_beyond_max_bs(self):
-        """The context dimension is per-request slack, not spare room for extra
-        requests: reusing FULL_MASK past max_bs runs off the end of the buffer.
-        Built explicitly because default_tree_mask_mode() is host-dependent."""
+        """FULL_MASK's context dimension is per-request slack, not spare room
+        for extra requests -- it must not be exempt from the check. Built
+        explicitly because default_tree_mask_mode() is host-dependent."""
         mask = VerifyMask(
             buffer=torch.zeros(
                 tree_mask_numel(


### PR DESCRIPTION
`VerifyMask.fits()` skipped the capacity check for FULL_MASK, so an eager batch past the captured `max_bs` reused a buffer sized for `max_bs` and ran off its end during target-verify mask extraction -- device-side `index out of bounds` assert and a dead scheduler. Both layouts are sized per request off worst-case per-request bounds, so `bs <= max_bs` is a sufficient bound for either; oversized batches now fall back to allocating, as they already did for QLEN_ONLY.

Reproduces on current main as `TestHybridAttnBackendSpeculativeDecodingPrefillBackend.test_gsm8k` (gsm8k score 0.0), whose server runs `--cuda-graph-max-bs-decode 8` with `max_running_requests=48`. Regression from #32920, which started routing `HybridAttnBackend` to its child's preallocated mask.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30672349777](https://github.com/sgl-project/sglang/actions/runs/30672349777)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30672349677](https://github.com/sgl-project/sglang/actions/runs/30672349677)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->