### PR TITLE
[AMD] Add ROCm DWDP weight backends

### DIFF
--- a/benchmark/dwdp/ROCM_BACKEND_RESULTS.md
+++ b/benchmark/dwdp/ROCM_BACKEND_RESULTS.md
@@ -1,0 +1,133 @@
+# ROCm DWDP backend validation
+
+All GPU work is submitted through Slurm with
+`smci355-ccs-aus-n08-21` explicitly excluded.
+
+## PoC results
+
+- HIP IPC handle export/open and peer copy:
+  - Slurm job `23950`
+  - node `smci355-ccs-aus-n08-25`
+  - result: `1 passed`
+- HIP VMM capability, allocation granularity, single-process mapping,
+  composite mapping, repeated teardown, and cross-process POSIX-FD import:
+  - Slurm jobs `23954`, `23965`, `23985` (4-rank manager),
+    `23986` (8-rank manager)
+  - node `smci355-ccs-aus-n08-29`
+  - result: primitive and full-manager suites passed (`8 passed` in job `23965`)
+- HSA pair-specific engine copy with BDF-mapped HIP/HSA agents:
+  - Slurm job `23965`
+  - node `smci355-ccs-aus-n08-29`
+  - result: two-peer-copy tests passed (`2 passed`)
+- Three-peer 256 MiB copy benchmark:
+  - Slurm job `23984`
+  - selected engine masks: GPU1 `0x4000`, GPU2 `0x0004`, GPU3 `0x1000`
+  - HSA aggregate: `169.2 GiB/s`; per-peer HIP streams: `167.9 GiB/s`
+  - HSA/HIP speed ratio for this transfer size: `1.008x`
+- HIP IPC two-slot prefetch with fused shared final partition:
+  - Slurm jobs `23964` (2 ranks), `23967` (4 ranks), `23972` (8 ranks)
+  - node `smci355-ccs-aus-n08-25`
+  - result: all configurations passed
+- Aiter gfx950 multi-B contract, boundary routing, MXFP4 stage1/stage2,
+  fused-shared uneven partitions, bias, and no-combine:
+  - Slurm job `23970`
+  - node `smci355-ccs-aus-n08-29`
+  - result: `34 passed`
+- SGLang DWDP layout, tensor schema, Aiter runner injection, import guard, and
+  server-argument tests:
+  - Slurm job `23977`
+  - node `smci355-ccs-aus-n08-25`
+  - result: `14 passed`
+- DeepSeek-R1 MXFP4 IPC/multi-B standalone model smoke:
+  - Slurm job `23982`
+  - node `smci355-ccs-aus-n08-29`
+  - result: server became healthy and generated deterministic text beginning
+    with `Paris`
+- DeepSeek-R1 MXFP4 IPC PD accuracy with NIXL:
+  - Slurm job `24016`
+  - node `smci355-ccs-aus-n09-21`
+  - topology: 4-GPU DWDP prefill plus 4-GPU DEP decode, graph capture disabled
+  - result: deterministic completion contained `Paris`; `1 passed` in
+    `150.14s`
+  - container prerequisites: `memlock=unlimited`, `NIXL_LOG_LEVEL=ERROR`,
+    `UCX_LOG_LEVEL=error`
+- DeepSeek-R1 MXFP4 IPC standalone accuracy:
+  - Slurm job `24017`
+  - node `smci355-ccs-aus-n09-21`
+  - result: deterministic completion contained `Paris`; `1 passed` in
+    `188.63s`
+  - postflight: 85-89 GiB remained immediately after server exit and returned
+    to 0.30 GiB per GPU on the second check 10 seconds later
+
+## Slurm node hygiene
+
+- Submission now requires Slurm state `idle`, eight readable VRAM counters,
+  at most 4 GiB used on any GPU, and at most 2 GiB skew. The allocated job
+  repeats the check before launching the container.
+- `smci355-ccs-aus-n09-25` was rejected with 27-40 GiB used on GPU0-1;
+  `smci355-ccs-aus-n08-29` was rejected with 153-155 GiB used on GPU0-3.
+- Standalone job `24013` functionally passed, but its node retained
+  76-78 GiB on GPU0-3 after exit. Postflight checks now wait up to 60 seconds
+  and fail the job if VRAM remains allocated. No process cleanup or GPU reset
+  was attempted.
+- IPC cleanup followed by setup/prefetch re-initialization passed in job
+  `24044`; postflight returned all GPUs to 0.30 GiB.
+- `smci355-ccs-aus-n08-21` remains unconditionally excluded.
+
+## End-to-end performance
+
+Configuration: DeepSeek-R1 MXFP4, 8 GPUs, graph capture disabled, 256 random
+prompts, concurrency 128, one output token, radix cache disabled.
+
+- DEP baseline, Slurm job `24015`, node `smci355-ccs-aus-n08-33`:
+  - ISL 4096: `52,544.67` input tok/s
+  - ISL 8192: `58,295.12` input tok/s
+  - ISL 16384: `49,473.02` input tok/s
+  - ISL 32768: `39,948.81` input tok/s
+- The sequential IPC launch in job `24015` encountered an internal-port
+  collision with the just-stopped DEP server before loading weights. The node
+  was clean after exit, so this is not an IPC correctness or memory result.
+- Isolated IPC with the default global chunk 32768 (4096 per DP8 rank):
+  - same-node job `24019`, node `smci355-ccs-aus-n08-33`
+  - ISL 4096: `17,839.62` input tok/s, `0.340x` DEP
+  - ISL 8192: `18,654.92` input tok/s, `0.320x` DEP
+  - ISL 16384: `19,029.53` input tok/s, `0.385x` DEP
+  - ISL 32768 at 256 prompts/concurrency 128 exceeded the available request
+    capacity before producing a result
+- Optimized long-prefill chunk, job `24020`, node
+  `smci355-ccs-aus-n09-21`: global chunk 262144 (32768 per DP8 rank), 64
+  prompts, concurrency 32, ISL 32768:
+  - DEP: `35,258.01` input tok/s
+  - IPC: `57,706.92` input tok/s
+  - IPC/DEP: `1.637x`
+  - both backends returned to 0.30 GiB used per GPU after the 10-second
+    postflight grace period
+- The matching optimized-chunk short/mid-context matrix, job `24021` on the
+  same node:
+  - ISL 4096: DEP `33,426.98`, IPC `19,340.84` input tok/s (`0.579x`)
+  - ISL 8192: DEP `55,856.05`, IPC `29,565.11` input tok/s (`0.529x`)
+  - ISL 16384: DEP `52,257.34`, IPC `63,183.95` input tok/s (`1.209x`)
+- IPC DWDP therefore crosses DEP between 8K and 16K for this configuration
+  and exceeds the `1.05x` long-context target at 16K and 32K. It should not be
+  selected for short-prefill traffic based on these results.
+
+## Open validation
+
+- HIP VMM passes primitive and small 2/4/8-rank manager tests, but
+  production-sized 58-60 layer mappings hit ROCm generic-allocation/access
+  limits (`hipMemSetAccess: hipErrorInvalidValue`). IPC is therefore the ROCm
+  `auto` default; VMM remains experimental.
+  Job `24043` additionally verified the composite-remap access fix
+  (`8 passed` manager/primitive plus `2 passed` HSA raw copy): every remapped
+  local handle now receives `set_access`; postflight VRAM was clean.
+- Conventional FP8 multi-B with FP32 128x128 block scales passed the gfx950
+  Aiter suite in job `24031` (`51 passed`), together with `28` SGLang
+  integration/lifecycle tests. MiMo-V2.5 job `24033` reached checkpoint shard
+  28/34, then was SIGKILLed with one GPU at about 267.5 GiB before DWDP backend
+  setup; full-model validation remains blocked by loader/VRAM capacity.
+- No GPT-OSS checkpoint is mounted in the Slurm container's `/models` volume,
+  so its fixed-prompt and PD model validation could not be run.
+- HIP/HSA tracing of overlap remains future work; the completed copy-engine
+  microbenchmark and end-to-end matrix are the current performance evidence.
+- VMM is excluded from production-size comparison because of the
+  generic-allocation limit above.

--- a/benchmark/dwdp/ROCM_DWDP_CURRENT_STATUS.md
+++ b/benchmark/dwdp/ROCM_DWDP_CURRENT_STATUS.md
@@ -1,0 +1,71 @@
+# ROCm DWDP current status
+
+Snapshot date: 2026-08-03
+
+This document records the state immediately before the first SGLang and Aiter
+commits for the ROCm DWDP port.
+
+## Source state
+
+- SGLang branch: `feature/dwdp-rocm`
+- SGLang base: `131bd51b01`
+- Aiter branch: `feature/dwdp-multib-rocm`
+- Aiter base: `702aacd`
+- The SGLang IPC backend depends on the matching Aiter multi-B changes.
+- The implementation will be proposed as two new linked PRs. The historical
+  SGLang and Aiter DWDP PRs are not force-updated because their bases and
+  interfaces are obsolete.
+
+## Validated functionality
+
+- HIP VMM primitives, POSIX-FD exchange, mapping, teardown, and composite
+  manager operation pass at small scale. Job `24043` reported 8 manager and
+  primitive tests plus 2 raw HSA copy tests passing.
+- HIP IPC rank-ordered multi-B prefetch passes 2-, 4-, and 8-rank synthetic
+  tests (`23964`, `23967`, and `23972`).
+- IPC cleanup followed by setup and prefetch re-initialization passes in job
+  `24044`.
+- Aiter gfx950 multi-B supports MXFP4, A8W4, MXFP8, and conventional FP8 with
+  FP32 128x128 block scales. Job `24031` reported 51 Aiter tests and 28 SGLang
+  integration/lifecycle tests passing.
+- HSA copy reached 169.2 GiB/s for three concurrent 256 MiB peer copies versus
+  167.9 GiB/s for per-peer HIP streams.
+- DeepSeek-R1 MXFP4 IPC standalone accuracy passed in `24017`; IPC/NIXL 4P+4D
+  PD accuracy passed in `24016`. Both deterministic completions contained
+  `Paris`.
+- The optimized DeepSeek-R1 long-prefill configuration uses a global chunk of
+  262144 at DWDP8, giving 32768 tokens per rank. IPC/DEP throughput was
+  0.579x, 0.529x, 1.209x, and 1.637x at 4K, 8K, 16K, and 32K input lengths.
+  IPC is therefore useful for long prefill, not short-prefill traffic.
+- Slurm submission rejects non-idle, occupied, or VRAM-unbalanced nodes before
+  `sbatch`, repeats the check after allocation, and verifies cleanup after the
+  container exits.
+
+## Production guidance
+
+- ROCm `auto` selects IPC.
+- IPC is the production candidate for gfx950 long-prefill workloads.
+- VMM remains experimental. Small-scale mapping is functional after applying
+  access permissions to every composite remap, but production-size 58-60-layer
+  configurations still hit ROCm generic-allocation/access limits.
+- VMM teardown releases resources but does not support setup after cleanup.
+- The known-bad node `smci355-ccs-aus-n08-21` is always excluded. No GPU reset
+  or unrelated process cleanup is part of this workflow.
+
+## Known blockers and incomplete validation
+
+- MiMo-V2.5 conventional FP8 kernels pass synthetic tests, but the full model
+  job `24033` was SIGKILLed while loading checkpoint shard 28/34 with one GPU
+  near 267.5 GiB, before DWDP backend setup.
+- No GPT-OSS checkpoint is mounted in the Slurm `/models` volume, so its model
+  smoke and PD validation are not complete.
+- DeepSeek task-level GSM8K and deterministic-logit parity against DEP/EP are
+  still pending; the current model-level checks are deterministic completion
+  checks.
+- HSA raw copies and IPC end-to-end use are validated, but production-scale
+  HIP VMM plus HSA overlap remains unvalidated.
+
+## Detailed evidence
+
+See `ROCM_BACKEND_RESULTS.md` for job IDs, node assignments, individual
+backend results, failure analysis, and benchmark details.

--- a/benchmark/dwdp/benchmark_hsa_copy.py
+++ b/benchmark/dwdp/benchmark_hsa_copy.py
@@ -1,0 +1,92 @@
+import statistics
+import time
+
+import torch
+
+from sglang.srt.layers.moe.dwdp.hsa_copy import HsaSdmaCopyEngine
+
+
+def _measure(fn, warmup=3, iterations=10):
+    for _ in range(warmup):
+        fn()
+    values = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn()
+        values.append((time.perf_counter() - start) * 1000)
+    return statistics.median(values)
+
+
+def main():
+    peer_count = min(torch.cuda.device_count() - 1, 3)
+    if peer_count < 1:
+        raise RuntimeError("HSA copy benchmark requires at least two GPUs")
+
+    size_bytes = 256 * 1024 * 1024
+    sources = [
+        torch.randint(
+            0,
+            256,
+            (size_bytes,),
+            dtype=torch.uint8,
+            device=f"cuda:{peer}",
+        )
+        for peer in range(1, peer_count + 1)
+    ]
+    destinations = [
+        torch.empty(size_bytes, dtype=torch.uint8, device="cuda:0") for _ in sources
+    ]
+    streams = [torch.cuda.Stream(device="cuda:0") for _ in sources]
+
+    # Establish peer access before bypassing HIP memcpy.
+    for destination, source in zip(destinations, sources):
+        destination.copy_(source)
+    torch.cuda.synchronize()
+
+    engine = HsaSdmaCopyEngine()
+    selected_engines = {
+        peer: engine.engine_for_devices(0, peer) for peer in range(1, peer_count + 1)
+    }
+
+    def run_hsa():
+        tickets = [
+            engine.submit(
+                destination,
+                source,
+                destination_device=0,
+                source_device=peer,
+            )
+            for peer, (destination, source) in enumerate(
+                zip(destinations, sources), start=1
+            )
+        ]
+        engine.wait_all(tickets)
+
+    def run_hip():
+        events = []
+        for stream, destination, source in zip(streams, destinations, sources):
+            with torch.cuda.stream(stream):
+                destination.copy_(source, non_blocking=True)
+                events.append(stream.record_event())
+        for event in events:
+            event.synchronize()
+
+    hsa_ms = _measure(run_hsa)
+    hip_ms = _measure(run_hip)
+    total_gib = size_bytes * peer_count / (1024**3)
+    print(
+        {
+            "peers": peer_count,
+            "bytes_per_peer": size_bytes,
+            "selected_engines": selected_engines,
+            "hsa_median_ms": hsa_ms,
+            "hsa_aggregate_gib_s": total_gib / (hsa_ms / 1000),
+            "hip_median_ms": hip_ms,
+            "hip_aggregate_gib_s": total_gib / (hip_ms / 1000),
+            "speedup": hip_ms / hsa_ms,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/dwdp/probe_hip_vmm_access.py
+++ b/benchmark/dwdp/probe_hip_vmm_access.py
@@ -1,0 +1,45 @@
+import torch
+
+from sglang.srt.layers.moe.dwdp import hip_vmm
+
+
+def probe(shareable: bool):
+    device = torch.cuda.current_device()
+    granularity = hip_vmm.get_allocation_granularity(
+        device,
+        shareable=shareable,
+        recommended=True,
+    )
+    results = []
+    for multiplier in (1, 2, 4, 8, 16, 64, 256, 1024, 4096, 16384):
+        size = granularity * multiplier
+        handle = (
+            hip_vmm.create_shareable_handle(size, device)
+            if shareable
+            else hip_vmm.create_local_handle(size, device)
+        )
+        mapping = None
+        try:
+            mapping = hip_vmm.map_handles(
+                [handle],
+                [size],
+                device,
+                alignment=granularity,
+            )
+        except Exception as error:
+            results.append((size, False, repr(error)))
+        else:
+            results.append((size, True, ""))
+        finally:
+            if mapping is not None:
+                mapping.close()
+            hip_vmm.release_handle(handle)
+    return granularity, results
+
+
+def main():
+    print({"local": probe(False), "shareable": probe(True)})
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/dwdp/run_rocm_backend_comparison.sh
+++ b/benchmark/dwdp/run_rocm_backend_comparison.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_PATH="${MODEL_PATH:-/models/DeepSeek-R1-0528-MXFP4-th}"
+TP_SIZE="${TP_SIZE:-4}"
+BACKENDS="${BACKENDS:-dep ipc}"
+INPUT_LENGTHS="${INPUT_LENGTHS:-4096 8192 16384 32768}"
+NUM_PROMPTS="${NUM_PROMPTS:-64}"
+MAX_CONCURRENCY="${MAX_CONCURRENCY:-32}"
+CHUNKED_PREFILL_SIZE="${CHUNKED_PREFILL_SIZE:-$((32768 * TP_SIZE))}"
+BASE_PORT="${BASE_PORT:-32000}"
+RESULT_DIR="${RESULT_DIR:-/results/dwdp-benchmark}"
+
+export SGLANG_USE_AITER=1
+export GPU_ARCHS="${GPU_ARCHS:-gfx950}"
+mkdir -p "$RESULT_DIR"
+
+case_index=0
+for backend in $BACKENDS; do
+    port=$((BASE_PORT + case_index * 100))
+    server_log="${RESULT_DIR}/${backend}-server.log"
+    common_args=(
+        --model-path "$MODEL_PATH"
+        --tp-size "$TP_SIZE"
+        --host 127.0.0.1
+        --port "$port"
+        --trust-remote-code
+        --watchdog-timeout 1800
+        --mem-fraction-static 0.80
+        --max-running-requests "$MAX_CONCURRENCY"
+        --chunked-prefill-size "$CHUNKED_PREFILL_SIZE"
+        --disable-cuda-graph
+        --disable-radix-cache
+        --attention-backend aiter
+        --log-level warning
+    )
+    if [[ "$backend" == "dep" ]]; then
+        backend_args=(
+            --dp-size "$TP_SIZE"
+            --enable-dp-attention
+            --ep-size "$TP_SIZE"
+            --moe-dense-tp-size 1
+        )
+    else
+        backend_args=(
+            --dwdp-size "$TP_SIZE"
+            --dwdp-weight-backend "$backend"
+        )
+    fi
+
+    python3 -m sglang.launch_server \
+        "${common_args[@]}" \
+        "${backend_args[@]}" \
+        >"$server_log" 2>&1 &
+    server_pid=$!
+    cleanup_server() {
+        if kill -0 "$server_pid" 2>/dev/null; then
+            SERVER_PID="$server_pid" python3 - <<'PY'
+import os
+
+from sglang.srt.utils import kill_process_tree
+
+kill_process_tree(int(os.environ["SERVER_PID"]), wait_timeout=30)
+PY
+            wait "$server_pid" || true
+        fi
+    }
+    wait_vram_clean() {
+        local attempt
+        for attempt in $(seq 1 6); do
+            if python3 scripts/ci/amd/check_dwdp_rocm_vram.py \
+                --expected-gpus "${EXPECTED_GPU_COUNT:-8}" \
+                --max-used-gib "${MAX_USED_VRAM_GIB:-4}" \
+                --max-skew-gib "${MAX_VRAM_SKEW_GIB:-2}"; then
+                return 0
+            fi
+            sleep 10
+        done
+        echo "VRAM did not return to the benchmark baseline after ${backend}" >&2
+        return 1
+    }
+    trap cleanup_server EXIT
+
+    ready=0
+    for _ in $(seq 1 360); do
+        if curl -fsS "http://127.0.0.1:${port}/health" >/dev/null; then
+            ready=1
+            break
+        fi
+        if ! kill -0 "$server_pid" 2>/dev/null; then
+            echo "${backend} server exited during startup" >&2
+            wait "$server_pid"
+        fi
+        sleep 5
+    done
+    [[ "$ready" == 1 ]] || {
+        echo "${backend} server did not become healthy" >&2
+        exit 1
+    }
+
+    for input_len in $INPUT_LENGTHS; do
+        output="${RESULT_DIR}/${backend}-isl${input_len}.jsonl"
+        python3 -m sglang.benchmark.serving \
+            --backend sglang \
+            --base-url "http://127.0.0.1:${port}" \
+            --model "$MODEL_PATH" \
+            --dataset-name random \
+            --num-prompts "$NUM_PROMPTS" \
+            --random-input-len "$input_len" \
+            --random-output-len 1 \
+            --random-range-ratio 1.0 \
+            --request-rate inf \
+            --max-concurrency "$MAX_CONCURRENCY" \
+            --output-file "$output"
+    done
+
+    cleanup_server
+    wait_vram_clean
+    trap - EXIT
+    case_index=$((case_index + 1))
+done
+
+python3 benchmark/dwdp/summarize_rocm_backend_comparison.py "$RESULT_DIR"

--- a/benchmark/dwdp/summarize_rocm_backend_comparison.py
+++ b/benchmark/dwdp/summarize_rocm_backend_comparison.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+
+
+RESULT_NAME = re.compile(r"(?P<backend>[^/]+)-isl(?P<input_length>\d+)\.jsonl$")
+SUMMARY_FIELDS = (
+    "backend",
+    "input_length",
+    "completed",
+    "duration",
+    "input_throughput",
+    "total_throughput",
+    "mean_e2e_latency_ms",
+    "p95_e2e_latency_ms",
+    "input_throughput_vs_dep",
+    "source",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge DEP/DWDP serving JSONL results into one summary."
+    )
+    parser.add_argument(
+        "result_dirs",
+        nargs="+",
+        type=Path,
+        help="Directories containing <backend>-isl<input_length>.jsonl files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Write summary.json and summary.csv here (defaults to the first input).",
+    )
+    return parser.parse_args()
+
+
+def read_last_result(path: Path) -> dict:
+    lines = [line for line in path.read_text().splitlines() if line.strip()]
+    if not lines:
+        raise ValueError(f"empty benchmark result: {path}")
+    return json.loads(lines[-1])
+
+
+def collect_results(result_dirs: list[Path]) -> list[dict]:
+    by_case = {}
+    for result_dir in result_dirs:
+        for path in sorted(result_dir.glob("*-isl*.jsonl")):
+            match = RESULT_NAME.fullmatch(path.name)
+            if match is None:
+                continue
+            result = read_last_result(path)
+            row = {
+                "backend": match.group("backend"),
+                "input_length": int(match.group("input_length")),
+                "completed": result["completed"],
+                "duration": result["duration"],
+                "input_throughput": result["input_throughput"],
+                "total_throughput": result["total_throughput"],
+                "mean_e2e_latency_ms": result["mean_e2e_latency_ms"],
+                "p95_e2e_latency_ms": result["p95_e2e_latency_ms"],
+                "source": str(path),
+            }
+            by_case[(row["backend"], row["input_length"])] = row
+
+    rows = sorted(by_case.values(), key=lambda row: (row["input_length"], row["backend"]))
+    dep_throughput = {
+        row["input_length"]: row["input_throughput"]
+        for row in rows
+        if row["backend"] == "dep"
+    }
+    for row in rows:
+        baseline = dep_throughput.get(row["input_length"])
+        row["input_throughput_vs_dep"] = (
+            row["input_throughput"] / baseline if baseline else None
+        )
+    return rows
+
+
+def write_summary(rows: list[dict], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.json").write_text(json.dumps(rows, indent=2) + "\n")
+    with (output_dir / "summary.csv").open("w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=SUMMARY_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    rows = collect_results(args.result_dirs)
+    if not rows:
+        raise SystemExit("no benchmark JSONL results found")
+    output_dir = args.output_dir or args.result_dirs[0]
+    write_summary(rows, output_dir)
+    for row in rows:
+        speedup = row["input_throughput_vs_dep"]
+        speedup_text = f", vs_dep={speedup:.3f}x" if speedup is not None else ""
+        print(
+            f"{row['backend']} ISL={row['input_length']}: "
+            f"{row['input_throughput']:.2f} input tok/s{speedup_text}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -94,6 +94,10 @@
       "destination": "/docs/advanced_features/dp_for_multi_modal_encoder"
     },
     {
+      "source": "/advanced_features/dwdp.html",
+      "destination": "/docs/advanced_features/dwdp"
+    },
+    {
       "source": "/advanced_features/epd_disaggregation.html",
       "destination": "/docs/advanced_features/epd_disaggregation"
     },
@@ -933,6 +937,7 @@
               "docs/advanced_features/quantized_kv_cache",
               "docs/advanced_features/dp_dpa_smg_guide",
               "docs/advanced_features/expert_parallelism",
+              "docs/advanced_features/dwdp",
               "docs/advanced_features/lora",
               "docs/advanced_features/pd_disaggregation",
               "docs/advanced_features/epd_disaggregation",

--- a/docs_new/docs/advanced_features/dwdp.mdx
+++ b/docs_new/docs/advanced_features/dwdp.mdx
@@ -1,0 +1,113 @@
+---
+title: Distributed Weight Data Parallelism
+---
+
+Distributed Weight Data Parallelism (DWDP) keeps each data-parallel rank's
+tokens local and asynchronously prefetches remote MoE expert weights. Unlike
+expert parallelism, the steady-state MoE forward has no token all-to-all or
+cross-rank output reduction.
+
+DWDP is intended for long-prefill workloads where expert-weight transfers can
+overlap the preceding layer's compute. PD-disaggregated prefill is the
+recommended deployment; standalone decode must fetch remote weights every
+step and is usually slower than EP.
+
+## ROCm backends
+
+ROCm provides two selectable weight backends:
+
+- `vmm`: HIP virtual-memory allocations are exported as POSIX file
+  descriptors and mapped into one contiguous full-expert virtual tensor. This
+  reuses the normal single-tensor MoE kernels.
+- `ipc`: PyTorch HIP IPC opens peer allocations and Aiter consumes a
+  rank-ordered list of weight and scale partitions through its multi-B kernel.
+- `auto`: selects IPC on ROCm. HIP VMM remains an explicit experimental
+  backend while ROCm's production-size generic-allocation limits are being
+  resolved.
+
+Use `--dwdp-weight-backend auto|vmm|ipc` to select a backend explicitly.
+
+Both backends use two ping-pong staging slots. On supported ROCm builds, SGLang
+submits peer transfers through pair-specific HSA SDMA engines. Set
+`SGLANG_DWDP_DISABLE_HSA_COPY=1` to use the per-peer HIP stream `copy_()`
+fallback for debugging.
+
+## Requirements
+
+The initial ROCm implementation requires:
+
+- one XGMI-connected node;
+- AMD Instinct MI355X (`gfx950`);
+- 2, 4, or 8 ranks with `--dwdp-size` equal to `--tp-size`;
+- routed experts evenly divisible by the DWDP size;
+- eager execution;
+- balanced free VRAM across all participating GPUs;
+- unlimited locked memory for UCX/NIXL PD deployments;
+- an Aiter build with `fused_moe_multi_b` when using the IPC backend.
+
+Pipeline parallelism, EPLB, speculative decoding, two-batch overlap, CUDA/HIP
+graphs, cross-node DWDP, and overlapping expert ownership are not supported.
+The IPC backend supports MXFP4/MXFP8 one-byte scale partitions; use VMM for
+conventional FP8 scales.
+
+## Launch
+
+ROCm PD prefill:
+
+```bash
+export SGLANG_USE_AITER=1
+export GPU_ARCHS=gfx950
+
+python3 -m sglang.launch_server \
+  --model-path /models/DeepSeek-R1-0528-MXFP4-th \
+  --tp-size 4 \
+  --dwdp-size 4 \
+  --dwdp-weight-backend auto \
+  --disaggregation-mode prefill \
+  --chunked-prefill-size 131072 \
+  --attention-backend aiter
+```
+
+Standalone validation:
+
+```bash
+python3 -m sglang.launch_server \
+  --model-path /models/DeepSeek-R1-0528-MXFP4-th \
+  --tp-size 4 \
+  --dwdp-size 4 \
+  --dwdp-weight-backend auto \
+  --attention-backend aiter
+```
+
+When DWDP is enabled, SGLang configures DP attention and DP LM head, uses dense
+TP size 1, disables MoE all-to-all, skips scheduler all-gathers and idle
+forwards, and disables graph capture.
+
+`--chunked-prefill-size` is a global DP budget and is divided by
+`--dwdp-size`. Weight prefetch has a mostly fixed cost per chunk, so ROCm DWDP
+needs a large per-rank chunk to amortize transfers. For example, use 131072
+with DWDP4 or 262144 with DWDP8 to target 32768 tokens per rank, subject to
+available KV-cache memory.
+
+On 8 MI355X GPUs with DeepSeek-R1 MXFP4, graph capture disabled, 64 prompts,
+and concurrency 32, a 32768 per-rank chunk measured 57,706.92 input tokens/s
+for IPC DWDP versus 35,258.01 for DEP (`1.637x`). A global chunk of 32768
+becomes only 4096 tokens per rank at DWDP8 and was substantially slower than
+DEP, so it is not a suitable long-prefill production setting. With the
+optimized chunk, IPC/DEP was `0.579x`, `0.529x`, `1.209x`, and `1.637x` at
+4K, 8K, 16K, and 32K input lengths respectively. Use DWDP for long-prefill
+traffic; DEP remains preferable for this model below the 8K-16K crossover.
+
+## Supported model paths
+
+- GPT-OSS MXFP4 uses its existing DWDP-local routing path.
+- MiMo-V2 uses the generic FusedMoE integration, but conventional FP8 requires
+  the experimental VMM backend until Aiter gains a separate FP32-scale
+  multi-B kernel.
+- DeepSeek-R1 MXFP4 supports the 256 routed experts plus one fused shared
+  expert. The shared expert is owned by the final logical partition, yielding
+  layouts such as `[64, 64, 64, 65]`.
+
+Always compare deterministic logits and task accuracy against the same model,
+quantization, GPU count, graph mode, and chunking under DEP/EP before using a
+new model or quantization scheme in production.

--- a/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension_rocm.cc
@@ -16,6 +16,8 @@ limitations under the License.
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <torch/library.h>
 
+#include "dwdp/hip_vmm.h"
+#include "dwdp/hsa_copy.h"
 #include "sgl_kernel_ops.h"
 
 TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
@@ -223,6 +225,38 @@ TORCH_LIBRARY_EXPAND(sgl_kernel, m) {
       "dst_indices, int layer_id, int item_size, int src_layout_dim, int page_size, int head_num, int block_quota, int "
       "num_warps_per_block) -> ()");
   m.impl("transfer_kv_per_layer_ph_lf", torch::kCUDA, &transfer_kv_per_layer_ph_lf);
+
+  /*
+   * From csrc/dwdp
+   *
+   * These are catch-all registrations because most VMM primitives have no
+   * Tensor argument from which the dispatcher could infer a backend.
+   */
+  m.def("hip_vmm_is_supported(int device_id) -> bool", &hip_vmm_is_supported);
+  m.def(
+      "hip_vmm_get_allocation_granularity(int device_id, bool shareable, bool recommended) -> int",
+      &hip_vmm_get_allocation_granularity);
+  m.def("hip_vmm_create(int size, int device_id, bool shareable) -> int", &hip_vmm_create);
+  m.def("hip_vmm_release(int handle) -> ()", &hip_vmm_release);
+  m.def("hip_vmm_address_reserve(int size, int alignment, int requested_address) -> int", &hip_vmm_address_reserve);
+  m.def("hip_vmm_address_free(int address, int size) -> ()", &hip_vmm_address_free);
+  m.def("hip_vmm_map(int address, int size, int handle, int offset) -> ()", &hip_vmm_map);
+  m.def("hip_vmm_unmap(int address, int size) -> ()", &hip_vmm_unmap);
+  m.def("hip_vmm_set_access(int address, int size, int device_id) -> ()", &hip_vmm_set_access);
+  m.def("hip_vmm_export_fd(int handle) -> int", &hip_vmm_export_fd);
+  m.def("hip_vmm_import_fd(int fd) -> int", &hip_vmm_import_fd);
+  m.def(
+      "hip_vmm_tensor_from_address(int address, int[] shape, ScalarType dtype, int device_id) -> Tensor",
+      &hip_vmm_tensor_from_address);
+  m.def("dwdp_hsa_copy_is_available() -> bool", &dwdp_hsa_copy_is_available);
+  m.def(
+      "dwdp_hsa_copy_engine_for_devices(int destination_device, int source_device) -> int",
+      &dwdp_hsa_copy_engine_for_devices);
+  m.def(
+      "dwdp_hsa_copy_async(Tensor destination, Tensor source, int destination_device, int source_device) -> int",
+      &dwdp_hsa_copy_async);
+  m.def("dwdp_hsa_copy_wait(int ticket) -> int", &dwdp_hsa_copy_wait);
+  m.def("dwdp_hsa_copy_destroy(int ticket) -> ()", &dwdp_hsa_copy_destroy);
 
   /*
    * From csrc/grammar

--- a/python/sglang/kernels/aot/csrc/dwdp/hip_vmm.h
+++ b/python/sglang/kernels/aot/csrc/dwdp/hip_vmm.h
@@ -1,0 +1,37 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+#include <cstdint>
+#include <vector>
+
+bool hip_vmm_is_supported(int64_t device_id);
+int64_t hip_vmm_get_allocation_granularity(int64_t device_id, bool shareable, bool recommended);
+int64_t hip_vmm_create(int64_t size, int64_t device_id, bool shareable);
+void hip_vmm_release(int64_t handle);
+int64_t hip_vmm_address_reserve(int64_t size, int64_t alignment, int64_t requested_address);
+void hip_vmm_address_free(int64_t address, int64_t size);
+void hip_vmm_map(int64_t address, int64_t size, int64_t handle, int64_t offset);
+void hip_vmm_unmap(int64_t address, int64_t size);
+void hip_vmm_set_access(int64_t address, int64_t size, int64_t device_id);
+// The returned fd is caller-owned and must be closed exactly once.
+int64_t hip_vmm_export_fd(int64_t handle);
+// Borrows fd for the duration of the call; it never consumes or closes fd.
+int64_t hip_vmm_import_fd(int64_t fd);
+at::Tensor hip_vmm_tensor_from_address(
+    int64_t address, const std::vector<int64_t>& shape, at::ScalarType dtype, int64_t device_id);

--- a/python/sglang/kernels/aot/csrc/dwdp/hip_vmm.hip
+++ b/python/sglang/kernels/aot/csrc/dwdp/hip_vmm.hip
@@ -1,0 +1,259 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_version.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "dwdp/hip_vmm.h"
+
+namespace {
+
+void check_hip(hipError_t status, const char* operation) {
+  if (status == hipSuccess) {
+    return;
+  }
+  const char* name = hipGetErrorName(status);
+  const char* detail = hipGetErrorString(status);
+  TORCH_CHECK(
+      false,
+      operation,
+      " failed with HIP error ",
+      static_cast<int>(status),
+      " (",
+      name == nullptr ? "unknown" : name,
+      "): ",
+      detail == nullptr ? "no error description" : detail);
+}
+
+int validate_device(int64_t device_id) {
+  TORCH_CHECK(device_id >= 0, "device_id must be non-negative, got ", device_id);
+  TORCH_CHECK(device_id <= std::numeric_limits<int>::max(), "device_id is too large for HIP: ", device_id);
+
+  int device_count = 0;
+  check_hip(hipGetDeviceCount(&device_count), "hipGetDeviceCount");
+  TORCH_CHECK(
+      device_id < device_count,
+      "device_id ",
+      device_id,
+      " is out of range for ",
+      device_count,
+      " visible HIP device(s)");
+  return static_cast<int>(device_id);
+}
+
+size_t validate_size(int64_t value, const char* name) {
+  TORCH_CHECK(value > 0, name, " must be positive, got ", value);
+  return static_cast<size_t>(value);
+}
+
+size_t validate_offset(int64_t value) {
+  TORCH_CHECK(value >= 0, "offset must be non-negative, got ", value);
+  return static_cast<size_t>(value);
+}
+
+void* validate_address(int64_t address, const char* name) {
+  TORCH_CHECK(address > 0, name, " must be a nonzero address, got ", address);
+  return reinterpret_cast<void*>(static_cast<uintptr_t>(address));
+}
+
+hipMemGenericAllocationHandle_t validate_handle(int64_t handle) {
+  TORCH_CHECK(handle > 0, "handle must be nonzero, got ", handle);
+  return reinterpret_cast<hipMemGenericAllocationHandle_t>(static_cast<uintptr_t>(handle));
+}
+
+template <typename Pointer>
+int64_t pointer_to_int(Pointer pointer, const char* operation) {
+  const auto raw = reinterpret_cast<uintptr_t>(pointer);
+  TORCH_CHECK(raw != 0, operation, " returned a null value");
+  TORCH_CHECK(
+      raw <= static_cast<uintptr_t>(std::numeric_limits<int64_t>::max()),
+      operation,
+      " returned an address outside the signed 64-bit range");
+  return static_cast<int64_t>(raw);
+}
+
+hipMemAllocationProp make_allocation_prop(int device_id, bool shareable) {
+  hipMemAllocationProp prop{};
+  prop.type = hipMemAllocationTypePinned;
+  prop.requestedHandleTypes = shareable ? hipMemHandleTypePosixFileDescriptor : hipMemHandleTypeNone;
+  prop.location.type = hipMemLocationTypeDevice;
+  prop.location.id = device_id;
+  return prop;
+}
+
+}  // namespace
+
+bool hip_vmm_is_supported(int64_t device_id) {
+  const int hip_device_id = validate_device(device_id);
+  int supported = 0;
+  const hipError_t status =
+      hipDeviceGetAttribute(&supported, hipDeviceAttributeVirtualMemoryManagementSupported, hip_device_id);
+  if (status == hipErrorNotSupported) {
+    return false;
+  }
+  check_hip(status, "hipDeviceGetAttribute(VirtualMemoryManagementSupported)");
+  return supported != 0;
+}
+
+int64_t hip_vmm_get_allocation_granularity(int64_t device_id, bool shareable, bool recommended) {
+  const int hip_device_id = validate_device(device_id);
+  const hipMemAllocationProp prop = make_allocation_prop(hip_device_id, shareable);
+  const auto option = recommended ? hipMemAllocationGranularityRecommended : hipMemAllocationGranularityMinimum;
+  size_t granularity = 0;
+  check_hip(hipMemGetAllocationGranularity(&granularity, &prop, option), "hipMemGetAllocationGranularity");
+  TORCH_CHECK(granularity > 0, "hipMemGetAllocationGranularity returned zero");
+  TORCH_CHECK(
+      granularity <= static_cast<size_t>(std::numeric_limits<int64_t>::max()),
+      "HIP allocation granularity is outside the signed 64-bit range");
+  return static_cast<int64_t>(granularity);
+}
+
+int64_t hip_vmm_create(int64_t size, int64_t device_id, bool shareable) {
+  const size_t allocation_size = validate_size(size, "size");
+  const int hip_device_id = validate_device(device_id);
+  const hipMemAllocationProp prop = make_allocation_prop(hip_device_id, shareable);
+
+  hipMemGenericAllocationHandle_t handle = nullptr;
+  const hipError_t status = hipMemCreate(&handle, allocation_size, &prop, 0);
+  if (status != hipSuccess && handle != nullptr) {
+    (void)hipMemRelease(handle);
+    handle = nullptr;
+  }
+  check_hip(status, "hipMemCreate");
+  return pointer_to_int(handle, "hipMemCreate");
+}
+
+void hip_vmm_release(int64_t handle) {
+  check_hip(hipMemRelease(validate_handle(handle)), "hipMemRelease");
+}
+
+int64_t hip_vmm_address_reserve(int64_t size, int64_t alignment, int64_t requested_address) {
+  const size_t reservation_size = validate_size(size, "size");
+  TORCH_CHECK(alignment >= 0, "alignment must be non-negative, got ", alignment);
+  TORCH_CHECK(
+      alignment == 0 || (alignment & (alignment - 1)) == 0,
+      "alignment must be zero or a power of two, got ",
+      alignment);
+  TORCH_CHECK(requested_address >= 0, "requested_address must be zero or a positive address, got ", requested_address);
+
+  void* address = nullptr;
+  const hipError_t status = hipMemAddressReserve(
+      &address,
+      reservation_size,
+      static_cast<size_t>(alignment),
+      reinterpret_cast<void*>(static_cast<uintptr_t>(requested_address)),
+      0);
+  if (status != hipSuccess && address != nullptr) {
+    (void)hipMemAddressFree(address, reservation_size);
+    address = nullptr;
+  }
+  check_hip(status, "hipMemAddressReserve");
+  return pointer_to_int(address, "hipMemAddressReserve");
+}
+
+void hip_vmm_address_free(int64_t address, int64_t size) {
+  check_hip(hipMemAddressFree(validate_address(address, "address"), validate_size(size, "size")), "hipMemAddressFree");
+}
+
+void hip_vmm_map(int64_t address, int64_t size, int64_t handle, int64_t offset) {
+  check_hip(
+      hipMemMap(
+          validate_address(address, "address"),
+          validate_size(size, "size"),
+          validate_offset(offset),
+          validate_handle(handle),
+          0),
+      "hipMemMap");
+}
+
+void hip_vmm_unmap(int64_t address, int64_t size) {
+  check_hip(hipMemUnmap(validate_address(address, "address"), validate_size(size, "size")), "hipMemUnmap");
+}
+
+void hip_vmm_set_access(int64_t address, int64_t size, int64_t device_id) {
+  hipMemAccessDesc access{};
+  access.location.type = hipMemLocationTypeDevice;
+  access.location.id = validate_device(device_id);
+  access.flags = hipMemAccessFlagsProtReadWrite;
+  check_hip(
+      hipMemSetAccess(validate_address(address, "address"), validate_size(size, "size"), &access, 1),
+      "hipMemSetAccess");
+}
+
+int64_t hip_vmm_export_fd(int64_t handle) {
+  int fd = -1;
+  const hipError_t status =
+      hipMemExportToShareableHandle(&fd, validate_handle(handle), hipMemHandleTypePosixFileDescriptor, 0);
+  if (status != hipSuccess && fd >= 0) {
+    (void)::close(fd);
+    fd = -1;
+  }
+  check_hip(status, "hipMemExportToShareableHandle(POSIX_FD)");
+  TORCH_CHECK(fd >= 0, "hipMemExportToShareableHandle returned an invalid fd");
+  return static_cast<int64_t>(fd);
+}
+
+int64_t hip_vmm_import_fd(int64_t fd) {
+  TORCH_CHECK(fd >= 0, "fd must be non-negative, got ", fd);
+  TORCH_CHECK(fd <= std::numeric_limits<int>::max(), "fd is too large: ", fd);
+  int native_fd = static_cast<int>(fd);
+
+  // HIP changed this ABI in ROCm 7.1. Older runtimes expect an int*, while
+  // ROCm 7.1+ expects the descriptor value cast to void*.
+#if HIP_VERSION >= 70100000
+  void* os_handle = reinterpret_cast<void*>(static_cast<uintptr_t>(native_fd));
+#else
+  void* os_handle = &native_fd;
+#endif
+
+  hipMemGenericAllocationHandle_t handle = nullptr;
+  const hipError_t status = hipMemImportFromShareableHandle(&handle, os_handle, hipMemHandleTypePosixFileDescriptor);
+  if (status != hipSuccess && handle != nullptr) {
+    (void)hipMemRelease(handle);
+    handle = nullptr;
+  }
+  check_hip(status, "hipMemImportFromShareableHandle(POSIX_FD)");
+  return pointer_to_int(handle, "hipMemImportFromShareableHandle");
+}
+
+at::Tensor hip_vmm_tensor_from_address(
+    int64_t address, const std::vector<int64_t>& shape, at::ScalarType dtype, int64_t device_id) {
+  void* data = validate_address(address, "address");
+  const int hip_device_id = validate_device(device_id);
+  TORCH_CHECK(dtype != at::ScalarType::Undefined, "dtype must be explicitly specified");
+
+  int64_t numel = 1;
+  for (const int64_t dimension : shape) {
+    TORCH_CHECK(dimension >= 0, "shape dimensions must be non-negative, got dimension ", dimension);
+    if (dimension == 0) {
+      numel = 0;
+      continue;
+    }
+    if (numel != 0) {
+      TORCH_CHECK(numel <= std::numeric_limits<int64_t>::max() / dimension, "shape element count overflows int64");
+      numel *= dimension;
+    }
+  }
+  (void)numel;
+
+  const auto options = at::TensorOptions().dtype(dtype).device(at::kCUDA, static_cast<c10::DeviceIndex>(hip_device_id));
+  // VMM ownership stays with the caller. The Tensor must not outlive the
+  // mapping; deleting it never releases or unmaps the external allocation.
+  return at::from_blob(data, shape, [](void*) {}, options);
+}

--- a/python/sglang/kernels/aot/csrc/dwdp/hsa_copy.h
+++ b/python/sglang/kernels/aot/csrc/dwdp/hsa_copy.h
@@ -1,0 +1,14 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved. */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+#include <cstdint>
+
+bool dwdp_hsa_copy_is_available();
+int64_t dwdp_hsa_copy_engine_for_devices(int64_t destination_device, int64_t source_device);
+int64_t dwdp_hsa_copy_async(
+    const at::Tensor& destination, const at::Tensor& source, int64_t destination_device, int64_t source_device);
+int64_t dwdp_hsa_copy_wait(int64_t ticket);
+void dwdp_hsa_copy_destroy(int64_t ticket);

--- a/python/sglang/kernels/aot/csrc/dwdp/hsa_copy.hip
+++ b/python/sglang/kernels/aot/csrc/dwdp/hsa_copy.hip
@@ -1,0 +1,177 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved. */
+
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+#include <hip/hip_runtime_api.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+#include <mutex>
+#include <vector>
+
+#include "dwdp/hsa_copy.h"
+
+namespace {
+
+std::once_flag hsa_init_once;
+hsa_status_t hsa_init_status = HSA_STATUS_ERROR_NOT_INITIALIZED;
+
+void ensure_hsa_initialized() {
+  std::call_once(hsa_init_once, [] { hsa_init_status = hsa_init(); });
+  TORCH_CHECK(hsa_init_status == HSA_STATUS_SUCCESS, "hsa_init failed: ", static_cast<int>(hsa_init_status));
+}
+
+void check_hsa(hsa_status_t status, const char* operation) {
+  if (status == HSA_STATUS_SUCCESS) {
+    return;
+  }
+  const char* detail = nullptr;
+  hsa_status_string(status, &detail);
+  TORCH_CHECK(
+      false,
+      operation,
+      " failed with HSA status ",
+      static_cast<int>(status),
+      ": ",
+      detail == nullptr ? "unknown" : detail);
+}
+
+hsa_signal_t signal_from_ticket(int64_t ticket) {
+  TORCH_CHECK(ticket > 0, "HSA copy ticket must be positive, got ", ticket);
+  return hsa_signal_t{static_cast<uint64_t>(ticket)};
+}
+
+hsa_status_t collect_gpu_agents(hsa_agent_t agent, void* data) {
+  hsa_device_type_t type{};
+  if (hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type) != HSA_STATUS_SUCCESS) {
+    return HSA_STATUS_SUCCESS;
+  }
+  if (type == HSA_DEVICE_TYPE_GPU) {
+    static_cast<std::vector<hsa_agent_t>*>(data)->push_back(agent);
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_agent_t agent_for_hip_device(int64_t device_id) {
+  TORCH_CHECK(device_id >= 0 && device_id <= std::numeric_limits<int>::max(), "invalid HIP device ", device_id);
+  char pci_bus_id[32] = {};
+  const hipError_t hip_status = hipDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), static_cast<int>(device_id));
+  TORCH_CHECK(hip_status == hipSuccess, "hipDeviceGetPCIBusId failed: ", hipGetErrorString(hip_status));
+
+  unsigned int domain = 0;
+  unsigned int bus = 0;
+  unsigned int device = 0;
+  unsigned int function = 0;
+  TORCH_CHECK(
+      std::sscanf(pci_bus_id, "%x:%x:%x.%x", &domain, &bus, &device, &function) == 4,
+      "cannot parse HIP PCI bus id ",
+      pci_bus_id);
+  const uint32_t expected_bdf = (bus << 8) | (device << 3) | function;
+
+  std::vector<hsa_agent_t> agents;
+  check_hsa(hsa_iterate_agents(collect_gpu_agents, &agents), "hsa_iterate_agents");
+  for (const hsa_agent_t agent : agents) {
+    uint32_t bdf = 0;
+    if (hsa_agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_BDFID), &bdf) ==
+            HSA_STATUS_SUCCESS &&
+        bdf == expected_bdf) {
+      return agent;
+    }
+  }
+  TORCH_CHECK(false, "no HSA GPU agent matches HIP device ", device_id, " (", pci_bus_id, ")");
+  return hsa_agent_t{0};
+}
+
+hsa_amd_sdma_engine_id_t select_engine(hsa_agent_t destination, hsa_agent_t source) {
+  uint32_t available = 0;
+  check_hsa(
+      hsa_amd_memory_copy_engine_status(destination, source, &available),
+      "hsa_amd_memory_copy_engine_status");
+  TORCH_CHECK(available != 0, "no HSA SDMA engine is available for the GPU pair");
+
+  uint32_t preferred = 0;
+  const hsa_status_t preferred_status =
+      hsa_amd_memory_get_preferred_copy_engine(destination, source, &preferred);
+  uint32_t candidates =
+      preferred_status == HSA_STATUS_SUCCESS ? (available & preferred) : 0;
+  if (candidates == 0) {
+    candidates = available;
+  }
+  const uint32_t selected = candidates & (~candidates + 1);
+  TORCH_CHECK(selected != 0, "failed to select an HSA SDMA engine");
+  return static_cast<hsa_amd_sdma_engine_id_t>(selected);
+}
+
+}  // namespace
+
+bool dwdp_hsa_copy_is_available() {
+  try {
+    ensure_hsa_initialized();
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+int64_t dwdp_hsa_copy_engine_for_devices(int64_t destination_device, int64_t source_device) {
+  ensure_hsa_initialized();
+  return static_cast<int64_t>(
+      select_engine(agent_for_hip_device(destination_device), agent_for_hip_device(source_device)));
+}
+
+int64_t dwdp_hsa_copy_async(
+    const at::Tensor& destination,
+    const at::Tensor& source,
+    int64_t destination_device,
+    int64_t source_device) {
+  ensure_hsa_initialized();
+  TORCH_CHECK(destination.is_cuda() && source.is_cuda(), "HSA DWDP copy requires GPU tensors");
+  TORCH_CHECK(destination.is_contiguous() && source.is_contiguous(), "HSA DWDP copy requires contiguous tensors");
+  TORCH_CHECK(
+      destination.numel() * destination.element_size() == source.numel() * source.element_size(),
+      "HSA DWDP copy byte-size mismatch");
+
+  hsa_signal_t completion{};
+  check_hsa(hsa_signal_create(1, 0, nullptr, &completion), "hsa_signal_create");
+  const hsa_agent_t destination_agent = agent_for_hip_device(destination_device);
+  const hsa_agent_t source_agent = agent_for_hip_device(source_device);
+  const auto engine = select_engine(destination_agent, source_agent);
+  const size_t bytes = static_cast<size_t>(destination.numel()) * destination.element_size();
+
+  const hsa_status_t status = hsa_amd_memory_async_copy_on_engine(
+      destination.data_ptr(),
+      destination_agent,
+      source.data_ptr(),
+      source_agent,
+      bytes,
+      0,
+      nullptr,
+      completion,
+      engine,
+      true);
+  if (status != HSA_STATUS_SUCCESS) {
+    hsa_signal_destroy(completion);
+    check_hsa(status, "hsa_amd_memory_async_copy_on_engine");
+  }
+  TORCH_CHECK(
+      completion.handle <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+      "HSA signal handle exceeds int64");
+  return static_cast<int64_t>(completion.handle);
+}
+
+int64_t dwdp_hsa_copy_wait(int64_t ticket) {
+  ensure_hsa_initialized();
+  const hsa_signal_value_t value = hsa_signal_wait_scacquire(
+      signal_from_ticket(ticket),
+      HSA_SIGNAL_CONDITION_LT,
+      1,
+      std::numeric_limits<uint64_t>::max(),
+      HSA_WAIT_STATE_BLOCKED);
+  return static_cast<int64_t>(value);
+}
+
+void dwdp_hsa_copy_destroy(int64_t ticket) {
+  ensure_hsa_initialized();
+  check_hsa(hsa_signal_destroy(signal_from_ticket(ticket)), "hsa_signal_destroy");
+}

--- a/python/sglang/kernels/aot/setup_rocm.py
+++ b/python/sglang/kernels/aot/setup_rocm.py
@@ -45,6 +45,8 @@ sources = [
     "csrc/allreduce/deterministic_all_reduce.hip",
     "csrc/allreduce/quick_all_reduce.cu",
     "csrc/common_extension_rocm.cc",
+    "csrc/dwdp/hsa_copy.hip",
+    "csrc/dwdp/hip_vmm.hip",
     "csrc/elementwise/activation.cu",
     "csrc/elementwise/deepseek_v4_topk.cu",
     "csrc/elementwise/dsv4_norm_rope.cu",
@@ -60,7 +62,14 @@ sources = [
 ]
 
 cxx_flags = ["-O3"]
-libraries = ["hiprtc", "amdhip64", "c10", "torch", "torch_python"]
+libraries = [
+    "hiprtc",
+    "amdhip64",
+    "hsa-runtime64",
+    "c10",
+    "torch",
+    "torch_python",
+]
 extra_link_args = ["-Wl,-rpath,$ORIGIN/../../torch/lib", f"-L/usr/lib/{arch}-linux-gnu"]
 
 default_target = "gfx942"

--- a/python/sglang/srt/layers/moe/dwdp/__init__.py
+++ b/python/sglang/srt/layers/moe/dwdp/__init__.py
@@ -1,13 +1,72 @@
-"""DWDP (Distributed Weight Data Parallelism): MoE prefill with tokens kept on-rank and peer expert weights prefetched via NVLink into a composite VMM address space."""
+"""DWDP: rank-local MoE tokens with prefetched peer expert weights."""
 
-from sglang.srt.layers.moe.dwdp.dwdp_manager import DwdpManager
-from sglang.srt.runtime_context import (
-    get_global_dwdp_manager,
-    set_global_dwdp_manager,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.moe.dwdp.dwdp_manager import DwdpManager
 
 __all__ = [
     "DwdpManager",
+    "create_dwdp_manager",
     "get_global_dwdp_manager",
     "set_global_dwdp_manager",
 ]
+
+
+def create_dwdp_manager(server_args):
+    """Select a DWDP backend without importing vendor modules eagerly."""
+
+    from sglang.srt.utils.common import is_hip
+
+    backend = getattr(server_args, "dwdp_weight_backend", "auto")
+    if is_hip():
+        if backend == "vmm":
+            try:
+                from sglang.srt.layers.moe.dwdp.rocm_vmm_manager import (
+                    RocmVmmDwdpManager,
+                )
+
+                if RocmVmmDwdpManager.is_available():
+                    return RocmVmmDwdpManager(server_args)
+                raise RuntimeError(
+                    "ROCm DWDP VMM backend was requested but HIP VMM "
+                    "capability is unavailable"
+                )
+            except ImportError:
+                raise
+
+        if backend in ("auto", "ipc"):
+            from sglang.srt.layers.moe.dwdp.rocm_ipc import RocmIpcDwdpManager
+
+            return RocmIpcDwdpManager(server_args)
+        raise ValueError(f"Unsupported ROCm DWDP weight backend: {backend}")
+
+    if backend == "ipc":
+        raise ValueError("DWDP IPC/multi-B backend is only supported on ROCm")
+    from sglang.srt.layers.moe.dwdp.dwdp_manager import DwdpManager
+
+    return DwdpManager(server_args)
+
+
+def __getattr__(name: str):
+    # Keep submodules such as hip_vmm importable without eagerly loading the
+    # CUDA-specific DWDP manager and transport dependency chain.
+    if name == "DwdpManager":
+        from sglang.srt.layers.moe.dwdp.dwdp_manager import DwdpManager
+
+        value = DwdpManager
+    elif name in ("get_global_dwdp_manager", "set_global_dwdp_manager"):
+        from sglang.srt.runtime_context import (
+            get_global_dwdp_manager,
+            set_global_dwdp_manager,
+        )
+
+        value = {
+            "get_global_dwdp_manager": get_global_dwdp_manager,
+            "set_global_dwdp_manager": set_global_dwdp_manager,
+        }[name]
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = value
+    return value

--- a/python/sglang/srt/layers/moe/dwdp/common.py
+++ b/python/sglang/srt/layers/moe/dwdp/common.py
@@ -1,0 +1,29 @@
+"""Platform-neutral helpers shared by DWDP backends."""
+
+
+def restore_storage_rank(original, expert_view):
+    """Restore a gathered logical expert view to the layer's storage rank."""
+    if original.ndim >= expert_view.ndim:
+        return expert_view.contiguous()
+    tail = tuple(original.shape[1:])
+    tail_numel = 1
+    for dim in tail:
+        tail_numel *= dim
+    if expert_view.numel() % tail_numel != 0:
+        raise ValueError(
+            f"Cannot restore logical shape {tuple(expert_view.shape)} to storage "
+            f"tail {tail}"
+        )
+    return expert_view.reshape((-1,) + tail).contiguous()
+
+
+def align_up(value: int, alignment: int) -> int:
+    if alignment <= 0 or (alignment & (alignment - 1)) != 0:
+        raise ValueError(f"alignment must be a positive power of 2, got {alignment}")
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def align_down(value: int, alignment: int) -> int:
+    if alignment <= 0 or (alignment & (alignment - 1)) != 0:
+        raise ValueError(f"alignment must be a positive power of 2, got {alignment}")
+    return (value // alignment) * alignment

--- a/python/sglang/srt/layers/moe/dwdp/dwdp_manager.py
+++ b/python/sglang/srt/layers/moe/dwdp/dwdp_manager.py
@@ -9,11 +9,13 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
+from sglang.srt.layers.moe.dwdp.common import restore_storage_rank
 from sglang.srt.layers.moe.dwdp.layout import (
     DwdpExpertLayout,
     build_layer_weight_specs,
     lookup_owner,
 )
+from sglang.srt.layers.moe.dwdp.tensor_schema import DwdpTensorSchema
 from sglang.srt.layers.moe.dwdp.transport import DWDPTransport
 from sglang.srt.layers.moe.dwdp.weight_buffer import WeightBuffer
 from sglang.srt.layers.moe.dwdp.weight_manager import DWDPWeightManager
@@ -25,11 +27,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_EXPERT_WEIGHT_NAMES = (
-    "w13_weight",
-    "w2_weight",
-)
-
 
 class DwdpManager:
     def __init__(self, server_args: ServerArgs):
@@ -40,20 +37,24 @@ class DwdpManager:
 
         self._weight_manager: Optional[DWDPWeightManager] = None
         self._moe_layer_indices: List[int] = []
+        self._moe_layers: List[Tuple[int, FusedMoE]] = []
+        self._schemas: Dict[int, DwdpTensorSchema] = {}
+        self._original_main_tensors: Dict[Tuple[int, str], torch.Tensor] = {}
+        self._original_side_tensors: Dict[Tuple[int, str], torch.Tensor] = {}
 
     def setup(self, model: nn.Module) -> None:
         if self._weight_manager is not None:
             return
 
-        moe_layers = self._collect_moe_layers(model)
-        if not moe_layers:
+        self._moe_layers = self._collect_moe_layers(model)
+        if not self._moe_layers:
             raise RuntimeError(
                 f"DWDP is enabled but no FusedMoE layers were found in "
                 f"{type(model).__name__}"
             )
-        self._moe_layer_indices = [li for li, _ in moe_layers]
+        self._moe_layer_indices = [li for li, _ in self._moe_layers]
 
-        expert_counts = {e.num_global_routed_experts for _, e in moe_layers}
+        expert_counts = {e.num_global_routed_experts for _, e in self._moe_layers}
         if len(expert_counts) != 1:
             raise RuntimeError(
                 f"DWDP requires a uniform routed expert count across MoE layers, "
@@ -65,10 +66,21 @@ class DwdpManager:
                 f"DWDP requires num_routed_experts ({num_routed}) to be divisible "
                 f"by dwdp_size ({self.dwdp_size})"
             )
+        shared_counts = {
+            int(getattr(experts, "num_fused_shared_experts", 0))
+            for _, experts in self._moe_layers
+        }
+        if len(shared_counts) != 1:
+            raise RuntimeError(
+                "DWDP requires a uniform fused shared expert count, got "
+                f"{sorted(shared_counts)}"
+            )
+        num_shared = shared_counts.pop()
         self.layout = DwdpExpertLayout(
             num_routed_experts=num_routed,
             dwdp_size=self.dwdp_size,
             dwdp_rank=self.dwdp_rank,
+            num_fused_shared_experts=num_shared,
         )
         logger.info(
             f"DWDP layout: {self.layout.num_routed_experts} experts, "
@@ -77,52 +89,99 @@ class DwdpManager:
         )
 
         local_params = {}
-        for li, experts in moe_layers:
-            local_params[(li, "w13_weight")] = experts.w13_weight.data
-            local_params[(li, "w2_weight")] = experts.w2_weight.data
+        local_routed = self.layout.num_experts_per_worker
+        local_count = self.layout.local_expert_end - self.layout.local_expert_start
+        main_weight_names = None
+        for li, experts in self._moe_layers:
+            if experts.quant_method is None:
+                raise RuntimeError(f"Layer {li} has no MoE quantization method")
+            schema = experts.quant_method.get_dwdp_tensor_schema(experts)
+            schema.validate(experts)
+            self._schemas[li] = schema
+            if main_weight_names is None:
+                main_weight_names = schema.main_weights
+            elif schema.main_weights != main_weight_names:
+                raise RuntimeError(
+                    "DWDP requires identical main weight names across layers"
+                )
+            for name in schema.main_weights:
+                storage_tensor = getattr(experts, name)
+                if isinstance(storage_tensor, torch.nn.Parameter):
+                    storage_tensor = storage_tensor.data
+                self._original_main_tensors[(li, name)] = storage_tensor
+                original = experts.quant_method.get_dwdp_tensor(experts, name)
+                required = local_routed + num_shared
+                if original.ndim == 0 or original.shape[0] < required:
+                    raise RuntimeError(
+                        f"Layer {li} tensor {name} has shape "
+                        f"{tuple(original.shape)}, expected at least {required} experts"
+                    )
+                local = original.narrow(0, 0, local_count)
+                if not local.is_contiguous():
+                    local = local.contiguous()
+                local_params[(li, name)] = local
         layer_weight_specs = build_layer_weight_specs(
-            local_params, self.layout.num_routed_experts
+            local_params, self.layout.num_experts
         )
 
         group = get_parallel().tp_group
-        transport = DWDPTransport.create(
-            layer_weight_specs=layer_weight_specs,
-            local_params=local_params,
-            group=group,
-            layout=self.layout,
-            device_id=self.device_id,
-        )
-
-        weight_buffer = WeightBuffer.create(
-            layer_weight_specs=layer_weight_specs,
-            handles=transport.handle_set,
-            local_start=self.layout.local_expert_start,
-            local_end=self.layout.local_expert_end,
-            dwdp_size=self.dwdp_size,
-            device_id=self.device_id,
-        )
-
-        self._fill_edge_bytes(weight_buffer, transport.peer_views)
-
-        self._weight_manager = DWDPWeightManager(
-            weight_buffer=weight_buffer,
-            peer_views=transport.peer_views,
-            peer_ranges=self.layout.peer_ranges,
-            moe_layer_indices=self._moe_layer_indices,
-            weight_names=list(_EXPERT_WEIGHT_NAMES),
-            dwdp_rank=self.dwdp_rank,
-            dwdp_size=self.dwdp_size,
-            transport=transport,
-        )
-
-        for li, experts in moe_layers:
-            experts.bind_full_expert_weights(
-                {
-                    name: weight_buffer.get_full_tensor(li, name)
-                    for name in weight_buffer.weight_names(li)
-                }
+        transport = None
+        weight_buffer = None
+        try:
+            transport = DWDPTransport.create(
+                layer_weight_specs=layer_weight_specs,
+                local_params=local_params,
+                group=group,
+                layout=self.layout,
+                device_id=self.device_id,
             )
-        self._allgather_small_params(moe_layers, group)
+            weight_buffer = WeightBuffer.create(
+                layer_weight_specs=layer_weight_specs,
+                handles=transport.handle_set,
+                local_start=self.layout.local_expert_start,
+                local_end=self.layout.local_expert_end,
+                dwdp_size=self.dwdp_size,
+                device_id=self.device_id,
+            )
+            self._fill_edge_bytes(weight_buffer, transport.peer_views)
+            self._allgather_small_params(self._moe_layers, self._schemas, group)
+
+            manager = DWDPWeightManager(
+                weight_buffer=weight_buffer,
+                peer_views=transport.peer_views,
+                peer_ranges=self.layout.peer_ranges,
+                moe_layer_indices=self._moe_layer_indices,
+                weight_names=list(main_weight_names),
+                dwdp_rank=self.dwdp_rank,
+                dwdp_size=self.dwdp_size,
+                transport=transport,
+            )
+            for li, experts in self._moe_layers:
+                experts.bind_full_expert_weights(
+                    {
+                        name: weight_buffer.get_full_tensor(li, name)
+                        for name in main_weight_names
+                    }
+                )
+            self._weight_manager = manager
+            for tensor in self._original_main_tensors.values():
+                tensor.untyped_storage().resize_(0)
+            torch.cuda.empty_cache()
+        except Exception:
+            layers = dict(self._moe_layers)
+            for (layer_idx, name), original in self._original_main_tensors.items():
+                layers[layer_idx].replace_expert_tensor(name, original)
+            for (layer_idx, name), original in self._original_side_tensors.items():
+                layers[layer_idx].replace_expert_tensor(name, original)
+            for _, experts in self._moe_layers:
+                experts.unbind_dwdp_weights()
+            if weight_buffer is not None:
+                weight_buffer.release()
+            if transport is not None:
+                transport.release()
+            self._original_main_tensors.clear()
+            self._original_side_tensors.clear()
+            raise
 
         logger.info("DWDP setup complete.")
 
@@ -139,9 +198,15 @@ class DwdpManager:
             self._weight_manager.record_compute_and_prefetch_next(layer_idx)
 
     def cleanup(self) -> None:
-        if self._weight_manager is not None:
-            self._weight_manager.release()
-            self._weight_manager = None
+        if self._weight_manager is None:
+            return
+        if dist.is_initialized():
+            get_parallel().tp_group.barrier()
+        self._weight_manager.release()
+        self._weight_manager = None
+        self._original_main_tensors.clear()
+        self._original_side_tensors.clear()
+        self._schemas.clear()
 
     @staticmethod
     def _collect_moe_layers(model: nn.Module) -> List[Tuple[int, FusedMoE]]:
@@ -191,21 +256,59 @@ class DwdpManager:
         torch.cuda.synchronize(weight_buffer.device_id)
 
     def _allgather_small_params(
-        self, moe_layers: List[Tuple[int, FusedMoE]], group
+        self,
+        moe_layers: List[Tuple[int, FusedMoE]],
+        schemas: Dict[int, DwdpTensorSchema],
+        group,
     ) -> None:
         local_experts = self.layout.num_experts_per_worker
-        num_total = self.layout.num_routed_experts
+        num_shared = self.layout.num_fused_shared_experts
 
         for li, experts in moe_layers:
-            for pname, data in experts.named_per_expert_tensors(local_experts):
-                shards = [torch.empty_like(data) for _ in range(self.dwdp_size)]
-                dist.all_gather(shards, data, group=group.device_group)
-                full = torch.cat(shards, dim=0)[:num_total].contiguous()
+            schema = schemas[li]
+            names = tuple(
+                dict.fromkeys(
+                    tuple(
+                        name
+                        for name in schema.partitioned
+                        if name not in schema.main_weights
+                    )
+                    + schema.replicated
+                )
+            )
+            for pname in names:
+                storage_tensor = getattr(experts, pname)
+                if isinstance(storage_tensor, torch.nn.Parameter):
+                    storage_tensor = storage_tensor.data
+                self._original_side_tensors.setdefault(
+                    (li, pname),
+                    storage_tensor,
+                )
+                data = experts.quant_method.get_dwdp_tensor(experts, pname)
+                required = local_experts + num_shared
+                if data.ndim == 0 or data.shape[0] < required:
+                    raise RuntimeError(
+                        f"Layer {li} side tensor {pname} has shape "
+                        f"{tuple(data.shape)}, expected at least {required} experts"
+                    )
+                routed = data.narrow(0, 0, local_experts)
+                shards = [torch.empty_like(routed) for _ in range(self.dwdp_size)]
+                dist.all_gather(shards, routed, group=group.device_group)
+                full = torch.cat(shards, dim=0)
+                if num_shared:
+                    full = torch.cat(
+                        [
+                            full,
+                            data.narrow(0, local_experts, num_shared),
+                        ],
+                        dim=0,
+                    )
+                full = restore_storage_rank(storage_tensor, full)
                 experts.replace_expert_tensor(pname, full)
 
                 logger.debug(
                     f"Layer {li}: allgathered {pname} "
-                    f"({local_experts} -> {full.shape[0]}) "
+                    f"({data.shape[0]} -> {full.shape[0]}) "
                     f"shape={tuple(full.shape)} dtype={full.dtype} "
                     f"size={full.numel() * full.element_size() / 1e6:.1f}MB"
                 )

--- a/python/sglang/srt/layers/moe/dwdp/hip_vmm.py
+++ b/python/sglang/srt/layers/moe/dwdp/hip_vmm.py
@@ -1,0 +1,310 @@
+"""ROCm-only HIP virtual-memory primitives for DWDP.
+
+The native operators are loaded lazily from ``sgl_kernel`` so importing this
+module is safe on CUDA and CPU-only installations. POSIX file descriptors have
+explicit ownership:
+
+* :func:`export_fd` returns a new descriptor owned by the caller, which must
+  eventually call ``os.close``.
+* :func:`import_fd` keeps the caller's descriptor open. It imports a temporary
+  duplicate and closes that duplicate after HIP has acquired its own dma-buf
+  reference. The returned HIP allocation handle must be released separately.
+
+Tensors returned by :func:`tensor_from_ptr` do not own the VMM mapping. They
+must be destroyed (and outstanding GPU work synchronized) before unmapping.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from dataclasses import dataclass, field
+from typing import Sequence, Tuple
+
+import torch
+
+__all__ = [
+    "HipVmmCleanupError",
+    "HipVmmUnavailableError",
+    "VmmMapping",
+    "align_down",
+    "align_up",
+    "create_local_handle",
+    "create_shareable_handle",
+    "export_fd",
+    "extension_availability",
+    "free_va",
+    "get_allocation_granularity",
+    "import_fd",
+    "is_supported",
+    "map_handle",
+    "map_handles",
+    "release_handle",
+    "reserve_va",
+    "set_access",
+    "tensor_from_ptr",
+    "unmap_va",
+]
+
+_REQUIRED_OPS = (
+    "hip_vmm_is_supported",
+    "hip_vmm_get_allocation_granularity",
+    "hip_vmm_create",
+    "hip_vmm_release",
+    "hip_vmm_address_reserve",
+    "hip_vmm_address_free",
+    "hip_vmm_map",
+    "hip_vmm_unmap",
+    "hip_vmm_set_access",
+    "hip_vmm_export_fd",
+    "hip_vmm_import_fd",
+    "hip_vmm_tensor_from_address",
+)
+
+# ROCm 7.x associates hipMemSetAccess with the physical allocation. Calling it
+# again through another VA alias returns hipErrorInvalidValue.
+ACCESS_IS_ALLOCATION_SCOPED = True
+
+
+class HipVmmUnavailableError(RuntimeError):
+    """Raised when the ROCm ``sgl_kernel`` VMM operators cannot be loaded."""
+
+
+class HipVmmCleanupError(RuntimeError):
+    """Raised after all possible cleanup actions were attempted."""
+
+    def __init__(self, context: str, errors: Sequence[BaseException]):
+        self.context = context
+        self.errors = tuple(errors)
+        details = "; ".join(f"{type(error).__name__}: {error}" for error in errors)
+        super().__init__(f"{context}: {details}")
+
+
+def align_up(value: int, alignment: int) -> int:
+    if alignment <= 0 or (alignment & (alignment - 1)) != 0:
+        raise ValueError(f"alignment must be a positive power of 2, got {alignment}")
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def align_down(value: int, alignment: int) -> int:
+    if alignment <= 0 or (alignment & (alignment - 1)) != 0:
+        raise ValueError(f"alignment must be a positive power of 2, got {alignment}")
+    return (value // alignment) * alignment
+
+
+@functools.lru_cache(maxsize=1)
+def _ops():
+    if torch.version.hip is None:
+        raise HipVmmUnavailableError("HIP VMM requires a ROCm build of PyTorch")
+
+    try:
+        import sgl_kernel  # noqa: F401
+    except Exception as error:
+        raise HipVmmUnavailableError(
+            f"failed to load the ROCm sgl_kernel extension: {error}"
+        ) from error
+
+    namespace = torch.ops.sgl_kernel
+    missing = [name for name in _REQUIRED_OPS if not hasattr(namespace, name)]
+    if missing:
+        raise HipVmmUnavailableError(
+            "the loaded sgl_kernel extension has no HIP VMM operators: "
+            + ", ".join(missing)
+        )
+    return namespace
+
+
+def extension_availability() -> Tuple[bool, str]:
+    """Return whether the ROCm extension and all HIP VMM operators are usable."""
+
+    try:
+        _ops()
+    except HipVmmUnavailableError as error:
+        return False, str(error)
+    return True, ""
+
+
+def is_supported(device_id: int) -> bool:
+    """Return the HIP device's VMM capability attribute."""
+
+    return bool(_ops().hip_vmm_is_supported(device_id))
+
+
+@functools.lru_cache(maxsize=None)
+def get_allocation_granularity(
+    device_id: int, *, shareable: bool = True, recommended: bool = True
+) -> int:
+    return int(
+        _ops().hip_vmm_get_allocation_granularity(device_id, shareable, recommended)
+    )
+
+
+def create_shareable_handle(size: int, device_id: int) -> int:
+    """Create a HIP allocation exportable as a POSIX file descriptor."""
+
+    return int(_ops().hip_vmm_create(size, device_id, True))
+
+
+def create_local_handle(size: int, device_id: int) -> int:
+    """Create a non-exportable HIP allocation."""
+
+    return int(_ops().hip_vmm_create(size, device_id, False))
+
+
+def release_handle(handle: int) -> None:
+    if handle != 0:
+        _ops().hip_vmm_release(handle)
+
+
+def reserve_va(size: int, alignment: int = 0, requested_address: int = 0) -> int:
+    return int(_ops().hip_vmm_address_reserve(size, alignment, requested_address))
+
+
+def free_va(address: int, size: int) -> None:
+    if address != 0:
+        _ops().hip_vmm_address_free(address, size)
+
+
+def map_handle(address: int, size: int, handle: int, offset: int = 0) -> None:
+    _ops().hip_vmm_map(address, size, handle, offset)
+
+
+def unmap_va(address: int, size: int) -> None:
+    if address != 0:
+        _ops().hip_vmm_unmap(address, size)
+
+
+def set_access(address: int, size: int, device_id: int) -> None:
+    _ops().hip_vmm_set_access(address, size, device_id)
+
+
+def export_fd(handle: int) -> int:
+    """Export ``handle`` to a new caller-owned POSIX file descriptor."""
+
+    return int(_ops().hip_vmm_export_fd(handle))
+
+
+def import_fd(fd: int) -> int:
+    """Import ``fd`` without consuming or closing the caller-owned descriptor."""
+
+    if fd < 0:
+        raise ValueError(f"fd must be non-negative, got {fd}")
+    duplicate = os.dup(fd)
+    try:
+        return int(_ops().hip_vmm_import_fd(duplicate))
+    finally:
+        os.close(duplicate)
+
+
+def tensor_from_ptr(
+    ptr: int,
+    shape: Tuple[int, ...],
+    dtype: torch.dtype,
+    device_id: int,
+) -> torch.Tensor:
+    """Wrap mapped external VA in a non-owning, contiguous HIP tensor."""
+
+    return _ops().hip_vmm_tensor_from_address(ptr, list(shape), dtype, device_id)
+
+
+@dataclass
+class VmmMapping:
+    """Own a VA reservation and its mapped regions, but not allocation handles."""
+
+    address: int
+    size: int
+    _mapped_regions: list[tuple[int, int]] = field(default_factory=list)
+
+    @property
+    def mapped_regions(self) -> tuple[tuple[int, int], ...]:
+        return tuple(self._mapped_regions)
+
+    @property
+    def closed(self) -> bool:
+        return self.address == 0
+
+    def close(self) -> None:
+        """Unmap every region in reverse order, then free the reservation."""
+
+        if self.closed:
+            return
+
+        errors: list[BaseException] = []
+        for index in range(len(self._mapped_regions) - 1, -1, -1):
+            region_address, region_size = self._mapped_regions[index]
+            try:
+                unmap_va(region_address, region_size)
+            except BaseException as error:
+                errors.append(error)
+            else:
+                del self._mapped_regions[index]
+
+        if not self._mapped_regions:
+            try:
+                free_va(self.address, self.size)
+            except BaseException as error:
+                errors.append(error)
+            else:
+                self.address = 0
+
+        if errors:
+            raise HipVmmCleanupError("HIP VMM mapping cleanup failed", errors)
+
+    def __enter__(self) -> VmmMapping:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        try:
+            self.close()
+        except BaseException as cleanup_error:
+            if exc_value is None:
+                raise
+            raise HipVmmCleanupError(
+                "HIP VMM cleanup failed while handling another exception",
+                (exc_value, cleanup_error),
+            ) from exc_value
+        return False
+
+
+def map_handles(
+    handles: Sequence[int],
+    sizes: Sequence[int],
+    device_id: int,
+    *,
+    alignment: int = 0,
+) -> VmmMapping:
+    """Map handles contiguously and roll back every completed step on failure."""
+
+    if not handles:
+        raise ValueError("at least one allocation handle is required")
+    if len(handles) != len(sizes):
+        raise ValueError(
+            f"handles and sizes must have equal length, got {len(handles)} and {len(sizes)}"
+        )
+    if any(size <= 0 for size in sizes):
+        raise ValueError(f"all mapping sizes must be positive, got {list(sizes)}")
+
+    total_size = sum(sizes)
+    if total_size > (1 << 63) - 1:
+        raise OverflowError(f"total mapping size exceeds int64: {total_size}")
+
+    address = reserve_va(total_size, alignment)
+    mapping = VmmMapping(address=address, size=total_size)
+    try:
+        offset = 0
+        for handle, size in zip(handles, sizes):
+            region_address = address + offset
+            map_handle(region_address, size, handle)
+            mapping._mapped_regions.append((region_address, size))
+            offset += size
+        set_access(address, total_size, device_id)
+    except BaseException as setup_error:
+        try:
+            mapping.close()
+        except BaseException as cleanup_error:
+            raise HipVmmCleanupError(
+                "HIP VMM setup failed and rollback was incomplete",
+                (setup_error, cleanup_error),
+            ) from setup_error
+        raise
+    return mapping

--- a/python/sglang/srt/layers/moe/dwdp/hsa_copy.py
+++ b/python/sglang/srt/layers/moe/dwdp/hsa_copy.py
@@ -1,0 +1,125 @@
+"""HSA SDMA copy engine used by ROCm DWDP backends."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class HsaCopyUnavailableError(RuntimeError):
+    pass
+
+
+class HsaSdmaCopyEngine:
+    """Submit tensor copies to pair-specific HSA SDMA engines.
+
+    Completion tickets are host-waited because HIP events cannot represent an
+    external HSA queue dependency. DWDP therefore keeps graph capture disabled.
+    """
+
+    def __init__(self):
+        if torch.version.hip is None:
+            raise HsaCopyUnavailableError("HSA copy requires ROCm PyTorch")
+        try:
+            import sgl_kernel  # noqa: F401
+        except Exception as error:
+            raise HsaCopyUnavailableError(
+                f"failed to load sgl_kernel HSA copy operators: {error}"
+            ) from error
+        required = (
+            "dwdp_hsa_copy_is_available",
+            "dwdp_hsa_copy_engine_for_devices",
+            "dwdp_hsa_copy_async",
+            "dwdp_hsa_copy_wait",
+            "dwdp_hsa_copy_destroy",
+        )
+        missing = [name for name in required if not hasattr(torch.ops.sgl_kernel, name)]
+        if missing:
+            raise HsaCopyUnavailableError(
+                f"sgl_kernel has no HSA copy operators: {missing}"
+            )
+        if not torch.ops.sgl_kernel.dwdp_hsa_copy_is_available():
+            raise HsaCopyUnavailableError("HSA SDMA copy API is unavailable")
+        self._ops = torch.ops.sgl_kernel
+
+    def engine_for_devices(self, destination_device: int, source_device: int) -> int:
+        return int(
+            self._ops.dwdp_hsa_copy_engine_for_devices(
+                destination_device,
+                source_device,
+            )
+        )
+
+    @classmethod
+    def create_or_none(cls):
+        if os.environ.get("SGLANG_DWDP_DISABLE_HSA_COPY", "0") == "1":
+            logger.info("ROCm DWDP HSA copy disabled by environment")
+            return None
+        try:
+            return cls()
+        except HsaCopyUnavailableError as error:
+            logger.warning(
+                "ROCm DWDP HSA copy unavailable; using HIP stream copy_: %s",
+                error,
+            )
+            return None
+
+    def submit(
+        self,
+        destination: torch.Tensor,
+        source: torch.Tensor,
+        *,
+        destination_device: int | None = None,
+        source_device: int | None = None,
+    ) -> int:
+        if not destination.is_contiguous() or not source.is_contiguous():
+            raise ValueError("HSA DWDP copies require contiguous tensors")
+        if destination.numel() != source.numel():
+            raise ValueError(
+                f"HSA DWDP copy size mismatch: {destination.shape} vs {source.shape}"
+            )
+        if destination.element_size() != source.element_size():
+            raise ValueError(
+                f"HSA DWDP copy dtype width mismatch: {destination.dtype} vs "
+                f"{source.dtype}"
+            )
+        destination_device = (
+            destination.device.index
+            if destination_device is None
+            else destination_device
+        )
+        source_device = source.device.index if source_device is None else source_device
+        if destination_device is None or source_device is None:
+            raise ValueError("HSA DWDP copy requires explicit HIP device indices")
+        return int(
+            self._ops.dwdp_hsa_copy_async(
+                destination,
+                source,
+                int(destination_device),
+                int(source_device),
+            )
+        )
+
+    def wait(self, ticket: int) -> None:
+        value = int(self._ops.dwdp_hsa_copy_wait(ticket))
+        self._ops.dwdp_hsa_copy_destroy(ticket)
+        if value != 0:
+            raise RuntimeError(
+                f"HSA DWDP copy ticket {ticket} completed with signal value {value}"
+            )
+
+    def wait_all(self, tickets: Iterable[int]) -> None:
+        first_error = None
+        for ticket in tickets:
+            try:
+                self.wait(ticket)
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error

--- a/python/sglang/srt/layers/moe/dwdp/layout.py
+++ b/python/sglang/srt/layers/moe/dwdp/layout.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 
-from sglang.srt.layers.moe.dwdp.vmm import align_down, align_up
+from sglang.srt.layers.moe.dwdp.common import align_down, align_up
 
 # one (start, end_capped) expert range per peer DWDP rank
 PeerRanges = List[Tuple[int, int]]
@@ -22,8 +22,20 @@ class DwdpExpertLayout:
         num_routed_experts: int,
         dwdp_size: int,
         dwdp_rank: int,
+        num_fused_shared_experts: int = 0,
     ):
+        if dwdp_size < 2:
+            raise ValueError(f"dwdp_size must be at least 2, got {dwdp_size}")
+        if not 0 <= dwdp_rank < dwdp_size:
+            raise ValueError(f"dwdp_rank must be in [0, {dwdp_size}), got {dwdp_rank}")
+        if num_fused_shared_experts < 0:
+            raise ValueError(
+                "num_fused_shared_experts must be non-negative, got "
+                f"{num_fused_shared_experts}"
+            )
         self.num_routed_experts = num_routed_experts
+        self.num_fused_shared_experts = num_fused_shared_experts
+        self.num_experts = num_routed_experts + num_fused_shared_experts
         self.dwdp_size = dwdp_size
         self.dwdp_rank = dwdp_rank
 
@@ -38,6 +50,8 @@ class DwdpExpertLayout:
             num_routed_experts - num_experts_per_worker,
         )
         self.local_expert_end = self.local_expert_start + num_experts_per_worker
+        if dwdp_rank == dwdp_size - 1:
+            self.local_expert_end += num_fused_shared_experts
 
         self.peer_ranges = compute_peer_ranges(
             dwdp_size=dwdp_size,
@@ -45,6 +59,12 @@ class DwdpExpertLayout:
             num_prefetch_experts=self.num_prefetch_experts,
             num_experts_total=num_routed_experts,
         )
+        if num_fused_shared_experts:
+            last_start, last_end = self.peer_ranges[-1]
+            self.peer_ranges[-1] = (
+                last_start,
+                last_end + num_fused_shared_experts,
+            )
 
 
 class WeightSpec:

--- a/python/sglang/srt/layers/moe/dwdp/page_pool.py
+++ b/python/sglang/srt/layers/moe/dwdp/page_pool.py
@@ -1,27 +1,18 @@
-# Adapted from NVIDIA TensorRT-LLM (https://github.com/NVIDIA/TensorRT-LLM)
-"""Double-buffered pool of local VMM pages backing the remote regions of the composite VA."""
+"""Physical page pool for DWDP double-buffered remote weight regions."""
 
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-from sglang.srt.layers.moe.dwdp.vmm import (
-    align_up,
-    create_local_handle,
-    get_allocation_granularity,
-    map_handle,
-    release_handle,
-)
+from sglang.srt.layers.moe.dwdp.common import align_up
+from sglang.srt.layers.moe.dwdp.layout import PageAlignedLayout
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_PAGE_SIZE_MULTIPLIER = 8
-
 
 class PagePool:
-    # local (non-fabric) handles avoid consuming NVLink routing table entries
-    DEFAULT_PAGE_SIZE_MULTIPLIER = DEFAULT_PAGE_SIZE_MULTIPLIER
+    DEFAULT_PAGE_SIZE_MULTIPLIER = 8
 
     def __init__(
         self,
@@ -29,31 +20,50 @@ class PagePool:
         device_id: int,
         granularity: Optional[int] = None,
         page_size: Optional[int] = None,
+        vmm_ops: Any = None,
     ):
+        if vmm_ops is None:
+            from sglang.srt.layers.moe.dwdp import vmm as vmm_ops
+
+        self._vmm_ops = vmm_ops
         self._device_id = device_id
-        self._granularity = granularity or get_allocation_granularity(device_id)
-
-        if page_size is None:
-            self._page_size = self.DEFAULT_PAGE_SIZE_MULTIPLIER * self._granularity
-        else:
-            self._page_size = page_size
-
+        self._granularity = granularity or vmm_ops.get_allocation_granularity(device_id)
+        self._page_size = (
+            self.DEFAULT_PAGE_SIZE_MULTIPLIER * self._granularity
+            if page_size is None
+            else page_size
+        )
         self._slot_sizes = list(slot_sizes)
         self._slot_pages = [
-            align_up(sz, self._page_size) // self._page_size for sz in slot_sizes
+            align_up(size, self._page_size) // self._page_size for size in slot_sizes
         ]
+        self._region_pool = getattr(
+            self._vmm_ops,
+            "ACCESS_IS_ALLOCATION_SCOPED",
+            False,
+        )
 
         self._page_handles: List[List[int]] = []
+        self._region_handles: Dict[Tuple[int, int, int], int] = {}
+        self._access_initialized: set[int] = set()
         self._released = False
 
         for slot_idx, num_pages in enumerate(self._slot_pages):
             handles = []
-            for _ in range(num_pages):
-                h = create_local_handle(self._page_size, device_id)
-                handles.append(h)
+            if not self._region_pool:
+                for _ in range(num_pages):
+                    handles.append(
+                        self._vmm_ops.create_local_handle(
+                            self._page_size,
+                            device_id,
+                        )
+                    )
             self._page_handles.append(handles)
             logger.debug(
-                f"PagePool slot {slot_idx}: {num_pages} pages × {self._page_size} B"
+                "PagePool slot %d: %d pages x %d B",
+                slot_idx,
+                num_pages,
+                self._page_size,
             )
 
     @classmethod
@@ -62,8 +72,14 @@ class PagePool:
         slot_sizes: List[int],
         device_id: int,
         page_size: Optional[int] = None,
+        vmm_ops: Any = None,
     ) -> PagePool:
-        return cls(slot_sizes, device_id, page_size=page_size)
+        return cls(
+            slot_sizes,
+            device_id,
+            page_size=page_size,
+            vmm_ops=vmm_ops,
+        )
 
     @property
     def page_size(self) -> int:
@@ -82,15 +98,70 @@ class PagePool:
         size: int,
         page_offset: int = 0,
     ) -> List[Tuple[int, int]]:
-        # does NOT call set_access; caller must set access on the whole composite VA
         aligned_size = align_up(size, self._page_size)
         num_pages_needed = aligned_size // self._page_size
 
+        if self._region_pool:
+            # ROCm 7.x rejects non-zero hipMemMap offsets and has a low active
+            # generic-allocation limit. Pool each stable pre/post region as one
+            # allocation instead of creating one allocation per page.
+            key = (slot, page_offset, aligned_size)
+            handle = self._region_handles.get(key)
+            is_new = handle is None
+            if is_new:
+                handle = self._vmm_ops.create_local_handle(
+                    aligned_size,
+                    self._device_id,
+                )
+                self._region_handles[key] = handle
+                self._page_handles[slot].append(handle)
+
+            self._vmm_ops.map_handle(
+                va_start,
+                aligned_size,
+                handle,
+                offset=0,
+            )
+            if handle not in self._access_initialized:
+                try:
+                    self._vmm_ops.set_access(
+                        va_start,
+                        aligned_size,
+                        self._device_id,
+                    )
+                except Exception as error:
+                    self._vmm_ops.unmap_va(va_start, aligned_size)
+                    if is_new:
+                        self._page_handles[slot].remove(handle)
+                        self._region_handles.pop(key, None)
+                        self._vmm_ops.release_handle(handle)
+                    raise RuntimeError(
+                        f"Failed to set region-pool VMM access: key={key}, "
+                        f"handle={handle:#x}, va={va_start:#x}, "
+                        f"size={aligned_size}"
+                    ) from error
+                self._access_initialized.add(handle)
+            return [(va_start, aligned_size)]
+
         mappings = []
-        for i in range(num_pages_needed):
-            va = va_start + i * self._page_size
-            handle = self._page_handles[slot][page_offset + i]
-            map_handle(va, self._page_size, handle, offset=0)
+        for index in range(num_pages_needed):
+            va = va_start + index * self._page_size
+            handle = self._page_handles[slot][page_offset + index]
+            self._vmm_ops.map_handle(
+                va,
+                self._page_size,
+                handle,
+                offset=0,
+            )
+            try:
+                self._vmm_ops.set_access(
+                    va,
+                    self._page_size,
+                    self._device_id,
+                )
+            except Exception:
+                self._vmm_ops.unmap_va(va, self._page_size)
+                raise
             mappings.append((va, self._page_size))
         return mappings
 
@@ -99,18 +170,22 @@ class PagePool:
             return
         self._released = True
         for handles in self._page_handles:
-            for h in handles:
-                release_handle(h)
+            for handle in handles:
+                self._vmm_ops.release_handle(handle)
         self._page_handles = [[], []]
+        self._region_handles.clear()
+        self._access_initialized.clear()
 
 
 def compute_slot_sizes(
-    layouts: Dict[int, Dict[str, PageAlignedLayout]],  # noqa: F821
+    layouts: Dict[int, Dict[str, PageAlignedLayout]],
     buffer_slot_assignments: Dict[int, int],
 ) -> List[int]:
     slot_sizes = [0, 0]
     for layer_idx, weight_layouts in layouts.items():
         slot = buffer_slot_assignments.get(layer_idx, layer_idx % 2)
-        total = sum(lo.pre_size + lo.post_size for lo in weight_layouts.values())
+        total = sum(
+            layout.pre_size + layout.post_size for layout in weight_layouts.values()
+        )
         slot_sizes[slot] = max(slot_sizes[slot], total)
     return slot_sizes

--- a/python/sglang/srt/layers/moe/dwdp/rocm_ipc.py
+++ b/python/sglang/srt/layers/moe/dwdp/rocm_ipc.py
@@ -1,0 +1,576 @@
+"""ROCm DWDP backend using HIP IPC and rank-ordered multi-B tensors."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from sglang.srt.layers.moe.dwdp.common import restore_storage_rank
+from sglang.srt.layers.moe.dwdp.hsa_copy import HsaSdmaCopyEngine
+from sglang.srt.layers.moe.dwdp.layout import DwdpExpertLayout
+from sglang.srt.layers.moe.dwdp.tensor_schema import DwdpTensorSchema
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.runtime_context import get_parallel
+
+logger = logging.getLogger(__name__)
+
+TensorKey = Tuple[int, str]
+PeerTensorKey = Tuple[int, int, str]
+
+_COPIED_TENSOR_ATTRS = (
+    "is_shuffled",
+    "weight_padded",
+    "is_transposed",
+)
+
+
+@dataclass(frozen=True)
+class DwdpPartitionView:
+    tensors: Tuple[torch.Tensor, ...]
+    partition_sizes: Tuple[int, ...]
+
+
+class RocmIpcDwdpManager:
+    """Materialize remote expert partitions in two HIP-allocated staging slots."""
+
+    weight_backend = "ipc"
+
+    def __init__(self, server_args):
+        self.dwdp_size = int(server_args.dwdp_size)
+        self.dwdp_rank = get_parallel().tp_rank
+        self.device_id = torch.cuda.current_device()
+        self.layout: Optional[DwdpExpertLayout] = None
+
+        self._moe_layers: List[Tuple[int, FusedMoE]] = []
+        self._moe_layer_indices: List[int] = []
+        self._schemas: Dict[int, DwdpTensorSchema] = {}
+        self._num_fused_shared = 0
+
+        self._local_tensors: Dict[TensorKey, torch.Tensor] = {}
+        self._local_routed: Dict[TensorKey, torch.Tensor] = {}
+        self._local_shared: Dict[TensorKey, torch.Tensor] = {}
+        self._original_replicated_tensors: Dict[TensorKey, torch.Tensor] = {}
+        self._peer_tensors: Dict[PeerTensorKey, torch.Tensor] = {}
+        self._peer_device_ids: Dict[int, int] = {}
+        self._peer_storages: List[torch.UntypedStorage] = []
+
+        self._prefetch_buffers: List[Dict[str, List[Optional[torch.Tensor]]]] = []
+        self._copy_streams: Dict[int, torch.cuda.Stream] = {}
+        self._prefetch_events: List[Dict[int, torch.cuda.Event]] = []
+        self._consume_events: List[torch.cuda.Event] = []
+        self._copy_engine = None
+        self._copy_tickets: List[List[int]] = [[], []]
+        self._initialized = False
+
+    @staticmethod
+    def _collect_moe_layers(model: nn.Module) -> List[Tuple[int, FusedMoE]]:
+        decoder = model.model if hasattr(model, "model") else model
+        result: List[Tuple[int, FusedMoE]] = []
+        for layer_idx, layer in enumerate(decoder.layers):
+            experts = next(
+                (module for module in layer.modules() if isinstance(module, FusedMoE)),
+                None,
+            )
+            if experts is not None:
+                result.append((layer_idx, experts))
+        return result
+
+    def setup(self, model: nn.Module) -> None:
+        if self._initialized:
+            return
+        arch = torch.cuda.get_device_properties(self.device_id).gcnArchName
+        if "gfx950" not in arch:
+            raise NotImplementedError(
+                f"ROCm IPC DWDP requires gfx950, got {arch!r}"
+            )
+        if torch.cuda.device_count() < self.dwdp_size:
+            raise RuntimeError(
+                f"ROCm IPC DWDP needs {self.dwdp_size} visible GPUs on one node, "
+                f"got {torch.cuda.device_count()}"
+            )
+        inaccessible = [
+            peer
+            for peer in range(torch.cuda.device_count())
+            if peer != self.device_id
+            and not torch.cuda.can_device_access_peer(self.device_id, peer)
+        ]
+        if inaccessible:
+            raise RuntimeError(
+                f"ROCm IPC DWDP requires full XGMI P2P; device {self.device_id} "
+                f"cannot access peers {inaccessible}"
+            )
+        try:
+            from aiter.fused_moe import fused_moe_multi_b  # noqa: F401
+        except (ImportError, AttributeError) as error:
+            raise RuntimeError(
+                "ROCm IPC DWDP requires an Aiter build with fused_moe_multi_b"
+            ) from error
+
+        self._moe_layers = self._collect_moe_layers(model)
+        if not self._moe_layers:
+            raise RuntimeError(
+                f"DWDP is enabled but no FusedMoE layers were found in "
+                f"{type(model).__name__}"
+            )
+        self._moe_layer_indices = [layer_idx for layer_idx, _ in self._moe_layers]
+
+        expert_counts = {
+            experts.num_global_routed_experts for _, experts in self._moe_layers
+        }
+        if len(expert_counts) != 1:
+            raise RuntimeError(
+                "ROCm IPC DWDP requires a uniform routed expert count, got "
+                f"{sorted(expert_counts)}"
+            )
+        num_routed = expert_counts.pop()
+        if num_routed % self.dwdp_size != 0:
+            raise ValueError(
+                f"num_routed_experts ({num_routed}) must be divisible by "
+                f"dwdp_size ({self.dwdp_size})"
+            )
+
+        shared_counts = {
+            int(getattr(experts, "num_fused_shared_experts", 0))
+            for _, experts in self._moe_layers
+        }
+        if len(shared_counts) != 1:
+            raise RuntimeError(
+                "ROCm IPC DWDP requires a uniform fused shared expert count, got "
+                f"{sorted(shared_counts)}"
+            )
+        self._num_fused_shared = shared_counts.pop()
+        self.layout = DwdpExpertLayout(
+            num_routed_experts=num_routed,
+            dwdp_size=self.dwdp_size,
+            dwdp_rank=self.dwdp_rank,
+            num_fused_shared_experts=self._num_fused_shared,
+        )
+
+        try:
+            self._register_tensors()
+            self._exchange_ipc_handles()
+            self._allocate_prefetch_buffers()
+            self._replicate_small_tensors()
+            for _, experts in self._moe_layers:
+                experts.bind_dwdp_partitioned_weights()
+            self._initialized = True
+        except Exception:
+            self.cleanup(synchronize_ranks=False)
+            raise
+
+        logger.info(
+            "ROCm IPC DWDP setup complete: rank=%d/%d, routed=%d, shared=%d",
+            self.dwdp_rank,
+            self.dwdp_size,
+            num_routed,
+            self._num_fused_shared,
+        )
+
+    def _register_tensors(self) -> None:
+        assert self.layout is not None
+        local_routed = self.layout.num_experts_per_worker
+
+        reference_specs: Dict[str, Tuple[Tuple[int, ...], torch.dtype]] = {}
+        reference_names: Optional[Tuple[str, ...]] = None
+        for layer_idx, experts in self._moe_layers:
+            if experts.quant_method is None:
+                raise RuntimeError(f"Layer {layer_idx} has no MoE quantization method")
+            schema = experts.quant_method.get_dwdp_tensor_schema(experts)
+            schema.validate(experts)
+            if reference_names is None:
+                reference_names = schema.partitioned
+            elif schema.partitioned != reference_names:
+                raise RuntimeError(
+                    "ROCm IPC DWDP requires identical partitioned tensor names "
+                    f"across layers; got {reference_names} and {schema.partitioned}"
+                )
+            self._schemas[layer_idx] = schema
+
+            for name in schema.partitioned:
+                tensor = experts.quant_method.get_dwdp_tensor(experts, name)
+                required = local_routed + self._num_fused_shared
+                if tensor.ndim == 0 or tensor.shape[0] < required:
+                    raise RuntimeError(
+                        f"Layer {layer_idx} tensor {name} has shape "
+                        f"{tuple(tensor.shape)}, expected at least {required} experts"
+                    )
+                if not tensor.is_contiguous():
+                    raise RuntimeError(
+                        f"Layer {layer_idx} tensor {name} must be contiguous for HIP IPC"
+                    )
+
+                key = (layer_idx, name)
+                self._local_tensors[key] = tensor
+                self._local_routed[key] = tensor.narrow(0, 0, local_routed)
+                if self._num_fused_shared:
+                    self._local_shared[key] = tensor.narrow(
+                        0, local_routed, self._num_fused_shared
+                    )
+
+                spec = (tuple(tensor.shape[1:]), tensor.dtype)
+                previous = reference_specs.setdefault(name, spec)
+                if previous != spec:
+                    raise RuntimeError(
+                        f"ROCm IPC DWDP requires uniform {name} specs across layers; "
+                        f"got {previous} and {spec}"
+                    )
+
+    def _exchange_ipc_handles(self) -> None:
+        group = get_parallel().tp_group
+        local_metadata = {}
+        for key, tensor in sorted(self._local_tensors.items()):
+            handle = tensor.untyped_storage()._share_cuda_()
+            local_metadata[key] = {
+                "handle": handle,
+                "shape": tuple(tensor.shape),
+                "stride": tuple(tensor.stride()),
+                "storage_offset": tensor.storage_offset(),
+                "dtype": tensor.dtype,
+                "source_device": tensor.device.index,
+            }
+
+        all_metadata = [None] * self.dwdp_size
+        dist.all_gather_object(
+            all_metadata,
+            local_metadata,
+            group=group.cpu_group,
+        )
+        local_keys = set(local_metadata)
+        for peer_rank, metadata in enumerate(all_metadata):
+            if set(metadata) != local_keys:
+                raise RuntimeError(
+                    "Mismatched ROCm DWDP IPC tensor keys: "
+                    f"rank {self.dwdp_rank} has {sorted(local_keys)}, "
+                    f"rank {peer_rank} has {sorted(metadata)}"
+                )
+            if peer_rank == self.dwdp_rank:
+                continue
+
+            for (layer_idx, name), item in metadata.items():
+                self._peer_device_ids[peer_rank] = int(item["source_device"])
+                original_handle = item["handle"]
+                redirected_handle = (self.device_id,) + tuple(original_handle)[1:]
+                target_device = torch.device("cuda", self.device_id)
+                with torch.cuda.device(target_device):
+                    storage = torch.UntypedStorage._new_shared_cuda(*redirected_handle)
+                    tensor = torch.empty(
+                        0,
+                        dtype=item["dtype"],
+                        device=target_device,
+                    ).set_(
+                        storage,
+                        storage_offset=item["storage_offset"],
+                        size=item["shape"],
+                        stride=item["stride"],
+                    )
+                self._peer_storages.append(storage)
+                self._peer_tensors[(peer_rank, layer_idx, name)] = tensor
+
+        group.barrier()
+
+    def _allocate_prefetch_buffers(self) -> None:
+        assert self.layout is not None
+        local_routed = self.layout.num_experts_per_worker
+        last_rank = self.dwdp_size - 1
+        first_layer = self._moe_layer_indices[0]
+        names = self._schemas[first_layer].partitioned
+        device = torch.device("cuda", self.device_id)
+
+        for _slot in range(2):
+            slot: Dict[str, List[Optional[torch.Tensor]]] = {}
+            for name in names:
+                reference = self._local_tensors[(first_layer, name)]
+                per_expert_shape = tuple(reference.shape[1:])
+                peer_buffers: List[Optional[torch.Tensor]] = [None] * self.dwdp_size
+                for peer_rank in range(self.dwdp_size):
+                    if peer_rank == self.dwdp_rank:
+                        continue
+                    count = local_routed
+                    if peer_rank == last_rank:
+                        count += self._num_fused_shared
+                    peer_buffers[peer_rank] = torch.empty(
+                        (count,) + per_expert_shape,
+                        dtype=reference.dtype,
+                        device=device,
+                    )
+                slot[name] = peer_buffers
+            self._prefetch_buffers.append(slot)
+
+        self._copy_streams = {
+            peer_rank: torch.cuda.Stream(device=device)
+            for peer_rank in range(self.dwdp_size)
+            if peer_rank != self.dwdp_rank
+        }
+        self._prefetch_events = [
+            {peer_rank: torch.cuda.Event() for peer_rank in self._copy_streams}
+            for _ in range(2)
+        ]
+        self._consume_events = [torch.cuda.Event(), torch.cuda.Event()]
+        current_stream = torch.cuda.current_stream(device)
+        for event in self._consume_events:
+            event.record(current_stream)
+        self._copy_engine = HsaSdmaCopyEngine.create_or_none()
+
+    def _replicate_small_tensors(self) -> None:
+        assert self.layout is not None
+        group = get_parallel().tp_group
+        local_routed = self.layout.num_experts_per_worker
+
+        for layer_idx, experts in self._moe_layers:
+            schema = self._schemas[layer_idx]
+            for name in schema.replicated:
+                key = (layer_idx, name)
+                storage_tensor = getattr(experts, name)
+                if isinstance(storage_tensor, torch.nn.Parameter):
+                    storage_tensor = storage_tensor.data
+                self._original_replicated_tensors.setdefault(key, storage_tensor)
+                tensor = experts.quant_method.get_dwdp_tensor(experts, name)
+                required = local_routed + self._num_fused_shared
+                if tensor.ndim == 0 or tensor.shape[0] < required:
+                    raise RuntimeError(
+                        f"Layer {layer_idx} replicated tensor {name} has shape "
+                        f"{tuple(tensor.shape)}, expected at least {required} experts"
+                    )
+                routed = tensor.narrow(0, 0, local_routed)
+                shards = [torch.empty_like(routed) for _ in range(self.dwdp_size)]
+                dist.all_gather(shards, routed, group=group.device_group)
+                full = torch.cat(shards, dim=0)
+                if self._num_fused_shared:
+                    full = torch.cat(
+                        [
+                            full,
+                            tensor.narrow(0, local_routed, self._num_fused_shared),
+                        ],
+                        dim=0,
+                    )
+                experts.replace_expert_tensor(
+                    name,
+                    restore_storage_rank(storage_tensor, full),
+                )
+
+    def _slot_for_layer(self, layer_idx: int) -> int:
+        return self._moe_layer_indices.index(layer_idx) % 2
+
+    def _next_moe_layer(self, layer_idx: int, distance: int = 1) -> Optional[int]:
+        position = self._moe_layer_indices.index(layer_idx) + distance
+        if position >= len(self._moe_layer_indices):
+            return None
+        return self._moe_layer_indices[position]
+
+    def _disable_hsa_copy_engine(self, completed_slot: int) -> None:
+        engine = self._copy_engine
+        if engine is None:
+            return
+        # wait_all() always destroys every submitted ticket, including when one
+        # signal reports an error. Do not wait the completed slot twice.
+        self._copy_tickets[completed_slot].clear()
+        for slot_idx, tickets in enumerate(self._copy_tickets):
+            if slot_idx == completed_slot or not tickets:
+                continue
+            try:
+                engine.wait_all(tickets)
+            except Exception:
+                logger.exception(
+                    "Failed while draining HSA DWDP IPC slot %s during fallback",
+                    slot_idx,
+                )
+            finally:
+                tickets.clear()
+        self._copy_engine = None
+
+    def prefetch_layer(self, layer_idx: int) -> None:
+        if not self._prefetch_buffers:
+            return
+        assert self.layout is not None
+        slot_idx = self._slot_for_layer(layer_idx)
+        local_routed = self.layout.num_experts_per_worker
+        last_rank = self.dwdp_size - 1
+        schema = self._schemas[layer_idx]
+
+        if self._copy_engine is not None:
+            self._consume_events[slot_idx].synchronize()
+            if self._copy_tickets[slot_idx]:
+                raise RuntimeError(
+                    f"DWDP IPC slot {slot_idx} has outstanding HSA tickets"
+                )
+
+        for peer_rank, stream in self._copy_streams.items():
+            with torch.cuda.stream(stream):
+                if self._copy_engine is None:
+                    stream.wait_event(self._consume_events[slot_idx])
+                for name in schema.partitioned:
+                    source = self._peer_tensors[(peer_rank, layer_idx, name)]
+                    destination = self._prefetch_buffers[slot_idx][name][peer_rank]
+                    assert destination is not None
+                    routed_destination = destination.narrow(0, 0, local_routed)
+                    routed_source = source.narrow(0, 0, local_routed)
+                    if self._copy_engine is None:
+                        routed_destination.copy_(
+                            routed_source,
+                            non_blocking=True,
+                        )
+                    else:
+                        self._copy_tickets[slot_idx].append(
+                            self._copy_engine.submit(
+                                routed_destination,
+                                routed_source,
+                                destination_device=self.device_id,
+                                source_device=self._peer_device_ids[peer_rank],
+                            )
+                        )
+                    if peer_rank == last_rank and self._num_fused_shared:
+                        destination.narrow(
+                            0,
+                            local_routed,
+                            self._num_fused_shared,
+                        ).copy_(
+                            self._local_shared[(layer_idx, name)],
+                            non_blocking=True,
+                        )
+                self._prefetch_events[slot_idx][peer_rank].record(stream)
+
+    def prefetch_first_layers(self) -> None:
+        if not self._initialized:
+            return
+        for layer_idx in self._moe_layer_indices[:2]:
+            self.prefetch_layer(layer_idx)
+
+    def wait_prefetch(self, layer_idx: int) -> None:
+        if not self._initialized:
+            return
+        slot_idx = self._slot_for_layer(layer_idx)
+        if self._copy_engine is not None:
+            try:
+                self._copy_engine.wait_all(self._copy_tickets[slot_idx])
+            except Exception:
+                logger.exception(
+                    "HSA DWDP IPC prefetch failed for layer %s; retrying with "
+                    "HIP copy_",
+                    layer_idx,
+                )
+                self._disable_hsa_copy_engine(slot_idx)
+                self.prefetch_layer(layer_idx)
+            else:
+                self._copy_tickets[slot_idx].clear()
+        compute_stream = torch.cuda.current_stream(self.device_id)
+        for event in self._prefetch_events[slot_idx].values():
+            compute_stream.wait_event(event)
+
+    def record_compute_and_prefetch_next(self, layer_idx: int) -> None:
+        if not self._initialized:
+            return
+        slot_idx = self._slot_for_layer(layer_idx)
+        self._consume_events[slot_idx].record(torch.cuda.current_stream(self.device_id))
+        next_next = self._next_moe_layer(layer_idx, distance=2)
+        if next_next is not None:
+            self.prefetch_layer(next_next)
+
+    def get_partition_view(
+        self,
+        layer_idx: int,
+        name: str,
+        reference: Optional[torch.Tensor] = None,
+    ) -> DwdpPartitionView:
+        if not self._initialized:
+            raise RuntimeError("ROCm IPC DWDP manager is not initialized")
+        assert self.layout is not None
+        if name not in self._schemas[layer_idx].partitioned:
+            raise KeyError(f"Tensor {name!r} is not partitioned for layer {layer_idx}")
+
+        local_routed = self.layout.num_experts_per_worker
+        last_rank = self.dwdp_size - 1
+        slot_idx = self._slot_for_layer(layer_idx)
+        parts: List[torch.Tensor] = []
+        sizes: List[int] = []
+        for rank in range(self.dwdp_size):
+            count = local_routed + (self._num_fused_shared if rank == last_rank else 0)
+            if rank == self.dwdp_rank:
+                local = self._local_tensors[(layer_idx, name)]
+                part = local.narrow(0, 0, count)
+            else:
+                part = self._prefetch_buffers[slot_idx][name][rank]
+                assert part is not None
+            parts.append(self._match_reference(part, reference))
+            sizes.append(count)
+        return DwdpPartitionView(tuple(parts), tuple(sizes))
+
+    def find_partitioned_name(
+        self,
+        layer_idx: int,
+        reference: Optional[torch.Tensor],
+    ) -> Optional[str]:
+        if reference is None:
+            return None
+        reference_storage = reference.untyped_storage().data_ptr()
+        for name in self._schemas[layer_idx].partitioned:
+            tensor = self._local_tensors[(layer_idx, name)]
+            if tensor.untyped_storage().data_ptr() == reference_storage:
+                return name
+        raise KeyError(
+            f"No DWDP partitioned tensor in layer {layer_idx} shares storage "
+            f"with shape={tuple(reference.shape)} dtype={reference.dtype}"
+        )
+
+    @staticmethod
+    def _match_reference(
+        tensor: torch.Tensor,
+        reference: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if reference is None:
+            return tensor
+        result = tensor
+        if result.dtype != reference.dtype:
+            result = result.view(reference.dtype)
+        target_tail = tuple(reference.shape[1:])
+        if tuple(result.shape[1:]) != target_tail:
+            target_numel = math.prod(target_tail)
+            if result[0].numel() != target_numel:
+                raise RuntimeError(
+                    f"Cannot view DWDP partition shape {tuple(result.shape)} like "
+                    f"{tuple(reference.shape)}"
+                )
+            result = result.reshape((result.shape[0],) + target_tail)
+        for attr in _COPIED_TENSOR_ATTRS:
+            if hasattr(reference, attr):
+                setattr(result, attr, getattr(reference, attr))
+        return result
+
+    def cleanup(self, synchronize_ranks: bool = True) -> None:
+        if synchronize_ranks and dist.is_initialized():
+            get_parallel().tp_group.barrier()
+        if self._copy_engine is not None:
+            for tickets in self._copy_tickets:
+                try:
+                    self._copy_engine.wait_all(tickets)
+                except Exception:
+                    logger.exception("Failed while draining HSA tickets during cleanup")
+                finally:
+                    tickets.clear()
+        if self._copy_streams and torch.cuda.is_available():
+            torch.cuda.synchronize(self.device_id)
+        layers = dict(self._moe_layers)
+        for (layer_idx, name), original in self._original_replicated_tensors.items():
+            layers[layer_idx].replace_expert_tensor(name, original)
+        for _, experts in self._moe_layers:
+            experts.unbind_dwdp_weights()
+        self._prefetch_buffers.clear()
+        self._prefetch_events.clear()
+        self._consume_events.clear()
+        self._copy_streams.clear()
+        self._peer_tensors.clear()
+        self._peer_device_ids.clear()
+        self._peer_storages.clear()
+        self._local_shared.clear()
+        self._local_routed.clear()
+        self._local_tensors.clear()
+        self._original_replicated_tensors.clear()
+        self._schemas.clear()
+        self._copy_tickets = [[], []]
+        self._copy_engine = None
+        self._initialized = False

--- a/python/sglang/srt/layers/moe/dwdp/rocm_vmm_manager.py
+++ b/python/sglang/srt/layers/moe/dwdp/rocm_vmm_manager.py
@@ -1,0 +1,307 @@
+"""ROCm DWDP manager backed by HIP VMM composite virtual addresses."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from sglang.srt.layers.moe.dwdp import hip_vmm
+from sglang.srt.layers.moe.dwdp.common import restore_storage_rank
+from sglang.srt.layers.moe.dwdp.hsa_copy import HsaSdmaCopyEngine
+from sglang.srt.layers.moe.dwdp.layout import (
+    DwdpExpertLayout,
+    build_layer_weight_specs,
+    lookup_owner,
+)
+from sglang.srt.layers.moe.dwdp.rocm_vmm_transport import RocmVmmTransport
+from sglang.srt.layers.moe.dwdp.tensor_schema import DwdpTensorSchema
+from sglang.srt.layers.moe.dwdp.weight_buffer import WeightBuffer
+from sglang.srt.layers.moe.dwdp.weight_manager import DWDPWeightManager
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.srt.runtime_context import get_parallel
+
+logger = logging.getLogger(__name__)
+
+
+class RocmVmmDwdpManager:
+    weight_backend = "vmm"
+
+    def __init__(self, server_args):
+        self.dwdp_size = int(server_args.dwdp_size)
+        self.dwdp_rank = get_parallel().tp_rank
+        self.device_id = torch.cuda.current_device()
+        self.layout: Optional[DwdpExpertLayout] = None
+        self._weight_manager: Optional[DWDPWeightManager] = None
+        self._schemas: Dict[int, DwdpTensorSchema] = {}
+        self._moe_layers: List[Tuple[int, FusedMoE]] = []
+        self._old_main_tensors: List[torch.Tensor] = []
+
+    @classmethod
+    def is_available(cls) -> bool:
+        available, _ = hip_vmm.extension_availability()
+        if not available or not torch.cuda.is_available():
+            return False
+        try:
+            return hip_vmm.is_supported(torch.cuda.current_device())
+        except Exception:
+            return False
+
+    @staticmethod
+    def _collect_moe_layers(model: nn.Module) -> List[Tuple[int, FusedMoE]]:
+        decoder = model.model if hasattr(model, "model") else model
+        result = []
+        for layer_idx, layer in enumerate(decoder.layers):
+            experts = next(
+                (module for module in layer.modules() if isinstance(module, FusedMoE)),
+                None,
+            )
+            if experts is not None:
+                result.append((layer_idx, experts))
+        return result
+
+    def setup(self, model: nn.Module) -> None:
+        if self._weight_manager is not None:
+            return
+        arch = torch.cuda.get_device_properties(self.device_id).gcnArchName
+        if "gfx950" not in arch:
+            raise NotImplementedError(
+                f"ROCm VMM DWDP requires gfx950, got {arch!r}"
+            )
+        if torch.cuda.device_count() < self.dwdp_size:
+            raise RuntimeError(
+                f"ROCm VMM DWDP needs {self.dwdp_size} visible GPUs on one node, "
+                f"got {torch.cuda.device_count()}"
+            )
+        inaccessible = [
+            peer
+            for peer in range(torch.cuda.device_count())
+            if peer != self.device_id
+            and not torch.cuda.can_device_access_peer(self.device_id, peer)
+        ]
+        if inaccessible:
+            raise RuntimeError(
+                f"ROCm VMM DWDP requires full XGMI P2P; device {self.device_id} "
+                f"cannot access peers {inaccessible}"
+            )
+        self._moe_layers = self._collect_moe_layers(model)
+        if not self._moe_layers:
+            raise RuntimeError(
+                f"DWDP is enabled but no FusedMoE layers were found in "
+                f"{type(model).__name__}"
+            )
+
+        expert_counts = {
+            experts.num_global_routed_experts for _, experts in self._moe_layers
+        }
+        shared_counts = {
+            int(getattr(experts, "num_fused_shared_experts", 0))
+            for _, experts in self._moe_layers
+        }
+        if len(expert_counts) != 1 or len(shared_counts) != 1:
+            raise RuntimeError(
+                "ROCm VMM DWDP requires uniform routed/shared expert counts"
+            )
+        num_routed = expert_counts.pop()
+        num_shared = shared_counts.pop()
+        if num_routed % self.dwdp_size != 0:
+            raise ValueError(
+                f"num_routed_experts ({num_routed}) must be divisible by "
+                f"dwdp_size ({self.dwdp_size})"
+            )
+
+        self.layout = DwdpExpertLayout(
+            num_routed_experts=num_routed,
+            dwdp_size=self.dwdp_size,
+            dwdp_rank=self.dwdp_rank,
+            num_fused_shared_experts=num_shared,
+        )
+        local_routed = self.layout.num_experts_per_worker
+        local_count = self.layout.local_expert_end - self.layout.local_expert_start
+
+        local_params: Dict[Tuple[int, str], torch.Tensor] = {}
+        reference_main_names = None
+        for layer_idx, experts in self._moe_layers:
+            if experts.quant_method is None:
+                raise RuntimeError(f"Layer {layer_idx} has no MoE quantization method")
+            schema = experts.quant_method.get_dwdp_tensor_schema(experts)
+            schema.validate(experts)
+            self._schemas[layer_idx] = schema
+            if reference_main_names is None:
+                reference_main_names = schema.main_weights
+            elif schema.main_weights != reference_main_names:
+                raise RuntimeError(
+                    "ROCm VMM DWDP requires identical main weight names across layers"
+                )
+
+            for name in schema.main_weights:
+                original = experts.quant_method.get_dwdp_tensor(experts, name)
+                required = local_routed + num_shared
+                if original.ndim == 0 or original.shape[0] < required:
+                    raise RuntimeError(
+                        f"Layer {layer_idx} tensor {name} has shape "
+                        f"{tuple(original.shape)}, expected at least {required} experts"
+                    )
+                local = original.narrow(0, 0, local_count)
+                if not local.is_contiguous():
+                    local = local.contiguous()
+                local_params[(layer_idx, name)] = local
+                self._old_main_tensors.append(original)
+
+        specs = build_layer_weight_specs(local_params, self.layout.num_experts)
+        transport = None
+        weight_buffer = None
+        try:
+            group = get_parallel().tp_group
+            transport = RocmVmmTransport.create(
+                layer_weight_specs=specs,
+                local_params=local_params,
+                group=group,
+                layout=self.layout,
+                device_id=self.device_id,
+            )
+            weight_buffer = WeightBuffer.create(
+                layer_weight_specs=specs,
+                handles=transport.handle_set,
+                local_start=self.layout.local_expert_start,
+                local_end=self.layout.local_expert_end,
+                dwdp_size=self.dwdp_size,
+                device_id=self.device_id,
+                vmm_ops=hip_vmm,
+            )
+            self._fill_edge_bytes(weight_buffer, transport.peer_views)
+            self._replicate_side_tensors(group)
+
+            manager = DWDPWeightManager(
+                weight_buffer=weight_buffer,
+                peer_views=transport.peer_views,
+                peer_ranges=self.layout.peer_ranges,
+                moe_layer_indices=[idx for idx, _ in self._moe_layers],
+                weight_names=list(reference_main_names),
+                dwdp_rank=self.dwdp_rank,
+                dwdp_size=self.dwdp_size,
+                transport=transport,
+                copy_engine=HsaSdmaCopyEngine.create_or_none(),
+                peer_device_ids=transport.peer_device_ids,
+            )
+            for layer_idx, experts in self._moe_layers:
+                experts.bind_full_expert_weights(
+                    {
+                        name: weight_buffer.get_full_tensor(layer_idx, name)
+                        for name in reference_main_names
+                    }
+                )
+            self._weight_manager = manager
+
+            for tensor in self._old_main_tensors:
+                tensor.untyped_storage().resize_(0)
+            self._old_main_tensors.clear()
+            torch.cuda.empty_cache()
+        except Exception:
+            if weight_buffer is not None:
+                weight_buffer.release()
+            if transport is not None:
+                transport.release()
+            raise
+
+        logger.info(
+            "ROCm VMM DWDP setup complete: rank=%d/%d, routed=%d, shared=%d",
+            self.dwdp_rank,
+            self.dwdp_size,
+            num_routed,
+            num_shared,
+        )
+
+    def _fill_edge_bytes(
+        self,
+        weight_buffer: WeightBuffer,
+        peer_views: Dict[Tuple[int, int, str], torch.Tensor],
+    ) -> None:
+        assert self.layout is not None
+        local_start = self.layout.local_expert_start
+        local_end = self.layout.local_expert_end
+        peer_ranges = self.layout.peer_ranges
+        for layer_idx in weight_buffer.layer_indices:
+            for name in weight_buffer.weight_names(layer_idx):
+                edge = weight_buffer.get_edge_info(layer_idx, name)
+                if edge.leading_edge == 0 and edge.trailing_edge == 0:
+                    continue
+                full_tensor = weight_buffer.get_full_tensor(layer_idx, name)
+                if edge.leading_edge > 0 and local_start > 0:
+                    previous = local_start - 1
+                    peer = lookup_owner(previous, peer_ranges)
+                    peer_start, _ = peer_ranges[peer]
+                    full_tensor[previous].copy_(
+                        peer_views[(peer, layer_idx, name)][previous - peer_start]
+                    )
+                if edge.trailing_edge > 0 and local_end < full_tensor.shape[0]:
+                    following = local_end
+                    peer = lookup_owner(following, peer_ranges)
+                    peer_start, _ = peer_ranges[peer]
+                    full_tensor[following].copy_(
+                        peer_views[(peer, layer_idx, name)][following - peer_start]
+                    )
+        torch.cuda.synchronize(self.device_id)
+
+    def _replicate_side_tensors(self, group) -> None:
+        assert self.layout is not None
+        local_routed = self.layout.num_experts_per_worker
+        num_shared = self.layout.num_fused_shared_experts
+        for layer_idx, experts in self._moe_layers:
+            schema = self._schemas[layer_idx]
+            names = tuple(
+                dict.fromkeys(
+                    tuple(
+                        name
+                        for name in schema.partitioned
+                        if name not in schema.main_weights
+                    )
+                    + schema.replicated
+                )
+            )
+            for name in names:
+                storage_tensor = getattr(experts, name)
+                if isinstance(storage_tensor, torch.nn.Parameter):
+                    storage_tensor = storage_tensor.data
+                tensor = experts.quant_method.get_dwdp_tensor(experts, name)
+                required = local_routed + num_shared
+                if tensor.ndim == 0 or tensor.shape[0] < required:
+                    raise RuntimeError(
+                        f"Layer {layer_idx} side tensor {name} has shape "
+                        f"{tuple(tensor.shape)}, expected at least {required} experts"
+                    )
+                routed = tensor.narrow(0, 0, local_routed)
+                shards = [torch.empty_like(routed) for _ in range(self.dwdp_size)]
+                dist.all_gather(shards, routed, group=group.device_group)
+                full = torch.cat(shards, dim=0)
+                if num_shared:
+                    full = torch.cat(
+                        [full, tensor.narrow(0, local_routed, num_shared)],
+                        dim=0,
+                    )
+                experts.replace_expert_tensor(
+                    name,
+                    restore_storage_rank(storage_tensor, full),
+                )
+
+    def prefetch_first_layers(self) -> None:
+        if self._weight_manager is not None:
+            self._weight_manager.prefetch_first_layers()
+
+    def wait_prefetch(self, layer_idx: int) -> None:
+        if self._weight_manager is not None:
+            self._weight_manager.wait_prefetch(layer_idx)
+
+    def record_compute_and_prefetch_next(self, layer_idx: int) -> None:
+        if self._weight_manager is not None:
+            self._weight_manager.record_compute_and_prefetch_next(layer_idx)
+
+    def cleanup(self, synchronize_ranks: bool = True) -> None:
+        if self._weight_manager is None:
+            return
+        self._weight_manager.release()
+        self._weight_manager = None
+        self._schemas.clear()

--- a/python/sglang/srt/layers/moe/dwdp/rocm_vmm_transport.py
+++ b/python/sglang/srt/layers/moe/dwdp/rocm_vmm_transport.py
@@ -1,0 +1,203 @@
+"""HIP VMM transport for the ROCm DWDP composite-address backend."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.distributed.device_communicators.vmm_utils import exchange_posix_fds
+from sglang.srt.layers.moe.dwdp import hip_vmm
+from sglang.srt.layers.moe.dwdp.common import align_down, align_up
+from sglang.srt.layers.moe.dwdp.layout import (
+    DwdpExpertLayout,
+    LayerWeightSpecs,
+    MnnvlHandleSet,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _close_fds(fds) -> None:
+    for fd in fds:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+class RocmVmmTransport:
+    def __init__(self):
+        self._handle_set: Optional[MnnvlHandleSet] = None
+        self._peer_views: Dict[Tuple[int, int, str], torch.Tensor] = {}
+        self._peer_device_ids: Dict[int, int] = {}
+        self._imported_handles: List[int] = []
+        self._peer_mappings: List[hip_vmm.VmmMapping] = []
+        self._released = False
+
+    @classmethod
+    def create(
+        cls,
+        layer_weight_specs: LayerWeightSpecs,
+        local_params: Dict[Tuple[int, str], torch.Tensor],
+        group,
+        layout: DwdpExpertLayout,
+        device_id: int,
+    ) -> RocmVmmTransport:
+        transport = cls()
+        sorted_keys = sorted(local_params)
+        granularity = hip_vmm.get_allocation_granularity(device_id)
+        handles: Dict[Tuple[int, str], int] = {}
+        sizes: Dict[Tuple[int, str], int] = {}
+
+        try:
+            for layer_idx, name in sorted_keys:
+                param = local_params[(layer_idx, name)]
+                spec = layer_weight_specs[layer_idx][name]
+                local_start_bytes = layout.local_expert_start * spec.expert_bytes
+                local_end_bytes = layout.local_expert_end * spec.expert_bytes
+                page_start = align_down(local_start_bytes, granularity)
+                page_end = align_up(local_end_bytes, granularity)
+                physical_size = page_end - page_start
+                data_offset = local_start_bytes - page_start
+
+                handle = hip_vmm.create_shareable_handle(physical_size, device_id)
+                handles[(layer_idx, name)] = handle
+                sizes[(layer_idx, name)] = physical_size
+                with hip_vmm.map_handles(
+                    [handle],
+                    [physical_size],
+                    device_id,
+                    alignment=granularity,
+                ) as mapping:
+                    mapped = hip_vmm.tensor_from_ptr(
+                        mapping.address + data_offset,
+                        tuple(param.shape),
+                        param.dtype,
+                        device_id,
+                    )
+                    mapped.copy_(param)
+                    torch.cuda.synchronize(device_id)
+                    del mapped
+
+            transport._handle_set = MnnvlHandleSet(handles=handles, sizes=sizes)
+            transport._import_peer_views(
+                sorted_keys,
+                layer_weight_specs,
+                group,
+                layout,
+                device_id,
+                granularity,
+            )
+            dist.barrier(group=group.device_group)
+            return transport
+        except Exception:
+            transport._handle_set = MnnvlHandleSet(handles=handles, sizes=sizes)
+            transport.release()
+            raise
+
+    def _import_peer_views(
+        self,
+        sorted_keys: List[Tuple[int, str]],
+        layer_weight_specs: LayerWeightSpecs,
+        group,
+        layout: DwdpExpertLayout,
+        device_id: int,
+        granularity: int,
+    ) -> None:
+        local_fds = [
+            hip_vmm.export_fd(self._handle_set.get_handle(layer_idx, name))
+            for layer_idx, name in sorted_keys
+        ]
+        all_device_ids = [None] * layout.dwdp_size
+        dist.all_gather_object(
+            all_device_ids,
+            device_id,
+            group=group.cpu_group,
+        )
+        self._peer_device_ids = {
+            rank: int(peer_device_id)
+            for rank, peer_device_id in enumerate(all_device_ids)
+        }
+        key_counts = [None] * layout.dwdp_size
+        dist.all_gather_object(key_counts, len(sorted_keys), group=group.cpu_group)
+        if any(count != len(sorted_keys) for count in key_counts):
+            _close_fds(local_fds)
+            raise RuntimeError(f"Mismatched ROCm DWDP VMM handle counts: {key_counts}")
+
+        peer_fds = exchange_posix_fds(
+            group.cpu_group,
+            layout.dwdp_rank,
+            layout.dwdp_size,
+            local_fds,
+            key_counts,
+        )
+        try:
+            for key_index, (layer_idx, name) in enumerate(sorted_keys):
+                spec = layer_weight_specs[layer_idx][name]
+                for peer_rank in range(layout.dwdp_size):
+                    if peer_rank == layout.dwdp_rank:
+                        continue
+                    peer_handle = hip_vmm.import_fd(peer_fds[(peer_rank, key_index)])
+                    self._imported_handles.append(peer_handle)
+
+                    peer_start, peer_end = layout.peer_ranges[peer_rank]
+                    peer_start_bytes = peer_start * spec.expert_bytes
+                    peer_end_bytes = peer_end * spec.expert_bytes
+                    peer_page_start = align_down(peer_start_bytes, granularity)
+                    peer_page_end = align_up(peer_end_bytes, granularity)
+                    physical_size = peer_page_end - peer_page_start
+                    data_offset = peer_start_bytes - peer_page_start
+
+                    mapping = hip_vmm.map_handles(
+                        [peer_handle],
+                        [physical_size],
+                        device_id,
+                        alignment=granularity,
+                    )
+                    self._peer_mappings.append(mapping)
+                    self._peer_views[(peer_rank, layer_idx, name)] = (
+                        hip_vmm.tensor_from_ptr(
+                            mapping.address + data_offset,
+                            (peer_end - peer_start,) + spec.full_shape[1:],
+                            spec.dtype,
+                            device_id,
+                        )
+                    )
+        finally:
+            _close_fds(local_fds)
+            _close_fds(peer_fds.values())
+
+    @property
+    def handle_set(self) -> MnnvlHandleSet:
+        if self._handle_set is None:
+            raise RuntimeError("ROCm DWDP VMM transport is not initialized")
+        return self._handle_set
+
+    @property
+    def peer_views(self) -> Dict[Tuple[int, int, str], torch.Tensor]:
+        return self._peer_views
+
+    @property
+    def peer_device_ids(self) -> Dict[int, int]:
+        return self._peer_device_ids
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._peer_views.clear()
+        self._peer_device_ids.clear()
+        for mapping in reversed(self._peer_mappings):
+            mapping.close()
+        self._peer_mappings.clear()
+        for handle in reversed(self._imported_handles):
+            hip_vmm.release_handle(handle)
+        self._imported_handles.clear()
+        if self._handle_set is not None:
+            for handle in reversed(list(self._handle_set.handles.values())):
+                hip_vmm.release_handle(handle)
+            self._handle_set = None

--- a/python/sglang/srt/layers/moe/dwdp/tensor_schema.py
+++ b/python/sglang/srt/layers/moe/dwdp/tensor_schema.py
@@ -1,0 +1,43 @@
+"""Explicit expert-tensor contracts shared by DWDP weight backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+from torch import nn
+
+
+@dataclass(frozen=True)
+class DwdpTensorSchema:
+    """Describe how an MoE quantization method stores expert-indexed tensors.
+
+    ``partitioned`` tensors are consumed as rank-ordered partitions by the IPC
+    backend. ``replicated`` tensors are gathered once during setup. Main
+    weights must be listed in ``main_weights`` so the VMM backend can stage
+    only the high-volume tensors while replicating smaller metadata.
+    """
+
+    main_weights: Tuple[str, ...] = ("w13_weight", "w2_weight")
+    partitioned: Tuple[str, ...] = ("w13_weight", "w2_weight")
+    replicated: Tuple[str, ...] = ()
+
+    def validate(self, layer: nn.Module) -> None:
+        missing = [name for name in self.partitioned if not hasattr(layer, name)]
+        if missing:
+            raise RuntimeError(
+                f"{type(layer).__name__} is missing DWDP partitioned tensors: "
+                f"{missing}"
+            )
+        unknown_main = set(self.main_weights) - set(self.partitioned)
+        if unknown_main:
+            raise ValueError(
+                "DWDP main weights must also be partitioned, got "
+                f"{sorted(unknown_main)}"
+            )
+
+
+def existing_tensor_names(layer: nn.Module, names: Iterable[str]) -> Tuple[str, ...]:
+    """Return explicitly requested tensor attributes that exist on ``layer``."""
+
+    return tuple(name for name in names if hasattr(layer, name))

--- a/python/sglang/srt/layers/moe/dwdp/transport.py
+++ b/python/sglang/srt/layers/moe/dwdp/transport.py
@@ -85,8 +85,6 @@ def _copy_local_weights_to_handles(
         unmap_va(temp_va, phys_size)
         free_va(temp_va, phys_size)
 
-        param.untyped_storage().resize_(0)
-
         handles[(layer_idx, name)] = handle
         sizes[(layer_idx, name)] = phys_size
 
@@ -94,8 +92,6 @@ def _copy_local_weights_to_handles(
             f"Phase 1: layer={layer_idx}, name={name}, "
             f"phys_size={phys_size}, data_offset={data_offset}"
         )
-
-    torch.cuda.empty_cache()
 
     return handles, sizes
 
@@ -236,3 +232,7 @@ class DWDPTransport:
         self._imported_handles.clear()
 
         self._peer_views.clear()
+        if self._handle_set is not None:
+            for handle in self._handle_set.handles.values():
+                release_handle(handle)
+            self._handle_set = None

--- a/python/sglang/srt/layers/moe/dwdp/vmm.py
+++ b/python/sglang/srt/layers/moe/dwdp/vmm.py
@@ -17,17 +17,7 @@ from sglang.srt.distributed.device_communicators.vmm_utils import (
 
 logger = logging.getLogger(__name__)
 
-
-def align_up(value: int, alignment: int) -> int:
-    if alignment <= 0 or (alignment & (alignment - 1)) != 0:
-        raise ValueError(f"alignment must be a positive power of 2, got {alignment}")
-    return ((value + alignment - 1) // alignment) * alignment
-
-
-def align_down(value: int, alignment: int) -> int:
-    if alignment <= 0 or (alignment & (alignment - 1)) != 0:
-        raise ValueError(f"alignment must be a positive power of 2, got {alignment}")
-    return (value // alignment) * alignment
+ACCESS_IS_ALLOCATION_SCOPED = False
 
 
 def _make_prop(device_id: int, handle_types: int) -> cuda.CUmemAllocationProp:

--- a/python/sglang/srt/layers/moe/dwdp/weight_buffer.py
+++ b/python/sglang/srt/layers/moe/dwdp/weight_buffer.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
@@ -15,15 +15,6 @@ from sglang.srt.layers.moe.dwdp.layout import (
     PageAlignedLayout,
 )
 from sglang.srt.layers.moe.dwdp.page_pool import PagePool, compute_slot_sizes
-from sglang.srt.layers.moe.dwdp.vmm import (
-    free_va,
-    get_allocation_granularity,
-    map_handle,
-    reserve_va,
-    set_access,
-    tensor_from_ptr,
-    unmap_va,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +28,30 @@ class WeightBuffer:
         local_end: int,
         dwdp_size: int,
         device_id: int,
+        vmm_ops: Any = None,
     ):
+        if vmm_ops is None:
+            from sglang.srt.layers.moe.dwdp import vmm as vmm_ops
+
+        self._vmm_ops = vmm_ops
         self._layer_weight_specs = layer_weight_specs
         self._handles = handles
         self._local_start = local_start
         self._local_end = local_end
         self._dwdp_size = dwdp_size
         self._device_id = device_id
-        self._granularity = get_allocation_granularity(device_id)
+        self._granularity = vmm_ops.get_allocation_granularity(device_id)
+        self._allocation_scoped_access = bool(
+            getattr(vmm_ops, "ACCESS_IS_ALLOCATION_SCOPED", False)
+        )
         self._pool_page_size = PagePool.DEFAULT_PAGE_SIZE_MULTIPLIER * self._granularity
+        if self._allocation_scoped_access:
+            # HIP reports a 4 KiB VMM granularity on MI35x. The CUDA-oriented
+            # 8x multiplier would create tens of thousands of 32 KiB handles
+            # for real MoE weights, eventually making hipMemSetAccess fail.
+            # Coarse pages keep the double buffer to a manageable allocation
+            # count while staying within hipMemSetAccess's per-range limit.
+            self._pool_page_size = max(self._pool_page_size, 32 * 1024 * 1024)
         self._page_pool: Optional[PagePool] = None
         self._moe_layer_indices = sorted(layer_weight_specs.keys())
         self._layouts: Dict[int, Dict[str, PageAlignedLayout]] = {}
@@ -66,9 +72,16 @@ class WeightBuffer:
         local_end: int,
         dwdp_size: int,
         device_id: int,
+        vmm_ops: Any = None,
     ) -> WeightBuffer:
         buf = cls(
-            layer_weight_specs, handles, local_start, local_end, dwdp_size, device_id
+            layer_weight_specs,
+            handles,
+            local_start,
+            local_end,
+            dwdp_size,
+            device_id,
+            vmm_ops,
         )
         for li, ws in layer_weight_specs.items():
             buf._layouts[li] = {}
@@ -86,7 +99,10 @@ class WeightBuffer:
         assignments = {li: buf.buffer_index_for_layer(li) for li in layer_weight_specs}
         slot_sizes = compute_slot_sizes(buf._layouts, assignments)
         buf._page_pool = PagePool.create(
-            slot_sizes, device_id, page_size=buf._pool_page_size
+            slot_sizes,
+            device_id,
+            page_size=buf._pool_page_size,
+            vmm_ops=buf._vmm_ops,
         )
 
         for li in buf._moe_layer_indices:
@@ -114,7 +130,7 @@ class WeightBuffer:
             spec = weight_specs[name]
             handle = self._handles.get_handle(layer_idx, name)
 
-            va_base = reserve_va(layout.total_size, self._granularity)
+            va_base = self._vmm_ops.reserve_va(layout.total_size, self._granularity)
             self._va_regions[layer_idx].append((va_base, layout.total_size))
             all_maps = self._mappings[layer_idx]
 
@@ -129,8 +145,18 @@ class WeightBuffer:
                 page_pool_offset += layout.pre_pages
 
             mnnvl_va = va_base + layout.pre_size
-            map_handle(mnnvl_va, layout.mnnvl_size, handle, offset=0)
+            self._vmm_ops.map_handle(mnnvl_va, layout.mnnvl_size, handle, offset=0)
             all_maps.append((mnnvl_va, layout.mnnvl_size))
+            try:
+                self._vmm_ops.set_access(
+                    mnnvl_va,
+                    layout.mnnvl_size,
+                    self._device_id,
+                )
+            except Exception:
+                self._vmm_ops.unmap_va(mnnvl_va, layout.mnnvl_size)
+                all_maps.pop()
+                raise
 
             if layout.post_size > 0:
                 post_va = mnnvl_va + layout.mnnvl_size
@@ -143,10 +169,8 @@ class WeightBuffer:
                 all_maps.extend(post_maps)
                 page_pool_offset += layout.post_pages
 
-            set_access(va_base, layout.total_size, self._device_id)
-
             tensor_start = va_base + layout.pre_padding
-            full_tensor = tensor_from_ptr(
+            full_tensor = self._vmm_ops.tensor_from_ptr(
                 ptr=tensor_start,
                 shape=spec.full_shape,
                 dtype=spec.dtype,
@@ -208,10 +232,10 @@ class WeightBuffer:
         self._released = True
         for li, maps in self._mappings.items():
             for va, sz in maps:
-                unmap_va(va, sz)
+                self._vmm_ops.unmap_va(va, sz)
         for li, regions in self._va_regions.items():
             for va, sz in regions:
-                free_va(va, sz)
+                self._vmm_ops.free_va(va, sz)
         self._mappings.clear()
         self._va_regions.clear()
         self._tensors.clear()

--- a/python/sglang/srt/layers/moe/dwdp/weight_manager.py
+++ b/python/sglang/srt/layers/moe/dwdp/weight_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import bisect
 import logging
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
@@ -26,6 +26,8 @@ class DWDPWeightManager:
         dwdp_rank: int,
         dwdp_size: int,
         transport=None,
+        copy_engine: Any = None,
+        peer_device_ids: Optional[Dict[int, int]] = None,
     ) -> None:
         self._weight_buffer = weight_buffer
         self._peer_views = peer_views
@@ -37,9 +39,12 @@ class DWDPWeightManager:
         self._dwdp_size = dwdp_size
         # transport handles underpin the VA mappings; must outlive this manager
         self._transport = transport
+        self._copy_engine = copy_engine
+        self._peer_device_ids = dict(peer_device_ids or {})
 
         device = torch.device("cuda", weight_buffer.device_id)
         self._copy_stream = torch.cuda.Stream(device=device)
+        self._copy_tickets: List[List[int]] = [[], []]
 
         self._prefetch_events: List[torch.cuda.Event] = [
             torch.cuda.Event() for _ in range(2)
@@ -77,15 +82,27 @@ class DWDPWeightManager:
     def prefetch_layer(self, layer_idx: int) -> None:
         buf_idx = self._weight_buffer.buffer_index_for_layer(layer_idx)
 
-        with torch.cuda.stream(self._copy_stream):
-            # WAR: wait for compute to finish reading this slot before overwriting
-            self._copy_stream.wait_event(self._consume_events[buf_idx])
+        if self._copy_engine is not None:
+            # HSA queues cannot consume a HIP event. Host-wait before reusing
+            # the slot; graph capture is disabled for DWDP.
+            self._consume_events[buf_idx].synchronize()
+            if self._copy_tickets[buf_idx]:
+                raise RuntimeError(
+                    f"DWDP copy slot {buf_idx} still has outstanding HSA tickets"
+                )
+            self._prefetch_layer_per_slice(layer_idx, buf_idx=buf_idx)
+        else:
+            with torch.cuda.stream(self._copy_stream):
+                # WAR: wait for compute to finish reading this slot before overwriting
+                self._copy_stream.wait_event(self._consume_events[buf_idx])
 
-            self._prefetch_layer_per_slice(layer_idx)
+                self._prefetch_layer_per_slice(layer_idx)
 
-            self._prefetch_events[buf_idx].record(self._copy_stream)
+                self._prefetch_events[buf_idx].record(self._copy_stream)
 
-    def _prefetch_layer_per_slice(self, layer_idx: int) -> None:
+    def _prefetch_layer_per_slice(
+        self, layer_idx: int, buf_idx: Optional[int] = None
+    ) -> None:
         for name in self._weight_names:
             remote_slices = self._weight_buffer.get_remote_slices(layer_idx, name)
             for dst_slice, expert_start, expert_end in remote_slices:
@@ -100,14 +117,63 @@ class DWDPWeightManager:
 
                     peer_key = (peer_rank, layer_idx, name)
                     src = self._peer_views[peer_key]
-                    dst_slice[dst_offset : dst_offset + n].copy_(
-                        src[local_offset : local_offset + n]
-                    )
+                    destination = dst_slice[dst_offset : dst_offset + n]
+                    source = src[local_offset : local_offset + n]
+                    if self._copy_engine is None:
+                        destination.copy_(source)
+                    else:
+                        assert buf_idx is not None
+                        self._copy_tickets[buf_idx].append(
+                            self._copy_engine.submit(
+                                destination,
+                                source,
+                                destination_device=self._weight_buffer.device_id,
+                                source_device=self._peer_device_ids.get(
+                                    peer_rank,
+                                    source.device.index,
+                                ),
+                            )
+                        )
                     dst_offset += n
                     cursor = chunk_end
 
+    def _disable_hsa_copy_engine(self, completed_slot: int) -> None:
+        engine = self._copy_engine
+        if engine is None:
+            return
+        self._copy_tickets[completed_slot].clear()
+        for slot_idx, tickets in enumerate(self._copy_tickets):
+            if slot_idx == completed_slot or not tickets:
+                continue
+            try:
+                engine.wait_all(tickets)
+            except Exception:
+                logger.exception(
+                    "Failed while draining HSA DWDP VMM slot %s during fallback",
+                    slot_idx,
+                )
+            finally:
+                tickets.clear()
+        self._copy_engine = None
+
     def wait_prefetch(self, layer_idx: int) -> None:
         buf_idx = self._weight_buffer.buffer_index_for_layer(layer_idx)
+        if self._copy_engine is not None:
+            try:
+                self._copy_engine.wait_all(self._copy_tickets[buf_idx])
+            except Exception:
+                logger.exception(
+                    "HSA DWDP prefetch failed for layer %s; retrying with HIP copy_",
+                    layer_idx,
+                )
+                self._disable_hsa_copy_engine(buf_idx)
+                with torch.cuda.stream(self._copy_stream):
+                    self._prefetch_layer_per_slice(layer_idx)
+                    self._prefetch_events[buf_idx].record(self._copy_stream)
+            else:
+                return
+            finally:
+                self._copy_tickets[buf_idx].clear()
         device = torch.device("cuda", self._weight_buffer.device_id)
         compute_stream = torch.cuda.current_stream(device)
         compute_stream.wait_event(self._prefetch_events[buf_idx])
@@ -133,6 +199,14 @@ class DWDPWeightManager:
             self.prefetch_layer(self._moe_layer_indices[1])
 
     def release(self) -> None:
+        if self._copy_engine is not None:
+            for tickets in self._copy_tickets:
+                try:
+                    self._copy_engine.wait_all(tickets)
+                except Exception:
+                    logger.exception("Failed while draining HSA tickets during release")
+                finally:
+                    tickets.clear()
         if self._weight_buffer is not None:
             self._weight_buffer.release()
             self._weight_buffer = None

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -419,6 +419,7 @@ class FusedMoE(torch.nn.Module):
         self.meta_overlap_args: Optional[dict] = None
 
         self._dwdp_bound = False
+        self._dwdp_original_topology: Optional[dict] = None
 
         if self.quant_method is not None and hasattr(self.quant_method, "runner"):
             self.runner = self.quant_method.runner
@@ -435,6 +436,40 @@ class FusedMoE(torch.nn.Module):
         Callers are weight-replication schemes that materialize all expert
         weights locally after load time (e.g. DWDP's composite-VA prefetch).
         """
+        self._bind_dwdp_expert_topology()
+
+        for name, tensor in weights.items():
+            self.replace_expert_tensor(name, tensor)
+
+        self._dwdp_bound = True
+
+    def bind_dwdp_partitioned_weights(self) -> None:
+        """Collapse EP metadata while retaining backend-owned weight partitions.
+
+        ROCm's IPC backend keeps the local parameter shard installed on the
+        module and supplies rank-ordered remote partitions to the MoE runner at
+        call time. This method updates only routing/dispatcher topology.
+        """
+        self._bind_dwdp_expert_topology()
+        self._dwdp_bound = True
+
+    def _bind_dwdp_expert_topology(self) -> None:
+        if self._dwdp_original_topology is None:
+            self._dwdp_original_topology = {
+                "moe_ep_size": self.moe_ep_size,
+                "moe_ep_rank": self.moe_ep_rank,
+                "_num_local_routed": self._num_local_routed,
+                "num_local_experts": self.num_local_experts,
+                "runner_num_local_experts": self.moe_runner_config.num_local_experts,
+                "dispatcher_moe_ep_size": self.dispatcher.moe_ep_size,
+                "dispatcher_moe_ep_rank": self.dispatcher.moe_ep_rank,
+                "dispatcher_num_local_experts": self.dispatcher.num_local_experts,
+                "dispatcher_num_local_routed_experts": (
+                    self.dispatcher.num_local_routed_experts
+                ),
+                "dispatcher_local_expert_mapping": self.dispatcher.local_expert_mapping,
+                "dispatcher_expert_mask_gpu": self.dispatcher.expert_mask_gpu,
+            }
         self.moe_ep_size = 1
         self.moe_ep_rank = 0
         self._num_local_routed = self._num_global_routed
@@ -448,10 +483,29 @@ class FusedMoE(torch.nn.Module):
         self.dispatcher.local_expert_mapping = None
         self.dispatcher.expert_mask_gpu = None
 
-        for name, tensor in weights.items():
-            self.replace_expert_tensor(name, tensor)
-
-        self._dwdp_bound = True
+    def unbind_dwdp_weights(self) -> None:
+        if not self._dwdp_bound:
+            return
+        state = self._dwdp_original_topology
+        if state is None:
+            raise RuntimeError("DWDP topology state was not captured before binding")
+        self.moe_ep_size = state["moe_ep_size"]
+        self.moe_ep_rank = state["moe_ep_rank"]
+        self._num_local_routed = state["_num_local_routed"]
+        self.num_local_experts = state["num_local_experts"]
+        self.moe_runner_config.num_local_experts = state["runner_num_local_experts"]
+        self.dispatcher.moe_ep_size = state["dispatcher_moe_ep_size"]
+        self.dispatcher.moe_ep_rank = state["dispatcher_moe_ep_rank"]
+        self.dispatcher.num_local_experts = state["dispatcher_num_local_experts"]
+        self.dispatcher.num_local_routed_experts = state[
+            "dispatcher_num_local_routed_experts"
+        ]
+        self.dispatcher.local_expert_mapping = state[
+            "dispatcher_local_expert_mapping"
+        ]
+        self.dispatcher.expert_mask_gpu = state["dispatcher_expert_mask_gpu"]
+        self._dwdp_original_topology = None
+        self._dwdp_bound = False
 
     def named_per_expert_tensors(
         self, num_local_experts: int
@@ -1385,6 +1439,11 @@ class FusedMoE(torch.nn.Module):
 
         if self._dwdp_bound:
             dwdp_mgr = get_global_dwdp_manager()
+            if dwdp_mgr is None:
+                raise RuntimeError(
+                    "FusedMoE is still bound to DWDP weights, but the global "
+                    "DWDP manager has already been cleared"
+                )
             dwdp_mgr.wait_prefetch(self.layer_id)
 
         dispatch_output = self.dispatcher.dispatch(

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import functools
 import inspect
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import torch
 
@@ -43,13 +43,20 @@ class AiterQuantType(str, Enum):
     PER_1X32 = "per_1x32"
 
 
+AiterWeightTensor = Union[
+    torch.Tensor,
+    List[torch.Tensor],
+    Tuple[torch.Tensor, ...],
+]
+
+
 @dataclass
 class AiterMoeQuantInfo(MoeQuantInfo):
-    w13_weight: torch.Tensor
-    w2_weight: torch.Tensor
+    w13_weight: AiterWeightTensor
+    w2_weight: AiterWeightTensor
     quant_type: AiterQuantType = AiterQuantType.NONE
-    w13_scale: Optional[torch.Tensor] = None
-    w2_scale: Optional[torch.Tensor] = None
+    w13_scale: Optional[AiterWeightTensor] = None
+    w2_scale: Optional[AiterWeightTensor] = None
     a13_scale: Optional[torch.Tensor] = None
     a2_scale: Optional[torch.Tensor] = None
     b13: Optional[torch.Tensor] = None
@@ -119,6 +126,56 @@ def _aiter_fused_moe_supports_no_combine() -> bool:
     return "no_combine" in inspect.signature(fused_moe).parameters
 
 
+def _normalize_dwdp_scale_partition(scale: torch.Tensor) -> torch.Tensor:
+    # MXFP4/MXFP8 E8M0 scales use Aiter's flattened shuffled matrix layout.
+    # Conventional FP8 keeps its FP32 [experts, N/128, K/128] block layout.
+    if scale.ndim > 2 and scale.element_size() == 1:
+        return scale.reshape(-1, scale.shape[-1]).contiguous()
+    return scale.contiguous()
+
+
+def _resolve_dwdp_partitioned_quant_info(
+    config: MoeRunnerConfig,
+    quant_info: AiterMoeQuantInfo,
+) -> AiterMoeQuantInfo:
+    from sglang.srt.runtime_context import get_global_dwdp_manager
+
+    manager = get_global_dwdp_manager()
+    if manager is None or getattr(manager, "weight_backend", None) != "ipc":
+        return quant_info
+    if config.layer_id is None:
+        raise RuntimeError("Aiter DWDP IPC execution requires a layer_id")
+
+    layer_idx = int(config.layer_id)
+    w13 = manager.get_partition_view(
+        layer_idx, "w13_weight", quant_info.w13_weight
+    ).tensors
+    w2 = manager.get_partition_view(
+        layer_idx, "w2_weight", quant_info.w2_weight
+    ).tensors
+
+    w13_scale = quant_info.w13_scale
+    if isinstance(w13_scale, torch.Tensor):
+        name = manager.find_partitioned_name(layer_idx, w13_scale)
+        w13_scale = manager.get_partition_view(layer_idx, name).tensors
+        w13_scale = tuple(_normalize_dwdp_scale_partition(scale) for scale in w13_scale)
+
+    w2_scale = quant_info.w2_scale
+    if isinstance(w2_scale, torch.Tensor):
+        name = manager.find_partitioned_name(layer_idx, w2_scale)
+        w2_scale = manager.get_partition_view(layer_idx, name).tensors
+        w2_scale = tuple(_normalize_dwdp_scale_partition(scale) for scale in w2_scale)
+
+    return replace(
+        quant_info,
+        w13_weight=w13,
+        w2_weight=w2,
+        w13_scale=w13_scale,
+        w2_scale=w2_scale,
+        expert_mask=None,
+    )
+
+
 class AiterRunnerCore(MoeRunnerCore):
     def run(
         self,
@@ -127,13 +184,6 @@ class AiterRunnerCore(MoeRunnerCore):
         running_state: dict,
         hooks: Optional[Any] = None,
     ) -> AiterRunnerOutput:
-        if self.config.no_combine and not _aiter_fused_moe_supports_no_combine():
-            raise NotImplementedError(
-                "no_combine=True requested but the installed aiter.fused_moe does "
-                "not accept a `no_combine` kwarg. Install an aiter build that "
-                "supports fused_moe no_combine output."
-            )
-
         if runner_input.hidden_states.shape[0] == 0:
             if self.config.no_combine:
                 topk = runner_input.topk_ids.shape[-1]
@@ -144,6 +194,21 @@ class AiterRunnerCore(MoeRunnerCore):
                     )
                 )
             return AiterRunnerOutput(hidden_states=runner_input.hidden_states)
+
+        quant_info = _resolve_dwdp_partitioned_quant_info(self.config, quant_info)
+        is_multi_b = isinstance(quant_info.w13_weight, (list, tuple))
+        if is_multi_b != isinstance(quant_info.w2_weight, (list, tuple)):
+            raise TypeError("Aiter W1 and W2 must both use multi-B partitions")
+        if (
+            self.config.no_combine
+            and not is_multi_b
+            and not _aiter_fused_moe_supports_no_combine()
+        ):
+            raise NotImplementedError(
+                "no_combine=True requested but the installed aiter.fused_moe does "
+                "not accept a `no_combine` kwarg. Install an aiter build that "
+                "supports fused_moe no_combine output."
+            )
 
         from aiter.fused_moe import fused_moe
 
@@ -183,16 +248,12 @@ class AiterRunnerCore(MoeRunnerCore):
         if self.config.no_combine:
             extra["no_combine"] = True
 
-        output = fused_moe(
+        common_kwargs = dict(
             hidden_states=runner_input.hidden_states,
-            w1=quant_info.w13_weight,
-            w2=quant_info.w2_weight,
             topk_weight=runner_input.topk_weights,
             topk_ids=runner_input.topk_ids,
             quant_type=_aiter_quant_type(runner_input.quant_type),
             activation=_aiter_activation(self.config.activation),
-            w1_scale=quant_info.w13_scale,
-            w2_scale=quant_info.w2_scale,
             a1_scale=a1_scale,
             a2_scale=quant_info.a2_scale,
             bias1=quant_info.b13,
@@ -203,6 +264,24 @@ class AiterRunnerCore(MoeRunnerCore):
             intermediate_pad=quant_info.intermediate_pad,
             **extra,
         )
+        if is_multi_b:
+            from aiter.fused_moe import fused_moe_multi_b
+
+            output = fused_moe_multi_b(
+                w1_partitions=quant_info.w13_weight,
+                w2_partitions=quant_info.w2_weight,
+                w1_scale_partitions=quant_info.w13_scale,
+                w2_scale_partitions=quant_info.w2_scale,
+                **common_kwargs,
+            )
+        else:
+            output = fused_moe(
+                w1=quant_info.w13_weight,
+                w2=quant_info.w2_weight,
+                w1_scale=quant_info.w13_scale,
+                w2_scale=quant_info.w2_scale,
+                **common_kwargs,
+            )
         return AiterRunnerOutput(hidden_states=output)
 
     @property

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -101,6 +101,24 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     ):
         raise NotImplementedError
 
+    def get_dwdp_tensor_schema(self, layer: torch.nn.Module):
+        """Return the explicit expert-tensor contract used by DWDP backends.
+
+        Quantization methods with partitioned scales or non-standard tensor
+        names must override this method. The default covers unquantized MoE.
+        """
+        from sglang.srt.layers.moe.dwdp.tensor_schema import DwdpTensorSchema
+
+        schema = DwdpTensorSchema()
+        schema.validate(layer)
+        return schema
+
+    def get_dwdp_tensor(self, layer: torch.nn.Module, name: str) -> torch.Tensor:
+        """Return an expert-major view used by DWDP backends."""
+
+        value = getattr(layer, name)
+        return value.data if isinstance(value, torch.nn.Parameter) else value
+
     @abstractmethod
     def apply(
         self,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1072,6 +1072,38 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 is_sm100_supported() or is_sm90_supported() or is_sm120_supported()
             ), "cutlass_fp8 MoE requires SM90, SM100, or SM120 GPUs"
 
+    def get_dwdp_tensor_schema(self, layer: torch.nn.Module):
+        from sglang.srt.layers.moe.dwdp.tensor_schema import (
+            DwdpTensorSchema,
+            existing_tensor_names,
+        )
+
+        scale_names = (
+            ("w13_weight_scale_inv", "w2_weight_scale_inv")
+            if self.block_quant
+            else ("w13_weight_scale1", "w2_weight_scale1")
+        )
+        partitioned = existing_tensor_names(
+            layer,
+            ("w13_weight", "w2_weight") + scale_names,
+        )
+        replicated = existing_tensor_names(
+            layer,
+            (
+                "w13_weight_bias",
+                "w2_weight_bias",
+                "gemm1_alpha",
+                "gemm1_beta",
+                "gemm1_clamp_limit",
+            ),
+        )
+        schema = DwdpTensorSchema(
+            partitioned=partitioned,
+            replicated=replicated,
+        )
+        schema.validate(layer)
+        return schema
+
     @staticmethod
     def is_deepgemm_moe_runner_backend_enabled() -> bool:
         """Check if MoE will actually use DeepGEMM runner for FP8."""

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -362,6 +362,49 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     "or SM120."
                 )
 
+    def get_dwdp_tensor_schema(self, layer: torch.nn.Module):
+        from sglang.srt.layers.moe.dwdp.tensor_schema import (
+            DwdpTensorSchema,
+            existing_tensor_names,
+        )
+
+        partitioned = existing_tensor_names(
+            layer,
+            (
+                "w13_weight",
+                "w2_weight",
+                "w13_weight_scale",
+                "w2_weight_scale",
+            ),
+        )
+        replicated = existing_tensor_names(
+            layer,
+            (
+                "w13_weight_bias",
+                "w2_weight_bias",
+                "gemm1_alpha",
+                "gemm1_beta",
+                "gemm1_clamp_limit",
+            ),
+        )
+        schema = DwdpTensorSchema(
+            partitioned=partitioned,
+            replicated=replicated,
+        )
+        schema.validate(layer)
+        return schema
+
+    def get_dwdp_tensor(self, layer: torch.nn.Module, name: str) -> torch.Tensor:
+        tensor = super().get_dwdp_tensor(layer, name)
+        if name in ("w13_weight_scale", "w2_weight_scale") and tensor.ndim == 2:
+            if tensor.shape[0] % self.num_experts != 0:
+                raise RuntimeError(
+                    f"Cannot restore expert axis for {name} with shape "
+                    f"{tuple(tensor.shape)} and {self.num_experts} experts"
+                )
+            tensor = tensor.view(self.num_experts, -1, tensor.shape[-1])
+        return tensor
+
     def create_weights(
         self,
         layer: torch.nn.Module,

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -721,6 +721,38 @@ class QuarkFusedMoEMethod(FusedMoEMethodBase):
     ):
         layer.scheme.create_moe_runner(layer, moe_runner_config)
 
+    def get_dwdp_tensor_schema(self, layer: torch.nn.Module):
+        from sglang.srt.layers.moe.dwdp.tensor_schema import (
+            DwdpTensorSchema,
+            existing_tensor_names,
+        )
+
+        partitioned = existing_tensor_names(
+            layer,
+            (
+                "w13_weight",
+                "w2_weight",
+                "w13_weight_scale",
+                "w2_weight_scale",
+            ),
+        )
+        replicated = existing_tensor_names(
+            layer,
+            (
+                "w13_weight_bias",
+                "w2_weight_bias",
+                "gemm1_alpha",
+                "gemm1_beta",
+                "gemm1_clamp_limit",
+            ),
+        )
+        schema = DwdpTensorSchema(
+            partitioned=partitioned,
+            replicated=replicated,
+        )
+        schema.validate(layer)
+        return schema
+
     def apply(
         self,
         layer: torch.nn.Module,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1105,11 +1105,11 @@ class ModelRunner:
             return
         if get_parallel().dwdp_size <= 1:
             return
-        from sglang.srt.layers.moe.dwdp import DwdpManager
+        from sglang.srt.layers.moe.dwdp import create_dwdp_manager
 
-        manager = DwdpManager(self.server_args)
-        set_global_dwdp_manager(manager)
+        manager = create_dwdp_manager(self.server_args)
         manager.setup(self.model)
+        set_global_dwdp_manager(manager)
 
     def init_lora_manager(self):
         self.lora_manager = LoRAManager(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -634,6 +634,7 @@ class DeepseekV2MoE(nn.Module):
             self.moe_ep_size > 1
             and self.num_fused_shared_experts > 0
             and not _uses_per_rank_shared_slots
+            and get_parallel().dwdp_size <= 1
         ):
             # if enable_ep_moe tp_szie == ep_size, every gpu get shared experts gemm output
             # so we scale with 1 / self.moe_ep_size in ep mode which will make it equalation as in tp mode

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1348,4 +1348,9 @@ def reset_context() -> None:
     _CONTEXT.flags = Flags()
     _CONTEXT.resources = Resources()
     _CONTEXT.forward = ForwardFlags()
-    set_global_dwdp_manager(None)
+    manager = get_global_dwdp_manager()
+    try:
+        if manager is not None:
+            manager.cleanup()
+    finally:
+        set_global_dwdp_manager(None)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1050,6 +1050,17 @@ class ServerArgs:
         ),
         NS("parallel"),
     ] = 1
+    dwdp_weight_backend: A[
+        str,
+        Arg(
+            help="Expert-weight backend for DWDP. 'vmm' uses a composite "
+            "virtual address, 'ipc' uses ROCm HIP IPC with Aiter multi-B, "
+            "and 'auto' selects IPC on ROCm or VMM on CUDA.",
+            choices=["auto", "vmm", "ipc"],
+            resolvable=True,
+        ),
+        NS("parallel"),
+    ] = "auto"
     dcp_comm_backend: A[
         str,
         Arg(
@@ -6310,6 +6321,16 @@ class ServerArgs:
         assert (
             not self.enable_two_batch_overlap
         ), "DWDP's prefetch event protocol does not support two-batch overlap"
+        assert is_cuda() or is_hip(), "DWDP is supported only on CUDA or ROCm"
+        if is_hip():
+            assert (
+                self.dwdp_size in (2, 4, 8)
+            ), "ROCm DWDP requires dwdp_size in {2, 4, 8}"
+            assert self.nnodes == 1, "ROCm DWDP currently requires a single node"
+        else:
+            assert (
+                self.dwdp_weight_backend != "ipc"
+            ), "DWDP IPC/multi-B backend is only supported on ROCm"
 
         if self.disaggregation_mode == "null":
             logger.warning(
@@ -6334,6 +6355,7 @@ class ServerArgs:
 
         logger.info(
             f"DWDP enabled: dwdp_size={self.dwdp_size}, "
+            f"weight_backend={self.dwdp_weight_backend}, "
             f"auto-forced dp_size={self.dp_size}, moe_ep_size={self.moe_ep_size}, "
             f"moe_dense_tp_size=1, moe_a2a_backend=none, "
             f"dp_attention_local_control_broadcast=True, "

--- a/scripts/ci/amd/check_dwdp_rocm_vram.py
+++ b/scripts/ci/amd/check_dwdp_rocm_vram.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import io
+import subprocess
+import sys
+
+
+GIB = 1024**3
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reject MI355X nodes with occupied or unbalanced VRAM."
+    )
+    parser.add_argument("--expected-gpus", type=int, default=8)
+    parser.add_argument("--max-used-gib", type=float, default=4.0)
+    parser.add_argument("--max-skew-gib", type=float, default=2.0)
+    return parser.parse_args()
+
+
+def query_vram() -> list[tuple[str, int, int]]:
+    result = subprocess.run(
+        ["rocm-smi", "--showmeminfo", "vram", "--csv"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"rocm-smi failed ({result.returncode}): {detail}")
+
+    lines = result.stdout.splitlines()
+    try:
+        header_index = next(
+            index for index, line in enumerate(lines) if line.startswith("device,")
+        )
+    except StopIteration as exc:
+        raise RuntimeError(f"rocm-smi returned no CSV header: {result.stdout!r}") from exc
+
+    reader = csv.DictReader(io.StringIO("\n".join(lines[header_index:])))
+    rows = []
+    for row in reader:
+        device = (row.get("device") or "").strip()
+        if not device.startswith("card"):
+            continue
+        total = int(row["VRAM Total Memory (B)"])
+        used = int(row["VRAM Total Used Memory (B)"])
+        rows.append((device, total, used))
+    return sorted(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        rows = query_vram()
+    except (OSError, RuntimeError, subprocess.TimeoutExpired, ValueError, KeyError) as exc:
+        print(f"VRAM preflight failed: {exc}", file=sys.stderr)
+        return 2
+
+    if len(rows) != args.expected_gpus:
+        print(
+            f"VRAM preflight failed: expected {args.expected_gpus} GPUs, got {len(rows)}",
+            file=sys.stderr,
+        )
+        return 3
+
+    used_gib = [used / GIB for _, _, used in rows]
+    free_gib = [(total - used) / GIB for _, total, used in rows]
+    max_used = max(used_gib)
+    skew = max(used_gib) - min(used_gib)
+    print(
+        "VRAM preflight: "
+        f"used_gib=[{', '.join(f'{value:.2f}' for value in used_gib)}], "
+        f"min_free_gib={min(free_gib):.2f}, "
+        f"max_used_gib={max_used:.2f}, skew_gib={skew:.2f}"
+    )
+
+    violations = []
+    if max_used > args.max_used_gib:
+        violations.append(
+            f"max used {max_used:.2f} GiB exceeds {args.max_used_gib:.2f} GiB"
+        )
+    if skew > args.max_skew_gib:
+        violations.append(f"skew {skew:.2f} GiB exceeds {args.max_skew_gib:.2f} GiB")
+    if violations:
+        print("VRAM preflight rejected node: " + "; ".join(violations), file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/amd/dwdp_rocm_job.slurm
+++ b/scripts/ci/amd/dwdp_rocm_job.slurm
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BAD_NODE="smci355-ccs-aus-n08-21"
+if [[ "$(hostname -s)" == "$BAD_NODE" ]]; then
+    echo "Refusing to run ROCm GPU tests on known-bad node $BAD_NODE" >&2
+    exit 97
+fi
+
+ARM="${DWDP_TEST_ARM:?DWDP_TEST_ARM is required}"
+IMAGE="${IMAGE:-rocm/pytorch-private:sglang-main-20260731-hisparse32368-rebased-e776c8a9}"
+SGLANG_WORKTREE="${SGLANG_WORKTREE:-/home/yanfwang/workspace/sglang-dwdp-rocm}"
+AITER_WORKTREE="${AITER_WORKTREE:-/home/yanfwang/workspace/aiter-dwdp-rocm}"
+RESULT_ROOT="${RESULT_ROOT:-/home/yanfwang/workspace/dwdp_rocm_slurm_results}"
+RESULT_DIR="${RESULT_ROOT}/${SLURM_JOB_ID}-${ARM}"
+
+mkdir -p "$RESULT_DIR"
+exec > >(tee "${RESULT_DIR}/stdout.log") 2> >(tee "${RESULT_DIR}/stderr.log" >&2)
+
+python3 "${SGLANG_WORKTREE}/scripts/ci/amd/check_dwdp_rocm_vram.py" \
+    --expected-gpus "${EXPECTED_GPU_COUNT:-8}" \
+    --max-used-gib "${MAX_USED_VRAM_GIB:-4}" \
+    --max-skew-gib "${MAX_VRAM_SKEW_GIB:-2}"
+
+postflight_vram() {
+    local job_status=$?
+    local attempt
+    local clean=0
+    trap - EXIT
+    set +e
+    for ((attempt = 1; attempt <= ${VRAM_POSTFLIGHT_ATTEMPTS:-6}; attempt++)); do
+        echo "VRAM postflight attempt ${attempt}/${VRAM_POSTFLIGHT_ATTEMPTS:-6}"
+        if python3 "${SGLANG_WORKTREE}/scripts/ci/amd/check_dwdp_rocm_vram.py" \
+            --expected-gpus "${EXPECTED_GPU_COUNT:-8}" \
+            --max-used-gib "${MAX_USED_VRAM_GIB:-4}" \
+            --max-skew-gib "${MAX_VRAM_SKEW_GIB:-2}"; then
+            clean=1
+            break
+        fi
+        sleep "${VRAM_POSTFLIGHT_INTERVAL_SECONDS:-10}"
+    done
+    if [[ "$clean" -ne 1 ]]; then
+        echo "VRAM postflight failed; leaving the node untouched and marking it unsafe" >&2
+        if [[ "$job_status" -eq 0 ]]; then
+            job_status=99
+        fi
+    fi
+    exit "$job_status"
+}
+trap postflight_vram EXIT
+
+echo "job_id=${SLURM_JOB_ID}"
+echo "node=$(hostname -s)"
+echo "arm=${ARM}"
+echo "image=${IMAGE}"
+echo "rocm=$(cat /opt/rocm/.info/version 2>/dev/null || true)"
+git -C "$SGLANG_WORKTREE" log -1 --format='sglang=%H %s'
+git -C "$AITER_WORKTREE" log -1 --format='aiter=%H %s'
+
+case "$ARM" in
+    vmm-poc)
+        TEST_COMMAND="rm -rf /tmp/dwdp-aot && cp -a python/sglang/kernels/aot /tmp/dwdp-aot && cd /tmp/dwdp-aot && rm -rf build && python3 setup_rocm.py build_ext --inplace && cd /sgl-workspace/sglang && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH python3 -m pytest -q test/registered/unit/layers/test_hip_vmm.py test/registered/amd/moe/test_dwdp_vmm_manager_amd.py && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH python3 -m pytest -q test/registered/amd/moe/test_dwdp_hsa_copy_amd.py"
+        ;;
+    vmm-access-probe)
+        TEST_COMMAND="rm -rf /tmp/dwdp-aot && cp -a python/sglang/kernels/aot /tmp/dwdp-aot && cd /tmp/dwdp-aot && rm -rf build && python3 setup_rocm.py build_ext --inplace && cd /sgl-workspace/sglang && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH python3 benchmark/dwdp/probe_hip_vmm_access.py"
+        ;;
+    ipc-poc)
+        TEST_COMMAND="python3 -m pytest -q test/registered/amd/moe/test_dwdp_ipc_amd.py"
+        ;;
+    aiter-multib)
+        TEST_COMMAND="cd /sgl-workspace/aiter && python3 -m pytest -q op_tests/test_moe_multi_b_contract.py op_tests/test_moe_multi_b_rocm.py && cd /sgl-workspace/sglang && python3 -m pytest -q test/registered/unit/layers/moe/test_aiter_runner.py test/registered/unit/layers/moe/test_dwdp_hsa_fallback.py test/registered/unit/layers/moe/test_dwdp_page_pool.py test/registered/unit/layers/moe/test_dwdp_tensor_schema.py test/registered/unit/layers/moe/test_dwdp_layout.py test/registered/unit/server_args/test_server_args.py::TestDwdpWeightBackend test/registered/unit/test_runtime_context.py::TestRuntimeContextSingletons::test_reset_context_cleans_up_dwdp_manager"
+        ;;
+    synthetic-2)
+        TEST_COMMAND="DWDP_TEST_WORLD_SIZE=2 python3 -m pytest -q test/registered/amd/moe/test_dwdp_prefetch_amd.py"
+        ;;
+    synthetic-4)
+        TEST_COMMAND="DWDP_TEST_WORLD_SIZE=4 python3 -m pytest -q test/registered/amd/moe/test_dwdp_prefetch_amd.py"
+        ;;
+    synthetic-8)
+        TEST_COMMAND="DWDP_TEST_WORLD_SIZE=8 python3 -m pytest -q test/registered/amd/moe/test_dwdp_prefetch_amd.py"
+        ;;
+    hsa-benchmark)
+        TEST_COMMAND="rm -rf /tmp/dwdp-aot && cp -a python/sglang/kernels/aot /tmp/dwdp-aot && cd /tmp/dwdp-aot && rm -rf build && python3 setup_rocm.py build_ext --inplace && cd /sgl-workspace/sglang && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH python3 benchmark/dwdp/benchmark_hsa_copy.py"
+        ;;
+    model-smoke)
+        TEST_COMMAND="rm -rf /tmp/dwdp-aot && cp -a python/sglang/kernels/aot /tmp/dwdp-aot && cd /tmp/dwdp-aot && rm -rf build && python3 setup_rocm.py build_ext --inplace && cd /sgl-workspace/sglang && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH bash test/manual/dwdp/run_model_smoke_rocm.sh"
+        ;;
+    standalone)
+        TEST_COMMAND="rm -rf /tmp/dwdp-aot && cp -a python/sglang/kernels/aot /tmp/dwdp-aot && cd /tmp/dwdp-aot && rm -rf build && python3 setup_rocm.py build_ext --inplace && cd /sgl-workspace/sglang && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH python3 -m pytest -q test/registered/amd/test_dwdp_standalone_amd.py"
+        ;;
+    pd)
+        TEST_COMMAND="rm -rf /tmp/dwdp-aot && cp -a python/sglang/kernels/aot /tmp/dwdp-aot && cd /tmp/dwdp-aot && rm -rf build && python3 setup_rocm.py build_ext --inplace && cd /sgl-workspace/sglang && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH python3 -m pytest -q test/registered/amd/disaggregation/test_disaggregation_dwdp_amd.py"
+        ;;
+    benchmark)
+        TEST_COMMAND="rm -rf /tmp/dwdp-aot && cp -a python/sglang/kernels/aot /tmp/dwdp-aot && cd /tmp/dwdp-aot && rm -rf build && python3 setup_rocm.py build_ext --inplace && cd /sgl-workspace/sglang && PYTHONPATH=/tmp/dwdp-aot/python:\$PYTHONPATH bash benchmark/dwdp/run_rocm_backend_comparison.sh"
+        ;;
+    *)
+        echo "Unknown DWDP_TEST_ARM: $ARM" >&2
+        exit 2
+        ;;
+esac
+
+if [[ -n "${DWDP_TEST_COMMAND:-}" ]]; then
+    TEST_COMMAND="$DWDP_TEST_COMMAND"
+fi
+printf 'command=%q\n' "$TEST_COMMAND"
+printf '%s\n' "$TEST_COMMAND" > "${RESULT_DIR}/command.txt"
+
+docker run --rm \
+    --privileged \
+    --user "$(id -u):$(id -g)" \
+    --ulimit memlock=-1:-1 \
+    --network=host \
+    --ipc=host \
+    --shm-size=256g \
+    --tmpfs /tmp:rw,exec,nosuid,size=64g \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --group-add=video \
+    --cap-add=SYS_PTRACE \
+    --security-opt seccomp=unconfined \
+    -e HOME=/tmp/dwdp-home \
+    -e USER="$USER" \
+    -e LOGNAME="$USER" \
+    -e SGLANG_USE_AITER=1 \
+    -e AMDGPU_TARGET=gfx950 \
+    -e BACKENDS="${BACKENDS:-}" \
+    -e MODEL_PATH="${MODEL_PATH:-}" \
+    -e DWDP_SIZE="${DWDP_SIZE:-}" \
+    -e TP_SIZE="${TP_SIZE:-}" \
+    -e INPUT_LENGTHS="${INPUT_LENGTHS:-}" \
+    -e NUM_PROMPTS="${NUM_PROMPTS:-}" \
+    -e MAX_CONCURRENCY="${MAX_CONCURRENCY:-}" \
+    -e CHUNKED_PREFILL_SIZE="${CHUNKED_PREFILL_SIZE:-}" \
+    -e BASE_PORT="${BASE_PORT:-}" \
+    -e EXPECTED_GPU_COUNT="${EXPECTED_GPU_COUNT:-8}" \
+    -e MAX_USED_VRAM_GIB="${MAX_USED_VRAM_GIB:-4}" \
+    -e MAX_VRAM_SKEW_GIB="${MAX_VRAM_SKEW_GIB:-2}" \
+    -e SGLANG_DWDP_TEST_BACKEND="${SGLANG_DWDP_TEST_BACKEND:-ipc}" \
+    -e SGLANG_DWDP_DISABLE_HSA_COPY="${SGLANG_DWDP_DISABLE_HSA_COPY:-0}" \
+    -e NIXL_LOG_LEVEL="${NIXL_LOG_LEVEL:-ERROR}" \
+    -e UCX_LOG_LEVEL="${UCX_LOG_LEVEL:-error}" \
+    -e DWDP_TEST_WORLD_SIZE="${DWDP_TEST_WORLD_SIZE:-2}" \
+    -e DWDP_TEST_NUM_LAYERS="${DWDP_TEST_NUM_LAYERS:-3}" \
+    -e DWDP_TEST_EXPERT_BYTES="${DWDP_TEST_EXPERT_BYTES:-32}" \
+    -e PYTHONPATH=/sgl-workspace/aiter:/sgl-workspace/sglang/python:/sgl-workspace/sglang/python/sglang/kernels/aot/python \
+    -v "${SGLANG_WORKTREE}:/sgl-workspace/sglang" \
+    -v "${AITER_WORKTREE}:/sgl-workspace/aiter" \
+    -v "${RESULT_DIR}:/results" \
+    -v /apps/data/models:/models:ro \
+    -w /sgl-workspace/sglang \
+    "$IMAGE" \
+    bash -lc "set -euo pipefail; mkdir -p \"\$HOME\"; memlock=\$(ulimit -l); echo \"memlock=\${memlock}\"; [[ \"\$memlock\" == unlimited ]] || { echo \"DWDP GPU jobs require unlimited memlock for UCX/NIXL (got \$memlock KiB)\" >&2; exit 98; }; ${TEST_COMMAND}"

--- a/scripts/ci/amd/submit_dwdp_rocm_slurm.sh
+++ b/scripts/ci/amd/submit_dwdp_rocm_slurm.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: NODE_LIST=node-a,node-b $0 <arm>" >&2
+    echo "Arms: vmm-poc, vmm-access-probe, ipc-poc, aiter-multib, synthetic-2, synthetic-4, synthetic-8, hsa-benchmark, model-smoke, standalone, pd, benchmark" >&2
+    exit 2
+fi
+
+ARM="$1"
+BAD_NODE="smci355-ccs-aus-n08-21"
+NODE_LIST="${NODE_LIST:?NODE_LIST must be a fixed comma-separated MI355X node pool}"
+SLURM_PARTITION="${SLURM_PARTITION:-Compute-Group01}"
+SLURM_ACCOUNT="${SLURM_ACCOUNT:-$USER}"
+TIME_LIMIT="${TIME_LIMIT:-02:00:00}"
+RESULT_ROOT="${RESULT_ROOT:-/home/yanfwang/workspace/dwdp_rocm_slurm_results}"
+EXPECTED_GPU_COUNT="${EXPECTED_GPU_COUNT:-8}"
+MAX_USED_VRAM_GIB="${MAX_USED_VRAM_GIB:-4}"
+MAX_VRAM_SKEW_GIB="${MAX_VRAM_SKEW_GIB:-2}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+VRAM_CHECK_SCRIPT="${SCRIPT_DIR}/check_dwdp_rocm_vram.py"
+
+# Keep the known-bad host out of both the candidate pool and Slurm allocation.
+IFS=',' read -r -a _nodes <<< "$NODE_LIST"
+_safe_nodes=()
+for _node in "${_nodes[@]}"; do
+    _node="${_node//[[:space:]]/}"
+    [[ -z "$_node" || "$_node" == "$BAD_NODE" ]] && continue
+    if [[ ! "$_node" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        echo "Invalid node name: $_node" >&2
+        exit 2
+    fi
+    _safe_nodes+=("$_node")
+done
+if [[ "${#_safe_nodes[@]}" -lt 1 ]]; then
+    echo "NODE_LIST has no usable nodes after excluding $BAD_NODE" >&2
+    exit 2
+fi
+
+# Slurm can report a node as idle while stale allocations still occupy VRAM.
+# Query memory only (never processes) and submit exclusively to clean nodes.
+_vram_clean_nodes=()
+for _node in "${_safe_nodes[@]}"; do
+    _state="$(sinfo -h -p "$SLURM_PARTITION" -n "$_node" -o "%T" | tr -d '[:space:]')"
+    if [[ "$_state" != idle ]]; then
+        echo "Skipping $_node because Slurm state is ${_state:-unknown}, not idle" >&2
+        continue
+    fi
+    echo "Checking VRAM on $_node before submission"
+    if ssh -o BatchMode=yes -o ConnectTimeout=10 "$_node" \
+        python3 "$VRAM_CHECK_SCRIPT" \
+        --expected-gpus "$EXPECTED_GPU_COUNT" \
+        --max-used-gib "$MAX_USED_VRAM_GIB" \
+        --max-skew-gib "$MAX_VRAM_SKEW_GIB"; then
+        _vram_clean_nodes+=("$_node")
+    else
+        echo "Skipping $_node because its VRAM preflight failed" >&2
+    fi
+done
+if [[ "${#_vram_clean_nodes[@]}" -lt 1 ]]; then
+    echo "No candidate node passed the VRAM preflight; no Slurm job was submitted" >&2
+    exit 3
+fi
+SAFE_NODE_LIST=$(IFS=,; echo "${_vram_clean_nodes[*]}")
+
+case ",${SLURM_EXCLUDE_NODES:-}," in
+    *",${BAD_NODE},"*) ;;
+    ",,") export SLURM_EXCLUDE_NODES="$BAD_NODE" ;;
+    *) export SLURM_EXCLUDE_NODES="${SLURM_EXCLUDE_NODES},${BAD_NODE}" ;;
+esac
+export DWDP_TEST_ARM="$ARM"
+export RESULT_ROOT
+export EXPECTED_GPU_COUNT
+export MAX_USED_VRAM_GIB
+export MAX_VRAM_SKEW_GIB
+
+mkdir -p "$RESULT_ROOT"
+timestamp=$(date +%Y%m%d-%H%M%S)
+log_prefix="${RESULT_ROOT}/dwdp-${ARM}-${timestamp}"
+
+job_id=$(
+    sbatch \
+        --parsable \
+        --exclusive \
+        --nodes=1 \
+        --ntasks-per-node=1 \
+        --gpus-per-node=8 \
+        --account="$SLURM_ACCOUNT" \
+        --partition="$SLURM_PARTITION" \
+        --time="$TIME_LIMIT" \
+        --nodelist="$SAFE_NODE_LIST" \
+        --exclude="$SLURM_EXCLUDE_NODES" \
+        --output="${log_prefix}-%j.out" \
+        --error="${log_prefix}-%j.err" \
+        --export=ALL \
+        "$(dirname "$0")/dwdp_rocm_job.slurm"
+)
+
+job_desc=$(scontrol show job -o "$job_id")
+echo "$job_desc"
+allocated_nodes=$(squeue --noheader --job "$job_id" --format="%N" | tr -d '[:space:]')
+if [[ "$allocated_nodes" == "$BAD_NODE" ]]; then
+    scancel "$job_id"
+    echo "Refusing allocation on excluded node $BAD_NODE; cancelled job $job_id" >&2
+    exit 1
+fi
+
+echo "Submitted DWDP arm '$ARM' as Slurm job $job_id"
+echo "Candidate nodes: $SAFE_NODE_LIST"
+echo "Excluded nodes: $SLURM_EXCLUDE_NODES"
+echo "Logs: ${log_prefix}-${job_id}.{out,err}"

--- a/test/manual/dwdp/README.md
+++ b/test/manual/dwdp/README.md
@@ -1,0 +1,41 @@
+# ROCm DWDP development tests
+
+Submit every GPU test through Slurm:
+
+```bash
+NODE_LIST=smci355-ccs-aus-n08-25,smci355-ccs-aus-n08-29,smci355-ccs-aus-n08-33,smci355-ccs-aus-n09-21,smci355-ccs-aus-n09-25 \
+SLURM_EXCLUDE_NODES=smci355-ccs-aus-n08-21 \
+bash scripts/ci/amd/submit_dwdp_rocm_slurm.sh vmm-poc
+```
+
+Available arms are printed by the submit script. The submitter removes
+`smci355-ccs-aus-n08-21` from the candidate pool, adds it to Slurm's exclusion
+list, and verifies the resulting job description.
+
+Before calling `sbatch`, the submitter requires Slurm state `idle` and reads
+each candidate's per-GPU VRAM usage. By default a node is rejected if any GPU
+uses more than 4 GiB, if the eight GPUs differ by more than 2 GiB, or if all
+eight GPUs cannot be queried. The allocated job repeats the same check before
+compilation or model startup to close the scheduling race. Thresholds can be
+changed with `MAX_USED_VRAM_GIB`, `MAX_VRAM_SKEW_GIB`, and
+`EXPECTED_GPU_COUNT`. If no node passes, no test job is submitted. The check
+reads memory counters only; it never resets a GPU or inspects or terminates
+processes.
+
+After the container exits, the job gives VRAM up to 60 seconds to return below
+the same limits. Persistent allocations mark the job failed and the node
+unsafe for later submissions, even if the functional test itself passed.
+
+Do not run ROCm GPU tests directly on the login host, reset GPUs, or terminate
+unrelated processes. CPU-only lint and static tests may run locally.
+
+Model smoke tests accept environment overrides:
+
+```bash
+NODE_LIST=smci355-ccs-aus-n08-25,smci355-ccs-aus-n08-33,smci355-ccs-aus-n09-21 \
+SLURM_EXCLUDE_NODES=smci355-ccs-aus-n08-21 \
+BACKENDS="vmm ipc" \
+BASE_PORT=39000 \
+MODEL_PATH=/models/DeepSeek-R1-0528-MXFP4-th \
+bash scripts/ci/amd/submit_dwdp_rocm_slurm.sh model-smoke
+```

--- a/test/manual/dwdp/run_model_smoke_rocm.sh
+++ b/test/manual/dwdp/run_model_smoke_rocm.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_PATH="${MODEL_PATH:-/models/DeepSeek-R1-0528-MXFP4-th}"
+DWDP_SIZE="${DWDP_SIZE:-4}"
+BACKENDS="${BACKENDS:-vmm ipc}"
+BASE_PORT="${BASE_PORT:-31000}"
+RESULT_DIR="${RESULT_DIR:-/results}"
+
+export SGLANG_USE_AITER=1
+export GPU_ARCHS="${GPU_ARCHS:-gfx950}"
+mkdir -p "$RESULT_DIR"
+
+backend_index=0
+for backend in $BACKENDS; do
+    port=$((BASE_PORT + backend_index * 100))
+    log_file="${RESULT_DIR}/model-smoke-${backend}.log"
+    python3 -m sglang.launch_server \
+        --model-path "$MODEL_PATH" \
+        --tp-size "$DWDP_SIZE" \
+        --dwdp-size "$DWDP_SIZE" \
+        --dwdp-weight-backend "$backend" \
+        --host 127.0.0.1 \
+        --port "$port" \
+        --trust-remote-code \
+        --watchdog-timeout 1800 \
+        --mem-fraction-static 0.80 \
+        --max-running-requests 8 \
+        --chunked-prefill-size 8192 \
+        --disable-radix-cache \
+        --attention-backend aiter \
+        >"$log_file" 2>&1 &
+    server_pid=$!
+
+    cleanup_server() {
+        if kill -0 "$server_pid" 2>/dev/null; then
+            SERVER_PID="$server_pid" python3 - <<'PY'
+import os
+
+from sglang.srt.utils import kill_process_tree
+
+kill_process_tree(int(os.environ["SERVER_PID"]), wait_timeout=30)
+PY
+            wait "$server_pid" || true
+        fi
+    }
+    wait_vram_clean() {
+        local attempt
+        for attempt in $(seq 1 6); do
+            if python3 scripts/ci/amd/check_dwdp_rocm_vram.py \
+                --expected-gpus "${EXPECTED_GPU_COUNT:-8}" \
+                --max-used-gib "${MAX_USED_VRAM_GIB:-4}" \
+                --max-skew-gib "${MAX_VRAM_SKEW_GIB:-2}"; then
+                return 0
+            fi
+            sleep 10
+        done
+        echo "VRAM did not return to the model-smoke baseline after ${backend}" >&2
+        return 1
+    }
+    trap cleanup_server EXIT
+
+    ready=0
+    for _ in $(seq 1 360); do
+        if curl -fsS "http://127.0.0.1:${port}/health" >/dev/null; then
+            ready=1
+            break
+        fi
+        if ! kill -0 "$server_pid" 2>/dev/null; then
+            echo "DWDP ${backend} server exited during startup" >&2
+            wait "$server_pid"
+        fi
+        sleep 5
+    done
+    if [[ "$ready" != 1 ]]; then
+        echo "DWDP ${backend} server did not become healthy" >&2
+        exit 1
+    fi
+
+    response=$(
+        curl -fsS "http://127.0.0.1:${port}/v1/completions" \
+            -H "Content-Type: application/json" \
+            -d "{
+                \"model\": \"${MODEL_PATH}\",
+                \"prompt\": \"The capital of France is\",
+                \"max_tokens\": 16,
+                \"temperature\": 0
+            }"
+    )
+    RESPONSE="$response" python3 - <<'PY'
+import json
+import os
+
+response = json.loads(os.environ["RESPONSE"])
+text = response["choices"][0]["text"]
+if not text.strip():
+    raise SystemExit("empty completion")
+print(text)
+PY
+
+    cleanup_server
+    wait_vram_clean
+    trap - EXIT
+    backend_index=$((backend_index + 1))
+done

--- a/test/registered/amd/disaggregation/test_disaggregation_dwdp_amd.py
+++ b/test/registered/amd/disaggregation/test_disaggregation_dwdp_amd.py
@@ -1,0 +1,139 @@
+import os
+import unittest
+
+import requests
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+    configure_nixl_pd_backend,
+)
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    popen_launch_pd_server,
+)
+
+register_amd_ci(
+    est_time=1800,
+    suite="stage-c-test-large-8-gpu-amd-mi35x",
+)
+
+MODEL_PATH = os.environ.get(
+    "SGLANG_DWDP_TEST_MODEL",
+    "/models/DeepSeek-R1-0528-MXFP4-th",
+)
+DWDP_BACKEND = os.environ.get("SGLANG_DWDP_TEST_BACKEND") or "ipc"
+
+
+class TestDisaggregationDwdpAmd(PDDisaggregationServerBase):
+    NUM_PREFILL_GPUS = 4
+    NUM_DECODE_GPUS = 4
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(MODEL_PATH):
+            raise unittest.SkipTest(f"DWDP test model is unavailable: {MODEL_PATH}")
+        os.environ.setdefault("SGLANG_USE_AITER", "1")
+        os.environ.setdefault("GPU_ARCHS", "gfx950")
+        super().setUpClass()
+        configure_nixl_pd_backend(cls)
+        cls.model = MODEL_PATH
+        cls.start_prefill()
+        cls.start_decode()
+        cls.wait_server_ready(
+            cls.prefill_url + "/health",
+            timeout=1800,
+            process=cls.process_prefill,
+        )
+        cls.wait_server_ready(
+            cls.decode_url + "/health",
+            timeout=1800,
+            process=cls.process_decode,
+        )
+        cls.launch_lb()
+
+    @classmethod
+    def start_prefill(cls):
+        args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp-size",
+            str(cls.NUM_PREFILL_GPUS),
+            "--dwdp-size",
+            str(cls.NUM_PREFILL_GPUS),
+            "--dwdp-weight-backend",
+            DWDP_BACKEND,
+            "--attention-backend",
+            "aiter",
+            "--disable-cuda-graph",
+            "--log-level",
+            "warning",
+            "--mem-fraction-static",
+            "0.80",
+            "--disable-radix-cache",
+        ]
+        args += cls.transfer_backend + cls.rdma_devices
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=args,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp-size",
+            str(cls.NUM_DECODE_GPUS),
+            "--dp-size",
+            str(cls.NUM_DECODE_GPUS),
+            "--enable-dp-attention",
+            "--ep-size",
+            str(cls.NUM_DECODE_GPUS),
+            "--moe-dense-tp-size",
+            "1",
+            "--attention-backend",
+            "aiter",
+            "--disable-cuda-graph",
+            "--log-level",
+            "warning",
+            "--mem-fraction-static",
+            "0.80",
+            "--disable-radix-cache",
+            "--base-gpu-id",
+            str(cls.NUM_PREFILL_GPUS),
+        ]
+        args += cls.transfer_backend + cls.rdma_devices
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=args,
+        )
+
+    def test_deterministic_completion(self):
+        response = requests.post(
+            self.base_url + "/v1/completions",
+            json={
+                "model": self.model,
+                "prompt": "The capital of France is",
+                "max_tokens": 16,
+                "temperature": 0,
+            },
+            timeout=300,
+        )
+        response.raise_for_status()
+        text = response.json()["choices"][0]["text"].strip()
+        self.assertIn("paris", text.lower(), msg=f"unexpected completion: {text!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/moe/test_dwdp_hsa_copy_amd.py
+++ b/test/registered/amd/moe/test_dwdp_hsa_copy_amd.py
@@ -1,0 +1,52 @@
+import pytest
+import torch
+
+from sglang.srt.layers.moe.dwdp.hsa_copy import (
+    HsaCopyUnavailableError,
+    HsaSdmaCopyEngine,
+)
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=60, suite="stage-b-test-2-gpu-large-amd")
+
+
+@pytest.fixture(scope="module")
+def copy_engine():
+    if torch.version.hip is None or torch.cuda.device_count() < 2:
+        pytest.skip("requires at least two ROCm GPUs")
+    try:
+        return HsaSdmaCopyEngine()
+    except HsaCopyUnavailableError as error:
+        pytest.skip(str(error))
+
+
+def test_hsa_copy_cross_gpu_bytes(copy_engine):
+    source = torch.arange(1 << 20, dtype=torch.int32, device="cuda:1")
+    destination = torch.empty_like(source, device="cuda:0")
+    # Establish HIP peer access before bypassing HIP's memcpy path.
+    destination.copy_(source)
+    torch.cuda.synchronize()
+    destination.zero_()
+    ticket = copy_engine.submit(destination, source)
+    copy_engine.wait(ticket)
+    torch.testing.assert_close(destination.cpu(), source.cpu(), rtol=0, atol=0)
+
+
+def test_hsa_copy_multiple_peer_engines(copy_engine):
+    peer_count = min(torch.cuda.device_count() - 1, 3)
+    sources = [
+        torch.full((1 << 20,), peer, dtype=torch.uint8, device=f"cuda:{peer}")
+        for peer in range(1, peer_count + 1)
+    ]
+    destinations = [torch.empty_like(source, device="cuda:0") for source in sources]
+    for destination, source in zip(destinations, sources):
+        destination.copy_(source)
+        destination.zero_()
+    torch.cuda.synchronize()
+    tickets = [
+        copy_engine.submit(destination, source)
+        for destination, source in zip(destinations, sources)
+    ]
+    copy_engine.wait_all(tickets)
+    for peer, destination in enumerate(destinations, start=1):
+        assert torch.all(destination == peer)

--- a/test/registered/amd/moe/test_dwdp_ipc_amd.py
+++ b/test/registered/amd/moe/test_dwdp_ipc_amd.py
@@ -1,0 +1,84 @@
+import os
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=120, suite="stage-b-test-2-gpu-large-amd")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _ipc_worker(rank: int, world_size: int, port: int):
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        local = (
+            torch.arange(32, device=f"cuda:{rank}", dtype=torch.int32).reshape(4, 8)
+            + rank * 1000
+        ).contiguous()
+        metadata = {
+            "handle": local.untyped_storage()._share_cuda_(),
+            "shape": tuple(local.shape),
+            "stride": tuple(local.stride()),
+            "storage_offset": local.storage_offset(),
+            "dtype": local.dtype,
+        }
+        all_metadata = [None] * world_size
+        dist.all_gather_object(all_metadata, metadata)
+
+        peer_rank = (rank + 1) % world_size
+        peer_metadata = all_metadata[peer_rank]
+        redirected_handle = (rank,) + tuple(peer_metadata["handle"])[1:]
+        with torch.cuda.device(rank):
+            peer_storage = torch.UntypedStorage._new_shared_cuda(*redirected_handle)
+            peer = torch.empty(
+                0,
+                dtype=peer_metadata["dtype"],
+                device=f"cuda:{rank}",
+            ).set_(
+                peer_storage,
+                storage_offset=peer_metadata["storage_offset"],
+                size=peer_metadata["shape"],
+                stride=peer_metadata["stride"],
+            )
+            copied = peer.clone()
+        torch.cuda.synchronize(rank)
+
+        expected = (
+            torch.arange(32, device=f"cuda:{rank}", dtype=torch.int32).reshape(4, 8)
+            + peer_rank * 1000
+        )
+        torch.testing.assert_close(copied, expected, rtol=0, atol=0)
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    torch.version.hip is None,
+    reason="ROCm HIP IPC test",
+)
+def test_rocm_ipc_peer_tensor_round_trip():
+    world_size = int(os.environ.get("DWDP_TEST_WORLD_SIZE", "2"))
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"requires {world_size} ROCm GPUs")
+    mp.spawn(
+        _ipc_worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/test/registered/amd/moe/test_dwdp_prefetch_amd.py
+++ b/test/registered/amd/moe/test_dwdp_prefetch_amd.py
@@ -1,0 +1,185 @@
+import os
+import socket
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+
+import sglang.srt.layers.moe.dwdp.rocm_ipc as rocm_ipc
+from sglang.srt.layers.moe.dwdp.tensor_schema import DwdpTensorSchema
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=180, suite="stage-c-test-large-8-gpu-amd-mi35x")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class _FakeQuantMethod:
+    def get_dwdp_tensor_schema(self, _layer):
+        return DwdpTensorSchema(
+            partitioned=(
+                "w13_weight",
+                "w2_weight",
+                "w13_weight_scale",
+                "w2_weight_scale",
+            ),
+            replicated=("w13_weight_bias",),
+        )
+
+    def get_dwdp_tensor(self, layer, name):
+        value = getattr(layer, name)
+        return value.data if isinstance(value, nn.Parameter) else value
+
+
+class _FakeExperts(nn.Module):
+    def __init__(self, rank: int, world_size: int, layer_idx: int):
+        super().__init__()
+        self.num_global_routed_experts = world_size * 2
+        self.num_fused_shared_experts = 1
+        self.quant_method = _FakeQuantMethod()
+        self.bound = False
+
+        routed = torch.tensor(
+            [rank * 2 + layer_idx * 100, rank * 2 + 1 + layer_idx * 100],
+            dtype=torch.int32,
+            device=f"cuda:{rank}",
+        )
+        shared = torch.tensor(
+            [9000 + layer_idx],
+            dtype=torch.int32,
+            device=f"cuda:{rank}",
+        )
+        values = torch.cat([routed, shared])
+        self.w13_weight = nn.Parameter(
+            values[:, None].repeat(1, 8),
+            requires_grad=False,
+        )
+        self.w2_weight = nn.Parameter(
+            values[:, None].repeat(1, 4),
+            requires_grad=False,
+        )
+        self.w13_weight_scale = nn.Parameter(
+            (values % 251).to(torch.uint8)[:, None].repeat(1, 2),
+            requires_grad=False,
+        )
+        self.w2_weight_scale = nn.Parameter(
+            (values % 251).to(torch.uint8)[:, None],
+            requires_grad=False,
+        )
+        self.w13_weight_bias = nn.Parameter(
+            values[:, None].to(torch.float32),
+            requires_grad=False,
+        )
+
+    def bind_dwdp_partitioned_weights(self):
+        self.bound = True
+
+    def unbind_dwdp_weights(self):
+        self.bound = False
+
+    def replace_expert_tensor(self, name, tensor):
+        setattr(self, name, nn.Parameter(tensor, requires_grad=False))
+
+
+class _FakeGroup:
+    def __init__(self, device_group, cpu_group):
+        self.device_group = device_group
+        self.cpu_group = cpu_group
+
+    def barrier(self):
+        dist.barrier(group=self.cpu_group)
+
+
+def _expected_partition(rank: int, layer_idx: int, is_last: bool):
+    values = [rank * 2 + layer_idx * 100, rank * 2 + 1 + layer_idx * 100]
+    if is_last:
+        values.append(9000 + layer_idx)
+    return values
+
+
+def _prefetch_worker(rank: int, world_size: int, port: int):
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    cpu_group = dist.new_group(ranks=list(range(world_size)), backend="gloo")
+    fake_group = _FakeGroup(dist.group.WORLD, cpu_group)
+    old_get_parallel = rocm_ipc.get_parallel
+    rocm_ipc.get_parallel = lambda: SimpleNamespace(
+        tp_rank=rank,
+        tp_group=fake_group,
+    )
+    try:
+        experts = [_FakeExperts(rank, world_size, layer_idx) for layer_idx in range(4)]
+        manager = rocm_ipc.RocmIpcDwdpManager(SimpleNamespace(dwdp_size=world_size))
+        manager._collect_moe_layers = lambda _model: list(enumerate(experts))
+        manager.setup(SimpleNamespace())
+        assert all(layer.bound for layer in experts)
+
+        manager.prefetch_first_layers()
+        for layer_idx in (0, 1):
+            manager.wait_prefetch(layer_idx)
+            view = manager.get_partition_view(layer_idx, "w13_weight")
+            assert view.partition_sizes == tuple(
+                3 if peer == world_size - 1 else 2 for peer in range(world_size)
+            )
+            for peer, partition in enumerate(view.tensors):
+                observed = partition[:, 0].cpu().tolist()
+                assert observed == _expected_partition(
+                    peer,
+                    layer_idx,
+                    peer == world_size - 1,
+                )
+
+        manager.record_compute_and_prefetch_next(0)
+        manager.wait_prefetch(2)
+        view = manager.get_partition_view(2, "w2_weight")
+        for peer, partition in enumerate(view.tensors):
+            assert partition[:, 0].cpu().tolist() == _expected_partition(
+                peer,
+                2,
+                peer == world_size - 1,
+            )
+        manager.cleanup()
+        assert all(not layer.bound for layer in experts)
+
+        manager.setup(SimpleNamespace())
+        assert all(layer.bound for layer in experts)
+        manager.prefetch_layer(0)
+        manager.wait_prefetch(0)
+        view = manager.get_partition_view(0, "w13_weight")
+        for peer, partition in enumerate(view.tensors):
+            assert partition[:, 0].cpu().tolist() == _expected_partition(
+                peer,
+                0,
+                peer == world_size - 1,
+            )
+        manager.cleanup()
+        dist.barrier(group=cpu_group)
+    finally:
+        rocm_ipc.get_parallel = old_get_parallel
+        dist.destroy_process_group(cpu_group)
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.version.hip is None, reason="ROCm DWDP prefetch test")
+def test_rocm_ipc_double_buffer_prefetch():
+    world_size = int(os.environ.get("DWDP_TEST_WORLD_SIZE", "2"))
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"requires {world_size} ROCm GPUs")
+    mp.spawn(
+        _prefetch_worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/test/registered/amd/moe/test_dwdp_vmm_manager_amd.py
+++ b/test/registered/amd/moe/test_dwdp_vmm_manager_amd.py
@@ -1,0 +1,166 @@
+import os
+import socket
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+
+import sglang.srt.layers.moe.dwdp.rocm_vmm_manager as rocm_vmm_manager
+from sglang.srt.layers.moe.dwdp.tensor_schema import DwdpTensorSchema
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=180, suite="stage-b-test-2-gpu-large-amd")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class _FakeQuantMethod:
+    def get_dwdp_tensor_schema(self, _layer):
+        return DwdpTensorSchema(
+            partitioned=(
+                "w13_weight",
+                "w2_weight",
+                "w13_weight_scale",
+                "w2_weight_scale",
+            ),
+        )
+
+    def get_dwdp_tensor(self, layer, name):
+        value = getattr(layer, name)
+        return value.data if isinstance(value, nn.Parameter) else value
+
+
+class _FakeExperts(nn.Module):
+    def __init__(self, rank: int, world_size: int, layer_idx: int):
+        super().__init__()
+        self.num_global_routed_experts = world_size * 2
+        self.num_fused_shared_experts = 1
+        self.quant_method = _FakeQuantMethod()
+        self.bound = False
+
+        routed = torch.tensor(
+            [rank * 2 + layer_idx * 100, rank * 2 + 1 + layer_idx * 100],
+            dtype=torch.int32,
+            device=f"cuda:{rank}",
+        )
+        shared = torch.tensor(
+            [9000 + layer_idx],
+            dtype=torch.int32,
+            device=f"cuda:{rank}",
+        )
+        values = torch.cat([routed, shared])
+        element_size = torch.tensor([], dtype=torch.int32).element_size()
+        expert_bytes = int(os.environ.get("DWDP_TEST_EXPERT_BYTES", "32"))
+        if expert_bytes % element_size != 0:
+            raise ValueError("DWDP_TEST_EXPERT_BYTES must be int32-aligned")
+        weight_width = expert_bytes // element_size
+        self.w13_weight = nn.Parameter(
+            values[:, None].repeat(1, weight_width), requires_grad=False
+        )
+        self.w2_weight = nn.Parameter(
+            values[:, None].repeat(1, max(1, weight_width // 2)),
+            requires_grad=False,
+        )
+        self.w13_weight_scale = nn.Parameter(
+            values[:, None].repeat(1, 2), requires_grad=False
+        )
+        self.w2_weight_scale = nn.Parameter(values[:, None], requires_grad=False)
+
+    def bind_full_expert_weights(self, weights):
+        for name, tensor in weights.items():
+            setattr(self, name, nn.Parameter(tensor, requires_grad=False))
+        self.bound = True
+
+    def unbind_dwdp_weights(self):
+        self.bound = False
+
+    def replace_expert_tensor(self, name, tensor):
+        setattr(self, name, nn.Parameter(tensor, requires_grad=False))
+
+
+class _FakeGroup:
+    def __init__(self, device_group, cpu_group):
+        self.device_group = device_group
+        self.cpu_group = cpu_group
+
+    def barrier(self):
+        dist.barrier(group=self.cpu_group)
+
+
+def _expected(world_size: int, layer_idx: int):
+    values = [
+        peer * 2 + offset + layer_idx * 100
+        for peer in range(world_size)
+        for offset in range(2)
+    ]
+    values.append(9000 + layer_idx)
+    return values
+
+
+def _vmm_worker(rank: int, world_size: int, port: int):
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    cpu_group = dist.new_group(ranks=list(range(world_size)), backend="gloo")
+    fake_group = _FakeGroup(dist.group.WORLD, cpu_group)
+    old_get_parallel = rocm_vmm_manager.get_parallel
+    rocm_vmm_manager.get_parallel = lambda: SimpleNamespace(
+        tp_rank=rank,
+        tp_group=fake_group,
+    )
+    manager = None
+    try:
+        num_layers = int(os.environ.get("DWDP_TEST_NUM_LAYERS", "3"))
+        experts = [
+            _FakeExperts(rank, world_size, layer_idx) for layer_idx in range(num_layers)
+        ]
+        manager = rocm_vmm_manager.RocmVmmDwdpManager(
+            SimpleNamespace(dwdp_size=world_size)
+        )
+        manager._collect_moe_layers = lambda _model: list(enumerate(experts))
+        manager.setup(SimpleNamespace())
+        assert all(layer.bound for layer in experts)
+
+        manager.prefetch_first_layers()
+        for layer_idx in (0, 1):
+            manager.wait_prefetch(layer_idx)
+            observed = experts[layer_idx].w13_weight[:, 0].cpu().tolist()
+            assert observed == _expected(world_size, layer_idx)
+            scales = experts[layer_idx].w13_weight_scale[:, 0].cpu().tolist()
+            assert scales == _expected(world_size, layer_idx)
+
+        if num_layers >= 3:
+            manager.record_compute_and_prefetch_next(0)
+            manager.wait_prefetch(2)
+            assert experts[2].w2_weight[:, 0].cpu().tolist() == _expected(world_size, 2)
+        dist.barrier(group=cpu_group)
+    finally:
+        if manager is not None:
+            manager.cleanup()
+        rocm_vmm_manager.get_parallel = old_get_parallel
+        dist.destroy_process_group(cpu_group)
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.version.hip is None, reason="ROCm DWDP VMM manager test")
+def test_rocm_vmm_manager_full_expert_tensor():
+    world_size = int(os.environ.get("DWDP_TEST_WORLD_SIZE", "2"))
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"requires {world_size} ROCm GPUs")
+    mp.spawn(
+        _vmm_worker,
+        args=(world_size, _free_port()),
+        nprocs=world_size,
+        join=True,
+    )

--- a/test/registered/amd/test_dwdp_standalone_amd.py
+++ b/test/registered/amd/test_dwdp_standalone_amd.py
@@ -1,0 +1,75 @@
+import os
+import unittest
+
+import requests
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import (
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    popen_launch_server,
+)
+
+register_amd_ci(
+    est_time=1200,
+    suite="stage-c-test-large-8-gpu-amd-mi35x",
+)
+
+MODEL_PATH = os.environ.get(
+    "SGLANG_DWDP_TEST_MODEL",
+    "/models/DeepSeek-R1-0528-MXFP4-th",
+)
+DWDP_BACKEND = os.environ.get("SGLANG_DWDP_TEST_BACKEND") or "ipc"
+
+
+class TestDwdpStandaloneAmd(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(MODEL_PATH):
+            raise unittest.SkipTest(f"DWDP test model is unavailable: {MODEL_PATH}")
+        os.environ.setdefault("SGLANG_USE_AITER", "1")
+        os.environ.setdefault("GPU_ARCHS", "gfx950")
+        cls.process = popen_launch_server(
+            model=MODEL_PATH,
+            base_url=DEFAULT_URL_FOR_TEST,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=[
+                "--tp-size",
+                "4",
+                "--dwdp-size",
+                "4",
+                "--dwdp-weight-backend",
+                DWDP_BACKEND,
+                "--trust-remote-code",
+                "--attention-backend",
+                "aiter",
+                "--disable-cuda-graph",
+                "--mem-fraction-static",
+                "0.80",
+                "--disable-radix-cache",
+            ],
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_deterministic_completion(self):
+        response = requests.post(
+            DEFAULT_URL_FOR_TEST + "/v1/completions",
+            json={
+                "model": MODEL_PATH,
+                "prompt": "The capital of France is",
+                "max_tokens": 16,
+                "temperature": 0,
+            },
+            timeout=300,
+        )
+        response.raise_for_status()
+        text = response.json()["choices"][0]["text"].strip()
+        self.assertIn("paris", text.lower(), msg=f"unexpected completion: {text!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/moe/test_aiter_runner.py
+++ b/test/registered/unit/layers/moe/test_aiter_runner.py
@@ -45,6 +45,7 @@ def _install_fake_aiter(monkeypatch, fused_moe):
 
     fake_fused_moe = ModuleType("aiter.fused_moe")
     fake_fused_moe.fused_moe = fused_moe
+    fake_fused_moe.fused_moe_multi_b = fused_moe
 
     fake_ops = ModuleType("aiter.ops")
     fake_ops.__path__ = []
@@ -86,6 +87,79 @@ def test_aiter_runner_forwards_no_combine_and_extra_fused_moe_kwargs(monkeypatch
     assert captured["quant_type"] == "per_1x32"
     assert captured["no_combine"] is True
     assert captured["custom_fused_moe_kwarg"] == "enabled"
+
+
+def test_aiter_runner_injects_rocm_dwdp_partitions(monkeypatch):
+    from types import SimpleNamespace
+
+    from sglang.srt.runtime_context import set_global_dwdp_manager
+
+    captured = {}
+
+    def fused_moe(**kwargs):
+        captured.update(kwargs)
+        return kwargs["hidden_states"]
+
+    _install_fake_aiter(monkeypatch, fused_moe)
+    weights1 = torch.empty((2, 8, 2))
+    weights2 = torch.empty((2, 4, 2))
+    scale1 = torch.empty((2, 8, 1), dtype=torch.uint8)
+    scale2 = torch.empty((2, 4, 1), dtype=torch.uint8)
+    refs = {
+        weights1.untyped_storage().data_ptr(): "w13_weight",
+        weights2.untyped_storage().data_ptr(): "w2_weight",
+        scale1.untyped_storage().data_ptr(): "w13_weight_scale",
+        scale2.untyped_storage().data_ptr(): "w2_weight_scale",
+    }
+
+    class FakeManager:
+        weight_backend = "ipc"
+
+        def find_partitioned_name(self, layer_idx, reference):
+            assert layer_idx == 3
+            return refs[reference.untyped_storage().data_ptr()]
+
+        def get_partition_view(self, layer_idx, name, reference=None):
+            assert layer_idx == 3
+            if reference is None:
+                reference = {
+                    "w13_weight_scale": scale1,
+                    "w2_weight_scale": scale2,
+                }[name]
+            return SimpleNamespace(tensors=(reference, reference.clone()))
+
+    set_global_dwdp_manager(FakeManager())
+    try:
+        runner = AiterRunnerCore(MoeRunnerConfig(activation="silu", layer_id=3))
+        runner.run(
+            _runner_input(),
+            _quant_info(
+                w13_weight=weights1,
+                w2_weight=weights2,
+                w13_scale=scale1,
+                w2_scale=scale2,
+                expert_mask=torch.ones(3, dtype=torch.bool),
+            ),
+            running_state={},
+        )
+    finally:
+        set_global_dwdp_manager(None)
+
+    assert len(captured["w1_partitions"]) == 2
+    assert len(captured["w2_partitions"]) == 2
+    assert len(captured["w1_scale_partitions"]) == 2
+    assert len(captured["w2_scale_partitions"]) == 2
+    assert captured["w1_scale_partitions"][0].shape == (16, 1)
+    assert captured["w2_scale_partitions"][0].shape == (8, 1)
+    assert captured["expert_mask"] is None
+
+
+def test_aiter_runner_preserves_fp32_block_scale_layout():
+    fp8_scale = torch.empty((2, 4, 3), dtype=torch.float32)
+    normalized = aiter_runner._normalize_dwdp_scale_partition(fp8_scale)
+    assert normalized.shape == (2, 4, 3)
+    assert normalized.dtype == torch.float32
+    assert normalized.is_contiguous()
 
 
 def test_aiter_runner_rejects_no_combine_when_fused_moe_does_not_support_it(

--- a/test/registered/unit/layers/moe/test_dwdp_hsa_fallback.py
+++ b/test/registered/unit/layers/moe/test_dwdp_hsa_fallback.py
@@ -1,0 +1,34 @@
+import pytest
+
+from sglang.srt.layers.moe.dwdp.rocm_ipc import RocmIpcDwdpManager
+from sglang.srt.layers.moe.dwdp.weight_manager import DWDPWeightManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(est_time=1, suite="base-c-test-cpu")
+
+
+class _FakeCopyEngine:
+    def __init__(self, fail=False):
+        self.fail = fail
+        self.calls = []
+
+    def wait_all(self, tickets):
+        self.calls.append(tuple(tickets))
+        if self.fail:
+            raise RuntimeError("injected drain failure")
+
+
+@pytest.mark.parametrize("manager_type", [RocmIpcDwdpManager, DWDPWeightManager])
+@pytest.mark.parametrize("drain_fails", [False, True])
+def test_hsa_fallback_drains_other_slot(manager_type, drain_fails):
+    manager = manager_type.__new__(manager_type)
+    engine = _FakeCopyEngine(fail=drain_fails)
+    manager._copy_engine = engine
+    manager._copy_tickets = [[11, 12], [21, 22]]
+
+    manager._disable_hsa_copy_engine(completed_slot=0)
+
+    assert engine.calls == [(21, 22)]
+    assert manager._copy_tickets == [[], []]
+    assert manager._copy_engine is None

--- a/test/registered/unit/layers/moe/test_dwdp_layout.py
+++ b/test/registered/unit/layers/moe/test_dwdp_layout.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.layers.moe.dwdp.layout import (
+    DwdpExpertLayout,
+    compute_peer_ranges,
+    lookup_owner,
+)
+from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-c-test-cpu")
+
+
+@pytest.mark.parametrize("size", [2, 4, 8])
+def test_equal_routed_partition_layout(size):
+    layout = DwdpExpertLayout(256, size, size - 1)
+    local = 256 // size
+    assert layout.num_experts_per_worker == local
+    assert layout.local_expert_start == 256 - local
+    assert layout.local_expert_end == 256
+    assert layout.peer_ranges == [
+        (rank * local, (rank + 1) * local) for rank in range(size)
+    ]
+
+
+def test_fused_shared_experts_extend_only_last_partition():
+    layouts = [
+        DwdpExpertLayout(
+            256,
+            4,
+            rank,
+            num_fused_shared_experts=1,
+        )
+        for rank in range(4)
+    ]
+    assert [
+        layout.local_expert_end - layout.local_expert_start for layout in layouts
+    ] == [
+        64,
+        64,
+        64,
+        65,
+    ]
+    assert layouts[0].peer_ranges == [
+        (0, 64),
+        (64, 128),
+        (128, 192),
+        (192, 257),
+    ]
+    assert lookup_owner(256, layouts[0].peer_ranges) == 3
+
+
+def test_lookup_owner_rejects_uncovered_expert():
+    ranges = compute_peer_ranges(
+        dwdp_size=2,
+        num_experts_per_worker=2,
+        num_prefetch_experts=2,
+        num_experts_total=4,
+    )
+    with pytest.raises(ValueError, match="not owned"):
+        lookup_owner(4, ranges)
+
+
+def test_fused_moe_dwdp_topology_round_trip():
+    layer = FusedMoE.__new__(FusedMoE)
+    mapping = object()
+    mask = object()
+    layer.moe_ep_size = 4
+    layer.moe_ep_rank = 2
+    layer._num_global_routed = 16
+    layer._num_local_routed = 4
+    layer.num_experts = 5
+    layer.num_local_experts = 5
+    layer.moe_runner_config = SimpleNamespace(num_local_experts=5)
+    layer.dispatcher = SimpleNamespace(
+        moe_ep_size=4,
+        moe_ep_rank=2,
+        num_local_experts=5,
+        num_local_routed_experts=4,
+        local_expert_mapping=mapping,
+        expert_mask_gpu=mask,
+    )
+    layer._dwdp_bound = False
+    layer._dwdp_original_topology = None
+
+    layer.bind_dwdp_partitioned_weights()
+    assert layer.moe_ep_size == 1
+    assert layer._num_local_routed == 16
+
+    layer.unbind_dwdp_weights()
+    assert layer.moe_ep_size == 4
+    assert layer.moe_ep_rank == 2
+    assert layer._num_local_routed == 4
+    assert layer.dispatcher.local_expert_mapping is mapping
+    assert layer.dispatcher.expert_mask_gpu is mask
+    assert layer._dwdp_bound is False

--- a/test/registered/unit/layers/moe/test_dwdp_page_pool.py
+++ b/test/registered/unit/layers/moe/test_dwdp_page_pool.py
@@ -1,0 +1,85 @@
+import pytest
+
+from sglang.srt.layers.moe.dwdp.page_pool import PagePool
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(est_time=1, suite="base-c-test-cpu")
+
+_MIB = 1024 * 1024
+
+
+class _FakeVmmOps:
+    ACCESS_IS_ALLOCATION_SCOPED = True
+
+    def __init__(self, fail_access_at=None):
+        self.fail_access_at = fail_access_at
+        self.next_handle = 1
+        self.created = []
+        self.mapped = []
+        self.accessed = []
+        self.unmapped = []
+        self.released = []
+
+    def get_allocation_granularity(self, device_id):
+        return 4096
+
+    def create_local_handle(self, size, device_id):
+        handle = self.next_handle
+        self.next_handle += 1
+        self.created.append((handle, size, device_id))
+        return handle
+
+    def map_handle(self, va, size, handle, offset=0):
+        self.mapped.append((va, size, handle, offset))
+
+    def set_access(self, va, size, device_id):
+        self.accessed.append((va, size, device_id))
+        if self.fail_access_at == len(self.accessed):
+            raise RuntimeError("injected access failure")
+
+    def unmap_va(self, va, size):
+        self.unmapped.append((va, size))
+
+    def release_handle(self, handle):
+        self.released.append(handle)
+
+
+def test_region_pool_maps_one_coarse_allocation():
+    ops = _FakeVmmOps()
+    pool = PagePool(
+        [64 * _MIB, 64 * _MIB],
+        device_id=0,
+        page_size=32 * _MIB,
+        vmm_ops=ops,
+    )
+
+    mappings = pool.map_pages(
+        slot=0,
+        va_start=0x10E00000,
+        size=64 * _MIB,
+    )
+
+    assert mappings == [(0x10E00000, 64 * _MIB)]
+    assert ops.created == [(1, 64 * _MIB, 0)]
+    assert ops.accessed == [(0x10E00000, 64 * _MIB, 0)]
+
+
+def test_region_pool_rolls_back_partial_mapping_failure():
+    ops = _FakeVmmOps(fail_access_at=1)
+    pool = PagePool(
+        [64 * _MIB, 64 * _MIB],
+        device_id=0,
+        page_size=32 * _MIB,
+        vmm_ops=ops,
+    )
+
+    with pytest.raises(RuntimeError, match="region-pool VMM access"):
+        pool.map_pages(
+            slot=0,
+            va_start=0x10E00000,
+            size=64 * _MIB,
+        )
+
+    assert ops.unmapped == [(0x10E00000, 64 * _MIB)]
+    assert ops.released == [1]

--- a/test/registered/unit/layers/moe/test_dwdp_tensor_schema.py
+++ b/test/registered/unit/layers/moe/test_dwdp_tensor_schema.py
@@ -1,0 +1,87 @@
+import subprocess
+import sys
+
+import pytest
+import torch
+from torch import nn
+
+from sglang.srt.layers.moe.dwdp.common import restore_storage_rank
+from sglang.srt.layers.moe.dwdp.tensor_schema import (
+    DwdpTensorSchema,
+    existing_tensor_names,
+)
+from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+
+class _ExpertLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w13_weight = nn.Parameter(torch.empty(2, 8, 4))
+        self.w2_weight = nn.Parameter(torch.empty(2, 4, 4))
+        self.w13_weight_scale = nn.Parameter(torch.empty(2, 8, 1))
+
+
+def test_schema_requires_explicit_partitioned_tensors():
+    layer = _ExpertLayer()
+    schema = DwdpTensorSchema(
+        partitioned=("w13_weight", "w2_weight", "w13_weight_scale")
+    )
+    schema.validate(layer)
+
+    del layer.w2_weight
+    with pytest.raises(RuntimeError, match="w2_weight"):
+        schema.validate(layer)
+
+
+def test_main_weights_must_be_partitioned():
+    layer = _ExpertLayer()
+    schema = DwdpTensorSchema(
+        main_weights=("w13_weight", "w2_weight"),
+        partitioned=("w13_weight",),
+    )
+    with pytest.raises(ValueError, match="main weights"):
+        schema.validate(layer)
+
+
+def test_existing_tensor_names_preserves_contract_order():
+    layer = _ExpertLayer()
+    assert existing_tensor_names(
+        layer,
+        ("w2_weight", "missing", "w13_weight_scale"),
+    ) == ("w2_weight", "w13_weight_scale")
+
+
+def test_mxfp4_flattened_scale_restores_expert_axis():
+    method = object.__new__(Mxfp4MoEMethod)
+    method.num_experts = 2
+    layer = _ExpertLayer()
+    layer.w13_weight_scale = nn.Parameter(torch.empty(16, 4))
+    restored = method.get_dwdp_tensor(layer, "w13_weight_scale")
+    assert restored.shape == (2, 8, 4)
+    assert (
+        restored.untyped_storage().data_ptr()
+        == layer.w13_weight_scale.untyped_storage().data_ptr()
+    )
+
+
+def test_gathered_scale_restores_original_storage_rank():
+    flattened_storage = torch.empty(16, 4)
+    gathered_expert_view = torch.empty(8, 8, 4)
+    restored = restore_storage_rank(flattened_storage, gathered_expert_view)
+    assert restored.shape == (64, 4)
+
+    fp8_storage = torch.empty(2, 4, 3)
+    fp8_gathered = torch.empty(8, 4, 3)
+    assert restore_storage_rank(fp8_storage, fp8_gathered).shape == (8, 4, 3)
+
+
+def test_dwdp_package_import_does_not_load_cuda_driver():
+    code = """
+import sys
+import sglang.srt.layers.moe.dwdp
+assert "cuda.bindings.driver" not in sys.modules
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/test/registered/unit/layers/test_hip_vmm.py
+++ b/test/registered/unit/layers/test_hip_vmm.py
@@ -1,0 +1,479 @@
+"""ROCm HIP VMM primitive and lifecycle tests."""
+
+from __future__ import annotations
+
+import array
+import gc
+import importlib.util
+import multiprocessing
+import os
+import socket
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=20, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+_PROBE_BYTES = 256
+_HIP_VMM_PATH = (
+    Path(__file__).resolve().parents[4] / "python/sglang/srt/layers/moe/dwdp/hip_vmm.py"
+)
+_HIP_VMM_MODULE_NAME = "_sglang_dwdp_hip_vmm_test_target"
+_HIP_VMM_SPEC = importlib.util.spec_from_file_location(
+    _HIP_VMM_MODULE_NAME, _HIP_VMM_PATH
+)
+if _HIP_VMM_SPEC is None or _HIP_VMM_SPEC.loader is None:
+    raise ImportError(f"could not load HIP VMM wrapper from {_HIP_VMM_PATH}")
+hip_vmm = importlib.util.module_from_spec(_HIP_VMM_SPEC)
+sys.modules[_HIP_VMM_MODULE_NAME] = hip_vmm
+_HIP_VMM_SPEC.loader.exec_module(hip_vmm)
+
+
+@pytest.fixture(scope="module")
+def hip_vmm_device() -> int:
+    if torch.version.hip is None:
+        pytest.skip("HIP VMM tests require a ROCm build of PyTorch")
+    if not torch.cuda.is_available():
+        pytest.skip("HIP VMM tests require a visible ROCm GPU")
+
+    available, reason = hip_vmm.extension_availability()
+    if not available:
+        pytest.skip(f"sgl_kernel ROCm HIP VMM extension unavailable: {reason}")
+
+    device_id = torch.cuda.current_device()
+    if not hip_vmm.is_supported(device_id):
+        pytest.skip(f"HIP VMM is not supported by device {device_id}")
+    return device_id
+
+
+def _close_handles(handles: list[int]) -> None:
+    errors = []
+    for handle in reversed(handles):
+        try:
+            hip_vmm.release_handle(handle)
+        except BaseException as error:
+            errors.append(error)
+    if errors:
+        raise hip_vmm.HipVmmCleanupError("test handle cleanup failed", errors)
+
+
+def _send_fd(sock: socket.socket, fd: int) -> None:
+    descriptors = array.array("i", [fd])
+    sent = sock.sendmsg(
+        [b"F"],
+        [(socket.SOL_SOCKET, socket.SCM_RIGHTS, descriptors.tobytes())],
+    )
+    if sent != 1:
+        raise RuntimeError(f"short sendmsg while transferring VMM fd: {sent}")
+
+
+def _recv_fd(sock: socket.socket) -> int:
+    item_size = array.array("i").itemsize
+    payload, ancillary, flags, _ = sock.recvmsg(1, socket.CMSG_SPACE(item_size))
+    if payload != b"F":
+        raise RuntimeError(f"invalid VMM fd payload: {payload!r}")
+    if flags & socket.MSG_CTRUNC:
+        raise RuntimeError("VMM fd ancillary data was truncated")
+
+    for level, kind, data in ancillary:
+        if level == socket.SOL_SOCKET and kind == socket.SCM_RIGHTS:
+            descriptors = array.array("i")
+            descriptors.frombytes(data[:item_size])
+            if descriptors:
+                return int(descriptors[0])
+    raise RuntimeError("SCM_RIGHTS message contained no VMM fd")
+
+
+def _fd_import_worker(
+    fd_socket: socket.socket,
+    result_pipe: Any,
+    device_id: int,
+    allocation_size: int,
+    expected: int,
+    replacement: int,
+) -> None:
+    received_fd = -1
+    imported_handle = 0
+    mapping = None
+    tensor = None
+    failure = None
+    cleanup_errors: list[BaseException] = []
+    try:
+        torch.cuda.set_device(device_id)
+        received_fd = _recv_fd(fd_socket)
+        imported_handle = hip_vmm.import_fd(received_fd)
+
+        # import_fd preserves its input. Close the SCM_RIGHTS descriptor now;
+        # HIP owns an independent dma-buf reference associated with the handle.
+        os.close(received_fd)
+        received_fd = -1
+
+        mapping = hip_vmm.map_handles(
+            [imported_handle],
+            [allocation_size],
+            device_id,
+            alignment=allocation_size,
+        )
+        tensor = hip_vmm.tensor_from_ptr(
+            mapping.address, (_PROBE_BYTES,), torch.uint8, device_id
+        )
+        observed = tensor.cpu()
+        if not torch.equal(
+            observed, torch.full((_PROBE_BYTES,), expected, dtype=torch.uint8)
+        ):
+            raise AssertionError(
+                f"imported rank read unexpected bytes: {observed.tolist()}"
+            )
+        tensor.fill_(replacement)
+        torch.cuda.synchronize(device_id)
+    except BaseException:
+        failure = traceback.format_exc()
+    finally:
+        if tensor is not None:
+            del tensor
+            try:
+                torch.cuda.synchronize(device_id)
+            except BaseException as error:
+                cleanup_errors.append(error)
+        if mapping is not None:
+            try:
+                mapping.close()
+            except BaseException as error:
+                cleanup_errors.append(error)
+        if imported_handle:
+            try:
+                hip_vmm.release_handle(imported_handle)
+            except BaseException as error:
+                cleanup_errors.append(error)
+        if received_fd >= 0:
+            try:
+                os.close(received_fd)
+            except BaseException as error:
+                cleanup_errors.append(error)
+        fd_socket.close()
+
+    try:
+        if failure is not None or cleanup_errors:
+            result_pipe.send(
+                (
+                    "error",
+                    failure,
+                    [f"{type(error).__name__}: {error}" for error in cleanup_errors],
+                )
+            )
+        else:
+            result_pipe.send(("ok",))
+    finally:
+        result_pipe.close()
+
+
+def test_capability_and_granularity(hip_vmm_device: int) -> None:
+    device_id = hip_vmm_device
+    assert hip_vmm.is_supported(device_id)
+
+    minimum = hip_vmm.get_allocation_granularity(
+        device_id, shareable=True, recommended=False
+    )
+    recommended = hip_vmm.get_allocation_granularity(device_id)
+    local = hip_vmm.get_allocation_granularity(device_id, shareable=False)
+    assert minimum > 0
+    assert recommended >= minimum
+    assert local > 0
+    assert minimum & (minimum - 1) == 0
+    assert recommended & (recommended - 1) == 0
+    assert local & (local - 1) == 0
+
+
+def test_single_process_tensor_read_write(hip_vmm_device: int) -> None:
+    device_id = hip_vmm_device
+    granularity = hip_vmm.get_allocation_granularity(device_id)
+    handle = hip_vmm.create_shareable_handle(granularity, device_id)
+    try:
+        with hip_vmm.map_handles(
+            [handle], [granularity], device_id, alignment=granularity
+        ) as mapping:
+            tensor = None
+            replacement_view = None
+            fp8_view = None
+            try:
+                expected = torch.arange(_PROBE_BYTES, dtype=torch.uint8)
+                tensor = hip_vmm.tensor_from_ptr(
+                    mapping.address, (_PROBE_BYTES,), torch.uint8, device_id
+                )
+                tensor.copy_(expected.to(device=f"cuda:{device_id}"))
+                torch.cuda.synchronize(device_id)
+                assert torch.equal(tensor.cpu(), expected)
+
+                # at::from_blob uses a no-op deleter: dropping one view leaves
+                # the VMM allocation intact and a new view sees the same bytes.
+                pointer = tensor.data_ptr()
+                tensor = None
+                gc.collect()
+                replacement_view = hip_vmm.tensor_from_ptr(
+                    mapping.address, (_PROBE_BYTES,), torch.uint8, device_id
+                )
+                assert replacement_view.data_ptr() == pointer
+                assert torch.equal(replacement_view.cpu(), expected)
+
+                fp8_dtype = getattr(torch, "float8_e4m3fnuz", None)
+                if fp8_dtype is not None:
+                    fp8_view = hip_vmm.tensor_from_ptr(
+                        mapping.address, (_PROBE_BYTES,), fp8_dtype, device_id
+                    )
+                    assert fp8_view.dtype == fp8_dtype
+                    assert fp8_view.data_ptr() == pointer
+                    assert torch.equal(fp8_view.view(torch.uint8).cpu(), expected)
+            finally:
+                fp8_view = None
+                replacement_view = None
+                tensor = None
+                torch.cuda.synchronize(device_id)
+    finally:
+        hip_vmm.release_handle(handle)
+
+
+def test_composite_va_from_two_handles(hip_vmm_device: int) -> None:
+    device_id = hip_vmm_device
+    granularity = hip_vmm.get_allocation_granularity(device_id, shareable=False)
+    handles = []
+    try:
+        for _ in range(2):
+            handles.append(hip_vmm.create_local_handle(granularity, device_id))
+        with hip_vmm.map_handles(
+            handles,
+            [granularity, granularity],
+            device_id,
+            alignment=granularity,
+        ) as mapping:
+            tensor = None
+            try:
+                tensor = hip_vmm.tensor_from_ptr(
+                    mapping.address,
+                    (2 * granularity,),
+                    torch.uint8,
+                    device_id,
+                )
+                tensor[:granularity].fill_(0x31)
+                tensor[granularity:].fill_(0xA7)
+                torch.cuda.synchronize(device_id)
+                boundary = tensor[granularity - 16 : granularity + 16].cpu()
+                assert torch.equal(
+                    boundary[:16], torch.full((16,), 0x31, dtype=torch.uint8)
+                )
+                assert torch.equal(
+                    boundary[16:], torch.full((16,), 0xA7, dtype=torch.uint8)
+                )
+            finally:
+                tensor = None
+                torch.cuda.synchronize(device_id)
+    finally:
+        _close_handles(handles)
+
+
+def test_repeated_setup_teardown(hip_vmm_device: int) -> None:
+    device_id = hip_vmm_device
+    granularity = hip_vmm.get_allocation_granularity(device_id, shareable=False)
+    for iteration in range(8):
+        handle = hip_vmm.create_local_handle(granularity, device_id)
+        try:
+            with hip_vmm.map_handles(
+                [handle], [granularity], device_id, alignment=granularity
+            ) as mapping:
+                tensor = None
+                try:
+                    tensor = hip_vmm.tensor_from_ptr(
+                        mapping.address, (64,), torch.uint8, device_id
+                    )
+                    tensor.fill_(iteration + 1)
+                    assert torch.equal(
+                        tensor.cpu(),
+                        torch.full((64,), iteration + 1, dtype=torch.uint8),
+                    )
+                finally:
+                    tensor = None
+                    torch.cuda.synchronize(device_id)
+        finally:
+            hip_vmm.release_handle(handle)
+
+
+def test_posix_fd_export_import_across_process(hip_vmm_device: int) -> None:
+    device_id = hip_vmm_device
+    granularity = hip_vmm.get_allocation_granularity(device_id)
+    handle = hip_vmm.create_shareable_handle(granularity, device_id)
+    exported_fd = -1
+    process = None
+    parent_socket = None
+    child_socket = None
+    parent_pipe = None
+    child_pipe = None
+    try:
+        with hip_vmm.map_handles(
+            [handle], [granularity], device_id, alignment=granularity
+        ) as mapping:
+            tensor = None
+            try:
+                tensor = hip_vmm.tensor_from_ptr(
+                    mapping.address, (_PROBE_BYTES,), torch.uint8, device_id
+                )
+                tensor.fill_(0x2D)
+                torch.cuda.synchronize(device_id)
+
+                exported_fd = hip_vmm.export_fd(handle)
+                context = multiprocessing.get_context("spawn")
+                parent_socket, child_socket = socket.socketpair()
+                parent_pipe, child_pipe = context.Pipe(duplex=False)
+                process = context.Process(
+                    target=_fd_import_worker,
+                    args=(
+                        child_socket,
+                        child_pipe,
+                        device_id,
+                        granularity,
+                        0x2D,
+                        0x6B,
+                    ),
+                )
+                process.start()
+                child_socket.close()
+                child_socket = None
+                child_pipe.close()
+                child_pipe = None
+
+                _send_fd(parent_socket, exported_fd)
+                os.close(exported_fd)
+                exported_fd = -1
+                parent_socket.close()
+                parent_socket = None
+
+                if not parent_pipe.poll(60):
+                    raise TimeoutError("timed out waiting for HIP VMM import rank")
+                result = parent_pipe.recv()
+                process.join(timeout=60)
+                if process.is_alive():
+                    process.terminate()
+                    process.join(timeout=10)
+                    raise TimeoutError("HIP VMM import rank did not exit")
+                assert process.exitcode == 0
+                assert result[0] == "ok", result
+
+                torch.cuda.synchronize(device_id)
+                assert torch.equal(
+                    tensor.cpu(),
+                    torch.full((_PROBE_BYTES,), 0x6B, dtype=torch.uint8),
+                )
+            finally:
+                if process is not None and process.is_alive():
+                    process.terminate()
+                    process.join(timeout=10)
+                tensor = None
+                torch.cuda.synchronize(device_id)
+    finally:
+        if exported_fd >= 0:
+            os.close(exported_fd)
+        if parent_socket is not None:
+            parent_socket.close()
+        if parent_pipe is not None:
+            parent_pipe.close()
+        if child_socket is not None:
+            child_socket.close()
+        if child_pipe is not None:
+            child_pipe.close()
+        hip_vmm.release_handle(handle)
+
+
+def test_composite_mapping_rolls_back_partial_failure(monkeypatch) -> None:
+    events = []
+
+    monkeypatch.setattr(
+        hip_vmm,
+        "reserve_va",
+        lambda size, alignment=0, requested_address=0: (
+            events.append(("reserve", size, alignment, requested_address)) or 0x10000
+        ),
+    )
+
+    def fake_map(address, size, handle, offset=0):
+        events.append(("map", address, size, handle, offset))
+        if handle == 22:
+            raise RuntimeError("injected second-map failure")
+
+    monkeypatch.setattr(hip_vmm, "map_handle", fake_map)
+    monkeypatch.setattr(
+        hip_vmm,
+        "set_access",
+        lambda address, size, device_id: events.append(
+            ("access", address, size, device_id)
+        ),
+    )
+    monkeypatch.setattr(
+        hip_vmm,
+        "unmap_va",
+        lambda address, size: events.append(("unmap", address, size)),
+    )
+    monkeypatch.setattr(
+        hip_vmm,
+        "free_va",
+        lambda address, size: events.append(("free", address, size)),
+    )
+
+    with pytest.raises(RuntimeError, match="injected second-map failure"):
+        hip_vmm.map_handles([11, 22], [4096, 4096], 0, alignment=4096)
+
+    assert events == [
+        ("reserve", 8192, 4096, 0),
+        ("map", 0x10000, 4096, 11, 0),
+        ("map", 0x11000, 4096, 22, 0),
+        ("unmap", 0x10000, 4096),
+        ("free", 0x10000, 8192),
+    ]
+
+
+def test_composite_mapping_rolls_back_access_failure(monkeypatch) -> None:
+    events = []
+
+    monkeypatch.setattr(
+        hip_vmm,
+        "reserve_va",
+        lambda size, alignment=0, requested_address=0: 0x20000,
+    )
+    monkeypatch.setattr(
+        hip_vmm,
+        "map_handle",
+        lambda address, size, handle, offset=0: events.append(
+            ("map", address, size, handle)
+        ),
+    )
+
+    def fail_access(address, size, device_id):
+        events.append(("access", address, size, device_id))
+        raise RuntimeError("injected access failure")
+
+    monkeypatch.setattr(hip_vmm, "set_access", fail_access)
+    monkeypatch.setattr(
+        hip_vmm,
+        "unmap_va",
+        lambda address, size: events.append(("unmap", address, size)),
+    )
+    monkeypatch.setattr(
+        hip_vmm,
+        "free_va",
+        lambda address, size: events.append(("free", address, size)),
+    )
+
+    with pytest.raises(RuntimeError, match="injected access failure"):
+        hip_vmm.map_handles([11, 22], [4096, 4096], 3, alignment=4096)
+
+    assert events == [
+        ("map", 0x20000, 4096, 11),
+        ("map", 0x21000, 4096, 22),
+        ("access", 0x20000, 8192, 3),
+        ("unmap", 0x21000, 4096),
+        ("unmap", 0x20000, 4096),
+        ("free", 0x20000, 8192),
+    ]

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1910,5 +1910,57 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestDwdpWeightBackend(CustomTestCase):
+    def _args(self, **overrides):
+        args = ServerArgs(model_path="dummy")
+        args.tp_size = 4
+        args.dwdp_size = 4
+        args.dwdp_weight_backend = "auto"
+        args.disaggregation_mode = "null"
+        args.enable_eplb = False
+        args.speculative_algorithm = None
+        args.pp_size = 1
+        args.enable_two_batch_overlap = False
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    @patch("sglang.srt.server_args.is_cuda", return_value=False)
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_rocm_auto_backend_forces_dwdp_topology(self, _is_hip, _is_cuda):
+        args = self._args()
+        args._handle_dwdp()
+        self.assertEqual(args.dwdp_weight_backend, "auto")
+        self.assertEqual(args.dp_size, 4)
+        self.assertEqual(args.moe_ep_size, 4)
+        self.assertEqual(args.moe_a2a_backend, "none")
+        self.assertTrue(args.disable_cuda_graph)
+
+    @patch("sglang.srt.server_args.is_cuda", return_value=True)
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    def test_cuda_rejects_ipc_backend(self, _is_hip, _is_cuda):
+        args = self._args(dwdp_weight_backend="ipc")
+        with self.assertRaisesRegex(AssertionError, "only supported on ROCm"):
+            args._handle_dwdp()
+
+    @patch("sglang.srt.server_args.is_cuda", return_value=False)
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_rocm_rejects_unsupported_partition_count(self, _is_hip, _is_cuda):
+        args = self._args(tp_size=16, dwdp_size=16)
+        with self.assertRaisesRegex(AssertionError, r"\{2, 4, 8\}"):
+            args._handle_dwdp()
+
+        args = self._args(tp_size=3, dwdp_size=3)
+        with self.assertRaisesRegex(AssertionError, r"\{2, 4, 8\}"):
+            args._handle_dwdp()
+
+    @patch("sglang.srt.server_args.is_cuda", return_value=False)
+    @patch("sglang.srt.server_args.is_hip", return_value=True)
+    def test_rocm_rejects_cross_node_dwdp(self, _is_hip, _is_cuda):
+        args = self._args(nnodes=2)
+        with self.assertRaisesRegex(AssertionError, "single node"):
+            args._handle_dwdp()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -18,10 +18,12 @@ from sglang.srt.runtime_context import (
     _FlagGroupBase,
     get_context,
     get_flags,
+    get_global_dwdp_manager,
     get_parallel,
     get_schedule,
     get_server_args,
     reset_context,
+    set_global_dwdp_manager,
 )
 from sglang.test.test_utils import CustomTestCase
 
@@ -70,6 +72,19 @@ class TestRuntimeContextSingletons(CustomTestCase):
         self.assertIsInstance(get_parallel(), ParallelContext)
         self.assertIsInstance(get_context(), RuntimeContext)
         self.assertIs(get_context().parallel, get_parallel())
+
+    def test_reset_context_cleans_up_dwdp_manager(self):
+        class FakeManager:
+            cleanup_calls = 0
+
+            def cleanup(self):
+                self.cleanup_calls += 1
+
+        manager = FakeManager()
+        set_global_dwdp_manager(manager)
+        reset_context()
+        self.assertEqual(manager.cleanup_calls, 1)
+        self.assertIsNone(get_global_dwdp_manager())
 
 
 class _IsolatedOverrides(CustomTestCase):


### PR DESCRIPTION
## Summary
- add ROCm HIP IPC and experimental HIP VMM backends for distributed weight data parallelism while preserving the CUDA VMM path
- integrate HSA SDMA prefetch, Aiter rank-ordered multi-B weights, explicit quantization tensor schemas, and DeepSeek/GPT-OSS/MiMo model paths
- add ROCm Slurm validation, VRAM hygiene checks, backend benchmarks, and deployment documentation

## Dependency
- requires ROCm/aiter#4514 for the gfx950 multi-B MoE kernels

## Test plan
- [x] HIP VMM primitive and small composite-manager tests
- [x] IPC 2/4/8-rank synthetic prefetch tests
- [x] HSA peer-copy correctness and 169.2 GiB/s aggregate benchmark
- [x] DeepSeek-R1 MXFP4 IPC standalone and 4P+4D NIXL PD deterministic accuracy
- [x] Aiter conventional FP8 and SGLang lifecycle/integration suites
- [x] DEP/IPC 4K-32K matrix; optimized IPC reaches 1.209x at 16K and 1.637x at 32K

## Known limitations
- ROCm `auto` selects IPC; HIP VMM remains experimental at production model scale
- MiMo-V2.5 full-model loading currently reaches the GPU memory limit before DWDP setup
- GPT-OSS model validation and DeepSeek GSM8K/logit parity remain follow-up work because the required checkpoint/evaluation capacity was unavailable

A detailed snapshot and Slurm job evidence are recorded in `benchmark/dwdp/ROCM_DWDP_CURRENT_STATUS.md` and `benchmark/dwdp/ROCM_BACKEND_RESULTS.md`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30778113047](https://github.com/sgl-project/sglang/actions/runs/30778113047)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30778112959](https://github.com/sgl-project/sglang/actions/runs/30778112959)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->