### PR TITLE
[Fix] Correct smg-grpc-servicer version from 0.5.3 to 0.5.5

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
   "setproctitle",
   "sgl-deep-gemm==0.1.5",
   "sglang-kernel==0.4.5",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "tilelang==0.1.11",

--- a/python/pyproject_cpu.toml
+++ b/python/pyproject_cpu.toml
@@ -55,7 +55,7 @@ dependencies = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tabulate",
   "tiktoken",

--- a/python/pyproject_npu.toml
+++ b/python/pyproject_npu.toml
@@ -56,7 +56,7 @@ dependencies = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",

--- a/python/pyproject_other.toml
+++ b/python/pyproject_other.toml
@@ -57,7 +57,7 @@ runtime_common = [
   "scipy",
   "sentencepiece",
   "setproctitle",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",

--- a/python/pyproject_xpu.toml
+++ b/python/pyproject_xpu.toml
@@ -55,7 +55,7 @@ dependencies = [
   "sentencepiece",
   "setproctitle",
   "sgl-kernel @ git+https://github.com/sgl-project/sgl-kernel-xpu.git",
-  "smg-grpc-servicer>=0.5.0",
+  "smg-grpc-servicer>=0.5.5",
   "soundfile==0.13.1",
   "tiktoken",
   "timm==1.0.16",

--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -221,7 +221,7 @@ async def serve_grpc(server_args, model_info=None):
                 exc_info=True,
             )
 
-    # Older smg-grpc-servicer releases (≤ 0.5.2) accept only (server_args,
+    # Older smg-grpc-servicer releases (≤ 0.5.4) accept only (server_args,
     # model_info) and reject the on_request_manager_ready hook. The hook is
     # what calls _start_sidecar_server, so dropping the kwarg disables the
     # entire HTTP sidecar (Prometheus /metrics and /start_profile +
@@ -237,7 +237,7 @@ async def serve_grpc(server_args, model_info=None):
         # start the sidecar that serves them — fail loud rather than silently
         # produce a server with no /metrics endpoint.
         raise RuntimeError(
-            "--enable-metrics requires smg-grpc-servicer ≥ 0.5.3 (the version "
+            "--enable-metrics requires smg-grpc-servicer ≥ 0.5.5 (the version "
             "that accepts 'on_request_manager_ready'); installed version "
             "lacks the hook so the HTTP sidecar would never start. Upgrade "
             "smg-grpc-servicer or remove --enable-metrics."
@@ -247,7 +247,7 @@ async def serve_grpc(server_args, model_info=None):
             "Installed smg-grpc-servicer does not accept "
             "'on_request_manager_ready'; HTTP sidecar disabled "
             "(no /metrics, /start_profile, /stop_profile). "
-            "Upgrade smg-grpc-servicer to ≥ 0.5.3 to enable it."
+            "Upgrade smg-grpc-servicer to ≥ 0.5.5 to enable it."
         )
 
     try:


### PR DESCRIPTION
## Problem

Two bugs in gRPC metrics path:

**Bug A** — Error messages say smg-grpc-servicer >= 0.5.3, but 0.5.4 still lacks the hook. Users following the error's advice get another crash.

**Bug B** — Pin smg-grpc-servicer>=0.5.0 lets pip resolve 0.5.4 (bundled in v0.5.13), which lacks on_request_manager_ready.

## Fix

1. grpc_server.py: 0.5.3 -> 0.5.5 in comment, RuntimeError, and warning
2. All 5 pyproject*.toml: >=0.5.0 -> >=0.5.5

## Verification

0.5.4: ['server_args', 'model_info'] — no hook
0.5.5: ['server_args', 'model_info', 'on_request_manager_ready'] — working

Fixes #28298

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30730639468](https://github.com/sgl-project/sglang/actions/runs/30730639468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30730639420](https://github.com/sgl-project/sglang/actions/runs/30730639420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->