### PR TITLE
Fix DeepSeek DSA top-k v2 defaulting on below SM90

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -83,6 +83,7 @@ from sglang.srt.utils.common import (
     is_no_spec_infer_or_topk_one,
     is_npu,
     is_remote_url,
+    is_sm80_supported,
     is_sm90_supported,
     is_sm100_or_sm110_supported,
     is_sm100_supported,
@@ -100,6 +101,24 @@ from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
+
+
+def _disable_topk_v2_without_thread_block_clusters() -> None:
+    """Turn off the fused top-k v2 kernel on CUDA devices below SM90.
+
+    ``topk_transform_512_v2`` uses ``cg::this_cluster()``, i.e. thread-block
+    clusters, which only exist from Hopper on. On SM8x the JIT compile fails
+    with "namespace cooperative_groups has no member this_cluster" while the
+    v1 path compiles and runs, so pick v1 the same way this file already does
+    for ROCm and SM120.
+    """
+    if is_sm80_supported():
+        logger.info(
+            "Disabling SGLANG_OPT_USE_TOPK_V2: the fused top-k v2 kernel needs "
+            "thread-block clusters (SM90+)."
+        )
+        envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+
 
 # Define constants
 DEFAULT_UVICORN_ACCESS_LOG_EXCLUDE_PREFIXES = ()
@@ -5228,6 +5247,10 @@ class ServerArgs:
             )
 
             run_post_process_pass(self, _deepseek_moe_quant_resolution)
+            if is_deepseek_dsa(hf_config):
+                # Same kernel, same reason as the HIP arm below: no
+                # thread-block clusters before SM90.
+                _disable_topk_v2_without_thread_block_clusters()
             if is_hip():
                 if is_deepseek_dsa(hf_config):
                     # The fused top-k v2 kernel (topk_transform_512_v2) is a
@@ -5286,6 +5309,8 @@ class ServerArgs:
                 envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
                 # Prefer TileLang over the Torch fallback.
                 envs.SGLANG_OPT_USE_TILELANG_INDEXER.set(True)
+            elif is_sm80_supported():
+                _disable_topk_v2_without_thread_block_clusters()
             elif is_hip():
                 envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
                 envs.SGLANG_OPT_USE_FUSED_COMPRESS.set(True)

--- a/test/registered/unit/server_args/test_topk_v2_arch_gate.py
+++ b/test/registered/unit/server_args/test_topk_v2_arch_gate.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import patch
+
+from sglang.srt import server_args as server_args_module
+from sglang.srt.environ import envs
+from sglang.srt.server_args import _disable_topk_v2_without_thread_block_clusters
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestTopkV2ArchGate(unittest.TestCase):
+    def setUp(self):
+        self._previous = envs.SGLANG_OPT_USE_TOPK_V2.get()
+        envs.SGLANG_OPT_USE_TOPK_V2.set(True)
+
+    def tearDown(self):
+        envs.SGLANG_OPT_USE_TOPK_V2.set(self._previous)
+
+    def test_disabled_below_sm90(self):
+        with patch.object(server_args_module, "is_sm80_supported", return_value=True):
+            _disable_topk_v2_without_thread_block_clusters()
+        self.assertFalse(envs.SGLANG_OPT_USE_TOPK_V2.get())
+
+    def test_left_alone_from_sm90_on(self):
+        with patch.object(server_args_module, "is_sm80_supported", return_value=False):
+            _disable_topk_v2_without_thread_block_clusters()
+        self.assertTrue(envs.SGLANG_OPT_USE_TOPK_V2.get())
+
+    def test_logs_the_reason(self):
+        with patch.object(server_args_module, "is_sm80_supported", return_value=True):
+            with self.assertLogs("sglang.srt.server_args", level="INFO") as logs:
+                _disable_topk_v2_without_thread_block_clusters()
+        self.assertTrue(
+            any("thread-block clusters" in line for line in logs.output), logs.output
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Refs #33194

Blocker A of #33194 only.

`topk_transform_512_v2` uses `cg::this_cluster()` — thread-block clusters, Hopper and later — at `python/sglang/kernels/jit/include/sgl_kernel/deepseek_v4/topk_impl.cuh:718`, with a fixed cluster size of 8 and `cluster.map_shared_rank` for distributed shared memory (`:759`, `:802`). `SGLANG_OPT_USE_TOPK_V2` defaults to `True` (`environ.py:1164`) and is turned off by architecture only for ROCm (`server_args.py:5241`, `:5294`) and SM120 (`:5283`). Pre-Hopper CUDA is not covered, so on SM8x the JIT compile fails with `namespace "cooperative_groups" has no member "this_cluster"` during CUDA-graph capture, while the v1 path compiles and runs — which is what `SGLANG_OPT_USE_TOPK_V2=0` recovers in the report.

## Modifications
This adds the missing arm, for the DSA family and for DeepSeek-V4, with the same reasoning the existing ROCm arm already spells out in its comment.

This does not address blockers B and C of that issue.

Line numbers refer to main at 8d106c3.

## Accuracy Tests
How I verified it:

- The SM90+ requirement is read from the kernel source, cited above.
- The gating gap is read from `server_args.py`: `is_hip()` and `is_sm120_supported()` arms exist, no pre-Hopper CUDA arm.
- New test `test/registered/unit/server_args/test_topk_v2_arch_gate.py`, 3 tests: disabled below SM90, untouched from SM90 on, and the reason is logged. `test/registered/unit/server_args/`: 143 passed.
- ruff (F401,F821,UP037), black, isort, codespell clean.

I do not have Ampere hardware, so I did not reproduce the JIT failure myself — that part rests on the report. The change is a default flip on an architecture where the kernel provably cannot compile, and it leaves SM90+ untouched.

## Speed Tests and Profiling
Not applicable.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30739695378](https://github.com/sgl-project/sglang/actions/runs/30739695378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30739695321](https://github.com/sgl-project/sglang/actions/runs/30739695321)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->