### PR TITLE
[CI] Fix runtime context setup in flat logprob tests

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2016,7 +2016,7 @@ class Scheduler(
             draft_worker=self.draft_worker,
             model_worker=self.model_worker,
             logprob_result_processor=SchedulerLogprobResultProcessor(
-                server_args=self.server_args, model_config=self.model_config
+                model_config=self.model_config
             ),
             output_streamer=self.output_streamer,
             abort_request=self.abort_request,

--- a/python/sglang/srt/managers/scheduler_components/logprob_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/logprob_result_processor.py
@@ -14,17 +14,13 @@ from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.io_struct import build_flat_input_top_logprobs_arrays
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.runtime_context import get_exec
-from sglang.srt.server_args import (
-    MIS_DELIMITER_TOKEN_ID,
-    ServerArgs,
-)
+from sglang.srt.server_args import MIS_DELIMITER_TOKEN_ID
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(kw_only=True, slots=True, frozen=True)
 class SchedulerLogprobResultProcessor:
-    server_args: ServerArgs
     model_config: ModelConfig
 
     def _process_input_token_logprobs(

--- a/test/registered/unit/managers/test_flat_raw_top_logprobs.py
+++ b/test/registered/unit/managers/test_flat_raw_top_logprobs.py
@@ -19,6 +19,7 @@ from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
+from sglang.srt import runtime_context as rc
 from sglang.srt.managers.io_struct import (
     BatchTokenIDOutput,
     GenerateReqInput,
@@ -38,6 +39,7 @@ from sglang.srt.managers.tokenizer_manager import (
 )
 from sglang.srt.observability.req_time_stats import APIServerReqTimeStats
 from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
@@ -318,9 +320,8 @@ class TestB64MetaInfo(CustomTestCase):
 
 
 def _make_logprob_processor() -> SchedulerLogprobResultProcessor:
-    # The processor only reads enable_mis and vocab_size from these.
     return SchedulerLogprobResultProcessor(
-        server_args=SimpleNamespace(enable_mis=False),
+        server_args=rc.get_context().server_args,
         model_config=SimpleNamespace(vocab_size=1_000_000),
     )
 
@@ -340,6 +341,12 @@ _SCHED_IDX_ROWS = [[11, 22], [33, 44], [55, 66], [77, 88], [99, 100]]
 
 class TestSchedulerFlatAssembly(CustomTestCase):
     """Scheduler-side flat assembly in the logprob result processor."""
+
+    def setUp(self):
+        rc.publish(ServerArgs(model_path="dummy"), role="test")
+
+    def tearDown(self):
+        rc.reset_context()
 
     def _make_req(self, flat: bool, num_tokens: int = 5) -> Req:
         return Req(

--- a/test/registered/unit/managers/test_flat_raw_top_logprobs.py
+++ b/test/registered/unit/managers/test_flat_raw_top_logprobs.py
@@ -39,7 +39,6 @@ from sglang.srt.managers.tokenizer_manager import (
 )
 from sglang.srt.observability.req_time_stats import APIServerReqTimeStats
 from sglang.srt.sampling.sampling_params import SamplingParams
-from sglang.srt.server_args import ServerArgs
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
@@ -320,8 +319,8 @@ class TestB64MetaInfo(CustomTestCase):
 
 
 def _make_logprob_processor() -> SchedulerLogprobResultProcessor:
+    # enable_mis comes from the published exec bag, not from here; see setUp.
     return SchedulerLogprobResultProcessor(
-        server_args=rc.get_context().server_args,
         model_config=SimpleNamespace(vocab_size=1_000_000),
     )
 
@@ -343,10 +342,12 @@ class TestSchedulerFlatAssembly(CustomTestCase):
     """Scheduler-side flat assembly in the logprob result processor."""
 
     def setUp(self):
-        rc.publish(ServerArgs(model_path="dummy"), role="test")
+        super().setUp()
+        self._server_args_override = rc.get_context().override_server_args()
+        self._server_args_override.install()
 
     def tearDown(self):
-        rc.reset_context()
+        self._server_args_override.restore()
 
     def _make_req(self, flat: bool, num_tokens: int = 5) -> Req:
         return Req(


### PR DESCRIPTION
## Summary

Fixes the test failure exposed when #32223 landed after #33013 by publishing the runtime config expected by the migrated namespace accessor


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30685714133](https://github.com/sgl-project/sglang/actions/runs/30685714133)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30685714061](https://github.com/sgl-project/sglang/actions/runs/30685714061)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->