### PR TITLE
test: stand up the config tiers two unit tests read from

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -552,10 +552,9 @@ def _acknowledge_deferred_cuda_ipc_cache_hits(
     parallel = get_parallel()
     if parallel.attn_tp_rank != 0:
         return
-    server_args = get_server_args()
-    # The pool's recycler uses ServerArgs.tp_size, so its acknowledgement must
+    # The pool's recycler counts the whole TP group, so the acknowledgement must
     # match that count even when an attention subgroup is smaller.
-    consumer_count = max(getattr(server_args, "tp_size", parallel.attn_tp_size), 1)
+    consumer_count = max(get_server_args().tp_size, 1)
     for item in items:
         item.acknowledge_deferred_cuda_ipc_feature(consumer_count)
 

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -14,9 +14,28 @@ import torch
 
 from sglang.srt.managers import mm_utils
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-b-test-cpu")
+
+
+@pytest.fixture(autouse=True)
+def publish_config_and_parallel_state():
+    """Applied to every test in this module (``autouse``), named by none of them.
+
+    The embedding path reads the config namespaces and the attention-TP rank —
+    process state a served engine establishes at startup. Without this the
+    accessors raise instead of answering.
+    """
+    override = get_context().override_server_args(tp_size=1)
+    override.install()
+    try:
+        with get_parallel().override(attn_tp_rank=0, attn_tp_size=1, tp_size=1):
+            yield
+    finally:
+        override.restore()
+
 
 HIDDEN = 16
 

--- a/test/registered/unit/hardware_backend/mlx/test_attn_dp_request_capacity.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attn_dp_request_capacity.py
@@ -13,6 +13,7 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -40,6 +41,7 @@ def _arch(*, hybrid: bool):
 
 
 def _stub_for_initialize(
+    test,
     *,
     dp_size: int,
     attn_dp_size: int,
@@ -47,16 +49,22 @@ def _stub_for_initialize(
     max_mamba_cache_size: int | None = None,
     pool_size: int = 64,
 ):
-    stub = MlxModelRunnerStub.__new__(MlxModelRunnerStub)
-    stub._mlx_pool_size = pool_size
-    stub.device = "cpu"
-    stub.ps = ParallelState.trivial(dp_size=dp_size, attn_dp_size=attn_dp_size)
-    stub.server_args = SimpleNamespace(
+    # ``initialize`` reads the config namespaces, so the config has to be
+    # published rather than stubbed onto the runner.
+    override = get_context().override_server_args(
         enable_memory_saver=False,
         max_running_requests=max_running_requests,
         max_mamba_cache_size=max_mamba_cache_size,
         disable_radix_cache=False,
     )
+    server_args = override.install()
+    test.addCleanup(override.restore)
+
+    stub = MlxModelRunnerStub.__new__(MlxModelRunnerStub)
+    stub._mlx_pool_size = pool_size
+    stub.device = "cpu"
+    stub.ps = ParallelState.trivial(dp_size=dp_size, attn_dp_size=attn_dp_size)
+    stub.server_args = server_args
     stub.model_config = SimpleNamespace(
         is_hybrid_swa=False,
         sliding_window_size=None,
@@ -80,14 +88,14 @@ def _initialize_stub(stub, *, hybrid: bool = False):
 class TestAttentionDpRequestCapacity(CustomTestCase):
     def test_pure_dp_replica_retains_full_request_limit(self):
         stub = _initialize_stub(
-            _stub_for_initialize(dp_size=4, attn_dp_size=1),
+            _stub_for_initialize(self, dp_size=4, attn_dp_size=1),
         )
         self.assertEqual(stub.max_running_requests, 8)
         self.assertEqual(stub.req_to_token_pool.size, 8)
 
     def test_attention_dp_partitions_request_limit(self):
         stub = _initialize_stub(
-            _stub_for_initialize(dp_size=4, attn_dp_size=4),
+            _stub_for_initialize(self, dp_size=4, attn_dp_size=4),
         )
         self.assertEqual(stub.max_running_requests, 2)
         self.assertEqual(stub.req_to_token_pool.size, 2)
@@ -95,6 +103,7 @@ class TestAttentionDpRequestCapacity(CustomTestCase):
     def test_attention_dp_partitions_explicit_auxiliary_state_limit(self):
         stub = _initialize_stub(
             _stub_for_initialize(
+                self,
                 dp_size=4,
                 attn_dp_size=4,
                 max_running_requests=8,
@@ -109,6 +118,7 @@ class TestAttentionDpRequestCapacity(CustomTestCase):
 
     def test_attention_dp_auxiliary_error_reports_global_cli_units(self):
         stub = _stub_for_initialize(
+            self,
             dp_size=4,
             attn_dp_size=4,
             max_running_requests=8,


### PR DESCRIPTION
## What

Two registered tests fail on `main` today. Both read process state that only a
served engine establishes, and nothing in the test published it:

- `test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py` — 3 of 5
  tests fail with `AssertionError: attention tensor model parallel group is not
  initialized`. The embedding path reads the attention-TP rank and the config;
  the test set up neither.
- `test/registered/unit/hardware_backend/mlx/test_attn_dp_request_capacity.py` —
  fails on the MLX runner with `ValueError: config namespace 'exec' not
  published`. It handed `MlxModelRunnerStub` a `SimpleNamespace` carrying the four
  fields `initialize()` used to read off the instance; those reads moved to the
  namespace accessors, so the stand-in stopped intercepting.

Failure logs: [mm](https://github.com/sgl-project/sglang/actions/runs/30761411348/job/91532597346),
[mlx](https://github.com/sgl-project/sglang/actions/runs/30761411354/job/91532593090).

## Fix

Both tests publish a real config instead of faking one, which is what the
runtime-context testing contract asks for — a faked accessor or a stubbed
`server_args` silently stops intercepting the moment a reader migrates, which is
exactly what happened here. The mm test also overrides the parallel tier
(`get_parallel().override(attn_tp_rank=0, ...)`) for the duration of each test.
The MLX stub still receives the published instance, so its own instance reads are
unchanged.

While here, one production line: `_acknowledge_deferred_cuda_ipc_cache_hits`
computed `getattr(server_args, "tp_size", parallel.attn_tp_size)`. Python
evaluates that default eagerly, so **every** call read the live attention-TP size
even though `tp_size` is always present on a resolved `ServerArgs` — a config read
that required a process group for no reason, and the reason the mm test tripped
the assert before reaching anything else. It reads `tp_size` directly now.

## Validation

The two test files: 5 passed + 4 skipped (MLX skips without `mlx` installed; the
four namespace reads its stub makes were verified to resolve under the new
publish). `test/registered/unit/{multimodal,managers}` plus the config ratchets:
358 passed. The MLX path itself needs the MLX runner in CI.

Split out of a larger `ServerArgs.override` burndown stack (#33242) so the
main-side fix can land on its own.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30770816029](https://github.com/sgl-project/sglang/actions/runs/30770816029)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30770815906](https://github.com/sgl-project/sglang/actions/runs/30770815906)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->