### PR TITLE
fix: don't block the event loop in remote_instance_transfer_engine_info

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1264,14 +1264,16 @@ async def remote_instance_transfer_engine_info(rank: int = None):
 
     server_args = _global_state.tokenizer_manager.server_args
     try:
-        resp = requests.get(
-            f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
-            params={"rank": rank},
-            timeout=5,
-        )
-        if resp.status_code == 200:
-            return resp.json()
-    except (requests.exceptions.RequestException, ValueError) as e:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=5)
+        ) as session:
+            async with session.get(
+                f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
+                params={"rank": rank},
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as e:
         logger.warning(f"Failed to get transfer engine info for rank {rank}: {e}")
 
     return ORJSONResponse(

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -1325,14 +1325,16 @@ async def remote_instance_transfer_engine_info(rank: int = None):
 
     server_args = _global_state.tokenizer_manager.server_args
     try:
-        resp = requests.get(
-            f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
-            params={"rank": rank},
-            timeout=5,
-        )
-        if resp.status_code == 200:
-            return resp.json()
-    except (requests.exceptions.RequestException, ValueError) as e:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=5)
+        ) as session:
+            async with session.get(
+                f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
+                params={"rank": rank},
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as e:
         logger.warning(f"Failed to get transfer engine info for rank {rank}: {e}")
 
     return ORJSONResponse(


### PR DESCRIPTION
## Motivation

`remote_instance_transfer_engine_info` is an `async def` FastAPI endpoint that makes a **synchronous** HTTP call:

```python
@app.get("/remote_instance_transfer_engine_info")
@auth_level(AuthLevel.ADMIN_OPTIONAL)
async def remote_instance_transfer_engine_info(rank: int = None):
    ...
    resp = requests.get(
        f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
        params={"rank": rank},
        timeout=5,
    )
```

A blocking call inside a coroutine stalls the **entire event loop**, not just that request. While `requests.get` waits, every other in-flight request on this server is frozen — token streaming included. With `timeout=5`, a slow or unreachable bootstrap URL freezes the whole server for the full five seconds.

This is not a latency nit: the cost lands on requests that have nothing to do with this endpoint.

## Modifications

Switched to `aiohttp`, which is **already imported in this file** (line 43) and already used correctly a few hundred lines below — the dp-rank fan-out at line 2116 does exactly this:

```python
async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5)) as session:
    async with session.get(
        f"{server_args.engine_info_bootstrap_url}/get_transfer_engine_info",
        params={"rank": rank},
    ) as resp:
        if resp.status == 200:
            return await resp.json()
except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as e:
```

Same 5s budget, same failure handling — `aiohttp.ClientError` and `asyncio.TimeoutError` cover what `requests.exceptions.RequestException` covered, and `ValueError` still catches a bad JSON body. `asyncio` is imported at line 20.

This endpoint was the only async one left on `requests`. The other `requests` calls in this file live in `_execute_server_warmup`, a sync function where blocking is intended — those are untouched.

## Accuracy Tests

Not applicable — no kernel or model forward code touched.

## Speed Tests and Profiling

No benchmark included. The change removes event-loop blocking rather than making this endpoint itself faster; its own latency is unchanged. The effect is on concurrent requests, which is hard to attribute cleanly in a microbenchmark, so I would rather state the mechanism than present a number I cannot isolate.

## Checklist

- [x] Format your code according to the pre-commit config, at the pinned versions:
  ```console
  $ isort --check-only python/sglang/srt/entrypoints/http_server.py    # isort 7.0.0
  $ black --check python/sglang/srt/entrypoints/http_server.py         # black 26.1.0
  All done! ✨ 🍰 ✨
  1 file would be left unchanged.
  $ ruff check --select=F401,F821,UP037 python/sglang/srt/entrypoints/http_server.py   # ruff 0.15.1
  All checks passed!
  ```
- [ ] Add unit tests — this endpoint needs a live bootstrap URL to exercise; happy to add one if you have a fixture in mind.
- [x] Update documentation — not applicable.
- [ ] Accuracy and speed benchmarks — not applicable, see above.
- [x] Follow the SGLang code style guidance.

Found with an AST scan for blocking calls (`time.sleep`, `requests.*`, `subprocess.run`, `urlopen`) inside `async def` bodies, excluding anything handed to `run_in_executor` / `to_thread`. The only other hit in `srt/` is the `time.sleep(0.1)` drain loop in `tokenizer_manager.py:2888`, which is on the shutdown path immediately before `kill_process_tree` — blocking there is intended, so it is left alone.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33099489844](https://github.com/sgl-project/sglang/actions/runs/33099489844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33099489708](https://github.com/sgl-project/sglang/actions/runs/33099489708)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33099489906](https://github.com/sgl-project/sglang/actions/runs/33099489906)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->