### PR TITLE
Optimize nightly NPU test pipeline execution time

### DIFF
--- a/.github/workflows/nightly-test-npu-e2e-multi-node.yml
+++ b/.github/workflows/nightly-test-npu-e2e-multi-node.yml
@@ -103,22 +103,30 @@ jobs:
           cp -r ${current_path}/* ${target_path}/
 
       - name: Clear resources
+        timeout-minutes: 30
         run: |
           cd ${ASCEND_E2E_TEST_CONFIG_PATH}
           kubectl delete -f ./k8s_multi_pd_*.yaml --ignore-not-found=true || true
 
           pod_name_prefix="${KUBE_JOB_NAME}-"
           echo "kube name space: $NAMESPACE, pod name prefix: ${pod_name_prefix}"
-          while true; do
+          max_wait_sec=600
+          waited_sec=0
+          while [ ${waited_sec} -lt ${max_wait_sec} ]; do
             if kubectl get po -A -n $NAMESPACE | grep -q "${pod_name_prefix}"; then
               echo "Found exist sglang job, sleeping for 30 seconds..."
               sleep 30
+              waited_sec=$((waited_sec + 30))
               kubectl get pods | grep "${pod_name_prefix}" | awk '{print $1}' | xargs kubectl delete pod -n $NAMESPACE || true
             else
               echo "No sglang job exist, start test case..."
               break
             fi
           done
+          if [ ${waited_sec} -ge ${max_wait_sec} ]; then
+            echo "ERROR: timed out waiting for pods to be cleaned up, aborting"
+            exit 1
+          fi
 
       - name: Run test
         timeout-minutes: 300
@@ -213,6 +221,7 @@ jobs:
 
       - name: Post process
         if: always()
+        timeout-minutes: 30
         run: |
           cd ${ASCEND_E2E_TEST_CONFIG_PATH}
           kubectl get pods -n $NAMESPACE | grep $KUBE_JOB_NAME
@@ -220,13 +229,20 @@ jobs:
 
           pod_name_prefix="${KUBE_JOB_NAME}-"
           echo "kube name space: $NAMESPACE, pod name prefix: ${pod_name_prefix}"
-          while true; do
+          max_wait_sec=600
+          waited_sec=0
+          while [ ${waited_sec} -lt ${max_wait_sec} ]; do
             if kubectl get po -A -n $NAMESPACE | grep -q "${pod_name_prefix}"; then
               echo "Found exist sglang job, sleeping for 30 seconds..."
               sleep 30
+              waited_sec=$((waited_sec + 30))
               kubectl get pods | grep "${pod_name_prefix}" | awk '{print $1}' | xargs kubectl delete pod -n $NAMESPACE || true
             else
               echo "No sglang job exist, start test case..."
               break
             fi
           done
+          if [ ${waited_sec} -ge ${max_wait_sec} ]; then
+            echo "ERROR: timed out waiting for pods to be cleaned up, aborting"
+            exit 1
+          fi

--- a/.github/workflows/nightly-test-npu-e2e-single-node.yml
+++ b/.github/workflows/nightly-test-npu-e2e-single-node.yml
@@ -174,8 +174,18 @@ jobs:
           echo "Log path: ${log_path}"
 
           echo "Running test case ${test_case}"
+          # Run the test with its output captured to a file, and stream the file
+          # live. Avoid a `| tee` pipeline, which can hang until the step timeout
+          # when a leaked child process (e.g. an orphaned sglang server) keeps the
+          # stdout pipe open after the test itself has finished.
+          : > /tmp/test_output.log
           test_exit_code=0
-          ${PYTHON_FOR_SGLANG} -u ${test_case} 2>&1 | tee /tmp/test_output.log || test_exit_code=$?
+          ${PYTHON_FOR_SGLANG} -u ${test_case} > /tmp/test_output.log 2>&1 &
+          TEST_PID=$!
+          tail -n +1 -f /tmp/test_output.log &
+          TAIL_PID=$!
+          wait ${TEST_PID} || test_exit_code=$?
+          kill ${TAIL_PID} 2>/dev/null || true
           echo "Finished test case ${test_case}"
 
           if [ "${test_exit_code}" = "0" ]; then

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -129,8 +129,8 @@ jobs:
       install_sglang_from_source: false
       transformers_version: ''
 
-  nightly-poc-single-node-tests:
-    name: single-node-poc
+  nightly-poc-single-node-tests-short:
+    name: single-node-poc-short
     if: ${{ !cancelled() }}
     needs: [set-image-config]
     strategy:
@@ -138,14 +138,12 @@ jobs:
       max-parallel: 6
       matrix:
         test_config:
+          # Test cases with an average execution time of no more than 1.5h
           # qwen3_6_35b_a3b performance tests
           - name: qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms.py
             test_type: 'perf'
-          - name: qwen3_6_35b_a3b_1p_aime26
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_aime26.py
           - name: qwen3_6_35b_a3b_1p_in64k_out1k_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_50ms.py
@@ -154,13 +152,6 @@ jobs:
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_50ms.py
             test_type: 'perf'
-          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms.py
-            test_type: 'perf'
-          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26.py
           - name: qwen3_6_35b_a3b_1p_in128k_out1k_prefix90_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in128k_out1k_prefix90_50ms.py
@@ -197,9 +188,6 @@ jobs:
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_27b/test_npu_qwen3_6_27b_1p_in1080p_30_out256_50ms.py
             test_type: 'perf'
-          - name: qwen3_6_27b_1p_gpqa
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_1p_gpqa.py
           # qwen3_32b performance tests
           - name: qwen3_32b_w8a8_2p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-4
@@ -265,18 +253,7 @@ jobs:
           - name: deepseek_v3_2_8p_aime25
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/accuracy/deepseek_v3_2/test_npu_deepseek_v3_2_8p_aime25.py
-          # glm4_7_flash accuracy tests
-          - name: glm4_7_flash_1p_aime25
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/glm4_7_flash/test_npu_glm4_7_flash_1p_aime25.py
-          # qwen3_vl_8b_thinking accuracy tests
-          - name: qwen3_vl_8b_thinking_1p_mmmu
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
-          # qwen3_vl_30b_a3b_thinking accuracy tests
-          - name: qwen3_vl_30b_a3b_thinking_1p_mmmu
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
+          # qwen3_235b performance tests
           - name: qwen3_235b_w8a8_8p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/performance/qwen3_235b_a22b/test_npu_qwen3_235b_w8a8_8p_in3k5_out1k5_50ms.py
@@ -304,10 +281,58 @@ jobs:
       install_sglang_from_source: false
       transformers_version: ''
 
+  nightly-poc-single-node-tests-long:
+    name: single-node-poc-long
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        test_config:
+          # Test cases with an average execution time of more than 1.5h
+          # qwen3_6_35b_a3b performance tests
+          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms.py
+            test_type: 'perf'
+          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26.py
+          # qwen3_6_27b accuracy tests
+          - name: qwen3_6_27b_1p_gpqa
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_1p_gpqa.py
+          # qwen3_6_35b_a3b accuracy tests
+          - name: qwen3_6_35b_a3b_1p_aime26
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_aime26.py
+          # glm4_7_flash accuracy tests
+          - name: glm4_7_flash_1p_aime25
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/glm4_7_flash/test_npu_glm4_7_flash_1p_aime25.py
+          # qwen3_vl_8b_thinking accuracy tests
+          - name: qwen3_vl_8b_thinking_1p_mmmu
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
+          # qwen3_vl_30b_a3b_thinking accuracy tests
+          - name: qwen3_vl_30b_a3b_thinking_1p_mmmu
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
+    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
+    with:
+      runner: ${{ matrix.test_config.runner }}
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_from_source: false
+      transformers_version: ''
+
   nightly-poc-multi-node-tests:
     name: multi-node-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-poc-single-node-tests]
+    needs: [set-image-config, nightly-poc-single-node-tests-short]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -359,7 +384,7 @@ jobs:
   nightly-poc-multi-node-mix-tests:
     name: multi-node-mix-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-poc-single-node-tests, nightly-poc-multi-node-tests]
+    needs: [set-image-config, nightly-poc-single-node-tests-short, nightly-poc-multi-node-tests]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -388,7 +413,8 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - nightly-poc-single-node-a2-tests
-      - nightly-poc-single-node-tests
+      - nightly-poc-single-node-tests-short
+      - nightly-poc-single-node-tests-long
       - nightly-poc-multi-node-tests
       - nightly-poc-multi-node-mix-tests
     runs-on: ubuntu-latest
@@ -411,7 +437,8 @@ jobs:
           }
 
           single_result_a2="${{ needs.nightly-poc-single-node-a2-tests.result }}"
-          single_result="${{ needs.nightly-poc-single-node-tests.result }}"
+          single_short_result="${{ needs.nightly-poc-single-node-tests-short.result }}"
+          single_long_result="${{ needs.nightly-poc-single-node-tests-long.result }}"
           multi_result="${{ needs.nightly-poc-multi-node-tests.result }}"
           mix_result="${{ needs.nightly-poc-multi-node-mix-tests.result }}"
 
@@ -430,7 +457,8 @@ jobs:
           echo "| Group | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| single-node-poc-a2 | $(group_icon ${single_result_a2}) ${single_result_a2} |" >> $GITHUB_STEP_SUMMARY
-          echo "| single-node-poc | $(group_icon ${single_result}) ${single_result} |" >> $GITHUB_STEP_SUMMARY
+          echo "| single-node-poc-short | $(group_icon ${single_short_result}) ${single_short_result} |" >> $GITHUB_STEP_SUMMARY
+          echo "| single-node-poc-long | $(group_icon ${single_long_result}) ${single_long_result} |" >> $GITHUB_STEP_SUMMARY
           echo "| multi-node-poc | $(group_icon ${multi_result}) ${multi_result} |" >> $GITHUB_STEP_SUMMARY
           echo "| multi-node-mix-poc | $(group_icon ${mix_result}) ${mix_result} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -469,5 +497,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
 
           FAIL=0
-          if [ "${single_result}" != "success" ] && [ "${single_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${single_result_a2}" != "success" ] && [ "${single_result_a2}" != "skipped" ]; then FAIL=1; fi
+          if [ "${single_short_result}" != "success" ] && [ "${single_short_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${single_long_result}" != "success" ] && [ "${single_long_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${multi_result}" != "success" ] && [ "${multi_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${mix_result}" != "success" ] && [ "${mix_result}" != "skipped" ]; then FAIL=1; fi
           exit $FAIL

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -111,7 +111,7 @@ jobs:
     needs: [ set-image-config ]
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         test_config:
           - name: qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_a2
@@ -138,7 +138,7 @@ jobs:
     needs: [set-image-config]
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 4
       matrix:
         test_config:
           # Performance test cases (single-node)
@@ -265,7 +265,7 @@ jobs:
     needs: [set-image-config]
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 4
       matrix:
         test_config:
           # Accuracy test cases with an average execution time of no more than 1.5h
@@ -335,7 +335,7 @@ jobs:
     needs: [set-image-config]
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         test_config:
           # Accuracy test cases with an average execution time of more than 1.5h

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -129,16 +129,73 @@ jobs:
       install_sglang_from_source: false
       transformers_version: ''
 
-  nightly-poc-single-node-tests-short:
-    name: single-node-poc-short
+  nightly-poc-single-node-tests-short-accuracy:
+    name: single-node-poc-short-accuracy
     if: ${{ !cancelled() }}
     needs: [set-image-config]
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 10
       matrix:
         test_config:
-          # Test cases with an average execution time of no more than 1.5h
+          # Accuracy test cases with an average execution time of no more than 1.5h
+          # qwen3_6_27b accuracy tests
+          - name: qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
+          # qwen3_32b accuracy tests
+          - name: qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-4-
+            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa.py
+          - name: qwen3_32b_bf16_8p_gpqa
+            runner: linux-aarch64-a3-16-
+            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_bf16_8p_gpqa.py
+          # qwen3_30b_a3b accuracy tests
+          - name: qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3_30b_a3b/test_npu_qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25.py
+          # qwen3-8b accuracy tests
+          - name: qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
+          - name: qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa.py
+          # qwen3_next_80b_a3b_instruct accuracy tests
+          - name: qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25
+            runner: linux-aarch64-a3-4-
+            test_case: test/registered/npu/accuracy/qwen3_next_80b_a3b_instruct/test_npu_qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25.py
+          # minimax_m2_5 accuracy tests
+          - name: minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-16-
+            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa.py
+          - name: minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa
+            runner: linux-aarch64-a3-16-
+            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa.py
+          # deepseek_v3_2 accuracy tests
+          - name: deepseek_v3_2_8p_aime25
+            runner: linux-aarch64-a3-16-
+            test_case: test/registered/npu/accuracy/deepseek_v3_2/test_npu_deepseek_v3_2_8p_aime25.py
+    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
+    with:
+      runner: ${{ matrix.test_config.runner }}
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_from_source: false
+      transformers_version: ''
+
+  nightly-poc-single-node-tests-short-performance:
+    name: single-node-poc-short-performance
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        test_config:
+          # Performance test cases with an average execution time of no more than 1.5h
           # qwen3_6_35b_a3b performance tests
           - name: qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-2
@@ -161,9 +218,6 @@ jobs:
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_27b/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms.py
             test_type: 'perf'
-          - name: qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
           - name: qwen3_6_27b_w8a8_2p_in16k_out1k_50ms
             runner: linux-aarch64-a3-4
             test_case: test/registered/npu/performance/qwen3_6_27b/test_npu_qwen3_6_27b_w8a8_2p_in16k_out1k_50ms.py
@@ -193,66 +247,38 @@ jobs:
             runner: linux-aarch64-a3-4
             test_case: test/registered/npu/performance/qwen3_32b/test_npu_qwen3_32b_w8a8_2p_in3k5_out1k5_50ms.py
             test_type: 'perf'
-          - name: qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-4
-            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa.py
           - name: qwen3_32b_bf16_8p_in18k_out4k_6ms
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/performance/qwen3_32b/test_npu_qwen3_32b_bf16_8p_in18k_out4k_6ms.py
             test_type: 'perf'
-          - name: qwen3_32b_bf16_8p_gpqa
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_bf16_8p_gpqa.py
           # qwen3_30b_a3b performance tests
           - name: qwen3_30b_w8a8_1p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_30b_a3b/test_npu_qwen3_30b_w8a8_1p_in3k5_out1k5_50ms.py
             test_type: 'perf'
-          - name: qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_30b_a3b/test_npu_qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25.py
           # qwen3-8b performance tests
           - name: qwen3_8b_w8a8_1p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in3k5_out1k5_50ms.py
             test_type: 'perf'
-          - name: qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
           - name: qwen3_8b_w8a8_1p_in6k_out1k5_bs16
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in6k_out1k5_bs16.py
             test_type: 'perf'
-          - name: qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa.py
           # qwen3_next_80b_a3b_instruct performance tests
           - name: qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16
             runner: linux-aarch64-a3-4
             test_case: test/registered/npu/performance/qwen3_next_80b_a3b_instruct/test_npu_qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16.py
             test_type: 'perf'
-          - name: qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25
-            runner: linux-aarch64-a3-4
-            test_case: test/registered/npu/accuracy/qwen3_next_80b_a3b_instruct/test_npu_qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25.py
           # minimax_m2_5 performance tests
           - name: minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/performance/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms.py
             test_type: 'perf'
-          - name: minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa.py
           - name: minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/performance/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms.py
             test_type: 'perf'
-          - name: minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa.py
-          # deepseek_v3_2 accuracy tests
-          - name: deepseek_v3_2_8p_aime25
-            runner: linux-aarch64-a3-16
-            test_case: test/registered/npu/accuracy/deepseek_v3_2/test_npu_deepseek_v3_2_8p_aime25.py
           # qwen3_235b performance tests
           - name: qwen3_235b_w8a8_8p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-16
@@ -281,8 +307,8 @@ jobs:
       install_sglang_from_source: false
       transformers_version: ''
 
-  nightly-poc-single-node-tests-long:
-    name: single-node-poc-long
+  nightly-poc-single-node-tests-long-accuracy:
+    name: single-node-poc-long-accuracy
     if: ${{ !cancelled() }}
     needs: [set-image-config]
     strategy:
@@ -290,35 +316,55 @@ jobs:
       max-parallel: 6
       matrix:
         test_config:
-          # Test cases with an average execution time of more than 1.5h
+          # Accuracy test cases with an average execution time of more than 1.5h
+          # qwen3_6_35b_a3b accuracy tests
+          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26.py
+          - name: qwen3_6_35b_a3b_1p_aime26
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_aime26.py
+          # qwen3_6_27b accuracy tests
+          - name: qwen3_6_27b_1p_gpqa
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_1p_gpqa.py
+          # glm4_7_flash accuracy tests
+          - name: glm4_7_flash_1p_aime25
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/glm4_7_flash/test_npu_glm4_7_flash_1p_aime25.py
+          # qwen3_vl_8b_thinking accuracy tests
+          - name: qwen3_vl_8b_thinking_1p_mmmu
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
+          # qwen3_vl_30b_a3b_thinking accuracy tests
+          - name: qwen3_vl_30b_a3b_thinking_1p_mmmu
+            runner: linux-aarch64-a3-2-
+            test_case: test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
+    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
+    with:
+      runner: ${{ matrix.test_config.runner }}
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_from_source: false
+      transformers_version: ''
+
+  nightly-poc-single-node-tests-long-performance:
+    name: single-node-poc-long-performance
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        test_config:
+          # Performance test cases with an average execution time of more than 1.5h
           # qwen3_6_35b_a3b performance tests
           - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms.py
             test_type: 'perf'
-          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26.py
-          # qwen3_6_27b accuracy tests
-          - name: qwen3_6_27b_1p_gpqa
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_1p_gpqa.py
-          # qwen3_6_35b_a3b accuracy tests
-          - name: qwen3_6_35b_a3b_1p_aime26
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_aime26.py
-          # glm4_7_flash accuracy tests
-          - name: glm4_7_flash_1p_aime25
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/glm4_7_flash/test_npu_glm4_7_flash_1p_aime25.py
-          # qwen3_vl_8b_thinking accuracy tests
-          - name: qwen3_vl_8b_thinking_1p_mmmu
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
-          # qwen3_vl_30b_a3b_thinking accuracy tests
-          - name: qwen3_vl_30b_a3b_thinking_1p_mmmu
-            runner: linux-aarch64-a3-2
-            test_case: test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
     uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
     with:
       runner: ${{ matrix.test_config.runner }}
@@ -332,10 +378,14 @@ jobs:
   nightly-poc-multi-node-tests:
     name: multi-node-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-poc-single-node-tests-short]
+    needs: [set-image-config, nightly-poc-single-node-tests-short-accuracy, nightly-poc-single-node-tests-short-performance]
     strategy:
       fail-fast: false
-      max-parallel: 1
+      # Run up to 2 multi-node cases in parallel to cut the serial wall time
+      # (glm5_1 alone takes ~3h each). Requires the NPU cluster to have enough
+      # free resources for 2 concurrent multi-node deployments (glm5_1 uses
+      # 32 NPUs across prefill/decode/router nodes); tune per cluster capacity.
+      max-parallel: 2
       matrix:
         test_config:
           # glm5_1 performance tests
@@ -384,10 +434,11 @@ jobs:
   nightly-poc-multi-node-mix-tests:
     name: multi-node-mix-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-poc-single-node-tests-short, nightly-poc-multi-node-tests]
+    needs: [set-image-config, nightly-poc-single-node-tests-short-accuracy, nightly-poc-single-node-tests-short-performance, nightly-poc-multi-node-tests]
     strategy:
       fail-fast: false
-      max-parallel: 1
+      # Run up to 2 mix cases in parallel (kimi_k2_6 uses 2 nodes each).
+      max-parallel: 2
       matrix:
         test_config:
           # kimi_k2_6 performance tests
@@ -413,8 +464,10 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - nightly-poc-single-node-a2-tests
-      - nightly-poc-single-node-tests-short
-      - nightly-poc-single-node-tests-long
+      - nightly-poc-single-node-tests-short-accuracy
+      - nightly-poc-single-node-tests-short-performance
+      - nightly-poc-single-node-tests-long-accuracy
+      - nightly-poc-single-node-tests-long-performance
       - nightly-poc-multi-node-tests
       - nightly-poc-multi-node-mix-tests
     runs-on: ubuntu-latest
@@ -437,8 +490,10 @@ jobs:
           }
 
           single_result_a2="${{ needs.nightly-poc-single-node-a2-tests.result }}"
-          single_short_result="${{ needs.nightly-poc-single-node-tests-short.result }}"
-          single_long_result="${{ needs.nightly-poc-single-node-tests-long.result }}"
+          short_acc_result="${{ needs.nightly-poc-single-node-tests-short-accuracy.result }}"
+          short_perf_result="${{ needs.nightly-poc-single-node-tests-short-performance.result }}"
+          long_acc_result="${{ needs.nightly-poc-single-node-tests-long-accuracy.result }}"
+          long_perf_result="${{ needs.nightly-poc-single-node-tests-long-performance.result }}"
           multi_result="${{ needs.nightly-poc-multi-node-tests.result }}"
           mix_result="${{ needs.nightly-poc-multi-node-mix-tests.result }}"
 
@@ -457,8 +512,10 @@ jobs:
           echo "| Group | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| single-node-poc-a2 | $(group_icon ${single_result_a2}) ${single_result_a2} |" >> $GITHUB_STEP_SUMMARY
-          echo "| single-node-poc-short | $(group_icon ${single_short_result}) ${single_short_result} |" >> $GITHUB_STEP_SUMMARY
-          echo "| single-node-poc-long | $(group_icon ${single_long_result}) ${single_long_result} |" >> $GITHUB_STEP_SUMMARY
+          echo "| single-node-poc-short-accuracy | $(group_icon ${short_acc_result}) ${short_acc_result} |" >> $GITHUB_STEP_SUMMARY
+          echo "| single-node-poc-short-performance | $(group_icon ${short_perf_result}) ${short_perf_result} |" >> $GITHUB_STEP_SUMMARY
+          echo "| single-node-poc-long-accuracy | $(group_icon ${long_acc_result}) ${long_acc_result} |" >> $GITHUB_STEP_SUMMARY
+          echo "| single-node-poc-long-performance | $(group_icon ${long_perf_result}) ${long_perf_result} |" >> $GITHUB_STEP_SUMMARY
           echo "| multi-node-poc | $(group_icon ${multi_result}) ${multi_result} |" >> $GITHUB_STEP_SUMMARY
           echo "| multi-node-mix-poc | $(group_icon ${mix_result}) ${mix_result} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -498,8 +555,10 @@ jobs:
 
           FAIL=0
           if [ "${single_result_a2}" != "success" ] && [ "${single_result_a2}" != "skipped" ]; then FAIL=1; fi
-          if [ "${single_short_result}" != "success" ] && [ "${single_short_result}" != "skipped" ]; then FAIL=1; fi
-          if [ "${single_long_result}" != "success" ] && [ "${single_long_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${short_acc_result}" != "success" ] && [ "${short_acc_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${short_perf_result}" != "success" ] && [ "${short_perf_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${long_acc_result}" != "success" ] && [ "${long_acc_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${long_perf_result}" != "success" ] && [ "${long_perf_result}" != "skipped" ]; then FAIL=1; fi
           if [ "${multi_result}" != "success" ] && [ "${multi_result}" != "skipped" ]; then FAIL=1; fi
           if [ "${mix_result}" != "success" ] && [ "${mix_result}" != "skipped" ]; then FAIL=1; fi
           exit $FAIL

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -103,6 +103,8 @@ jobs:
           else
             echo "skip_install_flag=${{ inputs.skip_install_flag }}" >> $GITHUB_OUTPUT
           fi
+
+
   nightly-poc-single-node-a2-tests:
     name: single-node-poc-a2
     if: ${{ !cancelled() }}
@@ -129,65 +131,9 @@ jobs:
       install_sglang_from_source: false
       transformers_version: ''
 
-  nightly-poc-single-node-tests-short-accuracy:
-    name: single-node-poc-short-accuracy
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix:
-        test_config:
-          # Accuracy test cases with an average execution time of no more than 1.5h
-          # qwen3_6_27b accuracy tests
-          - name: qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
-          # qwen3_32b accuracy tests
-          - name: qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-4-
-            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa.py
-          - name: qwen3_32b_bf16_8p_gpqa
-            runner: linux-aarch64-a3-16-
-            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_bf16_8p_gpqa.py
-          # qwen3_30b_a3b accuracy tests
-          - name: qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3_30b_a3b/test_npu_qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25.py
-          # qwen3-8b accuracy tests
-          - name: qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
-          - name: qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa.py
-          # qwen3_next_80b_a3b_instruct accuracy tests
-          - name: qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25
-            runner: linux-aarch64-a3-4-
-            test_case: test/registered/npu/accuracy/qwen3_next_80b_a3b_instruct/test_npu_qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25.py
-          # minimax_m2_5 accuracy tests
-          - name: minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa
-            runner: linux-aarch64-a3-16-
-            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa.py
-          - name: minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa
-            runner: linux-aarch64-a3-16-
-            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa.py
-          # deepseek_v3_2 accuracy tests
-          - name: deepseek_v3_2_8p_aime25
-            runner: linux-aarch64-a3-16-
-            test_case: test/registered/npu/accuracy/deepseek_v3_2/test_npu_deepseek_v3_2_8p_aime25.py
-    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
-    with:
-      runner: ${{ matrix.test_config.runner }}
-      test_type: ${{ matrix.test_config.test_type }}
-      test_config_name: ${{ matrix.test_config.name }}
-      test_case: ${{ matrix.test_config.test_case }}
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_from_source: false
-      transformers_version: ''
 
-  nightly-poc-single-node-tests-short-performance:
-    name: single-node-poc-short-performance
+  nightly-poc-single-node-tests-performance:
+    name: single-node-poc-performance
     if: ${{ !cancelled() }}
     needs: [set-image-config]
     strategy:
@@ -195,7 +141,7 @@ jobs:
       max-parallel: 6
       matrix:
         test_config:
-          # Performance test cases with an average execution time of no more than 1.5h
+          # Performance test cases (single-node)
           # qwen3_6_35b_a3b performance tests
           - name: qwen3_6_35b_a3b_1p_in3k5_out1k5_50ms
             runner: linux-aarch64-a3-2
@@ -297,70 +243,7 @@ jobs:
             runner: linux-aarch64-a3-16
             test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_8p_in8k_out1k_50ms.py
             test_type: 'perf'
-    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
-    with:
-      runner: ${{ matrix.test_config.runner }}
-      test_type: ${{ matrix.test_config.test_type }}
-      test_config_name: ${{ matrix.test_config.name }}
-      test_case: ${{ matrix.test_config.test_case }}
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_from_source: false
-      transformers_version: ''
-
-  nightly-poc-single-node-tests-long-accuracy:
-    name: single-node-poc-long-accuracy
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    strategy:
-      fail-fast: false
-      max-parallel: 6
-      matrix:
-        test_config:
-          # Accuracy test cases with an average execution time of more than 1.5h
-          # qwen3_6_35b_a3b accuracy tests
-          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26.py
-          - name: qwen3_6_35b_a3b_1p_aime26
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_aime26.py
-          # qwen3_6_27b accuracy tests
-          - name: qwen3_6_27b_1p_gpqa
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_1p_gpqa.py
-          # glm4_7_flash accuracy tests
-          - name: glm4_7_flash_1p_aime25
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/glm4_7_flash/test_npu_glm4_7_flash_1p_aime25.py
-          # qwen3_vl_8b_thinking accuracy tests
-          - name: qwen3_vl_8b_thinking_1p_mmmu
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
-          # qwen3_vl_30b_a3b_thinking accuracy tests
-          - name: qwen3_vl_30b_a3b_thinking_1p_mmmu
-            runner: linux-aarch64-a3-2-
-            test_case: test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
-    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
-    with:
-      runner: ${{ matrix.test_config.runner }}
-      test_type: ${{ matrix.test_config.test_type }}
-      test_config_name: ${{ matrix.test_config.name }}
-      test_case: ${{ matrix.test_config.test_case }}
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_from_source: false
-      transformers_version: ''
-
-  nightly-poc-single-node-tests-long-performance:
-    name: single-node-poc-long-performance
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    strategy:
-      fail-fast: false
-      max-parallel: 6
-      matrix:
-        test_config:
-          # Performance test cases with an average execution time of more than 1.5h
-          # qwen3_6_35b_a3b performance tests
+          # Performance case with an average execution time of more than 1.5h
           - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms
             runner: linux-aarch64-a3-2
             test_case: test/registered/npu/performance/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms.py
@@ -375,10 +258,114 @@ jobs:
       install_sglang_from_source: false
       transformers_version: ''
 
+
+  nightly-poc-single-node-tests-short-accuracy:
+    name: single-node-poc-short-accuracy
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        test_config:
+          # Accuracy test cases with an average execution time of no more than 1.5h
+          # qwen3_6_27b accuracy tests
+          - name: qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
+          # qwen3_32b accuracy tests
+          - name: qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_w8a8_2p_in3k5_out1k5_50ms_gpqa.py
+          - name: qwen3_32b_bf16_8p_gpqa
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/accuracy/qwen3_32b/test_npu_qwen3_32b_bf16_8p_gpqa.py
+          # qwen3_30b_a3b accuracy tests
+          - name: qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_30b_a3b/test_npu_qwen3_30b_w8a8_1p_in3k5_out1k5_50ms_aime25.py
+          # qwen3-8b accuracy tests
+          - name: qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in3k5_out1k5_50ms_gpqa.py
+          - name: qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3-8b/test_npu_qwen3_8b_w8a8_1p_in6k_out1k5_bs16_gpqa.py
+          # qwen3_next_80b_a3b_instruct accuracy tests
+          - name: qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25
+            runner: linux-aarch64-a3-4
+            test_case: test/registered/npu/accuracy/qwen3_next_80b_a3b_instruct/test_npu_qwen3_next_80b_w8a8_2p_in6k_out1k5_bs16_aime25.py
+          # minimax_m2_5 accuracy tests
+          - name: minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa.py
+          - name: minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa.py
+          # deepseek_v3_2 accuracy tests
+          - name: deepseek_v3_2_8p_aime25
+            runner: linux-aarch64-a3-16
+            test_case: test/registered/npu/accuracy/deepseek_v3_2/test_npu_deepseek_v3_2_8p_aime25.py
+          # glm4_7_flash accuracy tests
+          - name: glm4_7_flash_1p_aime25
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/glm4_7_flash/test_npu_glm4_7_flash_1p_aime25.py
+          # qwen3_vl_8b_thinking accuracy tests
+          - name: qwen3_vl_8b_thinking_1p_mmmu
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
+          # qwen3_6_35b_a3b accuracy tests
+          - name: qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_in64k_out1k_prefix90_50ms_aime26.py
+    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
+    with:
+      runner: ${{ matrix.test_config.runner }}
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_from_source: false
+      transformers_version: ''
+
+
+  nightly-poc-single-node-tests-long-accuracy:
+    name: single-node-poc-long-accuracy
+    if: ${{ !cancelled() }}
+    needs: [set-image-config]
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        test_config:
+          # Accuracy test cases with an average execution time of more than 1.5h
+          # qwen3_6_35b_a3b accuracy tests
+          - name: qwen3_6_35b_a3b_1p_aime26
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_6_35b_a3b/test_npu_qwen3_6_35b_a3b_1p_aime26.py
+          # qwen3_6_27b accuracy tests
+          - name: qwen3_6_27b_1p_gpqa
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_6_27b/test_npu_qwen3_6_27b_1p_gpqa.py
+          # qwen3_vl_30b_a3b_thinking accuracy tests
+          - name: qwen3_vl_30b_a3b_thinking_1p_mmmu
+            runner: linux-aarch64-a3-2
+            test_case: test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
+    uses: ./.github/workflows/nightly-test-npu-e2e-single-node.yml
+    with:
+      runner: ${{ matrix.test_config.runner }}
+      test_type: ${{ matrix.test_config.test_type }}
+      test_config_name: ${{ matrix.test_config.name }}
+      test_case: ${{ matrix.test_config.test_case }}
+      image: ${{ needs.set-image-config.outputs.image_a3 }}
+      install_sglang_from_source: false
+      transformers_version: ''
+
+
   nightly-poc-multi-node-tests:
     name: multi-node-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-poc-single-node-tests-short-accuracy, nightly-poc-single-node-tests-short-performance]
+    needs: [set-image-config, nightly-poc-single-node-a2-tests, nightly-poc-single-node-tests-performance, nightly-poc-single-node-tests-short-accuracy]
     strategy:
       fail-fast: false
       # Multi-node cases must run strictly serially: the NPU cluster can only
@@ -429,10 +416,11 @@ jobs:
       prefill_decode_deployment: ${{ matrix.test_config.prefill_decode_deployment }}
       transformers_version: ''
 
+
   nightly-poc-multi-node-mix-tests:
     name: multi-node-mix-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-poc-single-node-tests-short-accuracy, nightly-poc-single-node-tests-short-performance, nightly-poc-multi-node-tests]
+    needs: [set-image-config, nightly-poc-single-node-a2-tests, nightly-poc-single-node-tests-performance, nightly-poc-single-node-tests-short-accuracy, nightly-poc-multi-node-tests]
     strategy:
       fail-fast: false
       # Mix cases also run serially (kimi_k2_6 uses 2 nodes each).
@@ -458,14 +446,15 @@ jobs:
       install_sglang_from_source: false
       prefill_decode_deployment: 'mix'
       transformers_version: ''
+
+
   check-all-jobs:
     if: ${{ !cancelled() }}
     needs:
       - nightly-poc-single-node-a2-tests
       - nightly-poc-single-node-tests-short-accuracy
-      - nightly-poc-single-node-tests-short-performance
+      - nightly-poc-single-node-tests-performance
       - nightly-poc-single-node-tests-long-accuracy
-      - nightly-poc-single-node-tests-long-performance
       - nightly-poc-multi-node-tests
       - nightly-poc-multi-node-mix-tests
     runs-on: ubuntu-latest
@@ -489,9 +478,8 @@ jobs:
 
           single_result_a2="${{ needs.nightly-poc-single-node-a2-tests.result }}"
           short_acc_result="${{ needs.nightly-poc-single-node-tests-short-accuracy.result }}"
-          short_perf_result="${{ needs.nightly-poc-single-node-tests-short-performance.result }}"
+          perf_result="${{ needs.nightly-poc-single-node-tests-performance.result }}"
           long_acc_result="${{ needs.nightly-poc-single-node-tests-long-accuracy.result }}"
-          long_perf_result="${{ needs.nightly-poc-single-node-tests-long-performance.result }}"
           multi_result="${{ needs.nightly-poc-multi-node-tests.result }}"
           mix_result="${{ needs.nightly-poc-multi-node-mix-tests.result }}"
 
@@ -511,9 +499,8 @@ jobs:
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| single-node-poc-a2 | $(group_icon ${single_result_a2}) ${single_result_a2} |" >> $GITHUB_STEP_SUMMARY
           echo "| single-node-poc-short-accuracy | $(group_icon ${short_acc_result}) ${short_acc_result} |" >> $GITHUB_STEP_SUMMARY
-          echo "| single-node-poc-short-performance | $(group_icon ${short_perf_result}) ${short_perf_result} |" >> $GITHUB_STEP_SUMMARY
+          echo "| single-node-poc-performance | $(group_icon ${perf_result}) ${perf_result} |" >> $GITHUB_STEP_SUMMARY
           echo "| single-node-poc-long-accuracy | $(group_icon ${long_acc_result}) ${long_acc_result} |" >> $GITHUB_STEP_SUMMARY
-          echo "| single-node-poc-long-performance | $(group_icon ${long_perf_result}) ${long_perf_result} |" >> $GITHUB_STEP_SUMMARY
           echo "| multi-node-poc | $(group_icon ${multi_result}) ${multi_result} |" >> $GITHUB_STEP_SUMMARY
           echo "| multi-node-mix-poc | $(group_icon ${mix_result}) ${mix_result} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -554,9 +541,9 @@ jobs:
           FAIL=0
           if [ "${single_result_a2}" != "success" ] && [ "${single_result_a2}" != "skipped" ]; then FAIL=1; fi
           if [ "${short_acc_result}" != "success" ] && [ "${short_acc_result}" != "skipped" ]; then FAIL=1; fi
-          if [ "${short_perf_result}" != "success" ] && [ "${short_perf_result}" != "skipped" ]; then FAIL=1; fi
+          if [ "${perf_result}" != "success" ] && [ "${perf_result}" != "skipped" ]; then FAIL=1; fi
           if [ "${long_acc_result}" != "success" ] && [ "${long_acc_result}" != "skipped" ]; then FAIL=1; fi
-          if [ "${long_perf_result}" != "success" ] && [ "${long_perf_result}" != "skipped" ]; then FAIL=1; fi
           if [ "${multi_result}" != "success" ] && [ "${multi_result}" != "skipped" ]; then FAIL=1; fi
           if [ "${mix_result}" != "success" ] && [ "${mix_result}" != "skipped" ]; then FAIL=1; fi
           exit $FAIL
+

--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -192,7 +192,7 @@ jobs:
     needs: [set-image-config]
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 6
       matrix:
         test_config:
           # Performance test cases with an average execution time of no more than 1.5h
@@ -381,11 +381,9 @@ jobs:
     needs: [set-image-config, nightly-poc-single-node-tests-short-accuracy, nightly-poc-single-node-tests-short-performance]
     strategy:
       fail-fast: false
-      # Run up to 2 multi-node cases in parallel to cut the serial wall time
-      # (glm5_1 alone takes ~3h each). Requires the NPU cluster to have enough
-      # free resources for 2 concurrent multi-node deployments (glm5_1 uses
-      # 32 NPUs across prefill/decode/router nodes); tune per cluster capacity.
-      max-parallel: 2
+      # Multi-node cases must run strictly serially: the NPU cluster can only
+      # host one multi-node deployment at a time.
+      max-parallel: 1
       matrix:
         test_config:
           # glm5_1 performance tests
@@ -437,8 +435,8 @@ jobs:
     needs: [set-image-config, nightly-poc-single-node-tests-short-accuracy, nightly-poc-single-node-tests-short-performance, nightly-poc-multi-node-tests]
     strategy:
       fail-fast: false
-      # Run up to 2 mix cases in parallel (kimi_k2_6 uses 2 nodes each).
-      max-parallel: 2
+      # Mix cases also run serially (kimi_k2_6 uses 2 nodes each).
+      max-parallel: 1
       matrix:
         test_config:
           # kimi_k2_6 performance tests

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -802,6 +802,25 @@ def assert_metrics(self, metrics):
     if not metrics:
         raise Exception("No metrics obtained from benchmark")
 
+    # Fail loudly when the benchmark produced no usable metrics, instead of
+    # crashing later with a cryptic TypeError on float(None).
+    required_metrics = {
+        "mean_tpot": self.tpot,
+        "total_tps": self.output_token_throughput,
+        "mean_ttft": self.ttft,
+        "mean_e2e_latency": self.mean_e2e_latency,
+    }
+    missing = [
+        name
+        for name, expected in required_metrics.items()
+        if expected is not None and metrics.get(name) is None
+    ]
+    if missing:
+        raise Exception(
+            "Benchmark produced no valid metrics, missing: "
+            f"{missing}. Got: {metrics}"
+        )
+
     tc_name = self.__class__.__name__
     if self.tpot and metrics.get("mean_tpot"):
         dump_metric(


### PR DESCRIPTION
## Motivation

The nightly NPU test pipeline wall-clock time is dominated by several long-running single-node test cases (up to ~4.8h). Multi-node tests currently only start after all single-node cases finish, wasting execution time. In addition, leaked sglang server processes can keep CI steps from terminating even after the test reports success, and benchmark failures can be reported in ways that leave the job hanging until the step timeout.

## Modifications

- Split `single-node-poc` into three jobs by test type (durations refreshed from the latest nightly runs):
  - `single-node-poc-short-accuracy`: 13 accuracy cases (average duration <= 1.5h)
  - `single-node-poc-performance`: 24 performance cases (all single-node performance cases, merged from the previous short/long split)
  - `single-node-poc-long-accuracy`: 3 accuracy cases (average duration > 1.5h)
- `multi-node-poc` and `multi-node-mix-poc` now only wait for the a2, performance and short-accuracy jobs, so they start earlier while the long single-node cases still run. The two multi-node jobs run strictly serially (`max-parallel: 1`).
- Concurrency: a2-tests `max-parallel: 3`, performance `max-parallel: 4`, short-accuracy `max-parallel: 4`, long-accuracy `max-parallel: 3`. Job display order is a2, performance, short-accuracy, long-accuracy, multi-node, multi-node-mix.
- `check-all-jobs` aggregates results from all single-node groups and includes multi-node / multi-node-mix results in the FAIL gate.
- Multi-node E2E cleanup steps (`Clear resources`, `Post process`) now have a step timeout and a bounded wait loop that fails fast instead of looping forever when pods cannot be cleaned up.
- The single-node E2E `Run test` step now captures test output to a file and streams it live instead of using a `| tee` pipeline, so a leaked child process can no longer block the step until the 5h timeout.
- Perf metrics assertion now fails loudly with a clear message when the benchmark produces no usable metrics, instead of crashing with a cryptic `TypeError` on `float(None)`.

## Accuracy Tests

N/A - this PR does not touch any model or kernel code.

## Speed Tests and Profiling

N/A - this PR changes CI scheduling and test-lifecycle logic only. Expected effect: reduced pipeline wall-clock time by overlapping long-running single-node cases with multi-node tests, and no more hanging jobs caused by leaked server processes or missing benchmark metrics.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30741577084](https://github.com/sgl-project/sglang/actions/runs/30741577084)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30741576978](https://github.com/sgl-project/sglang/actions/runs/30741576978)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->