### PR TITLE
[Bugfix] Fix DeepSeek-V4 non-EP TBO for attention TP > 1

### DIFF
--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -932,15 +932,33 @@ def dp_reduce_scatterv_async(
     sizes: List[int],
     event_key=("combine", 0),
 ) -> torch.cuda.Event:
-    """Launch the variable-length reduce_scatterv (combine) on the shared DP TBO
-    comm stream; re-record + return a PERSISTENT event (keyed by `event_key`).
-    Matches the gatherv (SUM_LEN) path."""
+    """Launch the TBO variable-length combine on the shared comm stream.
+
+    ``sizes`` describes one shard per full-TP rank. For attention TP > 1,
+    reduce-scatter first returns that rank's shard, then an attention-TP
+    all-gather reconstructs the replicated DP-local output.
+    """
     comm = get_dp_tbo_comm_stream()
     compute = torch.cuda.current_stream()
     ev = _tbo_event(event_key)
+    attn_tp_size = get_attn_tensor_model_parallel_world_size()
+    if attn_tp_size == 1:
+        output_shard = output_local
+    else:
+        shard_rows = sizes[get_tp_group().rank_in_group]
+        assert output_local.shape[0] == shard_rows * attn_tp_size
+        output_shard = get_tbo_persistent_buffer(
+            ("combine_shard", event_key),
+            shard_rows,
+            output_local.shape[1],
+            output_local.dtype,
+            output_local.device,
+        )
     with torch.cuda.stream(comm):
         comm.wait_stream(compute)
-        get_tp_group().reduce_scatterv(global_tokens, output=output_local, sizes=sizes)
+        get_tp_group().reduce_scatterv(global_tokens, output=output_shard, sizes=sizes)
+        if attn_tp_size > 1:
+            get_attn_tp_group().all_gather_into_tensor(output_local, output_shard)
         ev.record(comm)
     return ev
 

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -171,7 +171,6 @@ class _DpGatheredBufferWrapper:
 
     @classmethod
     def set_metadata(cls, hidden_size: int, dtype: torch.dtype, device: torch.device):
-
         dp = get_flags().dp
         dp.buffer_hidden_size = hidden_size
         dp.buffer_dtype = dtype
@@ -194,7 +193,6 @@ class _DpGatheredBufferWrapper:
 
     @classmethod
     def get_global_dp_buffer(cls, group: GroupCoordinator) -> torch.Tensor:
-
         dp = get_flags().dp
         with use_symmetric_memory(group, disabled=not cls._dp_max_padding):
             buffer = torch.empty(
@@ -206,7 +204,6 @@ class _DpGatheredBufferWrapper:
 
     @classmethod
     def get_local_dp_buffer(cls, group: GroupCoordinator) -> torch.Tensor:
-
         dp = get_flags().dp
         with use_symmetric_memory(group, disabled=not cls._dp_max_padding):
             buffer = torch.empty(
@@ -253,17 +250,14 @@ class _DpGatheredBufferWrapper:
 
     @classmethod
     def get_dp_hidden_size(cls) -> int:
-
         return get_flags().dp.buffer_hidden_size
 
     @classmethod
     def get_dp_dtype(cls) -> torch.dtype:
-
         return get_flags().dp.buffer_dtype
 
     @classmethod
     def get_dp_device(cls) -> torch.device:
-
         return get_flags().dp.buffer_device
 
     @classmethod
@@ -336,7 +330,6 @@ def set_is_extend_in_batch(is_extend_in_batch: bool):
 
 
 def get_is_extend_in_batch() -> bool:
-
     return get_forward().is_extend_in_batch
 
 
@@ -939,7 +932,6 @@ def dp_reduce_scatter_tensor(output: torch.Tensor, input: torch.Tensor):
 # deadlock on the RCCL communicator), each overlapping the other's compute.
 # ---------------------------------------------------------------------------
 def get_dp_tbo_comm_stream() -> torch.cuda.Stream:
-
     return get_stream("dp_tbo_comm")
 
 
@@ -950,7 +942,6 @@ def get_dp_tbo_comm_stream() -> torch.cuda.Stream:
 # ("...create internal OS-specific events"). Reuse one event per (kind, subbatch)
 # and just re-record it (mirrors the mori CommStreamPool event reuse).
 def _tbo_event(key) -> torch.cuda.Event:
-
     pool = get_resources().tbo_event_pool
     ev = pool.get(key)
     if ev is None:
@@ -1013,15 +1004,33 @@ def dp_reduce_scatterv_async(
     sizes: List[int],
     event_key=("combine", 0),
 ) -> torch.cuda.Event:
-    """Launch the variable-length reduce_scatterv (combine) on the shared DP TBO
-    comm stream; re-record + return a PERSISTENT event (keyed by `event_key`).
-    Matches the gatherv (SUM_LEN) path."""
+    """Launch the TBO variable-length combine on the shared comm stream.
+
+    ``sizes`` describes one shard per full-TP rank. For attention TP > 1,
+    reduce-scatter first returns that rank's shard, then an attention-TP
+    all-gather reconstructs the replicated DP-local output.
+    """
     comm = get_dp_tbo_comm_stream()
     compute = torch.cuda.current_stream()
     ev = _tbo_event(event_key)
+    attn_tp_size = get_attn_tensor_model_parallel_world_size()
+    if attn_tp_size == 1:
+        output_shard = output_local
+    else:
+        shard_rows = sizes[get_tp_group().rank_in_group]
+        assert output_local.shape[0] == shard_rows * attn_tp_size
+        output_shard = get_tbo_persistent_buffer(
+            ("combine_shard", event_key),
+            shard_rows,
+            output_local.shape[1],
+            output_local.dtype,
+            output_local.device,
+        )
     with torch.cuda.stream(comm):
         comm.wait_stream(compute)
-        get_tp_group().reduce_scatterv(global_tokens, output=output_local, sizes=sizes)
+        get_tp_group().reduce_scatterv(global_tokens, output=output_shard, sizes=sizes)
+        if attn_tp_size > 1:
+            get_attn_tp_group().all_gather_into_tensor(output_local, output_shard)
         ev.record(comm)
     return ev
 

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -695,6 +695,7 @@ class DeepseekV2MoE(nn.Module):
         self.shared_experts_is_int8 = False
         self.shared_experts_is_fp8 = False
         self.shared_experts_weight_block_size = None
+        self.shared_experts: Optional[DeepseekV2MLP] = None
         self._shared_expert_tp1 = False
         # Shared experts: skip when fused into MoE kernel
         # (self.num_fused_shared_experts > 0) or when DeepEP/MegaMOE fusion is enabled.
@@ -863,7 +864,7 @@ class DeepseekV2MoE(nn.Module):
             and self.alt_stream is not None
             and self.num_fused_shared_experts == 0
             and hidden_states.shape[0] > 0
-            and hasattr(self, "shared_experts")
+            and self.shared_experts is not None
             and getattr(self.experts, "use_flashinfer_trtllm_moe", False)
             and not self._enable_a2a_moe
             and not self._fuse_shared_experts_inside_sbo
@@ -1045,7 +1046,7 @@ class DeepseekV2MoE(nn.Module):
         input_ids_global: Optional[torch.Tensor] = None,
         skip_shared_experts: bool = False,
     ) -> torch.Tensor:
-        if hasattr(self, "shared_experts") and use_intel_amx_backend(
+        if self.shared_experts is not None and use_intel_amx_backend(
             self.shared_experts.gate_up_proj
         ):
             return self.forward_cpu(hidden_states)
@@ -1103,7 +1104,6 @@ class DeepseekV2MoE(nn.Module):
             def _pre_combine_hook(
                 dispatcher: BaseDispatcher, combine_input: CombineInput
             ):
-
                 nonlocal shared_output
                 self.alt_stream.wait_stream(torch.cuda.current_stream())
                 with torch.cuda.stream(self.alt_stream):
@@ -1342,7 +1342,6 @@ class DeepseekV2MoE(nn.Module):
             def _post_dispatch_hook(
                 dispatcher: BaseDispatcher, dispatch_output: DispatchOutput
             ):
-
                 combine_overlap_args, down_gemm_overlap_args, meta_overlap_args = (
                     compute_overlap_args(dispatch_output, self.alt_stream)
                 )
@@ -1360,7 +1359,6 @@ class DeepseekV2MoE(nn.Module):
             def _pre_combine_hook(
                 dispatcher: BaseDispatcher, combine_input: CombineInput
             ):
-
                 nonlocal shared_output
 
                 if (
@@ -1398,7 +1396,6 @@ class DeepseekV2MoE(nn.Module):
             def _post_dispatch_hook(
                 dispatcher: BaseDispatcher, dispatch_output: DispatchOutput
             ):
-
                 combine_overlap_args, down_gemm_overlap_args, meta_overlap_args = (
                     compute_overlap_args(dispatch_output, self.alt_stream)
                 )
@@ -1527,7 +1524,7 @@ class DeepseekV2MoE(nn.Module):
         # Shared-expert side: fp8 block-128 weights served by a w8a8 linear
         # backend taught to accept a pre-quantized (q, scale) tuple: cutlass
         # or deepgemm (fp32 scales only, i.e. not UE8M0/Blackwell).
-        if self.num_fused_shared_experts != 0 or not hasattr(self, "shared_experts"):
+        if self.num_fused_shared_experts != 0 or self.shared_experts is None:
             return False, "no separate shared experts"
         if not self.shared_experts_is_fp8:
             return False, "shared experts not fp8"

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1854,7 +1854,9 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
             if _do_shared_local and local_hidden_states.shape[0] > 0:
                 _shared_local = self.mlp._forward_shared_experts(local_hidden_states)
-            dp_gather_partial(hidden_states, local_hidden_states, forward_batch)
+            # self_attn has already reduced across attention TP, so these hidden
+            # states are replicated and must not be summed by a partial gather.
+            dp_gather_replicate(hidden_states, local_hidden_states, forward_batch)
         _a2a_scatter_chunks: Optional[List[torch.Tensor]] = None
         if _use_tp_attn_a2a_scatter:
             s, r = get_parallel().attn_tp_size, get_parallel().attn_tp_rank
@@ -2372,7 +2374,10 @@ class DeepseekV4Model(nn.Module):
             )
             # Token ids are replicated within an attention-TP group. Use replicate
             # gather here to avoid summing duplicated ids when attention_tp_size > 1.
-            dp_gather_replicate(input_ids_global, input_ids[:, None], forward_batch)
+            # Clone because the MAX_LEN gather may zero its local input in place.
+            dp_gather_replicate(
+                input_ids_global, input_ids[:, None].clone(), forward_batch
+            )
             input_ids_global = input_ids_global.squeeze(-1)
         else:
             input_ids_global = input_ids

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -63,7 +63,6 @@ from sglang.srt.layers.dp_attention import (
     _tbo_event,
     attn_tp_all_gather,
     attn_tp_all_reduce,
-    dp_gather_partial,
     dp_gather_replicate,
     dp_reduce_scatter_tensor,
     dp_reduce_scatterv_async,
@@ -224,6 +223,30 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 # gather instead of on the gathered global buffer. Requires
 # SGLANG_SHARED_EXPERT_TP1=1 (replicated shared expert). Default OFF.
 _SHARED_EXPERT_LOCAL = get_bool_env_var("SGLANG_DP_SHARED_EXPERT_LOCAL")
+
+
+def _tbo_collective_sizes(
+    rank_sizes: List[int], attn_tp_size: int
+) -> Tuple[List[int], List[int]]:
+    if attn_tp_size < 1 or len(rank_sizes) % attn_tp_size != 0:
+        raise ValueError(f"Invalid TBO topology: {len(rank_sizes)=}, {attn_tp_size=}")
+
+    dp_sizes = []
+    tp_sizes = []
+    for start in range(0, len(rank_sizes), attn_tp_size):
+        replicas = rank_sizes[start : start + attn_tp_size]
+        if any(size != replicas[0] for size in replicas):
+            raise ValueError(f"TBO token counts differ within attention TP: {replicas}")
+        if replicas[0] % attn_tp_size != 0:
+            raise ValueError(
+                f"TBO token count {replicas[0]} is not divisible by "
+                f"attention TP size {attn_tp_size}"
+            )
+        dp_sizes.append(replicas[0])
+        tp_sizes.extend([replicas[0] // attn_tp_size] * attn_tp_size)
+    return dp_sizes, tp_sizes
+
+
 _is_gfx95_supported = is_gfx95_supported()
 _is_gfx942_supported = is_gfx942_supported()
 
@@ -2038,18 +2061,15 @@ class DeepseekV4DecoderLayer(nn.Module):
     # op_dispatch/op_combine. op_mhc_* and op_attn are reused (local hidden).
     # ------------------------------------------------------------------
     def op_gather_a(self, state):
-        # Launch the all_gatherv (local hidden -> global buffer) + the input_ids
-        # replicate-gather on the shared comm stream; record an event.
+        # Launch the all_gatherv (local hidden -> global buffer) on the shared
+        # comm stream; record an event.
         fb = state.forward_batch
         local = state.pop("hidden_states_mlp_input")  # LOCAL [M_local, hidden]
-        # Shared-expert-local: compute on LOCAL hidden before the gather; added
-        # back after the combine (same as the non-fused forward). Skipped in the
-        # global MoE via skip_shared_experts.
-        do_shared_local = (
-            _SHARED_EXPERT_LOCAL
-            and getattr(self.mlp, "shared_experts", None) is not None
-            and getattr(self.mlp, "_shared_expert_tp1", False)
-        )
+        # A TP1 shared expert is replicated, so compute it before the gather and
+        # add it after the reducing combine.
+        do_shared_local = getattr(
+            self.mlp, "shared_experts", None
+        ) is not None and getattr(self.mlp, "_shared_expert_tp1", False)
         state.do_shared_local = do_shared_local
         state.shared_local = (
             self.mlp._forward_shared_experts(local)
@@ -2065,14 +2085,22 @@ class DeepseekV4DecoderLayer(nn.Module):
         global_hidden = get_tbo_persistent_buffer(
             ("gh", sub), global_rows, local.shape[1], local.dtype, local.device
         )
+        attn_tp_size = get_parallel().attn_tp_size
+        local_shard = local.tensor_split(attn_tp_size)[
+            get_parallel().attn_tp_rank
+        ].contiguous()
+        tp_sizes = fb._tbo_tp_sizes
+        assert local_shard.shape[0] == tp_sizes[get_tp_group().rank_in_group]
         comm = get_dp_tbo_comm_stream()
         compute = torch.cuda.current_stream()
         with torch.cuda.stream(comm):
             comm.wait_stream(compute)
-            dp_gather_partial(global_hidden, local, fb)
+            get_tp_group().all_gatherv(
+                local_shard, sizes=tp_sizes, output=global_hidden
+            )
             state.gather_event = _tbo_event(("gather", sub))
             state.gather_event.record(comm)
-        state.gather_keepalive = local
+        state.gather_keepalive = local_shard
         state.global_hidden = global_hidden
 
     def op_gather_b(self, state):
@@ -2110,7 +2138,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         state.combine_event = dp_reduce_scatterv_async(
             local_out,
             global_out,
-            get_dp_global_num_tokens(),
+            state.forward_batch._tbo_tp_sizes,
             event_key=("combine", state.tbo_subbatch_index),
         )
         state.local_out = local_out
@@ -2242,6 +2270,8 @@ class DeepseekV4Model(nn.Module):
         DP-attention preparer allows it (mori `normal` mode permits prefill
         TBO). We additionally restrict to: prefill (EXTEND), single PP, and the
         non-CP path, which is the only case the DSV4 op strategy implements.
+        The non-EP strategy uses variable-size DP collectives and therefore
+        requires CP1, multi-rank DP, and SUM_LEN padding.
         """
         from sglang.srt.layers.moe import is_tbo_enabled
 
@@ -2254,6 +2284,15 @@ class DeepseekV4Model(nn.Module):
             # should enter the prefill TBO strategy.
             and forward_batch.global_forward_mode.is_extend_without_speculative()
             and not dsa_use_prefill_cp(forward_batch)
+            and (
+                not get_moe_a2a_backend().is_none()
+                or (
+                    get_parallel().attn_cp_size == 1
+                    and get_parallel().attn_dp_size > 1
+                    and forward_batch.dp_padding_mode is not None
+                    and forward_batch.dp_padding_mode.is_sum_len()
+                )
+            )
             and self.pp_group.world_size == 1
         )
 
@@ -2296,6 +2335,7 @@ class DeepseekV4Model(nn.Module):
         if get_moe_a2a_backend().is_none() and get_parallel().attn_dp_size > 1:
             tp_group = get_tp_group()
             world = tp_group.world_size
+            attn_tp_size = get_parallel().attn_tp_size
             children = forward_batch.tbo_children
             local_lens = torch.tensor(
                 [int(c.tbo_padded_len) for c in children],
@@ -2309,19 +2349,22 @@ class DeepseekV4Model(nn.Module):
             )
             tp_group.all_gather_into_tensor(gathered, local_lens)
             gathered_cpu = gathered.tolist()
-            rank = tp_group.rank_in_group
+            dp_rank = get_parallel().attn_dp_rank
+            attn_tp_rank = get_parallel().attn_tp_rank
             for idx, child in enumerate(children):
-                sizes = [gathered_cpu[r][idx] for r in range(world)]
-                child.global_num_tokens_cpu = sizes
-                child.global_num_tokens_gpu = gathered[:, idx].contiguous()
-                child.global_dp_buffer_len = sum(sizes)
+                rank_sizes = [gathered_cpu[r][idx] for r in range(world)]
+                dp_sizes, tp_sizes = _tbo_collective_sizes(rank_sizes, attn_tp_size)
+                child.global_num_tokens_cpu = dp_sizes
+                child.global_num_tokens_gpu = gathered[::attn_tp_size, idx].contiguous()
+                child.global_dp_buffer_len = sum(dp_sizes)
+                child._tbo_tp_sizes = tp_sizes
                 # Gather the ubatch's input_ids -> global ONCE here (cached on the
                 # child) instead of per-layer in op_gather_a. The hash MoE reads
                 # the SAME global ids every layer, so 61x2 per-layer all_gatherv of
                 # VARYING size (-> RCCL registers a new internal buffer per size ->
                 # HSA_STATUS_ERROR_OUT_OF_RESOURCES) collapses to 1 per ubatch.
                 local_ids = child.input_ids
-                rows = sizes[rank]
+                rows = dp_sizes[dp_rank]
                 if local_ids.shape[0] < rows:
                     padded_ids = local_ids.new_zeros((rows,))
                     padded_ids[: local_ids.shape[0]] = local_ids
@@ -2329,10 +2372,15 @@ class DeepseekV4Model(nn.Module):
                     padded_ids = local_ids[:rows]
                 else:
                     padded_ids = local_ids
+                local_ids_shard = padded_ids.tensor_split(attn_tp_size)[
+                    attn_tp_rank
+                ].contiguous()
                 gids = torch.empty(
-                    (sum(sizes),), dtype=local_ids.dtype, device=local_ids.device
+                    (sum(dp_sizes),),
+                    dtype=local_ids.dtype,
+                    device=local_ids.device,
                 )
-                tp_group.all_gatherv(padded_ids, sizes=sizes, output=gids)
+                tp_group.all_gatherv(local_ids_shard, sizes=tp_sizes, output=gids)
                 child._tbo_global_input_ids = gids
 
         outputs_arr = execute_overlapped_operations(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -73,7 +73,6 @@ from sglang.srt.layers.dp_attention import (
     _tbo_event,
     attn_tp_all_gather,
     attn_tp_all_reduce,
-    dp_gather_partial,
     dp_gather_replicate,
     dp_reduce_scatter_tensor,
     dp_reduce_scatterv_async,
@@ -321,6 +320,30 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 # gather instead of on the gathered global buffer. Requires
 # SGLANG_SHARED_EXPERT_TP1=1 (replicated shared expert). Default OFF.
 _SHARED_EXPERT_LOCAL = get_bool_env_var("SGLANG_DP_SHARED_EXPERT_LOCAL")
+
+
+def _tbo_collective_sizes(
+    rank_sizes: List[int], attn_tp_size: int
+) -> Tuple[List[int], List[int]]:
+    if attn_tp_size < 1 or len(rank_sizes) % attn_tp_size != 0:
+        raise ValueError(f"Invalid TBO topology: {len(rank_sizes)=}, {attn_tp_size=}")
+
+    dp_sizes = []
+    tp_sizes = []
+    for start in range(0, len(rank_sizes), attn_tp_size):
+        replicas = rank_sizes[start : start + attn_tp_size]
+        if any(size != replicas[0] for size in replicas):
+            raise ValueError(f"TBO token counts differ within attention TP: {replicas}")
+        if replicas[0] % attn_tp_size != 0:
+            raise ValueError(
+                f"TBO token count {replicas[0]} is not divisible by "
+                f"attention TP size {attn_tp_size}"
+            )
+        dp_sizes.append(replicas[0])
+        tp_sizes.extend([replicas[0] // attn_tp_size] * attn_tp_size)
+    return dp_sizes, tp_sizes
+
+
 _is_gfx95_supported = is_gfx95_supported()
 _is_gfx942_supported = is_gfx942_supported()
 _is_gfx1250_supported = is_gfx1250_supported()
@@ -2170,7 +2193,6 @@ class DeepseekV4DecoderLayer(nn.Module):
         post: torch.Tensor,
         comb: torch.Tensor,
     ):
-
         if x.shape[0] == 0:
             return torch.empty(
                 (0, self.hc_mult, x.shape[-1]), dtype=x.dtype, device=x.device
@@ -2731,17 +2753,14 @@ class DeepseekV4DecoderLayer(nn.Module):
     # op_dispatch/op_combine. op_mhc_* and op_attn are reused (local hidden).
     # ------------------------------------------------------------------
     def op_gather_a(self, state):
-        # Launch the all_gatherv (local hidden -> global buffer) + the input_ids
-        # replicate-gather on the shared comm stream; record an event.
+        # Launch the all_gatherv (local hidden -> global buffer) on the shared
+        # comm stream; record an event.
         fb = state.forward_batch
         local = state.pop("hidden_states_mlp_input")  # LOCAL [M_local, hidden]
-        # Shared-expert-local: compute on LOCAL hidden before the gather; added
-        # back after the combine (same as the non-fused forward). Skipped in the
-        # global MoE via skip_shared_experts.
+        # A TP1 shared expert is replicated, so compute it before the gather and
+        # add it after the reducing combine.
         do_shared_local = (
-            _SHARED_EXPERT_LOCAL
-            and getattr(self.mlp, "shared_experts", None) is not None
-            and getattr(self.mlp, "_shared_expert_tp1", False)
+            self.mlp.shared_experts is not None and self.mlp._shared_expert_tp1
         )
         state.do_shared_local = do_shared_local
         state.shared_local = (
@@ -2758,14 +2777,22 @@ class DeepseekV4DecoderLayer(nn.Module):
         global_hidden = get_tbo_persistent_buffer(
             ("gh", sub), global_rows, local.shape[1], local.dtype, local.device
         )
+        attn_tp_size = get_parallel().attn_tp_size
+        local_shard = local.tensor_split(attn_tp_size)[
+            get_parallel().attn_tp_rank
+        ].contiguous()
+        tp_sizes = fb._tbo_tp_sizes
+        assert local_shard.shape[0] == tp_sizes[get_tp_group().rank_in_group]
         comm = get_dp_tbo_comm_stream()
         compute = torch.cuda.current_stream()
         with torch.cuda.stream(comm):
             comm.wait_stream(compute)
-            dp_gather_partial(global_hidden, local, fb)
+            get_tp_group().all_gatherv(
+                local_shard, sizes=tp_sizes, output=global_hidden
+            )
             state.gather_event = _tbo_event(("gather", sub))
             state.gather_event.record(comm)
-        state.gather_keepalive = local
+        state.gather_keepalive = local_shard
         state.global_hidden = global_hidden
 
     def op_gather_b(self, state):
@@ -2803,7 +2830,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         state.combine_event = dp_reduce_scatterv_async(
             local_out,
             global_out,
-            get_dp_global_num_tokens(),
+            state.forward_batch._tbo_tp_sizes,
             event_key=("combine", state.tbo_subbatch_index),
         )
         state.local_out = local_out
@@ -2949,14 +2976,20 @@ class DeepseekV4Model(nn.Module):
         model-agnostically when --enable-two-batch-overlap is set and the
         DP-attention preparer allows it (mori `normal` mode permits prefill
         TBO). We additionally restrict to prefill (EXTEND), single PP, and
-        non-CP paths supported by the DSV4 op strategy.
+        non-CP paths supported by the DSV4 op strategy. The non-EP strategy
+        uses variable-size DP collectives and therefore requires CP1,
+        multi-rank DP, and SUM_LEN padding.
         """
         from sglang.srt.layers.moe import is_tbo_enabled
 
         path_ok = not dsa_use_prefill_cp(forward_batch) and (
-            not _is_hip
-            or not get_moe_a2a_backend().is_none()
-            or get_parallel().attn_dp_size > 1
+            not get_moe_a2a_backend().is_none()
+            or (
+                get_parallel().attn_cp_size == 1
+                and get_parallel().attn_dp_size > 1
+                and forward_batch.dp_padding_mode is not None
+                and forward_batch.dp_padding_mode.is_sum_len()
+            )
         )
         return (
             is_tbo_enabled()
@@ -3009,6 +3042,7 @@ class DeepseekV4Model(nn.Module):
         if get_moe_a2a_backend().is_none() and get_parallel().attn_dp_size > 1:
             tp_group = get_tp_group()
             world = tp_group.world_size
+            attn_tp_size = get_parallel().attn_tp_size
             children = forward_batch.tbo_children
             local_lens = torch.tensor(
                 [int(c.tbo_padded_len) for c in children],
@@ -3022,19 +3056,22 @@ class DeepseekV4Model(nn.Module):
             )
             tp_group.all_gather_into_tensor(gathered, local_lens)
             gathered_cpu = gathered.tolist()
-            rank = tp_group.rank_in_group
+            dp_rank = get_parallel().attn_dp_rank
+            attn_tp_rank = get_parallel().attn_tp_rank
             for idx, child in enumerate(children):
-                sizes = [gathered_cpu[r][idx] for r in range(world)]
-                child.global_num_tokens_cpu = sizes
-                child.global_num_tokens_gpu = gathered[:, idx].contiguous()
-                child.global_dp_buffer_len = sum(sizes)
+                rank_sizes = [gathered_cpu[r][idx] for r in range(world)]
+                dp_sizes, tp_sizes = _tbo_collective_sizes(rank_sizes, attn_tp_size)
+                child.global_num_tokens_cpu = dp_sizes
+                child.global_num_tokens_gpu = gathered[::attn_tp_size, idx].contiguous()
+                child.global_dp_buffer_len = sum(dp_sizes)
+                child._tbo_tp_sizes = tp_sizes
                 # Gather the ubatch's input_ids -> global ONCE here (cached on the
                 # child) instead of per-layer in op_gather_a. The hash MoE reads
                 # the SAME global ids every layer, so 61x2 per-layer all_gatherv of
                 # VARYING size (-> RCCL registers a new internal buffer per size ->
                 # HSA_STATUS_ERROR_OUT_OF_RESOURCES) collapses to 1 per ubatch.
                 local_ids = child.input_ids
-                rows = sizes[rank]
+                rows = dp_sizes[dp_rank]
                 if local_ids.shape[0] < rows:
                     padded_ids = local_ids.new_zeros((rows,))
                     padded_ids[: local_ids.shape[0]] = local_ids
@@ -3042,10 +3079,15 @@ class DeepseekV4Model(nn.Module):
                     padded_ids = local_ids[:rows]
                 else:
                     padded_ids = local_ids
+                local_ids_shard = padded_ids.tensor_split(attn_tp_size)[
+                    attn_tp_rank
+                ].contiguous()
                 gids = torch.empty(
-                    (sum(sizes),), dtype=local_ids.dtype, device=local_ids.device
+                    (sum(dp_sizes),),
+                    dtype=local_ids.dtype,
+                    device=local_ids.device,
                 )
-                tp_group.all_gatherv(padded_ids, sizes=sizes, output=gids)
+                tp_group.all_gatherv(local_ids_shard, sizes=tp_sizes, output=gids)
                 child._tbo_global_input_ids = gids
 
         outputs_arr = execute_overlapped_operations(
@@ -3308,7 +3350,6 @@ class DeepseekV4ForCausalLM(nn.Module):
         input_embeds: Optional[torch.Tensor] = None,
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
-
         with get_attn_tp_context().maybe_input_scattered(forward_batch):
             hidden_states = self.model.forward(
                 input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -14,7 +14,7 @@ from sglang.srt.layers.attention.dsa.utils import (
     is_dsa_prefill_cp_round_robin_split,
 )
 from sglang.srt.layers.dp_attention import (
-    dp_gather_partial,
+    dp_gather_replicate,
     get_global_dp_buffer_len,
     is_dp_attention_enabled,
 )
@@ -162,7 +162,12 @@ class DeepseekV4ModelNextN(nn.Module):
                 dtype=input_ids.dtype,
                 device=input_ids.device,
             )
-            dp_gather_partial(input_ids_global, input_ids[:, None], forward_batch)
+            # Token IDs are replicated within an attention-TP group. Use replicate
+            # gather to avoid summing duplicated IDs when attention_tp_size > 1.
+            # Clone because the MAX_LEN gather may zero its local input in place.
+            dp_gather_replicate(
+                input_ids_global, input_ids[:, None].clone(), forward_batch
+            )
             input_ids_global = input_ids_global.squeeze(-1)
         else:
             input_ids_global = input_ids

--- a/test/registered/amd/test_deepseek_v4_flash_fp8_tbo.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8_tbo.py
@@ -6,6 +6,7 @@ two-batch-overlap path on MI35x ROCm 7.2.
 TBO here is the DP-attention TP-MoE variant (moe_a2a_backend='none'): it overlaps
 one micro-batch's DP all_gatherv (pre-MoE gather) + reduce_scatterv (post-MoE
 combine) with the other micro-batch's attention + expert compute (prefill only).
+The TP8/DP2 topology exercises attention TP4.
 Enabled purely via `--enable-dp-attention` + `--enable-two-batch-overlap` (no opt-in
 env). This test guards that TBO does not regress GSM8K accuracy and that the DP TBO
 server launches + runs to completion (exercises op_gather/op_moe/op_combine and the
@@ -21,6 +22,8 @@ Registry: nightly-amd-8-gpu-mi35x-deepseek-v4-flash suite
 import os
 import unittest
 from types import SimpleNamespace
+
+import requests
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
@@ -72,7 +75,7 @@ COMMON_ENV_VARS = {
     "SGLANG_DP_USE_GATHERV": "1",
     "SGLANG_DP_USE_REDUCE_SCATTER": "1",
     "SGLANG_SHARED_EXPERT_TP1": "1",
-    "SGLANG_DP_SHARED_EXPERT_LOCAL": "1",
+    "SGLANG_TBO_DEBUG": "1",
     # ROCm HSA-resource stability for TBO at high concurrency.
     "GPU_MAX_HW_QUEUES": "5",
     # FP8 variant
@@ -96,7 +99,7 @@ class TestDeepseekV4FlashFp8Tbo(CustomTestCase):
             # DP attention + TBO: non-EP DP TP-MoE two-batch-overlap. DP TBO is
             # selected because moe_a2a_backend stays 'none'; no opt-in env needed.
             "--dp",
-            "8",
+            "2",
             "--enable-dp-attention",
             "--enable-prefill-delayer",
             "--enable-two-batch-overlap",
@@ -115,9 +118,9 @@ class TestDeepseekV4FlashFp8Tbo(CustomTestCase):
             "0.90",
             "--swa-full-tokens-ratio",
             "0.15",
-            # global chunk; DP-attention divides by dp_size=8 -> 8192/rank.
+            # Global chunk; DP-attention divides by dp_size=2 -> 8192/rank.
             "--chunked-prefill-size",
-            "65536",
+            "16384",
             "--disable-shared-experts-fusion",
             "--tool-call-parser",
             "deepseekv4",
@@ -136,6 +139,21 @@ class TestDeepseekV4FlashFp8Tbo(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
+
+    def test_single_request_tbo(self):
+        response = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": "What is 7 + 5?"}],
+                "temperature": 0,
+                "max_tokens": 32,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        text = response.json()["choices"][0]["message"]["content"]
+        self.assertIn("12", text, f"Expected 12, got {text!r}")
 
     def test_gsm8k_tbo(self):
         args = SimpleNamespace(

--- a/test/registered/amd/test_deepseek_v4_flash_fp8_tbo.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8_tbo.py
@@ -6,6 +6,7 @@ two-batch-overlap path on MI35x ROCm 7.2.
 TBO here is the DP-attention TP-MoE variant (moe_a2a_backend='none'): it overlaps
 one micro-batch's DP all_gatherv (pre-MoE gather) + reduce_scatterv (post-MoE
 combine) with the other micro-batch's attention + expert compute (prefill only).
+The TP8/DP2 topology exercises attention TP4.
 Enabled purely via `--enable-dp-attention` + `--enable-two-batch-overlap` (no opt-in
 env). This test guards that TBO does not regress GSM8K accuracy and that the DP TBO
 server launches + runs to completion (exercises op_gather/op_moe/op_combine and the
@@ -21,6 +22,8 @@ Registry: nightly-amd-8-gpu-mi35x-deepseek-v4-flash suite
 import os
 import unittest
 from types import SimpleNamespace
+
+import requests
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci
@@ -70,7 +73,7 @@ COMMON_ENV_VARS = {
     "SGLANG_DP_USE_GATHERV": "1",
     "SGLANG_DP_USE_REDUCE_SCATTER": "1",
     "SGLANG_SHARED_EXPERT_TP1": "1",
-    "SGLANG_DP_SHARED_EXPERT_LOCAL": "1",
+    "SGLANG_TBO_DEBUG": "1",
     # ROCm HSA-resource stability for TBO at high concurrency.
     "GPU_MAX_HW_QUEUES": "5",
     # FP8 variant
@@ -94,7 +97,7 @@ class TestDeepseekV4FlashFp8Tbo(CustomTestCase):
             # DP attention + TBO: non-EP DP TP-MoE two-batch-overlap. DP TBO is
             # selected because moe_a2a_backend stays 'none'; no opt-in env needed.
             "--dp",
-            "8",
+            "2",
             "--enable-dp-attention",
             "--enable-prefill-delayer",
             "--enable-two-batch-overlap",
@@ -113,9 +116,9 @@ class TestDeepseekV4FlashFp8Tbo(CustomTestCase):
             "0.90",
             "--swa-full-tokens-ratio",
             "0.15",
-            # global chunk; DP-attention divides by dp_size=8 -> 8192/rank.
+            # Global chunk; DP-attention divides by dp_size=2 -> 8192/rank.
             "--chunked-prefill-size",
-            "65536",
+            "16384",
             "--disable-shared-experts-fusion",
             "--tool-call-parser",
             "deepseekv4",
@@ -134,6 +137,21 @@ class TestDeepseekV4FlashFp8Tbo(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         kill_process_tree(cls.process.pid)
+
+    def test_single_request_tbo(self):
+        response = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": "What is 7 + 5?"}],
+                "temperature": 0,
+                "max_tokens": 32,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        text = response.json()["choices"][0]["message"]["content"]
+        self.assertIn("12", text, f"Expected 12, got {text!r}")
 
     def test_gsm8k_tbo(self):
         args = SimpleNamespace(

--- a/test/registered/unit/models/test_deepseek_v4_tbo_collectives.py
+++ b/test/registered/unit/models/test_deepseek_v4_tbo_collectives.py
@@ -1,0 +1,29 @@
+import unittest
+
+from sglang.srt.models.deepseek_v4 import _tbo_collective_sizes
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDeepseekV4TboCollectiveSizes(unittest.TestCase):
+    def test_attention_tp_shards_preserve_dp_layout(self):
+        dp_sizes, tp_sizes = _tbo_collective_sizes(
+            [8, 8, 8, 8, 12, 12, 12, 12], attn_tp_size=4
+        )
+
+        self.assertEqual(dp_sizes, [8, 12])
+        self.assertEqual(tp_sizes, [2, 2, 2, 2, 3, 3, 3, 3])
+        self.assertEqual(sum(dp_sizes), sum(tp_sizes))
+
+    def test_rejects_inconsistent_attention_tp_replicas(self):
+        with self.assertRaisesRegex(ValueError, "differ within attention TP"):
+            _tbo_collective_sizes([8, 8, 4, 8], attn_tp_size=4)
+
+    def test_rejects_unshardable_token_count(self):
+        with self.assertRaisesRegex(ValueError, "not divisible"):
+            _tbo_collective_sizes([6, 6, 6, 6], attn_tp_size=4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Depends on #31700.

DeepSeek-V4 Two-Batch Overlap (TBO) with DP attention,
`moe_a2a_backend=none`, and attention tensor parallelism greater than one
applies full-TP variable-length collectives to tensors replicated within each
attention-TP group. Treating those replicas as independent shards corrupts the
gather and combine layouts and produces invalid model output.

This change gives each full-TP rank one shard of its replicated DP-local tensor
and reconstructs the DP-local result across the attention-TP group after the
combine.

## Modifications

- Derive and validate DP-local token counts and full-TP shard counts for each
  TBO child batch.
- Shard replicated hidden states and input IDs across attention-TP ranks before
  the full-TP variable-length gather.
- Reduce-scatter the MoE output into one shard per full-TP rank, then
  all-gather within the attention-TP group to reconstruct the replicated
  DP-local output.
- Compute the replicated TP1 shared expert on the DP-local tensor and add it
  after the reducing combine.
- Select the non-EP TBO strategy for CP1, multi-rank DP, and SUM_LEN padding.
- Exercise attention TP in the registered DeepSeek-V4 TBO accuracy test and
  add focused tests for collective-size mapping and validation.

## Accuracy Tests

### H100 end-to-end setup

- Model: `nvidia/DeepSeek-V4-Pro-NVFP4`
- Hardware: 2 hosts × 8 NVIDIA H100 80GB
- Container: `lmsysorg/sglang:nightly-dev-cu13-20260801-e4c4faf8`
- Topology: TP16 / DP2 / attention-TP8
- MoE A2A backend: `none`
- TBO enabled
- Infrastructure: [NemoRL Sandbox Infrastructure Report](https://docs.google.com/document/d/1sT9QbbzXC110IC4f6T964OgKCnUouaSLYKznNnw35O8/edit?tab=t.0)

On host 0:

```bash
export NODE_RANK=0
export HEAD_NODE='<host-0 hostname>'
```

On host 1:

```bash
export NODE_RANK=1
export HEAD_NODE='<host-0 hostname>'
```

### Before: failure reproduction

The failure was reproduced both on pristine upstream `574ead753` and on the
parent of this change, `68d70aa8f`. Both reached the real two-chunk TBO path
and returned HTTP 200 responses with corrupted generated text.

The following server command was run on both hosts:

```bash
unset SGLANG_OPT_DEEPGEMM_HC_PRENORM
unset SGLANG_OPT_USE_TILELANG_MHC_PRE
unset SGLANG_OPT_USE_TILELANG_INDEXER
export SGLANG_SHARED_EXPERT_TP1=1
export SGLANG_DP_USE_GATHERV=1
export SGLANG_DP_USE_REDUCE_SCATTER=1
export SGLANG_TBO_DEBUG=1

python3 -m sglang.launch_server \
  --model-path /model \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 16 \
  --data-parallel-size 2 \
  --enable-dp-attention \
  --enable-dp-lm-head \
  --enable-prefill-delayer \
  --enable-two-batch-overlap \
  --nnodes 2 \
  --node-rank "$NODE_RANK" \
  --dist-init-addr "$HEAD_NODE:5000" \
  --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend marlin \
  --fp4-gemm-backend marlin \
  --chunked-prefill-size 4096 \
  --mem-fraction-static 0.94 \
  --context-length 2200 \
  --cuda-graph-max-bs 256 \
  --max-running-requests 256 \
  --disable-flashinfer-autotune \
  --disable-radix-cache \
  --disable-shared-experts-fusion \
  --host 0.0.0.0 \
  --port 8000
```

This exact probe and assertion were run after the server became ready:

```bash
curl --connect-timeout 2 --max-time 180 -sS \
  "http://$HEAD_NODE:8000/v1/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{"model":"deepseek-ai/DeepSeek-V4-Pro","messages":[{"role":"user","content":"What is 7 + 5? Answer with just the number."}],"temperature":0,"max_tokens":32}' \
  > single.json
jq -r '.choices[0].message.content' single.json | tee single.txt
grep -q 12 single.txt
```

Pristine upstream produced:

```text
我这里特 connKadaghanJF by,]_  . coding sni (* t LSD hob abcd[_ Witt vizunal 01 discern Amp Loy Vincent eb Wikisource  bur
```

`grep` exited 1: **FAIL**.

The parent of this change produced:

```text
رشف3223232323232323232323a3a3a3a
```

`grep` exited 1: **FAIL**.

The parent run was Slurm job `5616864` and also recorded 48 rank-level
`is_enable_two_chunk=True` events.

The pristine-upstream run recorded 48 rank-level
`is_enable_two_chunk=True` events, representing three global two-chunk
forwards. Slurm job `5618929` completed `0:0`; completion means the harness
successfully captured the expected failure.

### After: patched result

Source `6c9e7a54a` was run with the same model, container, hosts, and topology.
The following server command was run on both hosts:

```bash
unset SGLANG_OPT_DEEPGEMM_HC_PRENORM
unset SGLANG_OPT_USE_TILELANG_MHC_PRE
unset SGLANG_OPT_USE_TILELANG_INDEXER
export SGLANG_SHARED_EXPERT_TP1=1
export SGLANG_DP_USE_GATHERV=1
export SGLANG_DP_USE_REDUCE_SCATTER=1
export SGLANG_TBO_DEBUG=1

python3 -m sglang.launch_server \
  --model-path /model \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 16 \
  --data-parallel-size 2 \
  --enable-dp-attention \
  --enable-dp-lm-head \
  --enable-prefill-delayer \
  --enable-two-batch-overlap \
  --nnodes 2 \
  --node-rank "$NODE_RANK" \
  --dist-init-addr "$HEAD_NODE:5000" \
  --kv-cache-dtype fp8_e4m3 \
  --moe-runner-backend marlin \
  --fp4-gemm-backend marlin \
  --chunked-prefill-size 4096 \
  --mem-fraction-static 0.94 \
  --context-length 2200 \
  --cuda-graph-max-bs 256 \
  --max-running-requests 256 \
  --disable-flashinfer-autotune \
  --disable-radix-cache \
  --disable-shared-experts-fusion \
  --host 0.0.0.0 \
  --port 8000
```

This exact probe and assertion were then run:

```bash
curl --connect-timeout 2 --max-time 180 -sS \
  "http://$HEAD_NODE:8000/v1/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{"model":"deepseek-ai/DeepSeek-V4-Pro","messages":[{"role":"user","content":"What is 7 + 5? Answer with just the number."}],"temperature":0,"max_tokens":32}' \
  > single.json
jq -r '.choices[0].message.content' single.json | tee single.txt
grep -q 12 single.txt
```

Patched output:

```text
12
```

`grep` exited 0: **PASS**.

The following multi-answer check was run twice so both DP routes served it:

```bash
curl --connect-timeout 2 --max-time 180 -sS \
  "http://$HEAD_NODE:8000/v1/chat/completions" \
  -H 'Content-Type: application/json' \
  -d '{"model":"deepseek-ai/DeepSeek-V4-Pro","messages":[{"role":"user","content":"Answer each item concisely. 1. What is the capital of France? 2. What is the capital of Japan? 3. What is 4 times 5 plus 2?"}],"temperature":0,"max_tokens":192}' \
  > facts.json
jq -r '.choices[0].message.content' facts.json | tee facts.txt
grep -qi Paris facts.txt &&
grep -qi Tokyo facts.txt &&
grep -q 22 facts.txt
```

Both runs produced:

```text
1. Paris
2. Tokyo
3. 22
```

All three assertions exited 0: **PASS**.

The sky/seasons check also passed on both DP routes: its assertions found
`blue`, `scatter`, `season`, and `tilt`.

The full GSM8K sweep used:

```bash
OPENAI_API_KEY=EMPTY HF_HOME="$HF_HOME" "$EVAL_PY" -m lm_eval \
  --model local-chat-completions \
  --apply_chat_template \
  --include_path "$EVAL_TASK_DIR" \
  --tasks gsm8k \
  --output_path "$RUN_DIR/gsm8k" \
  --log_samples \
  --model_args "model=deepseek-ai/DeepSeek-V4-Pro,base_url=http://$HEAD_NODE:8000/v1/chat/completions,api_key=EMPTY,eos_string=</s>,max_retries=5,num_concurrent=16,timeout=1800,tokenized_requests=False,max_length=2200" \
  --gen_kwargs 'max_tokens=512,temperature=0,top_p=1'
```

| Requests | Flexible exact match | Strict exact match |
|---:|---:|---:|
| 1,319 / 1,319 | 0.9598 ± 0.0054 | 0.9598 ± 0.0054 |

Runtime coverage and stability:

- 9,864 `is_enable_two_chunk=True` rank records
- Maximum logged SWA token usage: 0.80
- Request errors: 0
- Retractions: 0
- Workload CUDA/OOM/server errors: 0
- Slurm job `5616859`: `COMPLETED 0:0`

Focused collective-size tests passed 3/3 in the matching container (Slurm job
`5618770`, `COMPLETED 0:0`).

## Speed Tests and Profiling

The 1,319-request GSM8K API phase completed in 9m01s at concurrency 16
(2.44 completed requests/s). The complete job, including checkpoint staging,
weight loading, JIT compilation, CUDA-graph capture, deterministic checks, and
GSM8K, completed in 26m03s.

The control configurations produce invalid output, so their generated-token
throughput is not a correctness-preserving performance baseline.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation applicability reviewed; no user-facing documentation change is needed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35291436605](https://github.com/sgl-project/sglang/actions/runs/35291436605)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35291436414](https://github.com/sgl-project/sglang/actions/runs/35291436414)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35291436555](https://github.com/sgl-project/sglang/actions/runs/35291436555)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->