### PR TITLE
fix(protocol): honor top-level enable_thinking field

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -878,6 +878,15 @@ class ChatCompletionRequest(BaseModel):
         r = values.get("reasoning")
         thinking = None
 
+        # Honor the top-level enable_thinking field used by qwen3/glm-5.2
+        # chat templates. Without this, a bare "enable_thinking": false in the
+        # request body is silently dropped (it is not a declared field), so
+        # callers cannot disable thinking via the documented OpenAI-style knob.
+        # Map it onto chat_template_kwargs so the template sees it.
+        top_enable_thinking = values.get("enable_thinking")
+        if top_enable_thinking is not None:
+            thinking = bool(top_enable_thinking)
+
         if r is not None and isinstance(r, dict):
             effort = r.get("effort")
             if effort is None:


### PR DESCRIPTION
## Motivation

qwen3/glm-5.2 chat templates use an `enable_thinking` kwarg to toggle thinking mode. The OpenAI `ChatCompletionRequest` does **not** declare `enable_thinking` as a field, so a bare `{"enable_thinking": false}` in the request body is silently dropped by pydantic — callers cannot disable thinking via the documented OpenAI-style knob.

## Fix

`normalize_reasoning_inputs` now reads the top-level `enable_thinking` and maps it onto `chat_template_kwargs` (alongside the existing `reasoning` / `reasoning_effort` handling), so the chat template sees it.

Precedence: `reasoning_effort` > `reasoning.enabled` > `enable_thinking` (top-level), since later assignments in the validator overwrite `thinking`.

## Verification

- `enable_thinking: false` (top-level, no other reasoning fields): thinking is disabled (`reasoning_content` empty)
- `enable_thinking: true`: thinking enabled
- `reasoning_effort: "none"`: still disables thinking (takes precedence over `enable_thinking`)
- No `enable_thinking` / `reasoning`: unchanged (template default)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30677566312](https://github.com/sgl-project/sglang/actions/runs/30677566312)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30677566234](https://github.com/sgl-project/sglang/actions/runs/30677566234)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

---

Part of the tracking issue #40529 (thinking models + stop_sequences: five related defects). Defect 4: top-level enable_thinking is not a declared field and was silently dropped during validation.