### PR TITLE
fix: preserve original global token counts in DSpark drafts

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -436,6 +436,7 @@ class DraftBlockProposer:
             batch.global_num_tokens_for_logprob,
         )
         device = self.draft_model_runner.device
+        forward_batch.original_global_num_tokens_cpu = batch.global_num_tokens
         forward_batch.global_num_tokens_cpu = gnt
         forward_batch.global_num_tokens_for_logprob_cpu = gnt_logprob
         forward_batch.global_num_tokens_gpu = torch.tensor(gnt, dtype=torch.int64).to(


### PR DESCRIPTION
## Motivation

When DSpark speculative decoding is used with DP attention and MLP TP gather is required, the manually constructed draft `ForwardBatch` does not populate `original_global_num_tokens_cpu`.

`DecodeCudaGraphRunner.can_run_graph()` uses this field to determine the CUDA graph batch size:

```python
cuda_graph_bs = max(forward_batch.original_global_num_tokens_cpu)
```

Because the field is `None`, the first decode request crashes with:

```text
TypeError: 'NoneType' object is not iterable
```

The normal `ScheduleBatch` to `ForwardBatch` conversion preserves the original global token counts, but the DSpark-specific `_fill_dp_moe_sync_metadata()` path only populates the speculative-scaled token counts.

Fixes #33286

## Modifications

Populate `forward_batch.original_global_num_tokens_cpu` from `batch.global_num_tokens` inside `DSparkDraft._fill_dp_moe_sync_metadata()`.

This preserves the original, unscaled token counts required by CUDA graph bucket selection, while keeping the existing speculative-scaled values in `global_num_tokens_cpu`.

The change matches the behavior of the standard `ScheduleBatch` to `ForwardBatch` conversion path.

## Accuracy Tests

This change only restores missing batch metadata and does not modify model computations, logits, sampling, or generated token values.

I verified that the server successfully generated responses after applying the change. Before the change, the first decode request consistently crashed in `DecodeCudaGraphRunner.can_run_graph()`.

Test configuration:

- DeepSeek-V4-Flash-0731-FP8
- DSpark speculative decoding
- DP attention enabled
- TP size: 8
- DP size: 8
- 8 × NVIDIA H20
- CUDA graph enabled
- SGLang 0.5.16
- PyTorch 2.11.0+cu130
- CUDA Toolkit 13.2

## Speed Tests and Profiling

This change does not introduce a new execution path or additional GPU operations. It only copies an existing CPU-side list reference into the DSpark draft `ForwardBatch`.

After the fix, DSpark successfully ran in the tested 8 × H20 configuration and achieved over 200 output tokens/s. This result is provided as a functional deployment observation rather than a controlled before-and-after performance benchmark, because the unpatched configuration crashes before decoding.

## Checklist

- [x] Format your code according to the [[Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit)](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [[Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests)](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [[Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations)](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [[Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [[Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed)](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [[guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30755589357](https://github.com/sgl-project/sglang/actions/runs/30755589357)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30755589277](https://github.com/sgl-project/sglang/actions/runs/30755589277)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->