### PR TITLE
[Fix] Propagate priority in EmbeddingReqInput.__getitem__ for batched requests

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1117,6 +1117,7 @@ class EmbeddingReqInput:
                 text=[self.text[i]] if self.text is not None else None,
                 sampling_params=self.sampling_params[i],
                 is_cross_encoder_request=True,
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
@@ -1144,6 +1145,7 @@ class EmbeddingReqInput:
                     else None
                 ),
                 sampling_params=self.sampling_params[i],
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),


### PR DESCRIPTION
## Problem

EmbeddingReqInput.__getitem__ drops the priority field when splitting batched requests. Both the cross-encoder and normal branches omit it.

**Repro:** req = EmbeddingReqInput(text=["hello", "world"], priority=7); req[0].priority -> None

## Fix

Added priority=self.priority to both branches of __getitem__.

**Before:** req[0].priority -> None (silently dropped)
**After:** req[0].priority -> 7 (correctly propagated)

Fixes #32844

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30730637835](https://github.com/sgl-project/sglang/actions/runs/30730637835)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30730637741](https://github.com/sgl-project/sglang/actions/runs/30730637741)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->