### PR TITLE
[kvcacheio] Fix mamba HiCache transfer kernel on ROCm (kDLCUDA → kDLGPU)

### DIFF
--- a/python/sglang/kernels/jit/csrc/kvcacheio/transfer_mamba.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/transfer_mamba.cuh
@@ -101,7 +101,7 @@ struct TransferMambaKernel {
 
     TensorMatcher({L})  //
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(src_indices)
         .verify(dst_indices);
 
@@ -147,13 +147,13 @@ struct TransferMambaKernel {
 
     TensorMatcher({L})  //
         .with_dtype<int64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(src_indices)
         .verify(dst_indices);
-    // src_ptrs is a 1D tensor of device pointers (uint64) on CUDA
+    // src_ptrs is a 1D tensor of device pointers (uint64) on the GPU
     TensorMatcher({static_cast<int64_t>(num_layers)})  //
         .with_dtype<uint64_t>()
-        .with_device<kDLCUDA>(device_)
+        .with_device<kDLGPU>(device_)
         .verify(src_ptrs);
 
     RuntimeCheck(item_size > 0, "transfer_mamba: item_size must be positive");


### PR DESCRIPTION
## Motivation

HiCache host backup/restore for hybrid-mamba models (e.g. **Kimi-K3**: KDA/linear +
MLA) is broken on AMD GPUs. When the prefill worker backs a mamba state up to the host
tier, the JIT kernel `TransferMambaKernel` aborts:

```
RuntimeError: Tensor match failed for Tensor<1>[strides=<1>, dtype=int64, device=rocm]
  at kernels/jit/csrc/kvcacheio/transfer_mamba.cuh
```

which kills the scheduler and disables HiCache for these models on ROCm entirely.

## Root cause

`TransferMambaKernel::run_pf_lf` and `run_lf_pf` hard-code the DLPack **device type** as
`kDLCUDA` in their `TensorMatcher` checks:

```cpp
TensorMatcher({L}).with_dtype<int64_t>().with_device<kDLCUDA>(device_)...
```

On ROCm, torch tensors carry the DLPack device type **`kDLROCM`**, not `kDLCUDA`, so the
match fails (reported as `... device=rocm`). The inputs are otherwise valid — same device,
correct dtype/shape (`src_indices`/`dst_indices` 1-D int64, `src_ptrs` `{num_layers}`
uint64).

Every **sibling kvcacheio kernel** (`hicache.cuh`, `staged_write_back.cuh`) — and the
deepseek_v4 / ngram JIT kernels — already use the portability alias **`kDLGPU`** (which
resolves to `kDLCUDA` on CUDA and `kDLROCM` on HIP). Only `transfer_mamba.cuh`
hard-coded `kDLCUDA`.

## What this PR does

Switch the three device checks in `transfer_mamba.cuh` from `kDLCUDA` to `kDLGPU`,
matching the rest of the kvcacheio kernels. No behavior change on CUDA (`kDLGPU`
resolves to `kDLCUDA` there); ROCm tensors (`kDLROCM`) now pass.

## Backward compatibility

None affected. On CUDA `kDLGPU == kDLCUDA`, so the checks are identical. This only widens
the accepted device set to include HIP, which was the intent (the kernel compiles under
both nvcc and hipcc).

## Testing

AMD **MI355X (gfx950)**, Kimi-K3, prefill HiCache enabled
(`--hicache-ratio 2 --hicache-io-backend kernel --hicache-write-policy write_through`,
radix cache on), PD disaggregation with DCP-8 decode over the mori backend:

| check | before | after |
|---|---|---|
| mamba host-backup kernel calls | all fail (`Tensor match failed ... device=rocm`) | all succeed, **0 errors** |
| prefill scheduler | crashes on first backup | stable |
| gsm8k (HiCache on) | scheduler down | **99/100 = 99.0%**, 0 truncated, 0 errors |

On CUDA the kernel is unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30729507764](https://github.com/sgl-project/sglang/actions/runs/30729507764)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30729507745](https://github.com/sgl-project/sglang/actions/runs/30729507745)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->