### PR TITLE
[dLLM] Schedule dLLM prefill and decode rows into one mixed round

### DIFF
--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -31,6 +31,12 @@ class SchedulerDllmMixin:
             else None
         )
         self.dllm_manager = DllmManager(dllm_config=self.dllm_config)
+        # Round composition, reported through get_internal_state: the enabled
+        # flag alone cannot distinguish a server that mixes from one that
+        # merely could. Counted unconditionally so the off case reads as a
+        # real zero rather than a missing field.
+        self.dllm_num_rounds = 0
+        self.dllm_num_mixed_rounds = 0
         self.dllm_mixed_batch_enabled = False
         if self.dllm_config is not None and envs.SGLANG_ENABLE_DLLM_MIXED_BATCH.get():
             # Only FDFO rounds can absorb a mixed round for free: a round there
@@ -233,12 +239,18 @@ class SchedulerDllmMixin:
         """Process prefill or decode batches for DLLM."""
         forward_mode = ForwardMode.DLLM_EXTEND
 
-        if self.dllm_mixed_batch_enabled:
+        prefill_reqs = self.dllm_manager.get_prefill_requests()
+        if self.dllm_mixed_batch_enabled and self._should_mix_dllm_batches(
+            num_prefill_reqs=len(prefill_reqs),
+            num_decode_reqs=len(self.dllm_manager.get_decode_requests()),
+            round_capacity=max(
+                self.dllm_manager.max_running_reqs - len(running_batch.reqs), 0
+            ),
+        ):
             self._process_dllm_batches_mixed(adder, running_batch=running_batch)
             return forward_mode
 
         # Try prefill batch first
-        prefill_reqs = self.dllm_manager.get_prefill_requests()
         if prefill_reqs:
             self._process_batch_by_phase(
                 adder,
@@ -259,6 +271,26 @@ class SchedulerDllmMixin:
             )
 
         return forward_mode
+
+    @staticmethod
+    def _should_mix_dllm_batches(
+        *, num_prefill_reqs: int, num_decode_reqs: int, round_capacity: int
+    ) -> bool:
+        """Whether this round has decode work that would otherwise sit behind a
+        partially filled prefill round.
+
+        The mixed path is a restriction of the either/or path, not a
+        replacement: it walks the waiting queue in arrival order rather than
+        prefill-first, and it does not wire priority preemption. Those costs
+        buy nothing on a round that holds only one phase, or on one whose
+        prefill rows already fill the round -- so such rounds stay on the
+        original path.
+        """
+        return (
+            num_prefill_reqs > 0
+            and num_decode_reqs > 0
+            and num_prefill_reqs < round_capacity
+        )
 
     def _process_dllm_batches_mixed(
         self: Scheduler, adder: PrefillAdder, running_batch: ScheduleBatch
@@ -355,6 +387,10 @@ class SchedulerDllmMixin:
                 self._add_request_to_queue(req)
 
         if can_run_list:
+            self.dllm_num_rounds += 1
+            num_prefill_rows = sum(req.is_dllm_prefill() for req in can_run_list)
+            if 0 < num_prefill_rows < len(can_run_list):
+                self.dllm_num_mixed_rounds += 1
             self.dllm_manager.add_staging_reqs(can_run_list)
             self.dllm_manager.increment_inflight_middle_chunks()
 

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, List, Optional, Set, Union
 
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.dllm.mixin.req import DllmReqPhase
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.mem_cache.common import release_kv_cache
@@ -14,6 +15,9 @@ from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.runtime_context import get_exec, get_schedule
 
 logger = logging.getLogger(__name__)
+
+_DLLM_STAGING_PHASES = (DllmReqPhase.STAGING_PREFILL, DllmReqPhase.STAGING_DECODE)
+_DLLM_INCOMING_PHASES = (DllmReqPhase.INCOMING_PREFILL, DllmReqPhase.INCOMING_DECODE)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import GenerationBatchResult, Scheduler
@@ -27,6 +31,20 @@ class SchedulerDllmMixin:
             else None
         )
         self.dllm_manager = DllmManager(dllm_config=self.dllm_config)
+        self.dllm_mixed_batch_enabled = False
+        if self.dllm_config is not None and envs.SGLANG_ENABLE_DLLM_MIXED_BATCH.get():
+            # Only FDFO rounds can absorb a mixed round for free: a round there
+            # is one denoise step, so a prompt-only row self-finishes on it and
+            # costs what it would have cost in its own round. The synchronous
+            # loop instead forwards the whole batch until every block is
+            # resolved, so a prompt row mixed into a denoise round would ride
+            # tens of forwards it does not need.
+            self.dllm_mixed_batch_enabled = self.dllm_config.first_done_first_out_mode
+            if not self.dllm_mixed_batch_enabled:
+                logger.warning(
+                    "SGLANG_ENABLE_DLLM_MIXED_BATCH needs --dllm-fdfo; "
+                    "keeping the prefill-first dLLM rounds."
+                )
 
     def get_new_batch_dllm(
         self: Scheduler, running_batch: ScheduleBatch
@@ -211,6 +229,10 @@ class SchedulerDllmMixin:
         """Process prefill or decode batches for DLLM."""
         forward_mode = ForwardMode.DLLM_EXTEND
 
+        if self.dllm_mixed_batch_enabled:
+            self._process_dllm_batches_mixed(adder, running_batch=running_batch)
+            return forward_mode
+
         # Try prefill batch first
         prefill_reqs = self.dllm_manager.get_prefill_requests()
         if prefill_reqs:
@@ -233,6 +255,70 @@ class SchedulerDllmMixin:
             )
 
         return forward_mode
+
+    def _process_dllm_batches_mixed(
+        self: Scheduler, adder: PrefillAdder, running_batch: ScheduleBatch
+    ) -> None:
+        """Build one mixed round from all phases: staging rows first (they
+        already hold KV/slots and must keep progressing), then incoming rows
+        up to the allocatable-request cap. Per-request treatment is identical
+        to the either/or path; only the round composition changes.
+        """
+        reqs = self.dllm_manager.waiting_queue
+
+        staging_reqs = [req for req in reqs if req.dllm_phase in _DLLM_STAGING_PHASES]
+        if staging_reqs:
+            staging_result = self.process_dllm_staging_reqs(adder, staging_reqs)
+            if staging_result != AddReqResult.CONTINUE:
+                return
+
+        incoming_reqs = [req for req in reqs if req.dllm_phase in _DLLM_INCOMING_PHASES]
+        if incoming_reqs:
+            self._process_dllm_incoming_reqs_mixed(
+                adder, incoming_reqs, running_batch=running_batch
+            )
+
+    def _process_dllm_incoming_reqs_mixed(
+        self: Scheduler,
+        adder: PrefillAdder,
+        reqs: List[Req],
+        running_batch: ScheduleBatch,
+    ) -> None:
+        """Admission gate for mixed rounds. The either/or gate compares
+        len(can_run_list) against free req slots, which starves incoming rows
+        here: can_run_list already carries every staging row, and incomplete
+        staging rows hold their req slot across FDFO rounds without drawing on
+        the free pool. Charge the row cap for every scheduled row but the slot
+        pool only for the rows that still need a fresh slot -- the same split
+        req_to_token_pool.alloc() makes. Priority preemption is not wired for
+        mixed rounds.
+        """
+        running_bs = len(running_batch.reqs)
+        new_slots_needed = sum(
+            1 for req in adder.can_run_list if req.req_pool_idx is None
+        )
+        admission_budget = min(
+            self.get_num_allocatable_reqs(running_bs + len(adder.can_run_list)),
+            self.req_to_token_pool.available_size() - new_slots_needed,
+        )
+
+        for req in reqs:
+            if admission_budget <= 0:
+                running_batch.batch_is_full = True
+                break
+
+            req.init_next_round_input(self.tree_cache)
+            res = adder.add_one_req(
+                req,
+                has_chunked_req=True,
+                truncation_align_size=self.truncation_align_size,
+            )
+
+            if res != AddReqResult.CONTINUE:
+                if res == AddReqResult.NO_TOKEN:
+                    running_batch.batch_is_full = True
+                break
+            admission_budget -= 1
 
     def _process_batch_by_phase(
         self,

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -40,7 +40,11 @@ class SchedulerDllmMixin:
             # resolved, so a prompt row mixed into a denoise round would ride
             # tens of forwards it does not need.
             self.dllm_mixed_batch_enabled = self.dllm_config.first_done_first_out_mode
-            if not self.dllm_mixed_batch_enabled:
+            if self.dllm_mixed_batch_enabled:
+                logger.info(
+                    "dLLM prefill and decode rows are scheduled into one round."
+                )
+            else:
                 logger.warning(
                     "SGLANG_ENABLE_DLLM_MIXED_BATCH needs --dllm-fdfo; "
                     "keeping the prefill-first dLLM rounds."

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -31,20 +31,15 @@ class SchedulerDllmMixin:
             else None
         )
         self.dllm_manager = DllmManager(dllm_config=self.dllm_config)
-        # Round composition, reported through get_internal_state: the enabled
-        # flag alone cannot distinguish a server that mixes from one that
-        # merely could. Counted unconditionally so the off case reads as a
-        # real zero rather than a missing field.
+        # Counted unconditionally so the disabled case reports a real zero
+        # rather than a missing field in get_internal_state.
         self.dllm_num_rounds = 0
         self.dllm_num_mixed_rounds = 0
         self.dllm_mixed_batch_enabled = False
         if self.dllm_config is not None and envs.SGLANG_ENABLE_DLLM_MIXED_BATCH.get():
-            # Only FDFO rounds can absorb a mixed round for free: a round there
-            # is one denoise step, so a prompt-only row self-finishes on it and
-            # costs what it would have cost in its own round. The synchronous
-            # loop instead forwards the whole batch until every block is
-            # resolved, so a prompt row mixed into a denoise round would ride
-            # tens of forwards it does not need.
+            # FDFO only: a round is one denoise step, so a prompt-only row
+            # self-finishes on it. The synchronous loop forwards until every
+            # block resolves, which a prompt row would ride for no reason.
             self.dllm_mixed_batch_enabled = self.dllm_config.first_done_first_out_mode
             if self.dllm_mixed_batch_enabled:
                 logger.info(
@@ -287,9 +282,6 @@ class SchedulerDllmMixin:
         The mixed path is a restriction of the either/or path, not a
         replacement: it walks the waiting queue in arrival order rather than
         prefill-first, and it does not attempt preemption when the round fills.
-        Those costs buy nothing on a round that holds only one phase, or on one
-        whose prefill rows already fill the round -- so such rounds stay on the
-        original path.
 
         Priority preemption is the one difference that is not just a
         trade-off: taking the mixed path would silently drop it. Until it is

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -246,6 +246,7 @@ class SchedulerDllmMixin:
             round_capacity=max(
                 self.dllm_manager.max_running_reqs - len(running_batch.reqs), 0
             ),
+            priority_preemption_enabled=self.enable_priority_preemption,
         ):
             self._process_dllm_batches_mixed(adder, running_batch=running_batch)
             return forward_mode
@@ -274,18 +275,29 @@ class SchedulerDllmMixin:
 
     @staticmethod
     def _should_mix_dllm_batches(
-        *, num_prefill_reqs: int, num_decode_reqs: int, round_capacity: int
+        *,
+        num_prefill_reqs: int,
+        num_decode_reqs: int,
+        round_capacity: int,
+        priority_preemption_enabled: bool,
     ) -> bool:
         """Whether this round has decode work that would otherwise sit behind a
         partially filled prefill round.
 
         The mixed path is a restriction of the either/or path, not a
         replacement: it walks the waiting queue in arrival order rather than
-        prefill-first, and it does not wire priority preemption. Those costs
-        buy nothing on a round that holds only one phase, or on one whose
-        prefill rows already fill the round -- so such rounds stay on the
+        prefill-first, and it does not attempt preemption when the round fills.
+        Those costs buy nothing on a round that holds only one phase, or on one
+        whose prefill rows already fill the round -- so such rounds stay on the
         original path.
+
+        Priority preemption is the one difference that is not just a
+        trade-off: taking the mixed path would silently drop it. Until it is
+        wired there, a scheduler running with it enabled keeps every round on
+        the either/or path.
         """
+        if priority_preemption_enabled:
+            return False
         return (
             num_prefill_reqs > 0
             and num_decode_reqs > 0

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, List, Optional, Set, Union
 
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.dllm.mixin.req import DllmReqPhase
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.mem_cache.common import release_kv_cache
@@ -13,6 +14,9 @@ from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
 
 logger = logging.getLogger(__name__)
+
+_DLLM_STAGING_PHASES = (DllmReqPhase.STAGING_PREFILL, DllmReqPhase.STAGING_DECODE)
+_DLLM_INCOMING_PHASES = (DllmReqPhase.INCOMING_PREFILL, DllmReqPhase.INCOMING_DECODE)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import GenerationBatchResult, Scheduler
@@ -26,6 +30,20 @@ class SchedulerDllmMixin:
             else None
         )
         self.dllm_manager = DllmManager(dllm_config=self.dllm_config)
+        self.dllm_mixed_batch_enabled = False
+        if self.dllm_config is not None and envs.SGLANG_ENABLE_DLLM_MIXED_BATCH.get():
+            # Only FDFO rounds can absorb a mixed round for free: a round there
+            # is one denoise step, so a prompt-only row self-finishes on it and
+            # costs what it would have cost in its own round. The synchronous
+            # loop instead forwards the whole batch until every block is
+            # resolved, so a prompt row mixed into a denoise round would ride
+            # tens of forwards it does not need.
+            self.dllm_mixed_batch_enabled = self.dllm_config.first_done_first_out_mode
+            if not self.dllm_mixed_batch_enabled:
+                logger.warning(
+                    "SGLANG_ENABLE_DLLM_MIXED_BATCH needs --dllm-fdfo; "
+                    "keeping the prefill-first dLLM rounds."
+                )
 
     def get_new_batch_dllm(
         self: Scheduler, running_batch: ScheduleBatch
@@ -210,6 +228,10 @@ class SchedulerDllmMixin:
         """Process prefill or decode batches for DLLM."""
         forward_mode = ForwardMode.DLLM_EXTEND
 
+        if self.dllm_mixed_batch_enabled:
+            self._process_dllm_batches_mixed(adder, running_batch=running_batch)
+            return forward_mode
+
         # Try prefill batch first
         prefill_reqs = self.dllm_manager.get_prefill_requests()
         if prefill_reqs:
@@ -232,6 +254,70 @@ class SchedulerDllmMixin:
             )
 
         return forward_mode
+
+    def _process_dllm_batches_mixed(
+        self: Scheduler, adder: PrefillAdder, running_batch: ScheduleBatch
+    ) -> None:
+        """Build one mixed round from all phases: staging rows first (they
+        already hold KV/slots and must keep progressing), then incoming rows
+        up to the allocatable-request cap. Per-request treatment is identical
+        to the either/or path; only the round composition changes.
+        """
+        reqs = self.dllm_manager.waiting_queue
+
+        staging_reqs = [req for req in reqs if req.dllm_phase in _DLLM_STAGING_PHASES]
+        if staging_reqs:
+            staging_result = self.process_dllm_staging_reqs(adder, staging_reqs)
+            if staging_result != AddReqResult.CONTINUE:
+                return
+
+        incoming_reqs = [req for req in reqs if req.dllm_phase in _DLLM_INCOMING_PHASES]
+        if incoming_reqs:
+            self._process_dllm_incoming_reqs_mixed(
+                adder, incoming_reqs, running_batch=running_batch
+            )
+
+    def _process_dllm_incoming_reqs_mixed(
+        self: Scheduler,
+        adder: PrefillAdder,
+        reqs: List[Req],
+        running_batch: ScheduleBatch,
+    ) -> None:
+        """Admission gate for mixed rounds. The either/or gate compares
+        len(can_run_list) against free req slots, which starves incoming rows
+        here: can_run_list already carries every staging row, and incomplete
+        staging rows hold their req slot across FDFO rounds without drawing on
+        the free pool. Charge the row cap for every scheduled row but the slot
+        pool only for the rows that still need a fresh slot -- the same split
+        req_to_token_pool.alloc() makes. Priority preemption is not wired for
+        mixed rounds.
+        """
+        running_bs = len(running_batch.reqs)
+        new_slots_needed = sum(
+            1 for req in adder.can_run_list if req.req_pool_idx is None
+        )
+        admission_budget = min(
+            self.get_num_allocatable_reqs(running_bs + len(adder.can_run_list)),
+            self.req_to_token_pool.available_size() - new_slots_needed,
+        )
+
+        for req in reqs:
+            if admission_budget <= 0:
+                running_batch.batch_is_full = True
+                break
+
+            req.init_next_round_input(self.tree_cache)
+            res = adder.add_one_req(
+                req,
+                has_chunked_req=True,
+                truncation_align_size=self.truncation_align_size,
+            )
+
+            if res != AddReqResult.CONTINUE:
+                if res == AddReqResult.NO_TOKEN:
+                    running_batch.batch_is_full = True
+                break
+            admission_budget -= 1
 
     def _process_batch_by_phase(
         self,

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -39,7 +39,11 @@ class SchedulerDllmMixin:
             # resolved, so a prompt row mixed into a denoise round would ride
             # tens of forwards it does not need.
             self.dllm_mixed_batch_enabled = self.dllm_config.first_done_first_out_mode
-            if not self.dllm_mixed_batch_enabled:
+            if self.dllm_mixed_batch_enabled:
+                logger.info(
+                    "dLLM prefill and decode rows are scheduled into one round."
+                )
+            else:
                 logger.warning(
                     "SGLANG_ENABLE_DLLM_MIXED_BATCH needs --dllm-fdfo; "
                     "keeping the prefill-first dLLM rounds."

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -515,6 +515,13 @@ class Envs:
     # ===================================================================
     # Scheduler token budgeting and admission
     # ===================================================================
+    # dLLM: schedule prefill-phase rows (block-size prompt chunks) and
+    # decode-phase rows (denoise blocks) into one mixed round instead of
+    # prefill-first either/or rounds. Every row is still exactly one block-size
+    # chunk, so the denoise step's uniform-block reshape holds; a prompt-only
+    # row self-finishes on its first denoise step. Requires --dllm-fdfo, where
+    # a round is a single denoise step; ignored otherwise.
+    SGLANG_ENABLE_DLLM_MIXED_BATCH = EnvBool(False)
     SGLANG_INIT_NEW_TOKEN_RATIO = EnvFloat(0.7)
     SGLANG_MIN_NEW_TOKEN_RATIO_FACTOR = EnvFloat(0.14)
     SGLANG_NEW_TOKEN_RATIO_DECAY_STEPS = EnvInt(600)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -423,6 +423,13 @@ class Envs:
     SGLANG_DYNAMIC_CHUNKING_SMOOTH_FACTOR = EnvFloat(0.75)
     SGLANG_SCHEDULER_SKIP_ALL_GATHER = EnvBool(False)
     SGLANG_SCHEDULER_DECREASE_PREFILL_IDLE = EnvBool(False)
+    # dLLM: schedule prefill-phase rows (block-size prompt chunks) and
+    # decode-phase rows (denoise blocks) into one mixed round instead of
+    # prefill-first either/or rounds. Every row is still exactly one block-size
+    # chunk, so the denoise step's uniform-block reshape holds; a prompt-only
+    # row self-finishes on its first denoise step. Requires --dllm-fdfo, where
+    # a round is a single denoise step; ignored otherwise.
+    SGLANG_ENABLE_DLLM_MIXED_BATCH = EnvBool(False)
     SGLANG_KILLPG_ON_SCHEDULER_EXCEPTION = EnvBool(False)
     SGLANG_PREFILL_DELAYER_MAX_DELAY_PASSES = EnvInt(None)
     SGLANG_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK = EnvFloat(None)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4354,6 +4354,8 @@ class Scheduler(
         # Requested via env var but silently downgraded when FDFO is off, so
         # report what the scheduler actually resolved rather than what was asked.
         ret["dllm_mixed_batch_enabled"] = self.dllm_mixed_batch_enabled
+        ret["dllm_num_rounds"] = self.dllm_num_rounds
+        ret["dllm_num_mixed_rounds"] = self.dllm_num_mixed_rounds
 
         if get_exec().moe.elastic_ep_backend is not None:
             from sglang.srt.elastic_ep.elastic_ep import ElasticEPStateManager

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4351,6 +4351,9 @@ class Scheduler(
         )
         ret["startup_time"] = self.startup_time
         ret["effective_max_running_requests_per_dp"] = self.max_running_requests
+        # Requested via env var but silently downgraded when FDFO is off, so
+        # report what the scheduler actually resolved rather than what was asked.
+        ret["dllm_mixed_batch_enabled"] = self.dllm_mixed_batch_enabled
 
         if get_exec().moe.elastic_ep_backend is not None:
             from sglang.srt.elastic_ep.elastic_ep import ElasticEPStateManager

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4002,6 +4002,9 @@ class Scheduler(
             "graph": round(self.tp_worker.model_runner.graph_mem_usage, 2),
         }
         ret["effective_max_running_requests_per_dp"] = self.max_running_requests
+        # Requested via env var but silently downgraded when FDFO is off, so
+        # report what the scheduler actually resolved rather than what was asked.
+        ret["dllm_mixed_batch_enabled"] = self.dllm_mixed_batch_enabled
 
         if self.server_args.elastic_ep_backend is not None:
             from sglang.srt.elastic_ep.elastic_ep import ElasticEPStateManager

--- a/test/registered/ascend/basic_function/dllm/test_npu_llada2_mini_large_batch.py
+++ b/test/registered/ascend/basic_function/dllm/test_npu_llada2_mini_large_batch.py
@@ -1,0 +1,96 @@
+"""Large-batch dLLM coverage on Ascend.
+
+test_npu_llada2_mini.py pins the single-request latency recipe: one running
+request and synchronous denoise (`--no-dllm-fdfo`). That leaves the FDFO
+scheduler -- the default, and the one a rollout deployment runs -- with no NPU
+e2e coverage at all, and several scheduler and denoise paths only exist above a
+row-count threshold that bs=1 cannot reach.
+
+This runs the same gsm8k check on the throughput recipe instead: FDFO, a wide
+batch, and (in the second case) prefill and decode rows scheduled into one
+round. Keep both files: they cover opposite ends of the deployment range.
+"""
+
+import unittest
+
+import requests
+
+from sglang.test.ascend.gsm8k_ascend_mixin import GSM8KAscendMixin
+from sglang.test.ascend.test_ascend_utils import LLaDA2_0_MINI_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=400, suite="stage-b-test-4-npu-a3", nightly=False)
+register_npu_ci(est_time=400, suite="nightly-1-npu-a3", nightly=True)
+
+# 64 concurrent requests x a 32-token denoise block = 2048 rows per forward,
+# past every row-count threshold on the dLLM path. Each concurrent request also
+# costs roughly 50 MB outside the static pool (its slice of the denoise
+# reduction's transients), so raising this means lowering mem-fraction-static.
+MAX_RUNNING_REQUESTS = 64
+
+
+def assert_mixed_rounds(test, expected: bool):
+    """The flag is requested by env var but downgraded when FDFO is off, so the
+    only honest check is what the scheduler resolved -- otherwise a test that
+    fails to pass the flag through looks identical to one that passes it."""
+    states = requests.get(test.base_url + "/server_info").json()["internal_states"]
+    test.assertTrue(states, "server reported no internal states")
+    for state in states:
+        test.assertEqual(state["dllm_mixed_batch_enabled"], expected)
+
+
+_LARGE_BATCH_ARGS = [
+    "--trust-remote-code",
+    "--mem-fraction-static",
+    "0.8",
+    "--attention-backend",
+    "ascend",
+    "--dllm-algorithm",
+    "LowConfidence",
+    "--dllm-fdfo",
+    "--max-running-requests",
+    str(MAX_RUNNING_REQUESTS),
+    # Capture the decode graph rather than inheriting the mixin's
+    # --disable-cuda-graph: graph replay is how this model is served at batch,
+    # and the NPU graph runner's own dLLM path is otherwise untested.
+    "--cuda-graph-config",
+    '{"decode":{"backend":"full","max_bs":%d,"bs":[1,8,16,32,%d]}}'
+    % (MAX_RUNNING_REQUESTS, MAX_RUNNING_REQUESTS),
+]
+
+
+class TestLLaDA2MiniLargeBatch(GSM8KAscendMixin, CustomTestCase):
+    """FDFO at a batch wide enough to reach the large-batch code paths."""
+
+    model = LLaDA2_0_MINI_WEIGHTS_PATH
+    other_args = _LARGE_BATCH_ARGS
+    gsm8k_parallel = MAX_RUNNING_REQUESTS
+    accuracy = 0.88
+
+    def test_resolved_mixed_round_mode(self):
+        assert_mixed_rounds(self, False)
+
+
+class TestLLaDA2MiniMixedRound(GSM8KAscendMixin, CustomTestCase):
+    """Same batch with prefill and decode rows scheduled into one round.
+
+    Accuracy must be unaffected: mixing changes which rows share a forward, not
+    what any row denoises.
+    """
+
+    model = LLaDA2_0_MINI_WEIGHTS_PATH
+    other_args = _LARGE_BATCH_ARGS
+    gsm8k_parallel = MAX_RUNNING_REQUESTS
+    accuracy = 0.88
+    # The mixin snapshots os.environ into `env` at class-definition time and
+    # passes it to the server process, so the flag has to go in there rather
+    # than through envs.override() in setUpClass.
+    env = {**GSM8KAscendMixin.env, "SGLANG_ENABLE_DLLM_MIXED_BATCH": "1"}
+
+    def test_resolved_mixed_round_mode(self):
+        assert_mixed_rounds(self, True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/dllm/test_dllm_large_batch.py
+++ b/test/registered/dllm/test_dllm_large_batch.py
@@ -1,0 +1,176 @@
+"""Large-batch dLLM coverage.
+
+The other dLLM e2e tests run at 1-4 concurrent requests. Several scheduler and
+denoise paths only exist above that: the retained-KV gather batches above a row
+count, the denoise reduction switches formulation above a row count, and mixed
+prefill/decode rounds need enough concurrent requests for a prefill row and a
+decode row to coexist at all. None of that is reachable at bs=4, so this runs
+the same gsm8k check at a batch wide enough to enter them -- the RL-rollout
+shape this model is served in.
+
+The mixed-round flag is parametrized here rather than unit-tested: the round
+composition needs a live Scheduler, PrefillAdder and both memory pools, and the
+one existing dLLM test of that shape rotted into a module-level skip when its
+fixtures drifted from the code. A server test cannot drift the same way.
+"""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=500, stage="base-b", runner_config="1-gpu-large")
+
+import unittest
+from types import SimpleNamespace
+
+import requests
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import kill_process_tree
+from sglang.test.run_eval import run_eval
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+MODEL = "inclusionAI/LLaDA2.0-mini"
+# 64 concurrent requests x a 32-token denoise block = 2048 rows per forward,
+# past every row-count threshold on the dLLM path. Larger would be more
+# representative of a rollout but would not cover anything more.
+# Each concurrent request costs roughly 50 MB outside the static pool: its
+# 32-row slice of the persistent fp32 [rows, vocab] logits buffer, of the fp32
+# softmax the denoise step allocates on top of it, and of the bf16 lm_head
+# output in the graph pool. At 64 that is ~3.2 GB against the ~8 GB that
+# mem-fraction-static 0.9 leaves free on an 80 GB card. Raising this past 64
+# means lowering mem-fraction-static with it.
+MAX_RUNNING_REQUESTS = 64
+# 400 rather than the 200 the bs=4 tests use: one flipped example moves the
+# score by 0.0025 instead of 0.005, and unmask order near LowConfidence's 0.95
+# gate does shift when the GEMM goes from 128 rows to 2048.
+GSM8K_NUM_EXAMPLES = 400
+GSM8K_SCORE_THRESHOLD = 0.88
+
+
+def assert_mixed_rounds(test, expected: bool):
+    """The flag is requested by env var but downgraded when FDFO is off, so the
+    only honest check is what the scheduler resolved -- otherwise a test that
+    fails to pass the flag through looks identical to one that passes it."""
+    states = requests.get(test.base_url + "/server_info").json()["internal_states"]
+    test.assertTrue(states, "server reported no internal states")
+    for state in states:
+        test.assertEqual(state["dllm_mixed_batch_enabled"], expected)
+
+
+def _server_args():
+    return [
+        "--trust-remote-code",
+        "--tp-size",
+        "1",
+        "--mem-fraction-static",
+        "0.9",
+        "--max-running-requests",
+        str(MAX_RUNNING_REQUESTS),
+        "--attention-backend",
+        "flashinfer",
+        "--dllm-algorithm",
+        "LowConfidence",
+        "--dllm-fdfo",
+        "--cuda-graph-bs-decode",
+        "1",
+        "8",
+        "16",
+        "32",
+        "64",
+    ]
+
+
+class _Gsm8kAtLargeBatch:
+    """gsm8k at MAX_RUNNING_REQUESTS, shared by both server configurations.
+
+    Deliberately not a CustomTestCase subclass: a shared base that defined
+    test_gsm8k *and* inherited the case class would be collected on its own and
+    launch a third server.
+    """
+
+    label = ""
+    mixed_rounds = False
+
+    def _run_gsm8k(self, label: str):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=GSM8K_NUM_EXAMPLES,
+            num_threads=MAX_RUNNING_REQUESTS,
+        )
+        metrics = run_eval(args)
+        print(f"[{label}] {metrics=}")
+        if is_in_ci():
+            write_github_step_summary(
+                f"### {label} (llada2-mini, bs={MAX_RUNNING_REQUESTS})\n"
+                f"score={metrics['score']:.4f}\n"
+            )
+        self.assertGreater(metrics["score"], GSM8K_SCORE_THRESHOLD)
+
+    def test_gsm8k(self):
+        self._run_gsm8k(self.label)
+
+    def test_resolved_mixed_round_mode(self):
+        assert_mixed_rounds(self, self.mixed_rounds)
+
+
+def _launch(cls):
+    cls.model = MODEL
+    cls.base_url = DEFAULT_URL_FOR_TEST
+    cls.process = popen_launch_server(
+        cls.model,
+        cls.base_url,
+        timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+        other_args=_server_args(),
+    )
+
+
+class TestDllmLargeBatch(_Gsm8kAtLargeBatch, CustomTestCase):
+    """dLLM at a batch wide enough to reach the large-batch code paths."""
+
+    label = "large batch"
+    mixed_rounds = False
+
+    @classmethod
+    def setUpClass(cls):
+        _launch(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+
+class TestDllmLargeBatchMixedRound(_Gsm8kAtLargeBatch, CustomTestCase):
+    """Same batch with prefill and decode rows scheduled into one round.
+
+    Accuracy must be unaffected: mixing changes which rows share a forward, not
+    what any row denoises.
+    """
+
+    label = "large batch, mixed rounds"
+    mixed_rounds = True
+
+    @classmethod
+    def setUpClass(cls):
+        # The server has to be spawned inside the override so it inherits it.
+        with envs.SGLANG_ENABLE_DLLM_MIXED_BATCH.override(True):
+            _launch(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)

--- a/test/registered/dllm/test_dllm_large_batch.py
+++ b/test/registered/dllm/test_dllm_large_batch.py
@@ -8,10 +8,8 @@ decode row to coexist at all. None of that is reachable at bs=4, so this runs
 the same gsm8k check at a batch wide enough to enter them -- the RL-rollout
 shape this model is served in.
 
-The mixed-round flag is parametrized here rather than unit-tested: the round
-composition needs a live Scheduler, PrefillAdder and both memory pools, and the
-one existing dLLM test of that shape rotted into a module-level skip when its
-fixtures drifted from the code. A server test cannot drift the same way.
+The mixed-round flag is parametrized here rather than unit-tested: round
+composition needs a live Scheduler, PrefillAdder and both memory pools.
 """
 
 from sglang.test.ci.ci_register import register_cuda_ci
@@ -39,16 +37,11 @@ MODEL = "inclusionAI/LLaDA2.0-mini"
 # 64 concurrent requests x a 32-token denoise block = 2048 rows per forward,
 # past every row-count threshold on the dLLM path. Larger would be more
 # representative of a rollout but would not cover anything more.
-# Each concurrent request costs roughly 50 MB outside the static pool: its
-# 32-row slice of the persistent fp32 [rows, vocab] logits buffer, of the fp32
-# softmax the denoise step allocates on top of it, and of the bf16 lm_head
-# output in the graph pool. At 64 that is ~3.2 GB against the ~8 GB that
-# mem-fraction-static 0.9 leaves free on an 80 GB card. Raising this past 64
-# means lowering mem-fraction-static with it.
+# Each concurrent request costs memory outside the static pool, so raising
+# this means lowering --mem-fraction-static with it.
 MAX_RUNNING_REQUESTS = 64
-# 400 rather than the 200 the bs=4 tests use: one flipped example moves the
-# score by 0.0025 instead of 0.005, and unmask order near LowConfidence's 0.95
-# gate does shift when the GEMM goes from 128 rows to 2048.
+# 400 (not the 200 the bs=4 tests use): unmask order near LowConfidence's
+# gate shifts at this batch, so halve the per-example score granularity.
 GSM8K_NUM_EXAMPLES = 400
 GSM8K_SCORE_THRESHOLD = 0.88
 

--- a/test/registered/dllm/test_dllm_large_batch.py
+++ b/test/registered/dllm/test_dllm_large_batch.py
@@ -54,13 +54,25 @@ GSM8K_SCORE_THRESHOLD = 0.88
 
 
 def assert_mixed_rounds(test, expected: bool):
-    """The flag is requested by env var but downgraded when FDFO is off, so the
-    only honest check is what the scheduler resolved -- otherwise a test that
-    fails to pass the flag through looks identical to one that passes it."""
+    """Assert on what the scheduler actually built, not just what it resolved.
+
+    ``dllm_mixed_batch_enabled`` is a startup constant: a server that resolved
+    it to True but never put a prefill row and a decode row in the same round
+    would satisfy it identically. ``dllm_num_mixed_rounds`` counts the rounds
+    whose can_run_list held both phases, so it separates the two. Call this
+    after traffic has flowed -- on an idle server every counter is 0.
+    """
     states = requests.get(test.base_url + "/server_info").json()["internal_states"]
     test.assertTrue(states, "server reported no internal states")
     for state in states:
         test.assertEqual(state["dllm_mixed_batch_enabled"], expected)
+        test.assertGreater(state["dllm_num_rounds"], 0, "no dLLM round was scheduled")
+        if expected:
+            test.assertGreater(
+                state["dllm_num_mixed_rounds"], 0, "no round mixed the two phases"
+            )
+        else:
+            test.assertEqual(state["dllm_num_mixed_rounds"], 0)
 
 
 def _server_args():
@@ -115,12 +127,11 @@ class _Gsm8kAtLargeBatch:
                 f"score={metrics['score']:.4f}\n"
             )
         self.assertGreater(metrics["score"], GSM8K_SCORE_THRESHOLD)
+        # After traffic, not before: the round counters need rounds to have run.
+        assert_mixed_rounds(self, self.mixed_rounds)
 
     def test_gsm8k(self):
         self._run_gsm8k(self.label)
-
-    def test_resolved_mixed_round_mode(self):
-        assert_mixed_rounds(self, self.mixed_rounds)
 
 
 def _launch(cls):

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
@@ -1,10 +1,8 @@
 """Large-batch dLLM coverage on Ascend.
 
 test_npu_llada2_mini.py pins the single-request latency recipe: one running
-request and synchronous denoise (`--no-dllm-fdfo`). That leaves the FDFO
-scheduler -- the default, and the one a rollout deployment runs -- with no NPU
-e2e coverage at all, and several scheduler and denoise paths only exist above a
-row-count threshold that bs=1 cannot reach.
+request and synchronous denoise (`--no-dllm-fdfo`). This file covers the FDFO
+scheduler at a batch wide enough to reach the row-count thresholds.
 
 This runs the same gsm8k check on the throughput recipe instead: FDFO, a wide
 batch, and (in the second case) prefill and decode rows scheduled into one
@@ -105,9 +103,7 @@ class TestLLaDA2MiniMixedRound(GSM8KAscendMixin, CustomTestCase):
     env = {**GSM8KAscendMixin.env, "SGLANG_ENABLE_DLLM_MIXED_BATCH": "1"}
 
     def test_gsm8k(self):
-        # Override rather than assert in a sibling test method: the round
-        # counters only mean something after traffic, and unittest's
-        # alphabetical ordering is not a contract to lean on.
+        # See TestLLaDA2MiniLargeBatch.test_gsm8k.
         super().test_gsm8k()
         assert_mixed_rounds(self, True)
 

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
@@ -31,13 +31,25 @@ MAX_RUNNING_REQUESTS = 64
 
 
 def assert_mixed_rounds(test, expected: bool):
-    """The flag is requested by env var but downgraded when FDFO is off, so the
-    only honest check is what the scheduler resolved -- otherwise a test that
-    fails to pass the flag through looks identical to one that passes it."""
+    """Assert on what the scheduler actually built, not just what it resolved.
+
+    ``dllm_mixed_batch_enabled`` is a startup constant: a server that resolved
+    it to True but never put a prefill row and a decode row in the same round
+    would satisfy it identically. ``dllm_num_mixed_rounds`` counts the rounds
+    whose can_run_list held both phases, so it separates the two. Call this
+    after traffic has flowed -- on an idle server every counter is 0.
+    """
     states = requests.get(test.base_url + "/server_info").json()["internal_states"]
     test.assertTrue(states, "server reported no internal states")
     for state in states:
         test.assertEqual(state["dllm_mixed_batch_enabled"], expected)
+        test.assertGreater(state["dllm_num_rounds"], 0, "no dLLM round was scheduled")
+        if expected:
+            test.assertGreater(
+                state["dllm_num_mixed_rounds"], 0, "no round mixed the two phases"
+            )
+        else:
+            test.assertEqual(state["dllm_num_mixed_rounds"], 0)
 
 
 _LARGE_BATCH_ARGS = [
@@ -68,7 +80,11 @@ class TestLLaDA2MiniLargeBatch(GSM8KAscendMixin, CustomTestCase):
     gsm8k_parallel = MAX_RUNNING_REQUESTS
     accuracy = 0.88
 
-    def test_resolved_mixed_round_mode(self):
+    def test_gsm8k(self):
+        # Override rather than assert in a sibling test method: the round
+        # counters only mean something after traffic, and unittest's
+        # alphabetical ordering is not a contract to lean on.
+        super().test_gsm8k()
         assert_mixed_rounds(self, False)
 
 
@@ -88,7 +104,11 @@ class TestLLaDA2MiniMixedRound(GSM8KAscendMixin, CustomTestCase):
     # than through envs.override() in setUpClass.
     env = {**GSM8KAscendMixin.env, "SGLANG_ENABLE_DLLM_MIXED_BATCH": "1"}
 
-    def test_resolved_mixed_round_mode(self):
+    def test_gsm8k(self):
+        # Override rather than assert in a sibling test method: the round
+        # counters only mean something after traffic, and unittest's
+        # alphabetical ordering is not a contract to lean on.
+        super().test_gsm8k()
         assert_mixed_rounds(self, True)
 
 

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
@@ -9,11 +9,14 @@ batch, and (in the second case) prefill and decode rows scheduled into one
 round. Keep both files: they cover opposite ends of the deployment range.
 """
 
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
 from sglang.test.ascend.gsm8k_ascend_mixin import GSM8KAscendMixin
+from sglang.test.ascend.npu_eval_accuracy_kit import _is_pr_pipeline
 from sglang.test.ascend.test_ascend_utils import LLaDA2_0_MINI_WEIGHTS_PATH
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -48,6 +51,39 @@ def assert_mixed_rounds(test, expected: bool):
             )
         else:
             test.assertEqual(state["dllm_num_mixed_rounds"], 0)
+
+
+def run_staggered_pr_traffic(base_url, num_requests=32):
+    """Concurrent, staggered requests so a mixed round can actually form.
+
+    On PR pipelines the mixin's test_gsm8k short-circuits to a single smoke
+    request. One request is either prefilling or decoding, never both, so
+    ``_should_mix_dllm_batches`` (which needs num_prefill_reqs > 0 AND
+    num_decode_reqs > 0 in the same round) can never pass and
+    ``dllm_num_mixed_rounds`` stays 0. Staggered arrivals keep later requests
+    in prefill while earlier ones are still denoising their 128-token
+    completions (>= 4 decode blocks, many rounds), which is exactly the
+    overlap the gate waits for. Prompts differ per request so prefix caching
+    cannot collapse a prefill into a no-op.
+    """
+
+    def one_request(i):
+        time.sleep(0.05 * i)
+        response = requests.post(
+            f"{base_url}/generate",
+            json={
+                "text": f"Question {i}: compute {i} + {i} and explain. Answer:",
+                "sampling_params": {"temperature": 0, "max_new_tokens": 128},
+            },
+            timeout=300,
+        )
+        assert response.status_code == 200, response.text
+
+    # max_workers must cover every request: the stagger relies on all threads
+    # starting their sleeps together rather than queueing behind the pool.
+    with ThreadPoolExecutor(max_workers=num_requests) as pool:
+        # list() drains the iterator so a worker's exception re-raises here.
+        list(pool.map(one_request, range(num_requests)))
 
 
 _LARGE_BATCH_ARGS = [
@@ -105,6 +141,11 @@ class TestLLaDA2MiniMixedRound(GSM8KAscendMixin, CustomTestCase):
     def test_gsm8k(self):
         # See TestLLaDA2MiniLargeBatch.test_gsm8k.
         super().test_gsm8k()
+        if _is_pr_pipeline:
+            # The PR smoke path sends one request, which can never put a
+            # prefill row and a decode row in the same round; drive real
+            # overlapping traffic before asserting the counter moved.
+            run_staggered_pr_traffic(self.base_url)
         assert_mixed_rounds(self, True)
 
 

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py
@@ -1,0 +1,96 @@
+"""Large-batch dLLM coverage on Ascend.
+
+test_npu_llada2_mini.py pins the single-request latency recipe: one running
+request and synchronous denoise (`--no-dllm-fdfo`). That leaves the FDFO
+scheduler -- the default, and the one a rollout deployment runs -- with no NPU
+e2e coverage at all, and several scheduler and denoise paths only exist above a
+row-count threshold that bs=1 cannot reach.
+
+This runs the same gsm8k check on the throughput recipe instead: FDFO, a wide
+batch, and (in the second case) prefill and decode rows scheduled into one
+round. Keep both files: they cover opposite ends of the deployment range.
+"""
+
+import unittest
+
+import requests
+
+from sglang.test.ascend.gsm8k_ascend_mixin import GSM8KAscendMixin
+from sglang.test.ascend.test_ascend_utils import LLaDA2_0_MINI_WEIGHTS_PATH
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=400, suite="base-b-test-4-npu-a3")
+register_npu_ci(est_time=400, suite="nightly-4-npu-a3", nightly=True)
+
+# 64 concurrent requests x a 32-token denoise block = 2048 rows per forward,
+# past every row-count threshold on the dLLM path. Each concurrent request also
+# costs roughly 50 MB outside the static pool (its slice of the denoise
+# reduction's transients), so raising this means lowering mem-fraction-static.
+MAX_RUNNING_REQUESTS = 64
+
+
+def assert_mixed_rounds(test, expected: bool):
+    """The flag is requested by env var but downgraded when FDFO is off, so the
+    only honest check is what the scheduler resolved -- otherwise a test that
+    fails to pass the flag through looks identical to one that passes it."""
+    states = requests.get(test.base_url + "/server_info").json()["internal_states"]
+    test.assertTrue(states, "server reported no internal states")
+    for state in states:
+        test.assertEqual(state["dllm_mixed_batch_enabled"], expected)
+
+
+_LARGE_BATCH_ARGS = [
+    "--trust-remote-code",
+    "--mem-fraction-static",
+    "0.8",
+    "--attention-backend",
+    "ascend",
+    "--dllm-algorithm",
+    "LowConfidence",
+    "--dllm-fdfo",
+    "--max-running-requests",
+    str(MAX_RUNNING_REQUESTS),
+    # Capture the decode graph rather than inheriting the mixin's
+    # --disable-cuda-graph: graph replay is how this model is served at batch,
+    # and the NPU graph runner's own dLLM path is otherwise untested.
+    "--cuda-graph-config",
+    '{"decode":{"backend":"full","max_bs":%d,"bs":[1,8,16,32,%d]}}'
+    % (MAX_RUNNING_REQUESTS, MAX_RUNNING_REQUESTS),
+]
+
+
+class TestLLaDA2MiniLargeBatch(GSM8KAscendMixin, CustomTestCase):
+    """FDFO at a batch wide enough to reach the large-batch code paths."""
+
+    model = LLaDA2_0_MINI_WEIGHTS_PATH
+    other_args = _LARGE_BATCH_ARGS
+    gsm8k_parallel = MAX_RUNNING_REQUESTS
+    accuracy = 0.88
+
+    def test_resolved_mixed_round_mode(self):
+        assert_mixed_rounds(self, False)
+
+
+class TestLLaDA2MiniMixedRound(GSM8KAscendMixin, CustomTestCase):
+    """Same batch with prefill and decode rows scheduled into one round.
+
+    Accuracy must be unaffected: mixing changes which rows share a forward, not
+    what any row denoises.
+    """
+
+    model = LLaDA2_0_MINI_WEIGHTS_PATH
+    other_args = _LARGE_BATCH_ARGS
+    gsm8k_parallel = MAX_RUNNING_REQUESTS
+    accuracy = 0.88
+    # The mixin snapshots os.environ into `env` at class-definition time and
+    # passes it to the server process, so the flag has to go in there rather
+    # than through envs.override() in setUpClass.
+    env = {**GSM8KAscendMixin.env, "SGLANG_ENABLE_DLLM_MIXED_BATCH": "1"}
+
+    def test_resolved_mixed_round_mode(self):
+        assert_mixed_rounds(self, True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/dllm/test_mixed_batch_gate.py
+++ b/test/registered/unit/dllm/test_mixed_batch_gate.py
@@ -22,9 +22,12 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestShouldMixDllmBatches(CustomTestCase):
-    def _gate(self, prefill: int, decode: int, capacity: int) -> bool:
+    def _gate(self, prefill: int, decode: int, capacity: int, preempt: bool = False):
         return SchedulerDllmMixin._should_mix_dllm_batches(
-            num_prefill_reqs=prefill, num_decode_reqs=decode, round_capacity=capacity
+            num_prefill_reqs=prefill,
+            num_decode_reqs=decode,
+            round_capacity=capacity,
+            priority_preemption_enabled=preempt,
         )
 
     def test_mixes_when_prefill_leaves_room_for_decode(self):
@@ -46,6 +49,14 @@ class TestShouldMixDllmBatches(CustomTestCase):
     def test_declines_when_the_round_has_no_capacity(self):
         # running_batch already holds max_running_reqs rows.
         self.assertFalse(self._gate(prefill=2, decode=5, capacity=0))
+
+    def test_declines_when_priority_preemption_is_enabled(self):
+        # The mixed path does not attempt preemption when the round fills, so
+        # taking it under --enable-priority-scheduling would silently drop a
+        # feature the either/or path provides. Same inputs as the mixing case
+        # above, so only the preemption flag decides.
+        self.assertTrue(self._gate(prefill=2, decode=5, capacity=8, preempt=False))
+        self.assertFalse(self._gate(prefill=2, decode=5, capacity=8, preempt=True))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/dllm/test_mixed_batch_gate.py
+++ b/test/registered/unit/dllm/test_mixed_batch_gate.py
@@ -1,0 +1,52 @@
+"""Unit tests for the dLLM mixed-round gate.
+
+``SGLANG_ENABLE_DLLM_MIXED_BATCH`` lets one round hold both prefill-phase and
+decode-phase rows. The mixed path is a restriction of the either/or path rather
+than a replacement: it walks the waiting queue in arrival order instead of
+prefill-first, and it does not wire priority preemption. Those costs are only
+worth paying when the round actually has decode work that would otherwise wait
+behind a partially filled prefill round, so the gate has to keep single-phase
+and already-full rounds on the original path.
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.dllm.mixin.scheduler import SchedulerDllmMixin
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestShouldMixDllmBatches(CustomTestCase):
+    def _gate(self, prefill: int, decode: int, capacity: int) -> bool:
+        return SchedulerDllmMixin._should_mix_dllm_batches(
+            num_prefill_reqs=prefill, num_decode_reqs=decode, round_capacity=capacity
+        )
+
+    def test_mixes_when_prefill_leaves_room_for_decode(self):
+        # The case the feature exists for: prefill alone would leave the round
+        # partly empty while decode rows wait.
+        self.assertTrue(self._gate(prefill=2, decode=5, capacity=8))
+
+    def test_declines_when_prefill_already_fills_the_round(self):
+        # Nothing to steal into: mixing would only cost the prefill-first
+        # ordering and preemption the either/or path keeps.
+        self.assertFalse(self._gate(prefill=8, decode=5, capacity=8))
+        self.assertFalse(self._gate(prefill=9, decode=5, capacity=8))
+
+    def test_declines_on_a_single_phase_round(self):
+        # A round with only one phase cannot be mixed by definition.
+        self.assertFalse(self._gate(prefill=4, decode=0, capacity=8))
+        self.assertFalse(self._gate(prefill=0, decode=4, capacity=8))
+
+    def test_declines_when_the_round_has_no_capacity(self):
+        # running_batch already holds max_running_reqs rows.
+        self.assertFalse(self._gate(prefill=2, decode=5, capacity=0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The dLLM scheduler builds every round from a single phase. `_process_dllm_batches` takes every prefill-phase row it can find, and only when there are none does it fall back to decode-phase rows:

```python
prefill_reqs = self.dllm_manager.get_prefill_requests()
if prefill_reqs:
    ...  # prefill-phase rows only
else:
    ...  # decode-phase rows only
```

So a round is all prompt chunks or all denoise blocks, never both. A round's row budget is `--max-running-requests` blocks; when the phase that wins a round cannot fill that budget, the rest of it goes unused and the other phase's rows wait a whole round for their next forward — even though the batch had room for them and they are the same shape.

Whether that costs anything depends entirely on the **arrival pattern**, and the honest summary is that it is sometimes nothing and sometimes very large:

- when every request arrives at once, all of them march through the phases in lockstep, there is nothing to mix, and this change does nothing;
- under continuous arrival with prompts long enough to span many block-size chunks, some rows are always in a prefill phase while others are in a decode phase, and the either/or scheduler spends most of its rounds on batches it cannot fill.

Arrival pattern is not observable at scheduling time, so there is no threshold that could pick between the two. The change is therefore opt-in, behind an env var that defaults to today's behavior.

## Modifications

All of it is in `dllm/mixin/scheduler.py`, behind `SGLANG_ENABLE_DLLM_MIXED_BATCH` (default off).

`_process_dllm_batches` gains one branch at the top; with the flag off the rest of the method is unchanged:

```python
if self.dllm_mixed_batch_enabled and self._should_mix_dllm_batches(
    num_prefill_reqs=len(prefill_reqs),
    num_decode_reqs=len(self.dllm_manager.get_decode_requests()),
    round_capacity=max(
        self.dllm_manager.max_running_reqs - len(running_batch.reqs), 0
    ),
    priority_preemption_enabled=self.enable_priority_preemption,
):
    self._process_dllm_batches_mixed(adder, running_batch=running_batch)
    return forward_mode
```

`_should_mix_dllm_batches` is a static predicate (unit-tested without a live `Scheduler`) and is a pure narrowing: every round that mixes under it would have mixed without it. It exists so the mixed path is only entered where it can do something -- a round that holds one phase, or whose prefill rows already fill it, keeps the prefill-first ordering of the either/or path. See *What the gate does and does not buy* below for what that is worth in practice.

`_process_dllm_batches_mixed` builds one round from all four phases: staging rows first — they already hold KV and a req slot and must keep progressing — then incoming rows up to the admission budget. Per-request treatment is the same calls in the same order as the either/or path (`process_dllm_staging_reqs` -> `adder.add_dllm_staging_req` for staging rows, `req.init_next_round_input` -> `adder.add_one_req` for incoming ones). Only the round composition changes.

**The rows are the same shape as before.** `PrefillAdder._add_dllm_req` sets each incoming row's extend range to `min(rem_dllm_tokens, block_size)` rounded down to the page size, and `add_dllm_staging_req` caps each staging row at `_get_dllm_remain_tokens()`, itself capped at `block_size`. Neither cap looks at the phase, so a prefill row and a decode row have always been the same width. That is what makes mixing them safe: the denoise step's `input_ids.view(batch_size, block_size)` sees exactly the same uniform block grid it sees today.

**A prompt-only row costs one forward, the same as in a prefill-only round.** Its block contains no `mask_id`, so on the first denoise step both algorithms find nothing to transfer — `LowConfidence` reports it done immediately, and `JointThreshold` takes the no-mask branch, finds `edit_mask` empty because the whole block is prompt, and marks it finished. It is emitted with a full accept length after that one forward, exactly as it would have been in its own round.

**The admission gate has to differ from the either/or one.** That gate is

```python
if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
    running_batch.batch_is_full = True
```

which starves incoming rows in a mixed round: `can_run_list` already carries every staging row by the time incoming rows are considered, and an incomplete staging row holds its req slot across FDFO rounds without drawing on the free pool at all. Comparing the two directly charges the free-slot pool for rows that are not asking it for anything.

The mixed gate splits the two the way `req_to_token_pool.alloc()` itself does — it charges the row cap for every scheduled row, but the slot pool only for the rows whose `req_pool_idx` is still `None`:

```python
admission_budget = min(
    self.get_num_allocatable_reqs(running_bs + len(adder.can_run_list)),
    self.req_to_token_pool.available_size() - new_slots_needed,
)
```

Priority preemption is not wired for mixed rounds: where the either/or incoming path calls `adder.preempt_to_schedule` on a full batch, the mixed one simply stops admitting. Rather than let the flag make that choice on an operator's behalf, the gate declines to mix at all while `--enable-priority-scheduling` is on, so preemption behaviour is unchanged either way. Wiring preemption into the mixed path is the real fix and belongs in its own change.

**Mixed rounds require `--dllm-fdfo`** (on by default), and this is a hard gate rather than a recommendation, because under `--no-dllm-fdfo` mixing is not a smaller win — it is a large loss.

The two modes mean different things by "a round". Under FDFO a round is a single denoise step, so a prompt row mixed into a denoise round rides exactly the one forward it needed anyway, and is a decode row by the next round. `_run_sync` instead keeps forwarding the *whole batch* until every block in it is resolved, and it short-circuits an all-prefill batch after one forward:

```python
out = model_runner.forward(...)
if all(start == self.block_size for start in start_list):
    return ...                                    # all-prefill: one forward
for _ in range(self.max_steps(self.block_size)):  # otherwise: whole batch, to completion
```

Mixing there costs twice over: one decode row in the batch falsifies `all(...)`, so a prefill round that would have returned after one forward now runs the loop; and every prompt row in it rides that loop. `max_steps` is `block_size + 1` for `LowConfidence` (33) and `block_size + max_post_edit_steps + 1` for `JointThreshold` (49 at the default 16), so each mixed-in prompt row pays 32-48 forwards it does not need.

So `--no-dllm-fdfo` keeps the either/or rounds and logs a warning if the env var was set. The resolved decision is reported as `dllm_mixed_batch_enabled` in `/server_info`, so an operator can confirm whether a requested flag actually took effect rather than inferring it from a startup log line. Alongside it, `dllm_num_rounds` and `dllm_num_mixed_rounds` report what the scheduler actually built — the CI cases below assert on those, since the flag alone cannot distinguish a server that mixes from one that merely could.

### Blast radius

| File | Scope |
| --- | --- |
| `dllm/mixin/scheduler.py` | dLLM-only **and** env-gated. |
| `environ.py` | One descriptor, `EnvBool(False)`. |

`SchedulerDllmMixin` is only entered through `get_new_batch_dllm`, and `Scheduler.get_next_batch_to_run` calls it under `if self.dllm_config is not None:` — an else-branch to the normal `get_new_batch_prefill`. So nothing here is on a shared path to begin with: a non-dLLM server never executes a line of this file.

Inside it, everything new sits behind the single gated branch above. `dllm_mixed_batch_enabled` is `False` unless the env var is set *and* `dllm_config is not None` *and* FDFO is on, and the gate narrows it further. With the flag unset `_process_dllm_batches` is byte-identical to today's apart from hoisting `prefill_reqs` one line earlier, and the two mixed-round methods are dead code.

The one shared-file symbol this touches is `Scheduler.get_num_allocatable_reqs`, which it calls (read-only) rather than re-deriving the pp/pool arithmetic locally.

### Configuration

One new environment variable, `SGLANG_ENABLE_DLLM_MIXED_BATCH` (`EnvBool(False)`).

| Value | Behavior |
| --- | --- |
| unset (default) | Prefill-first either/or rounds. Today's behavior, byte-identical. |
| `1` | Mixed rounds where a round has both phases and room for them. Requires `--dllm-fdfo` (the default); ignored with a warning under `--no-dllm-fdfo`, and never taken while `--enable-priority-scheduling` is on. `/server_info` reports `dllm_mixed_batch_enabled` for what the scheduler resolved, and `dllm_num_rounds` / `dllm_num_mixed_rounds` for what it built. |

```bash
SGLANG_ENABLE_DLLM_MIXED_BATCH=1 python3 -m sglang.launch_server \
  --model inclusionAI/LLaDA2.0-mini --trust-remote-code \
  --dllm-algorithm JointThreshold --max-running-requests 64
```

The descriptor sits in the `Scheduler token budgeting and admission` section of `Envs`. (An earlier revision claimed the three sibling dLLM PRs would auto-merge in any order; upstream has since reorganized `environ.py` into named sections, and all of them needed a rebase.)

There is deliberately no batch-size or workload threshold. The benefit tracks the arrival pattern, not the batch size — the two workloads below run at the same 64-row cap and land on opposite answers — and arrival pattern is not something the scheduler can read off the queue at admission time.

## What the gate does and does not buy

Measured on 910B3 / LLaDA2.1-mini / bs=64, counting round composition directly (a count, so it is not confounded by a shared host the way a throughput number is):

| workload | flag | rounds | mixed rounds |
| --- | --- | ---: | ---: |
| 64-request burst | off | 485 | 0 |
| 64-request burst | on, no gate | 515 | 5 (1.0%) |
| 64-request burst | on, gated | 528 | 4 (0.8%) |
| 512 req @ concurrency 64 | off | 6949 | 0 |
| 512 req @ concurrency 64 | on, no gate | 2004 | 1559 (77.8%) |
| 512 req @ concurrency 64 | on, gated | 2041 | 1557 (76.3%) |

The middle rows are where the feature earns its keep: under continuous ingress the same work takes 6949 rounds unmixed and about 2000 mixed, and 76% of those rounds carry both phases. That ratio is the mechanism, stated as something checkable rather than as a throughput claim.

**The gate itself is close to a no-op on these two workloads, and the table says so.** Continuous ingress keeps 1557 of 1559 mixed rounds -- that is the safety result, the gate does not cost the feature what it is for. In the burst case mixing barely happens either way, because a single cohort moves in lockstep: without any gate only 5 of 515 rounds hold both phases. The gate does divert the other ~510 rounds back to the prefill-first path, but on a round holding one phase, prefill-first and arrival order produce the same batch, so little is actually recovered.

What the gate is worth is therefore narrower than "a performance fix":

- it is a provable narrowing, argued from the code rather than from a measurement;
- it makes "when does mixing apply" an explicit, unit-tested predicate instead of an implicit consequence of the flag;
- it removes the one case where mixing genuinely costs something -- both phases present but prefill rows already filling the round, where arrival order would put decode rows ahead of prefill ones.

That last case is rare in both workloads above, which is why no behavioural difference shows up. Reported this way rather than as a win, since these runs do not support calling it one.

## Accuracy Tests

LLaDA2-mini on Ascend 910B3, 16 prompts, greedy (`temperature=0`), 128 new tokens each.

| Config | Outputs identical to baseline |
| --- | ---: |
| `SGLANG_ENABLE_DLLM_MIXED_BATCH=1`, issued sequentially (`parallel=1`) | 16/16 |

Under concurrency the outputs are *not* identical — but neither are two runs of the unmodified baseline against each other. With the same 16 prompts issued 16-way concurrent, baseline-vs-baseline agreed on 5/16 and 2/16 across three runs, and baseline-vs-mixed agreed on 2/16. That is the pre-existing batch-shape nondeterminism (batch width changes which matmul tiling the kernels pick), not something this flag introduces; a reproducible comparison has to pin the concurrency, and pinned at 1 it is token-identical.

## Speed Tests and Profiling

LLaDA2-mini on one Ascend 910B3, `--max-running-requests 64`. "Rounds" is the scheduler-pass count from the server log — the quantity this change acts on directly, and far less noisy than throughput. The baseline is run twice in each table to show the noise floor (3.8% and 4.2% on output tok/s).

**Burst arrival — the case where this does nothing.** `bench_serving --dataset-name random --num-prompts 64 --random-input-len 512 --random-output-len 256 --random-range-ratio 1`, all 64 requests issued at once:

| Config | Scheduler rounds | Output tok/s |
| --- | ---: | ---: |
| baseline (run 1) | 281 | 1085 |
| baseline (run 2) | 310 | 1045 |
| `MIXED_BATCH=1` | 331 | 1043 |

No change beyond noise, as expected: every request arrives at the same instant and moves through the phases together, so there is never a round with rows of both phases to merge.

Two caveats on that table, both raised in review. The round count does rise (281/310 -> 331) while throughput sits at the bottom of the baseline band, so it is not evidence *against* a small burst regression -- it is just not sensitive enough to settle one either way. And @vedantjh2 measured a burst regression on H200 that the gate above is meant to address. On this hardware the gate cannot be seen doing that, because mixing barely occurs in a burst to begin with (5 of 515 rounds ungated); the composition counts are in *What the gate does and does not buy*.

**Staggered arrival — the case it is for.** `--num-prompts 128 --request-rate 8 --random-input-len 1024 --random-output-len 256 --random-range-ratio 0.5`. Requests arrive continuously and each prompt is 16-32 block-size prefill chunks, so at any instant some rows are prefilling while others denoise. The server is saturated (8 req/s offered, 2.5 req/s served at baseline):

| Config | Scheduler rounds | Output tok/s | Duration | Mean TTFT | Mean E2E |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline (run 1) | 1733 | 503 | 50.6 s | 12.1 s | 29.7 s |
| baseline (run 2) | 1792 | 483 | 52.7 s | 12.7 s | 30.9 s |
| `MIXED_BATCH=1` | 522 | **890** | **28.6 s** | **4.2 s** | **11.6 s** |

-70% scheduler rounds, +80% output throughput, TTFT and end-to-end latency both down to roughly a third. The mechanism is visible in the round count: the either/or scheduler was spending most of its rounds on prefill-only or decode-only batches that could not fill the 64-row budget.

Those two tables together are the whole case for the flag being opt-in rather than a default: same model, same server, same row cap, and the only difference is when the requests showed up.

## Tests

### Large-batch e2e coverage (new)

Every dLLM e2e test today runs at 1-4 concurrent requests, and the Ascend one additionally pins `--no-dllm-fdfo`, so the FDFO scheduler — the default — has no NPU e2e coverage at all. That is a gap this PR cannot be reviewed against: mixed rounds need enough concurrent requests for a prefill row and a decode row to coexist in the first place, which four cannot supply.

Two files are added, one per backend, each running the existing gsm8k check at **64 running requests** — 64 x a 32-token block is 2048 rows per forward, past the row-count thresholds on the dLLM path — once with default scheduling and once with `SGLANG_ENABLE_DLLM_MIXED_BATCH`:

| File | Backend | Suite | est_time |
| --- | --- | --- | ---: |
| `test/registered/dllm/test_dllm_large_batch.py` | CUDA | `base-b` / `1-gpu-large` | 500 s |
| `test/registered/npu/basic_function/dllm/test_npu_llada2_mini_large_batch.py` | Ascend | `base-b-test-4-npu-a3` + `nightly-4-npu-a3` | 400 s |

Accuracy must be unaffected by mixing — it changes which rows share a forward, not what any row denoises — so both cases assert the same threshold as the existing tests.

Both files capture the decode CUDA/NPU graph rather than running eager. That is how the model is served at batch, and on Ascend it is also the only way the graph runner's dLLM replay path gets exercised at all — the existing NPU dLLM test inherits `--disable-cuda-graph` from its mixin.

Each case asserts round composition, not just configuration. `/server_info` now reports `dllm_num_rounds` and `dllm_num_mixed_rounds` alongside `dllm_mixed_batch_enabled`; a round counts as mixed when its `can_run_list` holds both phases. The flag alone is a startup constant, so a server that resolved it True and never built a two-phase round would pass an assertion on it identically. The tests require a nonzero mixed count with the flag on, zero with it off, and a nonzero round count either way, checked after the eval so there has been traffic. Those are the same fields an operator would query.

The Ascend file was run on a 910B3 while preparing this PR: 4 cases, 296 s, both accuracy thresholds met with the decode graph captured. The CUDA `est_time` is derived, not measured — from `test_dllm_batching_fdfo.py` (139 s for one server plus one gsm8k at 200 examples) the launch is about 82 s, so two launches, one graph capture at bs=64 and two 400-example evals put the upper bound near 384 s. It is registered at 500 s deliberately: the number feeds bin-packing, and over-reserving a slot costs less than a partition that runs long. Worth correcting once someone has a real timing from CI.

Per-commit rather than nightly: the per-commit suites already carry dLLM tests at 139 s, 300 s, 400 s and 1000 s (`test_llada2_mini_amd.py`), and across all registered tests `est_time` has a median of 40 s and a p90 of ~1180 s. These sit below that p90. Batch width, not sequence length, is what reaches the new paths, so short generations are enough and the runs stay cheap.

The Ascend file is **additive**, not a rewrite of `test_npu_llada2_mini.py`: that one pins the single-request latency recipe (bs=1, synchronous denoise) and is still worth having. The two cover opposite ends of the deployment range.

### Unit tests

`test/registered/unit/dllm/test_mixed_batch_gate.py`, five cases on `_should_mix_dllm_batches` (CPU, `base-a-test-cpu`): mixes when prefill leaves room, declines when prefill already fills the round, declines on a single-phase round, declines with no capacity, declines while priority preemption is on. Mutation-checked — forcing the predicate true turns three red, weakening `<` to `<=` turns the boundary case red, and dropping the preemption guard turns its case red.

That is testable because the gate is a static predicate over three integers and a bool. The rest of the mixed round is not, and is deliberately left to the server tests: it is a composition decision made from a live `Scheduler` — `PrefillAdder`, `req_to_token_pool`, `token_to_kv_pool_allocator`, a tree cache, and requests already carrying phase and slot state. The one existing dLLM test of that shape, `test/registered/unit/mem_cache/test_dllm_fdfo_kv_reuse.py`, is module-skipped and its fixtures no longer match the code it tests (un-skipping it raises `SimpleNamespace has no attribute out_cache_loc_dsv4`), so a second test built the same way would guard nothing within a release or two. Under the "what future diff turns this red?" test, the answer would be "editing the fixture". The server tests cannot drift that way — they drive the real scheduler.

Two further pieces are pinned structurally rather than by assertion:

- the admission budget's pp/pool arithmetic is not re-derived here — it calls `Scheduler.get_num_allocatable_reqs`, the same helper the either/or path uses, so the two cannot drift and the resolved-vs-pristine `ServerArgs` distinction is made in exactly one place;
- "the flag off changes nothing" is guaranteed by construction (a single early-return branch), not by a test that could only re-assert it.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35508978134](https://github.com/sgl-project/sglang/actions/runs/35508978134)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35508977862](https://github.com/sgl-project/sglang/actions/runs/35508977862)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35508978130](https://github.com/sgl-project/sglang/actions/runs/35508978130)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->