### PR TITLE
[Kimi-K3] Fail fast when FlashInfer kernel prerequisites are missing

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -338,8 +338,9 @@ def _dspark_verify_on_decode_backend(
 
 
 _KIMI_K3_DCP_PATCH_URL = (
-    "https://github.com/sgl-project/sglang/blob/main/"
-    "docker/kimi_k3/kimi_k3_cu13.Dockerfile#L116"
+    "https://github.com/sgl-project/sglang/blob/"
+    "b701464720ca22aa1851d5dda7144e84a410f2c7/"
+    "docker/kimi_k3/kimi_k3_cu13.Dockerfile#L116-L123"
 )
 
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -30,6 +30,7 @@ Two declaration forms, keyed on ``hf_config.architectures[0]``:
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -336,6 +337,34 @@ def _dspark_verify_on_decode_backend(
     return False
 
 
+_KIMI_K3_DCP_PATCH_URL = (
+    "https://github.com/sgl-project/sglang/blob/main/"
+    "docker/kimi_k3/kimi_k3_cu13.Dockerfile#L116"
+)
+
+
+def _require_kimi_k3_cutedsl_dcp_support() -> None:
+    try:
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+
+        parameters = inspect.signature(trtllm_batch_decode_with_kv_cache_mla).parameters
+    except (ImportError, TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "Kimi-K3 DCP with decode_attention_backend='cutedsl_mla' requires "
+            "a DCP-patched FlashInfer "
+            "trtllm_batch_decode_with_kv_cache_mla exposing enable_dcp in its "
+            f"signature. Apply the patch as shown in {_KIMI_K3_DCP_PATCH_URL}."
+        ) from exc
+
+    if "enable_dcp" not in parameters:
+        raise RuntimeError(
+            "Kimi-K3 DCP with decode_attention_backend='cutedsl_mla' requires "
+            "enable_dcp in the signature of "
+            "flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla. Apply "
+            f"the FlashInfer DCP patch as shown in {_KIMI_K3_DCP_PATCH_URL}."
+        )
+
+
 @_register_for("KimiK3ForConditionalGeneration")
 def _kimi_k3_overrides(server_args: Any, hf_config: Any) -> dict:
     if server_args.dcp_size > 1:
@@ -370,6 +399,7 @@ def _kimi_k3_overrides(server_args: Any, hf_config: Any) -> dict:
 
         prefill_backend, decode_backend = attention_backends_of(server_args)
         if decode_backend == "cutedsl_mla" or decode_backend is None:
+            _require_kimi_k3_cutedsl_dcp_support()
             logger.info(
                 "Kimi-K3 DCP keeps decode attention backend 'cutedsl_mla' "
                 f"(prefill={prefill_backend!r} -> 'trtllm_mla')."
@@ -481,9 +511,10 @@ def _kimi_k3_moe_runner_overrides(server_args: Any, hf_config: Any) -> dict:
     # MoE runner default, independent of the attention-backend gate above.
     # trtllm-gen fused MoE (flashinfer_mxfp4) beats marlin on both the decode
     # (M=bs) and the target-verify (M=bs*(gamma+1)) regimes on SM100/SM103;
-    # it hard-requires the SiTU cubin SDK on the box (K3's SiTU activation has
-    # no public cubins), so fall back to marlin when the SDK is absent.
-    if server_args.moe_runner_backend != "auto":
+    # it hard-requires the SiTU cubin pool on the box (K3's SiTU activation has
+    # no public cubins). Do not silently trade W4A8 for Marlin W4A16 when the
+    # default cannot start; explicit non-FlashInfer runner choices still win.
+    if server_args.moe_runner_backend not in ("auto", "flashinfer_mxfp4"):
         return {}
     if not (is_sm100_supported() and get_device_sm() in (100, 103)):
         return {}
@@ -491,17 +522,32 @@ def _kimi_k3_moe_runner_overrides(server_args: Any, hf_config: Any) -> dict:
         return {}
     from sglang.kernels.ops.moe.trtllm_gen_moe import available as _trtllm_gen_moe_ok
 
-    if _trtllm_gen_moe_ok():
+    if not _trtllm_gen_moe_ok():
+        raise RuntimeError(
+            "Kimi-K3 on Blackwell with moe_runner_backend='auto' or "
+            "'flashinfer_mxfp4' requires a valid "
+            "SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL. Install it with:\n"
+            "wget https://github.com/sgl-project/whl/releases/download/"
+            "trtllm_gen_moe_cubin_20260617/"
+            "trtllm_gen_moe_cubin_pool_20260617_v0613rc1.zip\n"
+            "sudo mkdir -p /opt/trtllm_gen_moe_cubin_pool\n"
+            "sudo unzip -q "
+            "trtllm_gen_moe_cubin_pool_20260617_v0613rc1.zip -d "
+            "/opt/trtllm_gen_moe_cubin_pool\n"
+            "export "
+            "SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/opt/trtllm_gen_moe_cubin_pool/"
+            "trtllm_gen_moe_cubin_pool_20260617_v0613rc1\n"
+            "To use Marlin "
+            "instead, set --moe-runner-backend marlin explicitly."
+        )
+
+    if server_args.moe_runner_backend == "auto":
         logger.info(
             "Kimi-K3 on SM100/SM103: moe_runner_backend=flashinfer_mxfp4 "
-            "(trtllm-gen SiTU cubin SDK found)."
+            "(trtllm-gen SiTU cubin pool found)."
         )
         return {"moe_runner_backend": "flashinfer_mxfp4"}
-    logger.info(
-        "Kimi-K3 on SM100/SM103: trtllm-gen MoE SDK not found; "
-        "moe_runner_backend=marlin."
-    )
-    return {"moe_runner_backend": "marlin"}
+    return {}
 
 
 @_register_for(


### PR DESCRIPTION
## Summary

- Keep Kimi-K3's Blackwell default MoE runner on `flashinfer_mxfp4` when the TRTLLM Gen SiTU cubin pool is available.
- Raise an actionable error when `SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL` is missing or invalid instead of silently falling back to Marlin. Explicit non-FlashInfer selections such as `--moe-runner-backend marlin` remain unchanged.
- For Kimi-K3 with `dcp_size > 1` and the default/explicit `cutedsl_mla` decode backend, verify that `flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla` exposes `enable_dcp`. If not, fail early with the Kimi-K3 Dockerfile patch instructions.

## Why

The previous Blackwell override silently changed the Kimi-K3 MoE implementation from FlashInfer MXFP4 to Marlin when the private TRTLLM Gen cubin pool was unavailable. This could make a launch appear valid while exercising a different kernel.

Similarly, an unpatched FlashInfer installation does not expose the DCP arguments required by Kimi-K3's CuTeDSL MLA path. Detecting this at argument resolution time gives users a deterministic and actionable failure instead of a later launch/runtime error.

## B300 validation

Hardware: 8x NVIDIA B300 SXM6 AC  
Model: `/scratch/models/Kimi-K3`  
FlashInfer: `flashinfer-python==0.6.15.post1`, `flashinfer-cubin==0.6.15.post1`, `flashinfer-jit-cache==0.6.15.post1+cu130`  
TRTLLM Gen pool: `trtllm_gen_moe_cubin_pool_20260617_v0613rc1` (1,696 cubins)

The GPU validation was run at Kimi-K3 base commit `578edb240a6d6f6f2fa4c31497276955d7f73432` plus this change. The PR was subsequently rebased onto the latest `kimi-k3`; the intervening commits did not modify `overrides.py`.

### Expected failures before installing/applying prerequisites

| Launch | Result | Evidence |
|---|---:|---|
| Low latency, cubin pool unset | exit 1 | Error requires a valid `SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL` and gives install commands; no Marlin fallback |
| Balanced, unpatched FlashInfer MLA | exit 1 | Error reports missing `enable_dcp` and links to the Kimi-K3 Dockerfile patch instructions |

### OCRBench after installing the cubin pool and applying the CuTeDSL MLA DCP patch

All runs used Kimi-Vendor-Verifier OCRBench with 1,000 samples, max thinking, streaming, 50 connections, `max_tokens=16384`, temperature 1.0, and top-p 0.95.

| Configuration | Verified kernel/backend | Accuracy | stderr | Total time | Benchmark errors |
|---|---|---:|---:|---:|---:|
| Low latency | MoE: `flashinfer_mxfp4` + TRTLLM Gen SiTU cubin; MLA: `trtllm_mla`; DCP=1 | **0.890** | 0.010 | 5:10 | 0 |
| Balanced | MoE: `flashinfer_mxfp4` + TRTLLM Gen SiTU cubin; decode: `cutedsl_mla`; prefill: `trtllm_mla`; DCP=8 | **0.887** | 0.010 | 6:36 | 0 |
| MegaMoE | MoE: `deep_gemm` + `megamoe`; decode: `cutedsl_mla`; prefill: `trtllm_mla`; EP=8, DCP=8 | **0.909** | 0.009 | 13:42 | 1 max-token sample |

For Low latency and Balanced, server logs reported `moe_runner_backend=flashinfer_mxfp4 (trtllm-gen SiTU cubin pool found)`; neither log contained a Marlin MoE path. Balanced and MegaMoE logged `flashinfer.cute_dsl MLA decode using impl=monolithic` on all eight ranks.

The MegaMoE benchmark completed all 1,000 samples; one sample reached the configured 16,384 completion-token limit and was recorded by the verifier as `max_tokens`.

## Local checks

- `python3 -m py_compile python/sglang/srt/arg_groups/overrides.py`
- `black --check python/sglang/srt/arg_groups/overrides.py`
- pre-commit hooks run by `git commit`
- `git diff --check`

No unit test is added in this PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30673607440](https://github.com/sgl-project/sglang/actions/runs/30673607440)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30673607482](https://github.com/sgl-project/sglang/actions/runs/30673607482)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->