### PR TITLE
[Fix] MiMo detector streaming: flush trailing text, survive split bot token

### DIFF
--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -203,14 +203,16 @@ class MiMoDetector(BaseFormatDetector):
 
         start = current_text.find(self.bot_token)
         if start == -1:
-            if self.current_tool_id > 0:
-                # Already processing tool calls, keep buffering
-                # (more tool calls might come, don't discard text yet)
-                return StreamingParseResult(normal_text="")
-            else:
-                # No tool calls seen yet, return as normal text
-                self._buffer = ""
-                return StreamingParseResult(normal_text=current_text)
+            # No complete bot token in the buffer. Hold back only a suffix
+            # that could be the start of a split bot token; flush the rest —
+            # unconditionally, so text after the last tool call still reaches
+            # the stream instead of being buffered forever.
+            partial_len = self._ends_with_partial_token(current_text, self.bot_token)
+            if partial_len:
+                self._buffer = current_text[-partial_len:]
+                return StreamingParseResult(normal_text=current_text[:-partial_len])
+            self._buffer = ""
+            return StreamingParseResult(normal_text=current_text)
 
         # Find end token AFTER the start token
         end = current_text.find(self.eot_token, start)

--- a/test/registered/unit/function_call/test_mimo_detector_streaming.py
+++ b/test/registered/unit/function_call/test_mimo_detector_streaming.py
@@ -1,0 +1,99 @@
+"""Streaming regression tests for srt/function_call/mimo_detector.py (#33186).
+
+No server, no model. Guards the equivalence contract between one-shot
+detect_and_parse and parse_streaming_increment that sibling detectors
+(Qwen25, GLM-4.7) already honor.
+"""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.mimo_detector import MiMoDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+TOOLS = [
+    Tool(
+        type="function",
+        function=Function(
+            name="search",
+            description="Search",
+            parameters={
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+            },
+        ),
+    ),
+]
+
+CALL_BLOCK = (
+    "<tool_call>\n<function=search>\n"
+    "<parameter=query>ls</parameter>\n</function>\n</tool_call>"
+)
+
+
+def _stream(detector, text, chunk_size):
+    normal = ""
+    calls = []
+    for i in range(0, len(text), chunk_size):
+        r = detector.parse_streaming_increment(text[i : i + chunk_size], TOOLS)
+        normal += r.normal_text
+        calls.extend(r.calls)
+    return normal, calls
+
+
+class TestMiMoStreamingRegression(CustomTestCase):
+    def test_text_after_last_tool_call_is_flushed(self):
+        """Bug regression (#33186): after the first parsed call, increments
+        with no further bot token were buffered forever, so anything the
+        model said after its last tool call was silently dropped from the
+        stream. Trailing text must still reach normal_text."""
+        detector = MiMoDetector()
+        r1 = detector.parse_streaming_increment(CALL_BLOCK, TOOLS)
+        self.assertEqual([c.name for c in r1.calls], ["search"])
+        r2 = detector.parse_streaming_increment("Done, files are listed.", TOOLS)
+        self.assertEqual(r2.normal_text, "Done, files are listed.")
+
+    def test_split_bot_token_across_increments_still_parses(self):
+        """Bug regression (#33186): a bot token split across increments was
+        flushed to normal_text as raw markup and the tool call was lost.
+        Only a potential marker suffix may be held back."""
+        detector = MiMoDetector()
+        r1 = detector.parse_streaming_increment("I will run it.\n<tool", TOOLS)
+        self.assertEqual(r1.normal_text, "I will run it.\n")
+        r2 = detector.parse_streaming_increment(CALL_BLOCK[len("<tool") :], TOOLS)
+        self.assertEqual([c.name for c in r2.calls], ["search"])
+        self.assertNotIn("<tool", r1.normal_text + r2.normal_text)
+
+    def test_char_level_streaming_matches_one_shot(self):
+        """Derived property: streamed output (concatenated normal_text plus
+        accumulated calls) must equal the one-shot parse of the same text,
+        regardless of chunk boundaries — the guarantee Qwen25/GLM-4.7
+        streaming already provides for the same wire format."""
+        text = "Let me check.\n" + CALL_BLOCK
+        one_shot = MiMoDetector().detect_and_parse(text, TOOLS)
+
+        streamed_normal, streamed_calls = _stream(MiMoDetector(), text, 1)
+        self.assertEqual(streamed_normal, one_shot.normal_text)
+        self.assertEqual(
+            [c.name for c in streamed_calls if c.name],
+            [c.name for c in one_shot.calls],
+        )
+        self.assertEqual(
+            "".join(c.parameters for c in streamed_calls if c.parameters),
+            "".join(c.parameters for c in one_shot.calls),
+        )
+
+    def test_text_between_two_calls_is_preserved(self):
+        """Completeness: interleaved normal text between two calls must not
+        be dropped or reordered once both calls have streamed."""
+        text = CALL_BLOCK + "\nand also\n" + CALL_BLOCK
+        streamed_normal, streamed_calls = _stream(MiMoDetector(), text, 7)
+        self.assertEqual(len([c for c in streamed_calls if c.name]), 2)
+        self.assertIn("and also", streamed_normal)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #33186: `MiMoDetector.parse_streaming_increment` diverged from its own one-shot `detect_and_parse` in two ways:

1. **Text after the last tool call was silently dropped.** Once a call had been parsed (`current_tool_id > 0`), every increment whose buffer contained no further `<tool_call>` returned `normal_text=""` and buffered forever — nothing drains the detector buffer at end of stream, so anything the model said after its final tool call never reached the client.
2. **A `<tool_call>` marker split across increments destroyed the call.** The no-marker branch flushed and cleared the whole buffer as normal text, so a partial marker prefix (`…<tool`) was streamed to the user as raw content and the call was never recognized.

## Modifications

`srt/function_call/mimo_detector.py` — replace the two-branch no-marker logic with the pattern `qwen25_detector.py` already uses for the same wire format: hold back only a suffix that could be the start of a split bot token (`_ends_with_partial_token`, base class), and flush everything else **unconditionally**.

`test/registered/unit/function_call/test_mimo_detector_streaming.py` — 4 CPU-only regression tests (trailing-text flush, split-marker survival, char-level streaming ≡ one-shot equivalence, interleaved text between two calls). Per the repo's unit-test admission bar, all 4 were verified to **fail on the pre-fix code**:

```
FAILED ...::test_text_after_last_tool_call_is_flushed              (pre-fix)
FAILED ...::test_split_bot_token_across_increments_still_parses    (pre-fix)
FAILED ...::test_char_level_streaming_matches_one_shot             (pre-fix)
FAILED ...::test_text_between_two_calls_is_preserved               (pre-fix)
```

## Testing

```bash
# command
pytest test/registered/unit/function_call/test_mimo_detector_streaming.py -v
# result (post-fix)
4 passed

# no regressions across the whole detector suite
pytest test/registered/unit/function_call/ -q
# 405 passed, 14 subtests passed
```

Also re-ran the one-shot vs chunked differential harness from #33186 across chunk sizes 1/3/7: streamed `normal_text` and accumulated call names/arguments now match the one-shot parse on all samples, including a `</parameter>` literal inside a parameter value.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30691157967](https://github.com/sgl-project/sglang/actions/runs/30691157967)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30691157875](https://github.com/sgl-project/sglang/actions/runs/30691157875)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->