### PR TITLE
[Fix] Cohere Command4: strip echoed `<|START_THINKING|>` in streaming and flush the final text block

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1424,6 +1424,20 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
         self._saw_text_start = False
         self._saw_text_end = False
         self._in_action_mode = False
+        self._resolved_think_start_echo = False
+
+    def _consume_echoed_think_start(self, buf: str) -> Optional[str]:
+        """Drop a ``<|START_THINKING|>`` echoed at the very start of the stream,
+        mirroring detect_and_parse. Returns None while ``buf`` is only a partial
+        token and more text is needed to decide."""
+        token = self.think_start_token + self.think_start_self_label
+        if buf.startswith(token):
+            self._resolved_think_start_echo = True
+            return buf[len(token) :]
+        if token.startswith(buf):
+            return None
+        self._resolved_think_start_echo = True
+        return buf
 
     @classmethod
     def _strip_text_markers(cls, raw: str) -> str:
@@ -1505,6 +1519,14 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
         ``force_reasoning`` semantics."""
         self._buffer += new_text
         buf = self._buffer
+
+        # Some checkpoints echo the START_THINKING token even though the chat
+        # template put it in the prefix; drop it as detect_and_parse does.
+        if not self._resolved_think_start_echo:
+            stripped = self._consume_echoed_think_start(buf)
+            if stripped is None:
+                return StreamingParseResult()
+            buf = self._buffer = stripped
 
         if not self._reasoning_done:
             # Look for any marker that ends reasoning: an explicit
@@ -1609,6 +1631,10 @@ class CohereCommand4Detector(BaseReasoningFormatDetector):
             )
         elif self._saw_text_start and not self._saw_text_end:
             ret = StreamingParseResult(normal_text=buffer)
+        elif not self._saw_text_start:
+            # Reasoning closed in the final increment, which returns early after
+            # emitting the trace, so the whole text/action block is still buffered.
+            ret = StreamingParseResult(normal_text=self._strip_text_markers(buffer))
         else:
             return StreamingParseResult()
         return self._maybe_apply_force_nonempty_content(ret)

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1363,5 +1363,82 @@ class TestCohereCommand4DetectorFinish(CustomTestCase):
         self.assertEqual(end.reasoning_text, "")
 
 
+class TestCohereCommand4DetectorStreamingParity(CustomTestCase):
+    """Streaming must agree with detect_and_parse on the same text.
+
+    Cohere's streaming path is a custom state machine rather than the base
+    class one, so the two implementations have to be kept in step by hand."""
+
+    ECHOED = (
+        "<|START_THINKING|>thinking<|END_THINKING|><|START_TEXT|>answer<|END_TEXT|>"
+    )
+    ACTION = 'thinking<|END_THINKING|><|START_ACTION|>[{"name": "f"}]<|END_ACTION|>'
+
+    @staticmethod
+    def _stream(text, chunks, **kwargs):
+        """Feed ``chunks`` through a fresh detector, then flush with finish()."""
+        detector = CohereCommand4Detector(**kwargs)
+        reasoning, normal = [], []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk)
+            reasoning.append(result.reasoning_text or "")
+            normal.append(result.normal_text or "")
+        end = detector.finish()
+        reasoning.append(end.reasoning_text or "")
+        normal.append(end.normal_text or "")
+        return "".join(reasoning), "".join(normal)
+
+    def _assert_matches_one_shot(self, text, **kwargs):
+        expected = CohereCommand4Detector(**kwargs).detect_and_parse(text)
+        for label, chunks in (
+            ("single increment", [text]),
+            ("character chunked", list(text)),
+        ):
+            with self.subTest(chunking=label):
+                reasoning, normal = self._stream(text, chunks, **kwargs)
+                self.assertEqual(reasoning, expected.reasoning_text)
+                self.assertEqual(normal, expected.normal_text)
+
+    def test_streaming_strips_echoed_think_start(self):
+        """Checkpoints that echo <|START_THINKING|> must not have the raw token
+        surface in streamed reasoning_content. detect_and_parse already drops
+        it; the streaming state machine used to pass it straight through."""
+        for chunks in ([self.ECHOED], list(self.ECHOED)):
+            reasoning, _ = self._stream(self.ECHOED, chunks)
+            self.assertNotIn("<|START_THINKING|>", reasoning)
+            self.assertEqual(reasoning, "thinking")
+
+    def test_streaming_matches_one_shot_with_echoed_think_start(self):
+        self._assert_matches_one_shot(self.ECHOED)
+        self._assert_matches_one_shot(self.ECHOED, stream_reasoning=False)
+
+    def test_finish_flushes_text_block_closed_in_final_increment(self):
+        """When <|END_THINKING|> and the whole text block land in the same
+        increment, the increment returns early after emitting the trace and the
+        answer is left in the buffer. finish() has to drain it."""
+        text = "thinking<|END_THINKING|><|START_TEXT|>answer<|END_TEXT|>"
+        reasoning, normal = self._stream(text, [text])
+        self.assertEqual(reasoning, "thinking")
+        self.assertEqual(normal, "answer")
+
+    def test_finish_flushes_action_block_closed_in_final_increment(self):
+        """Same path as above, but the model emitted a tool call instead of a
+        text answer -- the action block must reach the tool-call parser."""
+        reasoning, normal = self._stream(self.ACTION, [self.ACTION])
+        self.assertEqual(reasoning, "thinking")
+        self.assertEqual(normal, '<|START_ACTION|>[{"name": "f"}]<|END_ACTION|>')
+
+    def test_streaming_matches_one_shot_without_echo(self):
+        """Formats that never echo the start token must be unaffected."""
+        for text in (
+            "thinking<|END_THINKING|><|START_TEXT|>answer<|END_TEXT|>",
+            "<|START_TEXT|>answer<|END_TEXT|>",
+            self.ACTION,
+            "thinking<|END_THINKING|><|START_TEXT|>truncated",
+        ):
+            with self.subTest(text=text):
+                self._assert_matches_one_shot(text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`CohereCommand4Detector`'s streaming path has drifted from its own
`detect_and_parse`, so the same generation parses differently under `stream=True`:

- An echoed `<|START_THINKING|>` is stripped non-streaming but not streaming, so
  the raw control token reaches clients in `reasoning_content`.
- When `<|END_THINKING|>` and the text/action block arrive in one increment, the
  block is left in `_buffer` and `finish()` never drains it, dropping the answer
  — or a whole tool call. Reachable with `--stream-interval > 1`, or when the
  generation finishes in one delta.

## Modifications

- `parse_streaming_increment`: strip an echoed `<|START_THINKING|>`, buffering
  while the token is still partial.
- `finish()`: drain a leftover text/action block via the existing
  `_strip_text_markers()`.
- New `TestCohereCommand4DetectorStreamingParity`: streaming must equal
  `detect_and_parse` on every documented wire format, under single-increment and
  1-char chunking, for both `stream_reasoning` modes.

Non-streaming path unchanged.

## Tests

New tests fail on `main` (10 failures) and pass with the fix.
`test/registered/unit/{parser,function_call}`: 764 passed, 96 subtests passed.
`pre-commit` clean on both changed files.

## Accuracy Tests

N/A — parser-only, no model forward code.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
