### PR TITLE
[Fix] Propagate priority in EmbeddingReqInput.__getitem__

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1117,6 +1117,7 @@ class EmbeddingReqInput:
                 text=[self.text[i]] if self.text is not None else None,
                 sampling_params=self.sampling_params[i],
                 is_cross_encoder_request=True,
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),
@@ -1144,6 +1145,7 @@ class EmbeddingReqInput:
                     else None
                 ),
                 sampling_params=self.sampling_params[i],
+                priority=self.priority,
                 lora_path=self.lora_path[i] if self.lora_path is not None else None,
                 lora_id=self.lora_id[i] if self.lora_id is not None else None,
                 positional_embed_overrides=self._get_positional_embed_overrides_item(i),


### PR DESCRIPTION
Fixes #32844. priority was omitted from both branches of __getitem__, causing batched embedding requests to lose their priority. Added priority=self.priority to both cross-encoder and normal branches.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30730749653](https://github.com/sgl-project/sglang/actions/runs/30730749653)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30730749613](https://github.com/sgl-project/sglang/actions/runs/30730749613)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->