### PR TITLE
fix(sampler): abort requests with fully-NaN logits instead of sampling garbage (#33187)

### DIFF
--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -33,9 +33,17 @@ def to_openai_style_logprobs(
     def append_top_logprobs(top_logprobs):
         for tokens in top_logprobs:
             if tokens is not None:
-                ret_logprobs.top_logprobs.append(
-                    {token[2]: token[0] for token in tokens}
-                )
+                # tokens is ordered by descending logprob (highest first).
+                # When two distinct token ids decode to the same string
+                # (e.g. byte-fallback tokens all decoding to U+FFFD), a plain
+                # dict comprehension keyed by text silently drops all but the
+                # last -- which is the *lowest*-ranked candidate. Build the
+                # dict in reverse so the first (highest-ranked) occurrence
+                # wins, preserving the correct logprob for colliding text.
+                result = {}
+                for token in reversed(tokens):
+                    result[token[2]] = token[0]
+                ret_logprobs.top_logprobs.append(result)
             else:
                 ret_logprobs.top_logprobs.append(None)
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -709,6 +709,14 @@ class Envs:
     # Sanitize NaN logits before sampling kernels and log a throttled warning
     # (see sanitize_nan_logits).
     SGLANG_SANITIZE_NAN_LOGITS = EnvBool(False)
+    # When SGLANG_SANITIZE_NAN_LOGITS is on, an all-NaN logits row is sanitized
+    # to a constant and softmax becomes a uniform random sample over the whole
+    # vocab — garbage streamed to the client as a healthy 200 response, and the
+    # corrupted KV poisons every subsequent step of that request. With this flag
+    # on, requests whose next-token logits row is entirely NaN are aborted with
+    # a retriable 5xx instead of being sampled, and their KV is not inserted into
+    # the prefix cache (see sanitize_nan_logits / _nan_row_mask).
+    SGLANG_ABORT_ON_FULL_NAN_LOGITS = EnvBool(False)
 
     # VLM
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -127,6 +127,12 @@ class LogitsProcessorOutput:
 
     mm_input_embeds: Optional[torch.Tensor] = None
 
+    # Per-row mask (shape [batch]) marking requests whose next-token logits row
+    # was entirely NaN before sanitization. Set by Sampler._preprocess_logits
+    # when SGLANG_ABORT_ON_FULL_NAN_LOGITS is on; the scheduler aborts those
+    # requests instead of sampling a uniform-random token. None otherwise.
+    full_nan_logits_mask: Optional[torch.Tensor] = None
+
 
 @dataclasses.dataclass
 class LogitsMetadata:

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -82,12 +82,24 @@ class Sampler(nn.Module):
         self.use_ascend_backend = get_global_server_args().sampling_backend == "ascend"
 
     def _preprocess_logits(
-        self, logits: torch.Tensor, sampling_info: SamplingBatchInfo
+        self,
+        logits: torch.Tensor,
+        sampling_info: SamplingBatchInfo,
+        logits_output: Optional["LogitsProcessorOutput"] = None,
     ) -> torch.Tensor:
-        """Apply custom logit processors and sanitize non-finite logits."""
+        """Apply custom logit processors and sanitize non-finite logits.
+
+        When logits_output is provided and SGLANG_ABORT_ON_FULL_NAN_LOGITS is
+        set, records a per-row mask of all-NaN logits rows on logits_output so
+        the scheduler can abort those requests instead of sampling a uniform
+        random token (see sanitize_nan_logits)."""
         if sampling_info.has_custom_logit_processor:
             apply_custom_logit_processor(logits, sampling_info)
-        sanitize_nan_logits(logits, "sampler: next_token_logits")
+        full_nan_mask = sanitize_nan_logits(
+            logits, "sampler: next_token_logits", return_full_nan_mask=True
+        )
+        if logits_output is not None:
+            logits_output.full_nan_logits_mask = full_nan_mask
         return logits
 
     def forward(
@@ -116,7 +128,7 @@ class Sampler(nn.Module):
         logits = logits_output.next_token_logits
 
         # Preprocess logits (custom processors and NaN handling)
-        logits = self._preprocess_logits(logits, sampling_info)
+        logits = self._preprocess_logits(logits, sampling_info, logits_output)
 
         if sampling_info.is_all_greedy:
             if _use_aiter and not _disable_aiter_greedy_sample:
@@ -423,7 +435,7 @@ class Sampler(nn.Module):
             return
 
         # Preprocess logits (custom processors and NaN handling)
-        logits = self._preprocess_logits(logits_output.next_token_logits, sampling_info)
+        logits = self._preprocess_logits(logits_output.next_token_logits, sampling_info, logits_output)
 
         # Compute logprobs
         logprobs = torch.nn.functional.log_softmax(logits, dim=-1)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1538,6 +1538,26 @@ class Req(ReqDllmMixin):
             error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError"
         )
 
+    def set_finish_with_internal_error(self, error_msg: str):
+        """Mark the request as finished with a 500-style abort.
+
+        Used for runtime failures that are not the client's fault (e.g. a
+        fully-NaN logits row that would otherwise be sampled as garbage). The
+        request is not inserted into the prefix cache so the poisoned KV cannot
+        be shared with other requests."""
+        if get_tensor_model_parallel_rank() == 0:
+            logger.error(f"{error_msg}, {self.rid=}")
+        self.multimodal_inputs = None
+        self.grammar = None
+        self.origin_input_ids = array("q", [0])
+        self.return_logprob = False
+        self.logprob_start_len = -1
+        # Do not let the corrupted KV be shared via the prefix cache.
+        self.skip_radix_cache_insert = True
+        self.to_finish = FINISH_ABORT(
+            error_msg, HTTPStatus.INTERNAL_SERVER_ERROR, "InternalServerError"
+        )
+
     def update_reasoning_tokens(self, token_id, think_end_id):
         if self._is_reasoning_over:
             return

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1524,7 +1524,24 @@ class Req(ReqDllmMixin):
         logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
         self.has_log_time_stats = True
 
-    def set_finish_with_abort(self, error_msg: str):
+    def set_finish_with_abort(
+        self,
+        error_msg: str,
+        status_code: HTTPStatus = HTTPStatus.BAD_REQUEST,
+        err_type: str = "BadRequestError",
+        skip_radix_cache_insert: bool = False,
+    ):
+        """Mark the request as finished with an abort.
+
+        Args:
+            error_msg: Human-readable error message.
+            status_code: HTTP status code returned to the client.
+            err_type: Error type string for the response payload.
+            skip_radix_cache_insert: When True, the request's KV is not inserted
+                into the prefix cache. Used for runtime failures (e.g. a
+                fully-NaN logits row) where the corrupted KV must not be shared
+                with other requests.
+        """
         if get_tensor_model_parallel_rank() == 0:
             logger.error(f"{error_msg}, {self.rid=}")
         self.multimodal_inputs = None
@@ -1534,29 +1551,9 @@ class Req(ReqDllmMixin):
         )  # set it to one token to skip the long prefill
         self.return_logprob = False
         self.logprob_start_len = -1
-        self.to_finish = FINISH_ABORT(
-            error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError"
-        )
-
-    def set_finish_with_internal_error(self, error_msg: str):
-        """Mark the request as finished with a 500-style abort.
-
-        Used for runtime failures that are not the client's fault (e.g. a
-        fully-NaN logits row that would otherwise be sampled as garbage). The
-        request is not inserted into the prefix cache so the poisoned KV cannot
-        be shared with other requests."""
-        if get_tensor_model_parallel_rank() == 0:
-            logger.error(f"{error_msg}, {self.rid=}")
-        self.multimodal_inputs = None
-        self.grammar = None
-        self.origin_input_ids = array("q", [0])
-        self.return_logprob = False
-        self.logprob_start_len = -1
-        # Do not let the corrupted KV be shared via the prefix cache.
-        self.skip_radix_cache_insert = True
-        self.to_finish = FINISH_ABORT(
-            error_msg, HTTPStatus.INTERNAL_SERVER_ERROR, "InternalServerError"
-        )
+        if skip_radix_cache_insert:
+            self.skip_radix_cache_insert = True
+        self.to_finish = FINISH_ABORT(error_msg, status_code, err_type)
 
     def update_reasoning_tokens(self, token_id, think_end_id):
         if self._is_reasoning_over:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -917,10 +917,13 @@ class SchedulerBatchResultProcessor:
         aborted: set = set()
         for i, req in enumerate(batch.reqs):
             if i < mask_cpu.shape[0] and bool(mask_cpu[i]):
-                req.set_finish_with_internal_error(
+                req.set_finish_with_abort(
                     "Aborted: next-token logits were entirely NaN "
                     "(SGLANG_ABORT_ON_FULL_NAN_LOGITS). "
-                    "Sampling would have produced a uniform-random token."
+                    "Sampling would have produced a uniform-random token.",
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    err_type="InternalServerError",
+                    skip_radix_cache_insert=True,
                 )
                 aborted.add(i)
         if aborted:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -210,12 +210,22 @@ class SchedulerBatchResultProcessor:
 
             self._validate_pp_skip_output_comm(batch, result)
 
+            # Abort requests whose next-token logits were entirely NaN before
+            # sanitization (would otherwise be sampled as uniform-random
+            # garbage). Skipped rows are filtered out below.
+            aborted_full_nan = self._abort_full_nan_logits_reqs(batch, logits_output)
+
             hidden_state_offset = 0
 
             # Check finish conditions
             logprob_pt = 0
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
+                if i in aborted_full_nan:
+                    # Already aborted; release KV without inserting into cache.
+                    release_kv_cache(req, self.tree_cache)
+                    req.time_stats.set_completion_time()
+                    continue
                 if (
                     req.finished() and req.inflight_middle_chunks <= 0
                 ) or req.is_retracted:
@@ -653,6 +663,13 @@ class SchedulerBatchResultProcessor:
             next_token_ids=next_token_ids,
         )
 
+        # Abort requests whose next-token logits were entirely NaN before
+        # sanitization (would otherwise be sampled as uniform-random garbage,
+        # with the corrupted KV poisoning every subsequent step).
+        aborted_full_nan = self._abort_full_nan_logits_reqs(batch, logits_output)
+        if aborted_full_nan:
+            self.metrics_reporter.num_generated_tokens -= len(aborted_full_nan)
+
         self.metrics_reporter.num_generated_tokens += len(batch.reqs)
         if not batch.spec_algorithm.is_none():
             self.metrics_reporter.update_spec_metrics(
@@ -673,6 +690,13 @@ class SchedulerBatchResultProcessor:
             ):
                 # NOTE: This (req.finished() or req.is_retracted) should only happen when overlap scheduling is enabled.
                 # And all the over-allocated tokens will be freed in `release_kv_cache`.
+                continue
+
+            if i in aborted_full_nan:
+                # Already aborted with a 5xx; release KV without inserting into
+                # the prefix cache so the poisoned state cannot be shared.
+                release_kv_cache(req, self.tree_cache)
+                req.time_stats.set_completion_time()
                 continue
 
             # next_token_id is a per-req list: 1 token for non-spec, the verified
@@ -865,6 +889,45 @@ class SchedulerBatchResultProcessor:
         think_end_id = self.model_config.think_end_id
         if req.require_reasoning and think_end_id is not None:
             req.update_reasoning_tokens(next_token_id, think_end_id)
+
+    def _abort_full_nan_logits_reqs(
+        self,
+        batch: ScheduleBatch,
+        logits_output: Optional[LogitsProcessorOutput],
+    ) -> set:
+        """Abort requests whose next-token logits row was entirely NaN.
+
+        Returns the set of batch indices that were aborted so callers can skip
+        normal processing for them. A fully-NaN row, after sanitization to a
+        constant, becomes a uniform random sample over the whole vocab —
+        garbage streamed to the client as a healthy 200 response, with the
+        corrupted KV poisoning every subsequent step. Aborting with a 5xx and
+        skipping prefix-cache insertion is strictly safer.
+
+        Only active when SGLANG_ABORT_ON_FULL_NAN_LOGITS is set; the mask is
+        None otherwise.
+        """
+        if logits_output is None:
+            return set()
+        mask = getattr(logits_output, "full_nan_logits_mask", None)
+        if mask is None:
+            return set()
+        mask_cpu = mask.cpu() if mask.is_cuda else mask
+        aborted: set = set()
+        for i, req in enumerate(batch.reqs):
+            if i < mask_cpu.shape[0] and bool(mask_cpu[i]):
+                req.set_finish_with_internal_error(
+                    "Aborted: next-token logits were entirely NaN "
+                    "(SGLANG_ABORT_ON_FULL_NAN_LOGITS). "
+                    "Sampling would have produced a uniform-random token."
+                )
+                aborted.add(i)
+        if aborted:
+            logger.warning(
+                "Aborted %d request(s) with fully-NaN next-token logits.",
+                len(aborted),
+            )
+        return aborted
 
     def _mamba_prefix_cache_update(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from http import HTTPStatus
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -63,17 +63,31 @@ def maybe_warn_nan(tensor: Optional[torch.Tensor], msg: str = ""):
     _nan_warner.check(tensor, msg)
 
 
-def sanitize_nan_logits(logits: torch.Tensor, msg: str = ""):
+def sanitize_nan_logits(
+    logits: torch.Tensor, msg: str = "", return_full_nan_mask: bool = False
+):
     """Detect NaN (assert in CI, throttled warning in prod), then sanitize in
     place: NaN logits (e.g. fp16 activation overflow) are undefined behavior
     in sampling kernels and can come back as out-of-vocab token ids. +-1e30
     rather than dtype min/max because callers divide logits by temperature,
-    which would overflow dtype min/max to +-Inf and softmax back to NaN."""
+    which would overflow dtype min/max to +-Inf and softmax back to NaN.
+
+    When return_full_nan_mask is True, returns a boolean tensor of shape
+    [batch] marking rows that were entirely NaN before sanitization. Such rows
+    become a uniform distribution after sanitization (softmax over a constant),
+    so callers can use the mask to abort the request instead of sampling
+    garbage. Returns None when the flag is False or SGLANG_SANITIZE_NAN_LOGITS
+    is off."""
     maybe_detect_nan(logits, msg)
     if not envs.SGLANG_SANITIZE_NAN_LOGITS.get():
-        return
+        return None
+    full_nan_mask = None
+    if return_full_nan_mask and envs.SGLANG_ABORT_ON_FULL_NAN_LOGITS.get():
+        # Capture before nan_to_num_ wipes the NaNs.
+        full_nan_mask = torch.isnan(logits).all(dim=-1)
     maybe_warn_nan(logits, msg)
     torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
+    return full_nan_mask if return_full_nan_mask else None
 
 
 def maybe_detect_nan(tensor: Optional[torch.Tensor], msg: str = ""):

--- a/python/sglang/srt/utils/async_probe.py
+++ b/python/sglang/srt/utils/async_probe.py
@@ -87,7 +87,7 @@ def sanitize_nan_logits(
         full_nan_mask = torch.isnan(logits).all(dim=-1)
     maybe_warn_nan(logits, msg)
     torch.nan_to_num_(logits, nan=-1e30, posinf=1e30, neginf=-1e30)
-    return full_nan_mask if return_full_nan_mask else None
+    return full_nan_mask
 
 
 def maybe_detect_nan(tensor: Optional[torch.Tensor], msg: str = ""):


### PR DESCRIPTION
## Problem

When `SGLANG_SANITIZE_NAN_LOGITS=1` is enabled, `sanitize_nan_logits()` replaces all NaN logits with the same constant (`-1e30`). When an **entire row** of logits is NaN, softmax over a constant row becomes a **uniform random distribution** over the whole vocab — the sampler draws pure random tokens (multilingual BPE salad) and streams them to the client as a healthy 200 response. Worse, the NaN'd step's KV is written to the request's KV cache, so **every subsequent step of that request is also corrupted**.

This was reported in #33187 as a follow-up to #32968 (transient NaN-contaminated logits on Kimi-K3): enabling the sanitize flag stops the device-side assert crashes, but converts a loud failure into silent garbage in the visible stream.

## Fix

Add an opt-in flag `SGLANG_ABORT_ON_FULL_NAN_LOGITS` (default off):

1. `sanitize_nan_logits()` gains a `return_full_nan_mask` parameter that captures a per-row boolean mask of all-NaN rows **before** `nan_to_num_` wipes them.
2. `Sampler._preprocess_logits()` records the mask on `LogitsProcessorOutput.full_nan_logits_mask`.
3. `batch_result_processor` (both prefill and decode paths) aborts affected requests with a **retriable 5xx** (`HTTPStatus.INTERNAL_SERVER_ERROR`) and sets `skip_radix_cache_insert=True` so the poisoned KV is **not** shared via the prefix cache.

## Design choices

- **Opt-in, default off**: no behavior change for existing deployments.
- **Only fully-NaN rows are aborted**: partial-NaN rows (individual token overflow) still go through the existing sanitize path — no false positives.
- **5xx, not 4xx**: this is a server-side numerical failure, the client can retry.
- **Cache hygiene**: `skip_radix_cache_insert` prevents the corrupted KV from being shared with other requests that share a prefix.

## Verification (CPU, no GPU needed)

Verified the core logic on CPU with the real sglang code:
- A fully-NaN row softmaxes to a **perfect uniform distribution** (max deviation from `1/vocab` = 0.0) — proving the failure mode described in the issue.
- A partially-NaN row is **not** flagged (`mask=[False]`).
- With either flag off, the mask is `None` and behavior is **identical** to before the change.



## Files changed (6 files, +136 / -12)

- `python/sglang/srt/environ.py` — new `SGLANG_ABORT_ON_FULL_NAN_LOGITS` flag
- `python/sglang/srt/utils/async_probe.py` — `sanitize_nan_logits()` returns full-NaN mask
- `python/sglang/srt/layers/logits_processor.py` — `LogitsProcessorOutput.full_nan_logits_mask` field
- `python/sglang/srt/layers/sampler.py` — `_preprocess_logits()` records the mask
- `python/sglang/srt/managers/schedule_batch.py` — `set_finish_with_abort()` gains `status_code`/`err_type`/`skip_radix_cache_insert` params
- `python/sglang/srt/managers/scheduler_components/batch_result_processor.py` — `_abort_full_nan_logits_reqs()` + calls in prefill/decode paths

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->