### PR TITLE
Support MXFP8 dense Marlin W8A16 on SM80/SM90

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -67,7 +67,10 @@ from sglang.srt.layers.quantization.fp8_utils import (
     requant_block_scale_ue8m0_for_deepgemm,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
-from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
+from sglang.srt.layers.quantization.marlin_utils_fp8 import (
+    prepare_fp8_layer_for_marlin,
+    prepare_mxfp8_layer_for_marlin,
+)
 from sglang.srt.layers.quantization.unquant import (
     UnquantizedFusedMoEMethod,
     UnquantizedLinearMethod,
@@ -84,6 +87,7 @@ from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import (
     cpu_has_amx_support,
     get_bool_env_var,
+    get_device_capability,
     is_cpu,
     is_cuda,
     is_gfx95_supported,
@@ -294,6 +298,8 @@ class Fp8Config(QuantizationConfig):
             return 95
         if self.use_mxfp8 and _mxfp8_to_block_fp8_required:
             return 94
+        if self.use_mxfp8 and _is_cuda:
+            return 80
 
         return 100 if self.use_mxfp8 else 80
 
@@ -451,6 +457,7 @@ class Fp8LinearMethod(LinearMethodBase):
         # For GPUs that lack FP8 hardware support, we can leverage the Marlin
         # kernel for fast weight-only FP8 quantization
         self.use_marlin = False
+        force_marlin = False
         if _is_cuda:
             force_marlin = get_bool_env_var("SGLANG_FORCE_FP8_MARLIN")
             auto_enable = can_auto_enable_marlin_fp8()
@@ -461,18 +468,40 @@ class Fp8LinearMethod(LinearMethodBase):
             self.use_mxfp8 or self.quant_config.weight_block_size is not None
         )
         self.convert_mxfp8_to_block = self.use_mxfp8 and _mxfp8_to_block_fp8_required
+        self.use_mxfp8_marlin = (
+            self.use_mxfp8
+            and _is_cuda
+            and not self.convert_mxfp8_to_block
+            and (force_marlin or self._can_auto_enable_mxfp8_marlin())
+        )
+        self.use_marlin = self.use_marlin or self.use_mxfp8_marlin
         self.weight_block_size = self.quant_config.weight_block_size
         self.w8a8_block_fp8_linear = None
         self.w8a8_mxfp8_linear = None
-        if self.use_mxfp8 and not self.convert_mxfp8_to_block:
+        if (
+            self.use_mxfp8
+            and not self.convert_mxfp8_to_block
+            and not self.use_mxfp8_marlin
+        ):
             self.w8a8_mxfp8_linear = dispatch_w8a8_mxfp8_linear()
-        else:
+        elif not self.use_mxfp8_marlin:
             self.w8a8_block_fp8_linear = dispatch_w8a8_block_fp8_linear()
         self.is_checkpoint_fp8_serialized = (
             self.quant_config.is_checkpoint_fp8_serialized
         )
         self.use_aiter_fp8_per_token = envs.SGLANG_USE_AITER_FP8_PER_TOKEN.get()
         self.use_per_token_if_dynamic = False
+
+    @staticmethod
+    def _can_auto_enable_mxfp8_marlin() -> bool:
+        try:
+            major, minor = get_device_capability()
+            if major is None or minor is None:
+                return False
+            sm = major * 10 + minor
+            return 80 <= sm < 100
+        except Exception:
+            return False
 
     @staticmethod
     def validate_block_quant_shapes(
@@ -663,12 +692,17 @@ class Fp8LinearMethod(LinearMethodBase):
             # MXFP8 (e4m3fn + UE8M0) must NOT be fnuz-normalized; check before
             # the fnuz branch since is_fp8_fnuz() is also True on gfx942.
             if not self.is_checkpoint_fp8_serialized:
-                self._quantize_mxfp8_weights(layer)
+                self._quantize_mxfp8_weights(
+                    layer, process_scale=not self.use_mxfp8_marlin
+                )
                 return
             # MXFP8 scales are stored as UE8M0 uint8; no requantization here.
             # Keep parameter object to preserve weight_loader attrs for hot reload.
+            layer.weight.requires_grad_(False)
             layer.weight_scale_inv.requires_grad_(False)
             layer.weight_scale_inv.format_ue8m0 = True
+            if self.use_mxfp8_marlin:
+                return
             self._process_mxfp8_linear_weight_scale(layer)
             return
         # If ROCm, normalize the weights and scales to e4m3fnuz
@@ -805,7 +839,9 @@ class Fp8LinearMethod(LinearMethodBase):
             # Triton path consumes canonical 2D UE8M0 uint8 scales directly.
             return
 
-    def _quantize_mxfp8_weights(self, layer: Module) -> None:
+    def _quantize_mxfp8_weights(
+        self, layer: Module, process_scale: bool = True
+    ) -> None:
         weight = layer.weight.data
         qweight, weight_scale = mxfp8_group_quantize(weight)
         # Keep parameter objects to preserve weight_loader attrs for hot reload.
@@ -820,7 +856,8 @@ class Fp8LinearMethod(LinearMethodBase):
                 "weight_scale_inv", Parameter(weight_scale, requires_grad=False)
             )
         layer.weight_scale_inv.format_ue8m0 = True
-        self._process_mxfp8_linear_weight_scale(layer)
+        if process_scale:
+            self._process_mxfp8_linear_weight_scale(layer)
         layer.input_scale = None
 
     def process_weights_after_loading(self, layer: Module) -> None:
@@ -931,7 +968,10 @@ class Fp8LinearMethod(LinearMethodBase):
         if self.use_marlin:
             if self.block_quant:
                 layer.weight_block_size = self.quant_config.weight_block_size
-            prepare_fp8_layer_for_marlin(layer, not self.block_quant)
+            if self.use_mxfp8_marlin:
+                prepare_mxfp8_layer_for_marlin(layer)
+            else:
+                prepare_fp8_layer_for_marlin(layer, not self.block_quant)
             # Activations not quantized for marlin.
             del layer.input_scale
 
@@ -941,6 +981,17 @@ class Fp8LinearMethod(LinearMethodBase):
         x: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        if self.use_mxfp8_marlin:
+            return torch.ops.sglang.apply_mxfp8_marlin_linear(
+                input=x,
+                weight=layer.weight,
+                weight_scale=layer.weight_scale,
+                workspace=layer.workspace,
+                size_n=layer.output_size_per_partition,
+                size_k=layer.input_size_per_partition,
+                bias=bias,
+            )
+
         if self.use_marlin:
             return torch.ops.sglang.apply_fp8_marlin_linear(
                 input=x,

--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -26,7 +27,7 @@ from sglang.srt.layers.quantization.utils import (
     pack_cols,
     unpack_cols,
 )
-from sglang.srt.utils import get_device_capability, is_cuda
+from sglang.srt.utils import get_device_capability, is_cuda, round_up
 from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
@@ -224,6 +225,85 @@ def check_marlin_supports_shape(
     except ValueError as e:
         return False, e.__str__()
     return True, None
+
+
+def marlin_padded_nk(size_n: int, size_k: int, group_size: int = -1) -> tuple[int, int]:
+    """Return a minimally padded Marlin GEMM shape.
+
+    Marlin supports two thread-tile families: (N % 64, K % 128) or
+    (N % 128, K % 64). Padding keeps K divisible by the quant group size so
+    grouped scales remain whole.
+    """
+    group = group_size if group_size > 0 else 1
+    candidates = (
+        (round_up(size_n, 64), round_up(size_k, math.lcm(128, group))),
+        (round_up(size_n, 128), round_up(size_k, math.lcm(64, group))),
+    )
+    padded_nk = min(candidates, key=lambda nk: (nk[0] * nk[1], nk[0] + nk[1]))
+    if padded_nk != (size_n, size_k):
+        logger.warning_once(
+            "Marlin requires thread-tile padding for some weight shapes in "
+            "this model. Activations and/or outputs of the padded layers are "
+            "padded/sliced on every forward; performance may be degraded."
+        )
+    return padded_nk
+
+
+def marlin_repacked_nk(qweight: torch.Tensor, num_bits: int) -> tuple[int, int]:
+    """Recover the padded (N, K) used to repack a Marlin weight."""
+    pack_factor = 32 // num_bits
+    size_k = qweight.size(0) * GPTQ_MARLIN_TILE
+    size_n = qweight.size(1) * pack_factor // GPTQ_MARLIN_TILE
+    return size_n, size_k
+
+
+def marlin_pad_qweight(
+    qweight: torch.Tensor,
+    size_n: int,
+    size_k: int,
+    padded_n: int,
+    padded_k: int,
+) -> torch.Tensor:
+    """Zero-pad a GPTQ-layout packed weight before Marlin repack."""
+    if (padded_n, padded_k) == (size_n, size_k):
+        return qweight
+    pack_factor = size_k // qweight.size(0)
+    return torch.nn.functional.pad(
+        qweight,
+        (0, padded_n - size_n, 0, (padded_k - size_k) // pack_factor),
+    )
+
+
+def marlin_pad_scales(
+    scales: torch.Tensor,
+    size_n: int,
+    size_k: int,
+    padded_n: int,
+    padded_k: int,
+    group_size: int,
+) -> torch.Tensor:
+    """Zero-pad weight scales shaped as [num_groups, N]."""
+    if (padded_n, padded_k) == (size_n, size_k):
+        return scales
+    pad_rows = padded_k // group_size - scales.size(0) if group_size > 0 else 0
+    assert pad_rows >= 0
+    return torch.nn.functional.pad(scales, (0, padded_n - size_n, 0, pad_rows))
+
+
+def marlin_pad_dim(x: torch.Tensor, size: int, padded: int) -> torch.Tensor:
+    """Zero-pad the last dimension from the logical size to the padded size."""
+    if padded == size:
+        return x
+    return torch.nn.functional.pad(x, (0, padded - size))
+
+
+def marlin_unpad_output(
+    output: torch.Tensor, size_n: int, padded_n: int
+) -> torch.Tensor:
+    """Slice a padded Marlin output back to the logical output width."""
+    if padded_n == size_n:
+        return output
+    return output[..., :size_n].contiguous()
 
 
 def check_marlin_supports_layer(layer: LinearBase, group_size: int) -> bool:

--- a/python/sglang/srt/layers/quantization/marlin_utils_fp8.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils_fp8.py
@@ -8,8 +8,14 @@ import torch
 from sglang.srt.layers.quantization.marlin_utils import (
     USE_FP32_REDUCE_DEFAULT,
     marlin_make_workspace,
+    marlin_pad_dim,
+    marlin_pad_qweight,
+    marlin_pad_scales,
+    marlin_padded_nk,
     marlin_permute_bias,
     marlin_permute_scales,
+    marlin_repacked_nk,
+    marlin_unpad_output,
     should_use_atomic_add_reduce,
 )
 from sglang.srt.layers.quantization.utils import get_scalar_types
@@ -98,6 +104,98 @@ def apply_fp8_marlin_linear(
         output.add_(bias)
 
     return output.reshape(out_shape)
+
+
+def fake_apply_mxfp8_marlin_linear(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    size_n: int,
+    size_k: int,
+    bias: Optional[torch.Tensor],
+    use_fp32_reduce: bool = USE_FP32_REDUCE_DEFAULT,
+) -> torch.Tensor:
+    out_shape = input.shape[:-1] + (size_n,)
+    fake_output = torch.empty(out_shape, dtype=input.dtype, device=input.device)
+    return fake_output
+
+
+@register_custom_op(fake_impl=fake_apply_mxfp8_marlin_linear)
+def apply_mxfp8_marlin_linear(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    size_n: int,
+    size_k: int,
+    bias: Optional[torch.Tensor],
+    use_fp32_reduce: bool = USE_FP32_REDUCE_DEFAULT,
+) -> torch.Tensor:
+    # MXFP8 Marlin runs as W8A16: weights stay FP8 E4M3, while activations
+    # remain fp16/bf16 and scales are numeric fp16/bf16 values.
+    reshaped_x = input.reshape(-1, input.shape[-1])
+    out_shape = input.shape[:-1] + (size_n,)
+
+    padded_n, padded_k = marlin_repacked_nk(weight, num_bits=8)
+    reshaped_x = marlin_pad_dim(reshaped_x, size_k, padded_k)
+
+    use_atomic_add = should_use_atomic_add_reduce(
+        m=reshaped_x.size(0),
+        n=padded_n,
+        k=padded_k,
+        device=input.device,
+        dtype=input.dtype,
+    )
+
+    output = gptq_marlin_gemm(
+        a=reshaped_x,
+        c=None,
+        b_q_weight=weight,
+        b_scales=weight_scale,
+        global_scale=None,
+        b_zeros=None,
+        g_idx=None,
+        perm=None,
+        workspace=workspace,
+        b_q_type=scalar_types.float8_e4m3fn,
+        size_m=reshaped_x.size(0),
+        size_n=padded_n,
+        size_k=padded_k,
+        use_atomic_add=use_atomic_add,
+        use_fp32_reduce=use_fp32_reduce,
+    )
+
+    bias_added = False
+    if bias is not None and bias.shape[-1] == padded_n:
+        output.add_(bias)
+        bias_added = True
+
+    output = marlin_unpad_output(output, size_n, padded_n)
+    if bias is not None and not bias_added:
+        output.add_(bias)
+    return output.reshape(out_shape)
+
+
+def _mxfp8_scale_to_dtype(scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Interpret raw UE8M0 scale bytes as numeric powers of two."""
+    scale = scale.contiguous()
+    if scale.dtype == torch.uint8:
+        return (scale.to(torch.int32) << 23).view(torch.float32).to(dtype)
+
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is not None and scale.dtype == e8m0_dtype:
+        return scale.to(dtype)
+
+    return scale.to(dtype)
+
+
+def _get_mxfp8_weight_scale(layer: torch.nn.Module) -> tuple[torch.Tensor, str]:
+    for scale_name in ("weight_scale_inv", "weight_scale"):
+        scale = getattr(layer, scale_name, None)
+        if scale is not None:
+            return scale, scale_name
+    raise AttributeError("MXFP8 Marlin requires a weight_scale_inv or weight_scale")
 
 
 def prepare_fp8_layer_for_marlin(
@@ -189,6 +287,77 @@ def prepare_fp8_layer_for_marlin(
     if hasattr(layer, "bias") and layer.bias is not None:
         assert layer.bias.shape == (part_size_n,)
         bias = marlin_permute_bias(layer.bias)
+        layer.bias = torch.nn.Parameter(bias, requires_grad=False)
+
+
+def prepare_mxfp8_layer_for_marlin(layer: torch.nn.Module) -> None:
+    logger.warning_once(
+        "Your GPU does not have native support for MXFP8 computation but "
+        "MXFP8 quantization is being used. Weight-only FP8 compression will "
+        "be used leveraging the Marlin kernel. This may degrade "
+        "performance for compute-heavy workloads."
+    )
+
+    part_size_n = layer.output_size_per_partition
+    part_size_k = layer.input_size_per_partition
+    group_size = 32
+    assert part_size_k % group_size == 0, (
+        "MXFP8 Marlin requires input_size_per_partition to be divisible by 32."
+    )
+    padded_n, padded_k = marlin_padded_nk(part_size_n, part_size_k, group_size)
+
+    assert layer.weight.shape == (part_size_n, part_size_k)
+
+    device = layer.weight.device
+    layer.workspace = marlin_make_workspace(device)
+
+    perm = torch.empty(0, dtype=torch.int, device=device)
+    qweight = pack_fp8_to_int32(layer.weight, size_k_first=False)
+    qweight = qweight.T.contiguous()
+    qweight = marlin_pad_qweight(
+        qweight,
+        size_n=part_size_n,
+        size_k=part_size_k,
+        padded_n=padded_n,
+        padded_k=padded_k,
+    )
+
+    marlin_qweight = gptq_marlin_repack(
+        b_q_weight=qweight,
+        perm=perm,
+        size_k=padded_k,
+        size_n=padded_n,
+        num_bits=8,
+    )
+    layer.weight = torch.nn.Parameter(marlin_qweight, requires_grad=False)
+
+    scale_param, scale_name = _get_mxfp8_weight_scale(layer)
+    scale_groups = part_size_k // group_size
+    scales = scale_param.data[:part_size_n, :scale_groups]
+    scales = _mxfp8_scale_to_dtype(scales, layer.orig_dtype)
+    scales = scales.T.contiguous()
+    scales = marlin_pad_scales(
+        scales,
+        size_n=part_size_n,
+        size_k=part_size_k,
+        padded_n=padded_n,
+        padded_k=padded_k,
+        group_size=group_size,
+    )
+    marlin_scales = marlin_permute_scales(
+        s=scales,
+        size_k=padded_k,
+        size_n=padded_n,
+        group_size=group_size,
+    )
+    marlin_scales = fp8_fused_exponent_bias_into_scales(marlin_scales)
+    layer.weight_scale = torch.nn.Parameter(marlin_scales, requires_grad=False)
+    if scale_name == "weight_scale_inv":
+        del layer.weight_scale_inv
+
+    if hasattr(layer, "bias") and layer.bias is not None:
+        assert layer.bias.shape == (part_size_n,)
+        bias = marlin_permute_bias(marlin_pad_dim(layer.bias, part_size_n, padded_n))
         layer.bias = torch.nn.Parameter(bias, requires_grad=False)
 
 

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -17,7 +17,7 @@ from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.layers.modelopt_utils import QUANT_CFG_CHOICES
-from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
+from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
 from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptFp4LinearMethod,
@@ -521,6 +521,14 @@ class TestParseQuantHfConfig(CustomTestCase):
 
 
 class TestModelOptMixedPrecisionConfig(CustomTestCase):
+    def _mxfp8_config(self):
+        return Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[1, 32],
+            use_mxfp8=True,
+        )
+
     def test_minimax_mixed_precision_resolves_runtime_names_and_mxfp8(self):
         quant_config = ModelOptMixedPrecisionConfig.from_config(
             {
@@ -728,6 +736,52 @@ class TestModelOptMixedPrecisionConfig(CustomTestCase):
         self.assertEqual(
             quant_config._resolve_quant_algo("model.layers.2.mixer.qkv_proj"),
             "FP8",
+        )
+
+    @patch("sglang.srt.layers.quantization.fp8.is_npu", return_value=False)
+    @patch("sglang.srt.layers.quantization.fp8._is_musa", False)
+    @patch("sglang.srt.layers.quantization.fp8._is_hip", False)
+    @patch("sglang.srt.layers.quantization.fp8._is_cuda", True)
+    @patch("sglang.srt.layers.quantization.fp8._mxfp8_to_block_fp8_required", False)
+    def test_mxfp8_min_capability_allows_cuda_sm80_marlin(self, _):
+        self.assertEqual(self._mxfp8_config().get_min_capability(), 80)
+
+    @patch("sglang.srt.layers.quantization.fp8.cutlass_fp8_supported")
+    @patch("sglang.srt.layers.quantization.fp8.can_auto_enable_marlin_fp8")
+    @patch("sglang.srt.layers.quantization.fp8.get_bool_env_var")
+    @patch("sglang.srt.layers.quantization.fp8.get_device_capability")
+    @patch("sglang.srt.layers.quantization.fp8._is_cuda", True)
+    @patch("sglang.srt.layers.quantization.fp8._mxfp8_to_block_fp8_required", False)
+    def test_mxfp8_cuda_sm80_dense_auto_uses_marlin_w8a16(
+        self,
+        mock_get_device_capability,
+        mock_get_bool_env_var,
+        mock_can_auto_enable_marlin_fp8,
+        mock_cutlass_fp8_supported,
+    ):
+        mock_get_device_capability.return_value = (8, 0)
+        mock_get_bool_env_var.return_value = False
+        mock_can_auto_enable_marlin_fp8.return_value = False
+        mock_cutlass_fp8_supported.return_value = False
+
+        method = Fp8LinearMethod(self._mxfp8_config())
+
+        self.assertTrue(method.use_marlin)
+        self.assertTrue(method.use_mxfp8_marlin)
+        self.assertIsNone(method.w8a8_mxfp8_linear)
+        self.assertIsNone(method.w8a8_block_fp8_linear)
+
+    def test_mxfp8_marlin_reinterprets_ue8m0_scale_bytes(self):
+        from sglang.srt.layers.quantization.marlin_utils_fp8 import (
+            _mxfp8_scale_to_dtype,
+        )
+
+        scale_u8 = torch.tensor([127, 128, 126, 0], dtype=torch.uint8)
+        scale_fp32 = _mxfp8_scale_to_dtype(scale_u8, torch.float32)
+
+        torch.testing.assert_close(
+            scale_fp32,
+            torch.tensor([1.0, 2.0, 0.5, 0.0], dtype=torch.float32),
         )
 
 


### PR DESCRIPTION
## Summary
- Add a dense MXFP8 Marlin W8A16 path for CUDA SM80-SM90.
- Repack MXFP8 E4M3 weights into the existing SGLang Marlin layout and reinterpret UE8M0 scale bytes into fp16/bf16 numeric scales for SGLang's current Marlin GEMM surface.
- Keep native MXFP8 routing for Blackwell/gfx95 and keep existing NVFP4 MoE routing unchanged.
- Add focused unit coverage for CUDA SM80 capability/routing and UE8M0 scale decoding.

## Why
Nemotron-H mixed-precision ModelOpt checkpoints can mark dense attention/mixer layers as MXFP8 while using NVFP4 for MoE experts. SGLang already parses those mixed layer annotations and already has the NVFP4 MoE Marlin path for SM80-SM90, but dense MXFP8 previously still routed to native/block-scaled MXFP8 kernels that require Blackwell or ROCm gfx95. On A100, that means the model cannot use the dense MXFP8 path correctly.

vLLM supports this case with a dedicated MXFP8 kernel selection chain: FlashInfer MXFP8 kernels first, then MarlinMxfp8LinearKernel for SM80+, then emulation. SGLang was missing the dense MXFP8 Marlin prepare/apply route. This PR adds that route without changing CUDA kernels by adapting MXFP8 checkpoint tensors to SGLang's existing FP8 Marlin GEMM interface.

## Hardware scope
- A100 / SM80: dense MXFP8 runs through Marlin W8A16.
- H100 / SM90: dense MXFP8 can also use this Marlin W8A16 fallback path.
- Blackwell / SM100+: unchanged default native MXFP8 path unless Marlin is explicitly forced.
- NVFP4 MoE: unchanged; existing ModelOpt/Nemotron-H override continues to select Marlin for SM80-SM90.

## Testing
- `python -m py_compile python/sglang/srt/layers/quantization/marlin_utils.py python/sglang/srt/layers/quantization/marlin_utils_fp8.py python/sglang/srt/layers/quantization/fp8.py test/registered/unit/model_loader/test_modelopt_loader.py`
- `uvx ruff check --select F821 python/sglang/srt/layers/quantization/marlin_utils.py python/sglang/srt/layers/quantization/marlin_utils_fp8.py python/sglang/srt/layers/quantization/fp8.py test/registered/unit/model_loader/test_modelopt_loader.py`
- `uvx isort --check-only python/sglang/srt/layers/quantization/marlin_utils.py python/sglang/srt/layers/quantization/marlin_utils_fp8.py python/sglang/srt/layers/quantization/fp8.py test/registered/unit/model_loader/test_modelopt_loader.py`
- `git diff --check`

Not run locally: `python -m unittest test.registered.unit.model_loader.test_modelopt_loader.TestModelOptMixedPrecisionConfig`, because this shell does not have torch installed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30744583462](https://github.com/sgl-project/sglang/actions/runs/30744583462)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30744583321](https://github.com/sgl-project/sglang/actions/runs/30744583321)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->