### PR TITLE
fix(mlx): skip transformers resolution for KV cache

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -37,6 +37,7 @@ from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.registry import TreeCacheBuildContext, create_tree_cache
 from sglang.srt.model_loader.utils import get_resolved_model_impl
 from sglang.srt.runtime_context import get_parallel
+from sglang.srt.utils.tensor_bridge import use_mlx
 
 if TYPE_CHECKING:
 
@@ -147,7 +148,7 @@ def build_kv_cache(
     sliding_window_size: Optional[int] = None
     full_tokens_per_layer: Optional[int] = None
     swa_tokens_per_layer: Optional[int] = None
-    uses_transformers_backend = (
+    uses_transformers_backend = not use_mlx() and (
         get_resolved_model_impl(model_config) == ModelImpl.TRANSFORMERS
     )
 

--- a/test/registered/unit/mem_cache/test_kv_cache_builder.py
+++ b/test/registered/unit/mem_cache/test_kv_cache_builder.py
@@ -1,0 +1,94 @@
+"""CPU-only regression tests for KV cache construction."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+from sglang.srt.mem_cache import kv_cache_builder
+from sglang.test.test_utils import CustomTestCase
+
+
+class TestBuildKVCache(CustomTestCase):
+    def test_mlx_skips_transformers_architecture_resolution(self):
+        model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(),
+            is_multimodal=False,
+        )
+        req_to_token_pool = object()
+        token_to_kv_pool_allocator = SimpleNamespace(page_size=1)
+        tp_worker = SimpleNamespace(
+            is_hybrid_swa=False,
+            model_runner=SimpleNamespace(model_config=model_config),
+            get_memory_pool=lambda: (
+                req_to_token_pool,
+                token_to_kv_pool_allocator,
+            ),
+        )
+        server_args = SimpleNamespace(
+            chunked_prefill_size=None,
+            disable_radix_cache=False,
+            disaggregation_decode_enable_radix_cache=False,
+            enable_dp_attention=False,
+            enable_mamba_extra_buffer=lambda: False,
+            enable_mamba_extra_buffer_lazy=lambda: False,
+            enable_session_radix_cache=False,
+            radix_eviction_policy="lru",
+        )
+        tree_cache = object()
+
+        with (
+            mock.patch.object(kv_cache_builder, "use_mlx", return_value=True),
+            mock.patch.object(
+                kv_cache_builder,
+                "get_resolved_model_impl",
+                side_effect=ValueError("cannot resolve remote architecture"),
+            ),
+            mock.patch.object(
+                kv_cache_builder, "linear_attn_model_spec", return_value=None
+            ),
+            mock.patch.object(kv_cache_builder, "hybrid_gdn_config", return_value=None),
+            mock.patch.object(
+                kv_cache_builder, "hybrid_lightning_config", return_value=None
+            ),
+            mock.patch.object(
+                kv_cache_builder, "kimi_linear_config", return_value=None
+            ),
+            mock.patch.object(kv_cache_builder, "mamba2_config", return_value=None),
+            mock.patch.object(kv_cache_builder, "is_deepseek_dsa", return_value=False),
+            mock.patch.object(
+                kv_cache_builder,
+                "get_parallel",
+                return_value=SimpleNamespace(dcp_enabled=False),
+            ),
+            mock.patch.object(
+                kv_cache_builder, "create_tree_cache", return_value=tree_cache
+            ),
+            mock.patch.object(kv_cache_builder, "init_mm_embedding_cache"),
+        ):
+            result = kv_cache_builder.build_kv_cache(
+                server_args=server_args,
+                model_config=model_config,
+                tp_worker=tp_worker,
+                page_size=1,
+                spec_algorithm=SimpleNamespace(is_eagle=lambda: False),
+                attn_tp_cpu_group=None,
+                tp_cpu_group=None,
+                attn_cp_cpu_group=None,
+                enable_metrics=False,
+                enable_kv_cache_events=False,
+                ps=SimpleNamespace(pp_rank=0, pp_size=1, tp_rank=0, tp_size=1),
+                tp_group=None,
+                pp_group=SimpleNamespace(cpu_group=None),
+                enable_hierarchical_cache=False,
+            )
+
+        self.assertIs(result.tree_cache, tree_cache)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

MLX model startup currently reaches Transformers architecture resolution while building the KV cache. Models such as Hunyuan that rely on remote `auto_map` entries can fail there even though MLX loads them through `mlx_lm` and does not use the Transformers backend.

Fixes #32521.

## Modifications

- Short-circuit Transformers backend detection when the MLX backend is active.
- Add a CPU regression test that makes architecture resolution fail if it is called and verifies KV cache construction still completes on the MLX path.

## Accuracy Tests

Not applicable. This changes backend selection during startup and does not modify model outputs.

## Speed Tests and Profiling

Not applicable. The MLX path now avoids an unnecessary architecture-resolution call.

## Validation

- Focused actual-function harness: fails on upstream `main` and passes with this change.
- Repository pre-commit hooks: passed, including Black, isort, Ruff, codespell, AST, and registered-test validation.
- Python bytecode compilation: passed for both changed files.
- The registered CPU test was collection-blocked locally by a missing optional test dependency and is registered for `base-a-test-cpu` CI.

## Checklist

- [x] Format code according to the project pre-commit configuration.
- [x] Add a registered CPU unit test.
- [x] Documentation is not required for this internal startup fix.
- [x] Accuracy and speed benchmarks are not applicable to this control-flow fix.
- [x] Follow the SGLang code style guidance.
