### PR TITLE
[PD] Add a queues.prealloc_ready counter to the load snapshot

### DIFF
--- a/python/sglang/srt/managers/load_snapshot.py
+++ b/python/sglang/srt/managers/load_snapshot.py
@@ -171,6 +171,7 @@ class QueueMetrics(msgspec.Struct, array_like=True):
     grammar: int
     paused: int
     retracted: int
+    prealloc_ready: int
 
 
 # LoadSnapshot's nested sub-struct fields; every other struct field is a flat

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -165,6 +165,7 @@ class SchedulerLoadInquirer:
         mode_str = "null"
         prefill_bootstrap = prefill_inflight = 0
         decode_prealloc = decode_transfer = decode_retracted = 0
+        decode_prealloc_ready = 0
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             mode_str = "prefill"
             prefill_bootstrap = len(self.get_disagg_prefill_bootstrap_queue().queue)
@@ -175,6 +176,11 @@ class SchedulerLoadInquirer:
             decode_transfer = len(self.get_disagg_decode_transfer_queue().queue)
             decode_retracted = len(
                 self.get_disagg_decode_prealloc_queue().retracted_queue
+            )
+            decode_prealloc_ready = sum(
+                1
+                for decode_req in self.get_disagg_decode_prealloc_queue().queue
+                if decode_req.waiting_for_input
             )
         disaggregation = DisaggregationMetrics(
             mode=mode_str,
@@ -192,6 +198,7 @@ class SchedulerLoadInquirer:
             grammar=stats.num_grammar_queue_reqs,
             paused=stats.num_paused_reqs,
             retracted=stats.num_retracted_reqs,
+            prealloc_ready=decode_prealloc_ready,
         )
 
         totals = self.get_decode_moment_totals()

--- a/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
+++ b/test/registered/unit/entrypoints/test_v1_loads_aggregate.py
@@ -171,7 +171,9 @@ class TestGetLoads(CustomTestCase):
                     disaggregation=DisaggregationMetrics(
                         mode="decode", decode_transfer_queue_reqs=4
                     ),
-                    queues=QueueMetrics(waiting=2, grammar=1, paused=0, retracted=3),
+                    queues=QueueMetrics(
+                        waiting=2, grammar=1, paused=0, retracted=3, prealloc_ready=1
+                    ),
                 )
             )
 


### PR DESCRIPTION
## Motivation

The decode-side load snapshot reports the prealloc queue as a single depth
(`disaggregation.decode_prealloc_queue_reqs`), which mixes two very different
states: requests still waiting on the prefill side to finish its KV handshake,
and requests whose handshake is already done and that are blocked only on
decode-side admission. Only the latter is decode-side pressure, so consumers of
`/v1/loads` (autoscalers, routers, dashboards) cannot tell a decode pool that is
genuinely out of capacity from one that is simply waiting on prefill.

## Modifications

Add one counter, `queues.prealloc_ready`: the number of decode prealloc-queue
entries with `waiting_for_input` set, i.e. handshake-complete and blocked only
on decode admission. Entries still waiting on prefill stay excluded, so a
prefill backlog does not read as decode-side pressure.

- `load_snapshot.py`: new `prealloc_ready` field on `QueueMetrics`.
- `load_inquirer.py`: populate it in decode mode; it stays 0 for prefill and
  non-disaggregated engines.
- `test_v1_loads_aggregate.py`: updated the `QueueMetrics` construction for the
  new field.

Purely additive — no behavior change, just a new counter surfaced through
`/v1/loads` under `queues`.

## Accuracy Tests

Not applicable — no model or kernel code touched.

## Speed Tests and Profiling

Not applicable. The counter is a single pass over the decode prealloc queue,
computed only on the existing load-snapshot path in decode mode.



## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30672305006](https://github.com/sgl-project/sglang/actions/runs/30672305006)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30672304977](https://github.com/sgl-project/sglang/actions/runs/30672304977)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->