### PR TITLE
feat(scheduler): add lpm anti-starvation aging (#31954)

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -909,6 +909,10 @@ class Req(ReqDllmMixin):
         # time and used to estimate uncached tokens / sort by longest prefix for
         # load reporting.
         self.num_matched_prefix_tokens = 0
+        # Number of scheduler passes this request has spent in the waiting queue
+        # without being admitted. Used by the lpm aging term to bound
+        # cache-cold request starvation.
+        self.waiting_passes = 0
         # Tokens loaded from storage backend (L3) during prefetch for this request
         self.storage_hit_length = 0
         # The node to lock until for swa radix tree lock ref
@@ -1553,6 +1557,7 @@ class Req(ReqDllmMixin):
         self.last_node = None
         self.cache_protected_len = 0
         self.num_matched_prefix_tokens = 0
+        self.waiting_passes = 0
         self.swa_uuid_for_lock = None
         self.swa_prefix_lock_released = False
         self.skip_lock_node_ids = {}

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -172,6 +172,7 @@ class SchedulePolicy:
         enable_hierarchical_cache: bool,
         enable_priority_scheduling: bool,
         schedule_low_priority_values_first: bool,
+        lpm_aging_tokens_per_pass: int = 0,
     ):
         self.policy = self._validate_and_adjust_policy(policy, tree_cache)
         self.tree_cache = tree_cache
@@ -179,6 +180,9 @@ class SchedulePolicy:
         self.enable_priority_scheduling = enable_priority_scheduling
         self.schedule_low_priority_values_first = schedule_low_priority_values_first
         self.priority_sign = 1 if schedule_low_priority_values_first else -1
+        # Aging term for the lpm sort key: -(matched_prefix + N * waiting_passes).
+        # 0 (default) preserves the original lpm behavior exactly.
+        self.lpm_aging_tokens_per_pass = lpm_aging_tokens_per_pass
 
         # It is used to find the matching prefix for in-batch prefix caching.
         self.waiting_queue_radix_tree = RadixCache.create_simulated()
@@ -186,6 +190,14 @@ class SchedulePolicy:
     def calc_priority(
         self, waiting_queue: List[Req], running_batch: Optional[ScheduleBatch] = None
     ) -> None:
+        # Each call to calc_priority is one scheduler pass. Age every request
+        # still in the waiting queue so the lpm aging term can bound
+        # cache-cold request starvation. Only the lpm sort key consumes this
+        # field; other policies ignore it.
+        if self.lpm_aging_tokens_per_pass > 0:
+            for r in waiting_queue:
+                r.waiting_passes += 1
+
         policy = self._determine_active_policy(waiting_queue)
 
         # Populate req.num_matched_prefix_tokens at schedule time. Cache-aware policies
@@ -213,7 +225,9 @@ class SchedulePolicy:
             )
             if policy == CacheAwarePolicy.LPM:
                 SchedulePolicy._sort_by_longest_prefix(
-                    waiting_queue, temporary_deprioritized
+                    waiting_queue,
+                    temporary_deprioritized,
+                    self.lpm_aging_tokens_per_pass,
                 )
             elif policy == CacheAwarePolicy.DFS_WEIGHT:
                 SchedulePolicy._sort_by_dfs_weight(waiting_queue, self.tree_cache)
@@ -312,12 +326,25 @@ class SchedulePolicy:
 
     @staticmethod
     def _sort_by_longest_prefix(
-        waiting_queue: List[Req], temporary_deprioritized: Set[int]
+        waiting_queue: List[Req],
+        temporary_deprioritized: Set[int],
+        aging_tokens_per_pass: int = 0,
     ) -> None:
-        """Sorts the waiting queue based on the longest prefix match."""
+        """Sorts the waiting queue based on the longest prefix match.
+
+        When aging_tokens_per_pass > 0, the sort key becomes
+        -(num_matched_prefix_tokens + aging_tokens_per_pass * waiting_passes),
+        so requests that have waited longer move up in the queue. This bounds
+        starvation of cache-cold requests under high radix-cache hit rates
+        without giving up lpm's cache-locality ordering. 0 (default) preserves
+        the original behavior exactly.
+        """
         waiting_queue.sort(
             key=lambda r: (
-                -r.num_matched_prefix_tokens
+                -(
+                    r.num_matched_prefix_tokens
+                    + aging_tokens_per_pass * r.waiting_passes
+                )
                 if r.rid not in temporary_deprioritized
                 else float("inf")
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1129,6 +1129,7 @@ class Scheduler(
             self.enable_hierarchical_cache,
             self.enable_priority_scheduling,
             self.schedule_low_priority_values_first,
+            lpm_aging_tokens_per_pass=self.server_args.lpm_aging_tokens_per_pass,
         )
         self.prefill_delayer: Optional[PrefillDelayer] = None
         self.max_prefill_bs: int = 0
@@ -3170,6 +3171,11 @@ class Scheduler(
             return None, running_batch
 
         can_run_set = set(can_run_list)
+        # Requests admitted to the running batch leave the waiting queue; reset
+        # their aging counter so a future re-queue (e.g. preemption) starts
+        # fresh rather than inheriting a stale age.
+        for req in can_run_list:
+            req.waiting_passes = 0
         self.waiting_queue = [x for x in self.waiting_queue if x not in can_run_set]
         if adder.preempt_list:
             for req in adder.preempt_list:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -809,6 +809,16 @@ class ServerArgs:
         ),
         NS("schedule"),
     ] = "fcfs"
+    lpm_aging_tokens_per_pass: A[
+        int,
+        Arg(
+            help="Aging term added to the lpm (longest-prefix-match) sort key per "
+            "waiting pass, to prevent cache-cold requests from being starved "
+            "by cache-hot arrivals. The lpm sort key becomes "
+            "-(num_matched_prefix_tokens + N * waiting_passes). 0 (default) "
+            "preserves the original lpm behavior exactly.",
+        ),
+    ] = 0
     enable_priority_scheduling: A[
         bool,
         "Enable priority scheduling. Requests with higher priority integer values will be scheduled first by default.",


### PR DESCRIPTION
## Summary

Implements the anti-starvation aging mechanism for the `lpm` (longest-prefix-match) schedule policy proposed in #31954.

## Problem

`lpm` sorts the waiting queue purely by matched-prefix length, with no aging or arrival-time term. At high radix hit rates this starves cache-cold requests: a cold request (zero prefix match) is re-displaced by *every* cache-hot arrival, and its wait is unbounded as long as hot traffic keeps arriving. On production traffic (GLM-5.2-NVFP4, 8x B300, ~96% radix hit rate) cache-miss requests formed a 20-60s TTFT tail.

## Solution

Add `--lpm-aging-tokens-per-pass N` (default `0` = exactly current behavior). The lpm sort key becomes:

```
-(num_matched_prefix_tokens + N * waiting_passes)
```

Aging composes with match length rather than overriding it: fresh cache-hot requests still sort first, but a cold request's effective match grows until it must be scheduled, bounding worst-case displacement at roughly `ceil(max_match / N)` passes.

## Changes

- `server_args.py`: add `lpm_aging_tokens_per_pass` arg (default 0)
- `schedule_batch.py`: add `Req.waiting_passes` counter (initialized to 0 in both `__init__` paths)
- `schedule_policy.py`:
  - accept `lpm_aging_tokens_per_pass` in `SchedulePolicy.__init__`
  - increment `waiting_passes` for all waiting requests at the start of `calc_priority` (one call = one scheduler pass)
  - pass the aging term into `_sort_by_longest_prefix` and fold it into the sort key
- `scheduler.py`:
  - wire `server_args.lpm_aging_tokens_per_pass` into `SchedulePolicy` construction
  - reset `waiting_passes = 0` when a request is admitted to the running batch (so re-queue after preemption starts fresh)

## Verification

- All four files parse cleanly (`ast.parse`).
- Verified the sort key directly with mock `Req` objects:
  - `N=0` preserves pure lpm ordering (cold always loses to hot)
  - `N=10`, cold req waited 11 passes -> effective 110 > 100 -> cold sorts first
  - `N=10`, cold req waited 5 passes -> effective 50 < 100 -> hot still sorts first
  - deprioritized requests still sort last regardless of age
  - among multiple cold reqs, the one with the most `waiting_passes` sorts first
- No GPU required: this is pure Python scheduling logic.

Closes #31954

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30707252576](https://github.com/sgl-project/sglang/actions/runs/30707252576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30707252455](https://github.com/sgl-project/sglang/actions/runs/30707252455)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->