### PR TITLE
feat(openai): support drop_thinking for DeepSeek chat encoding

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -891,6 +891,7 @@ class OpenAIServingChat(OpenAIServingBase):
         thinking_mode = (
             ThinkingMode.THINKING if thinking_requested else ThinkingMode.CHAT
         )
+        drop_thinking = (request.chat_template_kwargs or {}).get("drop_thinking", True)
         messages = [msg.model_dump() for msg in request.messages]
         for message in messages:
             normalize_assistant_tool_call_arguments(message)
@@ -976,12 +977,15 @@ class OpenAIServingChat(OpenAIServingBase):
                 real_input = encoding_dsv4.encode_messages(
                     messages,
                     thinking_mode=thinking_mode,
+                    drop_thinking=drop_thinking,
                     reasoning_effort=v4_reasoning_effort,
                 )
                 prompt_ids = self.tokenizer_manager.tokenizer.encode(real_input)
             else:
                 real_input = encoding_dsv32.encode_messages(
-                    messages, thinking_mode=thinking_mode
+                    messages,
+                    thinking_mode=thinking_mode,
+                    drop_thinking=drop_thinking,
                 )
                 prompt_ids = self.tokenizer_manager.tokenizer.encode(real_input)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DeepSeek V4/V3.2 encoders support the `drop_thinking` option, but the OpenAI-compatible chat endpoint did not forward this request-level option. As a result, requests such as `chat_template_kwargs={"drop_thinking": false}` were silently ignored.

This change exposes that existing option through the OpenAI-compatible API while keeping the default value unchanged for backward compatibility.

## Modifications

- Read `drop_thinking` from `request.chat_template_kwargs`.
- Forward the option to both DeepSeek V4 and V3.2 custom chat encoders.
- Preserve the existing default value of `True` for backward compatibility.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30708801990](https://github.com/sgl-project/sglang/actions/runs/30708801990)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30708801914](https://github.com/sgl-project/sglang/actions/runs/30708801914)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->