### PR TITLE
[Test] Add unit tests for poll_based_barrier

### DIFF
--- a/test/registered/unit/utils/test_poll_based_barrier.py
+++ b/test/registered/unit/utils/test_poll_based_barrier.py
@@ -1,0 +1,97 @@
+"""Unit tests for PollBasedBarrier without a live distributed process group."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.srt.utils.poll_based_barrier as barrier_module
+from sglang.srt.utils.poll_based_barrier import PollBasedBarrier
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _TwoRankAllReduce:
+    """Deterministic two-rank MIN collective used by the state-machine tests."""
+
+    def __init__(self, peer_arrivals):
+        self._peer_arrivals = iter(peer_arrivals)
+        self.calls = []
+
+    def __call__(self, tensor, op, group):
+        local_arrived = bool(tensor.item())
+        peer_arrived = next(self._peer_arrivals)
+        self.calls.append((local_arrived, op, group))
+        tensor.fill_(local_arrived and peer_arrived)
+
+
+class TestPollBasedBarrier(CustomTestCase):
+    def setUp(self):
+        self.cpu_group = object()
+        world_group = SimpleNamespace(cpu_group=self.cpu_group)
+        self._world_group_patch = patch.object(
+            barrier_module, "get_world_group", return_value=world_group
+        )
+        self._world_group_patch.start()
+        self.addCleanup(self._world_group_patch.stop)
+
+    def test_waits_for_peer_then_resets_for_next_round(self):
+        collective = _TwoRankAllReduce([False, True, True])
+        barrier = PollBasedBarrier()
+
+        barrier.local_arrive()
+        with patch.object(torch.distributed, "all_reduce", collective):
+            self.assertFalse(barrier.poll_global_arrived())
+
+            # A rank cannot enter the next round while this round is pending.
+            with self.assertRaises(AssertionError):
+                barrier.local_arrive()
+
+            self.assertTrue(barrier.poll_global_arrived())
+
+            # Completion resets local state, so the barrier is reusable.
+            barrier.local_arrive()
+            self.assertTrue(barrier.poll_global_arrived())
+
+        self.assertEqual([call[0] for call in collective.calls], [True, True, True])
+
+    def test_local_arrival_is_required_for_completion(self):
+        collective = _TwoRankAllReduce([True, True])
+        barrier = PollBasedBarrier()
+
+        with patch.object(torch.distributed, "all_reduce", collective):
+            self.assertFalse(barrier.poll_global_arrived())
+            barrier.local_arrive()
+            self.assertTrue(barrier.poll_global_arrived())
+
+        self.assertEqual([call[0] for call in collective.calls], [False, True])
+
+    def test_uses_min_reduction_on_cpu_world_group(self):
+        collective = _TwoRankAllReduce([True])
+        barrier = PollBasedBarrier()
+        barrier.local_arrive()
+
+        with patch.object(torch.distributed, "all_reduce", collective):
+            self.assertTrue(barrier.poll_global_arrived())
+
+        _, op, group = collective.calls[0]
+        self.assertIs(op, torch.distributed.ReduceOp.MIN)
+        self.assertIs(group, self.cpu_group)
+
+    def test_noop_participates_without_signaling_completion(self):
+        collective = _TwoRankAllReduce([True])
+        barrier = PollBasedBarrier(noop=True)
+
+        with patch.object(torch.distributed, "all_reduce", collective):
+            self.assertFalse(barrier.poll_global_arrived())
+
+        # Noop ranks contribute an arrived value to avoid blocking active ranks,
+        # but do not report a local completion to their caller.
+        self.assertTrue(collective.calls[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Add direct unit-test coverage for `srt/utils/poll_based_barrier.py` as part of #20865. The class previously had no focused tests, even though its reset behavior coordinates request unblocking across ranks.

## Modifications

- Add four CPU unit tests for local/global arrival, delayed peer arrival, reset and reuse across rounds, duplicate-arrival rejection, noop behavior, and collective wiring.
- Use a deterministic two-rank `MIN` collective that mutates the real boolean tensor, so the tests exercise `PollBasedBarrier` state transitions without starting a distributed process group, server, or model.
- Register the test in `base-a-test-cpu`.

## Test Results

```text
$ .venv/bin/python -m pytest test/registered/unit/utils/test_poll_based_barrier.py -v --disable-warnings
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-9.1.1, pluggy-1.6.0 -- /home/steven/sglang/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/steven/sglang/test
configfile: pytest.ini
plugins: asyncio-1.4.0, cov-7.1.0, anyio-4.12.1
asyncio: mode=auto, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 4 items

test/registered/unit/utils/test_poll_based_barrier.py::TestPollBasedBarrier::test_local_arrival_is_required_for_completion PASSED [ 25%]
test/registered/unit/utils/test_poll_based_barrier.py::TestPollBasedBarrier::test_noop_participates_without_signaling_completion PASSED [ 50%]
test/registered/unit/utils/test_poll_based_barrier.py::TestPollBasedBarrier::test_uses_min_reduction_on_cpu_world_group PASSED [ 75%]
test/registered/unit/utils/test_poll_based_barrier.py::TestPollBasedBarrier::test_waits_for_peer_then_resets_for_next_round PASSED [100%]

======================== 4 passed, 16 warnings in 4.24s ========================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

Branch coverage for `poll_based_barrier.py`: **100%** (20 statements, 2 branches). The test also passed 20 consecutive runs.

## Accuracy Tests

Not applicable; this is a CPU-only unit-test change and does not affect model outputs.

## Speed Tests and Profiling

Not applicable; this change does not modify runtime code.

## Checklist

- [x] Format code with pre-commit (all applicable hooks passed).
- [x] Add and register unit tests.
- [x] Documentation is not required for this test-only change.
- [x] Accuracy and speed testing are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30690966327](https://github.com/sgl-project/sglang/actions/runs/30690966327)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30690966222](https://github.com/sgl-project/sglang/actions/runs/30690966222)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->