### PR TITLE
Fix quantized DeepSeek-V4 dropping the fused wq_a+wkv projections

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -476,16 +476,18 @@ class MqaAttentionBase(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("wqkv_a", prefix),
             )
-            if not _is_dense_linear(self.wqkv_a):
-                # The quantization method built a packed layer instead of a
-                # plain weight. The wq_a+wkv fusion concatenates the two
-                # checkpoint tensors on dim 0, which is the output axis of the
-                # dense layout only, so fall back to the separate projections
-                # rather than joining tensors on the wrong axis.
+            unfusable = _unfusable_layer_leaves(self.wqkv_a, _WQKV_A_FUSABLE_LEAVES)
+            if unfusable:
+                # The quantization method built parameters this fusion has no
+                # shard for. The wq_a+wkv fusion concatenates the two checkpoint
+                # tensors on dim 0, which is the output axis of the dense layout
+                # only, so fall back to the separate projections rather than
+                # joining tensors on the wrong axis or dropping the rest.
                 print_warning_once(
                     "Disabling the wq_a+wkv fusion: quantization method "
-                    f"{type(self.wqkv_a.quant_method).__name__} builds a packed "
-                    "layer with no plain 'weight' parameter."
+                    f"{type(self.wqkv_a.quant_method).__name__} builds "
+                    f"{list(unfusable)} alongside the leaves this fusion can "
+                    f"join ({sorted(_WQKV_A_FUSABLE_LEAVES)})."
                 )
                 del self.wqkv_a
                 fuse = False
@@ -3263,15 +3265,33 @@ def _summarize_unplaced_weights(names: List[str], top: int = 5) -> str:
     )
 
 
-def _is_dense_linear(layer: nn.Module) -> bool:
-    """Whether the layer's quantization method built a plain dense weight.
+def _unfusable_layer_leaves(
+    layer: nn.Module, fusable_leaves: frozenset
+) -> Tuple[str, ...]:
+    """Parameters of ``layer`` this fusion cannot join, sorted.
 
-    Format-agnostic: packed schemes register their own parameters
-    (`.qweight`/`.qzeros`/`.scales` and friends) and no `weight`, so a missing
-    `weight` is the signal that the layer cannot take a dim-0 concatenation of
-    two dense checkpoint tensors.
+    The build-side counterpart of `_reject_unfusable_leaf`: both ask the same
+    question -- can this leaf be concatenated on dim 0 -- one of the layer that
+    was built, the other of the tensor that arrived. Asking it of the built
+    parameters is what keeps the check format-agnostic, and it is strictly
+    wider than testing for a plain `weight`: a scheme can register `weight` and
+    still carry parameters the fusion has no shard for. Per-tensor fp8 is the
+    case in the tree today -- `Fp8LinearMethod` registers `weight` plus
+    `weight_scale` and `input_scale` (`layers/quantization/fp8.py`), so a
+    `weight`-only test leaves the fusion enabled and the two scale tensors then
+    reach `_reject_unfusable_leaf`, turning a checkpoint that would load
+    unfused into one that does not load at all. Packed schemes register
+    `.qweight`/`.qzeros`/`.scales` and friends and no `weight`; compressed
+    tensors registers `weight_packed`/`weight_scale`/`weight_shape`/
+    `weight_zero_point`. None of them has to be named here.
     """
-    return hasattr(layer, "weight")
+    return tuple(
+        sorted(
+            name
+            for name, _ in layer.named_parameters(recurse=False)
+            if name not in fusable_leaves
+        )
+    )
 
 
 def _fused_module_prefixes(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -14,6 +14,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -477,6 +478,9 @@ class MqaAttentionBase(nn.Module):
                 prefix=add_prefix("wqkv_a", prefix),
             )
             unfusable = _unfusable_layer_leaves(self.wqkv_a, _WQKV_A_FUSABLE_LEAVES)
+            shard_sizes = (self.q_lora_rank, self.head_dim)
+            block_size = getattr(quant_config, "weight_block_size", None)
+            scales_align = _block_scale_concat_is_exact(shard_sizes, block_size)
             if unfusable:
                 # The quantization method built parameters this fusion has no
                 # shard for. The wq_a+wkv fusion concatenates the two checkpoint
@@ -489,6 +493,15 @@ class MqaAttentionBase(nn.Module):
                     f"{list(unfusable)} alongside the leaves this fusion can "
                     f"join ({sorted(_WQKV_A_FUSABLE_LEAVES)})."
                 )
+            elif not scales_align:
+                print_warning_once(
+                    "Disabling the wq_a+wkv fusion: the projection sizes "
+                    f"{shard_sizes} do not split into whole "
+                    f"{block_size[0]}-row scale blocks, so concatenating the "
+                    "two shards' block scales would not reproduce the layout "
+                    "of the fused parameter."
+                )
+            if unfusable or not scales_align:
                 del self.wqkv_a
                 fuse = False
                 self.fuse_wqa_wkv = False
@@ -3292,6 +3305,43 @@ def _unfusable_layer_leaves(
             if name not in fusable_leaves
         )
     )
+
+
+def _block_scale_concat_is_exact(
+    shard_sizes: Sequence[int], weight_block_size: Optional[Sequence[int]]
+) -> bool:
+    """Whether concatenating per-shard block scales reproduces the fused layout.
+
+    A block-quantized weight carries one scale row per ``block`` rows of
+    output, so a shard of ``n`` rows ships ``ceil(n / block)`` scale rows. The
+    fusion concatenates the shards' scales on dim 0 exactly as it concatenates
+    their weights, which gives ``sum(ceil(n_i / block))`` rows against the
+    ``ceil(sum(n_i) / block)`` the fused parameter declares.
+
+    Those differ exactly at a seam where both sides are partial and their two
+    remainders still fit inside one block: the shards then pad to a scale row
+    each where the fused layout shares one, so the concatenation is one row
+    long and every scale past the seam describes the wrong rows. A shard that
+    is a whole number of blocks never creates such a seam, and neither do two
+    remainders that overflow a block, which is why this is computed rather
+    than asserted. The mismatch is a row count the fusion never compares, so
+    it would surface as wrong numbers, not as a shape error.
+
+    Returns True when there is no block scale to worry about (dense and
+    per-tensor schemes report no ``weight_block_size``).
+
+    Every published DeepSeek-V4 geometry divides evenly -- ``q_lora_rank``
+    1024 and ``head_dim`` 512 against a 128-row block -- so this is a
+    precondition on the fusion rather than a live repair.
+    """
+    if not weight_block_size:
+        return True
+    block = weight_block_size[0]
+    if block <= 0:
+        return True
+    total = sum(shard_sizes)
+    per_shard = sum(-(-size // block) for size in shard_sizes)
+    return per_shard == -(-total // block)
 
 
 def _fused_module_prefixes(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -156,6 +156,7 @@ from sglang.srt.utils import (
     is_gfx942_supported,
     log_info_on_rank0,
     make_layers,
+    print_warning_once,
 )
 from sglang.srt.utils.common import is_sm120_supported
 from sglang.srt.utils.custom_op import register_custom_op
@@ -474,7 +475,21 @@ class MqaAttentionBase(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("wqkv_a", prefix),
             )
-        else:
+            if not _is_dense_linear(self.wqkv_a):
+                # The quantization method built a packed layer instead of a
+                # plain weight. The wq_a+wkv fusion concatenates the two
+                # checkpoint tensors on dim 0, which is the output axis of the
+                # dense layout only, so fall back to the separate projections
+                # rather than joining tensors on the wrong axis.
+                print_warning_once(
+                    "Disabling the wq_a+wkv fusion: quantization method "
+                    f"{type(self.wqkv_a.quant_method).__name__} builds a packed "
+                    "layer with no plain 'weight' parameter."
+                )
+                del self.wqkv_a
+                fuse = False
+                self.fuse_wqa_wkv = False
+        if not fuse:
             self.wq_a = ReplicatedLinear(
                 self.hidden_size,
                 self.q_lora_rank,
@@ -2844,7 +2859,12 @@ class DeepseekV4ForCausalLM(nn.Module):
         cache_compressor_weight = {}
         COMPRESSOR_PART = ".compressor.w"
 
-        fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get()
+        # The built model is authoritative: MqaAttentionBase falls back to
+        # separate wq_a/wkv projections when the quantization method builds a
+        # packed layer, in which case there is no wqkv_a to load into.
+        fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get() and any(
+            ".wqkv_a." in param_name for param_name in params_dict
+        )
         cache_wqkv_a_weight: dict[str, dict[str, torch.Tensor]] = {}
 
         def auto_weight_loader(module):
@@ -3205,6 +3225,17 @@ _COMPRESSOR_SHARD_ORDER = ("kv", "wgate")
 # geometry, so their join axis differs and is not handled here.
 _WQKV_A_FUSABLE_LEAVES = frozenset({"weight", "weight_scale_inv"})
 _COMPRESSOR_FUSABLE_LEAVES = frozenset({"weight"})
+
+
+def _is_dense_linear(layer: nn.Module) -> bool:
+    """Whether the layer's quantization method built a plain dense weight.
+
+    Format-agnostic: packed schemes register their own parameters
+    (`.qweight`/`.qzeros`/`.scales` and friends) and no `weight`, so a missing
+    `weight` is the signal that the layer cannot take a dim-0 concatenation of
+    two dense checkpoint tensors.
+    """
+    return hasattr(layer, "weight")
 
 
 def _classify_fused_shard(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import functools
 import logging
 import time
+from collections import Counter
 from contextlib import contextmanager, nullcontext
 from typing import (
     TYPE_CHECKING,
@@ -2866,6 +2867,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             ".wqkv_a." in param_name for param_name in params_dict
         )
         cache_wqkv_a_weight: dict[str, dict[str, torch.Tensor]] = {}
+        unplaced_weight_names: List[str] = []
 
         def auto_weight_loader(module):
             return getattr(module, "weight_loader", default_weight_loader)
@@ -3131,6 +3133,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                                         logger.warning(
                                             f"{name} not found in params_dict."
                                         )
+                                        unplaced_weight_names.append(name)
                                     continue
                                 param = params_dict[name]
 
@@ -3152,6 +3155,10 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         assert len(cache_compressor_weight) == 0
         assert len(cache_wqkv_a_weight) == 0, cache_wqkv_a_weight.keys()
+
+        if unplaced_weight_names:
+            logger.warning(_summarize_unplaced_weights(unplaced_weight_names))
+
         unloaded_params = params_dict.keys() - loaded_params
 
         skipped_checking_patterns = [
@@ -3225,6 +3232,23 @@ _COMPRESSOR_SHARD_ORDER = ("kv", "wgate")
 # geometry, so their join axis differs and is not handled here.
 _WQKV_A_FUSABLE_LEAVES = frozenset({"weight", "weight_scale_inv"})
 _COMPRESSOR_FUSABLE_LEAVES = frozenset({"weight"})
+
+
+def _generalize_module_prefix(name: str) -> str:
+    """Drop the leaf and collapse layer indices, so per-layer names aggregate."""
+    parts = name.split(".")[:-1]
+    return ".".join("*" if part.isdigit() else part for part in parts)
+
+
+def _summarize_unplaced_weights(names: List[str], top: int = 5) -> str:
+    prefixes = Counter(_generalize_module_prefix(name) for name in names)
+    top_prefixes = ", ".join(
+        f"{prefix} ({count})" for prefix, count in prefixes.most_common(top)
+    )
+    return (
+        f"{len(names)} checkpoint weights were not placed into any parameter. "
+        f"Top module prefixes: {top_prefixes}"
+    )
 
 
 def _is_dense_linear(layer: nn.Module) -> bool:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2860,12 +2860,16 @@ class DeepseekV4ForCausalLM(nn.Module):
         cache_compressor_weight = {}
         COMPRESSOR_PART = ".compressor.w"
 
-        # The built model is authoritative: MqaAttentionBase falls back to
-        # separate wq_a/wkv projections when the quantization method builds a
-        # packed layer, in which case there is no wqkv_a to load into.
-        fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get() and any(
-            ".wqkv_a." in param_name for param_name in params_dict
-        )
+        # The built model is authoritative, and it is authoritative per layer:
+        # MqaAttentionBase drops wqkv_a and builds separate wq_a/wkv
+        # projections for each layer whose quantization method produced a
+        # packed layer. A checkpoint that quantizes only some attention blocks
+        # (per-layer entries in quantization_config) therefore keeps wqkv_a on
+        # some layers and not on others, so the decision is taken per attention
+        # module -- the one the tensor under load belongs to -- and never for
+        # the model as a whole. The env variable stays a global kill switch.
+        fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get()
+        fused_wqkv_a_prefixes = _fused_module_prefixes(params_dict, "wqkv_a")
         cache_wqkv_a_weight: dict[str, dict[str, torch.Tensor]] = {}
         unplaced_weight_names: List[str] = []
 
@@ -3084,10 +3088,18 @@ class DeepseekV4ForCausalLM(nn.Module):
                                         func_args=(param, fused_weight),
                                     )
                                     loaded_params.add(param_name)
-                            elif fuse_wqa_wkv and (
-                                classified := _classify_fused_shard(
-                                    name, _WQKV_A_SHARD_IDS
+                            elif (
+                                fuse_wqa_wkv
+                                and (
+                                    classified := _classify_fused_shard(
+                                        name, _WQKV_A_SHARD_IDS
+                                    )
                                 )
+                                # Only this tensor's own layer decides: if that
+                                # layer kept wqkv_a, fuse into it; if it built
+                                # the separate projections, the generic path
+                                # below loads the tensor into wq_a / wkv.
+                                and classified[1] in fused_wqkv_a_prefixes
                             ):
                                 shard_id, parent, leaf = classified
                                 if leaf not in _WQKV_A_FUSABLE_LEAVES:
@@ -3260,6 +3272,24 @@ def _is_dense_linear(layer: nn.Module) -> bool:
     two dense checkpoint tensors.
     """
     return hasattr(layer, "weight")
+
+
+def _fused_module_prefixes(
+    params_dict: dict[str, nn.Parameter], module_name: str
+) -> Set[str]:
+    """Parent prefixes of the built ``<prefix>.<module_name>.<leaf>`` parameters.
+
+    The prefix, not a parsed layer index, is the key: it is exactly what
+    ``_classify_fused_shard`` returns for a checkpoint tensor, and it also
+    covers the names that carry no layer index at all -- the MTP layer is
+    rewritten to ``model.decoder`` before it reaches the dispatch.
+    """
+    segment = f".{module_name}."
+    return {
+        param_name.rsplit(segment, 1)[0]
+        for param_name in params_dict
+        if segment in param_name
+    }
 
 
 def _classify_fused_shard(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3023,26 +3023,35 @@ class DeepseekV4ForCausalLM(nn.Module):
                             ) and not self.pp_group.is_last_rank:
                                 continue
                             elif COMPRESSOR_PART in name:
-                                is_kv = name.endswith(".wkv.weight")
-                                is_wgate = name.endswith(".wgate.weight")
-                                assert is_kv != is_wgate
-                                key = name.rsplit(".", 2)[0]
+                                classified = _classify_fused_shard(
+                                    name, _COMPRESSOR_SHARD_IDS
+                                )
+                                if classified is None:
+                                    raise ValueError(
+                                        f"Unexpected compressor tensor '{name}': "
+                                        f"expected one of "
+                                        f"{sorted(_COMPRESSOR_SHARD_IDS)} as the "
+                                        f"module name segment."
+                                    )
+                                shard_id, key, leaf = classified
+                                if leaf not in _COMPRESSOR_FUSABLE_LEAVES:
+                                    _reject_unfusable_leaf(
+                                        name,
+                                        leaf,
+                                        _COMPRESSOR_FUSABLE_LEAVES,
+                                        "The compressor wkv+wgate fusion supports "
+                                        "dense checkpoints only.",
+                                    )
                                 assert key.endswith(".compressor")
-                                if key not in cache_compressor_weight:
-                                    cache_compressor_weight[key] = (
-                                        is_kv,
-                                        _clone_if_runai_streamed_tensor(loaded_weight),
-                                    )
-                                else:
-                                    assert key in cache_compressor_weight
-                                    cached_is_kv, cached_weight = (
-                                        cache_compressor_weight[key]
-                                    )
-                                    assert cached_is_kv != is_kv
-                                    kv = loaded_weight if is_kv else cached_weight
-                                    wgate = loaded_weight if is_wgate else cached_weight
-                                    fused_weight = torch.cat([kv, wgate], dim=0)
-                                    param_name = key + ".wkv_gate.weight"
+                                param_name = f"{key}.wkv_gate.{leaf}"
+                                fused_weight = _pop_fused_weight(
+                                    cache_compressor_weight,
+                                    param_name,
+                                    shard_id,
+                                    loaded_weight,
+                                    _COMPRESSOR_SHARD_ORDER,
+                                )
+                                if fused_weight is not None:
                                     param = params_dict[param_name]
                                     weight_loader = auto_weight_loader(param)
                                     maybe_executor_submit(
@@ -3053,29 +3062,30 @@ class DeepseekV4ForCausalLM(nn.Module):
                                         func_args=(param, fused_weight),
                                     )
                                     loaded_params.add(param_name)
-                                    cache_compressor_weight.pop(key)
                             elif fuse_wqa_wkv and (
-                                name.endswith(".wq_a.weight")
-                                or name.endswith(".wq_a.weight_scale_inv")
-                                or name.endswith(".wkv.weight")
-                                or name.endswith(".wkv.weight_scale_inv")
+                                classified := _classify_fused_shard(
+                                    name, _WQKV_A_SHARD_IDS
+                                )
                             ):
-                                is_q = ".wq_a." in name
-                                param_name = name.replace(
-                                    ".wq_a." if is_q else ".wkv.", ".wqkv_a."
-                                )
-                                bucket = cache_wqkv_a_weight.setdefault(param_name, {})
-                                shard_key = "q" if is_q else "kv"
-                                assert (
-                                    shard_key not in bucket
-                                ), f"duplicate shard {shard_key} for {param_name}"
-                                bucket[shard_key] = _clone_if_runai_streamed_tensor(
-                                    loaded_weight
-                                )
-                                if len(bucket) == 2:
-                                    fused_weight = torch.cat(
-                                        [bucket["q"], bucket["kv"]], dim=0
+                                shard_id, parent, leaf = classified
+                                if leaf not in _WQKV_A_FUSABLE_LEAVES:
+                                    _reject_unfusable_leaf(
+                                        name,
+                                        leaf,
+                                        _WQKV_A_FUSABLE_LEAVES,
+                                        "Set SGLANG_OPT_FUSE_WQA_WKV=0 to load this "
+                                        "checkpoint with separate wq_a and wkv "
+                                        "projections.",
                                     )
+                                param_name = f"{parent}.wqkv_a.{leaf}"
+                                fused_weight = _pop_fused_weight(
+                                    cache_wqkv_a_weight,
+                                    param_name,
+                                    shard_id,
+                                    loaded_weight,
+                                    _WQKV_A_SHARD_ORDER,
+                                )
+                                if fused_weight is not None:
                                     param = params_dict[param_name]
                                     weight_loader = auto_weight_loader(param)
                                     maybe_executor_submit(
@@ -3086,7 +3096,6 @@ class DeepseekV4ForCausalLM(nn.Module):
                                         func_args=(param, fused_weight),
                                     )
                                     loaded_params.add(param_name)
-                                    cache_wqkv_a_weight.pop(param_name)
                             else:
                                 if (
                                     "k_scale" in name or "v_scale" in name
@@ -3178,6 +3187,76 @@ class DeepseekV4ForCausalLM(nn.Module):
 
 
 EntryClass = [DeepseekV4ForCausalLM]
+
+
+# Shard id per module name segment for the projection pairs that are fused at
+# load time. Keyed by the segment (`...<segment>.<leaf>`), never by the leaf, so
+# that an unknown checkpoint layout is reported instead of falling through to
+# the generic loader path and being dropped as "not found in params_dict".
+_WQKV_A_SHARD_IDS = {"wq_a": "q", "wkv": "kv"}
+_WQKV_A_SHARD_ORDER = ("q", "kv")
+_COMPRESSOR_SHARD_IDS = {"wkv": "kv", "wgate": "wgate"}
+_COMPRESSOR_SHARD_ORDER = ("kv", "wgate")
+
+# Checkpoint leaves the fusions below can join. Both fusions concatenate on
+# dim 0, which is the output axis only for the dense `[output, input]` layout
+# and its block scale. Packed layouts (`.qweight`/`.qzeros`/`.scales`) are laid
+# out `[input, output]` with per-format packing and group-quantization
+# geometry, so their join axis differs and is not handled here.
+_WQKV_A_FUSABLE_LEAVES = frozenset({"weight", "weight_scale_inv"})
+_COMPRESSOR_FUSABLE_LEAVES = frozenset({"weight"})
+
+
+def _classify_fused_shard(
+    name: str, shard_ids: dict[str, str]
+) -> Optional[Tuple[str, str, str]]:
+    """Classify a checkpoint tensor by its module name segment.
+
+    Returns ``(shard_id, parent_prefix, leaf)`` for ``<parent>.<segment>.<leaf>``
+    when ``segment`` is one of ``shard_ids``, otherwise ``None``.
+    """
+    module_name, sep, leaf = name.rpartition(".")
+    if not sep:
+        return None
+    parent, sep, segment = module_name.rpartition(".")
+    if not sep:
+        return None
+    shard_id = shard_ids.get(segment)
+    if shard_id is None:
+        return None
+    return shard_id, parent, leaf
+
+
+def _reject_unfusable_leaf(
+    name: str, leaf: str, fusable_leaves: frozenset, hint: str
+) -> None:
+    raise ValueError(
+        f"Cannot fuse checkpoint tensor '{name}': the '{leaf}' leaf indicates a "
+        f"weight layout this fusion does not handle (supported leaves: "
+        f"{sorted(fusable_leaves)}). The fusion concatenates on dim 0, which is "
+        f"the output axis of the dense layout only. {hint}"
+    )
+
+
+def _pop_fused_weight(
+    cache: dict,
+    param_name: str,
+    shard_id: str,
+    loaded_weight: torch.Tensor,
+    shard_order: Tuple[str, ...],
+) -> Optional[torch.Tensor]:
+    """Buffer one shard of a fused parameter.
+
+    Returns the concatenated weight once every shard in ``shard_order`` has been
+    seen, otherwise ``None``.
+    """
+    bucket = cache.setdefault(param_name, {})
+    assert shard_id not in bucket, f"duplicate shard {shard_id} for {param_name}"
+    bucket[shard_id] = _clone_if_runai_streamed_tensor(loaded_weight)
+    if len(bucket) < len(shard_order):
+        return None
+    del cache[param_name]
+    return torch.cat([bucket[shard] for shard in shard_order], dim=0)
 
 
 def _dequant_fp8(weight: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:

--- a/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
+++ b/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
@@ -17,6 +17,7 @@ from sglang.srt.models.deepseek_v4 import (
     DeepseekV4ForCausalLM,
     _classify_fused_shard,
     _fused_module_prefixes,
+    _block_scale_concat_is_exact,
     _unfusable_layer_leaves,
     _pop_fused_weight,
     _reject_unfusable_leaf,
@@ -323,12 +324,51 @@ def layer_with_params(*names):
     return layer
 
 
+class TestBlockScaleConcatPrecondition(unittest.TestCase):
+    """The fusion concatenates block scales on dim 0 like the weights.
+
+    That reproduces the fused parameter's scale layout only while every shard
+    but the last is a whole number of blocks.
+    """
+
+    def test_no_block_size_means_nothing_to_check(self):
+        self.assertTrue(_block_scale_concat_is_exact((1024, 512), None))
+        self.assertTrue(_block_scale_concat_is_exact((1000, 500), []))
+
+    def test_published_v4_geometry_is_exact(self):
+        # q_lora_rank 1024, head_dim 448 + 64, against a 128-row block.
+        self.assertTrue(_block_scale_concat_is_exact((1024, 512), [128, 128]))
+
+    def test_two_partial_shards_that_share_a_block_are_not_exact(self):
+        # 1000 % 128 = 104, 520 % 128 = 8; both partial and 112 <= 128, so the
+        # two shards pad to a scale row each where the fused layout shares one.
+        self.assertFalse(_block_scale_concat_is_exact((1000, 520), [128, 128]))
+
+    def test_a_partial_shard_beside_a_whole_one_is_still_exact(self):
+        self.assertTrue(_block_scale_concat_is_exact((1000, 512), [128, 128]))
+        self.assertTrue(_block_scale_concat_is_exact((1024, 500), [128, 128]))
+
+    def test_remainders_that_overflow_a_block_are_still_exact(self):
+        # 104 + 88 > 128: the seam already costs a whole row either way.
+        self.assertTrue(_block_scale_concat_is_exact((1000, 600), [128, 128]))
+
+    def test_the_mismatch_is_a_row_count_not_a_shape_error(self):
+        """Why this is a precondition and not an assertion downstream.
+
+        The concatenated scales have MORE rows than the fused parameter
+        declares, and the fusion never compares the two, so a misaligned
+        geometry shifts every scale past the seam instead of raising.
+        """
+        block, shards = 128, (1000, 520)
+        per_shard = sum(-(-n // block) for n in shards)
+        fused = -(-sum(shards) // block)
+        self.assertEqual((per_shard, fused), (13, 12))
+
+
 class TestPackedLayerFallback(unittest.TestCase):
     def test_unquantized_replicated_linear_is_fusable(self):
         layer = ReplicatedLinear(8, 4, bias=False, quant_config=None)
-        self.assertEqual(
-            _unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES), ()
-        )
+        self.assertEqual(_unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES), ())
 
     def test_packed_layer_is_not_fusable(self):
         layer = layer_with_params("qweight", "qzeros", "scales")
@@ -362,9 +402,7 @@ class TestPackedLayerFallback(unittest.TestCase):
     def test_block_scaled_fp8_layer_stays_fusable(self):
         """The path this fusion exists for must not be disabled by the widening."""
         layer = layer_with_params("weight", "weight_scale_inv")
-        self.assertEqual(
-            _unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES), ()
-        )
+        self.assertEqual(_unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES), ())
 
     def test_the_weight_only_predicate_accepted_per_tensor_fp8(self):
         """The predicate this replaced, kept executable.
@@ -393,7 +431,7 @@ class TestPackedLayerFallback(unittest.TestCase):
         weights = [
             (f"{ATTN_PREFIX}.{proj}.{leaf}", torch.full((4, 8), float(i)))
             for i, (proj, leaf) in enumerate(
-                (p, l) for p in ("wq_a", "wkv") for l in leaves
+                (projection, name) for projection in ("wq_a", "wkv") for name in leaves
             )
         ]
 

--- a/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
+++ b/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
@@ -17,7 +17,7 @@ from sglang.srt.models.deepseek_v4 import (
     DeepseekV4ForCausalLM,
     _classify_fused_shard,
     _fused_module_prefixes,
-    _is_dense_linear,
+    _unfusable_layer_leaves,
     _pop_fused_weight,
     _reject_unfusable_leaf,
     _summarize_unplaced_weights,
@@ -310,16 +310,97 @@ class TestLoadWeightsFusedProjection(unittest.TestCase):
         torch.testing.assert_close(params[f"{ATTN_PREFIX}.wq_a.qweight"].data, qweight)
 
 
-class TestPackedLayerFallback(unittest.TestCase):
-    def test_unquantized_replicated_linear_is_dense(self):
-        layer = ReplicatedLinear(8, 4, bias=False, quant_config=None)
-        self.assertTrue(_is_dense_linear(layer))
+def layer_with_params(*names):
+    """A stand-in for a built linear carrying exactly ``names``.
 
-    def test_packed_layer_is_not_dense(self):
-        layer = torch.nn.Module()
-        for packed_name in ("qweight", "qzeros", "scales"):
-            layer.register_parameter(packed_name, torch.nn.Parameter(torch.zeros(2, 2)))
-        self.assertFalse(_is_dense_linear(layer))
+    Used for the schemes whose real quantization method cannot be constructed
+    without a device (compressed tensors probes the device capability before it
+    picks a scheme). The parameter names are the ones those methods register.
+    """
+    layer = torch.nn.Module()
+    for name in names:
+        layer.register_parameter(name, torch.nn.Parameter(torch.zeros(2, 2)))
+    return layer
+
+
+class TestPackedLayerFallback(unittest.TestCase):
+    def test_unquantized_replicated_linear_is_fusable(self):
+        layer = ReplicatedLinear(8, 4, bias=False, quant_config=None)
+        self.assertEqual(
+            _unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES), ()
+        )
+
+    def test_packed_layer_is_not_fusable(self):
+        layer = layer_with_params("qweight", "qzeros", "scales")
+        self.assertEqual(
+            _unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES),
+            ("qweight", "qzeros", "scales"),
+        )
+
+    def test_per_tensor_fp8_layer_is_not_fusable(self):
+        """`weight` is present, so a `weight`-only test would leave the fusion on.
+
+        `Fp8LinearMethod` registers `weight_scale` and `input_scale` beside the
+        weight; the fusion has no shard for either, so the layer has to build
+        the separate projections.
+        """
+        layer = layer_with_params("weight", "weight_scale", "input_scale")
+        self.assertEqual(
+            _unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES),
+            ("input_scale", "weight_scale"),
+        )
+
+    def test_compressed_tensors_packed_layer_is_not_fusable(self):
+        layer = layer_with_params(
+            "weight_packed", "weight_scale", "weight_shape", "weight_zero_point"
+        )
+        self.assertEqual(
+            _unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES),
+            ("weight_packed", "weight_scale", "weight_shape", "weight_zero_point"),
+        )
+
+    def test_block_scaled_fp8_layer_stays_fusable(self):
+        """The path this fusion exists for must not be disabled by the widening."""
+        layer = layer_with_params("weight", "weight_scale_inv")
+        self.assertEqual(
+            _unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES), ()
+        )
+
+    def test_the_weight_only_predicate_accepted_per_tensor_fp8(self):
+        """The predicate this replaced, kept executable.
+
+        `hasattr(layer, "weight")` answers True for per-tensor fp8, which is why
+        that checkpoint reached `_reject_unfusable_leaf` at load time instead of
+        building the separate projections.
+        """
+        layer = layer_with_params("weight", "weight_scale", "input_scale")
+        self.assertTrue(hasattr(layer, "weight"))
+        self.assertTrue(_unfusable_layer_leaves(layer, _WQKV_A_FUSABLE_LEAVES))
+
+    def test_per_tensor_fp8_checkpoint_loads_through_the_separate_projections(self):
+        """End to end: every scale reaches its own parameter.
+
+        Before the build-side check covered it, the layer kept `wqkv_a`, the
+        `weight` shards fused, and the first scale tensor raised -- a checkpoint
+        that loads unfused became one that does not load.
+        """
+        leaves = ("weight", "weight_scale", "input_scale")
+        params = {
+            f"{ATTN_PREFIX}.{proj}.{leaf}": torch.nn.Parameter(torch.zeros(4, 8))
+            for proj in ("wq_a", "wkv")
+            for leaf in leaves
+        }
+        weights = [
+            (f"{ATTN_PREFIX}.{proj}.{leaf}", torch.full((4, 8), float(i)))
+            for i, (proj, leaf) in enumerate(
+                (p, l) for p in ("wq_a", "wkv") for l in leaves
+            )
+        ]
+
+        run_load_weights(params, weights, fuse_wqa_wkv=True)
+
+        for name, expected in weights:
+            torch.testing.assert_close(params[name].data, expected)
 
     def test_loader_skips_fusion_when_the_model_has_no_wqkv_a(self):
         # MqaAttentionBase built the unfused pair because the quantization

--- a/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
+++ b/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -15,6 +16,7 @@ from sglang.srt.models.deepseek_v4 import (
     _WQKV_A_SHARD_ORDER,
     DeepseekV4ForCausalLM,
     _classify_fused_shard,
+    _fused_module_prefixes,
     _is_dense_linear,
     _pop_fused_weight,
     _reject_unfusable_leaf,
@@ -26,6 +28,8 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 ATTN_PREFIX = "model.layers.3.self_attn"
 COMPRESSOR_PREFIX = "model.layers.3.self_attn.compressor"
+DENSE_LAYER = "model.layers.0.self_attn"
+PACKED_LAYER = "model.layers.1.self_attn"
 
 
 def run_load_weights(params, weights, fuse_wqa_wkv=True):
@@ -333,6 +337,114 @@ class TestPackedLayerFallback(unittest.TestCase):
         )
 
         torch.testing.assert_close(params[f"{ATTN_PREFIX}.wq_a.qweight"].data, qweight)
+
+
+class TestMixedPrecisionCheckpoint(unittest.TestCase):
+    """Per-layer quantization: some layers dense and fused, others packed.
+
+    A checkpoint that excludes individual attention blocks from quantization
+    (`quantization_config.extra_config` with `bits: 16` entries) builds a model
+    in which layer 0 keeps `wqkv_a` and layer 1 does not. The fusion decision
+    has to follow the layer under load, not the model as a whole.
+    """
+
+    def mixed_params(self):
+        return {
+            # Layer 0 stayed dense, so MqaAttentionBase kept the fusion.
+            f"{DENSE_LAYER}.wqkv_a.weight": torch.nn.Parameter(torch.zeros(10, 4)),
+            # Layer 1 is packed, so MqaAttentionBase dropped wqkv_a and built
+            # the separate projections.
+            f"{PACKED_LAYER}.wq_a.qweight": torch.nn.Parameter(torch.zeros(4, 8)),
+            f"{PACKED_LAYER}.wq_a.scales": torch.nn.Parameter(torch.zeros(1, 8)),
+            f"{PACKED_LAYER}.wkv.qweight": torch.nn.Parameter(torch.zeros(4, 2)),
+            f"{PACKED_LAYER}.wkv.scales": torch.nn.Parameter(torch.zeros(1, 2)),
+        }
+
+    def test_prefixes_report_the_layers_that_kept_the_fusion(self):
+        prefixes = _fused_module_prefixes(self.mixed_params(), "wqkv_a")
+
+        self.assertEqual(prefixes, {DENSE_LAYER})
+
+    def test_prefixes_cover_the_mtp_naming_space(self):
+        # load_weights rewrites the MTP layer prefix to "model.decoder", which
+        # carries no layer index.
+        params = {
+            "model.decoder.self_attn.wqkv_a.weight": torch.nn.Parameter(
+                torch.zeros(2, 2)
+            )
+        }
+
+        self.assertEqual(
+            _fused_module_prefixes(params, "wqkv_a"), {"model.decoder.self_attn"}
+        )
+
+    def test_mixed_checkpoint_loads_every_layer(self):
+        wq_a = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
+        wkv = torch.arange(2 * 4, dtype=torch.float32).reshape(2, 4) + 100
+        packed = {
+            f"{PACKED_LAYER}.wq_a.qweight": torch.ones(4, 8),
+            f"{PACKED_LAYER}.wq_a.scales": torch.full((1, 8), 2.0),
+            f"{PACKED_LAYER}.wkv.qweight": torch.full((4, 2), 3.0),
+            f"{PACKED_LAYER}.wkv.scales": torch.full((1, 2), 4.0),
+        }
+        params = self.mixed_params()
+
+        run_load_weights(
+            params,
+            [
+                (f"{DENSE_LAYER}.wq_a.weight", wq_a),
+                (f"{DENSE_LAYER}.wkv.weight", wkv),
+                *packed.items(),
+            ],
+        )
+
+        # The dense layer is fused exactly as on a uniform dense checkpoint.
+        torch.testing.assert_close(
+            params[f"{DENSE_LAYER}.wqkv_a.weight"].data, torch.cat([wq_a, wkv], dim=0)
+        )
+        # The packed layer loads through its own separate projections.
+        for name, weight in packed.items():
+            torch.testing.assert_close(params[name].data, weight)
+
+    def test_mixed_checkpoint_emits_no_unplaced_summary(self):
+        params = self.mixed_params()
+
+        with self.assertLogs("sglang.srt.models.deepseek_v4", level="WARNING") as logs:
+            logging.getLogger("sglang.srt.models.deepseek_v4").warning("probe")
+            run_load_weights(
+                params,
+                [
+                    (f"{DENSE_LAYER}.wq_a.weight", torch.zeros(8, 4)),
+                    (f"{DENSE_LAYER}.wkv.weight", torch.zeros(2, 4)),
+                    (f"{PACKED_LAYER}.wq_a.qweight", torch.zeros(4, 8)),
+                    (f"{PACKED_LAYER}.wq_a.scales", torch.zeros(1, 8)),
+                    (f"{PACKED_LAYER}.wkv.qweight", torch.zeros(4, 2)),
+                    (f"{PACKED_LAYER}.wkv.scales", torch.zeros(1, 2)),
+                ],
+            )
+
+        self.assertEqual(
+            [record for record in logs.output if "not placed" in record], []
+        )
+        self.assertEqual(
+            [record for record in logs.output if "not found in params_dict" in record],
+            [],
+        )
+
+    def test_packed_tensor_for_a_fused_layer_is_still_refused(self):
+        # The layer kept wqkv_a, so a packed checkpoint tensor for it is a real
+        # disagreement between model and checkpoint and must not be joined.
+        params = self.mixed_params()
+
+        with self.assertRaises(ValueError) as ctx:
+            run_load_weights(
+                params,
+                [(f"{DENSE_LAYER}.wq_a.qweight", torch.zeros(4, 8))],
+            )
+
+        message = str(ctx.exception)
+        self.assertIn(f"{DENSE_LAYER}.wq_a.qweight", message)
+        self.assertIn("SGLANG_OPT_FUSE_WQA_WKV=0", message)
 
 
 class TestUnplacedWeightSummary(unittest.TestCase):

--- a/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
+++ b/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
@@ -18,6 +18,7 @@ from sglang.srt.models.deepseek_v4 import (
     _is_dense_linear,
     _pop_fused_weight,
     _reject_unfusable_leaf,
+    _summarize_unplaced_weights,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -332,6 +333,47 @@ class TestPackedLayerFallback(unittest.TestCase):
         )
 
         torch.testing.assert_close(params[f"{ATTN_PREFIX}.wq_a.qweight"].data, qweight)
+
+
+class TestUnplacedWeightSummary(unittest.TestCase):
+    def test_summary_counts_and_collapses_layer_indices(self):
+        names = [
+            f"model.layers.{layer}.self_attn.{module}.{leaf}"
+            for layer in range(43)
+            for module in ("wq_a", "wkv")
+            for leaf in ("qweight", "qzeros", "scales")
+        ]
+
+        summary = _summarize_unplaced_weights(names)
+
+        self.assertIn("258 checkpoint weights were not placed", summary)
+        self.assertIn("model.layers.*.self_attn.wq_a (129)", summary)
+        self.assertIn("model.layers.*.self_attn.wkv (129)", summary)
+
+    def test_summary_lists_at_most_top_prefixes(self):
+        names = [f"module_{i}.leaf" for i in range(20)]
+        summary = _summarize_unplaced_weights(names, top=2)
+        self.assertIn("20 checkpoint weights were not placed", summary)
+        self.assertEqual(summary.count("(1)"), 2)
+
+    def test_load_weights_emits_one_summary(self):
+        params = {f"{ATTN_PREFIX}.wq_b.weight": torch.nn.Parameter(torch.zeros(2, 2))}
+        weights = [
+            (f"model.layers.{layer}.self_attn.q_norm.stray", torch.zeros(2))
+            for layer in range(3)
+        ]
+
+        with self.assertLogs("sglang.srt.models.deepseek_v4", level="WARNING") as logs:
+            run_load_weights(params, weights)
+
+        summaries = [
+            record
+            for record in logs.output
+            if "checkpoint weights were not placed" in record
+        ]
+        self.assertEqual(len(summaries), 1)
+        self.assertIn("3 checkpoint weights were not placed", summaries[0])
+        self.assertIn("model.layers.*.self_attn.q_norm (3)", summaries[0])
 
 
 class TestFusedShardBuffer(unittest.TestCase):

--- a/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
+++ b/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
@@ -1,0 +1,322 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.models.deepseek_v4 import (
+    _COMPRESSOR_FUSABLE_LEAVES,
+    _COMPRESSOR_SHARD_IDS,
+    _COMPRESSOR_SHARD_ORDER,
+    _WQKV_A_FUSABLE_LEAVES,
+    _WQKV_A_SHARD_IDS,
+    _WQKV_A_SHARD_ORDER,
+    DeepseekV4ForCausalLM,
+    _classify_fused_shard,
+    _pop_fused_weight,
+    _reject_unfusable_leaf,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+ATTN_PREFIX = "model.layers.3.self_attn"
+COMPRESSOR_PREFIX = "model.layers.3.self_attn.compressor"
+
+
+def run_load_weights(params, weights, fuse_wqa_wkv=True):
+    """Drive the real DeepseekV4ForCausalLM.load_weights over a name stream.
+
+    ``params`` stands in for ``named_parameters()``; everything load_weights
+    needs beyond the weight-placement logic is stubbed out.
+    """
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_hidden_layers=8, n_routed_experts=1),
+        quant_config=None,
+        num_fused_shared_experts=0,
+        pp_group=SimpleNamespace(is_first_rank=True, is_last_rank=True),
+        model=SimpleNamespace(),
+        named_parameters=lambda: list(params.items()),
+        remap_weight_name_to_dpsk_hf_format=(
+            DeepseekV4ForCausalLM.remap_weight_name_to_dpsk_hf_format
+        ),
+        post_load_weights=lambda **kwargs: None,
+        _prewarm_mhc_pre_kernels=lambda: None,
+    )
+    with patch.object(envs.SGLANG_OPT_FUSE_WQA_WKV, "get", return_value=fuse_wqa_wkv):
+        DeepseekV4ForCausalLM.load_weights(model, list(weights))
+
+
+def fuse_wqa_wkv_stream(names_and_weights):
+    """Mimic the wq_a+wkv arm of DeepseekV4ForCausalLM.load_weights.
+
+    Returns the fused parameters keyed by target parameter name, plus the names
+    the arm did not claim (which load_weights hands to the generic path).
+    """
+    cache = {}
+    fused = {}
+    unclaimed = []
+    for name, loaded_weight in names_and_weights:
+        classified = _classify_fused_shard(name, _WQKV_A_SHARD_IDS)
+        if classified is None:
+            unclaimed.append(name)
+            continue
+        shard_id, parent, leaf = classified
+        if leaf not in _WQKV_A_FUSABLE_LEAVES:
+            _reject_unfusable_leaf(
+                name,
+                leaf,
+                _WQKV_A_FUSABLE_LEAVES,
+                "Set SGLANG_OPT_FUSE_WQA_WKV=0 to load this checkpoint with "
+                "separate wq_a and wkv projections.",
+            )
+        param_name = f"{parent}.wqkv_a.{leaf}"
+        fused_weight = _pop_fused_weight(
+            cache, param_name, shard_id, loaded_weight, _WQKV_A_SHARD_ORDER
+        )
+        if fused_weight is not None:
+            fused[param_name] = fused_weight
+    assert not cache, cache.keys()
+    return fused, unclaimed
+
+
+class TestWqaWkvFusionClassification(unittest.TestCase):
+    def test_dense_stream_fuses_on_dim0(self):
+        wq_a = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
+        wkv = torch.arange(2 * 4, dtype=torch.float32).reshape(2, 4) + 100
+        wq_a_scale = torch.arange(2 * 1, dtype=torch.float32).reshape(2, 1)
+        wkv_scale = torch.arange(1 * 1, dtype=torch.float32).reshape(1, 1) + 50
+
+        fused, unclaimed = fuse_wqa_wkv_stream(
+            [
+                (f"{ATTN_PREFIX}.wq_a.weight", wq_a),
+                (f"{ATTN_PREFIX}.wkv.weight", wkv),
+                (f"{ATTN_PREFIX}.wq_a.weight_scale_inv", wq_a_scale),
+                (f"{ATTN_PREFIX}.wkv.weight_scale_inv", wkv_scale),
+            ]
+        )
+
+        self.assertEqual(unclaimed, [])
+        self.assertEqual(
+            sorted(fused),
+            [f"{ATTN_PREFIX}.wqkv_a.weight", f"{ATTN_PREFIX}.wqkv_a.weight_scale_inv"],
+        )
+        torch.testing.assert_close(
+            fused[f"{ATTN_PREFIX}.wqkv_a.weight"], torch.cat([wq_a, wkv], dim=0)
+        )
+        torch.testing.assert_close(
+            fused[f"{ATTN_PREFIX}.wqkv_a.weight_scale_inv"],
+            torch.cat([wq_a_scale, wkv_scale], dim=0),
+        )
+
+    def test_shard_order_is_q_then_kv_regardless_of_arrival_order(self):
+        wq_a = torch.ones(8, 4)
+        wkv = torch.zeros(2, 4)
+
+        fused, _ = fuse_wqa_wkv_stream(
+            [
+                (f"{ATTN_PREFIX}.wkv.weight", wkv),
+                (f"{ATTN_PREFIX}.wq_a.weight", wq_a),
+            ]
+        )
+
+        torch.testing.assert_close(
+            fused[f"{ATTN_PREFIX}.wqkv_a.weight"], torch.cat([wq_a, wkv], dim=0)
+        )
+
+    def test_packed_stream_is_refused_instead_of_dropped(self):
+        # auto_round / gptq packing: the checkpoint carries .qweight, .qzeros
+        # and .scales instead of a dense .weight.
+        for leaf in ("qweight", "qzeros", "scales"):
+            name = f"{ATTN_PREFIX}.wq_a.{leaf}"
+            with self.subTest(leaf=leaf):
+                with self.assertRaises(ValueError) as ctx:
+                    fuse_wqa_wkv_stream([(name, torch.zeros(2, 2))])
+                message = str(ctx.exception)
+                self.assertIn(name, message)
+                self.assertIn(leaf, message)
+                self.assertIn("SGLANG_OPT_FUSE_WQA_WKV=0", message)
+
+    def test_packed_wkv_is_refused(self):
+        name = f"{ATTN_PREFIX}.wkv.qweight"
+        with self.assertRaises(ValueError) as ctx:
+            fuse_wqa_wkv_stream([(name, torch.zeros(2, 2))])
+        self.assertIn(name, str(ctx.exception))
+
+    def test_unrelated_names_are_left_to_the_generic_path(self):
+        names = [
+            f"{ATTN_PREFIX}.wq_b.weight",
+            f"{ATTN_PREFIX}.wo_a.weight",
+            "model.embed_tokens.weight",
+            "lm_head.weight",
+        ]
+        fused, unclaimed = fuse_wqa_wkv_stream([(n, torch.zeros(1)) for n in names])
+        self.assertEqual(fused, {})
+        self.assertEqual(unclaimed, names)
+
+
+class TestCompressorFusionClassification(unittest.TestCase):
+    def test_dense_stream_fuses_kv_then_wgate(self):
+        cache = {}
+        kv = torch.arange(4 * 3, dtype=torch.float32).reshape(4, 3)
+        wgate = torch.arange(2 * 3, dtype=torch.float32).reshape(2, 3) + 100
+
+        results = []
+        for name, loaded_weight in [
+            (f"{COMPRESSOR_PREFIX}.wgate.weight", wgate),
+            (f"{COMPRESSOR_PREFIX}.wkv.weight", kv),
+        ]:
+            shard_id, key, leaf = _classify_fused_shard(name, _COMPRESSOR_SHARD_IDS)
+            self.assertEqual(key, COMPRESSOR_PREFIX)
+            self.assertIn(leaf, _COMPRESSOR_FUSABLE_LEAVES)
+            results.append(
+                _pop_fused_weight(
+                    cache,
+                    f"{key}.wkv_gate.{leaf}",
+                    shard_id,
+                    loaded_weight,
+                    _COMPRESSOR_SHARD_ORDER,
+                )
+            )
+
+        self.assertIsNone(results[0])
+        torch.testing.assert_close(results[1], torch.cat([kv, wgate], dim=0))
+        self.assertEqual(cache, {})
+
+    def test_unrecognized_leaf_raises_named_error(self):
+        name = f"{COMPRESSOR_PREFIX}.wkv.qweight"
+        shard_id, key, leaf = _classify_fused_shard(name, _COMPRESSOR_SHARD_IDS)
+        self.assertEqual(shard_id, "kv")
+        self.assertNotIn(leaf, _COMPRESSOR_FUSABLE_LEAVES)
+        with self.assertRaises(ValueError) as ctx:
+            _reject_unfusable_leaf(
+                name,
+                leaf,
+                _COMPRESSOR_FUSABLE_LEAVES,
+                "The compressor wkv+wgate fusion supports dense checkpoints only.",
+            )
+        self.assertIn(name, str(ctx.exception))
+        self.assertIn("qweight", str(ctx.exception))
+
+    def test_unrecognized_segment_is_not_classified(self):
+        # ".compressor.w" also prefix-matches names the fusion cannot handle.
+        self.assertIsNone(
+            _classify_fused_shard(
+                f"{COMPRESSOR_PREFIX}.wsomething.weight", _COMPRESSOR_SHARD_IDS
+            )
+        )
+
+
+class TestLoadWeightsFusedProjection(unittest.TestCase):
+    """End-to-end over the real load_weights branch chain."""
+
+    def test_dense_stream_places_the_fused_parameter(self):
+        wq_a = torch.arange(8 * 4, dtype=torch.float32).reshape(8, 4)
+        wkv = torch.arange(2 * 4, dtype=torch.float32).reshape(2, 4) + 100
+        params = {
+            f"{ATTN_PREFIX}.wqkv_a.weight": torch.nn.Parameter(torch.zeros(10, 4))
+        }
+
+        run_load_weights(
+            params,
+            [
+                (f"{ATTN_PREFIX}.wq_a.weight", wq_a),
+                (f"{ATTN_PREFIX}.wkv.weight", wkv),
+            ],
+        )
+
+        torch.testing.assert_close(
+            params[f"{ATTN_PREFIX}.wqkv_a.weight"].data,
+            torch.cat([wq_a, wkv], dim=0),
+        )
+
+    def test_packed_stream_raises_instead_of_skipping(self):
+        # The reporter's auto_round checkpoint (packing_format
+        # auto_round:auto_gptq) ships these names. They used to fall through to
+        # the generic path, log "not found in params_dict" and be dropped.
+        params = {
+            f"{ATTN_PREFIX}.wqkv_a.qweight": torch.nn.Parameter(torch.zeros(4, 10))
+        }
+        weights = [
+            (f"{ATTN_PREFIX}.wq_a.qweight", torch.zeros(4, 8)),
+            (f"{ATTN_PREFIX}.wkv.qweight", torch.zeros(4, 2)),
+        ]
+
+        with self.assertRaises(ValueError) as ctx:
+            run_load_weights(params, weights)
+
+        message = str(ctx.exception)
+        self.assertIn(f"{ATTN_PREFIX}.wq_a.qweight", message)
+        self.assertIn("SGLANG_OPT_FUSE_WQA_WKV=0", message)
+
+    def test_compressor_dense_stream_places_the_fused_parameter(self):
+        kv = torch.arange(4 * 3, dtype=torch.float32).reshape(4, 3)
+        wgate = torch.arange(2 * 3, dtype=torch.float32).reshape(2, 3) + 100
+        params = {
+            f"{COMPRESSOR_PREFIX}.wkv_gate.weight": torch.nn.Parameter(
+                torch.zeros(6, 3)
+            )
+        }
+
+        run_load_weights(
+            params,
+            [
+                (f"{COMPRESSOR_PREFIX}.wkv.weight", kv),
+                (f"{COMPRESSOR_PREFIX}.wgate.weight", wgate),
+            ],
+        )
+
+        torch.testing.assert_close(
+            params[f"{COMPRESSOR_PREFIX}.wkv_gate.weight"].data,
+            torch.cat([kv, wgate], dim=0),
+        )
+
+    def test_compressor_packed_stream_raises_named_error(self):
+        params = {
+            f"{COMPRESSOR_PREFIX}.wkv_gate.qweight": torch.nn.Parameter(
+                torch.zeros(3, 6)
+            )
+        }
+        weights = [
+            (f"{COMPRESSOR_PREFIX}.wkv.qweight", torch.zeros(3, 4)),
+            (f"{COMPRESSOR_PREFIX}.wgate.qweight", torch.zeros(3, 2)),
+        ]
+
+        with self.assertRaises(ValueError) as ctx:
+            run_load_weights(params, weights)
+
+        self.assertIn(f"{COMPRESSOR_PREFIX}.wkv.qweight", str(ctx.exception))
+
+    def test_packed_stream_loads_unfused_when_fusion_is_off(self):
+        qweight = torch.ones(4, 8)
+        params = {
+            f"{ATTN_PREFIX}.wq_a.qweight": torch.nn.Parameter(torch.zeros(4, 8)),
+        }
+
+        run_load_weights(
+            params,
+            [(f"{ATTN_PREFIX}.wq_a.qweight", qweight)],
+            fuse_wqa_wkv=False,
+        )
+
+        torch.testing.assert_close(params[f"{ATTN_PREFIX}.wq_a.qweight"].data, qweight)
+
+
+class TestFusedShardBuffer(unittest.TestCase):
+    def test_duplicate_shard_is_rejected(self):
+        cache = {}
+        _pop_fused_weight(cache, "p", "q", torch.zeros(1), _WQKV_A_SHARD_ORDER)
+        with self.assertRaises(AssertionError):
+            _pop_fused_weight(cache, "p", "q", torch.zeros(1), _WQKV_A_SHARD_ORDER)
+
+    def test_incomplete_bucket_stays_in_cache(self):
+        cache = {}
+        self.assertIsNone(
+            _pop_fused_weight(cache, "p", "q", torch.zeros(1), _WQKV_A_SHARD_ORDER)
+        )
+        self.assertEqual(list(cache), ["p"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
+++ b/test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.models.deepseek_v4 import (
     _COMPRESSOR_FUSABLE_LEAVES,
     _COMPRESSOR_SHARD_IDS,
@@ -14,6 +15,7 @@ from sglang.srt.models.deepseek_v4 import (
     _WQKV_A_SHARD_ORDER,
     DeepseekV4ForCausalLM,
     _classify_fused_shard,
+    _is_dense_linear,
     _pop_fused_weight,
     _reject_unfusable_leaf,
 )
@@ -298,6 +300,35 @@ class TestLoadWeightsFusedProjection(unittest.TestCase):
             params,
             [(f"{ATTN_PREFIX}.wq_a.qweight", qweight)],
             fuse_wqa_wkv=False,
+        )
+
+        torch.testing.assert_close(params[f"{ATTN_PREFIX}.wq_a.qweight"].data, qweight)
+
+
+class TestPackedLayerFallback(unittest.TestCase):
+    def test_unquantized_replicated_linear_is_dense(self):
+        layer = ReplicatedLinear(8, 4, bias=False, quant_config=None)
+        self.assertTrue(_is_dense_linear(layer))
+
+    def test_packed_layer_is_not_dense(self):
+        layer = torch.nn.Module()
+        for packed_name in ("qweight", "qzeros", "scales"):
+            layer.register_parameter(packed_name, torch.nn.Parameter(torch.zeros(2, 2)))
+        self.assertFalse(_is_dense_linear(layer))
+
+    def test_loader_skips_fusion_when_the_model_has_no_wqkv_a(self):
+        # MqaAttentionBase built the unfused pair because the quantization
+        # method produced a packed layer, so load_weights must not try to fuse
+        # even though SGLANG_OPT_FUSE_WQA_WKV is on.
+        qweight = torch.ones(4, 8)
+        params = {
+            f"{ATTN_PREFIX}.wq_a.qweight": torch.nn.Parameter(torch.zeros(4, 8)),
+        }
+
+        run_load_weights(
+            params,
+            [(f"{ATTN_PREFIX}.wq_a.qweight", qweight)],
+            fuse_wqa_wkv=True,
         )
 
         torch.testing.assert_close(params[f"{ATTN_PREFIX}.wq_a.qweight"].data, qweight)


### PR DESCRIPTION
## Motivation
Fixes #33245

`load_weights` selected the `wq_a`+`wkv` fusion inputs by enumerating `.weight`-family leaf suffixes (`deepseek_v4.py:3057-3062`), so the branch is structurally unreachable for any packed layout. The tensors fall through to the generic path, hit `if name not in params_dict:` (`:3100-3105`), and are dropped with a `logger.warning`. Same shape one branch above: the compressor arm is guarded by the `.compressor.w` substring but classified by `.wkv.weight` / `.wgate.weight` suffixes with a bare `assert is_kv != is_wgate` (`:3026-3028`), so a packed compressor tensor trips an assertion with an empty message.

## Modifications
Three commits, smallest first.

**1. Classify the fused projection inputs by name segment.**

Both sites now key on the `.wq_a.` / `.wkv.` / `.wgate.` module name segment, which is what makes the failure format-independent — the reporter's checkpoint is auto_round (`auto_round:auto_gptq`, tensors named `.qweight` / `.qzeros` / `.scales`), different names from any other packed format, same miss. Enumerating leaves means a new arm per quantization format.

A leaf the fusion cannot join is then refused by name, pointing at `SGLANG_OPT_FUSE_WQA_WKV=0`, instead of being dropped. Refused rather than joined because both fusions concatenate on dim 0, which is the output axis of the dense layout only: GPTQ allocates `qweight` as `[input // pack_factor, output]` with `input_dim=0, output_dim=1` (`layers/quantization/gptq/schemes/gptq_linear.py:80-91`), AWQ as `[input, output // pack_factor]`, also `input_dim=0` (`awq/schemes/awq_linear.py:54-65`), while the dense weight is `[output, input]` with `output_dim=0` (`layers/quantization/unquant.py:152-160`). `qzeros` and `scales` carry their own group geometry on top. I verified this for gptq and awq only and did not audit every packed format.

The dense and fp8 block-scaled paths are unchanged: same concatenation order, same result.

**2. Skip the fusion when the built layer is packed.**

`MqaAttentionBase.__init__` (`deepseek_v4.py:454-500`) now checks whether the constructed `wqkv_a` exposes a plain `weight` parameter; if it does not, it drops it and builds the separate `wq_a` / `wkv` projections, warning once. This is deliberately not an allow-list of quant-config names — the existing precedent at `deepseek_v2.py:774` and `:1955` enumerates `{"awq", "awq_marlin", "moe_wna16"}` and would miss gptq and auto_round, which is how this class of bug arises. `load_weights` derives the same decision from the model that was actually built (`.wqkv_a.` present in `params_dict`) rather than reading the env a second time, so the two cannot disagree.

That turns the reporter's configuration from "loads, serves, produces garbage" into a correct load through the path he already verified works with `SGLANG_OPT_FUSE_WQA_WKV=0`.

**3. Summarize unplaced checkpoint weights after loading.**

Suggested by @Hakureirm in the issue. One `logger.warning` at the end of `load_weights` with the count and the top offending module prefixes, layer indices collapsed. To be precise about what was and was not already there: upstream does summarize *unfilled parameters* (`deepseek_v4.py:3148-3151`, "Some weights are not initialized from checkpoints"), and I confirmed it fires in the bug case. The missing direction is the other one — checkpoint tensors that were read and placed nowhere, which is what 258 per-tensor `not found in params_dict` lines communicate today.

Line numbers refer to main at 8d106c3.

## Accuracy Tests
How I verified it (CPU only, synthetic name streams driving the real `load_weights` — I have no Ampere hardware and did not load a real checkpoint):

Packed `wq_a`/`wkv` stream, before and after commit 1:
```
UNPATCHED: model.layers.3.self_attn.wq_a.qweight not found in params_dict.
           model.layers.3.self_attn.wkv.qweight not found in params_dict.
           Some weights are not initialized from checkpoints: {'...wqkv_a.qweight'}
           no exception; load_weights returned normally
           wqkv_a.qweight all zeros (never filled): True
PATCHED:   ValueError: Cannot fuse checkpoint tensor '...wq_a.qweight': the
           'qweight' leaf indicates a weight layout this fusion does not handle
           ... Set SGLANG_OPT_FUSE_WQA_WKV=0 ...
```
Compressor, before and after commit 1: bare `AssertionError` with an empty message becomes a named `ValueError`.

Packed model, before and after commit 2: `ValueError` becomes `no exception; load_weights returned normally; wq_a.qweight filled with the checkpoint tensor: True`.

Commit 3 output: `3 checkpoint weights were not placed into any parameter. Top module prefixes: model.layers.*.self_attn.q_norm (3)`.

Tests: `test/registered/unit/model_loader/test_deepseek_v4_fused_projection_loading.py`, 21 tests / 3 subtests, green. Neighbouring loader and override suites: 7 failures before and after, the same 7 names, all pre-existing GPU-dependent errors.

ruff (F401,F821,UP037), black, isort, codespell clean.

## Speed Tests and Profiling
Not applicable.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30854080896](https://github.com/sgl-project/sglang/actions/runs/30854080896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30854080627](https://github.com/sgl-project/sglang/actions/runs/30854080627)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->