### PR TITLE
[MiniMax-M3] Fix PP proxy layout with MoE A2A

### DIFF
--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -35,6 +35,9 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     PPProxyTensors,
 )
+from sglang.srt.model_executor.model_runner_components.misc_utils import (
+    should_use_pp_send_allgather,
+)
 from sglang.srt.observability.req_time_stats import set_time_batch
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.utils import DynamicGradMode, broadcast_pyobj, point_to_point_pyobj
@@ -557,9 +560,16 @@ class SchedulerPPMixin:
 
     def init_pp_loop_state(self: Scheduler):
         self.pp_loop_size: int = self.ps.pp_size + self.server_args.pp_async_batch_depth
-        # In CP mode, attention weights are duplicated, eliminating the need for the attention TP all-gather operation.
-        self.require_attn_tp_allgather = (
-            not self.server_args.enable_dsa_prefill_context_parallel
+        # Typed PP messages share one receive path, so proxy and output messages
+        # must use the same transport layout. Preserve TP lanes when a model can
+        # emit token-sharded proxy tensors.
+        self.require_attn_tp_allgather = should_use_pp_send_allgather(
+            enable_dsa_prefill_context_parallel=(
+                self.server_args.enable_dsa_prefill_context_parallel
+            ),
+            preserve_tp_lanes=(
+                self.tp_worker.model_runner.requires_pp_proxy_tp_lane_preservation()
+            ),
         )
         self.mbs = [None] * self.pp_loop_size
         self.last_mbs = [None] * self.pp_loop_size

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -714,6 +714,15 @@ class ModelRunner:
             start_layer=self.layer_info.start_layer,
         )
 
+    def get_pp_proxy_token_scatter_factor(self) -> int:
+        get_scatter_factor = getattr(
+            self.model, "get_pp_proxy_token_scatter_factor", None
+        )
+        return get_scatter_factor() if get_scatter_factor is not None else 1
+
+    def requires_pp_proxy_tp_lane_preservation(self) -> bool:
+        return getattr(self.model, "requires_pp_proxy_tp_lane_preservation", False)
+
     def decode_num_tokens_per_req(
         self, *, num_draft_tokens: Optional[int] = None
     ) -> int:

--- a/python/sglang/srt/model_executor/model_runner_components/misc_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/misc_utils.py
@@ -13,6 +13,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def compute_pp_proxy_num_tokens(
+    *, num_tokens: int, pp_rank: int, token_scatter_factor: int
+) -> int:
+    if token_scatter_factor < 1:
+        raise ValueError(
+            f"token_scatter_factor must be positive, got {token_scatter_factor}"
+        )
+    if pp_rank == 0:
+        return num_tokens
+    if num_tokens % token_scatter_factor != 0:
+        raise ValueError(
+            f"PP proxy token count {num_tokens} is not divisible by "
+            f"scatter factor {token_scatter_factor}"
+        )
+    return num_tokens // token_scatter_factor
+
+
+def should_use_pp_send_allgather(
+    *, enable_dsa_prefill_context_parallel: bool, preserve_tp_lanes: bool
+) -> bool:
+    return not enable_dsa_prefill_context_parallel and not preserve_tp_lanes
+
+
 def maybe_disable_chunked_prefix_cache(
     *, server_args: ServerArgs, use_mla_backend: bool, is_draft_worker: bool
 ) -> None:

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -40,6 +40,9 @@ from sglang.srt.model_executor.forward_batch_info import (
     PPProxyTensors,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.srt.model_executor.model_runner_components.misc_utils import (
+    compute_pp_proxy_num_tokens,
+)
 from sglang.srt.model_executor.runner.flashinfer_autotune import (
     run_flashinfer_autotune_forward,
     should_run_flashinfer_autotune,
@@ -464,8 +467,12 @@ class BaseRunner(ABC):
             extend_start_loc = None
 
         if mr.server_args.pp_size > 1:
-            # PP0 already cp-split hidden_states before send.
-            pp_hidden_tokens = num_tokens
+            # Later PP stages may receive token-sharded proxy tensors.
+            pp_hidden_tokens = compute_pp_proxy_num_tokens(
+                num_tokens=num_tokens,
+                pp_rank=mr.ps.pp_rank,
+                token_scatter_factor=mr.get_pp_proxy_token_scatter_factor(),
+            )
             if (
                 capture_forward_mode == ForwardMode.EXTEND
                 and mr.ps.pp_rank != 0

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -64,6 +64,9 @@ from sglang.srt.model_executor.forward_batch_info import (
     enable_num_token_non_padded,
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.srt.model_executor.model_runner_components.misc_utils import (
+    compute_pp_proxy_num_tokens,
+)
 from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
     BaseCudaGraphRunner,
     freeze_gc,
@@ -729,8 +732,15 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         pp_proxy_tensors = None
         # pipeline parallelism
         if self.pp_size > 1:
+            pp_hidden_tokens = compute_pp_proxy_num_tokens(
+                num_tokens=num_tokens,
+                pp_rank=self.model_runner.ps.pp_rank,
+                token_scatter_factor=(
+                    self.model_runner.get_pp_proxy_token_scatter_factor()
+                ),
+            )
             pp_proxy_tensors = PPProxyTensors(
-                {k: v[:num_tokens] for k, v in buffers.pp_proxy_tensors.items()}
+                {k: v[:pp_hidden_tokens] for k, v in buffers.pp_proxy_tensors.items()}
             )
 
         if self.require_mlp_tp_gather:

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -1349,6 +1349,13 @@ class MiniMaxM3Model(nn.Module):
     def get_input_embeddings(self) -> torch.Tensor:
         return self.embed_tokens
 
+    def get_pp_proxy_token_scatter_factor(self) -> int:
+        if self.pp_group.is_first_rank or get_moe_a2a_backend().is_none():
+            return 1
+
+        input_mode = self.layers[self.start_layer].layer_scatter_modes.layer_input_mode
+        return get_parallel().attn_tp_size if input_mode == ScatterMode.SCATTERED else 1
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -1429,6 +1436,9 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
         self.config = config
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
+        self.requires_pp_proxy_tp_lane_preservation = (
+            not get_moe_a2a_backend().is_none()
+        )
 
         self.num_fused_shared_experts = 0
         self.determine_num_fused_shared_experts()
@@ -1454,6 +1464,9 @@ class MiniMaxM3SparseForCausalLM(nn.Module):
 
     def get_input_embeddings(self):
         return self.model.get_input_embeddings()
+
+    def get_pp_proxy_token_scatter_factor(self) -> int:
+        return self.model.get_pp_proxy_token_scatter_factor()
 
     def determine_num_fused_shared_experts(self):
         if get_server_args().disable_shared_experts_fusion:

--- a/python/sglang/srt/models/minimax_m3_vl.py
+++ b/python/sglang/srt/models/minimax_m3_vl.py
@@ -64,6 +64,9 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
         self.config = config
         self.quant_config = quant_config
         self.pp_group = get_pp_group()
+        self.requires_pp_proxy_tp_lane_preservation = (
+            not get_moe_a2a_backend().is_none()
+        )
 
         self.use_data_parallel = get_server_args().mm_enable_dp_encoder
 
@@ -187,6 +190,9 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module):
 
     def get_input_embeddings(self):
         return self.model.embed_tokens
+
+    def get_pp_proxy_token_scatter_factor(self) -> int:
+        return self.model.get_pp_proxy_token_scatter_factor()
 
     def forward(
         self,

--- a/test/registered/unit/model_executor/test_pp_proxy_layout.py
+++ b/test/registered/unit/model_executor/test_pp_proxy_layout.py
@@ -1,0 +1,114 @@
+"""Unit tests for pipeline-parallel proxy tensor layout helpers."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.communicator import ScatterMode
+from sglang.srt.model_executor.model_runner_components.misc_utils import (
+    compute_pp_proxy_num_tokens,
+    should_use_pp_send_allgather,
+)
+from sglang.srt.models.minimax_m3 import MiniMaxM3Model
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestPPProxyLayout(CustomTestCase):
+    def test_scattered_proxy_uses_local_token_count_after_pp0(self):
+        self.assertEqual(
+            compute_pp_proxy_num_tokens(
+                num_tokens=8, pp_rank=1, token_scatter_factor=2
+            ),
+            4,
+        )
+
+    def test_pp0_and_replicated_proxy_keep_full_token_count(self):
+        self.assertEqual(
+            compute_pp_proxy_num_tokens(
+                num_tokens=8, pp_rank=0, token_scatter_factor=2
+            ),
+            8,
+        )
+        self.assertEqual(
+            compute_pp_proxy_num_tokens(
+                num_tokens=8, pp_rank=2, token_scatter_factor=1
+            ),
+            8,
+        )
+
+    def test_scattered_proxy_requires_divisible_token_count(self):
+        with self.assertRaisesRegex(ValueError, "not divisible"):
+            compute_pp_proxy_num_tokens(num_tokens=7, pp_rank=1, token_scatter_factor=2)
+
+    def test_send_allgather_requires_replicated_non_cp_proxy(self):
+        self.assertTrue(
+            should_use_pp_send_allgather(
+                enable_dsa_prefill_context_parallel=False,
+                preserve_tp_lanes=False,
+            )
+        )
+        self.assertFalse(
+            should_use_pp_send_allgather(
+                enable_dsa_prefill_context_parallel=False,
+                preserve_tp_lanes=True,
+            )
+        )
+        self.assertFalse(
+            should_use_pp_send_allgather(
+                enable_dsa_prefill_context_parallel=True,
+                preserve_tp_lanes=False,
+            )
+        )
+
+    def test_lane_preserving_transport_allows_replicated_stage_input(self):
+        self.assertEqual(
+            compute_pp_proxy_num_tokens(
+                num_tokens=8, pp_rank=1, token_scatter_factor=1
+            ),
+            8,
+        )
+        self.assertFalse(
+            should_use_pp_send_allgather(
+                enable_dsa_prefill_context_parallel=False,
+                preserve_tp_lanes=True,
+            )
+        )
+
+    def test_minimax_uses_stage_input_layout_for_proxy_size(self):
+        backend = SimpleNamespace(is_none=lambda: False)
+        model = object.__new__(MiniMaxM3Model)
+        object.__setattr__(model, "pp_group", SimpleNamespace(is_first_rank=False))
+        object.__setattr__(model, "start_layer", 0)
+
+        with patch(
+            "sglang.srt.models.minimax_m3.get_moe_a2a_backend",
+            return_value=backend,
+        ), patch(
+            "sglang.srt.models.minimax_m3.get_parallel",
+            return_value=SimpleNamespace(attn_tp_size=2),
+        ):
+            for input_mode, expected_factor in (
+                (ScatterMode.SCATTERED, 2),
+                (ScatterMode.TP_ATTN_FULL, 1),
+            ):
+                object.__setattr__(
+                    model,
+                    "layers",
+                    [
+                        SimpleNamespace(
+                            layer_scatter_modes=SimpleNamespace(
+                                layer_input_mode=input_mode
+                            )
+                        )
+                    ],
+                )
+                self.assertEqual(
+                    model.get_pp_proxy_token_scatter_factor(), expected_factor
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With pipeline parallelism and a MoE A2A backend, MiniMax-M3 can emit token-sharded PP proxy tensors. The existing PP send-allgather path assumes that attention TP ranks hold replicated tensors: each rank sends one slice and the receiver reconstructs the full tensor with an all-gather.

Applying that path to an already-sharded proxy drops data. For example, TP-local proxies `[0, 1, 2, 3]` and `[4, 5, 6, 7]` are reconstructed as `[0, 1, 6, 7]`.

The same layout must also be reflected in PP proxy buffer views used by warmup and decode CUDA graph capture.

## Modifications

- Let models request lane-preserving PP transport when their proxy tensors may be token-sharded.
- Derive the MiniMax-M3 PP proxy token count from the current stage's input `LayerScatterModes`.
- Use the local proxy token count in shared runner and decode CUDA graph buffer views.
- Apply the same model capability to MiniMax-M3-VL.
- Add CPU tests for PP transport selection, proxy token counts, and MiniMax-M3 stage input layouts.

## Accuracy Tests

A local four-process CPU/Gloo reproducer using SGLang's `GroupCoordinator.send_tensor_dict` and `recv_tensor_dict` produced:

```text
replicated + send-allgather:
  rank 2: [0, 1, 2, 3, 4, 5, 6, 7]
  rank 3: [0, 1, 2, 3, 4, 5, 6, 7]

token-sharded + send-allgather:
  rank 2: [0, 1, 6, 7]
  rank 3: [0, 1, 6, 7]

token-sharded + lane-preserving send:
  rank 2: [0, 1, 2, 3]
  rank 3: [4, 5, 6, 7]
```

The registered CPU test covers replicated and scattered proxy sizes, divisibility checks, transport selection, and MiniMax-M3 stage input layouts. All 6 tests passed.

As a supplemental smoke test, the full 60-layer/128-expert MiniMax-M3 ran on 6x NVIDIA H20 NVLink 96 GB with TP=2, PP=3, EP=2, DeepEP, and DeepGEMM. Two deterministic 128-token generations returned identical, non-empty responses without a scheduler exception.

This run used a third-party MXFP4 checkpoint dequantized to FP8 and included #32671 plus independent checkpoint-loading changes, so it is supplemental rather than isolated evidence. CUDA graph was disabled; the proxy buffer sizing change is covered by the registered CPU test.

All applicable pre-commit hooks passed.

## Speed Tests and Profiling

Not yet measured. Because typed proxy and output messages share the same receive path, MiniMax-M3 with MoE A2A now uses lane-preserving transport for both. PP communication profiling is pending.

## Checklist

- [x] Format the code with the repository's pre-commit hooks.
- [x] Add registered CPU unit tests.
- [x] Documentation update: N/A.
- [ ] Provide PP communication performance results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->