### PR TITLE
Fix DSV4 indexer torch fallback allocating a num_heads-oversized intermediate

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1125,6 +1125,9 @@ class Envs:
     # Deprecated: DSV4 compressor V2 is always used.
     SGLANG_OPT_USE_COMPRESSOR_V2 = EnvBool(True)
     SGLANG_FP8_PAGED_MQA_LOGITS_TORCH = EnvBool(False)
+    # Sequence-axis chunk width, in KV positions, for the torch paged MQA logits
+    # fallback. Rounded down to whole KV pages; 0 disables chunking.
+    SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK = EnvInt(8192)
     SGLANG_TOPK_TRANSFORM_512_TORCH = EnvBool(False)
     SGLANG_OPT_FLASHMLA_SPARSE_PREFILL = EnvBool(True)
 

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -170,6 +170,17 @@ def _aiter_fp8_paged_mqa_logits(
     return logits
 
 
+def _indexer_logits_chunk_pages(block_size: int, max_pages: int) -> int:
+    """Sequence-axis chunk width in KV pages for the torch paged MQA logits path."""
+    chunk_positions = envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.get()
+    chunk_pages = max_pages
+    if chunk_positions and chunk_positions > 0:
+        # Round down to whole pages so a chunk never straddles a page boundary,
+        # but never below a single page.
+        chunk_pages = min(max_pages, max(1, int(chunk_positions) // block_size))
+    return max(1, chunk_pages)
+
+
 def fp8_paged_mqa_logits_torch_sm120(
     q_fp8: torch.Tensor,
     kvcache_fp8: torch.Tensor,
@@ -219,36 +230,60 @@ def fp8_paged_mqa_logits_torch_sm120(
     assert clean_logits == False
 
     max_pages = (max_seq_len + block_size - 1) // block_size
-    max_padded_seq = max_pages * block_size
 
     kvcache_flat = kvcache_fp8.view(-1, block_size * (head_dim + 4))
     SCALE_OFFSET = block_size * head_dim
 
     page_ids = page_table[:, :max_pages]
-    kvcache_gathered = kvcache_flat[page_ids]
-
-    kv_value_raw = kvcache_gathered[..., :SCALE_OFFSET]
-    kv_scale_raw = kvcache_gathered[..., SCALE_OFFSET:]
-
-    kv_value = kv_value_raw.contiguous().view(dtype=FP8_DTYPE).to(torch.bfloat16)
-    kv_value = kv_value.view(batch_size, max_padded_seq, head_dim)
-
-    kv_scale = kv_scale_raw.contiguous().view(dtype=torch.float32)
-    kv_scale = kv_scale.view(batch_size, max_padded_seq)
 
     q = q_fp8[:, 0].to(torch.bfloat16)
+    q_t = q.transpose(1, 2)
+    weight_row = weight.unsqueeze(1)
 
-    score = torch.bmm(kv_value, q.transpose(1, 2))
+    # `bmm` produces a [batch, positions, num_heads] score block whose head axis
+    # is summed away two ops later, so a whole-sequence pass peaks at num_heads
+    # times the returned [batch, max_seq_len]. Walk the sequence in page-aligned
+    # chunks instead and write each chunk straight into the output: no reduction
+    # crosses a chunk boundary (relu is elementwise, the bmm reduces over
+    # head_dim, the head sum stays within one row), so the result is unchanged.
+    # bmm(bf16, bf16) -> bf16, scaled by `weight` and then by the float32 KV
+    # scales; mirror that promotion so the output dtype matches a single pass.
+    logits_dtype = torch.promote_types(
+        torch.promote_types(q.dtype, weight.dtype), torch.float32
+    )
+    logits = torch.full(
+        (batch_size, max_seq_len), float("-inf"), dtype=logits_dtype, device=device
+    )
 
-    score = F.relu(score)
-    score = score * weight.unsqueeze(1)
-    score = score.sum(dim=2)
+    chunk_pages = _indexer_logits_chunk_pages(block_size, max_pages)
+    for page_start in range(0, max_pages, chunk_pages):
+        page_stop = min(max_pages, page_start + chunk_pages)
+        seq_start = page_start * block_size
+        chunk_seq = (page_stop - page_start) * block_size
 
-    score = score * kv_scale
+        kvcache_gathered = kvcache_flat[page_ids[:, page_start:page_stop]]
 
-    out_width = min(max_padded_seq, max_seq_len)
-    logits = score.new_full((batch_size, max_seq_len), float("-inf"))
-    logits[:, :out_width] = score[:, :out_width]
+        kv_value_raw = kvcache_gathered[..., :SCALE_OFFSET]
+        kv_scale_raw = kvcache_gathered[..., SCALE_OFFSET:]
+
+        kv_value = kv_value_raw.contiguous().view(dtype=FP8_DTYPE).to(torch.bfloat16)
+        kv_value = kv_value.view(batch_size, chunk_seq, head_dim)
+
+        kv_scale = kv_scale_raw.contiguous().view(dtype=torch.float32)
+        kv_scale = kv_scale.view(batch_size, chunk_seq)
+
+        score = torch.bmm(kv_value, q_t)
+
+        score = F.relu(score)
+        score = score * weight_row
+        score = score.sum(dim=2)
+
+        score = score * kv_scale
+
+        # Only the last chunk can run past max_seq_len, since the padded span is
+        # a whole number of pages; every earlier chunk copies in full.
+        out_width = min(seq_start + chunk_seq, max_seq_len) - seq_start
+        logits[:, seq_start : seq_start + out_width] = score[:, :out_width]
 
     positions = torch.arange(max_seq_len, device=device)
     invalid_mask = positions.unsqueeze(0) >= seq_lens.unsqueeze(1)

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -64,6 +64,17 @@ IndexerQuery: TypeAlias = Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
 _arange_cache = {}
 
 
+def _indexer_logits_chunk_pages(block_size: int, max_pages: int) -> int:
+    """Sequence-axis chunk width in KV pages for the torch paged MQA logits path."""
+    chunk_positions = envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.get()
+    chunk_pages = max_pages
+    if chunk_positions and chunk_positions > 0:
+        # Round down to whole pages so a chunk never straddles a page boundary,
+        # but never below a single page.
+        chunk_pages = min(max_pages, max(1, int(chunk_positions) // block_size))
+    return max(1, chunk_pages)
+
+
 def fp8_paged_mqa_logits_torch(
     q_fp8: torch.Tensor,
     kvcache_fp8: torch.Tensor,
@@ -95,37 +106,72 @@ def fp8_paged_mqa_logits_torch(
     kvcache_flat = kvcache_fp8.view(-1, total_dim)
 
     pages_clamped = page_table.clamp(min=0)
-    kvcache_gathered = kvcache_flat[pages_clamped]
-
-    kv_values_raw = kvcache_gathered[..., :SCALE_OFFSET].contiguous()
-    kv_values_fp8 = kv_values_raw.view(dtype=FP8_DTYPE)
-    kv_values = kv_values_fp8.to(torch.bfloat16)
-    kv_values = kv_values.reshape(batch_size, max_num_pages * block_size, head_dim)
-
-    kv_scales_raw = kvcache_gathered[..., SCALE_OFFSET:].contiguous()
-    kv_scales = kv_scales_raw.view(dtype=torch.float32)
-    kv_scales = kv_scales.reshape(batch_size, max_num_pages * block_size)
 
     q_float = q_fp8[:, 0].to(torch.bfloat16)
-    scores = torch.bmm(kv_values, q_float.transpose(1, 2))
-    scores = F.relu(scores)
-    scores = scores * weight.unsqueeze(1)
-    scores = scores.sum(dim=2)
-    scores = scores * kv_scales
+    q_t = q_float.transpose(1, 2)
+    weight_row = weight.unsqueeze(1)
 
     padded_seq_len = max_num_pages * block_size
+    device = q_float.device
     cache = _arange_cache
-    arange_key = f"arange_{padded_seq_len}_{scores.device}"
+    arange_key = f"arange_{padded_seq_len}_{device}"
     if arange_key not in cache:
-        cache[arange_key] = torch.arange(padded_seq_len, device=scores.device)
+        cache[arange_key] = torch.arange(padded_seq_len, device=device)
     positions = cache[arange_key].unsqueeze(0)
-    valid_mask = positions < seq_lens.unsqueeze(1)
-    scores = scores.masked_fill(~valid_mask, 0.0)
+    seq_lens_col = seq_lens.unsqueeze(1)
 
-    if padded_seq_len < max_seq_len:
-        scores = F.pad(scores, (0, max_seq_len - padded_seq_len), value=0.0)
-    else:
-        scores = scores[:, :max_seq_len]
+    # Same shape as the SM120 variant below: `bmm` materializes
+    # [batch, positions, num_heads] and the head axis is summed away two ops
+    # later, so a whole-sequence pass peaks at num_heads times the returned
+    # [batch, max_seq_len] -- and the gather feeding it pulls the whole context
+    # KV in first. Walk the sequence in page-aligned chunks instead, gather only
+    # that chunk's pages and write its scores straight into the output. No
+    # reduction crosses a chunk boundary (relu is elementwise, the bmm reduces
+    # over head_dim, the head sum stays within one row), so the result is
+    # unchanged. Positions past the sequence length keep the 0.0 the unchunked
+    # `masked_fill` wrote, positions past the gathered span the 0.0 of its
+    # `F.pad`. bmm(bf16, bf16) -> bf16, scaled by `weight` and then by the
+    # float32 KV scales; mirror that promotion so the output dtype matches a
+    # single pass.
+    logits_dtype = torch.promote_types(
+        torch.promote_types(q_float.dtype, weight.dtype), torch.float32
+    )
+    scores = torch.zeros((batch_size, max_seq_len), dtype=logits_dtype, device=device)
+
+    chunk_pages = _indexer_logits_chunk_pages(block_size, max_num_pages)
+    for page_start in range(0, max_num_pages, chunk_pages):
+        seq_start = page_start * block_size
+        if seq_start >= max_seq_len:
+            # The page table can be wider than max_seq_len; the unchunked pass
+            # computed those positions and then truncated them away.
+            break
+        page_stop = min(max_num_pages, page_start + chunk_pages)
+        chunk_seq = (page_stop - page_start) * block_size
+
+        kvcache_gathered = kvcache_flat[pages_clamped[:, page_start:page_stop]]
+
+        kv_values_raw = kvcache_gathered[..., :SCALE_OFFSET].contiguous()
+        kv_values_fp8 = kv_values_raw.view(dtype=FP8_DTYPE)
+        kv_values = kv_values_fp8.to(torch.bfloat16)
+        kv_values = kv_values.reshape(batch_size, chunk_seq, head_dim)
+
+        kv_scales_raw = kvcache_gathered[..., SCALE_OFFSET:].contiguous()
+        kv_scales = kv_scales_raw.view(dtype=torch.float32)
+        kv_scales = kv_scales.reshape(batch_size, chunk_seq)
+
+        chunk_scores = torch.bmm(kv_values, q_t)
+        chunk_scores = F.relu(chunk_scores)
+        chunk_scores = chunk_scores * weight_row
+        chunk_scores = chunk_scores.sum(dim=2)
+        chunk_scores = chunk_scores * kv_scales
+
+        valid_mask = positions[:, seq_start : seq_start + chunk_seq] < seq_lens_col
+        chunk_scores = chunk_scores.masked_fill(~valid_mask, 0.0)
+
+        # Only the last chunk can run past max_seq_len, since the padded span is
+        # a whole number of pages; every earlier chunk copies in full.
+        out_width = min(seq_start + chunk_seq, max_seq_len) - seq_start
+        scores[:, seq_start : seq_start + out_width] = chunk_scores[:, :out_width]
 
     return scores
 
@@ -168,17 +214,6 @@ def _aiter_fp8_paged_mqa_logits(
         Preshuffle=aiter_can_use_preshuffle_paged_mqa(),
     )
     return logits
-
-
-def _indexer_logits_chunk_pages(block_size: int, max_pages: int) -> int:
-    """Sequence-axis chunk width in KV pages for the torch paged MQA logits path."""
-    chunk_positions = envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.get()
-    chunk_pages = max_pages
-    if chunk_positions and chunk_positions > 0:
-        # Round down to whole pages so a chunk never straddles a page boundary,
-        # but never below a single page.
-        chunk_pages = min(max_pages, max(1, int(chunk_positions) // block_size))
-    return max(1, chunk_pages)
 
 
 def fp8_paged_mqa_logits_torch_sm120(

--- a/test/registered/unit/layers/attention/test_dsv4_indexer_logits_seq_chunk.py
+++ b/test/registered/unit/layers/attention/test_dsv4_indexer_logits_seq_chunk.py
@@ -1,0 +1,144 @@
+import unittest
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsv4.indexer import (
+    FP8_DTYPE,
+    _indexer_logits_chunk_pages,
+    fp8_paged_mqa_logits_torch_sm120,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+HEAD_DIM = 128
+BLOCK_SIZE = 64
+# Byte layout of one KV page row: block_size * head_dim value bytes followed by
+# block_size float32 scales, all addressed as FP8 elements.
+SCALE_OFFSET = BLOCK_SIZE * HEAD_DIM
+PAGE_BYTES = BLOCK_SIZE * (HEAD_DIM + 4)
+
+
+def finite_fp8_bytes(shape, generator):
+    """Random float8_e4m3fn bit patterns, both signs, with the NaN codes removed."""
+    raw = torch.randint(0, 256, shape, generator=generator, dtype=torch.uint8)
+    # 0x7f and 0xff are the only NaN encodings in float8_e4m3fn.
+    return torch.where(raw % 0x80 == 0x7F, torch.tensor(0x38, dtype=torch.uint8), raw)
+
+
+def make_inputs(batch_size, num_heads, seq_lens, max_seq_len, seed=0):
+    """Build a valid CPU FP8 paged-MQA input set with finite values only."""
+    generator = torch.Generator().manual_seed(seed)
+    num_pages = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE * batch_size + 1
+
+    raw = torch.empty(num_pages, PAGE_BYTES, dtype=torch.uint8)
+    raw[:, :SCALE_OFFSET] = finite_fp8_bytes(
+        (num_pages, SCALE_OFFSET), generator=generator
+    )
+    scales = 0.5 + torch.rand(num_pages, BLOCK_SIZE, generator=generator)
+    raw[:, SCALE_OFFSET:] = scales.view(dtype=torch.uint8)
+    kvcache_fp8 = raw.view(dtype=FP8_DTYPE).view(num_pages, BLOCK_SIZE, 1, HEAD_DIM + 4)
+
+    q_fp8 = finite_fp8_bytes(
+        (batch_size, 1, num_heads, HEAD_DIM), generator=generator
+    ).view(dtype=FP8_DTYPE)
+
+    weight = torch.randn(batch_size, num_heads, generator=generator)
+    seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32)
+    max_pages = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    page_table = torch.randint(
+        0, num_pages, (batch_size, max_pages), generator=generator, dtype=torch.int32
+    )
+    return q_fp8, kvcache_fp8, weight, seq_lens_t, page_table
+
+
+def run(inputs, max_seq_len, chunk_positions):
+    q_fp8, kvcache_fp8, weight, seq_lens, page_table = inputs
+    with envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.override(chunk_positions):
+        return fp8_paged_mqa_logits_torch_sm120(
+            q_fp8,
+            kvcache_fp8,
+            weight,
+            seq_lens,
+            page_table,
+            None,
+            max_seq_len,
+            clean_logits=False,
+        )
+
+
+class TestIndexerLogitsChunkPages(unittest.TestCase):
+    def test_disabled_returns_full_span(self):
+        with envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.override(0):
+            self.assertEqual(_indexer_logits_chunk_pages(BLOCK_SIZE, 37), 37)
+
+    def test_rounds_down_to_whole_pages(self):
+        with envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.override(191):
+            self.assertEqual(_indexer_logits_chunk_pages(BLOCK_SIZE, 37), 2)
+        with envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.override(192):
+            self.assertEqual(_indexer_logits_chunk_pages(BLOCK_SIZE, 37), 3)
+
+    def test_sub_page_chunk_yields_one_page(self):
+        with envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.override(1):
+            self.assertEqual(_indexer_logits_chunk_pages(BLOCK_SIZE, 37), 1)
+
+    def test_never_exceeds_available_pages(self):
+        with envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.override(8192):
+            self.assertEqual(_indexer_logits_chunk_pages(BLOCK_SIZE, 3), 3)
+
+
+class TestIndexerLogitsSeqChunk(unittest.TestCase):
+    # (batch_size, num_heads, seq_lens, max_seq_len)
+    SHAPES = [
+        (2, 4, [200, 130], 200),
+        (1, 8, [64], 64),
+        (3, 2, [321, 5, 199], 321),
+        (2, 16, [500, 500], 512),
+    ]
+    CHUNK_POSITIONS = [1, 64, 100, 128, 192, 4096]
+
+    def test_chunked_matches_unchunked_bitwise(self):
+        for batch_size, num_heads, seq_lens, max_seq_len in self.SHAPES:
+            inputs = make_inputs(batch_size, num_heads, seq_lens, max_seq_len)
+            reference = run(inputs, max_seq_len, 0)
+            self.assertEqual(reference.shape, (batch_size, max_seq_len))
+            for chunk_positions in self.CHUNK_POSITIONS:
+                with self.subTest(
+                    shape=(batch_size, num_heads, max_seq_len), chunk=chunk_positions
+                ):
+                    got = run(inputs, max_seq_len, chunk_positions)
+                    self.assertEqual(got.dtype, reference.dtype)
+                    torch.testing.assert_close(got, reference, atol=0, rtol=0)
+
+    def test_length_mask_preserved(self):
+        batch_size, num_heads, seq_lens, max_seq_len = 3, 2, [321, 5, 199], 321
+        inputs = make_inputs(batch_size, num_heads, seq_lens, max_seq_len)
+        for chunk_positions in [0, 64, 100, 4096]:
+            with self.subTest(chunk=chunk_positions):
+                logits = run(inputs, max_seq_len, chunk_positions)
+                for row, seq_len in enumerate(seq_lens):
+                    self.assertTrue(
+                        torch.isinf(logits[row, seq_len:]).all()
+                        and (logits[row, seq_len:] < 0).all(),
+                        f"row {row} not -inf past seq_len {seq_len}",
+                    )
+                    self.assertTrue(
+                        torch.isfinite(logits[row, :seq_len]).all(),
+                        f"row {row} has non-finite values inside seq_len {seq_len}",
+                    )
+
+    def test_tail_chunk_is_not_truncated(self):
+        # max_seq_len is neither a multiple of the chunk width nor of the page
+        # size, so the final chunk is the only partially copied one.
+        batch_size, num_heads, max_seq_len = 2, 4, 421
+        seq_lens = [421, 421]
+        inputs = make_inputs(batch_size, num_heads, seq_lens, max_seq_len)
+        reference = run(inputs, max_seq_len, 0)
+        got = run(inputs, max_seq_len, 128)
+        self.assertTrue(torch.equal(got, reference))
+        self.assertTrue(torch.isfinite(reference).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_dsv4_indexer_logits_seq_chunk.py
+++ b/test/registered/unit/layers/attention/test_dsv4_indexer_logits_seq_chunk.py
@@ -6,6 +6,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsv4.indexer import (
     FP8_DTYPE,
     _indexer_logits_chunk_pages,
+    fp8_paged_mqa_logits_torch,
     fp8_paged_mqa_logits_torch_sm120,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -27,8 +28,14 @@ def finite_fp8_bytes(shape, generator):
     return torch.where(raw % 0x80 == 0x7F, torch.tensor(0x38, dtype=torch.uint8), raw)
 
 
-def make_inputs(batch_size, num_heads, seq_lens, max_seq_len, seed=0):
-    """Build a valid CPU FP8 paged-MQA input set with finite values only."""
+def make_inputs(batch_size, num_heads, seq_lens, max_seq_len, seed=0, extra_pages=0):
+    """Build a valid CPU FP8 paged-MQA input set with finite values only.
+
+    ``extra_pages`` widens the page table past ``max_seq_len``, which the
+    non-SM120 fallback allows: it sizes its span from ``page_table.shape[1]``
+    and truncates, where the SM120 variant derives the span from
+    ``max_seq_len``.
+    """
     generator = torch.Generator().manual_seed(seed)
     num_pages = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE * batch_size + 1
 
@@ -46,17 +53,17 @@ def make_inputs(batch_size, num_heads, seq_lens, max_seq_len, seed=0):
 
     weight = torch.randn(batch_size, num_heads, generator=generator)
     seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32)
-    max_pages = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    max_pages = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE + extra_pages
     page_table = torch.randint(
         0, num_pages, (batch_size, max_pages), generator=generator, dtype=torch.int32
     )
     return q_fp8, kvcache_fp8, weight, seq_lens_t, page_table
 
 
-def run(inputs, max_seq_len, chunk_positions):
+def run(inputs, max_seq_len, chunk_positions, fn=fp8_paged_mqa_logits_torch_sm120):
     q_fp8, kvcache_fp8, weight, seq_lens, page_table = inputs
     with envs.SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK.override(chunk_positions):
-        return fp8_paged_mqa_logits_torch_sm120(
+        return fn(
             q_fp8,
             kvcache_fp8,
             weight,
@@ -136,6 +143,77 @@ class TestIndexerLogitsSeqChunk(unittest.TestCase):
         inputs = make_inputs(batch_size, num_heads, seq_lens, max_seq_len)
         reference = run(inputs, max_seq_len, 0)
         got = run(inputs, max_seq_len, 128)
+        self.assertTrue(torch.equal(got, reference))
+        self.assertTrue(torch.isfinite(reference).all())
+
+
+class TestTorchFallbackLogitsSeqChunk(unittest.TestCase):
+    """Same corpus against `fp8_paged_mqa_logits_torch`, the non-SM120 twin.
+
+    It is the function `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1` selects on
+    anything below SM120 (indexer.py, the `is_sm120_supported()` branch of the
+    logits kernel dispatch), so it is the fallback in production use. It masks
+    invalid positions with 0.0 rather than -inf and sizes its span from the
+    page table instead of from `max_seq_len`; the chunk loop is otherwise the
+    same shape as the SM120 one.
+    """
+
+    SHAPES = TestIndexerLogitsSeqChunk.SHAPES
+    CHUNK_POSITIONS = TestIndexerLogitsSeqChunk.CHUNK_POSITIONS
+
+    def test_chunked_matches_unchunked_bitwise(self):
+        for batch_size, num_heads, seq_lens, max_seq_len in self.SHAPES:
+            inputs = make_inputs(batch_size, num_heads, seq_lens, max_seq_len)
+            reference = run(inputs, max_seq_len, 0, fp8_paged_mqa_logits_torch)
+            self.assertEqual(reference.shape, (batch_size, max_seq_len))
+            for chunk_positions in self.CHUNK_POSITIONS:
+                with self.subTest(
+                    shape=(batch_size, num_heads, max_seq_len), chunk=chunk_positions
+                ):
+                    got = run(
+                        inputs, max_seq_len, chunk_positions, fp8_paged_mqa_logits_torch
+                    )
+                    self.assertEqual(got.dtype, reference.dtype)
+                    torch.testing.assert_close(got, reference, atol=0, rtol=0)
+
+    def test_wide_page_table_is_truncated_bitwise(self):
+        # page_table.shape[1] sets this function's span, so a table wider than
+        # max_seq_len makes the last kept chunk a partial one and puts whole
+        # chunks past the output entirely.
+        batch_size, num_heads, seq_lens, max_seq_len = 2, 4, [421, 300], 421
+        inputs = make_inputs(
+            batch_size, num_heads, seq_lens, max_seq_len, extra_pages=5
+        )
+        reference = run(inputs, max_seq_len, 0, fp8_paged_mqa_logits_torch)
+        self.assertEqual(reference.shape, (batch_size, max_seq_len))
+        for chunk_positions in [64, 128, 192, 4096]:
+            with self.subTest(chunk=chunk_positions):
+                got = run(
+                    inputs, max_seq_len, chunk_positions, fp8_paged_mqa_logits_torch
+                )
+                self.assertTrue(torch.equal(got, reference))
+
+    def test_length_mask_is_zero_not_neg_inf(self):
+        batch_size, num_heads, seq_lens, max_seq_len = 3, 2, [321, 5, 199], 321
+        inputs = make_inputs(batch_size, num_heads, seq_lens, max_seq_len)
+        for chunk_positions in [0, 64, 100, 4096]:
+            with self.subTest(chunk=chunk_positions):
+                logits = run(
+                    inputs, max_seq_len, chunk_positions, fp8_paged_mqa_logits_torch
+                )
+                self.assertTrue(torch.isfinite(logits).all())
+                for row, seq_len in enumerate(seq_lens):
+                    self.assertTrue(
+                        (logits[row, seq_len:] == 0).all(),
+                        f"row {row} not zero past seq_len {seq_len}",
+                    )
+
+    def test_tail_chunk_is_not_truncated(self):
+        batch_size, num_heads, max_seq_len = 2, 4, 421
+        seq_lens = [421, 421]
+        inputs = make_inputs(batch_size, num_heads, seq_lens, max_seq_len)
+        reference = run(inputs, max_seq_len, 0, fp8_paged_mqa_logits_torch)
+        got = run(inputs, max_seq_len, 128, fp8_paged_mqa_logits_torch)
         self.assertTrue(torch.equal(got, reference))
         self.assertTrue(torch.isfinite(reference).all())
 


### PR DESCRIPTION
## Motivation
Fixes #33246

Both torch paged-MQA-logits fallbacks materialize the whole `[batch, padded_seq, num_heads]` `bmm` result and sum the head axis away a few lines later, so the peak intermediate is `num_heads` times the `[batch, max_seq_len]` the function returns. The existing `_QUERY_CHUNK = 1024` chunks the *batch* axis and `torch.cat`s the pieces, so it does not bound this.

- `fp8_paged_mqa_logits_torch_sm120`, the SM120 variant.
- `fp8_paged_mqa_logits_torch` (`indexer.py:67`, `bmm` at `:110`), which the logits dispatch selects for every card below SM120 when `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1` (`indexer.py:712`). Here `kvcache_flat[pages_clamped]` (`:98`) also gathers the whole context KV before the `bmm`, so the peak is the gather plus the score block.

## Modifications
This walks the sequence axis in page-aligned chunks and writes each chunk's `[batch, chunk]` result straight into the output; gathering per chunk keeps only that chunk's pages resident. No reduction crosses a chunk boundary — relu is elementwise, the `bmm` reduces over `head_dim`, the head sum stays inside one row — so the result is unchanged. The width comes from `SGLANG_DSV4_INDEXER_LOGITS_SEQ_CHUNK` (KV positions, rounded down to whole 64-position pages, default 8192); `0` restores the single-pass shape. Both functions run the same loop off the same env.

Two details differ in the non-SM120 twin and are handled explicitly: it masks invalid positions with `0.0` rather than `-inf`, and it sizes its span from `page_table.shape[1]`, which can exceed `max_seq_len` — chunks starting past the output are skipped, where the unchunked pass computed and then truncated them.

### Credit, and what this does not cover
The gap in `fp8_paged_mqa_logits_torch` was identified by @Leoyzen on #33246, along with the vLLM precedent (`VLLM_SPARSE_INDEXER_MAX_LOGITS_MB` + `split_indexer_prefill_chunks`, vllm-project/vllm#36178, merged 2026-04-01, chunking the query axis under a logits-bytes budget) and sglang's own DSA budget pattern (`dsa/dsa_indexer.py:1067` `_get_mqa_logits_budget_bytes`, `:1103` `_should_chunk_mqa_logits`, `:1120` `_get_topk_ragged`). @Hakureirm reproduced the same failure on an independent configuration — auto_round W4A16, TP8, 8xA800, against MXFP4/Marlin/TP4 — which is what makes this a property of the indexer shape rather than of a quantization format or parallel layout.

Deliberately not in this PR:

- **The deep_gemm default path** (`fp8_paged_mqa_logits`). The allocation happens inside the C++ extension, so bounding it from Python requires either a per-chunk `get_paged_mqa_logits_metadata` rebuild or a routing change. That is an open approach question in #33246, not something to settle here.
- **The env coupling at `indexer.py:502-508`**, where `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH` also disables the non-paged indexer, so one switch costs both the full-width torch BMM and the varlen route. Deleting that clause is a three-line diff but not a three-line change: the non-paged path calls `deep_gemm.fp8_mqa_logits` (`:623`), which @Hakureirm measured rejecting `arch_major == 8` on A800, so decoupling without an arch guard would route exactly the cards that need the fallback into an assertion. It belongs with whichever PR lands that guard.
- **The quadratic term.** Chunking bounds the allocation, which is what #33246 is about; each query row still scores against its full causal prefix, so the score-slot count is unchanged no matter how the axis is sliced. @Hakureirm's 256K→512K measurement (2.0x tokens, 3.13x wall clock) is the curve to expect after this lands.

## Accuracy Tests
How I verified it (CPU only — I have no GPU on this box):

- Bit-identity against the pre-change functions, loaded from the parent commit as separate modules. `fp8_paged_mqa_logits_torch_sm120`: 5 shapes x 8 chunk widths (0, 1, 64, 100, 128, 192, 4096, 8192), all `torch.equal`. `fp8_paged_mqa_logits_torch`: the same 5 shapes x 8 widths x 2 page-table widths (exactly `max_seq_len`, and 5 pages wider), 80/80 `torch.equal` with matching dtype. Shapes include `max_seq_len` values that are multiples of neither 64 nor any chunk width.
- `test/registered/unit/layers/attention/test_dsv4_indexer_logits_seq_chunk.py`, 11 tests / 60 subtests, green; the identity corpus runs against both functions. Deliberate mutations make it red: an off-by-one on the last chunk's width (19 failures in the fallback class, 20 in the SM120 one), rounding the chunk width up instead of down (1), and masking each chunk against positions `[0, chunk)` instead of its own window (20).
- `test/registered/unit/layers/attention/`: 46 passed, no new failures.
- ruff (F401,F821,UP037), black, isort, codespell clean.

CUDA-graph capture safety is source reasoning, not measured. The loop trip count is `ceil(max_pages / chunk_pages)`; `max_pages` derives from `max_seq_len` (SM120) or from `page_table.shape[1]` (fallback), both host ints from tensor shapes, and `block_size` comes from `kvcache_fp8.shape[1]`. No `.item()` and no tensor-valued branch, so the loop unrolls into a fixed op sequence at capture time. I could not run a capture test.

The `batch_size > 1024` recursion is untouched and untested here (CPU-prohibitive).

## Speed Tests and Profiling
Peak intermediate, measured by recording the largest `torch.bmm` output `numel`: batch=2, heads=16, max_seq_len=32768 gives 1,048,576 elements unchunked, 262,144 at the 8192 default, 32,768 at chunk=1024. The returned tensor is 65,536 elements, i.e. the unchunked peak is exactly `num_heads` times it. Element counts, not allocator bytes.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
