### PR TITLE
[DO NOT MERGE] ServerArgs.override burndown — stack review & CI

### DIFF
--- a/.claude/skills/sglang-runtime-context/SKILL.md
+++ b/.claude/skills/sglang-runtime-context/SKILL.md
@@ -69,10 +69,10 @@ resolved configuration lives in the namespace bags.**
 - **Per-instance boundaries** — the tokenizer-manager family, everything under
   `entrypoints/`, and the tokenizer-process multimodal processors read
   `self.server_args`: several `Engine`s can share one process, and the process-global
-  bags are last-publish-wins across engines. (The mm-processor boundary is not yet
-  airtight: `BaseMultimodalProcessor.process_mm_data` still reads `base_gpu_id` /
-  `rl_on_policy_target` through `get_server_args()` — a known last-publish-wins gap,
-  not a pattern to copy.)
+  bags are last-publish-wins across engines. `base_gpu_id` also differs per worker
+  (the encode-server DP workers each specialize their own copy), so no process-global
+  value can stand in for it — `BaseMultimodalProcessor._fast_image_processor_device`
+  is the shape to copy.
 - **Whole-object passes** (`f(server_args)` handing the instance along) keep the
   supplied-instance contract; don't rewrite the parameter reads to bag reads unless the
   field is runtime-mutated (see the elastic-EP `ep_size` case in

--- a/.claude/skills/sglang-runtime-context/SKILL.md
+++ b/.claude/skills/sglang-runtime-context/SKILL.md
@@ -237,10 +237,13 @@ Never module-skip a test "until the migration settles" — seed the context inst
 ## Hard-won pitfalls (check these before/while refactoring)
 
 - **Moving code drops first-line guards**: early returns (`if self.is_draft_worker: return`)
-  are the easiest thing to lose when relocating a method body. Only drafts built through
-  `build_draft_tp_worker()` get private bags (a preserved publish of the rewritten copy);
-  drafts constructed directly with `is_draft_worker=True` skip publish and **share the
-  target's bags** — a draft-side write there poisons the target.
+  are the easiest thing to lose when relocating a method body. Every draft is built
+  under a preserved publish of its own config: the scheduler makes the copy with
+  `draft_server_args_copy()` (seeded from the resolved config, so load-time overrides
+  carry) and publishes it around the worker factory, and `build_draft_tp_worker()`
+  nests the same shape for dflash / dspark. The publish ends when construction does —
+  anything the draft reads later (`alloc_memory_pool`, `init_attention_backends`,
+  cuda-graph capture) is back on the target's bags.
 - **Registry-completeness timing**: a gate that consults an extensible list is only correct
   after the registrars ran (platform `init_backend()` at module import). See "load-time vs
   resolution-time".

--- a/STACK_REVIEW_PLACEHOLDER.md
+++ b/STACK_REVIEW_PLACEHOLDER.md
@@ -1,0 +1,14 @@
+# Stack review vehicle — DO NOT MERGE
+
+This PR aggregates the full diff of a stacked series so CI can run once over
+the whole stack and reviewers can see the combined change. Merge the member
+PRs in stack order instead; if this PR is ever used as a squash vehicle,
+drop the commit that adds this file first.
+
+Members (merge in order):
+
+1. config: retire three ServerArgs.override sites that no reader needed
+2. spec: give the v2 draft workers their own ServerArgs copy
+3. config: keep runtime hicache and weight-version updates off ServerArgs
+4. observability: publish the generated forward-pass-metrics endpoint to the bags
+5. config: retire the last process-global config field reads

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -579,10 +579,10 @@ def prewarm_mhc_pre(
     the TileLang/DeepGEMM on-disk JIT cache, so this cost is paid only on a cold
     cache; later server runs hit the cache. Driven once per process from load_weights.
     """
-    from sglang.srt.runtime_context import get_server_args
+    from sglang.srt.runtime_context import get_schedule
 
     hc_mult, hidden_size = residual.shape[-2], residual.shape[-1]
-    max_num_tokens = get_server_args().chunked_prefill_size
+    max_num_tokens = get_schedule().chunked_prefill_size
     buckets = get_mhc_pre_token_count_representatives(
         max_num_tokens, hc_mult * hidden_size
     )

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -40,7 +40,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     compute_position,
 )
 from sglang.srt.model_executor.forward_context import get_attn_backend
-from sglang.srt.runtime_context import get_device, get_parallel, get_server_args
+from sglang.srt.runtime_context import get_device, get_exec, get_parallel
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import BumpAllocator, empty_context, get_bool_env_var, is_hip
 
@@ -634,7 +634,7 @@ class TboForwardBatchPreparer:
             sum_field=None,
         )
         _, child_b.extend_start_loc = compute_position(
-            get_server_args().attention_backend,
+            get_exec().kernel.attention_backend,
             child_b.extend_prefix_lens,
             child_b.extend_seq_lens,
             child_b.extend_num_tokens,

--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -22,7 +22,7 @@ from typing import Dict, List, NamedTuple, Optional, Tuple
 import torch
 
 from sglang.srt.parser.reasoning_parser import ReasoningParser
-from sglang.srt.runtime_context import get_resources
+from sglang.srt.runtime_context import get_context, get_resources
 from sglang.srt.server_args import ServerArgs
 
 logger = logging.getLogger(__name__)
@@ -360,7 +360,7 @@ def create_grammar_backend(
                 "Falling back to grammar_backend='none'. "
                 "Structured outputs (JSON schema, regex, EBNF) will not be available."
             )
-            server_args.override("grammar.import_fallback", grammar_backend="none")
+            get_context().override("grammar.import_fallback", grammar_backend="none")
             return None
     elif name == "llguidance":
         from sglang.srt.constrained.llguidance_backend import GuidanceBackend

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1271,7 +1271,9 @@ class Engine(EngineScoreMixin, EngineBase):
         )
         return msgspec_to_builtins(
             {
-                **dataclasses.asdict(self.tokenizer_manager.server_args),
+                **self.tokenizer_manager.resolved_config_dict(
+                    dataclasses.asdict(self.tokenizer_manager.server_args)
+                ),
                 **self._scheduler_init_result.scheduler_infos[0],
                 "internal_states": internal_states,
                 "version": __version__,

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -379,7 +379,7 @@ class RuntimeHandle:
             "model_path": self.tokenizer_manager.model_path,
             "tokenizer_path": self.tokenizer_manager.server_args.tokenizer_path,
             "is_generation": self.tokenizer_manager.is_generation,
-            "weight_version": self.tokenizer_manager.server_args.weight_version,
+            "weight_version": self.tokenizer_manager.config_value("weight_version"),
             "model_type": getattr(model_config.hf_config, "model_type", None),
             "architectures": getattr(model_config.hf_config, "architectures", None),
         }
@@ -393,7 +393,9 @@ class RuntimeHandle:
         return json.dumps(result, default=str)
 
     def get_server_info(self) -> str:
-        result: Dict[str, Any] = dataclasses.asdict(self.server_args)
+        result: Dict[str, Any] = self.tokenizer_manager.resolved_config_dict(
+            dataclasses.asdict(self.tokenizer_manager.server_args)
+        )
         result.update(self.scheduler_info)
         return json.dumps(msgspec_to_builtins(result), default=str)
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -710,12 +710,13 @@ async def model_info():
         "tokenizer_path": _global_state.tokenizer_manager.server_args.tokenizer_path,
         "is_generation": _global_state.tokenizer_manager.is_generation,
         "preferred_sampling_params": _global_state.tokenizer_manager.server_args.preferred_sampling_params,
-        "weight_version": _global_state.tokenizer_manager.server_args.weight_version,
+        "weight_version": _global_state.tokenizer_manager.config_value(
+            "weight_version"
+        ),
         "has_image_understanding": model_config.is_image_understandable_model,
         "has_audio_understanding": model_config.is_audio_understandable_model,
         "model_type": getattr(model_config.hf_config, "model_type", None),
         "architectures": getattr(model_config.hf_config, "architectures", None),
-        "weight_version": _global_state.tokenizer_manager.server_args.weight_version,
         # "hf_config": model_config.hf_config.to_dict(),
     }
     embedding_model_spec = getattr(model_config, "embedding_model_spec", None)
@@ -761,7 +762,9 @@ async def server_info():
     # server_args.model_config is not serializable but should be excluded by asdict.
     return msgspec_to_builtins(
         {
-            **dataclasses.asdict(server_args),
+            **_global_state.tokenizer_manager.resolved_config_dict(
+                dataclasses.asdict(server_args)
+            ),
             **_global_state.scheduler_info,
             "internal_states": internal_states,
             "version": __version__,
@@ -1091,10 +1094,13 @@ async def hicache_storage_backend_status():
         return _admin_api_key_missing_response()
 
     return {
-        "hicache_storage_backend": _global_state.tokenizer_manager.server_args.hicache_storage_backend,
-        "hicache_storage_backend_extra_config": _global_state.tokenizer_manager.server_args.hicache_storage_backend_extra_config,
-        "hicache_storage_prefetch_policy": _global_state.tokenizer_manager.server_args.hicache_storage_prefetch_policy,
-        "hicache_write_policy": _global_state.tokenizer_manager.server_args.hicache_write_policy,
+        name: _global_state.tokenizer_manager.config_value(name)
+        for name in (
+            "hicache_storage_backend",
+            "hicache_storage_backend_extra_config",
+            "hicache_storage_prefetch_policy",
+            "hicache_write_policy",
+        )
     }
 
 
@@ -1385,8 +1391,7 @@ async def update_weight_version(
     # Use a simple approach without the complex lock mechanism for now
     # since weight_version update is a simple operation that doesn't affect model weights
     try:
-        # Update the weight version in server args (the single source of truth)
-        _global_state.tokenizer_manager.server_args.override(
+        _global_state.tokenizer_manager.record_config_updates(
             "http.update_weight_version", weight_version=obj.new_version
         )
 

--- a/python/sglang/srt/entrypoints/openai/realtime/session.py
+++ b/python/sglang/srt/entrypoints/openai/realtime/session.py
@@ -338,12 +338,12 @@ class RealtimeConnection:
         if (
             transcription is not None
             and transcription.model
-            and transcription.model != self.server_args.served_model_name
+            and transcription.model != self.tokenizer_manager.served_model_name
         ):
             await self._send_error(
                 "not_supported",
                 f"Model {transcription.model!r} is not served by this endpoint "
-                f"(serving {self.server_args.served_model_name!r}); set "
+                f"(serving {self.tokenizer_manager.served_model_name!r}); set "
                 f"transcription.model to null or to the server's model name.",
                 param="session.audio.input.transcription.model",
             )

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1279,7 +1279,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     logger.warning(
                         "Model '%s' supports only 'low' reasoning effort; "
                         "requested '%s' treated as default thinking",
-                        self.tokenizer_manager.server_args.served_model_name,
+                        self.tokenizer_manager.served_model_name,
                         request.reasoning_effort,
                     )
 

--- a/python/sglang/srt/entrypoints/openai/serving_classify.py
+++ b/python/sglang/srt/entrypoints/openai/serving_classify.py
@@ -39,7 +39,7 @@ class OpenAIServingClassify(OpenAIServingBase):
         self.model_name = (
             self.tokenizer_manager.served_model_name
             if self.tokenizer_manager.served_model_name
-            else self.tokenizer_manager.server_args.model_path
+            else self.tokenizer_manager.model_path
         )
         if not self.id2label:
             raise ValueError("id2label mapping is missing")

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -13,6 +13,7 @@ from sglang.srt.configs.linear_attn_model_registry import (
     get_linear_attn_config,
     import_backend_class,
 )
+from sglang.srt.runtime_context import get_context
 from sglang.srt.utils import get_device_capability, is_hip, is_musa, is_npu
 
 _is_musa = is_musa()
@@ -353,7 +354,7 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
             )
             from sglang.srt.layers.attention.linear.gdn_backend import (
                 GDNAttnBackend,
-                maybe_set_default_flashinfer_gdn_prefill,
+                flashinfer_gdn_prefill_default,
             )
         else:
             from sglang.srt.hardware_backend.npu.attention.ascend_gdn_backend import (
@@ -367,9 +368,15 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
             )
 
         check_environments()
+        prefill_default = None
         if hybrid_gdn_config(runner.model_config) is not None and not is_npu():
-            maybe_set_default_flashinfer_gdn_prefill(runner)
-        initialize_linear_attn_config(runner.server_args)
+            prefill_default = flashinfer_gdn_prefill_default(runner)
+        if prefill_default is not None:
+            get_context().override(
+                "gdn_backend.sm100_flashinfer_default",
+                linear_attn_prefill_backend=prefill_default,
+            )
+        initialize_linear_attn_config(runner.server_args, prefill_default)
         hybrid_backend_cls = HybridLinearAttnBackend
         if hybrid_gdn_config(runner.model_config) is not None:
             if is_blackwell():

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -376,7 +376,9 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
                 "gdn_backend.sm100_flashinfer_default",
                 linear_attn_prefill_backend=prefill_default,
             )
-        initialize_linear_attn_config(runner.server_args, prefill_default)
+        initialize_linear_attn_config(
+            runner.server_args, prefill_default=prefill_default
+        )
         hybrid_backend_cls = HybridLinearAttnBackend
         if hybrid_gdn_config(runner.model_config) is not None:
             if is_blackwell():

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -63,8 +63,8 @@ elif is_cpu():
     fused_gdn_gating = torch.ops.sgl_kernel.fused_gdn_gating_cpu
 
 
-def maybe_set_default_flashinfer_gdn_prefill(model_runner: ModelRunner) -> None:
-    """Use FlashInfer for the narrow SM100 GDN prefill domain we validated."""
+def flashinfer_gdn_prefill_default(model_runner: ModelRunner) -> Optional[str]:
+    """FlashInfer for the narrow SM100 GDN prefill domain we validated, else None."""
     args = model_runner.server_args
     if (
         args.linear_attn_prefill_backend is not None
@@ -73,7 +73,7 @@ def maybe_set_default_flashinfer_gdn_prefill(model_runner: ModelRunner) -> None:
         or not is_cuda()
         or torch.cuda.get_device_capability()[0] != 10
     ):
-        return
+        return None
 
     cuda_version = torch.version.cuda
     chunk_size = args.chunked_prefill_size
@@ -89,20 +89,17 @@ def maybe_set_default_flashinfer_gdn_prefill(model_runner: ModelRunner) -> None:
         or model_runner.req_to_token_pool.mamba_pool.mamba_cache.temporal.dtype
         != torch.bfloat16
     ):
-        return
+        return None
 
     from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
         is_flashinfer_gdn_prefill_available,
     )
 
-    if is_flashinfer_gdn_prefill_available():
-        # server_args is resolved (read-only) by the time backends initialize;
-        # route this load-time default through the audited mutation entry.
-        args.override(
-            "gdn_backend.sm100_flashinfer_default",
-            linear_attn_prefill_backend="flashinfer",
-        )
-        rank0_log("Defaulting SM100 GDN prefill backend to FlashInfer.")
+    if not is_flashinfer_gdn_prefill_available():
+        return None
+
+    rank0_log("Defaulting SM100 GDN prefill backend to FlashInfer.")
+    return "flashinfer"
 
 
 class GDNKernelDispatcher:

--- a/python/sglang/srt/layers/attention/linear/utils.py
+++ b/python/sglang/srt/layers/attention/linear/utils.py
@@ -43,13 +43,15 @@ LINEAR_ATTN_DECODE_BACKEND: Optional[LinearAttnKernelBackend] = None
 LINEAR_ATTN_PREFILL_BACKEND: Optional[LinearAttnKernelBackend] = None
 
 
-def initialize_linear_attn_config(server_args: ServerArgs):
+def initialize_linear_attn_config(
+    server_args: ServerArgs, prefill_default: Optional[str] = None
+):
     global LINEAR_ATTN_DECODE_BACKEND
     global LINEAR_ATTN_PREFILL_BACKEND
 
     base = server_args.linear_attn_backend
     decode = server_args.linear_attn_decode_backend or base
-    prefill = server_args.linear_attn_prefill_backend or base
+    prefill = server_args.linear_attn_prefill_backend or prefill_default or base
 
     LINEAR_ATTN_DECODE_BACKEND = LinearAttnKernelBackend(decode)
     LINEAR_ATTN_PREFILL_BACKEND = LinearAttnKernelBackend(prefill)

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -18,7 +18,7 @@ from sglang.srt.layers.rotary_embedding.yarn import (
     yarn_get_mscale_simple,
     yarn_linear_ramp_mask,
 )
-from sglang.srt.runtime_context import get_exec, get_server_args
+from sglang.srt.runtime_context import get_exec
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cuda,
@@ -42,7 +42,6 @@ if _is_xpu:
     from sgl_kernel import multimodal_rotary_embedding
 
 from sglang.kernels.ops.attention.mrope import apply_interleaved_rope_triton
-from sglang.srt.runtime_context import get_server_args
 
 
 def apply_interleaved_rope(x: torch.Tensor, mrope_section: list) -> torch.Tensor:
@@ -144,7 +143,7 @@ class MRotaryEmbedding(RotaryEmbedding):
         last_dim = cos_sin.size()[-1]
         cos, sin = cos_sin.chunk(2, dim=-1)
         if self.mrope_interleaved:
-            if support_triton(get_server_args().attention_backend):
+            if support_triton(get_exec().kernel.attention_backend):
                 cos = apply_interleaved_rope_triton(cos, self.mrope_section)
                 sin = apply_interleaved_rope_triton(sin, self.mrope_section)
             else:

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -38,6 +38,7 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_schedule,
     get_server_args,
+    get_serving,
 )
 from sglang.srt.utils import flatten_nested_list, is_hip, is_npu, print_warning_once
 from sglang.srt.utils.stale_shm_cleanup import make_shm_name
@@ -554,7 +555,7 @@ def _acknowledge_deferred_cuda_ipc_cache_hits(
         return
     # The pool's recycler counts the whole TP group, so the acknowledgement must
     # match that count even when an attention subgroup is smaller.
-    consumer_count = max(get_server_args().tp_size, 1)
+    consumer_count = max(parallel.tp_size, 1)
     for item in items:
         item.acknowledge_deferred_cuda_ipc_feature(consumer_count)
 
@@ -2024,7 +2025,7 @@ def wrap_shm_features(obj):
     """
     Scan the object for multimodal tensors and wrap them in SHM pointers.
     """
-    if _get_is_default_transport() or get_server_args().skip_tokenizer_init:
+    if _get_is_default_transport() or get_serving().skip_tokenizer_init:
         return obj
 
     if obj.mm_inputs:
@@ -2085,7 +2086,7 @@ def unwrap_shm_features(obj):
     Restore ShmPointerMMData wrappers back into standard torch.Tensors.
     Handles both single requests and batch requests.
     """
-    if _get_is_default_transport() or get_server_args().skip_tokenizer_init:
+    if _get_is_default_transport() or get_serving().skip_tokenizer_init:
         return obj
     # Handle batch requests
     if isinstance(obj, BaseBatchReq):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3982,7 +3982,7 @@ class Scheduler(
                 )
             if recv_req.hicache_write_policy is not None:
                 hicache_fields["hicache_write_policy"] = recv_req.hicache_write_policy
-            self.server_args.override("scheduler.attach_hicache", **hicache_fields)
+            get_context().override("scheduler.attach_hicache", **hicache_fields)
             logger.info(
                 f"Attached HiCache storage backend: {recv_req.hicache_storage_backend}"
             )
@@ -4023,7 +4023,7 @@ class Scheduler(
         if ok or (not self.enable_hicache_storage):
             # Treat "already disabled / nothing to do" as success for idempotence.
             self.enable_hicache_storage = False
-            self.server_args.override(
+            get_context().override(
                 "scheduler.detach_hicache",
                 hicache_storage_backend=None,
                 hicache_storage_backend_extra_config=None,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -862,31 +862,27 @@ class Scheduler(
             self.external_corpus_manager = None
             return
 
+        from sglang.srt.speculative.draft_worker_common import (
+            draft_server_args_copy,
+        )
+
         # Launch a draft worker for speculative decoding
-        draft_worker_kwargs = dict(
+        draft_server_args = draft_server_args_copy(
             server_args=self.server_args,
+            target_model_config=self.tp_worker.model_runner.model_config,
+        )
+        draft_worker_kwargs = dict(
+            server_args=draft_server_args,
             gpu_id=self.ps.gpu_id,
             ps=self.ps,
             nccl_port=self.nccl_port,
             target_worker=self.tp_worker,
         )
 
-        if get_spec().speculative_draft_load_format is not None:
-            # Write the draft load_format onto server_args (not just the bag):
-            # the draft worker is built from a copy of self.server_args and
-            # build_load_config reads server_args.load_format, so a bag-only
-            # override would be ignored and the draft would load in the target's
-            # format.
-            self.server_args.override(
-                "scheduler.draft_load_format",
-                load_format=get_spec().speculative_draft_load_format,
-            )
-            logger.info(
-                f"Using draft model load_format: '{get_spec().speculative_draft_load_format}'"
-            )
-
-        DraftWorkerClass = self.spec_algorithm.create_worker(self.server_args)
-        self.draft_worker = DraftWorkerClass(**draft_worker_kwargs)
+        DraftWorkerClass = self.spec_algorithm.create_worker(draft_server_args)
+        with get_context().preserve_config():
+            get_context().set_server_args(draft_server_args)
+            self.draft_worker = DraftWorkerClass(**draft_worker_kwargs)
 
         if self.spec_algorithm.is_ngram():
             from sglang.srt.speculative.external_corpus_manager import (

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -26,7 +26,7 @@ from sglang.srt.observability.metrics_collector import (
     SchedulerStats,
     compute_routing_key_stats,
 )
-from sglang.srt.runtime_context import get_spec
+from sglang.srt.runtime_context import get_context, get_observability, get_spec
 from sglang.srt.utils.device_timer import DeviceTimer
 from sglang.srt.utils.scheduler_status_logger import SchedulerStatusLogger
 
@@ -215,11 +215,11 @@ class SchedulerMetricsReporter:
             self.scheduler._fpm_worker_id = (
                 self.scheduler.server_args.forward_pass_metrics_worker_id
             )
-            base_endpoint = self.scheduler.server_args.forward_pass_metrics_ipc_name
+            base_endpoint = get_observability().forward_pass_metrics_ipc_name
             if base_endpoint is None:
                 ipc_path = tempfile.NamedTemporaryFile(delete=False).name
                 base_endpoint = f"ipc://{ipc_path}"
-                self.scheduler.server_args.override(
+                get_context().override(
                     "metrics_reporter.ipc_endpoint",
                     forward_pass_metrics_ipc_name=base_endpoint,
                 )

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -343,7 +343,7 @@ class TokenizerControlMixin:
                 )
             if hicache_write_policy is not None:
                 hicache_fields["hicache_write_policy"] = hicache_write_policy
-            self.server_args.override("tokenizer.attach_hicache", **hicache_fields)
+            self.record_config_updates("tokenizer.attach_hicache", **hicache_fields)
         return out
 
     async def detach_hicache_storage(
@@ -359,7 +359,7 @@ class TokenizerControlMixin:
         out = DetachHiCacheStorageReqOutput(success=all_success, message=all_message)
         # TODO: partial rollback if failed
         if all_success:
-            self.server_args.override(
+            self.record_config_updates(
                 "tokenizer.detach_hicache",
                 hicache_storage_backend=None,
                 hicache_storage_backend_extra_config=None,
@@ -920,6 +920,6 @@ class TokenizerControlMixin:
     ) -> None:
         """Update weight version if provided."""
         if weight_version is not None:
-            self.server_args.override(
+            self.record_config_updates(
                 "tokenizer.weight_version", weight_version=weight_version
             )

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -347,6 +347,11 @@ class InputFormat(Enum):
     CROSS_ENCODER_PAIRS = 3  # Cross-encoder pairs like [["query", "document"]]
 
 
+_SERVER_ARGS_FIELDS = frozenset(f.name for f in dataclasses.fields(ServerArgs))
+
+_MANAGER_OWNED_FIELDS = ("model_path", "served_model_name")
+
+
 class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     """TokenizerManager is a process that tokenizes the text."""
 
@@ -369,6 +374,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     ):
         # Parse args
         self.server_args = server_args
+        self._config_updates: List[Tuple[str, Dict[str, Any]]] = []
         self.elastic_worker_count = server_args.dp_size
         self.elastic_pending_ep_size = None
         self.elastic_scale_phase = "idle"
@@ -1863,9 +1869,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     ) -> Tuple[bool, str]:
         self.auto_create_handle_loop()
 
-        # default the load format to the server_args
         if obj.load_format is None:
-            obj.load_format = self.server_args.load_format
+            obj.load_format = self.config_value("load_format")
         logger.info("Start update_weights. Load format=%s", obj.load_format)
 
         if obj.abort_all_requests:
@@ -1889,11 +1894,57 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         return success, message, num_paused_requests
 
+    def record_config_updates(self, source: str, **fields) -> None:
+        """Record a control-plane config change for this engine.
+
+        Per-engine state: several ``Engine``s can share one tokenizer process.
+        The readback endpoints overlay these onto the startup config. The
+        process-global sibling is ``RuntimeContext.override`` /
+        ``resolved_server_args_dict``, which writes the config bags every
+        process shares.
+        """
+        unknown = sorted(f for f in fields if f not in _SERVER_ARGS_FIELDS)
+        if unknown:
+            raise ValueError(
+                f"{unknown} are not ServerArgs fields; the readback endpoints "
+                "overlay these onto a serialized ServerArgs, so an unknown key "
+                "would surface as a phantom config entry."
+            )
+        self._config_updates.append((source, dict(fields)))
+
+    def config_value(self, name: str):
+        """The value in effect for one config field, control-plane updates first."""
+        if name in _MANAGER_OWNED_FIELDS:
+            return getattr(self, name)
+        for _source, fields in reversed(self._config_updates):
+            if name in fields:
+                return fields[name]
+        return getattr(self.server_args, name)
+
+    def _dump_config_snapshot(self) -> Optional[Dict[str, Any]]:
+        """The config in effect, or None when it cannot be serialized.
+
+        A dump is worth having even when the config is not: request data is the
+        part that cannot be reconstructed afterwards.
+        """
+        try:
+            return self.resolved_config_dict(dataclasses.asdict(self.server_args))
+        except Exception as e:
+            logger.error(f"Failed to snapshot the resolved config for the dump: {e!r}")
+            return None
+
+    def resolved_config_dict(self, base: Dict[str, Any]) -> Dict[str, Any]:
+        """``base`` (a serialized ``ServerArgs``) with the control-plane updates on top."""
+        resolved = dict(base)
+        for _source, fields in self._config_updates:
+            resolved.update(fields)
+        for name in _MANAGER_OWNED_FIELDS:
+            resolved[name] = getattr(self, name)
+        return resolved
+
     def _update_model_path_info(self, model_path: str, load_format: str):
         self.served_model_name = model_path
-        self.server_args.override(
-            "tokenizer.update_weights", model_path=model_path, load_format=load_format
-        )
+        self.record_config_updates("tokenizer.update_weights", load_format=load_format)
         self.model_path = model_path
 
     async def _wait_for_model_update_from_disk(
@@ -2035,7 +2086,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 "id": rid,
                 "finish_reason": recv_obj.finished_reasons[i],
                 "prompt_tokens": recv_obj.prompt_tokens[i],
-                "weight_version": self.server_args.weight_version,
+                "weight_version": self.config_value("weight_version"),
                 "num_retractions": recv_obj.retraction_counts[i],
             }
 
@@ -2764,6 +2815,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         logger.info(log_message)
         to_dump_with_server_args = {
             "server_args": self.server_args,
+            "config_updates": list(self._config_updates),
+            "resolved_config": self._dump_config_snapshot(),
             "requests": data_list.copy(),
         }
 
@@ -2783,6 +2836,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f.seek(0)
                     f.truncate()
                     to_dump_with_server_args["server_args"] = None
+                    # The snapshot copies the same object field by field.
+                    to_dump_with_server_args["resolved_config"] = None
                     pickle.dump(to_dump_with_server_args, f)
 
         asyncio.create_task(asyncio.to_thread(background_task))
@@ -2845,6 +2900,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Write the data to the file
                 data_to_dump_with_server_args = {
                     "server_args": self.server_args,
+                    "config_updates": list(self._config_updates),
+                    "resolved_config": self._dump_config_snapshot(),
                     "requests": data_to_dump,
                     "launch_command": " ".join(sys.argv),
                 }
@@ -2862,6 +2919,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         f.seek(0)
                         f.truncate()
                         data_to_dump_with_server_args["server_args"] = None
+                        # The snapshot copies the same object field by field.
+                        data_to_dump_with_server_args["resolved_config"] = None
                         pickle.dump(data_to_dump_with_server_args, f)
                 logger.error(
                     f"Dumped {len(self.crash_dump_request_list)} finished and {len(unfinished_requests)} unfinished requests before crash to {filename}"
@@ -2974,7 +3033,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         meta_info = {
             "id": recv_obj.rid,
             "finish_reason": finish_reason,
-            "weight_version": self.server_args.weight_version,
+            "weight_version": self.config_value("weight_version"),
             "e2e_latency": state.time_stats.get_e2e_latency(),
         }
         is_stream = getattr(state.obj, "stream", False)

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -26,7 +26,7 @@ from sglang.srt.mem_cache.common import (
     evict_from_tree_cache,
 )
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
-from sglang.srt.runtime_context import get_server_args
+from sglang.srt.runtime_context import get_exec, get_server_args
 from sglang.srt.utils import (
     is_cpu,
     is_cuda,
@@ -65,7 +65,7 @@ def write_cache_indices(
     prefix_tensors: list[torch.Tensor],
     req_to_token_pool: ReqToTokenPool,
 ):
-    if support_triton(get_server_args().attention_backend):
+    if support_triton(get_exec().kernel.attention_backend):
         prefix_pointers = torch.tensor(
             [t.data_ptr() for t in prefix_tensors],
             dtype=torch.uint64,
@@ -106,7 +106,7 @@ def get_last_loc(
     req_pool_indices_tensor: torch.Tensor,
     prefix_lens_tensor: torch.Tensor,
 ) -> torch.Tensor:
-    attn_backend = get_server_args().attention_backend
+    attn_backend = get_exec().kernel.attention_backend
     uses_triton_dispatch = attn_backend not in ("ascend", "torch_native")
 
     if _is_hip and uses_triton_dispatch:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -311,17 +311,6 @@ class UnifiedRadixCache(BasePrefixCache):
             attach_hybrid_pool_to_unified_cache,
         )
 
-        # Direct IO layout fixup (must happen before pool creation)
-        if server_args.hicache_io_backend == "direct":
-            if server_args.hicache_mem_layout == "page_first":
-                server_args.override(
-                    "hicache.mem_layout_force", hicache_mem_layout="page_first_direct"
-                )
-                logger.warning(
-                    "Page first layout is not supported with direct IO backend, "
-                    "switching to page first direct layout"
-                )
-
         self.load_cache_event = threading.Event()
         self.sidecar_pool_specs.clear()
         self.extra_metric_labels = server_args.extra_metric_labels

--- a/python/sglang/srt/models/gpt_oss.py
+++ b/python/sglang/srt/models/gpt_oss.py
@@ -72,7 +72,6 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_forward,
     get_parallel,
-    get_server_args,
 )
 from sglang.srt.utils import (
     LazyValue,
@@ -421,7 +420,7 @@ class GptOssAttention(nn.Module):
 
         # Choose dtype of sinks based on attention backend: trtllm_mha requires float32,
         # others can use bfloat16
-        attn_backend = get_server_args().attention_backend
+        attn_backend = get_exec().kernel.attention_backend
         sinks_dtype = torch.float32 if attn_backend == "trtllm_mha" else torch.bfloat16
         self.sinks = nn.Parameter(
             torch.empty(self.num_heads, dtype=sinks_dtype), requires_grad=False

--- a/python/sglang/srt/models/inkling_common/dense_mlp.py
+++ b/python/sglang/srt/models/inkling_common/dense_mlp.py
@@ -18,7 +18,7 @@ from sglang.srt.models.inkling_common.util import (
     lora_compatible_layout_enabled,
 )
 from sglang.srt.models.llama import LlamaMLP
-from sglang.srt.runtime_context import get_exec, get_server_args
+from sglang.srt.runtime_context import get_exec, get_model
 
 logger = logging.getLogger(__name__)
 
@@ -484,7 +484,7 @@ class InklingBatchDenseMLP(nn.Module, FusedMoELoadingMixin):
         # All shared experts must share one global weight scale (reshard with
         # single_global_scale=True). ModelOpt's input_scale = amax / (6 * 448).
         flat2 = scale2.reshape(-1).float()
-        if get_server_args().load_format == "dummy" and not bool(
+        if get_model().load_format == "dummy" and not bool(
             torch.all(flat2 == flat2[0])
         ):
             # Dummy loading uses per-element noise; replace it with a valid scale.

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -20,7 +20,6 @@ from sglang.srt.managers.schedule_batch import (
     MultimodalProcessorOutput,
 )
 from sglang.srt.multimodal.processors.executor import MultimodalProcessorExecutor
-from sglang.srt.runtime_context import get_server_args
 from sglang.srt.utils import (
     CLIENT_MEDIA_EXCEPTIONS,
     envs,
@@ -483,6 +482,37 @@ class BaseMultimodalProcessor(ABC):
             return self._processor, self._tokenizer
         return processor, processor.tokenizer
 
+    def _fast_image_processor_device(self, processor) -> Optional[str]:
+        """The device for the fast image processor, or None to leave it unset.
+
+        Resolved from this processor's own ``server_args``: engines sharing a
+        tokenizer process each carry their own ``base_gpu_id``.
+        """
+        server_args = self.server_args
+        if _is_cpu or server_args.rl_on_policy_target is not None:
+            return "cpu"
+        if _is_xpu:
+            return "xpu"
+        if not _is_npu:
+            return f"cuda:{server_args.base_gpu_id}"
+        if processor.__class__.__name__ not in {"Glm4vProcessor", "Glm46VProcessor"}:
+            # For qwen-vl, the processor hits a reshape issue from the Ascend
+            # dims restriction.
+            from sglang.srt.hardware_backend.npu.modules.qwen_vl_processor import (
+                npu_apply_qwen_image_preprocess_patch,
+            )
+
+            npu_apply_qwen_image_preprocess_patch()
+            return "npu"
+        if processor.__class__.__name__ == "Glm46VProcessor":
+            from sglang.srt.hardware_backend.npu.modules.glm46v_processor import (
+                npu_apply_glm46v_image_preprocess_patch,
+            )
+
+            npu_apply_glm46v_image_preprocess_patch()
+            return "npu"
+        return None
+
     def process_mm_data(
         self,
         input_text,
@@ -535,31 +565,9 @@ class BaseMultimodalProcessor(ABC):
             and isinstance(processor.image_processor, BaseImageProcessor)
             and not self.disable_fast_image_processor
         ):
-            if _is_cpu or get_server_args().rl_on_policy_target is not None:
-                kwargs["device"] = "cpu"
-            elif _is_xpu:
-                kwargs["device"] = "xpu"
-            elif not _is_npu:
-                base_gpu_id = get_server_args().base_gpu_id
-                kwargs["device"] = f"cuda:{base_gpu_id}"
-            elif processor.__class__.__name__ not in {
-                "Glm4vProcessor",
-                "Glm46VProcessor",
-            }:
-                # Note: for qwen-vl, processor has some reshape issue because of dims restriction on Ascend.
-                from sglang.srt.hardware_backend.npu.modules.qwen_vl_processor import (
-                    npu_apply_qwen_image_preprocess_patch,
-                )
-
-                npu_apply_qwen_image_preprocess_patch()
-                kwargs["device"] = "npu"
-            elif processor.__class__.__name__ == "Glm46VProcessor":
-                from sglang.srt.hardware_backend.npu.modules.glm46v_processor import (
-                    npu_apply_glm46v_image_preprocess_patch,
-                )
-
-                npu_apply_glm46v_image_preprocess_patch()
-                kwargs["device"] = "npu"
+            device = self._fast_image_processor_device(processor)
+            if device is not None:
+                kwargs["device"] = device
 
         # Avoid double BOS when the chat template already wrote one.
         if self._tokenizer_auto_adds_specials and isinstance(input_text, str):

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -912,17 +912,23 @@ class RuntimeContext:
         """Serialize the *resolved* config: the pristine ``server_args`` fields
         with every post-publish ``override`` overlaid.
 
-        Reporting endpoints (``/server_info``, ``get_internal_state``) surface
-        the config the process is *currently* running, not the startup record,
-        so they read this rather than serializing ``server_args`` directly —
-        otherwise runtime updates (weight version, model path, tunables set via
-        ``/set_internal_state``) never show up in the readback.
+        ``get_internal_state`` reports this, and ``/server_info`` carries it in
+        the ``internal_states`` block, so scheduler-side runtime changes show up
+        in a readback: HiCache attach/detach, the generated forward-pass-metrics
+        endpoint, tunables set via ``/set_internal_state``.
 
         ``base`` defaults to ``dict(vars(server_args))`` (matching the legacy
         ``vars`` dump); pass ``dataclasses.asdict(server_args)`` when nested
-        dataclass fields must be expanded first (``/server_info``). Override
-        leaves are flat ``ServerArgs`` field names, so overlaying them onto the
-        top level of either base is exact.
+        dataclass fields must be expanded first. Override leaves are flat
+        ``ServerArgs`` field names, so overlaying them onto the top level of
+        either base is exact.
+
+        This covers the process-global bags only. Per-engine control-plane
+        changes (weight version, model path, the tokenizer's HiCache mirror)
+        live on the tokenizer manager — several ``Engine``s can share one
+        process — and ``TokenizerManager.resolved_config_dict`` overlays those
+        for the top-level ``/server_info`` body. The two are separate logs, not
+        one merged dict.
         """
         d = dict(vars(self.server_args)) if base is None else dict(base)
         for _source, fields in self._overrides_log:

--- a/python/sglang/srt/speculative/draft_worker_common.py
+++ b/python/sglang/srt/speculative/draft_worker_common.py
@@ -10,7 +10,7 @@ import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
-from sglang.srt.runtime_context import get_context, get_schedule
+from sglang.srt.runtime_context import get_context, get_schedule, get_spec
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
@@ -61,6 +61,13 @@ def _resolve_draft_attention_backend_fallback(
     return draft_backend
 
 
+def _draft_load_format_fields() -> dict:
+    draft_load_format = get_spec().speculative_draft_load_format
+    if draft_load_format is None:
+        return {}
+    return dict(load_format=draft_load_format)
+
+
 def draft_server_args_overrides(target_model_config, draft_backend) -> dict:
     """Pre-publish field adjustments for a draft ``ServerArgs`` copy.
 
@@ -78,7 +85,39 @@ def draft_server_args_overrides(target_model_config, draft_backend) -> dict:
         attention_backend=draft_backend,
         context_length=target_model_config.context_len,
         disable_chunked_prefix_cache=get_schedule().disable_chunked_prefix_cache,
+        **_draft_load_format_fields(),
     )
+
+
+def draft_server_args_copy(server_args: ServerArgs, target_model_config) -> ServerArgs:
+    """A draft-only ``ServerArgs`` for the workers that build their own draft.
+
+    Starts from the config the process resolved, not from the pristine seed:
+    the copy is published while the draft builds, and load-time overrides made
+    before this point (the chunked-prefix gate, the SM100 GDN prefill default)
+    are part of what the draft's layers must see. On top of that,
+    ``context_length`` follows the target (the draft reads target KV) and
+    ``load_format`` follows ``--speculative-draft-load-format``. The target's
+    own instance is untouched.
+    """
+    draft_load_format = get_spec().speculative_draft_load_format
+    if draft_load_format is not None:
+        logger.info(f"Using draft model load_format: '{draft_load_format}'")
+
+    resolved = {}
+    for _source, fields in get_context().overrides_log():
+        resolved.update(fields)
+
+    draft_server_args = deepcopy(server_args)
+    draft_server_args.override(
+        "draft_worker.copy",
+        **{
+            **resolved,
+            "context_length": target_model_config.context_len,
+            **_draft_load_format_fields(),
+        },
+    )
+    return draft_server_args
 
 
 def build_draft_tp_worker(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -264,12 +264,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.hot_token_id = None
         elif get_spec().speculative_token_map is not None:
             self.hot_token_id = load_token_map(get_spec().speculative_token_map)
-            self.server_args.override(
-                "eagle_worker.hot_token_map",
-                json_model_override_args=(
-                    f'{{"hot_vocab_size": {len(self.hot_token_id)}}}'
-                ),
-            )
         else:
             self.hot_token_id = None
 
@@ -1008,12 +1002,6 @@ class EAGLEWorkerV2(BaseSpecWorker):
         self.page_size = server_args.page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
-        )
-
-        # Override the context length of the draft model to be the same as the target model.
-        server_args.override(
-            "spec_worker.match_target_context_length",
-            context_length=target_worker.model_runner.model_config.context_len,
         )
 
         self._draft_worker = EagleDraftWorker(

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -679,12 +679,6 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
         self.req_to_token_pool, self.token_to_kv_pool_allocator = (
             target_worker.get_memory_pool()
         )
-        # Match the draft context length to the target (assistant reads target KV).
-        server_args.override(
-            "spec_worker.match_target_context_length",
-            context_length=target_worker.model_runner.model_config.context_len,
-        )
-
         self._draft_worker = FrozenKVMTPDraftWorker(
             server_args,
             gpu_id,

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -907,12 +907,6 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
             server_args.speculative_algorithm
         )
 
-        # Override the context length of the draft model to be the same as the target model.
-        server_args.override(
-            "spec_worker.match_target_context_length",
-            context_length=target_worker.model_runner.model_config.context_len,
-        )
-
         self._draft_worker = MultiLayerEagleDraftWorker(
             server_args,
             gpu_id,

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -150,12 +150,6 @@ class StandaloneWorkerV2(EAGLEWorkerV2):
             server_args.speculative_algorithm
         )
 
-        # Override the context length of the draft model to be the same as the target model.
-        server_args.override(
-            "spec_worker.match_target_context_length",
-            context_length=target_worker.model_runner.model_config.context_len,
-        )
-
         # Create our custom draft worker that doesn't share embeddings/lm_head
         self._draft_worker = StandaloneDraftWorker(
             server_args,

--- a/test/registered/unit/constrained/test_base_grammar_backend.py
+++ b/test/registered/unit/constrained/test_base_grammar_backend.py
@@ -316,15 +316,21 @@ class TestCreateGrammarBackend(unittest.TestCase):
     @patch("sglang.srt.constrained.xgrammar_backend.XGrammarGrammarBackend")
     def test_xgrammar_unsupported_tokenizer_falls_back_to_none(self, mock_xgrammar_cls):
         from sglang.srt.constrained.xgrammar_backend import TokenizerNotSupportedError
+        from sglang.srt.runtime_context import get_context, get_exec
 
         mock_xgrammar_cls.side_effect = TokenizerNotSupportedError(
             "unsupported tokenizer"
         )
-        args = self._make_server_args("xgrammar")
+        override = get_context().override_server_args(grammar_backend="xgrammar")
+        server_args = override.install()
+        self.addCleanup(override.restore)
 
-        result = create_grammar_backend(args, "tok", 32000, {1})
-        self.assertIsNone(result)
-        self.assertEqual(args.grammar_backend, "none")
+        self.assertIsNone(create_grammar_backend(server_args, "tok", 32000, {1}))
+        self.assertEqual(get_exec().kernel.grammar_backend, "none")
+        self.assertEqual(
+            get_context().resolved_server_args_dict()["grammar_backend"], "none"
+        )
+        self.assertEqual(server_args.grammar_backend, "xgrammar")
 
     @patch("sglang.srt.constrained.llguidance_backend.GuidanceBackend")
     def test_llguidance_backend(self, mock_guidance_cls):

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -48,6 +48,9 @@ class _MockTokenizerManager:
             stream_response_default_include_usage=False,
             default_chat_template_kwargs=None,
         )
+        # The manager tracks the served name itself; a weight update rewrites it.
+        self.served_model_name = "test-model"
+
         # Mock hf_config for _resolve_chat_encoding_spec check
         mock_hf_config = Mock()
         mock_hf_config.architectures = ["LlamaForCausalLM"]

--- a/test/registered/unit/entrypoints/test_server_info.py
+++ b/test/registered/unit/entrypoints/test_server_info.py
@@ -28,6 +28,7 @@ from types import SimpleNamespace
 
 from sglang.srt.entrypoints import http_server
 from sglang.srt.lora.lora_registry import LoRARef
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -36,7 +37,9 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 def _call_server_info_with(
-    server_args: ServerArgs, internal_states: list[dict] | None = None
+    server_args: ServerArgs,
+    internal_states: list[dict] | None = None,
+    config_updates: dict | None = None,
 ) -> dict:
     """Invoke `http_server.server_info()` against a stub global state.
 
@@ -50,11 +53,16 @@ def _call_server_info_with(
     async def _fake_internal_state():
         return internal_states or [{"max_req_input_len": 1024}]
 
+    tokenizer_manager = TokenizerManager.__new__(TokenizerManager)
+    tokenizer_manager.server_args = server_args
+    tokenizer_manager.model_path = server_args.model_path
+    tokenizer_manager.served_model_name = server_args.served_model_name
+    tokenizer_manager._config_updates = (
+        [("test", dict(config_updates))] if config_updates else []
+    )
+    tokenizer_manager.get_internal_state = _fake_internal_state
     stub_state = SimpleNamespace(
-        tokenizer_manager=SimpleNamespace(
-            server_args=server_args,
-            get_internal_state=_fake_internal_state,
-        ),
+        tokenizer_manager=tokenizer_manager,
         scheduler_info={"max_req_input_len": 1024},
     )
     prior_state = http_server.get_global_state()
@@ -231,6 +239,18 @@ class TestServerInfoKvEventsField(CustomTestCase):
                 )
                 info = _call_server_info_with(args)
                 self.assertIsNone(info["kv_events"])
+
+
+class TestServerInfoControlPlaneUpdates(CustomTestCase):
+    """Runtime control-plane updates live on the manager, not on ServerArgs."""
+
+    def test_recorded_updates_win_over_the_startup_config(self):
+        server_args = ServerArgs(model_path="dummy", weight_version="v1")
+        payload = _call_server_info_with(
+            server_args, config_updates={"weight_version": "v2"}
+        )
+        self.assertEqual(payload["weight_version"], "v2")
+        self.assertEqual(server_args.weight_version, "v1")
 
 
 class TestServerInfoExistingFieldsPreserved(CustomTestCase):

--- a/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
+++ b/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
@@ -11,7 +11,7 @@ from sglang.srt.layers.attention.linear import gdn_backend
 from sglang.srt.layers.attention.linear.gdn_backend import (
     GDNAttnBackend,
     GDNKernelDispatcher,
-    maybe_set_default_flashinfer_gdn_prefill,
+    flashinfer_gdn_prefill_default,
 )
 from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
     maybe_build_flashinfer_checkpoint_plan,
@@ -38,11 +38,6 @@ def make_runner(
         mamba_radix_cache_strategy="no_buffer",
         enable_dynamic_chunking=False,
         chunked_prefill_size=8192,
-    )
-    # The policy routes its load-time default through the audited mutation entry
-    # (server_args.override); mirror that on the stub so the write lands.
-    args.override = MagicMock(
-        side_effect=lambda _source, **fields: vars(args).update(fields)
     )
     for name, value in arg_overrides.items():
         setattr(args, name, value)
@@ -87,16 +82,10 @@ class TestFlashInferGDNPrefillBackendPolicy(unittest.TestCase):
                 return_value=flashinfer_available,
             ),
         ):
-            maybe_set_default_flashinfer_gdn_prefill(runner)
-        return runner.server_args.linear_attn_prefill_backend
+            return flashinfer_gdn_prefill_default(runner)
 
     def test_selects_flashinfer_for_supported_sm100_gdn(self):
-        runner = make_runner()
-        self.assertEqual(self.apply_policy(runner), "flashinfer")
-        runner.server_args.override.assert_called_once_with(
-            "gdn_backend.sm100_flashinfer_default",
-            linear_attn_prefill_backend="flashinfer",
-        )
+        self.assertEqual(self.apply_policy(make_runner()), "flashinfer")
 
     def test_selects_flashinfer_for_radix_cache_strategies(self):
         for strategy in ("no_buffer", "extra_buffer", "extra_buffer_lazy"):
@@ -107,11 +96,11 @@ class TestFlashInferGDNPrefillBackendPolicy(unittest.TestCase):
                 )
                 self.assertEqual(self.apply_policy(runner), "flashinfer")
 
-    def test_preserves_explicit_prefill_override(self):
+    def test_declines_when_the_prefill_backend_is_explicit(self):
         for backend in ("triton", "flashinfer", "cutedsl"):
             with self.subTest(backend=backend):
                 runner = make_runner(linear_attn_prefill_backend=backend)
-                self.assertEqual(self.apply_policy(runner), backend)
+                self.assertIsNone(self.apply_policy(runner))
 
     def test_rejects_unsupported_capability(self):
         cases = (

--- a/test/registered/unit/layers/attention/test_linear_attn_config.py
+++ b/test/registered/unit/layers/attention/test_linear_attn_config.py
@@ -1,0 +1,92 @@
+"""Backend selection in initialize_linear_attn_config.
+
+The SM100 GDN default reaches the module state as an argument rather than as a
+ServerArgs mutation, so the precedence between an explicit flag, that default,
+and the shared base backend is pinned here.
+"""
+
+import unittest
+
+from sglang.srt.layers.attention.linear import utils as linear_utils
+from sglang.srt.layers.attention.linear.utils import (
+    LinearAttnKernelBackend,
+    initialize_linear_attn_config,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestLinearAttnConfig(CustomTestCase):
+    def setUp(self):
+        saved = (
+            linear_utils.LINEAR_ATTN_DECODE_BACKEND,
+            linear_utils.LINEAR_ATTN_PREFILL_BACKEND,
+        )
+
+        def restore():
+            (
+                linear_utils.LINEAR_ATTN_DECODE_BACKEND,
+                linear_utils.LINEAR_ATTN_PREFILL_BACKEND,
+            ) = saved
+
+        self.addCleanup(restore)
+
+    def _init(self, prefill_default=None, **fields):
+        args = ServerArgs(model_path="dummy")
+        for key, value in fields.items():
+            setattr(args, key, value)
+        initialize_linear_attn_config(args, prefill_default)
+        return (
+            linear_utils.LINEAR_ATTN_PREFILL_BACKEND,
+            linear_utils.LINEAR_ATTN_DECODE_BACKEND,
+        )
+
+    def test_default_applies_when_the_flag_is_unset(self):
+        prefill, _ = self._init(
+            prefill_default="flashinfer", linear_attn_backend="triton"
+        )
+        self.assertEqual(prefill, LinearAttnKernelBackend.FLASHINFER)
+
+    def test_explicit_flag_wins_over_the_default(self):
+        prefill, _ = self._init(
+            prefill_default="flashinfer",
+            linear_attn_backend="triton",
+            linear_attn_prefill_backend="cutedsl",
+        )
+        self.assertEqual(prefill, LinearAttnKernelBackend.CUTEDSL)
+
+    def test_base_backend_applies_without_a_default(self):
+        prefill, decode = self._init(linear_attn_backend="triton")
+        self.assertEqual(prefill, LinearAttnKernelBackend.TRITON)
+        self.assertEqual(decode, LinearAttnKernelBackend.TRITON)
+
+    def test_a_recorded_default_shows_in_the_resolved_config(self):
+        from sglang.srt.runtime_context import get_context, get_exec
+
+        override = get_context().override_server_args(linear_attn_backend="triton")
+        server_args = override.install()
+        self.addCleanup(override.restore)
+
+        get_context().override(
+            "gdn_backend.sm100_flashinfer_default",
+            linear_attn_prefill_backend="flashinfer",
+        )
+        self.assertEqual(get_exec().mamba.linear_attn_prefill_backend, "flashinfer")
+        self.assertEqual(
+            get_context().resolved_server_args_dict()["linear_attn_prefill_backend"],
+            "flashinfer",
+        )
+        self.assertIsNone(server_args.linear_attn_prefill_backend)
+
+    def test_the_default_does_not_reach_the_decode_backend(self):
+        _, decode = self._init(
+            prefill_default="flashinfer", linear_attn_backend="triton"
+        )
+        self.assertEqual(decode, LinearAttnKernelBackend.TRITON)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_hicache_attach.py
+++ b/test/registered/unit/managers/test_scheduler_hicache_attach.py
@@ -1,0 +1,76 @@
+"""Runtime HiCache attach/detach lands on the config bags.
+
+The attach RPC used to mutate the scheduler's ServerArgs so the readback would
+show the change; the namespace readers never saw it. Both now go through
+get_context().override, so get_memory() and the resolved-config readback agree
+and the published instance stays as the launcher left it.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.io_struct import (
+    AttachHiCacheStorageReqInput,
+    DetachHiCacheStorageReqInput,
+)
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.runtime_context import get_context, get_memory
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestSchedulerHiCacheAttach(CustomTestCase):
+    def _scheduler(self, **fields):
+        override = get_context().override_server_args(
+            enable_hierarchical_cache=True, **fields
+        )
+        self.server_args = override.install()
+        self.addCleanup(override.restore)
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.server_args = self.server_args
+        scheduler.enable_hierarchical_cache = True
+        scheduler.enable_hicache_storage = False
+        scheduler.is_fully_idle = lambda: True
+        scheduler.tree_cache = SimpleNamespace(
+            attach_storage_backend=lambda **kwargs: (True, "attached"),
+            detach_storage_backend=lambda: (True, "detached"),
+        )
+        return scheduler
+
+    def test_attach_reaches_the_namespace_readers(self):
+        scheduler = self._scheduler(hicache_storage_backend=None)
+        out = scheduler.attach_hicache_storage_wrapped(
+            AttachHiCacheStorageReqInput(
+                hicache_storage_backend="file",
+                hicache_write_policy="write_through",
+            )
+        )
+
+        self.assertTrue(out.success)
+        self.assertEqual(get_memory().hicache_storage_backend, "file")
+        self.assertEqual(get_memory().hicache_write_policy, "write_through")
+        self.assertEqual(
+            get_context().resolved_server_args_dict()["hicache_storage_backend"],
+            "file",
+        )
+        self.assertIsNone(self.server_args.hicache_storage_backend)
+
+    def test_detach_clears_the_backend_for_the_same_readers(self):
+        scheduler = self._scheduler(hicache_storage_backend="file")
+        scheduler.enable_hicache_storage = True
+
+        out = scheduler.detach_hicache_storage_wrapped(DetachHiCacheStorageReqInput())
+
+        self.assertTrue(out.success)
+        self.assertIsNone(get_memory().hicache_storage_backend)
+        self.assertIsNone(
+            get_context().resolved_server_args_dict()["hicache_storage_backend"]
+        )
+        self.assertEqual(self.server_args.hicache_storage_backend, "file")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_tokenizer_config_updates.py
+++ b/test/registered/unit/managers/test_tokenizer_config_updates.py
@@ -1,0 +1,216 @@
+"""Control-plane config updates stay on the tokenizer manager.
+
+Regression: runtime updates (weight version, model path, HiCache attach) were
+written onto the manager's ServerArgs instance so that the readback endpoints
+would show them. They are per-engine — several Engines can share a tokenizer
+process — so they live on the manager and the endpoints overlay them.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+import sglang
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _manager(**fields):
+    manager = TokenizerManager.__new__(TokenizerManager)
+    manager.server_args = ServerArgs(model_path="dummy", **fields)
+    manager._config_updates = []
+    return manager
+
+
+class TestTokenizerConfigUpdates(CustomTestCase):
+    def test_startup_config_shows_through_until_something_updates_it(self):
+        manager = _manager(weight_version="v1")
+        self.assertEqual(manager.config_value("weight_version"), "v1")
+
+        manager.record_config_updates("test", weight_version="v2")
+        self.assertEqual(manager.config_value("weight_version"), "v2")
+
+    def test_the_serverargs_instance_is_not_written(self):
+        manager = _manager(weight_version="v1")
+        manager.record_config_updates("test", weight_version="v2")
+        self.assertEqual(manager.server_args.weight_version, "v1")
+
+    def test_two_engines_keep_their_own_updates(self):
+        first, second = _manager(weight_version="v1"), _manager(weight_version="v1")
+        first.record_config_updates("test", weight_version="v2")
+        self.assertEqual(second.config_value("weight_version"), "v1")
+
+    def test_the_readback_dict_carries_the_updates(self):
+        manager = _manager(hicache_storage_backend=None)
+        manager.record_config_updates(
+            "test", hicache_storage_backend="file", hicache_write_policy="write_through"
+        )
+        manager.model_path = "dummy"
+        manager.served_model_name = "dummy"
+        resolved = manager.resolved_config_dict(
+            {"hicache_storage_backend": None, "model_path": "dummy"}
+        )
+        self.assertEqual(resolved["hicache_storage_backend"], "file")
+        self.assertEqual(resolved["hicache_write_policy"], "write_through")
+        self.assertEqual(resolved["model_path"], "dummy")
+
+    def test_detach_reports_the_backend_as_gone(self):
+        manager = _manager(hicache_storage_backend="file")
+        manager.record_config_updates(
+            "test",
+            hicache_storage_backend=None,
+            hicache_storage_backend_extra_config=None,
+        )
+        self.assertIsNone(manager.config_value("hicache_storage_backend"))
+
+    def test_an_unknown_field_is_refused(self):
+        manager = _manager()
+        with self.assertRaisesRegex(ValueError, "not ServerArgs fields"):
+            manager.record_config_updates("test", waight_version="v2")
+
+    def test_the_source_is_kept_for_provenance(self):
+        manager = _manager(weight_version="v1")
+        manager.record_config_updates("http.update_weight_version", weight_version="v2")
+        self.assertEqual(
+            manager._config_updates,
+            [("http.update_weight_version", {"weight_version": "v2"})],
+        )
+
+    def test_the_dump_snapshot_identifies_the_running_checkpoint(self):
+        import dataclasses
+
+        manager = _manager(load_format="auto")
+        manager.model_path = "at-startup"
+        manager.served_model_name = "at-startup"
+        manager._update_model_path_info("after-reload", "dummy")
+
+        snapshot = manager.resolved_config_dict(dataclasses.asdict(manager.server_args))
+        self.assertEqual(snapshot["model_path"], "after-reload")
+        self.assertEqual(snapshot["served_model_name"], "after-reload")
+        self.assertEqual(snapshot["load_format"], "dummy")
+        self.assertEqual(manager.server_args.model_path, "dummy")
+
+    def test_an_unsnapshotable_config_does_not_lose_the_dump(self):
+        class Hostile:
+            def __deepcopy__(self, memo):
+                raise RuntimeError("refuses to be copied")
+
+        manager = _manager()
+        manager.model_path = "dummy"
+        manager.served_model_name = "dummy"
+        manager.server_args.custom_sigquit_handler = Hostile()
+
+        self.assertIsNone(manager._dump_config_snapshot())
+
+    def test_an_unpickleable_field_does_not_lose_the_dump(self):
+        import dataclasses
+        import pickle
+
+        manager = _manager()
+        manager.model_path = "dummy"
+        manager.served_model_name = "dummy"
+        # What --custom-sigquit-handler leaves on a real ServerArgs.
+        manager.server_args.custom_sigquit_handler = lambda *_: None
+
+        payload = {
+            "server_args": manager.server_args,
+            "config_updates": list(manager._config_updates),
+            "resolved_config": manager.resolved_config_dict(
+                dataclasses.asdict(manager.server_args)
+            ),
+            "requests": [],
+        }
+        with self.assertRaises(Exception):
+            pickle.dumps(payload)
+
+        # The fallback drops both copies of the offending object, not just one.
+        payload["server_args"] = None
+        payload["resolved_config"] = None
+        self.assertTrue(pickle.dumps(payload))
+
+    def test_the_model_path_readback_follows_the_manager(self):
+        manager = _manager()
+        manager.model_path = "after-update"
+        manager.served_model_name = "after-update"
+        resolved = manager.resolved_config_dict({"model_path": "at-startup"})
+        self.assertEqual(resolved["model_path"], "after-update")
+        self.assertEqual(resolved["served_model_name"], "after-update")
+
+
+CONTROL_PLANE_FIELDS = (
+    "weight_version",
+    "model_path",
+    "served_model_name",
+    "load_format",
+    "hicache_storage_backend",
+    "hicache_storage_backend_extra_config",
+    "hicache_storage_prefetch_policy",
+    "hicache_write_policy",
+)
+
+# Modules that answer readbacks or fill responses; the tokenizer manager's own
+# __init__ seeds attributes from the constructor argument, which is not a
+# readback and not matched by the patterns below. Prometheus label sets are
+# exempt: a label must stay fixed for the lifetime of the series, so the metrics
+# collector keeps the name the server started with.
+EXEMPT_LINES = (
+    (
+        "srt/managers/tokenizer_manager.py",
+        '"model_name": self.server_args.served_model_name',
+    ),
+)
+READBACK_MODULES = (
+    "srt/managers/tokenizer_manager.py",
+    "srt/managers/tokenizer_control_mixin.py",
+    "srt/managers/multi_tokenizer_mixin.py",
+    "srt/entrypoints/http_server.py",
+    "srt/entrypoints/grpc_bridge.py",
+    "srt/entrypoints/engine.py",
+    "srt/entrypoints/openai",
+)
+
+
+class TestControlPlaneFieldsAreNotReadFromTheInstance(CustomTestCase):
+    def test_readbacks_go_through_the_manager(self):
+        root = Path(next(iter(sglang.__path__)))
+        patterns = [
+            re.compile(
+                rf"self\.server_args\.{f}\b|tokenizer_manager\.server_args\.{f}\b"
+            )
+            for f in CONTROL_PLANE_FIELDS
+        ]
+        stale = []
+        for rel in READBACK_MODULES:
+            paths = (
+                sorted((root / rel).rglob("*.py"))
+                if (root / rel).is_dir()
+                else [root / rel]
+            )
+            for path in paths:
+                for number, line in enumerate(path.read_text().split("\n"), 1):
+                    if any(
+                        rel_exempt == path.relative_to(root).as_posix()
+                        and needle in line
+                        for rel_exempt, needle in EXEMPT_LINES
+                    ):
+                        continue
+                    if any(p.search(line) for p in patterns):
+                        stale.append(
+                            f"{path.relative_to(root)}:{number}: {line.strip()}"
+                        )
+        self.assertEqual(
+            stale,
+            [],
+            "control-plane fields change at runtime and the update lives on the "
+            "TokenizerManager; read them with config_value() / "
+            "resolved_config_dict() so the readback reflects the change:\n"
+            + "\n".join(stale),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -98,6 +98,7 @@ def _make_tokenizer_manager() -> TokenizerManager:
     """Create a TokenizerManager with mocked dependencies, bypassing __init__."""
     tm = TokenizerManager.__new__(TokenizerManager)
     tm.server_args = MagicMock()
+    tm._config_updates = []
     tm.server_args.enable_trace = False
     tm.server_args.enable_metrics = False
     tm.server_args.enable_lora = False

--- a/test/registered/unit/mem_cache/test_dllm_fdfo_kv_reuse.py
+++ b/test/registered/unit/mem_cache/test_dllm_fdfo_kv_reuse.py
@@ -7,9 +7,9 @@ from types import SimpleNamespace
 import torch
 
 from sglang.srt.dllm.mixin.scheduler import DllmManager
-from sglang.srt.mem_cache import allocation
 from sglang.srt.mem_cache.allocation import alloc_for_extend
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -117,16 +117,11 @@ class TestDllmFdfoKvReuse(unittest.TestCase):
         self.pool = ReqToTokenPool(
             size=8, max_context_len=64, device="cpu", enable_memory_saver=False
         )
-        self._old_support_triton = allocation.support_triton
-        self._old_get_server_args = allocation.get_server_args
-        allocation.support_triton = lambda _: False
-        allocation.get_server_args = lambda: SimpleNamespace(
+        override = get_context().override_server_args(
             attention_backend="torch_native", dcp_size=1
         )
-
-    def tearDown(self):
-        allocation.support_triton = self._old_support_triton
-        allocation.get_server_args = self._old_get_server_args
+        override.install()
+        self.addCleanup(override.restore)
 
     def test_alloc_for_extend_mixed_reuse_allocates_only_fresh_and_writes_rows(self):
         allocator = _FakeAllocator(base=200)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -530,6 +530,7 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
             model_path="dummy",
             page_size=self.cfg.page_size,
             hicache_io_backend="direct",
+            hicache_mem_layout="page_first_direct",
             hicache_write_policy=write_policy,
         )
         set_global_server_args_for_scheduler(server_args)
@@ -2869,6 +2870,7 @@ class UnifiedRadixCacheSuite:
             model_path="dummy",
             page_size=self.cfg.page_size,
             hicache_io_backend="direct",
+            hicache_mem_layout="page_first_direct",
             hicache_write_policy=write_policy,
             hicache_storage_backend=storage_backend,
             hicache_storage_backend_extra_config=storage_extra_config,
@@ -6231,6 +6233,7 @@ class TestUnifiedRadixPrefetchCorruption(CustomTestCase):
             model_path="dummy",
             page_size=self.cfg.page_size,
             hicache_io_backend="direct",
+            hicache_mem_layout="page_first_direct",
             hicache_write_policy=write_policy,
         )
         server_args._mamba_cache_chunk_size = max(FLA_CHUNK_SIZE, self.cfg.page_size)

--- a/test/registered/unit/multimodal/test_processor_device_selection.py
+++ b/test/registered/unit/multimodal/test_processor_device_selection.py
@@ -1,0 +1,81 @@
+"""The fast-image-processor device comes from the processor's own ServerArgs.
+
+Regression: the device decision read the published global ServerArgs, which is
+last-publish-wins. Two engines in one tokenizer process then shared whichever
+config published last, so one engine's images were preprocessed on the other
+engine's GPU.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+BASE = "sglang.srt.multimodal.processors.base_processor"
+
+
+class _Processor:
+    pass
+
+
+class _StubProcessor(BaseMultimodalProcessor):
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def _make(**fields):
+    processor = _StubProcessor.__new__(_StubProcessor)
+    processor.server_args = ServerArgs(model_path="dummy", **fields)
+    return processor
+
+
+class TestFastImageProcessorDevice(CustomTestCase):
+    def _device(self, processor, **platform):
+        flags = {"_is_cpu": False, "_is_xpu": False, "_is_npu": False}
+        flags.update(platform)
+        with patch.multiple(BASE, **flags):
+            return processor._fast_image_processor_device(_Processor())
+
+    def test_device_follows_the_instance_base_gpu_id(self):
+        self.assertEqual(self._device(_make(base_gpu_id=3)), "cuda:3")
+
+    def test_engines_in_one_process_keep_their_own_device(self):
+        first, second = _make(base_gpu_id=0), _make(base_gpu_id=5)
+        self.assertEqual(self._device(first), "cuda:0")
+        self.assertEqual(self._device(second), "cuda:5")
+
+    def test_publishing_another_config_does_not_move_the_device(self):
+        from sglang.srt.runtime_context import get_context
+
+        processor = _make(base_gpu_id=2)
+        override = get_context().override_server_args(base_gpu_id=7)
+        override.install()
+        self.addCleanup(override.restore)
+        self.assertEqual(self._device(processor), "cuda:2")
+
+    def test_rl_on_policy_target_forces_cpu(self):
+        processor = _make(base_gpu_id=3, rl_on_policy_target="fsdp")
+        self.assertEqual(self._device(processor), "cpu")
+
+    def test_cpu_and_xpu_platforms_win_over_base_gpu_id(self):
+        processor = _make(base_gpu_id=3)
+        self.assertEqual(self._device(processor, _is_cpu=True), "cpu")
+        self.assertEqual(self._device(processor, _is_xpu=True), "xpu")
+
+    def test_npu_glm4v_leaves_the_device_unset(self):
+        class Glm4vProcessor:
+            pass
+
+        processor = _make(base_gpu_id=3)
+        with patch.multiple(BASE, _is_cpu=False, _is_xpu=False, _is_npu=True):
+            device = processor._fast_image_processor_device(Glm4vProcessor())
+        self.assertIsNone(device)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -1,3 +1,4 @@
+from sglang.srt.runtime_context import get_context, get_observability
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -70,22 +71,19 @@ class _DummyPublisherThread:
         pass
 
 
-def _fake_server_args(**fields):
-    """server_args stand-in: carries fields and the override() entry point."""
+def _publish_server_args(test, **fields):
+    """Publish a config for the reporter under test and return the instance."""
     fields.setdefault("decode_log_interval", 40)
-    ns = types.SimpleNamespace(**fields)
-
-    def _override(source, **updates):
-        for key, value in updates.items():
-            setattr(ns, key, value)
-
-    ns.override = _override
-    return ns
+    override = get_context().override_server_args(**fields)
+    server_args = override.install()
+    test.addCleanup(override.restore)
+    return server_args
 
 
-def _make_reporter(scheduler) -> SchedulerMetricsReporter:
+def _make_reporter(test, scheduler) -> SchedulerMetricsReporter:
     if not hasattr(scheduler, "server_args"):
-        scheduler.server_args = _fake_server_args(
+        scheduler.server_args = _publish_server_args(
+            test,
             enable_metrics=False,
             enable_metrics_for_all_schedulers=False,
             kv_events_config=None,
@@ -133,7 +131,7 @@ class TestForwardPassMetrics(unittest.TestCase):
         self.scheduler._fpm_gpu_time_acc = 0.0
         self.scheduler.waiting_queue = []
         self.scheduler.disaggregation_mode = DisaggregationMode.NULL
-        self.reporter = _make_reporter(self.scheduler)
+        self.reporter = _make_reporter(self, self.scheduler)
         self.scheduler.enable_fpm = True
 
     def _make_batch(self, **overrides):
@@ -274,7 +272,8 @@ class TestForwardPassMetrics(unittest.TestCase):
 
     def test_init_metrics_uses_server_worker_id(self):
         scheduler = types.SimpleNamespace()
-        scheduler.server_args = _fake_server_args(
+        scheduler.server_args = _publish_server_args(
+            self,
             enable_metrics=False,
             enable_metrics_for_all_schedulers=False,
             extra_metric_labels=None,
@@ -290,7 +289,7 @@ class TestForwardPassMetrics(unittest.TestCase):
             "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
             _DummyPublisherThread,
         ):
-            reporter = _make_reporter(scheduler)
+            reporter = _make_reporter(self, scheduler)
 
         self.assertTrue(scheduler.enable_fpm)
         self.assertEqual(scheduler._fpm_worker_id, "endpoint-42")
@@ -298,11 +297,20 @@ class TestForwardPassMetrics(unittest.TestCase):
         self.assertEqual(scheduler._fpm_publisher.worker_id, "endpoint-42")
         self.assertEqual(scheduler._fpm_publisher.dp_rank, 2)
         self.assertTrue(scheduler._fpm_publisher.endpoint.startswith("ipc://"))
-        self.assertIsNotNone(scheduler.server_args.forward_pass_metrics_ipc_name)
+        # The bag is what makes the write a bag write: an instance mutation
+        # would still show up in the resolved dict through its ServerArgs base.
+        endpoint = get_observability().forward_pass_metrics_ipc_name
+        self.assertTrue(endpoint.startswith("ipc://"))
+        self.assertEqual(
+            get_context().resolved_server_args_dict()["forward_pass_metrics_ipc_name"],
+            endpoint,
+        )
+        self.assertIsNone(scheduler.server_args.forward_pass_metrics_ipc_name)
 
     def test_init_fpm_disabled_on_non_last_pp_rank(self):
         scheduler = types.SimpleNamespace()
-        scheduler.server_args = _fake_server_args(
+        scheduler.server_args = _publish_server_args(
+            self,
             enable_metrics=False,
             enable_metrics_for_all_schedulers=False,
             extra_metric_labels=None,
@@ -318,7 +326,7 @@ class TestForwardPassMetrics(unittest.TestCase):
             "sglang.srt.observability.forward_pass_metrics._FpmPublisherThread",
             _DummyPublisherThread,
         ):
-            reporter = _make_reporter(scheduler)
+            reporter = _make_reporter(self, scheduler)
 
         self.assertFalse(scheduler.enable_fpm)
 

--- a/test/registered/unit/spec/test_draft_server_args_copy.py
+++ b/test/registered/unit/spec/test_draft_server_args_copy.py
@@ -1,0 +1,84 @@
+"""The draft's ServerArgs is a copy; the target's stays as the launcher left it.
+
+Regression: the v2 spec workers wrote the draft's context_length (and the
+scheduler the draft's load_format) onto the ServerArgs instance they share with
+the target worker, so every later reader of that instance saw draft values.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.runtime_context import get_context
+from sglang.srt.speculative.draft_worker_common import (
+    draft_server_args_copy,
+    draft_server_args_overrides,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+TARGET_MODEL_CONFIG = SimpleNamespace(context_len=4096)
+
+
+class TestDraftServerArgsCopy(CustomTestCase):
+    def _seed(self, **fields):
+        override = get_context().override_server_args(**fields)
+        server_args = override.install()
+        self.addCleanup(override.restore)
+        return server_args
+
+    def test_the_draft_context_length_follows_the_target(self):
+        target = self._seed(context_length=None)
+        draft = draft_server_args_copy(target, TARGET_MODEL_CONFIG)
+        self.assertEqual(draft.context_length, 4096)
+
+    def test_the_target_instance_is_left_alone(self):
+        target = self._seed(context_length=None, load_format="auto")
+        draft = draft_server_args_copy(target, TARGET_MODEL_CONFIG)
+        self.assertIsNot(draft, target)
+        self.assertIsNone(target.context_length)
+        self.assertEqual(target.load_format, "auto")
+
+    def test_the_draft_load_format_applies_only_when_configured(self):
+        target = self._seed(load_format="auto", speculative_draft_load_format="dummy")
+        self.assertEqual(
+            draft_server_args_copy(target, TARGET_MODEL_CONFIG).load_format, "dummy"
+        )
+        self.assertEqual(target.load_format, "auto")
+
+        target = self._seed(load_format="auto")
+        self.assertEqual(
+            draft_server_args_copy(target, TARGET_MODEL_CONFIG).load_format, "auto"
+        )
+
+    def test_load_time_overrides_reach_the_draft(self):
+        target = self._seed(disable_chunked_prefix_cache=False)
+        # What the target runner resolved before the draft is built — e.g. the
+        # chunked-prefix gate for an attention backend that cannot serve it.
+        get_context().override("test.gate", disable_chunked_prefix_cache=True)
+
+        draft = draft_server_args_copy(target, TARGET_MODEL_CONFIG)
+        self.assertTrue(draft.disable_chunked_prefix_cache)
+        self.assertFalse(target.disable_chunked_prefix_cache)
+
+    def test_the_draft_specific_fields_win_over_the_resolved_ones(self):
+        target = self._seed(context_length=None, load_format="auto")
+        get_context().override("test.late", context_length=128, load_format="npcache")
+
+        draft = draft_server_args_copy(target, TARGET_MODEL_CONFIG)
+        self.assertEqual(draft.context_length, 4096)
+
+    def test_the_built_draft_overrides_carry_the_load_format_too(self):
+        self._seed(speculative_draft_load_format="dummy")
+        fields = draft_server_args_overrides(TARGET_MODEL_CONFIG, "triton")
+        self.assertEqual(fields["load_format"], "dummy")
+
+        self._seed()
+        self.assertNotIn(
+            "load_format", draft_server_args_overrides(TARGET_MODEL_CONFIG, "triton")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_spec_worker_draft_isolation.py
+++ b/test/registered/unit/spec/test_spec_worker_draft_isolation.py
@@ -1,0 +1,130 @@
+"""The scheduler hands every draft worker a ServerArgs copy.
+
+Regression: the v2 spec workers wrote the draft's context_length onto the
+instance they share with the target worker, and the scheduler wrote the draft's
+load_format onto that same object, so the target's config carried draft values
+for the rest of the process. The copy is made once, before the worker factory,
+so plugin algorithms registered through SpeculativeAlgorithm.register get it too.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _StopConstruction(Exception):
+    """Cuts the draft worker off once its ServerArgs is captured."""
+
+
+def _scheduler(server_args):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.server_args = server_args
+    model_config = SimpleNamespace(context_len=4096)
+    scheduler.tp_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(model_config=model_config)
+    )
+    scheduler.ps = SimpleNamespace(gpu_id=0)
+    scheduler.nccl_port = 0
+    return scheduler
+
+
+class TestSchedulerDraftServerArgs(CustomTestCase):
+    def _seed(self, **fields):
+        override = get_context().override_server_args(
+            speculative_algorithm="EAGLE", **fields
+        )
+        server_args = override.install()
+        self.addCleanup(override.restore)
+        return server_args
+
+    def _captured_draft_args(self, server_args):
+        seen = {}
+
+        def worker_class(**kwargs):
+            seen["server_args"] = kwargs["server_args"]
+            raise _StopConstruction
+
+        scheduler = _scheduler(server_args)
+        scheduler.spec_algorithm = SimpleNamespace(
+            is_none=lambda: False,
+            is_ngram=lambda: False,
+            create_worker=lambda _sa: worker_class,
+        )
+        with self.assertRaises(_StopConstruction):
+            scheduler.maybe_init_draft_worker()
+        return seen["server_args"]
+
+    def test_the_draft_gets_a_copy_carrying_the_target_context_length(self):
+        server_args = self._seed(context_length=None)
+        draft = self._captured_draft_args(server_args)
+        self.assertIsNot(draft, server_args)
+        self.assertEqual(draft.context_length, 4096)
+        self.assertIsNone(server_args.context_length)
+
+    def test_the_draft_config_is_published_while_the_draft_is_built(self):
+        from sglang.srt.runtime_context import get_model
+
+        server_args = self._seed(
+            load_format="auto", speculative_draft_load_format="dummy"
+        )
+        seen = {}
+
+        def worker_class(**kwargs):
+            seen["published"] = get_model().load_format
+            raise _StopConstruction
+
+        scheduler = _scheduler(server_args)
+        scheduler.spec_algorithm = SimpleNamespace(
+            is_none=lambda: False,
+            is_ngram=lambda: False,
+            create_worker=lambda _sa: worker_class,
+        )
+        with self.assertRaises(_StopConstruction):
+            scheduler.maybe_init_draft_worker()
+
+        # Model-level weight loading reads the bags, not the instance it was
+        # handed, so the draft's config has to be the published one while it
+        # builds — and the target's has to be back afterwards.
+        self.assertEqual(seen["published"], "dummy")
+        self.assertEqual(get_model().load_format, "auto")
+
+    def test_the_worker_factory_sees_the_draft_config(self):
+        server_args = self._seed(
+            load_format="auto", speculative_draft_load_format="dummy"
+        )
+        seen = {}
+
+        def create_worker(factory_server_args):
+            seen["load_format"] = factory_server_args.load_format
+            raise _StopConstruction
+
+        scheduler = _scheduler(server_args)
+        scheduler.spec_algorithm = SimpleNamespace(
+            is_none=lambda: False,
+            is_ngram=lambda: False,
+            create_worker=create_worker,
+        )
+        with self.assertRaises(_StopConstruction):
+            scheduler.maybe_init_draft_worker()
+
+        # A registered algorithm may pick its worker class from the config it
+        # is handed, so the factory and the worker must see the same one.
+        self.assertEqual(seen["load_format"], "dummy")
+
+    def test_a_configured_draft_load_format_never_reaches_the_target(self):
+        server_args = self._seed(
+            load_format="auto", speculative_draft_load_format="dummy"
+        )
+        draft = self._captured_draft_args(server_args)
+        self.assertEqual(draft.load_format, "dummy")
+        self.assertEqual(server_args.load_format, "auto")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_global_config_read_ratchet.py
+++ b/test/registered/unit/test_global_config_read_ratchet.py
@@ -1,0 +1,165 @@
+"""Ratchet guard: process-global config reads may only decrease.
+
+``get_server_args()`` returns the published ``ServerArgs`` — one process's
+startup record. Config decisions read the namespace accessors instead
+(``get_exec()`` / ``get_memory()`` / …), which carry the resolved value
+including post-publish overrides, and per-runner values come from the runner
+that owns them.
+
+Two shapes count as a read: the direct ``get_server_args().field``, and the
+alias ``sa = get_server_args()`` followed by ``sa.field`` in the same function.
+A whole-object pass (``def f(server_args)``) is not a global read and is not
+counted — there the caller decided which instance to hand over.
+
+What legitimately remains:
+
+- **Derived APIs.** ``@property`` and method members of ``ServerArgs``
+  (``mamba_cache_chunk_size``, ``get_model_config()``,
+  ``enable_mamba_extra_buffer()``, …) are computed from several fields plus the
+  HF config, so they are not namespace leaves and ``ServerArgs`` is their only
+  home. Exempt by name below.
+- **Config-intent reads of live-shadowed sizes.** ``get_parallel()`` shadows
+  ``tp/pp/dcp/attn_cp/moe_dp_size`` with the live topology, so a config-intent
+  read of one has nowhere else to go. Each exempt site needs an answer the live
+  property cannot give:
+
+  - ``dsa_indexer.pp_size`` gates ``pp_size > 1 and not get_pp_group()...``, and
+    the short circuit is the point: with PP off the group is never touched, which
+    is what lets the ``Indexer`` be constructed before distributed init. The live
+    property would demand the group either way.
+  - ``allocation.dcp_size`` asks whether DCP was *configured*; the live property
+    reads ``get_dcp_group()``, and that group is only installed when DCP is on.
+  - ``cuda_ipc_transport_utils.tp_size`` runs in the tokenizer process, which has
+    no groups at all (the call site already guards for "not published yet").
+- The alias-form baseline is not zero yet. Lowering it is the next slice; the
+  failure message lists the sites whenever the count moves.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import ast
+import unittest
+from pathlib import Path
+
+import sglang
+from sglang.test.test_utils import CustomTestCase
+
+# srt is the migrated surface; the rest of the package has no reads today and is
+# scanned so a new one cannot appear there unnoticed.
+_PACKAGE_ROOT = Path(next(iter(sglang.__path__)))
+
+_DERIVED_MEMBERS = frozenset(
+    {
+        "cutedsl_moe_max_num_tokens",
+        "enable_mamba_extra_buffer",
+        "enable_mamba_extra_buffer_lazy",
+        "get_attention_backends",
+        "get_model_config",
+        "mamba_cache_chunk_size",
+        "max_speculative_num_draft_tokens",
+        "model_config",
+        "use_mla_backend",
+    }
+)
+
+_CONFIG_INTENT_SIZES = frozenset(
+    {
+        ("srt/layers/attention/dsa/dsa_indexer.py", "pp_size"),
+        ("srt/mem_cache/allocation.py", "dcp_size"),
+        ("srt/utils/cuda_ipc_transport_utils.py", "tp_size"),
+    }
+)
+
+_DIRECT_BASELINE = 0
+_ALIAS_BASELINE = 12
+
+
+def _is_global_call(node) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "get_server_args"
+    )
+
+
+def _collect(rel: str, tree: ast.AST):
+    """The (direct, alias) field reads in one module."""
+    direct, alias = [], []
+
+    def counted(attr: str) -> bool:
+        return attr not in _DERIVED_MEMBERS and (rel, attr) not in _CONFIG_INTENT_SIZES
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and _is_global_call(node.value)
+            and counted(node.attr)
+        ):
+            direct.append(f"{rel}:{node.lineno}: get_server_args().{node.attr}")
+
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        params = {a.arg for a in list(node.args.args) + list(node.args.kwonlyargs)}
+        bound = {}
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Assign) and _is_global_call(inner.value):
+                for target in inner.targets:
+                    if isinstance(target, ast.Name) and target.id not in params:
+                        bound.setdefault(target.id, inner.lineno)
+        if not bound:
+            continue
+        for inner in ast.walk(node):
+            if (
+                isinstance(inner, ast.Attribute)
+                and isinstance(inner.value, ast.Name)
+                and inner.value.id in bound
+                and inner.lineno >= bound[inner.value.id]
+                and counted(inner.attr)
+            ):
+                alias.append(
+                    f"{rel}:{inner.lineno}: {inner.value.id}.{inner.attr} "
+                    f"(bound from get_server_args() at line {bound[inner.value.id]})"
+                )
+    return direct, alias
+
+
+def _field_reads():
+    direct, alias = [], []
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:
+            continue
+        module_direct, module_alias = _collect(rel, tree)
+        direct += module_direct
+        alias += module_alias
+    return direct, alias
+
+
+class TestGlobalConfigReadRatchet(CustomTestCase):
+    def _check(self, kind, reads, baseline):
+        if len(reads) > baseline:
+            self.fail(
+                f"{kind} process-global config field reads grew: {len(reads)} > "
+                f"baseline {baseline}. Read the namespace accessor for the "
+                "field's namespace, or the owning runner for a per-runner "
+                "field:\n" + "\n".join(reads)
+            )
+        if len(reads) < baseline:
+            self.fail(
+                f"{kind} process-global config field reads shrank: {len(reads)} < "
+                f"baseline {baseline}. Lower the baseline in this file to lock "
+                "in the progress."
+            )
+
+    def test_global_field_reads_match_the_baseline(self):
+        direct, alias = _field_reads()
+        self._check("direct", direct, _DIRECT_BASELINE)
+        self._check("alias-form", alias, _ALIAS_BASELINE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_server_args_writer_ratchet.py
+++ b/test/registered/unit/test_server_args_writer_ratchet.py
@@ -49,7 +49,7 @@ _EXCLUDED = (
     "multimodal_gen",
 )
 
-_BASELINE = 19
+_BASELINE = 18
 
 
 class TestServerArgsWriterRatchet(CustomTestCase):

--- a/test/registered/unit/test_server_args_writer_ratchet.py
+++ b/test/registered/unit/test_server_args_writer_ratchet.py
@@ -49,7 +49,7 @@ _EXCLUDED = (
     "multimodal_gen",
 )
 
-_BASELINE = 26
+_BASELINE = 19
 
 
 class TestServerArgsWriterRatchet(CustomTestCase):

--- a/test/registered/unit/test_server_args_writer_ratchet.py
+++ b/test/registered/unit/test_server_args_writer_ratchet.py
@@ -49,7 +49,7 @@ _EXCLUDED = (
     "multimodal_gen",
 )
 
-_BASELINE = 34
+_BASELINE = 31
 
 
 class TestServerArgsWriterRatchet(CustomTestCase):

--- a/test/registered/unit/test_server_args_writer_ratchet.py
+++ b/test/registered/unit/test_server_args_writer_ratchet.py
@@ -49,7 +49,7 @@ _EXCLUDED = (
     "multimodal_gen",
 )
 
-_BASELINE = 31
+_BASELINE = 26
 
 
 class TestServerArgsWriterRatchet(CustomTestCase):


### PR DESCRIPTION
Review/CI vehicle for the stacked series (full diff vs main; do not merge — merge the members in order):

1. #33238 — retire three `ServerArgs.override` writes that no reader needed (ratchet 34 → 31)
2. #33239 — the draft worker is built from a `ServerArgs` copy instead of mutating the target's (31 → 26)
3. #33240 — runtime control-plane updates (HiCache attach/detach, weight version, model path) leave the `ServerArgs` instance (26 → 19)
4. #33241 — the generated forward-pass-metrics endpoint is published through the resolved config (19 → 18)
5. #33244 — the last process-global config field reads move to the namespace accessors, or to the owning instance where the field is per-worker

Together: nothing writes config onto a published `ServerArgs` for a reader to find, and nothing reads config off the process-global instance when the value has a namespace. `ServerArgs` is back to being the startup record.

The head carries one extra commit adding `STACK_REVIEW_PLACEHOLDER.md`; drop it if this branch is ever squashed.

Each member lowers its ratchet baseline itself, so every commit in the stack is green on its own — the ratchet tests were run at each commit.

## Review round 1 — what changed

Nine findings, all real, all fixed in the originating commit:

- **Plugin speculative algorithms lost the draft load format** (Codex, #33239). The scheduler used to apply it before *every* worker factory; the first version of this PR only covered the four built-in workers, so an algorithm registered through `SpeculativeAlgorithm.register` would have loaded its draft in the target's format. The copy moved up into `Scheduler.maybe_init_draft_worker`, so it is made once for every algorithm — which also removes the local-rebinding footgun the second reviewer flagged (the workers no longer shadow `server_args` with a draft copy mid-`__init__`).
- **Two readbacks regressed** (Codex, #33238). Deleting the XGrammar-fallback and SM100-GDN writes was justified as "no reader" — but `get_internal_state` / `/server_info` report the *whole* resolved config, so both values silently stopped reflecting reality. Each is now recorded with `get_context().override`, which keeps the readback truthful without putting anything back on the instance. Both have a test asserting the value shows in `resolved_server_args_dict()` while the published instance stays pristine.
- **`model_path` was dual-sourced** (#33240): operational code read `self.model_path`, readbacks read the overlay dict. `resolved_config_dict` now injects the manager's live `model_path` / `served_model_name`, so there is one store per value.
- **`record_config_updates` was an unvalidated free-form merge** (#33240): it now rejects keys that are not `ServerArgs` fields (a typo would otherwise surface as a phantom entry in `/server_info`) and keeps `(source, fields)` for provenance, like the context's override log.
- **The scheduler HiCache attach/detach had no test** (#33240) — the highest-value correctness fix in that PR was unguarded. Added, and verified to fail if the write is put back on the instance.
- **The forward-pass-metrics test was weak** (#33241): `resolved_server_args_dict` overlays `vars(server_args)`, so an instance write would have kept it green. It now asserts through `get_observability()` and that the published instance stays `None`.
- **The new read ratchet only saw one syntactic shape** (#33244): `sa = get_server_args(); sa.field` escaped it, so `_BASELINE = 0` overstated the result. It is now scope-aware and package-wide, with an honest split: direct-form 0, alias-form 12 (mostly per-runner fields in model code), and the exempt derived APIs listed by name. The one package-level read outside `srt` (`kernels/ops/layernorm/mhc.py`) is flipped.
- Two further comments were acknowledged without a change: `OpenAIServingClassify` freezing `model_name` at construction is pre-existing and orthogonal, and extracting the manager's control-plane bookkeeping into its own collaborator is worth doing only if more fields accumulate.

## Validation

Full registered CPU battery (16 partitions) at the stack tip against the same battery on `main`: identical failure sets, zero new failures. Per-area unit suites (`mem_cache`, `constrained`, `layers/attention`, `spec`, `managers`, `entrypoints`, `observability`, `multimodal`, `server_args`) and every config ratchet pass.

**What could not be validated locally**, called out per PR as well:

- No speculative-decoding checkpoint on the dev box, so #33239 has had no EAGLE / MTP end-to-end run. Its unit tests pin the copy semantics and the scheduler handoff, but the speculative CI suites are the real gate.
- The SM100 GDN FlashInfer prefill default in #33238 only executes on Blackwell with a hybrid-GDN model.
- The runtime HiCache attach/detach HTTP round-trip in #33240 needs a served model with hierarchical cache enabled; the scheduler side is unit-tested.
- The reads flipped in #33244 sit in model and attention paths that need a GPU to execute. The flips are value-preserving — the bags are projected from the same published config — but the model and speculative suites are the real check.

Related: the per-role namespace enforcement shipped in #33172 was exercised on this branch (record + enforce modes, dp_size=2) and behaved as declared; no change here depends on it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30771349345](https://github.com/sgl-project/sglang/actions/runs/30771349345)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #30771349277](https://github.com/sgl-project/sglang/actions/runs/30771349277)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->