### PR TITLE
Fix batch-invariant ops test mutating process-global torch state at import

### DIFF
--- a/test/registered/unit/batch_invariant_ops/test_batch_invariant_ops.py
+++ b/test/registered/unit/batch_invariant_ops/test_batch_invariant_ops.py
@@ -14,22 +14,28 @@ from sglang.test.test_utils import CustomTestCase
 register_cuda_ci(est_time=10, suite="nightly-1-gpu", nightly=True)
 register_amd_ci(est_time=10, suite="nightly-amd-1-gpu-mi35x", nightly=True)
 
-device_type = getattr(torch.accelerator.current_accelerator(), "type", "cpu")
-torch.set_default_device(device_type)
-
-# Just to get the logging out of the way
-with set_batch_invariant_mode(True):
-    pass
-
 
 class TestBatchInvariantOps(CustomTestCase):
     @classmethod
     def setUpClass(cls):
+        # Scoped to this class, not module scope: pytest imports every test
+        # module in one process during collection, so a module-level
+        # set_default_device leaks into unrelated tests, and a module-level
+        # set_batch_invariant_mode makes the import itself fail on a host
+        # without an accelerator.
+        if not torch.accelerator.is_available():
+            raise unittest.SkipTest("batch-invariant ops require an accelerator")
+        cls._prev_default_device = torch.get_default_device()
+        torch.set_default_device(torch.accelerator.current_accelerator().type)
+        # Just to get the logging out of the way
+        with set_batch_invariant_mode(True):
+            pass
         batch_invariant_ops._ENABLE_MM_COMPARISON_TEST = True
 
     @classmethod
     def tearDownClass(cls):
         batch_invariant_ops._ENABLE_MM_COMPARISON_TEST = False
+        torch.set_default_device(cls._prev_default_device)
 
     def _test_batch_invariance(self, M, K, N, dtype):
         """


### PR DESCRIPTION
## Motivation
`test/registered/unit/batch_invariant_ops/test_batch_invariant_ops.py` runs two side effects at module scope:

```python
device_type = getattr(torch.accelerator.current_accelerator(), "type", "cpu")
torch.set_default_device(device_type)

with set_batch_invariant_mode(True):
    pass
```

pytest imports every test module in one process during collection, so both land on any run that merely collects this file.

On a host without CUDA this is not a no-op: `torch.accelerator.current_accelerator()` reports the build's accelerator rather than an available one, so it returns `device(type='cuda')` and the module sets the process default device to `cuda`. `set_batch_invariant_mode` then raises `RuntimeError: No supported accelerator (CUDA/XPU) available`. The import fails — but the default device stays `cuda`, and from that point `torch.get_default_device()` and even `torch.zeros(2)` raise `RuntimeError: No CUDA GPUs are available` for the rest of the process. Under pytest the collection error also aborts the entire session, so nothing else in the run executes.

## Modifications
This moves both into `setUpClass`, restores the previous default device in `tearDownClass`, and skips the class when `torch.accelerator.is_available()` is false. On a GPU runner the behaviour is unchanged apart from the default device being scoped to this class instead of the process.

## Accuracy Tests
How I verified it, on a CPU-only host:

```
before: pytest test/registered/unit/batch_invariant_ops/
        -> "Interrupted: 1 error during collection", no tests collected
after:  -> 6 skipped

before: DEFAULT before: cpu
        RAISED at import: RuntimeError No supported accelerator (CUDA/XPU) available
        DEFAULT after: get_default_device raised RuntimeError No CUDA GPUs are available
        ALLOC after: torch.zeros(2) raised RuntimeError No CUDA GPUs are available
after:  default device after import: cpu
```

ruff (F401,F821,UP037), black, isort, codespell clean.

I have no GPU available, so I could not run the tests themselves; the assertions and their inputs are untouched.

## Speed Tests and Profiling
Not applicable.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30739432255](https://github.com/sgl-project/sglang/actions/runs/30739432255)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30739432151](https://github.com/sgl-project/sglang/actions/runs/30739432151)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->