### PR TITLE
BUG:skip when spech4 deepseekv4

### DIFF
--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -134,7 +134,9 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
 
     run_post_process_pass(server_args, _deepseek_v4_kv_cache_dtype)
 
-    if cfg.max_running_requests is None:
+    # Leave the field unset under speculative decoding so the speculative hook,
+    # a later writer, can apply its own default of 48 (see #33199).
+    if cfg.max_running_requests is None and cfg.speculative_algorithm is None:
         declare_resolution(
             server_args,
             "apply_deepseek_v4_defaults",

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -46,7 +46,10 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
 
     run_post_process_pass(server_args, _deepseek_v4_kv_cache_dtype)
 
-    if server_args.max_running_requests is None:
+    if (
+        server_args.max_running_requests is None
+        and server_args.speculative_algorithm is None
+    ):
         server_args.max_running_requests = 256
         logger.warning(
             f"Setting max_running_requests to {server_args.max_running_requests} for {model_arch}."


### PR DESCRIPTION

## Motivation
https://github.com/sgl-project/sglang/issues/33199

## Modifications
 DSv4 fill skip itself when spec decoding is on.
previous 256 

## Accuracy Tests
should be fine NA


## Speed Tests and Profiling
NA

## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35050080426](https://github.com/sgl-project/sglang/actions/runs/35050080426)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35050080290](https://github.com/sgl-project/sglang/actions/runs/35050080290)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35050080497](https://github.com/sgl-project/sglang/actions/runs/35050080497)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->