### PR TITLE
[Attention] Reshape the fused-QKV q slice for FA3 instead of copying it

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1451,7 +1451,10 @@ class FlashAttentionBackend(AttentionBackend):
                 )
             else:
                 result = flash_attn_with_kvcache(
-                    q=q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+                    # q is a column slice of the fused QKV output, so its rows
+                    # are strided over the K/V columns. FA3 takes q_row_stride
+                    # and q_head_stride, so reshape it rather than copy it.
+                    q=q.reshape(-1, layer.tp_q_head_num, layer.head_dim),
                     k_cache=key_cache,
                     v_cache=value_cache,
                     page_table=page_table,

--- a/test/registered/kernels/ops/attention/test_fa3_strided_q.py
+++ b/test/registered/kernels/ops/attention/test_fa3_strided_q.py
@@ -1,0 +1,146 @@
+"""FA3 reads a strided (fused-QKV) q without a copy.
+
+``forward_extend`` reshapes ``qkv[:, :q_size]`` with ``reshape`` instead of
+``contiguous().view``. FA3 takes ``q_row_stride`` / ``q_head_stride`` as kernel
+arguments, so it must read only the q columns of the fused buffer, bit for bit
+like the copied version.
+"""
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.flash_attention import (
+    flash_attn_with_kvcache,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+# FA3 (ver=3) needs Hopper or newer.
+_no_fa3 = not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9
+
+HEAD_DIM = 128
+
+
+def _paged_kv(total_tokens, num_kv_heads, seqlens, device, dtype):
+    """A page_size=1 KV cache plus the index metadata for ``seqlens``."""
+    k_cache, v_cache = (
+        torch.randn(total_tokens, 1, num_kv_heads, HEAD_DIM, device=device, dtype=dtype)
+        for _ in range(2)
+    )
+    max_seqlen = max(seqlens)
+    page_table = torch.zeros(len(seqlens), max_seqlen, device=device, dtype=torch.int32)
+    start = 0
+    for i, seqlen in enumerate(seqlens):
+        page_table[i, :seqlen] = torch.arange(
+            start, start + seqlen, device=device, dtype=torch.int32
+        )
+        start += seqlen
+    cache_seqlens = torch.tensor(seqlens, device=device, dtype=torch.int32)
+    cu_seqlens_q = torch.zeros(len(seqlens) + 1, device=device, dtype=torch.int32)
+    cu_seqlens_q[1:] = cache_seqlens.cumsum(0)
+    return k_cache, v_cache, page_table, cache_seqlens, cu_seqlens_q, max_seqlen
+
+
+class TestFa3StridedQ(CustomTestCase):
+    @unittest.skipIf(_no_fa3, "FA3 requires compute capability sm90 (Hopper) or newer")
+    def test_fused_qkv_slice_matches_copy_bitwise(self):
+        """A strided q slice gives bit-identical output to the copied q.
+
+        The k/v columns of the fused buffer are poisoned with NaN: if FA3
+        ignored ``q_row_stride`` and read outside the q columns, the output
+        would be NaN rather than merely different.
+        """
+        torch.manual_seed(0)
+        device, dtype = "cuda", torch.bfloat16
+
+        for num_q_heads, num_kv_heads, seqlens in (
+            (16, 8, [17, 33]),  # GQA, ragged
+            (14, 2, [1, 512]),  # Qwen3-style GQA, wide length spread
+            (8, 8, [64]),  # MHA, single sequence
+        ):
+            with self.subTest(num_q_heads=num_q_heads, num_kv_heads=num_kv_heads):
+                total_tokens = sum(seqlens)
+                q_size = num_q_heads * HEAD_DIM
+                kv_size = num_kv_heads * HEAD_DIM
+
+                # Fused QKV projection output; q is the leading column slice.
+                qkv = torch.randn(
+                    total_tokens, q_size + 2 * kv_size, device=device, dtype=dtype
+                )
+                qkv[:, q_size:] = float("nan")
+                q = qkv[:, :q_size]
+
+                q_strided = q.reshape(-1, num_q_heads, HEAD_DIM)
+                # The whole point of the patch: the reshape copies nothing.
+                self.assertEqual(q_strided.data_ptr(), q.data_ptr())
+                self.assertFalse(q_strided.is_contiguous())
+                self.assertEqual(
+                    q_strided.stride(), (q_size + 2 * kv_size, HEAD_DIM, 1)
+                )
+
+                (
+                    k_cache,
+                    v_cache,
+                    page_table,
+                    cache_seqlens,
+                    cu_seqlens_q,
+                    max_seqlen,
+                ) = _paged_kv(total_tokens, num_kv_heads, seqlens, device, dtype)
+
+                def run(q_heads):
+                    return flash_attn_with_kvcache(
+                        q=q_heads,
+                        k_cache=k_cache,
+                        v_cache=v_cache,
+                        page_table=page_table,
+                        cache_seqlens=cache_seqlens,
+                        cu_seqlens_q=cu_seqlens_q,
+                        max_seqlen_q=max_seqlen,
+                        softmax_scale=HEAD_DIM**-0.5,
+                        causal=True,
+                        ver=3,
+                    )
+
+                out_strided = run(q_strided)
+                out_copy = run(q.contiguous().view(-1, num_q_heads, HEAD_DIM))
+
+                self.assertFalse(torch.isnan(out_strided).any())
+                self.assertTrue(torch.equal(out_strided, out_copy))
+
+    def test_reshape_matches_contiguous_view_for_3d_q(self):
+        """``reshape`` returns what ``contiguous().view`` returned for a 3-D q.
+
+        The call site is 2-D today, but the reshape has to keep reflowing the
+        leading dims the way the copy did rather than splitting the last one,
+        and it has to keep accepting every layout the copy accepted.
+        """
+        num_heads, head_dim = 4, 8
+        for q in (
+            torch.randn(6, 2, 32),  # contiguous
+            torch.randn(6, 2, 64)[..., :32],  # strided rows
+            torch.randn(6, 2, 64)[..., ::2],  # strided rows and last dim
+        ):
+            with self.subTest(stride=q.stride()):
+                got = q.reshape(-1, num_heads, head_dim)
+                self.assertEqual(got.shape, (12, num_heads, head_dim))
+                # Mergeable leading dims: still a view, still zero copy.
+                self.assertEqual(got.data_ptr(), q.data_ptr())
+                self.assertTrue(
+                    torch.equal(got, q.contiguous().view(-1, num_heads, head_dim))
+                )
+
+        # Leading dims that cannot be merged are the one layout ``view`` would
+        # reject. ``reshape`` copies instead, exactly as the old expression did.
+        q = torch.randn(6, 4, 32)[:, :2]
+        with self.assertRaises(RuntimeError):
+            q.view(-1, num_heads, head_dim)
+        got = q.reshape(-1, num_heads, head_dim)
+        self.assertNotEqual(got.data_ptr(), q.data_ptr())
+        self.assertTrue(torch.equal(got, q.contiguous().view(-1, num_heads, head_dim)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On the FA3 extend path we copy `q` once per layer, per forward, and nothing needs the copy.

`q` arrives as a column slice of the fused QKV projection output — `qkv[:, :q_size]` — so its last dim is contiguous but its rows are strided over the K/V columns. The call site materialized that slice:

```python
q = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
```

FA3 reads a strided `q` natively: `q_row_stride` and `q_head_stride` are kernel arguments, and the only declared contract on `q` in `flash_api.cpp` is `TORCH_CHECK(q.stride(-1) == 1)` — there is no `CHECK_CONTIGUOUS`. `k` and `v` at the same call site are already passed as bare `.view()`s of equally strided slices, and the MLA absorbed path already hands FA3 a *nonzero-offset* strided `q` (`q_rope = q_all[:, :, v_head_dim:]`) in production.

Measured cost of the copy, profiling an embedding workload (Qwen3-arch, 28 layers, 16 q heads / 8 kv heads, head_dim 128, bf16 activations, fp8 linears) on 1×H200:

| | |
|---|---|
| launches | 840 per 30 forwards = exactly one per layer |
| share of GPU kernel time | **7.66%** |
| bytes moved | 1.07 GB read+write per forward at 131k tokens |
| achieved bandwidth | ~1.55 TB/s, **46% of peak** — a generic `elementwise_kernel<128,4>`, not vectorized |
| arithmetic performed | none |

For scale on a larger model: Qwen3-32B at TP2, a 4096-token prefill copies 32 MiB per layer, ~4.0 GiB of extra HBM traffic per forward across 64 layers.

## Modifications

One line at one call site (`forward_extend`, non-MLA, the `flash_attn_with_kvcache` arm), plus a three-line comment:

```python
# q is a column slice of the fused QKV output, so its rows
# are strided over the K/V columns. FA3 takes q_row_stride
# and q_head_stride, so reshape it rather than copy it.
q=q.reshape(-1, layer.tp_q_head_num, layer.head_dim),
```

`reshape` rather than `view`, deliberately: for this call site's layout it returns the same zero-copy view (verified in situ on a live server — 140/140 recorded calls kept the same `data_ptr`, output stride `(4096, 128, 1)`), and for any layout that cannot be viewed it copies, which is exactly what the old expression did. So there is no guard, and no behavioural difference to guard against.

The other seven `q.contiguous().view(...)` sites in the file are untouched. The decode sites copy ~8 KiB per layer, where the cost is launch-bound rather than bandwidth-bound and the measured delta is within noise (±0.9% across five geometries); the context-parallel, cascade and MLA sites deserve their own coverage and are better handled separately.

## Accuracy Tests

This is a layout change — `reshape` on this input is pure metadata, no copy and no arithmetic — so the only question is whether FA3 reads the same elements. Verified bitwise, not by tolerance.

**Per-call equivalence in a real run.** Every FA3 invocation in real serving forwards was intercepted on both builds and compared. Inputs were compared first, because comparing outputs is meaningless otherwise: `q` values (as contiguous CPU copies, since the two builds pass different strides by design), the `k_cache`/`v_cache` rows actually addressed by `page_table`, plus `page_table`, `cache_seqlens`, `cu_seqlens_q`, `cu_seqlens_k_new` and all 33 scalar arguments.

| request | prompt tokens | FA3 calls | inputs identical | outputs bitwise identical |
|---|---|---|---|---|
| 4 docs | 5,443 | 56 | 56 | 56 |
| 4 docs (repeat) | 5,443 | 56 | 56 | 56 |
| 32 ragged docs | 14,935 | 56 | 56 | 56 |
| 32 ragged docs (repeat) | 14,935 | 56 | 56 | 56 |
| 100 docs, crosses a chunked-prefill boundary | 136,102 | 84 | 84 | 84 |
| **total** | | **308** | **308** | **308** |

10,141,745,152 output elements compared, zero differing. The 100-doc run split into forward batches of 1364 / 131072 / 3666 tokens, and its third batch contains a sequence with `cache_seqlens=1358 > extend_len=946`, i.e. a genuine partial-prefix continuation. Batch splits were identical across builds, so call indices line up one to one.

The comparison also proves the two builds took different paths, so it is not vacuous: on all 308 calls the baseline `q` was contiguous with stride `(2048, 128, 1)`, while the patched `q` was non-contiguous with stride `(4096, 128, 1)` and its storage was the whole fused buffer. `4096 = 2048 + 2·(8·128)` is exactly the fused-QKV row width.

**Other checks.**

- Kernel level, three geometries (16q/8kv ragged, 14q/2kv, 8q/8kv MHA): `torch.equal` against the contiguous reference, with the K/V columns of the fused buffer **poisoned with NaN** first, so an out-of-column read would surface as NaN rather than as a small numeric delta. No NaN in the output, exact equality.
- A wider sweep over 25 architectures × TP {1,2,8} × head_dim {64,80,96,128,192,256}: 204/204 bitwise identical.
- End to end: embeddings identical to the unpatched build at the same SHA (0 of 8192 elements differ, max abs diff 0.0); Llama-3.1-8B batch-1 greedy generation token-exact over 2048 completion tokens, 16/16 prompts.
- New unit test `test/registered/kernels/ops/attention/test_fa3_strided_q.py`: the bitwise + NaN-poisoning test above, plus a case pinning that `reshape` reproduces `contiguous().view(-1, H, D)` for 3-D `q` layouts that cannot be viewed (it copies, as before).
- Targeted CI, patched vs unpatched at the same SHA: 4/4 green, including `registered/attention/unittests/dense/test_fa3.py` (10 passed, 36 subtests) — the non-fused-QKV consumer, which constructs `q` directly — and `prefill_only/test_fa_skip_kv_cache_piecewise_nan.py`, which covers the sibling `flash_attn_varlen_func` branch of the same `forward_extend` that this PR does not touch. A larger sweep on an earlier base was also run on both arms: MUST-RUN 8/8 pass patched, 7/7 comparable pass on the baseline, 0 divergences; EAGLE+fa3 accept length 1.7137/4.0511 patched vs 1.7100/4.0580 baseline.

A coverage gap worth flagging: the existing attention unit tests build `q` from separate `q_proj`/`k_proj`/`v_proj`, so **nothing in-tree had ever fed FA3 a strided `q`**. The new test closes that.

## Speed Tests and Profiling

1×H200, embedding serving, 32 docs/request, concurrency 16, steady-state window, two runs per arm, same session:

| | docs/s | p50 |
|---|---|---|
| baseline | 377.60 / 376.89 | 1.296 s |
| patched | **400.36 / 398.93** | 1.220 s |
| | **+5.94%** | −5.9% |

The copy kernel is gone, and the comparison is controlled — flash-attention launch counts are identical on both arms:

| 30-step profile | baseline | patched |
|---|---|---|
| `elementwise_kernel<128,4,…direct_copy_kernel_cuda…>` launches | 840 | **0** |
| total copy GPU time | 586.9 ms (7.66%) | **10.1 ms (0.14%)** |
| flash-attention launches | 3390 | 3390 |

Kernel level, across 33 geometry × token-count points: the copy saves 54.1 µs per layer; the strided `q` makes the attention kernel itself 0–3% slower, and only at ≥8k tokens; net **10.2–37.8%** of (attention + copy) per layer.

Scope of the benefit, stated plainly: this converts to throughput only when prefill is GPU-bound. At an operating point where the frontend is the bottleneck the same patch measures **+0.1%**, i.e. noise, and decode-dominated serving will not see it either. The beneficiaries are prefill-heavy workloads — embedding, reranking, RAG ingestion, long-prompt prefill.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation — N/A, internal attention-backend change with no user-facing surface.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes for reviewers

- **Aliasing.** The old copy handed FA3 an independent buffer; the reshape aliases the fused QKV allocation. Within a layer nothing writes `qkv` after the FA3 launch (qk-norm and RoPE are in-place and precede it, `store_kvcache` only reads from it), and the next layer's QKV GEMM is ordered on the same stream. The 308/308 per-call result and the bit-identical embeddings across independent server launches are consistent with that, but it is the one property the copy used to mask.
- **TP > 1 was not exercised on GPU here.** TP 2/4/8 rests on the arithmetic plus a host-side probe over real model configs (10 models × TP 1/2/4/8, all taking the zero-copy path), not on a multi-GPU run.
- **Separate finding, not in this PR.** While checking whether a `stride(-1) != 1` `q` could reach the kernel, I found that `flash_attn_with_kvcache` is already safe — both FA3 kernel providers normalize `q` with `maybe_contiguous` — but `flash_attn_varlen_func` is normalized by neither, while `flashattention_backend.py` already passes it a bare `q.view(...)` on the MLA chunked-prefix path. That is a pre-existing gap, unrelated to this change, and I will send it separately with a test that fails on `main`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30732350451](https://github.com/sgl-project/sglang/actions/runs/30732350451)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30732350411](https://github.com/sgl-project/sglang/actions/runs/30732350411)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->