### PR TITLE
[Kimi K3] Keep native tool-call format when constraints fail

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1066,11 +1066,13 @@ class OpenAIServingChat(OpenAIServingBase):
                 required_parsed_natively = parser.detector.parses_required_natively()
                 if self.chat_encoding_spec == "kimi_k3":
                     tool_call_stop = parser.detector.eot_token
-            # Fallback: use generic JSON schema for required/named tool choice
-            # only when no parser-specific constraint was set
             if (
                 tool_call_constraint is None
                 and not required_parsed_natively
+                and not (
+                    self.chat_encoding_spec == "kimi_k3"
+                    and self.tool_call_parser == "kimi_k3"
+                )
                 and (
                     request.tool_choice == "required"
                     or isinstance(request.tool_choice, ToolChoice)

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -661,7 +661,7 @@ class ServingChatTestCase(unittest.TestCase):
                 parser.get_structure_constraint.call_args.kwargs["thinking_mode"]
             )
 
-    def test_kimi_k3_tool_call_stops_at_tools_close(self):
+    def test_kimi_k3_constraint_failure_keeps_native_stop_format(self):
         self.template_manager.chat_template_name = None
         self.template_manager.jinja_template_content_format = "string"
         self.chat.chat_encoding_spec = "kimi_k3"
@@ -695,7 +695,7 @@ class ServingChatTestCase(unittest.TestCase):
             ):
                 parser = parser_cls.return_value
                 parser.detector.eot_token = TOOLS_CLOSE
-                parser.detector.parses_required_natively.return_value = True
+                parser.detector.parses_required_natively.return_value = False
                 parser.get_structure_constraint.return_value = None
                 request = ChatCompletionRequest(
                     model="x",


### PR DESCRIPTION
## Summary

- keep Kimi K3 required and named tool calls in the native XTML format when structural-tag construction returns no constraint
- preserve the existing generic JSON-schema fallback for no-parser and non-K3 parser paths
- reuse the existing K3 stop-format test as the focused regression case

## Motivation

FunctionCallParser already catches parser-specific constraint construction errors. The serving-layer fallback could then replace the K3 XTML format with a generic JSON grammar. The rendered prompt and response parser still expect XTML, so the generated output could not be parsed as tool calls.

This PR is stacked on #33025 and intentionally changes only the Kimi K3 renderer plus parser combination.

## Validation

- pre-commit on both changed files
- py_compile and git diff --check
- full test_serving_chat.py on a clean devbox checkout: 91 passed, 38 subtests passed
- behavior matrix: no parser -> json_schema; non-K3 parser -> json_schema; Kimi K3 parser -> no incompatible fallback

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30693389306](https://github.com/sgl-project/sglang/actions/runs/30693389306)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30693389224](https://github.com/sgl-project/sglang/actions/runs/30693389224)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->