### PR TITLE
Fix DeepSeek-OCR batching crash on variable local-crop counts

### DIFF
--- a/python/sglang/srt/models/deepseek_ocr.py
+++ b/python/sglang/srt/models/deepseek_ocr.py
@@ -1702,9 +1702,8 @@ class DeepseekOCRForCausalLM(nn.Module):
                 .type(target_dtype)
                 .to(device=pixel_values.device)
             )
-            images_spatial_crop = (
-                item.images_spatial_crop.type(torch.long)
-                .to(device=pixel_values.device)
+            images_spatial_crop = item.images_spatial_crop.type(torch.long).to(
+                device=pixel_values.device
             )
             if images_spatial_crop.dim() == 2:
                 images_spatial_crop = images_spatial_crop.unsqueeze(0)

--- a/python/sglang/srt/models/deepseek_ocr.py
+++ b/python/sglang/srt/models/deepseek_ocr.py
@@ -1689,30 +1689,42 @@ class DeepseekOCRForCausalLM(nn.Module):
             else self.vision_model.dtype
         )
         has_local_crops = self._collect_mm_flag(mm_items, "has_local_crops")
-        pixel_values = torch.stack([item.feature for item in mm_items], dim=0).type(
-            target_dtype
-        )
 
-        images_crop = (
-            torch.stack([item.images_crop for item in mm_items], dim=0)
-            .type(target_dtype)
-            .to(device=pixel_values.device)
-        )
-        images_spatial_crop = (
-            torch.cat([item.images_spatial_crop for item in mm_items], dim=0)
-            .type(torch.long)
-            .to(device=pixel_values.device)
-        )
+        # Different images may have a different number of local crop patches
+        # (images_crop shape [1, num_patches, 3, H, W] varies per item), so we
+        # cannot stack them into a single tensor. Process each item separately
+        # and concatenate the resulting feature sequences.
+        vision_feature_lists: List[torch.Tensor] = []
+        for idx, item in enumerate(mm_items):
+            pixel_values = item.feature.unsqueeze(0).type(target_dtype)
+            images_crop = (
+                item.images_crop.unsqueeze(0)
+                .type(target_dtype)
+                .to(device=pixel_values.device)
+            )
+            images_spatial_crop = (
+                item.images_spatial_crop.type(torch.long)
+                .to(device=pixel_values.device)
+            )
+            if images_spatial_crop.dim() == 2:
+                images_spatial_crop = images_spatial_crop.unsqueeze(0)
 
-        assert images_crop.dim() == 6
-        assert images_spatial_crop.dim() == 3
+            assert images_crop.dim() == 6
+            assert images_spatial_crop.dim() == 3
 
-        vision_feature_lists = self._pixel_values_to_embedding(
-            pixel_values=pixel_values,
-            images_crop=images_crop,
-            images_spatial_crop=images_spatial_crop,
-            has_local_crops=has_local_crops,
-        )
+            item_has_local_crops = (
+                [has_local_crops[idx]] if has_local_crops is not None else None
+            )
+
+            vision_feature_lists.extend(
+                self._pixel_values_to_embedding(
+                    pixel_values=pixel_values,
+                    images_crop=images_crop,
+                    images_spatial_crop=images_spatial_crop,
+                    has_local_crops=item_has_local_crops,
+                )
+            )
+
         vision_features = torch.cat(vision_feature_lists, dim=0).type(target_dtype)
 
         return vision_features

--- a/test/registered/xpu/test_deepseek_ocr.py
+++ b/test/registered/xpu/test_deepseek_ocr.py
@@ -6,9 +6,13 @@ import json
 import os
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import requests
+import torch
 
+from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.models.deepseek_ocr import DeepseekOCRForCausalLM
 from sglang.srt.utils import kill_process_tree
 from sglang.srt.utils.hf_transformers import get_tokenizer
 from sglang.test.ci.ci_register import register_xpu_ci
@@ -107,6 +111,77 @@ class TestDeepSeekOCR(CustomTestCase):
 
     def test_moe(self):
         self.run_decode()
+
+
+@unittest.skipUnless(
+    hasattr(torch, "xpu") and torch.xpu.is_available(),
+    "requires an available XPU device",
+)
+class TestDeepSeekOCRProcessImageInputBatchedUnequalCrops(CustomTestCase):
+    """Regression: `_process_image_input` used to `torch.stack` `images_crop`
+    across `mm_items`, which crashed when two OCR requests in the same batch
+    had different `num_patches` (e.g. 6 vs 4). Guards against reintroducing
+    the stack. Runs on XPU to match the intended deployment target."""
+
+    def _make_item(self, num_patches, tiles_w, tiles_h):
+        item = MultimodalDataItem(modality=Modality.IMAGE)
+        item.feature = torch.zeros(3, 640, 640, dtype=torch.float32, device=self.device)
+        item.images_crop = torch.zeros(
+            1, num_patches, 3, 640, 640, dtype=torch.float32, device=self.device
+        )
+        item.images_spatial_crop = torch.tensor(
+            [[[tiles_w, tiles_h]]], dtype=torch.long, device=self.device
+        )
+        item.has_local_crops = True
+        return item
+
+    def test_batched_unequal_num_patches_no_crash(self):
+        self.device = torch.device("xpu")
+
+        items = [
+            self._make_item(num_patches=6, tiles_w=3, tiles_h=2),
+            self._make_item(num_patches=4, tiles_w=2, tiles_h=2),
+        ]
+
+        def fake_pixel_values_to_embedding(
+            pixel_values, images_crop, images_spatial_crop, has_local_crops
+        ):
+            self.assertEqual(pixel_values.shape[0], 1)
+            self.assertEqual(images_crop.dim(), 6)
+            self.assertEqual(images_spatial_crop.dim(), 3)
+            self.assertEqual(pixel_values.device.type, "xpu")
+            self.assertEqual(images_crop.device.type, "xpu")
+            self.assertEqual(images_spatial_crop.device.type, "xpu")
+            n_patches = images_crop.shape[2]
+            return [torch.zeros(n_patches, 8, dtype=torch.float32, device=self.device)]
+
+        instance = DeepseekOCRForCausalLM.__new__(DeepseekOCRForCausalLM)
+        instance.is_ocr2 = False
+
+        stub_param = torch.zeros(1, dtype=torch.float32, device=self.device)
+
+        class _Stub:
+            dtype = torch.float32
+
+            @staticmethod
+            def parameters():
+                return iter([stub_param])
+
+        instance.sam_model = _Stub()
+        instance.vision_model = _Stub()
+
+        with patch.object(
+            DeepseekOCRForCausalLM,
+            "_pixel_values_to_embedding",
+            side_effect=fake_pixel_values_to_embedding,
+            autospec=False,
+        ):
+            out = DeepseekOCRForCausalLM._process_image_input(instance, items)
+
+        # Feature sequences from both items must be concatenated in order.
+        # 6 rows for item A + 4 rows for item B = 10 rows.
+        self.assertEqual(out.shape, (10, 8))
+        self.assertEqual(out.device.type, "xpu")
 
 
 if __name__ == "__main__":

--- a/test/registered/xpu/test_deepseek_ocr.py
+++ b/test/registered/xpu/test_deepseek_ocr.py
@@ -113,34 +113,42 @@ class TestDeepSeekOCR(CustomTestCase):
         self.run_decode()
 
 
-@unittest.skipUnless(
-    hasattr(torch, "xpu") and torch.xpu.is_available(),
-    "requires an available XPU device",
-)
+def _device_available(device: str) -> bool:
+    if device == "cpu":
+        return True
+    if device == "cuda":
+        return torch.cuda.is_available()
+    if device == "xpu":
+        return hasattr(torch, "xpu") and torch.xpu.is_available()
+    return False
+
+
 class TestDeepSeekOCRProcessImageInputBatchedUnequalCrops(CustomTestCase):
     """Regression: `_process_image_input` used to `torch.stack` `images_crop`
     across `mm_items`, which crashed when two OCR requests in the same batch
     had different `num_patches` (e.g. 6 vs 4). Guards against reintroducing
-    the stack. Runs on XPU to match the intended deployment target."""
+    the stack. Runs on each device the host provides (CPU / XPU / CUDA)."""
 
-    def _make_item(self, num_patches, tiles_w, tiles_h):
+    def _make_item(self, device, num_patches, tiles_w, tiles_h):
         item = MultimodalDataItem(modality=Modality.IMAGE)
-        item.feature = torch.zeros(3, 640, 640, dtype=torch.float32, device=self.device)
+        item.feature = torch.zeros(3, 640, 640, dtype=torch.float32, device=device)
         item.images_crop = torch.zeros(
-            1, num_patches, 3, 640, 640, dtype=torch.float32, device=self.device
+            1, num_patches, 3, 640, 640, dtype=torch.float32, device=device
         )
         item.images_spatial_crop = torch.tensor(
-            [[[tiles_w, tiles_h]]], dtype=torch.long, device=self.device
+            [[[tiles_w, tiles_h]]], dtype=torch.long, device=device
         )
         item.has_local_crops = True
         return item
 
-    def test_batched_unequal_num_patches_no_crash(self):
-        self.device = torch.device("xpu")
+    def _run_batched_unequal_num_patches(self, device: str):
+        if not _device_available(device):
+            self.skipTest(f"device {device!r} not available on this host")
+        torch_device = torch.device(device)
 
         items = [
-            self._make_item(num_patches=6, tiles_w=3, tiles_h=2),
-            self._make_item(num_patches=4, tiles_w=2, tiles_h=2),
+            self._make_item(torch_device, num_patches=6, tiles_w=3, tiles_h=2),
+            self._make_item(torch_device, num_patches=4, tiles_w=2, tiles_h=2),
         ]
 
         def fake_pixel_values_to_embedding(
@@ -149,16 +157,16 @@ class TestDeepSeekOCRProcessImageInputBatchedUnequalCrops(CustomTestCase):
             self.assertEqual(pixel_values.shape[0], 1)
             self.assertEqual(images_crop.dim(), 6)
             self.assertEqual(images_spatial_crop.dim(), 3)
-            self.assertEqual(pixel_values.device.type, "xpu")
-            self.assertEqual(images_crop.device.type, "xpu")
-            self.assertEqual(images_spatial_crop.device.type, "xpu")
+            self.assertEqual(pixel_values.device.type, torch_device.type)
+            self.assertEqual(images_crop.device.type, torch_device.type)
+            self.assertEqual(images_spatial_crop.device.type, torch_device.type)
             n_patches = images_crop.shape[2]
-            return [torch.zeros(n_patches, 8, dtype=torch.float32, device=self.device)]
+            return [torch.zeros(n_patches, 8, dtype=torch.float32, device=torch_device)]
 
         instance = DeepseekOCRForCausalLM.__new__(DeepseekOCRForCausalLM)
         instance.is_ocr2 = False
 
-        stub_param = torch.zeros(1, dtype=torch.float32, device=self.device)
+        stub_param = torch.zeros(1, dtype=torch.float32, device=torch_device)
 
         class _Stub:
             dtype = torch.float32
@@ -181,7 +189,16 @@ class TestDeepSeekOCRProcessImageInputBatchedUnequalCrops(CustomTestCase):
         # Feature sequences from both items must be concatenated in order.
         # 6 rows for item A + 4 rows for item B = 10 rows.
         self.assertEqual(out.shape, (10, 8))
-        self.assertEqual(out.device.type, "xpu")
+        self.assertEqual(out.device.type, torch_device.type)
+
+    def test_batched_unequal_num_patches_no_crash_cpu(self):
+        self._run_batched_unequal_num_patches("cpu")
+
+    def test_batched_unequal_num_patches_no_crash_xpu(self):
+        self._run_batched_unequal_num_patches("xpu")
+
+    def test_batched_unequal_num_patches_no_crash_cuda(self):
+        self._run_batched_unequal_num_patches("cuda")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`_process_image_input` in `python/sglang/srt/models/deepseek_ocr.py` batches multiple `MultimodalDataItem`s into a single vision-encoder forward pass. It used `torch.stack` to fuse each item's `images_crop` tensor:

```python
images_crop = torch.stack([item.images_crop for item in mm_items], dim=0)
```

Each item's `images_crop` has shape `[1, num_patches, 3, 640, 640]`, where `num_patches` depends on the image's aspect ratio / resolution. Two OCR requests batched into the same forward pass with different tile counts (e.g. 6 vs 4) therefore crash the scheduler:

```
RuntimeError: stack expects each tensor to be equal size,
  but got [1, 6, 3, 640, 640] at entry 0
      and [1, 4, 3, 640, 640] at entry 1
```

Reproduced via `benchmark/ocr/bench_sglang.py --concurrency 8` on olmOCR-bench (`multi_column` split).

## Fix

`_pixel_values_to_embedding` already loops item-by-item internally and returns a list of per-item feature tensors that get concatenated by the caller, so the cross-item stack was never needed for correctness — only for convenience. Iterate `mm_items` instead, run each through `_pixel_values_to_embedding` with a 1-sized batch, and concat the resulting features. Downstream `merge_multimodal_embeddings` sees the same flat sequence.

## Regression test

Added `TestDeepSeekOCRProcessImageInputBatchedUnequalCrops` in `test/registered/xpu/test_deepseek_ocr.py`. Builds two `MultimodalDataItem`s with `images_crop` shapes `[1, 6, 3, 640, 640]` and `[1, 4, 3, 640, 640]` — the exact 6-vs-4 mismatch from the crash traceback — stubs `_pixel_values_to_embedding`, and calls `_process_image_input`. Parameterized over three devices; each test method skips cleanly when its device is unavailable on the host runner:

- `test_batched_unequal_num_patches_no_crash_cpu`
- `test_batched_unequal_num_patches_no_crash_xpu`
- `test_batched_unequal_num_patches_no_crash_cuda`

### Test results

Verified on a host with CPU + XPU (no CUDA), running the new test class against **both** the fixed code (this PR) and the pre-fix `torch.stack` code:

| Device | Pre-fix (bug present) | With patch (this PR) |
|---|---|---|
| CPU | ❌ `RuntimeError: stack expects each tensor to be equal size, but got [1, 6, 3, 640, 640] at entry 0 and [1, 4, 3, 640, 640] at entry 1` | ✅ OK |
| XPU | ❌ same `RuntimeError` | ✅ OK |
| CUDA | ⏭  skipped (no CUDA device on this runner) | ⏭  skipped (no CUDA device on this runner) |

Full run:

```
$ cd test/registered/xpu && PYTHONPATH=../../../python python -m unittest -v \
    test_deepseek_ocr.TestDeepSeekOCRProcessImageInputBatchedUnequalCrops

test_batched_unequal_num_patches_no_crash_cpu ... ok
test_batched_unequal_num_patches_no_crash_cuda ... skipped "device 'cuda' not available on this host"
test_batched_unequal_num_patches_no_crash_xpu ... ok

Ran 3 tests in 0.128s

OK (skipped=1)
```

Total wall-clock: ~0.13s (no server spin-up; regression is exercised via a stubbed `_pixel_values_to_embedding` so the test doesn't need real vision-encoder weights).

### E2E sanity

Also confirmed on the OCR benchmark that used to crash:

```
python benchmark/ocr/bench_sglang.py \
    --port 30000 --split all --concurrency 8 \
    --output-dir logs/ --bench-dir /data/olmOCR-bench/bench_data/
```

Runs to completion post-patch (was crashing on the `multi_column` split before).

## Checklist

- [x] Pre-commit clean on both modified files (`pre-commit run --files ...`).
- [x] Regression test fails on pre-fix code, passes on the fix (verified on CPU and XPU).
- [x] Single-image requests still work — no regression for `--concurrency 1`.
~

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31015641600](https://github.com/sgl-project/sglang/actions/runs/31015641600)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31015641266](https://github.com/sgl-project/sglang/actions/runs/31015641266)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->