### PR TITLE
fix(reasoning): avoid empty content when reasoning is truncated by a stop

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1518,7 +1518,9 @@ class OpenAIServingChat(OpenAIServingBase):
                         request=request,
                         tokenizer=self.tokenizer_manager.tokenizer,
                     )
-                    reasoning_text, text = parser.parse_non_stream(text)
+                    reasoning_text, text = parser.parse_non_stream(
+                        text, finish_reason=finish_reason
+                    )
                 except Exception as e:
                     logger.error(f"Reasoning parsing error: {e}")
                     return self.create_error_response(

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1493,9 +1493,25 @@ class ReasoningParser:
 
         self.detector = detector_class(**kwargs)
 
-    def parse_non_stream(self, full_text: str) -> Tuple[Optional[str], Optional[str]]:
+    def parse_non_stream(
+        self, full_text: str, finish_reason: Optional[dict] = None
+    ) -> Tuple[Optional[str], Optional[str]]:
         """Non-streaming call: one-time parsing"""
         ret = self.detector.detect_and_parse(full_text)
+        # If reasoning was truncated by a stop (user stop_sequences or EOS)
+        # before the think_end token appeared, normal_text would be empty and
+        # the whole output would land in reasoning_text — leaving the response
+        # content empty. When the finish reason is a stop (not a length cap),
+        # the reasoning phase had effectively ended, so move the reasoning
+        # content to normal_text to avoid an empty response. Length truncation
+        # keeps reasoning as-is, as the model may still be mid-reasoning.
+        if (
+            finish_reason
+            and finish_reason.get("type") == "stop"
+            and not ret.normal_text
+            and ret.reasoning_text
+        ):
+            ret.normal_text, ret.reasoning_text = ret.reasoning_text, ret.normal_text
         return ret.reasoning_text, ret.normal_text
 
     def parse_non_stream_blocks(self, full_text: str) -> list[dict]:


### PR DESCRIPTION
## Motivation

In non-streaming mode, when reasoning (thinking) is truncated by a **stop** (user `stop_sequences` or EOS) before the `think_end` token appears, the reasoning parser classifies the entire truncated reasoning as `reasoning_text` and leaves `normal_text` empty. The response `content` is then empty, which breaks clients that expect at least one content block.

This happens because `_detect_and_parse_impl` returns `StreamingParseResult(reasoning_text=processed_text)` when `think_end` is absent — it assumes the model is still mid-reasoning. But when the finish reason is a stop, the reasoning phase had effectively ended (the stop cut off the `think_end` token too).

## Fix

`ReasoningParser.parse_non_stream` now accepts `finish_reason`. When the finish reason is a **stop** (not a `length` cap) and `normal_text` would be empty, it moves the reasoning content to `normal_text` so the response is non-empty.

A `length` truncation (`max_tokens` reached) keeps reasoning as-is, since the model may genuinely still be mid-reasoning.

The fix is in `parse_non_stream` rather than in the detector, so it applies uniformly without touching the `detect_and_parse` signatures of the various detector subclasses (GptOss, MiniMaxM3, etc.).

## Verification

- Thinking + `stop_sequences` where the stop hits during reasoning (before `think_end`): response content is non-empty instead of empty
- Normal thinking (no stop, ends naturally): unchanged
- `max_tokens` truncation during reasoning: reasoning stays in `reasoning_text` (unchanged)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30677477183](https://github.com/sgl-project/sglang/actions/runs/30677477183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30677477106](https://github.com/sgl-project/sglang/actions/runs/30677477106)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---

Part of the tracking issue #40529 (thinking models + stop_sequences: five related defects). Defect 3: when the think-end marker is missing because a user stop truncated it, remaining text is classified as normal content based on finish_reason instead of dumping everything into reasoning.