### PR TITLE
[AMD]Fuse Q/K L2 normalization in Qwen3.5 GDN 

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/chunk.py
+++ b/python/sglang/kernels/ops/attention/fla/chunk.py
@@ -14,11 +14,16 @@ from sglang.kernels.ops.attention.fla.cumsum import chunk_local_cumsum
 from sglang.kernels.ops.attention.fla.index import (
     prepare_chunk_indices,
 )
-from sglang.kernels.ops.attention.fla.l2norm import l2norm_fwd
+from sglang.kernels.ops.attention.fla.l2norm import (
+    can_fuse_l2norm_qk,
+    fused_l2norm_qk,
+    l2norm_fwd,
+)
 from sglang.kernels.ops.attention.fla.utils import (
     SUPPRESS_LEVEL,
     autocast_custom_fwd,
     input_guard,
+    is_amd,
     is_intel,
 )
 
@@ -102,12 +107,12 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         cu_seqlens: Optional[torch.LongTensor] = None,
         use_qk_l2norm_in_kernel: bool = False,
     ):
-        q_orig = q
-        k_orig = k
-
         if use_qk_l2norm_in_kernel:
-            q = l2norm_fwd(q)
-            k = l2norm_fwd(k)
+            if is_amd and can_fuse_l2norm_qk(q, k):
+                q, k = fused_l2norm_qk(q, k)
+            else:
+                q = l2norm_fwd(q)
+                k = l2norm_fwd(k)
 
         chunk_indices = (
             prepare_chunk_indices(cu_seqlens, CHUNK_SIZE)

--- a/python/sglang/kernels/ops/attention/fla/chunk.py
+++ b/python/sglang/kernels/ops/attention/fla/chunk.py
@@ -14,13 +14,20 @@ from sglang.kernels.ops.attention.fla.cumsum import chunk_local_cumsum
 from sglang.kernels.ops.attention.fla.index import (
     prepare_chunk_indices,
 )
-from sglang.kernels.ops.attention.fla.l2norm import l2norm_fwd
+from sglang.kernels.ops.attention.fla.l2norm import (
+    can_fuse_l2norm_qk,
+    fused_l2norm_qk,
+    l2norm_fwd,
+)
 from sglang.kernels.ops.attention.fla.utils import (
     SUPPRESS_LEVEL,
     autocast_custom_fwd,
     input_guard,
     is_intel,
 )
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
 
 if is_intel:
     from sglang.srt.hardware_backend.xpu.kernels.fla.chunk_delta_h import (
@@ -102,12 +109,12 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         cu_seqlens: Optional[torch.LongTensor] = None,
         use_qk_l2norm_in_kernel: bool = False,
     ):
-        q_orig = q
-        k_orig = k
-
         if use_qk_l2norm_in_kernel:
-            q = l2norm_fwd(q)
-            k = l2norm_fwd(k)
+            if _is_hip and can_fuse_l2norm_qk(q, k):
+                q, k = fused_l2norm_qk(q, k)
+            else:
+                q = l2norm_fwd(q)
+                k = l2norm_fwd(k)
 
         chunk_indices = (
             prepare_chunk_indices(cu_seqlens, CHUNK_SIZE)

--- a/python/sglang/kernels/ops/attention/fla/l2norm.py
+++ b/python/sglang/kernels/ops/attention/fla/l2norm.py
@@ -14,6 +14,152 @@ from sglang.kernels.ops.attention.fla.utils import input_guard
 BT_LIST = [8, 16, 32, 64, 128]
 
 
+@triton.jit(do_not_specialize=["TQ", "TK"])
+def fused_l2norm_qk_kernel(
+    q,
+    k,
+    q_out,
+    k_out,
+    eps,
+    TQ,
+    TK,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+
+    rows = i_t * BT + tl.arange(0, BT)
+    cols = tl.arange(0, BD)
+    col_mask = cols < D
+
+    q_mask = (rows[:, None] < TQ) & col_mask[None, :]
+    q_offs = rows[:, None] * D + cols[None, :]
+    b_q = tl.load(q + q_offs, mask=q_mask, other=0.0).to(tl.float32)
+    q_var = tl.sum(b_q * b_q, axis=1)
+    b_q_out = b_q / tl.sqrt(q_var + eps)[:, None]
+    tl.store(q_out + q_offs, b_q_out.to(q_out.dtype.element_ty), mask=q_mask)
+
+    k_mask = (rows[:, None] < TK) & col_mask[None, :]
+    k_offs = rows[:, None] * D + cols[None, :]
+    b_k = tl.load(k + k_offs, mask=k_mask, other=0.0).to(tl.float32)
+    k_var = tl.sum(b_k * b_k, axis=1)
+    b_k_out = b_k / tl.sqrt(k_var + eps)[:, None]
+    tl.store(k_out + k_offs, b_k_out.to(k_out.dtype.element_ty), mask=k_mask)
+
+
+@triton.jit(do_not_specialize=["TQ", "TK"])
+def fused_l2norm_qk_kernel1(
+    q,
+    k,
+    q_out,
+    k_out,
+    D,
+    BD: tl.constexpr,
+    eps,
+    TQ,
+    TK,
+):
+    i_t = tl.program_id(0)
+    cols = tl.arange(0, BD)
+    mask = cols < D
+    offs = i_t * D + cols
+
+    if i_t < TQ:
+        b_q = tl.load(q + offs, mask=mask, other=0.0).to(tl.float32)
+        q_var = tl.sum(b_q * b_q, axis=0)
+        b_q_out = b_q / tl.sqrt(q_var + eps)
+        tl.store(q_out + offs, b_q_out.to(q_out.dtype.element_ty), mask=mask)
+
+    if i_t < TK:
+        b_k = tl.load(k + offs, mask=mask, other=0.0).to(tl.float32)
+        k_var = tl.sum(b_k * b_k, axis=0)
+        b_k_out = b_k / tl.sqrt(k_var + eps)
+        tl.store(k_out + offs, b_k_out.to(k_out.dtype.element_ty), mask=mask)
+
+
+def can_fuse_l2norm_qk(q: torch.Tensor, k: torch.Tensor) -> bool:
+    if q.device != k.device or q.dtype != k.dtype:
+        return False
+    if not q.is_cuda or q.dtype not in (torch.bfloat16, torch.float32):
+        return False
+    if q.shape != k.shape:
+        return False
+    q_rows = q.numel() // q.shape[-1]
+    # Wide-shape sweep is positive through D=512 except for the launch-bound
+    # D=512, rows<32 corner. Keep unbenchmarked larger head dims on the existing
+    # two-kernel path.
+    if q.shape[-1] > 512 or (q.shape[-1] == 512 and q_rows < 32):
+        return False
+    if q.stride(-1) != 1 or k.stride(-1) != 1:
+        return False
+    # `view(-1, D)` in the kernel wrapper must be valid without an implicit copy.
+    if not q.is_contiguous() or not k.is_contiguous():
+        return False
+    return True
+
+
+def fused_l2norm_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: Optional[torch.dtype] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not can_fuse_l2norm_qk(q, k):
+        raise ValueError("Incompatible Q/K tensors for fused_l2norm_qk")
+
+    q_shape_og = q.shape
+    k_shape_og = k.shape
+    q_flat = q.view(-1, q.shape[-1])
+    k_flat = k.view(-1, k.shape[-1])
+    TQ, TK, D = q_flat.shape[0], k_flat.shape[0], q_flat.shape[-1]
+
+    if output_dtype is None:
+        q_out = torch.empty_like(q_flat)
+        k_out = torch.empty_like(k_flat)
+    else:
+        q_out = torch.empty_like(q_flat, dtype=output_dtype)
+        k_out = torch.empty_like(k_flat, dtype=output_dtype)
+
+    MAX_FUSED_SIZE = 65536 // q.element_size()
+    BD = min(MAX_FUSED_SIZE, triton.next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer doesn't support feature dim >= 64KB.")
+
+    if D <= 512:
+        BT = 16
+        fused_l2norm_qk_kernel[(triton.cdiv(max(TQ, TK), BT),)](
+            q_flat,
+            k_flat,
+            q_out,
+            k_out,
+            eps,
+            TQ=TQ,
+            TK=TK,
+            D=D,
+            BT=BT,
+            BD=BD,
+            num_warps=8,
+            num_stages=3,
+        )
+    else:
+        fused_l2norm_qk_kernel1[(max(TQ, TK),)](
+            q_flat,
+            k_flat,
+            q_out,
+            k_out,
+            eps=eps,
+            D=D,
+            BD=BD,
+            TQ=TQ,
+            TK=TK,
+            num_warps=8,
+            num_stages=3,
+        )
+
+    return q_out.view(q_shape_og), k_out.view(k_shape_og)
+
+
 # @triton.autotune(
 #     configs=[
 #         triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8, 16, 32]

--- a/test/registered/kernels/benchmark/attention/bench_gdn_l2norm.py
+++ b/test/registered/kernels/benchmark/attention/bench_gdn_l2norm.py
@@ -1,0 +1,56 @@
+import torch
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.ops.attention.fla.l2norm import fused_l2norm_qk, l2norm_fwd
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(
+    est_time=8, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+register_amd_ci(est_time=8, stage="jit-kernel-benchmark", runner_config="amd")
+
+
+def _run_fused(q: torch.Tensor, k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    return fused_l2norm_qk(q, k)
+
+
+def _run_separate(
+    q: torch.Tensor, k: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return l2norm_fwd(q), l2norm_fwd(k)
+
+
+FN_MAP = {
+    "fused": _run_fused,
+    "separate": _run_separate,
+}
+
+
+@marker.parametrize("tokens", [15, 16, 17, 257, 1024], [257])
+@marker.parametrize(
+    "local_heads,head_dim",
+    [
+        (2, 128),
+        (4, 128),
+        (8, 128),
+        (16, 128),
+        (8, 256),
+    ],
+)
+@marker.benchmark("impl", ["fused", "separate"])
+def benchmark(tokens: int, local_heads: int, head_dim: int, impl: str):
+    q = torch.randn(tokens, local_heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(tokens, local_heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    return marker.do_bench(
+        FN_MAP[impl],
+        input_args=(q, k),
+        warmup_iters=80,
+        replay_iters=1200,
+        graph_clone_args=(0, 1),
+        memory_args=(q, k),
+        memory_output=None,
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/ops/attention/test_fused_gdn_l2norm.py
+++ b/test/registered/kernels/ops/attention/test_fused_gdn_l2norm.py
@@ -1,0 +1,285 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.fla import chunk as chunk_mod
+from sglang.kernels.ops.attention.fla.l2norm import (
+    can_fuse_l2norm_qk,
+    fused_l2norm_qk,
+    l2norm_fwd,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=8, stage="jit-kernel-unit", runner_config="amd")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("tokens", [1, 15, 16, 17, 257])
+@pytest.mark.parametrize("local_heads", [2, 4, 8, 16])
+def test_fused_l2norm_qk_matches_separate_qwen35_equal_heads(
+    dtype, tokens, local_heads
+):
+    torch.manual_seed(2026)
+    head_dim = 128
+    q = torch.randn(tokens, local_heads, head_dim, dtype=dtype, device="cuda")
+    k = torch.randn(tokens, local_heads, head_dim, dtype=dtype, device="cuda")
+
+    q_ref = l2norm_fwd(q)
+    k_ref = l2norm_fwd(k)
+    q_fused, k_fused = fused_l2norm_qk(q, k)
+
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    rtol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    torch.testing.assert_close(q_fused, q_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(k_fused, k_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_fused_l2norm_qk_generic_d256(dtype):
+    torch.manual_seed(99)
+    q = torch.randn(257, 8, 256, dtype=dtype, device="cuda")
+    k = torch.randn(257, 8, 256, dtype=dtype, device="cuda")
+
+    q_ref = l2norm_fwd(q)
+    k_ref = l2norm_fwd(k)
+    q_fused, k_fused = fused_l2norm_qk(q, k)
+
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    rtol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    torch.testing.assert_close(q_fused, q_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(k_fused, k_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_asymmetric_rows():
+    q = torch.randn(17, 16, 128, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(17, 8, 128, dtype=torch.bfloat16, device="cuda")
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+def test_can_fuse_l2norm_qk_rejects_cpu_tensors():
+    q = torch.randn(4, 2, 128, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_unvalidated_dtype():
+    q = torch.randn(4, 2, 128, dtype=torch.float16, device="cuda")
+    k = torch.randn_like(q)
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_different_shapes_with_equal_rows():
+    q = torch.randn(4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(8, 1, 128, dtype=torch.bfloat16, device="cuda")
+    assert q.numel() == k.numel()
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+@pytest.mark.parametrize(
+    "rows,expected",
+    [
+        (16, False),
+        (32, True),
+    ],
+)
+def test_can_fuse_l2norm_qk_d512_small_row_guard(rows, expected):
+    q = torch.randn(rows, 1, 512, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn_like(q)
+    assert can_fuse_l2norm_qk(q, k) is expected
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_unbenchmarked_large_head_dim():
+    q = torch.randn(64, 1, 1024, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn_like(q)
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_chunk_uses_fused_qk_l2norm(monkeypatch):
+    seen = {"fused": 0, "separate": 0}
+
+    def fake_can_fuse(q, k):
+        return True
+
+    def fake_fused(q, k, eps=1e-6, output_dtype=None):
+        seen["fused"] += 1
+        return q + 3, k + 5
+
+    def fake_l2norm(*args, **kwargs):
+        seen["separate"] += 1
+        raise AssertionError("Fallback l2norm_fwd should not run in fused path")
+
+    def fake_chunk_fwd(**kwargs):
+        q = kwargs["q"]
+        k = kwargs["k"]
+        assert torch.allclose(q, q_in + 3)
+        assert torch.allclose(k, k_in + 5)
+        o = torch.zeros_like(kwargs["v"])
+        return (
+            kwargs["g"],
+            o,
+            torch.empty(0, device=o.device),
+            None,
+            kwargs["initial_state"],
+            None,
+        )
+
+    monkeypatch.setattr(chunk_mod, "_is_hip", True, raising=False)
+    monkeypatch.setattr(chunk_mod, "can_fuse_l2norm_qk", fake_can_fuse)
+    monkeypatch.setattr(chunk_mod, "fused_l2norm_qk", fake_fused)
+    monkeypatch.setattr(chunk_mod, "l2norm_fwd", fake_l2norm)
+    monkeypatch.setattr(chunk_mod, "chunk_gated_delta_rule_fwd", fake_chunk_fwd)
+
+    q_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    v = torch.randn(1, 4, 2, 64, dtype=torch.bfloat16, device="cuda")
+    g = torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda")
+    beta = torch.sigmoid(torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda"))
+    initial_state = torch.randn(1, 2, 64, 128, dtype=torch.float32, device="cuda")
+    initial_state_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    chunk_mod.chunk_gated_delta_rule(
+        q=q_in,
+        k=k_in,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert seen["fused"] == 1
+    assert seen["separate"] == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_chunk_falls_back_to_two_l2norm_calls(monkeypatch):
+    seen = {"fused": 0, "separate": 0}
+
+    def fake_can_fuse(q, k):
+        return False
+
+    def fake_fused(*args, **kwargs):
+        seen["fused"] += 1
+        raise AssertionError("fused_l2norm_qk should not run in fallback path")
+
+    def fake_l2norm(x, eps=1e-6, output_dtype=None):
+        seen["separate"] += 1
+        return x + 7
+
+    def fake_chunk_fwd(**kwargs):
+        q = kwargs["q"]
+        k = kwargs["k"]
+        assert torch.allclose(q, q_in + 7)
+        assert torch.allclose(k, k_in + 7)
+        o = torch.zeros_like(kwargs["v"])
+        return (
+            kwargs["g"],
+            o,
+            torch.empty(0, device=o.device),
+            None,
+            kwargs["initial_state"],
+            None,
+        )
+
+    monkeypatch.setattr(chunk_mod, "_is_hip", True, raising=False)
+    monkeypatch.setattr(chunk_mod, "can_fuse_l2norm_qk", fake_can_fuse)
+    monkeypatch.setattr(chunk_mod, "fused_l2norm_qk", fake_fused)
+    monkeypatch.setattr(chunk_mod, "l2norm_fwd", fake_l2norm)
+    monkeypatch.setattr(chunk_mod, "chunk_gated_delta_rule_fwd", fake_chunk_fwd)
+
+    q_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    v = torch.randn(1, 4, 2, 64, dtype=torch.bfloat16, device="cuda")
+    g = torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda")
+    beta = torch.sigmoid(torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda"))
+    initial_state = torch.randn(1, 2, 64, 128, dtype=torch.float32, device="cuda")
+    initial_state_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    chunk_mod.chunk_gated_delta_rule(
+        q=q_in,
+        k=k_in,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert seen["fused"] == 0
+    assert seen["separate"] == 2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_chunk_non_hip_uses_two_l2norm_even_if_fusible(monkeypatch):
+    seen = {"fused": 0, "separate": 0}
+
+    def fake_can_fuse(q, k):
+        return True
+
+    def fake_fused(*args, **kwargs):
+        seen["fused"] += 1
+        return args[0], args[1]
+
+    def fake_l2norm(x, eps=1e-6, output_dtype=None):
+        seen["separate"] += 1
+        return x + 11
+
+    def fake_chunk_fwd(**kwargs):
+        assert torch.allclose(kwargs["q"], q_in + 11)
+        assert torch.allclose(kwargs["k"], k_in + 11)
+        o = torch.zeros_like(kwargs["v"])
+        return (
+            kwargs["g"],
+            o,
+            torch.empty(0, device=o.device),
+            None,
+            kwargs["initial_state"],
+            None,
+        )
+
+    monkeypatch.setattr(chunk_mod, "_is_hip", False, raising=False)
+    monkeypatch.setattr(chunk_mod, "can_fuse_l2norm_qk", fake_can_fuse)
+    monkeypatch.setattr(chunk_mod, "fused_l2norm_qk", fake_fused)
+    monkeypatch.setattr(chunk_mod, "l2norm_fwd", fake_l2norm)
+    monkeypatch.setattr(chunk_mod, "chunk_gated_delta_rule_fwd", fake_chunk_fwd)
+
+    q_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    v = torch.randn(1, 4, 2, 64, dtype=torch.bfloat16, device="cuda")
+    g = torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda")
+    beta = torch.sigmoid(torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda"))
+    initial_state = torch.randn(1, 2, 64, 128, dtype=torch.float32, device="cuda")
+    initial_state_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    chunk_mod.chunk_gated_delta_rule(
+        q=q_in,
+        k=k_in,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert seen["fused"] == 0
+    assert seen["separate"] == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/kernels/ops/attention/test_fused_gdn_l2norm.py
+++ b/test/registered/kernels/ops/attention/test_fused_gdn_l2norm.py
@@ -1,0 +1,285 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.fla import chunk as chunk_mod
+from sglang.kernels.ops.attention.fla.l2norm import (
+    can_fuse_l2norm_qk,
+    fused_l2norm_qk,
+    l2norm_fwd,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=8, stage="jit-kernel-unit", runner_config="amd")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("tokens", [1, 15, 16, 17, 257])
+@pytest.mark.parametrize("local_heads", [2, 4, 8, 16])
+def test_fused_l2norm_qk_matches_separate_qwen35_equal_heads(
+    dtype, tokens, local_heads
+):
+    torch.manual_seed(2026)
+    head_dim = 128
+    q = torch.randn(tokens, local_heads, head_dim, dtype=dtype, device="cuda")
+    k = torch.randn(tokens, local_heads, head_dim, dtype=dtype, device="cuda")
+
+    q_ref = l2norm_fwd(q)
+    k_ref = l2norm_fwd(k)
+    q_fused, k_fused = fused_l2norm_qk(q, k)
+
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    rtol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    torch.testing.assert_close(q_fused, q_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(k_fused, k_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_fused_l2norm_qk_generic_d256(dtype):
+    torch.manual_seed(99)
+    q = torch.randn(257, 8, 256, dtype=dtype, device="cuda")
+    k = torch.randn(257, 8, 256, dtype=dtype, device="cuda")
+
+    q_ref = l2norm_fwd(q)
+    k_ref = l2norm_fwd(k)
+    q_fused, k_fused = fused_l2norm_qk(q, k)
+
+    atol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    rtol = 2e-2 if dtype == torch.bfloat16 else 1e-5
+    torch.testing.assert_close(q_fused, q_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(k_fused, k_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_asymmetric_rows():
+    q = torch.randn(17, 16, 128, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(17, 8, 128, dtype=torch.bfloat16, device="cuda")
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+def test_can_fuse_l2norm_qk_rejects_cpu_tensors():
+    q = torch.randn(4, 2, 128, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_unvalidated_dtype():
+    q = torch.randn(4, 2, 128, dtype=torch.float16, device="cuda")
+    k = torch.randn_like(q)
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_different_shapes_with_equal_rows():
+    q = torch.randn(4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(8, 1, 128, dtype=torch.bfloat16, device="cuda")
+    assert q.numel() == k.numel()
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+@pytest.mark.parametrize(
+    "rows,expected",
+    [
+        (16, False),
+        (32, True),
+    ],
+)
+def test_can_fuse_l2norm_qk_d512_small_row_guard(rows, expected):
+    q = torch.randn(rows, 1, 512, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn_like(q)
+    assert can_fuse_l2norm_qk(q, k) is expected
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_can_fuse_l2norm_qk_rejects_unbenchmarked_large_head_dim():
+    q = torch.randn(64, 1, 1024, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn_like(q)
+    assert not can_fuse_l2norm_qk(q, k)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_chunk_uses_fused_qk_l2norm(monkeypatch):
+    seen = {"fused": 0, "separate": 0}
+
+    def fake_can_fuse(q, k):
+        return True
+
+    def fake_fused(q, k, eps=1e-6, output_dtype=None):
+        seen["fused"] += 1
+        return q + 3, k + 5
+
+    def fake_l2norm(*args, **kwargs):
+        seen["separate"] += 1
+        raise AssertionError("Fallback l2norm_fwd should not run in fused path")
+
+    def fake_chunk_fwd(**kwargs):
+        q = kwargs["q"]
+        k = kwargs["k"]
+        assert torch.allclose(q, q_in + 3)
+        assert torch.allclose(k, k_in + 5)
+        o = torch.zeros_like(kwargs["v"])
+        return (
+            kwargs["g"],
+            o,
+            torch.empty(0, device=o.device),
+            None,
+            kwargs["initial_state"],
+            None,
+        )
+
+    monkeypatch.setattr(chunk_mod, "is_amd", True, raising=False)
+    monkeypatch.setattr(chunk_mod, "can_fuse_l2norm_qk", fake_can_fuse)
+    monkeypatch.setattr(chunk_mod, "fused_l2norm_qk", fake_fused)
+    monkeypatch.setattr(chunk_mod, "l2norm_fwd", fake_l2norm)
+    monkeypatch.setattr(chunk_mod, "chunk_gated_delta_rule_fwd", fake_chunk_fwd)
+
+    q_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    v = torch.randn(1, 4, 2, 64, dtype=torch.bfloat16, device="cuda")
+    g = torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda")
+    beta = torch.sigmoid(torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda"))
+    initial_state = torch.randn(1, 2, 64, 128, dtype=torch.float32, device="cuda")
+    initial_state_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    chunk_mod.chunk_gated_delta_rule(
+        q=q_in,
+        k=k_in,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert seen["fused"] == 1
+    assert seen["separate"] == 0
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_chunk_falls_back_to_two_l2norm_calls(monkeypatch):
+    seen = {"fused": 0, "separate": 0}
+
+    def fake_can_fuse(q, k):
+        return False
+
+    def fake_fused(*args, **kwargs):
+        seen["fused"] += 1
+        raise AssertionError("fused_l2norm_qk should not run in fallback path")
+
+    def fake_l2norm(x, eps=1e-6, output_dtype=None):
+        seen["separate"] += 1
+        return x + 7
+
+    def fake_chunk_fwd(**kwargs):
+        q = kwargs["q"]
+        k = kwargs["k"]
+        assert torch.allclose(q, q_in + 7)
+        assert torch.allclose(k, k_in + 7)
+        o = torch.zeros_like(kwargs["v"])
+        return (
+            kwargs["g"],
+            o,
+            torch.empty(0, device=o.device),
+            None,
+            kwargs["initial_state"],
+            None,
+        )
+
+    monkeypatch.setattr(chunk_mod, "is_amd", True, raising=False)
+    monkeypatch.setattr(chunk_mod, "can_fuse_l2norm_qk", fake_can_fuse)
+    monkeypatch.setattr(chunk_mod, "fused_l2norm_qk", fake_fused)
+    monkeypatch.setattr(chunk_mod, "l2norm_fwd", fake_l2norm)
+    monkeypatch.setattr(chunk_mod, "chunk_gated_delta_rule_fwd", fake_chunk_fwd)
+
+    q_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    v = torch.randn(1, 4, 2, 64, dtype=torch.bfloat16, device="cuda")
+    g = torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda")
+    beta = torch.sigmoid(torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda"))
+    initial_state = torch.randn(1, 2, 64, 128, dtype=torch.float32, device="cuda")
+    initial_state_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    chunk_mod.chunk_gated_delta_rule(
+        q=q_in,
+        k=k_in,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert seen["fused"] == 0
+    assert seen["separate"] == 2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU")
+def test_chunk_non_amd_uses_two_l2norm_even_if_fusible(monkeypatch):
+    seen = {"fused": 0, "separate": 0}
+
+    def fake_can_fuse(q, k):
+        return True
+
+    def fake_fused(*args, **kwargs):
+        seen["fused"] += 1
+        return args[0], args[1]
+
+    def fake_l2norm(x, eps=1e-6, output_dtype=None):
+        seen["separate"] += 1
+        return x + 11
+
+    def fake_chunk_fwd(**kwargs):
+        assert torch.allclose(kwargs["q"], q_in + 11)
+        assert torch.allclose(kwargs["k"], k_in + 11)
+        o = torch.zeros_like(kwargs["v"])
+        return (
+            kwargs["g"],
+            o,
+            torch.empty(0, device=o.device),
+            None,
+            kwargs["initial_state"],
+            None,
+        )
+
+    monkeypatch.setattr(chunk_mod, "is_amd", False, raising=False)
+    monkeypatch.setattr(chunk_mod, "can_fuse_l2norm_qk", fake_can_fuse)
+    monkeypatch.setattr(chunk_mod, "fused_l2norm_qk", fake_fused)
+    monkeypatch.setattr(chunk_mod, "l2norm_fwd", fake_l2norm)
+    monkeypatch.setattr(chunk_mod, "chunk_gated_delta_rule_fwd", fake_chunk_fwd)
+
+    q_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    k_in = torch.randn(1, 4, 2, 128, dtype=torch.bfloat16, device="cuda")
+    v = torch.randn(1, 4, 2, 64, dtype=torch.bfloat16, device="cuda")
+    g = torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda")
+    beta = torch.sigmoid(torch.randn(1, 4, 2, dtype=torch.bfloat16, device="cuda"))
+    initial_state = torch.randn(1, 2, 64, 128, dtype=torch.float32, device="cuda")
+    initial_state_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+
+    chunk_mod.chunk_gated_delta_rule(
+        q=q_in,
+        k=k_in,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        initial_state_indices=initial_state_indices,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    assert seen["fused"] == 0
+    assert seen["separate"] == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
Reduce GDN prefill launches for benchmarked BF16/FP32 GPU shapes while preserving the original path on unsupported platforms, dtypes, layouts, and launch-bound wide shapes.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
The Triton GDN prefill path normalizes Q and K with two separate `l2norm_fwd` launches. Qwen3.5 GDN uses equal Q/K head layouts, so both normalizations can be computed in one Triton launch.

This change reduces GDN prefill launch overhead on AMD GPUs while preserving the existing two-kernel implementation as the fallback.
<!-- Describe the purpose and goals of this pull request. -->

## Modifications
- Add `fused_l2norm_qk` to normalize compatible Q/K tensors in one Triton launch.
- Preserve runtime token-count behavior with `do_not_specialize` to avoid recompilation by sequence length.
- Enable automatic fused routing only when:
  - the platform is AMD;
  - execution is in the GDN `chunk_gated_delta_rule` path;
  - Q/K are GPU BF16/FP32 tensors with identical shape and contiguous layout.
- Preserve two existing `l2norm_fwd` calls for:
  - non-AMD platforms;
  - asymmetric Q/K row layouts;
  - non-contiguous or otherwise incompatible tensors.
  - unbenchmarked head dimensions larger than 512;
  - the launch-bound `head_dim=512, rows<32` corner.
- Add AMD/CUDA correctness tests, explicit fused/fallback dispatch tests, and a focused benchmark.

No KDA, Mamba, full-attention, CuTe DSL, FlashInfer, CPU, NPU, or XPU path is changed.
<!-- Detail the changes made in this pull request. -->

## Accuracy Tests
```bash
PYTHONPATH=python python3 -m pytest -q \
  test/registered/kernels/ops/attention/test_fused_gdn_l2norm.py \
  test/registered/attention/test_chunk_gated_delta_rule.py
```
<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling
Representative equal-head Qwen3.5 GDN shapes (`head_dim=128`):

| Tokens | Local heads | Fused (us) | Separate (us) | Latency reduction |
|---:|---:|---:|---:|---:|
| 16 | 2 | 3.34 | 5.32 | 37.2% |
| 16 | 8 | 3.41 | 5.30 | 35.7% |
| 257 | 8 | 4.87 | 6.50 | 25.1% |
| 1024 | 2 | 4.94 | 6.49 | 23.9% |
| 1024 | 8 | 10.73 | 13.35 | 19.6% |
| 1024 | 16 | 17.67 | 21.02 | 16.0% |

Across the tested Qwen3.5 equal-head `D=128` cases, fused normalization reduced median latency by approximately **16–38%**.

Expanded BF16 sweep:

- tokens: 1–16384;
- local heads: 1–64;
- head dimensions: 64/128/256/512;
- 135 total shape combinations.

| Head dim | Auto-enabled shapes | Minimum speedup | Median speedup | Maximum speedup |
|---:|---:|---:|---:|---:|
| 64 | 27 | 1.13× | 1.19× | 1.48× |
| 128 | 63 | 1.11× | 1.15× | 1.48× |
| 256 | 27 | 1.06× | 1.14× | 1.52× |
| 512 (`rows>=32`) | 14 | 1.03× | 1.09× | 1.14× |



| Model | Parallelism | Scenario | ISL | OSL | Concurrency | Requests per cycle | Metric | Paired mean improvement |
|---|---:|---|---:|---:|---:|---:|---|---:|
| 27B | TP1 | Short-prefill online latency | 256 | 8 | 1 | 64 | Mean TTFT | +0.79% |
| 27B | TP1 | Long-prefill online latency | 8192 | 8 | 1 | 32 | Mean TTFT | +0.016% |
| 27B | TP1 | Concurrent serving throughput | 4096 | 128 | 64 | 64 | Input throughput | +0.19% |
| 397B | TP8 | Short-prefill online latency | 256 | 8 | 1 | 64 | Mean TTFT | +0.99% |
| 397B | TP8 | Long-prefill online latency | 8192 | 8 | 1 | 64 | Mean TTFT | +0.048% |
| 397B | TP8 | Concurrent serving throughput | 4096 | 128 | 64 | 64 | Input throughput | +0.013% |
<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32249402953](https://github.com/sgl-project/sglang/actions/runs/32249402953)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32249402656](https://github.com/sgl-project/sglang/actions/runs/32249402656)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32249402776](https://github.com/sgl-project/sglang/actions/runs/32249402776)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->