### PR TITLE
fix(detokenizer): use rfind to trim stop string at the actual hit point

### DIFF
--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -186,8 +186,16 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
         # TODO(lmzheng): handle the case where multiple stop strs are hit
 
         # Trim stop str.
+        # Use rfind (not find) so we locate the *last* occurrence of the stop
+        # string — the actual stop hit point at the tail of the output. When
+        # reasoning is enabled the decoded text concatenates thinking content
+        # and the final answer, and the stop string can legitimately appear
+        # inside the thinking section (e.g. the model quotes the stop string
+        # while planning). `find` would match that earlier occurrence and
+        # truncate the whole answer away. `rfind` correctly anchors on the
+        # real hit at the end of the normal text.
         if isinstance(matched, str) and isinstance(output, str):
-            pos = output.find(matched)
+            pos = output.rfind(matched)
             if pos == -1:
                 return output
             end = pos + len(matched)


### PR DESCRIPTION
## Motivation

When reasoning (thinking) is enabled together with `stop_sequences`, the final answer can be truncated away entirely, leaving only a fragment of the reasoning.

`DetokenizerManager.trim_matched_stop` trims the matched stop string from the decoded output using `output.find(matched)`, which returns the **first** occurrence. With reasoning enabled, the decoded text concatenates the thinking content and the final answer — and the stop string can legitimately appear inside the thinking section (the model often quotes the target word while planning). `find()` matches that earlier occurrence and truncates from the middle of the reasoning, dropping the whole answer.

## Reproduction

Deploy sglang with a reasoning model (e.g. `--reasoning-parser qwen3`) and send a request where the stop string also appears in the model thinking:

- system prompt asks the model to insert a specific phrase at the end of its answer
- `stop_sequences` contains a word from that phrase
- `thinking` enabled

The model mentions the phrase in its reasoning, then writes it in the answer. **Expected**: the answer is returned up to (but excluding) the stop word. **Actual (bug)**: the answer is empty/truncated, because `find()` matched the occurrence inside the reasoning section.

## Fix

`find` → `rfind`. The real stop hit always comes from the most recently generated token, so it is the **last** occurrence in the decoded text. `rfind()` anchors on it correctly.

For non-reasoning outputs where the stop string appears at most once, `find()` and `rfind()` are equivalent — no behavior change for the common case.

## Verification

- 20 consecutive requests with thinking + stop: 0 failures (answer truncated correctly at the stop word, thinking block intact)
- Non-reasoning + stop: unchanged
- No stop / EOS / stop_token_ids: unchanged (different code path)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30677017465](https://github.com/sgl-project/sglang/actions/runs/30677017465)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30677017402](https://github.com/sgl-project/sglang/actions/runs/30677017402)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---

Part of the tracking issue #40529 (thinking models + stop_sequences: five related defects). Defect 5: masked by #33152 on stock builds — becomes observable once the scheduler no longer stops inside the reasoning phase.