### PR TITLE
Classify packed DeepSeek layers by what was built, not by quantization name

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -352,6 +352,8 @@ class DeepseekV2MLP(nn.Module):
             if (
                 gemm_output_zero_allocator is not None
                 and x.shape[0] <= 256
+                # A packed layer has qweight, not weight.
+                and getattr(self.gate_up_proj, "weight", None) is not None
                 and self.gate_up_proj.weight.dtype == torch.uint8
             ):
                 y = gemm_output_zero_allocator.allocate(
@@ -366,6 +368,7 @@ class DeepseekV2MLP(nn.Module):
         if (
             self.swiglu_limit is not None
             and not self.down_proj.reduce_results
+            and getattr(self.down_proj, "weight", None) is not None
             and self.down_proj.weight.dtype == torch.uint8
             and hasattr(self.down_proj, "weight_scale_inv")
         ):
@@ -771,13 +774,14 @@ class DeepseekV2MoE(nn.Module):
                 self.shared_experts._enable_nvfp4_gemm_swiglu_fusion = True
                 self.shared_experts.down_proj._accepts_prequantized_fp4 = True
             self._shared_expert_tp1 = _shared_expert_use_tp1
-            is_packed_weight = hasattr(
-                self.shared_experts.gate_up_proj.quant_method, "quant_config"
-            ) and self.shared_experts.gate_up_proj.quant_method.quant_config.get_name() in {
-                "awq",
-                "awq_marlin",
-                "moe_wna16",
-            }
+            # Ask the layer that was built, not a list of quantization names.
+            # Any packed layout stores qweight/qzeros/scales and exposes no plain
+            # `weight`, so this covers gptq and auto_round without naming them --
+            # the enumeration below used to miss both, and the two dtype reads
+            # that follow raise AttributeError on a layer it failed to classify.
+            is_packed_weight = (
+                getattr(self.shared_experts.gate_up_proj, "weight", None) is None
+            )
             self.shared_experts_is_int8 = (
                 not is_packed_weight
                 and self.shared_experts.gate_up_proj.weight.dtype == torch.int8
@@ -1952,19 +1956,18 @@ class DeepseekV2AttentionMLA(
         )
 
         self.has_fused_proj = hasattr(self, "fused_qkv_a_proj_with_mqa")
-        self.is_packed_weight = (
-            self.has_fused_proj
-            and hasattr(self.fused_qkv_a_proj_with_mqa.quant_method, "quant_config")
-            and self.fused_qkv_a_proj_with_mqa.quant_method.quant_config.get_name()
-            in {"awq", "awq_marlin", "moe_wna16"}
+        self.is_packed_weight = self.has_fused_proj and (
+            getattr(self.fused_qkv_a_proj_with_mqa, "weight", None) is None
         )
         self._use_min_latency_fused_a_gemm: bool | None = None
         self.fused_a_gemm_backend = "auto"
 
         self.has_q_b_proj = hasattr(self, "q_b_proj")
         q_b_proj_verified_shapes = {(2048, 2048), (4096, 2048)}
-        self._q_b_proj_verified_shape = self.has_q_b_proj and (
-            tuple(self.q_b_proj.weight.shape) in q_b_proj_verified_shapes
+        self._q_b_proj_verified_shape = (
+            self.has_q_b_proj
+            and getattr(self.q_b_proj, "weight", None) is not None
+            and tuple(self.q_b_proj.weight.shape) in q_b_proj_verified_shapes
         )
         self._use_min_latency_q_b_gemm: bool | None = None
 


### PR DESCRIPTION
## Motivation

Serving a DeepSeek checkpoint quantized with auto-round or gptq crashes during model init with an `AttributeError` on `.weight`.

`deepseek_v2.py` decides whether a layer is packed by comparing `quant_config.get_name()` against `{"awq", "awq_marlin", "moe_wna16"}`, then reads `.weight.dtype` on the assumption that anything outside that set is dense. gptq and auto_round are not in the set. A layer built by either stores `qweight`, `qzeros` and `scales`, and has no `weight` at all, so the next line raises.

The list cannot be finished by adding two more names -- the next packing format puts it back. This was called out as precedent in #33245, where the same enumeration pattern in `deepseek_v4.py` silently dropped weights instead of raising.

## Modifications

Ask the layer that was actually built. Every packed layout stores `qweight` and exposes no plain `weight`, which is precisely the property the following code depends on:

```python
is_packed_weight = getattr(self.shared_experts.gate_up_proj, "weight", None) is None
```

Two sites classified by quant name (`DeepseekV2MoE.__init__`, `DeepseekV2AttentionMLA.__init__`); both now key on the built layer.

Two further sites read `.weight.dtype` and `.weight.shape` with no classification in front of them at all (`DeepseekV2MLP.forward`, and the `q_b_proj` shape check). They fail the same way on the same checkpoints, so they are guarded here too.

## Accuracy Tests

Not applicable in the usual sense -- this changes which branch is taken during init, not any numerics. On a dense or awq checkpoint the classification result is identical, so the arithmetic paths are unchanged.

Behaviourally: DeepSeek-V4-Flash-0731 quantized with auto-round (`auto_round:auto_gptq`, W4A16, group 128) loads and serves correctly on 8xA800 with this change and raises `AttributeError` without it. Needle-in-a-haystack at 4K / 32K / 128K passes 4/4.

## Speed Tests and Profiling

No performance impact. `getattr` on a module attribute at init time, four times.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests -- I did not find an existing harness that constructs these layers under a packed quant config without a real checkpoint, and I would rather ask where such a test belongs than guess. Happy to add one.
- [ ] Update documentation according to Write documentations -- no user-facing surface change.
- [x] Provide accuracy and speed benchmark results -- above.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30741450794](https://github.com/sgl-project/sglang/actions/runs/30741450794)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30741450740](https://github.com/sgl-project/sglang/actions/runs/30741450740)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->