### PR TITLE
[AMD][Kimi-K3] Fix tiny_k_gemm dispatch regression on gfx950

### DIFF
--- a/python/sglang/kernels/ops/kimi_k3/__init__.py
+++ b/python/sglang/kernels/ops/kimi_k3/__init__.py
@@ -5,11 +5,14 @@ from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     import torch
 
+from sglang.kernels.jit.utils.common import is_hip_runtime
+
 _K3_N_GEMM_DISPATCH_MAP = {
     (144, 7168): 16,
     (896, 7168): 8,
 }
-_K3_K_GEMM_DISPATCH_MAP: dict = {}  # tiny_k_gemm is 2.5x slower than torch.linear on gfx950
+# tiny_k_gemm is 2.5x slower than torch.linear for (1536, 128) on AMD gfx950
+_K3_K_GEMM_DISPATCH_MAP: dict = {} if is_hip_runtime() else {(1536, 128): 12}
 
 
 def situ_and_mul(

--- a/python/sglang/kernels/ops/kimi_k3/__init__.py
+++ b/python/sglang/kernels/ops/kimi_k3/__init__.py
@@ -9,9 +9,7 @@ _K3_N_GEMM_DISPATCH_MAP = {
     (144, 7168): 16,
     (896, 7168): 8,
 }
-_K3_K_GEMM_DISPATCH_MAP = {
-    (1536, 128): 12,
-}
+_K3_K_GEMM_DISPATCH_MAP: dict = {}  # tiny_k_gemm is 2.5x slower than torch.linear on gfx950
 
 
 def situ_and_mul(


### PR DESCRIPTION
## Motivation

The `tiny_k_gemm` JIT kernel is dispatched for the `f_b_proj` shape `(N=1536, K=128)` on gfx950, but it is **2.46x slower** than `torch.linear` at this shape due to occupancy mismatch (32.87µs vs 13.39µs on MI355X). This fires for every decode step across all 69 KDA linear attention layers in Kimi-K3.

## Modifications

`python/sglang/kernels/ops/kimi_k3/__init__.py`: Remove the `(1536, 128)` entry from `_K3_K_GEMM_DISPATCH_MAP`, restoring `torch.linear` as the correct kernel for this shape on gfx950.

## Accuracy Tests

No change to numerical outputs — both kernels compute identical results.

## Speed Tests and Profiling

Measured on MI355X (gfx950) at M=1:

| Kernel | Time |
|---|---|
| `tiny_k_gemm` (removed) | 32.87 µs |
| `torch.linear` (restored) | 13.39 µs |
| **Speedup** | **2.46x** |

End-to-end: ~1.25ms saved per decode step on Kimi-K3 TP8.

## Repro Steps

**Hardware:** AMD MI355X (gfx950), ROCm 7.x

**Unit test (verifies dispatch map + correctness):**
```bash
python test/manual/test_amd_k3_gemm_dispatch_fix.py
```

**Manual verification:**
```bash
python -c "
from sglang.srt.utils import is_hip
from sglang.kernels.ops.kimi_k3 import _K3_K_GEMM_DISPATCH_MAP
print('is_hip:', is_hip())
print('(1536,128) in map:', (1536, 128) in _K3_K_GEMM_DISPATCH_MAP)
# On gfx950 this must print False
"
```

**Latency comparison:**
```bash
python -c "
import torch, time
device = 'cuda'
M, N, K = 1, 1536, 128
x = torch.randn(M, K, device=device, dtype=torch.bfloat16)
w = torch.randn(N, K, device=device, dtype=torch.bfloat16)
for _ in range(100): torch.mm(x, w.t())
torch.cuda.synchronize()
t0 = time.perf_counter()
for _ in range(1000): torch.mm(x, w.t())
torch.cuda.synchronize()
print(f'torch.mm: {(time.perf_counter()-t0)/1000*1e6:.2f} us')
"
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30953183030](https://github.com/sgl-project/sglang/actions/runs/30953183030)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30953180303](https://github.com/sgl-project/sglang/actions/runs/30953180303)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->