### PR TITLE
[Spec] Gate GLM-5.2 MTP index sharing by backend capability

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -270,6 +270,10 @@ class AttentionBackend(ABC):
         """Check if the current backend supports triton."""
         return True
 
+    def supports_dsa_indexer_metadata(self) -> bool:
+        """Whether this backend can provide DSA indexer metadata for MTP reuse."""
+        return False
+
     def get_indexer_metadata(
         self,
         layer_id: int,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -3458,6 +3458,9 @@ class DeepseekSparseAttnBackend(
             topk_transform_method = TopkTransformMethod.PAGED
         return topk_transform_method
 
+    def supports_dsa_indexer_metadata(self) -> bool:
+        return True
+
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> DSAIndexerMetadata:

--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -182,6 +182,12 @@ class HybridAttnBackend(AttentionBackend):
             q, k, v, layer, forward_batch, save_kv_cache, **kwargs
         )
 
+    def supports_dsa_indexer_metadata(self) -> bool:
+        return (
+            self.prefill_backend.supports_dsa_indexer_metadata()
+            and self.decode_backend.supports_dsa_indexer_metadata()
+        )
+
     def get_indexer_metadata(
         self, layer_id: int, forward_batch: ForwardBatch
     ) -> Optional[BaseIndexerMetadata]:

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -169,6 +169,9 @@ class TboAttnBackend(AttentionBackend):
     def forward_decode(self, *args, **kwargs):
         return self.primary.forward_decode(*args, **kwargs)
 
+    def supports_dsa_indexer_metadata(self) -> bool:
+        return self.primary.supports_dsa_indexer_metadata()
+
     def get_indexer_metadata(self, layer_id: int, forward_batch: ForwardBatch):
         return self.primary.get_indexer_metadata(layer_id, forward_batch)
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -241,11 +241,21 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         # Populate DSA index-share fields from the draft runner's hf_config.
         # Reused by the attention unit-test harnesses, which skip __init__.
         hf_config = self.draft_runner.model_config.hf_config
+        attn_backend = getattr(self.draft_runner, "attn_backend", None)
+        supports_indexer_metadata = (
+            attn_backend is not None
+            and getattr(
+                attn_backend,
+                "supports_dsa_indexer_metadata",
+                lambda: False,
+            )()
+        )
         # Reuse the first draft step's DSA indexer topk across the rest;
         # topk == 1 only (select_top_k_tokens reorders rows, desyncing indices).
         self.index_share_for_mtp_iteration = (
             getattr(hf_config, "index_share_for_mtp_iteration", False)
             and self.topk == 1
+            and supports_indexer_metadata
         )
         # GLM-5.2 MTP IndexShare: seed reused indexer top-k from draft-extend
         # (last verified token), not draft-decode step 0.
@@ -316,6 +326,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
     def init_attention_backend(self):
         # Create multi-step attn backends and cuda graph runners
+
+        # The runner's attention backend is initialized after this worker is
+        # constructed. Refresh the capability-gated DSA reuse state before the
+        # backend factory consumes it. White-box tests may supply a partial
+        # runner that deliberately omits model_config.
+        if hasattr(self.draft_runner, "model_config"):
+            self._init_dsa_index_share_state()
 
         self.draft_extend_attn_backend = None
 

--- a/test/registered/unit/spec/test_eagle_worker_v2_dsa_index_share.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_dsa_index_share.py
@@ -1,0 +1,107 @@
+"""Regression tests for PP+MTP on dense and sparse MLA backends."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
+from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
+from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _IndexerCapableBackend(AttentionBackend):
+    def supports_dsa_indexer_metadata(self) -> bool:
+        return True
+
+
+class _FakeDraftBackendFactory:
+    captured_seed = None
+
+    def __init__(self, *args, seed_dsa_topk_from_draft_extend=False, **kwargs):
+        type(self).captured_seed = seed_dsa_topk_from_draft_extend
+
+    def create_decode_backend(self):
+        return object()
+
+    def create_draft_extend_backend(self):
+        return None
+
+
+def _make_worker(attn_backend):
+    worker = object.__new__(EagleDraftWorker)
+    worker.topk = 1
+    worker.speculative_num_steps = 2
+    worker.server_args = SimpleNamespace()
+    worker.draft_runner = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                index_share_for_mtp_iteration=True,
+                index_topk=2048,
+            )
+        ),
+        attn_backend=attn_backend,
+    )
+    return worker
+
+
+class TestAttentionBackendIndexerCapability(CustomTestCase):
+    def test_default_backend_does_not_support_indexer_metadata(self):
+        self.assertFalse(AttentionBackend().supports_dsa_indexer_metadata())
+
+    def test_sparse_dsa_backend_supports_indexer_metadata(self):
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        self.assertTrue(backend.supports_dsa_indexer_metadata())
+
+    def test_hybrid_requires_prefill_and_decode_indexer_support(self):
+        backend = object.__new__(HybridAttnBackend)
+        backend.prefill_backend = _IndexerCapableBackend()
+        backend.decode_backend = _IndexerCapableBackend()
+        self.assertTrue(backend.supports_dsa_indexer_metadata())
+
+        backend.decode_backend = AttentionBackend()
+        self.assertFalse(backend.supports_dsa_indexer_metadata())
+
+    def test_tbo_delegates_indexer_support_to_primary(self):
+        backend = object.__new__(TboAttnBackend)
+        backend.primary = _IndexerCapableBackend()
+        self.assertTrue(backend.supports_dsa_indexer_metadata())
+
+
+class TestEagleDenseIndexerSharing(CustomTestCase):
+    def test_dense_backend_disables_index_sharing(self):
+        worker = _make_worker(AttentionBackend())
+        worker._init_dsa_index_share_state()
+
+        self.assertFalse(worker.index_share_for_mtp_iteration)
+        self.assertFalse(worker.seed_dsa_topk_from_draft_extend)
+
+    def test_sparse_backend_keeps_index_sharing(self):
+        worker = _make_worker(_IndexerCapableBackend())
+        worker._init_dsa_index_share_state()
+
+        self.assertTrue(worker.index_share_for_mtp_iteration)
+        self.assertTrue(worker.seed_dsa_topk_from_draft_extend)
+
+    def test_backend_factory_receives_refreshed_seed_state(self):
+        worker = _make_worker(_IndexerCapableBackend())
+        worker.seed_dsa_topk_from_draft_extend = False
+        _FakeDraftBackendFactory.captured_seed = None
+
+        with patch(
+            "sglang.srt.speculative.eagle_worker_v2.DraftBackendFactory",
+            _FakeDraftBackendFactory,
+        ):
+            worker.init_attention_backend()
+
+        self.assertTrue(_FakeDraftBackendFactory.captured_seed)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

GLM-5.2 exposes `index_share_for_mtp_iteration` in its config even when the
runtime selects a dense MLA attention backend. EAGLE therefore enables DSA
indexer reuse from model config alone and asks draft-extend to capture a DSA
seed. Dense MLA backends cannot provide that metadata, so PP+MTP startup fails
with `DSA MHA indexer did not produce the requested MTP seed`.

This was reproduced with `nvidia/GLM-5.2-NVFP4`, TP1/PP7, FlashInfer MLA, and
NEXTN speculative decoding.

## Modifications

- Add an explicit `supports_dsa_indexer_metadata()` attention-backend
  capability, defaulting to false and enabled by `DeepseekSparseAttnBackend`.
- Propagate the capability through hybrid and TBO wrappers.
- Gate GLM-5.2 MTP index sharing on the active draft-runner backend rather
  than model config alone.
- Refresh the gate after the runner initializes its attention backend and
  before `DraftBackendFactory` consumes the seed setting.
- Add registered CPU regression coverage for dense, sparse, hybrid, TBO, and
  post-initialization refresh behavior.

The change keeps the existing DSA IndexShare behavior from #29787/#30839 when
the backend can provide indexer metadata, while dense MLA uses ordinary MTP
without the unsupported DSA reuse path.

## Accuracy Tests

- Full 1,048,576-token context remained available.
- A 65,536-token prompt completed with 128 output tokens and no server restart.
- OpenAI-compatible chat smoke test returned exact `OK` with reasoning disabled.
- Zero container restarts and no node memory pressure during the four-profile
  NEXTN sweep.

## Speed Tests and Profiling

Hardware/model: 7x RTX PRO 6000, TP1/PP7, `nvidia/GLM-5.2-NVFP4`, BF16 KV
cache. Retained NEXTN profile: steps/top-k/draft tokens = `3/1/4`.

| Workload | MTP disabled | Patched MTP | Change |
|---|---:|---:|---:|
| Short single request | 26.672 tok/s | 38.624 tok/s warm; 57.240 tok/s sweep peak | +44.81% warm |
| 65K single request | 22.186 tok/s | 47.127 tok/s | +112.41% |
| Two concurrent requests | 47.918 tok/s aggregate | 93.633 tok/s aggregate | +95.41% |

The 65K TTFT changed from 23.427 s to 24.212 s (+3.35%).

## Validation

- New registered regression test: 7/7 passed.
- Neighboring EAGLE, DFlash/hybrid, and verify-mask tests: 27 passed, 1
  platform skip.
- Repository pre-commit hooks: passed.
- `git diff --check`: passed.

## Checklist

- [x] Format code with the repository pre-commit configuration.
- [x] Add registered unit tests.
- [x] Documentation is not required; this changes an internal capability gate
      and adds no user-facing flag.
- [x] Provide production accuracy and speed measurements.
- [x] Follow the existing SGLang backend and speculative-worker code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30754091626](https://github.com/sgl-project/sglang/actions/runs/30754091626)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30754091495](https://github.com/sgl-project/sglang/actions/runs/30754091495)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->