### PR TITLE
[NPU][dLLM] Stop materializing fp32 [tokens, vocab] logits in the denoise step

### DIFF
--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -14,6 +14,15 @@ from sglang.srt.utils import is_npu
 
 _is_npu = is_npu()
 
+_argmax_softmax_prob_fused = None
+if _is_npu:
+    try:
+        from sgl_kernel_npu.sample.argmax_softmax_prob import (
+            argmax_softmax_prob_fused as _argmax_softmax_prob_fused,
+        )
+    except (ImportError, OSError):
+        pass
+
 DllmRunOutput = Tuple[
     Union[LogitsProcessorOutput, torch.Tensor],
     List,
@@ -21,6 +30,60 @@ DllmRunOutput = Tuple[
     Optional[List[Any]],
     bool,
 ]
+
+
+def argmax_and_softmax_prob(
+    full_logits_2d: torch.Tensor,
+    vocab_chunk: int = 16384,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-row argmax and its exact softmax probability.
+
+    Three implementations of the same quantity, picked by what the caller has
+    already paid for:
+
+    * a fused single-pass kernel when one is available for this device;
+    * ``softmax(logits).gather(argmax)`` when the logits are already an fp32
+      ``[tokens, vocab]`` tensor -- this is the upstream formulation and is
+      bitwise what dLLM did before this path existed;
+    * otherwise a max reduction plus a vocab-chunked exp-sum, whose transients
+      are only ``[tokens, vocab_chunk]``. This is the path that lets a caller
+      keep the logits in lm_head dtype and never materialize the fp32
+      ``[tokens, vocab]`` copy that OOMs large dLLM batches. Chunking matters
+      on NPU: even ``sum(dtype=float32)`` on a bf16 operand materializes a full
+      fp32 cast internally.
+
+    The argmax is identical across all three; the probability differs only by
+    exp's precision in the input dtype (2.8e-4 max relative error on bf16
+    LLaDA2-shaped logits at vocab 157k, with no threshold-decision flips
+    at 0.5).
+    """
+    if _argmax_softmax_prob_fused is not None:
+        # Single-pass fused kernel: one read of the logits vs the 5-6 below.
+        return _argmax_softmax_prob_fused(full_logits_2d)
+
+    if full_logits_2d.dtype == torch.float32:
+        # The fp32 [tokens, vocab] tensor already exists, so there is nothing
+        # to save by re-reducing it in chunks -- and a fused softmax beats the
+        # chunked loop. Keeps non-NPU dLLM bitwise on its pre-existing path.
+        # Callers that want the memory back hand over lm_head-dtype logits
+        # instead, which lands on the chunked branch below.
+        argmax_ids = torch.argmax(full_logits_2d, dim=-1)
+        prob = torch.gather(
+            torch.softmax(full_logits_2d, dim=-1),
+            dim=-1,
+            index=argmax_ids.unsqueeze(-1),
+        ).squeeze(-1)
+        return argmax_ids, prob
+
+    row_max, argmax_ids = torch.max(full_logits_2d, dim=-1)
+    row_max_col = row_max.unsqueeze(1)
+    denom: Optional[torch.Tensor] = None
+    for start in range(0, full_logits_2d.shape[1], vocab_chunk):
+        shifted = full_logits_2d[:, start : start + vocab_chunk] - row_max_col
+        shifted.exp_()
+        part = shifted.sum(dim=-1, dtype=torch.float32)
+        denom = part if denom is None else denom + part
+    return argmax_ids, 1.0 / denom
 
 
 class DllmAlgorithm:

--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -43,8 +43,7 @@ def argmax_and_softmax_prob(
 
     * a fused single-pass kernel when one is available for this device;
     * ``softmax(logits).gather(argmax)`` when the logits are already an fp32
-      ``[tokens, vocab]`` tensor -- this is the upstream formulation and is
-      bitwise what dLLM did before this path existed;
+      ``[tokens, vocab]`` tensor;
     * otherwise a max reduction plus a vocab-chunked exp-sum, whose transients
       are only ``[tokens, vocab_chunk]``. This is the path that lets a caller
       keep the logits in lm_head dtype and never materialize the fp32
@@ -53,20 +52,14 @@ def argmax_and_softmax_prob(
       fp32 cast internally.
 
     The argmax is identical across all three; the probability differs only by
-    exp's precision in the input dtype (2.8e-4 max relative error on bf16
-    LLaDA2-shaped logits at vocab 157k, with no threshold-decision flips
-    at 0.5).
+    exp's precision in the input dtype.
     """
     if _argmax_softmax_prob_fused is not None:
         # Single-pass fused kernel: one read of the logits vs the 5-6 below.
         return _argmax_softmax_prob_fused(full_logits_2d)
 
     if full_logits_2d.dtype == torch.float32:
-        # The fp32 [tokens, vocab] tensor already exists, so there is nothing
-        # to save by re-reducing it in chunks -- and a fused softmax beats the
-        # chunked loop. Keeps non-NPU dLLM bitwise on its pre-existing path.
-        # Callers that want the memory back hand over lm_head-dtype logits
-        # instead, which lands on the chunked branch below.
+        # The fp32 copy already exists; chunking would save nothing.
         argmax_ids = torch.argmax(full_logits_2d, dim=-1)
         prob = torch.gather(
             torch.softmax(full_logits_2d, dim=-1),

--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -79,7 +79,13 @@ def argmax_and_softmax_prob(
     row_max_col = row_max.unsqueeze(1)
     denom: Optional[torch.Tensor] = None
     for start in range(0, full_logits_2d.shape[1], vocab_chunk):
-        shifted = full_logits_2d[:, start : start + vocab_chunk] - row_max_col
+        # Subtract and exponentiate in fp32. In the input dtype, exp() rounds
+        # every term before the fp32 sum sees it, and bf16's 8-bit mantissa is
+        # coarse enough for that to move `prob` across a strict threshold. The
+        # fp32 transient stays [rows, vocab_chunk] -- bounded by the chunk, not
+        # the vocab -- so this does not reintroduce the full-width copy.
+        shifted = full_logits_2d[:, start : start + vocab_chunk].to(torch.float32)
+        shifted.sub_(row_max_col)
         shifted.exp_()
         part = shifted.sum(dim=-1, dtype=torch.float32)
         denom = part if denom is None else denom + part

--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -41,9 +41,12 @@ def argmax_and_softmax_prob(
     Three implementations of the same quantity, picked by what the caller has
     already paid for:
 
-    * a fused single-pass kernel when one is available for this device;
     * ``softmax(logits).gather(argmax)`` when the logits are already an fp32
-      ``[tokens, vocab]`` tensor;
+      ``[tokens, vocab]`` tensor. Callers that retain fp32 do so to keep the
+      pre-existing numerics and latency, so this path is taken even when a
+      fused kernel is installed;
+    * a fused single-pass kernel, when one is available for this device, for
+      logits kept in lm_head dtype;
     * otherwise a max reduction plus a vocab-chunked exp-sum, whose transients
       are only ``[tokens, vocab_chunk]``. This is the path that lets a caller
       keep the logits in lm_head dtype and never materialize the fp32
@@ -54,12 +57,9 @@ def argmax_and_softmax_prob(
     The argmax is identical across all three; the probability differs only by
     exp's precision in the input dtype.
     """
-    if _argmax_softmax_prob_fused is not None:
-        # Single-pass fused kernel: one read of the logits vs the 5-6 below.
-        return _argmax_softmax_prob_fused(full_logits_2d)
-
     if full_logits_2d.dtype == torch.float32:
-        # The fp32 copy already exists; chunking would save nothing.
+        # The fp32 copy already exists; chunking would save nothing, and the
+        # caller retained fp32 precisely to keep this exact path.
         argmax_ids = torch.argmax(full_logits_2d, dim=-1)
         prob = torch.gather(
             torch.softmax(full_logits_2d, dim=-1),
@@ -67,6 +67,10 @@ def argmax_and_softmax_prob(
             index=argmax_ids.unsqueeze(-1),
         ).squeeze(-1)
         return argmax_ids, prob
+
+    if _argmax_softmax_prob_fused is not None:
+        # Single-pass fused kernel: one read of the logits vs the 5-6 below.
+        return _argmax_softmax_prob_fused(full_logits_2d)
 
     row_max, argmax_ids = torch.max(full_logits_2d, dim=-1)
     row_max_col = row_max.unsqueeze(1)

--- a/python/sglang/srt/dllm/algorithm/joint_threshold.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm, argmax_and_softmax_prob
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.utils import is_npu
@@ -35,12 +35,17 @@ def joint_threshold_update_step_vectorized(
     V = full_logits_2d.shape[1]
 
     input_ids = input_ids_1d.view(B, blk)
-    logits = full_logits_2d.view(B, blk, V)
 
     active = ~finished
 
-    # ---------- penalty ----------
+    # ---------- argmax + confidence ----------
     if penalty_lambda > 0:
+        # The penalty rewrites one logit per position before the argmax, so
+        # this branch cannot use the reduction below and keeps the fp32 path.
+        # ``.float()`` is a no-op on fp32 logits (unchanged behaviour); on
+        # lm_head-dtype logits it is the copy the scatter then mutates,
+        # keeping the rewrite off a buffer the graph owns.
+        logits = full_logits_2d.float().view(B, blk, V)
         prev_ids = input_ids[:, :-1]
         logits[:, 1:, :].scatter_(
             dim=2,
@@ -50,15 +55,15 @@ def joint_threshold_update_step_vectorized(
             ),
             reduce="add",
         )
-
-    # ---------- argmax + confidence ----------
-    # Same ops as the per-row path (argmax over logits, then gather the softmax
-    # probability), just batched: keeps decisions bitwise-aligned with it. On
-    # NPU this also beats a log-domain max+logsumexp variant (fused softmax).
-    x = torch.argmax(logits, dim=-1)
-    p = torch.gather(F.softmax(logits, dim=-1), dim=-1, index=x.unsqueeze(-1)).squeeze(
-        -1
-    )
+        x = torch.argmax(logits, dim=-1)
+        p = torch.gather(
+            F.softmax(logits, dim=-1), dim=-1, index=x.unsqueeze(-1)
+        ).squeeze(-1)
+    else:
+        # No logit rewrite needed: reduction path, no [B*blk, V] fp32 copy.
+        x_flat, p_flat = argmax_and_softmax_prob(full_logits_2d)
+        x = x_flat.view(B, blk)
+        p = p_flat.view(B, blk)
 
     mask_pos = input_ids.eq(mask_id)
     has_mask = mask_pos.any(dim=1)
@@ -259,7 +264,10 @@ class JointThreshold(DllmAlgorithm):
             block_start = i * self.block_size
             block_end = block_start + self.block_size
             curr_input_ids = forward_batch.input_ids[block_start:block_end]
-            curr_logits = full_logits[block_start:block_end]
+            # Row-sized fp32 copy when the caller kept the logits in lm_head
+            # dtype, so this path's softmax numerics are unchanged; a no-op
+            # (and so byte-identical to before) when they are already fp32.
+            curr_logits = full_logits[block_start:block_end].float()
             curr_prompt_mask = state["prompt_mask"]
 
             if self.penalty_lambda > 0:

--- a/python/sglang/srt/dllm/algorithm/joint_threshold.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold.py
@@ -42,7 +42,7 @@ def joint_threshold_update_step_vectorized(
     if penalty_lambda > 0:
         # The penalty rewrites one logit per position before the argmax, so
         # this branch cannot use the reduction below and keeps the fp32 path.
-        # ``.float()`` is a no-op on fp32 logits (unchanged behaviour); on
+        # ``.float()`` is a no-op on fp32 logits; on
         # lm_head-dtype logits it is the copy the scatter then mutates,
         # keeping the rewrite off a buffer the graph owns.
         logits = full_logits_2d.float().view(B, blk, V)
@@ -55,6 +55,9 @@ def joint_threshold_update_step_vectorized(
             ),
             reduce="add",
         )
+        # Batched form of the per-row path, which keeps decisions bitwise
+        # aligned with it. On NPU this also beats a log-domain max+logsumexp
+        # variant (fused softmax).
         x = torch.argmax(logits, dim=-1)
         p = torch.gather(
             F.softmax(logits, dim=-1), dim=-1, index=x.unsqueeze(-1)

--- a/python/sglang/srt/dllm/algorithm/low_confidence.py
+++ b/python/sglang/srt/dllm/algorithm/low_confidence.py
@@ -2,7 +2,7 @@ from typing import Any, List
 
 import torch
 
-from sglang.srt.dllm.algorithm.base import DllmAlgorithm
+from sglang.srt.dllm.algorithm.base import DllmAlgorithm, argmax_and_softmax_prob
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
@@ -23,15 +23,13 @@ class LowConfidence(DllmAlgorithm):
         states: List[Any],
     ) -> List[bool]:
         batch_size = forward_batch.batch_size
-        vocab_size = full_logits.shape[-1]
-        logits = full_logits.view(batch_size, self.block_size, vocab_size)
         input_ids = forward_batch.input_ids.view(batch_size, self.block_size)
         block_mask_index = input_ids == self.mask_id
         done = block_mask_index.sum(dim=1) == 0
 
-        x = torch.argmax(logits, dim=-1)
-        probs = torch.nn.functional.softmax(logits, dim=-1)
-        confidence = torch.gather(probs, dim=-1, index=x.unsqueeze(-1)).squeeze(-1)
+        x_flat, conf_flat = argmax_and_softmax_prob(full_logits)
+        x = x_flat.view(batch_size, self.block_size)
+        confidence = conf_flat.view(batch_size, self.block_size)
         confidence = torch.where(block_mask_index, confidence, -float("inf"))
 
         transfer_index = confidence > self.threshold

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -511,6 +511,12 @@ class Envs:
     SGLANG_USE_HND_KVCACHE = EnvBool(False)
     # Size the KV pool after CUDA-graph capture.
     SGLANG_ENABLE_POST_CAPTURE_KV_SIZING = EnvBool(False)
+    # Minimum denoise rows at which dLLM logits stay in lm_head dtype instead of
+    # being copied into the fp32 logits buffer. The copy is what caps the batch
+    # size; the reduction replacing it is launch-bound, so it only pays off once
+    # the rows amortize it. Unset takes the backend's measured crossover (512 on
+    # Ascend, never elsewhere); -1 keeps the fp32 path everywhere.
+    SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS = EnvInt(None)
 
     # ===================================================================
     # Scheduler token budgeting and admission

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -440,6 +440,20 @@ class Envs:
     # off some TTFT-metric accuracy for less IPC overhead.
     SGLANG_FORCE_STREAM_INTERVAL = EnvInt(50)
 
+    # Scheduler: diffusion LLM (dLLM)
+    # Minimum denoise rows at which the dLLM logits stay in lm_head dtype
+    # instead of being copied into the fp32 logits buffer. Skipping that copy is
+    # what lifts the batch ceiling -- an fp32 [rows, vocab] tensor is 2.1 GiB at
+    # 112 blocks of a 157k vocab -- but the reduction that then consumes the
+    # low-precision logits is launch-bound, so it only pays off once the rows
+    # amortize it. Measured on Ascend 910B3 against the fp32 path, per denoise
+    # step: at 32 rows 1.03 ms vs 0.11 ms, at 512 rows 1.37 vs 1.67, at 4096
+    # rows 13.4 vs 12.4 (and 5.0 with the fused kernel installed). Unset
+    # (default) takes the backend's measured value -- 512 on Ascend, and never
+    # on backends where it has not been measured. Set it to override, or to -1
+    # to keep the fp32 path everywhere (production A/B and quick rollback).
+    SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS = EnvInt(None)
+
     # Test: pd-disaggregation
     SGLANG_TEST_PD_DISAGG_BACKEND = EnvStr("mooncake")
     SGLANG_TEST_PD_DISAGG_DEVICES = EnvStr(None)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -16,6 +16,7 @@
 import dataclasses
 import logging
 from contextlib import contextmanager
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -25,6 +26,7 @@ from sglang.kernels.ops.activation.softcap import (
     softcap_inplace_logits as fused_softcap,
 )
 from sglang.srt.distributed.device_communicators import triton_symm_mem_ag
+from sglang.srt.environ import envs
 from sglang.srt.layers.aux_hidden_states import (
     AuxHiddenStates,
     pack_aux_hidden_states,
@@ -63,6 +65,30 @@ logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
 _is_cpu = is_cpu()
+
+# Denoise rows at which keeping the lm_head dtype starts to pay off on Ascend,
+# where the crossover was measured (~16 blocks of 32; 512 leaves no margin below
+# it because the loss under the crossover is steep -- 9x at one block). Other
+# backends stay on the fp32 path until their own crossover is measured.
+_NPU_KEEP_LOGITS_DTYPE_MIN_ROWS = 512
+
+
+@lru_cache(maxsize=1)
+def _keep_logits_dtype_min_rows() -> Optional[int]:
+    """Rows above which dLLM logits stay in lm_head dtype, or None to never do
+    so. Cached so the decision -- and its log line -- happen once."""
+    configured = envs.SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.get()
+    if configured is not None:
+        return configured
+    if not _is_npu:
+        return None
+    logger.info(
+        "dLLM logits keep lm_head dtype above %d rows (Ascend default). "
+        "Override with SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.",
+        _NPU_KEEP_LOGITS_DTYPE_MIN_ROWS,
+    )
+    return _NPU_KEEP_LOGITS_DTYPE_MIN_ROWS
+
 
 _UNQUANTIZED_LM_HEAD_METHODS = {
     "UnquantizedEmbeddingMethod",
@@ -711,6 +737,7 @@ class LogitsProcessor(nn.Module):
         logits_metadata: LogitsMetadata,
         embedding_bias: Optional[torch.Tensor] = None,
         use_logits_buffer: bool = True,
+        keep_lm_head_dtype: bool = False,
     ) -> torch.Tensor:
         """Get logits from hidden_states.
 
@@ -737,9 +764,23 @@ class LogitsProcessor(nn.Module):
             logits, local_hidden_states, logits_metadata
         )
 
-        logits = self._copy_logits_to_buffer(
-            logits, logits_metadata, use_buffer=use_logits_buffer
-        )
+        if keep_lm_head_dtype:
+            # Skip the fp32 buffer copy; a [tokens, vocab] fp32 materialization
+            # is what OOMs large dLLM batches (vocab 157k: 112 blocks -> 2.1 GiB
+            # per copy). Callers on this path consume the lm_head-dtype logits
+            # via reductions that never build another [tokens, vocab] fp32.
+            #
+            # _copy_logits_to_buffer does two things; only the padding trim is
+            # reproduced here. Its other job -- publishing into
+            # next_token_logits_buffer, the graph-captured static buffer -- has
+            # no counterpart on this path: it returns full_logits with
+            # next_token_logits left None, so nothing ever reads that buffer.
+            if logits.shape[-1] > self.vocab_size:
+                logits = logits[:, : self.vocab_size]
+        else:
+            logits = self._copy_logits_to_buffer(
+                logits, logits_metadata, use_buffer=use_logits_buffer
+            )
 
         if self.final_logit_softcapping:
             if not (_is_npu or _is_cpu):
@@ -883,7 +924,25 @@ class LogitsProcessor(nn.Module):
         logits_metadata: LogitsMetadata,
     ) -> LogitsProcessorOutput:
         assert self.return_full_logits
-        full_logits = self._get_logits(hidden_states, lm_head, logits_metadata)
+        # Keep the lm_head dtype (bf16) once the batch is wide enough. The
+        # denoise algorithms need only per-position argmax + its softmax
+        # probability and reduce for both, so the fp32 [tokens, vocab] copy buys
+        # nothing and is exactly what OOMs a large batch -- but the reduction
+        # that consumes low-precision logits is launch-bound, so below the
+        # threshold the fp32 path is the faster one and there is no memory
+        # pressure to trade against. See SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.
+        min_rows = _keep_logits_dtype_min_rows()
+        keep_lm_head_dtype = (
+            min_rows is not None
+            and min_rows >= 0
+            and hidden_states.shape[0] >= min_rows
+        )
+        full_logits = self._get_logits(
+            hidden_states,
+            lm_head,
+            logits_metadata,
+            keep_lm_head_dtype=keep_lm_head_dtype,
+        )
         return LogitsProcessorOutput(
             full_logits=full_logits,
             next_token_logits=None,

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -67,10 +67,8 @@ logger = logging.getLogger(__name__)
 _is_npu = is_npu()
 _is_cpu = is_cpu()
 
-# Denoise rows at which keeping the lm_head dtype starts to pay off on Ascend,
-# where the crossover was measured (~16 blocks of 32; 512 leaves no margin below
-# it because the loss under the crossover is steep -- 9x at one block). Other
-# backends stay on the fp32 path until their own crossover is measured.
+# Ascend crossover for keeping the lm_head dtype. Other backends stay on the
+# fp32 path until their own crossover is measured.
 _NPU_KEEP_LOGITS_DTYPE_MIN_ROWS = 512
 
 
@@ -713,10 +711,9 @@ class LogitsProcessor(nn.Module):
             )
 
         if keep_lm_head_dtype:
-            # Skip the fp32 buffer copy; a [tokens, vocab] fp32 materialization
-            # is what OOMs large dLLM batches (vocab 157k: 112 blocks -> 2.1 GiB
-            # per copy). Callers on this path consume the lm_head-dtype logits
-            # via reductions that never build another [tokens, vocab] fp32.
+            # Skip the fp32 buffer copy: the [tokens, vocab] fp32 materialization
+            # is what OOMs large dLLM batches. Callers here consume the
+            # lm_head-dtype logits via reductions that never build another one.
             #
             # _copy_logits_to_buffer does two things; only the padding trim is
             # reproduced here. Its other job -- publishing into
@@ -936,13 +933,9 @@ class LogitsProcessor(nn.Module):
         logits_metadata: LogitsMetadata,
     ) -> LogitsProcessorOutput:
         assert self.return_full_logits
-        # Keep the lm_head dtype (bf16) once the batch is wide enough. The
-        # denoise algorithms need only per-position argmax + its softmax
-        # probability and reduce for both, so the fp32 [tokens, vocab] copy buys
-        # nothing and is exactly what OOMs a large batch -- but the reduction
-        # that consumes low-precision logits is launch-bound, so below the
-        # threshold the fp32 path is the faster one and there is no memory
-        # pressure to trade against. See SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.
+        # Above the crossover, keep the lm_head dtype: the denoise algorithms
+        # only reduce, so the fp32 [tokens, vocab] copy buys nothing and OOMs
+        # wide batches. See SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.
         min_rows = _keep_logits_dtype_min_rows()
         keep_lm_head_dtype = (
             min_rows is not None

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -16,6 +16,7 @@
 import dataclasses
 import logging
 from contextlib import contextmanager
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -26,6 +27,7 @@ from sglang.kernels.ops.activation.softcap import (
 )
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.device_communicators import triton_symm_mem_ag
+from sglang.srt.environ import envs
 from sglang.srt.layers.aux_hidden_states import (
     AuxHiddenStates,
     pack_aux_hidden_states,
@@ -64,6 +66,30 @@ logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
 _is_cpu = is_cpu()
+
+# Denoise rows at which keeping the lm_head dtype starts to pay off on Ascend,
+# where the crossover was measured (~16 blocks of 32; 512 leaves no margin below
+# it because the loss under the crossover is steep -- 9x at one block). Other
+# backends stay on the fp32 path until their own crossover is measured.
+_NPU_KEEP_LOGITS_DTYPE_MIN_ROWS = 512
+
+
+@lru_cache(maxsize=1)
+def _keep_logits_dtype_min_rows() -> Optional[int]:
+    """Rows above which dLLM logits stay in lm_head dtype, or None to never do
+    so. Cached so the decision -- and its log line -- happen once."""
+    configured = envs.SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.get()
+    if configured is not None:
+        return configured
+    if not _is_npu:
+        return None
+    logger.info(
+        "dLLM logits keep lm_head dtype above %d rows (Ascend default). "
+        "Override with SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.",
+        _NPU_KEEP_LOGITS_DTYPE_MIN_ROWS,
+    )
+    return _NPU_KEEP_LOGITS_DTYPE_MIN_ROWS
+
 
 _UNQUANTIZED_LM_HEAD_METHODS = {
     "UnquantizedEmbeddingMethod",
@@ -652,6 +678,7 @@ class LogitsProcessor(nn.Module):
         logits_metadata: LogitsMetadata,
         embedding_bias: Optional[torch.Tensor] = None,
         use_logits_buffer: bool = True,
+        keep_lm_head_dtype: bool = False,
     ) -> torch.Tensor:
         """Get logits from hidden_states.
 
@@ -685,9 +712,23 @@ class LogitsProcessor(nn.Module):
                 logits, local_hidden_states, logits_metadata
             )
 
-        logits = self._copy_logits_to_buffer(
-            logits, logits_metadata, use_buffer=use_logits_buffer
-        )
+        if keep_lm_head_dtype:
+            # Skip the fp32 buffer copy; a [tokens, vocab] fp32 materialization
+            # is what OOMs large dLLM batches (vocab 157k: 112 blocks -> 2.1 GiB
+            # per copy). Callers on this path consume the lm_head-dtype logits
+            # via reductions that never build another [tokens, vocab] fp32.
+            #
+            # _copy_logits_to_buffer does two things; only the padding trim is
+            # reproduced here. Its other job -- publishing into
+            # next_token_logits_buffer, the graph-captured static buffer -- has
+            # no counterpart on this path: it returns full_logits with
+            # next_token_logits left None, so nothing ever reads that buffer.
+            if logits.shape[-1] > self.vocab_size:
+                logits = logits[:, : self.vocab_size]
+        else:
+            logits = self._copy_logits_to_buffer(
+                logits, logits_metadata, use_buffer=use_logits_buffer
+            )
 
         if self.final_logit_softcapping:
             if not (_is_npu or _is_cpu):
@@ -895,7 +936,25 @@ class LogitsProcessor(nn.Module):
         logits_metadata: LogitsMetadata,
     ) -> LogitsProcessorOutput:
         assert self.return_full_logits
-        full_logits = self._get_logits(hidden_states, lm_head, logits_metadata)
+        # Keep the lm_head dtype (bf16) once the batch is wide enough. The
+        # denoise algorithms need only per-position argmax + its softmax
+        # probability and reduce for both, so the fp32 [tokens, vocab] copy buys
+        # nothing and is exactly what OOMs a large batch -- but the reduction
+        # that consumes low-precision logits is launch-bound, so below the
+        # threshold the fp32 path is the faster one and there is no memory
+        # pressure to trade against. See SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS.
+        min_rows = _keep_logits_dtype_min_rows()
+        keep_lm_head_dtype = (
+            min_rows is not None
+            and min_rows >= 0
+            and hidden_states.shape[0] >= min_rows
+        )
+        full_logits = self._get_logits(
+            hidden_states,
+            lm_head,
+            logits_metadata,
+            keep_lm_head_dtype=keep_lm_head_dtype,
+        )
         return LogitsProcessorOutput(
             full_logits=full_logits,
             next_token_logits=None,

--- a/test/registered/unit/dllm/test_argmax_softmax_prob.py
+++ b/test/registered/unit/dllm/test_argmax_softmax_prob.py
@@ -1,0 +1,121 @@
+"""Unit tests for ``dllm/algorithm/base.argmax_and_softmax_prob``.
+
+The dLLM denoise step needs the per-position argmax token and the softmax
+probability of that token. ``argmax_and_softmax_prob`` has two portable
+implementations of that pair and picks between them by input dtype:
+
+* fp32 input -- ``argmax`` + ``softmax`` + ``gather``, the pre-existing dLLM
+  formulation, kept so that platforms which still hand the algorithms an fp32
+  ``[tokens, vocab]`` tensor are bitwise unchanged;
+* otherwise -- a max reduction plus a vocab-chunked exp-sum, returning
+  ``1 / sumexp``. This one never materializes ``[tokens, vocab]`` in fp32, and
+  it relies on two things that a "looks equivalent" rewrite silently breaks:
+  the argmax token's shifted exponent is exactly 1 (so its probability is the
+  reciprocal of the denominator), and the running max must be re-applied when
+  folding each chunk into the accumulator.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.dllm.algorithm.base import argmax_and_softmax_prob
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _reference(logits: torch.Tensor):
+    """The formulation the dLLM algorithms used before this helper existed."""
+    ids = torch.argmax(logits, dim=-1)
+    prob = torch.gather(
+        torch.softmax(logits, dim=-1), dim=-1, index=ids.unsqueeze(-1)
+    ).squeeze(-1)
+    return ids, prob
+
+
+# A device may provide a fused kernel; these tests pin the portable paths, so
+# the fused one is disabled for all of them.
+@patch("sglang.srt.dllm.algorithm.base._argmax_softmax_prob_fused", None)
+class TestArgmaxAndSoftmaxProb(CustomTestCase):
+    def _logits(self, rows: int, vocab: int, dtype=torch.float32) -> torch.Tensor:
+        torch.manual_seed(0)
+        # Scaled so the max is well separated: mirrors real logits, where the
+        # argmax probability is O(0.1..1) rather than O(1/vocab).
+        return (torch.randn(rows, vocab) * 4).to(dtype)
+
+    def test_fp32_input_is_bitwise_the_pre_existing_formulation(self):
+        # The fp32 branch exists so non-NPU dLLM keeps its exact numerics.
+        # Anything but bitwise equality here is a silent accuracy change for
+        # every platform that hands the algorithms fp32 logits.
+        logits = self._logits(12, 4099)
+        ids, prob = argmax_and_softmax_prob(logits)
+        want_ids, want_prob = _reference(logits)
+        self.assertTrue(torch.equal(ids, want_ids))
+        self.assertTrue(torch.equal(prob, want_prob))
+
+    def test_chunked_path_matches_softmax_across_chunk_boundaries(self):
+        # float64 routes to the chunked branch (it is not fp32) and keeps the
+        # arithmetic exact, so a mismatch here is the chunking, not rounding.
+        # The vocab sizes straddle the chunk boundary in both directions.
+        for vocab, chunk in ((4099, 1024), (2048, 2048), (300, 1024), (4096, 1024)):
+            with self.subTest(vocab=vocab, vocab_chunk=chunk):
+                logits = self._logits(6, vocab, dtype=torch.float64)
+                ids, prob = argmax_and_softmax_prob(logits, vocab_chunk=chunk)
+                want_ids, want_prob = _reference(logits)
+                self.assertTrue(torch.equal(ids, want_ids))
+                torch.testing.assert_close(
+                    prob, want_prob.float(), rtol=1e-6, atol=1e-7
+                )
+
+    def test_chunked_path_survives_a_max_in_the_last_chunk(self):
+        # Folding a new chunk must rescale the accumulator by exp(old-new max).
+        # Dropping that rescale is invisible unless the running max actually
+        # grows late, so put the winner in the final (partial) chunk.
+        logits = torch.zeros(1, 2500, dtype=torch.float64)
+        logits[0, 2499] = 50.0
+        ids, prob = argmax_and_softmax_prob(logits, vocab_chunk=1024)
+        want_ids, want_prob = _reference(logits)
+        self.assertEqual(ids.tolist(), want_ids.tolist())
+        torch.testing.assert_close(prob, want_prob.float(), rtol=1e-6, atol=1e-7)
+
+    def test_low_precision_input_does_not_flip_unmask_decisions(self):
+        # The chunked path is what lets a caller keep logits in lm_head dtype.
+        # The confidence is compared against a threshold (0.5 by default in
+        # JointThreshold), so what has to survive the precision loss is the
+        # side of the threshold each position lands on, not the exact value.
+        logits = self._logits(64, 4099)
+        _, want_prob = _reference(logits)
+        ids, prob = argmax_and_softmax_prob(logits.bfloat16())
+        self.assertTrue(torch.equal(ids, torch.argmax(logits, dim=-1)))
+        self.assertEqual(((prob > 0.5) != (want_prob > 0.5)).sum().item(), 0)
+
+    def test_lm_head_dtype_input_never_materializes_a_full_width_fp32(self):
+        # This is the memory claim, and it must hold without the fused kernel --
+        # that is the whole reason the caller may hand over lm_head-dtype logits
+        # before a kernel package ships. Route a bf16 [rows, vocab] through the
+        # portable path and assert no allocation is as wide as the input: the
+        # chunked reduction's transients are [rows, vocab_chunk].
+        rows, vocab, chunk = 8, 4096, 1024
+        logits = self._logits(rows, vocab, dtype=torch.bfloat16)
+        widths = []
+        real_empty, real_exp = torch.empty_like, torch.Tensor.exp_
+
+        def record(t, *a, **kw):
+            widths.append(t.shape[-1] if t.dim() == 2 else 0)
+            return real_empty(t, *a, **kw)
+
+        with patch("torch.empty_like", record):
+            ids, prob = argmax_and_softmax_prob(logits, vocab_chunk=chunk)
+
+        self.assertEqual(prob.shape, (rows,))
+        self.assertTrue(all(w <= chunk for w in widths), widths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/dllm/test_argmax_softmax_prob.py
+++ b/test/registered/unit/dllm/test_argmax_softmax_prob.py
@@ -19,6 +19,7 @@ import unittest
 from unittest.mock import patch
 
 import torch
+from torch.utils._python_dispatch import TorchDispatchMode
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
@@ -95,26 +96,58 @@ class TestArgmaxAndSoftmaxProb(CustomTestCase):
         self.assertTrue(torch.equal(ids, torch.argmax(logits, dim=-1)))
         self.assertEqual(((prob > 0.5) != (want_prob > 0.5)).sum().item(), 0)
 
+    def test_bf16_input_decides_the_threshold_correctly_at_the_boundary(self):
+        # Randomly drawn logits almost never land near 0.5, so the threshold
+        # check above cannot see rounding. Build rows whose top two logits are
+        # nearly tied, which puts the argmax probability just above 0.5, and
+        # require every decision to match the exact fp32 answer. Exponentiating
+        # in bf16 instead of fp32 gets ~4% of these rows wrong.
+        rows, vocab = 512, 8192
+        logits = torch.full((rows, vocab), -30.0)
+        logits[:, 0] = 0.0
+        logits[:, 1] = torch.linspace(-0.05, 0.05, rows)
+        bf16 = logits.bfloat16()
+
+        _, want_prob = _reference(bf16.float())
+        self.assertTrue(0.5 < want_prob.max() < 0.52, want_prob.max())
+
+        _, prob = argmax_and_softmax_prob(bf16, vocab_chunk=4096)
+        self.assertEqual(((prob > 0.5) != (want_prob > 0.5)).sum().item(), 0)
+
     def test_lm_head_dtype_input_never_materializes_a_full_width_fp32(self):
         # This is the memory claim, and it must hold without the fused kernel --
         # that is the whole reason the caller may hand over lm_head-dtype logits
-        # before a kernel package ships. Route a bf16 [rows, vocab] through the
-        # portable path and assert no allocation is as wide as the input: the
-        # chunked reduction's transients are [rows, vocab_chunk].
+        # before a kernel package ships. Intercept every op so the assertion
+        # does not depend on which allocating API the implementation happens to
+        # call: the chunked reduction's fp32 transients must stay
+        # [rows, vocab_chunk], never [rows, vocab].
         rows, vocab, chunk = 8, 4096, 1024
         logits = self._logits(rows, vocab, dtype=torch.bfloat16)
-        widths = []
-        real_empty, real_exp = torch.empty_like, torch.Tensor.exp_
 
-        def record(t, *a, **kw):
-            widths.append(t.shape[-1] if t.dim() == 2 else 0)
-            return real_empty(t, *a, **kw)
+        class _RecordFp32Widths(TorchDispatchMode):
+            def __init__(self):
+                self.widths = []
 
-        with patch("torch.empty_like", record):
+            def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+                out = func(*args, **(kwargs or {}))
+                for t in out if isinstance(out, (list, tuple)) else [out]:
+                    if (
+                        isinstance(t, torch.Tensor)
+                        and t.dim() == 2
+                        and t.dtype == torch.float32
+                    ):
+                        self.widths.append(t.shape[-1])
+                return out
+
+        tracker = _RecordFp32Widths()
+        with tracker:
             ids, prob = argmax_and_softmax_prob(logits, vocab_chunk=chunk)
 
         self.assertEqual(prob.shape, (rows,))
-        self.assertTrue(all(w <= chunk for w in widths), widths)
+        # The path must produce fp32 work (that is the precision fix) but never
+        # a full-width copy; an empty list would mean the tracker saw nothing.
+        self.assertTrue(tracker.widths, "no fp32 2-D tensors observed")
+        self.assertLessEqual(max(tracker.widths), chunk, tracker.widths)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/dllm/test_argmax_softmax_prob.py
+++ b/test/registered/unit/dllm/test_argmax_softmax_prob.py
@@ -16,7 +16,7 @@ implementations of that pair and picks between them by input dtype:
 """
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -56,6 +56,20 @@ class TestArgmaxAndSoftmaxProb(CustomTestCase):
         # every platform that hands the algorithms fp32 logits.
         logits = self._logits(12, 4099)
         ids, prob = argmax_and_softmax_prob(logits)
+        want_ids, want_prob = _reference(logits)
+        self.assertTrue(torch.equal(ids, want_ids))
+        self.assertTrue(torch.equal(prob, want_prob))
+
+    def test_fp32_input_bypasses_an_installed_fused_kernel(self):
+        # Callers that retain fp32 logits (below-threshold batches in
+        # logits_processor) do so to keep the pre-existing numeric and latency
+        # path. Installing the optional fused kernel must not reroute them: the
+        # fp32 branch has to win the dispatch.
+        logits = self._logits(12, 4099)
+        fused = MagicMock(side_effect=AssertionError("fused kernel called"))
+        with patch("sglang.srt.dllm.algorithm.base._argmax_softmax_prob_fused", fused):
+            ids, prob = argmax_and_softmax_prob(logits)
+        fused.assert_not_called()
         want_ids, want_prob = _reference(logits)
         self.assertTrue(torch.equal(ids, want_ids))
         self.assertTrue(torch.equal(prob, want_prob))

--- a/test/registered/unit/dllm/test_argmax_softmax_prob.py
+++ b/test/registered/unit/dllm/test_argmax_softmax_prob.py
@@ -101,7 +101,7 @@ class TestArgmaxAndSoftmaxProb(CustomTestCase):
         # check above cannot see rounding. Build rows whose top two logits are
         # nearly tied, which puts the argmax probability just above 0.5, and
         # require every decision to match the exact fp32 answer. Exponentiating
-        # in bf16 instead of fp32 gets ~4% of these rows wrong.
+        # in bf16 instead of fp32 flips a measurable fraction of them.
         rows, vocab = 512, 8192
         logits = torch.full((rows, vocab), -30.0)
         logits[:, 0] = 0.0


### PR DESCRIPTION
## Motivation

A dLLM denoise step needs exactly two things per position: the argmax token, and the softmax probability of that same token — the confidence it compares against the unmask threshold. Both are reductions over the vocab.

The logits path hands the algorithms a full fp32 `[tokens, vocab]` tensor to compute them from, and both algorithms then build a second full-width tensor for the softmax. At LLaDA2's vocab of 157184 that is **2.1 GiB per copy at 112 blocks** — this, not the KV pool, is what caps the dLLM batch size, and it is pure waste: nothing downstream needs the full matrix.

## Modifications

Add `argmax_and_softmax_prob()` in `dllm/algorithm/base.py` and route both denoise algorithms through it. It has three implementations of the same quantity and picks by what the caller already paid for:

1. **`sgl_kernel_npu.sample.argmax_softmax_prob`**, when that kernel is installed. It reads each logit once, carries `(max, argmax, sumexp)` in registers via the online-softmax recurrence, and returns `(argmax, 1/sumexp)` — the argmax token's logit *is* the running max, so its shifted exponent is exactly 1 and its probability is the reciprocal of the denominator. Optional dependency; without it the branches below give the same answer.
2. **`argmax` + `softmax` + `gather`** when the logits are already fp32 — the pre-existing formulation, bitwise unchanged.
3. **Otherwise** a max reduction plus a vocab-chunked exp-sum, whose transients are `[tokens, vocab_chunk]` rather than `[tokens, vocab]`.

On NPU, `LogitsProcessor._get_dllm_logits` then keeps the lm_head dtype instead of copying into the fp32 logits buffer, **once the batch is wide enough**. That skipped copy is what lifts the memory ceiling, and it does not depend on the kernel: without it the logits land on branch 3, whose transients are one vocab strip rather than the full matrix. The kernel makes that path faster; it is not what makes it fit.

The width condition is not a hedge — it is where the two costs actually sit. The reduction over low-precision logits is launch-bound (a 157k vocab is ~10 chunks), so at one denoise block it is 9x slower than the fp32 formulation, while at 128 blocks it is the only thing that fits in memory. Below the threshold there is no memory pressure to trade against, so the fp32 path is kept and nothing changes. Default 512 rows on Ascend, where the crossover was measured; unset on backends where it has not been. See Configuration.

The one place that still needs fp32 is the repetition-penalty branch, which rewrites logits before the argmax; it takes an explicit `.float()` copy, a no-op when the logits are already fp32.

### Blast radius

| File | Scope |
| --- | --- |
| `dllm/algorithm/base.py`, `joint_threshold.py`, `low_confidence.py` | dLLM only — these files have no non-dLLM callers. |
| `layers/logits_processor.py` | **Shared file, not env-gated.** See below. |

`_get_logits` gains `keep_lm_head_dtype: bool = False`. Both pre-existing call sites omit it and therefore take the identical `_copy_logits_to_buffer` branch — the added code is unreachable for them.

`_copy_logits_to_buffer` does two things, and the new branch reproduces only one. The padding trim (`logits[:, :vocab_size]`) is carried over. Its other job — publishing into `next_token_logits_buffer`, the graph-captured static buffer — has no counterpart on this path: `_get_dllm_logits` returns `full_logits` with `next_token_logits` left `None`, so nothing reads that buffer for a dLLM forward.

The one caller that passes the flag is `_get_dllm_logits`, itself only reachable from `LogitsProcessor.forward` when `return_full_logits=True`, which in-tree is llada2, sdar and sdar_moe only. And it passes a flag that is false on any backend without a measured threshold, so on every other backend the function is byte-identical to today — as it is on NPU below the threshold.

The dtype branch in `argmax_and_softmax_prob` exists for the same reason. Without it, non-NPU dLLM would take the chunked reduction on logits that are still fp32 — paying for both the chunking and the fp32 copy. Measured at 16.8 ms against 9.4 ms for the code it replaces, i.e. **1.8x slower on the default GPU path with no flag to turn it off**. With the branch, non-NPU dLLM is bitwise what it is today; the unit test asserts that with `torch.equal`.

### Configuration

One new environment variable, `SGLANG_DLLM_KEEP_LOGITS_DTYPE_MIN_ROWS` (`EnvInt(None)`), the denoise row count at which the logits stay in lm_head dtype. It follows the same shape as `SGLANG_DLLM_BATCHED_GATHER_MIN_ROWS` in #33047 — a measured per-backend default, an integer override, and `-1` to disable — but it is a separate knob: the two gate different quantities and their measured crossovers differ by two orders of magnitude, so one value cannot serve both.

| Value | Behavior | When to use |
| --- | --- | --- |
| unset (default) | Ascend: keep lm_head dtype at 512+ rows. Other backends: always fp32. | Normal serving, both latency and throughput. |
| `N` (>= 0) | Keep it at `N`+ rows. | Enabling it on a backend after measuring its crossover, or retuning Ascend. |
| `-1` | Never. | Production A/B and quick rollback. |

The resolved default is logged once at INFO.

## Accuracy Tests

The fused kernel is not bit-identical to the fp32 reference (it accumulates the same sum in a different order), so it was checked directly on Ascend 910B3 at vocab 157184, bf16 logits:

| Quantity | Result |
| --- | --- |
| argmax id | identical on every row |
| softmax probability | max relative error 3.5e-7 |
| decisions at a 0.5 unmask threshold | no flips |

Branches 2 and 3 need no such check: branch 2 *is* the pre-existing expression, and branch 3 differs from it only by chunking a sum.

End to end, LLaDA2-mini gsm8k (zero-shot, full 1319 samples): accuracy unchanged.

## Speed Tests and Profiling

Measured on Ascend 910B3, LLaDA2-mini logits (vocab 157184), per denoise step, all three paths against each other:

| rows | blocks | before (fp32) | after, no kernel | after, with kernel |
| ---: | ---: | ---: | ---: | ---: |
| 32 | 1 | 0.11 ms | 1.03 ms | 0.19 ms |
| 128 | 4 | 0.38 ms | 1.01 ms | 0.20 ms |
| 512 | 16 | 1.67 ms | 1.37 ms | 0.62 ms |
| 1024 | 32 | 3.26 ms | 2.52 ms | 1.28 ms |
| 2048 | 64 | 6.34 ms | 4.90 ms | 2.54 ms |
| 4096 | 128 | 12.40 ms | 13.41 ms | 5.02 ms |

Two things this table decides. First, the threshold: without the kernel the crossover is 512 rows, and below it the loss is steep rather than marginal — 9x at one block, because a 157k vocab chunks into ~10 launches while the fp32 formulation is three fused ops. Second, that the threshold has to exist at all rather than gating on kernel availability: even with the kernel, one block is 1.6x slower than the fp32 path.

At and above the threshold the kernel is a flat ~2.5x, and the no-kernel path is 1.2-1.3x up to 64 blocks, turning into an 8% loss at 128. That last cell is the trade the memory result is worth: 128 blocks is where the fp32 copy stops fitting.

The memory result does not wait for the kernel. Above the threshold the fp32 `[tokens, vocab]` copy is gone on NPU either way, which is what put a ceiling on the batch size at 112+ blocks.

## Unit Tests

`test/registered/unit/dllm/test_argmax_softmax_prob.py` (CPU-only, no server, `base-a-test-cpu`), 5 cases:

- the fp32 branch is bitwise the pre-existing `argmax` + `softmax` + `gather` formulation — this assertion *is* the "non-NPU unchanged" claim above, not a restatement of it;
- the chunked branch's `1/sumexp` identity, and its running-max rescale across a chunk boundary;
- lm_head-dtype input allocates nothing wider than one vocab strip — the memory claim, asserted with the fused kernel patched out, which is the configuration it has to hold in.

Mutation-checked: dropping the `- row_max` shift fails 3 of the 5.

The row threshold has no unit test: it is one comparison against a resolved constant, and the thing worth guarding — that the code below it is untouched — is already guaranteed structurally, since `keep_lm_head_dtype=False` reaches the identical pre-existing branch.

The kernel itself is tested in its own repository, where it can run on the hardware it targets.

## Dependency note

The fused path imports `sgl_kernel_npu.sample.argmax_softmax_prob` (sgl-project/sgl-kernel-npu#644). The import is guarded and every branch of `argmax_and_softmax_prob` returns the same values, so this PR is complete and correct without it.

The memory result does not depend on it either — branch 3 reduces in vocab strips, so the ceiling lifts on any NPU as soon as this PR lands.

What the kernel changes is speed above the threshold: 5.0 ms against 13.4 ms at 128 blocks. Without it that path is 8% slower than the fp32 formulation it replaces, which is the deliberate trade — the OOM is a hard failure at 112+ blocks, the 8% is a soft cost on a path that still runs, and it disappears on upgrade. Below the threshold the kernel is irrelevant either way, since the fp32 path is kept.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35508977487](https://github.com/sgl-project/sglang/actions/runs/35508977487)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35508977363](https://github.com/sgl-project/sglang/actions/runs/35508977363)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35508977494](https://github.com/sgl-project/sglang/actions/runs/35508977494)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->