### PR TITLE
Fix DSV4 torch paged-MQA-logits dispatch selecting a variant that asserts

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -43,7 +43,6 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
 from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.utils import add_prefix, is_cuda, is_hip, is_xpu
-from sglang.srt.utils.common import is_sm120_supported
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -74,7 +73,19 @@ def fp8_paged_mqa_logits_torch(
     max_seq_len: int,
     clean_logits: bool = True,
 ) -> torch.Tensor:
-    """Vectorized implementation compatible with CUDA graph capture."""
+    """Vectorized implementation compatible with CUDA graph capture.
+
+    Reference implementation only. It requires a 1-D ``seq_lens`` while the
+    paged call site passes a trailing dim of 1, so it is not reachable from
+    the serving path; ``fp8_paged_mqa_logits_torch_sm120`` is what the
+    dispatch hands out.
+
+    Positions at or beyond ``seq_lens[i]`` are filled with ``-inf``, same as
+    ``fp8_paged_mqa_logits_torch_sm120``. That is not a contract consumers may
+    rely on: the other producers of these logits allocate the output with
+    ``torch.empty`` and leave the tail beyond ``seq_lens`` undefined. Every
+    consumer has to bound itself by ``seq_lens``.
+    """
     _ = deep_gemm_metadata
     batch_size, _, num_heads, head_dim = q_fp8.shape
     block_size = kvcache_fp8.shape[1]
@@ -120,10 +131,10 @@ def fp8_paged_mqa_logits_torch(
         cache[arange_key] = torch.arange(padded_seq_len, device=scores.device)
     positions = cache[arange_key].unsqueeze(0)
     valid_mask = positions < seq_lens.unsqueeze(1)
-    scores = scores.masked_fill(~valid_mask, 0.0)
+    scores = scores.masked_fill(~valid_mask, float("-inf"))
 
     if padded_seq_len < max_seq_len:
-        scores = F.pad(scores, (0, max_seq_len - padded_seq_len), value=0.0)
+        scores = F.pad(scores, (0, max_seq_len - padded_seq_len), value=float("-inf"))
     else:
         scores = scores[:, :max_seq_len]
 
@@ -180,7 +191,21 @@ def fp8_paged_mqa_logits_torch_sm120(
     max_seq_len: int,
     clean_logits: bool = True,
 ) -> torch.Tensor:
-    """CUDA-graph-compatible FP8 paged MQA logits for SM120 (vectorized, no .item())."""
+    """CUDA-graph-compatible FP8 paged MQA logits (vectorized, no ``.item()``).
+
+    Nothing in the body is SM120-specific -- it dequantizes with ``Tensor.to``
+    and accumulates with ``bmm`` -- and it is the variant the torch backend
+    dispatches to on every architecture. Two things distinguish it from
+    ``fp8_paged_mqa_logits_torch``, and both are about the call site rather
+    than the hardware: it squeezes the trailing dim off ``seq_lens``, which
+    arrives 2-D from the paged indexer, and it walks
+    ``ceil(max_seq_len / block_size)`` pages instead of the full capture-time
+    page-table width.
+
+    Positions at or beyond ``seq_lens[i]`` are filled with ``-inf``. That is
+    not a contract consumers may rely on; see the note in
+    ``fp8_paged_mqa_logits_torch``.
+    """
     _ = deep_gemm_metadata
     batch_size, _, num_heads, head_dim = q_fp8.shape
     block_size = kvcache_fp8.shape[1]
@@ -710,10 +735,11 @@ class C4IndexerBackendMixin:
         elif envs.SGLANG_OPT_USE_AITER_INDEXER.get():
             fn = _aiter_fp8_paged_mqa_logits
         elif envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():
-            if is_sm120_supported():
-                fn = fp8_paged_mqa_logits_torch_sm120
-            else:
-                fn = fp8_paged_mqa_logits_torch
+            # Not an architecture choice: `fp8_paged_mqa_logits_torch` asserts
+            # on a 1-D `seq_lens`, and `_c4sl` below carries a trailing dim of
+            # 1 on this path. `fp8_paged_mqa_logits_torch_sm120` handles both
+            # and contains nothing SM120-specific.
+            fn = fp8_paged_mqa_logits_torch_sm120
         elif is_xpu():
             from sgl_kernel import fp8_paged_mqa_logits_triton
 

--- a/test/registered/unit/layers/attention/test_dsv4_indexer_torch_logits.py
+++ b/test/registered/unit/layers/attention/test_dsv4_indexer_torch_logits.py
@@ -1,0 +1,90 @@
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.dsv4.indexer import (
+    FP8_DTYPE,
+    fp8_paged_mqa_logits_torch,
+    fp8_paged_mqa_logits_torch_sm120,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+HEAD_DIM = 128
+BLOCK_SIZE = 64
+
+
+def _build_inputs(seq_lens, num_heads=4, seed=0):
+    """Inputs in the layout the paged indexer call site produces."""
+    batch_size = len(seq_lens)
+    max_seq_len = max(seq_lens)
+    max_pages = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    num_pages = batch_size * max_pages + 1
+
+    torch.manual_seed(seed)
+    q_fp8 = torch.randn(batch_size, 1, num_heads, HEAD_DIM).to(FP8_DTYPE)
+    kvcache_fp8 = torch.randn(num_pages, BLOCK_SIZE, 1, HEAD_DIM + 4).to(FP8_DTYPE)
+    weight = torch.randn(batch_size, num_heads)
+    page_table = torch.zeros(batch_size, max_pages, dtype=torch.int64)
+    for i in range(batch_size):
+        page_table[i] = torch.arange(1 + i * max_pages, 1 + (i + 1) * max_pages)
+    seq_lens_t = torch.tensor(seq_lens, dtype=torch.int32)
+    return q_fp8, kvcache_fp8, weight, seq_lens_t, page_table, max_seq_len
+
+
+class TestDsv4IndexerTorchLogits(unittest.TestCase):
+    def test_reference_and_dispatched_variants_agree(self):
+        """Both torch variants produce the same logits, tail included."""
+        for seq_lens in ([70, 100], [64, 128], [1, 191], [200]):
+            with self.subTest(seq_lens=seq_lens):
+                q, kv, w, sl, pt, msl = _build_inputs(seq_lens)
+                ref = fp8_paged_mqa_logits_torch(q, kv, w, sl, pt, None, msl, False)
+                out = fp8_paged_mqa_logits_torch_sm120(
+                    q, kv, w, sl, pt, None, msl, False
+                )
+                self.assertEqual(ref.shape, out.shape)
+                for i, length in enumerate(seq_lens):
+                    self.assertTrue(
+                        torch.equal(ref[i, :length], out[i, :length]),
+                        f"valid region differs for row {i}",
+                    )
+
+    def test_both_variants_fill_the_tail_with_neg_inf(self):
+        """Positions at or beyond seq_lens are -inf in both variants."""
+        seq_lens = [70, 100]
+        q, kv, w, sl, pt, msl = _build_inputs(seq_lens)
+        for fn in (fp8_paged_mqa_logits_torch, fp8_paged_mqa_logits_torch_sm120):
+            with self.subTest(fn=fn.__name__):
+                out = fn(q, kv, w, sl, pt, None, msl, False)
+                positions = torch.arange(msl)
+                invalid = positions.unsqueeze(0) >= sl.unsqueeze(1)
+                self.assertTrue(
+                    torch.all(torch.isinf(out[invalid]) & (out[invalid] < 0)),
+                    f"{fn.__name__} left non -inf values past seq_lens",
+                )
+
+    def test_padded_tail_beyond_page_boundary_is_neg_inf(self):
+        """max_seq_len shorter than the padded page span still masks the gap."""
+        # 191 pads to 3 pages = 192 positions; row 0 ends at 10.
+        seq_lens = [10, 191]
+        q, kv, w, sl, pt, msl = _build_inputs(seq_lens)
+        ref = fp8_paged_mqa_logits_torch(q, kv, w, sl, pt, None, msl, False)
+        self.assertTrue(torch.all(torch.isneginf(ref[0, 10:])))
+        self.assertTrue(torch.all(torch.isneginf(ref[1, 191:])))
+
+    def test_only_the_dispatched_variant_accepts_the_paged_seq_lens_shape(self):
+        """The paged call site passes seq_lens with a trailing dim of 1."""
+        seq_lens = [70, 100]
+        q, kv, w, sl, pt, msl = _build_inputs(seq_lens)
+        sl_2d = sl.unsqueeze(-1)
+
+        out = fp8_paged_mqa_logits_torch_sm120(q, kv, w, sl_2d, pt, None, msl, False)
+        self.assertEqual(out.shape, (len(seq_lens), msl))
+
+        with self.assertRaises(AssertionError):
+            fp8_paged_mqa_logits_torch(q, kv, w, sl_2d, pt, None, msl, False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Refs #33247

With `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1` the dispatch picks `fp8_paged_mqa_logits_torch` on every non-SM120 device (`indexer.py:713-716`). That function asserts `seq_lens.shape == (batch_size,)` (`:87`), but the paged call site gives `seq_lens` a trailing dim of 1 for exactly this backend — `if _c4sl.dim() == 1 and not _use_tilelang and not _use_aiter: _c4sl = _c4sl.unsqueeze(-1)` (`:746-747`) — and passes `_c4sl` to `fn` at `:774`. So the call raises `AssertionError` instead of running.

## Modifications
Only `fp8_paged_mqa_logits_torch_sm120` squeezes that dim (`:215-216`), and nothing in its body is SM120-specific: it dequantizes with `Tensor.to` and accumulates with `bmm`. This dispatches to it unconditionally. An architecture predicate should not be selecting which calling convention is accepted.

Two smaller things in the same change, following the discussion on #33247:

- the reference implementation's length mask moves from `0.0` to `-inf`, so the two agree outside `[0, seq_lens)` as well;
- both docstrings now state that the tail past `seq_lens` is not something consumers may rely on. `tilelang_fp8_paged_mqa_logits` allocates its output with `page_table.new_empty` (`kernels/ops/attention/dsa/tilelang_kernel.py:1504`) and `_aiter_fp8_paged_mqa_logits` with `torch.empty` (`indexer.py:153`), so `-inf` is an implementation detail of the torch variants, not a contract. Consumers must bound themselves by `seq_lens`.

Line numbers refer to main at 8d106c3.

## Accuracy Tests
How I verified it (CPU only — I have no GPU on this box):

- Calling `fp8_paged_mqa_logits_torch` with the 2-D `seq_lens` the call site constructs raises at `indexer.py:87`; `fp8_paged_mqa_logits_torch_sm120` with the same inputs returns `(2, 100)`.
- The two variants are bit-identical inside `[0, seq_lens)`. Before this change the reference left `0.0` past `seq_lens` while the dispatched variant left `-inf`.
- New test `test/registered/unit/layers/attention/test_dsv4_indexer_torch_logits.py`, 4 tests / 6 subtests; 2 of them are red without the source change.
- ruff (F401,F821,UP037), black, isort, codespell clean.

The existing parity test `test/registered/kernels/ops/attention/test_sm120_paged_mqa_logits.py` is unaffected: it compares only `[:seq_len]` and separately asserts the SM120 tail is `-inf` (`:141-154`). I could not run it — it skips without CUDA (`:161`).

## Speed Tests and Profiling
Not applicable.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30739237438](https://github.com/sgl-project/sglang/actions/runs/30739237438)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30739237320](https://github.com/sgl-project/sglang/actions/runs/30739237320)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->