### PR TITLE
[CUDA Graph] Reduce memory by reusing a process-wide capture stream

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -52,6 +52,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
 from sglang.srt.platforms.device_mixin import _DEVICE_TO_DISTRIBUTED_BACKEND
 from sglang.srt.runtime_context import (
     get_global_dwdp_manager,
+    get_stream,
     set_global_dwdp_manager,
 )
 from sglang.srt.utils import (
@@ -107,6 +108,9 @@ def get_torch_distributed_pg_options(group_name=None):
 @dataclass
 class GraphCaptureContext:
     stream: torch.get_device_module().Stream
+
+
+_PROCESS_GRAPH_CAPTURE_STREAM = "cuda_graph_capture"
 
 
 @dataclass
@@ -1953,21 +1957,22 @@ def get_mooncake_transfer_engine():
 
 @contextmanager
 def graph_capture(stream=None):
+    """Coordinate graph capture across all parallel groups.
+
+    Default captures reuse one process-level side stream. Combined with the
+    process-level graph memory pool, this lets separate runner capture sessions
+    reuse allocator blocks that are compatible in size and lifetime. Callers
+    that require a particular stream can still pass it explicitly.
     """
-    `graph_capture` is a context manager which should surround the code that
-    is capturing the CUDA graph. Its main purpose is to ensure that the
-    some operations will be run after the graph is captured, before the graph
-    is replayed. It returns a `GraphCaptureContext` object which contains the
-    necessary data for the graph capture. Currently, it only contains the
-    stream that the graph capture is running on. This stream is set to the
-    current CUDA stream when the context manager is entered and reset to the
-    default stream when the context manager is exited. This is to ensure that
-    the graph capture is running on a separate stream from the default stream,
-    in order to explicitly distinguish the kernels to capture
-    from other kernels possibly launched on background in the default stream.
-    """
+    tp_group = get_tp_group()
+    if stream is None:
+        stream = get_stream(
+            _PROCESS_GRAPH_CAPTURE_STREAM,
+            factory=tp_group.device_module.Stream,
+        )
+
     with (
-        get_tp_group().graph_capture(stream=stream) as context,
+        tp_group.graph_capture(stream=stream) as context,
         get_pp_group().graph_capture(context),
     ):
         with contextlib.ExitStack() as stack:

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -50,7 +50,7 @@ import dataclasses
 import os
 import sys
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -755,16 +755,20 @@ class RuntimeContext:
         self.resources = Resources()
         self.forward = ForwardFlags()
 
-    def get_stream(self, name: str) -> Any:
-        """Named process-level CUDA side stream: get-or-create, shared by
-        name (the keyed-lazy pattern of the persistent buffers). Creation is
-        a driver call that must stay outside cuda-graph capture — call sites
-        lease their stream at init/warmup time."""
+    def get_stream(self, name: str, *, factory: Callable[[], Any] | None = None) -> Any:
+        """Named process-level side stream: get-or-create, shared by name.
+
+        ``factory`` lets device-agnostic call sites create a stream from their
+        active device module. CUDA-only callers keep the default. Stream
+        creation is a driver call that must stay outside graph capture.
+        """
         stream = self.resources.streams.get(name)
         if stream is None:
-            import torch
+            if factory is None:
+                import torch
 
-            stream = torch.cuda.Stream()
+                factory = torch.cuda.Stream
+            stream = factory()
             self.resources.streams[name] = stream
         return stream
 
@@ -1310,8 +1314,8 @@ def publish_role() -> str | None:
     return _CONTEXT._publish_role
 
 
-def get_stream(name: str) -> Any:
-    return _CONTEXT.get_stream(name)
+def get_stream(name: str, *, factory: Callable[[], Any] | None = None) -> Any:
+    return _CONTEXT.get_stream(name, factory=factory)
 
 
 def set_stream(name: str, stream: Any) -> Any:

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -554,6 +554,20 @@ class TestNamedStreams(_IsolatedServerArgs):
         self.assertIsNot(a, c)
         self.assertEqual(len(created), 2)
 
+    def test_get_or_create_accepts_device_factory(self):
+        reset_context()
+        created = []
+
+        def factory():
+            stream = object()
+            created.append(stream)
+            return stream
+
+        a = get_context().get_stream("device", factory=factory)
+        b = get_context().get_stream("device", factory=factory)
+        self.assertIs(a, b)
+        self.assertEqual(len(created), 1)
+
     def test_get_buffer_keyed_lazy(self):
         reset_context()
         created = []
@@ -579,6 +593,58 @@ class TestNamedStreams(_IsolatedServerArgs):
         get_context().set_stream("alt", object())
         reset_context()
         self.assertEqual(get_context().resources.streams, {})
+
+    def test_graph_capture_default_stream_is_process_scoped(self):
+        from contextlib import contextmanager
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from sglang.srt.distributed import parallel_state
+
+        reset_context()
+        created_streams = []
+
+        class FakeDeviceModule:
+            @staticmethod
+            def Stream():
+                stream = object()
+                created_streams.append(stream)
+                return stream
+
+        @contextmanager
+        def coordinator_capture(graph_capture_context=None, stream=None):
+            if graph_capture_context is None:
+                graph_capture_context = parallel_state.GraphCaptureContext(stream)
+            yield graph_capture_context
+
+        group = SimpleNamespace(
+            device_module=FakeDeviceModule,
+            graph_capture=coordinator_capture,
+        )
+        with (
+            patch.object(parallel_state, "get_tp_group", return_value=group),
+            patch.object(parallel_state, "get_pp_group", return_value=group),
+            patch.object(parallel_state, "_DCP", None),
+            patch.object(parallel_state, "_ATTN_TP", None),
+            patch.object(parallel_state, "_MOE_EP", None),
+            patch.object(parallel_state, "_MOE_TP", None),
+        ):
+            with parallel_state.graph_capture() as first:
+                pass
+            with parallel_state.graph_capture() as second:
+                pass
+            explicit_stream = object()
+            with parallel_state.graph_capture(stream=explicit_stream) as explicit:
+                pass
+
+            reset_context()
+            with parallel_state.graph_capture() as after_reset:
+                pass
+
+        self.assertEqual(len(created_streams), 2)
+        self.assertIs(first.stream, second.stream)
+        self.assertIs(explicit.stream, explicit_stream)
+        self.assertIsNot(after_reset.stream, first.stream)
 
     def test_capturer_slots_roundtrip_and_reset(self):
         from sglang.srt.state_capturer.indexer_topk import (


### PR DESCRIPTION
## Motivation

SGLang already uses a process-wide graph-private memory pool across CUDA graph runners. However, each default `graph_capture()` session previously created its own side stream. Sharing only the pool handle does not let the CUDA caching allocator reuse all compatible blocks when those allocations belong to different streams.

[PyTorch's graph memory management documentation](https://docs.pytorch.org/docs/stable/notes/cuda.html#graph-memory-management) describes why captured allocations must remain in graph-private pools and when multiple captures may safely share a private pool. More specifically, the [PyTorch CUDAGraph Trees implementation](https://github.com/pytorch/pytorch/blob/c1a0be23f6d7d417d2c3215b5eff2a47d9280b1e/torch/_inductor/cudagraph_trees.py#L2307-L2311) explains the stream-level allocator constraint:

> the cuda caching allocator will remember the stream a segment is allocated to and only allocate that segment to the same stream ... allocations to separate streams will not be reused

It therefore uses a single stream for all allocations in the shared memory pool. SGLang's previous per-session streams could similarly leave otherwise reusable blocks separated by stream, especially when several runners capture into the same process-wide pool.

This PR reuses one process-wide capture stream for default graph capture sessions so the existing shared graph pool can reuse compatible allocations across runners more effectively.

## Modifications

- Lease the default CUDA graph capture stream from `RuntimeContext`'s process-level named-stream registry.
- Create that stream through the active device module's `Stream` factory instead of hard-coding CUDA, preserving the existing device abstraction.
- Preserve explicitly supplied streams without changing their behavior.
- Extend `RuntimeContext.get_stream()` with an optional factory while keeping `torch.cuda.Stream` as the default for existing callers.
- Add unit coverage for device-specific factories, stream reuse across capture sessions, explicit-stream preservation, and stream recreation after `reset_context()`.

## Accuracy Tests

This change does not modify model math, kernels, graph inputs, or graph replay order. Both serving configurations in the profiling section reached the ready state and handled requests successfully.

```bash
PYTHONPATH=python pytest -q test/registered/unit/test_runtime_context.py
```

Result:

```text
67 passed
```

The full repository pre-commit suite also passes:

```bash
pre-commit run --all-files
```

## Speed Tests and Profiling

The change only selects the side stream used while capturing graphs; it does not change the captured kernel sequence or the replay path. The primary expected effect is lower post-capture GPU memory usage, so this section reports process memory after the server reached the ready state and all configured CUDA graphs had been captured.

The A/B runs used one otherwise-idle NVIDIA A800 80GB GPU and the same software environment. The base was upstream commit `00a219f6c9e5b38ec7beddcfcb99266601182443`. On this A800 environment, SGLang resolves FlashInfer as the default attention backend. The explicit `--attention-backend flashinfer` arguments below only pin the backend for reproducibility; FlashInfer was not selected specifically to enable this optimization, and the optimization itself is backend-agnostic. Memory was read in MiB from NVML with:

```bash
nvidia-smi -i 0 \
    --query-compute-apps=pid,process_name,used_memory \
    --format=csv,noheader,nounits
```

### Qwen3-32B with FlashInfer

```bash
python3 -m sglang.launch_server \
    --model-path Qwen/Qwen3-32B \
    --attention-backend flashinfer
```

### EAGLE3 with D=16 and FlashInfer

```bash
python3 -m sglang.launch_server \
    --model-path Qwen/Qwen3-8B \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path AngelSlim/Qwen3-8B_eagle3 \
    --speculative-num-steps 15 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 16 \
    --attention-backend flashinfer \
    --trust-remote-code
```

| Configuration | Upstream main | This PR | Reduction |
| --- | ---: | ---: | ---: |
| Qwen3-32B, FlashInfer | 72,774 MiB | 72,512 MiB | 262 MiB (0.36%) |
| Qwen3-8B + EAGLE3 D=16, FlashInfer | 76,396 MiB | 75,374 MiB | 1,022 MiB (1.34%) |

Each run started from a clean GPU, and the readings were taken after graph capture had completed. The larger reduction in EAGLE3 is consistent with its additional target and draft graph runners creating more capture sessions that can benefit from the common stream.

The effect is even more pronounced with adaptive speculative decoding, which captures additional states and runner suites in the same process. In a separate A800 EAGLE3 adaptive D4/D8/D16 A/B run, the post-capture process memory reduction was about 1.6 GiB, compared with about 1.0 GiB for the fixed-D16 reproduction above. This optimization is not adaptive-specific: adaptive mode simply provides more independently initiated captures that can reuse allocator blocks once they use the common stream. The fixed-D16 command remains the primary speculative reproduction because it does not require an additional adaptive configuration file.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API or configuration changes; no documentation update is needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Model accuracy is unaffected; applicable memory profiling is provided above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30730102877](https://github.com/sgl-project/sglang/actions/runs/30730102877)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30730102779](https://github.com/sgl-project/sglang/actions/runs/30730102779)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->