### PR TITLE
fix(openai): preserve highest-ranked candidate on top_logprobs text c…

### DIFF
--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -33,9 +33,17 @@ def to_openai_style_logprobs(
     def append_top_logprobs(top_logprobs):
         for tokens in top_logprobs:
             if tokens is not None:
-                ret_logprobs.top_logprobs.append(
-                    {token[2]: token[0] for token in tokens}
-                )
+                # tokens is ordered by descending logprob (highest first).
+                # When two distinct token ids decode to the same string
+                # (e.g. byte-fallback tokens all decoding to U+FFFD), a plain
+                # dict comprehension keyed by text silently drops all but the
+                # last -- which is the *lowest*-ranked candidate. Build the
+                # dict in reverse so the first (highest-ranked) occurrence
+                # wins, preserving the correct logprob for colliding text.
+                result = {}
+                for token in reversed(tokens):
+                    result[token[2]] = token[0]
+                ret_logprobs.top_logprobs.append(result)
             else:
                 ret_logprobs.top_logprobs.append(None)
 


### PR DESCRIPTION
…ollision (#32290)

to_openai_style_logprobs built the top_logprobs dict with {token[2]: token[0] for token in tokens}, keyed by decoded token text. When two distinct token ids decode to the same string (e.g. byte-fallback tokens all decoding to U+FFFD), the dict comprehension silently merged them and kept the *last* (lowest-ranked) candidate's logprob.

Build the dict in reverse order so the first (highest-ranked) occurrence wins on key collision. The OpenAI API still requires Dict[str, float] so duplicate text entries cannot be preserved, but at least the surviving logprob is now the correct (highest) one.

Fixes #32290

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30698903654](https://github.com/sgl-project/sglang/actions/runs/30698903654)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30698903570](https://github.com/sgl-project/sglang/actions/runs/30698903570)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->