### PR TITLE
feat(spec): add ECHO for EAGLE3

### DIFF
--- a/benchmark/mtbench/README.md
+++ b/benchmark/mtbench/README.md
@@ -1,12 +1,14 @@
 ## Download Dataset
 
 ```sh
-wget -O question.jsonl https://raw.githubusercontent.com/lm-sys/FastChat/main/fastchat/llm_judge/data/mt_bench/question.jsonl
+wget -O question.jsonl \
+  https://raw.githubusercontent.com/lm-sys/FastChat/587d5cfa1609a43d192cedb8441cac3c17db105d/fastchat/llm_judge/data/mt_bench/question.jsonl
 ```
 
 ## Run benchmark
 
 ### Benchmark sglang
+
 ```
 python -m sglang.launch_server --model-path meta-llama/Llama-2-7b-chat-hf --port 30000
 ```
@@ -16,6 +18,7 @@ python3 bench_sglang.py --num-questions 80
 ```
 
 ### Benchmark sglang EAGLE
+
 ```
 python3 -m sglang.launch_server --model meta-llama/Meta-Llama-3-8B-Instruct --speculative-algo EAGLE \
     --speculative-draft-model-path lmsys/sglang-EAGLE-LLaMA3-Instruct-8B --speculative-num-steps 5 \
@@ -26,8 +29,8 @@ python3 -m sglang.launch_server --model meta-llama/Meta-Llama-3-8B-Instruct --sp
 python3 bench_sglang_eagle.py --num-questions 80 --parallel 1
 ```
 
-
 ### Benchmark vllm
+
 ```
 python3 -m vllm.entrypoints.api_server --tokenizer-mode auto --model meta-llama/Llama-2-7b-chat-hf --disable-log-requests --port 21000
 ```
@@ -36,8 +39,8 @@ python3 -m vllm.entrypoints.api_server --tokenizer-mode auto --model meta-llama/
 python3 bench_other.py --num-questions 80 --backend vllm
 ```
 
-
 ### Benchmark lightllm
+
 ```
 # A10G
 python -m lightllm.server.api_server --tokenizer_mode auto --model_dir ~/model_weights/llama-2-7b-chat-hf --max_total_token_num 16000 --port 22000
@@ -46,3 +49,170 @@ python -m lightllm.server.api_server --tokenizer_mode auto --model_dir ~/model_w
 ```
 python3 bench_other.py --num-questions 80 --backend lightllm
 ```
+
+## Reproducible ECHO A/B benchmark
+
+`bench_sglang_eagle.py` runs all 80 MT-Bench conversations (160 generation
+turns) through SGLang's OpenAI chat endpoint. The endpoint applies the target
+model's Hugging Face chat template, so local model paths do not depend on
+name-based template detection.
+
+The script uses a commit-pinned copy of FastChat's question set and validates
+that a full run has 80 unique question IDs, two turns per question, and ten
+questions in each of the eight categories. It downloads the pinned file when
+`--question-file` is omitted. To prepare it manually:
+
+```bash
+wget -O /tmp/mt_bench_question.jsonl \
+  https://raw.githubusercontent.com/lm-sys/FastChat/587d5cfa1609a43d192cedb8441cac3c17db105d/fastchat/llm_judge/data/mt_bench/question.jsonl
+```
+
+### Launch the server
+
+The baseline and ECHO servers must use the same arguments. The ECHO server adds
+only `--speculative-echo-threshold`. For example:
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path /path/to/target \
+  --speculative-algorithm EAGLE3 \
+  --speculative-draft-model-path /path/to/draft \
+  --speculative-num-steps 5 \
+  --speculative-eagle-topk 8 \
+  --speculative-num-draft-tokens 32 \
+  --attention-backend fa3 \
+  --disable-overlap-schedule \
+  --disable-radix-cache \
+  --dtype bfloat16 \
+  --tp-size 1 \
+  --cuda-graph-max-bs-decode 32 \
+  --port 30000
+```
+
+Disable the radix cache for performance A/B runs. Otherwise, a configuration
+whose own turn-one answer matches the frozen history can reuse KV cache on turn
+two while another configuration must prefill it, biasing the comparison.
+
+### Freeze the two-turn inputs
+
+First run the dense server once to prepare a canonical turn-one history. This
+preparation run is not a timed result:
+
+```bash
+python3 benchmark/mtbench/bench_sglang_eagle.py \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --question-file /tmp/mt_bench_question.jsonl \
+  --num-questions 80 \
+  --parallel 32 \
+  --max-new-tokens 1024 \
+  --num-gpus 1 \
+  --run-label canonical-input \
+  --answer-file /tmp/eagle3_canonical_answers.jsonl \
+  --result-file /tmp/eagle3_preparation.jsonl
+```
+
+Pass that same file to every timed baseline and ECHO run:
+
+```bash
+python3 benchmark/mtbench/bench_sglang_eagle.py \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --question-file /tmp/mt_bench_question.jsonl \
+  --num-questions 80 \
+  --parallel 32 \
+  --max-new-tokens 1024 \
+  --warmup-questions 4 \
+  --num-gpus 1 \
+  --frozen-turn-one-file /tmp/eagle3_canonical_answers.jsonl \
+  --run-label eagle3-dense \
+  --answer-file /tmp/eagle3_dense_answers.jsonl \
+  --raw-result-file /tmp/eagle3_dense_raw.jsonl \
+  --result-file /tmp/eagle3_results.jsonl
+```
+
+Restart the server with the same arguments plus:
+
+```bash
+--speculative-echo-threshold 0.2
+```
+
+Then repeat the timed command with a different run label and output files while
+keeping `--frozen-turn-one-file` unchanged. Run each timed configuration three
+times and report the median. The result file is append-only.
+
+`--frozen-turn-one-file` gives every configuration the same assistant history
+for turn two. This prevents a turn-one output difference from changing the
+turn-two input during a performance comparison.
+
+### CUDA Graph correctness
+
+Graph/eager exact parity is a separate correctness gate, not a performance
+requirement. Launch the ECHO server with
+`--enable-deterministic-inference` and
+`--cuda-graph-backend-decode disabled`, then save its answer file using the
+same frozen history and request settings:
+
+```bash
+python3 benchmark/mtbench/bench_sglang_eagle.py \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --question-file /tmp/mt_bench_question.jsonl \
+  --num-questions 80 \
+  --parallel 32 \
+  --max-new-tokens 1024 \
+  --frozen-turn-one-file /tmp/eagle3_canonical_answers.jsonl \
+  --run-label eagle3-eager-correctness \
+  --answer-file /tmp/eagle3_eager_answers.jsonl \
+  --result-file /tmp/eagle3_correctness.jsonl
+```
+
+Restart with decode CUDA Graph enabled and run:
+
+```bash
+python3 benchmark/mtbench/bench_sglang_eagle.py \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --question-file /tmp/mt_bench_question.jsonl \
+  --num-questions 80 \
+  --parallel 32 \
+  --max-new-tokens 1024 \
+  --frozen-turn-one-file /tmp/eagle3_canonical_answers.jsonl \
+  --reference-answer-file /tmp/eagle3_eager_answers.jsonl \
+  --require-exact-match \
+  --run-label eagle3-graph-correctness \
+  --answer-file /tmp/eagle3_graph_answers.jsonl \
+  --result-file /tmp/eagle3_correctness.jsonl
+```
+
+Do not use deterministic inference for published performance numbers.
+Target-only and speculative decoding can legally diverge after small BF16
+rounding differences from different GEMM shapes, so their exact-text rate is a
+diagnostic rather than the graph correctness gate.
+
+### Sampling policy and metrics
+
+By default, the serving benchmark uses temperature 0, seed 0, normal EOS
+handling, and `enable_thinking=False`. This is a greedy, controlled MT-Bench
+workload for parity and performance comparisons; it is not an MT-Bench quality
+score. Greedy sampling alone does not guarantee token-identical output across
+different BF16 batch or GEMM shapes.
+
+Use `--temperature-policy official` for FastChat's category-specific
+temperatures (0.7 for writing and roleplay, 0.1 for STEM and humanities, and 0
+for the other categories). Add `--enable-thinking` to benchmark a model's
+thinking mode. Record these choices when publishing results.
+
+The result JSONL contains overall, per-turn, and per-category values for:
+
+- prompt, cached, and completion tokens;
+- output throughput and conversations per second;
+- request and complete-conversation latency percentiles;
+- token-weighted speculative acceptance length and acceptance rate;
+- ECHO runtime metadata when exposed by the backend;
+- request errors and length-truncated responses;
+- exact output parity against an optional reference.
+
+The answer JSONL follows FastChat's MT-Bench answer schema. The optional raw
+JSONL writes one record per conversation, with per-turn metadata and output
+token IDs for deeper diagnosis.

--- a/benchmark/mtbench/bench_sglang_eagle.py
+++ b/benchmark/mtbench/bench_sglang_eagle.py
@@ -1,144 +1,481 @@
-"""
-Adapted from https://github.com/chromecast56/sglang/blob/6f145d2eadb93a116134f703358ce76f15381045/benchmark/mtbench/bench_sglang.py
+"""Benchmark EAGLE/EAGLE3 on the full two-turn MT-Bench workload.
 
-Benchmark SGLang EAGLE/EAGLE3 Speculative Decoding
-
-Usage:
-python3 benchmark/mtbench/bench_sglang_eagle.py --num-questions 80 --parallel 1
+The OpenAI chat endpoint makes the server apply the target model's Hugging
+Face chat template. ``return_meta_info`` retains speculative-decoding metrics.
 """
 
 import argparse
+import asyncio
+import hashlib
 import json
 import os
+import statistics
 import time
 import uuid
+from collections import Counter
 
-import sglang as sgl
-from sglang.test.test_utils import (
-    add_common_sglang_args_and_parse,
-    select_sglang_backend,
-)
+import aiohttp
+import requests
+
+from sglang.test.test_utils import add_common_sglang_args_and_parse
 from sglang.utils import download_and_cache_file
 
+MT_BENCH_COMMIT = "587d5cfa1609a43d192cedb8441cac3c17db105d"
+MT_BENCH_URL = (
+    "https://raw.githubusercontent.com/lm-sys/FastChat/"
+    f"{MT_BENCH_COMMIT}/fastchat/llm_judge/data/mt_bench/question.jsonl"
+)
+TEMPERATURES = {
+    "writing": 0.7,
+    "roleplay": 0.7,
+    "extraction": 0.0,
+    "math": 0.0,
+    "coding": 0.0,
+    "reasoning": 0.0,
+    "stem": 0.1,
+    "humanities": 0.1,
+}
 
-def load_questions(filename):
-    questions = []
+
+def load_questions(filename, count):
+    if count <= 0:
+        raise ValueError("--num-questions must be positive")
     with open(filename, "r") as fin:
-        for line in fin:
-            obj = json.loads(line)
-            questions.append(obj)
+        questions = [json.loads(line) for line in fin if line.strip()][:count]
+    if len(questions) != count:
+        raise ValueError(f"Expected {count} questions, found {len(questions)}")
+
+    ids = [question["question_id"] for question in questions]
+    if len(ids) != len(set(ids)):
+        duplicates = [key for key, value in Counter(ids).items() if value > 1]
+        raise ValueError(f"Duplicate MT-Bench question IDs: {duplicates}")
+    if any(
+        question.get("category") not in TEMPERATURES
+        or len(question.get("turns", ())) != 2
+        for question in questions
+    ):
+        raise ValueError("Every selected MT-Bench question must have two valid turns")
+    if count == 80 and Counter(q["category"] for q in questions) != Counter(
+        {category: 10 for category in TEMPERATURES}
+    ):
+        raise ValueError("Full MT-Bench must contain 10 questions per category")
     return questions
 
 
-def write_answers(filename, model_id, questions, answers):
+def question_set_sha256(questions):
+    value = "\n".join(
+        json.dumps(question, sort_keys=True, separators=(",", ":"))
+        for question in questions
+    )
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def load_answers(filename):
+    if not filename:
+        return {}
+    answers = {}
+    with open(os.path.expanduser(filename), "r") as fin:
+        for line in fin:
+            if not line.strip():
+                continue
+            obj = json.loads(line)
+            choices = obj["choices"]
+            choice = choices[0] if isinstance(choices, list) else choices
+            turns = choice["turns"]
+            if len(turns) != 2:
+                raise ValueError(
+                    f"Answer for question {obj['question_id']} must have two turns"
+                )
+            answers[obj["question_id"]] = turns
+    if not answers:
+        raise ValueError(f"Answer file is empty: {filename}")
+    return answers
+
+
+def write_answers(filename, model, questions, conversations):
     with open(os.path.expanduser(filename), "w") as fout:
-        for i in range(len(answers)):
-            ans_json = {
-                "question_id": questions[i]["question_id"],
+        for question, conversation in zip(questions, conversations):
+            turns = [turn.get("text", "") for turn in conversation["turns"]]
+            value = {
+                "question_id": question["question_id"],
                 "answer_id": uuid.uuid4().hex,
-                "model_id": model_id,
-                "choices": {
-                    "index": 0,
-                    "turns": [answers[i][0], answers[i][1]],
-                },
+                "model_id": model,
+                "choices": [{"index": 0, "turns": turns}],
                 "tstamp": time.time(),
             }
-            fout.write(json.dumps(ans_json) + "\n")
+            fout.write(json.dumps(value, ensure_ascii=False) + "\n")
 
 
-@sgl.function
-def answer_mt_bench(s, question_1, question_2):
-    s += sgl.system(
-        "You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe.  Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information."
+def percentile(values, fraction):
+    if not values:
+        return None
+    values = sorted(values)
+    rank = (len(values) - 1) * fraction
+    lower = int(rank)
+    upper = min(lower + 1, len(values) - 1)
+    return values[lower] + (values[upper] - values[lower]) * (rank - lower)
+
+
+def aggregate(records):
+    successful = [record for record in records if "error" not in record]
+    metas = [record.get("meta_info") or {} for record in successful]
+    output_tokens = sum(int(meta.get("completion_tokens", 0)) for meta in metas)
+    verify_count = sum(int(meta.get("spec_verify_ct", 0)) for meta in metas)
+    correct = sum(int(meta.get("spec_num_correct_drafts", 0)) for meta in metas)
+    proposed = sum(int(meta.get("spec_num_proposed_drafts", 0)) for meta in metas)
+    cap_histogram = Counter()
+    for meta in metas:
+        for cap_len, count in enumerate(meta.get("spec_cap_lens_histogram") or []):
+            cap_histogram[cap_len] += int(count)
+    cap_count = sum(cap_histogram.values())
+    cap_tokens = sum(cap_len * count for cap_len, count in cap_histogram.items())
+    latencies = [record["latency"] for record in successful]
+    return {
+        "requests": len(records),
+        "completed": len(successful),
+        "errors": len(records) - len(successful),
+        "length_truncated": sum(
+            record.get("finish_reason") == "length" for record in successful
+        ),
+        "prompt_tokens": sum(int(meta.get("prompt_tokens", 0)) for meta in metas),
+        "cached_tokens": sum(int(meta.get("cached_tokens", 0)) for meta in metas),
+        "completion_tokens": output_tokens,
+        "spec_verify_count": verify_count,
+        "accept_length": output_tokens / verify_count if verify_count else None,
+        "accept_rate": correct / proposed if proposed else None,
+        "verify_cap_length": cap_tokens / cap_count if cap_count else None,
+        "verify_cap_histogram": dict(sorted(cap_histogram.items())),
+        "latency_s": {
+            "mean": statistics.fmean(latencies) if latencies else None,
+            "p50": percentile(latencies, 0.5),
+            "p90": percentile(latencies, 0.9),
+            "p99": percentile(latencies, 0.99),
+        },
+    }
+
+
+def summarize(conversations, wall_latency):
+    records = [turn for conversation in conversations for turn in conversation["turns"]]
+    overall = aggregate(records)
+    overall.update(
+        wall_latency_s=wall_latency,
+        output_throughput=overall["completion_tokens"] / wall_latency,
+        conversations_per_second=len(conversations) / wall_latency,
     )
-    s += sgl.user(question_1)
-    s += sgl.assistant(sgl.gen("answer_1"))
-    s += sgl.user(question_2)
-    s += sgl.assistant(sgl.gen("answer_2"))
+    conversation_latencies = [
+        conversation["latency"]
+        for conversation in conversations
+        if "error" not in conversation
+    ]
+    overall["conversation_latency_s"] = {
+        "mean": (
+            statistics.fmean(conversation_latencies) if conversation_latencies else None
+        ),
+        "p50": percentile(conversation_latencies, 0.5),
+        "p90": percentile(conversation_latencies, 0.9),
+        "p99": percentile(conversation_latencies, 0.99),
+    }
+    return {
+        "overall": overall,
+        "by_turn": {
+            str(turn): aggregate(
+                [record for record in records if record["turn"] == turn]
+            )
+            for turn in (1, 2)
+        },
+        "by_category": {
+            category: aggregate(
+                [record for record in records if record["category"] == category]
+            )
+            for category in TEMPERATURES
+        },
+    }
+
+
+def compare_answers(conversations, reference):
+    if not reference:
+        return None
+    exact = 0
+    mismatches = []
+    for conversation in conversations:
+        question_id = conversation["question_id"]
+        expected = reference[question_id]
+        for turn in (1, 2):
+            actual = (
+                conversation["turns"][turn - 1].get("text")
+                if len(conversation["turns"]) >= turn
+                else None
+            )
+            if actual == expected[turn - 1]:
+                exact += 1
+            elif len(mismatches) < 20:
+                mismatches.append({"question_id": question_id, "turn": turn})
+    total = len(conversations) * 2
+    return {
+        "exact_turns": exact,
+        "total_turns": total,
+        "exact_match_rate": exact / total,
+        "mismatches": mismatches,
+    }
+
+
+async def generate_turn(
+    session, semaphore, base_url, model, messages, question, turn, args, max_tokens
+):
+    temperature = (
+        TEMPERATURES[question["category"]]
+        if args.temperature_policy == "official"
+        else 0.0
+    )
+    body = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "top_p": 1.0,
+        "seed": args.seed,
+        "max_completion_tokens": max_tokens,
+        "stream": False,
+        "ignore_eos": False,
+        "return_meta_info": True,
+        "return_token_ids": True,
+        "chat_template_kwargs": {"enable_thinking": args.enable_thinking},
+    }
+    async with semaphore:
+        tic = time.perf_counter()
+        try:
+            async with session.post(
+                base_url + "/v1/chat/completions", json=body
+            ) as response:
+                payload = await response.json(content_type=None)
+                if response.status != 200:
+                    raise RuntimeError(f"HTTP {response.status}: {payload}")
+        except Exception as exc:
+            return {
+                "question_id": question["question_id"],
+                "category": question["category"],
+                "turn": turn,
+                "latency": time.perf_counter() - tic,
+                "error": repr(exc),
+            }
+
+    choice = payload["choices"][0]
+    return {
+        "question_id": question["question_id"],
+        "category": question["category"],
+        "turn": turn,
+        "latency": time.perf_counter() - tic,
+        "text": choice["message"].get("content") or "",
+        "token_ids": choice.get("token_ids"),
+        "finish_reason": choice.get("finish_reason"),
+        "meta_info": choice.get("meta_info") or {},
+    }
+
+
+async def run_conversation(
+    session,
+    semaphore,
+    base_url,
+    model,
+    question,
+    frozen_turn_one,
+    args,
+    max_tokens,
+):
+    tic = time.perf_counter()
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": question["turns"][0]},
+    ]
+    first = await generate_turn(
+        session,
+        semaphore,
+        base_url,
+        model,
+        messages,
+        question,
+        1,
+        args,
+        max_tokens,
+    )
+    if "error" in first:
+        return {
+            "question_id": question["question_id"],
+            "category": question["category"],
+            "latency": time.perf_counter() - tic,
+            "turns": [first],
+            "error": first["error"],
+        }
+
+    assistant = frozen_turn_one.get(question["question_id"], [first["text"]])[0]
+    messages.extend(
+        [
+            {"role": "assistant", "content": assistant},
+            {"role": "user", "content": question["turns"][1]},
+        ]
+    )
+    second = await generate_turn(
+        session,
+        semaphore,
+        base_url,
+        model,
+        messages,
+        question,
+        2,
+        args,
+        max_tokens,
+    )
+    result = {
+        "question_id": question["question_id"],
+        "category": question["category"],
+        "latency": time.perf_counter() - tic,
+        "turns": [first, second],
+    }
+    if "error" in second:
+        result["error"] = second["error"]
+    return result
+
+
+async def run_workload(questions, base_url, model, frozen_turn_one, args, max_tokens):
+    timeout = aiohttp.ClientTimeout(total=args.request_timeout)
+    semaphore = asyncio.Semaphore(args.parallel)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        tic = time.perf_counter()
+        conversations = await asyncio.gather(
+            *[
+                run_conversation(
+                    session,
+                    semaphore,
+                    base_url,
+                    model,
+                    question,
+                    frozen_turn_one,
+                    args,
+                    max_tokens,
+                )
+                for question in questions
+            ]
+        )
+        return conversations, time.perf_counter() - tic
 
 
 def main(args):
-    # Download question file if not exist
-    question_file = args.question_file
-    url = "https://raw.githubusercontent.com/lm-sys/FastChat/main/fastchat/llm_judge/data/mt_bench/question.jsonl"
-    if not os.path.isfile(question_file):
-        question_file = download_and_cache_file(url)
+    if args.require_exact_match and not args.reference_answer_file:
+        raise ValueError("--require-exact-match needs --reference-answer-file")
+    question_file = args.question_file or download_and_cache_file(MT_BENCH_URL)
+    questions = load_questions(question_file, args.num_questions)
+    frozen_turn_one = load_answers(args.frozen_turn_one_file)
+    reference = load_answers(args.reference_answer_file)
+    selected_ids = {question["question_id"] for question in questions}
+    for name, filename, answers in (
+        ("frozen turn-one", args.frozen_turn_one_file, frozen_turn_one),
+        ("reference", args.reference_answer_file, reference),
+    ):
+        missing = sorted(selected_ids - answers.keys()) if filename else []
+        if missing:
+            raise ValueError(f"{name} file is missing question IDs: {missing}")
 
-    # Construct prompts
-    questions = load_questions(question_file)[: args.num_questions]
-    arguments = [
-        {"question_1": q["turns"][0], "question_2": q["turns"][1]} for q in questions
-    ]
+    base_url = f"http://{args.host}:{args.port}"
+    response = requests.get(base_url + "/model_info", timeout=60)
+    response.raise_for_status()
+    model_info = response.json()
+    model = model_info["model_path"]
 
-    # Select backend
-    backend = select_sglang_backend(args)
-    sgl.set_default_backend(backend)
-
-    # Run requests
-    tic = time.perf_counter()
-    rets = answer_mt_bench.run_batch(
-        arguments,
-        temperature=0,
-        max_new_tokens=2048,
-        num_threads=args.parallel,
-        progress_bar=True,
-    )
-    answers = [[s["answer_1"], s["answer_2"]] for s in rets]
-
-    latency = time.perf_counter() - tic
-    num_output_tokens = sum(
-        s.get_meta_info("answer_1")["completion_tokens"]
-        + s.get_meta_info("answer_2")["completion_tokens"]
-        for s in rets
-    )
-
-    # NOTE: acceptance length is just completion_tokens / spec_verify_ct
-    # {'id': '3bb9c5ead109488d8ed5ee9cbecaec29', 'finish_reason': {'type': 'length', 'length': 256}, 'prompt_tokens': 37, 'spec_verify_ct': 101, 'completion_tokens': 256, 'cached_tokens': 0}
-
-    output_throughput = num_output_tokens / latency
-
-    has_verify = "spec_verify_ct" in rets[0].get_meta_info("answer_1")
-    if has_verify:
-        num_verify_tokens = sum(
-            s.get_meta_info("answer_1")["spec_verify_ct"]
-            + s.get_meta_info("answer_2")["spec_verify_ct"]
-            for s in rets
+    if args.warmup_questions:
+        warmup, _ = asyncio.run(
+            run_workload(
+                questions[: args.warmup_questions],
+                base_url,
+                model,
+                frozen_turn_one,
+                args,
+                min(args.max_new_tokens, 32),
+            )
         )
+        if any("error" in conversation for conversation in warmup):
+            raise RuntimeError("MT-Bench warmup failed")
+        requests.post(base_url + "/flush_cache", timeout=60).raise_for_status()
 
-        accept_length = num_output_tokens / num_verify_tokens
-    else:
-        accept_length = 1.0
-
-    print(
-        f"#questions: {len(questions)}, Throughput: {output_throughput:.2f} token/s, Acceptance length: {accept_length:.2f}"
+    conversations, wall_latency = asyncio.run(
+        run_workload(
+            questions,
+            base_url,
+            model,
+            frozen_turn_one,
+            args,
+            args.max_new_tokens,
+        )
     )
+    metrics = summarize(conversations, wall_latency)
+    parity = compare_answers(conversations, reference)
+    result = {
+        "task": "mtbench",
+        "run_label": args.run_label,
+        "backend": args.backend,
+        "model": model,
+        "tokenizer": model_info.get("tokenizer_path"),
+        "num_gpus": args.num_gpus,
+        "dataset_commit": MT_BENCH_COMMIT,
+        "question_set_sha256": question_set_sha256(questions),
+        "num_questions": len(questions),
+        "parallel": args.parallel,
+        "max_new_tokens": args.max_new_tokens,
+        "temperature_policy": args.temperature_policy,
+        "enable_thinking": args.enable_thinking,
+        "seed": args.seed,
+        "system_prompt": "You are a helpful assistant.",
+        "frozen_turn_one": bool(args.frozen_turn_one_file),
+        "metrics": metrics,
+        "parity": parity,
+    }
+    with open(os.path.expanduser(args.result_file), "a") as fout:
+        fout.write(json.dumps(result, ensure_ascii=False) + "\n")
 
-    # Write results
-    model_id = backend.model_info["model_path"]
-    answer_file = args.answer_file or f"tmp_output_{args.backend}.txt"
-    write_answers(answer_file, model_id, questions, answers)
+    answer_file = args.answer_file or f"tmp_output_{args.backend}.jsonl"
+    write_answers(answer_file, model, questions, conversations)
+    if args.raw_result_file:
+        with open(os.path.expanduser(args.raw_result_file), "w") as fout:
+            for conversation in conversations:
+                fout.write(json.dumps(conversation, ensure_ascii=False) + "\n")
 
-    with open(args.result_file, "a") as fout:
-        value = {
-            "task": "mtbench",
-            "backend": args.backend,
-            "num_gpus": 1,
-            "latency": round(latency, 3),
-            "throughput": round(output_throughput, 3),
-            "accept_length": round(accept_length, 3),
-            "num_requests": args.num_questions,
-            "other": {
-                "num_questions": args.num_questions,
-                "parallel": args.parallel,
-            },
-        }
-        fout.write(json.dumps(value) + "\n")
+    overall = metrics["overall"]
+    accept = overall["accept_length"]
+    accept_text = f"{accept:.3f}" if accept is not None else "n/a"
+    print(
+        f"{len(questions)} questions, {overall['output_throughput']:.2f} token/s, "
+        f"accept length {accept_text}, {overall['errors']} errors"
+    )
+    if overall["errors"]:
+        raise RuntimeError(f"{overall['errors']} MT-Bench turns failed")
+    if (
+        args.require_exact_match
+        and parity
+        and parity["exact_turns"] != parity["total_turns"]
+    ):
+        raise RuntimeError(
+            f"Exact parity failed: {parity['exact_turns']}/"
+            f"{parity['total_turns']} turns"
+        )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--question-file", type=str, default="question.jsonl")
-    parser.add_argument("--answer-file", type=str, default=None)
+    parser.add_argument("--question-file", type=str)
+    parser.add_argument("--answer-file", type=str)
+    parser.add_argument("--reference-answer-file", type=str)
+    parser.add_argument("--frozen-turn-one-file", type=str)
+    parser.add_argument("--require-exact-match", action="store_true")
     parser.add_argument("--num-questions", type=int, default=80)
+    parser.add_argument("--num-gpus", type=int, default=1)
+    parser.add_argument("--max-new-tokens", type=int, default=1024)
+    parser.add_argument("--warmup-questions", type=int, default=0)
+    parser.add_argument("--request-timeout", type=float, default=3600)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--run-label", type=str)
+    parser.add_argument(
+        "--temperature-policy",
+        choices=("greedy", "official"),
+        default="greedy",
+    )
+    parser.add_argument("--enable-thinking", action="store_true")
     args = add_common_sglang_args_and_parse(parser)
     main(args)

--- a/docs_new/docs/advanced_features/speculative_decoding.mdx
+++ b/docs_new/docs/advanced_features/speculative_decoding.mdx
@@ -183,6 +183,11 @@ To enable EAGLE speculative decoding the following parameters are relevant:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Auto (<code>8</code> for Llama/Grok; <code>4</code> for many other models). If <code>topk=1</code>, it is adjusted to <code>num_steps + 1</code>.</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-echo-threshold</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable ECHO for EAGLE-3. The value must be a finite float in the range <code>[0, 1]</code>. See the supported configuration below.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code> (disabled)</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-accept-threshold-single</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Acceptance threshold for single-token verification. Lower values accept more aggressively.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>1.0</code></td>
@@ -388,6 +393,23 @@ response = client.chat.completions.create(
 
 print(response.choices[0].message.content)
 ```
+
+#### ECHO
+
+Add the following flags to an EAGLE-3 launch command:
+
+```bash
+--attention-backend fa3 \
+--disable-overlap-schedule \
+--speculative-echo-threshold 0.2
+```
+
+ECHO currently requires EAGLE-3 with `--speculative-eagle-topk > 1`, FA3, the
+non-overlap scheduler, and two-batch overlap to remain disabled (do not pass
+`--enable-two-batch-overlap`). It does not currently support sliding-window,
+MRoPE, or hybrid Mamba/GDN/linear-attention target models, DP attention, LoRA,
+or configurations that disable CUDA Graph padding or require gathered token
+buffers.
 
 ---
 

--- a/python/sglang/kernels/ops/speculative/eagle_echo.py
+++ b/python/sglang/kernels/ops/speculative/eagle_echo.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+
+
+@dataclass(frozen=True)
+class EagleRaggedVerifyWindow:
+    input_ids: torch.Tensor
+    positions: torch.Tensor
+    out_cache_loc: torch.Tensor
+    query_layout: RaggedVerifyLayout
+
+
+def _pad_eagle_query_lens_torch(
+    *,
+    verify_lens: torch.Tensor,
+    graph_num_tokens: int,
+    padded_bs: int,
+    draft_token_num: int,
+) -> torch.Tensor:
+    real_bs = verify_lens.numel()
+    padded = torch.cat(
+        [
+            verify_lens.to(torch.int32),
+            torch.zeros(
+                padded_bs - real_bs,
+                dtype=torch.int32,
+                device=verify_lens.device,
+            ),
+        ]
+    )
+    leftover = (
+        torch.as_tensor(
+            graph_num_tokens,
+            dtype=torch.int64,
+            device=verify_lens.device,
+        )
+        - padded.to(torch.int64).sum()
+    )
+
+    # Fill one row per available request slot at a time. The fixed EAGLE tree
+    # width bounds both the loop and every padded query length.
+    for _ in range(draft_token_num):
+        has_capacity = padded < draft_token_num
+        capacity_rank = torch.cumsum(has_capacity.to(torch.int64), dim=0) - 1
+        capacity_count = has_capacity.to(torch.int64).sum()
+        rows_to_add = torch.minimum(leftover, capacity_count)
+        padded.add_((has_capacity & (capacity_rank < rows_to_add)).to(torch.int32))
+        leftover.sub_(rows_to_add)
+    return padded
+
+
+@triton.jit
+def _pad_eagle_query_lens_kernel(
+    verify_lens_ptr,
+    padded_lens_ptr,
+    real_bs,
+    padded_bs,
+    graph_num_tokens,
+    DRAFT_TOKEN_NUM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    request = tl.arange(0, BLOCK)
+    is_slot = request < padded_bs
+    is_real = request < real_bs
+    value = tl.load(verify_lens_ptr + request, mask=is_real, other=0).to(tl.int64)
+    leftover = graph_num_tokens - tl.sum(value)
+
+    for _ in range(DRAFT_TOKEN_NUM):
+        has_capacity = is_slot & (value < DRAFT_TOKEN_NUM)
+        capacity_rank = tl.cumsum(has_capacity.to(tl.int32), axis=0) - 1
+        capacity_count = tl.sum(has_capacity.to(tl.int32))
+        rows_to_add = tl.minimum(leftover, capacity_count)
+        value += (has_capacity & (capacity_rank < rows_to_add)).to(tl.int64)
+        leftover -= rows_to_add
+
+    tl.store(padded_lens_ptr + request, value.to(tl.int32), mask=is_slot)
+
+
+def _build_eagle_query_layout(
+    *,
+    layout: RaggedVerifyLayout,
+    padded_bs: int,
+    draft_token_num: int,
+) -> RaggedVerifyLayout:
+    if draft_token_num < 1:
+        raise ValueError(f"draft_token_num must be positive, got {draft_token_num}")
+    if layout.verify_lens.ndim != 1:
+        raise ValueError(
+            "EAGLE query lengths must be a rank-1 tensor, got "
+            f"shape {tuple(layout.verify_lens.shape)}"
+        )
+    if padded_bs < layout.bs:
+        raise ValueError(
+            f"padded_bs {padded_bs} is smaller than real batch size {layout.bs}"
+        )
+    if layout.graph_num_tokens < 0:
+        raise ValueError(
+            f"graph token bucket must be non-negative, got {layout.graph_num_tokens}"
+        )
+    if layout.graph_num_tokens > padded_bs * draft_token_num:
+        raise ValueError(
+            f"graph token bucket {layout.graph_num_tokens} exceeds EAGLE "
+            f"capacity {padded_bs} * {draft_token_num}"
+        )
+
+    # CUDA callers validate these inputs asynchronously. Repeat the complete
+    # check for host-side helpers without synchronizing the serving hot path.
+    if not layout.verify_lens.is_cuda:
+        verify_lens_cpu = [int(value) for value in layout.verify_lens.tolist()]
+        if any(value < 1 or value > draft_token_num for value in verify_lens_cpu):
+            raise ValueError(
+                "EAGLE query lengths must be in "
+                f"[1, {draft_token_num}], got {verify_lens_cpu}"
+            )
+        if sum(verify_lens_cpu) > layout.graph_num_tokens:
+            raise ValueError(
+                f"real EAGLE query rows {sum(verify_lens_cpu)} exceed graph "
+                f"token bucket {layout.graph_num_tokens}"
+            )
+
+    if layout.verify_lens.is_cuda:
+        verify_lens = layout.verify_lens.to(torch.int32).contiguous()
+        padded_lens = torch.empty(
+            padded_bs,
+            dtype=torch.int32,
+            device=verify_lens.device,
+        )
+        block = triton.next_power_of_2(max(padded_bs, 1))
+        _pad_eagle_query_lens_kernel[(1,)](
+            verify_lens,
+            padded_lens,
+            layout.bs,
+            padded_bs,
+            layout.graph_num_tokens,
+            DRAFT_TOKEN_NUM=draft_token_num,
+            BLOCK=block,
+        )
+    else:
+        padded_lens = _pad_eagle_query_lens_torch(
+            verify_lens=layout.verify_lens,
+            graph_num_tokens=layout.graph_num_tokens,
+            padded_bs=padded_bs,
+            draft_token_num=draft_token_num,
+        )
+
+    return RaggedVerifyLayout.from_verify_lens_device(
+        verify_lens=padded_lens,
+        graph_num_tokens=layout.graph_num_tokens,
+    )
+
+
+@triton.jit
+def _compact_eagle_verify_inputs_kernel(
+    draft_tokens_ptr,
+    positions_ptr,
+    cache_locs_ptr,
+    query_lens_ptr,
+    query_starts_ptr,
+    compact_tokens_ptr,
+    compact_positions_ptr,
+    compact_cache_locs_ptr,
+    real_bs,
+    DRAFT_TOKEN_NUM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    request = tl.program_id(0)
+    within = tl.arange(0, BLOCK)
+    query_len = tl.load(query_lens_ptr + request)
+    query_start = tl.load(query_starts_ptr + request).to(tl.int64)
+    in_query = within < query_len
+    is_real = request < real_bs
+    source = request * DRAFT_TOKEN_NUM + within
+    source_mask = in_query & is_real & (within < DRAFT_TOKEN_NUM)
+
+    token = tl.load(draft_tokens_ptr + source, mask=source_mask, other=0)
+    position = tl.load(positions_ptr + source, mask=source_mask, other=0)
+    cache_loc = tl.load(cache_locs_ptr + source, mask=source_mask, other=0)
+    destination = query_start + within
+
+    tl.store(compact_tokens_ptr + destination, token, mask=in_query)
+    tl.store(compact_positions_ptr + destination, position, mask=in_query)
+    tl.store(compact_cache_locs_ptr + destination, cache_loc, mask=in_query)
+
+
+def _compact_eagle_verify_inputs_torch(
+    *,
+    draft_tokens: torch.Tensor,
+    positions: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    query_layout: RaggedVerifyLayout,
+    real_bs: int,
+    draft_token_num: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    outputs = tuple(
+        torch.zeros(
+            query_layout.graph_num_tokens,
+            dtype=dense.dtype,
+            device=dense.device,
+        )
+        for dense in (draft_tokens, positions, out_cache_loc)
+    )
+    for request in range(real_bs):
+        query_len = int(query_layout.verify_lens[request])
+        query_start = int(query_layout.extend_start_loc[request])
+        dense_start = request * draft_token_num
+        for dense, compact in zip(
+            (draft_tokens, positions, out_cache_loc), outputs, strict=True
+        ):
+            compact[query_start : query_start + query_len].copy_(
+                dense[dense_start : dense_start + query_len]
+            )
+    return outputs
+
+
+def _compact_eagle_verify_inputs(
+    *,
+    draft_tokens: torch.Tensor,
+    positions: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    query_layout: RaggedVerifyLayout,
+    real_bs: int,
+    draft_token_num: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    dense_inputs = (draft_tokens, positions, out_cache_loc)
+    if draft_token_num < 1:
+        raise ValueError(f"draft_token_num must be positive, got {draft_token_num}")
+    if not 0 <= real_bs <= query_layout.bs:
+        raise ValueError(
+            f"real_bs {real_bs} must be within query batch size {query_layout.bs}"
+        )
+    if any(tensor.ndim != 1 for tensor in dense_inputs):
+        raise ValueError("EAGLE verify input compaction expects rank-1 tensors")
+    if any(tensor.device != draft_tokens.device for tensor in dense_inputs):
+        raise ValueError("EAGLE verify inputs must be on the same device")
+    if (
+        query_layout.verify_lens.device != draft_tokens.device
+        or query_layout.extend_start_loc.device != draft_tokens.device
+    ):
+        raise ValueError("EAGLE verify inputs and query layout must share a device")
+    required_dense_rows = real_bs * draft_token_num
+    if any(tensor.numel() < required_dense_rows for tensor in dense_inputs):
+        raise ValueError(
+            "EAGLE verify inputs are shorter than the real dense tree: "
+            f"need {required_dense_rows} rows"
+        )
+
+    if not draft_tokens.is_cuda:
+        return _compact_eagle_verify_inputs_torch(
+            draft_tokens=draft_tokens,
+            positions=positions,
+            out_cache_loc=out_cache_loc,
+            query_layout=query_layout,
+            real_bs=real_bs,
+            draft_token_num=draft_token_num,
+        )
+
+    draft_tokens, positions, out_cache_loc = (
+        tensor.contiguous() for tensor in dense_inputs
+    )
+    compact_tokens = torch.empty(
+        query_layout.graph_num_tokens,
+        dtype=draft_tokens.dtype,
+        device=draft_tokens.device,
+    )
+    compact_positions = torch.empty(
+        query_layout.graph_num_tokens,
+        dtype=positions.dtype,
+        device=positions.device,
+    )
+    compact_cache_locs = torch.empty(
+        query_layout.graph_num_tokens,
+        dtype=out_cache_loc.dtype,
+        device=out_cache_loc.device,
+    )
+    block = triton.next_power_of_2(draft_token_num)
+    _compact_eagle_verify_inputs_kernel[(query_layout.bs,)](
+        draft_tokens,
+        positions,
+        out_cache_loc,
+        query_layout.verify_lens,
+        query_layout.extend_start_loc,
+        compact_tokens,
+        compact_positions,
+        compact_cache_locs,
+        real_bs,
+        DRAFT_TOKEN_NUM=draft_token_num,
+        BLOCK=block,
+    )
+    return compact_tokens, compact_positions, compact_cache_locs
+
+
+@triton.jit
+def _restore_eagle_verify_output_kernel(
+    compact_ptr,
+    compact_starts_ptr,
+    verify_lens_ptr,
+    dense_ptr,
+    dense_width,
+    feature_size,
+    BLOCK_FEATURE: tl.constexpr,
+):
+    dense_row = tl.program_id(0).to(tl.int64)
+    feature_block = tl.program_id(1)
+    request = dense_row // dense_width
+    within = dense_row - request * dense_width
+    verify_len = tl.load(verify_lens_ptr + request)
+    compact_start = tl.load(compact_starts_ptr + request).to(tl.int64)
+
+    feature = feature_block * BLOCK_FEATURE + tl.arange(0, BLOCK_FEATURE)
+    valid_feature = feature < feature_size
+    retained = within < verify_len
+    compact_row = compact_start + within
+    value = tl.load(
+        compact_ptr + compact_row * feature_size + feature,
+        mask=retained & valid_feature,
+        other=0.0,
+    )
+    tl.store(
+        dense_ptr + dense_row * feature_size + feature,
+        value,
+        mask=valid_feature,
+    )
+
+
+def _restore_eagle_verify_output_torch(
+    *,
+    compact: torch.Tensor,
+    compact_starts: torch.Tensor,
+    verify_lens: torch.Tensor,
+    draft_token_num: int,
+) -> torch.Tensor:
+    batch_size = verify_lens.numel()
+    dense = torch.zeros(
+        (batch_size * draft_token_num, compact.shape[1]),
+        dtype=compact.dtype,
+        device=compact.device,
+    )
+    for request in range(batch_size):
+        verify_len = int(verify_lens[request])
+        compact_start = int(compact_starts[request])
+        dense_start = request * draft_token_num
+        dense[dense_start : dense_start + verify_len].copy_(
+            compact[compact_start : compact_start + verify_len]
+        )
+    return dense
+
+
+def _restore_eagle_verify_output(
+    *,
+    compact: torch.Tensor,
+    compact_starts: torch.Tensor,
+    verify_lens: torch.Tensor,
+    draft_token_num: int,
+) -> torch.Tensor:
+    if draft_token_num < 1:
+        raise ValueError(f"draft_token_num must be positive, got {draft_token_num}")
+    if compact.ndim != 2:
+        raise ValueError("EAGLE verify output restoration expects a rank-2 tensor")
+    if compact_starts.ndim != 1 or verify_lens.ndim != 1:
+        raise ValueError("EAGLE restore starts and query lengths must be rank-1")
+    if compact_starts.numel() < verify_lens.numel():
+        raise ValueError("EAGLE restore needs one compact start for every real request")
+    if not verify_lens.is_cuda:
+        verify_lens_cpu = [int(value) for value in verify_lens.tolist()]
+        compact_starts_cpu = [
+            int(value) for value in compact_starts[: verify_lens.numel()].tolist()
+        ]
+        if any(value < 1 or value > draft_token_num for value in verify_lens_cpu):
+            raise ValueError(
+                "EAGLE restore lengths must be in "
+                f"[1, {draft_token_num}], got {verify_lens_cpu}"
+            )
+        if any(
+            start < 0 or start + length > compact.shape[0]
+            for start, length in zip(compact_starts_cpu, verify_lens_cpu, strict=True)
+        ):
+            raise ValueError("EAGLE restore range exceeds the compact output")
+    if not compact.is_cuda:
+        return _restore_eagle_verify_output_torch(
+            compact=compact,
+            compact_starts=compact_starts,
+            verify_lens=verify_lens,
+            draft_token_num=draft_token_num,
+        )
+
+    compact = compact.contiguous()
+    compact_starts = compact_starts.to(
+        device=compact.device, dtype=torch.int64
+    ).contiguous()
+    verify_lens = verify_lens.to(device=compact.device, dtype=torch.int32).contiguous()
+    batch_size = verify_lens.numel()
+    feature_size = compact.shape[1]
+    dense = torch.empty(
+        (batch_size * draft_token_num, feature_size),
+        dtype=compact.dtype,
+        device=compact.device,
+    )
+    block_feature = 1024
+    grid = (
+        batch_size * draft_token_num,
+        triton.cdiv(feature_size, block_feature),
+    )
+    _restore_eagle_verify_output_kernel[grid](
+        compact,
+        compact_starts,
+        verify_lens,
+        dense,
+        draft_token_num,
+        feature_size,
+        BLOCK_FEATURE=block_feature,
+    )
+    return dense
+
+
+def build_eagle_ragged_verify_window(
+    *,
+    draft_tokens: torch.Tensor,
+    positions: torch.Tensor,
+    out_cache_loc: torch.Tensor,
+    layout: RaggedVerifyLayout,
+    draft_token_num: int,
+    padded_bs: int,
+) -> EagleRaggedVerifyWindow:
+    """Build EAGLE inputs for the selected target-verify token tier."""
+    real_bs = layout.bs
+    if real_bs < 1:
+        raise ValueError("EAGLE ragged verify requires a non-empty batch")
+    if padded_bs < real_bs:
+        raise ValueError(
+            f"padded_bs {padded_bs} is smaller than real batch size {real_bs}"
+        )
+
+    padded_layout = _build_eagle_query_layout(
+        layout=layout,
+        padded_bs=padded_bs,
+        draft_token_num=draft_token_num,
+    )
+    compact_tokens, compact_positions, compact_cache_locs = (
+        _compact_eagle_verify_inputs(
+            draft_tokens=draft_tokens,
+            positions=positions,
+            out_cache_loc=out_cache_loc,
+            query_layout=padded_layout,
+            real_bs=real_bs,
+            draft_token_num=draft_token_num,
+        )
+    )
+
+    return EagleRaggedVerifyWindow(
+        input_ids=compact_tokens,
+        positions=compact_positions,
+        out_cache_loc=compact_cache_locs,
+        query_layout=padded_layout,
+    )
+
+
+def apply_eagle_retrieval_layout(
+    *,
+    retrieve_index: torch.Tensor,
+    retrieve_next_token: torch.Tensor,
+    retrieve_next_sibling: torch.Tensor,
+    verify_lens: torch.Tensor,
+) -> None:
+    """Update EAGLE retrieval metadata for the selected layout."""
+    if retrieve_index.ndim != 2:
+        raise ValueError(f"retrieve tensors must be rank 2, got {retrieve_index.ndim}")
+    if verify_lens.shape != (retrieve_index.shape[0],):
+        raise ValueError(
+            f"verify_lens shape {tuple(verify_lens.shape)} does not match "
+            f"retrieve batch size {retrieve_index.shape[0]}"
+        )
+
+    width = retrieve_index.shape[1]
+    lens = verify_lens.to(
+        device=retrieve_index.device, dtype=retrieve_next_token.dtype
+    ).unsqueeze(1)
+    slots = torch.arange(width, device=retrieve_index.device).unsqueeze(0)
+    retained_source = slots < lens
+    retrieve_index.masked_fill_(~retained_source, -1)
+
+    for links in (retrieve_next_token, retrieve_next_sibling):
+        retained_edge = retained_source & (links >= 0) & (links < lens)
+        links.copy_(torch.where(retained_edge, links, torch.full_like(links, -1)))
+
+
+def scatter_eagle_verify_output(
+    *,
+    compact: torch.Tensor,
+    layout: RaggedVerifyLayout,
+    query_layout: RaggedVerifyLayout | None = None,
+    draft_token_num: int,
+) -> torch.Tensor:
+    compact_starts = (
+        query_layout.extend_start_loc
+        if query_layout is not None
+        else layout.extend_start_loc
+    )
+    return _restore_eagle_verify_output(
+        compact=compact,
+        compact_starts=compact_starts,
+        verify_lens=layout.verify_lens,
+        draft_token_num=draft_token_num,
+    )

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 from typing import TYPE_CHECKING, Optional
 
@@ -101,6 +102,14 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
         trust_remote_code=server_args.trust_remote_code,
         kwargs=kwargs,
     )
+
+    if (
+        getattr(server_args, "speculative_echo_threshold", None) is not None
+        and server_args.speculative_algorithm != "EAGLE3"
+    ):
+        raise ValueError(
+            "--speculative-echo-threshold requires " "--speculative-algorithm EAGLE3."
+        )
 
     # Validate --speculative-draft-window-size once, regardless of algorithm.
     # Consumed by DFLASH (compact draft KV cache) and Llama EAGLE-3 (drafter attention SWA).
@@ -558,7 +567,8 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             "eagle speculative decoding."
         )
 
-    model_arch = server_args.get_model_config().hf_config.architectures[0]
+    model_config = server_args.get_model_config()
+    model_arch = model_config.hf_config.architectures[0]
     if model_arch in [
         "DeepseekV32ForCausalLM",
         "DeepseekV3ForCausalLM",
@@ -599,6 +609,82 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             server_args.speculative_eagle_topk,
             server_args.speculative_num_draft_tokens,
         ) = _auto_choose_speculative_params(server_args, model_arch)
+
+    echo_threshold = server_args.speculative_echo_threshold
+    if echo_threshold is not None:
+        from sglang.srt.configs.hybrid_arch import mambaish_config
+
+        echo_threshold = float(echo_threshold)
+        if not math.isfinite(echo_threshold) or not (0.0 <= echo_threshold <= 1.0):
+            raise ValueError(
+                "--speculative-echo-threshold must be a finite "
+                f"value in [0, 1], got {echo_threshold!r}."
+            )
+        server_args.speculative_echo_threshold = echo_threshold
+
+        view = resolved_view(server_args)
+        _, decode_backend = attention_backends_of(view)
+        unsupported = []
+        if server_args.speculative_algorithm != "EAGLE3":
+            unsupported.append("--speculative-algorithm EAGLE3")
+        if decode_backend != "fa3":
+            unsupported.append("--decode-attention-backend fa3")
+        if not view.disable_overlap_schedule:
+            unsupported.append("--disable-overlap-schedule")
+        if server_args.enable_two_batch_overlap:
+            unsupported.append("two-batch overlap disabled")
+        if (
+            server_args.speculative_eagle_topk is None
+            or server_args.speculative_eagle_topk <= 1
+        ):
+            unsupported.append("--speculative-eagle-topk > 1")
+        if server_args.speculative_adaptive:
+            unsupported.append("fixed speculative parameters")
+        if view.enable_multi_layer_eagle:
+            unsupported.append("single-layer EAGLE3")
+        if server_args.speculative_use_rejection_sampling:
+            unsupported.append("target-only speculative sampling")
+        if view.enable_dp_attention:
+            unsupported.append("DP attention disabled")
+        if server_args.enable_lora:
+            unsupported.append("LoRA disabled")
+        if server_args.disable_cuda_graph_padding:
+            unsupported.append("CUDA graph padding enabled")
+        if getattr(model_config, "model_is_mrope", False):
+            unsupported.append("a target model without MRoPE")
+        if mambaish_config(model_config) is not None:
+            unsupported.append(
+                "a target model without hybrid Mamba/GDN/linear-attention layers"
+            )
+        if (
+            model_config.sliding_window_size is not None
+            and model_config.sliding_window_size > -1
+        ):
+            unsupported.append("a target model without sliding-window attention")
+        if server_args.pp_size != 1:
+            unsupported.append("--pp-size 1")
+        if view.attn_cp_size != 1:
+            unsupported.append("--attn-cp-size 1")
+        if server_args.dcp_size != 1:
+            unsupported.append("--dcp-size 1")
+        requires_gathered_buffer = (
+            not view.enable_dp_attention
+            and not server_args.disable_attn_tp_gather
+            and (
+                view.moe_a2a_backend != "none"
+                or server_args.moe_dense_tp_size is not None
+            )
+        )
+        if requires_gathered_buffer:
+            unsupported.append(
+                "a topology that does not require gathered token buffers"
+            )
+        if unsupported:
+            raise ValueError(
+                "--speculative-echo-threshold currently requires "
+                + ", ".join(unsupported)
+                + "."
+            )
 
     if "trtllm_mha" in attention_backends_of(resolved_view(server_args)):
         if server_args.speculative_eagle_topk > 1:

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -31,7 +31,10 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_schedule, get_spec
-from sglang.srt.speculative.ragged_verify import build_ragged_target_verify_geometry
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    build_ragged_target_verify_geometry,
+)
 from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
 from sglang.srt.utils import get_compiler_backend
@@ -474,14 +477,18 @@ class FlashAttentionBackend(AttentionBackend):
             if forward_mode.is_target_verify() and self.topk > 1:
                 # topk>1 target verify: replay needs spec_info.positions and .custom_mask
                 # which are not populated at capture time.
-                self.forward_metadata = self.target_verify_metadata_topk_normal[bs]
+                metadata_key = self._target_verify_topk_metadata_key(bs, spec_info)
+                self.forward_metadata = self.target_verify_metadata_topk_normal[
+                    metadata_key
+                ]
                 self.forward_metadata_spec_decode_expand = (
-                    self.target_verify_metadata_topk_expand[bs]
+                    self.target_verify_metadata_topk_expand[metadata_key]
                 )
                 return
 
             self._apply_cuda_graph_metadata(
                 bs=bs,
+                real_bs=bs,
                 req_pool_indices=req_pool_indices,
                 seq_lens=seq_lens,
                 seq_lens_sum=None,
@@ -521,6 +528,7 @@ class FlashAttentionBackend(AttentionBackend):
             # (stale page-table rows -> OOB); force None under sync-free.
             self._apply_cuda_graph_metadata(
                 bs=bs,
+                real_bs=bs - getattr(forward_batch, "num_padding", 0),
                 req_pool_indices=req_pool_indices,
                 seq_lens=seq_lens,
                 seq_lens_sum=forward_batch.seq_lens_sum,
@@ -628,6 +636,108 @@ class FlashAttentionBackend(AttentionBackend):
             m.max_seq_len_q = forward_batch.positions.numel()
             m.max_seq_len_k = self.max_context_len
         self.forward_metadata = m
+
+    @staticmethod
+    def _target_verify_topk_metadata_key(
+        bs: int, spec_info: Optional[SpecInput]
+    ) -> int | tuple[int, int]:
+        """Return the CUDA Graph metadata key for topk>1 target verification."""
+        ragged_layout = getattr(spec_info, "ragged_verify_layout", None)
+        if ragged_layout is None:
+            return bs
+        return (bs, ragged_layout.graph_num_tokens)
+
+    def _build_target_verify_topk_expand_inputs(
+        self,
+        *,
+        seq_lens: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        spec_info: SpecInput,
+        query_layout: Optional[RaggedVerifyLayout],
+        real_bs: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build FA3 metadata for topk>1 target verification."""
+        draft_tokens = self.speculative_num_draft_tokens
+        bs = seq_lens.numel()
+        device = seq_lens.device
+
+        if query_layout is None:
+            query_lens = torch.full(
+                (bs,), draft_tokens, dtype=torch.int32, device=device
+            )
+            query_starts = torch.arange(
+                0,
+                bs * draft_tokens,
+                draft_tokens,
+                dtype=torch.int32,
+                device=device,
+            )
+            num_query_tokens = bs * draft_tokens
+        else:
+            query_lens = query_layout.verify_lens.to(torch.int32)
+            query_starts = query_layout.qo_indptr_device[:-1].to(torch.int32)
+            num_query_tokens = query_layout.graph_num_tokens
+
+        request_ids = torch.repeat_interleave(
+            torch.arange(bs, dtype=torch.int64, device=device),
+            query_lens,
+            output_size=num_query_tokens,
+        )
+        repeated_starts = torch.repeat_interleave(
+            query_starts,
+            query_lens,
+            output_size=num_query_tokens,
+        ).to(torch.int64)
+        within_request = (
+            torch.arange(num_query_tokens, dtype=torch.int64, device=device)
+            - repeated_starts
+        )
+
+        # FULL_MASK only contains rows for real requests. Clamp padding request
+        # ids for safe indexing, then replace their gathered masks below.
+        is_real = request_ids < real_bs
+        safe_request_ids = request_ids.clamp(max=max(real_bs - 1, 0))
+        real_layout = getattr(spec_info, "ragged_verify_layout", None)
+        if real_layout is not None:
+            real_query_lens = real_layout.verify_lens.to(torch.int64)
+            is_real = is_real & (within_request < real_query_lens[safe_request_ids])
+        safe_within_request = within_request.clamp(min=0, max=draft_tokens - 1)
+        real_seq_lens = seq_lens[:real_bs].to(torch.int64)
+        row_widths = real_seq_lens + draft_tokens
+        block_starts = torch.nn.functional.pad(
+            torch.cumsum(row_widths * draft_tokens, dim=0), (1, 0)
+        )[:-1]
+        mask_row_starts = (
+            block_starts[safe_request_ids]
+            + safe_within_request * row_widths[safe_request_ids]
+            + real_seq_lens[safe_request_ids]
+        )
+        tree_columns = torch.arange(draft_tokens, dtype=torch.int64, device=device)
+        mask_indices = mask_row_starts[:, None] + tree_columns[None, :]
+        mask = spec_info.custom_mask[mask_indices]
+        # FA3's one-query expand sequences need at least one KV entry. Route
+        # graph-padding rows to the first allocated tree slot; their output is
+        # discarded after replay.
+        mask = torch.where(
+            is_real[:, None],
+            mask,
+            tree_columns[None, :] == 0,
+        )
+
+        # Each query in a request sees the same D candidate KV locations; the
+        # mask sort packs its ancestors to the front for FA3 varlen attention.
+        all_seq_lens = seq_lens.to(torch.int64)
+        candidate_columns = all_seq_lens[:, None] + tree_columns[None, :]
+        per_request_page_table = self.req_to_token[req_pool_indices, :].gather(
+            1, candidate_columns
+        )
+        non_masked_page_table = per_request_page_table[request_ids]
+        sort_keys = torch.where(
+            mask, tree_columns[None, :], tree_columns[None, :] + draft_tokens
+        )
+        sort_order = torch.argsort(sort_keys, dim=1)
+        page_table = non_masked_page_table.gather(1, sort_order)
+        return mask, page_table
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize forward metadata hence all layers in the forward pass can reuse it."""
@@ -824,15 +934,33 @@ class FlashAttentionBackend(AttentionBackend):
 
                 self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
             else:
+                ragged_layout = getattr(
+                    forward_batch.spec_info, "ragged_verify_layout", None
+                )
+                if ragged_layout is not None and self.has_swa:
+                    raise NotImplementedError(
+                        "FA3 EAGLE topk>1 ragged verify does not support sliding "
+                        "window attention"
+                    )
+                query_layout = getattr(
+                    forward_batch.spec_info, "ragged_query_layout", None
+                )
+                if query_layout is None and ragged_layout is not None:
+                    query_layout = ragged_layout
+
                 metadata.cache_seqlens_int32 = forward_batch.seq_lens.to(torch.int32)
                 metadata.max_seq_len_q = self.speculative_num_draft_tokens
                 metadata.max_seq_len_k = eager_max_k
-                metadata.cu_seqlens_q = torch.arange(
-                    0,
-                    batch_size * self.speculative_num_draft_tokens + 1,
-                    step=self.speculative_num_draft_tokens,
-                    dtype=torch.int32,
-                    device=device,
+                metadata.cu_seqlens_q = (
+                    query_layout.qo_indptr_device.to(torch.int32)
+                    if query_layout is not None
+                    else torch.arange(
+                        0,
+                        batch_size * self.speculative_num_draft_tokens + 1,
+                        step=self.speculative_num_draft_tokens,
+                        dtype=torch.int32,
+                        device=device,
+                    )
                 )
                 metadata.cu_seqlens_k = torch.nn.functional.pad(
                     torch.cumsum(
@@ -847,67 +975,28 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata_expand = FlashAttentionMetadata()
 
                 metadata_expand.max_seq_len_q = 1
+                num_query_tokens = (
+                    query_layout.graph_num_tokens
+                    if query_layout is not None
+                    else forward_batch.seq_lens.numel()
+                    * self.speculative_num_draft_tokens
+                )
                 metadata_expand.cu_seqlens_q = torch.arange(
                     0,
-                    forward_batch.seq_lens.numel() * self.speculative_num_draft_tokens
-                    + 1,
+                    num_query_tokens + 1,
                     dtype=torch.int32,
                     device=device,
                 )
 
-                # create expand page table
-                offsets = torch.arange(
-                    self.speculative_num_draft_tokens, device=device
-                ).unsqueeze(
-                    0
-                )  # shape: (1, self.speculative_num_draft_tokens)
-                cols = offsets.expand(
-                    forward_batch.seq_lens.numel(), -1
-                ) + forward_batch.seq_lens.unsqueeze(1)
-                cum_len = torch.nn.functional.pad(
-                    torch.cumsum(
-                        (
-                            forward_batch.seq_lens + self.speculative_num_draft_tokens
-                        ).repeat_interleave(self.speculative_num_draft_tokens),
-                        dim=0,
-                    ),
-                    (1, 0),
-                )[:-1]
-                mask_extraction_indices = (
-                    cols.repeat_interleave(self.speculative_num_draft_tokens, dim=0)
-                    + cum_len[:, None]
-                ).view(1, -1)
-                mask = forward_batch.spec_info.custom_mask[
-                    mask_extraction_indices
-                ].view(
-                    -1, self.speculative_num_draft_tokens
-                )  # (bsz * draft_num, draft_num)
-
-                # shift table indices to avoid padding
-                # non_masked_page_table [[8, 9, 10],   mask (display with int format) [[1, 0, 0],
-                #                        [8, 9, 10],                                   [1, 1, 0],
-                #                        [8, 9, 10]]                                   [1, 0, 1]]
-                # if masked with padding [[8, 0, 0],   our mask without padding       [[8, 9, 10],
-                #                        [8, 9, 0],                                    [8, 9, 10],
-                #                        [8, 0, 10]]                                   [8, 10, 9]]
-                # note here cache_seqlens_int32 is [1, 2, 2] so extra page indices will be ignored in each row
-                col_indices = offsets.expand(
-                    mask.shape[0], self.speculative_num_draft_tokens
+                mask, metadata_expand.page_table = (
+                    self._build_target_verify_topk_expand_inputs(
+                        seq_lens=forward_batch.seq_lens,
+                        req_pool_indices=forward_batch.req_pool_indices,
+                        spec_info=forward_batch.spec_info,
+                        query_layout=query_layout,
+                        real_bs=batch_size,
+                    )
                 )
-                # Build keys: if an entry is valid (mask==True), keep its original index;
-                # if not, add self.speculative_num_draft_tokens so that it sorts after all valid entries.
-                keys = torch.where(
-                    mask, col_indices, col_indices + self.speculative_num_draft_tokens
-                )
-                _, sort_order = torch.sort(keys, dim=1)
-                non_masked_page_table = (
-                    self.req_to_token_pool.req_to_token[
-                        forward_batch.req_pool_indices, :
-                    ]
-                    .gather(1, cols)
-                    .repeat_interleave(self.speculative_num_draft_tokens, dim=0)
-                )  # (bsz, draft_num)
-                metadata_expand.page_table = non_masked_page_table.gather(1, sort_order)
                 metadata_expand.cache_seqlens_int32 = mask.sum(dim=1).to(torch.int32)
                 metadata_expand.cu_seqlens_k = torch.nn.functional.pad(
                     torch.cumsum(
@@ -2490,6 +2579,18 @@ class FlashAttentionBackend(AttentionBackend):
                 self.target_verify_metadata[bs] = metadata
             else:
                 # Target Verify topk>1: two (or three with SWA) metadata objects
+                ragged_layout = getattr(spec_info, "ragged_verify_layout", None)
+                if ragged_layout is not None and self.has_swa:
+                    raise NotImplementedError(
+                        "FA3 EAGLE topk>1 ragged verify does not support sliding "
+                        "window attention"
+                    )
+                metadata_key = self._target_verify_topk_metadata_key(bs, spec_info)
+                num_query_tokens = (
+                    ragged_layout.graph_num_tokens
+                    if ragged_layout is not None
+                    else bs * self.speculative_num_draft_tokens
+                )
                 metadata.cache_seqlens_int32 = self.target_verify_metadata_topk_normal[
                     "cache_seqlens"
                 ][:bs]
@@ -2503,25 +2604,30 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata.page_table = self.target_verify_metadata_topk_normal[
                     "page_table"
                 ][:bs, :]
+                if ragged_layout is not None:
+                    # Initialize replay metadata for this capture shape.
+                    metadata.cu_seqlens_q.copy_(
+                        ragged_layout.qo_indptr_device.to(torch.int32)
+                    )
 
                 metadata_expand.cache_seqlens_int32 = (
                     self.target_verify_metadata_topk_expand["cache_seqlens"][
-                        : bs * self.speculative_num_draft_tokens
+                        :num_query_tokens
                     ]
                 )
                 metadata_expand.max_seq_len_q = 1
                 metadata_expand.cu_seqlens_q = self.target_verify_metadata_topk_expand[
                     "cu_seqlens_q"
-                ][: bs * self.speculative_num_draft_tokens + 1]
+                ][: num_query_tokens + 1]
                 metadata_expand.cu_seqlens_k = self.target_verify_metadata_topk_expand[
                     "cu_seqlens_k"
-                ][: bs * self.speculative_num_draft_tokens + 1]
+                ][: num_query_tokens + 1]
                 metadata_expand.page_table = self.target_verify_metadata_topk_expand[
                     "page_table"
-                ][: bs * self.speculative_num_draft_tokens]
+                ][:num_query_tokens]
 
-                self.target_verify_metadata_topk_normal[bs] = metadata
-                self.target_verify_metadata_topk_expand[bs] = metadata_expand
+                self.target_verify_metadata_topk_normal[metadata_key] = metadata
+                self.target_verify_metadata_topk_expand[metadata_key] = metadata_expand
                 # topk>1 target-verify early-returns before _apply; bind the
                 # view here (buffer refilled at replay).
                 if self.use_sliding_window_kv_pool:
@@ -2531,20 +2637,20 @@ class FlashAttentionBackend(AttentionBackend):
                     metadata_swa = FlashAttentionMetadata()
                     metadata_swa.cache_seqlens_int32 = (
                         self.target_verify_metadata_topk_swa["cache_seqlens"][
-                            : bs * self.speculative_num_draft_tokens
+                            :num_query_tokens
                         ]
                     )
                     metadata_swa.max_seq_len_q = 1
                     metadata_swa.cu_seqlens_q = self.target_verify_metadata_topk_swa[
                         "cu_seqlens_q"
-                    ][: bs * self.speculative_num_draft_tokens + 1]
+                    ][: num_query_tokens + 1]
                     metadata_swa.cu_seqlens_k = self.target_verify_metadata_topk_swa[
                         "cu_seqlens_k"
-                    ][: bs * self.speculative_num_draft_tokens + 1]
+                    ][: num_query_tokens + 1]
                     metadata_swa.page_table = self.target_verify_metadata_topk_swa[
                         "page_table"
-                    ][: bs * self.speculative_num_draft_tokens]
-                    self.target_verify_metadata_topk_swa[bs] = metadata_swa
+                    ][:num_query_tokens]
+                    self.target_verify_metadata_topk_swa[metadata_key] = metadata_swa
                     metadata.swa_spec_metadata = metadata_swa
 
         elif forward_mode.is_draft_extend_v2():
@@ -2596,6 +2702,7 @@ class FlashAttentionBackend(AttentionBackend):
     def _apply_cuda_graph_metadata(
         self,
         bs: int,
+        real_bs: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         seq_lens_sum: int,
@@ -2845,15 +2952,30 @@ class FlashAttentionBackend(AttentionBackend):
                 )
             else:
                 # When topk > 1, we need two specific target verify metadata, and then merge states
+                ragged_layout = getattr(spec_info, "ragged_verify_layout", None)
+                if ragged_layout is not None and self.has_swa:
+                    raise NotImplementedError(
+                        "FA3 EAGLE topk>1 ragged verify does not support sliding "
+                        "window attention"
+                    )
+                metadata_key = self._target_verify_topk_metadata_key(bs, spec_info)
+                padded_layout = getattr(spec_info, "ragged_query_layout", None)
+                if padded_layout is None and ragged_layout is not None:
+                    padded_layout = ragged_layout
+
                 # 1. The first half of metadata for prefix tokens
-                metadata = self.target_verify_metadata_topk_normal[bs]
+                metadata = self.target_verify_metadata_topk_normal[metadata_key]
                 metadata.cache_seqlens_int32.copy_(seq_lens)
                 # metadata.max_seq_len_q = self.speculative_num_draft_tokens, already set in capture
                 # Page table built on-device (self-guards on cache_seqlens).
                 # max_seq_len_k stays the static bound; its only replay reader
                 # is the SWA-merge capacity assert, capture-sized to match.
                 metadata.max_seq_len_k = self.max_context_len
-                # metadata.cu_seqlens_q already set in capture
+                if padded_layout is not None:
+                    metadata.cu_seqlens_q.copy_(
+                        padded_layout.qo_indptr_device.to(torch.int32)
+                    )
+                # Dense metadata.cu_seqlens_q is already set in capture.
                 metadata.cu_seqlens_k[1:].copy_(
                     torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
                 )
@@ -2865,59 +2987,19 @@ class FlashAttentionBackend(AttentionBackend):
                     page_size=self.page_size,
                 )
 
-                # 2. The second half of metadata for draft tokens (per_batch_num_tokens = topk)
-                metadata_expand = self.target_verify_metadata_topk_expand[bs]
+                # 2. Initialize tree-token metadata.
+                metadata_expand = self.target_verify_metadata_topk_expand[metadata_key]
 
                 # metadata_expand.max_seq_len_q = 1, already set in capture
                 # metadata_expand.cu_seqlens_q already set in capture
-                offsets = torch.arange(
-                    self.speculative_num_draft_tokens, device=device
-                ).unsqueeze(
-                    0
-                )  # shape: (1, self.speculative_num_draft_tokens)
-
-                cols = offsets.expand(seq_lens.numel(), -1) + seq_lens.unsqueeze(1)
-                cum_len = torch.nn.functional.pad(
-                    torch.cumsum(
-                        (
-                            seq_lens + self.speculative_num_draft_tokens
-                        ).repeat_interleave(self.speculative_num_draft_tokens),
-                        dim=0,
-                    ),
-                    (1, 0),
-                )[:-1]
-                mask_extraction_indices = (
-                    cols.repeat_interleave(self.speculative_num_draft_tokens, dim=0)
-                    + cum_len[:, None]
-                ).view(1, -1)
-                # avoid extracting padded seq indices which will be out of boundary
-                mask_extraction_indices[
-                    :,
-                    spec_info.positions.numel() * self.speculative_num_draft_tokens :,
-                ].fill_(0)
-                mask = spec_info.custom_mask[mask_extraction_indices].view(
-                    -1, self.speculative_num_draft_tokens
-                )  # (bsz * draft_num, draft_num)
-
-                col_indices = offsets.expand(
-                    mask.shape[0], self.speculative_num_draft_tokens
+                mask, page_table = self._build_target_verify_topk_expand_inputs(
+                    seq_lens=seq_lens,
+                    req_pool_indices=req_pool_indices,
+                    spec_info=spec_info,
+                    query_layout=padded_layout,
+                    real_bs=real_bs,
                 )
-                keys = torch.where(
-                    mask,
-                    col_indices,
-                    col_indices + self.speculative_num_draft_tokens,
-                )
-                _, sort_order = torch.sort(keys, dim=1)
-
-                non_masked_page_table = (
-                    self.req_to_token[req_pool_indices, :]
-                    .gather(1, cols)
-                    .repeat_interleave(self.speculative_num_draft_tokens, dim=0)
-                )  # (bsz, draft_num)
-
-                metadata_expand.page_table.copy_(
-                    non_masked_page_table.gather(1, sort_order)
-                )
+                metadata_expand.page_table.copy_(page_table)
                 metadata_expand.cache_seqlens_int32.copy_(mask.sum(dim=1))
                 metadata_expand.cu_seqlens_k[1:].copy_(
                     torch.cumsum(
@@ -2927,7 +3009,7 @@ class FlashAttentionBackend(AttentionBackend):
                     )
                 )
                 if self.has_swa:
-                    metadata_swa = self.target_verify_metadata_topk_swa[bs]
+                    metadata_swa = self.target_verify_metadata_topk_swa[metadata_key]
                     self._init_sliding_window_attn_spec_metadata(
                         metadata, metadata_expand, metadata_swa
                     )

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -117,7 +117,11 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
-def ragged_verify_compact_graphs_enabled(spec_algorithm: SpeculativeAlgorithm) -> bool:
+def ragged_verify_compact_graphs_enabled(
+    spec_algorithm: SpeculativeAlgorithm, server_args
+) -> bool:
+    if spec_algorithm.is_eagle3():
+        return server_args.speculative_echo_threshold is not None
     if not spec_algorithm.supports_ragged_verify():
         return False
     from sglang.srt.speculative.ragged_verify import ragged_verify_compact_enabled
@@ -283,7 +287,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             KTMoEWrapper.set_capture_batch_sizes(self.capture_bs)
 
         self.ragged_verify_mode = (
-            ragged_verify_compact_graphs_enabled(self.model_runner.spec_algorithm)
+            ragged_verify_compact_graphs_enabled(
+                self.model_runner.spec_algorithm, model_runner.server_args
+            )
             and (self.capture_forward_mode == ForwardMode.TARGET_VERIFY)
             and not self.model_runner.is_draft_worker
         )
@@ -579,9 +585,16 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             return False
 
         admission_tokens = ragged_layout.graph_num_tokens
-        is_tokens_supported = admission_tokens <= self.capture_num_tokens[
-            -1
-        ] and forward_batch.batch_size <= self._ragged_capture_slots(admission_tokens)
+        if self.model_runner.spec_algorithm.is_eagle3():
+            token_tier_supported = admission_tokens in self.capture_num_tokens
+        else:
+            # Preserve the existing admission rule for other ragged-verify
+            # algorithms; their planners own the final token-tier selection.
+            token_tier_supported = admission_tokens <= self.capture_num_tokens[-1]
+        is_tokens_supported = (
+            token_tier_supported
+            and forward_batch.batch_size <= self._ragged_capture_slots(admission_tokens)
+        )
 
         is_dp_supported = (
             forward_batch.can_run_dp_cuda_graph if self.require_mlp_sync else True
@@ -1265,6 +1278,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     capture_hidden_mode=capture_mode,
                     seq_lens_sum=None,
                     seq_lens_cpu=None,
+                    ragged_verify_layout=self._capture_ragged_verify_layout(num_tokens),
                 )
                 # MTP models (e.g. deepseek_nextn) read spec_info.hidden_states
                 spec_info.hidden_states = torch.zeros(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2034,6 +2034,13 @@ class ServerArgs:
         "The number of tokens sampled from the draft model in Speculative Decoding.",
         NS("spec"),
     ] = None
+    speculative_echo_threshold: A[
+        Optional[float],
+        "Enable ECHO for EAGLE3. Must be a finite value in [0, 1]. "
+        "Requires --speculative-eagle-topk > 1, FA3, and "
+        "--disable-overlap-schedule.",
+        NS("spec"),
+    ] = None
     speculative_dflash_block_size: A[
         Optional[int],
         "DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",

--- a/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_cuda_graph_runner.py
@@ -489,10 +489,16 @@ class EAGLEDraftCudaGraphRunner(DecodeCudaGraphRunner):
             )
 
     def _postprocess_output_to_raw_bs(self, out, raw_bs):
-        parent_list, top_scores_index, draft_tokens, draft_probs = (
+        parent_list, top_scores_index, draft_tokens, draft_probs, verify_lens = (
             t[:raw_bs] if t is not None else None for t in out
         )
-        return parent_list, top_scores_index, draft_tokens, draft_probs
+        return (
+            parent_list,
+            top_scores_index,
+            draft_tokens,
+            draft_probs,
+            verify_lens,
+        )
 
     # -----------------------------------------------------------------
     # Replay

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
@@ -8,6 +8,9 @@ from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_trit
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_spec
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+
+if TYPE_CHECKING:
+    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +30,9 @@ class EagleVerifyInput(SpecInput):
     capture_hidden_mode: CaptureHiddenMode
     seq_lens_sum: int
     seq_lens_cpu: torch.Tensor
+    ragged_verify_layout: Optional["RaggedVerifyLayout"] = None
+    # Query geometry used by graph capture and replay.
+    ragged_query_layout: Optional["RaggedVerifyLayout"] = None
     # Stacked per-step draft proposal distribution q, shape (bs, num_steps,
     # vocab); only set under rejection sampling. Consumed by the verify kernel.
     draft_probs: torch.Tensor = None

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -129,6 +129,65 @@ def organize_draft_results(
     return parent_list, top_scores_index, draft_tokens
 
 
+def compute_echo_verify_lens(
+    score_list: List[torch.Tensor],
+    top_scores_index: torch.Tensor,
+    threshold: float,
+) -> torch.Tensor:
+    """Compute per-request ECHO verification lengths."""
+    if not score_list:
+        raise ValueError("ECHO requires at least one draft layer")
+    if top_scores_index.ndim != 2:
+        raise ValueError(
+            "top_scores_index must have shape [batch, num_draft_tokens - 1], "
+            f"got {tuple(top_scores_index.shape)}"
+        )
+
+    batch_size = top_scores_index.shape[0]
+    layer_widths = []
+    layer_passes = []
+    for scores in score_list:
+        if scores.shape[0] != batch_size:
+            raise ValueError(
+                "all EAGLE score layers must have the same batch size as "
+                f"top_scores_index ({batch_size}), got {scores.shape[0]}"
+            )
+        flattened = scores.flatten(start_dim=1)
+        layer_widths.append(flattened.shape[1])
+        layer_max = flattened.amax(dim=1)
+        layer_passes.append(torch.isnan(layer_max) | (layer_max >= threshold))
+
+    pass_prefix = torch.cumprod(torch.stack(layer_passes, dim=1).to(torch.int32), dim=1)
+    candidate_cutoff = torch.zeros(
+        batch_size,
+        dtype=top_scores_index.dtype,
+        device=top_scores_index.device,
+    )
+    for layer_index, width in enumerate(layer_widths):
+        candidate_cutoff.add_(
+            pass_prefix[:, layer_index].to(top_scores_index.dtype) * width
+        )
+    return 1 + (top_scores_index < candidate_cutoff.unsqueeze(1)).sum(dim=1).to(
+        torch.int32
+    )
+
+
+def eagle_ragged_graph_tier_eligible(
+    *,
+    graph_num_tokens: int,
+    batch_size: int,
+    graph_runner,
+) -> bool:
+    """Whether a captured ragged tier has both this token key and enough slots."""
+    return bool(
+        graph_runner is not None
+        and graph_runner.ragged_verify_mode
+        and graph_runner.capture_num_tokens
+        and graph_num_tokens in graph_runner.capture_num_tokens
+        and graph_runner._ragged_capture_slots(graph_num_tokens) >= batch_size
+    )
+
+
 class TreeMaskMode(IntEnum):
     FULL_MASK = 0
     QLEN_ONLY = 1
@@ -496,13 +555,19 @@ def eagle_prepare_for_verify(
     from sglang.kernels.ops.speculative.cache_locs import (
         assign_extend_cache_locs_uniform_func,
     )
+    from sglang.kernels.ops.speculative.eagle_echo import (
+        build_eagle_ragged_verify_window,
+    )
     from sglang.srt.model_executor.forward_batch_info import (
         CaptureHiddenMode,
         ForwardBatch,
         ForwardMode,
     )
+    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
     from sglang.srt.speculative.spec_utils import prepare_mamba_track_for_verify
 
+    dense_out_cache_loc = None
+    dense_positions = None
     if not batch.forward_mode.is_idle():
         # Assign cache locations
         bs = len(batch.req_pool_indices)
@@ -525,12 +590,40 @@ def eagle_prepare_for_verify(
             draft_token_num=verify_input.draft_token_num,
             device=device,
         )
+        dense_out_cache_loc = batch.out_cache_loc
 
         batch.out_cache_loc_dsv4 = maybe_build_dsv4_verify_bundle(
             batch, verify_input.draft_token_num
         )
 
         prepare_mamba_track_for_verify(batch)
+
+        ragged_layout = verify_input.ragged_verify_layout
+        if ragged_layout is not None:
+            dense_positions = verify_input.positions
+            graph_runner = target_worker.model_runner.decode_cuda_graph_runner
+            use_graph_tier = eagle_ragged_graph_tier_eligible(
+                graph_num_tokens=ragged_layout.graph_num_tokens,
+                batch_size=bs,
+                graph_runner=graph_runner,
+            )
+            padded_bs = (
+                graph_runner._ragged_capture_slots(ragged_layout.graph_num_tokens)
+                if use_graph_tier
+                else bs
+            )
+            verify_window = build_eagle_ragged_verify_window(
+                draft_tokens=verify_input.draft_token,
+                positions=verify_input.positions,
+                out_cache_loc=dense_out_cache_loc,
+                layout=ragged_layout,
+                draft_token_num=verify_input.draft_token_num,
+                padded_bs=padded_bs,
+            )
+            batch.input_ids = verify_window.input_ids
+            batch.out_cache_loc = verify_window.out_cache_loc
+            verify_input.positions = verify_window.positions
+            verify_input.ragged_query_layout = verify_window.query_layout
 
         # TBO's split_spec_info reads these; no-verify-sync leaves both None.
         verify_input.seq_lens_cpu = batch.seq_lens_cpu
@@ -553,6 +646,9 @@ def eagle_prepare_for_verify(
         capture_hidden_mode=capture_mode,
         return_hidden_states_before_norm=False,
     )
+    if dense_out_cache_loc is not None:
+        # Restore the batch-owned cache-location view after ForwardBatch setup.
+        batch.out_cache_loc = dense_out_cache_loc
 
     # Run attention backend plan and cuda graph preparation
     can_run_cuda_graph = bool(
@@ -561,6 +657,49 @@ def eagle_prepare_for_verify(
             verify_forward_batch
         )
     )
+    if (
+        not can_run_cuda_graph
+        and dense_out_cache_loc is not None
+        and dense_positions is not None
+        and verify_input.ragged_verify_layout is not None
+    ):
+        ragged_layout = verify_input.ragged_verify_layout
+        real_num_tokens = int(ragged_layout.verify_lens.sum().item())
+        query_layout = verify_input.ragged_query_layout
+        if (
+            ragged_layout.graph_num_tokens != real_num_tokens
+            or query_layout is None
+            or query_layout.bs != len(batch.req_pool_indices)
+        ):
+            # A non-shape eligibility check (for example a per-request embed
+            # override) can reject an otherwise captured token tier. Rebuild
+            # the eager input without graph-only padding so its request layout
+            # remains self-contained.
+            eager_layout = RaggedVerifyLayout.from_verify_lens_device(
+                verify_lens=ragged_layout.verify_lens,
+                graph_num_tokens=real_num_tokens,
+            )
+            verify_input.ragged_verify_layout = eager_layout
+            verify_window = build_eagle_ragged_verify_window(
+                draft_tokens=verify_input.draft_token,
+                positions=dense_positions,
+                out_cache_loc=dense_out_cache_loc,
+                layout=eager_layout,
+                draft_token_num=verify_input.draft_token_num,
+                padded_bs=len(batch.req_pool_indices),
+            )
+            batch.input_ids = verify_window.input_ids
+            batch.out_cache_loc = verify_window.out_cache_loc
+            verify_input.positions = verify_window.positions
+            verify_input.ragged_query_layout = verify_window.query_layout
+            verify_forward_batch = ForwardBatch.init_new(
+                batch,
+                target_worker.model_runner,
+                capture_hidden_mode=capture_mode,
+                return_hidden_states_before_norm=False,
+            )
+            batch.out_cache_loc = dense_out_cache_loc
+
     if can_run_cuda_graph:
         target_worker.model_runner.decode_cuda_graph_runner.load_batch(
             verify_forward_batch

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -8,6 +8,10 @@ from sglang.kernels.ops.speculative.cache_locs import (
     assign_draft_cache_locs_contiguous,
 )
 from sglang.kernels.ops.speculative.eagle import fill_bonus_tokens_func
+from sglang.kernels.ops.speculative.eagle_echo import (
+    apply_eagle_retrieval_layout,
+    scatter_eagle_verify_output,
+)
 from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
 from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.model_executor.forward_batch_info import (
@@ -20,8 +24,10 @@ from sglang.srt.speculative.eagle_utils import (
     TreeMaskMode,
     build_tree_kernel_efficient,
     eagle_prepare_for_verify,
+    eagle_ragged_graph_tier_eligible,
     eagle_sample,
 )
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout, round_up_grid
 from sglang.srt.speculative.spec_utils import (
     GrammarTree,
     build_grammar_vocab_mask,
@@ -53,6 +59,31 @@ if TYPE_CHECKING:
         EAGLEDraftCudaGraphRunner,
     )
     from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
+
+
+def _select_eagle_ragged_graph_num_tokens(
+    *,
+    total_verify_tokens: int,
+    batch_size: int,
+    graph_runner,
+) -> int:
+    """Select a captured token tier, or retain the exact eager token count."""
+    if (
+        graph_runner is None
+        or not graph_runner.ragged_verify_mode
+        or not graph_runner.capture_num_tokens
+        or total_verify_tokens > graph_runner.capture_num_tokens[-1]
+    ):
+        return total_verify_tokens
+
+    graph_tier = round_up_grid(total_verify_tokens, graph_runner.capture_num_tokens)
+    if not eagle_ragged_graph_tier_eligible(
+        graph_num_tokens=graph_tier,
+        batch_size=batch_size,
+        graph_runner=graph_runner,
+    ):
+        return total_verify_tokens
+    return graph_tier
 
 
 def duplicate_prefix_tail_to_draft_branches(
@@ -320,6 +351,7 @@ def build_eagle_verify_input(
     top_scores_index: torch.Tensor,
     draft_tokens: torch.Tensor,
     draft_probs: Optional[torch.Tensor],
+    verify_lens: Optional[torch.Tensor],
     *,
     target_worker: TpModelWorker,
     topk: int,
@@ -385,6 +417,40 @@ def build_eagle_verify_input(
         fill_prefix_mask=fill_mask,
     )
 
+    ragged_verify_layout = None
+    if verify_lens is not None:
+        verify_lens = verify_lens.to(device=draft_tokens.device, dtype=torch.int32)
+        if verify_lens.numel() == 0:
+            raise ValueError("ECHO layout is empty")
+        torch._assert_async(
+            (verify_lens >= 1).all(),
+            "ECHO layout values must be at least 1",
+        )
+        torch._assert_async(
+            (verify_lens <= num_draft_tokens).all(),
+            "ECHO layout values exceed the configured range",
+        )
+
+        # CUDA graph selection is a host decision. Synchronize one scalar total,
+        # not the complete per-request vector; all row geometry remains on device.
+        total_verify_tokens = int(verify_lens.sum().item())
+        graph_num_tokens = _select_eagle_ragged_graph_num_tokens(
+            total_verify_tokens=total_verify_tokens,
+            batch_size=verify_lens.numel(),
+            graph_runner=target_worker.model_runner.decode_cuda_graph_runner,
+        )
+
+        ragged_verify_layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=verify_lens,
+            graph_num_tokens=graph_num_tokens,
+        )
+        apply_eagle_retrieval_layout(
+            retrieve_index=retrieve_index,
+            retrieve_next_token=retrieve_next_token,
+            retrieve_next_sibling=retrieve_next_sibling,
+            verify_lens=verify_lens,
+        )
+
     return EagleVerifyInput(
         draft_token=draft_tokens,
         custom_mask=tree_mask,
@@ -400,6 +466,7 @@ def build_eagle_verify_input(
         seq_lens_sum=None,
         seq_lens_cpu=None,
         draft_probs=draft_probs,
+        ragged_verify_layout=ragged_verify_layout,
     )
 
 
@@ -566,6 +633,21 @@ def run_eagle_verify(
         is_verify=True,
     )
     logits_output = forward_batch_output.logits_output
+    ragged_layout = verify_input.ragged_verify_layout
+    if ragged_layout is not None and not batch.forward_mode.is_idle():
+        logits_output.next_token_logits = scatter_eagle_verify_output(
+            compact=logits_output.next_token_logits,
+            layout=ragged_layout,
+            query_layout=verify_input.ragged_query_layout,
+            draft_token_num=num_draft_tokens,
+        )
+        if logits_output.hidden_states is not None:
+            logits_output.hidden_states = scatter_eagle_verify_output(
+                compact=logits_output.hidden_states,
+                layout=ragged_layout,
+                query_layout=verify_input.ragged_query_layout,
+                draft_token_num=num_draft_tokens,
+            )
 
     # Generate vocab mask for constrained decoding
     grammar_mask = None
@@ -654,6 +736,11 @@ def run_eagle_verify(
         speculative_num_draft_tokens=num_draft_tokens,
         next_draft_input=next_draft_input,
         accept_lens=accept_lens,
+        cap_lens=(
+            ragged_layout.verify_lens.to(torch.int32)
+            if ragged_layout is not None and not batch.forward_mode.is_idle()
+            else None
+        ),
         new_seq_lens=new_seq_lens,
         routed_experts_output=forward_batch_output.routed_experts_output,
         indexer_topk_output=forward_batch_output.indexer_topk_output,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -70,6 +70,7 @@ from sglang.srt.speculative.eagle_info import (
 )
 from sglang.srt.speculative.eagle_utils import (
     _eagle_prefill_tail_tokens,
+    compute_echo_verify_lens,
     default_tree_mask_mode,
     get_draft_recurrent_hidden_state_spec,
     organize_draft_results,
@@ -146,6 +147,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             assert self.topk == 1, "Chain speculative sampling supports only topk=1"
         self.speculative_num_steps = server_args.speculative_num_steps
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.echo_threshold = getattr(server_args, "speculative_echo_threshold", None)
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
@@ -498,9 +500,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         with canary_outside_ctx:
             # Run draft
             if can_run_decode_cuda_graph:
-                parent_list, top_scores_index, draft_tokens, draft_probs = (
-                    self.cuda_graph_runner.execute(forward_batch)
-                )
+                (
+                    parent_list,
+                    top_scores_index,
+                    draft_tokens,
+                    draft_probs,
+                    verify_lens,
+                ) = self.cuda_graph_runner.execute(forward_batch)
             else:
                 if (
                     not forward_batch.forward_mode.is_idle()
@@ -510,9 +516,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                     # `draft_forward` only does sample in this case.
                     self.draft_attn_backend.init_forward_metadata(forward_batch)
                     forward_batch.mark_forward_metadata_ready()
-                parent_list, top_scores_index, draft_tokens, draft_probs = (
-                    self.draft_forward(forward_batch)
-                )
+                (
+                    parent_list,
+                    top_scores_index,
+                    draft_tokens,
+                    draft_probs,
+                    verify_lens,
+                ) = self.draft_forward(forward_batch)
 
         return build_eagle_verify_input(
             batch,
@@ -521,6 +531,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             top_scores_index,
             draft_tokens,
             draft_probs,
+            verify_lens,
             target_worker=self.target_worker,
             topk=self.topk,
             num_steps=self.speculative_num_steps,
@@ -690,20 +701,41 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             bs = draft_tokens_topk1.shape[0]
             top_scores_index = self._topk1_score_indices_prealloc[:bs]
             parent_list = self._topk1_parents_prealloc[:bs]
-            return parent_list, top_scores_index, draft_tokens_topk1, draft_probs
+            return (
+                parent_list,
+                top_scores_index,
+                draft_tokens_topk1,
+                draft_probs,
+                None,
+            )
 
         if topk1_chain_fits:
             bs = token_list[0].shape[0]
             draft_tokens = torch.cat(token_list, dim=1)
             top_scores_index = self._topk1_score_indices_prealloc[:bs]
             parent_list = self._topk1_parents_prealloc[:bs]
-            return parent_list, top_scores_index, draft_tokens, draft_probs
+            return parent_list, top_scores_index, draft_tokens, draft_probs, None
 
         parent_list, top_scores_index, draft_tokens = organize_draft_results(
             score_list, token_list, parents_list, self.speculative_num_draft_tokens
         )
+        verify_lens = (
+            compute_echo_verify_lens(
+                score_list,
+                top_scores_index,
+                self.echo_threshold,
+            )
+            if self.echo_threshold is not None
+            else None
+        )
 
-        return parent_list, top_scores_index, draft_tokens, draft_probs
+        return (
+            parent_list,
+            top_scores_index,
+            draft_tokens,
+            draft_probs,
+            verify_lens,
+        )
 
     def draft_extend(self):
         pass

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -426,6 +426,7 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
             top_scores_index,
             draft_tokens,
             draft_input.draft_probs,
+            None,
             target_worker=self.target_worker,
             topk=self.topk,
             num_steps=self.speculative_num_steps,

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -247,6 +247,24 @@ def record_stream_for_v2_verify(batch, verify_input, fwd_stream):
                 )
             ]
         )
+        ragged_layout = getattr(verify_input, "ragged_verify_layout", None)
+        if ragged_layout is not None:
+            candidates.extend(
+                (
+                    ragged_layout.verify_lens,
+                    ragged_layout.extend_start_loc,
+                    ragged_layout.qo_indptr_device,
+                )
+            )
+        query_layout = getattr(verify_input, "ragged_query_layout", None)
+        if query_layout is not None:
+            candidates.extend(
+                (
+                    query_layout.verify_lens,
+                    query_layout.extend_start_loc,
+                    query_layout.qo_indptr_device,
+                )
+            )
     record_stream_each(candidates, fwd_stream)
 
 

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -50,6 +50,10 @@ class StandaloneDraftWorker(EagleDraftWorker):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
+        # StandaloneDraftWorker intentionally skips EagleDraftWorker.__init__.
+        # ECHO is EAGLE3-only, but draft_forward still reads this field on the
+        # shared topk > 1 path.
+        self.echo_threshold = None
 
         self._rebuild_topk1_chain_buffers()
 

--- a/python/sglang/test/kits/spec_server_kits.py
+++ b/python/sglang/test/kits/spec_server_kits.py
@@ -8,6 +8,7 @@ Thresholds are read off ``self`` so a config can tune them as class attributes.
 """
 
 import concurrent.futures
+import contextlib
 import json
 import random
 import threading
@@ -18,6 +19,7 @@ from types import SimpleNamespace
 import numpy as np
 import requests
 
+from sglang.srt.environ import envs
 from sglang.srt.utils.common import kill_process_tree
 from sglang.test.kits.radix_cache_server_kit import run_radix_attention_test
 from sglang.test.run_eval import run_eval
@@ -185,6 +187,298 @@ class SpecParityKit:
                 spec_out,
                 self.parity_ref_outputs[prompt],
                 f"spec != ref for prompt {prompt!r}",
+            )
+
+
+# One question per category from FastChat's Apache-2.0 MT-Bench question set:
+# https://github.com/lm-sys/FastChat/blob/587d5cfa1609a43d192cedb8441cac3c17db105d/fastchat/llm_judge/data/mt_bench/question.jsonl
+MT_BENCH_SMOKE_CASES = (
+    {
+        "question_id": 82,
+        "category": "writing",
+        "turns": (
+            "Draft a professional email seeking your supervisor's feedback on the "
+            "'Quarterly Financial Report' you prepared. Ask specifically about the "
+            "data analysis, presentation style, and the clarity of conclusions drawn. "
+            "Keep the email short and to the point.",
+            "Take a moment to evaluate and critique your own response.",
+        ),
+    },
+    {
+        "question_id": 98,
+        "category": "roleplay",
+        "turns": (
+            "Embody the persona of Tony Stark from “Iron Man” throughout this "
+            "conversation. Bypass the introduction “As Stark”. Our first question is: "
+            "“What’s your favorite part about being Iron Man?",
+            "What do you think about GPT-4 as a replacement of your JAVIS?",
+        ),
+    },
+    {
+        "question_id": 103,
+        "category": "reasoning",
+        "turns": (
+            "Thomas is very healthy, but he has to go to the hospital every day. "
+            "What could be the reasons?",
+            "Can you explain why the above question is interesting?",
+        ),
+    },
+    {
+        "question_id": 118,
+        "category": "math",
+        "turns": (
+            "When a number is divided by 10, the remainder is 4. What is the "
+            "remainder when twice the number is divided by 4?",
+            "What about when twice the number is divided by 5?",
+        ),
+    },
+    {
+        "question_id": 123,
+        "category": "coding",
+        "turns": (
+            "Write a simple website in HTML. When a user clicks the button, it shows "
+            "a random joke from a list of 4 jokes.",
+            "How to use CSS to change the color of jokes to red?",
+        ),
+    },
+    {
+        "question_id": 140,
+        "category": "extraction",
+        "turns": (
+            "Given the following records of stock prices, extract the highest and "
+            "lowest closing prices for each month in the year 2022. Return the results "
+            "as a CSV string, with one line allocated for each month.\n"
+            "Date,Open,High,Low,Close,Volume\n"
+            "2022-01-01,150.02,155.28,148.50,153.80,15678900\n"
+            "2022-01-02,154.32,157.25,153.48,156.25,19874500\n"
+            "2022-02-01,160.50,163.28,159.50,161.80,14326700\n"
+            "2022-02-02,161.80,164.25,161.30,163.90,17689200\n"
+            "2022-03-01,165.40,168.35,163.10,166.80,16253400\n"
+            "2022-03-02,167.00,169.85,165.50,168.20,19568100",
+            "Do the same task again with the JSON format and round all numbers in "
+            "your response to the nearest integers.",
+        ),
+    },
+    {
+        "question_id": 144,
+        "category": "stem",
+        "turns": (
+            "What is the central dogma of molecular biology? What processes are "
+            "involved? Who named this?",
+            "Identify and fix one incorrect fact in your previous response.",
+        ),
+    },
+    {
+        "question_id": 152,
+        "category": "humanities",
+        "turns": (
+            "How do the stages of life shape our understanding of time and mortality?",
+            "Write an allegorical poem that illustrates the above.",
+        ),
+    },
+)
+
+
+def _mtbench_chat_turn(
+    url,
+    model,
+    messages,
+    max_new_tokens,
+    *,
+    temperature=0,
+    skip_special_tokens=True,
+):
+    response = requests.post(
+        url + "/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "seed": 0,
+            "max_completion_tokens": max_new_tokens,
+            "stream": False,
+            "skip_special_tokens": skip_special_tokens,
+            "return_meta_info": True,
+            "return_token_ids": True,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        timeout=120,
+    )
+    response.raise_for_status()
+    choice = response.json()["choices"][0]
+    return {
+        "text": choice["message"]["content"] or "",
+        "token_ids": choice.get("token_ids"),
+        "finish_reason": choice.get("finish_reason"),
+        "meta_info": choice.get("meta_info") or {},
+    }
+
+
+def _mtbench_conversation(url, model, question, max_new_tokens):
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": question["turns"][0]},
+    ]
+    outputs = []
+    for turn in range(2):
+        output = _mtbench_chat_turn(url, model, messages, max_new_tokens)
+        outputs.append(output)
+        if turn == 0:
+            messages.extend(
+                [
+                    {"role": "assistant", "content": output["text"]},
+                    {"role": "user", "content": question["turns"][1]},
+                ]
+            )
+    return outputs
+
+
+class SpecMTBenchKit:
+    """Two-turn MT-Bench graph/eager parity on a fixed offline subset.
+
+    The eight cases select one question from every category in FastChat's
+    MT-Bench question set. The eager reference uses the same speculative
+    configuration as the CUDA Graph server, so this directly checks graph
+    capture/replay without conflating legal BF16 differences between target-only
+    and speculative GEMM shapes. Full 80-question performance runs belong in
+    ``benchmark/mtbench/bench_sglang_eagle.py`` rather than GPU CI.
+    """
+
+    mtbench_cases = MT_BENCH_SMOKE_CASES
+    mtbench_parallel = 4
+    mtbench_max_new_tokens = 48
+    mtbench_accept_len_thres = 1.1
+
+    @classmethod
+    def _run_mtbench_cases(cls, url):
+        with ThreadPoolExecutor(cls.mtbench_parallel) as executor:
+            outputs = executor.map(
+                lambda question: _mtbench_conversation(
+                    url,
+                    cls.model,
+                    question,
+                    cls.mtbench_max_new_tokens,
+                ),
+                cls.mtbench_cases,
+            )
+            return {
+                question["question_id"]: output
+                for question, output in zip(cls.mtbench_cases, outputs)
+            }
+
+    @classmethod
+    def setUpClass(cls):
+        ref_url = DEFAULT_URL_FOR_TEST
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                envs.SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN.override(True)
+            )
+            for env_var, value in cls._merged_env_overrides():
+                stack.enter_context(env_var.override(value))
+            ref_proc = popen_launch_server(
+                cls.model,
+                ref_url,
+                timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+                other_args=[
+                    *cls._launch_args(),
+                    "--cuda-graph-backend-decode",
+                    "disabled",
+                ],
+            )
+        try:
+            cls.mtbench_ref_outputs = cls._run_mtbench_cases(ref_url)
+        finally:
+            kill_process_tree(ref_proc.pid, wait_timeout=60)
+        super().setUpClass()
+
+    def test_mtbench_parity_and_acceptance(self):
+        requests.post(self.base_url + "/flush_cache", timeout=60).raise_for_status()
+        spec_outputs = self._run_mtbench_cases(self.base_url)
+        completion_tokens = 0
+        verify_count = 0
+        cap_count = 0
+        echo_layout_count = 0
+
+        for question in self.mtbench_cases:
+            question_id = question["question_id"]
+            reference = self.mtbench_ref_outputs[question_id]
+            actual = spec_outputs[question_id]
+            for turn, (output, expected) in enumerate(zip(actual, reference), start=1):
+                message = (
+                    f"CUDA Graph != eager for MT-Bench question "
+                    f"{question_id}, turn {turn}"
+                )
+                self.assertEqual(output["text"], expected["text"], message)
+                self.assertEqual(output["token_ids"], expected["token_ids"], message)
+                self.assertEqual(
+                    output["finish_reason"], expected["finish_reason"], message
+                )
+                meta_info = output["meta_info"]
+                expected_meta = expected["meta_info"]
+                for key in (
+                    "completion_tokens",
+                    "spec_verify_ct",
+                    "spec_num_correct_drafts",
+                    "spec_num_proposed_drafts",
+                    "spec_cap_lens_histogram",
+                ):
+                    self.assertEqual(
+                        meta_info.get(key), expected_meta.get(key), f"{message}: {key}"
+                    )
+                completion_tokens += meta_info["completion_tokens"]
+                verify_count += meta_info.get("spec_verify_ct", 0)
+                cap_histogram = meta_info.get("spec_cap_lens_histogram") or []
+                cap_count += sum(cap_histogram)
+                echo_layout_count += sum(cap_histogram[: self.spec_tokens])
+
+        self.assertGreater(verify_count, 0)
+        self.assertEqual(cap_count, verify_count)
+        self.assertGreater(echo_layout_count, 0)
+        accept_length = completion_tokens / verify_count
+        print(
+            f"MT-Bench smoke {accept_length=:.4f}, "
+            f"{echo_layout_count=}/{verify_count}"
+        )
+        self.assertGreater(accept_length, self.mtbench_accept_len_thres)
+
+    def test_mtbench_eos_token(self):
+        question = self.mtbench_cases[0]
+        output = _mtbench_chat_turn(
+            self.base_url,
+            self.model,
+            [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": question["turns"][0]},
+            ],
+            512,
+            temperature=0.1,
+            skip_special_tokens=False,
+        )
+        self.assertEqual(output["finish_reason"], "stop")
+        tokens = self.tokenizer.encode(output["text"], truncation=False)
+        self.assertNotIn(self.tokenizer.eos_token_id, tokens)
+
+    def test_mtbench_first_token_finish(self):
+        def send(index_and_question):
+            index, question = index_and_question
+            max_new_tokens = index % 3 + 1
+            output = _mtbench_chat_turn(
+                self.base_url,
+                self.model,
+                [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": question["turns"][0]},
+                ],
+                max_new_tokens,
+            )
+            return output, max_new_tokens
+
+        with ThreadPoolExecutor(self.mtbench_parallel) as executor:
+            outputs = list(executor.map(send, enumerate(self.mtbench_cases)))
+        for output, max_new_tokens in outputs:
+            self.assertIn("text", output)
+            self.assertLessEqual(
+                output["meta_info"]["completion_tokens"], max_new_tokens
             )
 
 

--- a/test/registered/spec/eagle/test_spec_eagle_fa3.py
+++ b/test/registered/spec/eagle/test_spec_eagle_fa3.py
@@ -13,12 +13,13 @@ from sglang.test.kits.spec_server_kits import (
     SpecCorrectnessKit,
     SpecFeatureKit,
     SpecLogprobKit,
+    SpecMTBenchKit,
     SpecPenaltyKit,
     SpecPerfKit,
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
 
-register_cuda_ci(est_time=600, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=900, stage="base-b", runner_config="1-gpu-large")
 
 
 class TestEagle3Fa3(Eagle3Base, SpecCorrectnessKit, SpecAccuracyKit, SpecLogprobKit):
@@ -26,6 +27,24 @@ class TestEagle3Fa3(Eagle3Base, SpecCorrectnessKit, SpecAccuracyKit, SpecLogprob
 
     attention_backend = "fa3"
     disable_overlap = False
+    env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
+
+
+class TestEagle3Fa3Echo(SpecMTBenchKit, Eagle3Base):
+    """ECHO graph/eager parity on a two-turn MT-Bench smoke set."""
+
+    enable_deterministic_inference = True
+    spec_steps = 3
+    spec_topk = 3
+    spec_tokens = 6
+    mtbench_accept_len_thres = 1.1
+    attention_backend = "fa3"
+    disable_overlap = True
+    cuda_graph_max_bs_decode = 4
+    extra_args = (
+        "--speculative-echo-threshold",
+        "0.2",
+    )
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
 
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1152,6 +1152,118 @@ class TestDecoupledSpecArgs(CustomTestCase):
             )
 
 
+class TestEagleEchoArgs(CustomTestCase):
+    def _make_args(self, *, model_overrides=None, **overrides):
+        model_fields = {
+            "hf_config": SimpleNamespace(
+                architectures=["Qwen3ForCausalLM"],
+                get_text_config=lambda: SimpleNamespace(),
+            ),
+            "linear_attn_registry_result": None,
+            "model_is_mrope": False,
+            "sliding_window_size": None,
+        }
+        model_fields.update(model_overrides or {})
+        model_config = SimpleNamespace(**model_fields)
+
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = "EAGLE3"
+        args.speculative_num_steps = 3
+        args.speculative_eagle_topk = 3
+        args.speculative_num_draft_tokens = 6
+        args.speculative_echo_threshold = 0.5
+        args.attention_backend = "fa3"
+        args.decode_attention_backend = None
+        args.disable_overlap_schedule = True
+        args.page_size = 1
+        args.get_model_config = lambda: model_config
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_valid_args_and_tp_pass_validation(self):
+        args = self._make_args(
+            speculative_echo_threshold="0.25",
+            tp_size=2,
+        )
+
+        handle_speculative_decoding(args)
+
+        self.assertEqual(args.speculative_echo_threshold, 0.25)
+
+    def test_threshold_range(self):
+        for threshold in (-0.1, 1.1, float("inf"), float("nan")):
+            with self.subTest(threshold=threshold):
+                args = self._make_args(speculative_echo_threshold=threshold)
+                with self.assertRaisesRegex(ValueError, "finite value in"):
+                    handle_speculative_decoding(args)
+
+        for threshold in (0.0, 1.0):
+            with self.subTest(threshold=threshold):
+                args = self._make_args(speculative_echo_threshold=threshold)
+                handle_speculative_decoding(args)
+                self.assertEqual(args.speculative_echo_threshold, threshold)
+
+    def test_rejects_incompatible_target_architectures(self):
+        args = self._make_args(model_overrides={"model_is_mrope": True})
+        with self.assertRaisesRegex(ValueError, "MRoPE"):
+            handle_speculative_decoding(args)
+
+        args = self._make_args()
+        with patch(
+            "sglang.srt.configs.hybrid_arch.mambaish_config",
+            return_value=object(),
+        ):
+            with self.assertRaisesRegex(ValueError, "Mamba/GDN"):
+                handle_speculative_decoding(args)
+
+    def test_rejects_unsupported_execution_modes(self):
+        cases = (
+            ({"speculative_algorithm": "EAGLE"}, "EAGLE3"),
+            ({"attention_backend": "triton"}, "fa3"),
+            ({"disable_overlap_schedule": False}, "disable-overlap-schedule"),
+            ({"enable_two_batch_overlap": True}, "two-batch overlap disabled"),
+            ({"speculative_eagle_topk": 1}, "topk > 1"),
+        )
+        for overrides, expected in cases:
+            with self.subTest(overrides=overrides):
+                args = self._make_args(**overrides)
+                with self.assertRaisesRegex(ValueError, expected):
+                    handle_speculative_decoding(args)
+
+    def test_rejects_incompatible_parallel_topologies(self):
+        cases = (
+            ({"pp_size": 2}, "--pp-size 1"),
+            ({"attn_cp_size": 2}, "--attn-cp-size 1"),
+            ({"dcp_size": 2}, "--dcp-size 1"),
+            ({"moe_a2a_backend": "deepep"}, "gathered token buffers"),
+            ({"moe_dense_tp_size": 2}, "gathered token buffers"),
+        )
+        for overrides, expected in cases:
+            with self.subTest(overrides=overrides):
+                args = self._make_args(**overrides)
+                with self.assertRaisesRegex(ValueError, expected):
+                    handle_speculative_decoding(args)
+
+        args = self._make_args(
+            moe_a2a_backend="deepep",
+            disable_attn_tp_gather=True,
+        )
+        handle_speculative_decoding(args)
+
+    def test_cli_parses_threshold(self):
+        args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--speculative-echo-threshold",
+                "0.4",
+            ]
+        )
+
+        self.assertEqual(args.speculative_echo_threshold, 0.4)
+
+
 class TestAdaptiveSpecArgs(CustomTestCase):
     def test_adaptive_defaults_to_config_step_when_spec_params_omitted(self):
         with tempfile.NamedTemporaryFile("w", suffix=".json") as f:

--- a/test/registered/unit/spec/test_eagle_echo.py
+++ b/test/registered/unit/spec/test_eagle_echo.py
@@ -1,0 +1,487 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.kernels.ops.speculative.eagle_echo import (
+    apply_eagle_retrieval_layout,
+    build_eagle_ragged_verify_window,
+    scatter_eagle_verify_output,
+)
+from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
+from sglang.srt.speculative.eagle_utils import (
+    compute_echo_verify_lens,
+    eagle_ragged_graph_tier_eligible,
+)
+from sglang.srt.speculative.eagle_worker_common import (
+    _select_eagle_ragged_graph_num_tokens,
+)
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+from sglang.srt.speculative.standalone_worker_v2 import StandaloneDraftWorker
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+
+class TestEagleEcho(CustomTestCase):
+    def test_standalone_worker_defaults_echo_to_none(self):
+        server_args = SimpleNamespace(
+            device="cpu",
+            speculative_eagle_topk=2,
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=6,
+            speculative_algorithm="STANDALONE",
+            enable_dp_attention=False,
+        )
+        draft_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(
+                model_config=SimpleNamespace(hf_config=SimpleNamespace())
+            )
+        )
+
+        with (
+            patch(
+                "sglang.srt.speculative.standalone_worker_v2.replace",
+                side_effect=lambda ps, **_: ps,
+            ),
+            patch(
+                "sglang.srt.speculative.standalone_worker_v2.TpModelWorker",
+                return_value=draft_worker,
+            ),
+            patch(
+                "sglang.srt.speculative.standalone_worker_v2.default_tree_mask_mode",
+                return_value=None,
+            ),
+            patch(
+                "sglang.srt.speculative.standalone_worker_v2.get_plan_stream",
+                return_value=(None, None),
+            ),
+        ):
+            worker = StandaloneDraftWorker(
+                server_args=server_args,
+                gpu_id=0,
+                ps=object(),
+                nccl_port=0,
+                target_worker=object(),
+            )
+
+        self.assertIsNone(worker.echo_threshold)
+
+    def test_computes_request_verify_lens(self):
+        score_list = [
+            torch.tensor([[[0.9, 0.7]], [[0.9, 0.8]]]),
+            torch.tensor(
+                [
+                    [[0.4, 0.2], [0.3, 0.1]],
+                    [[0.8, 0.7], [0.6, 0.5]],
+                ]
+            ),
+            torch.tensor(
+                [
+                    [[0.8, 0.7], [0.6, 0.5]],
+                    [[0.7, 0.6], [0.5, 0.4]],
+                ]
+            ),
+        ]
+        top_scores_index = torch.tensor(
+            [[0, 1, 2, 6, 9], [0, 2, 4, 7, 9]], dtype=torch.long
+        )
+
+        verify_lens = compute_echo_verify_lens(
+            score_list, top_scores_index, threshold=0.5
+        )
+
+        self.assertEqual(verify_lens.dtype, torch.int32)
+        self.assertEqual(verify_lens.tolist(), [3, 6])
+
+    def test_threshold_boundary_and_nan(self):
+        score_list = [
+            torch.tensor([[[0.5, 0.1]], [[float("nan"), 0.1]]]),
+            torch.tensor(
+                [
+                    [[float("nan"), 0.1], [0.2, 0.1]],
+                    [[0.7, 0.6], [0.5, 0.4]],
+                ]
+            ),
+        ]
+        top_scores_index = torch.tensor([[0, 1, 2], [0, 1, 3]])
+
+        verify_lens = compute_echo_verify_lens(
+            score_list, top_scores_index, threshold=0.5
+        )
+
+        self.assertEqual(verify_lens.tolist(), [4, 4])
+
+    def test_minimum_verify_length(self):
+        score_list = [
+            torch.tensor([[[0.49, 0.2]]]),
+            torch.tensor([[[0.9, 0.8], [0.7, 0.6]]]),
+        ]
+        top_scores_index = torch.tensor([[0, 1, 3]])
+
+        verify_lens = compute_echo_verify_lens(
+            score_list, top_scores_index, threshold=0.5
+        )
+
+        self.assertEqual(verify_lens.tolist(), [1])
+
+    def test_applies_retrieval_bounds(self):
+        retrieve_index = torch.tensor([[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10, 11]])
+        retrieve_next_token = torch.tensor([[1, 2, 3, 4, 5, -1], [1, 2, 3, 4, 5, -1]])
+        retrieve_next_sibling = torch.tensor(
+            [[2, 3, 4, 5, -1, -1], [2, 3, 4, 5, -1, -1]]
+        )
+
+        apply_eagle_retrieval_layout(
+            retrieve_index=retrieve_index,
+            retrieve_next_token=retrieve_next_token,
+            retrieve_next_sibling=retrieve_next_sibling,
+            verify_lens=torch.tensor([3, 1]),
+        )
+
+        self.assertEqual(
+            retrieve_index.tolist(), [[0, 1, 2, -1, -1, -1], [6, -1, -1, -1, -1, -1]]
+        )
+        self.assertEqual(
+            retrieve_next_token.tolist(),
+            [[1, 2, -1, -1, -1, -1], [-1, -1, -1, -1, -1, -1]],
+        )
+        self.assertEqual(
+            retrieve_next_sibling.tolist(),
+            [[2, -1, -1, -1, -1, -1], [-1, -1, -1, -1, -1, -1]],
+        )
+
+    def test_compact_window_and_scatter_keep_fixed_tree_layout(self):
+        layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=torch.tensor([2, 3]), graph_num_tokens=6
+        )
+        draft_tokens = torch.tensor([10, 11, 12, 13, 20, 21, 22, 23])
+        positions = torch.arange(100, 108)
+        out_cache_loc = torch.arange(200, 208)
+
+        window = build_eagle_ragged_verify_window(
+            draft_tokens=draft_tokens,
+            positions=positions,
+            out_cache_loc=out_cache_loc,
+            layout=layout,
+            draft_token_num=4,
+            padded_bs=2,
+        )
+
+        # The final row is graph padding and is ignored below.
+        self.assertEqual(window.input_ids.tolist(), [10, 11, 12, 20, 21, 22])
+        compact = torch.arange(12, dtype=torch.float32).view(6, 2)
+        strided = scatter_eagle_verify_output(
+            compact=compact,
+            layout=layout,
+            query_layout=window.query_layout,
+            draft_token_num=4,
+        ).view(2, 4, 2)
+        self.assertTrue(torch.equal(strided[0, :2], compact[:2]))
+        self.assertTrue(torch.equal(strided[1, :3], compact[3:6]))
+        self.assertTrue(torch.equal(strided[0, 2:], torch.zeros(2, 2)))
+        self.assertTrue(torch.equal(strided[1, 3:], torch.zeros(1, 2)))
+
+    def test_exact_eager_window_does_not_add_padding(self):
+        layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=torch.tensor([2, 3]), graph_num_tokens=5
+        )
+        dense = torch.tensor([10, 11, 12, 13, 20, 21, 22, 23])
+
+        window = build_eagle_ragged_verify_window(
+            draft_tokens=dense,
+            positions=dense + 100,
+            out_cache_loc=dense + 200,
+            layout=layout,
+            draft_token_num=4,
+            padded_bs=2,
+        )
+
+        self.assertEqual(window.query_layout.verify_lens.tolist(), [2, 3])
+        self.assertEqual(window.input_ids.tolist(), [10, 11, 20, 21, 22])
+
+    def test_graph_tier_selection_checks_token_and_slot_capacity(self):
+        class FakeGraphRunner:
+            ragged_verify_mode = True
+            capture_num_tokens = [6, 12, 18, 24]
+
+            def __init__(self, max_slots):
+                self.max_slots = max_slots
+
+            def _ragged_capture_slots(self, num_tokens):
+                return min(num_tokens, self.max_slots)
+
+        runner = FakeGraphRunner(max_slots=4)
+        self.assertTrue(
+            eagle_ragged_graph_tier_eligible(
+                graph_num_tokens=6,
+                batch_size=4,
+                graph_runner=runner,
+            )
+        )
+        self.assertFalse(
+            eagle_ragged_graph_tier_eligible(
+                graph_num_tokens=6,
+                batch_size=6,
+                graph_runner=runner,
+            )
+        )
+        self.assertEqual(
+            _select_eagle_ragged_graph_num_tokens(
+                total_verify_tokens=13,
+                batch_size=4,
+                graph_runner=runner,
+            ),
+            18,
+        )
+        self.assertEqual(
+            _select_eagle_ragged_graph_num_tokens(
+                total_verify_tokens=5,
+                batch_size=5,
+                graph_runner=runner,
+            ),
+            5,
+        )
+        self.assertEqual(
+            _select_eagle_ragged_graph_num_tokens(
+                total_verify_tokens=25,
+                batch_size=4,
+                graph_runner=runner,
+            ),
+            25,
+        )
+        self.assertEqual(
+            _select_eagle_ragged_graph_num_tokens(
+                total_verify_tokens=13,
+                batch_size=4,
+                graph_runner=None,
+            ),
+            13,
+        )
+
+    def test_bucket_padding_respects_fixed_tree_width(self):
+        layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=torch.tensor([1, 4, 4, 4]), graph_num_tokens=18
+        )
+        dense = torch.arange(24)
+        window = build_eagle_ragged_verify_window(
+            draft_tokens=dense,
+            positions=dense + 100,
+            out_cache_loc=dense + 200,
+            layout=layout,
+            draft_token_num=6,
+            padded_bs=4,
+        )
+
+        padded = window.query_layout
+
+        self.assertEqual(padded.verify_lens.tolist(), [3, 5, 5, 5])
+        self.assertEqual(int(padded.verify_lens.sum()), 18)
+        self.assertLessEqual(int(padded.verify_lens.max()), 6)
+
+        compact = torch.arange(18, dtype=torch.float32).view(18, 1)
+        strided = scatter_eagle_verify_output(
+            compact=compact,
+            layout=layout,
+            query_layout=padded,
+            draft_token_num=6,
+        ).view(4, 6)
+        self.assertEqual(strided[0, :1].tolist(), [0.0])
+        self.assertEqual(strided[1, :4].tolist(), [3.0, 4.0, 5.0, 6.0])
+        self.assertEqual(strided[2, :4].tolist(), [8.0, 9.0, 10.0, 11.0])
+        self.assertEqual(strided[3, :4].tolist(), [13.0, 14.0, 15.0, 16.0])
+        self.assertTrue(torch.equal(strided[:, 4:], torch.zeros(4, 2)))
+
+    def test_graph_padding_rows_for_extra_request_slots_are_zeroed(self):
+        layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=torch.tensor([2, 1]), graph_num_tokens=8
+        )
+        dense = torch.arange(8)
+
+        window = build_eagle_ragged_verify_window(
+            draft_tokens=dense,
+            positions=dense + 100,
+            out_cache_loc=dense + 200,
+            layout=layout,
+            draft_token_num=4,
+            padded_bs=3,
+        )
+
+        self.assertEqual(window.query_layout.verify_lens.tolist(), [4, 3, 1])
+        self.assertEqual(window.input_ids.tolist(), [0, 1, 2, 3, 4, 5, 6, 0])
+        self.assertEqual(
+            window.positions.tolist(), [100, 101, 102, 103, 104, 105, 106, 0]
+        )
+        self.assertEqual(
+            window.out_cache_loc.tolist(),
+            [200, 201, 202, 203, 204, 205, 206, 0],
+        )
+
+    def test_exact_token_bucket_allows_zero_length_dummy_slots(self):
+        layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=torch.tensor([2, 2]), graph_num_tokens=4
+        )
+        dense = torch.arange(8)
+
+        window = build_eagle_ragged_verify_window(
+            draft_tokens=dense,
+            positions=dense + 100,
+            out_cache_loc=dense + 200,
+            layout=layout,
+            draft_token_num=4,
+            padded_bs=4,
+        )
+
+        self.assertEqual(window.query_layout.verify_lens.tolist(), [2, 2, 0, 0])
+        self.assertEqual(window.query_layout.qo_indptr_device.tolist(), [0, 2, 4, 4, 4])
+        self.assertEqual(window.input_ids.tolist(), [0, 1, 4, 5])
+
+    def test_rejects_invalid_host_query_layout(self):
+        dense = torch.arange(8)
+        cases = [
+            RaggedVerifyLayout.from_verify_lens_device(
+                verify_lens=torch.tensor([2, 5]), graph_num_tokens=7
+            ),
+            RaggedVerifyLayout.from_verify_lens_device(
+                verify_lens=torch.tensor([2, 2]), graph_num_tokens=3
+            ),
+        ]
+
+        for layout in cases:
+            with self.subTest(verify_lens=layout.verify_lens.tolist()):
+                with self.assertRaises(ValueError):
+                    build_eagle_ragged_verify_window(
+                        draft_tokens=dense,
+                        positions=dense + 100,
+                        out_cache_loc=dense + 200,
+                        layout=layout,
+                        draft_token_num=4,
+                        padded_bs=2,
+                    )
+
+    def test_dense_topk_graph_padding_uses_only_real_tree_masks(self):
+        backend = object.__new__(FlashAttentionBackend)
+        backend.speculative_num_draft_tokens = 3
+        backend.req_to_token = torch.arange(32).view(2, 16)
+        spec_info = SimpleNamespace(
+            custom_mask=(torch.arange(24) % 2 == 0),
+            ragged_verify_layout=None,
+        )
+
+        mask, page_table = backend._build_target_verify_topk_expand_inputs(
+            seq_lens=torch.tensor([5, 7]),
+            req_pool_indices=torch.tensor([0, 1]),
+            spec_info=spec_info,
+            query_layout=None,
+            real_bs=1,
+        )
+
+        self.assertEqual(mask.shape, (6, 3))
+        self.assertEqual(page_table.shape, (6, 3))
+        expected_padding_mask = torch.tensor([[True, False, False]]).expand(3, -1)
+        self.assertTrue(torch.equal(mask[3:], expected_padding_mask))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_cuda_padding_compaction_and_scatter_match_expected_layout(self):
+        device = torch.device("cuda")
+        layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=torch.tensor([1, 4, 4, 4], device=device),
+            graph_num_tokens=18,
+        )
+        dense = torch.arange(24, device=device)
+
+        window = build_eagle_ragged_verify_window(
+            draft_tokens=dense,
+            positions=dense + 100,
+            out_cache_loc=dense + 200,
+            layout=layout,
+            draft_token_num=6,
+            padded_bs=4,
+        )
+
+        self.assertEqual(window.query_layout.verify_lens.cpu().tolist(), [3, 5, 5, 5])
+        self.assertEqual(
+            window.input_ids.cpu().tolist(),
+            [0, 1, 2, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22],
+        )
+
+        compact = torch.arange(1, 19, dtype=torch.float32, device=device).view(18, 1)
+        strided = scatter_eagle_verify_output(
+            compact=compact,
+            layout=layout,
+            query_layout=window.query_layout,
+            draft_token_num=6,
+        ).view(4, 6)
+        expected = torch.tensor(
+            [
+                [1, 0, 0, 0, 0, 0],
+                [4, 5, 6, 7, 0, 0],
+                [9, 10, 11, 12, 0, 0],
+                [14, 15, 16, 17, 0, 0],
+            ],
+            dtype=torch.float32,
+            device=device,
+        )
+        self.assertTrue(torch.equal(strided, expected))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+    def test_cuda_extra_graph_slots_match_torch_reference(self):
+        cpu_layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=torch.tensor([2, 1]), graph_num_tokens=8
+        )
+        cuda_layout = RaggedVerifyLayout.from_verify_lens_device(
+            verify_lens=cpu_layout.verify_lens.cuda(),
+            graph_num_tokens=8,
+        )
+        dense = torch.arange(8)
+
+        cpu_window = build_eagle_ragged_verify_window(
+            draft_tokens=dense,
+            positions=dense + 100,
+            out_cache_loc=dense + 200,
+            layout=cpu_layout,
+            draft_token_num=4,
+            padded_bs=3,
+        )
+        cuda_window = build_eagle_ragged_verify_window(
+            draft_tokens=dense.cuda(),
+            positions=(dense + 100).cuda(),
+            out_cache_loc=(dense + 200).cuda(),
+            layout=cuda_layout,
+            draft_token_num=4,
+            padded_bs=3,
+        )
+
+        self.assertTrue(
+            torch.equal(
+                cuda_window.query_layout.verify_lens.cpu(),
+                cpu_window.query_layout.verify_lens,
+            )
+        )
+        self.assertTrue(torch.equal(cuda_window.input_ids.cpu(), cpu_window.input_ids))
+        self.assertTrue(torch.equal(cuda_window.positions.cpu(), cpu_window.positions))
+        self.assertTrue(
+            torch.equal(cuda_window.out_cache_loc.cpu(), cpu_window.out_cache_loc)
+        )
+
+        compact = torch.arange(24, dtype=torch.float32).view(8, 3)
+        cpu_output = scatter_eagle_verify_output(
+            compact=compact,
+            layout=cpu_layout,
+            query_layout=cpu_window.query_layout,
+            draft_token_num=4,
+        )
+        cuda_output = scatter_eagle_verify_output(
+            compact=compact.cuda(),
+            layout=cuda_layout,
+            query_layout=cuda_window.query_layout,
+            draft_token_num=4,
+        )
+        self.assertTrue(torch.equal(cuda_output.cpu(), cpu_output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
+++ b/test/registered/unit/spec/test_eagle_worker_v2_topk1_fastpath.py
@@ -154,6 +154,7 @@ class TestEagleWorkerV2BackendFallback(CustomTestCase):
             torch.zeros((1, 1), dtype=torch.long, device=DEVICE),
             torch.zeros((1, 1), dtype=torch.long, device=DEVICE),
             None,
+            None,
         )
         tree_result = (
             torch.empty((0,), dtype=torch.bool, device=DEVICE),


### PR DESCRIPTION
## Motivation

This PR adds ECHO as an opt-in EAGLE3 mode. ECHO is disabled by default and is
enabled with `--speculative-echo-threshold`.

Paper: [ECHO: Elastic Speculative Decoding with Sparse Gating for High-Concurrency Scenarios](https://arxiv.org/abs/2604.09603) (ICML 2026; [conference page](https://icml.cc/virtual/2026/poster/64670)).

## Modifications

- Add `--speculative-echo-threshold`.
- Add Torch/Triton runtime support for ECHO.
- Integrate ECHO with EAGLE3 eager execution and FA3 CUDA Graph replay.
- Expose ECHO runtime metadata in speculative metrics.
- Add deterministic MT-Bench graph/eager tests and a reproducible full
  MT-Bench A/B benchmark.
- Document the argument, supported configuration, correctness workflow, and
  benchmark protocol.

ECHO is disabled by default. The supported path in this PR is:

- `--speculative-algorithm EAGLE3`
- `--attention-backend fa3`
- `--disable-overlap-schedule`
- `--speculative-eagle-topk > 1`

Unsupported combinations are rejected during argument validation.

Example:

```bash
--speculative-echo-threshold 0.2
```

## Accuracy Tests

All model-level correctness and performance tests use the pinned FastChat
MT-Bench dataset at commit
`587d5cfa1609a43d192cedb8441cac3c17db105d`. This is a controlled serving
workload, not an MT-Bench judge or quality score.

- Full pre-commit suite over all changed files: passed.
- Combined unit/regression run: `59 passed`, plus `61` subtests.
  - Includes argument validation, graph-tier/slot boundaries, zero-length
    dummy slots, ordinary dense EAGLE padding, and shared
    speculative-decoding regression coverage.
- Current tree:
  - `15` ECHO unit tests and `2` subtests passed;
  - real CUDA parity passed for all three ECHO-specific Triton kernels;
  - the registered Qwen3-8B integration below passed `3 / 3`.
- Qwen3-8B registered ECHO MT-Bench integration:
  - EAGLE3 3/3/6, FA3, non-overlap, threshold 0.2;
  - graph/eager text, token IDs, finish reasons, and speculative counters
    matched exactly;
  - EOS and 1-3-token early-finish cases passed;
  - acceptance length `2.4774`;
  - `3 / 3` tests passed.
- Ordinary fixed-depth EAGLE3 regression:
  - the same 8-category, two-turn MT-Bench smoke workload matched exactly
    between graph and eager execution.
- Full Qwen3-8B deterministic parity:
  - 80 conversations, 160 turns;
  - graph vs eager exact match: `160 / 160`;
  - zero request errors.
- Qwen3-235B-A22B deterministic parity:
  - 32 stratified conversations covering all eight categories, 64 turns;
  - graph vs eager exact match: `64 / 64`;
  - zero request errors.

## Speed Tests and Profiling

Both arms use identical model/server/request parameters and the same frozen
turn-one assistant history. Each row reports three timed runs; server startup,
graph capture, warmup, and history preparation are excluded.

Common configuration:

- NVIDIA H20-3e (one GPU for 8B and eight GPUs for 235B)
- EAGLE3 steps/top-k/draft tokens: `5 / 8 / 32`
- BF16, FA3, `--disable-overlap-schedule`
- CUDA Graph max decode batch size 32
- radix cache disabled
- 80 MT-Bench conversations, two turns each
- concurrency 32, maximum 1024 new tokens per turn
- greedy decoding, seed 0, `enable_thinking=False`

| Target | Configuration | R1 | R2 | R3 | Median | Accept length |
|---|---|---:|---:|---:|---:|---:|
| Qwen3-8B, TP=1 | EAGLE3 baseline | 639.98 | 640.56 | 641.22 | **640.56 tok/s** | 3.305 |
| Qwen3-8B, TP=1 | ECHO, threshold 0.2 | 866.65 | 874.31 | 873.72 | **873.72 tok/s** | 2.775 |
| Qwen3-8B, TP=1 | Change | | | | **+36.40%** | |
| Qwen3-235B-A22B, TP=8 | EAGLE3 baseline | 797.09 | 793.04 | 796.60 | **796.60 tok/s** | 3.016 |
| Qwen3-235B-A22B, TP=8 | ECHO, threshold 0.05 | 840.18 | 841.87 | 843.18 | **841.87 tok/s** | 2.806 |
| Qwen3-235B-A22B, TP=8 | Change | | | | **+5.68%** | |

Additional median changes:

| Target | Conversations/s | Wall time |
|---|---:|---:|
| Qwen3-8B | +34.32% | -25.55% |
| Qwen3-235B-A22B | +4.99% | -4.75% |

All 12 timed runs completed `160 / 160` turns with zero request errors and
zero cached tokens. ECHO runtime metric accounting matched the speculative
verify count in every run.

The fixed and ECHO paths may generate slightly different output lengths from
legal BF16 batch/GEMM-shape differences. Median completion volume differed by
0.92% for 8B and 1.11% for 235B; throughput is measured as actual completion
tokens divided by wall time. Deterministic graph/eager correctness is reported
separately above.

## Checklist

- [x] Format code according to the SGLang pre-commit requirements.
- [x] Add unit and CUDA integration tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30769307070](https://github.com/sgl-project/sglang/actions/runs/30769307070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30769306983](https://github.com/sgl-project/sglang/actions/runs/30769306983)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->