### PR TITLE
Support runtime HiCache storage attach/detach on UnifiedRadixCache

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1534,7 +1534,7 @@ class UnifiedRadixCache(BasePrefixCache):
         n_storage_hit: Optional[int],
         n_backup: Optional[int],
         n_release: Optional[int],
-        extra_release_counts: Optional[dict[PoolName, int]],
+        extra_release_counts: Optional[dict[PoolName, Optional[int]]],
         log_metrics: bool,
     ) -> None:
         cc = self.cache_controller
@@ -1679,6 +1679,65 @@ class UnifiedRadixCache(BasePrefixCache):
             log_metrics=True,
         )
 
+    def _drain_storage_control_queues_local(self) -> None:
+        """Drain the control queues without the cross-rank size all-reduce.
+
+        Used on the detach path, where the collective in
+        ``drain_storage_control_queues`` cannot be relied on. Storage hits are not
+        drained: allocating host pages for a new prefetch while tearing storage
+        down would immediately leak them.
+        """
+        cc = self.cache_controller
+        extra_release_queues = getattr(cc, "extra_host_mem_release_queues", {})
+        self._drain_storage_control_queues_impl(
+            n_revoke=None,
+            n_storage_hit=0,
+            n_backup=None,
+            n_release=None,
+            extra_release_counts={name: None for name in extra_release_queues},
+            log_metrics=False,
+        )
+
+    def _force_release_pending_storage_ops(self) -> None:
+        """Release leftover prefetch/backup bookkeeping after storage teardown.
+
+        Assumes the controller's storage threads are already stopped, so nothing
+        can touch these structures concurrently. Anything still tracked here never
+        got a revoke or an ack, so its host pages and host locks must be dropped
+        here or they leak for the lifetime of the process.
+        """
+        cc = self.cache_controller
+
+        for req_id in list(self.ongoing_prefetch):
+            info = self.ongoing_prefetch.get(req_id)
+            if info is None:
+                continue
+            try:
+                if info.host_indices is not None:
+                    cc.mem_pool_host.free(info.host_indices)
+            except Exception:
+                logger.exception("Failed to free host indices for prefetch %s", req_id)
+            try:
+                # Drops the anchor host lock, queues the extra-pool frees and
+                # gives back the prefetch token budget.
+                self._revoke_pending_prefetch(req_id)
+            except Exception:
+                logger.exception("Failed to revoke pending prefetch %s", req_id)
+                self.ongoing_prefetch.pop(req_id, None)
+        self.prefetch_loaded_tokens_by_reqid.clear()
+
+        for operation_id in list(self.ongoing_backup):
+            entry = self.ongoing_backup.pop(operation_id, None)
+            if entry is None:
+                continue
+            node_id, lock_params = entry
+            try:
+                self.dec_host_lock_ref(node_id, lock_params)
+            except Exception:
+                logger.exception(
+                    "Failed to release host lock for backup %s", operation_id
+                )
+
     def _apply_storage_runtime_config(
         self,
         *,
@@ -1736,6 +1795,25 @@ class UnifiedRadixCache(BasePrefixCache):
         else:
             self.storage_metrics_collector = None
 
+    def _set_storage_policies(
+        self,
+        hicache_storage_prefetch_policy: Optional[str],
+        hicache_write_policy: Optional[str],
+    ) -> None:
+        if hicache_storage_prefetch_policy is not None:
+            self.prefetch_stop_policy = hicache_storage_prefetch_policy
+            logger.info(
+                "Set hicache_storage_prefetch_policy to %s",
+                hicache_storage_prefetch_policy,
+            )
+        if hicache_write_policy is not None:
+            self.cache_controller.write_policy = hicache_write_policy
+            self.write_through_threshold = (
+                1 if hicache_write_policy == "write_through" else 2
+            )
+            self.is_write_back = hicache_write_policy == "write_back"
+            logger.info("Set hicache_write_policy to %s", hicache_write_policy)
+
     def attach_storage_backend(
         self,
         storage_backend: str,
@@ -1744,18 +1822,144 @@ class UnifiedRadixCache(BasePrefixCache):
         hicache_storage_prefetch_policy: Optional[str] = None,
         hicache_write_policy: Optional[str] = None,
     ) -> tuple[bool, str]:
-        return (
-            False,
-            "UnifiedRadixCache does not support runtime HiCache storage attach yet. "
-            "Configure hicache_storage_backend at startup instead.",
+        """Attach (enable) a storage backend at runtime.
+
+        Starts the storage threads inside ``HybridCacheController`` and enables the
+        prefetch/backup paths. Caller must ensure there are no running/queued
+        requests to avoid races.
+        """
+        if self.cache_controller is None:
+            return (
+                False,
+                "Hierarchical cache is not initialized; cannot attach a HiCache storage backend.",
+            )
+
+        # Validate inputs first (no side effects).
+        if hicache_storage_prefetch_policy is not None:
+            allowed = ["best_effort", "wait_complete", "timeout"]
+            if hicache_storage_prefetch_policy not in allowed:
+                return (
+                    False,
+                    f"Invalid hicache_storage_prefetch_policy: {hicache_storage_prefetch_policy!r}. "
+                    f"Expected one of {allowed}.",
+                )
+
+        if hicache_write_policy is not None:
+            allowed = ["write_back", "write_through", "write_through_selective"]
+            if hicache_write_policy not in allowed:
+                return (
+                    False,
+                    f"Invalid hicache_write_policy: {hicache_write_policy!r}. "
+                    f"Expected one of {allowed}.",
+                )
+
+        # If already enabled:
+        # - backend unchanged: treat as success, update policies only.
+        # - backend changed: treat as failure, do NOT update policies.
+        if self.enable_storage:
+            current_backend = self.cache_controller.storage_backend_type
+            if current_backend == storage_backend:
+                self._set_storage_policies(
+                    hicache_storage_prefetch_policy, hicache_write_policy
+                )
+                return (
+                    True,
+                    "HiCache storage backend already enabled with same backend; policies updated.",
+                )
+
+            return (
+                False,
+                f"HiCache storage backend is already enabled with backend '{current_backend}'. "
+                f"Cannot attach different backend '{storage_backend}'. Detach first.",
+            )
+
+        # Not enabled: update policies before the controller attach so the storage
+        # threads observe the new values.
+        self._set_storage_policies(
+            hicache_storage_prefetch_policy, hicache_write_policy
         )
 
-    def detach_storage_backend(self) -> tuple[bool, str]:
-        return (
-            False,
-            "UnifiedRadixCache does not support runtime HiCache storage detach yet. "
-            "Restart without hicache_storage_backend to disable it.",
+        logger.info("Attaching HiCache storage backend: %s", storage_backend)
+        try:
+            (
+                extra_config,
+                prefetch_threshold,
+                prefetch_timeout_base,
+                prefetch_timeout_per_ki_token,
+                hicache_storage_pass_prefix_keys,
+            ) = HybridCacheController.parse_storage_backend_extra_config(
+                storage_backend_extra_config_json
+            )
+        except Exception as e:
+            logger.exception("Failed to parse storage_backend_extra_config_json: %s", e)
+            return (
+                False,
+                f"Failed to parse storage_backend_extra_config_json "
+                f"'{storage_backend_extra_config_json}': {e}",
+            )
+
+        try:
+            self.cache_controller.attach_storage_backend(
+                storage_backend=storage_backend,
+                prefetch_threshold=prefetch_threshold,
+                model_name=served_model_name,
+                storage_backend_extra_config=extra_config,
+                host_pools=(
+                    self.host_pool_group.entries
+                    if self.host_pool_group is not None
+                    else None
+                ),
+            )
+        except Exception as e:
+            logger.exception("Failed to attach storage backend '%s'", storage_backend)
+            return False, f"Failed to attach storage backend '{storage_backend}': {e}"
+
+        self._apply_storage_runtime_config(
+            storage_backend=storage_backend,
+            prefetch_threshold=prefetch_threshold,
+            prefetch_timeout_base=prefetch_timeout_base,
+            prefetch_timeout_per_ki_token=prefetch_timeout_per_ki_token,
+            hicache_storage_pass_prefix_keys=hicache_storage_pass_prefix_keys,
+            enable_storage=True,
+            enable_storage_metrics=self._enable_metrics_flag,
+            extra_metric_labels=self.extra_metric_labels,
         )
+        return True, "Attached HiCache storage backend successfully."
+
+    def detach_storage_backend(self) -> tuple[bool, str]:
+        """Detach (disable) the storage backend at runtime.
+
+        Caller must ensure there are no running/queued requests to avoid races.
+        """
+        if self.cache_controller is None:
+            return (
+                False,
+                "Hierarchical cache is not initialized; cannot detach a HiCache storage backend.",
+            )
+
+        try:
+            # Drain before the storage threads go away: once `ongoing_*` is cleared,
+            # acks and releases can no longer be matched to nodes and would leak
+            # host pages and host locks.
+            self._drain_storage_control_queues_local()
+            # Idempotent detach: always ask the controller to best-effort clean up,
+            # even when `enable_storage` is already False, since a previous partial
+            # detach may have left threads or a backend instance behind.
+            self.cache_controller.detach_storage_backend()
+        except Exception as e:
+            logger.exception("Failed to detach storage backend.")
+            # Admin operations must not take the server down; report the failure.
+            return False, f"Failed to detach HiCache storage backend: {e}"
+
+        self._drain_storage_control_queues_local()
+        self._force_release_pending_storage_ops()
+        # The force release above routes its frees back through the release queues.
+        self._drain_storage_control_queues_local()
+
+        self.enable_storage = False
+        self.enable_storage_metrics = False
+        self.storage_metrics_collector = None
+        return True, "Detached HiCache storage backend successfully."
 
     def clear_storage_backend(self) -> bool:
         try:

--- a/test/registered/unit/mem_cache/test_unified_radix_storage_attach_detach.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_storage_attach_detach.py
@@ -1,0 +1,340 @@
+"""Unit tests for runtime HiCache storage attach/detach on UnifiedRadixCache."""
+
+import inspect
+import unittest
+from queue import Queue
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+from sglang.srt.mem_cache.unified_radix_cache import (
+    UnifiedRadixCache,
+    _OngoingPrefetch,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+PAGE_SIZE = 64
+
+
+class FakeHostPool:
+    def __init__(self):
+        self.freed = []
+        self.page_size = PAGE_SIZE
+
+    def free(self, indices):
+        self.freed.append(indices)
+
+
+class FakeHybridCacheController:
+    """Stands in for HybridCacheController on the control path only."""
+
+    def __init__(self, storage_backend=None):
+        self.enable_storage = storage_backend is not None
+        self.storage_backend_type = storage_backend
+        self.write_policy = "write_through_selective"
+        self.mem_pool_host = FakeHostPool()
+        self.prefetch_revoke_queue = Queue()
+        self.prefetch_hit_queue = Queue()
+        self.ack_backup_queue = Queue()
+        self.host_mem_release_queue = Queue()
+        self.extra_host_mem_release_queues = {}
+        self.prefetch_tokens_occupied = 0
+        self.attach_calls = []
+        self.detach_calls = 0
+        self.released_extra_pools = []
+
+    def attach_storage_backend(
+        self,
+        storage_backend,
+        prefetch_threshold=256,
+        model_name=None,
+        storage_backend_extra_config=None,
+        host_pools=None,
+    ):
+        if self.enable_storage:
+            raise RuntimeError("Storage backend already attached.")
+        self.attach_calls.append(
+            {
+                "storage_backend": storage_backend,
+                "prefetch_threshold": prefetch_threshold,
+                "model_name": model_name,
+                "storage_backend_extra_config": storage_backend_extra_config,
+                "host_pools": host_pools,
+            }
+        )
+        self.storage_backend_type = storage_backend
+        self.enable_storage = True
+
+    def detach_storage_backend(self):
+        self.detach_calls += 1
+        self.storage_backend_type = None
+        self.enable_storage = False
+
+    def append_host_mem_release(self, host_indices=None, extra_pools=None):
+        if host_indices is not None:
+            self.host_mem_release_queue.put(host_indices)
+        self.released_extra_pools.append(list(extra_pools or []))
+
+
+class FakeTreeCore:
+    """Holds the tree-owned state the UnifiedRadixCache facade delegates to."""
+
+    def __init__(self):
+        self.page_size = PAGE_SIZE
+        self.enable_storage = False
+        self.write_through_threshold = 2
+        self.is_write_back = False
+        self.dec_host_lock_ref_calls = []
+
+    def dec_host_lock_ref(self, node_id, params=None):
+        self.dec_host_lock_ref_calls.append((node_id, params))
+        return None
+
+
+def make_cache(storage_backend=None):
+    """Build a UnifiedRadixCache carrying only the state the control path reads."""
+    cache = UnifiedRadixCache.__new__(UnifiedRadixCache)
+    cache.disable = False
+    cache.tree_core = FakeTreeCore()
+    cache.tree_core.enable_storage = storage_backend is not None
+    cache.cache_controller = FakeHybridCacheController(storage_backend)
+    cache.host_pool_group = SimpleNamespace(entries=["kv-entry"])
+    cache.ongoing_prefetch = {}
+    cache.ongoing_backup = {}
+    cache.prefetch_loaded_tokens_by_reqid = {}
+    cache.prefetch_stop_policy = "best_effort"
+    cache.enable_storage_metrics = False
+    cache.storage_metrics_collector = None
+    cache._enable_metrics_flag = False
+    cache.extra_metric_labels = None
+    return cache
+
+
+def make_hiradix_stub(storage_backend=None):
+    """Duck-typed stand-in for HiRadixCache on the same control path.
+
+    Used to compare UnifiedRadixCache's results against the reference
+    implementation by calling the unbound HiRadixCache methods on it.
+    """
+    stub = SimpleNamespace(
+        enable_storage=storage_backend is not None,
+        enable_storage_metrics=False,
+        prefetch_stop_policy="best_effort",
+        write_through_threshold=2,
+        cache_controller=SimpleNamespace(
+            storage_backend_type=storage_backend,
+            write_policy="write_through_selective",
+            detach_storage_backend=lambda: None,
+        ),
+    )
+    stub._drain_storage_control_queues_local = lambda: None
+    stub._force_release_pending_storage_ops = lambda: None
+    return stub
+
+
+class TestUnifiedRadixStorageAttach(unittest.TestCase):
+    def test_attach_without_storage_succeeds(self):
+        cache = make_cache()
+        self.assertFalse(cache.enable_storage)
+
+        ok, msg = cache.attach_storage_backend(
+            storage_backend="file",
+            storage_backend_extra_config_json='{"prefetch_threshold": 128}',
+            served_model_name="my-model",
+            hicache_storage_prefetch_policy="timeout",
+            hicache_write_policy="write_through",
+        )
+
+        self.assertTrue(ok, msg)
+        self.assertTrue(cache.enable_storage)
+        self.assertTrue(cache.cache_controller.enable_storage)
+        self.assertEqual(cache.cache_controller.storage_backend_type, "file")
+        self.assertEqual(len(cache.cache_controller.attach_calls), 1)
+        call = cache.cache_controller.attach_calls[0]
+        self.assertEqual(call["storage_backend"], "file")
+        self.assertEqual(call["model_name"], "my-model")
+        self.assertEqual(call["prefetch_threshold"], 128)
+        self.assertEqual(call["storage_backend_extra_config"], {})
+        self.assertEqual(call["host_pools"], ["kv-entry"])
+        # Policies land on the tree and the controller.
+        self.assertEqual(cache.prefetch_stop_policy, "timeout")
+        self.assertEqual(cache.cache_controller.write_policy, "write_through")
+        self.assertEqual(cache.write_through_threshold, 1)
+        self.assertFalse(cache.is_write_back)
+        # Runtime config derived from the parsed extra config.
+        self.assertEqual(cache.prefetch_threshold, 128)
+        self.assertEqual(cache.prefetch_timeout_base, 1.0)
+        self.assertFalse(cache.hicache_storage_pass_prefix_keys)
+
+    def test_attach_write_back_policy_sets_tree_flag(self):
+        cache = make_cache()
+        ok, _ = cache.attach_storage_backend(
+            storage_backend="file",
+            hicache_write_policy="write_back",
+        )
+        self.assertTrue(ok)
+        self.assertTrue(cache.is_write_back)
+        self.assertEqual(cache.write_through_threshold, 2)
+
+    def test_attach_rejects_invalid_policies(self):
+        cache = make_cache()
+        ok, msg = cache.attach_storage_backend(
+            storage_backend="file", hicache_storage_prefetch_policy="nope"
+        )
+        self.assertFalse(ok)
+        self.assertIn("Invalid hicache_storage_prefetch_policy", msg)
+
+        ok, msg = cache.attach_storage_backend(
+            storage_backend="file", hicache_write_policy="nope"
+        )
+        self.assertFalse(ok)
+        self.assertIn("Invalid hicache_write_policy", msg)
+        # Nothing was attached by the rejected calls.
+        self.assertFalse(cache.enable_storage)
+        self.assertEqual(cache.cache_controller.attach_calls, [])
+
+    def test_attach_same_backend_while_attached_matches_hiradix(self):
+        cache = make_cache(storage_backend="file")
+        unified = cache.attach_storage_backend(
+            storage_backend="file",
+            hicache_storage_prefetch_policy="wait_complete",
+            hicache_write_policy="write_through",
+        )
+        hiradix = HiRadixCache.attach_storage_backend(
+            make_hiradix_stub(storage_backend="file"),
+            storage_backend="file",
+            hicache_storage_prefetch_policy="wait_complete",
+            hicache_write_policy="write_through",
+        )
+
+        self.assertEqual(unified, hiradix)
+        self.assertTrue(unified[0])
+        # Same-backend attach only refreshes policies, it does not re-attach.
+        self.assertEqual(cache.cache_controller.attach_calls, [])
+        self.assertEqual(cache.prefetch_stop_policy, "wait_complete")
+        self.assertEqual(cache.write_through_threshold, 1)
+
+    def test_attach_different_backend_while_attached_matches_hiradix(self):
+        cache = make_cache(storage_backend="file")
+        unified = cache.attach_storage_backend(storage_backend="mooncake")
+        hiradix = HiRadixCache.attach_storage_backend(
+            make_hiradix_stub(storage_backend="file"),
+            storage_backend="mooncake",
+        )
+
+        self.assertEqual(unified, hiradix)
+        self.assertFalse(unified[0])
+        self.assertIn("Detach first", unified[1])
+        self.assertTrue(cache.enable_storage)
+        self.assertEqual(cache.cache_controller.storage_backend_type, "file")
+
+    def test_attach_reports_controller_failure(self):
+        cache = make_cache()
+
+        def boom(**kwargs):
+            raise RuntimeError("backend unavailable")
+
+        cache.cache_controller.attach_storage_backend = boom
+        ok, msg = cache.attach_storage_backend(storage_backend="file")
+        self.assertFalse(ok)
+        self.assertIn("backend unavailable", msg)
+        self.assertFalse(cache.enable_storage)
+
+    def test_attach_reports_bad_extra_config_json(self):
+        cache = make_cache()
+        ok, msg = cache.attach_storage_backend(
+            storage_backend="file", storage_backend_extra_config_json="{not json"
+        )
+        self.assertFalse(ok)
+        self.assertIn("Failed to parse storage_backend_extra_config_json", msg)
+        self.assertFalse(cache.enable_storage)
+
+
+class TestUnifiedRadixStorageDetach(unittest.TestCase):
+    def test_detach_succeeds_and_leaves_tree_usable(self):
+        cache = make_cache(storage_backend="file")
+        cache.enable_storage_metrics = True
+        cache.storage_metrics_collector = object()
+
+        ok, msg = cache.detach_storage_backend()
+
+        self.assertTrue(ok, msg)
+        self.assertEqual(cache.cache_controller.detach_calls, 1)
+        self.assertFalse(cache.enable_storage)
+        self.assertFalse(cache.enable_storage_metrics)
+        self.assertIsNone(cache.storage_metrics_collector)
+        # The tree stays usable without storage: attach works again afterwards.
+        ok, msg = cache.attach_storage_backend(storage_backend="file")
+        self.assertTrue(ok, msg)
+        self.assertTrue(cache.enable_storage)
+
+    def test_detach_releases_pending_storage_ops(self):
+        cache = make_cache(storage_backend="file")
+        host_indices = torch.arange(4)
+        cache.ongoing_prefetch["req-0"] = _OngoingPrefetch(
+            anchor_node_id=7,
+            prefetch_key=[1, 2, 3, 4],
+            host_indices=host_indices,
+            operation=SimpleNamespace(),
+            anchor_lock_params=None,
+            comp_xfers={},
+        )
+        cache.ongoing_backup[11] = (9, None)
+        cache.prefetch_loaded_tokens_by_reqid["req-0"] = 4
+        cache.cache_controller.prefetch_tokens_occupied = 4
+
+        ok, msg = cache.detach_storage_backend()
+
+        self.assertTrue(ok, msg)
+        self.assertEqual(cache.ongoing_prefetch, {})
+        self.assertEqual(cache.ongoing_backup, {})
+        self.assertEqual(cache.prefetch_loaded_tokens_by_reqid, {})
+        self.assertEqual(cache.cache_controller.prefetch_tokens_occupied, 0)
+        self.assertEqual(len(cache.cache_controller.mem_pool_host.freed), 1)
+        self.assertTrue(
+            torch.equal(cache.cache_controller.mem_pool_host.freed[0], host_indices)
+        )
+        # Host locks of the anchor node and the pending backup were dropped.
+        self.assertIn((7, None), cache.tree_core.dec_host_lock_ref_calls)
+        self.assertIn((9, None), cache.tree_core.dec_host_lock_ref_calls)
+
+    def test_detach_without_storage_matches_hiradix(self):
+        cache = make_cache()
+        unified = cache.detach_storage_backend()
+        hiradix = HiRadixCache.detach_storage_backend(make_hiradix_stub())
+
+        self.assertEqual(unified, hiradix)
+        self.assertTrue(unified[0])
+        self.assertFalse(cache.enable_storage)
+        # Idempotent: the controller is asked to clean up regardless.
+        self.assertEqual(cache.cache_controller.detach_calls, 1)
+
+    def test_detach_reports_controller_failure(self):
+        cache = make_cache(storage_backend="file")
+
+        def boom():
+            raise RuntimeError("threads still alive")
+
+        cache.cache_controller.detach_storage_backend = boom
+        ok, msg = cache.detach_storage_backend()
+        self.assertFalse(ok)
+        self.assertIn("threads still alive", msg)
+        # Storage stays marked enabled so the caller can retry the detach.
+        self.assertTrue(cache.enable_storage)
+
+
+class TestUnifiedRadixStorageStubsRemoved(unittest.TestCase):
+    def test_no_unsupported_stub_messages(self):
+        for method in (
+            UnifiedRadixCache.attach_storage_backend,
+            UnifiedRadixCache.detach_storage_backend,
+        ):
+            source = inspect.getsource(method)
+            self.assertNotIn("does not support runtime HiCache storage", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
Closes #32817

`UnifiedRadixCache.attach_storage_backend` and `detach_storage_backend` were stubs returning `(False, "UnifiedRadixCache does not support runtime HiCache storage attach/detach yet ...")` (`unified_radix_cache.py:1739` and `:1753`), so `PUT` and `DELETE` on `/hicache/storage-backend` fail for any model served through the unified tree. The route reaches them directly: `http_server.py:1025` / `:1059` → `tokenizer_control_mixin.py:312` → the scheduler handlers registered at `scheduler.py:1435-1436`, which call `self.tree_cache.attach_storage_backend(...)` at `scheduler.py:3964` and `detach_storage_backend()` at `:4013`/`:4022`, both gated on `is_fully_idle()`.

## Modifications
This implements them by mirroring the working `HiRadixCache` (`hiradix_cache.py:364` / `:482`) and `HiMambaRadixCache` (`hi_mamba_radix_cache.py:1305` / `:1402`) paths on top of the tree's own `init_hicache` and the already-factored `_apply_storage_runtime_config`. No controller change was needed: `UnifiedRadixCache` holds a `HybridCacheController` (`unified_radix_cache.py:207`, assigned at `hybrid_cache/hybrid_pool_assembler.py:1334`), which already provides `attach_storage_backend` (`hybrid_cache_controller.py:217`), `parse_storage_backend_extra_config` (`:234`) and `append_host_mem_release` (`:328`), and inherits `detach_storage_backend` from `managers/cache_controller.py:536`.

Endpoint behaviour matches HiRadixCache exactly, including the already-attached cases: re-attaching the same backend updates the policies and returns success, a different backend is refused and asks for a detach first (`hiradix_cache.py:398-423`). The tests assert against the unbound `HiRadixCache` methods rather than against copied strings, so the two cannot drift apart silently.

Three places where the unified tree genuinely differs from HiRadixCache, all deliberate:

- `_drain_storage_control_queues_local` drains without the cross-rank all-reduce, and does not drain storage hits — allocating host pages for a new prefetch while tearing storage down would leak them immediately.
- `_force_release_pending_storage_ops` is written against unified's `_OngoingPrefetch` NamedTuple and its `ongoing_backup: dict[int, tuple[NodeId, DecLockRefParams]]`. Extra-pool frees go back through `append_host_mem_release`, so detach runs one extra local drain afterwards; HiRadixCache frees inline.
- `_set_storage_policies` also updates `self.is_write_back`, because `init_hicache` derives that flag from `cache_controller.write_policy` (`unified_radix_cache.py:367-370`) and `evict` reads it (`:489`). HiRadixCache has no such flag.

One-character type widening on `_drain_storage_control_queues_impl`: `extra_release_counts` becomes `Optional[dict[PoolName, Optional[int]]]`, because `None` already means "drain all" in `_drain_queue` and the teardown path passes it. No runtime change.

Not included: an auto-detaching `shutdown()`. `HiRadixCache` (`:308`) and `HiMambaRadixCache` (`:1260`) have one; `UnifiedRadixCache` has no `shutdown` at all today, and adding one is a separate behaviour change.

Line numbers refer to main at 8d106c3.

## Accuracy Tests
How I verified it (CPU only — no GPU, no model, no real storage backend):

- New test `test/registered/unit/mem_cache/test_unified_radix_storage_attach_detach.py`, 12 tests with a stubbed controller and pools. All 12 fail against the stubs and pass with the implementation.
- `test/registered/unit/mem_cache/` before and after: identical failure set (`comm` on the sorted failure lists is empty in both directions), +12 passed. The pre-existing failures in that directory are environmental on a CPU host ("No accelerator ... available", `torch.cpu has no attribute memory_allocated`); `test_hicache_nixl_storage.py` cannot even be collected without the `nixl` module and was excluded from both runs.
- ruff (F401,F821,UP037), black, isort, codespell clean.

I did not exercise the HTTP endpoint end to end. `test/registered/hicache/test_hicache_storage_runtime_attach_detach.py` does that and needs a GPU server, which I do not have; the claim here rests on the dispatch chain cited above plus unit-level behaviour.

## Speed Tests and Profiling
Not applicable.

## Checklist
- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30739771358](https://github.com/sgl-project/sglang/actions/runs/30739771358)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30739771216](https://github.com/sgl-project/sglang/actions/runs/30739771216)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->