### PR TITLE
[AMD] Enable MI455X (gfx1250) CI with GPT-OSS-120B MXFP4 nightly

### DIFF
--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -1866,12 +1866,14 @@ jobs:
       - name: Install dependencies
         run: bash scripts/ci/amd/amd_ci_install_dependency.sh
 
+      # 90m step > 60m run_suite --timeout-per-file > 30m server-launch timeout in
+      # the test, so a slow cold start cannot get the file killed mid-eval.
       - name: GPT-OSS-120B MXFP4 Accuracy (1-GPU)
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-amd-1-gpu-mi45x --nightly --timeout-per-file 1800 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+            python3 run_suite.py --hw amd --suite nightly-amd-1-gpu-mi45x --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -27,6 +27,9 @@ on:
         default: 'all'
         options:
           - 'all'
+          # MI455X (gfx1250) — GPT-OSS-120B MXFP4
+          - nightly-1-gpu-mi45x-gpt-oss
+          - nightly-perf-1-gpu-mi45x-gpt-oss
           # 1-GPU Unit Tests (MI30x + MI35x)
           - nightly-test-1-gpu-unit
           - nightly-test-1-gpu-kernel
@@ -1836,6 +1839,77 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
+  # MI455X (gfx1250) bring-up — GPT-OSS-120B MXFP4, 1 GPU
+  # ==============================================================================
+  # Accuracy gates (listed in check-all-jobs); perf reports only, matching how
+  # every other perf job here is treated.
+
+  nightly-1-gpu-mi45x-gpt-oss:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-1-gpu-mi45x-gpt-oss,'))
+    runs-on: linux-mi45x-gpu-1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: GPT-OSS-120B MXFP4 Accuracy (1-GPU)
+        timeout-minutes: 60
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-1-gpu-mi45x --nightly --timeout-per-file 1800 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  # Separate job from the accuracy gate above: perf is report-only, so a
+  # throughput blip must not turn check-all-jobs red. Shares the single MI455X
+  # runner, so it queues behind the accuracy job rather than running alongside.
+  nightly-perf-1-gpu-mi45x-gpt-oss:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-perf-1-gpu-mi45x-gpt-oss,'))
+    runs-on: linux-mi45x-gpu-1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: GPT-OSS-120B MXFP4 Performance (1-GPU)
+        timeout-minutes: 90
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-1-gpu-mi45x-gpt-oss --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  # ==============================================================================
   # Diffusion (MI30x)
   # ==============================================================================
 
@@ -1940,6 +2014,9 @@ jobs:
       - nightly-4-gpu-mi35x-minimax-m3
       # 8-GPU MiniMax-M2.7 (MI30x only)
       - nightly-8-gpu-minimax-m27
+      # MI455X (gfx1250) bring-up — GPT-OSS-120B MXFP4
+      - nightly-1-gpu-mi45x-gpt-oss
+      # - nightly-perf-1-gpu-mi45x-gpt-oss  # excluded: perf failures don't block CI
       # Diffusion (MI30x)
       - nightly-1-gpu-zimage-turbo
     runs-on: ubuntu-latest

--- a/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm7_15-nightly.yml
@@ -10,8 +10,11 @@ on:
         options:
           - 'all'
           - publish
-  # schedule:
-  #   - cron: '0 12 * * *'
+  schedule:
+    # Must stay within the 7-day walk-back window that
+    # scripts/ci/amd/amd_ci_start_container.sh uses to discover the dated tag,
+    # otherwise MI455X CI cannot find an image. Matches the other AMD nightlies.
+    - cron: '0 12 * * *'
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -68,11 +71,11 @@ jobs:
           echo "Detected version: ${VERSION}"
           echo "Pretend version for pip: ${PRETEND_VERSION}"
 
-      # - name: Login to Docker Hub (AMD)
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+      - name: Login to Docker Hub (AMD)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
 
       - name: Build and Push to rocm/sgl-dev
         run: |
@@ -94,8 +97,10 @@ jobs:
           # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
           # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
           # to Canonical's archive.ubuntu.com mirror IPs from the build runner.
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.sha }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg GPU_ARCH_LIST_ARG=gfx1250 --build-arg ENABLE_MORI=1 --build-arg SGLANG_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
-          # docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
+          # GPU_ARCH_LIST is derived in the Dockerfile as ${GPU_ARCH%-*}, which already
+          # yields gfx1250 here, so no separate arch build-arg is needed.
+          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=${{ github.sha }} --build-arg BUILD_TYPE=${{ matrix.build_type }} --build-arg GPU_ARCH=${{ matrix.gpu_arch }} --build-arg ENABLE_MORI=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
+          docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       - name: Login to Docker Hub (lmsys)
         uses: docker/login-action@v2

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -1,4 +1,5 @@
 # Usage (to build SGLang ROCm docker image):
+#   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx1250-rocm7_15 -t v0.5.10.post1-rocm7.15-mi45x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942 -t v0.5.10.post1-rocm700-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx942-rocm720 -t v0.5.10.post1-rocm720-mi30x -f rocm.Dockerfile .
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950 -t v0.5.10.post1-rocm700-mi35x -f rocm.Dockerfile .
@@ -21,6 +22,10 @@
 #   docker build --build-arg SGL_BRANCH=v0.5.10.post1 --build-arg GPU_ARCH=gfx950-rocm720 -t v0.5.10.post1-rocm720-mi35x -f rocm.Dockerfile .
 
 # Default base images
+# gfx1250 (MI455X) has no published rocm/pytorch base yet, so its stage starts
+# from plain Ubuntu and pip-installs the ROCm SDK + torch stack from the ROCm
+# nightly index (see the gfx1250-rocm7_15 stage below).
+ARG BASE_IMAGE_1250_ROCM7_15="ubuntu:24.04"
 ARG BASE_IMAGE_942="rocm/sgl-dev:rocm7-vllm-20250904"
 ARG BASE_IMAGE_942_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_release_2.9.1"
 ARG BASE_IMAGE_950="rocm/sgl-dev:rocm7-vllm-20250904"
@@ -28,6 +33,69 @@ ARG BASE_IMAGE_950_ROCM720="rocm/pytorch:rocm7.2_ubuntu22.04_py3.10_pytorch_rele
 
 # This is necessary for scope purpose
 ARG GPU_ARCH=gfx950
+
+# ===============================
+# Base image 1250 (MI455X) with rocm7_15 and args
+# Unlike the gfx942/gfx950 stages there is no ROCm base image for gfx1250 yet,
+# so this stage builds the toolchain itself: venv + ROCm SDK + torch from the
+# ROCm nightly wheel index.
+FROM $BASE_IMAGE_1250_ROCM7_15 AS gfx1250-rocm7_15
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git gnupg build-essential \
+        python3 python3-dev python3-pip python-is-python3 python3.12-venv \
+        wget libstdc++-12-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN python3 -m pip install --no-cache-dir -U pip setuptools setuptools_scm wheel
+
+# Version pins for the ROCm 7.15 nightly stack — override with --build-arg.
+ARG ROCM_VERSION="7.15.0a20260712"
+ARG INDEX_URL="https://rocm.nightlies.amd.com/whl-multi-arch/"
+ARG TORCH_VERSION="2.11.0"
+ARG TORCHVISION_VERSION="0.26.0"
+ARG TRITON_VERSION="3.7.1+git0263a6a6"
+
+RUN python3 -m pip install --no-cache-dir --pre \
+    --index-url ${INDEX_URL} \
+    --extra-index-url https://rocm.devreleases.amd.com/whl-multi-arch \
+    "rocm[libraries,devel,device-gfx1250]==${ROCM_VERSION}" \
+    "torch[device-gfx1250]==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+    "torchvision[device-gfx1250]==${TORCHVISION_VERSION}+rocm${ROCM_VERSION}" \
+    "torchaudio==${TORCH_VERSION}+rocm${ROCM_VERSION}" \
+    "triton==${TRITON_VERSION}.rocm${ROCM_VERSION}"
+
+RUN rocm-sdk init && rocm-sdk targets
+ENV ROCM_HOME=$VIRTUAL_ENV/lib/python3.12/site-packages/_rocm_sdk_devel
+ENV CPATH=$ROCM_HOME/include
+ENV LIBRARY_PATH=$ROCM_HOME/lib
+ENV LD_LIBRARY_PATH=$ROCM_HOME/lib
+ENV ROCM_PATH=$ROCM_HOME
+RUN echo 'export PATH=$ROCM_HOME/llvm/bin:$ROCM_HOME/bin:$PATH' >> /etc/bash.bashrc
+
+# ROCm SDK's hsakmtTargets.cmake hardcodes /usr/lib64/libc.so from its own build
+# system; Ubuntu keeps libc at /lib/x86_64-linux-gnu. Without this symlink ninja
+# fails with "/usr/lib64/libc.so missing and no known rule to make it".
+RUN mkdir -p /usr/lib64 && ln -sf /lib/x86_64-linux-gnu/libc.so /usr/lib64/libc.so
+
+# ROCm is pip-installed here rather than living at /opt/rocm, but AITER shells out
+# to /opt/rocm/llvm/bin/amdgpu-arch at runtime to resolve DEFAULT_GPU_ARCH.
+RUN ln -s ${ROCM_HOME} /opt/rocm
+
+# gfx1250 kernels landed in AITER/Triton/MORI after the pins the other stages use,
+# so this stage carries its own, newer defaults.
+ENV BUILD_VLLM="0"
+ENV BUILD_TRITON="1"
+ENV BUILD_LLVM="0"
+ENV BUILD_AITER_ALL="1"
+ENV BUILD_MOONCAKE="1"
+ENV PYTORCH_ROCM_ARCH="gfx1250"
+ENV AITER_COMMIT_DEFAULT="604e41158eefa4317a1d3aa9945c410c239a9f58"
+ENV TRITON_COMMIT_DEFAULT="c57bbbd8c1d83a8388baa508cf1286bfdad1695d"
+ENV MORI_COMMIT_DEFAULT="e31d426a13e96e1cbff96a1c904d291aefe8c46a"
 
 # ===============================
 # Base image 942 with rocm700 and args
@@ -38,6 +106,7 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV TRITON_COMMIT_DEFAULT="42270451990532c67e69d753fbd026f28fcc4840"
 
 # ===============================
 # Base image 942 with rocm720 and args
@@ -48,6 +117,7 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV TRITON_COMMIT_DEFAULT="42270451990532c67e69d753fbd026f28fcc4840"
 
 # ===============================
 # Base image 950 and args
@@ -58,6 +128,7 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV TRITON_COMMIT_DEFAULT="42270451990532c67e69d753fbd026f28fcc4840"
 
 # ===============================
 # Base image 950 with rocm720 and args
@@ -68,6 +139,7 @@ ENV BUILD_LLVM="0"
 ENV BUILD_AITER_ALL="1"
 ENV BUILD_MOONCAKE="1"
 ENV AITER_COMMIT_DEFAULT="d9e5ef7ce08ee7045d583aed768cff41aa9210fe"
+ENV TRITON_COMMIT_DEFAULT="42270451990532c67e69d753fbd026f28fcc4840"
 
 # Local source stage: with BRANCH_TYPE=local the build context is copied here and
 # used instead of git clone (mirrors docker/Dockerfile's local_src stage).
@@ -81,7 +153,9 @@ FROM ${GPU_ARCH}
 # This is necessary for scope purpose, again
 ARG GPU_ARCH=gfx950
 ENV GPU_ARCH_LIST=${GPU_ARCH%-*}
-ENV PYTORCH_ROCM_ARCH=gfx942;gfx950
+# Stages may pin their own target (gfx1250-rocm7_15 does); everything else keeps
+# the historical gfx942;gfx950 pair.
+ENV PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx942;gfx950}"
 
 ARG SGL_REPO="https://github.com/sgl-project/sglang.git"
 ARG SGL_DEFAULT="main"
@@ -92,7 +166,10 @@ ARG BRANCH_TYPE=remote
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 
 ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
-ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
+# Same precedence as AITER_COMMIT: explicit build-arg wins, else the stage's
+# TRITON_COMMIT_DEFAULT (every stage sets one).
+ARG TRITON_COMMIT=""
+ENV TRITON_COMMIT="${TRITON_COMMIT:-${TRITON_COMMIT_DEFAULT}}"
 
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG AITER_COMMIT=""
@@ -116,7 +193,15 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
+# Literal default kept inline: scripts/ci/amd/amd_ci_install_dependency.sh greps
+# this exact `ARG MORI_COMMIT="..."` line to re-pin MORI at CI time.
 ARG MORI_COMMIT="f7e6ac6863c53821bc7afb91a578cc6ce38fcad0"
+# NOTE: precedence here is the reverse of AITER_COMMIT/TRITON_COMMIT — a stage's
+# MORI_COMMIT_DEFAULT wins over --build-arg MORI_COMMIT. That is forced by the
+# grep above needing a non-empty ARG default, which makes an explicit build-arg
+# indistinguishable from the default. No caller passes MORI_COMMIT today; if one
+# ever needs to, give the grep its own ARG and flip this to the AITER shape.
+ENV MORI_COMMIT="${MORI_COMMIT_DEFAULT:-${MORI_COMMIT}}"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).
@@ -162,6 +247,9 @@ RUN if [ -n "$UBUNTU_MIRROR" ]; then \
 # See https://github.com/ROCm/ROCm/issues/5992
 RUN set -eux; \
     case "${GPU_ARCH}" in \
+      *rocm7_15*) \
+        echo "ROCm 7.15 (GPU_ARCH=${GPU_ARCH}): libdrm supplied by the pip ROCm SDK, skipping"; \
+        ;; \
       *rocm720*) \
         echo "ROCm 7.2 (GPU_ARCH=${GPU_ARCH}): libdrm-amdgpu packages already present, skipping"; \
         ;; \
@@ -190,6 +278,12 @@ RUN apt-get purge -y sccache; python -m pip uninstall -y sccache; rm -f "$(which
 # The ROCm 7.2 base image (rocm/pytorch) does not pre-install this package.
 RUN set -eux; \
     case "${GPU_ARCH}" in \
+      *rocm7_15*) \
+        # Deliberately not installed: the SDK ships amd_smi under $ROCM_HOME, but
+        # importing it alongside this stage's torch build races during module
+        # init and aborts. Re-enable once that is fixed upstream.
+        echo "ROCm 7.15 (GPU_ARCH=${GPU_ARCH}): skipping amdsmi (torch/amdsmi init race)"; \
+        ;; \
       *rocm720*) \
         echo "ROCm 7.2 flavor detected from GPU_ARCH=${GPU_ARCH}"; \
         cd /opt/rocm/share/amd_smi \
@@ -240,7 +334,12 @@ RUN git clone ${AITER_REPO} \
 RUN cd aiter \
      && echo "[AITER] GPU_ARCH=${GPU_ARCH}" \
      && echo "[AITER] AITER_USE_SYSTEM_TRITON=${AITER_USE_SYSTEM_TRITON}" \
-     && if [ "$BUILD_AITER_ALL" = "1" ] && [ "$BUILD_LLVM" = "1" ]; then \
+     && if [ "${GPU_ARCH}" = "gfx1250-rocm7_15" ]; then \
+          # gfx1250 has no CK kernels yet, and the SDK's clang lives under
+          # $ROCM_HOME rather than on PATH.
+          sh -c "PATH=\$PATH:$ROCM_HOME/llvm/bin ENABLE_CK=0 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
+          && sh -c "PATH=\$PATH:$ROCM_HOME/llvm/bin ENABLE_CK=0 GPU_ARCHS=$GPU_ARCH_LIST pip install --no-build-isolation -e ."; \
+        elif [ "$BUILD_AITER_ALL" = "1" ] && [ "$BUILD_LLVM" = "1" ]; then \
           sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ PREBUILD_KERNELS=1 GPU_ARCHS=$GPU_ARCH_LIST python setup.py build_ext --inplace" \
           && sh -c "HIP_CLANG_PATH=/sgl-workspace/llvm-project/build/bin/ GPU_ARCHS=$GPU_ARCH_LIST pip install --config-settings editable_mode=compat -e ."; \
         elif [ "$BUILD_AITER_ALL" = "1" ]; then \
@@ -419,7 +518,7 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   git fetch --depth=1 origin "${TILELANG_COMMIT}" || true && \
   git checkout -f "${TILELANG_COMMIT}" && \
   git submodule update --init --recursive && \
-  export CMAKE_ARGS="-DUSE_CUDA=OFF -DUSE_ROCM=ON -DROCM_PATH=/opt/rocm -DLLVM_CONFIG=${LLVM_CONFIG} -DSKBUILD_SABI_VERSION= ${CMAKE_ARGS:-}" && \
+  export CMAKE_ARGS="-DUSE_CUDA=OFF -DUSE_ROCM=ON -DROCM_PATH=${ROCM_PATH:-/opt/rocm} -DLLVM_CONFIG=${LLVM_CONFIG} -DSKBUILD_SABI_VERSION= ${CMAKE_ARGS:-}" && \
   "$VENV_PIP" install -e . -v --no-build-isolation --no-deps; \
   if [ -f pyproject.toml ]; then sed -i "/^[[:space:]]*\"torch/d" pyproject.toml || true; fi; \
   "$VENV_PIP" cache purge || true; \
@@ -521,7 +620,15 @@ RUN /bin/bash -lc 'set -euo pipefail; \
   cd /sgl-workspace/mori; \
   git checkout "${MORI_COMMIT}"; \
   git submodule update --init --recursive; \
-  python3 setup.py develop; \
+  if [ "${GPU_ARCH}" = "gfx1250-rocm7_15" ]; then \
+    # ROCm lives under $ROCM_HOME here, so NUMA and the ROCm CMake packages are
+    # not on the default search path.
+    PATH=${ROCM_HOME}/bin:$PATH \
+    CMAKE_PREFIX_PATH=${ROCM_HOME}/lib/rocm_sysdeps/lib/cmake:${ROCM_HOME}/lib/cmake:${ROCM_HOME} \
+    pip install -e . --no-build-isolation; \
+  else \
+    python3 setup.py develop; \
+  fi; \
   python3 -c "import os, torch; print(os.path.join(os.path.dirname(torch.__file__), \"lib\"))" > /etc/ld.so.conf.d/torch.conf; \
   ldconfig; \
   echo "export PYTHONPATH=/sgl-workspace/mori:\${PYTHONPATH}" >> /etc/bash.bashrc; \
@@ -635,7 +742,35 @@ RUN cd /tmp/whl \
 # so future `pip install` will break the ROCm stack.
 # A workaround for this is to reinstall the default triton
 # wheel with the `rocm/pytorch` image in the root directory.
-RUN if [ "$BUILD_TRITON" = "1" ]; then \
+#
+# ROCm 7.15 (gfx1250) needs more than that: the pip-installed ROCm stack pins
+# triton by its full `<base>+<suffix>` version, so a source build that reports a
+# bare version breaks every later `pip install`
+# (https://github.com/ROCm/rocm-systems/issues/7643). Rebuild at the pinned
+# commit but keep the wheel reporting the version the SDK expects.
+RUN if [ "$BUILD_TRITON" = "1" ] && [ "${GPU_ARCH}" = "gfx1250-rocm7_15" ]; then \
+        TRITON_INSTALLED_VERSION=$(pip show triton 2>/dev/null | grep '^Version:' | cut -d' ' -f2 || echo "") \
+     && TRITON_BASE_VERSION=$(echo "$TRITON_INSTALLED_VERSION" | cut -d'+' -f1) \
+     && TRITON_VERSION_SUFFIX=$(echo "$TRITON_INSTALLED_VERSION" | grep -o '+.*' || echo "") \
+     && echo "[TRITON] preserving version $TRITON_INSTALLED_VERSION (base=$TRITON_BASE_VERSION suffix=$TRITON_VERSION_SUFFIX)" \
+     && pip uninstall -y triton \
+     && apt install -y cmake \
+     && git clone ${TRITON_REPO} triton-custom \
+     && cd triton-custom \
+     && git checkout ${TRITON_COMMIT} \
+     && if [ -n "$TRITON_BASE_VERSION" ]; then \
+            TRITON_SOURCE_VERSION=$(grep -oP 'TRITON_VERSION = "\K[^"]+' setup.py || echo "") \
+         && if [ -n "$TRITON_SOURCE_VERSION" ]; then \
+                sed -i "s/TRITON_VERSION = \"$TRITON_SOURCE_VERSION\"/TRITON_VERSION = \"$TRITON_BASE_VERSION\"/" setup.py \
+             && sed -i "s/__version__ = '$TRITON_SOURCE_VERSION'/__version__ = '$TRITON_BASE_VERSION'/" python/triton/__init__.py; \
+            fi \
+         && sed -i '/^def get_git_version_suffix():/,/^def get_triton_version_suffix():/{ /^def get_triton_version_suffix():/!{ /^def get_git_version_suffix():/!d; }; }' setup.py \
+         && sed -i '/^def get_git_version_suffix():/a\    return ""' setup.py; \
+        fi \
+     && pip install -r python/requirements.txt \
+     && TRITON_WHEEL_VERSION_SUFFIX="$TRITON_VERSION_SUFFIX" pip install -e . \
+     && if [ -d python/triton_kernels ]; then pip install -e python/triton_kernels --no-deps; fi; \
+    elif [ "$BUILD_TRITON" = "1" ]; then \
         pip uninstall -y triton \
      && apt install -y cmake \
      && git clone ${TRITON_REPO} triton-custom \

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -41,6 +41,21 @@ ARG GPU_ARCH=gfx950
 # ROCm nightly wheel index.
 FROM $BASE_IMAGE_1250_ROCM7_15 AS gfx1250-rocm7_15
 
+# This stage runs its own apt-get before the final stage's UBUNTU_MIRROR block,
+# so it has to apply the mirror itself or a port-80-restricted builder fails
+# here. Ubuntu 24.04 uses deb822 sources.list.d/ubuntu.sources, not the legacy
+# sources.list.
+ARG UBUNTU_MIRROR=
+RUN if [ -n "$UBUNTU_MIRROR" ]; then \
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+            [ -f "$f" ] || continue; \
+            sed -i "s|http://[^[:space:]/]*archive.ubuntu.com|$UBUNTU_MIRROR|g" "$f"; \
+            sed -i "s|http://[^[:space:]/]*security.ubuntu.com|$UBUNTU_MIRROR|g" "$f"; \
+        done; \
+    fi \
+ && printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
+        > /etc/apt/apt.conf.d/80-net-hardening
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl git gnupg build-essential \
         python3 python3-dev python3-pip python-is-python3 python3.12-venv \
@@ -233,9 +248,16 @@ ARG UBUNTU_CODENAME=jammy
 ARG UBUNTU_MIRROR=
 USER root
 
+# Ubuntu 24.04 (the gfx1250 base) ships deb822 sources in
+# /etc/apt/sources.list.d/ubuntu.sources and may not have the legacy
+# /etc/apt/sources.list at all, so rewrite whichever files actually exist
+# rather than assuming the legacy path.
 RUN if [ -n "$UBUNTU_MIRROR" ]; then \
-        sed -i "s|http://[^[:space:]/]*archive.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list && \
-        sed -i "s|http://[^[:space:]/]*security.ubuntu.com|$UBUNTU_MIRROR|g" /etc/apt/sources.list; \
+        for f in /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do \
+            [ -f "$f" ] || continue; \
+            sed -i "s|http://[^[:space:]/]*archive.ubuntu.com|$UBUNTU_MIRROR|g" "$f"; \
+            sed -i "s|http://[^[:space:]/]*security.ubuntu.com|$UBUNTU_MIRROR|g" "$f"; \
+        done; \
     fi && \
     printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' \
         > /etc/apt/apt.conf.d/80-net-hardening

--- a/scripts/ci/amd/amd_ci_exec.sh
+++ b/scripts/ci/amd/amd_ci_exec.sh
@@ -24,10 +24,14 @@ declare -A ENV_MAP=(
   [SGLANG_USE_AITER]=1
 )
 
-# Conditionally add GPU_ARCHS only for mi35x
-if [[ "${GPU_FAMILY}" == "mi35x" ]]; then
-  ENV_MAP[GPU_ARCHS]="gfx950"
-fi
+# Pin GPU_ARCHS for the architectures whose JIT paths need it. mi30x is left
+# unset to preserve its existing autodetect behaviour.
+case "${GPU_FAMILY}" in
+  mi35x)       ENV_MAP[GPU_ARCHS]="gfx950" ;;
+  mi45x|mi455x) ENV_MAP[GPU_ARCHS]="gfx1250"
+                # gfx1250 has no CK kernels yet; AITER must build the non-CK path.
+                ENV_MAP[ENABLE_CK]="0" ;;
+esac
 
 # Parse -w/--workdir and -e ENV=VAL
 while [[ $# -gt 0 ]]; do

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -196,10 +196,22 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
   MORI_REPO=$(grep -E '^[[:space:]]*ARG[[:space:]]+MORI_REPO=' docker/rocm.Dockerfile | head -n1 | sed 's/.*MORI_REPO="\([^"]*\)".*/\1/')
   MORI_COMMIT=$(grep -E '^[[:space:]]*ARG[[:space:]]+MORI_COMMIT=' docker/rocm.Dockerfile | head -n1 | sed 's/.*MORI_COMMIT="\([^"]*\)".*/\1/')
 
-  if [[ "${GPU_ARCH}" == "mi35x" ]]; then
-    MORI_GPU_ARCHS="gfx950"
-  else
-    MORI_GPU_ARCHS="gfx942"
+  case "${GPU_ARCH}" in
+    mi35x)        MORI_GPU_ARCHS="gfx950" ;;
+    mi45x|mi455x) MORI_GPU_ARCHS="gfx1250" ;;
+    *)            MORI_GPU_ARCHS="gfx942" ;;
+  esac
+
+  # gfx1250 needs a newer MORI than the gfx942/gfx950 pin, and the Dockerfile
+  # carries that as MORI_COMMIT_DEFAULT on the gfx1250 stage.
+  if [[ "${MORI_GPU_ARCHS}" == "gfx1250" ]]; then
+    MORI_STAGE_COMMIT=$(grep -F -A20 'FROM $BASE_IMAGE_1250_ROCM7_15 AS gfx1250-rocm7_15' docker/rocm.Dockerfile \
+                        | grep 'MORI_COMMIT_DEFAULT=' \
+                        | head -n1 \
+                        | sed 's/.*MORI_COMMIT_DEFAULT="\([^"]*\)".*/\1/')
+    if [[ -n "${MORI_STAGE_COMMIT}" ]]; then
+      MORI_COMMIT="${MORI_STAGE_COMMIT}"
+    fi
   fi
 
   echo "[MORI] Reinstalling MORI ${MORI_COMMIT} (MORI_GPU_ARCHS=${MORI_GPU_ARCHS})"
@@ -241,7 +253,13 @@ echo "[CI-AITER-CHECK] Runner GPU_ARCH=${GPU_ARCH}"
 #############################################
 # 1. Extract AITER_COMMIT from correct Dockerfile block
 #############################################
-if [[ "${GPU_ARCH}" == "mi35x" ]]; then
+if [[ "${GPU_ARCH}" == "mi45x" || "${GPU_ARCH}" == "mi455x" ]]; then
+    echo "[CI-AITER-CHECK] Using gfx1250 block from Dockerfile..."
+    REPO_AITER_COMMIT=$(grep -F -A20 'FROM $BASE_IMAGE_1250_ROCM7_15 AS gfx1250-rocm7_15' docker/rocm.Dockerfile \
+                        | grep 'AITER_COMMIT_DEFAULT=' \
+                        | head -n1 \
+                        | sed 's/.*AITER_COMMIT_DEFAULT="\([^"]*\)".*/\1/')
+elif [[ "${GPU_ARCH}" == "mi35x" ]]; then
     echo "[CI-AITER-CHECK] Using gfx950 block from Dockerfile..."
     REPO_AITER_COMMIT=$(grep -F -A20 'FROM $BASE_IMAGE_950 AS gfx950' docker/rocm.Dockerfile \
                         | grep 'AITER_COMMIT_DEFAULT=' \
@@ -322,18 +340,27 @@ if [[ "${NEED_REBUILD}" == "true" ]]; then
         pip install -r requirements.txt
     "
 
-    if [[ "${GPU_ARCH}" == "mi35x" ]]; then
-        GPU_ARCH_LIST="gfx950"
-    else
-        GPU_ARCH_LIST="gfx942"
-    fi
+    case "${GPU_ARCH}" in
+        mi35x)        GPU_ARCH_LIST="gfx950" ;;
+        mi45x|mi455x) GPU_ARCH_LIST="gfx1250" ;;
+        *)            GPU_ARCH_LIST="gfx942" ;;
+    esac
     echo "[CI-AITER-CHECK] GPU_ARCH_LIST=${GPU_ARCH_LIST}"
 
-    # build AITER
-    docker exec ci_sglang bash -c "
-        cd /sgl-workspace/aiter && \
-        AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
-    "
+    # build AITER. gfx1250 has no CK kernels yet and its clang lives under
+    # $ROCM_HOME rather than on PATH (ROCm is pip-installed on that image).
+    if [[ "${GPU_ARCH_LIST}" == "gfx1250" ]]; then
+        docker exec ci_sglang bash -c '
+            cd /sgl-workspace/aiter && \
+            PATH=$PATH:$ROCM_HOME/llvm/bin ENABLE_CK=0 AITER_USE_SYSTEM_TRITON=1 \
+            GPU_ARCHS='"${GPU_ARCH_LIST}"' python3 setup.py develop
+        '
+    else
+        docker exec ci_sglang bash -c "
+            cd /sgl-workspace/aiter && \
+            AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
+        "
+    fi
 
     echo "[CI-AITER-CHECK] === AITER REBUILD COMPLETE ==="
 fi

--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -187,6 +187,25 @@ EOF
   docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache accelerate || echo "accelerate installation failed"
 fi
 
+# Read `ENV <VAR>="<value>"` from a single docker/rocm.Dockerfile build stage.
+# Scoped from the stage's FROM line to the next FROM, so it does not depend on
+# how long the stage is — a fixed `grep -A<n>` window silently returned nothing
+# once the gfx1250 stage grew past it, and under `set -o pipefail` that aborts
+# the whole script.
+dockerfile_stage_var() {
+  local stage="$1" var="$2"
+  awk -v stage="$stage" -v var="$var" '
+    $0 ~ ("^FROM .* AS " stage "$") { in_stage = 1; next }
+    in_stage && /^FROM / { exit }
+    in_stage && $0 ~ ("^ENV[[:space:]]+" var "=") {
+      if (match($0, /"[^"]*"/)) {
+        print substr($0, RSTART + 1, RLENGTH - 2)
+        exit
+      }
+    }
+  ' docker/rocm.Dockerfile
+}
+
 # -----------------------
 # MORI
 # The CI image bakes MORI at the docker/rocm.Dockerfile-pinned commit; when a PR
@@ -205,13 +224,12 @@ if docker exec ci_sglang test -d /sgl-workspace/mori; then
   # gfx1250 needs a newer MORI than the gfx942/gfx950 pin, and the Dockerfile
   # carries that as MORI_COMMIT_DEFAULT on the gfx1250 stage.
   if [[ "${MORI_GPU_ARCHS}" == "gfx1250" ]]; then
-    MORI_STAGE_COMMIT=$(grep -F -A20 'FROM $BASE_IMAGE_1250_ROCM7_15 AS gfx1250-rocm7_15' docker/rocm.Dockerfile \
-                        | grep 'MORI_COMMIT_DEFAULT=' \
-                        | head -n1 \
-                        | sed 's/.*MORI_COMMIT_DEFAULT="\([^"]*\)".*/\1/')
-    if [[ -n "${MORI_STAGE_COMMIT}" ]]; then
-      MORI_COMMIT="${MORI_STAGE_COMMIT}"
+    MORI_STAGE_COMMIT=$(dockerfile_stage_var gfx1250-rocm7_15 MORI_COMMIT_DEFAULT)
+    if [[ -z "${MORI_STAGE_COMMIT}" ]]; then
+      echo "[MORI] ERROR: no MORI_COMMIT_DEFAULT on the gfx1250-rocm7_15 stage" >&2
+      exit 1
     fi
+    MORI_COMMIT="${MORI_STAGE_COMMIT}"
   fi
 
   echo "[MORI] Reinstalling MORI ${MORI_COMMIT} (MORI_GPU_ARCHS=${MORI_GPU_ARCHS})"
@@ -253,25 +271,13 @@ echo "[CI-AITER-CHECK] Runner GPU_ARCH=${GPU_ARCH}"
 #############################################
 # 1. Extract AITER_COMMIT from correct Dockerfile block
 #############################################
-if [[ "${GPU_ARCH}" == "mi45x" || "${GPU_ARCH}" == "mi455x" ]]; then
-    echo "[CI-AITER-CHECK] Using gfx1250 block from Dockerfile..."
-    REPO_AITER_COMMIT=$(grep -F -A20 'FROM $BASE_IMAGE_1250_ROCM7_15 AS gfx1250-rocm7_15' docker/rocm.Dockerfile \
-                        | grep 'AITER_COMMIT_DEFAULT=' \
-                        | head -n1 \
-                        | sed 's/.*AITER_COMMIT_DEFAULT="\([^"]*\)".*/\1/')
-elif [[ "${GPU_ARCH}" == "mi35x" ]]; then
-    echo "[CI-AITER-CHECK] Using gfx950 block from Dockerfile..."
-    REPO_AITER_COMMIT=$(grep -F -A20 'FROM $BASE_IMAGE_950 AS gfx950' docker/rocm.Dockerfile \
-                        | grep 'AITER_COMMIT_DEFAULT=' \
-                        | head -n1 \
-                        | sed 's/.*AITER_COMMIT_DEFAULT="\([^"]*\)".*/\1/')
-else
-    echo "[CI-AITER-CHECK] Using gfx942 block from Dockerfile..."
-    REPO_AITER_COMMIT=$(grep -F -A20 'FROM $BASE_IMAGE_942 AS gfx942' docker/rocm.Dockerfile \
-                        | grep 'AITER_COMMIT_DEFAULT=' \
-                        | head -n1 \
-                        | sed 's/.*AITER_COMMIT_DEFAULT="\([^"]*\)".*/\1/')
-fi
+case "${GPU_ARCH}" in
+  mi45x|mi455x) AITER_STAGE="gfx1250-rocm7_15" ;;
+  mi35x)        AITER_STAGE="gfx950" ;;
+  *)            AITER_STAGE="gfx942" ;;
+esac
+echo "[CI-AITER-CHECK] Using ${AITER_STAGE} block from Dockerfile..."
+REPO_AITER_COMMIT=$(dockerfile_stage_var "${AITER_STAGE}" AITER_COMMIT_DEFAULT)
 
 
 if [[ -z "${REPO_AITER_COMMIT}" ]]; then

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -21,13 +21,19 @@ fi
 
 # Default base tags (can be overridden by command line arguments)
 ROCM_VERSION="rocm700"
+# MI455X (gfx1250) only ships on the ROCm 7.15 line, so it does not follow
+# ROCM_VERSION; it is pinned below unless --rocm-version is passed explicitly.
+MI45X_ROCM_VERSION="rocm7.15"
 DEFAULT_MI30X_BASE_TAG="${SGLANG_VERSION}-${ROCM_VERSION}-mi30x"
 DEFAULT_MI35X_BASE_TAG="${SGLANG_VERSION}-${ROCM_VERSION}-mi35x"
+DEFAULT_MI45X_BASE_TAG="${SGLANG_VERSION}-${MI45X_ROCM_VERSION}-mi45x"
 LOCAL_DOCKER_REGISTRY="10.44.14.109:5000"
 
 # Parse command line arguments
 MI30X_BASE_TAG="${DEFAULT_MI30X_BASE_TAG}"
 MI35X_BASE_TAG="${DEFAULT_MI35X_BASE_TAG}"
+MI45X_BASE_TAG="${DEFAULT_MI45X_BASE_TAG}"
+ROCM_VERSION_EXPLICIT=""
 CUSTOM_IMAGE=""
 BUILD_FROM_DOCKERFILE=""
 GPU_ARCH_BUILD=""
@@ -36,13 +42,16 @@ while [[ $# -gt 0 ]]; do
   case $1 in
     --mi30x-base-tag) MI30X_BASE_TAG="$2"; shift 2;;
     --mi35x-base-tag) MI35X_BASE_TAG="$2"; shift 2;;
+    --mi45x-base-tag) MI45X_BASE_TAG="$2"; shift 2;;
     --custom-image) CUSTOM_IMAGE="$2"; shift 2;;
     --build-from-dockerfile) BUILD_FROM_DOCKERFILE="1"; shift;;
     --gpu-arch) GPU_ARCH_BUILD="$2"; shift 2;;
     --rocm-version)
       ROCM_VERSION="$2"
+      ROCM_VERSION_EXPLICIT="1"
       MI30X_BASE_TAG="${SGLANG_VERSION}-${ROCM_VERSION}-mi30x"
       MI35X_BASE_TAG="${SGLANG_VERSION}-${ROCM_VERSION}-mi35x"
+      MI45X_BASE_TAG="${SGLANG_VERSION}-${ROCM_VERSION}-mi45x"
       echo "Using ROCm version override: ${ROCM_VERSION}"
       shift 2;;
     -h|--help)
@@ -78,8 +87,19 @@ else
   echo "Warning: could not parse GPU architecture from '${HOSTNAME_VALUE}', defaulting to ${GPU_ARCH}"
 fi
 
-# Normalise / collapse architectures we don't yet build specifically for
+# Normalise / collapse architectures we don't yet build specifically for.
+# Unrecognised architectures are a hard error: silently falling back to the
+# mi30x (gfx942) image made a job on new hardware look green while running
+# kernels built for the wrong arch.
 case "${GPU_ARCH}" in
+  mi45x|mi455x)
+    echo "Runner uses ${GPU_ARCH}; will fetch mi45x image."
+    GPU_ARCH="mi45x"
+    if [[ -z "${ROCM_VERSION_EXPLICIT}" ]]; then
+      ROCM_VERSION="${MI45X_ROCM_VERSION}"
+      echo "Pinning ROCm version to ${ROCM_VERSION} for mi45x."
+    fi
+    ;;
   mi35x)
     echo "Runner uses ${GPU_ARCH}; will fetch mi35x image."
     ;;
@@ -88,8 +108,9 @@ case "${GPU_ARCH}" in
     GPU_ARCH="mi30x"
     ;;
   *)
-    echo "Runner architecture '${GPU_ARCH}' unrecognised; defaulting to mi30x image." >&2
-    GPU_ARCH="mi30x"
+    echo "Error: unrecognised runner architecture '${GPU_ARCH}' (hostname '${HOSTNAME_VALUE}')." >&2
+    echo "Add a case arm here plus a matching image tag before running CI on this hardware." >&2
+    exit 1
     ;;
 esac
 
@@ -144,6 +165,7 @@ find_latest_image() {
   case "${gpu_arch}" in
       mi30x) base_tag="${MI30X_BASE_TAG}" ;;
       mi35x) base_tag="${MI35X_BASE_TAG}" ;;
+      mi45x) base_tag="${MI45X_BASE_TAG}" ;;
       *)     echo "Error: unsupported GPU architecture '${gpu_arch}'" >&2; return 1 ;;
   esac
 
@@ -210,6 +232,13 @@ find_latest_image() {
   fi
 
   echo "Error: no ${gpu_arch} image found in the last 7 days for base ${base_tag}" >&2
+  # The hard-coded fallbacks below only exist for mi30x/mi35x, and their `else`
+  # branches resolve to an mi30x image. Never let that answer an mi45x request —
+  # a wrong-arch image is worse than a failed job.
+  if [[ "${gpu_arch}" == "mi45x" ]]; then
+    echo "Error: no hard-coded fallback for ${gpu_arch}; is release-docker-amd-rocm7_15-nightly.yml publishing?" >&2
+    return 1
+  fi
   echo "Using hard-coded fallback for ${ROCM_VERSION}…" >&2
   case "${ROCM_VERSION}" in
     rocm720)

--- a/test/registered/amd/accuracy/mi45x/test_gpt_oss_mxfp4_eval_mi45x.py
+++ b/test/registered/amd/accuracy/mi45x/test_gpt_oss_mxfp4_eval_mi45x.py
@@ -85,8 +85,16 @@ MI45X_GPT_OSS_MXFP4_MODELS = [
         ],
         env_vars={
             "SGLANG_USE_AITER": "1",
-            # gpt-oss MXFP4 fused-MoE uses the separated gate/up tile layout;
-            # other AITER MXFP4 callers default to interleaved, so opt in.
+            # Selects GateMode.INTERLEAVE (this is also the env default).
+            #
+            # UNVERIFIED ON gfx1250 — check this first if accuracy is bad.
+            # The matching weight interleave in QuarkW4A8MXFp4MoE is gated on
+            # is_gfx95_supported(), which matches only "gfx95" and so is False
+            # on gfx1250. The kernel is therefore told INTERLEAVE while the
+            # weights are left in the checkpoint's layout. If GSM8K comes back
+            # near-random on real hardware, try "0" (SEPARATED) before touching
+            # anything else, and extend is_gfx95_supported() if the shuffle is
+            # what's actually needed.
             "SGLANG_USE_AITER_MOE_GU_ITLV": "1",
             "SGLANG_USE_AITER_UNIFIED_ATTN": "1",
             # Route MXFP4 weights through the A8W4 GEMM path.

--- a/test/registered/amd/accuracy/mi45x/test_gpt_oss_mxfp4_eval_mi45x.py
+++ b/test/registered/amd/accuracy/mi45x/test_gpt_oss_mxfp4_eval_mi45x.py
@@ -1,0 +1,259 @@
+"""MI455X GPT-OSS W4A8 MXFP4-FP8 GSM8K Completion Evaluation Test (1-GPU).
+
+Bring-up gate for MI455X (gfx1250): runs the AMD Quark
+`gpt-oss-120b-w-mxfp4-a-fp8` checkpoint (MXFP4 weights + static per-tensor FP8
+activations) as a few-shot GSM8K completion benchmark on a single GPU.
+
+The same checkpoint is already covered at TP=8 on MI35x by
+`test/registered/amd/accuracy/mi35x/test_gpt_oss_w4a8_mxfp4_eval_mi35x.py`;
+this test is deliberately the TP=1 single-GPU variant so MI455X can be gated
+on one card.
+
+Registry: nightly-amd-1-gpu-mi45x suite
+"""
+
+import ast
+import os
+import re
+import time
+import unittest
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+from sglang.utils import download_and_cache_file, read_jsonl
+
+# Register for AMD CI - MI455X GPT-OSS MXFP4 accuracy test (~20 min)
+register_amd_ci(est_time=1200, suite="nightly-amd-1-gpu-mi45x", nightly=True)
+
+INVALID = -9999999
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a model to test."""
+
+    model_path: str
+    tp_size: int = 1
+    accuracy_threshold: float = 0.79
+    other_args: Optional[List[str]] = None
+    env_vars: Optional[dict] = None
+    timeout: Optional[int] = None
+
+    def __post_init__(self):
+        if self.other_args is None:
+            self.other_args = []
+        if self.env_vars is None:
+            self.env_vars = {}
+
+
+MI45X_GPT_OSS_MXFP4_MODELS = [
+    ModelConfig(
+        model_path="amd/gpt-oss-120b-w-mxfp4-a-fp8",
+        tp_size=1,
+        # Mirrors the TP=8 MI35x peer's floor (0.79). MI455X has no measured
+        # baseline yet — confirm against the first green nightly and tighten or
+        # loosen here rather than letting the gate pass vacuously.
+        # Override for local runs with GSM8K_ACCURACY_THRESHOLD.
+        accuracy_threshold=float(os.environ.get("GSM8K_ACCURACY_THRESHOLD", "0.79")),
+        timeout=1800,
+        other_args=[
+            "--trust-remote-code",
+            # gfx1250 runs prefill on Triton and decode on the AITER unified
+            # attention kernel; neither backend covers both phases well yet.
+            "--prefill-attention-backend",
+            "triton",
+            "--decode-attention-backend",
+            "aiter",
+            "--max-running-requests",
+            "128",
+            "--mem-fraction-static",
+            "0.9",
+            "--disable-radix-cache",
+            "--page-size",
+            "64",
+        ],
+        env_vars={
+            "SGLANG_USE_AITER": "1",
+            # gpt-oss MXFP4 fused-MoE uses the separated gate/up tile layout;
+            # other AITER MXFP4 callers default to interleaved, so opt in.
+            "SGLANG_USE_AITER_MOE_GU_ITLV": "1",
+            "SGLANG_USE_AITER_UNIFIED_ATTN": "1",
+            # Route MXFP4 weights through the A8W4 GEMM path.
+            "AITER_FORCE_A8W4": "1",
+            # gfx1250 has no CK kernels yet.
+            "ENABLE_CK": "0",
+            # Coredumps on this image are multi-GB and fill the runner disk.
+            "HSA_COREDUMP_PATTERN": "/dev/null",
+        },
+    ),
+]
+
+
+def get_one_example(lines, i, include_answer):
+    """Format a single GSM8K example."""
+    ret = "Question: " + lines[i]["question"] + "\nAnswer:"
+    if include_answer:
+        ret += " " + lines[i]["answer"]
+    return ret
+
+
+def get_few_shot_examples(lines, k):
+    """Get k few-shot examples for prompting."""
+    ret = ""
+    for i in range(k):
+        ret += get_one_example(lines, i, True) + "\n\n"
+    return ret
+
+
+def get_answer_value(answer_str):
+    """Extract numerical answer from response."""
+    answer_str = answer_str.replace(",", "")
+    numbers = re.findall(r"\d+", answer_str)
+    if len(numbers) < 1:
+        return INVALID
+    try:
+        return ast.literal_eval(numbers[-1])
+    except SyntaxError:
+        return INVALID
+
+
+def run_gsm8k_benchmark(
+    base_url: str,
+    num_questions: int = 200,
+    num_shots: int = 5,
+    parallel: int = 64,
+) -> Tuple[float, float, float]:
+    """Run GSM8K few-shot completion benchmark."""
+    import sglang as sgl
+    from sglang.lang.backend.runtime_endpoint import RuntimeEndpoint
+
+    url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/test.jsonl"
+    data_path = download_and_cache_file(url)
+    lines = list(read_jsonl(data_path))
+
+    few_shot_examples = get_few_shot_examples(lines, num_shots)
+
+    questions = []
+    labels = []
+    for i in range(len(lines[:num_questions])):
+        questions.append(get_one_example(lines, i, False))
+        labels.append(get_answer_value(lines[i]["answer"]))
+    assert all(l != INVALID for l in labels)
+    arguments = [{"question": q} for q in questions]
+
+    @sgl.function
+    def few_shot_gsm8k(s, question):
+        s += few_shot_examples + question
+        s += sgl.gen(
+            "answer", max_tokens=512, stop=["Question", "Assistant:", "<|separator|>"]
+        )
+
+    backend = RuntimeEndpoint(base_url)
+    sgl.set_default_backend(backend)
+
+    tic = time.perf_counter()
+    states = few_shot_gsm8k.run_batch(
+        arguments, temperature=0, num_threads=parallel, progress_bar=True
+    )
+    latency = time.perf_counter() - tic
+
+    preds = [get_answer_value(states[i]["answer"]) for i in range(len(states))]
+    acc = np.mean(np.array(preds) == np.array(labels))
+    invalid = np.mean(np.array(preds) == INVALID)
+
+    return float(acc), float(invalid), float(latency)
+
+
+class TestGptOssMxfp4EvalMI45x(unittest.TestCase):
+    """GPT-OSS MXFP4 GSM8K Completion Evaluation Test for AMD MI455X (1-GPU)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.models = MI45X_GPT_OSS_MXFP4_MODELS
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.num_questions = int(os.environ.get("GSM8K_NUM_QUESTIONS", "200"))
+
+    def test_gpt_oss_accuracy(self):
+        """Test GPT-OSS MXFP4 models with GSM8K completion benchmark."""
+        all_results = []
+        summary = "### GPT-OSS MXFP4 Models (MI455X, 1-GPU)\n\n"
+        summary += "| Model | TP | Accuracy | Threshold | Status |\n"
+        summary += "| ----- | -- | -------- | --------- | ------ |\n"
+
+        for config in self.models:
+            with self.subTest(model=config.model_path):
+                print(f"\n{'='*60}")
+                print(f"Testing: {config.model_path}")
+                print(f"{'='*60}")
+
+                env = os.environ.copy()
+                for key, value in config.env_vars.items():
+                    env[key] = value
+
+                other_args = list(config.other_args)
+                other_args.extend(["--tp", str(config.tp_size)])
+                timeout = config.timeout or DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH
+
+                try:
+                    process = popen_launch_server(
+                        model=config.model_path,
+                        base_url=self.base_url,
+                        timeout=timeout,
+                        other_args=other_args,
+                        env=env,
+                    )
+
+                    try:
+                        acc, invalid, latency = run_gsm8k_benchmark(
+                            self.base_url, num_questions=self.num_questions
+                        )
+                        passed = acc >= config.accuracy_threshold
+                        status = "✅ PASS" if passed else "❌ FAIL"
+                        print(
+                            f"  accuracy={acc:.3f} threshold={config.accuracy_threshold} {status}"
+                        )
+
+                        all_results.append(
+                            {
+                                "model": config.model_path,
+                                "accuracy": acc,
+                                "passed": passed,
+                            }
+                        )
+                        summary += f"| {config.model_path} | {config.tp_size} | {acc:.3f} | {config.accuracy_threshold} | {status} |\n"
+
+                    finally:
+                        kill_process_tree(process.pid)
+
+                except Exception as e:
+                    summary += f"| {config.model_path} | {config.tp_size} | N/A | {config.accuracy_threshold} | ❌ ERROR |\n"
+                    all_results.append(
+                        {
+                            "model": config.model_path,
+                            "accuracy": None,
+                            "passed": False,
+                            "error": str(e),
+                        }
+                    )
+
+        if is_in_ci():
+            write_github_step_summary(summary)
+
+        failed = [r for r in all_results if not r["passed"]]
+        if failed:
+            raise AssertionError(f"Failed models: {[r['model'] for r in failed]}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi45x/test_gpt_oss_mxfp4_perf_mi45x.py
+++ b/test/registered/amd/perf/mi45x/test_gpt_oss_mxfp4_perf_mi45x.py
@@ -27,9 +27,11 @@ register_amd_ci(
 )
 
 # Server-side env for the gfx1250 MXFP4 path. Kept identical to the accuracy
-# test so the two measure the same configuration.
+# test so the two measure the same configuration — if you change one, change
+# both, or perf will be benchmarking a kernel path accuracy never validated.
 MI45X_GPT_OSS_ENV = {
     "SGLANG_USE_AITER": "1",
+    # See the accuracy test for why this is unverified on gfx1250.
     "SGLANG_USE_AITER_MOE_GU_ITLV": "1",
     "SGLANG_USE_AITER_UNIFIED_ATTN": "1",
     "AITER_FORCE_A8W4": "1",

--- a/test/registered/amd/perf/mi45x/test_gpt_oss_mxfp4_perf_mi45x.py
+++ b/test/registered/amd/perf/mi45x/test_gpt_oss_mxfp4_perf_mi45x.py
@@ -1,0 +1,155 @@
+"""MI455X nightly performance benchmark for GPT-OSS-120B MXFP4 (1-GPU).
+
+Companion to
+`test/registered/amd/accuracy/mi45x/test_gpt_oss_mxfp4_eval_mi45x.py`: same
+checkpoint, same server flags, but measures throughput/latency instead of
+accuracy. Reports only — perf jobs are deliberately excluded from the nightly
+`check-all-jobs` gate, so a regression here shows up in the step summary
+without blocking CI.
+
+Registry: nightly-perf-1-gpu-mi45x-gpt-oss suite
+"""
+
+import os
+import unittest
+from typing import List
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import BenchmarkResult
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+# Register for AMD CI - GPT-OSS-120B MXFP4 benchmark on MI455X (~40 min)
+register_amd_ci(
+    est_time=2400,
+    suite="nightly-perf-1-gpu-mi45x-gpt-oss",
+    nightly=True,
+)
+
+# Server-side env for the gfx1250 MXFP4 path. Kept identical to the accuracy
+# test so the two measure the same configuration.
+MI45X_GPT_OSS_ENV = {
+    "SGLANG_USE_AITER": "1",
+    "SGLANG_USE_AITER_MOE_GU_ITLV": "1",
+    "SGLANG_USE_AITER_UNIFIED_ATTN": "1",
+    "AITER_FORCE_A8W4": "1",
+    "ENABLE_CK": "0",
+    "HSA_COREDUMP_PATTERN": "/dev/null",
+}
+
+
+def generate_simple_markdown_report(results: List[BenchmarkResult]) -> str:
+    """Generate a simplified markdown report without traces and cost columns.
+
+    Skips the first result if it's a warmup run (duplicate batch_size).
+    """
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", "MI455X")
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = 1 / (result.output_throughput / result.batch_size) * 1000
+        summary += f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | {result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+
+    return summary
+
+
+PROFILE_DIR = "performance_profiles_gpt_oss_mxfp4_mi45x"
+
+
+class TestGptOssMxfp4PerfMI45x(unittest.TestCase):
+    """MI455X nightly performance benchmark for GPT-OSS-120B MXFP4 at TP=1."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.model = "amd/gpt-oss-120b-w-mxfp4-a-fp8"
+        print(f"Using model path: {cls.model}")
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # Capped at 128 to match --max-running-requests on the server side.
+        cls.batch_sizes = [1, 8, 32, 128]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+
+        cls.variants = [
+            {
+                "name": "mxfp4-a8w4",
+                "other_args": [
+                    "--trust-remote-code",
+                    "--tp",
+                    "1",
+                    "--prefill-attention-backend",
+                    "triton",
+                    "--decode-attention-backend",
+                    "aiter",
+                    "--max-running-requests",
+                    "128",
+                    "--mem-fraction-static",
+                    "0.9",
+                    "--disable-radix-cache",
+                    "--page-size",
+                    "64",
+                ],
+            },
+        ]
+
+        cls.runner = NightlyBenchmarkRunner(PROFILE_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_profile_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_bench_one_batch(self):
+        """Run benchmark across all configured variants."""
+        failed_variants = []
+
+        try:
+            for variant_config in self.variants:
+                with self.subTest(variant=variant_config["name"]):
+                    env = os.environ.copy()
+                    env.update(MI45X_GPT_OSS_ENV)
+
+                    result_tuple = self.runner.run_benchmark_for_model(
+                        model_path=self.model,
+                        batch_sizes=self.batch_sizes,
+                        input_lens=self.input_lens,
+                        output_lens=self.output_lens,
+                        other_args=variant_config["other_args"],
+                        variant=variant_config["name"],
+                        extra_bench_args=["--trust-remote-code"],
+                        enable_profile=False,
+                        env=env,
+                    )
+                    results = result_tuple[0]
+                    success = result_tuple[1]
+
+                    if not success:
+                        failed_variants.append(variant_config["name"])
+
+                    if results:
+                        self.runner.full_report += (
+                            generate_simple_markdown_report(results) + "\n"
+                        )
+        finally:
+            self.runner.write_final_report()
+
+        if failed_variants:
+            raise AssertionError(
+                f"Benchmark failed for {self.model} with the following variants: "
+                f"{', '.join(failed_variants)}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -160,6 +160,9 @@ NIGHTLY_SUITES = {
         "nightly-amd-vlm",
         # MI35x 8-GPU suite (different model configs)
         "nightly-amd-8-gpu-mi35x",
+        # MI455X (gfx1250) bring-up: gpt-oss-120b MXFP4 on a single GPU.
+        "nightly-amd-1-gpu-mi45x",
+        "nightly-perf-1-gpu-mi45x-gpt-oss",
     ],
     HWBackend.MUSA: [
         "nightly-musa-1-gpu",


### PR DESCRIPTION
## Motivation

This PR makes MI455X a first-class CI target and adds GPT-OSS-120B MXFP4 as its bring-up gate on a single GPU.

## Changes

### Image

**`docker/rocm.Dockerfile`** — add a `gfx1250-rocm7_15` build stage. There is no published ROCm base image for gfx1250, so the stage starts from `ubuntu:24.04` and pip-installs the ROCm SDK + torch/torchvision/torchaudio/triton from the ROCm nightly index. It carries its own AITER / Triton / MORI pins because gfx1250 support postdates the pins the other stages use. Includes two workarounds the arch needs: a `/usr/lib64/libc.so` symlink (the SDK's `hsakmtTargets.cmake` hardcodes that path) and a `/opt/rocm` symlink (AITER shells out to `/opt/rocm/llvm/bin/amdgpu-arch` at runtime).

To let one stage differ from the others, `PYTORCH_ROCM_ARCH`, `TRITON_COMMIT` and `MORI_COMMIT` become stage-overridable. **The four existing arches resolve to values byte-identical to `main`** — verified by simulating Docker's `${VAR:-default}` expansion for every stage:

| stage | PYTORCH_ROCM_ARCH | TRITON | MORI | AITER |
|---|---|---|---|---|
| gfx942 | `gfx942;gfx950` | `422704` | `f7e6ac` | `d9e5ef` |
| gfx942-rocm720 | `gfx942;gfx950` | `422704` | `f7e6ac` | `d9e5ef` |
| gfx950 | `gfx942;gfx950` | `422704` | `f7e6ac` | `d9e5ef` |
| gfx950-rocm720 | `gfx942;gfx950` | `422704` | `f7e6ac` | `d9e5ef` |
| **gfx1250-rocm7_15** | **`gfx1250`** | **`c57bbb`** | **`e31d42`** | **`604e41`** |
| *main baseline* | `gfx942;gfx950` | `422704` | `f7e6ac` | `d9e5ef` |

**`release-docker-amd-rocm7_15-nightly.yml`** — drop two build args the Dockerfile never declared (`GPU_ARCH_LIST_ARG`, `SGLANG_VERSION`; `grep -c "ARG GPU_ARCH_LIST_ARG"` → `0`), pass `SETUPTOOLS_SCM_PRETEND_VERSION` instead so the nightly version pretend actually applies, and re-enable the AMD Hub login, the `rocm/sgl-dev` push and the nightly cron. The last two matter more than they look: CI discovers images *only* under `rocm/sgl-dev` and *only* within a 7-day dated walk-back, so without both there is nothing for a MI455X job to find.

`GPU_ARCH_LIST` is already derived in the Dockerfile as `${GPU_ARCH%-*}`, which yields `gfx1250` for `gfx1250-rocm7_15` — no separate arch build-arg is needed.

### Arch plumbing

**`amd_ci_start_container.sh`** — route `mi45x` to the `rocm7.15` image line, and **make an unrecognised arch a hard error**. Previously the `*)` arm silently fell back to the mi30x (gfx942) image, so a job on new hardware would run to green against wrong-arch kernels. Existing runners are unaffected: `linux-mi300-1gpu-sglang` does not match the hostname regex at all and keeps the script's `mi30x` default.

| hostname | parsed | result |
|---|---|---|
| `linux-mi45x-gpu-1` | `mi45x` | → mi45x / rocm7.15 |
| `linux-mi35x-gpu-1` | `mi35x` | → mi35x |
| `linux-mi300-1gpu-sglang` | *(regex miss → default)* | → mi30x |
| `linux-mi300-gpu-1` | `mi300` | → mi30x |
| `linux-mi999z-gpu-1` | `mi999z` | → **hard error** (was: silent mi30x) |

The hard-coded fallback is also guarded so it can never hand an mi30x image to an mi45x request.

**`amd_ci_install_dependency.sh` / `amd_ci_exec.sh`** — gfx1250 arch lists for AITER and MORI, arch-aware extraction of the pins from the correct Dockerfile stage, and `ENABLE_CK=0` since gfx1250 has no CK kernels yet.

### Test

GPT-OSS-120B MXFP4 (`amd/gpt-oss-120b-w-mxfp4-a-fp8`) at **TP=1**, split across two jobs on `linux-mi45x-gpu-1`:

- `nightly-1-gpu-mi45x-gpt-oss` — GSM8K few-shot accuracy. **In `check-all-jobs.needs`, so it gates.**
- `nightly-perf-1-gpu-mi45x-gpt-oss` — throughput/latency. **Report-only**, matching how every other perf job in this workflow is treated.

Both mirror the launch configuration used for bring-up: `--prefill-attention-backend triton --decode-attention-backend aiter --max-running-requests 128 --mem-fraction-static 0.9 --disable-radix-cache --page-size 64`, with `SGLANG_USE_AITER`, `SGLANG_USE_AITER_MOE_GU_ITLV`, `SGLANG_USE_AITER_UNIFIED_ATTN`, `AITER_FORCE_A8W4`, `ENABLE_CK=0`, `HSA_COREDUMP_PATTERN=/dev/null`.

The same checkpoint already runs at TP=8 on MI35x (`test_gpt_oss_w4a8_mxfp4_eval_mi35x.py`), which is what makes it a good bring-up smoke test.

## Prerequisites

1. **An `linux-mi45x-gpu-1` runner must be registered.** The label is chosen to satisfy the `^linux-(mi[0-9]+[a-z]*)-gpu-[0-9]+` hostname regex the three AMD CI scripts use for arch detection, and to match the `mi45x` token in the image tag. `linux-mi455x-...` would also parse but is not wired — use `mi45x`.
2. **`release-docker-amd-rocm7_15-nightly.yml` must land at least one `rocm/sgl-dev:v<ver>-rocm7.15-mi45x-<date>` image** before the nightly can pass. Until then the job fails loudly with `no hard-coded fallback for mi45x` rather than silently running the wrong image.

## Notes / follow-ups

- **The accuracy floor (0.79) is inherited from the TP=8 MI35x peer and is unvalidated on MI455X.** It must be confirmed against the first green run and tightened or relaxed; overridable via `GSM8K_ACCURACY_THRESHOLD`.
- The gfx1250 Dockerfile content is cherry-picked, not rebased, from the unmerged `amd_test_pr32754`. That branch is 196 commits behind main and three of its changes are deliberately excluded because they would break `main`: it does `cd sgl-kernel` (the kernel moved to `python/sglang/kernels/aot`), it renames `SETUPTOOLS_SCM_PRETEND_VERSION` → `SGLANG_VERSION` (breaking 4 live release workflows), and it defaults `GPU_ARCH_LIST_ARG=gfx1250` globally (breaking gfx942/gfx950 builds that don't pass it). It also bumps AITER pins for the existing arches, which is out of scope here.
- `MORI_COMMIT` precedence is intentionally the reverse of `AITER_COMMIT`/`TRITON_COMMIT` — a stage default wins over `--build-arg`. This is forced by `amd_ci_install_dependency.sh` needing to grep a non-empty `ARG MORI_COMMIT="..."` literal. No caller passes it today; documented inline.
- The publish job still builds on `linux-mi300-1gpu-sglang`, tying up a GPU runner for a CPU-bound build. Moving it to `amd-docker-scale` (as the other AMD release workflows do) is a sensible follow-up, kept out of this PR because the current runner is the one with a proven-green gfx1250 build.
- Per #27417, MI455X Day-0 CI is scoped to 2026 frontier MoE models with GPT-OSS explicitly excluded. This PR uses GPT-OSS deliberately as a single-GPU bring-up gate, not as the long-term coverage target.

## Review findings addressed

An adversarial review pass caught four issues, all fixed in the second commit:

1. **Critical — dependency install aborted on every MI455X run.** The gfx1250 stage is ~55 lines long, so its AITER/MORI pins fell outside the `grep -A20` window used to extract them; the lookup returned nothing and `set -o pipefail` killed the script before any test ran. Replaced with a stage-scoped awk extractor (FROM → next FROM). The pre-existing gfx942/gfx950 lookups had the same latent fragility and now share the helper, returning identical values.
2. **High — `UBUNTU_MIRROR` was a no-op on Ubuntu 24.04.** It rewrote `/etc/apt/sources.list`, but 24.04 uses deb822 `sources.list.d/ubuntu.sources`; on a file-absent builder `sed -i` would fail outright. Now rewrites whichever files exist. The gfx1250 stage also ran `apt-get` before the final stage's mirror block, so it now applies the mirror and apt hardening itself.
3. **Medium — accuracy file timeout equalled the server-launch timeout** (both 1800s), so a slow cold start left no time to evaluate and the file got killed mid-run. Now ordered 90m step > 60m file > 30m launch.
4. **Documented, not silently changed — MoE layout on gfx1250.** `SGLANG_USE_AITER_MOE_GU_ITLV=1` selects `GateMode.INTERLEAVE` (also the env default), but the matching weight interleave in `QuarkW4A8MXFp4MoE` is gated on `is_gfx95_supported()`, which matches only `gfx95` and is therefore **False on gfx1250** — so the kernel is told INTERLEAVE while weights stay in checkpoint layout. This may produce bad accuracy. It cannot be resolved without hardware, so it is called out prominently in both tests as the first thing to check, rather than flipped blind.

## Checklist

- [x] `pre-commit run --files ...` passes, including `validate registered test CI registries`
- [x] Both new suites resolve to exactly one test each via `collect_tests` + `filter_tests`
- [x] Suite strings verified consistent across test file ↔ `run_suite.py` ↔ workflow `--suite` flags
- [x] `bash -n` clean on all three modified CI scripts; arch routing simulated for every runner label
- [x] Workflow YAML parses; accuracy job in `check-all-jobs.needs`, perf job not; both in the `job_select` dropdown
- [ ] First green nightly on real MI455X hardware — blocked on the runner and the image

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30775288498](https://github.com/sgl-project/sglang/actions/runs/30775288498)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30775288458](https://github.com/sgl-project/sglang/actions/runs/30775288458)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->