### PR TITLE
[Bench] Fix peak output throughput counting chunks instead of tokens

### DIFF
--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -1058,6 +1058,20 @@ async def get_request(
             await asyncio.sleep(interval)
 
 
+def _expand_itl_per_token(
+    output: RequestFuncOutput, tokenizer: PreTrainedTokenizerBase
+) -> List[float]:
+    """Spread each streaming chunk's ITL over the tokens it carries.
+
+    A chunk holds ``accept_length`` tokens under speculative decoding.
+    """
+    per_token_itls: List[float] = []
+    for chunk_itl, text_chunk in zip(output.itl, output.text_chunks):
+        num_tokens = len(tokenizer.encode(text_chunk, add_special_tokens=False))
+        per_token_itls.extend([chunk_itl / num_tokens] * num_tokens)
+    return per_token_itls
+
+
 def calculate_metrics(
     input_requests: Optional[List[DatasetRow]],
     outputs: List[RequestFuncOutput],
@@ -1077,13 +1091,18 @@ def calculate_metrics(
     tpots: List[float] = []
     ttfts: List[float] = []
     e2e_latencies: List[float] = []
-    retokenized_itls: List[float] = []
 
     use_retokenized_itl = (
         accept_length is not None
         and accept_length > 0
         and backend in ("sglang-oai", "sglang-oai-chat")
     )
+
+    # Per-token ITL series, shared by the ITL stats and the peak throughput.
+    itls_per_output = [
+        _expand_itl_per_token(output, tokenizer) if use_retokenized_itl else output.itl
+        for output in outputs
+    ]
 
     for i in range(len(outputs)):
         if outputs[i].success:
@@ -1099,17 +1118,7 @@ def calculate_metrics(
                 total_input_vision += input_requests[i].vision_prompt_len
             if output_len > 1:
                 tpots.append((outputs[i].latency - outputs[i].ttft) / (output_len - 1))
-            if use_retokenized_itl:
-                for k, itl in enumerate(outputs[i].itl):
-                    num_tokens = len(
-                        tokenizer.encode(
-                            outputs[i].text_chunks[k], add_special_tokens=False
-                        )
-                    )
-                    adjusted_itl = itl / num_tokens
-                    retokenized_itls.extend([adjusted_itl] * num_tokens)
-            else:
-                itls += outputs[i].itl
+            itls += itls_per_output[i]
             ttfts.append(outputs[i].ttft)
 
             e2e_latencies.append(outputs[i].latency)
@@ -1140,13 +1149,13 @@ def calculate_metrics(
         tokens_per_second = np.zeros(duration_seconds)
         concurrent_requests_per_second = np.zeros(duration_seconds)
 
-        for output in outputs:
+        for i, output in enumerate(outputs):
             if not output.success:
                 continue
 
             token_times = [output.start_time + output.ttft]
             current_time = token_times[0]
-            for itl_value in output.itl:
+            for itl_value in itls_per_output[i]:
                 current_time += itl_value
                 token_times.append(current_time)
 
@@ -1190,7 +1199,6 @@ def calculate_metrics(
             else:
                 print("tip: install termplotlib and gnuplot to plot the metrics")
 
-    itls = retokenized_itls if use_retokenized_itl else itls
     metrics = BenchmarkMetrics(
         completed=completed,
         total_input=total_input,


### PR DESCRIPTION
## Motivation

With speculative decoding enabled, `bench_serving` reports a **peak output token throughput far below the average output token throughput**, which is impossible by definition. Measured on Qwen3.6-35B-A3B-FP8 with DFlash speculative decoding (`accept_length ≈ 4.1`):

```
Output token throughput (tok/s):         414.75
Peak output token throughput (tok/s):    111.00   <-- 27% of the average
```

The two metrics count different things. `output_throughput` divides the token counts the server reports in `usage.completion_tokens` by the benchmark duration, so it counts real tokens. The peak metric instead rebuilds a token timeline from `output.itl`, assuming one entry per token:

```python
token_times = [output.start_time + output.ttft]
current_time = token_times[0]
for itl_value in output.itl:      # one bucket increment per entry
    current_time += itl_value
    token_times.append(current_time)
```

That assumption only holds for the native `sglang` backend, which expands each chunk gap over the `completion_tokens` delta (`serving.py:748-753`). The `sglang-oai` and `sglang-oai-chat` backends append **one `itl` entry per SSE chunk** (`serving.py:347`, `serving.py:541`), and a chunk carries `accept_length` tokens under speculative decoding. So `len(itl) ≈ output_len / accept_length` and the peak counts chunks per second rather than tokens per second.

`calculate_metrics` already had the machinery to fix this: `use_retokenized_itl` re-tokenizes each `text_chunk` to recover a per-token ITL series. But the result was assigned to `itls` only *after* the peak-throughput loop had run, and that loop read the raw per-chunk `output.itl` directly, so the correction never reached the peak metric. This is why the ITL percentiles were already correct while the peak was not.

## Modifications

- Extract the chunk→token ITL expansion into `_expand_itl_per_token()`.
- Compute it once into `itls_per_output` and share it between the ITL statistics and the peak-throughput loop, instead of expanding inline and discarding the result for the peak.
- Drop the now-unused `retokenized_itls` accumulator and the trailing `itls = retokenized_itls if use_retokenized_itl else itls` reassignment that caused the ordering bug.

When `use_retokenized_itl` is false, `itls_per_output` is just `output.itl`, so those paths are untouched. Single file, +23/-15, no API or CLI change.

## Accuracy Tests

N/A — benchmark metric aggregation only, no kernel or model forward code touched.

## Speed Tests and Profiling

Does not affect inference speed; it corrects a reported metric.

**Setup**: Qwen3.6-35B-A3B-FP8 (TP=2) on 2 × RTX 5090, DFlash speculative decoding, `sglang-oai-chat` backend, 480 requests × 256 output tokens, `--max-concurrency 1`.

Only the peak metric moves. Everything else is within run-to-run noise, which is the intended blast radius:

| Metric | Before | After |
|---|---|---|
| **Peak output token throughput (tok/s)** | **111.00** | **564.00** |
| Output token throughput (tok/s) | 414.75 | 413.66 |
| Total generated tokens | 122880 | 122880 |
| Accept length | 4.10 | 4.00 |
| Mean / Median TPOT (ms) | 1.94 / 1.94 | 1.94 / 1.94 |
| Mean / Median ITL (ms) | 1.94 / 1.19 | 1.94 / 1.19 |
| P90 / P95 / P99 ITL (ms) | 4.02 / 4.36 / 8.28 | 4.02 / 4.41 / 8.29 |
| Mean E2E latency (ms) | 616.89 | 618.50 |
| Peak concurrent requests | 4 | 4 |

The peak now sits above the average instead of at 27% of it, confirming the fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30693902711](https://github.com/sgl-project/sglang/actions/runs/30693902711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30693902666](https://github.com/sgl-project/sglang/actions/runs/30693902666)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->