### PR TITLE
build: make flash-attn-4 optional

### DIFF
--- a/docs_new/docs/get-started/install.mdx
+++ b/docs_new/docs/get-started/install.mdx
@@ -25,6 +25,12 @@ pip install uv
 uv pip install --prerelease=allow sglang
 ```
 
+The standard install uses SGLang's vendored FA4 implementation and does not install the external `flash-attn-4` package. If you have configured SGLang to use the external pip FA4 implementation, install its dependency with:
+
+```bash Command
+uv pip install --prerelease=allow "sglang[fa4]"
+```
+
 The major version of Cuda is 13 by default. To install sglang under Cuda 12 with pip or uv, please try the following commands:
 ```bash Command
 pip install --upgrade pip

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "easydict",  # Required by remote model code (e.g. DeepSeek-OCR) loaded via trust_remote_code; validated by transformers 5.4+ check_imports
   "einops",
   "fastapi",
-  "flash-attn-4>=4.0.0b18",
   "flashinfer_python[cu13]==0.6.15.post1", # keep it aligned with jit-cache version in Dockerfile
   "gguf",
   "helion==0.2.6",
@@ -99,6 +98,7 @@ default = true
 [project.optional-dependencies]
 checkpoint-engine = ["checkpoint-engine==0.1.2"]
 runai = ["runai-model-streamer[s3,gcs,azure]>=0.15.7"]
+fa4 = ["flash-attn-4>=4.0.0b18"]
 diffusion = [
   "addict==2.4.0",
   "av==16.1.0",
@@ -176,6 +176,7 @@ dev = ["sglang[test]"]
 
 all = [
   "sglang[diffusion]",
+  "sglang[fa4]",
   "sglang[http2]",
   "sglang[tracing]",
 ]


### PR DESCRIPTION
## Summary

- remove the external `flash-attn-4` package from SGLang's core dependencies
- add `sglang[fa4]` and retain it in `sglang[all]`
- document that the standard install uses SGLang's vendored FA4 implementation

## Motivation

SGLang already packages the vendored FA4 implementation used by the default runtime path. Requiring the external `flash-attn-4` distribution in every base install adds an unnecessary architecture-specific dependency and blocks otherwise supported installations on GPUs that do not use that package.

The opt-in extra preserves the existing external-pip path without changing runtime backend selection.

## Validation

- parsed `python/pyproject.toml` and asserted the core/extra/all dependency contracts
- built the wheel with `python3 -m pip wheel --no-deps --no-build-isolation ./python`
- inspected wheel `METADATA`: no core `flash-attn-4` requirement; `extra == "fa4"` retains `flash-attn-4>=4.0.0b18`
- verified the built wheel still contains the vendored FA4 interface modules
- `git diff --check`

Related to sgl-project/sglang-omni#1120.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30739202628](https://github.com/sgl-project/sglang/actions/runs/30739202628)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30739202567](https://github.com/sgl-project/sglang/actions/runs/30739202567)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->