### PR TITLE
spec: DSPARK PD-disaggregation via native draft-KV transfer

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -369,6 +369,8 @@ class FutureMap:
             # FIXME(lsyin): only prefill; not compatible with mixed mode
             return
         indices = draft_input.future_indices
+        if indices is None:
+            return
         if indices.shape[0] == 0:
             return
         # FIXME: indices = batch.req_pool_indices, pinned 2 iters via


### PR DESCRIPTION
**Turns out the DSPARK draft-KV transfer landed upstream already / is in some other PR that landed recently**

Reduced from the original DSPARK PD-disagg commit: the spec_info
DSPARK branch and draft-KV transfer landed upstream via https://github.com/sgl-project/sglang/pull/32541 and the
DP/EP draft-batch fields via https://github.com/sgl-project/sglang/pull/33098, this one-line guard is the only piece
still missing on main.

---

Original PR body

## Motivation

We are trying to bring up 4xB200 prefill + 4xB200 decode for Dsv4 flash 0731 (excellent model),
but with vanilla nightly we bumped into incompatibilities between DSPARK and PD-disagg (and file based HiCache).

Originally we went with sgl-project/sglang#31466 but found that has incompatibility with HiCache,
after some inspection I think we can get this done with a much smaller set of changes presented here,
instead of the full hidden-row transfer system.

We have now a running setup on top of 07/31 nightly showing DSPARK with 3-5x improvement in single user case and KV cache seems to be functioning correctly.

## Modifications

Two hunks make DSPARK work in PD disaggregation with symmetric TP:

1. spec_info.py: build_disagg_draft_input DSPARK branch
2. overlap_utils.py: FutureMap.resolve_future tolerates future_indices=None.

To get a working setup:
- A prefill engine started with `--speculative-algorithm DSPARK` runs DSparkWorkerV2._forward_prefill on every extend batch, building draft KV from target hidden states exactly like unified serving.
- For DSV4 / SWA, PD transfer now ships draft KV alongside target KV
- `--speculative-algorithm DSPARK` must be on both engines

Here is our full launch commands:

Prefill:

```bash
SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR=/mnt/nvme/hicache \
sglang serve \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --trust-remote-code \
  --tp 4 \
  --base-gpu-id 0 \
  --moe-runner-backend flashinfer_mxfp4 \
  --disable-flashinfer-autotune \
  --swa-full-tokens-ratio 0.1 \
  --reasoning-parser deepseek-v4 \
  --tool-call-parser deepseekv4 \
  --speculative-algorithm DSPARK \
  --chunked-prefill-size 16384 \
  --mem-fraction-static 0.90 \
  --enable-hierarchical-cache \
  --hicache-ratio 2 \
  --hicache-size 0 \
  --hicache-mem-layout page_first_direct \
  --hicache-io-backend direct \
  --hicache-write-policy write_through \
  --hicache-storage-backend file \
  --hicache-storage-prefetch-policy wait_complete \
  --disaggregation-transfer-backend nixl \
  --disaggregation-mode prefill \
  --disaggregation-bootstrap-port 8998 \
  --host 0.0.0.0 \
  --port 30000
```

Decode:

```bash
sglang serve \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --trust-remote-code \
  --tp 4 \
  --base-gpu-id 4 \
  --moe-runner-backend flashinfer_mxfp4 \
  --disable-flashinfer-autotune \
  --swa-full-tokens-ratio 0.1 \
  --reasoning-parser deepseek-v4 \
  --tool-call-parser deepseekv4 \
  --speculative-algorithm DSPARK \
  --chunked-prefill-size 4096 \
  --mem-fraction-static 0.87 \
  --cuda-graph-max-bs 64 \
  --disaggregation-transfer-backend nixl \
  --disaggregation-mode decode \
  --host 0.0.0.0 \
  --port 30001
```

Router:

```bash
python3 -m sglang_router.launch_router \
  --pd-disaggregation \
  --prefill http://127.0.0.1:30000 8998 \
  --decode http://127.0.0.1:30001 \
  --host 0.0.0.0 \
  --port 8000
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30960127898](https://github.com/sgl-project/sglang/actions/runs/30960127898)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30960127702](https://github.com/sgl-project/sglang/actions/runs/30960127702)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->