### PR TITLE
Fix hf3fs _batch_set returning a scalar on the MLA skip-backup path

### DIFF
--- a/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
@@ -434,9 +434,11 @@ class HiCacheHF3FS(HiCacheStorage):
         keys: List[str],
         values: Optional[Any] = None,
     ) -> List[bool]:
-        # In MLA backend, only one rank needs to backup the KV cache
+        # In MLA backend, only one rank needs to backup the KV cache.
+        # Return one entry per key so callers can consume the result uniformly
+        # (e.g. `all(...)` in HiCacheController._page_set_zero_copy).
         if self.skip_backup:
-            return True
+            return [True] * len(keys)
 
         # Todo: Add prefix block's hash key
         key_with_prefix = [(key, "") for key in keys]

--- a/test/registered/unit/mem_cache/test_hicache_hf3fs_storage.py
+++ b/test/registered/unit/mem_cache/test_hicache_hf3fs_storage.py
@@ -1,0 +1,107 @@
+"""Unit tests for the HF3FS HiCache storage backend -- no server, no model loading."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import torch
+
+from sglang.srt.mem_cache.storage.hf3fs.mini_3fs_metadata_server import (
+    Hf3fsLocalMetadataClient,
+)
+from sglang.srt.mem_cache.storage.hf3fs.storage_hf3fs import HiCacheHF3FS
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+BYTES_PER_PAGE = 64
+NUM_PAGES = 8
+
+
+class MockHostKVCache:
+    """Minimal HostKVCache stand-in with a page-first (zero-copy) layout."""
+
+    def __init__(self, num_pages: int = NUM_PAGES, page_size: int = 1):
+        self.page_size = page_size
+        self.layout = "page_first"
+        self.dtype = torch.uint8
+        self.buffer = torch.arange(
+            num_pages * BYTES_PER_PAGE, dtype=torch.int64
+        ).remainder(256)
+        self.buffer = self.buffer.to(torch.uint8).view(num_pages, BYTES_PER_PAGE)
+
+    def get_data_page(self, index, flat: bool = True) -> torch.Tensor:
+        return self.buffer[int(index) // self.page_size]
+
+
+class TestHiCacheHF3FSSkipBackup(CustomTestCase):
+    """`_batch_set` must honour its `List[bool]` contract on every return path."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.stores = []
+
+    def tearDown(self):
+        for store in self.stores:
+            store.close()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_store(self, rank: int, is_mla_model: bool = True) -> HiCacheHF3FS:
+        store = HiCacheHF3FS(
+            rank=rank,
+            file_path=os.path.join(self.temp_dir, f"hicache.{rank}.bin"),
+            file_size=NUM_PAGES * BYTES_PER_PAGE,
+            numjobs=1,
+            bytes_per_page=BYTES_PER_PAGE,
+            entries=2,
+            client_timeout=1,
+            dtype=torch.uint8,
+            metadata_client=Hf3fsLocalMetadataClient(),
+            is_mla_model=is_mla_model,
+            is_page_first_layout=True,
+            use_mock_client=True,
+        )
+        self.stores.append(store)
+        store.register_mem_pool_host(MockHostKVCache())
+        return store
+
+    def test_batch_set_returns_one_entry_per_key_on_skip_backup(self):
+        store = self._make_store(rank=1)
+        self.assertTrue(store.skip_backup)
+
+        keys = ["page0", "page1", "page2"]
+        results = store._batch_set(keys, values=None)
+
+        self.assertIsInstance(results, list)
+        self.assertEqual(results, [True] * len(keys))
+
+    def test_batch_set_v1_result_is_consumable_by_all_on_skip_backup(self):
+        """Mirrors HiCacheController._page_set_zero_copy, which does `all(...)`.
+
+        A scalar return raises `TypeError: 'bool' object is not iterable` here.
+        """
+        store = self._make_store(rank=1)
+        self.assertTrue(store.skip_backup)
+
+        results = store.batch_set_v1(["page0", "page1"], torch.tensor([0, 1]))
+
+        self.assertTrue(all(results))
+        self.assertEqual(results, [True, True])
+
+    def test_batch_set_v1_backup_rank_writes_and_returns_per_key_list(self):
+        """Control: the rank that does back up keeps returning a per-key list."""
+        store = self._make_store(rank=0)
+        self.assertFalse(store.skip_backup)
+
+        keys = ["page0", "page1"]
+        results = store.batch_set_v1(keys, torch.tensor([0, 1]))
+
+        self.assertEqual(results, [True, True])
+        self.assertTrue(all(results))
+        self.assertEqual(store.batch_exists(keys), len(keys))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`HiCacheHF3FS._batch_set` is annotated `-> List[bool]`, and the `HiCacheStorage` base class documents `batch_set_v1` as returning "a list of booleans indicating success for each key". On the MLA skip-backup path it returns the scalar `True` instead:

https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py#L432-L439

The consumer for this backend treats the result as a sequence — `HiCacheController._page_set_zero_copy` does `all(self.storage_backend.batch_set_v1(...))`, and `hf3fs` is one of the backends routed to it. `all(True)` raises `TypeError: 'bool' object is not iterable`; it is a crash, not a silently wrong success value.

Today that call is shadowed: `HiCacheController.backup_skip` gates `_page_backup` on `is_mla_model and tp_rank != 0`, the exact predicate `HiCacheHF3FS.skip_backup` is built from, and both read the same `HiCacheStorageConfig`. So the controller currently never reaches `_batch_set` when `skip_backup` is set, and the contract violation stays latent. It is still reachable for any direct caller of the public `batch_set_v1` API that does not duplicate the controller's guard, and the two guards drifting apart is a plausible future change.

The sibling backends already return a list on their equivalent paths: `hicache_nixl.py` returns `[True] * len(keys)` and `umbp_store.py` returns `[True] * page_count`. `hf3fs` is the outlier.

## Modifications

- `python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py`: return `[True] * len(keys)` on the skip-backup path instead of the scalar `True`. `keys` is not expanded on this path (`mha_zero_copy` is `is_zero_copy and not is_mla_model`, and `skip_backup` implies `is_mla_model`), so its length is the page count the caller passed in.
- `test/registered/unit/mem_cache/test_hicache_hf3fs_storage.py`: new CPU unit test (`register_cpu_ci`, mock HF3FS client, local metadata client) covering the skip-backup return shape, the `all(...)` consumption pattern used by the controller, and the backup rank as a control.

## Accuracy Tests

Not applicable — no model-output change; the unit test covers the contract.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

Test run:

```
python3 test/registered/unit/mem_cache/test_hicache_hf3fs_storage.py
Ran 3 tests in 0.002s
OK
```

With the fix reverted, 2 of the 3 fail:

```
AssertionError: True is not an instance of <class 'list'>
TypeError: 'bool' object is not iterable
```

`pre-commit run --files <both files>` passes on all hooks.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30741173875](https://github.com/sgl-project/sglang/actions/runs/30741173875)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30741173829](https://github.com/sgl-project/sglang/actions/runs/30741173829)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->