### PR TITLE
[rust-server] Reland: fix TCP-layer TTFT stalls (#33026)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2571,6 +2571,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_json",
+ "socket2 0.6.4",
  "thiserror",
  "tokio",
  "tracing",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3"
 pyo3 = { version = "0.29.0", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+socket2 = "0.6"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/rust/sglang-server/Cargo.toml
+++ b/rust/sglang-server/Cargo.toml
@@ -24,6 +24,7 @@ futures = { workspace = true }
 pyo3 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+socket2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/rust/sglang-server/src/api_server.rs
+++ b/rust/sglang-server/src/api_server.rs
@@ -31,7 +31,7 @@ struct AppState {
 }
 
 pub async fn serve(
-    listener: std::net::TcpListener,
+    socket: tokio::net::TcpSocket,
     senders: Senders,
     egress_buf: usize,
     server_args: Arc<ServerArgs>,
@@ -61,12 +61,12 @@ pub async fn serve(
         .with_state(state);
     let app = log::apply(app, &server_args);
 
-    // The listener was already bound synchronously in `runtime::start` (so a port
-    // conflict fails startup); adopt it into the tokio reactor here.
-    let listener = match tokio::net::TcpListener::from_std(listener) {
+    // The socket was already bound synchronously in `runtime::start` (so a port
+    // conflict fails startup); start listening here, on the api runtime.
+    let listener = match socket.listen(1024) {
         Ok(l) => l,
         Err(e) => {
-            tracing::error!(error = %e, "failed to adopt pre-bound listener");
+            tracing::error!(error = %e, "listen failed");
             return;
         }
     };
@@ -79,6 +79,14 @@ pub async fn serve(
     // runtime drops → detached handlers cancel → their `AbortGuard`s fire, release
     // `Senders` clones → tok/detok channels close → workers exit. Full drain is
     // deferred (see `request_shutdown`).
+    // Match Python (asyncio sets TCP_NODELAY); avoids a ~13 ms
+    // Nagle/delayed-ACK penalty on keep-alive connections.
+    use axum::serve::ListenerExt;
+    let listener = listener.tap_io(|io| {
+        if let Err(e) = io.set_nodelay(true) {
+            tracing::debug!(error = %e, "set_nodelay failed");
+        }
+    });
     // `with_connect_info` exposes the peer address to the access-log middleware.
     let serve = axum::serve(
         listener,

--- a/rust/sglang-server/src/api_server.rs
+++ b/rust/sglang-server/src/api_server.rs
@@ -31,7 +31,7 @@ struct AppState {
 }
 
 pub async fn serve(
-    socket: tokio::net::TcpSocket,
+    listener: std::net::TcpListener,
     senders: Senders,
     egress_buf: usize,
     server_args: Arc<ServerArgs>,
@@ -61,12 +61,12 @@ pub async fn serve(
         .with_state(state);
     let app = log::apply(app, &server_args);
 
-    // The socket was already bound synchronously in `runtime::start` (so a port
-    // conflict fails startup); start listening here, on the api runtime.
-    let listener = match socket.listen(1024) {
+    // The listener was already bound synchronously in `runtime::start` (so a port
+    // conflict fails startup); adopt it into the tokio reactor here.
+    let listener = match tokio::net::TcpListener::from_std(listener) {
         Ok(l) => l,
         Err(e) => {
-            tracing::error!(error = %e, "listen failed");
+            tracing::error!(error = %e, "failed to adopt pre-bound listener");
             return;
         }
     };

--- a/rust/sglang-server/src/runtime.rs
+++ b/rust/sglang-server/src/runtime.rs
@@ -94,11 +94,21 @@ impl Drop for Runtime {
 pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
     // Bind the API server port before spawning any thread, so an unavailable
     // port (EADDRINUSE) is a hard startup error.
-    let listener = std::net::TcpListener::bind(cfg.rust_server_args.http_addr)
-        .map_err(|e| format!("bind {} failed: {e}", cfg.rust_server_args.http_addr))?;
-    listener
-        .set_nonblocking(true)
-        .map_err(|e| format!("listener set_nonblocking failed: {e}"))?;
+    let addr = cfg.rust_server_args.http_addr;
+    let socket = match addr {
+        std::net::SocketAddr::V4(_) => tokio::net::TcpSocket::new_v4(),
+        std::net::SocketAddr::V6(_) => tokio::net::TcpSocket::new_v6(),
+    }
+    .map_err(|e| format!("socket for {addr} failed: {e}"))?;
+    socket
+        .set_reuseaddr(true)
+        .map_err(|e| format!("set_reuseaddr failed: {e}"))?;
+    if let Err(e) = socket.set_recv_buffer_size(16 * 1024 * 1024) {
+        eprintln!("warning: set_recv_buffer_size on listener failed: {e}");
+    }
+    socket
+        .bind(addr)
+        .map_err(|e| format!("bind {addr} failed: {e}"))?;
 
     let (shutdown_tx, shutdown_rx) = flume::unbounded::<()>();
     let mut threads = Vec::new();
@@ -267,7 +277,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
                 }
                 let rt = builder.build().expect("build api runtime");
                 rt.block_on(api_server::serve(
-                    listener,
+                    socket,
                     senders,
                     cfg.rust_server_args.channel_cap,
                     cfg.server_args.clone(),

--- a/rust/sglang-server/src/runtime.rs
+++ b/rust/sglang-server/src/runtime.rs
@@ -93,22 +93,31 @@ impl Drop for Runtime {
 /// startup misconfiguration (e.g. no tokenizer for a non-skip server).
 pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
     // Bind the API server port before spawning any thread, so an unavailable
-    // port (EADDRINUSE) is a hard startup error.
+    // port (EADDRINUSE) is a hard startup error. socket2 rather than
+    // `std::net::TcpListener` so SO_RCVBUF can be set before `listen`.
     let addr = cfg.rust_server_args.http_addr;
-    let socket = match addr {
-        std::net::SocketAddr::V4(_) => tokio::net::TcpSocket::new_v4(),
-        std::net::SocketAddr::V6(_) => tokio::net::TcpSocket::new_v6(),
-    }
+    let socket = socket2::Socket::new(
+        socket2::Domain::for_address(addr),
+        socket2::Type::STREAM,
+        Some(socket2::Protocol::TCP),
+    )
     .map_err(|e| format!("socket for {addr} failed: {e}"))?;
     socket
-        .set_reuseaddr(true)
+        .set_reuse_address(true)
         .map_err(|e| format!("set_reuseaddr failed: {e}"))?;
     if let Err(e) = socket.set_recv_buffer_size(16 * 1024 * 1024) {
         eprintln!("warning: set_recv_buffer_size on listener failed: {e}");
     }
     socket
-        .bind(addr)
+        .bind(&addr.into())
         .map_err(|e| format!("bind {addr} failed: {e}"))?;
+    socket
+        .listen(1024)
+        .map_err(|e| format!("listen on {addr} failed: {e}"))?;
+    let listener: std::net::TcpListener = socket.into();
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("listener set_nonblocking failed: {e}"))?;
 
     let (shutdown_tx, shutdown_rx) = flume::unbounded::<()>();
     let mut threads = Vec::new();
@@ -277,7 +286,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
                 }
                 let rt = builder.build().expect("build api runtime");
                 rt.block_on(api_server::serve(
-                    socket,
+                    listener,
                     senders,
                     cfg.rust_server_args.channel_cap,
                     cfg.server_args.clone(),


### PR DESCRIPTION
Relands #33026, resolving the issue of `runtime::tests` failing in the `test_cargo_workspace` CI job ([log](https://github.com/sgl-project/sglang/actions/runs/30723127006/job/91430085608)), which caused the revert (#33257): `tokio::net::TcpSocket::listen()` needs a reactor, so #33026 moved `listen()` from the synchronous `runtime::start()` onto the async api runtime, and tests connecting right after `start()` returned raced it (`ECONNREFUSED`). This reland builds the listener with `socket2` instead — it can set `SO_RCVBUF` before bind while staying synchronous, so `start()` binds **and** listens before spawning any thread, restoring the tested guarantee with no test changes.

--- 

Two TCP-layer TTFT stalls in the Rust server, found benchmarking Rust vs Python TM (gpt-oss-120b + MiMo-V2.5-Pro, 8×B300, `bench_serving` c=1, seed 42, `--disable-radix-cache`):

1. **~200 ms on large request bodies.** A headers+body burst larger than the kernel's initial rcvbuf (`tcp_rmem[1]` = 87380 B) drops its tail before hyper polls the body. Hits the first large-body request of every connection. **Fix:** `SO_RCVBUF` 16 MiB on the listener (inherited by accepted sockets; covers a 1M-token body; lazily allocated; clamped by `net.core.rmem_max`).
2. **+13 ms on keep-alive connections.** hyper/axum doesn't set `TCP_NODELAY` (Python's asyncio does); Nagle + delayed-ACK. **Fix:** `set_nodelay(true)` via `ListenerExt::tap_io`.

All rows measured on `main` at `55b6769b0e`, unfixed vs this fix, Python TM on the same base as reference:

| TTFT (mean ms) | before | after | Python TM ref |
| --- | ---: | ---: | ---: |
| gpt-oss 16K in | 192 (P99 369) | **157 (P99 161)** | 166 |
| gpt-oss 64K in | 1253 (P99 1463) | **1047 (P99 1060)** | 1080 |
| MiMo 64K in | 2197 | **1957** | 1986 |
| MiMo 256K in | 9716 | **9513** | 9669 |
| gpt-oss in=1, keep-alive ×128 | 40.9 | **26.4** | 26.4 |

Raw-socket probe (headers+390 KB in one `send`, time to response headers): 208 ms → 0.4 ms. Decode path unaffected (ITL parity with Python through c=256).

## Test

`cargo test --workspace` passes locally (including the two tests that failed in CI); `cargo fmt --check` and `cargo clippy --workspace` clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30741441092](https://github.com/sgl-project/sglang/actions/runs/30741441092)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30741440965](https://github.com/sgl-project/sglang/actions/runs/30741440965)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->