### PR TITLE
Add H20 FP8 fused MoE Triton configs for Qwen3.5-397B

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
@@ -1,0 +1,106 @@
+{
+  "1": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "2": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "4": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "7": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "14": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "28": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "56": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "112": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "224": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "1024": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "2048": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "4096": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  }
+}

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128]_down.json
@@ -1,0 +1,106 @@
+{
+  "1": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "2": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "4": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "7": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "14": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "28": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 16,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "56": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 64,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "112": {
+    "BLOCK_SIZE_M": 16,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "224": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "512": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "1024": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "2048": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  },
+  "4096": {
+    "BLOCK_SIZE_M": 64,
+    "BLOCK_SIZE_N": 128,
+    "BLOCK_SIZE_K": 128,
+    "GROUP_SIZE_M": 32,
+    "num_warps": 4,
+    "num_stages": 3
+  }
+}


### PR DESCRIPTION
## Motivation

Qwen3.5-397B-A17B-FP8 on NVIDIA H20 currently falls back to the default Triton fused MoE kernel config for the FP8 W8A8 MoE shape:

    E=512, N=128, device_name=NVIDIA_H20, dtype=fp8_w8a8, block_shape=[128, 128]

In speculative decoding with EAGLE/tree verification, the target model forward path is a major part of the verify latency. On H20, the missing tuned fused MoE configs caused SGLang to use the default MoE kernel config during target forward.

This PR adds H20-specific Triton 3.6.0 fused MoE configs for Qwen3.5-397B-A17B-FP8.

## Modifications

Added two tuned Triton fused MoE FP8 config files for NVIDIA H20:

    python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
    python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128]_down.json

This PR only adds pre-tuned config JSON files. It does not change model code, kernel code, sampling logic, or model outputs.

Baseline logs show the missing config warning:

    Using default MoE kernel config. Performance might be sub-optimal!
    Config file not found at .../E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
    Config file not found at .../E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128]_down.json

With this PR, the tuned run loads both config files:

    Using MoE kernel config from .../E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128].json
    Using MoE kernel config from .../E=512,N=128,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128]_down.json

## Accuracy Tests

Not applicable. This PR only adds tuned launch configs for the existing Triton fused MoE kernels. It does not change model weights, model forward logic, sampling logic, or kernel math.

## Speed Tests and Profiling

### Environment

- GPU: 8x NVIDIA H20
- Model: `/data/nfs3/Qwen3.5-397B-A17B-FP8`
- SGLang base: latest `main` at `558c9bdcc2edd4e1fe9345165acc62c885b02f10`
- Runtime container: `sglang-nightly-dev-cu13-20260724-433429b1.sif`
- Attention backend: `fa3`
- MoE runner backend: `auto`
- MoE A2A backend: `none`
- Effective FP8 MoE backend: Triton fused MoE
- TP: 8
- DP: 2
- Context length: 8192
- Workload: custom high-entropy prompts, 64 prompts per run
- Output length: 512
- Speculative decoding:
  - `--speculative-algorithm EAGLE`
  - `--speculative-num-steps 3`
  - `--speculative-eagle-topk 2`
  - `--speculative-num-draft-tokens 7`

### Microbenchmark

Small-token fused MoE microbenchmark for this shape showed lower latency with the tuned config:

| Tokens | Default | Tuned |
| ---: | ---: | ---: |
| 7 | ~101 us | ~63 us |
| 14 | ~190 us | ~105 us |
| 28 | ~297 us | ~166 us |
| 56 | ~468 us | ~253 us |
| 112 | ~596 us | ~335 us |

### End-to-end serving benchmark

Benchmark command shape:

    python3 -m sglang.benchmark.serving \
      --backend sglang \
      --dataset-name custom \
      --dataset-path /home/weihz/sglang_mtp_tree_exp/datasets/high_entropy_open_long_1024_64.jsonl \
      --sharegpt-output-len 512 \
      --sharegpt-context-len 8192 \
      --num-prompts 64 \
      --request-rate inf \
      --max-concurrency <batch_size> \
      --temperature 0.8 \
      --top-p 0.95 \
      --seed 12345 \
      --disable-tqdm \
      --output-details

Results on the same H20 node, baseline and tuned runs executed sequentially:

| Max concurrency | Output tok/s baseline | Output tok/s tuned | Delta | target_forward p50 baseline | target_forward p50 tuned | Delta | verify total p50 baseline | verify total p50 tuned | Delta |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 201.75 | 220.87 | +9.48% | 29.820 ms | 21.517 ms | -27.84% | 42.091 ms | 33.455 ms | -20.52% |
| 8 | 372.17 | 423.95 | +13.92% | 27.040 ms | 20.388 ms | -24.60% | 39.319 ms | 32.261 ms | -17.95% |
| 16 | 618.43 | 698.68 | +12.98% | 33.745 ms | 24.758 ms | -26.63% | 46.027 ms | 36.695 ms | -20.28% |

The accept length stayed approximately the same:

| Max concurrency | Baseline accept len | Tuned accept len |
| ---: | ---: | ---: |
| 4 | 3.043 | 3.062 |
| 8 | 2.972 | 3.003 |
| 16 | 3.003 | 3.066 |

Validation checks:

    python -m json.tool passed for both added JSON files.
    get_moe_configs() successfully loaded the new H20 configs.
    End-to-end serving benchmark completed successfully.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`python -m json.tool` passed for the added JSON files.)
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Not applicable; config-only PR.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable; config-only PR.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30741869992](https://github.com/sgl-project/sglang/actions/runs/30741869992)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30741869918](https://github.com/sgl-project/sglang/actions/runs/30741869918)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->