### PR TITLE
docs: drop unreachable inkling LoRA benchmark entry

### DIFF
--- a/docs_new/src/snippets/configs/thinkingmachines/inkling-benchmarks.jsx
+++ b/docs_new/src/snippets/configs/thinkingmachines/inkling-benchmarks.jsx
@@ -53,5 +53,4 @@ export const benchmarks = [
   { match: { hw: "gb300"  , variant: "lora"    , quant: "nvfp4" , strategy: "balanced"     , nodes: "single"   } },
   { match: { hw: "h200"   , variant: "lora"    , quant: "nvfp4" , strategy: "balanced"     , nodes: "single"   } },
   { match: { hw: "gb300"  , variant: "lora"    , quant: "bf16"  , strategy: "balanced"     , nodes: "multi-2"  } },
-  { match: { hw: "h200"   , variant: "lora"    , quant: "bf16"  , strategy: "balanced"     , nodes: "single"   } },
 ];


### PR DESCRIPTION
`docs_new/src/snippets/configs/thinkingmachines/inkling-benchmarks.jsx` carries an entry for `h200 / lora / bf16 / balanced / single`, but `inkling.jsx` declares no such cell. The LoRA cells are:

```
b200  | nvfp4 | balanced | single
b300  | nvfp4 | balanced | single
gb200 | nvfp4 | balanced | single
gb300 | nvfp4 | balanced | single
h200  | nvfp4 | balanced | single
gb300 | bf16  | balanced | multi-2
```

`findBenchmark` in `_deployment.jsx` keys on the same match tuple as `findCell`, so no picker selection can resolve this entry. It carries no data either, so removing it changes nothing that renders — it just stops the file from claiming a cell that does not exist.

Found while adding a static check that every benchmarks `match` tuple names a real cell; that check is not part of this PR.

## Verification

- `node docs_new/scripts/check_cookbook_configs.mjs` reports the same single pre-existing failure (`popular-models.jsx: no export const config`) before and after — this change adds none.
- Confirmed against `inkling.jsx` on `main` that no cell matches the removed tuple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30736403219](https://github.com/sgl-project/sglang/actions/runs/30736403219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30736403162](https://github.com/sgl-project/sglang/actions/runs/30736403162)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->