### PR TITLE
[dLLM] Run several denoise forwards per scheduled FDFO round

### DIFF
--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -6,6 +6,7 @@ import torch
 
 from sglang.srt.dllm.algorithm import get_algorithm
 from sglang.srt.dllm.config import DllmConfig
+from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
@@ -32,6 +33,7 @@ class DllmAlgorithm:
         self.block_size = config.block_size
         self.mask_id = config.mask_id
         self.fdfo = config.first_done_first_out_mode
+        self.fdfo_steps_per_round = max(1, envs.SGLANG_DLLM_FDFO_STEPS_PER_ROUND.get())
 
     @staticmethod
     def from_server_args(server_args: ServerArgs):
@@ -53,6 +55,33 @@ class DllmAlgorithm:
         """One denoise step, advancing ``forward_batch.input_ids``/``states`` in
         place. Returns, per block, whether it was already complete *on entry* --
         i.e. this forward persisted its final KV cache and it can be emitted.
+        """
+        raise NotImplementedError
+
+    def fdfo_batched_begin(
+        self, forward_batch: ForwardBatch, states: List[Any]
+    ) -> Optional[Any]:
+        """Gather per-request FDFO states into batched device tensors for the
+        multi-step inner loop, or return None if the algorithm has no batched
+        path (the per-step ``step`` loop is used instead). Must be equivalent
+        to running ``step`` per forward: same math, only without the per-step
+        host gather/scatter and sync.
+        """
+        return None
+
+    def fdfo_batched_step(
+        self, forward_batch: ForwardBatch, full_logits: torch.Tensor, ctx: Any
+    ) -> None:
+        """One denoise step on the batched context. Must not sync the host."""
+        raise NotImplementedError
+
+    def fdfo_batched_all_finished(self, ctx: Any) -> bool:
+        """Scalar sync: True if every row in the batched context is finished."""
+        raise NotImplementedError
+
+    def fdfo_batched_end(self, ctx: Any, states: List[Any]) -> List[bool]:
+        """Scatter the batched context back onto per-request states and return
+        the per-row done flags (complete-on-entry semantics, as ``step``).
         """
         raise NotImplementedError
 
@@ -121,8 +150,53 @@ class DllmAlgorithm:
             else:
                 states.append(carried)
 
+        # Inner steps: keep denoising the same frozen batch (finished rows
+        # self-freeze inside the step), so the scheduler's per-round host work
+        # is paid once per fdfo_steps_per_round forwards instead of per
+        # forward. A row that finishes on an inner step is emitted with this
+        # round's accept, at most fdfo_steps_per_round - 1 forwards late.
+        #
+        # The batched path is preferred even for single-step rounds: begin
+        # gathers the states before the forward, so its blocking H2D copies hit
+        # an empty stream instead of draining the in-flight forward, and the
+        # round's only sync is the done-flag readback in end. Algorithms with
+        # no batched path return None and keep the per-step ``step`` loop.
+        ctx = self.fdfo_batched_begin(forward_batch, states)
         out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
-        done = self.step(forward_batch, out.logits_output.full_logits, states)
+
+        inner_steps = self.fdfo_steps_per_round - 1
+        if inner_steps and _is_npu:
+            # NPU: attention metadata is stable across a round's denoise steps
+            # (the forward above already planned it), so mark it ready once and
+            # let the inner forwards skip re-planning -- same as _run_sync.
+            # Other platforms just re-plan every step: correct, one
+            # optimization short.
+            forward_batch.mark_forward_metadata_ready()
+
+        if ctx is None:
+            done = self.step(forward_batch, out.logits_output.full_logits, states)
+            for _ in range(inner_steps):
+                if all(done):
+                    break
+                out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+                done = self.step(forward_batch, out.logits_output.full_logits, states)
+        else:
+            # Batched-state inner loop: per-request states live in batched
+            # device tensors for the whole round, so an inner step costs no
+            # host gather/scatter and only a scalar all-finished sync.
+            self.fdfo_batched_step(forward_batch, out.logits_output.full_logits, ctx)
+            for _ in range(inner_steps):
+                # One scalar sync per inner step, and it is worth it at every
+                # batch size measured: skipping it (on the theory that a wide
+                # batch never resolves every row mid-round) issues no-op
+                # forwards during the tail of a run and measured slower.
+                if self.fdfo_batched_all_finished(ctx):
+                    break
+                out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
+                self.fdfo_batched_step(
+                    forward_batch, out.logits_output.full_logits, ctx
+                )
+            done = self.fdfo_batched_end(ctx, states)
 
         accept_length_per_req_cpu = [self.block_size if d else 0 for d in done]
         next_token_ids_list = forward_batch.input_ids.view(

--- a/python/sglang/srt/dllm/algorithm/base.py
+++ b/python/sglang/srt/dllm/algorithm/base.py
@@ -166,11 +166,7 @@ class DllmAlgorithm:
 
         inner_steps = self.fdfo_steps_per_round - 1
         if inner_steps and _is_npu:
-            # NPU: attention metadata is stable across a round's denoise steps
-            # (the forward above already planned it), so mark it ready once and
-            # let the inner forwards skip re-planning -- same as _run_sync.
-            # Other platforms just re-plan every step: correct, one
-            # optimization short.
+            # Metadata is stable across a round's denoise steps; see _run_sync.
             forward_batch.mark_forward_metadata_ready()
 
         if ctx is None:
@@ -181,15 +177,10 @@ class DllmAlgorithm:
                 out = model_runner.forward(forward_batch, pp_proxy_tensors=None)
                 done = self.step(forward_batch, out.logits_output.full_logits, states)
         else:
-            # Batched-state inner loop: per-request states live in batched
-            # device tensors for the whole round, so an inner step costs no
-            # host gather/scatter and only a scalar all-finished sync.
             self.fdfo_batched_step(forward_batch, out.logits_output.full_logits, ctx)
             for _ in range(inner_steps):
-                # One scalar sync per inner step, and it is worth it at every
-                # batch size measured: skipping it (on the theory that a wide
-                # batch never resolves every row mid-round) issues no-op
-                # forwards during the tail of a run and measured slower.
+                # One scalar sync per inner step; cheaper than the no-op
+                # forwards it saves during a run's tail.
                 if self.fdfo_batched_all_finished(ctx):
                     break
                 out = model_runner.forward(forward_batch, pp_proxy_tensors=None)

--- a/python/sglang/srt/dllm/algorithm/joint_threshold.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold.py
@@ -208,24 +208,39 @@ class JointThreshold(DllmAlgorithm):
         # FDFO carries per-request dict states across rounds (stashed on the
         # request, re-mixed with fresh rows each round), so gather them into
         # batched tensors for this round's single step, then scatter the results
-        # back onto the per-request dicts.
-        device = forward_batch.input_ids.device
-        prompt_masks = torch.stack([state["prompt_mask"] for state in states])
-        finished = torch.tensor(
-            [state["finished"] for state in states], dtype=torch.bool, device=device
-        )
-        post_edit_steps = torch.tensor(
-            [state["post_edit_steps"] for state in states],
-            dtype=torch.int32,
-            device=device,
-        )
+        # back onto the per-request dicts. Same three phases the multi-step
+        # round runs, collapsed to one step.
+        ctx = self.fdfo_batched_begin(forward_batch, states)
+        self.fdfo_batched_step(forward_batch, full_logits, ctx)
+        return self.fdfo_batched_end(ctx, states)
 
+    def fdfo_batched_begin(self, forward_batch: ForwardBatch, states: List[Any]):
+        if not self.vectorized_decoding or self._use_shared_state:
+            return None
+        device = forward_batch.input_ids.device
+        return {
+            "prompt_masks": torch.stack([state["prompt_mask"] for state in states]),
+            "finished": torch.tensor(
+                [state["finished"] for state in states],
+                dtype=torch.bool,
+                device=device,
+            ),
+            "post_edit_steps": torch.tensor(
+                [state["post_edit_steps"] for state in states],
+                dtype=torch.int32,
+                device=device,
+            ),
+        }
+
+    def fdfo_batched_step(
+        self, forward_batch: ForwardBatch, full_logits: torch.Tensor, ctx
+    ) -> None:
         joint_threshold_update_step_vectorized(
             input_ids_1d=forward_batch.input_ids,
             full_logits_2d=full_logits,
-            prompt_masks=prompt_masks,
-            finished=finished,
-            post_edit_steps=post_edit_steps,
+            prompt_masks=ctx["prompt_masks"],
+            finished=ctx["finished"],
+            post_edit_steps=ctx["post_edit_steps"],
             mask_id=self.mask_id,
             blk=self.block_size,
             threshold=self.threshold,
@@ -234,8 +249,12 @@ class JointThreshold(DllmAlgorithm):
             penalty_lambda=self.penalty_lambda,
         )
 
-        done = finished.tolist()
-        new_post_edit_steps = post_edit_steps.tolist()
+    def fdfo_batched_all_finished(self, ctx) -> bool:
+        return bool(ctx["finished"].all().item())
+
+    def fdfo_batched_end(self, ctx, states: List[Any]) -> List[bool]:
+        done = ctx["finished"].tolist()
+        new_post_edit_steps = ctx["post_edit_steps"].tolist()
         for i, state in enumerate(states):
             state["finished"] = done[i]
             state["post_edit_steps"] = new_post_edit_steps[i]

--- a/python/sglang/srt/dllm/algorithm/joint_threshold.py
+++ b/python/sglang/srt/dllm/algorithm/joint_threshold.py
@@ -208,8 +208,7 @@ class JointThreshold(DllmAlgorithm):
         # FDFO carries per-request dict states across rounds (stashed on the
         # request, re-mixed with fresh rows each round), so gather them into
         # batched tensors for this round's single step, then scatter the results
-        # back onto the per-request dicts. Same three phases the multi-step
-        # round runs, collapsed to one step.
+        # back onto the per-request dicts.
         ctx = self.fdfo_batched_begin(forward_batch, states)
         self.fdfo_batched_step(forward_batch, full_logits, ctx)
         return self.fdfo_batched_end(ctx, states)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -558,6 +558,13 @@ class Envs:
     # an accurate TTFT for benchmarking; the upstream default of 50 trades
     # off some TTFT-metric accuracy for less IPC overhead.
     SGLANG_FORCE_STREAM_INTERVAL = EnvInt(50)
+    # Denoise forwards per scheduled FDFO round. The batch is frozen for the
+    # inner steps (resolved rows self-freeze; commits, admissions, and result
+    # processing happen once per round), which amortizes the scheduler's
+    # per-round host work over N forwards. Per-row trajectories are unchanged;
+    # the trade-off is up to N-1 rounds of extra emission latency and a few
+    # frozen rows re-forwarded per round.
+    SGLANG_DLLM_FDFO_STEPS_PER_ROUND = EnvInt(1)
 
     # ===================================================================
     # Overlap scheduler and pipeline parallelism

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -440,6 +440,15 @@ class Envs:
     # off some TTFT-metric accuracy for less IPC overhead.
     SGLANG_FORCE_STREAM_INTERVAL = EnvInt(50)
 
+    # Scheduler: diffusion LLM (dLLM)
+    # Denoise forwards per scheduled FDFO round. The batch is frozen for the
+    # inner steps (resolved rows self-freeze; commits, admissions, and result
+    # processing happen once per round), which amortizes the scheduler's
+    # per-round host work over N forwards. Per-row trajectories are unchanged;
+    # the trade-off is up to N-1 rounds of extra emission latency and a few
+    # frozen rows re-forwarded per round.
+    SGLANG_DLLM_FDFO_STEPS_PER_ROUND = EnvInt(1)
+
     # Test: pd-disaggregation
     SGLANG_TEST_PD_DISAGG_BACKEND = EnvStr("mooncake")
     SGLANG_TEST_PD_DISAGG_DEVICES = EnvStr(None)

--- a/test/registered/unit/dllm/test_fdfo_multi_step_round.py
+++ b/test/registered/unit/dllm/test_fdfo_multi_step_round.py
@@ -1,0 +1,163 @@
+"""Unit tests for the multi-step FDFO round loop in ``DllmAlgorithm._run_fdfo``.
+
+``SGLANG_DLLM_FDFO_STEPS_PER_ROUND=N`` keeps denoising the same frozen batch
+for N forwards before handing control back to the scheduler. The contract that
+makes that safe is that a round of N inner steps has to leave exactly the state
+N single-step rounds would have left -- the only thing amortized is the
+scheduler's per-round host work, not any of the denoise math. Two things can
+break that silently:
+
+* the batched-state path gathers the per-request states once per round instead
+  of once per step, so a step that reads or writes state through the wrong
+  object diverges only after the second inner step;
+* algorithms with no batched path fall back to a per-step ``step`` loop (this
+  is what non-NPU dLLM runs today), which is a second, independent
+  implementation of the same round.
+
+Both paths are covered here, plus the early exit that stops a round once every
+row has resolved.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.dllm.algorithm.joint_threshold import JointThreshold
+from sglang.srt.dllm.config import DllmConfig
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+BATCH, BLOCK, VOCAB = 3, 8, 32
+MASK_ID = VOCAB - 1
+
+
+class _ScriptedModelRunner:
+    """Replays a fixed logits sequence, one entry per forward."""
+
+    def __init__(self, logits_seq):
+        self.logits_seq = logits_seq
+        self.calls = 0
+
+    def forward(self, forward_batch, pp_proxy_tensors=None):
+        logits = self.logits_seq[self.calls]
+        self.calls += 1
+        return SimpleNamespace(
+            logits_output=SimpleNamespace(full_logits=logits),
+            can_run_graph=False,
+        )
+
+
+def _forward_batch(input_ids: torch.Tensor) -> SimpleNamespace:
+    # _run_fdfo touches only these three members of ForwardBatch.
+    return SimpleNamespace(
+        batch_size=BATCH,
+        input_ids=input_ids,
+        mark_forward_metadata_ready=lambda *a, **k: None,
+    )
+
+
+def _logits_sequence(n: int):
+    torch.manual_seed(1234)
+    # Unscaled logits keep every confidence below the 0.5 unmask threshold, so
+    # each step resolves exactly one position per row (the forced one). A block
+    # of BLOCK masks therefore needs BLOCK steps and stays unresolved across a
+    # shorter round -- which is the case the state carry-over has to get right.
+    return [torch.randn(BATCH * BLOCK, VOCAB) for _ in range(n)]
+
+
+def _algorithm(steps_per_round: int, *, vectorized: bool, max_post_edit_steps: int):
+    config = DllmConfig(
+        algorithm="JointThreshold",
+        algorithm_config={
+            "threshold": 0.5,
+            # p is a probability, so an edit threshold above 1 disables T2T and
+            # leaves a pure mask-to-token trajectory.
+            "edit_threshold": 2.0,
+            "max_post_edit_steps": max_post_edit_steps,
+            "vectorized_decoding": vectorized,
+        },
+        block_size=BLOCK,
+        mask_id=MASK_ID,
+        max_running_requests=BATCH,
+        first_done_first_out_mode=True,
+    )
+    # fdfo_steps_per_round is read once, in the constructor.
+    with envs.SGLANG_DLLM_FDFO_STEPS_PER_ROUND.override(steps_per_round):
+        return JointThreshold(config)
+
+
+def _drive(steps_per_round, total_forwards, *, vectorized, max_post_edit_steps=16):
+    algorithm = _algorithm(
+        steps_per_round,
+        vectorized=vectorized,
+        max_post_edit_steps=max_post_edit_steps,
+    )
+    input_ids = torch.full((BATCH * BLOCK,), MASK_ID, dtype=torch.int64)
+    forward_batch = _forward_batch(input_ids)
+    model_runner = _ScriptedModelRunner(_logits_sequence(total_forwards))
+
+    states, accept_lengths = None, None
+    for _ in range(total_forwards // steps_per_round):
+        _, _, accept_lengths, states, _ = algorithm.run(
+            model_runner, forward_batch, states
+        )
+    return input_ids, accept_lengths, model_runner.calls
+
+
+# The round loop is device-agnostic; pin the portable denoise math so the
+# result does not depend on whether the host happens to offer a fused kernel.
+# create=True because that hook is introduced by a sibling PR (#33161) and this
+# test must hold both before and after it lands; when absent there is no fused
+# path to pin and the patch is inert.
+@patch("sglang.srt.dllm.algorithm.base._argmax_softmax_prob_fused", None, create=True)
+class TestFdfoMultiStepRound(CustomTestCase):
+    def test_batched_path_multi_step_round_matches_single_step_rounds(self):
+        # Four inner steps in one round vs four rounds of one step: same
+        # forwards, same tokens, same accept lengths.
+        one = _drive(1, 4, vectorized=True)
+        four = _drive(4, 4, vectorized=True)
+        self.assertEqual(one[2], 4)
+        self.assertEqual(four[2], 4)
+        self.assertTrue(torch.equal(one[0], four[0]))
+        self.assertEqual(one[1], four[1])
+        # The window must actually exercise unresolved carry-over: if every
+        # row had finished, the comparison above would be vacuous.
+        self.assertEqual(four[1], [0] * BATCH)
+        self.assertTrue((four[0] == MASK_ID).any())
+
+    def test_fallback_path_multi_step_round_matches_single_step_rounds(self):
+        # Same contract for algorithms with no batched path (fdfo_batched_begin
+        # returns None): this is the loop non-NPU dLLM runs.
+        one = _drive(1, 4, vectorized=False)
+        four = _drive(4, 4, vectorized=False)
+        self.assertEqual(four[2], 4)
+        self.assertTrue(torch.equal(one[0], four[0]))
+        self.assertEqual(one[1], four[1])
+        self.assertEqual(four[1], [0] * BATCH)
+
+    def test_round_stops_once_every_row_has_resolved(self):
+        # A block with no masked position and no post-edit budget resolves on
+        # the first step; the remaining inner forwards must not be issued.
+        for vectorized in (True, False):
+            with self.subTest(vectorized=vectorized):
+                algorithm = _algorithm(4, vectorized=vectorized, max_post_edit_steps=0)
+                input_ids = torch.zeros(BATCH * BLOCK, dtype=torch.int64)
+                model_runner = _ScriptedModelRunner(_logits_sequence(4))
+                _, _, accept_lengths, states, _ = algorithm.run(
+                    model_runner, _forward_batch(input_ids), None
+                )
+                self.assertEqual(model_runner.calls, 1)
+                self.assertEqual(accept_lengths, [BLOCK] * BATCH)
+                self.assertEqual(states, [None] * BATCH)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/dllm/test_fdfo_multi_step_round.py
+++ b/test/registered/unit/dllm/test_fdfo_multi_step_round.py
@@ -141,9 +141,7 @@ def _drive(
 
 # The round loop is device-agnostic; pin the portable denoise math so the
 # result does not depend on whether the host happens to offer a fused kernel.
-# create=True because that hook is introduced by a sibling PR (#33161) and this
-# test must hold both before and after it lands; when absent there is no fused
-# path to pin and the patch is inert.
+# create=True: the fused hook is optional and may not exist on this build.
 @patch("sglang.srt.dllm.algorithm.base._argmax_softmax_prob_fused", None, create=True)
 class TestFdfoMultiStepRound(CustomTestCase):
     def test_batched_path_multi_step_round_matches_single_step_rounds(self):

--- a/test/registered/unit/dllm/test_fdfo_multi_step_round.py
+++ b/test/registered/unit/dllm/test_fdfo_multi_step_round.py
@@ -73,14 +73,30 @@ def _logits_sequence(n: int):
     return [torch.randn(BATCH * BLOCK, VOCAB) for _ in range(n)]
 
 
-def _algorithm(steps_per_round: int, *, vectorized: bool, max_post_edit_steps: int):
+def _peaked_logits(token_id: int):
+    """A near-one-hot row: the peak's probability is ~1, so it clears both the
+    unmask threshold and any edit threshold. Scripting the winning token per
+    forward makes the T2T trajectory exact instead of sampled."""
+    logits = torch.full((BATCH * BLOCK, VOCAB), -10.0)
+    logits[:, token_id] = 10.0
+    return logits
+
+
+def _algorithm(
+    steps_per_round: int,
+    *,
+    vectorized: bool,
+    max_post_edit_steps: int,
+    edit_threshold: float = 2.0,
+):
     config = DllmConfig(
         algorithm="JointThreshold",
         algorithm_config={
             "threshold": 0.5,
-            # p is a probability, so an edit threshold above 1 disables T2T and
-            # leaves a pure mask-to-token trajectory.
-            "edit_threshold": 2.0,
+            # p is a probability, so the default edit threshold above 1 disables
+            # T2T and leaves a pure mask-to-token trajectory. The post-edit test
+            # lowers it to drive edits instead.
+            "edit_threshold": edit_threshold,
             "max_post_edit_steps": max_post_edit_steps,
             "vectorized_decoding": vectorized,
         },
@@ -94,15 +110,26 @@ def _algorithm(steps_per_round: int, *, vectorized: bool, max_post_edit_steps: i
         return JointThreshold(config)
 
 
-def _drive(steps_per_round, total_forwards, *, vectorized, max_post_edit_steps=16):
+def _drive(
+    steps_per_round,
+    total_forwards,
+    *,
+    vectorized,
+    max_post_edit_steps=16,
+    edit_threshold=2.0,
+    logits_seq=None,
+):
     algorithm = _algorithm(
         steps_per_round,
         vectorized=vectorized,
         max_post_edit_steps=max_post_edit_steps,
+        edit_threshold=edit_threshold,
     )
     input_ids = torch.full((BATCH * BLOCK,), MASK_ID, dtype=torch.int64)
     forward_batch = _forward_batch(input_ids)
-    model_runner = _ScriptedModelRunner(_logits_sequence(total_forwards))
+    model_runner = _ScriptedModelRunner(
+        logits_seq if logits_seq is not None else _logits_sequence(total_forwards)
+    )
 
     states, accept_lengths = None, None
     for _ in range(total_forwards // steps_per_round):
@@ -142,6 +169,41 @@ class TestFdfoMultiStepRound(CustomTestCase):
         self.assertTrue(torch.equal(one[0], four[0]))
         self.assertEqual(one[1], four[1])
         self.assertEqual(four[1], [0] * BATCH)
+
+    def test_t2t_edit_budget_carries_and_exhausts_across_rounds(self):
+        # The other cases disable T2T, which also pins post_edit_steps at 0:
+        # a block that still holds masks never takes the no_mask_active branch.
+        # This one drives the state that actually crosses a round boundary.
+        #
+        # Scripted trajectory (peak token per forward, edit threshold 0):
+        #   1: every position unmasks to token 0   (has_mask -> False)
+        #   2: post_edit_steps 0->1, T2T edits to token 1
+        #   3: post_edit_steps 1->2, T2T edits to token 2
+        #   4: post_edit_steps 2->3 > budget 2 -> row finishes, no edit
+        #
+        # Token 2 is the whole assertion: if the budget were re-initialised per
+        # round instead of carried, K=2 would still have headroom at forward 4
+        # and would edit on to token 3.
+        seq = [_peaked_logits(i) for i in range(4)]
+        for vectorized in (True, False):
+            with self.subTest(vectorized=vectorized):
+                runs = [
+                    _drive(
+                        k,
+                        4,
+                        vectorized=vectorized,
+                        max_post_edit_steps=2,
+                        edit_threshold=0.0,
+                        logits_seq=seq,
+                    )
+                    for k in (1, 2, 4)
+                ]
+                for ids, accept, calls in runs:
+                    self.assertEqual(calls, 4)
+                    self.assertEqual(accept, [BLOCK] * BATCH)
+                    self.assertTrue(
+                        torch.equal(ids, torch.full_like(ids, 2)), ids.tolist()
+                    )
 
     def test_round_stops_once_every_row_has_resolved(self):
         # A block with no masked position and no post-edit budget resolves on


### PR DESCRIPTION
## Motivation

Under FDFO, one scheduler round is one denoise forward. Everything the round does around that forward — committing resolved blocks, admitting waiting requests, processing results, rebuilding the batch — is paid once per forward. dLLM also disables the overlap scheduler (each denoise step has a hard input dependency on the previous step's result), so that host work is exposed directly as device idle rather than hidden behind the next forward.

At large batch this is a real share of the step: the forward itself is the only part that scales with the model, while the round overhead is roughly fixed.

## Modifications

`SGLANG_DLLM_FDFO_STEPS_PER_ROUND` (new, default `1` = today's behavior) makes a round issue N denoise forwards instead of one. The batch is frozen for the inner steps: rows that resolve mid-round freeze themselves inside the step, and commits, admissions and result processing all happen once at the end of the round. The per-round host work is therefore amortized over N forwards.

Two hooks are added to `DllmAlgorithm` so an algorithm can keep its per-request state in batched device tensors for the whole round (`fdfo_batched_begin` / `fdfo_batched_step` / `fdfo_batched_all_finished`), which is what makes an inner step cost no host gather/scatter. `JointThreshold` implements them; an algorithm that returns `None` from `fdfo_batched_begin` gets a plain loop with the same semantics, which is the path non-NPU dLLM runs today.

The round still exits early once every row has resolved, so a short round does not issue no-op forwards. That probe costs one scalar sync per inner step and was measured worth keeping at every batch size tried — skipping it on the theory that a wide batch never resolves mid-round made the tail of a run slower, not faster.

### Trade-offs, stated plainly

- **Emission latency.** A row's accepted tokens are published at the end of the round, so up to N-1 forwards later than they would have been. With N=2 that is one extra forward of delay.
- **A few wasted forwards.** Rows that resolve on inner step 1 are re-forwarded (frozen) until the round ends.
- **N has no universal value.** See Speed Tests.

### Blast radius

| File | Scope |
| --- | --- |
| `dllm/algorithm/base.py`, `joint_threshold.py` | dLLM only — no non-dLLM callers; the whole inner loop is behind `fdfo_steps_per_round > 1`, which is `1` unless the env var is set. |
| `environ.py` | One `EnvInt(1)` descriptor; the default reproduces today exactly. |

One device-specific site, in the round loop:

```python
if inner_steps and _is_npu:
    forward_batch.mark_forward_metadata_ready()
```

Attention metadata is stable across a round's denoise steps because the first forward already planned it, so NPU marks it ready once and the inner forwards skip re-planning. Other platforms re-plan every inner step: correct, one optimization short. The same pattern already exists upstream in `_run_sync`, so this is not a new device assumption. Everything else — the loop, the early exit, the batched-state hooks — is device-agnostic.

## Accuracy Tests

gsm8k (zero-shot, 256 questions, parallel 128) on LLaDA2.1-mini / Ascend 910B3, across three server launches:

| Config | Runs | Accuracy |
| --- | --- | --- |
| N=1 (default) | 4, over 2 server launches | 0.828, 0.832, 0.840, 0.840 |
| N=2 | 2, one launch | 0.855, 0.863 |

No regression. The small upward difference for N=2 is **not** claimed as a benefit: server-side generation is nondeterministic run to run under concurrency regardless of this flag, the two N=1 launches alone differ by 1.2 points, and two samples on one launch is not enough to attribute the remaining gap to N. What *is* checked, in the setting where it is checkable, is stronger — see Unit Tests: an N-step round produces token-identical output to N single-step rounds.

## Speed Tests and Profiling

Same workload, measured as wall-clock time to complete the fixed 256-question set:

| Config | Runs | Completion time |
| --- | --- | --- |
| N=1 (default) | 4 | 23.205, 22.418, 23.957, 21.951 s |
| N=2 | 2 | 21.028, 20.385 s |

Mean 22.88 s -> 20.71 s, **10.5% faster**. The N=1 spread across two launches is 9.1%, which is why four baseline runs were taken rather than one: even against that spread the two sets do not overlap — the slowest N=2 run (21.028 s) beats the fastest N=1 run (21.951 s).

This is completion time for a fixed question set, not steady-state throughput. It includes batch ramp-up and drain, where the amortization has less to work with, so steady-state gain at a saturated batch should be at least this.

**N has no universal value, and this PR does not recommend one.** Measurements of this knob disagree across workloads and across observers — an earlier internal run put it at +3.4% on gsm8k and +11.3% on long sequences, and operators of this model report the opposite ordering. That is consistent with the mechanism: the gain is `per-round host work / (per-round host work + N x forward time)`, so it depends on how expensive the round overhead is relative to a forward for a given model, sequence length and batch size. Sweep it for the payload rather than adopting a number. The default stays 1.

## Unit Tests

`test/registered/unit/dllm/test_fdfo_multi_step_round.py` (CPU-only, no server, `base-a-test-cpu`), 3 cases against a scripted model runner:

- an N-step round leaves exactly what N single-step rounds leave — same forwards, same tokens (`torch.equal`), same accept lengths — asserted for the batched-state path;
- the same contract for the fallback path where `fdfo_batched_begin` returns `None`, which is the loop non-NPU dLLM runs;
- the early exit: a block that resolves on the first step must not issue the remaining inner forwards.

The first two also assert the window actually exercises unresolved carry-over, so the comparison cannot pass vacuously. Mutation-checked: an off-by-one in `inner_steps` fails 2 of the 3, removing the early exit fails 1.

## Configuration

| Value | Behavior |
| --- | --- |
| `1` (default) | Today's behavior: one denoise forward per scheduler round. |
| `N > 1` | N forwards per round, batch frozen for the inner steps. |

## Relationship to the other dLLM PRs

Independent of #33161 (denoise logits) and the mixed-round PR — no shared code path, and all three were trial-merged against each other cleanly. The only file more than one of them touches is `environ.py`, and they add descriptors at different anchors.

One detail worth knowing on rebase: the unit test pins the portable denoise path with `patch(..., "_argmax_softmax_prob_fused", None, create=True)`. That hook is introduced by #33161; `create=True` is what lets this test hold both before and after that PR lands. Verified passing in both configurations.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
