### PR TITLE
Harden Kimi K3 parser edge cases

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -176,6 +176,19 @@ def neutralize_kimi_k3_image_placeholder(text: str) -> str:
     return text.replace(KIMI_K3_IMAGE_PLACEHOLDER, KIMI_K3_IMAGE_PLACEHOLDER_ESCAPED)
 
 
+def neutralize_kimi_k3_image_placeholder_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return neutralize_kimi_k3_image_placeholder(value)
+    if isinstance(value, list):
+        return [neutralize_kimi_k3_image_placeholder_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: neutralize_kimi_k3_image_placeholder_value(item)
+            for key, item in value.items()
+        }
+    return value
+
+
 class OpenAIServingChat(OpenAIServingBase):
     """Handler for /v1/chat/completions requests"""
 
@@ -384,6 +397,25 @@ class OpenAIServingChat(OpenAIServingBase):
             elif content is None:
                 message["content"] = ""
 
+            if message.get("role") == "assistant":
+                for key in ("reasoning_content", "reasoning"):
+                    if key in message:
+                        message[key] = neutralize_kimi_k3_image_placeholder_value(
+                            message[key]
+                        )
+                for tool_call in message.get("tool_calls") or []:
+                    function = (
+                        tool_call.get("function")
+                        if isinstance(tool_call, dict)
+                        else None
+                    )
+                    if isinstance(function, dict) and "arguments" in function:
+                        function["arguments"] = (
+                            neutralize_kimi_k3_image_placeholder_value(
+                                function["arguments"]
+                            )
+                        )
+
             source = request.messages[index]
             if (
                 isinstance(source, ChatCompletionMessageGenericParam)
@@ -460,7 +492,9 @@ class OpenAIServingChat(OpenAIServingBase):
             template_kwargs = dict(request.chat_template_kwargs or {})
             template_kwargs.pop("tokenize", None)
             template_kwargs.pop("return_dict", None)
-            template_kwargs["image_prompts"] = ["<|media_pad|>"] * image_count
+            template_kwargs.pop("image_prompts", None)
+            if image_count:
+                template_kwargs["image_prompts"] = ["<|media_pad|>"] * image_count
 
             if (
                 request.reasoning_effort in ("low", "high", "max")

--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -11,6 +11,18 @@ CALL_OPEN = "<|open|>call"
 CALL_CLOSE = "<|close|>call<|sep|>"
 ARGUMENT_CLOSE = "<|close|>argument<|sep|>"
 
+# max_tokens can stop after an XTML control token or channel name, before <|sep|>.
+_PARTIAL_MARKER_SUFFIXES = (
+    "<|open|>",
+    "<|close|>",
+    THINK_CLOSE.removesuffix("<|sep|>"),
+    RESPONSE_OPEN.removesuffix("<|sep|>"),
+    RESPONSE_CLOSE.removesuffix("<|sep|>"),
+    TOOLS_OPEN.removesuffix("<|sep|>"),
+    TOOLS_CLOSE.removesuffix("<|sep|>"),
+    MESSAGE_CLOSE.removesuffix("<|sep|>"),
+)
+
 
 def partial_suffix_len(text: str, markers: List[str]) -> int:
     best = 0
@@ -20,6 +32,13 @@ def partial_suffix_len(text: str, markers: List[str]) -> int:
                 best = length
                 break
     return best
+
+
+def strip_partial_marker_suffix(text: str) -> str:
+    for suffix in _PARTIAL_MARKER_SUFFIXES:
+        if text.endswith(suffix):
+            return text[: -len(suffix)]
+    return text
 
 
 def strip_response_wrappers(text: str) -> str:
@@ -32,4 +51,5 @@ def strip_response_wrappers(text: str) -> str:
             text = text[open_idx + len(RESPONSE_OPEN) :]
     else:
         text = text.replace(RESPONSE_CLOSE, "")
-    return text.replace(MESSAGE_CLOSE, "")
+    text = text.replace(MESSAGE_CLOSE, "")
+    return strip_partial_marker_suffix(text)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -20,6 +20,7 @@ from sglang.srt.function_call.kimik3_format import (
     THINK_OPEN,
     TOOLS_OPEN,
     partial_suffix_len,
+    strip_partial_marker_suffix,
     strip_response_wrappers,
 )
 from sglang.srt.parser.harmony_parser import HarmonyParser
@@ -429,9 +430,6 @@ class KimiK2Detector(BaseReasoningFormatDetector):
         )
 
 
-_THINK_CLOSE_WITHOUT_SEP = THINK_CLOSE.split("<|sep|>")[0]
-
-
 class KimiK3Detector(BaseReasoningFormatDetector):
     """Detector for the Kimi K3 XTML think channel.
 
@@ -495,10 +493,6 @@ class KimiK3Detector(BaseReasoningFormatDetector):
         ]
         return min(found) if found else -1
 
-    @staticmethod
-    def _strip_dangling_think_close(text: str) -> str:
-        return text.removesuffix(_THINK_CLOSE_WITHOUT_SEP)
-
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         in_reasoning = self._in_reasoning or self.think_start_token in text
         if not in_reasoning and self.think_end_token not in text:
@@ -511,13 +505,11 @@ class KimiK3Detector(BaseReasoningFormatDetector):
             channel_idx = self._next_channel_idx(text, start)
             if channel_idx != -1:
                 return StreamingParseResult(
-                    reasoning_text=self._strip_dangling_think_close(
-                        text[start:channel_idx]
-                    ),
+                    reasoning_text=strip_partial_marker_suffix(text[start:channel_idx]),
                     normal_text=self._clean_content(text[channel_idx:]),
                 )
             return StreamingParseResult(
-                reasoning_text=self._strip_dangling_think_close(text[start:])
+                reasoning_text=strip_partial_marker_suffix(text[start:])
             )
 
         reasoning_text = text[start:close_idx]
@@ -562,7 +554,7 @@ class KimiK3Detector(BaseReasoningFormatDetector):
 
             channel_idx = self._next_channel_idx(buf)
             if channel_idx != -1:
-                reasoning_text = self._strip_dangling_think_close(buf[:channel_idx])
+                reasoning_text = strip_partial_marker_suffix(buf[:channel_idx])
                 self._buffer = buf[channel_idx:]
                 self._in_reasoning = False
                 self._reasoning_done = True
@@ -581,7 +573,7 @@ class KimiK3Detector(BaseReasoningFormatDetector):
                 markers.append(self.think_start_token)
             holdback = partial_suffix_len(buf, markers)
             emit = buf[: len(buf) - holdback] if holdback else buf
-            emit = self._strip_dangling_think_close(emit)
+            emit = strip_partial_marker_suffix(emit)
             self._buffer = buf[len(emit) :]
             return StreamingParseResult(reasoning_text=emit)
 

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -771,6 +771,24 @@ class ServingChatTestCase(unittest.TestCase):
                         {"type": "image_url", "image_url": {"url": "image-1"}},
                     ],
                 },
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "Inspect <|kimi_image_placeholder|>",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "inspect",
+                                "arguments": {
+                                    "source": "<|kimi_image_placeholder|>",
+                                    "nested": ["<|kimi_image_placeholder|>"],
+                                },
+                            },
+                        }
+                    ],
+                },
             ],
             tools=[tool],
             tool_choice="required",
@@ -797,6 +815,17 @@ class ServingChatTestCase(unittest.TestCase):
             rendered_messages[1]["content"][0]["text"],
             "Explain <| kimi_image_placeholder |>",
         )
+        self.assertEqual(
+            rendered_messages[2]["reasoning_content"],
+            "Inspect <| kimi_image_placeholder |>",
+        )
+        self.assertEqual(
+            rendered_messages[2]["tool_calls"][0]["function"]["arguments"],
+            {
+                "source": "<| kimi_image_placeholder |>",
+                "nested": ["<| kimi_image_placeholder |>"],
+            },
+        )
         self.assertEqual(call.kwargs["image_prompts"], ["<|media_pad|>"])
         self.assertEqual(call.kwargs["tool_choice"], "required")
         self.assertNotIn("strict", call.kwargs["tools"][0]["function"])
@@ -808,7 +837,7 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(result.prompt_ids, [7, 8, 9])
         self.assertEqual(result.image_data[0].url, "image-1")
 
-    def test_kimi_k3_preserves_assistant_history_and_raw_arguments(self):
+    def test_kimi_k3_neutralizes_text_only_assistant_history(self):
         self.template_manager.chat_template_name = None
         self.chat.chat_encoding_spec = "kimi_k3"
         self.tm.tokenizer.apply_chat_template.return_value = [1, 2, 3]
@@ -819,13 +848,14 @@ class ServingChatTestCase(unittest.TestCase):
                 {
                     "role": "assistant",
                     "content": None,
+                    "reasoning_content": "Read <|kimi_image_placeholder|>",
                     "tool_calls": [
                         {
                             "id": "call-1",
                             "type": "function",
                             "function": {
                                 "name": "shell",
-                                "arguments": "not-json",
+                                "arguments": "not-json <|kimi_image_placeholder|>",
                             },
                         }
                     ],
@@ -836,10 +866,17 @@ class ServingChatTestCase(unittest.TestCase):
         self.chat._process_messages(request, is_multimodal=False)
 
         messages = self.tm.tokenizer.apply_chat_template.call_args.args[0]
+        kwargs = self.tm.tokenizer.apply_chat_template.call_args.kwargs
         self.assertEqual(messages[-1]["role"], "assistant")
         self.assertEqual(
-            messages[-1]["tool_calls"][0]["function"]["arguments"], "not-json"
+            messages[-1]["reasoning_content"],
+            "Read <| kimi_image_placeholder |>",
         )
+        self.assertEqual(
+            messages[-1]["tool_calls"][0]["function"]["arguments"],
+            "not-json <| kimi_image_placeholder |>",
+        )
+        self.assertNotIn("image_prompts", kwargs)
 
     def test_message_tools_participate_in_validation(self):
         tool = {

--- a/test/registered/unit/parser/test_kimik3_reasoning_parser.py
+++ b/test/registered/unit/parser/test_kimik3_reasoning_parser.py
@@ -84,6 +84,40 @@ def test_non_stream_recovers_missing_think_separator() -> None:
     assert result.normal_text == "reply"
 
 
+@pytest.mark.parametrize(
+    ("text", "reasoning", "content"),
+    [
+        ("deep thought<|close|>", "deep thought", ""),
+        ("deep thought<|close|>think", "deep thought", ""),
+        (f"{THINK_CLOSE}<|open|>", "", ""),
+        (f"{THINK_CLOSE}<|open|>response", "", ""),
+        (
+            f"{THINK_CLOSE}{RESPONSE_OPEN}the answer<|close|>response",
+            "",
+            "the answer",
+        ),
+        (
+            f"{THINK_CLOSE}{RESPONSE_OPEN}the answer{RESPONSE_CLOSE}<|close|>message",
+            "",
+            "the answer",
+        ),
+    ],
+)
+def test_non_stream_strips_partial_marker_suffixes(
+    text: str, reasoning: str, content: str
+) -> None:
+    result = KimiK3Detector(force_reasoning=True).detect_and_parse(text)
+    assert result.reasoning_text == reasoning
+    assert result.normal_text == content
+
+
+def test_non_stream_preserves_non_marker_angle_bracket_suffix() -> None:
+    result = KimiK3Detector(force_reasoning=True).detect_and_parse(
+        f"{THINK_CLOSE}{RESPONSE_OPEN}answer <3"
+    )
+    assert result.normal_text == "answer <3"
+
+
 @pytest.mark.parametrize("chunk_size", [1, 4, 13])
 def test_streaming_split_markers(chunk_size: int) -> None:
     detector = KimiK3Detector(force_reasoning=True)


### PR DESCRIPTION
Stacked on #33025.

## Summary

- neutralize Kimi K3 image placeholders in assistant reasoning and nested tool-call arguments before chat-template rendering
- rebuild `image_prompts` from the current request images instead of preserving stale user-provided values
- strip partial XTML control-marker suffixes when generation stops mid-marker

## Tests

- `pre-commit run --files` on all changed files
- focused devbox suites: 177 passed, 34 subtests passed
- `python3 -m py_compile` on all changed files

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30687826006](https://github.com/sgl-project/sglang/actions/runs/30687826006)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30687825929](https://github.com/sgl-project/sglang/actions/runs/30687825929)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->