### PR TITLE
[GPT-OSS] Support FlashInfer A2A and routed MoE runner

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -276,7 +276,12 @@ class FusedMoE(torch.nn.Module):
         self._pending_fp8_shared_scales: dict[tuple[int, str], torch.Tensor] = {}
 
         assert intermediate_size % self.moe_tp_size == 0
-        self.intermediate_size_per_partition = intermediate_size // self.moe_tp_size
+        self.intermediate_size_per_partition_unpadded = (
+            intermediate_size // self.moe_tp_size
+        )
+        self.intermediate_size_per_partition = (
+            self.intermediate_size_per_partition_unpadded
+        )
         self.reduce_results = reduce_results
         self.use_presharded_weights = use_presharded_weights
 
@@ -680,8 +685,8 @@ class FusedMoE(torch.nn.Module):
             shard_size = expert_data.shape[shard_dim]
 
         if self.use_padded_loading:
-            if _is_cpu and is_bias:
-                shard_dim = 1
+            if is_bias:
+                shard_dim = -1
             expert_data, loaded_weight = narrow_padded_param_and_loaded_weight(
                 expert_data,
                 loaded_weight,

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator, Optional, cast
 
 import torch
+import torch.nn.functional as F
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
@@ -1157,6 +1158,11 @@ class FlashInferTrtllmBf16MoeQuantInfo(MoeQuantInfo):
     # Expert-parallel metadata
     global_num_experts: int
     local_expert_offset: int
+    kernel_hidden_size: int
+    input_pad_value: float
+    gemm1_alpha: Optional[torch.Tensor] = None
+    gemm1_beta: Optional[torch.Tensor] = None
+    gemm1_clamp_limit: Optional[torch.Tensor] = None
 
 
 def fused_experts_none_to_flashinfer_trtllm_bf16(
@@ -1206,6 +1212,19 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
     )
 
     hidden_states = dispatch_output.hidden_states
+    logical_hidden_size = hidden_states.shape[-1]
+    if quant_info.kernel_hidden_size < logical_hidden_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM BF16 kernel hidden size cannot be smaller than "
+            f"the logical hidden size: {quant_info.kernel_hidden_size} < "
+            f"{logical_hidden_size}"
+        )
+    if quant_info.kernel_hidden_size != logical_hidden_size:
+        hidden_states = F.pad(
+            hidden_states,
+            (0, quant_info.kernel_hidden_size - logical_hidden_size),
+            value=quant_info.input_pad_value,
+        )
     topk_output = dispatch_output.topk_output
 
     with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
@@ -1240,6 +1259,9 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
                 ),
                 tune_max_num_tokens=next_power_of_2(hidden_states.shape[0]),
                 activation_type=activation_type,
+                gemm1_alpha=quant_info.gemm1_alpha,
+                gemm1_beta=quant_info.gemm1_beta,
+                gemm1_clamp_limit=quant_info.gemm1_clamp_limit,
             )
         else:
             assert TopKOutputChecker.format_is_bypassed(topk_output)
@@ -1263,9 +1285,14 @@ def fused_experts_none_to_flashinfer_trtllm_bf16(
                 routed_scaling_factor=runner_config.routed_scaling_factor,
                 tune_max_num_tokens=next_power_of_2(hidden_states.shape[0]),
                 activation_type=activation_type,
+                gemm1_alpha=quant_info.gemm1_alpha,
+                gemm1_beta=quant_info.gemm1_beta,
+                gemm1_clamp_limit=quant_info.gemm1_clamp_limit,
             )
 
-    return StandardCombineInput(hidden_states=final_hidden_states)
+    return StandardCombineInput(
+        hidden_states=final_hidden_states[:, :logical_hidden_size].contiguous()
+    )
 
 
 @register_fused_func("none", "flashinfer_trtllm")

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
 
@@ -133,6 +134,161 @@ def get_bf16_gemm_backend() -> Bf16GemmBackend:
     if _BF16_GEMM_BACKEND is None:
         _BF16_GEMM_BACKEND = Bf16GemmBackend.AUTO
     return _BF16_GEMM_BACKEND
+
+
+def _prepare_flashinfer_trtllm_bf16_weights(
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    w13_bias: Optional[torch.Tensor],
+    w2_bias: Optional[torch.Tensor],
+    *,
+    hidden_size: int,
+    intermediate_size: int,
+    gemm1_alpha: Optional[float],
+    gate_up_interleaved: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Pad canonical BF16 MoE weights and fold static biases into them.
+
+    FlashInfer's TRT-LLM kernel consumes split [up, gate] W13 rows and has no
+    bias arguments. GPT-OSS checkpoints instead store [gate0, up0, ...], so
+    deinterleave those rows before padding. The first padded hidden and
+    intermediate channels provide constant-one features for the two bias terms.
+    """
+    kernel_hidden_size = ((hidden_size + 127) // 128) * 128
+    kernel_intermediate_size = w2.shape[-1]
+    if kernel_intermediate_size < intermediate_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM W2 has fewer columns than the logical "
+            f"intermediate size: {kernel_intermediate_size} < {intermediate_size}"
+        )
+    if w2.shape[-2] < hidden_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM W2 has fewer rows than the logical hidden "
+            f"size: {w2.shape[-2]} < {hidden_size}"
+        )
+
+    num_experts = w13.shape[0]
+    if w2.shape[0] != num_experts:
+        raise ValueError("W13 and W2 must have the same number of experts")
+
+    def validate_w13_bias_shape(bias: torch.Tensor) -> None:
+        valid_rows = {2 * intermediate_size, 2 * kernel_intermediate_size}
+        if (
+            bias.dim() != 2
+            or bias.shape[0] != num_experts
+            or bias.shape[1] not in valid_rows
+        ):
+            raise ValueError(
+                "W13 bias must have shape "
+                f"({num_experts}, {2 * intermediate_size}) or "
+                f"({num_experts}, {2 * kernel_intermediate_size}), got "
+                f"{tuple(bias.shape)}"
+            )
+
+    def validate_w2_bias_shape(bias: torch.Tensor) -> None:
+        if bias.dim() != 2 or tuple(bias.shape) != (num_experts, hidden_size):
+            raise ValueError(
+                f"W2 bias must have shape ({num_experts}, {hidden_size}), got "
+                f"{tuple(bias.shape)}"
+            )
+
+    def get_w13_halves(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        compact_rows = 2 * intermediate_size
+        padded_rows = 2 * kernel_intermediate_size
+        row_dim = -2 if tensor.dim() == 3 else -1
+        if tensor.shape[row_dim] not in {compact_rows, padded_rows}:
+            raise ValueError(
+                "W13 must have either logical or kernel-padded rows, got "
+                f"{tensor.shape[row_dim]} rows for logical={intermediate_size} and "
+                f"kernel={kernel_intermediate_size}"
+            )
+        if gate_up_interleaved:
+            compact = tensor.narrow(row_dim, 0, compact_rows)
+            row_indices = torch.arange(
+                compact_rows, device=tensor.device, dtype=torch.long
+            )
+            gate = compact.index_select(row_dim, row_indices[0::2])
+            up = compact.index_select(row_dim, row_indices[1::2])
+            return up, gate
+        if tensor.shape[row_dim] == compact_rows:
+            gate_start = intermediate_size
+        else:
+            gate_start = kernel_intermediate_size
+        return (
+            tensor.narrow(row_dim, 0, intermediate_size),
+            tensor.narrow(row_dim, gate_start, intermediate_size),
+        )
+
+    if w13.shape[-1] < hidden_size:
+        raise ValueError(
+            "FlashInfer TRT-LLM W13 has fewer columns than the logical hidden "
+            f"size: {w13.shape[-1]} < {hidden_size}"
+        )
+    up_weight, gate_weight = get_w13_halves(w13)
+    prepared_w13 = torch.zeros(
+        num_experts,
+        2 * kernel_intermediate_size,
+        kernel_hidden_size,
+        dtype=w13.dtype,
+        device=w13.device,
+    )
+    prepared_w13[:, :intermediate_size, :hidden_size] = up_weight[:, :, :hidden_size]
+    prepared_w13[
+        :,
+        kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+        :hidden_size,
+    ] = gate_weight[:, :, :hidden_size]
+
+    prepared_w2 = torch.zeros(
+        num_experts,
+        kernel_hidden_size,
+        kernel_intermediate_size,
+        dtype=w2.dtype,
+        device=w2.device,
+    )
+    prepared_w2[:, :hidden_size, :intermediate_size] = w2[
+        :, :hidden_size, :intermediate_size
+    ]
+
+    if w13_bias is not None:
+        validate_w13_bias_shape(w13_bias)
+        if kernel_hidden_size == hidden_size:
+            raise ValueError(
+                "FlashInfer TRT-LLM W13 bias folding requires a padded hidden channel"
+            )
+        up_bias, gate_bias = get_w13_halves(w13_bias)
+        prepared_w13[:, :intermediate_size, hidden_size] = up_bias[
+            :, :intermediate_size
+        ].to(prepared_w13.dtype)
+        prepared_w13[
+            :,
+            kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+            hidden_size,
+        ] = gate_bias[:, :intermediate_size].to(prepared_w13.dtype)
+
+    if w2_bias is not None:
+        validate_w2_bias_shape(w2_bias)
+        if kernel_hidden_size == hidden_size:
+            raise ValueError(
+                "FlashInfer TRT-LLM W2 bias folding requires a padded hidden channel"
+            )
+        if kernel_intermediate_size == intermediate_size:
+            raise ValueError(
+                "FlashInfer TRT-LLM W2 bias folding requires a padded intermediate channel"
+            )
+        if gemm1_alpha is None:
+            raise ValueError("FlashInfer TRT-LLM W2 bias folding requires gemm1_alpha")
+        gate = 1.0
+        up = 1.0 / (gate / (1.0 + math.exp(-gemm1_alpha * gate))) - 1.0
+        prepared_w13[:, intermediate_size, hidden_size] = up
+        prepared_w13[:, kernel_intermediate_size + intermediate_size, hidden_size] = (
+            gate
+        )
+        prepared_w2[:, :hidden_size, intermediate_size] = w2_bias[:, :hidden_size].to(
+            prepared_w2.dtype
+        )
+
+    return prepared_w13, prepared_w2, kernel_hidden_size
 
 
 class UnquantizedEmbeddingMethod(QuantizeMethodBase):
@@ -374,6 +530,61 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
         # Reorder rows of W1 for fused gated activation
         if self.use_flashinfer_trtllm_moe:
+            if layer.moe_runner_config.is_gated:
+                hidden_size = layer.moe_runner_config.hidden_size
+                intermediate_size = layer.intermediate_size_per_partition_unpadded
+                prepared_w13, prepared_w2, kernel_hidden_size = (
+                    _prepare_flashinfer_trtllm_bf16_weights(
+                        layer.w13_weight.data,
+                        layer.w2_weight.data,
+                        getattr(layer, "w13_weight_bias", None),
+                        getattr(layer, "w2_weight_bias", None),
+                        hidden_size=hidden_size,
+                        intermediate_size=intermediate_size,
+                        gemm1_alpha=layer.moe_runner_config.gemm1_alpha,
+                        gate_up_interleaved=(
+                            layer.moe_runner_config.gate_up_interleaved
+                        ),
+                    )
+                )
+                copy_or_rebind_param(layer, "w13_weight", prepared_w13)
+                copy_or_rebind_param(layer, "w2_weight", prepared_w2)
+
+                num_local_experts = layer.num_local_experts
+                device = prepared_w13.device
+                gemm1_alpha = layer.moe_runner_config.gemm1_alpha
+                gemm1_clamp_limit = layer.moe_runner_config.gemm1_clamp_limit
+                self._flashinfer_kernel_hidden_size = kernel_hidden_size
+                self._flashinfer_input_pad_value = float(
+                    getattr(layer, "w13_weight_bias", None) is not None
+                    or getattr(layer, "w2_weight_bias", None) is not None
+                )
+                self._flashinfer_gemm1_alpha = (
+                    torch.full(
+                        (num_local_experts,),
+                        gemm1_alpha,
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    if gemm1_alpha is not None
+                    else None
+                )
+                self._flashinfer_gemm1_beta = (
+                    torch.ones(num_local_experts, dtype=torch.float32, device=device)
+                    if gemm1_alpha is not None
+                    else None
+                )
+                self._flashinfer_gemm1_clamp_limit = (
+                    torch.full(
+                        (num_local_experts,),
+                        gemm1_clamp_limit,
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                    if gemm1_clamp_limit is not None
+                    else None
+                )
+
             from flashinfer.fused_moe.core import (
                 _maybe_get_cached_w3_w1_permute_indices,
                 convert_to_block_layout,
@@ -479,6 +690,29 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
             return
 
         expected_numel = expected_shape[0] * expected_shape[1] * expected_shape[2]
+        kernel_hidden_size = ((layer.hidden_size + 127) // 128) * 128
+        if weight_name.endswith(".experts.w13_weight"):
+            prepared_shape = (
+                layer.num_local_experts,
+                expected_shape[1],
+                kernel_hidden_size,
+            )
+        else:
+            prepared_shape = (
+                layer.num_local_experts,
+                kernel_hidden_size,
+                expected_shape[2],
+            )
+        prepared_numel = prepared_shape[0] * prepared_shape[1] * prepared_shape[2]
+        if (
+            layer.moe_runner_config.is_gated
+            and kernel_hidden_size != layer.hidden_size
+            and param.data.numel() == prepared_numel
+        ):
+            param.data = torch.empty(
+                expected_shape, dtype=param.data.dtype, device=param.data.device
+            )
+            return
         if param.data.numel() != expected_numel:
             raise RuntimeError(
                 f"Cannot restore flashinfer TRT-LLM BF16 MoE weight shape for {weight_name}: "
@@ -548,8 +782,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
 
     @property
     def load_up_proj_weight_first(self) -> bool:
-        # FlashInfer CUTLASS kernel assumes [Up, Gate] Proj as W13
-        return self.use_flashinfer_cutlass
+        # FlashInfer kernels assume [Up, Gate] projections in W13.
+        return self.use_flashinfer_cutlass or self.use_flashinfer_trtllm_moe
 
     def apply(
         self,
@@ -617,11 +851,23 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, MultiPlatformOp):
                 FlashInferTrtllmBf16MoeQuantInfo,
             )
 
+            is_gated = layer.moe_runner_config.is_gated
             quant_info = FlashInferTrtllmBf16MoeQuantInfo(
                 gemm1_weights=layer.w13_weight,
                 gemm2_weights=layer.w2_weight,
                 global_num_experts=layer.num_experts,
                 local_expert_offset=layer.moe_ep_rank * layer.num_local_experts,
+                kernel_hidden_size=(
+                    self._flashinfer_kernel_hidden_size
+                    if is_gated
+                    else layer.hidden_size
+                ),
+                input_pad_value=(self._flashinfer_input_pad_value if is_gated else 0.0),
+                gemm1_alpha=self._flashinfer_gemm1_alpha if is_gated else None,
+                gemm1_beta=self._flashinfer_gemm1_beta if is_gated else None,
+                gemm1_clamp_limit=(
+                    self._flashinfer_gemm1_clamp_limit if is_gated else None
+                ),
             )
             return self.runner.run(dispatch_output, quant_info)
         else:

--- a/python/sglang/srt/lora/trtllm_lora_temp/lora_layer.py
+++ b/python/sglang/srt/lora/trtllm_lora_temp/lora_layer.py
@@ -120,6 +120,7 @@ def init_experimental_sgl_trtllm_lora(layer, base_layer) -> None:
             FlashInferTrtllmBf16MoeQuantInfo,
         )
 
+        is_gated = base_layer.moe_runner_config.is_gated
         layer._lora_runner = None
         layer._quant_info = FlashInferTrtllmBf16MoeQuantInfo(
             gemm1_weights=base_layer.w13_weight.data,
@@ -127,6 +128,35 @@ def init_experimental_sgl_trtllm_lora(layer, base_layer) -> None:
             global_num_experts=int(base_layer.num_experts),
             local_expert_offset=int(base_layer.moe_ep_rank)
             * int(base_layer.num_local_experts),
+            kernel_hidden_size=(
+                getattr(
+                    quant_method,
+                    "_flashinfer_kernel_hidden_size",
+                    base_layer.hidden_size,
+                )
+                if is_gated
+                else base_layer.hidden_size
+            ),
+            input_pad_value=(
+                getattr(quant_method, "_flashinfer_input_pad_value", 0.0)
+                if is_gated
+                else 0.0
+            ),
+            gemm1_alpha=(
+                getattr(quant_method, "_flashinfer_gemm1_alpha", None)
+                if is_gated
+                else None
+            ),
+            gemm1_beta=(
+                getattr(quant_method, "_flashinfer_gemm1_beta", None)
+                if is_gated
+                else None
+            ),
+            gemm1_clamp_limit=(
+                getattr(quant_method, "_flashinfer_gemm1_clamp_limit", None)
+                if is_gated
+                else None
+            ),
         )
         # Expose w13_weight/w2_weight on the bf16 quant-info so the backend-agnostic
         # cuda-graph MoE buffer init (BaseLoRABackend.init_cuda_graph_moe_buffers) reads

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -44,7 +44,10 @@ from sglang.srt.layers.linear import (
     RowParallelLinear,
 )
 from sglang.srt.layers.logits_processor import LogitsProcessor
-from sglang.srt.layers.moe import get_moe_a2a_backend
+from sglang.srt.layers.moe import (
+    get_moe_a2a_backend,
+    should_skip_post_experts_all_reduce,
+)
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
@@ -118,6 +121,26 @@ class GptOssConfig(PretrainedConfig):
 logger = logging.getLogger(__name__)
 
 
+def _narrow_fused_moe_ep_weight(
+    loaded_weight: torch.Tensor, num_experts: int
+) -> torch.Tensor:
+    parallel = get_parallel()
+    if parallel.moe_ep_size == 1:
+        return loaded_weight
+    assert num_experts % parallel.moe_ep_size == 0
+    num_local_experts = num_experts // parallel.moe_ep_size
+    if loaded_weight.shape[0] == num_local_experts:
+        return loaded_weight
+    if loaded_weight.shape[0] != num_experts:
+        raise ValueError(
+            f"Expected {num_experts} global or {num_local_experts} local experts, "
+            f"got {loaded_weight.shape[0]}"
+        )
+    return loaded_weight.narrow(
+        0, parallel.moe_ep_rank * num_local_experts, num_local_experts
+    )
+
+
 # Aligned with HF's implementation, using sliding window inclusive with the last token
 # SGLang assumes exclusive
 def get_attention_sliding_window_size(config):
@@ -147,6 +170,9 @@ class TinyGemmLinear(ReplicatedLinear):
         )
 
     def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if x.ndim == 2 and x.shape[0] == 0:
+            return x.new_empty((0, self.output_size)), None
+
         if (
             self._use_tinygemm
             and x.ndim == 2
@@ -330,7 +356,9 @@ class GptOssSparseMoeBlock(nn.Module):
             topk_output = self.topk(router_input, router_logits)
             final_hidden_states = self.experts(hidden_states, topk_output)
 
-        if self.tp_size > 1 and not get_forward().fuse_mlp_allreduce:
+        if self.tp_size > 1 and not should_skip_post_experts_all_reduce(
+            is_tp_path=True
+        ):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         # When input was pre-padded, FusedMoE.forward_impl captured the
@@ -1253,6 +1281,9 @@ class GptOssForCausalLM(nn.Module):
                         continue
                     param = params_dict[name]
                     weight_loader = param.weight_loader
+                    loaded_weight = _narrow_fused_moe_ep_weight(
+                        loaded_weight, self.config.num_local_experts
+                    )
                     if "bias" not in name:
                         loaded_weight = loaded_weight.transpose(-2, -1)
                     if "w2_weight_bias" in name and get_parallel().moe_tp_rank != 0:

--- a/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
+++ b/test/registered/unit/layers/test_flashinfer_trtllm_bf16_padding.py
@@ -1,0 +1,683 @@
+"""CPU coverage for biased BF16 FlashInfer TRT-LLM MoE weight preparation."""
+
+import unittest
+from contextlib import nullcontext
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+from torch.nn import Parameter
+
+from sglang.srt.layers.quantization import unquant
+from sglang.srt.layers.quantization.unquant import (
+    UnquantizedFusedMoEMethod,
+    _prepare_flashinfer_trtllm_bf16_weights,
+)
+from sglang.srt.lora.trtllm_lora_temp import lora_layer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+# The runner imports quantization registry state, so initialize unquant first.
+# isort: off
+from sglang.srt.layers.moe.moe_runner import flashinfer_trtllm
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher.standard import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import BypassedTopKOutput, PackedTopKOutput, TopKConfig
+
+# isort: on
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+
+def gpt_oss_activation(
+    gate_up: torch.Tensor, alpha: float, limit: float
+) -> torch.Tensor:
+    """GPT-OSS SwiGLU for the FlashInfer [up, gate] projection order."""
+    up, gate = gate_up.chunk(2, dim=-1)
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    return gate * torch.sigmoid(gate * alpha) * (up + 1.0)
+
+
+class TestFlashInferTrtllmBf16Padding(CustomTestCase):
+    @staticmethod
+    def _make_restore_layer() -> SimpleNamespace:
+        return SimpleNamespace(
+            num_local_experts=1,
+            hidden_size=2880,
+            intermediate_size_per_partition=128,
+            moe_runner_config=SimpleNamespace(is_gated=True),
+        )
+
+    def test_biased_bf16_weights_match_bias_free_padded_moe(self):
+        """Bias folding must preserve each expert's GPT-OSS MoE output."""
+        torch.manual_seed(0)
+        num_experts = 2
+        hidden_size = 3
+        intermediate_size = 5
+        kernel_intermediate_size = 128
+        alpha = 1.702
+        limit = 7.0
+
+        x = torch.randn(4, hidden_size, dtype=torch.bfloat16)
+        w13 = torch.randn(
+            num_experts, 2 * intermediate_size, hidden_size, dtype=torch.bfloat16
+        )
+        w2 = torch.zeros(
+            num_experts,
+            hidden_size,
+            kernel_intermediate_size,
+            dtype=torch.bfloat16,
+        )
+        w2[..., :intermediate_size] = torch.randn(
+            num_experts, hidden_size, intermediate_size, dtype=torch.bfloat16
+        )
+        w13_bias = torch.randn(num_experts, 2 * intermediate_size, dtype=torch.float32)
+        w2_bias = torch.randn(num_experts, hidden_size, dtype=torch.float32)
+
+        prepared_w13, prepared_w2, kernel_hidden_size = (
+            _prepare_flashinfer_trtllm_bf16_weights(
+                w13,
+                w2,
+                w13_bias,
+                w2_bias,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                gemm1_alpha=alpha,
+            )
+        )
+
+        self.assertEqual(kernel_hidden_size, 128)
+        self.assertEqual(prepared_w13.shape, (num_experts, 256, 128))
+        self.assertEqual(prepared_w2.shape, (num_experts, 128, 128))
+
+        x_padded = F.pad(x, (0, kernel_hidden_size - hidden_size), value=1.0)
+        for expert in range(num_experts):
+            expected = F.linear(
+                gpt_oss_activation(
+                    F.linear(x.float(), w13[expert].float(), w13_bias[expert]),
+                    alpha,
+                    limit,
+                ),
+                w2[expert, :, :intermediate_size].float(),
+                w2_bias[expert],
+            )
+            actual = F.linear(
+                gpt_oss_activation(
+                    F.linear(x_padded, prepared_w13[expert]), alpha, limit
+                ),
+                prepared_w2[expert],
+            )[:, :hidden_size]
+
+            torch.testing.assert_close(actual.float(), expected, atol=0.03, rtol=0.03)
+
+    def test_preparation_preserves_up_then_gate_projection_order(self):
+        """FlashInfer weights must retain FusedMoE's [up, gate] row order."""
+        hidden_size = 3
+        intermediate_size = 5
+        w13 = (
+            torch.arange(2 * 2 * intermediate_size * hidden_size, dtype=torch.float32)
+            .reshape(2, 2 * intermediate_size, hidden_size)
+            .to(torch.bfloat16)
+        )
+        w2 = torch.zeros(2, hidden_size, 128, dtype=torch.bfloat16)
+
+        prepared_w13, _, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            w2,
+            None,
+            None,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            gemm1_alpha=1.702,
+        )
+
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, :hidden_size],
+            w13[:, :intermediate_size],
+        )
+        torch.testing.assert_close(
+            prepared_w13[:, 128 : 128 + intermediate_size, :hidden_size],
+            w13[:, intermediate_size:],
+        )
+
+    def test_preparation_deinterleaves_gpt_oss_gate_up_checkpoint_rows(self):
+        """GPT-OSS checkpoint [gate0, up0, ...] rows become FlashInfer [up, gate]."""
+        hidden_size = 3
+        intermediate_size = 5
+        kernel_intermediate_size = 128
+        gate = torch.arange(
+            intermediate_size * hidden_size, dtype=torch.float32
+        ).reshape(intermediate_size, hidden_size)
+        up = gate + 100
+        interleaved = torch.stack((gate, up), dim=1).reshape(
+            1, 2 * intermediate_size, hidden_size
+        )
+        runtime_padded = torch.zeros(
+            1,
+            2 * kernel_intermediate_size,
+            hidden_size,
+            dtype=torch.bfloat16,
+        )
+        runtime_padded[:, : 2 * intermediate_size] = interleaved.to(torch.bfloat16)
+        gate_bias = torch.arange(intermediate_size, dtype=torch.float32)
+        up_bias = gate_bias + 100
+        interleaved_bias = torch.stack((gate_bias, up_bias), dim=1).reshape(1, -1)
+        runtime_padded_bias = torch.zeros(
+            1, 2 * kernel_intermediate_size, dtype=torch.float32
+        )
+        runtime_padded_bias[:, : 2 * intermediate_size] = interleaved_bias
+
+        prepared_w13, _, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            runtime_padded,
+            torch.zeros(
+                1,
+                hidden_size,
+                kernel_intermediate_size,
+                dtype=torch.bfloat16,
+            ),
+            runtime_padded_bias,
+            None,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            gemm1_alpha=1.702,
+            gate_up_interleaved=True,
+        )
+
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, :hidden_size],
+            up.unsqueeze(0).to(torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            prepared_w13[
+                :,
+                kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+                :hidden_size,
+            ],
+            gate.unsqueeze(0).to(torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, hidden_size],
+            up_bias.unsqueeze(0).to(torch.bfloat16),
+        )
+        torch.testing.assert_close(
+            prepared_w13[
+                :,
+                kernel_intermediate_size : kernel_intermediate_size + intermediate_size,
+                hidden_size,
+            ],
+            gate_bias.unsqueeze(0).to(torch.bfloat16),
+        )
+
+    def test_preparation_reads_runtime_padded_w13_layout(self):
+        """Only logical [up, gate] rows survive a runtime-padded W13 input."""
+        hidden_size = 3
+        intermediate_size = 5
+        w13 = torch.full((2, 256, hidden_size), 9.0, dtype=torch.bfloat16)
+        up = torch.full((2, intermediate_size, hidden_size), 2.0, dtype=torch.bfloat16)
+        gate = torch.full(
+            (2, intermediate_size, hidden_size), 3.0, dtype=torch.bfloat16
+        )
+        w13[:, :intermediate_size] = up
+        w13[:, 128 : 128 + intermediate_size] = gate
+
+        prepared_w13, _, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            torch.zeros(2, hidden_size, 128, dtype=torch.bfloat16),
+            None,
+            None,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            gemm1_alpha=1.702,
+        )
+
+        torch.testing.assert_close(
+            prepared_w13[:, :intermediate_size, :hidden_size], up
+        )
+        torch.testing.assert_close(
+            prepared_w13[:, 128 : 128 + intermediate_size, :hidden_size], gate
+        )
+        self.assertEqual(prepared_w13[:, intermediate_size:128].count_nonzero(), 0)
+        self.assertEqual(
+            prepared_w13[:, 128 + intermediate_size :, :hidden_size].count_nonzero(),
+            0,
+        )
+
+    def test_preparation_supports_each_bias_independently(self):
+        """W13 and W2 bias folding must not require the other bias tensor."""
+        w13 = torch.zeros(2, 10, 3, dtype=torch.bfloat16)
+        w2 = torch.zeros(2, 3, 128, dtype=torch.bfloat16)
+        w13_bias = torch.arange(20, dtype=torch.float32).view(2, 10)
+        w2_bias = torch.arange(6, dtype=torch.float32).view(2, 3)
+
+        w13_only, w2_without_bias, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            w2,
+            w13_bias,
+            None,
+            hidden_size=3,
+            intermediate_size=5,
+            gemm1_alpha=1.702,
+        )
+        torch.testing.assert_close(w13_only[:, :5, 3], w13_bias[:, :5].bfloat16())
+        torch.testing.assert_close(w13_only[:, 128:133, 3], w13_bias[:, 5:].bfloat16())
+        self.assertEqual(w2_without_bias.count_nonzero(), 0)
+
+        w2_only_w13, w2_only, _ = _prepare_flashinfer_trtllm_bf16_weights(
+            w13,
+            w2,
+            None,
+            w2_bias,
+            hidden_size=3,
+            intermediate_size=5,
+            gemm1_alpha=1.702,
+        )
+        self.assertNotEqual(w2_only_w13[:, 5, 3].count_nonzero(), 0)
+        torch.testing.assert_close(w2_only[:, :3, 5], w2_bias.bfloat16())
+
+    def test_preparation_rejects_invalid_bias_shapes_without_broadcasting(self):
+        """Per-expert bias tensors must exactly match the prepared weights."""
+        w13 = torch.zeros(2, 10, 3, dtype=torch.bfloat16)
+        w2 = torch.zeros(2, 3, 128, dtype=torch.bfloat16)
+
+        for bad_w13_bias in (
+            torch.zeros(1, 10, dtype=torch.float32),
+            torch.zeros(2, 9, dtype=torch.float32),
+        ):
+            with self.subTest(w13_bias_shape=tuple(bad_w13_bias.shape)):
+                with self.assertRaises(ValueError):
+                    _prepare_flashinfer_trtllm_bf16_weights(
+                        w13,
+                        w2,
+                        bad_w13_bias,
+                        None,
+                        hidden_size=3,
+                        intermediate_size=5,
+                        gemm1_alpha=1.702,
+                    )
+
+        for bad_w2_bias in (
+            torch.zeros(1, 3, dtype=torch.float32),
+            torch.zeros(2, 4, dtype=torch.float32),
+        ):
+            with self.subTest(w2_bias_shape=tuple(bad_w2_bias.shape)):
+                with self.assertRaises(ValueError):
+                    _prepare_flashinfer_trtllm_bf16_weights(
+                        w13,
+                        w2,
+                        None,
+                        bad_w2_bias,
+                        hidden_size=3,
+                        intermediate_size=5,
+                        gemm1_alpha=1.702,
+                    )
+
+    @patch.object(
+        unquant,
+        "get_moe_runner_backend",
+        return_value=unquant.MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
+    )
+    def test_hot_load_replaces_prepared_w13_with_canonical_shape(self, _):
+        """Prepared W13's padded hidden width must be discarded before reload."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+        layer = self._make_restore_layer()
+        param = Parameter(torch.empty(1, 256, 2944, dtype=torch.bfloat16))
+
+        method.maybe_restore_flashinfer_trtllm_bf16_weight_shape_for_load(
+            layer, param, "model.experts.w13_weight"
+        )
+
+        self.assertEqual(tuple(param.shape), (1, 256, 2880))
+
+    @patch.object(
+        unquant,
+        "get_moe_runner_backend",
+        return_value=unquant.MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
+    )
+    def test_hot_load_replaces_prepared_w2_with_canonical_shape(self, _):
+        """Prepared W2's padded output width must be discarded before reload."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+        layer = self._make_restore_layer()
+        param = Parameter(torch.empty(1, 2944, 128, dtype=torch.bfloat16))
+
+        method.maybe_restore_flashinfer_trtllm_bf16_weight_shape_for_load(
+            layer, param, "model.experts.w2_weight"
+        )
+
+        self.assertEqual(tuple(param.shape), (1, 2880, 128))
+
+    @patch.object(
+        unquant,
+        "get_moe_runner_backend",
+        return_value=unquant.MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
+    )
+    def test_hot_load_rejects_unrecognized_weight_numel(self, _):
+        """Hot reload must not reshape tensors outside either known layout."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+
+        with self.assertRaisesRegex(RuntimeError, "Cannot restore"):
+            method.maybe_restore_flashinfer_trtllm_bf16_weight_shape_for_load(
+                self._make_restore_layer(),
+                Parameter(torch.empty(1, 17, 17, dtype=torch.bfloat16)),
+                "model.experts.w13_weight",
+            )
+
+    def test_non_gated_flashinfer_path_skips_bf16_preparation(self):
+        """Non-gated FlashInfer MoE keeps its pre-existing block-layout path."""
+        method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+        method.use_flashinfer_trtllm_moe = True
+        method.use_deep_gemm = False
+        method._cache_permute_indices = {}
+        layer = SimpleNamespace(
+            moe_runner_config=SimpleNamespace(is_gated=False),
+            w13_weight=Parameter(torch.zeros(1, 5, 3, dtype=torch.bfloat16)),
+            w2_weight=Parameter(torch.zeros(1, 3, 128, dtype=torch.bfloat16)),
+            num_local_experts=1,
+        )
+        flashinfer = ModuleType("flashinfer")
+        flashinfer.__path__ = []
+        fused_moe = ModuleType("flashinfer.fused_moe")
+        fused_moe.__path__ = []
+        core = ModuleType("flashinfer.fused_moe.core")
+        calls = []
+
+        def w13_permute(_, weight, *__, **kwargs):
+            calls.append("w13_permute")
+            self.assertFalse(kwargs["is_gated_act_gemm"])
+            return torch.arange(weight.shape[0])
+
+        def w2_permute(_, weight, __):
+            calls.append("w2_permute")
+            return torch.arange(weight.shape[0])
+
+        def block_layout(weight, _):
+            calls.append("block_layout")
+            return weight
+
+        core._maybe_get_cached_w3_w1_permute_indices = w13_permute
+        core.convert_to_block_layout = block_layout
+        core.get_w2_permute_indices_with_cache = w2_permute
+
+        with (
+            patch.object(unquant, "_is_cpu", False),
+            patch.object(
+                unquant,
+                "_prepare_flashinfer_trtllm_bf16_weights",
+                side_effect=AssertionError("non-gated path must not prepare weights"),
+            ),
+            patch.dict(
+                "sys.modules",
+                {
+                    "flashinfer": flashinfer,
+                    "flashinfer.fused_moe": fused_moe,
+                    "flashinfer.fused_moe.core": core,
+                },
+            ),
+        ):
+            method.process_weights_after_loading(layer)
+
+        self.assertEqual(
+            calls,
+            ["w13_permute", "w2_permute", "block_layout", "block_layout"],
+        )
+
+    def test_bf16_runner_pads_inputs_and_restores_logical_width(self):
+        """Both BF16 kernels receive padded inputs and return logical outputs."""
+        tokens, hidden_size, kernel_hidden_size = 3, 2880, 2944
+        input_pad_value = 1.0
+        alpha = torch.tensor([1.702])
+        beta = torch.tensor([1.0])
+        clamp_limit = torch.tensor([7.0])
+        quant_info = flashinfer_trtllm.FlashInferTrtllmBf16MoeQuantInfo(
+            gemm1_weights=torch.empty(1),
+            gemm2_weights=torch.empty(1),
+            global_num_experts=1,
+            local_expert_offset=0,
+            kernel_hidden_size=kernel_hidden_size,
+            input_pad_value=input_pad_value,
+            gemm1_alpha=alpha,
+            gemm1_beta=beta,
+            gemm1_clamp_limit=clamp_limit,
+        )
+        runner_config = MoeRunnerConfig(
+            activation="silu",
+            is_gated=True,
+            num_fused_shared_experts=0,
+            num_local_experts=1,
+            intermediate_size_per_partition=128,
+            top_k=1,
+        )
+        hidden_states = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
+        kernel_result = torch.randn(kernel_hidden_size, tokens).transpose(0, 1)
+
+        flashinfer = ModuleType("flashinfer")
+        flashinfer.__path__ = []
+        fused_moe = ModuleType("flashinfer.fused_moe")
+        fused_moe.__path__ = []
+        core = ModuleType("flashinfer.fused_moe.core")
+        core.ActivationType = SimpleNamespace(
+            Swiglu=SimpleNamespace(value=1),
+            Geglu=SimpleNamespace(value=2),
+        )
+
+        for use_routed_topk in (False, True):
+            with self.subTest(use_routed_topk=use_routed_topk):
+                kernel_calls = []
+
+                def mock_kernel(**kwargs):
+                    kernel_calls.append(kwargs)
+                    return kernel_result
+
+                if use_routed_topk:
+                    fused_moe.trtllm_bf16_routed_moe = mock_kernel
+                    topk_output = PackedTopKOutput(
+                        packed_topk_ids=torch.zeros(tokens, 1, dtype=torch.int32),
+                        router_logits=torch.empty(tokens, 1),
+                    )
+                else:
+                    fused_moe.trtllm_bf16_moe = mock_kernel
+                    topk_output = BypassedTopKOutput(
+                        hidden_states=hidden_states,
+                        router_logits=torch.empty(tokens, 1),
+                        topk_config=TopKConfig(top_k=1),
+                    )
+
+                dispatch_output = StandardDispatchOutput(
+                    hidden_states=hidden_states,
+                    hidden_states_scale=None,
+                    topk_output=topk_output,
+                )
+                with (
+                    patch.dict(
+                        "sys.modules",
+                        {
+                            "flashinfer": flashinfer,
+                            "flashinfer.fused_moe": fused_moe,
+                            "flashinfer.fused_moe.core": core,
+                        },
+                    ),
+                    patch.object(flashinfer_trtllm, "get_tp_group", return_value=None),
+                    patch.object(
+                        flashinfer_trtllm,
+                        "use_symmetric_memory",
+                        return_value=nullcontext(),
+                    ),
+                    patch.object(
+                        flashinfer_trtllm, "is_allocation_symmetric", return_value=False
+                    ),
+                ):
+                    output = (
+                        flashinfer_trtllm.fused_experts_none_to_flashinfer_trtllm_bf16(
+                            dispatch_output,
+                            quant_info,
+                            runner_config,
+                            use_routed_topk=use_routed_topk,
+                        )
+                    )
+
+                self.assertEqual(len(kernel_calls), 1)
+                kernel_input = kernel_calls[0]["hidden_states"]
+                self.assertEqual(
+                    tuple(kernel_input.shape), (tokens, kernel_hidden_size)
+                )
+                torch.testing.assert_close(kernel_input[:, :hidden_size], hidden_states)
+                torch.testing.assert_close(
+                    kernel_input[:, hidden_size:],
+                    torch.full(
+                        (tokens, kernel_hidden_size - hidden_size),
+                        input_pad_value,
+                        dtype=hidden_states.dtype,
+                    ),
+                )
+                self.assertIs(kernel_calls[0]["gemm1_alpha"], alpha)
+                self.assertIs(kernel_calls[0]["gemm1_beta"], beta)
+                self.assertIs(kernel_calls[0]["gemm1_clamp_limit"], clamp_limit)
+                self.assertEqual(
+                    tuple(output.hidden_states.shape), (tokens, hidden_size)
+                )
+                self.assertTrue(output.hidden_states.is_contiguous())
+                torch.testing.assert_close(
+                    output.hidden_states, kernel_result[:, :hidden_size]
+                )
+
+    def test_forward_cuda_builds_bf16_padding_payload_for_gated_and_non_gated(self):
+        """Gated preparation values flow through, while non-gated uses safe defaults."""
+
+        class FakeBackend:
+            def is_triton_kernels(self):
+                return False
+
+            def is_deep_gemm(self):
+                return False
+
+        class CaptureRunner:
+            runner_backend = FakeBackend()
+
+            def run(self, dispatch_output, quant_info):
+                self.quant_info = quant_info
+                return dispatch_output
+
+        dispatch_output = StandardDispatchOutput(
+            hidden_states=torch.empty(2, 2880, dtype=torch.bfloat16),
+            hidden_states_scale=None,
+            topk_output=SimpleNamespace(),
+        )
+        alpha = torch.tensor([1.702])
+        beta = torch.tensor([1.0])
+        clamp_limit = torch.tensor([7.0])
+
+        for is_gated in (True, False):
+            with self.subTest(is_gated=is_gated):
+                method = UnquantizedFusedMoEMethod.__new__(UnquantizedFusedMoEMethod)
+                method.use_flashinfer_cutlass = False
+                method.use_flashinfer_trtllm_moe = True
+                method.runner = CaptureRunner()
+                if is_gated:
+                    method._flashinfer_kernel_hidden_size = 2944
+                    method._flashinfer_input_pad_value = 1.0
+                    method._flashinfer_gemm1_alpha = alpha
+                    method._flashinfer_gemm1_beta = beta
+                    method._flashinfer_gemm1_clamp_limit = clamp_limit
+                layer = SimpleNamespace(
+                    w13_weight=Parameter(torch.empty(1)),
+                    w2_weight=Parameter(torch.empty(1)),
+                    num_experts=4,
+                    moe_ep_rank=1,
+                    num_local_experts=2,
+                    hidden_size=2880,
+                    moe_runner_config=SimpleNamespace(is_gated=is_gated),
+                )
+
+                method.forward_cuda(layer, dispatch_output)
+                quant_info = method.runner.quant_info
+
+                self.assertEqual(
+                    quant_info.kernel_hidden_size, 2944 if is_gated else 2880
+                )
+                self.assertEqual(quant_info.input_pad_value, 1.0 if is_gated else 0.0)
+                self.assertIs(quant_info.gemm1_alpha, alpha if is_gated else None)
+                self.assertIs(quant_info.gemm1_beta, beta if is_gated else None)
+                self.assertIs(
+                    quant_info.gemm1_clamp_limit, clamp_limit if is_gated else None
+                )
+
+    def test_bf16_lora_payload_uses_prepared_values_or_non_gated_fallback(self):
+        """BF16 LoRA construction must satisfy the padded runner payload contract."""
+        alpha = torch.tensor([1.702])
+        beta = torch.tensor([1.0])
+        clamp_limit = torch.tensor([7.0])
+
+        for is_gated in (True, False):
+            with self.subTest(is_gated=is_gated):
+                quant_method = SimpleNamespace(quant_config=None, block_quant=False)
+                if is_gated:
+                    quant_method._flashinfer_kernel_hidden_size = 2944
+                    quant_method._flashinfer_input_pad_value = 1.0
+                    quant_method._flashinfer_gemm1_alpha = alpha
+                    quant_method._flashinfer_gemm1_beta = beta
+                    quant_method._flashinfer_gemm1_clamp_limit = clamp_limit
+                base_layer = SimpleNamespace(
+                    quant_method=quant_method,
+                    w13_weight=Parameter(torch.empty(1, 2, 2, 2)),
+                    w2_weight=Parameter(torch.empty(1, 2, 2, 2)),
+                    num_experts=4,
+                    moe_ep_rank=1,
+                    num_local_experts=2,
+                    hidden_size=2880,
+                    moe_runner_config=SimpleNamespace(is_gated=is_gated),
+                )
+                layer = SimpleNamespace()
+
+                with patch.object(lora_layer, "_warm_sgl_trtllm_moe_module"):
+                    lora_layer.init_experimental_sgl_trtllm_lora(layer, base_layer)
+
+                quant_info = layer._quant_info
+                self.assertEqual(
+                    quant_info.kernel_hidden_size, 2944 if is_gated else 2880
+                )
+                self.assertEqual(quant_info.input_pad_value, 1.0 if is_gated else 0.0)
+                self.assertIs(quant_info.gemm1_alpha, alpha if is_gated else None)
+                self.assertIs(quant_info.gemm1_beta, beta if is_gated else None)
+                self.assertIs(
+                    quant_info.gemm1_clamp_limit, clamp_limit if is_gated else None
+                )
+
+    def test_bias_folding_requires_spare_padded_channels(self):
+        """Bias folding must reject kernel shapes with no synthetic channels."""
+        with self.assertRaises(ValueError):
+            _prepare_flashinfer_trtllm_bf16_weights(
+                torch.zeros(2, 10, 128, dtype=torch.bfloat16),
+                torch.zeros(2, 128, 128, dtype=torch.bfloat16),
+                torch.zeros(2, 10, dtype=torch.float32),
+                None,
+                hidden_size=128,
+                intermediate_size=5,
+                gemm1_alpha=1.702,
+            )
+
+        with self.assertRaises(ValueError):
+            _prepare_flashinfer_trtllm_bf16_weights(
+                torch.zeros(2, 10, 128, dtype=torch.bfloat16),
+                torch.zeros(2, 128, 128, dtype=torch.bfloat16),
+                None,
+                torch.zeros(2, 128, dtype=torch.float32),
+                hidden_size=128,
+                intermediate_size=5,
+                gemm1_alpha=1.702,
+            )
+
+        with self.assertRaises(ValueError):
+            _prepare_flashinfer_trtllm_bf16_weights(
+                torch.zeros(2, 256, 3, dtype=torch.bfloat16),
+                torch.zeros(2, 3, 128, dtype=torch.bfloat16),
+                None,
+                torch.zeros(2, 3, dtype=torch.float32),
+                hidden_size=3,
+                intermediate_size=128,
+                gemm1_alpha=1.702,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
+++ b/test/registered/unit/models/test_gpt_oss_ep_weight_loading.py
@@ -1,0 +1,188 @@
+"""Unit tests for GPT-OSS expert-parallel checkpoint slicing."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.layers.moe import MoeRunnerBackend
+from sglang.srt.layers.moe.fused_moe_triton import layer as fused_moe_layer
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.models.gpt_oss import (
+    GptOssSparseMoeBlock,
+    TinyGemmLinear,
+    _narrow_fused_moe_ep_weight,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestGptOssEpWeightLoading(CustomTestCase):
+    def _make_fused_moe_shell(self) -> FusedMoE:
+        """Build the minimum loader surface without allocating expert weights."""
+        layer = FusedMoE.__new__(FusedMoE)
+        torch.nn.Module.__init__(layer)
+        layer.__dict__["use_padded_loading"] = True
+        layer.quant_config = None
+        layer.use_presharded_weights = False
+        return layer
+
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_global_expert_weights_are_sliced_for_ep_rank(self, get_parallel):
+        """Global checkpoint experts must be narrowed to the current EP rank."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=4, moe_ep_rank=2)
+        weight = torch.arange(128 * 2).view(128, 2)
+
+        actual = _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+        torch.testing.assert_close(actual, weight[64:96])
+
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_ep_one_keeps_global_expert_weights(self, get_parallel):
+        """EP1 must preserve the checkpoint tensor without an unnecessary copy."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=1, moe_ep_rank=0)
+        weight = torch.arange(128 * 2).view(128, 2)
+
+        actual = _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+        self.assertIs(actual, weight)
+
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_local_expert_weights_are_not_sliced_again(self, get_parallel):
+        """Already-local checkpoint experts must not be narrowed a second time."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=4, moe_ep_rank=2)
+        weight = torch.arange(32 * 2).view(32, 2)
+
+        actual = _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+        self.assertIs(actual, weight)
+
+    @patch("sglang.srt.models.gpt_oss.get_parallel")
+    def test_invalid_expert_dimension_is_rejected(self, get_parallel):
+        """A checkpoint must contain either all experts or this rank's experts."""
+        get_parallel.return_value = SimpleNamespace(moe_ep_size=4, moe_ep_rank=2)
+        weight = torch.arange(64 * 2).view(64, 2)
+
+        with self.assertRaisesRegex(
+            ValueError, "Expected 128 global or 32 local experts, got 64"
+        ):
+            _narrow_fused_moe_ep_weight(weight, num_experts=128)
+
+    def test_w2_bias_loading_uses_its_last_dimension(self):
+        """Fused down-projection biases must ignore the weight shard dimension."""
+        layer = self._make_fused_moe_shell()
+        expert_data = torch.empty(2, 4)
+        loaded_weight = torch.arange(8, dtype=torch.float32).view(2, 4)
+
+        layer._load_w2(
+            expert_data=expert_data,
+            shard_dim=2,
+            shard_id="w2",
+            loaded_weight=loaded_weight,
+            tp_rank=0,
+            is_bias=True,
+        )
+
+        torch.testing.assert_close(expert_data, loaded_weight)
+
+    def test_tinygemm_linear_accepts_empty_idle_batch(self):
+        """DP ranks without work must not launch tinygemm with zero M."""
+        layer = TinyGemmLinear.__new__(TinyGemmLinear)
+        torch.nn.Module.__init__(layer)
+        layer.output_size = 128
+        layer._use_tinygemm = True
+        x = torch.empty((0, 64), dtype=torch.bfloat16)
+
+        output, output_bias = layer(x)
+
+        self.assertEqual(output.shape, (0, 128))
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertIsNone(output_bias)
+
+    @patch(
+        "sglang.srt.models.gpt_oss.should_skip_post_experts_all_reduce",
+        create=True,
+        return_value=True,
+    )
+    @patch("sglang.srt.models.gpt_oss.tensor_model_parallel_all_reduce")
+    @patch(
+        "sglang.srt.models.gpt_oss.get_forward",
+        return_value=SimpleNamespace(fuse_mlp_allreduce=False),
+    )
+    @patch(
+        "sglang.srt.models.gpt_oss.is_in_tc_piecewise_cuda_graph",
+        return_value=False,
+    )
+    def test_flashinfer_a2a_output_is_not_all_reduced(
+        self, _is_piecewise, _get_forward, all_reduce, _should_skip
+    ):
+        """FlashInfer combine already returns the complete source-rank output."""
+        block = GptOssSparseMoeBlock.__new__(GptOssSparseMoeBlock)
+        torch.nn.Module.__init__(block)
+        block.tp_size = 4
+        block.hidden_size = 3
+        block.__dict__["router"] = Mock(
+            return_value=(torch.zeros((2, 4), dtype=torch.float32), None)
+        )
+        topk_output = object()
+        block.__dict__["topk"] = Mock(return_value=topk_output)
+        block.__dict__["experts"] = Mock(side_effect=lambda x, _: x + 1)
+        hidden_states = torch.zeros((2, 3), dtype=torch.bfloat16)
+
+        actual = block.forward_normal(hidden_states)
+
+        torch.testing.assert_close(actual, hidden_states + 1)
+        all_reduce.assert_not_called()
+
+    @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_moe_runner")
+    @patch.object(fused_moe_layer.UnquantizedFusedMoEMethod, "create_weights")
+    @patch.object(fused_moe_layer, "create_moe_dispatcher")
+    @patch.object(
+        fused_moe_layer,
+        "get_moe_a2a_backend",
+        return_value=SimpleNamespace(is_ascend_fuseep=lambda: False),
+    )
+    @patch.object(
+        fused_moe_layer,
+        "get_server_args",
+        return_value=SimpleNamespace(
+            ep_join_mode="none", moe_runner_backend="flashinfer_trtllm_routed"
+        ),
+    )
+    @patch.object(
+        fused_moe_layer,
+        "get_parallel",
+        return_value=SimpleNamespace(
+            moe_ep_size=1, moe_ep_rank=0, moe_tp_size=1, moe_tp_rank=0
+        ),
+    )
+    @patch.object(
+        fused_moe_layer, "has_per_rank_fused_shared_slots", return_value=False
+    )
+    @patch.object(
+        fused_moe_layer, "create_kt_config_from_server_args", return_value=None
+    )
+    @patch.object(
+        fused_moe_layer,
+        "get_moe_runner_backend",
+        return_value=MoeRunnerBackend.FLASHINFER_TRTLLM_ROUTED,
+    )
+    def test_flashinfer_constructor_keeps_logical_intermediate_size(self, *_):
+        """Kernel allocation padding must not overwrite the logical MoE size."""
+        layer = FusedMoE(
+            num_experts=1,
+            hidden_size=1,
+            intermediate_size=2880,
+            layer_id=0,
+            params_dtype=torch.float32,
+        )
+
+        self.assertEqual(layer.intermediate_size_per_partition_unpadded, 2880)
+        self.assertEqual(layer.intermediate_size_per_partition, 2944)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Split PR 1 of #32714. Add GPT-OSS BF16 support for the FlashInfer A2A path and FlashInfer TRT-LLM routed MoE runner without depending on either CP optimization PR.

## Modifications

- shard GPT-OSS BF16 experts for EP loading
- preserve logical MoE sizes while padding BF16 kernel weights
- prepare and deinterleave GPT-OSS MoE projections for FlashInfer
- handle empty routed batches and avoid double reduction of FlashInfer A2A output
- preserve the BF16 MoE payload for LoRA
- add focused routed-MoE padding and GPT-OSS EP weight-loading tests

This is a pure split of #32714: every changed file is copied byte-for-byte from its head. This PR owns 7 files and has no changed-file overlap with the other two split PRs.

## Accuracy Tests

- Added unit coverage is unchanged from #32714.
- Local `py_compile` passed for all 7 changed Python files.
- Focused pytest collection was blocked on this macOS checkout by missing SGLang runtime dependencies (`pybase64` after installing the basic pytest dependencies); functional tests were not reported as passing locally.

## Speed Tests and Profiling

No benchmark was rerun for this code-only split. See #32714 for the original combined-stack measurements.

## Split Verification

- Base: `9bdbb180b100751f03575ba68fd9aa657d30501d`
- Source head: `def2f41b14a31d1720fd23590049726d26412411`
- Three split PR file sets: 7 + 5 + 4 files, pairwise disjoint
- Combined split tree: `15a4adef6389ad78b370918663a2252a3dbf7b13`
- Source PR tree: `15a4adef6389ad78b370918663a2252a3dbf7b13`

## Checklist

- [x] Format code with pre-commit (all hooks passed for this commit).
- [x] Preserve the original unit tests assigned to this split.
- [x] No documentation change is required for this pure split.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->