### PR TITLE
[Fix] Validate structural_tag mutual exclusivity in SamplingParams.verify()

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -196,9 +196,10 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
             self.json_schema,
             self.regex,
             self.ebnf,
+            self.structural_tag,
         ]  # since mutually exclusive, only one can be set
         if sum(x is not None for x in grammars) > 1:
-            raise ValueError("Only one of regex, json_schema, or ebnf can be set.")
+            raise ValueError("Only one of regex, json_schema, ebnf, or structural_tag can be set.")
 
     def normalize(self, tokenizer):
         # Process stop strings


### PR DESCRIPTION
Fixes #31680. Added structural_tag to grammars list — previously structural_tag + regex passed silently with one silently dropped. Now raises ValueError like the other combinations.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30730748186](https://github.com/sgl-project/sglang/actions/runs/30730748186)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30730748129](https://github.com/sgl-project/sglang/actions/runs/30730748129)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->