### PR TITLE
[Perf][DSV4] Remove prefill CP KV and compressor materialization

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/direct_cp_kv_store.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/direct_cp_kv_store.cuh
@@ -1,0 +1,165 @@
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/math.cuh>
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+#include <sgl_kernel/vec.cuh>
+#include <sgl_kernel/warp.cuh>
+
+#include <sgl_kernel/deepseek_v4/fp8_utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <bit>
+#include <cstdint>
+#include <cuda_fp8.h>
+
+namespace {
+
+using deepseek_v4::fp8::cast_to_ue8m0;
+using deepseek_v4::fp8::inv_scale_ue8m0;
+using deepseek_v4::fp8::pack_fp8;
+
+struct DirectCPKVStoreParam {
+  const void* __restrict__ input;
+  const void* __restrict__ indices;
+  uint64_t cache_multicast;
+  uint32_t num_tokens;
+  uint32_t num_pages;
+};
+
+SGL_DEVICE uint16_t fp8x2_bits(fp8x2_e4m3_t value) {
+  static_assert(sizeof(value) == sizeof(uint16_t));
+  return *reinterpret_cast<const uint16_t*>(&value);
+}
+
+SGL_DEVICE uint32_t bf16x2_bits(bf16x2_t value) {
+  static_assert(sizeof(value) == sizeof(uint32_t));
+  return *reinterpret_cast<const uint32_t*>(&value);
+}
+
+SGL_DEVICE void multimem_store_v4_u32(
+    void* ptr, uint32_t x, uint32_t y, uint32_t z, uint32_t w) {
+  asm volatile(
+      "multimem.st.relaxed.sys.global.v4.f32 [%0], {%1, %2, %3, %4};"
+      :
+      : "l"(ptr), "f"(__uint_as_float(x)), "f"(__uint_as_float(y)),
+        "f"(__uint_as_float(z)), "f"(__uint_as_float(w))
+      : "memory");
+}
+
+SGL_DEVICE void multimem_store_v2_u32(void* ptr, uint32_t x, uint32_t y) {
+  asm volatile(
+      "multimem.st.relaxed.sys.global.v2.f32 [%0], {%1, %2};"
+      :
+      : "l"(ptr), "f"(__uint_as_float(x)), "f"(__uint_as_float(y))
+      : "memory");
+}
+
+template <typename Float, typename IndicesT, uint32_t kPageBits>
+__global__ __launch_bounds__(256, 2) void direct_cp_store_flashmla_cache(
+    DirectCPKVStoreParam param) {
+  using namespace device;
+  constexpr int64_t kPageBytes = host::div_ceil(584 << kPageBits, 576) * 576;
+
+  const uint32_t bid = blockIdx.x;
+  const uint32_t tid = threadIdx.x;
+  const uint32_t wid = tid / 32;
+  const uint32_t lane = tid % 32;
+  __shared__ uint8_t scales[8];
+
+  const int64_t index =
+      static_cast<int64_t>(static_cast<const IndicesT*>(param.indices)[bid]);
+  if (index < 0 || index >= static_cast<int64_t>(param.num_pages) << kPageBits) {
+    __trap();
+  }
+  using Float2 = packed_t<Float>;
+  const auto elems = static_cast<const Float2*>(param.input)[tid + bid * 256];
+  auto* cache = reinterpret_cast<uint8_t*>(param.cache_multicast);
+  const int32_t page = index >> kPageBits;
+  const int32_t offset = index & ((1 << kPageBits) - 1);
+  auto* page_ptr = cache + static_cast<int64_t>(page) * kPageBytes;
+  auto* value_ptr = page_ptr + static_cast<int64_t>(offset) * 576;
+
+  if (wid != 7) {
+    const auto [x, y] = cast<fp32x2_t>(elems);
+    const auto abs_max = warp::reduce_max(fmaxf(fabs(x), fabs(y)));
+    const auto scale_raw = fmaxf(1e-4f, abs_max) / kFP8E4M3Max;
+    const auto scale_ue8m0 = cast_to_ue8m0(scale_raw);
+    const auto inv_scale = inv_scale_ue8m0(scale_ue8m0);
+    const uint32_t packed = fp8x2_bits(pack_fp8(x * inv_scale, y * inv_scale));
+
+    const uint32_t pair = packed | (__shfl_down_sync(0xffffffff, packed, 1) << 16);
+    const uint32_t group_base = lane & ~7u;
+    const uint32_t r0 = __shfl_sync(0xffffffff, pair, group_base);
+    const uint32_t r1 = __shfl_sync(0xffffffff, pair, group_base + 2);
+    const uint32_t r2 = __shfl_sync(0xffffffff, pair, group_base + 4);
+    const uint32_t r3 = __shfl_sync(0xffffffff, pair, group_base + 6);
+    if ((lane & 7u) == 0) {
+      multimem_store_v4_u32(value_ptr + tid * 2, r0, r1, r2, r3);
+    }
+    if (lane == 0) scales[wid] = static_cast<uint8_t>(scale_ue8m0);
+  } else {
+    const uint32_t packed = bf16x2_bits(cast<bf16x2_t>(elems));
+    const uint32_t group_base = lane & ~3u;
+    const uint32_t r0 = __shfl_sync(0xffffffff, packed, group_base);
+    const uint32_t r1 = __shfl_sync(0xffffffff, packed, group_base + 1);
+    const uint32_t r2 = __shfl_sync(0xffffffff, packed, group_base + 2);
+    const uint32_t r3 = __shfl_sync(0xffffffff, packed, group_base + 3);
+    if ((lane & 3u) == 0) {
+      multimem_store_v4_u32(value_ptr + 448 + lane * 4, r0, r1, r2, r3);
+    }
+  }
+
+  if (tid == 0) scales[7] = 0;
+  __syncthreads();
+  if (tid == 0) {
+    const uint32_t lo = static_cast<uint32_t>(scales[0]) |
+                        (static_cast<uint32_t>(scales[1]) << 8) |
+                        (static_cast<uint32_t>(scales[2]) << 16) |
+                        (static_cast<uint32_t>(scales[3]) << 24);
+    const uint32_t hi = static_cast<uint32_t>(scales[4]) |
+                        (static_cast<uint32_t>(scales[5]) << 8) |
+                        (static_cast<uint32_t>(scales[6]) << 16);
+    auto* scale_ptr = page_ptr + (576 << kPageBits) + static_cast<int64_t>(offset) * 8;
+    multimem_store_v2_u32(scale_ptr, lo, hi);
+  }
+}
+
+template <typename Float, typename IndicesT, uint32_t kPageSize>
+struct DirectCPKVStoreKernel {
+  static constexpr int32_t kLogSize = std::countr_zero(kPageSize);
+
+  static void run(
+      tvm::ffi::TensorView input,
+      tvm::ffi::TensorView cache,
+      int64_t cache_multicast,
+      tvm::ffi::TensorView indices) {
+    using namespace host;
+    static_assert(std::has_single_bit(kPageSize));
+    auto N = SymbolicSize{"num_tokens"};
+    auto device_ = SymbolicDevice{};
+    device_.set_options<kDLCUDA>();
+    TensorMatcher({N, 512}).with_dtype<Float>().with_device(device_).verify(input);
+    TensorMatcher({-1, -1}).with_dtype<uint8_t>().with_device(device_).verify(cache);
+    TensorMatcher({N}).with_dtype<IndicesT>().with_device(device_).verify(indices);
+    RuntimeCheck(cache_multicast != 0, "cache multicast pointer is null");
+    RuntimeCheck(cache.size(1) >= host::div_ceil(584 * kPageSize, 576) * 576,
+                 "cache page stride is smaller than the packed DSV4 layout");
+    const auto num_tokens = static_cast<uint32_t>(N.unwrap());
+    if (num_tokens == 0) return;
+    const auto params = DirectCPKVStoreParam{
+        .input = input.data_ptr(),
+        .indices = indices.data_ptr(),
+        .cache_multicast = static_cast<uint64_t>(cache_multicast),
+        .num_tokens = num_tokens,
+        .num_pages = static_cast<uint32_t>(cache.size(0)),
+    };
+    LaunchKernel(num_tokens, 256, device_.unwrap())(
+        direct_cp_store_flashmla_cache<Float, IndicesT, kLogSize>, params);
+  }
+};
+
+}  // namespace

--- a/python/sglang/kernels/ops/attention/dsv4/cp_compress.py
+++ b/python/sglang/kernels/ops/attention/dsv4/cp_compress.py
@@ -1,0 +1,549 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Consumer-direct DSV4 compressor for interleaved context parallelism.
+
+The normal CP path all-gathers the full FP32 ``[kv, score]`` projection before
+compressing it.  For an aligned single-sequence round-robin split, compression
+is separable by CP rank: each rank publishes one online-softmax state per
+compression window, and every consumer merges the four peer states directly.
+
+This module deliberately implements an object contract, not another all-gather:
+the shared object is ``[max, exp_sum, weighted_kv_sum]`` per window.  No rank
+ever materializes a peer's token-level score tensor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+import triton
+import triton.language as tl
+
+from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
+    _blockwise_barrier,
+)
+
+
+@triton.jit
+def _peer_barrier_kernel(
+    signal_pad_ptrs,
+    RANK: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+):
+    _blockwise_barrier(signal_pad_ptrs, RANK, WORLD_SIZE, sem="acq_rel")
+
+
+@triton.jit
+def _online_update(max_value, exp_sum, weighted_sum, score, value):
+    new_max = tl.maximum(max_value, score)
+    old_scale = tl.exp(max_value - new_max)
+    new_scale = tl.exp(score - new_max)
+    return (
+        new_max,
+        exp_sum * old_scale + new_scale,
+        weighted_sum * old_scale + value * new_scale,
+    )
+
+
+@triton.jit
+def _c128_local_state_kernel(
+    kv_score,
+    ape,
+    partial,
+    num_windows,
+    slot_offset,
+    RANK: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    window = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < HEAD_DIM
+
+    max_value = tl.full((BLOCK,), float("-inf"), tl.float32)
+    exp_sum = tl.zeros((BLOCK,), tl.float32)
+    weighted_sum = tl.zeros((BLOCK,), tl.float32)
+    local_per_window: tl.constexpr = 128 // WORLD_SIZE
+    for token in tl.static_range(local_per_window):
+        local_row = window * local_per_window + token
+        position = RANK + token * WORLD_SIZE
+        value = tl.load(kv_score + local_row * (2 * HEAD_DIM) + offsets, mask=mask)
+        score = tl.load(
+            kv_score + local_row * (2 * HEAD_DIM) + HEAD_DIM + offsets,
+            mask=mask,
+        )
+        score += tl.load(ape + position * HEAD_DIM + offsets, mask=mask)
+        max_value, exp_sum, weighted_sum = _online_update(
+            max_value, exp_sum, weighted_sum, score, value
+        )
+
+    base = partial + slot_offset + window * (3 * HEAD_DIM) + offsets
+    tl.store(base, max_value, mask=mask)
+    tl.store(base + HEAD_DIM, exp_sum, mask=mask)
+    tl.store(base + 2 * HEAD_DIM, weighted_sum, mask=mask)
+
+
+@triton.jit
+def _c4_local_state_kernel(
+    kv_score,
+    ape,
+    carry,
+    plan_c,
+    kv_score_buffer,
+    partial,
+    num_windows,
+    slot_offset,
+    HAS_PREFIX: tl.constexpr,
+    USE_PAGED_PREFIX: tl.constexpr,
+    STORE_CARRY: tl.constexpr,
+    RANK: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    window = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < HEAD_DIM
+    row_base = window * (4 * HEAD_DIM)
+
+    # The C4 projection layout is
+    # [kv_overlap, kv_normal, score_overlap, score_normal].  Each CP4 rank
+    # owns one token in the previous overlap half and one in the current half.
+    value = tl.load(kv_score + row_base + HEAD_DIM + offsets, mask=mask)
+    score = tl.load(kv_score + row_base + 3 * HEAD_DIM + offsets, mask=mask)
+    score += tl.load(ape + (4 + RANK) * HEAD_DIM + offsets, mask=mask)
+    max_value = score
+    exp_sum = tl.full((BLOCK,), 1.0, tl.float32)
+    weighted_sum = value
+
+    if window == 0:
+        if HAS_PREFIX:
+            if USE_PAGED_PREFIX:
+                plan_i32 = plan_c.to(tl.pointer_type(tl.int32))
+                read_page_0 = tl.load(plan_i32 + 2)
+                previous_base = (read_page_0 * 4 + RANK) * (4 * HEAD_DIM)
+                previous_value = tl.load(
+                    kv_score_buffer + previous_base + offsets, mask=mask
+                )
+                previous_score = tl.load(
+                    kv_score_buffer + previous_base + 2 * HEAD_DIM + offsets,
+                    mask=mask,
+                )
+            else:
+                previous_value = tl.load(carry + offsets, mask=mask)
+                previous_score = tl.load(carry + HEAD_DIM + offsets, mask=mask)
+            previous_score += tl.load(ape + RANK * HEAD_DIM + offsets, mask=mask)
+            max_value, exp_sum, weighted_sum = _online_update(
+                max_value,
+                exp_sum,
+                weighted_sum,
+                previous_score,
+                previous_value,
+            )
+    else:
+        previous_base = (window - 1) * (4 * HEAD_DIM)
+        previous_value = tl.load(kv_score + previous_base + offsets, mask=mask)
+        previous_score = tl.load(
+            kv_score + previous_base + 2 * HEAD_DIM + offsets, mask=mask
+        )
+        previous_score += tl.load(ape + RANK * HEAD_DIM + offsets, mask=mask)
+        max_value, exp_sum, weighted_sum = _online_update(
+            max_value,
+            exp_sum,
+            weighted_sum,
+            previous_score,
+            previous_value,
+        )
+
+    base = partial + slot_offset + window * (3 * HEAD_DIM) + offsets
+    tl.store(base, max_value, mask=mask)
+    tl.store(base + HEAD_DIM, exp_sum, mask=mask)
+    tl.store(base + 2 * HEAD_DIM, weighted_sum, mask=mask)
+
+    # Persist this rank's final overlap projection for the first output of the
+    # next aligned prefill chunk.  Peer consumers never read this local object.
+    if STORE_CARRY and window == num_windows - 1:
+        tl.store(
+            carry + offsets,
+            tl.load(kv_score + row_base + offsets, mask=mask),
+            mask=mask,
+        )
+        tl.store(
+            carry + HEAD_DIM + offsets,
+            tl.load(kv_score + row_base + 2 * HEAD_DIM + offsets, mask=mask),
+            mask=mask,
+        )
+
+
+@triton.jit
+def _merge_peer_states_kernel(
+    peer_ptrs,
+    output,
+    num_windows,
+    slot_offset,
+    RATIO: tl.constexpr,
+    WORLD_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    window = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < HEAD_DIM
+    object_offset = slot_offset + window * (3 * HEAD_DIM)
+
+    global_max = tl.full((BLOCK,), float("-inf"), tl.float32)
+    for rank in tl.static_range(WORLD_SIZE):
+        peer = tl.load(peer_ptrs + rank).to(tl.pointer_type(tl.float32))
+        rank_max = tl.load(peer + object_offset + offsets, mask=mask)
+        global_max = tl.maximum(global_max, rank_max)
+
+    global_sum = tl.zeros((BLOCK,), tl.float32)
+    global_weighted_sum = tl.zeros((BLOCK,), tl.float32)
+    for rank in tl.static_range(WORLD_SIZE):
+        peer = tl.load(peer_ptrs + rank).to(tl.pointer_type(tl.float32))
+        rank_max = tl.load(peer + object_offset + offsets, mask=mask)
+        rank_sum = tl.load(peer + object_offset + HEAD_DIM + offsets, mask=mask)
+        rank_weighted_sum = tl.load(
+            peer + object_offset + 2 * HEAD_DIM + offsets, mask=mask
+        )
+        scale = tl.exp(rank_max - global_max)
+        global_sum += rank_sum * scale
+        global_weighted_sum += rank_weighted_sum * scale
+
+    tl.store(
+        output + window * HEAD_DIM + offsets,
+        global_weighted_sum / global_sum,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _stage_c4_writes_kernel(
+    kv_score,
+    plan_w,
+    write_stage,
+    num_write,
+    num_local_rows,
+    write_slot_offset,
+    RANK: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    write_id = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    width: tl.constexpr = 4 * HEAD_DIM
+    mask = offsets < width
+    plan_i32 = plan_w.to(tl.pointer_type(tl.int32))
+    ragged_id = tl.load(plan_i32 + write_id * 2)
+    valid = (
+        (write_id < num_write)
+        & (ragged_id >= 0)
+        & (ragged_id < num_local_rows * 4)
+        & (ragged_id % 4 == RANK)
+    )
+    local_row = ragged_id // 4
+    values = tl.load(kv_score + local_row * width + offsets, mask=mask & valid)
+    tl.store(
+        write_stage + write_slot_offset + write_id * width + offsets,
+        values,
+        mask=mask & valid,
+    )
+
+
+@triton.jit
+def _consume_c4_writes_kernel(
+    peer_write_ptrs,
+    plan_w,
+    kv_score_buffer,
+    num_write,
+    num_state_rows,
+    write_slot_offset,
+    HEAD_DIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    write_id = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    width: tl.constexpr = 4 * HEAD_DIM
+    mask = offsets < width
+    plan_i32 = plan_w.to(tl.pointer_type(tl.int32))
+    ragged_id = tl.load(plan_i32 + write_id * 2)
+    write_loc = tl.load(plan_i32 + write_id * 2 + 1)
+    valid = (
+        (write_id < num_write)
+        & (ragged_id >= 0)
+        & (write_loc >= 0)
+        & (write_loc < num_state_rows)
+    )
+    owner = tl.where(valid, ragged_id % 4, 0)
+    peer = tl.load(peer_write_ptrs + owner).to(tl.pointer_type(tl.float32))
+    values = tl.load(
+        peer + write_slot_offset + write_id * width + offsets,
+        mask=mask & valid,
+    )
+    tl.store(kv_score_buffer + write_loc * width + offsets, values, mask=mask & valid)
+
+
+@dataclass
+class CPCompressorState:
+    group: dist.ProcessGroup
+    rank: int
+    world_size: int
+    ratio: int
+    head_dim: int
+    max_global_tokens: int
+    partial: torch.Tensor
+    peer_buffers: list[torch.Tensor]
+    peer_ptrs: torch.Tensor
+    write_stage: torch.Tensor | None
+    write_handle: Any | None
+    write_peer_buffers: list[torch.Tensor] | None
+    peer_write_ptrs: torch.Tensor | None
+    max_c4_writes: int
+    handle: Any
+    generation: int = 0
+
+
+def create_cp_compressor_state(
+    group: dist.ProcessGroup,
+    rank: int,
+    ratio: int,
+    head_dim: int,
+    max_global_tokens: int,
+    device: torch.device,
+) -> CPCompressorState:
+    """Collectively allocate a double-buffered partial-state object."""
+    world_size = group.size()
+    if world_size != 4:
+        raise ValueError(f"CP compressor currently requires CP4, got {world_size}")
+    if ratio not in (4, 128):
+        raise ValueError(f"unsupported compression ratio {ratio}")
+    if max_global_tokens % ratio:
+        raise ValueError("max_global_tokens must align to the compression ratio")
+    max_windows = max_global_tokens // ratio
+    symm_mem.set_signal_pad_size(max(symm_mem.get_signal_pad_size(), world_size * 4))
+    with torch.inference_mode(False), torch.no_grad():
+        partial = symm_mem.empty(
+            (2, max_windows, 3, head_dim), dtype=torch.float32, device=device
+        )
+    handle = symm_mem.rendezvous(partial, group=group)
+    peers = [
+        handle.get_buffer(peer, list(partial.shape), torch.float32)
+        for peer in range(world_size)
+    ]
+    peer_ptrs = torch.tensor(
+        [peer.data_ptr() for peer in peers], dtype=torch.uint64, device=device
+    )
+    write_stage = None
+    write_handle = None
+    write_peers = None
+    peer_write_ptrs = None
+    max_c4_writes = 0
+    if ratio == 4:
+        # Aligned C4 writes four tail rows per 128-token SWA page plus the final
+        # four rows. Keep this sparse write-set separate from token projections.
+        max_c4_writes = max_global_tokens // 32 + 4
+        with torch.inference_mode(False), torch.no_grad():
+            write_stage = symm_mem.empty(
+                (2, max_c4_writes, 4, head_dim),
+                dtype=torch.float32,
+                device=device,
+            )
+        write_handle = symm_mem.rendezvous(write_stage, group=group)
+        write_peers = [
+            write_handle.get_buffer(peer, list(write_stage.shape), torch.float32)
+            for peer in range(world_size)
+        ]
+        peer_write_ptrs = torch.tensor(
+            [peer.data_ptr() for peer in write_peers],
+            dtype=torch.uint64,
+            device=device,
+        )
+    return CPCompressorState(
+        group=group,
+        rank=rank,
+        world_size=world_size,
+        ratio=ratio,
+        head_dim=head_dim,
+        max_global_tokens=max_global_tokens,
+        partial=partial,
+        peer_buffers=peers,
+        peer_ptrs=peer_ptrs,
+        write_stage=write_stage,
+        write_handle=write_handle,
+        write_peer_buffers=write_peers,
+        peer_write_ptrs=peer_write_ptrs,
+        max_c4_writes=max_c4_writes,
+        handle=handle,
+    )
+
+
+def cp_compress_aligned(
+    state: CPCompressorState,
+    kv_score_local: torch.Tensor,
+    ape: torch.Tensor,
+    *,
+    prefix_tokens: int = 0,
+    c4_carry: torch.Tensor | None = None,
+    c4_plan_c: torch.Tensor | None = None,
+    c4_plan_w: torch.Tensor | None = None,
+    c4_state_buffer: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compress one aligned, single-request, round-robin CP4 token shard.
+
+    Returns the compact FP32 ``[num_windows, head_dim]`` output expected by
+    ``compress_forward`` and ``compress_norm_rope_store``.
+    """
+    ratio, head_dim, world_size = state.ratio, state.head_dim, state.world_size
+    if kv_score_local.dtype != torch.float32 or not kv_score_local.is_contiguous():
+        raise ValueError("kv_score_local must be contiguous FP32")
+    expected_width = (4 if ratio == 4 else 2) * head_dim
+    if kv_score_local.ndim != 2 or kv_score_local.shape[1] != expected_width:
+        raise ValueError(
+            f"expected local shape [tokens,{expected_width}], got {tuple(kv_score_local.shape)}"
+        )
+    global_tokens = kv_score_local.shape[0] * world_size
+    if not 0 < global_tokens <= state.max_global_tokens or global_tokens % ratio:
+        raise ValueError(f"unaligned global token count {global_tokens}")
+    if prefix_tokens % ratio:
+        raise ValueError(f"unaligned prefix token count {prefix_tokens}")
+    if ape.shape != ((8 if ratio == 4 else 128), head_dim):
+        raise ValueError(f"unexpected APE shape {tuple(ape.shape)}")
+    if ape.dtype != torch.float32 or not ape.is_contiguous():
+        raise ValueError("APE must be contiguous FP32")
+
+    num_windows = global_tokens // ratio
+    max_windows = state.max_global_tokens // ratio
+    slot = state.generation & 1
+    slot_offset = slot * max_windows * 3 * head_dim
+    block = min(256, triton.next_power_of_2(head_dim))
+    grid = (num_windows, triton.cdiv(head_dim, block))
+    if ratio == 128:
+        _c128_local_state_kernel[grid](
+            kv_score_local,
+            ape,
+            state.partial,
+            num_windows,
+            slot_offset,
+            RANK=state.rank,
+            WORLD_SIZE=world_size,
+            HEAD_DIM=head_dim,
+            BLOCK=block,
+            num_warps=4,
+        )
+    else:
+        use_paged_prefix = c4_plan_c is not None and c4_state_buffer is not None
+        store_carry = c4_carry is not None
+        if prefix_tokens and not use_paged_prefix:
+            if c4_carry is None or c4_carry.shape != (2, head_dim):
+                raise ValueError(f"C4 prefix requires carry shape (2,{head_dim})")
+            if c4_carry.dtype != torch.float32 or not c4_carry.is_contiguous():
+                raise ValueError("C4 carry must be contiguous FP32")
+        if c4_carry is None:
+            c4_carry = kv_score_local
+        if c4_plan_c is not None:
+            if (
+                c4_plan_c.dtype != torch.uint8
+                or c4_plan_c.shape != (num_windows, 16)
+                or not c4_plan_c.is_contiguous()
+            ):
+                raise ValueError("C4 plan_c must be contiguous [num_windows,16] uint8")
+        if use_paged_prefix:
+            assert c4_state_buffer is not None
+            if c4_state_buffer.ndim != 2 or c4_state_buffer.shape[1] != 4 * head_dim:
+                raise ValueError("C4 state buffer must have shape [rows,4*head_dim]")
+        _c4_local_state_kernel[grid](
+            kv_score_local,
+            ape,
+            c4_carry,
+            c4_plan_c if c4_plan_c is not None else kv_score_local,
+            c4_state_buffer if c4_state_buffer is not None else kv_score_local,
+            state.partial,
+            num_windows,
+            slot_offset,
+            HAS_PREFIX=prefix_tokens > 0,
+            USE_PAGED_PREFIX=use_paged_prefix,
+            STORE_CARRY=store_carry,
+            RANK=state.rank,
+            HEAD_DIM=head_dim,
+            BLOCK=block,
+            num_warps=4,
+        )
+        if (c4_plan_w is None) != (c4_state_buffer is None):
+            raise ValueError("C4 plan_w and state buffer must be provided together")
+        if c4_plan_w is not None:
+            if c4_plan_w.dtype != torch.uint8 or c4_plan_w.shape[-1] != 8:
+                raise ValueError("C4 plan_w must have shape [W,8] uint8")
+            if (
+                c4_state_buffer.dtype != torch.float32
+                or not c4_state_buffer.is_contiguous()
+            ):
+                raise ValueError("C4 state buffer must be contiguous FP32")
+            num_write = c4_plan_w.shape[0]
+            if num_write > state.max_c4_writes:
+                raise ValueError(
+                    f"C4 plan has {num_write} writes, capacity is {state.max_c4_writes}"
+                )
+            assert state.write_stage is not None
+            write_slot_offset = slot * state.max_c4_writes * 4 * head_dim
+            if num_write:
+                write_grid = (num_write, triton.cdiv(4 * head_dim, block))
+                _stage_c4_writes_kernel[write_grid](
+                    kv_score_local,
+                    c4_plan_w,
+                    state.write_stage,
+                    num_write,
+                    kv_score_local.shape[0],
+                    write_slot_offset,
+                    RANK=state.rank,
+                    HEAD_DIM=head_dim,
+                    BLOCK=block,
+                    num_warps=4,
+                )
+
+    # Release local partial writes and acquire all peer publications. Double
+    # buffering makes this the only barrier needed for safe reuse.
+    _peer_barrier_kernel[(1,)](
+        state.handle.signal_pad_ptrs_dev,
+        RANK=state.rank,
+        WORLD_SIZE=world_size,
+        num_warps=1,
+    )
+    output = kv_score_local.new_empty((num_windows, head_dim))
+    _merge_peer_states_kernel[grid](
+        state.peer_ptrs,
+        output,
+        num_windows,
+        slot_offset,
+        RATIO=ratio,
+        WORLD_SIZE=world_size,
+        HEAD_DIM=head_dim,
+        BLOCK=block,
+        num_warps=4,
+    )
+    if ratio == 4 and c4_plan_w is not None and num_write:
+        assert state.peer_write_ptrs is not None
+        _consume_c4_writes_kernel[write_grid](
+            state.peer_write_ptrs,
+            c4_plan_w,
+            c4_state_buffer,
+            num_write,
+            c4_state_buffer.shape[0],
+            write_slot_offset,
+            HEAD_DIM=head_dim,
+            BLOCK=block,
+            num_warps=4,
+        )
+    # No read-complete barrier is needed: before this parity is reused two
+    # calls later, every rank must enter and leave the intervening publication
+    # barrier, which happens after its reads from this call. Double buffering
+    # therefore makes that next publication the reuse fence.
+    state.generation += 1
+    return output

--- a/python/sglang/kernels/ops/attention/dsv4/direct_cp_kv_store.py
+++ b/python/sglang/kernels/ops/attention/dsv4/direct_cp_kv_store.py
@@ -1,0 +1,60 @@
+"""Producer-direct CP stores into replicated packed DSV4 KV caches."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.distributed.device_communicators.triton_symm_mem_ag import (
+    _blockwise_barrier,
+)
+
+
+@triton.jit
+def _direct_store_barrier(signal_ptrs, RANK: tl.constexpr, WORLD: tl.constexpr):
+    _blockwise_barrier(signal_ptrs, RANK, WORLD, sem="acq_rel")
+
+
+@cache_once
+def _jit_direct_store(dtype: torch.dtype, index_dtype: torch.dtype, page_size: int):
+    args = make_cpp_args(dtype, index_dtype, page_size)
+    return load_jit(
+        "direct_cp_kv_store",
+        *args,
+        cuda_files=["deepseek_v4/direct_cp_kv_store.cuh"],
+        cuda_wrappers=[("run", f"DirectCPKVStoreKernel<{args}>::run")],
+    )
+
+
+def direct_cp_kv_store(
+    *,
+    cache: torch.Tensor,
+    handle: Any,
+    cache_multicast: int,
+    local_kv: torch.Tensor,
+    local_indices: torch.Tensor,
+    rank: int,
+    world_size: int,
+    page_size: int,
+) -> None:
+    if local_kv.shape != (local_indices.numel(), 512):
+        raise ValueError(
+            f"local KV shape {tuple(local_kv.shape)} does not match "
+            f"indices {local_indices.numel()} x 512"
+        )
+    _jit_direct_store(local_kv.dtype, local_indices.dtype, page_size).run(
+        local_kv,
+        cache,
+        int(cache_multicast),
+        local_indices,
+    )
+    _direct_store_barrier[(1,)](
+        handle.signal_pad_ptrs_dev,
+        RANK=rank,
+        WORLD=world_size,
+        num_warps=1,
+    )

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1117,6 +1117,10 @@ class Envs:
     SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS = EnvInt(8192)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)
+    # Let each DSV4 CP rank publish its local BF16 KV rows directly into the
+    # replicated packed FlashMLA cache through a multicast mapping. This removes
+    # the BF16 KV all-gather and rerange materialization.
+    SGLANG_OPT_DSV4_CP_DIRECT_KV_STORE = EnvBool(False)
     SGLANG_EXPERIMENTAL_ONLINE_C128_MTP = EnvBool(False)
     SGLANG_DSV4_COMPRESS_STATE_DTYPE = EnvStr("float32")
     # Deprecated: DSV4 compressor V2 is always used.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1121,6 +1121,9 @@ class Envs:
     # replicated packed FlashMLA cache through a multicast mapping. This removes
     # the BF16 KV all-gather and rerange materialization.
     SGLANG_OPT_DSV4_CP_DIRECT_KV_STORE = EnvBool(False)
+    # CP4 prefill: publish per-window compressor states through symmetric
+    # memory instead of all-gathering token-level FP32 projections.
+    SGLANG_OPT_USE_CP_COMPRESS = EnvBool(False)
     SGLANG_EXPERIMENTAL_ONLINE_C128_MTP = EnvBool(False)
     SGLANG_DSV4_COMPRESS_STATE_DTYPE = EnvStr("float32")
     # Deprecated: DSV4 compressor V2 is always used.

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -1605,6 +1605,30 @@ class DeepseekV4AttnBackend(
                 cache_nope_fp8_rope_bf16_pack=swa_k_pack,
             )
 
+    def can_store_cache_cp_direct(self) -> bool:
+        return self.token_to_kv_pool.has_direct_cp_swa_store()
+
+    def store_cache_cp_direct(
+        self, layer_id: int, local_swa_k: torch.Tensor, forward_batch: ForwardBatch
+    ) -> None:
+        """Store this rank's round-robin token rows into all replicated caches."""
+        if not self.can_store_cache_cp_direct():
+            raise RuntimeError("direct CP cache store is not enabled")
+        parallel = get_parallel()
+        swa_loc = self.get_swa_out_cache_loc(forward_batch)
+        local_swa_loc = swa_loc[parallel.attn_cp_rank :: parallel.attn_cp_size]
+        local_rows = local_swa_loc.numel()
+        if local_swa_k.shape[0] < local_rows:
+            raise RuntimeError(
+                f"rank-local KV has {local_swa_k.shape[0]} rows, expected at "
+                f"least {local_rows}"
+            )
+        self.token_to_kv_pool.set_swa_key_buffer_radix_cp_direct(
+            layer_id=layer_id,
+            swa_loc=local_swa_loc.to(torch.int32).contiguous(),
+            cache_k=local_swa_k[:local_rows].contiguous(),
+        )
+
     def forward(
         self,
         q: torch.Tensor,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -502,6 +502,10 @@ class DeepseekV4AttnBackend(
         super().__init__()
         self.model_runner = model_runner
         self.device = torch.device(model_runner.device)
+        if envs.SGLANG_OPT_USE_CP_COMPRESS.get():
+            self.initialize_cp_compressor_states(
+                self.device, int(model_runner.server_args.chunked_prefill_size)
+            )
         self.max_context_len = model_runner.model_config.context_len
         head_dim = model_runner.model_config.head_dim
         assert (

--- a/python/sglang/srt/layers/attention/dsv4/compressor.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor.py
@@ -422,7 +422,7 @@ class Compressor(MultiPlatformOp):
         return ret
 
     def compute_kv_score(self, x: torch.Tensor, forward_batch: ForwardBatch):
-        kv_score = linear_bf16_fp32(x, self.wkv_gate.weight)
+        kv_score = self.compute_kv_score_local(x)
 
         # CUDA path: delegate to backend
         if dsa_use_prefill_cp(forward_batch):
@@ -433,6 +433,10 @@ class Compressor(MultiPlatformOp):
                 torch.cuda.current_stream(),
             )
         return kv_score
+
+    def compute_kv_score_local(self, x: torch.Tensor) -> torch.Tensor:
+        """Project this rank's local CP token shard without materializing peers."""
+        return linear_bf16_fp32(x, self.wkv_gate.weight)
 
     def forward_native(
         self,

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, List, Literal, Optional, TypeAlias, Union, cast
 
 import torch
-
 from sglang.kernels.jit.utils import is_hip_runtime
 from sglang.kernels.ops.attention.dsv4 import (
     CompressorDecodePlan,
@@ -11,7 +11,18 @@ from sglang.kernels.ops.attention.dsv4 import (
     compress_forward,
     compress_norm_rope_store,
 )
+from sglang.kernels.ops.attention.dsv4.cp_compress import (
+    CPCompressorState,
+    cp_compress_aligned,
+    create_cp_compressor_state,
+)
+from sglang.srt.distributed.parallel_state import get_attn_cp_group
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.utils import (
+    dsa_use_prefill_cp,
+    is_dsa_prefill_cp_round_robin_split,
+)
+from sglang.srt.runtime_context import get_parallel, get_server_args
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.deepseek_v4_backend import DSV4Metadata
@@ -26,6 +37,7 @@ CompressMetadata: TypeAlias = Union[CompressorDecodePlan, CompressorPrefillPlan]
 FusedCompressMetadata: TypeAlias = CompressMetadata
 
 _is_hip = is_hip_runtime()
+logger = logging.getLogger(__name__)
 
 
 def _use_online_compress(compress_ratio: int) -> bool:
@@ -130,6 +142,104 @@ class CompressorBackendMixin:
     def __init__(self):
         super().__init__()
         self.forward_metadata: DSV4Metadata
+        # Reused sequentially by all model layers; carries remain layer-local.
+        self._cp_compressor_states: dict[tuple[int, int], CPCompressorState] = {}
+        self._reported_cp_compressor_keys: set[tuple[int, int]] = set()
+
+    def initialize_cp_compressor_states(
+        self, device: torch.device, max_tokens: int
+    ) -> None:
+        """Collectively create stable peer objects before any model forward."""
+        if not envs.SGLANG_OPT_USE_CP_COMPRESS.get():
+            return
+        cp_group = get_attn_cp_group()
+        if cp_group.world_size != 4 or max_tokens <= 0:
+            raise ValueError("CP compressor requires CP4 and bounded chunked prefill")
+        for ratio, head_dim in ((4, 128), (4, 512), (128, 512)):
+            self._cp_compressor_states[(ratio, head_dim)] = create_cp_compressor_state(
+                cp_group.device_group,
+                cp_group.rank_in_group,
+                ratio,
+                head_dim,
+                max_tokens,
+                device,
+            )
+
+    def _cp_compress_context(
+        self,
+        forward_batch: ForwardBatch,
+        compressor: Compressor,
+        local_tokens: int,
+    ) -> Optional[tuple[int, int]]:
+        if (
+            not envs.SGLANG_OPT_USE_CP_COMPRESS.get()
+            or _is_hip
+            or not dsa_use_prefill_cp(forward_batch)
+            or not is_dsa_prefill_cp_round_robin_split()
+            or get_parallel().attn_cp_size != 4
+            or torch.cuda.is_current_stream_capturing()
+            or not forward_batch.forward_mode.is_extend_without_speculative()
+        ):
+            return None
+        extend_lens = forward_batch.extend_seq_lens_cpu
+        seq_lens = forward_batch.seq_lens_cpu
+        if extend_lens is None or seq_lens is None or len(extend_lens) != 1:
+            return None
+        global_tokens = int(extend_lens[0])
+        total_tokens = int(seq_lens[0].item())
+        prefix_tokens = total_tokens - global_tokens
+        max_tokens = get_server_args().chunked_prefill_size
+        if (
+            max_tokens is None
+            or max_tokens <= 0
+            or global_tokens != local_tokens * 4
+            or not 0 < global_tokens <= max_tokens
+            or global_tokens % compressor.ratio
+            or prefix_tokens < 0
+            or prefix_tokens % compressor.ratio
+        ):
+            return None
+        plan = self._get_paged_compress_metadata(compressor.ratio)
+        if (
+            plan.is_decode
+            or plan.compress_ratio != compressor.ratio
+            or plan.plan_c.dtype != torch.uint8
+            or not plan.plan_c.is_contiguous()
+            or plan.plan_c.shape != (global_tokens // compressor.ratio, 16)
+        ):
+            return None
+        if compressor.ratio == 4:
+            state_buffer = compressor.get_state_pool(self).kv_score_buffer.kv_score
+            if (
+                plan.plan_w.dtype != torch.uint8
+                or not plan.plan_w.is_contiguous()
+                or plan.plan_w.ndim != 2
+                or plan.plan_w.shape[1] != 8
+                or state_buffer.dtype != torch.float32
+                or not state_buffer.is_contiguous()
+                or state_buffer.ndim != 2
+                or state_buffer.shape[1] != 4 * compressor.head_dim
+            ):
+                return None
+        elif plan.plan_w.shape[0] != 0:
+            return None
+        online_c128_mtp = getattr(self, "online_c128_mtp", None)
+        if online_c128_mtp is not None and online_c128_mtp.enabled():
+            return None
+        return global_tokens, prefix_tokens
+
+    def _get_cp_compressor_state(
+        self, compressor: Compressor, device: torch.device
+    ) -> CPCompressorState:
+        key = (compressor.ratio, compressor.head_dim)
+        state = self._cp_compressor_states.get(key)
+        if state is None:
+            raise RuntimeError(
+                "CP compressor peer objects were not initialized before forward"
+            )
+        if state.partial.device != device:
+            raise RuntimeError("CP compressor state is on the wrong device")
+        return state
 
     def _get_paged_compress_metadata(self, compress_ratio: int) -> CompressMetadata:
         attr_name = f"c{compress_ratio}_compress_metadata"
@@ -156,6 +266,7 @@ class CompressorBackendMixin:
         out_loc: torch.Tensor,
         use_fp4_indexer: bool = False,
         bf16_store: bool = False,
+        kv_compressed: Optional[torch.Tensor] = None,
     ) -> None:
         assert compress_ratio == 4 or compress_ratio == 128
         assert rotate == is_indexer == (head_dim == 128)
@@ -165,25 +276,26 @@ class CompressorBackendMixin:
             assert head_dim == 128
 
         plan = self._get_paged_compress_metadata(compress_ratio)
-        is_online = _use_online_compress(compress_ratio)
-        if is_online:
-            kv_score_buffer = kv_score_buffer.view(-1, 1, head_dim * 3)
-        else:
-            coff = 2 if is_overlap_compress(compress_ratio) else 1
-            last_dim = 2 * head_dim * coff
-            assert kv_score_buffer.shape[-1] == last_dim
-            kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
+        if kv_compressed is None:
+            is_online = _use_online_compress(compress_ratio)
+            if is_online:
+                kv_score_buffer = kv_score_buffer.view(-1, 1, head_dim * 3)
+            else:
+                coff = 2 if is_overlap_compress(compress_ratio) else 1
+                last_dim = 2 * head_dim * coff
+                assert kv_score_buffer.shape[-1] == last_dim
+                kv_score_buffer = kv_score_buffer.view(-1, compress_ratio, last_dim)
 
-        # Step 1: compress_forward
-        kv_compressed = compress_forward(
-            kv_score_buffer=kv_score_buffer,
-            kv_score_input=kv_score_input,
-            ape=ape.view(-1, head_dim),
-            plan=plan,
-            compress_ratio=compress_ratio,
-            head_dim=head_dim,
-            is_online=is_online,
-        )
+            # Step 1: compress_forward
+            kv_compressed = compress_forward(
+                kv_score_buffer=kv_score_buffer,
+                kv_score_input=kv_score_input,
+                ape=ape.view(-1, head_dim),
+                plan=plan,
+                compress_ratio=compress_ratio,
+                head_dim=head_dim,
+                is_online=is_online,
+            )
 
         # Step 2: norm + rope + store
         compress_norm_rope_store(
@@ -211,7 +323,39 @@ class CompressorBackendMixin:
 
         token_to_kv_pool = self.token_to_kv_pool
         token_to_kv_pool = cast("DeepSeekV4TokenToKVPool", token_to_kv_pool)
-        kv_score_input = compressor.compute_kv_score(x, forward_batch)
+        cp_context = self._cp_compress_context(forward_batch, compressor, x.shape[0])
+        if cp_context is None:
+            kv_score_input = compressor.compute_kv_score(x, forward_batch)
+            kv_compressed = None
+        else:
+            _, prefix_tokens = cp_context
+            kv_score_input = compressor.compute_kv_score_local(x)
+            cp_state = self._get_cp_compressor_state(compressor, x.device)
+            key = (compressor.ratio, compressor.head_dim)
+            if key not in self._reported_cp_compressor_keys:
+                logger.info(
+                    "using memory-semantic CP compressor: ratio=%d, "
+                    "head_dim=%d, world_size=%d",
+                    compressor.ratio,
+                    compressor.head_dim,
+                    cp_state.world_size,
+                )
+                self._reported_cp_compressor_keys.add(key)
+            plan = self._get_paged_compress_metadata(compressor.ratio)
+            c4_state_buffer = (
+                compressor.get_state_pool(self).kv_score_buffer.kv_score
+                if compressor.ratio == 4
+                else None
+            )
+            kv_compressed = cp_compress_aligned(
+                cp_state,
+                kv_score_input,
+                compressor.ape.view(-1, compressor.head_dim),
+                prefix_tokens=prefix_tokens,
+                c4_plan_c=plan.plan_c if compressor.ratio == 4 else None,
+                c4_plan_w=plan.plan_w if compressor.ratio == 4 else None,
+                c4_state_buffer=c4_state_buffer,
+            )
 
         state_pool = compressor.get_state_pool(self)
         from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
@@ -267,6 +411,7 @@ class CompressorBackendMixin:
                 out_loc=out_loc,
                 use_fp4_indexer=use_fp4_indexer,
                 bf16_store=bf16_store,
+                kv_compressed=kv_compressed,
             )
         online_c128_mtp = getattr(self, "online_c128_mtp", None)
         if online_c128_mtp is not None:

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -21,7 +21,12 @@ from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.deepseek_v4_compress_state import CompressStatePool
 from sglang.srt.mem_cache.memory_pool import KVCache
-from sglang.srt.runtime_context import get_exec, get_server_args, get_spec
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_parallel,
+    get_server_args,
+    get_spec,
+)
 from sglang.srt.utils import ceil_div, is_hip
 
 logger = logging.getLogger(__name__)
@@ -61,6 +66,7 @@ class DeepSeekV4SingleKVPool(KVCache):
         enable_memory_saver: bool,
         start_layer: Optional[int] = None,
         end_layer: Optional[int] = None,
+        direct_cp_store: bool = False,
     ):
         super().__init__(
             size,
@@ -79,10 +85,70 @@ class DeepSeekV4SingleKVPool(KVCache):
         self.quantize_block_size = 64
         self.rope_storage_dtype = torch.bfloat16
         self.k_with_scale_buffer_dtype = torch.int8
+        self.direct_cp_store = bool(direct_cp_store)
+        self.direct_cp_handle = None
+        self._direct_cp_root = None
         self._create_buffers()
 
     def _create_buffers(self):
         with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            if self.direct_cp_store:
+                if self.custom_mem_pool is not None:
+                    raise RuntimeError(
+                        "DSV4 direct CP KV store is incompatible with a custom KV "
+                        "memory pool"
+                    )
+                import torch.distributed._symmetric_memory as symm_mem
+
+                parallel = get_parallel()
+                group = parallel.attn_cp_group.device_group
+                world_size = parallel.attn_cp_size
+                if world_size != 4:
+                    raise RuntimeError(
+                        "DSV4 direct CP KV store currently requires attn CP size 4, "
+                        f"got {world_size}"
+                    )
+                num_pages = (self.size + self.page_size + 1) // self.page_size
+                bytes_per_token = self.get_bytes_per_token()
+                if bytes_per_token != 584 or self.store_dtype != torch.uint8:
+                    raise RuntimeError(
+                        "DSV4 direct CP KV store requires the 584-byte packed "
+                        "FlashMLA uint8 cache layout"
+                    )
+                self.kv_cache_total_dim = bytes_per_token
+                self.bytes_per_page_padded = (
+                    ceil_div(self.page_size * bytes_per_token, 576) * 576
+                )
+                symm_mem.set_signal_pad_size(
+                    max(symm_mem.get_signal_pad_size(), world_size * 4)
+                )
+                with torch.inference_mode(False), torch.no_grad():
+                    root = symm_mem.empty(
+                        (self.layer_num, num_pages, self.bytes_per_page_padded),
+                        dtype=self.store_dtype,
+                        device=self.device,
+                    )
+                root.zero_()
+                handle = symm_mem.rendezvous(root, group=group)
+                if handle.multicast_ptr == 0:
+                    raise RuntimeError(
+                        "DSV4 direct CP KV store requires an NVLink multicast mapping"
+                    )
+                if handle.rank != parallel.attn_cp_rank:
+                    raise RuntimeError(
+                        f"symmetric-memory rank {handle.rank} != attn CP rank "
+                        f"{parallel.attn_cp_rank}"
+                    )
+                self._direct_cp_root = root
+                self.direct_cp_handle = handle
+                self.kv_buffer = list(root.unbind(0))
+                logger.info(
+                    "Using direct CP publication into the packed DSV4 SWA cache "
+                    "(%d layers, %.2f GiB)",
+                    self.layer_num,
+                    root.nbytes / (1024**3),
+                )
+                return
             with (
                 torch.cuda.use_mem_pool(self.custom_mem_pool)
                 if self.custom_mem_pool
@@ -570,6 +636,31 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         )
 
         self._unified_kv = is_unified_kv_triton()
+        direct_cp_store = envs.SGLANG_OPT_DSV4_CP_DIRECT_KV_STORE.get()
+        if direct_cp_store:
+            server_args = get_server_args()
+            if _is_hip:
+                raise RuntimeError("DSV4 direct CP KV store is CUDA-only")
+            if self._unified_kv:
+                raise RuntimeError(
+                    "DSV4 direct CP KV store does not support unified KV layout"
+                )
+            if enable_memory_saver:
+                raise RuntimeError(
+                    "DSV4 direct CP KV store does not support KV cache "
+                    "pause/resume"
+                )
+            if (
+                not server_args.enable_dsa_prefill_context_parallel
+                or server_args.dsa_prefill_cp_mode != "round-robin-split"
+                or get_parallel().attn_cp_size != 4
+                or server_args.nnodes != 1
+                or swa_page_size != 256
+            ):
+                raise RuntimeError(
+                    "DSV4 direct CP KV store requires single-node CP4, DSA prefill "
+                    "round-robin split, and SWA page size 256"
+                )
 
         if self._unified_kv:
             self.swa_kv_pool = None
@@ -607,6 +698,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 device=device,
                 enable_memory_saver=enable_memory_saver,
                 global_page_size=swa_page_size,
+                direct_cp_store=direct_cp_store,
             )
 
             c4_kv_pool_type = DeepSeekV4SingleKVPool
@@ -832,6 +924,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         enable_memory_saver: bool,
         global_page_size: int,
         cls: type = DeepSeekV4SingleKVPool,
+        direct_cp_store: bool = False,
     ) -> DeepSeekV4SingleKVPool:
         """Build a full / SWA / c4 / c128 single-KV pool. ``global_page_size``
         is the model-wide page_size (== ``page_size`` for the SWA pool, larger
@@ -848,6 +941,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
             layer_num,
             device,
             enable_memory_saver,
+            direct_cp_store=direct_cp_store,
         )
 
     def _make_indexer_pool(
@@ -1169,6 +1263,40 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     ) -> None:
         return self.swa_kv_pool.set_key_buffer_fused(
             self._swa_local_layer_id(layer_id), swa_loc, cache_k
+        )
+
+    def has_direct_cp_swa_store(self) -> bool:
+        return bool(self.swa_kv_pool is not None and self.swa_kv_pool.direct_cp_store)
+
+    def set_swa_key_buffer_radix_cp_direct(
+        self,
+        layer_id: int,
+        swa_loc: torch.Tensor,
+        cache_k: torch.Tensor,
+    ) -> None:
+        """Publish rank-local BF16 rows into every rank's packed SWA cache."""
+        pool = self.swa_kv_pool
+        if pool is None or not pool.direct_cp_store:
+            raise RuntimeError("direct CP SWA store was not initialized")
+        if pool.direct_cp_handle is None or pool._direct_cp_root is None:
+            raise RuntimeError("direct CP SWA symmetric-memory handle is missing")
+
+        from sglang.kernels.ops.attention.dsv4.direct_cp_kv_store import (
+            direct_cp_kv_store,
+        )
+
+        parallel = get_parallel()
+        cache = pool.kv_buffer[self._swa_local_layer_id(layer_id)]
+        cache_offset = cache.data_ptr() - pool._direct_cp_root.data_ptr()
+        direct_cp_kv_store(
+            cache=cache,
+            handle=pool.direct_cp_handle,
+            cache_multicast=pool.direct_cp_handle.multicast_ptr + cache_offset,
+            local_kv=cache_k,
+            local_indices=swa_loc,
+            rank=parallel.attn_cp_rank,
+            world_size=parallel.attn_cp_size,
+            page_size=pool.page_size,
         )
 
     def set_swa_key_buffer_radix_fused_norm_rope(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1062,15 +1062,23 @@ class MQALayer(MqaAttentionBase):
             kv = None
 
             if not unified and use_cp:
-                # DSA CP: keep bf16 kv around for the cross-rank all-gather, then
-                # write to the FlashMLA cache after gather.
+                # DSA CP: either publish each rank's local rows directly into all
+                # packed FlashMLA caches, or materialize the legacy full BF16 KV.
                 kv = self._compute_kv_bf16(x, positions, qkv_a=qkv_a)
-                kv = cp_all_gather_rerange_output(
-                    kv.contiguous(),
-                    self.cp_size,
-                    forward_batch,
-                    torch.cuda.current_stream(),
-                )
+                if attn_backend.can_store_cache_cp_direct():
+                    attn_backend.store_cache_cp_direct(
+                        layer_id=self.layer_id,
+                        local_swa_k=kv,
+                        forward_batch=forward_batch,
+                    )
+                    kv = None
+                else:
+                    kv = cp_all_gather_rerange_output(
+                        kv.contiguous(),
+                        self.cp_size,
+                        forward_batch,
+                        torch.cuda.current_stream(),
+                    )
         elif _is_npu:
             q_lora = self.q_norm(q_lora)
             q, _ = self.wq_b(q_lora)
@@ -1123,20 +1131,28 @@ class MQALayer(MqaAttentionBase):
                         torch.cuda.current_stream(),
                     )
             elif use_cp:
-                # NSA CP: keep bf16 kv around for the cross-rank all-gather, then
-                # write to the FlashMLA cache after gather.
+                # NSA CP: publish rank-local rows directly into the replicated
+                # packed cache when enabled; otherwise retain the BF16 gather.
                 kv = self._compute_kv_bf16(x_linear, positions, qkv_a=qkv_a)
-                kv = cp_all_gather_rerange_output(
-                    kv.contiguous(),
-                    self.cp_size,
-                    forward_batch,
-                    torch.cuda.current_stream(),
-                )
-                attn_backend.store_cache(
-                    layer_id=self.layer_id,
-                    swa_k=kv,
-                    forward_batch=forward_batch,
-                )
+                if attn_backend.can_store_cache_cp_direct():
+                    attn_backend.store_cache_cp_direct(
+                        layer_id=self.layer_id,
+                        local_swa_k=kv,
+                        forward_batch=forward_batch,
+                    )
+                    kv = None
+                else:
+                    kv = cp_all_gather_rerange_output(
+                        kv.contiguous(),
+                        self.cp_size,
+                        forward_batch,
+                        torch.cuda.current_stream(),
+                    )
+                    attn_backend.store_cache(
+                        layer_id=self.layer_id,
+                        swa_k=kv,
+                        forward_batch=forward_batch,
+                    )
             else:
                 self._compute_kv_to_cache(
                     x_linear, positions, forward_batch, attn_backend, qkv_a=qkv_a

--- a/test/registered/kernels/ops/attention/test_dsv4_direct_cp_kv_store.py
+++ b/test/registered/kernels/ops/attention/test_dsv4_direct_cp_kv_store.py
@@ -1,0 +1,116 @@
+"""Exactness test for producer-direct DSV4 CP KV-cache publication."""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+from sglang.kernels.jit.utils import cache_once, get_ci_test_range
+from sglang.kernels.ops.attention.dsv4.attn import fused_store_cache
+from sglang.kernels.ops.attention.dsv4.direct_cp_kv_store import direct_cp_kv_store
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+PAGE_SIZE = 256
+PAGE_BYTES = ((584 * PAGE_SIZE + 575) // 576) * 576
+MAX_TOKENS = 4096
+TEST_TOKENS = get_ci_test_range([1024, 4096], [1024])
+
+
+@dataclass
+class _State:
+    group: dist.ProcessGroup
+    rank: int
+    world_size: int
+    cache: torch.Tensor
+    handle: Any
+
+
+@cache_once
+def _init_state() -> _State:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    assert world_size == 4
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)), local_rank=local_rank, backend="nccl"
+    )
+    atexit.register(dist.destroy_process_group)
+    logging.disable(logging.INFO)
+    torch.cuda.set_stream(torch.cuda.Stream())
+
+    group = ps._WORLD.device_group
+    symm_mem.set_signal_pad_size(max(symm_mem.get_signal_pad_size(), world_size * 4))
+    with torch.inference_mode(False), torch.no_grad():
+        cache = symm_mem.empty(
+            (MAX_TOKENS // PAGE_SIZE, PAGE_BYTES),
+            dtype=torch.uint8,
+            device=f"cuda:{local_rank}",
+        )
+    cache.zero_()
+    handle = symm_mem.rendezvous(cache, group=group)
+    if handle.multicast_ptr == 0:
+        pytest.skip("NVLink multicast mapping is unavailable")
+    return _State(group, local_rank, world_size, cache, handle)
+
+
+@pytest.mark.parametrize("global_tokens", TEST_TOKENS)
+@torch.inference_mode()
+def test_dsv4_direct_cp_kv_store_exact(global_tokens: int) -> None:
+    state = _init_state()
+    assert global_tokens % state.world_size == 0
+    device = state.cache.device
+
+    torch.manual_seed(20260801 + global_tokens)
+    global_kv = torch.randn((global_tokens, 512), dtype=torch.bfloat16, device=device)
+    local_kv = global_kv[state.rank :: state.world_size].contiguous()
+    global_indices = torch.randperm(
+        MAX_TOKENS, dtype=torch.int32, device=device
+    )[:global_tokens]
+    local_indices = global_indices[state.rank :: state.world_size].contiguous()
+
+    gathered = torch.empty_like(global_kv)
+    dist.all_gather_into_tensor(gathered, local_kv, group=state.group)
+    gathered = (
+        gathered.view(state.world_size, -1, 512)
+        .transpose(0, 1)
+        .reshape(global_tokens, 512)
+    )
+    reference = torch.zeros_like(state.cache)
+    fused_store_cache(
+        gathered,
+        reference,
+        global_indices,
+        page_size=PAGE_SIZE,
+        type="flashmla",
+    )
+
+    state.cache.zero_()
+    dist.barrier(group=state.group)
+    direct_cp_kv_store(
+        cache=state.cache,
+        handle=state.handle,
+        cache_multicast=state.handle.multicast_ptr,
+        local_kv=local_kv,
+        local_indices=local_indices,
+        rank=state.rank,
+        world_size=state.world_size,
+        page_size=PAGE_SIZE,
+    )
+    torch.testing.assert_close(state.cache, reference, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(4,))

--- a/test/registered/kernels/ops/attention/test_dsv4_direct_cp_kv_store.py
+++ b/test/registered/kernels/ops/attention/test_dsv4_direct_cp_kv_store.py
@@ -76,9 +76,9 @@ def test_dsv4_direct_cp_kv_store_exact(global_tokens: int) -> None:
     torch.manual_seed(20260801 + global_tokens)
     global_kv = torch.randn((global_tokens, 512), dtype=torch.bfloat16, device=device)
     local_kv = global_kv[state.rank :: state.world_size].contiguous()
-    global_indices = torch.randperm(
-        MAX_TOKENS, dtype=torch.int32, device=device
-    )[:global_tokens]
+    global_indices = torch.randperm(MAX_TOKENS, dtype=torch.int32, device=device)[
+        :global_tokens
+    ]
     local_indices = global_indices[state.rank :: state.world_size].contiguous()
 
     gathered = torch.empty_like(global_kv)

--- a/test/registered/kernels/ops/communication/test_cp_compress.py
+++ b/test/registered/kernels/ops/communication/test_cp_compress.py
@@ -1,0 +1,271 @@
+"""Four-GPU correctness for consumer-direct DSV4 CP compression.
+
+Usage::
+
+    python test/registered/kernels/ops/communication/test_cp_compress.py --num-gpu 4
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import time
+
+import pytest
+import sglang.srt.distributed.parallel_state as ps
+import torch
+import torch.distributed as dist
+from sglang.kernels.jit.utils import cache_once
+from sglang.kernels.ops.attention.dsv4.cp_compress import (
+    cp_compress_aligned,
+    create_cp_compressor_state,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kernels.utils import multigpu_pytest_main
+
+register_cuda_ci(est_time=120, stage="extra-b", runner_config="4-gpu-b200")
+
+
+@cache_once
+def _init_group() -> tuple[dist.ProcessGroup, int]:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    ps._WORLD = ps.init_world_group(
+        ranks=list(range(world_size)), local_rank=local_rank, backend="nccl"
+    )
+    atexit.register(dist.destroy_process_group)
+    torch.cuda.set_stream(torch.cuda.Stream())
+    assert ps._WORLD.device_group is not None
+    return ps._WORLD.device_group, ps._WORLD.rank_in_group
+
+
+def _gather_interleaved(local: torch.Tensor, group: dist.ProcessGroup) -> torch.Tensor:
+    rank_major = torch.empty(
+        (local.shape[0] * group.size(), local.shape[1]),
+        dtype=local.dtype,
+        device=local.device,
+    )
+    dist.all_gather_into_tensor(rank_major, local, group=group)
+    return (
+        rank_major.view(group.size(), local.shape[0], local.shape[1])
+        .transpose(0, 1)
+        .reshape(-1, local.shape[1])
+    )
+
+
+def _softmax_weighted(kv: torch.Tensor, score: torch.Tensor) -> torch.Tensor:
+    weights = torch.softmax(score, dim=1)
+    return (kv * weights).sum(dim=1)
+
+
+def _reference_c128(global_input: torch.Tensor, ape: torch.Tensor) -> torch.Tensor:
+    windows = global_input.shape[0] // 128
+    head_dim = ape.shape[1]
+    x = global_input.view(windows, 128, 2, head_dim)
+    return _softmax_weighted(x[:, :, 0], x[:, :, 1] + ape)
+
+
+def _reference_c4(
+    global_input: torch.Tensor,
+    ape: torch.Tensor,
+    previous: torch.Tensor | None,
+) -> torch.Tensor:
+    windows = global_input.shape[0] // 4
+    head_dim = ape.shape[1]
+    x = global_input.view(windows, 4, 4, head_dim)
+    outputs = []
+    for window in range(windows):
+        current = x[window]
+        kv = current[:, 1]
+        score = current[:, 3] + ape[4:]
+        prior = previous if window == 0 else x[window - 1]
+        if prior is not None:
+            kv = torch.cat((prior[:, 0], kv), dim=0)
+            score = torch.cat((prior[:, 2] + ape[:4], score), dim=0)
+        outputs.append(_softmax_weighted(kv[None], score[None])[0])
+    return torch.stack(outputs)
+
+
+@pytest.mark.parametrize("ratio,head_dim", [(4, 128), (4, 512), (128, 512)])
+@torch.inference_mode()
+def test_changing_input_and_aligned_prefix(ratio: int, head_dim: int) -> None:
+    group, rank = _init_group()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    global_tokens = 512
+    local_tokens = global_tokens // group.size()
+    width = (4 if ratio == 4 else 2) * head_dim
+    state = create_cp_compressor_state(
+        group, rank, ratio, head_dim, global_tokens, device
+    )
+    carry = (
+        torch.empty((2, head_dim), dtype=torch.float32, device=device)
+        if ratio == 4
+        else None
+    )
+    ape_rows = 8 if ratio == 4 else 128
+    torch.manual_seed(1000 + ratio + head_dim)
+    ape = torch.randn((ape_rows, head_dim), dtype=torch.float32, device=device)
+    previous = None
+    for iteration in range(3):
+        # Deliberately skew one producer before the intervening publication
+        # barrier; iteration 2 then reuses parity zero without stale reads.
+        if iteration == 1 and rank == 0:
+            time.sleep(0.02)
+        torch.manual_seed(28639 + iteration * 10 + rank)
+        local = torch.randn((local_tokens, width), dtype=torch.float32, device=device)
+        global_input = _gather_interleaved(local, group)
+        actual = cp_compress_aligned(
+            state,
+            local,
+            ape,
+            prefix_tokens=iteration * global_tokens,
+            c4_carry=carry,
+        )
+        expected = (
+            _reference_c4(global_input, ape, previous)
+            if ratio == 4
+            else _reference_c128(global_input, ape)
+        )
+        torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-5)
+        if ratio == 4:
+            previous = global_input[-4:].view(4, 4, head_dim)
+
+
+@pytest.mark.parametrize("head_dim", [128, 512])
+@torch.inference_mode()
+def test_c4_sparse_plan_w_state_buffer(head_dim: int) -> None:
+    group, rank = _init_group()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    global_tokens = 512
+    local_tokens = global_tokens // group.size()
+    width = 4 * head_dim
+    state = create_cp_compressor_state(group, rank, 4, head_dim, global_tokens, device)
+    carry = torch.empty((2, head_dim), dtype=torch.float32, device=device)
+    ape = torch.zeros((8, head_dim), dtype=torch.float32, device=device)
+
+    # These are exactly the four C4 tail rows from each 128-token SWA page.
+    # Every owner rank appears once per page under round-robin CP4.
+    ragged_ids = torch.tensor(
+        [
+            124,
+            125,
+            126,
+            127,
+            252,
+            253,
+            254,
+            255,
+            380,
+            381,
+            382,
+            383,
+            508,
+            509,
+            510,
+            511,
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    num_slots = 41
+    sentinel = -12345.0
+    state_buffer = torch.empty(
+        (num_slots, 4, head_dim), dtype=torch.float32, device=device
+    )
+
+    # Three generations force reuse of double-buffer slot zero. Inputs and
+    # destinations change each time, catching stale peer-stage publication.
+    for iteration in range(3):
+        dist.barrier(group)
+        torch.manual_seed(39000 + iteration * 10 + rank)
+        local = torch.randn((local_tokens, width), dtype=torch.float32, device=device)
+        global_input = _gather_interleaved(local, group)
+        write_locs = (
+            torch.arange(ragged_ids.numel(), dtype=torch.int32, device=device) * 7
+            + iteration * 3
+        ) % num_slots
+        plan_i32 = torch.stack((ragged_ids, write_locs), dim=1).contiguous()
+        plan_w = plan_i32.view(torch.uint8)
+        assert plan_w.shape == (ragged_ids.numel(), 8)
+
+        state_buffer.fill_(sentinel)
+        cp_compress_aligned(
+            state,
+            local,
+            ape,
+            prefix_tokens=iteration * global_tokens,
+            c4_carry=carry,
+            c4_plan_w=plan_w,
+            c4_state_buffer=state_buffer,
+        )
+
+        expected = torch.full_like(state_buffer, sentinel)
+        expected[write_locs.long()] = global_input.index_select(
+            0, ragged_ids.long()
+        ).view(-1, 4, head_dim)
+        torch.testing.assert_close(state_buffer, expected, rtol=0, atol=0)
+
+    assert state.generation == 3
+
+
+@pytest.mark.parametrize("head_dim", [128, 512])
+@torch.inference_mode()
+def test_c4_paged_prefix_reads_plan_c_history(head_dim: int) -> None:
+    group, rank = _init_group()
+    device = torch.device(f"cuda:{int(os.environ['LOCAL_RANK'])}")
+    global_tokens = 512
+    local_tokens = global_tokens // group.size()
+    state = create_cp_compressor_state(group, rank, 4, head_dim, global_tokens, device)
+    torch.manual_seed(48000 + head_dim)
+    ape = torch.randn((8, head_dim), dtype=torch.float32, device=device)
+    state_buffer = torch.zeros((32, 4 * head_dim), dtype=torch.float32, device=device)
+    page = 5
+
+    previous = None
+    for iteration in range(2):
+        torch.manual_seed(49000 + iteration * 10 + rank)
+        local = torch.randn(
+            (local_tokens, 4 * head_dim), dtype=torch.float32, device=device
+        )
+        global_input = _gather_interleaved(local, group)
+        plan_c_i32 = torch.zeros(
+            (global_tokens // 4, 4), dtype=torch.int32, device=device
+        )
+        plan_c_i32[0, 2] = page
+        plan_c = plan_c_i32.view(torch.uint8)
+        if iteration == 0:
+            ragged = torch.arange(
+                global_tokens - 4,
+                global_tokens,
+                dtype=torch.int32,
+                device=device,
+            )
+            write_locs = torch.arange(
+                page * 4, page * 4 + 4, dtype=torch.int32, device=device
+            )
+            plan_w = torch.stack((ragged, write_locs), dim=1).view(torch.uint8)
+        else:
+            plan_w = torch.empty((0, 8), dtype=torch.uint8, device=device)
+
+        actual = cp_compress_aligned(
+            state,
+            local,
+            ape,
+            prefix_tokens=iteration * global_tokens,
+            c4_plan_c=plan_c,
+            c4_plan_w=plan_w,
+            c4_state_buffer=state_buffer,
+        )
+        torch.testing.assert_close(
+            actual,
+            _reference_c4(global_input, ape, previous),
+            rtol=2e-5,
+            atol=2e-5,
+        )
+        previous = global_input[-4:].view(4, 4, head_dim)
+
+
+if __name__ == "__main__":
+    multigpu_pytest_main(__name__, __file__, num_gpus=(4,))


### PR DESCRIPTION
# Summary

This PR optimizes two communication-heavy procedures in DSV4 prefill context
parallelism: 
- publishing SWA KV into the packed FlashMLA cache and 
- compressing C4/C128 projection windows.

DSA CP already distributes current-chunk tokens across ranks. This PR makes
the two large prefill objects directly addressable with stable physical
storage, explicit ownership, local/peer views, and publish/wait synchronization.

The existing path materializes both objects through complete collectives:

```text
rank-local BF16 KV rows
  -> KV AllGather + rerange
  -> complete BF16 KV tensor on every rank
  -> local quantize/pack/cache store

rank-local token projections
  -> projection AllGather
  -> complete token-level FP32 projection tensor on every rank
  -> window compression
```

This PR replaces the SWA KV path with direct publication into its final cache
layout:

```text
rank-local BF16 KV rows
  -> quantize and pack owner-local rows
  -> multicast-store each row into every rank's packed FlashMLA cache
  -> publish at the layer boundary
  -> attention consumes its local replicated cache
```

It replaces projection materialization with owner-sharded C4/C128 compression:

```text
rank-local token projections
  -> owner-local online-softmax state per compression window
  -> publish one owner-local symmetric-memory object per rank
  -> consumer directly merges local/peer states
  -> compressed KV rows and C4 paged state
```

The new path removes those materialization boundaries. Data still crosses GPU
boundaries and synchronization is still required, but consumers operate on the
final replicated KV layout or directly merge owner-sharded compressor state.

# Performance

Four GB200 GPUs, DeepSeek-V4-Flash, TP4/attention-CP4, EP4 MegaMoE, chunk size
16384, radix cache disabled, concurrency 1, random range ratio 1.0, output
length 1, fixed server/request seed 28639, and two warmups. A is the baseline;
B uses the same commit and configuration with only this PR enabled. Each arm
has two clean server restarts.

| Input | Requests | A: CP4 + EP4 MegaMoE | B: A + this PR | B-A |
| ---: | ---: | ---: | ---: | ---: |
| 16K | 300 | 238.54 ms | 226.60 ms | -11.94 ms (-5.01%) |
| 32K | 150 | 450.74 ms | 438.06 ms | -12.68 ms (-2.81%) |
| 64K | 100 | 927.05 ms | 881.20 ms | -45.85 ms (-4.95%) |
| 128K | 50 | 1784.71 ms | 1683.81 ms | -100.90 ms (-5.65%) |

These are restart-average mean TTFT values using one common-valid request mask
per cell. All four cross-restart B-versus-A pairings are faster at 64K and
128K. At 16K and 32K, the two-run average is faster, but one cross-restart
comparison is slower. More repeated runs are needed before treating the gains
at those two lengths as stable.

A matched 16K four-rank trace _**reduces NCCL AllGather calls from 106 to 1 per
rank.**_ On the slowest rank, summed AllGather kernel duration falls from 46.02 ms
to 0.71 ms. This _**removes 105/106 calls (99.06%) and 98.45% of the observed
AllGather kernel-duration attribution.**_ The remaining TTFT ceiling is dominated
by MegaMoE (up to about 107 ms/rank) and the direct-KV publication barrier (up
to about 25 ms/rank).

# Correctness

- Memory-semantic compressor: 7/7 four-GPU tests passed, including C4/C128,
  repeated generations, deliberate rank skew, sparse ownership, and paged C4
  continuation.
- Direct packed KV publication: 2/2 four-GPU byte-exact tests passed at 1K and
  4K tokens.
- The full four-restart suite completed 2400/2400 requests. One B 128K request
  produced a zero client TTFT despite no reported request error, so request 19
  is removed from all four 128K arms; 49 common-valid samples remain per run.
- Source SHA, dirty status, fixed seeds, resolved server arguments, feature
  markers, competing-feature markers, and GPU release are audited for every
  restart.

The benchmark orchestration under `artifacts/e2e_comparison/` is local evidence
infrastructure and is not included in this source PR. The commands, exact
environment, raw JSONL, trace summaries, and deterministic analyzer are kept in
the accompanying evidence bundle.

# Follow-up

The same stable-object contract can be integrated with Shared-DCP from #32851,
so Query, Top-K, Output/LSE, compressor state, and packed KV publication share
one ownership and synchronization model. That integration is intentionally
left to a later PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30731296112](https://github.com/sgl-project/sglang/actions/runs/30731296112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30731296023](https://github.com/sgl-project/sglang/actions/runs/30731296023)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->