### PR TITLE
Fix Mooncake connector ignoring memory-registration failures

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -270,35 +270,73 @@ class MooncakeKVManager(CommonKVManager):
     def init_engine(self):
         self.engine = get_mooncake_transfer_engine()
 
+    def _batch_register_checked(self, ptrs, lens, what: str) -> None:
+        """Register memory regions, aborting if the transport reports failure.
+
+        ``MooncakeTransferEngine.batch_register`` returns an int status
+        (0 = success, -1 when the underlying binding raised) and only logs at
+        DEBUG level. An unregistered region is not addressable by RDMA, so
+        continuing past a failure defers the symptom to a later transfer error
+        or a silently wrong payload. The NIXL connector already raises from its
+        registration path; this makes Mooncake behave the same.
+        """
+        ret = self.engine.batch_register(ptrs, lens)
+        if ret != 0:
+            raise RuntimeError(
+                f"Mooncake memory registration failed for {what}: "
+                f"{len(ptrs)} regions, {sum(lens)} bytes, batch_register "
+                f"returned {ret}"
+            )
+
+    def _batch_deregister_logged(self, ptrs, what: str) -> None:
+        """Deregister on the teardown path, where a failure only leaks a
+        registration and must not mask whatever caused the teardown."""
+        ret = self.engine.batch_deregister(ptrs)
+        if ret != 0:
+            logger.warning(
+                "Mooncake memory deregistration failed for %s: %d regions, "
+                "batch_deregister returned %s",
+                what,
+                len(ptrs),
+                ret,
+            )
+
+    def _register_staging_memory(self, ptr: int, size: int, what: str) -> None:
+        self._batch_register_checked([ptr], [size], what)
+
     def register_buffer_to_engine(self):
         # Batch register KV data buffers
         if self.kv_args.kv_data_ptrs and self.kv_args.kv_data_lens:
-            self.engine.batch_register(
-                self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens
+            self._batch_register_checked(
+                self.kv_args.kv_data_ptrs, self.kv_args.kv_data_lens, "KV data buffers"
             )
 
         # Batch register auxiliary data buffers
         if self.kv_args.aux_data_ptrs and self.kv_args.aux_data_lens:
-            self.engine.batch_register(
-                self.kv_args.aux_data_ptrs, self.kv_args.aux_data_lens
+            self._batch_register_checked(
+                self.kv_args.aux_data_ptrs,
+                self.kv_args.aux_data_lens,
+                "auxiliary data buffers",
             )
 
-        for ptrs, lens in zip(
-            self.kv_args.state_data_ptrs, self.kv_args.state_data_lens
+        for i, (ptrs, lens) in enumerate(
+            zip(self.kv_args.state_data_ptrs, self.kv_args.state_data_lens)
         ):
             if ptrs and lens:
-                self.engine.batch_register(ptrs, lens)
+                self._batch_register_checked(ptrs, lens, f"state data buffers {i}")
 
     def deregister_buffer_to_engine(self):
         if self.kv_args.kv_data_ptrs:
-            self.engine.batch_deregister(self.kv_args.kv_data_ptrs)
+            self._batch_deregister_logged(self.kv_args.kv_data_ptrs, "KV data buffers")
 
         if self.kv_args.aux_data_ptrs:
-            self.engine.batch_deregister(self.kv_args.aux_data_ptrs)
+            self._batch_deregister_logged(
+                self.kv_args.aux_data_ptrs, "auxiliary data buffers"
+            )
 
-        for ptrs in self.kv_args.state_data_ptrs or []:
+        for i, ptrs in enumerate(self.kv_args.state_data_ptrs or []):
             if ptrs:
-                self.engine.batch_deregister(ptrs)
+                self._batch_deregister_logged(ptrs, f"state data buffers {i}")
 
         if hasattr(self, "connection_pool"):
             with self.connection_lock:
@@ -325,7 +363,9 @@ class MooncakeKVManager(CommonKVManager):
         )
 
         self._staging_ctx.buffers = init_staging_buffers(
-            lambda ptr, size: self.engine.batch_register([ptr], [size]),
+            lambda ptr, size: self._register_staging_memory(
+                ptr, size, "prefill staging buffer"
+            ),
             self.kv_args,
             count,
             get_schedule().chunked_prefill_size,
@@ -338,7 +378,9 @@ class MooncakeKVManager(CommonKVManager):
         )
 
         self._staging_ctx.allocator = init_staging_allocator(
-            lambda ptr, size: self.engine.batch_register([ptr], [size]),
+            lambda ptr, size: self._register_staging_memory(
+                ptr, size, "decode staging allocator pool"
+            ),
             self.kv_args,
         )
         self.kv_buffer_tensors = None

--- a/test/registered/unit/disaggregation/test_mooncake_register_status.py
+++ b/test/registered/unit/disaggregation/test_mooncake_register_status.py
@@ -1,0 +1,68 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_manager(register_ret=0, deregister_ret=0):
+    """A MooncakeKVManager with only the pieces these methods touch."""
+    manager = MooncakeKVManager.__new__(MooncakeKVManager)
+    manager.engine = MagicMock()
+    manager.engine.batch_register.return_value = register_ret
+    manager.engine.batch_deregister.return_value = deregister_ret
+    manager.kv_args = SimpleNamespace(
+        kv_data_ptrs=[0x1000, 0x2000],
+        kv_data_lens=[4096, 8192],
+        aux_data_ptrs=[0x3000],
+        aux_data_lens=[256],
+        state_data_ptrs=[[0x4000]],
+        state_data_lens=[[512]],
+    )
+    return manager
+
+
+class TestMooncakeRegisterStatus(unittest.TestCase):
+    def test_successful_registration_registers_every_buffer_class(self):
+        manager = _make_manager()
+        manager.register_buffer_to_engine()
+        self.assertEqual(manager.engine.batch_register.call_count, 3)
+
+    def test_failed_kv_registration_raises(self):
+        manager = _make_manager(register_ret=-1)
+        with self.assertRaises(RuntimeError) as ctx:
+            manager.register_buffer_to_engine()
+        message = str(ctx.exception)
+        self.assertIn("KV data buffers", message)
+        self.assertIn("2 regions", message)
+        self.assertIn("12288 bytes", message)
+        self.assertIn("-1", message)
+
+    def test_failed_registration_stops_before_the_next_buffer_class(self):
+        manager = _make_manager(register_ret=-1)
+        with self.assertRaises(RuntimeError):
+            manager.register_buffer_to_engine()
+        self.assertEqual(manager.engine.batch_register.call_count, 1)
+
+    def test_failed_staging_registration_raises(self):
+        manager = _make_manager(register_ret=1)
+        with self.assertRaises(RuntimeError) as ctx:
+            manager._register_staging_memory(0x5000, 1024, "prefill staging buffer")
+        self.assertIn("prefill staging buffer", str(ctx.exception))
+
+    def test_failed_deregistration_only_warns(self):
+        manager = _make_manager(deregister_ret=-1)
+        with self.assertLogs(
+            "sglang.srt.disaggregation.mooncake.conn", level="WARNING"
+        ) as logs:
+            manager._batch_deregister_logged([0x1000], "KV data buffers")
+        self.assertTrue(
+            any("deregistration failed" in line for line in logs.output), logs.output
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
`MooncakeTransferEngine.batch_register` returns an int status — 0 on success, `-1` when the underlying binding raised — and only logs the failure at DEBUG level (`python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py:160-175`). Every caller in the Mooncake connector discarded it:

- `register_buffer_to_engine` for KV, auxiliary and state buffers (`disaggregation/mooncake/conn.py:273-290`)
- the two staging register callbacks handed to `staging_handler` (`:328`, `:341`), both `lambda ptr, size: self.engine.batch_register([ptr], [size])`

An unregistered region is not addressable by RDMA, so a failed registration does not surface where it happened; it surfaces later as a transfer error or a wrong payload. The NIXL connector already raises in the same situation (`disaggregation/nixl/conn.py:559-563` for staging, `:1382-1385` and `:1394-1396` for KV and aux), so this only brings Mooncake in line.

## Modifications
Registration now raises a `RuntimeError` naming the buffer class, the region count, the total bytes and the return code.

Deregistration is deliberately left non-fatal. It runs on the teardown path, where a failure leaks a registration but cannot corrupt data, and raising there would mask whatever caused the teardown; it is logged at WARNING instead of being dropped.

Line numbers refer to main at 8d106c3.

## Accuracy Tests
How I verified it (CPU only, stubbed engine — I have no RDMA fabric or GPU here):

- `test/registered/unit/disaggregation/test_mooncake_register_status.py`, 5 tests: successful path still registers all three buffer classes; a non-zero status raises with the expected message; the failure stops before the next buffer class instead of registering on top of it; the staging callback raises; a failed deregistration only warns.
- 4 of the 5 are red against the unpatched file.
- `test/registered/unit/disaggregation/`: 97 passed, no new failures.
- ruff (F401,F821,UP037), black, isort, codespell clean.

## Speed Tests and Profiling
Not applicable.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30739526205](https://github.com/sgl-project/sglang/actions/runs/30739526205)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30739526120](https://github.com/sgl-project/sglang/actions/runs/30739526120)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->