### PR TITLE
[PD] Skip cached-prefix early-send when the decode requires DCP relayout

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -149,6 +149,14 @@ class BaseKVSender(ABC):
     def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
         return num_pages > 0
 
+    def requires_dcp_relayout(self) -> bool:
+        """Whether this request's KV transfer goes through the token-granular DCP
+        relayout (TP-only prefill -> DCP-sharded decode). When True the transfer must
+        cover the full sequence as one plan, so the cached-prefix early-send (which
+        splits the transfer into chunks the relayout cannot reassemble) is skipped.
+        Backends/requests without DCP relayout return False."""
+        return False
+
     @abstractmethod
     def get_transfer_metric(self) -> KVTransferMetric:
         """Return backend-specific transfer metrics for this sender."""

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -292,6 +292,16 @@ class CommonKVManager(BaseKVManager):
             f"Unsupported PD DCP topology: {self.dcp_size} -> {dst_dcp_size}"
         )
 
+    def serves_dcp_relayout_decode(self) -> bool:
+        """True if any registered decode peer needs the token-granular DCP relayout
+        (set on the peer's register info at registration). Used to skip the
+        cached-prefix early-send, whose split transfer the relayout cannot reassemble.
+        """
+        return any(
+            getattr(peer, "requires_dcp_relayout", False)
+            for peer in self.decode_kv_args_table.values()
+        )
+
     def prepare_dcp_token_item_lens(self, dst_page_item_lens: List[int]) -> List[int]:
         page_size = self.kv_args.page_size
         src_token_lens = [
@@ -1126,6 +1136,9 @@ class CommonKVSender(BaseKVSender):
 
     def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
         return num_pages > 0 or last_chunk
+
+    def requires_dcp_relayout(self) -> bool:
+        return self.kv_mgr.serves_dcp_relayout_decode()
 
     def get_transfer_metric(self) -> KVTransferMetric:
         total_bytes = self._transfer_num_kv_indices * self.kv_mgr.kv_item_lens_sum

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1083,6 +1083,15 @@ class SchedulerDisaggregationPrefillMixin:
         ):
             return
 
+        # DCP KV relayout (TP-only prefill -> DCP-sharded decode) transfers the full
+        # sequence as one token-granular per-rank plan. The cached-prefix early-send
+        # would split the transfer into chunks the relayout cannot reassemble, dropping
+        # the newly-computed tail on the decode (KV-cache-hit requests then decode
+        # without the fresh suffix). Skip the optional early-send for DCP-sharded
+        # decodes; the regular final send covers the full range.
+        if req.disagg_kv_sender.requires_dcp_relayout():
+            return
+
         # Device-resident prefix only; page-aligned so start_send_idx stays exact.
         cached_end = len(req.prefix_indices) - req.host_hit_length
         if cached_end <= req.start_send_idx:


### PR DESCRIPTION
### Problem
Under PD disaggregation with **decode context parallel (DCP)** and **prefill prefix cache (radix)**,
a request that HITS a cached prefix produces wrong output on the DCP-sharded decode (no crash).

### Root cause
The cached-prefix early-send (`maybe_send_cached_prefix_chunk`, gated by
`SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX`, default on) early-sends the reused prefix as a
**separate** KV chunk. When the decode is DCP-sharded, the KV transfer goes through the
**token-granular DCP relayout** (`requires_dcp_relayout`), which builds one per-rank plan over the
sequence. The newly-computed tail (sent later as the final chunk) then does not get relayed as part
of that plan, so the DCP-sharded decode is **missing the fresh suffix KV** and decodes garbage.

Isolated on AMD MI355X (Kimi-K3 1P1D + DCP8, page_size 64, long shared prefix), using the mori DCP
relayout: a probe showed only the cached-prefix pages are relayed on reuse; the new tokens are never
transferred. gsm8k on reused long prefixes: **16.7%**. Single-server / non-DCP PD with the same
prefix cache are correct (98.3% / 96.7%), confirming it is specific to the DCP relayout path.

### Fix
Skip the cached-prefix early-send when the decode peer requires the DCP relayout; the regular final
send then covers the full sequence as one relayout plan.
- `BaseKVSender.requires_dcp_relayout()` → `False` (default)
- `CommonKVManager.serves_dcp_relayout_decode()` → any registered decode peer whose register info has
  `requires_dcp_relayout` set (mooncake/nixl already set this at registration)
- `CommonKVSender.requires_dcp_relayout()` override → covers both mooncake and nixl
- `prefill.py::maybe_send_cached_prefix_chunk` returns early when it is True

Non-DCP PD is unaffected (`requires_dcp_relayout()` returns False → early-send unchanged).

### Validation
With the fix (mori DCP relayout path, MI355X): reused-long-prefix gsm8k **16.7% → 96.7%**
(cold/no-reuse baseline 98.3%). The gate uses the existing `requires_dcp_relayout` mechanism, so it
applies to the mooncake / nixl DCP relayout paths as well (those backends could hit the same
cached-prefix/tail split; I could only test the mori path directly on AMD hardware).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30778036771](https://github.com/sgl-project/sglang/actions/runs/30778036771)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30778036683](https://github.com/sgl-project/sglang/actions/runs/30778036683)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->