### PR TITLE
fix(kimi-k3): align kimi-k3 branch with DCP + DSpark fix and cleanup

### DIFF
--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -179,7 +179,8 @@ def _release_overallocated_kv_indices(
     req: Req, start_p: int, end_p: int, tree_cache: BasePrefixCache
 ) -> None:
     global_server_args = get_server_args()
-    page_size = global_server_args.page_size
+    allocator = tree_cache.token_to_kv_pool_allocator
+    page_size = allocator.page_size
     spec_algo = global_server_args.speculative_algorithm
 
     # strip_thinking_cache intentionally reports output tokens as overallocated
@@ -196,11 +197,9 @@ def _release_overallocated_kv_indices(
         indices_to_free = tree_cache.req_to_token_pool.req_to_token[req.req_pool_idx][
             start_p:end_p
         ]
-        # start_p is ceil-aligned above: never shares a page with
-        # cache_finished_req's tail frees in the same group.
-        tree_cache.token_to_kv_pool_allocator.free_segment(
-            indices_to_free, start_pos=start_p
-        )
+        # start_p is aligned to the allocator's physical page size above, so it
+        # never shares a page with cache_finished_req's tail free in this group.
+        allocator.free_segment(indices_to_free, start_pos=start_p)
 
 
 def available_and_evictable_str(tree_cache: BasePrefixCache) -> str:

--- a/test/registered/dcp/test_kimi_linear_dcp_dspark4.py
+++ b/test/registered/dcp/test_kimi_linear_dcp_dspark4.py
@@ -26,9 +26,9 @@ register_cuda_ci(est_time=350, stage="extra-b", runner_config="4-gpu-b200")
 
 KIMI_LINEAR_MODEL = "moonshotai/Kimi-Linear-48B-A3B-Instruct"
 GSM8K_SCORE_THRESHOLD = 0.88
-# Speculative decoding derives concurrency from the draft-token memory reserve
-# and capture clamps to it, so a ceiling past this covers no reachable batch.
-CUDA_GRAPH_MAX_BS_DECODE = 64
+CUDA_GRAPH_MAX_BS_DECODE = 128
+MAX_RUNNING_REQUESTS = 128
+GSM8K_NUM_THREADS = 128
 
 
 def _has_four_blackwell_gpus() -> bool:
@@ -129,6 +129,8 @@ class TestKimiLinearDCPDSpark4(CustomTestCase):
             "4",
             "--dcp-size",
             "4",
+            "--max-running-requests",
+            str(MAX_RUNNING_REQUESTS),
             "--attention-backend",
             "tokenspeed_mla",
             "--kv-cache-dtype",
@@ -141,6 +143,8 @@ class TestKimiLinearDCPDSpark4(CustomTestCase):
             draft_path,
             "--speculative-draft-load-format",
             "dummy",
+            "--speculative-attention-mode",
+            "decode",
             "--speculative-draft-attention-backend",
             "trtllm_mha",
             "--cuda-graph-max-bs-decode",
@@ -148,6 +152,8 @@ class TestKimiLinearDCPDSpark4(CustomTestCase):
             "--cuda-graph-backend-prefill",
             "disabled",
             "--trust-remote-code",
+            "--random-seed",
+            "0",
             "--dtype",
             "bfloat16",
             "--mem-fraction-static",
@@ -190,7 +196,7 @@ class TestKimiLinearDCPDSpark4(CustomTestCase):
                     api="completion",
                     max_tokens=512,
                     num_examples=200,
-                    num_threads=128,
+                    num_threads=GSM8K_NUM_THREADS,
                     num_shots=5,
                 )
             )

--- a/test/registered/unit/mem_cache/test_paged_free_segment.py
+++ b/test/registered/unit/mem_cache/test_paged_free_segment.py
@@ -6,11 +6,14 @@ deferral. See PagedTokenToKVPoolAllocator.free_segment for why unique is avoided
 """
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.common import _release_overallocated_kv_indices
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
@@ -102,6 +105,41 @@ class TestFreeSegment(unittest.TestCase):
         alloc.free_segment(row, start_pos=0)
         with self.assertRaises(AssertionError):
             alloc.free_group_end()
+
+    def test_overallocated_tail_uses_allocator_page_size_under_dcp(self):
+        # Scaled-down DCP example: the configured logical page is 1 while the
+        # allocator page is widened to 4. cache_finished_req has already freed
+        # the committed tail [4, 5), so over-allocation cleanup for [5, 7)
+        # must not release the same physical page again.
+        alloc = _make_allocator()
+        alloc.debug_mode = True
+        row = _make_kv_row(alloc, 2 * PAGE_SIZE)
+        tree_cache = SimpleNamespace(
+            token_to_kv_pool_allocator=alloc,
+            req_to_token_pool=SimpleNamespace(req_to_token=row.unsqueeze(0)),
+        )
+        req = SimpleNamespace(req_pool_idx=0)
+
+        before = len(alloc.free_pages)
+        alloc.free_group_begin()
+        alloc.free_segment(row[PAGE_SIZE : PAGE_SIZE + 1], start_pos=PAGE_SIZE)
+        with patch(
+            "sglang.srt.mem_cache.common.get_server_args",
+            return_value=SimpleNamespace(
+                page_size=1,
+                speculative_algorithm="DSPARK",
+                strip_thinking_cache=False,
+            ),
+        ):
+            _release_overallocated_kv_indices(
+                req,
+                start_p=PAGE_SIZE + 1,
+                end_p=2 * PAGE_SIZE - 1,
+                tree_cache=tree_cache,
+            )
+        alloc.free_group_end()
+
+        self.assertEqual(len(alloc.free_pages), before + 1)
 
 
 class TestFreeSegments(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Align the Kimi Linear DCP + DSpark test with #32828 by explicitly setting CUDA graph, max-running-request, and GSM8K concurrency to 128.
- Align speculative over-allocation cleanup to the allocator physical page size, avoiding duplicate frees when DCP widens pages (#32701).
- Add regression coverage for the logical/physical page-size mismatch.

## Testing

- `python -m pytest test/registered/unit/mem_cache/test_paged_free_segment.py -v` — 12 passed.
- `python -m pytest test/registered/dcp/test_kimi_linear_dcp_dspark4.py -v -s` — passed both qrep subtests on 4x B200; qrep=false GSM8K score 0.900.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30676688963](https://github.com/sgl-project/sglang/actions/runs/30676688963)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30676688879](https://github.com/sgl-project/sglang/actions/runs/30676688879)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->