### PR TITLE
[FA4] Skip unsupported descale tensors in decode

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1821,10 +1821,12 @@ class FlashAttentionBackend(AttentionBackend):
         fa_k_descale, fa_v_descale = None, None
         # only use kv scaling if: 1) fp8 kv is explicitly enabled, 2) RadixAttention
         # has corresponding quantization method so that layer.k_scale is not None,
-        # 3) layer.head_dim <= 256 since fa3 kernel require fp16 and bf16 data type in this case.
+        # 3) layer.head_dim <= 256 since fa3 kernel require fp16 and bf16 data type in this case,
+        # 4) fa_impl_ver != 4 since fa4 does not currently support fp8 queries and keys.
         if (
             self.kv_cache_dtype_str != "auto"
             and layer.head_dim <= 256
+            and self.fa_impl_ver != 4
             and not self.kv_cache_is_mxfp8
         ):
             if layer.k_scale is not None:

--- a/test/registered/unit/layers/attention/test_flashattention_backend.py
+++ b/test/registered/unit/layers/attention/test_flashattention_backend.py
@@ -1,0 +1,106 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.attention import flashattention_backend  # noqa: E402
+from sglang.srt.layers.attention.flashattention_backend import (  # noqa: E402
+    FlashAttentionBackend,
+)
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestFlashAttentionBackendDecodeScaling(CustomTestCase):
+    def _make_backend(self, fa_impl_ver):
+        backend = object.__new__(FlashAttentionBackend)
+        backend.fa_impl_ver = fa_impl_ver
+        backend.use_mla = False
+        backend.kv_cache_is_mxfp8 = False
+        backend.kv_cache_dtype_str = "bfloat16"
+        backend.kv_cache_dtype = torch.bfloat16
+        backend.has_local_attention = False
+        backend.attention_chunk_size = None
+        backend.topk = 0
+        backend.page_size = 1
+        backend.use_sliding_window_kv_pool = False
+        backend.is_prefill_aware_swa = False
+        backend.num_splits = 0
+        backend.token_to_kv_pool = SimpleNamespace(
+            get_kv_buffer=lambda _layer_id: (
+                torch.zeros(1, 1, 8),
+                torch.zeros(1, 1, 8),
+            )
+        )
+        backend.forward_metadata = SimpleNamespace(
+            local_attn_metadata=None,
+            page_table=torch.zeros(1, 1, dtype=torch.int32),
+            cache_seqlens_int32=torch.ones(1, dtype=torch.int32),
+            cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+            max_seq_len_q=1,
+            scheduler_metadata=None,
+            pa_swa_page_table=None,
+        )
+        return backend
+
+    def _run_decode(self, fa_impl_ver):
+        backend = self._make_backend(fa_impl_ver)
+        layer = SimpleNamespace(
+            is_cross_attention=False,
+            attn_type=None,
+            sliding_window_size=None,
+            head_dim=8,
+            v_head_dim=8,
+            tp_q_head_num=1,
+            tp_k_head_num=1,
+            tp_v_head_num=1,
+            k_scale=torch.tensor(2.0),
+            v_scale=torch.tensor(3.0),
+            layer_id=0,
+            scaling=1.0,
+            logit_cap=0.0,
+        )
+        forward_batch = SimpleNamespace(
+            batch_size=1,
+            spec_info=None,
+            _attn_output=None,
+        )
+        kernel = MagicMock(side_effect=lambda **kwargs: torch.zeros_like(kwargs["q"]))
+
+        with patch.object(flashattention_backend, "flash_attn_with_kvcache", kernel):
+            backend.forward_decode(
+                torch.ones(1, 8, dtype=torch.float16),
+                None,
+                None,
+                layer,
+                forward_batch,
+                save_kv_cache=False,
+            )
+
+        kernel.assert_called_once()
+        return kernel.call_args.kwargs
+
+    def test_fa4_decode_does_not_pass_unsupported_descale_tensors(self):
+        kernel_kwargs = self._run_decode(fa_impl_ver=4)
+
+        self.assertNotIn("k_descale", kernel_kwargs)
+        self.assertNotIn("v_descale", kernel_kwargs)
+        self.assertEqual(kernel_kwargs["q"].dtype, torch.float16)
+
+    def test_fa3_decode_preserves_supported_descale_tensors(self):
+        kernel_kwargs = self._run_decode(fa_impl_ver=3)
+
+        self.assertTrue(torch.equal(kernel_kwargs["k_descale"], torch.tensor([[2.0]])))
+        self.assertTrue(torch.equal(kernel_kwargs["v_descale"], torch.tensor([[3.0]])))
+        self.assertEqual(kernel_kwargs["q"].dtype, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #31640.

FA4 decode currently enters the regular FP8 KV-cache scaling path and forwards `k_descale` and `v_descale`, even though the FA4 kernel rejects those arguments. The extend path already excludes FA4 from the same scaling branch.

## Modifications

- Mirror the existing FA4 exclusion from `forward_extend` in `forward_decode`.
- Add CPU unit coverage at the FlashAttention kernel boundary verifying that FA4 omits descale tensors and preserves the query dtype.
- Add inverse coverage verifying that FA3 continues to receive descale tensors and the KV-cache dtype conversion.

## Accuracy Tests

- `python -m pytest -q test/registered/unit/layers/attention/test_flashattention_backend.py` (2 passed)
- `python -m pytest -q test/registered/unit/layers/attention` (30 passed, 24 subtests passed)

No model-level accuracy test was run because this fixes an exception before FA4 kernel execution and does not alter a previously successful FA4 output path.

## Speed Tests and Profiling

Not run. The change adds one backend-version predicate to an existing decode branch and does not change kernel work.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: internal bug fix with no user-facing interface change.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable for the unsupported pre-kernel path; see above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30725879589](https://github.com/sgl-project/sglang/actions/runs/30725879589)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30725879510](https://github.com/sgl-project/sglang/actions/runs/30725879510)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->