### PR TITLE
Fix: preserve priority when splitting a batched EmbeddingReqInput (#32844)

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1119,6 +1119,7 @@ class EmbeddingReqInput:
         if self.is_cross_encoder_request:
             sub = EmbeddingReqInput(
                 rid=self.rid[i],
+                priority=self.priority,
                 text=[self.text[i]] if self.text is not None else None,
                 sampling_params=self.sampling_params[i],
                 is_cross_encoder_request=True,
@@ -1137,6 +1138,7 @@ class EmbeddingReqInput:
         else:
             sub = EmbeddingReqInput(
                 rid=self.rid[i],
+                priority=self.priority,
                 text=self.text[i] if self.text is not None else None,
                 input_ids=self.input_ids[i] if self.input_ids is not None else None,
                 image_data=self.image_data[i] if self.image_data is not None else None,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1,7 +1,7 @@
 import copy
 import unittest
 
-from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.test.ci.ci_register import (
     register_amd_ci,
     register_cpu_ci,
@@ -618,6 +618,32 @@ class TestGenerateReqInputNormalization(CustomTestCase):
                 text="Hello", input_ids=[1, 2, 3], input_embeds=[[0.1, 0.2]]
             )
             req.normalize_batch_and_arguments()
+
+
+class TestEmbeddingReqInputSubrequest(CustomTestCase):
+    """Splitting a batched EmbeddingReqInput must preserve per-request fields."""
+
+    def test_priority_preserved_in_batch(self):
+        req = EmbeddingReqInput(text=["hello", "world"], priority=7)
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req[0].priority, 7)
+        self.assertEqual(req[1].priority, 7)
+
+    def test_priority_preserved_in_cross_encoder_batch(self):
+        req = EmbeddingReqInput(
+            text=[["query 1", "doc 1"], ["query 2", "doc 2"]],
+            is_cross_encoder_request=True,
+            priority=3,
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req[0].priority, 3)
+        self.assertEqual(req[1].priority, 3)
+
+    def test_priority_defaults_to_none_when_unset(self):
+        req = EmbeddingReqInput(text=["a", "b"])
+        req.normalize_batch_and_arguments()
+        self.assertIsNone(req[0].priority)
+        self.assertIsNone(req[1].priority)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #32844.

`EmbeddingReqInput.__getitem__` does not preserve `priority` when a batched
embedding request is split into per-request objects. The pipeline carries priority
after tokenization (`TokenizerManager._create_tokenized_object()` →
`TokenizedEmbeddingReqInput`, and `Scheduler.handle_embedding_request()` reads
`recv_req.priority`), but batched embeddings are split via `obj[i]`, and both
branches of `EmbeddingReqInput.__getitem__` (normal and cross-encoder) rebuilt the
sub-object **without** `priority` — so each sub-request fell back to `None` and the
batch was scheduled as if no priority was set. `GenerateReqInput.__getitem__`
already forwards `priority`; this brings embeddings in line.

Reproduction (from the issue):

```python
from sglang.srt.managers.io_struct import EmbeddingReqInput
req = EmbeddingReqInput(text=["hello", "world"], priority=7)
req.normalize_batch_and_arguments()
print(req[0].priority, req[1].priority)   # main: None None ; fixed: 7 7
```

## Modifications

- `EmbeddingReqInput.__getitem__`: pass `priority=self.priority` in **both** the
  normal and cross-encoder branches (two lines).
- `test/registered/unit/managers/test_io_struct.py`: add `TestEmbeddingReqInputSubrequest`
  with regression tests covering the normal batch, the cross-encoder batch, and the
  default (`priority` unset → `None`).

## Accuracy Tests

N/A — request-plumbing fix, no model/kernel/forward-path code changed.

## Speed Tests and Profiling

N/A — no inference-path change.

## Checklist

- [x] Formatted to the SGLang pre-commit style.
- [x] Added unit tests (regression tests for both batch types).
- [ ] Update documentation — N/A.
- [ ] Accuracy/speed benchmarks — N/A.
- [x] Follows the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30679001454](https://github.com/sgl-project/sglang/actions/runs/30679001454)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30679001356](https://github.com/sgl-project/sglang/actions/runs/30679001356)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->