### PR TITLE
Fix non-EP DeepSeek-V4 TBO for attention TP > 1

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2245,6 +2245,12 @@ class DeepseekV4Model(nn.Module):
             and forward_batch.global_forward_mode.is_extend_without_speculative()
             and not dsa_use_prefill_cp(forward_batch)
             and self.pp_group.world_size == 1
+            # The non-EP path gathers variable-length metadata across the full
+            # TP group and is only valid when each DP shard has one attention
+            # rank. EP/Mori TBO uses a different communication strategy.
+            and (
+                not get_moe_a2a_backend().is_none() or get_parallel().attn_tp_size == 1
+            )
         )
 
     def _forward_layers_tbo(

--- a/test/registered/unit/models/test_deepseek_v4_tbo_policy.py
+++ b/test/registered/unit/models/test_deepseek_v4_tbo_policy.py
@@ -1,0 +1,56 @@
+"""Unit tests for the DeepSeek-V4 two-batch-overlap policy."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import sglang.srt.models.deepseek_v4 as deepseek_v4
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestDeepseekV4TboPolicy(CustomTestCase):
+    def _can_run_tbo(self, *, non_ep: bool, attn_tp_size: int) -> bool:
+        model = SimpleNamespace(pp_group=SimpleNamespace(world_size=1))
+        forward_batch = SimpleNamespace(
+            can_run_tbo=True,
+            tbo_children=[object(), object()],
+            global_forward_mode=SimpleNamespace(
+                is_extend_without_speculative=lambda: True
+            ),
+        )
+        backend = SimpleNamespace(is_none=lambda: non_ep)
+
+        with (
+            patch(
+                "sglang.srt.layers.moe.is_tbo_enabled",
+                return_value=True,
+            ),
+            patch.object(deepseek_v4, "dsa_use_prefill_cp", return_value=False),
+            patch.object(
+                deepseek_v4,
+                "get_moe_a2a_backend",
+                return_value=backend,
+            ),
+            patch.object(
+                deepseek_v4,
+                "get_parallel",
+                return_value=SimpleNamespace(attn_tp_size=attn_tp_size),
+            ),
+        ):
+            return deepseek_v4.DeepseekV4Model._can_run_tbo(model, forward_batch)
+
+    def test_non_ep_tbo_falls_back_with_multiple_attention_tp_ranks(self):
+        self.assertFalse(self._can_run_tbo(non_ep=True, attn_tp_size=4))
+
+    def test_non_ep_tbo_remains_enabled_with_one_attention_tp_rank(self):
+        self.assertTrue(self._can_run_tbo(non_ep=True, attn_tp_size=1))
+
+    def test_ep_tbo_is_not_restricted_by_attention_tp_size(self):
+        self.assertTrue(self._can_run_tbo(non_ep=False, attn_tp_size=4))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #32669.

The non-EP DeepSeek-V4 two-batch-overlap path uses TP-wide metadata and combine behavior that is only valid when the attention tensor-parallel size is 1. Enabling it for larger attention-TP configurations can route execution through an incompatible path.

## Modifications

- Require attention tensor-parallel size 1 before enabling the non-EP TBO path.
- Add a registered policy regression test covering the supported and unsupported configurations.

## Accuracy Tests

The policy regression test and all applicable pre-commit checks pass. End-to-end DeepSeek-V4 accuracy testing was not run because the required model and GPU environment are not available locally.

## Speed Tests and Profiling

Not applicable. The change preserves TBO for the supported attention-TP=1 configuration and disables it for the incompatible attention-TP>1 configuration.

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add unit tests according to the contribution guide.
- [x] Update documentation where applicable; no documentation change is required for this internal policy correction.
- [x] Provide accuracy and speed results where applicable; limitations are stated above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30713565966](https://github.com/sgl-project/sglang/actions/runs/30713565966)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30713565865](https://github.com/sgl-project/sglang/actions/runs/30713565865)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->