### PR TITLE
feat(sgl-router): forward per-request attribution headers on the cache-sim /ingest_ids tee

### DIFF
--- a/experimental/sgl-router/src/server/cache_sim_tee.rs
+++ b/experimental/sgl-router/src/server/cache_sim_tee.rs
@@ -48,6 +48,30 @@ enum TeeKind {
     Extend,
 }
 
+/// Per-request attribution an upstream gateway stamps on the request it
+/// dispatches (the `x-radixark-*` headers), read off the incoming request here
+/// and RE-ATTACHED verbatim to the cache-sim tee POST. Pure pass-through: the
+/// router never mints these — it relays what the upstream resolved (endpoint /
+/// key / slug at auth, correlation server-minted). The cache-sim receiver reads
+/// them back off the headers into each record, so the record is self-describing:
+/// it can be partitioned by `slug` and deduped / correlated by `correlation_id`
+/// without a separate lookup.
+///
+/// All optional: the upstream sets only non-empty values (a shared-bearer request
+/// has no `key_id`; a direct-to-router request with no such gateway has none),
+/// and each absent field is simply not sent — never as an empty header, which
+/// would look like a real value downstream.
+#[derive(Clone, Default)]
+pub struct Attribution {
+    /// `x-radixark-correlation-id` — the upstream's server-minted join key,
+    /// distinct from the tee body's `request_id` (the router's own rid). Used
+    /// downstream as the record's dedup + correlation key.
+    pub correlation_id: Option<String>,
+    pub endpoint_id: Option<String>,
+    pub key_id: Option<String>,
+    pub slug: Option<String>,
+}
+
 struct TeeMsg {
     kind: TeeKind,
     model: String,
@@ -56,6 +80,7 @@ struct TeeMsg {
     request_id: String,
     prompt_len: Option<usize>,
     choice: Option<Choice>,
+    attr: Attribution,
 }
 
 /// Which of an `n > 1` response's alternative continuations an extension is.
@@ -182,7 +207,7 @@ impl CacheSimTee {
     /// dropped + counted, a closed channel (sender task gone) likewise. Empty
     /// id lists are a no-op. Cheap enough to call unconditionally on the hot
     /// path.
-    pub fn offer(&self, model: &str, input_ids: &[u32], request_id: &str) {
+    pub fn offer(&self, model: &str, input_ids: &[u32], request_id: &str, attr: Attribution) {
         self.offer_kind(
             TeeKind::Ingest,
             model,
@@ -191,6 +216,7 @@ impl CacheSimTee {
             None,
             None,
             None,
+            attr,
         );
     }
 
@@ -209,6 +235,11 @@ impl CacheSimTee {
         choice: Option<Choice>,
         output_tokens: Option<u64>,
     ) {
+        // The extend (response-completion, insert-only) path runs in a detached
+        // task that no longer holds the ingress request headers, so it carries no
+        // attribution for now. The attributed path is the ingest tee above;
+        // threading attribution here is a follow-up (capture it at ingress
+        // alongside the extend prompt).
         self.offer_kind(
             TeeKind::Extend,
             model,
@@ -217,6 +248,7 @@ impl CacheSimTee {
             prompt_len,
             choice,
             output_tokens,
+            Attribution::default(),
         );
     }
 
@@ -230,6 +262,7 @@ impl CacheSimTee {
         prompt_len: Option<usize>,
         choice: Option<Choice>,
         output_tokens: Option<u64>,
+        attr: Attribution,
     ) {
         if input_ids.is_empty() {
             return;
@@ -265,6 +298,7 @@ impl CacheSimTee {
             prompt_len,
             choice,
             output_tokens,
+            attr,
         };
         match self.tx.try_send(msg) {
             Ok(()) => {}
@@ -330,13 +364,23 @@ async fn run_sender(
         // would blind the one health signal this counter exists to be. `error`
         // stays transport-only (connect refused / DNS / the 2s timeout) so a
         // dashboard can tell "cache-sim rejecting" from "cache-sim unreachable".
-        match client
-            .post(url)
-            .header("content-type", "application/json")
-            .body(bytes)
-            .send()
-            .await
-        {
+        // Re-attach the upstream's per-request attribution as x-radixark-* headers
+        // so the cache-sim receiver reads them into each record (it reads headers,
+        // not the JSON body). Non-empty values only — an empty header would look
+        // like a real value and collapse a downstream group-by / join. Pure
+        // pass-through: the router relays what the upstream stamped, minting nothing.
+        let mut rb = client.post(url).header("content-type", "application/json");
+        for (name, value) in [
+            ("x-radixark-correlation-id", &msg.attr.correlation_id),
+            ("x-radixark-endpoint-id", &msg.attr.endpoint_id),
+            ("x-radixark-key-id", &msg.attr.key_id),
+            ("x-radixark-endpoint-slug", &msg.attr.slug),
+        ] {
+            if let Some(v) = value.as_deref().filter(|s| !s.is_empty()) {
+                rb = rb.header(name, v);
+            }
+        }
+        match rb.body(bytes).send().await {
             Ok(r) if r.status().is_success() => metrics.record_cache_sim_tee(sent),
             Ok(_) => metrics.record_cache_sim_tee(http_error),
             Err(_) => metrics.record_cache_sim_tee(error),
@@ -371,43 +415,66 @@ mod tests {
 
     #[tokio::test]
     async fn offer_posts_input_ids_to_ingest_ids() {
-        // Mock cache-sim: capture the last /ingest_ids body, reply 204.
-        let captured: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
-        let app =
-            Router::new()
-                .route(
-                    "/ingest_ids",
-                    post(
-                        |State(cap): State<Arc<Mutex<Option<Vec<u8>>>>>,
-                         body: axum::body::Bytes| async move {
-                            *cap.lock().unwrap() = Some(body.to_vec());
-                            axum::http::StatusCode::NO_CONTENT
-                        },
-                    ),
-                )
-                .with_state(Arc::clone(&captured));
+        // Mock cache-sim: capture the last /ingest_ids body + headers, reply 204.
+        type Captured = Arc<Mutex<Option<(Vec<u8>, axum::http::HeaderMap)>>>;
+        let captured: Captured = Arc::new(Mutex::new(None));
+        let app = Router::new()
+            .route(
+                "/ingest_ids",
+                post(
+                    |State(cap): State<Captured>,
+                     headers: axum::http::HeaderMap,
+                     body: axum::body::Bytes| async move {
+                        *cap.lock().unwrap() = Some((body.to_vec(), headers));
+                        axum::http::StatusCode::NO_CONTENT
+                    },
+                ),
+            )
+            .with_state(Arc::clone(&captured));
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
         let metrics = MetricsRegistry::new();
         let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64);
-        tee.offer("m", &[10, 11, 12], "rid-1");
+        // Full attribution — plus an empty key_id, which must be OMITTED
+        // (not sent as a blank header).
+        tee.offer(
+            "m",
+            &[10, 11, 12],
+            "rid-1",
+            Attribution {
+                correlation_id: Some("corr-abc".into()),
+                endpoint_id: Some("ep-1".into()),
+                key_id: Some(String::new()),
+                slug: Some("demo-slug".into()),
+            },
+        );
 
         // The sender POSTs asynchronously; poll until the body lands.
-        let mut body = None;
+        let mut captured_pair = None;
         for _ in 0..80 {
-            if let Some(b) = captured.lock().unwrap().clone() {
-                body = Some(b);
+            if let Some(p) = captured.lock().unwrap().clone() {
+                captured_pair = Some(p);
                 break;
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
-        let body = body.expect("cache-sim never received a POST");
+        let (body, headers) = captured_pair.expect("cache-sim never received a POST");
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["model"], "m");
         assert_eq!(v["input_ids"], serde_json::json!([10, 11, 12]));
         assert_eq!(v["request_id"], "rid-1", "the join key must reach the wire");
+        // Per-request attribution is forwarded as x-radixark-* headers
+        // (pass-through) so the cache-sim receiver can self-describe each record.
+        let hdr = |n: &str| headers.get(n).and_then(|v| v.to_str().ok());
+        assert_eq!(hdr("x-radixark-correlation-id"), Some("corr-abc"));
+        assert_eq!(hdr("x-radixark-endpoint-id"), Some("ep-1"));
+        assert_eq!(hdr("x-radixark-endpoint-slug"), Some("demo-slug"));
+        assert!(
+            headers.get("x-radixark-key-id").is_none(),
+            "an empty attribution value must be omitted, never sent blank"
+        );
         // The ingest body IS the prompt, so a boundary would be redundant —
         // and its presence on this path would mean the receiver had two
         // disagreeing notions of where the prompt ends.
@@ -490,7 +557,7 @@ mod tests {
     async fn ingest_never_carries_a_boundary() {
         let metrics = Arc::new(MetricsRegistry::default());
         let (tee, mut rx) = unstarted(4, Arc::clone(&metrics));
-        tee.offer("m", &[1, 2, 3], "rid-1");
+        tee.offer("m", &[1, 2, 3], "rid-1", Attribution::default());
         let msg = rx.try_recv().unwrap();
         assert!(msg.prompt_len.is_none());
         assert_eq!(msg.request_id, "rid-1");
@@ -581,7 +648,7 @@ mod tests {
         // overflow and must be counted as dropped (and never block).
         let (tee, _rx) = unstarted(1, Arc::clone(&metrics));
         for _ in 0..5 {
-            tee.offer("m", &[1, 2, 3], "rid-1");
+            tee.offer("m", &[1, 2, 3], "rid-1", Attribution::default());
         }
         let rendered = metrics.render();
         assert!(
@@ -594,7 +661,7 @@ mod tests {
     async fn offer_ignores_empty_ids() {
         let metrics = MetricsRegistry::new();
         let (tee, mut rx) = unstarted(4, Arc::clone(&metrics));
-        tee.offer("m", &[], "rid-1");
+        tee.offer("m", &[], "rid-1", Attribution::default());
         // Nothing enqueued.
         assert!(rx.try_recv().is_err());
     }
@@ -613,7 +680,7 @@ mod tests {
 
         let metrics = MetricsRegistry::new();
         let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64);
-        tee.offer("m", &[1, 2, 3], "rid-1");
+        tee.offer("m", &[1, 2, 3], "rid-1", Attribution::default());
 
         let mut rendered = String::new();
         for _ in 0..80 {
@@ -640,7 +707,7 @@ mod tests {
         let metrics = MetricsRegistry::new();
         let (tee, rx) = unstarted(4, Arc::clone(&metrics));
         drop(rx); // no receiver → channel closed
-        tee.offer("m", &[1, 2, 3], "rid-1");
+        tee.offer("m", &[1, 2, 3], "rid-1", Attribution::default());
         assert!(
             metrics
                 .render()
@@ -666,7 +733,11 @@ mod tests {
                 panic!("capture budget is not bounded");
             }
         }
-        assert_eq!(held.len(), 64, "exactly the budget many permits are granted");
+        assert_eq!(
+            held.len(),
+            64,
+            "exactly the budget many permits are granted"
+        );
         assert!(
             tee.try_acquire_capture_permit().is_none(),
             "an exhausted budget must refuse further captures",

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -404,7 +404,12 @@ async fn chat_completions_inner(
     // downstream from a response that generated nothing. The bias would grow
     // exactly when the fleet is shedding, i.e. anti-correlated with health.
     if let (Some(tee), Some(t)) = (ctx.cache_sim_tee.as_ref(), request_tokens.as_ref()) {
-        tee.offer(&model_str, &t.ids, &derived_request_id);
+        tee.offer(
+            &model_str,
+            &t.ids,
+            &derived_request_id,
+            tee_attribution(&headers),
+        );
     }
     if let Some(p) = &phase {
         p.set(RequestPhase::Dispatch);
@@ -1800,6 +1805,29 @@ fn derive_request_id(client_rid: Option<&str>, headers: &HeaderMap) -> String {
     {
         Some(id) => format!("router-{id}"),
         None => format!("router-{}", uuid::Uuid::new_v4().simple()),
+    }
+}
+
+/// Read the upstream's per-request attribution headers off the incoming request
+/// so the ingress tee can re-forward them verbatim to the cache-sim (an upstream
+/// gateway stamps them; the cache-sim receiver reads them back into each record).
+/// Pure pass-through — the router mints nothing here, it only relays what the
+/// upstream resolved. Empty headers are treated as absent (same contract as
+/// `derive_request_id`), so a blank never masquerades as a real
+/// endpoint/key/slug/correlation.
+fn tee_attribution(headers: &HeaderMap) -> crate::server::cache_sim_tee::Attribution {
+    let get = |name: &str| {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+    };
+    crate::server::cache_sim_tee::Attribution {
+        correlation_id: get("x-radixark-correlation-id"),
+        endpoint_id: get("x-radixark-endpoint-id"),
+        key_id: get("x-radixark-key-id"),
+        slug: get("x-radixark-endpoint-slug"),
     }
 }
 


### PR DESCRIPTION
## Problem

The cache-sim ingest tee (`/ingest_ids`) POSTed only `content-type` — it forwarded none of the upstream gateway's per-request attribution headers. So the teed records reached the receiver with no `slug` / `endpoint_id` / `key_id` / `correlation_id`, leaving each record unattributable (no way to partition by slug or dedup/correlate).

## Fix (pure pass-through)

An upstream gateway already stamps `x-radixark-endpoint-id` / `-key-id` / `-endpoint-slug` / `-correlation-id` on the request it dispatches, and they ride through to the router's chat handler. Read them off the incoming request and re-attach them verbatim to the `/ingest_ids` POST — the router mints nothing.

- `chat.rs`: `tee_attribution(&headers)` extracts the four `x-radixark-*` headers (empty treated as absent, mirroring `derive_request_id`) at the ingress-tee call site.
- `cache_sim_tee.rs`: new `Attribution` carried on `TeeMsg`; `run_sender` sets the non-empty values as the same `x-radixark-*` headers on the POST.

The cache-sim receiver reads them back off the headers into each record, so the record is self-describing. Additive + safe to deploy in any order — an older cache-sim ignores unknown headers.

## Scope

`/ingest_ids` (ingest tee) only. The `/extend_ids` tee runs in a detached response-completion task without the ingress headers, so it carries no attribution for now — a follow-up (capture attribution at ingress alongside the extend prompt).

## Tests

The ingest-tee mock now asserts the `x-radixark-*` headers are forwarded and that an empty value is omitted (never sent blank). `cargo test --lib cache_sim_tee` (10) + `routes::chat` (45) pass; `cargo fmt --check` + `cargo clippy --lib` clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30732300512](https://github.com/sgl-project/sglang/actions/runs/30732300512)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30732300416](https://github.com/sgl-project/sglang/actions/runs/30732300416)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->