### PR TITLE
Fix Gemma4 installing a redundant causal image-attention mask

### DIFF
--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -339,6 +339,13 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         )
 
         split_images = []
+        # Whether any request actually widened the mask beyond the causal fill
+        # below. If none did, the assembled mask is bit-for-bit the causal
+        # predicate the extend kernel already applies on its own (see the
+        # IS_CAUSAL branch in kernels/ops/attention/extend_attention.py), so
+        # installing it would only add a mask load per tile without changing the
+        # result.
+        wrote_bidirectional = False
 
         for i in range(forward_batch.batch_size):
             extend_seq_len = forward_batch.extend_seq_lens[i]
@@ -374,12 +381,22 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                                     im_begin - prefix_len : im_end + 1 - prefix_len,
                                     im_begin : im_end + 1,
                                 ] = 1
+                                # A single-token span rewrites only the diagonal
+                                # element the causal fill already set.
+                                if im_end > im_begin:
+                                    wrote_bidirectional = True
                             elif (
                                 im_end >= prefix_len
                                 and im_begin < prefix_len + extend_seq_len
                             ):
                                 split_images.append((i, im_begin, im_end))
 
+            # Appended unconditionally: the batch shares one flat mask buffer
+            # addressed by mask_indptr, and USE_CUSTOM_MASK is a whole-launch
+            # tl.constexpr, so a request cannot opt out individually. A
+            # zero-length slot would leave the kernel reading the next request's
+            # bytes with this request's row stride. Skipping is therefore decided
+            # once for the whole batch, after the loop.
             bidirectional_attn_masks_list.append(bidirectional_attn_mask.flatten())
             bidirectional_attn_mask_indptr[i + 1] = (
                 bidirectional_attn_mask_indptr[i] + bidirectional_attn_mask.nelement()
@@ -397,7 +414,7 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             logger.warning_once(
                 "Those images will receive causal attention. Disable chunked prefill (--chunked-prefill-size=-1) for full bidirectional attention.",
             )
-        if bidirectional_attn_masks_list:
+        if bidirectional_attn_masks_list and wrote_bidirectional:
             bidirectional_attn_masks = torch.cat(bidirectional_attn_masks_list, dim=0)
             get_attn_backend().forward_metadata.mask_indptr = (
                 bidirectional_attn_mask_indptr

--- a/test/registered/unit/models/test_gemma4_bidirectional_mask.py
+++ b/test/registered/unit/models/test_gemma4_bidirectional_mask.py
@@ -1,0 +1,188 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.models.gemma4_mm import Gemma4ForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def make_request(extend: int, prefix: int, image_spans=None):
+    """One request spec. `image_spans` are inclusive (begin, end) token offsets."""
+    if image_spans is None:
+        return SimpleNamespace(extend=extend, prefix=prefix, mm_inputs=None)
+    mm_items = [
+        SimpleNamespace(is_image=lambda: True, offsets=list(image_spans)),
+    ]
+    return SimpleNamespace(
+        extend=extend, prefix=prefix, mm_inputs=SimpleNamespace(mm_items=mm_items)
+    )
+
+
+def make_forward_batch(requests):
+    return SimpleNamespace(
+        forward_mode=ForwardMode.EXTEND,
+        batch_size=len(requests),
+        extend_seq_lens=torch.tensor([r.extend for r in requests]),
+        extend_prefix_lens=torch.tensor([r.prefix for r in requests]),
+        mm_inputs=[r.mm_inputs for r in requests],
+    )
+
+
+def run_prepare(requests):
+    """Drive prepare_attn_masks against a stub batch; return the attention backend.
+
+    `prepare_attn_masks` does not touch `self`, so it is invoked unbound.
+    """
+    backend = object.__new__(TritonAttnBackend)
+    backend.forward_metadata = SimpleNamespace(custom_mask=None, mask_indptr=None)
+    forward_batch = make_forward_batch(requests)
+    input_ids = torch.zeros(sum(r.extend for r in requests), dtype=torch.long)
+    with patch("sglang.srt.models.gemma4_mm.get_attn_backend", return_value=backend):
+        Gemma4ForConditionalGeneration.prepare_attn_masks(
+            None, forward_batch, input_ids, torch.bool
+        )
+    return backend
+
+
+def slot_of(backend, requests, index):
+    """The submatrix the flat custom mask reserves for `requests[index]`."""
+    indptr = backend.forward_metadata.mask_indptr
+    flat = backend.forward_metadata.custom_mask
+    req = requests[index]
+    return flat[indptr[index] : indptr[index + 1]].reshape(
+        req.extend, req.extend + req.prefix
+    )
+
+
+def causal_slot(extend: int, prefix: int):
+    return torch.ones(extend, extend + prefix, dtype=torch.bool).tril(diagonal=prefix)
+
+
+# A genuinely contained multi-token image span; used to force mask installation
+# so that the degenerate requests sharing the batch can be inspected.
+CONTAINED = make_request(extend=8, prefix=4, image_spans=[(6, 9)])
+
+
+class TestGemma4MaskSkippedWhenCausal(unittest.TestCase):
+    """Batches in which no image span widens the mask must not install one."""
+
+    def assert_no_mask(self, requests):
+        backend = run_prepare(requests)
+        self.assertIsNone(backend.forward_metadata.custom_mask)
+        self.assertIsNone(backend.forward_metadata.mask_indptr)
+
+    def test_text_only_batch(self):
+        self.assert_no_mask([make_request(extend=6, prefix=0)])
+
+    def test_image_span_wholly_in_cached_prefix(self):
+        # Multi-turn follow-up: the image tokens were prefilled in an earlier
+        # turn, so the span sits entirely below prefix_len and neither branch
+        # of the offset dispatch fires.
+        self.assert_no_mask([make_request(extend=6, prefix=12, image_spans=[(2, 5)])])
+
+    def test_chunked_prefill_split_span(self):
+        # Span crosses the chunk boundary, so it only lands in `split_images`.
+        self.assert_no_mask([make_request(extend=8, prefix=8, image_spans=[(6, 10)])])
+
+    def test_chunked_prefill_span_running_past_chunk_end(self):
+        self.assert_no_mask([make_request(extend=8, prefix=8, image_spans=[(12, 20)])])
+
+    def test_single_token_image_span(self):
+        # im_begin == im_end rewrites only the diagonal element the causal fill
+        # already set.
+        self.assert_no_mask([make_request(extend=8, prefix=4, image_spans=[(6, 6)])])
+
+    def test_several_degenerate_requests_together(self):
+        self.assert_no_mask(
+            [
+                make_request(extend=6, prefix=12, image_spans=[(2, 5)]),
+                make_request(extend=8, prefix=8, image_spans=[(6, 10)]),
+                make_request(extend=8, prefix=4, image_spans=[(6, 6)]),
+                make_request(extend=5, prefix=3),
+            ]
+        )
+
+
+class TestGemma4MaskInstalledWhenBidirectional(unittest.TestCase):
+    def test_contained_span_installs_non_causal_mask(self):
+        requests = [make_request(extend=8, prefix=4, image_spans=[(6, 9)])]
+        backend = run_prepare(requests)
+        self.assertIsNotNone(backend.forward_metadata.custom_mask)
+        mask = slot_of(backend, requests, 0)
+        # Rows 2..5 are the span's query rows, columns 6..9 its key columns.
+        self.assertTrue(mask[2:6, 6:10].all())
+        # The upper-triangular part of that block is what the causal fill left
+        # at zero, so the installed mask genuinely differs from tril.
+        self.assertFalse(torch.equal(mask, causal_slot(8, 4)))
+        self.assertTrue(mask[2, 9])
+
+    def test_two_spans_one_contained_one_split(self):
+        requests = [make_request(extend=8, prefix=4, image_spans=[(6, 9), (0, 5)])]
+        backend = run_prepare(requests)
+        self.assertIsNotNone(backend.forward_metadata.custom_mask)
+
+    def test_mixed_batch_reserves_full_slot_for_text_only_request(self):
+        text_only = make_request(extend=5, prefix=3)
+        requests = [text_only, CONTAINED]
+        backend = run_prepare(requests)
+        self.assertIsNotNone(backend.forward_metadata.custom_mask)
+
+        expected = [0]
+        for req in requests:
+            expected.append(expected[-1] + req.extend * (req.extend + req.prefix))
+        self.assertEqual(
+            backend.forward_metadata.mask_indptr.tolist(),
+            expected,
+        )
+        self.assertEqual(
+            backend.forward_metadata.custom_mask.numel(),
+            expected[-1],
+        )
+        # The text-only request keeps a full, correctly strided slot.
+        self.assertTrue(torch.equal(slot_of(backend, requests, 0), causal_slot(5, 3)))
+
+
+class TestGemma4DegenerateSlotsAreExactlyCausal(unittest.TestCase):
+    """Pin the degeneracy claim on the bytes the loop actually produces.
+
+    The per-request loop body does not depend on whether some other request in
+    the batch widened its mask, so pairing each degenerate request with a
+    genuinely contained span exposes the exact buffer that would otherwise have
+    been installed on its own.
+    """
+
+    def assert_slot_is_causal(self, degenerate):
+        requests = [degenerate, CONTAINED]
+        backend = run_prepare(requests)
+        self.assertIsNotNone(backend.forward_metadata.custom_mask)
+        self.assertTrue(
+            torch.equal(
+                slot_of(backend, requests, 0),
+                causal_slot(degenerate.extend, degenerate.prefix),
+            )
+        )
+
+    def test_span_in_cached_prefix_slot_is_causal(self):
+        self.assert_slot_is_causal(
+            make_request(extend=6, prefix=12, image_spans=[(2, 5)])
+        )
+
+    def test_split_span_slot_is_causal(self):
+        self.assert_slot_is_causal(
+            make_request(extend=8, prefix=8, image_spans=[(6, 10)])
+        )
+
+    def test_single_token_span_slot_is_causal(self):
+        self.assert_slot_is_causal(
+            make_request(extend=8, prefix=4, image_spans=[(6, 6)])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Refs #33033

`Gemma4ForConditionalGeneration.prepare_attn_masks` fills every request's mask with `tril(diagonal=prefix_len)` (`gemma4_mm.py:352-354`) and only then writes bidirectional blocks for image spans fully contained in the extend window (`:369-381`). Three common batches never get such a write:

- a follow-up turn whose image span sits wholly in the cached prefix — with `im_end < prefix_len` neither the `if` nor the `elif` at `:369-381` fires;
- a chunked-prefill chunk that splits a span — the `elif` body only appends to `split_images`;
- a single-token span — it writes the element `(r, prefix_len + r)`, which `tril(diagonal=prefix_len)` already set.

For those the installed mask is bit-for-bit the causal predicate the Triton extend kernel applies on its own: `extend_attention.py:540-545` computes `mask_causual = (cur_block_m*BLOCK_M + offs_m[:, None]) >= (start_n + offs_n[None, :])` — and it is an `elif` on `if USE_CUSTOM_MASK` (`:525`), i.e. the custom mask *replaces* that predicate rather than adding to it. Gemma4 runs with `IS_CAUSAL=True` (`triton_backend.py:1296`, and `gemma4_causal.py:392` builds `RadixAttention` with the default `AttentionType.DECODER`). Installing the mask there is a bool buffer, a `torch.cat`, and one extra `tl.load` per stage-2 tile, for no change in output.

## Modifications
This tracks whether any bidirectional bit was actually written and skips the install when none was.

The skip has to be at **batch** granularity, and the change documents why at the append site. The mask is one flat buffer addressed by `mask_indptr` (`extend_attention.py:321`), and the row offset is computed from that base plus *this* request's own `cur_seq_len` (`:314`, `:379-386`, `:526-534`). A per-request skip would leave a zero-length slot, so request *i*'s base would equal request *i+1*'s and the kernel would read the next request's bytes at this request's stride. `USE_CUSTOM_MASK` is a whole-launch `tl.constexpr` derived from `custom_mask is not None` (`:290`, `:721`, `:795`), so there is no per-request switch either way.

`gemma3_mm.py:217` has the same structure and the same unconditional install; left untouched here, and the existing `TODO(kpham-sgl)` at `gemma4_mm.py:326` already points at it.

Line numbers refer to main at 8d106c3.

## Accuracy Tests
How I verified it (CPU only — I have no GPU on this box):

- New test `test/registered/unit/models/test_gemma4_bidirectional_mask.py`, 12 cases. 6 are red against the unpatched file and green with it; the other 6 are invariant guards that must pass both ways (the non-degenerate path still installs a non-causal mask; a mixed text+image batch still reserves the text-only request's full slot, with `mask_indptr` the exact prefix sum).
- The degeneracy claim is pinned on bytes rather than prose: each degenerate request is paired in a batch with a genuinely contained span so the mask *is* installed, and its own slot is then asserted `torch.equal` to `tril(diagonal=prefix_len)`.
- ruff (F401,F821,UP037), black, isort, codespell clean.

## Speed Tests and Profiling
I make no performance claim here — nothing was measured, and this PR is the correctness/no-op half only. It does not address the quadratic allocation the issue asks about: the buffer is still built and then discarded when the install is skipped.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30739237999](https://github.com/sgl-project/sglang/actions/runs/30739237999)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30739237906](https://github.com/sgl-project/sglang/actions/runs/30739237906)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->