### PR TITLE
Fix DSpark loading for hybrid DSV4 NVFP4

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -263,10 +263,11 @@ def _get_quantization_config(
                     ModelOptFp4Config,
                 )
 
-                # MTP MoE layers (model.decoder.*) are not NVFP4 quantized.
+                # Draft experts serialized under mtp.* remain source MXFP4.
+                # NextN exposes them as model.decoder.*; DSpark as stages.*.
                 nvfp4_exclude_modules = list(
                     nvfp4_meta.get("exclude_modules") or []
-                ) + ["model.decoder.*"]
+                ) + ["model.decoder.*", "stages.*"]
                 nvfp4_config = ModelOptFp4Config(
                     is_checkpoint_nvfp4_serialized=True,
                     group_size=int(nvfp4_meta["group_size"]),

--- a/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
+++ b/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
@@ -29,7 +29,7 @@ def _make_processor(server_mode: str = "full") -> SchedulerBatchResultProcessor:
             enable_return_hidden_states=True,
             return_hidden_states_mode=server_mode,
         ),
-        model_config=SimpleNamespace(think_end_id=None),
+        model_config=SimpleNamespace(think_end_ids=None),
         token_to_kv_pool_allocator=Mock(),
         tree_cache=None,
         hisparse_coordinator=None,

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -1737,6 +1737,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 attention_backend=None,
                 decode_attention_backend=None,
                 prefill_attention_backend=None,
+                speculative_draft_attention_backend=None,
                 page_size=1,
             )
             defaults.update(kw)


### PR DESCRIPTION
## Summary

Add `stages.*` to the hybrid DSV4 NVFP4 exclusions so bundled MXFP4 DSpark experts load correctly instead of skipping their scales.

The issue repeated across the expert scales in all three DSpark stages; for example:

```text
DSpark V4 draft: unexpected weight 'mtp.0.ffn.experts.198.w1.scale' -> 'stages.0.mlp.experts.198.gate_proj.weight_scale_inv'
DSpark V4 draft: unexpected weight 'mtp.0.ffn.experts.198.w2.scale' -> 'stages.0.mlp.experts.198.down_proj.weight_scale_inv'
DSpark V4 draft: unexpected weight 'mtp.0.ffn.experts.198.w3.scale' -> 'stages.0.mlp.experts.198.up_proj.weight_scale_inv'
```

With the fix:

```text
FlashInfer TRTLLM MoE deferred finalize is disabled (moe_runner_backend=flashinfer_trtllm_routed, quant_method=Mxfp4FlashinferTrtllmMoEMethod).
Shuffling FP4 expert weights for TRT-LLM MxFP4 kernel (layer: stages.0.mlp.experts)...
Shuffling FP4 expert weights for TRT-LLM MxFP4 kernel (layer: stages.1.mlp.experts)...
Shuffling FP4 expert weights for TRT-LLM MxFP4 kernel (layer: stages.2.mlp.experts)...
Initialized DSpark draft runner. attention_backend=dsv4, model=DeepseekV4ForCausalLMDSpark, gamma=5, verify_num_draft_tokens=6, mask_token_id=128799, markov_head=DSparkV4MarkovHead
```

All three stages loaded with no unexpected-weight warnings.

## Accuracy Tests

```bash
CUDA_VISIBLE_DEVICES=3 sglang serve \
  --model-path mmangkad/DeepSeek-V4-Flash-0731-NVFP4 \
  --moe-runner-backend flashinfer_trtllm_routed \
  --speculative-algorithm DSPARK \
  --reasoning-parser deepseek-v4 \
  --tool-call-parser deepseekv4 \
  --trust-remote-code
```

```bash
sgl-eval run --base-url http://127.0.0.1:30000/v1 --num-threads 256 gsm8k

Run directory: /root/.sgl_eval/sgl_eval_gsm8k_20260802-052559
gsm8k: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1319/1319 [00:14<00:00, 90.45it/s, acc=96.89%]
== gsm8k ==
1319 examples (single-shot)  |  14.6s  |  8771 tok/s  |  128K tokens

* score           =  96.89%
  stop_rate       =  100.00%
  truncated_rate  =  0.00%
  error_rate      =  0.00%

Metrics: /root/.sgl_eval/sgl_eval_gsm8k_20260802-052559/metrics.json
Predictions: /root/.sgl_eval/sgl_eval_gsm8k_20260802-052559  (1 jsonl file(s))
```


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30744340205](https://github.com/sgl-project/sglang/actions/runs/30744340205)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30744340109](https://github.com/sgl-project/sglang/actions/runs/30744340109)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->