### PR TITLE
fix(scheduler): skip user stop checks during the reasoning phase

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1373,7 +1373,9 @@ class Req(ReqDllmMixin):
 
         return False
 
-    def _check_token_based_finish(self, new_accepted_tokens: List[int]) -> bool:
+    def _check_token_based_finish(
+        self, new_accepted_tokens: List[int], skip_user_stop: bool = False
+    ) -> bool:
         if self.sampling_params.ignore_eos:
             return False
 
@@ -1381,7 +1383,12 @@ class Req(ReqDllmMixin):
         matched_eos = False
 
         for i, token_id in enumerate(new_accepted_tokens):
-            if self.sampling_params.stop_token_ids:
+            # User-specified stop_token_ids are skipped during the reasoning
+            # phase — they are an explicit stop intent meant for the final
+            # answer, not the thinking content. System eos / think_end /
+            # chat-stop tokens below are always checked so reasoning can end
+            # normally.
+            if not skip_user_stop and self.sampling_params.stop_token_ids:
                 matched_eos |= token_id in self.sampling_params.stop_token_ids
             if self.eos_token_ids:
                 matched_eos |= token_id in self.eos_token_ids
@@ -1496,13 +1503,22 @@ class Req(ReqDllmMixin):
         if self._check_vocab_boundary_finish(new_accepted_tokens):
             return
 
+        # When reasoning is enabled, skip user-provided stop checks (stop
+        # strings/regex and user stop_token_ids) during the reasoning phase —
+        # they are meant to delimit the final answer, not the thinking content.
+        # System eos / think_end detection still runs so reasoning can end
+        # normally.
+        in_reasoning = self.require_reasoning and not self._is_reasoning_over
+
         # Stop string beats EOS/stop-token matched in the same step (speculative
         # decoding can accept >1 token): token-based would trim only the last
         # token and leak the stop string.
-        if self._check_str_based_finish(new_accepted_len):
+        if not in_reasoning and self._check_str_based_finish(new_accepted_len):
             return
 
-        if self._check_token_based_finish(new_accepted_tokens):
+        if self._check_token_based_finish(
+            new_accepted_tokens, skip_user_stop=in_reasoning
+        ):
             return
 
         if self.grammar is not None and self.grammar.is_terminated():


### PR DESCRIPTION
## Motivation

When reasoning (thinking) is enabled together with `stop_sequences`, generation can terminate during the **reasoning phase** if the stop string appears inside the thinking content — the model often quotes the target word while planning. The final answer is then never produced (empty content).

User-provided stop checks (`stop` strings/regex and `stop_token_ids`) are meant to delimit the final answer, not the thinking content, but `update_finish_state` evaluates them against the full decoded text at every decode step.

## Fix

Skip user-provided stop checks while the request is still in the reasoning phase (`require_reasoning and not _is_reasoning_over`):

- `_check_str_based_finish` is skipped during reasoning
- `_check_token_based_finish` gains a `skip_user_stop` flag that skips user `stop_token_ids` but **still checks system eos / think_end / chat-stop tokens**, so reasoning can end normally

Once reasoning ends (`_is_reasoning_over` becomes `True` when `update_reasoning_tokens` detects the think_end token), user stop checks resume for the final answer.

Non-reasoning requests (`require_reasoning=False`) are unaffected — `in_reasoning` is always `False`, so all checks run as before.

## Verification

- Thinking + `stop_sequences` where the stop word also appears in reasoning: reasoning completes fully, final answer produced and truncated at the stop word
- Non-reasoning + `stop_sequences`: unchanged
- EOS / `stop_token_ids` (non-reasoning): unchanged

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30677102046](https://github.com/sgl-project/sglang/actions/runs/30677102046)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30677101967](https://github.com/sgl-project/sglang/actions/runs/30677101967)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---

Part of the tracking issue #40529 (thinking models + stop_sequences: five related defects). Defect 1: this is the semantic change discussed in the tracking issue (user stops delimit the final answer, not the thinking content; system EOS / think-end still detected during reasoning). Also covers the family of #24839.