### PR TITLE
[CI] Add speculative_draft_attention_backend to the page-constraint test view

### DIFF
--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1737,6 +1737,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 attention_backend=None,
                 decode_attention_backend=None,
                 prefill_attention_backend=None,
+                speculative_draft_attention_backend=None,
                 page_size=1,
             )
             defaults.update(kw)


### PR DESCRIPTION
## Problem

`base-a-test-cpu` fails on `main`: `test_model_overrides.py::TestGoldenModelOverrides::test_page_constraint_passes_at_callable_level` raises

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'speculative_draft_attention_backend'
```

Seen in scheduled run [30723127006](https://github.com/sgl-project/sglang/actions/runs/30723127006/job/91430085617); the partition was green in the four scheduled runs before it.

## Cause

#25545 added one line to `_mla_backend_page_constraints`:

```python
or view.speculative_draft_attention_backend == "trtllm_mha"
```

The `_view` helper in this test builds a `SimpleNamespace` with only four fields, and `ResolvedView.__getattr__` forwards to it — so the new read raises on a stub that the real `ServerArgs` would satisfy. #25545 touched four files, none of them this test.

## Fix

Add the field to the stub's defaults.

## Validation

Reproduced at the failing sha `131bd51b01` on an H100 devbox — the exact `AttributeError` — then with this line applied `test_model_overrides.py` runs **68 tests, OK**.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30738761871](https://github.com/sgl-project/sglang/actions/runs/30738761871)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30738761801](https://github.com/sgl-project/sglang/actions/runs/30738761801)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->